### PR TITLE
Remove Ref<MediaPromise> MediaSourcePrivateClient::seekToTime(const MediaTime& time)

### DIFF
--- a/Source/WebCore/Modules/mediasource/MediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSource.cpp
@@ -165,17 +165,6 @@ private:
         return promise;
     }
 
-    Ref<MediaPromise> seekToTime(const MediaTime& time) final
-    {
-        MediaPromise::AutoRejectProducer producer(PlatformMediaError::SourceRemoved);
-        auto promise = producer.promise();
-
-        ensureWeakOnDispatcher([producer = WTFMove(producer), time](MediaSource& parent) mutable {
-            parent.seekToTime(time)->chainTo(WTFMove(producer));
-        });
-        return promise;
-    }
-
     RefPtr<MediaSourcePrivate> mediaSourcePrivate() const final
     {
         Locker locker { m_lock };
@@ -470,13 +459,6 @@ void MediaSource::completeSeek()
     });
     promise->chainTo(WTFMove(*m_seekTargetPromise));
     m_seekTargetPromise.reset();
-}
-
-Ref<MediaPromise> MediaSource::seekToTime(const MediaTime& time)
-{
-    for (Ref sourceBuffer : m_activeSourceBuffers.get())
-        sourceBuffer->seekToTime(time);
-    return MediaPromise::createAndResolve();
 }
 
 PlatformTimeRanges MediaSource::seekable()

--- a/Source/WebCore/Modules/mediasource/MediaSource.h
+++ b/Source/WebCore/Modules/mediasource/MediaSource.h
@@ -206,7 +206,6 @@ private:
     void removeSourceBufferWithOptionalDestruction(SourceBuffer&, bool withDestruction);
 
     Ref<MediaTimePromise> waitForTarget(const SeekTarget&);
-    Ref<MediaPromise> seekToTime(const MediaTime&);
     using RendererType = MediaSourcePrivateClient::RendererType;
     void failedToCreateRenderer(RendererType);
 

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
@@ -599,12 +599,6 @@ Ref<SourceBuffer::ComputeSeekPromise> SourceBuffer::computeSeekTime(const SeekTa
     return m_private->computeSeekTime(target);
 }
 
-void SourceBuffer::seekToTime(const MediaTime& time)
-{
-    ALWAYS_LOG(LOGIDENTIFIER, time);
-    m_private->seekToTime(time);
-}
-
 bool SourceBuffer::virtualHasPendingActivity() const
 {
     return !!m_source;

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.h
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.h
@@ -113,7 +113,6 @@ public:
     void removedFromMediaSource();
     using ComputeSeekPromise = SourceBufferPrivate::ComputeSeekPromise;
     Ref<ComputeSeekPromise> computeSeekTime(const SeekTarget&);
-    void seekToTime(const MediaTime&);
 
     bool hasVideo() const;
 

--- a/Source/WebCore/platform/graphics/MediaSourcePrivate.cpp
+++ b/Source/WebCore/platform/graphics/MediaSourcePrivate.cpp
@@ -104,11 +104,10 @@ Ref<MediaTimePromise> MediaSourcePrivate::waitForTarget(const SeekTarget& target
     return MediaTimePromise::createAndReject(PlatformMediaError::ClientDisconnected);
 }
 
-Ref<MediaPromise> MediaSourcePrivate::seekToTime(const MediaTime& time)
+void MediaSourcePrivate::seekToTime(const MediaTime& seekTime)
 {
-    if (RefPtr client = this->client())
-        return client->seekToTime(time);
-    return MediaPromise::createAndReject(PlatformMediaError::ClientDisconnected);
+    for (RefPtr sourceBuffer : m_activeSourceBuffers)
+        sourceBuffer->seekToTime(seekTime);
 }
 
 void MediaSourcePrivate::removeSourceBuffer(SourceBufferPrivate& sourceBuffer)

--- a/Source/WebCore/platform/graphics/MediaSourcePrivate.h
+++ b/Source/WebCore/platform/graphics/MediaSourcePrivate.h
@@ -101,7 +101,7 @@ public:
     MediaTime currentTime() const;
 
     Ref<MediaTimePromise> waitForTarget(const SeekTarget&);
-    Ref<MediaPromise> seekToTime(const MediaTime&);
+    void seekToTime(const MediaTime&);
 
     virtual void setTimeFudgeFactor(const MediaTime& fudgeFactor) { m_timeFudgeFactor = fudgeFactor; }
     MediaTime timeFudgeFactor() const { return m_timeFudgeFactor; }

--- a/Source/WebCore/platform/graphics/MediaSourcePrivateClient.h
+++ b/Source/WebCore/platform/graphics/MediaSourcePrivateClient.h
@@ -45,7 +45,6 @@ public:
     virtual void setPrivateAndOpen(Ref<MediaSourcePrivate>&&) = 0;
     virtual void reOpen() = 0;
     virtual Ref<MediaTimePromise> waitForTarget(const SeekTarget&) = 0;
-    virtual Ref<MediaPromise> seekToTime(const MediaTime&) = 0;
     virtual RefPtr<MediaSourcePrivate> mediaSourcePrivate() const = 0;
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
@@ -294,7 +294,7 @@ void SourceBufferPrivate::provideMediaData(TrackID trackID)
 
 void SourceBufferPrivate::provideMediaData(TrackBuffer& trackBuffer, TrackID trackID)
 {
-    if (isSeeking())
+    if (trackBuffer.needsReenqueueing() || isSeeking())
         return;
     RefPtr client = this->client();
     if (!client)

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -534,10 +534,7 @@ void MediaPlayerPrivateMediaSourceAVFObjC::seekInternal()
         mediaSourcePrivate->willSeek();
         [protectedThis->m_synchronizer setRate:0 time:PAL::toCMTime(seekedTime)];
 
-        mediaSourcePrivate->seekToTime(seekedTime)->whenSettled(RunLoop::currentSingleton(), [weakThis = WTFMove(weakThis)]() mutable {
-            if (RefPtr protectedThis = weakThis.get())
-                protectedThis->maybeCompleteSeek();
-        });
+        mediaSourcePrivate->seekToTime(seekedTime);
     });
 }
 

--- a/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.cpp
+++ b/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.cpp
@@ -242,24 +242,21 @@ void MockMediaPlayerMediaSource::seekToTarget(const SeekTarget& target)
         if (!protectedThis || !result)
             return;
 
-        protectedThis->protectedMediaSourcePrivate()->seekToTime(*result)->whenSettled(RunLoop::currentSingleton(), [weakThis, seekTime = *result] {
-            RefPtr protectedThis = weakThis.get();
-            if (!protectedThis)
-                return;
-            protectedThis->m_lastSeekTarget.reset();
-            protectedThis->m_currentTime = seekTime;
+        const auto seekTime = *result;
+        protectedThis->protectedMediaSourcePrivate()->seekToTime(seekTime);
+        protectedThis->m_lastSeekTarget.reset();
+        protectedThis->m_currentTime = seekTime;
 
-            if (RefPtr player = protectedThis->m_player.get()) {
-                player->seeked(seekTime);
-                player->timeChanged();
-            }
+        if (RefPtr player = protectedThis->m_player.get()) {
+            player->seeked(seekTime);
+            player->timeChanged();
+        }
 
-            if (protectedThis->m_playing) {
-                callOnMainThread([protectedThis = WTFMove(protectedThis)] {
-                    protectedThis->advanceCurrentTime();
-                });
-            }
-        });
+        if (protectedThis->m_playing) {
+            callOnMainThread([protectedThis = WTFMove(protectedThis)] {
+                protectedThis->advanceCurrentTime();
+            });
+        }
     });
 }
 

--- a/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.cpp
@@ -100,14 +100,6 @@ Ref<MediaTimePromise> RemoteMediaSourceProxy::waitForTarget(const SeekTarget& ta
     return MediaTimePromise::createAndReject(PlatformMediaError::IPCError);
 }
 
-Ref<MediaPromise> RemoteMediaSourceProxy::seekToTime(const MediaTime& time)
-{
-    if (RefPtr connection = connectionToWebProcess())
-        return connection->connection().sendWithPromisedReply<MediaPromiseConverter>(Messages::MediaSourcePrivateRemoteMessageReceiver::ProxySeekToTime(time), m_identifier);
-
-    return MediaPromise::createAndReject(PlatformMediaError::IPCError);
-}
-
 #if !RELEASE_LOG_DISABLED
 void RemoteMediaSourceProxy::setLogIdentifier(uint64_t)
 {

--- a/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.h
@@ -70,7 +70,6 @@ public:
     void setPrivateAndOpen(Ref<WebCore::MediaSourcePrivate>&&) final;
     void reOpen() final;
     Ref<WebCore::MediaTimePromise> waitForTarget(const WebCore::SeekTarget&) final;
-    Ref<WebCore::MediaPromise> seekToTime(const MediaTime&) final;
     RefPtr<WebCore::MediaSourcePrivate> mediaSourcePrivate() const final { return m_private; }
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.messages.in
@@ -57,7 +57,6 @@ messages -> RemoteSourceBufferProxy {
     SetAppendWindowEnd(MediaTime appendWindowEnd)
     SetMaximumBufferSize(uint64_t size) -> ()
     ComputeSeekTime(struct WebCore::SeekTarget target) -> (Expected<MediaTime, WebCore::PlatformMediaError> seekedTime)
-    SeekToTime(MediaTime time)
     UpdateTrackIds(Vector<std::pair<WebCore::TrackID, WebCore::TrackID>> identifierPairs)
     BufferedSamplesForTrackId(WebCore::TrackID trackID) -> (WebCore::SourceBufferPrivate::SamplesPromise::Result samples)
     EnqueuedSamplesForTrackID(WebCore::TrackID trackID) -> (WebCore::SourceBufferPrivate::SamplesPromise::Result samples)

--- a/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.cpp
@@ -279,17 +279,6 @@ void MediaSourcePrivateRemote::MessageReceiver::proxyWaitForTarget(const WebCore
     completionHandler(makeUnexpected(PlatformMediaError::ClientDisconnected));
 }
 
-void MediaSourcePrivateRemote::MessageReceiver::proxySeekToTime(const MediaTime& time, CompletionHandler<void(MediaPromise::Result&&)>&& completionHandler)
-{
-    assertIsCurrent(MediaSourcePrivateRemote::queueSingleton());
-
-    if (auto client = this->client()) {
-        client->seekToTime(time)->whenSettled(MediaSourcePrivateRemote::queueSingleton(), WTFMove(completionHandler));
-        return;
-    }
-    completionHandler(makeUnexpected(PlatformMediaError::SourceRemoved));
-}
-
 MediaSourcePrivateRemote::MessageReceiver::MessageReceiver(MediaSourcePrivateRemote& parent)
     : m_parent(parent)
 {

--- a/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.h
@@ -98,7 +98,6 @@ public:
         MessageReceiver(MediaSourcePrivateRemote&);
         void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
         void proxyWaitForTarget(const WebCore::SeekTarget&, CompletionHandler<void(WebCore::MediaTimePromise::Result&&)>&&);
-        void proxySeekToTime(const MediaTime&, CompletionHandler<void(WebCore::MediaPromise::Result&&)>&&);
 
         RefPtr<WebCore::MediaSourcePrivateClient> client() const;
         ThreadSafeWeakPtr<MediaSourcePrivateRemote> m_parent;

--- a/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemoteMessageReceiver.messages.in
+++ b/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemoteMessageReceiver.messages.in
@@ -31,7 +31,6 @@
 ]
 messages -> MediaSourcePrivateRemoteMessageReceiver {
     ProxyWaitForTarget(struct WebCore::SeekTarget target) -> (Expected<MediaTime, WebCore::PlatformMediaError> seekedTime);
-    ProxySeekToTime(MediaTime time) -> (Expected<void, WebCore::PlatformMediaError> result);
 }
 
 #endif

--- a/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.cpp
@@ -384,13 +384,6 @@ Ref<SourceBufferPrivate::ComputeSeekPromise> SourceBufferPrivateRemote::computeS
     });
 }
 
-void SourceBufferPrivateRemote::seekToTime(const MediaTime& time)
-{
-    ensureWeakOnDispatcher([time](auto& buffer) {
-        buffer.sendToProxy(Messages::RemoteSourceBufferProxy::SeekToTime(time));
-    });
-}
-
 void SourceBufferPrivateRemote::updateTrackIds(Vector<std::pair<TrackID, TrackID>>&& trackIDPairs)
 {
     ensureWeakOnDispatcher([trackIDPairs = WTFMove(trackIDPairs)](auto& buffer) mutable {

--- a/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h
@@ -130,7 +130,6 @@ private:
     bool canAppend(uint64_t requiredSize) const final;
 
     Ref<ComputeSeekPromise> computeSeekTime(const WebCore::SeekTarget&) final;
-    void seekToTime(const MediaTime&) final;
 
     void updateTrackIds(Vector<std::pair<TrackID, TrackID>>&&) final;
     uint64_t totalTrackBufferSizeInBytes() const final;


### PR DESCRIPTION
#### c77c73d19764bd86543cb9d188962dd64cd6e114
<pre>
Remove Ref&lt;MediaPromise&gt; MediaSourcePrivateClient::seekToTime(const MediaTime&amp; time)
<a href="https://bugs.webkit.org/show_bug.cgi?id=298908">https://bugs.webkit.org/show_bug.cgi?id=298908</a>
<a href="https://rdar.apple.com/160652035">rdar://160652035</a>

Reviewed by Youenn Fablet.

There is no need to jump back to the content process only to go back to GPUP;
re-enqueueing sample to the SourceBufferPrivate is new a synchronous operation
in all implementations, so we can remove this asynchronous API.

Covered by existings tests. No change in JS observable behaviour other than
seeking operations will be faster.

* Source/WebCore/Modules/mediasource/MediaSource.cpp:
(WebCore::MediaSource::seekToTime): Deleted.
* Source/WebCore/Modules/mediasource/MediaSource.h:
* Source/WebCore/Modules/mediasource/SourceBuffer.cpp:
(WebCore::SourceBuffer::seekToTime): Deleted.
* Source/WebCore/Modules/mediasource/SourceBuffer.h:
* Source/WebCore/platform/graphics/MediaSourcePrivate.cpp:
(WebCore::MediaSourcePrivate::seekToTime):
* Source/WebCore/platform/graphics/MediaSourcePrivate.h:
* Source/WebCore/platform/graphics/MediaSourcePrivateClient.h:
* Source/WebCore/platform/graphics/SourceBufferPrivate.cpp:
(WebCore::SourceBufferPrivate::provideMediaData):
* Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.cpp:
(WebCore::MockMediaPlayerMediaSource::seekToTarget):
* Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.cpp:
(WebKit::RemoteMediaSourceProxy::seekToTime): Deleted.
* Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.h:
* Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.messages.in:
* Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.cpp:
(WebKit::MediaSourcePrivateRemote::MessageReceiver::proxySeekToTime): Deleted.
* Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.h:
* Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemoteMessageReceiver.messages.in:
* Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.cpp:
(WebKit::SourceBufferPrivateRemote::seekToTime): Deleted.
* Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h:

Canonical link: <a href="https://commits.webkit.org/300016@main">https://commits.webkit.org/300016@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/150f01c8dbf124a3128bac371fa95bd86265dd55

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121035 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40731 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31389 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127453 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73115 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0b5fe66e-890e-4bab-a3e7-520b90f976b0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122911 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41433 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49310 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91928 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61156 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/01f90398-3bac-472d-a103-e9a3ee033116) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123987 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33078 "Found 1 new test failure: editing/text-iterator/hidden-textarea-selection-quirk.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108496 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72616 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/75c27e08-40e0-42f5-818e-47fc8f8edf4d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32102 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26599 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71043 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102583 "Found 13 new API test failures: TestWebKitAPI.PasteHTML.StripsMSOListWhenMissingMSOHTMLElement, TestWebKitAPI.PasteHTML.StripsFileAndJavaScriptURLs, TestWebKitAPI.PasteHTML.PreservesMSOListOnH4, TestWebKitAPI.PasteHTML.DoesNotSanitizeHTMLWhenCustomPasteboardDataIsDisabled, TestWebKitAPI.PasteHTML.StripsSystemFontNames, TestWebKitAPI.PasteHTML.DoesNotAddStandardFontFamily, TestWebKitAPI.PasteHTML.DoesNotStripFileURLsWhenCustomPasteboardDataIsDisabled, TestWebKitAPI.PasteHTML.PreservesMSOList, TestWebKitAPI.PasteHTML.SanitizesHTML, TestWebKitAPI.PasteHTML.KeepsHTTPURLs ... (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26778 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130307 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47962 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36442 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100537 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48330 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104663 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100439 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25466 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45846 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23897 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44650 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47820 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53533 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47291 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50638 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48975 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->