### PR TITLE
Fix smart pointers errors with CFRunLoopGetMain()/CFRunLoopGetCurrent()

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
@@ -140,7 +140,6 @@ UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm
 UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.mm
 UIProcess/WebAuthentication/Cocoa/CcidConnection.mm
 UIProcess/WebAuthentication/Cocoa/HidConnection.mm
-UIProcess/WebAuthentication/Cocoa/HidService.mm
 UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm
 UIProcess/WebAuthentication/Cocoa/LocalConnection.mm
 UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm
@@ -178,7 +177,6 @@ WebProcess/Plugins/PDF/WKAccessibilityPDFDocumentObject.mm
 WebProcess/WebPage/Cocoa/WebPageCocoa.mm
 WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemote.mm
 WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteCustom.mm
-WebProcess/WebPage/WebDisplayRefreshMonitor.cpp
 WebProcess/WebPage/WebPage.cpp
 WebProcess/WebPage/mac/PageBannerMac.mm
 WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm
@@ -191,4 +189,3 @@ webpushd/WebPushDaemon.mm
 webpushd/WebPushDaemonMain.mm
 webpushd/_WKMockUserNotificationCenter.mm
 webpushd/webpushtool/WebPushToolConnection.mm
-webpushd/webpushtool/WebPushToolMain.mm

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/HidConnection.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/HidConnection.mm
@@ -76,7 +76,7 @@ void HidConnection::initialize()
 {
 #if HAVE(SECURITY_KEY_API)
     IOHIDDeviceOpen(m_device.get(), kIOHIDOptionsTypeSeizeDevice);
-    IOHIDDeviceScheduleWithRunLoop(m_device.get(), CFRunLoopGetCurrent(), kCFRunLoopDefaultMode);
+    IOHIDDeviceScheduleWithRunLoop(m_device.get(), retainPtr(CFRunLoopGetCurrent()).get(), kCFRunLoopDefaultMode);
     m_inputBuffer.resize(kHidMaxPacketSize);
     IOHIDDeviceRegisterInputReportCallback(m_device.get(), m_inputBuffer.mutableSpan().data(), m_inputBuffer.size(), &reportReceived, this);
 #endif
@@ -87,7 +87,7 @@ void HidConnection::terminate()
 {
 #if HAVE(SECURITY_KEY_API)
     IOHIDDeviceRegisterInputReportCallback(m_device.get(), m_inputBuffer.mutableSpan().data(), m_inputBuffer.size(), nullptr, nullptr);
-    IOHIDDeviceUnscheduleFromRunLoop(m_device.get(), CFRunLoopGetCurrent(), kCFRunLoopDefaultMode);
+    IOHIDDeviceUnscheduleFromRunLoop(m_device.get(), retainPtr(CFRunLoopGetCurrent()).get(), kCFRunLoopDefaultMode);
     IOHIDDeviceClose(m_device.get(), kIOHIDOptionsTypeNone);
 #endif
     m_isInitialized = false;

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/HidService.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/HidService.mm
@@ -73,7 +73,7 @@ HidService::HidService(AuthenticatorTransportServiceObserver& observer)
 HidService::~HidService()
 {
 #if HAVE(SECURITY_KEY_API)
-    IOHIDManagerUnscheduleFromRunLoop(m_manager.get(), CFRunLoopGetCurrent(), kCFRunLoopDefaultMode);
+    IOHIDManagerUnscheduleFromRunLoop(m_manager.get(), retainPtr(CFRunLoopGetCurrent()).get(), kCFRunLoopDefaultMode);
     IOHIDManagerClose(m_manager.get(), kIOHIDOptionsTypeNone);
 #endif
 }
@@ -86,7 +86,7 @@ void HidService::startDiscoveryInternal()
 void HidService::platformStartDiscovery()
 {
 #if HAVE(SECURITY_KEY_API)
-    IOHIDManagerScheduleWithRunLoop(m_manager.get(), CFRunLoopGetCurrent(), kCFRunLoopDefaultMode);
+    IOHIDManagerScheduleWithRunLoop(m_manager.get(), retainPtr(CFRunLoopGetCurrent()).get(), kCFRunLoopDefaultMode);
     IOHIDManagerOpen(m_manager.get(), kIOHIDOptionsTypeNone);
 #endif
 }

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -6976,11 +6976,12 @@ void WebViewImpl::computeHasVisualSearchResults(const URL& imageURL, ShareableBi
     auto startTime = MonotonicTime::now();
     [ensureImageAnalyzer() processRequest:request.get() progressHandler:nil completionHandler:makeBlockPtr([completion = WTFMove(completion), startTime] (CocoaImageAnalysis *analysis, NSError *) mutable {
         BOOL result = [analysis hasResultsForAnalysisTypes:VKAnalysisTypeVisualSearch];
-        CFRunLoopPerformBlock(CFRunLoopGetMain(), (__bridge CFStringRef)NSEventTrackingRunLoopMode, makeBlockPtr([completion = WTFMove(completion), result, startTime] () mutable {
+        RetainPtr loop = CFRunLoopGetMain();
+        CFRunLoopPerformBlock(loop.get(), (__bridge CFStringRef)NSEventTrackingRunLoopMode, makeBlockPtr([completion = WTFMove(completion), result, startTime] () mutable {
             RELEASE_LOG(ImageAnalysis, "Image analysis completed in %.0f ms (found visual search results? %d)", (MonotonicTime::now() - startTime).milliseconds(), result);
             completion(result);
         }).get());
-        CFRunLoopWakeUp(CFRunLoopGetMain());
+        CFRunLoopWakeUp(loop.get());
     }).get()];
 }
 

--- a/Source/WebKit/WebProcess/WebPage/WebDisplayRefreshMonitor.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebDisplayRefreshMonitor.cpp
@@ -93,7 +93,7 @@ bool WebDisplayRefreshMonitor::startNotificationMechanism()
         });
     }
 
-    m_runLoopObserver->schedule(CFRunLoopGetCurrent());
+    m_runLoopObserver->schedule(retainPtr(CFRunLoopGetCurrent()).get());
 #endif
     m_displayLinkIsActive = true;
 

--- a/Source/WebKit/webpushd/webpushtool/WebPushToolMain.mm
+++ b/Source/WebKit/webpushd/webpushtool/WebPushToolMain.mm
@@ -172,7 +172,7 @@ class WebPushToolVerb {
 public:
     virtual ~WebPushToolVerb() = default;
     virtual void run(WebPushTool::Connection&) = 0;
-    virtual void done() { CFRunLoopStop(CFRunLoopGetMain()); }
+    virtual void done() { CFRunLoopStop(retainPtr(CFRunLoopGetMain()).get()); }
 };
 
 class InjectPushMessageVerb : public WebPushToolVerb {


### PR DESCRIPTION
#### 1af87bb4a5ef066a6347dfb7f51e7ccd8b8284ab
<pre>
Fix smart pointers errors with CFRunLoopGetMain()/CFRunLoopGetCurrent()
<a href="https://bugs.webkit.org/show_bug.cgi?id=298865">https://bugs.webkit.org/show_bug.cgi?id=298865</a>

Reviewed by Chris Dumez.

Ownership follows the The Get Rule, so they need a RetainPtr:
<a href="https://developer.apple.com/documentation/corefoundation/cfrunloopgetcurrent()?language=objc">https://developer.apple.com/documentation/corefoundation/cfrunloopgetcurrent()?language=objc</a>
<a href="https://developer.apple.com/documentation/corefoundation/cfrunloopgetmain()?language=objc">https://developer.apple.com/documentation/corefoundation/cfrunloopgetmain()?language=objc</a>

* Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations:
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/HidConnection.mm:
(WebKit::HidConnection::initialize):
(WebKit::HidConnection::terminate):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/HidService.mm:
(WebKit::HidService::~HidService):
(WebKit::HidService::platformStartDiscovery):
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::computeHasVisualSearchResults):
* Source/WebKit/WebProcess/WebPage/WebDisplayRefreshMonitor.cpp:
(WebKit::WebDisplayRefreshMonitor::startNotificationMechanism):
* Source/WebKit/webpushd/webpushtool/WebPushToolMain.mm:
(WebKit::WebPushToolVerb::done):

Canonical link: <a href="https://commits.webkit.org/300027@main">https://commits.webkit.org/300027@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/839fe42630ea8c38dc09b0869651679bd8b3cd45

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121082 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40778 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31436 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127501 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73163 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41480 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49357 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91972 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61186 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124034 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33122 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108540 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72656 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32146 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71092 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/102628 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26822 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130354 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48009 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36486 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100581 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48377 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104707 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100483 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25473 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45887 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23940 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44703 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47867 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53580 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47338 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50685 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49022 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->