### PR TITLE
Address more safer cpp warnings in platform/

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
@@ -49,17 +49,14 @@ platform/cocoa/LocalizedStringsCocoa.mm
 platform/cocoa/NetworkExtensionContentFilter.mm
 platform/cocoa/ParentalControlsContentFilter.mm
 platform/cocoa/PlatformPasteboardCocoa.mm
-platform/cocoa/PlatformSpeechSynthesizerCocoa.mm
 platform/cocoa/SearchPopupMenuCocoa.mm
 platform/cocoa/SystemBattery.mm
 platform/cocoa/UserAgentCocoa.mm
-platform/cocoa/VideoFullscreenCaptions.mm
 platform/cocoa/WebAVPlayerLayer.mm
 platform/gamepad/cocoa/GameControllerGamepad.mm
 platform/gamepad/cocoa/GameControllerGamepadProvider.mm
 platform/gamepad/cocoa/GameControllerHapticEngines.mm
 platform/gamepad/mac/HIDGamepadElement.cpp
-platform/gamepad/mac/HIDGamepadProvider.mm
 platform/graphics/BitmapImageDescriptor.cpp
 platform/graphics/DestinationColorSpace.cpp
 platform/graphics/avfoundation/AVTrackPrivateAVFObjCImpl.mm

--- a/Source/WebCore/SaferCPPExpectations/UnretainedLambdaCapturesCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UnretainedLambdaCapturesCheckerExpectations
@@ -1,4 +1,3 @@
-platform/cocoa/SharedVideoFrameInfo.mm
 platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
 platform/graphics/cv/VideoFrameCV.mm
 platform/mac/WebCoreObjCExtras.mm

--- a/Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
@@ -25,11 +25,8 @@ platform/audio/cocoa/AudioEncoderCocoa.cpp
 platform/audio/cocoa/AudioFileReaderCocoa.cpp
 platform/audio/cocoa/PlatformRawAudioDataCocoa.cpp
 platform/cf/KeyedDecoderCF.cpp
-platform/cf/RunLoopObserverCF.cpp
 platform/cocoa/DragImageCocoa.mm
-platform/cocoa/MIMETypeRegistryCocoa.mm
 platform/cocoa/PlatformPasteboardCocoa.mm
-platform/cocoa/PlatformSpeechSynthesizerCocoa.mm
 platform/cocoa/RemoteCommandListenerCocoa.mm
 platform/cocoa/SearchPopupMenuCocoa.mm
 platform/cocoa/SerializedPlatformDataCueValue.mm

--- a/Source/WebCore/platform/cf/RunLoopObserverCF.cpp
+++ b/Source/WebCore/platform/cf/RunLoopObserverCF.cpp
@@ -76,11 +76,10 @@ void RunLoopObserver::runLoopObserverFired(CFRunLoopObserverRef, CFRunLoopActivi
 
 void RunLoopObserver::schedule(PlatformRunLoop runLoop, OptionSet<Activity> activity)
 {
-    if (!runLoop)
-        runLoop = CFRunLoopGetCurrent();
+    RetainPtr effectiveRunLoop = runLoop ? runLoop : CFRunLoopGetCurrent();
 
     // Make sure we wake up the loop or the observer could be delayed until some other source fires.
-    CFRunLoopWakeUp(runLoop);
+    CFRunLoopWakeUp(effectiveRunLoop.get());
 
     if (m_runLoopObserver)
         return;
@@ -88,7 +87,7 @@ void RunLoopObserver::schedule(PlatformRunLoop runLoop, OptionSet<Activity> acti
     CFRunLoopObserverContext context = { 0, this, 0, 0, 0 };
     m_runLoopObserver = adoptCF(CFRunLoopObserverCreate(kCFAllocatorDefault, cfRunLoopActivity(activity), isRepeating(), cfRunLoopOrder(m_order), runLoopObserverFired, &context));
 
-    CFRunLoopAddObserver(runLoop, m_runLoopObserver.get(), kCFRunLoopCommonModes);
+    CFRunLoopAddObserver(effectiveRunLoop.get(), m_runLoopObserver.get(), kCFRunLoopCommonModes);
 }
 
 void RunLoopObserver::invalidate()

--- a/Source/WebCore/platform/cocoa/MIMETypeRegistryCocoa.mm
+++ b/Source/WebCore/platform/cocoa/MIMETypeRegistryCocoa.mm
@@ -181,9 +181,9 @@ String MIMETypeRegistry::preferredExtensionForMIMEType(const String& type)
     if (isUSDMIMEType(type))
         return "usdz"_s;
 
-    NSString *preferredExtension = [[NSURLFileTypeMappings sharedMappings] preferredExtensionForMIMEType:type.createNSString().get()];
-    if (preferredExtension.length)
-        return preferredExtension;
+    RetainPtr preferredExtension = [[NSURLFileTypeMappings sharedMappings] preferredExtensionForMIMEType:type.createNSString().get()];
+    if ([preferredExtension length])
+        return preferredExtension.get();
 
     auto mapEntry = additionalExtensionsMap().find(type);
     if (mapEntry != additionalExtensionsMap().end())

--- a/Source/WebCore/platform/cocoa/PlatformSpeechSynthesizerCocoa.mm
+++ b/Source/WebCore/platform/cocoa/PlatformSpeechSynthesizerCocoa.mm
@@ -92,7 +92,7 @@ static float getAVSpeechUtteranceMaximumSpeechRate()
     m_synthesizerObject = synthesizer;
 
 #if HAVE(AVSPEECHSYNTHESIS_VOICES_CHANGE_NOTIFICATION)
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(availableVoicesDidChange) name:AVSpeechSynthesisAvailableVoicesDidChangeNotification object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(availableVoicesDidChange) name:RetainPtr { AVSpeechSynthesisAvailableVoicesDidChangeNotification }.get() object:nil];
 #endif
 
     return self;
@@ -150,13 +150,13 @@ static float getAVSpeechUtteranceMaximumSpeechRate()
     if (!avVoice)
         avVoice = [PAL::getAVSpeechSynthesisVoiceClassSingleton() voiceWithLanguage:voiceLanguage.get()];
 
-    AVSpeechUtterance *avUtterance = [PAL::getAVSpeechUtteranceClassSingleton() speechUtteranceWithString:utterance->text().createNSString().get()];
+    RetainPtr<AVSpeechUtterance> avUtterance = [PAL::getAVSpeechUtteranceClassSingleton() speechUtteranceWithString:utterance->text().createNSString().get()];
 
     [avUtterance setRate:[self mapSpeechRateToPlatformRate:utterance->rate()]];
     [avUtterance setVolume:utterance->volume()];
     [avUtterance setPitchMultiplier:utterance->pitch()];
     [avUtterance setVoice:avVoice];
-    utterance->setWrapper(avUtterance);
+    utterance->setWrapper(avUtterance.get());
     m_utterance = WTFMove(utterance);
 
     // macOS won't send a did start speaking callback for empty strings.
@@ -165,7 +165,7 @@ static float getAVSpeechUtteranceMaximumSpeechRate()
         m_synthesizerObject->client().didStartSpeaking(Ref { *m_utterance });
 #endif
 
-    [m_synthesizer speakUtterance:avUtterance];
+    [m_synthesizer speakUtterance:avUtterance.get()];
     END_BLOCK_OBJC_EXCEPTIONS
 }
 

--- a/Source/WebCore/platform/cocoa/SharedVideoFrameInfo.mm
+++ b/Source/WebCore/platform/cocoa/SharedVideoFrameInfo.mm
@@ -198,13 +198,13 @@ RetainPtr<CVPixelBufferRef> SharedVideoFrameInfo::createPixelBufferFromMemory(st
             return nullptr;
     }
 
-    auto pixelBuffer = adoptCF(rawPixelBuffer);
-    auto status = CVPixelBufferLockBaseAddress(rawPixelBuffer, 0);
+    RetainPtr pixelBuffer = adoptCF(rawPixelBuffer);
+    auto status = CVPixelBufferLockBaseAddress(pixelBuffer.get(), 0);
     if (status != noErr)
         return nullptr;
 
-    auto scope = makeScopeExit([&rawPixelBuffer] {
-        CVPixelBufferUnlockBaseAddress(rawPixelBuffer, 0);
+    auto scope = makeScopeExit([pixelBuffer] {
+        CVPixelBufferUnlockBaseAddress(pixelBuffer.get(), 0);
     });
 
     data = copyToCVPixelBufferPlane(rawPixelBuffer, 0, data, m_height, m_bytesPerRow);
@@ -225,8 +225,8 @@ bool SharedVideoFrameInfo::writePixelBuffer(CVPixelBufferRef pixelBuffer, std::s
         return false;
     }
 
-    auto scope = makeScopeExit([&pixelBuffer] {
-        CVPixelBufferUnlockBaseAddress(pixelBuffer, kCVPixelBufferLock_ReadOnly);
+    auto scope = makeScopeExit([pixelBuffer = RetainPtr { pixelBuffer }] {
+        CVPixelBufferUnlockBaseAddress(pixelBuffer.get(), kCVPixelBufferLock_ReadOnly);
     });
 
     encode(data);

--- a/Source/WebCore/platform/cocoa/VideoFullscreenCaptions.h
+++ b/Source/WebCore/platform/cocoa/VideoFullscreenCaptions.h
@@ -42,6 +42,7 @@ public:
     WEBCORE_EXPORT void setTrackRepresentationHidden(bool);
 
     WEBCORE_EXPORT virtual CALayer* captionsLayer();
+    RetainPtr<CALayer> protectedCaptionsLayer();
     WEBCORE_EXPORT void setCaptionsFrame(const CGRect&);
     WEBCORE_EXPORT virtual void setupCaptionsLayer(CALayer *parent, const FloatSize&);
     WEBCORE_EXPORT void removeCaptionsLayer();

--- a/Source/WebCore/platform/cocoa/VideoFullscreenCaptions.mm
+++ b/Source/WebCore/platform/cocoa/VideoFullscreenCaptions.mm
@@ -80,20 +80,26 @@ CALayer *VideoFullscreenCaptions::captionsLayer()
     return m_captionsLayer.get();
 }
 
+RetainPtr<CALayer> VideoFullscreenCaptions::protectedCaptionsLayer()
+{
+    return captionsLayer();
+}
+
 void VideoFullscreenCaptions::setCaptionsFrame(const CGRect& frame)
 {
-    [captionsLayer() setFrame:frame];
+    [protectedCaptionsLayer() setFrame:frame];
 }
 
 void VideoFullscreenCaptions::setupCaptionsLayer(CALayer *parent, const WebCore::FloatSize& initialSize)
 {
     [CATransaction begin];
     [CATransaction setDisableActions:YES];
-    [captionsLayer() removeFromSuperlayer];
-    [parent addSublayer:captionsLayer()];
-    captionsLayer().zPosition = FLT_MAX;
-    [captionsLayer() setAnchorPoint:CGPointZero];
-    [captionsLayer() setBounds:CGRectMake(0, 0, initialSize.width(), initialSize.height())];
+    RetainPtr captionsLayer = this->captionsLayer();
+    [captionsLayer removeFromSuperlayer];
+    [parent addSublayer:captionsLayer.get()];
+    captionsLayer.get().zPosition = FLT_MAX;
+    [captionsLayer setAnchorPoint:CGPointZero];
+    [captionsLayer setBounds:CGRectMake(0, 0, initialSize.width(), initialSize.height())];
     [CATransaction commit];
 }
 

--- a/Source/WebCore/platform/gamepad/mac/HIDGamepadProvider.mm
+++ b/Source/WebCore/platform/gamepad/mac/HIDGamepadProvider.mm
@@ -143,7 +143,7 @@ void HIDGamepadProvider::openAndScheduleManager()
 
     m_initialGamepadsConnected = false;
 
-    IOHIDManagerScheduleWithRunLoop(m_manager.get(), CFRunLoopGetCurrent(), kCFRunLoopDefaultMode);
+    IOHIDManagerScheduleWithRunLoop(m_manager.get(), RetainPtr { CFRunLoopGetCurrent() }.get(), kCFRunLoopDefaultMode);
     IOHIDManagerOpen(m_manager.get(), kIOHIDOptionsTypeNone);
 
     // Any connections we are notified of within the connectionDelayInterval of listening likely represent
@@ -155,7 +155,7 @@ void HIDGamepadProvider::closeAndUnscheduleManager()
 {
     LOG(Gamepad, "HIDGamepadProvider closing/unscheduling HID manager");
 
-    IOHIDManagerUnscheduleFromRunLoop(m_manager.get(), CFRunLoopGetCurrent(), kCFRunLoopDefaultMode);
+    IOHIDManagerUnscheduleFromRunLoop(m_manager.get(), RetainPtr { CFRunLoopGetCurrent() }.get(), kCFRunLoopDefaultMode);
     IOHIDManagerClose(m_manager.get(), kIOHIDOptionsTypeNone);
 
     m_gamepadVector.clear();
@@ -287,7 +287,8 @@ void HIDGamepadProvider::deviceRemoved(IOHIDDeviceRef device)
 
 void HIDGamepadProvider::valuesChanged(IOHIDValueRef value)
 {
-    RetainPtr device = IOHIDElementGetDevice(IOHIDValueGetElement(value));
+    RetainPtr element = IOHIDValueGetElement(value);
+    RetainPtr device = IOHIDElementGetDevice(element.get());
 
     HIDGamepad* gamepad = m_gamepadMap.get(device.get());
 


### PR DESCRIPTION
#### 7c2e0b7bb06c1e28efeac915a33731e1434057f3
<pre>
Address more safer cpp warnings in platform/
<a href="https://bugs.webkit.org/show_bug.cgi?id=298921">https://bugs.webkit.org/show_bug.cgi?id=298921</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UnretainedLambdaCapturesCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations:
* Source/WebCore/platform/cf/RunLoopObserverCF.cpp:
(WebCore::RunLoopObserver::schedule):
* Source/WebCore/platform/cocoa/MIMETypeRegistryCocoa.mm:
(WebCore::MIMETypeRegistry::preferredExtensionForMIMEType):
* Source/WebCore/platform/cocoa/PlatformSpeechSynthesizerCocoa.mm:
(-[WebSpeechSynthesisWrapper initWithSpeechSynthesizer:]):
(-[WebSpeechSynthesisWrapper speakUtterance:]):
* Source/WebCore/platform/cocoa/SharedVideoFrameInfo.mm:
(WebCore::SharedVideoFrameInfo::createPixelBufferFromMemory):
(WebCore::SharedVideoFrameInfo::writePixelBuffer):
* Source/WebCore/platform/cocoa/VideoFullscreenCaptions.h:
* Source/WebCore/platform/cocoa/VideoFullscreenCaptions.mm:
(WebCore::VideoFullscreenCaptions::protectedCaptionsLayer):
(WebCore::VideoFullscreenCaptions::setCaptionsFrame):
(WebCore::VideoFullscreenCaptions::setupCaptionsLayer):
* Source/WebCore/platform/gamepad/mac/HIDGamepadProvider.mm:
(WebCore::HIDGamepadProvider::openAndScheduleManager):
(WebCore::HIDGamepadProvider::closeAndUnscheduleManager):
(WebCore::HIDGamepadProvider::valuesChanged):

Canonical link: <a href="https://commits.webkit.org/300060@main">https://commits.webkit.org/300060@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1cec579d6dc169b28c4a29cd8813b107a4b09a4b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121086 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40782 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31440 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127505 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73167 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0c7f0483-5e4c-49f9-8317-bd6d3061caed) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122962 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41484 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49361 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91976 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61190 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4cc9b616-9859-476d-a9f2-8bda7f4e53bb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124038 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33126 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108539 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72660 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2efd13f9-cea3-409c-aa40-952e92890445) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32150 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26642 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71096 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102632 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26821 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130358 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48013 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36490 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100583 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48381 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104706 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100485 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25486 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45891 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23939 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44707 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47871 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53584 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47342 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50689 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49026 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->