### PR TITLE
Script 'update-angle' assumess target Webkit commit is always main

### DIFF
--- a/Tools/Scripts/update-angle
+++ b/Tools/Scripts/update-angle
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # This script updates the copy of ANGLE in Source/ThirdParty/ANGLE
 # with the latest changes from upstream.
@@ -8,6 +8,8 @@ set -e
 cd "$(dirname "$0")/../../Source/ThirdParty/ANGLE"
 ANGLE_DIR="$PWD"
 ANGLE_TARGET_COMMIT="origin/main"
+WEBKIT_TARGET_COMMIT=$(git rev-parse HEAD)
+WEBKIT_TARGET_COMMIT_SHORT=$(git rev-parse --abbrev-ref HEAD)
 q="-q"
 
 # Check for modified files in WebKit ignoring untracked file except in ANGLE dir
@@ -80,6 +82,7 @@ while [[ $# -gt 0 ]]; do
             exit 0
             ;;
         -v|--verbose)
+            echo "WEBKIT_TARGET_COMMIT: $WEBKIT_TARGET_COMMIT ($WEBKIT_TARGET_COMMIT_SHORT)"
             q=""
             ;;
         --generate-changes)
@@ -180,12 +183,10 @@ if wait_for_rebase_to_complete ; then
     cleanup_after_successful_rebase_and_exit
 fi
 
-PREVIOUS_ANGLE_COMMIT_HASH=$(grep -m 1 -o -E "[a-z0-9]{40}" ANGLE.plist)
-
 cd ../../..
 echo "Creating WebKit branch that only contains ANGLE changes, using git-filter-repo."
 echo "This may take a few minutes, but massively speeds up rebasing later."
-git branch -f just-angle main && git-filter-repo --refs refs/heads/just-angle --path Source/ThirdParty/ANGLE --path-rename Source/ThirdParty/ANGLE/: --force
+git branch -f just-angle ${WEBKIT_TARGET_COMMIT} && git-filter-repo --refs refs/heads/just-angle --path Source/ThirdParty/ANGLE --path-rename Source/ThirdParty/ANGLE/: --force
 cd "$ANGLE_DIR"
 
 echo "Downloading latest ANGLE via git clone."


### PR DESCRIPTION
#### 08137aa17cea9f07cc1247a67bb9b261ad9daace
<pre>
Script &apos;update-angle&apos; assumess target Webkit commit is always main
<a href="https://bugs.webkit.org/show_bug.cgi?id=298928">https://bugs.webkit.org/show_bug.cgi?id=298928</a>

Reviewed by Kimmo Kinnunen.

At it is, the script doesn&apos;t work in a scenario where we&apos;re trying to
bisect a past ANGLE interval update.  The script assumes the target
WebKit commit is always &apos;main&apos;.  When bisecting a past ANGLE update
interval we&apos;d like the script doesn&apos;t see ANGLE changes before a
certain WebKit commit.

To achieve that, the target WebKit commit is set to HEAD, which works
both if the current commit is tip of main or a past commit.

In addition, the shebang was changed to &apos;/usr/bin/env bash&apos; since strictly
talking this is a Bash script (the script uses double brackets and read -r,
only available in Bash).  A spared line was also removed.

* Tools/Scripts/update-angle:

Canonical link: <a href="https://commits.webkit.org/300020@main">https://commits.webkit.org/300020@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6b8a10fc117740bad553ae397fcb3503f7e8a2d6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121076 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40772 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31430 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127495 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73157 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122952 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41474 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49351 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/91967 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/61181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124028 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/33114 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/108534 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/72651 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32138 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/26637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71086 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/102620 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/26816 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130348 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48003 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36481 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/100576 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48371 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/104701 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100478 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45879 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/23934 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44695 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19204 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47861 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47332 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50679 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49016 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->