### PR TITLE
Build on the public macOS 26 SDK

### DIFF
--- a/Source/WebKit/Platform/cocoa/WKMaterialHostingSupport.swift
+++ b/Source/WebKit/Platform/cocoa/WKMaterialHostingSupport.swift
@@ -25,10 +25,14 @@
 
 internal import WebKit_Internal
 
+#if USE_APPLE_INTERNAL_SDK
 #if canImport(UIKit)
 @_weakLinked @_spi(Private) @_spi(ForUIKitOnly) internal import SwiftUI
 #else
 @_weakLinked @_spi(Private) @_spi(ForAppKitOnly) internal import SwiftUI
+#endif
+#else
+internal import SwiftUI_SPI
 #endif
 
 #if canImport(UIKit)

--- a/Source/WebKit/Platform/spi/Cocoa/SwiftUI_SPI.swiftinterface
+++ b/Source/WebKit/Platform/spi/Cocoa/SwiftUI_SPI.swiftinterface
@@ -1,0 +1,55 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -enable-objc-interop -enable-library-evolution -swift-version 5 -enforce-exclusivity=checked -O -library-level api -enable-experimental-feature Macros -enable-experimental-feature ExtensionMacros -module-abi-name SwiftUI -enable-experimental-feature IsolatedAny2 -enable-upcoming-feature InferSendableFromCaptures -enable-experimental-feature DebugDescriptionMacro -enable-bare-slash-regex -user-module-version 7.0.84.1.401 -module-name SwiftUI_SPI -module-abi-name SwiftUI -package-name SwiftUI
+// swift-module-flags-ignorable: -public-module-name SwiftUI -formal-cxx-interoperability-mode=off -project-name SwiftUI -interface-compiler-version 6.2
+import _Concurrency
+import CoreFoundation
+import QuartzCore
+import Swift
+@_exported import SwiftUI
+
+@available(iOS 26.0, macOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+public struct _ShapeSet : Swift.Sendable {
+  public init(shapes: [SwiftUI.AnyShape], smoothness: CoreFoundation.CGFloat = 0)
+}
+
+@available(iOS 26.0, macOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+extension SwiftUI.View {
+  nonisolated public func materialEffect(_ material: SwiftUI_SPI.Material, in shape: SwiftUI_SPI._ShapeSet) -> some SwiftUI.View
+  
+  @_alwaysEmitIntoClient nonisolated public func materialEffect<S>(_ material: SwiftUI_SPI.Material, in shape: S) -> some SwiftUI.View where S : SwiftUI.Shape {
+        return materialEffect(material,
+            in: _ShapeSet(shapes: [AnyShape(shape)]))
+    }
+  
+}
+
+@_hasMissingDesignatedInitializers @available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
+public class CAHostingLayer<Content> : QuartzCore.CALayer where Content : SwiftUI.View {
+  public init(rootView: Content, environment: SwiftUI.EnvironmentValues = .init())
+  @objc override dynamic public func layoutSublayers()
+  public var rootView: Content {
+    get
+    set
+  }
+}
+
+public struct Material : Swift.Sendable {
+}
+
+extension SwiftUI_SPI.Material {
+  @available(iOS 26.0, macOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+  public struct _GlassVariant : Swift.Hashable, Swift.Sendable {
+    public static let regular: SwiftUI_SPI.Material._GlassVariant
+    public static let clear: SwiftUI_SPI.Material._GlassVariant
+    public static let avplayer: SwiftUI_SPI.Material._GlassVariant
+    public func forceSubdued() -> SwiftUI_SPI.Material._GlassVariant
+    public func adaptive(_ enabled: Swift.Bool) -> SwiftUI_SPI.Material._GlassVariant
+    public static func == (a: SwiftUI_SPI.Material._GlassVariant, b: SwiftUI_SPI.Material._GlassVariant) -> Swift.Bool
+    public func hash(into hasher: inout Swift.Hasher)
+    public var hashValue: Swift.Int {
+      get
+    }
+  }
+  @available(iOS 26.0, macOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+  public static func _glass(_ variant: SwiftUI_SPI.Material._GlassVariant = .regular) -> SwiftUI_SPI.Material
+}

--- a/Source/WebKit/Platform/spi/mac/AppKitSPI.h
+++ b/Source/WebKit/Platform/spi/mac/AppKitSPI.h
@@ -97,6 +97,29 @@ static const NSWindowStyleMask NSWindowStyleMaskAlertWindow = (NSWindowStyleMask
 - (instancetype)initWithItem:(id)item linkMetadata:(LPLinkMetadata *)linkMetadata;
 @end
 
+typedef NS_ENUM(NSInteger, NSScrollPocketStyle) {
+    NSScrollPocketStyleAutomatic,
+    NSScrollPocketStyleSoft,
+    NSScrollPocketStyleHard,
+};
+
+typedef NS_ENUM(NSInteger, NSScrollPocketEdge) {
+    NSScrollPocketEdgeTop    = 0,
+    NSScrollPocketEdgeBottom = 1,
+    NSScrollPocketEdgeLeft   = 2,
+    NSScrollPocketEdgeRight  = 3,
+};
+
+@interface NSScrollPocket : NSView
+- (void)addElementContainer:(NSView *)elementContainer;
+- (void)removeElementContainer:(NSView *)elementContainer;
+@property (nonatomic) BOOL prefersSolidColorHardPocket;
+@property NSScrollPocketEdge edge;
+@property NSScrollPocketStyle style;
+@property (copy, nullable) NSColor *captureColor;
+@property (readonly, strong) NSView *captureView;
+@end
+
 #endif
 
 @interface NSPopover (IPI)
@@ -122,19 +145,6 @@ static const NSWindowStyleMask NSWindowStyleMaskAlertWindow = (NSWindowStyleMask
 typedef void (^NSWindowSnapshotReadinessHandler) (void);
 - (NSWindowSnapshotReadinessHandler)_holdResizeSnapshotWithReason:(NSString *)reason;
 @end
-#endif
-
-#if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
-
-@interface NSScrollPocket (Staging_151173930)
-- (void)addElementContainer:(NSView *)elementContainer;
-- (void)removeElementContainer:(NSView *)elementContainer;
-@end
-
-@interface NSScrollPocket (Staging_149248735)
-@property (nonatomic) BOOL prefersSolidColorHardPocket;
-@end
-
 #endif
 
 #endif // PLATFORM(MAC)

--- a/Tools/TestWebKitAPI/Tests/TestWebKitAPI/mac/AppKitSPI.h
+++ b/Tools/TestWebKitAPI/Tests/TestWebKitAPI/mac/AppKitSPI.h
@@ -107,6 +107,10 @@ NSString * const NSInspectorBarTextAlignmentItemIdentifier = @"NSInspectorBarTex
 @property (readonly) NSView *_presentingView;
 @end
 
+@interface NSScrollPocket : NSView
+@property (copy, nullable) NSColor *captureColor;
+@end
+
 #endif
 
 @protocol NSTextInputClient_Async_Staging_44648564


### PR DESCRIPTION
#### 736f1346ebad18a58e260dda11c80035284b3444
<pre>
Build on the public macOS 26 SDK
<a href="https://bugs.webkit.org/show_bug.cgi?id=297336">https://bugs.webkit.org/show_bug.cgi?id=297336</a>
<a href="https://rdar.apple.com/158778411">rdar://158778411</a>

Reviewed by Aditya Keerthi and Wenson Hsieh.

* Source/WebKit/Platform/cocoa/WKMaterialHostingSupport.swift: Import
  SwiftUI_SPI module as needed.
* Source/WebKit/Platform/spi/Cocoa/SwiftUI_SPI.swiftinterface: Added.
* Source/WebKit/Platform/spi/mac/AppKitSPI.h: Declare the NSScrollPocket
  interface we are using from AppKit SPI.
* Tools/TestWebKitAPI/Tests/TestWebKitAPI/mac/AppKitSPI.h: Ditto.

Canonical link: <a href="https://commits.webkit.org/300040@main">https://commits.webkit.org/300040@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/85d9e6410166c614b29956abfe346cb2aa603e02

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121033 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40729 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31387 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127451 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73113 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/035be237-f762-4dfa-bc86-8915713f670d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122909 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41431 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49308 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91926 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61155 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5485d2bf-db96-4c0c-a58a-17f5631ea366) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123985 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33076 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108492 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72613 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8eed5a72-0cd0-43ad-8efe-67d55441438a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32100 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26595 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71041 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102581 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26774 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130305 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47960 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36440 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100534 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48328 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104659 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100436 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25480 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45844 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23893 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44648 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47818 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53531 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47289 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50636 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48973 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->