### PR TITLE
Address safer CPP warnings in ScrollingTree.cpp

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -635,7 +635,6 @@ page/scrolling/AsyncScrollingCoordinator.h
 page/scrolling/ScrollAnchoringController.cpp
 page/scrolling/ScrollSnapOffsetsInfo.cpp
 page/scrolling/ScrollingCoordinator.cpp
-page/scrolling/ScrollingTree.cpp
 page/scrolling/ScrollingTreeGestureState.cpp
 page/scrolling/ThreadedScrollingCoordinator.cpp
 page/scrolling/mac/ScrollingCoordinatorMac.mm

--- a/Source/WebCore/page/scrolling/ScrollingTree.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTree.cpp
@@ -563,7 +563,7 @@ void ScrollingTree::removeAllNodes()
 {
     auto nodes = std::exchange(m_nodeMap, { });
     for (auto iter : nodes)
-        iter.value->willBeDestroyed();
+        Ref { *iter.value }->willBeDestroyed();
 
     m_nodeMap.clear();
     {
@@ -734,22 +734,22 @@ FloatRect ScrollingTree::layoutViewport() const
 void ScrollingTree::viewWillStartLiveResize()
 {
     Locker locker { m_treeLock };
-    if (m_rootNode)
-        m_rootNode->viewWillStartLiveResize();
+    if (RefPtr rootNode = m_rootNode)
+        rootNode->viewWillStartLiveResize();
 }
 
 void ScrollingTree::viewWillEndLiveResize()
 {
     Locker locker { m_treeLock };
-    if (m_rootNode)
-        m_rootNode->viewWillEndLiveResize();
+    if (RefPtr rootNode = m_rootNode)
+        rootNode->viewWillEndLiveResize();
 }
 
 void ScrollingTree::viewSizeDidChange()
 {
     Locker locker { m_treeLock };
-    if (m_rootNode)
-        m_rootNode->viewSizeDidChange();
+    if (RefPtr rootNode = m_rootNode)
+        rootNode->viewSizeDidChange();
 }
 
 void ScrollingTree::setGestureState(std::optional<WheelScrollGestureState> gestureState)


### PR DESCRIPTION
#### 4dc8dfe2050ee747600f579e0566ce2db7b21bca
<pre>
Address safer CPP warnings in ScrollingTree.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=298922">https://bugs.webkit.org/show_bug.cgi?id=298922</a>

Reviewed by Geoffrey Garen.

* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/page/scrolling/ScrollingTree.cpp:
(WebCore::ScrollingTree::removeAllNodes):
(WebCore::ScrollingTree::viewWillStartLiveResize):
(WebCore::ScrollingTree::viewWillEndLiveResize):
(WebCore::ScrollingTree::viewSizeDidChange):

Canonical link: <a href="https://commits.webkit.org/300066@main">https://commits.webkit.org/300066@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9a55963f3f1b57a9099432d37f3f2ec4a09431a1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121061 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40757 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31415 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127480 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73142 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/846000fc-fda5-45e6-9088-c56138335f46) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122937 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41459 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49336 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91952 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61170 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/34492c03-582b-48ff-8714-3eda67a205e9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124013 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33101 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108515 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72638 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/397f5b2c-2833-45ba-ab4d-c56baba057cb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32124 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26618 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71069 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102607 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26797 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130333 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47988 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36466 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100560 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48356 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104682 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100462 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25494 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45864 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23915 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44676 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47846 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53559 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47317 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50664 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49001 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->