### PR TITLE
[JSC] Improve error message for calling constructor without `new`

### DIFF
--- a/JSTests/stress/calling-non-callable-constructors.js
+++ b/JSTests/stress/calling-non-callable-constructors.js
@@ -19,13 +19,13 @@ shouldThrow(() => {
     }
 
     C();
-}, `TypeError: Cannot call a class constructor without |new|`);
+}, `TypeError: Cannot call a class constructor C without |new|`);
 
 shouldThrow(() => {
     Promise();
-}, `TypeError: Cannot call a constructor without |new|`);
+}, `TypeError: Cannot call a constructor Promise without |new|`);
 
 shouldThrow(() => {
     class DerivedPromise extends Promise { }
     DerivedPromise();
-}, `TypeError: Cannot call a class constructor without |new|`);
+}, `TypeError: Cannot call a class constructor DerivedPromise without |new|`);

--- a/JSTests/stress/constructor-call-without-new.js
+++ b/JSTests/stress/constructor-call-without-new.js
@@ -1,0 +1,34 @@
+function shouldThrow(testFunction, expectedError) {
+    let actualError = null;
+    try {
+        testFunction();
+    } catch (e) {
+        actualError = e;
+    }
+
+    if (!actualError) {
+        throw new Error(
+            `Expected to throw "${expectedError}" but no error was thrown`,
+        );
+    }
+
+    const actualMessage = String(actualError);
+    if (actualMessage !== expectedError) {
+        throw new Error(
+            `Expected error: "${expectedError}"\nActual error: "${actualMessage}"`,
+        );
+    }
+}
+
+{
+    class Foo { }
+    shouldThrow(() => {
+        Foo();
+    }, "TypeError: Cannot call a class constructor Foo without |new|");
+}
+
+{
+  shouldThrow(() => {
+    (class { })()
+  }, "TypeError: Cannot call a class constructor without |new|");
+}

--- a/JSTests/stress/constructor-kind-naked-should-not-be-applied-to-inner-functions.js
+++ b/JSTests/stress/constructor-kind-naked-should-not-be-applied-to-inner-functions.js
@@ -17,4 +17,4 @@ new Promise((resolve) => {
     resolve(42);
 });
 drainMicrotasks();
-shouldThrow(() => Promise(function () { }), `TypeError: Cannot call a constructor without |new|`)
+shouldThrow(() => Promise(function () { }), `TypeError: Cannot call a constructor Promise without |new|`)

--- a/JSTests/stress/promise-cannot-be-called.js
+++ b/JSTests/stress/promise-cannot-be-called.js
@@ -21,7 +21,7 @@ function shouldThrow(func, errorMessage) {
 var executorCalled = false;
 shouldThrow(() => {
     Promise(function (resolve, reject) { executorCalled = true; });
-}, `TypeError: Cannot call a constructor without |new|`);
+}, `TypeError: Cannot call a constructor Promise without |new|`);
 shouldBe(executorCalled, false);
 
 // But should accept inheriting Promise.

--- a/LayoutTests/js/Promise-types-expected.txt
+++ b/LayoutTests/js/Promise-types-expected.txt
@@ -18,25 +18,25 @@ PASS aPromise.catch.length is 1
 PASS aPromise.finally is an instance of Function
 PASS aPromise.finally.length is 1
 aPromise2 = Promise(...)
-PASS Promise(function(resolve, reject) { resolve(1); }) threw exception TypeError: Cannot call a constructor without |new|.
+PASS Promise(function(resolve, reject) { resolve(1); }) threw exception TypeError: Cannot call a constructor Promise without |new|.
 
 Promise constructor
 
 PASS Promise.length is 1
 PASS new Promise() threw exception TypeError: Promise constructor takes a function argument.
-PASS Promise() threw exception TypeError: Cannot call a constructor without |new|.
+PASS Promise() threw exception TypeError: Cannot call a constructor Promise without |new|.
 PASS new Promise(1) threw exception TypeError: Promise constructor takes a function argument.
 PASS new Promise('hello') threw exception TypeError: Promise constructor takes a function argument.
 PASS new Promise([]) threw exception TypeError: Promise constructor takes a function argument.
 PASS new Promise({}) threw exception TypeError: Promise constructor takes a function argument.
 PASS new Promise(null) threw exception TypeError: Promise constructor takes a function argument.
 PASS new Promise(undefined) threw exception TypeError: Promise constructor takes a function argument.
-PASS Promise(1) threw exception TypeError: Cannot call a constructor without |new|.
-PASS Promise('hello') threw exception TypeError: Cannot call a constructor without |new|.
-PASS Promise([]) threw exception TypeError: Cannot call a constructor without |new|.
-PASS Promise({}) threw exception TypeError: Cannot call a constructor without |new|.
-PASS Promise(null) threw exception TypeError: Cannot call a constructor without |new|.
-PASS Promise(undefined) threw exception TypeError: Cannot call a constructor without |new|.
+PASS Promise(1) threw exception TypeError: Cannot call a constructor Promise without |new|.
+PASS Promise('hello') threw exception TypeError: Cannot call a constructor Promise without |new|.
+PASS Promise([]) threw exception TypeError: Cannot call a constructor Promise without |new|.
+PASS Promise({}) threw exception TypeError: Cannot call a constructor Promise without |new|.
+PASS Promise(null) threw exception TypeError: Cannot call a constructor Promise without |new|.
+PASS Promise(undefined) threw exception TypeError: Cannot call a constructor Promise without |new|.
 
 Promise statics
 

--- a/LayoutTests/js/class-syntax-call-expected.txt
+++ b/LayoutTests/js/class-syntax-call-expected.txt
@@ -4,9 +4,9 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 
 PASS new A
-PASS A():::"TypeError: Cannot call a class constructor without |new|"
+PASS A():::"TypeError: Cannot call a class constructor A without |new|"
 PASS new B
-PASS B():::"TypeError: Cannot call a class constructor without |new|"
+PASS B():::"TypeError: Cannot call a class constructor B without |new|"
 PASS new (class { constructor() {} })()
 PASS (class { constructor() {} })():::"TypeError: Cannot call a class constructor without |new|"
 PASS new (class extends null { constructor() { super() } })():::"TypeError: function is not a constructor (evaluating 'super()')"

--- a/LayoutTests/js/class-syntax-default-constructor-expected.txt
+++ b/LayoutTests/js/class-syntax-default-constructor-expected.txt
@@ -4,11 +4,11 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 
 PASS new A instanceof A
-PASS A():::TypeError: Cannot call a class constructor without |new|
+PASS A():::TypeError: Cannot call a class constructor A without |new|
 PASS A.prototype.constructor instanceof Function
 PASS A.prototype.constructor.name:::"A"
 PASS new B instanceof A; new B instanceof A
-PASS B():::TypeError: Cannot call a class constructor without |new|
+PASS B():::TypeError: Cannot call a class constructor B without |new|
 PASS B.prototype.constructor.name:::"B"
 PASS A !== B
 PASS A.prototype.constructor !== B.prototype.constructor

--- a/LayoutTests/js/script-tests/Promise-types.js
+++ b/LayoutTests/js/script-tests/Promise-types.js
@@ -47,12 +47,12 @@ shouldThrow("new Promise({})", "'TypeError: Promise constructor takes a function
 shouldThrow("new Promise(null)", "'TypeError: Promise constructor takes a function argument'");
 shouldThrow("new Promise(undefined)", "'TypeError: Promise constructor takes a function argument'");
 
-shouldThrow("Promise(1)", "'TypeError: Cannot call a constructor without |new|'");
-shouldThrow("Promise('hello')", "'TypeError: Cannot call a constructor without |new|'");
-shouldThrow("Promise([])", "'TypeError: Cannot call a constructor without |new|'");
-shouldThrow("Promise({})", "'TypeError: Cannot call a constructor without |new|'");
-shouldThrow("Promise(null)", "'TypeError: Cannot call a constructor without |new|'");
-shouldThrow("Promise(undefined)", "'TypeError: Cannot call a constructor without |new|'");
+shouldThrow("Promise(1)", "'TypeError: Cannot call a constructor Promise without |new|'");
+shouldThrow("Promise('hello')", "'TypeError: Cannot call a constructor Promise without |new|'");
+shouldThrow("Promise([])", "'TypeError: Cannot call a constructor Promise without |new|'");
+shouldThrow("Promise({})", "'TypeError: Cannot call a constructor Promise without |new|'");
+shouldThrow("Promise(null)", "'TypeError: Cannot call a constructor Promise without |new|'");
+shouldThrow("Promise(undefined)", "'TypeError: Cannot call a constructor Promise without |new|'");
 
 // Promise statics
 debug("");
@@ -72,5 +72,4 @@ shouldNotThrow("Promise.reject(1)");
 // Should return Promise objects.
 shouldBeType("Promise.resolve(1)", "Promise");
 shouldBeType("Promise.reject(1)", "Promise");
-
 

--- a/LayoutTests/js/script-tests/class-syntax-call.js
+++ b/LayoutTests/js/script-tests/class-syntax-call.js
@@ -32,9 +32,9 @@ function shouldNotThrow(s) {
 }
 
 shouldNotThrow('new A');
-shouldThrow('A()', '"TypeError: Cannot call a class constructor without |new|"');
+shouldThrow('A()', '"TypeError: Cannot call a class constructor A without |new|"');
 shouldNotThrow('new B');
-shouldThrow('B()', '"TypeError: Cannot call a class constructor without |new|"');
+shouldThrow('B()', '"TypeError: Cannot call a class constructor B without |new|"');
 shouldNotThrow('new (class { constructor() {} })()');
 shouldThrow('(class { constructor() {} })()', '"TypeError: Cannot call a class constructor without |new|"');
 shouldThrow('new (class extends null { constructor() { super() } })()', '"TypeError: function is not a constructor (evaluating \'super()\')"');

--- a/LayoutTests/js/script-tests/class-syntax-default-constructor.js
+++ b/LayoutTests/js/script-tests/class-syntax-default-constructor.js
@@ -43,11 +43,11 @@ class A { };
 class B extends A { };
 
 shouldBeTrue('new A instanceof A');
-shouldThrow('A()', '"TypeError: Cannot call a class constructor without |new|"');
+shouldThrow('A()', '"TypeError: Cannot call a class constructor A without |new|"');
 shouldBeTrue('A.prototype.constructor instanceof Function');
 shouldBe('A.prototype.constructor.name', '"A"');
 shouldBeTrue('new B instanceof A; new B instanceof A');
-shouldThrow('B()', '"TypeError: Cannot call a class constructor without |new|"');
+shouldThrow('B()', '"TypeError: Cannot call a class constructor B without |new|"');
 shouldBe('B.prototype.constructor.name', '"B"');
 shouldBeTrue('A !== B');
 shouldBeTrue('A.prototype.constructor !== B.prototype.constructor');

--- a/LayoutTests/performance-api/performance-observer-exception-expected.txt
+++ b/LayoutTests/performance-api/performance-observer-exception-expected.txt
@@ -5,7 +5,7 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 PerformanceObserver callback fired
 PASS onerror: EXCEPTION MESSAGE IN CALLBACK
-PASS onerror: TypeError: Cannot call a class constructor without |new|
+PASS onerror: TypeError: Cannot call a class constructor MyObserver without |new|
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
@@ -533,14 +533,32 @@ BytecodeGenerator::BytecodeGenerator(VM& vm, FunctionNode* functionNode, Unlinke
         break;
     case ConstructorKind::Naked:
         if (!isConstructor()) {
-            emitThrowTypeError("Cannot call a constructor without |new|"_s);
+            String constructorName = functionNode->ident().string();
+            if (!constructorName || constructorName.isEmpty())
+                emitThrowTypeError("Cannot call a constructor without |new|"_s);
+            else {
+                auto errorMessageStr = tryMakeString("Cannot call a constructor "_s, constructorName, " without |new|"_s);
+                if (!errorMessageStr)
+                    emitThrowTypeError("Cannot call a constructor without |new|"_s);
+                else
+                    emitThrowTypeError(Identifier::fromString(m_vm, errorMessageStr));
+            }
             return;
         }
         break;
     case ConstructorKind::Base:
     case ConstructorKind::Extends:
         if (!isConstructor()) {
-            emitThrowTypeError("Cannot call a class constructor without |new|"_s);
+            String constructorName = functionNode->ident().string();
+            if (!constructorName || constructorName.isEmpty())
+                emitThrowTypeError("Cannot call a class constructor without |new|"_s);
+            else {
+                auto errorMessageStr = tryMakeString("Cannot call a class constructor "_s, constructorName, " without |new|"_s);
+                if (!errorMessageStr)
+                    emitThrowTypeError("Cannot call a class constructor without |new|"_s);
+                else
+                    emitThrowTypeError(Identifier::fromString(m_vm, errorMessageStr));
+            }
             return;
         }
         break;


### PR DESCRIPTION
#### dabbab2ba61ec615fba37cb099de201ff4be572c
<pre>
[JSC] Improve error message for calling constructor without `new`
<a href="https://bugs.webkit.org/show_bug.cgi?id=298927">https://bugs.webkit.org/show_bug.cgi?id=298927</a>

Reviewed by Yusuke Suzuki.

Calling constructors without `new` is invalid:

        class Foo {}
        Foo();

Current JSC throws a TypeError with the message &quot;Cannot call a class
constructor without |new|&quot; for such code.

This patch changes this error message to include the constructor name
for debugging experience.

Test: JSTests/stress/constructor-call-without-new.js

Test: JSTests/stress/constructor-call-without-new.js
* JSTests/stress/calling-non-callable-constructors.js:
(shouldThrow):
* JSTests/stress/constructor-call-without-new.js: Added.
(shouldThrow):
(throw.new.Error):
* JSTests/stress/constructor-kind-naked-should-not-be-applied-to-inner-functions.js:
(shouldThrow.Promise):
* JSTests/stress/promise-cannot-be-called.js:
(shouldThrow):
* LayoutTests/js/Promise-types-expected.txt:
* LayoutTests/js/class-syntax-call-expected.txt:
* LayoutTests/js/class-syntax-default-constructor-expected.txt:
* LayoutTests/js/script-tests/Promise-types.js:
* LayoutTests/js/script-tests/class-syntax-call.js:
* LayoutTests/js/script-tests/class-syntax-default-constructor.js:
* LayoutTests/performance-api/performance-observer-exception-expected.txt:
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp:
(JSC::BytecodeGenerator::BytecodeGenerator):

Canonical link: <a href="https://commits.webkit.org/301023@main">https://commits.webkit.org/301023@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/22a9660a15cdaedf26e2f98968348f362c2666aa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124708 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44380 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35115 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131550 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76630 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45084 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52950 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94880 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62935 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127662 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35957 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111532 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75449 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34888 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29687 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75029 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/116813 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105714 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29918 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134216 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/123228 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51556 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39370 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103355 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51968 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107753 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103127 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26254 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48502 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26775 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48544 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51430 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57227 "Built successfully") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/156305 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50823 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/156305 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54179 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52518 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->