### PR TITLE
[JSC] Add B3::MemoryCopy and B3::MemoryFill

### DIFF
--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -1990,6 +1990,7 @@
 		E32FEA2C27448F3700FF41C1 /* JSONAtomStringCacheInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = E32FEA2A27448F3600FF41C1 /* JSONAtomStringCacheInlines.h */; };
 		E32FEA2D27448F3700FF41C1 /* JSONAtomStringCache.h in Headers */ = {isa = PBXBuildFile; fileRef = E32FEA2B27448F3600FF41C1 /* JSONAtomStringCache.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E33095DD23210A1B00EB7856 /* JSInternalFieldObjectImpl.h in Headers */ = {isa = PBXBuildFile; fileRef = E33095DC23210A1400EB7856 /* JSInternalFieldObjectImpl.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		E3344A942E75522F004F63F5 /* B3Operations.h in Headers */ = {isa = PBXBuildFile; fileRef = E3344A912E75522F004F63F5 /* B3Operations.h */; };
 		E334CBB521FD96A9000EB178 /* RegExpGlobalData.h in Headers */ = {isa = PBXBuildFile; fileRef = E334CBB321FD96A9000EB178 /* RegExpGlobalData.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E33637A61B63220200EE0840 /* ReflectObject.h in Headers */ = {isa = PBXBuildFile; fileRef = E33637A41B63220200EE0840 /* ReflectObject.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E3369129296EEBFE00324FD7 /* WasmOperationsInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = E3369128296EEBFE00324FD7 /* WasmOperationsInlines.h */; };
@@ -2078,6 +2079,7 @@
 		E3A0531C21342B680022EC14 /* WasmSectionParser.h in Headers */ = {isa = PBXBuildFile; fileRef = E3A0531821342B670022EC14 /* WasmSectionParser.h */; };
 		E3A107282B7F2F8100ED24A3 /* ProfilerSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = E3A107272B7F2F7E00ED24A3 /* ProfilerSupport.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E3A32BC71FC83147007D7E76 /* WeakMapImpl.h in Headers */ = {isa = PBXBuildFile; fileRef = E3A32BC61FC8312E007D7E76 /* WeakMapImpl.h */; };
+		E3A38EFD2E754D3B00D53DDD /* B3BulkMemoryValue.h in Headers */ = {isa = PBXBuildFile; fileRef = E3A38EFB2E754D3B00D53DDD /* B3BulkMemoryValue.h */; };
 		E3A421431D6F58930007C617 /* PreciseJumpTargetsInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = E3A421421D6F588F0007C617 /* PreciseJumpTargetsInlines.h */; };
 		E3AC277721FDB4940024452C /* RegExpCachedResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 86F75EFC151C062F007C9BA3 /* RegExpCachedResult.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E3B2329D2DF7A0CC00ECC447 /* ConcatKeyAtomStringCache.h in Headers */ = {isa = PBXBuildFile; fileRef = E3B2329A2DF7A0BE00ECC447 /* ConcatKeyAtomStringCache.h */; };
@@ -5742,6 +5744,8 @@
 		E3305FB020B0F78700CEB82B /* InByVariant.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = InByVariant.cpp; sourceTree = "<group>"; };
 		E3305FB120B0F78800CEB82B /* InByVariant.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InByVariant.h; sourceTree = "<group>"; };
 		E33095DC23210A1400EB7856 /* JSInternalFieldObjectImpl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = JSInternalFieldObjectImpl.h; sourceTree = "<group>"; };
+		E3344A912E75522F004F63F5 /* B3Operations.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = B3Operations.h; path = b3/B3Operations.h; sourceTree = "<group>"; };
+		E3344A922E75522F004F63F5 /* B3Operations.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = B3Operations.cpp; path = b3/B3Operations.cpp; sourceTree = "<group>"; };
 		E334CBB221FD96A8000EB178 /* RegExpGlobalData.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RegExpGlobalData.cpp; sourceTree = "<group>"; };
 		E334CBB321FD96A9000EB178 /* RegExpGlobalData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RegExpGlobalData.h; sourceTree = "<group>"; };
 		E33637A31B63220200EE0840 /* ReflectObject.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ReflectObject.cpp; sourceTree = "<group>"; };
@@ -5886,6 +5890,8 @@
 		E3A107272B7F2F7E00ED24A3 /* ProfilerSupport.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ProfilerSupport.h; sourceTree = "<group>"; };
 		E3A32BC51FC8312D007D7E76 /* WeakMapImpl.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WeakMapImpl.cpp; sourceTree = "<group>"; };
 		E3A32BC61FC8312E007D7E76 /* WeakMapImpl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WeakMapImpl.h; sourceTree = "<group>"; };
+		E3A38EFB2E754D3B00D53DDD /* B3BulkMemoryValue.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = B3BulkMemoryValue.h; path = b3/B3BulkMemoryValue.h; sourceTree = "<group>"; };
+		E3A38EFC2E754D3B00D53DDD /* B3BulkMemoryValue.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = B3BulkMemoryValue.cpp; path = b3/B3BulkMemoryValue.cpp; sourceTree = "<group>"; };
 		E3A421421D6F588F0007C617 /* PreciseJumpTargetsInlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PreciseJumpTargetsInlines.h; sourceTree = "<group>"; };
 		E3B2329A2DF7A0BE00ECC447 /* ConcatKeyAtomStringCache.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ConcatKeyAtomStringCache.h; sourceTree = "<group>"; };
 		E3B2329B2DF7A0BE00ECC447 /* ConcatKeyAtomStringCache.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ConcatKeyAtomStringCache.cpp; sourceTree = "<group>"; };
@@ -6607,6 +6613,8 @@
 				E392E6F724D25FA600B20767 /* B3BottomTupleValue.h */,
 				0F6B8ADE1C4EFE1700969052 /* B3BreakCriticalEdges.cpp */,
 				0F6B8ADF1C4EFE1700969052 /* B3BreakCriticalEdges.h */,
+				E3A38EFC2E754D3B00D53DDD /* B3BulkMemoryValue.cpp */,
+				E3A38EFB2E754D3B00D53DDD /* B3BulkMemoryValue.h */,
 				DD4BEC0E29CB85AF00398E35 /* B3CanonicalizePrePostIncrements.cpp */,
 				DD4BEC0F29CB85AF00398E35 /* B3CanonicalizePrePostIncrements.h */,
 				DC9A0C1C1D2D94EF0085124E /* B3CaseCollection.cpp */,
@@ -6698,6 +6706,8 @@
 				0F5BF1681F23A0AA0029D91D /* B3NaturalLoops.h */,
 				0FEC84D71BDACDAC0080FF74 /* B3Opcode.cpp */,
 				0FEC84D81BDACDAC0080FF74 /* B3Opcode.h */,
+				E3344A922E75522F004F63F5 /* B3Operations.cpp */,
+				E3344A912E75522F004F63F5 /* B3Operations.h */,
 				33743649224D79EF00C8C227 /* B3OptimizeAssociativeExpressionTrees.cpp */,
 				3374364A224D79EF00C8C227 /* B3OptimizeAssociativeExpressionTrees.h */,
 				0FEC84D91BDACDAC0080FF74 /* B3Origin.cpp */,
@@ -10553,6 +10563,7 @@
 				DCFDFBD91D1F5D9B00FE3D72 /* B3BottomProvider.h in Headers */,
 				E392E6F924D25FA900B20767 /* B3BottomTupleValue.h in Headers */,
 				0F6B8AE31C4EFE1700969052 /* B3BreakCriticalEdges.h in Headers */,
+				E3A38EFD2E754D3B00D53DDD /* B3BulkMemoryValue.h in Headers */,
 				DD4BEC1129CB85E000398E35 /* B3CanonicalizePrePostIncrements.h in Headers */,
 				DC9A0C201D2D9CB30085124E /* B3CaseCollection.h in Headers */,
 				DC9A0C1F1D2D9CB10085124E /* B3CaseCollectionInlines.h in Headers */,
@@ -10605,6 +10616,7 @@
 				0F2C63C21E664A5C00C13839 /* B3NativeTraits.h in Headers */,
 				0F5BF1691F23A0AA0029D91D /* B3NaturalLoops.h in Headers */,
 				0FEC85221BDACDAC0080FF74 /* B3Opcode.h in Headers */,
+				E3344A942E75522F004F63F5 /* B3Operations.h in Headers */,
 				0FEC85241BDACDAC0080FF74 /* B3Origin.h in Headers */,
 				0F4C91661C29F4F2004341A6 /* B3OriginDump.h in Headers */,
 				0FEC85261BDACDAC0080FF74 /* B3PatchpointSpecial.h in Headers */,

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -117,6 +117,7 @@ b3/B3Bank.cpp
 b3/B3BasicBlock.cpp
 b3/B3BlockInsertionSet.cpp
 b3/B3BottomTupleValue.cpp
+b3/B3BulkMemoryValue.cpp
 b3/B3BreakCriticalEdges.cpp
 b3/B3CanonicalizePrePostIncrements.cpp
 b3/B3CCallValue.cpp
@@ -159,6 +160,7 @@ b3/B3MathExtras.cpp
 b3/B3MemoryValue.cpp
 b3/B3MoveConstants.cpp
 b3/B3Opcode.cpp
+b3/B3Operations.cpp
 b3/B3OptimizeAssociativeExpressionTrees.cpp
 b3/B3Origin.cpp
 b3/B3OriginDump.cpp

--- a/Source/JavaScriptCore/b3/B3BulkMemoryValue.cpp
+++ b/Source/JavaScriptCore/b3/B3BulkMemoryValue.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "B3BulkMemoryValue.h"
+
+#if ENABLE(B3_JIT)
+
+#include "B3ValueInlines.h"
+
+namespace JSC { namespace B3 {
+
+BulkMemoryValue::~BulkMemoryValue() = default;
+
+void BulkMemoryValue::dumpMeta(CommaPrinter& comma, PrintStream& out) const
+{
+    out.print(comma, "readRange = ", readRange(), comma, "writeRange = ", writeRange());
+}
+
+BulkMemoryValue::BulkMemoryValue(Kind kind, Origin origin, Value* child0, Value* child1, Value* child2)
+    : Value(CheckedOpcode, kind, Void, Three, origin, child0, child1, child2)
+{
+}
+
+} } // namespace JSC::B3
+
+#endif // ENABLE(B3_JIT)
+

--- a/Source/JavaScriptCore/b3/B3BulkMemoryValue.h
+++ b/Source/JavaScriptCore/b3/B3BulkMemoryValue.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(B3_JIT)
+
+#include "B3Value.h"
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
+namespace JSC::B3 {
+
+class JS_EXPORT_PRIVATE BulkMemoryValue final : public Value {
+public:
+    static bool accepts(Kind kind) { return kind == MemoryCopy || kind == MemoryFill; }
+
+    ~BulkMemoryValue() final;
+
+    const HeapRange& readRange() const { return m_readRange; }
+    void setReadRange(const HeapRange& range) { m_readRange = range; }
+
+    const HeapRange& writeRange() const { return m_writeRange; }
+    void setWriteRange(const HeapRange& range) { m_writeRange = range; }
+
+    B3_SPECIALIZE_VALUE_FOR_FIXED_CHILDREN(3)
+    B3_SPECIALIZE_VALUE_FOR_FINAL_SIZE_FIXED_CHILDREN
+
+private:
+    void dumpMeta(CommaPrinter&, PrintStream&) const final;
+
+    friend class Procedure;
+    friend class Value;
+
+    BulkMemoryValue(Kind, Origin, Value*, Value*, Value*);
+
+    HeapRange m_readRange { HeapRange::top() };
+    HeapRange m_writeRange { HeapRange::top() };
+};
+
+} // namespace JSC::B3
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+
+#endif // ENABLE(B3_JIT)

--- a/Source/JavaScriptCore/b3/B3LowerInt64.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerInt64.cpp
@@ -1005,6 +1005,8 @@ private:
         case Nop:
         case WasmAddress:
         case WasmBoundsCheck:
+        case MemoryCopy:
+        case MemoryFill:
             return;
         case Set: {
             if (m_value->child(0)->type() != Int64)

--- a/Source/JavaScriptCore/b3/B3LowerMacrosAfterOptimizations.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerMacrosAfterOptimizations.cpp
@@ -35,6 +35,7 @@
 #include "B3ConstFloatValue.h"
 #include "B3ConstPtrValue.h"
 #include "B3InsertionSetInlines.h"
+#include "B3Operations.h"
 #include "B3PhaseScope.h"
 #include "B3ValueInlines.h"
 
@@ -203,7 +204,37 @@ private:
                 }
                 break;
             }
-                
+
+            case MemoryCopy: {
+                Value* functionAddress = m_insertionSet.insert<ConstPtrValue>(m_index, m_origin, tagCFunction<OperationPtrTag>(operationMemoryCopy));
+                Value* result = m_insertionSet.insert<CCallValue>(
+                    m_index,
+                    m_value->type(),
+                    m_origin,
+                    m_value->effects(),
+                    functionAddress,
+                    m_value->child(0),
+                    m_value->child(1),
+                    m_value->child(2));
+                m_value->replaceWithIdentity(result);
+                break;
+            }
+
+            case MemoryFill: {
+                Value* functionAddress = m_insertionSet.insert<ConstPtrValue>(m_index, m_origin, tagCFunction<OperationPtrTag>(operationMemoryFill));
+                Value* result = m_insertionSet.insert<CCallValue>(
+                    m_index,
+                    m_value->type(),
+                    m_origin,
+                    m_value->effects(),
+                    functionAddress,
+                    m_value->child(0),
+                    m_value->child(1),
+                    m_value->child(2));
+                m_value->replaceWithIdentity(result);
+                break;
+            }
+
             default:
                 break;
             }

--- a/Source/JavaScriptCore/b3/B3LowerToAir.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerToAir.cpp
@@ -4187,6 +4187,13 @@ private:
             return;
         }
 
+        case MemoryCopy:
+        case MemoryFill: {
+            // They should be lowered already.
+            RELEASE_ASSERT_NOT_REACHED();
+            return;
+        }
+
         case B3::VectorExtractLane: {
             SIMDValue* value = m_value->as<SIMDValue>();
             auto lane = value->simdLane();

--- a/Source/JavaScriptCore/b3/B3LowerToAir32_64.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerToAir32_64.cpp
@@ -4295,6 +4295,13 @@ private:
             return;
         }
 
+        case MemoryCopy:
+        case MemoryFill: {
+            // They should be lowered already.
+            RELEASE_ASSERT_NOT_REACHED();
+            return;
+        }
+
         case B3::VectorExtractLane: {
             SIMDValue* value = m_value->as<SIMDValue>();
             auto lane = value->simdLane();

--- a/Source/JavaScriptCore/b3/B3Opcode.h
+++ b/Source/JavaScriptCore/b3/B3Opcode.h
@@ -294,7 +294,13 @@ enum Opcode : uint8_t {
     // Wasm it is important that the first child initially be a ZExt32 so the top bits are cleared.
     // We do WasmAddress(ZExt32(ptr), ...) so that we can avoid generating extraneous moves in Air.
     WasmAddress,
-    
+
+    // This is used for Wasm bulk memory operation `memory.copy`
+    MemoryCopy,
+
+    // This is used for Wasm bulk memory operation `memory.fill`
+    MemoryFill,
+
     // This is used to represent standalone fences - i.e. fences that are not part of other
     // instructions. It's expressive enough to expose mfence on x86 and dmb ish/ishst on ARM. On
     // x86, it also acts as a compiler store-store fence in those cases where it would have been a

--- a/Source/JavaScriptCore/b3/B3Operations.cpp
+++ b/Source/JavaScriptCore/b3/B3Operations.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "B3Operations.h"
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
+#if ENABLE(B3_JIT)
+
+namespace JSC::B3 {
+
+
+JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationMemoryCopy, void, (void* dst, const void* src, size_t count))
+{
+    memmove(dst, src, count);
+}
+
+JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationMemoryFill, void, (void* dst, int32_t target, size_t count))
+{
+    memset(dst, target, count);
+}
+
+} // namespace JSC::B3
+
+#endif // ENABLE(B3_JIT)
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/JavaScriptCore/b3/B3Operations.h
+++ b/Source/JavaScriptCore/b3/B3Operations.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(B3_JIT)
+
+#include <JavaScriptCore/JITOperationValidation.h>
+#include <JavaScriptCore/OperationResult.h>
+#include <JavaScriptCore/UGPRPair.h>
+#include <wtf/Platform.h>
+
+namespace JSC::B3 {
+
+JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationMemoryCopy, void, (void* dst, const void* src, size_t count));
+JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationMemoryFill, void, (void* dst, int32_t target, size_t count));
+
+} // namespace JSC::B3
+
+#endif // ENABLE(B3_JIT)

--- a/Source/JavaScriptCore/b3/B3Validate.cpp
+++ b/Source/JavaScriptCore/b3/B3Validate.cpp
@@ -428,6 +428,22 @@ public:
                 validateFence(value);
                 validateStackAccess(value);
                 break;
+            case MemoryCopy:
+                VALIDATE(!value->kind().isChill(), ("At ", *value));
+                VALIDATE(value->numChildren() == 3, ("At ", *value));
+                VALIDATE(value->child(0)->type() == pointerType(), ("At ", *value));
+                VALIDATE(value->child(1)->type() == pointerType(), ("At ", *value));
+                VALIDATE(value->child(2)->type() == pointerType(), ("At ", *value));
+                VALIDATE(value->type() == Void, ("At ", *value));
+                break;
+            case MemoryFill:
+                VALIDATE(!value->kind().isChill(), ("At ", *value));
+                VALIDATE(value->numChildren() == 3, ("At ", *value));
+                VALIDATE(value->child(0)->type() == pointerType(), ("At ", *value));
+                VALIDATE(value->child(1)->type() == Int32, ("At ", *value));
+                VALIDATE(value->child(2)->type() == pointerType(), ("At ", *value));
+                VALIDATE(value->type() == Void, ("At ", *value));
+                break;
             case AtomicWeakCAS:
                 VALIDATE(!value->kind().isChill(), ("At ", *value));
                 VALIDATE(value->numChildren() == 3, ("At ", *value));

--- a/Source/JavaScriptCore/b3/B3Value.cpp
+++ b/Source/JavaScriptCore/b3/B3Value.cpp
@@ -32,6 +32,7 @@
 #include "B3AtomicValue.h"
 #include "B3BasicBlockInlines.h"
 #include "B3BottomProvider.h"
+#include "B3BulkMemoryValue.h"
 #include "B3CCallValue.h"
 #include "B3FenceValue.h"
 #include "B3MemoryValue.h"
@@ -809,6 +810,19 @@ Effects Value::effects() const
             result.reads = memory->fenceRange();
             result.fence = true;
         }
+        result.controlDependent = true;
+        break;
+    }
+    case MemoryCopy: {
+        const auto* memory = as<BulkMemoryValue>();
+        result.reads = memory->readRange();
+        result.writes = memory->writeRange();
+        result.controlDependent = true;
+        break;
+    }
+    case MemoryFill: {
+        const auto* memory = as<BulkMemoryValue>();
+        result.writes = memory->writeRange();
         result.controlDependent = true;
         break;
     }

--- a/Source/JavaScriptCore/b3/B3Value.h
+++ b/Source/JavaScriptCore/b3/B3Value.h
@@ -564,6 +564,8 @@ protected:
         case VectorRelaxedMAdd:
         case VectorRelaxedNMAdd:
         case VectorRelaxedLaneSelect:
+        case MemoryFill:
+        case MemoryCopy:
             return 3 * sizeof(Value*);
         case CCall:
         case Check:
@@ -802,6 +804,8 @@ private:
         case VectorRelaxedMAdd:
         case VectorRelaxedNMAdd:
         case VectorRelaxedLaneSelect:
+        case MemoryCopy:
+        case MemoryFill:
             if (numArgs != 3) [[unlikely]]
                 badKind(kind, numArgs);
             return Three;

--- a/Source/JavaScriptCore/b3/B3ValueInlines.h
+++ b/Source/JavaScriptCore/b3/B3ValueInlines.h
@@ -30,6 +30,7 @@
 #include "B3ArgumentRegValue.h"
 #include "B3AtomicValue.h"
 #include "B3BottomTupleValue.h"
+#include "B3BulkMemoryValue.h"
 #include "B3CCallValue.h"
 #include "B3CheckValue.h"
 #include "B3Const128Value.h"
@@ -152,6 +153,9 @@ namespace JSC { namespace B3 {
     case Store16: \
     case Store: \
         return MACRO(MemoryValue); \
+    case MemoryCopy: \
+    case MemoryFill: \
+        return MACRO(BulkMemoryValue); \
     case Switch: \
         return MACRO(SwitchValue); \
     case Upsilon: \

--- a/Source/JavaScriptCore/b3/testb3.h
+++ b/Source/JavaScriptCore/b3/testb3.h
@@ -1395,4 +1395,9 @@ void testMulHigh64();
 void testUMulHigh32();
 void testUMulHigh64();
 
+void testMemoryCopy();
+void testMemoryCopyConstant();
+void testMemoryFill();
+void testMemoryFillConstant();
+
 #endif // ENABLE(B3_JIT)

--- a/Source/JavaScriptCore/b3/testb3_1.cpp
+++ b/Source/JavaScriptCore/b3/testb3_1.cpp
@@ -947,6 +947,10 @@ void run(const TestConfig* config)
         RUN(testMulHigh64());
         RUN(testUMulHigh32());
         RUN(testUMulHigh64());
+        RUN(testMemoryCopy());
+        RUN(testMemoryFill());
+        RUN(testMemoryCopyConstant());
+        RUN(testMemoryFillConstant());
     }
 
     Lock lock;


### PR DESCRIPTION
#### 229760706c12a975b3f07f98c2c53a90abcbb42c
<pre>
[JSC] Add B3::MemoryCopy and B3::MemoryFill
<a href="https://bugs.webkit.org/show_bug.cgi?id=298906">https://bugs.webkit.org/show_bug.cgi?id=298906</a>
<a href="https://rdar.apple.com/160649162">rdar://160649162</a>

Reviewed by Yijia Huang.

This patch adds B3 MemoryCopy and MemoryFill values. They reserve
memcpy / memset semantics, and B3 strength reduction attempts to lower
them to sequence of loads and stores for small constant size. If the
size is unknown, it gets lowered to a function call eventually.
By using this, we refresh Wasm MemoryCopy and MemoryFill
implementations. They do bound check and emit these B3 values. And if
possible, they get lowered to loads / stores, omitting function calls.
This is useful since we are finding many wasm bulk memory.copy /
memory.fill are getting constant count via inlining and we can avoid
calling a function for these cases.

Tests: Source/JavaScriptCore/b3/testb3_1.cpp
       Source/JavaScriptCore/b3/testb3_8.cpp
* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/Sources.txt:
* Source/JavaScriptCore/b3/B3BulkMemoryValue.cpp: Added.
(JSC::B3::BulkMemoryValue::dumpMeta const):
(JSC::B3::BulkMemoryValue::BulkMemoryValue):
* Source/JavaScriptCore/b3/B3BulkMemoryValue.h: Added.
* Source/JavaScriptCore/b3/B3LowerInt64.cpp:
* Source/JavaScriptCore/b3/B3LowerMacrosAfterOptimizations.cpp:
* Source/JavaScriptCore/b3/B3LowerToAir.cpp:
* Source/JavaScriptCore/b3/B3LowerToAir32_64.cpp:
* Source/JavaScriptCore/b3/B3Opcode.h:
* Source/JavaScriptCore/b3/B3Operations.cpp: Added.
(JSC::B3::JSC_DEFINE_NOEXCEPT_JIT_OPERATION):
* Source/JavaScriptCore/b3/B3Operations.h: Added.
* Source/JavaScriptCore/b3/B3ReduceStrength.cpp:
* Source/JavaScriptCore/b3/B3Validate.cpp:
* Source/JavaScriptCore/b3/B3Value.cpp:
(JSC::B3::Value::effects const):
* Source/JavaScriptCore/b3/B3Value.h:
* Source/JavaScriptCore/b3/B3ValueInlines.h:
* Source/JavaScriptCore/b3/testb3.h:
* Source/JavaScriptCore/b3/testb3_1.cpp:
(run):
* Source/JavaScriptCore/b3/testb3_8.cpp:
(testMemoryCopy):
(testMemoryCopyConstant):
(testMemoryFill):
(testMemoryFillConstant):
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::OMGIRGenerator::addMemoryFill):
(JSC::Wasm::OMGIRGenerator::addMemoryCopy):

Canonical link: <a href="https://commits.webkit.org/300210@main">https://commits.webkit.org/300210@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4e372ac3bb30bff16020daa29567088644f1bb40

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121427 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41124 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31783 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127868 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73510 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4d7d8414-cf4f-4274-99cf-f0a86136d47b) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41826 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49703 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92235 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61367 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/df80d4ce-aa89-46ad-a15f-1c04d110d0c5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124379 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33392 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108786 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72911 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5b3cc24a-46f7-4d8b-a2d1-23c7d40e70ac) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32408 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26939 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71448 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/113557 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102888 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27113 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130702 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/119947 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48355 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36767 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100825 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48723 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104998 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100732 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46144 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24211 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45051 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19281 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48213 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53926 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/150109 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47685 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/38193 "Found 1 new JSC stress test failure: stress/dont-link-virtual-calls-on-compiler-thread.js.no-llint (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51031 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49367 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->