### PR TITLE
GPUP: Filters are not encoded in stateful manner

### DIFF
--- a/Source/WebCore/platform/graphics/SourceImage.cpp
+++ b/Source/WebCore/platform/graphics/SourceImage.cpp
@@ -137,7 +137,7 @@ IntSize SourceImage::size() const
             return imageBuffer->backendSize();
         },
         [&] (RenderingResourceIdentifier) -> IntSize {
-            ASSERT_NOT_REACHED();
+            ASSERT_NOT_REACHED(); // <-- WebCore code calls size(). This here is a making WebCore worse by imposing GPUP related things in WebCore code, needlessly.
             return { };
         }
     );

--- a/Source/WebCore/platform/graphics/SourceImage.h
+++ b/Source/WebCore/platform/graphics/SourceImage.h
@@ -38,7 +38,7 @@ public:
     using ImageVariant = Variant<
         Ref<NativeImage>,
         Ref<ImageBuffer>,
-        RenderingResourceIdentifier
+        RenderingResourceIdentifier // <-- The purpose of the commit is to eventually be able to remove this.
     >;
 
     SourceImage(ImageVariant&&);
@@ -57,7 +57,7 @@ public:
     ImageBuffer* imageBufferIfExists() const;
     ImageBuffer* imageBuffer() const;
 
-    RenderingResourceIdentifier imageIdentifier() const;
+    RenderingResourceIdentifier imageIdentifier() const; // <-- The encoder uses this detail to be able to encode quite convenient way: The identifier "happens" to be available, because it is pre-cached manually in non-buggy cases. In buggy cases it's forgotten.
     IntSize size() const;
 
 private:

--- a/Source/WebCore/platform/graphics/filters/FEImage.h
+++ b/Source/WebCore/platform/graphics/filters/FEImage.h
@@ -43,7 +43,7 @@ public:
     bool operator==(const FEImage&) const;
 
     const SourceImage& sourceImage() const { return m_sourceImage; }
-    void setImageSource(SourceImage&& sourceImage) { m_sourceImage = WTFMove(sourceImage); }
+    void setImageSource(SourceImage&& sourceImage) { m_sourceImage = WTFMove(sourceImage); } // <<- This exists only for GPUP to backfill the FEImage
 
     FloatRect sourceImageRect() const { return m_sourceImageRect; }
     const SVGPreserveAspectRatioValue& preserveAspectRatio() const { return m_preserveAspectRatio; }

--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -46,6 +46,7 @@ $(PROJECT_DIR)/GPUProcess/RemoteSharedResourceCache.messages.in
 $(PROJECT_DIR)/GPUProcess/ShapeDetection/RemoteBarcodeDetector.messages.in
 $(PROJECT_DIR)/GPUProcess/ShapeDetection/RemoteFaceDetector.messages.in
 $(PROJECT_DIR)/GPUProcess/ShapeDetection/RemoteTextDetector.messages.in
+$(PROJECT_DIR)/GPUProcess/graphics/FilterData.serialization.in
 $(PROJECT_DIR)/GPUProcess/graphics/PathSegment.serialization.in
 $(PROJECT_DIR)/GPUProcess/graphics/RemoteGraphicsContext.messages.in
 $(PROJECT_DIR)/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -597,6 +597,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	GPUProcess/GPUProcessCreationParameters.serialization.in \
 	GPUProcess/GPUProcessPreferences.serialization.in \
 	GPUProcess/GPUProcessSessionParameters.serialization.in \
+	GPUProcess/graphics/FilterData.serialization.in \
 	GPUProcess/graphics/PathSegment.serialization.in \
 	GPUProcess/graphics/RemoteGraphicsContextGLInitializationState.serialization.in \
 	GPUProcess/graphics/WebGPU/RemoteGPURequestAdapterResponse.serialization.in \

--- a/Source/WebKit/GPUProcess/graphics/FilterData.cpp
+++ b/Source/WebKit/GPUProcess/graphics/FilterData.cpp
@@ -1,0 +1,417 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#if ENABLE(GPU_PROCESS)
+#include "FilterData.h"
+
+#include "RemoteRenderingBackend.h"
+#include "RemoteRenderingBackendProxy.h"
+#include "RemoteResourceCache.h"
+#include "RemoteResourceCacheProxy.h"
+#include <WebCore/CSSFilter.h>
+#include <WebCore/FEBlend.h>
+#include <WebCore/FEColorMatrix.h>
+#include <WebCore/FEComponentTransfer.h>
+#include <WebCore/FEComposite.h>
+#include <WebCore/FEConvolveMatrix.h>
+#include <WebCore/FEDiffuseLighting.h>
+#include <WebCore/FEDisplacementMap.h>
+#include <WebCore/FEDropShadow.h>
+#include <WebCore/FEFlood.h>
+#include <WebCore/FEGaussianBlur.h>
+#include <WebCore/FEImage.h>
+#include <WebCore/FEMerge.h>
+#include <WebCore/FEOffset.h>
+#include <WebCore/FESpecularLighting.h>
+#include <WebCore/FETile.h>
+#include <WebCore/SourceAlpha.h>
+#include <WebCore/SourceGraphic.h>
+#include <wtf/StdLibExtras.h>
+
+namespace WebKit {
+using namespace WebCore;
+
+namespace {
+struct ToDataContext {
+    RemoteRenderingBackendProxy& renderingBackend;
+    const DestinationColorSpace& fallbackColorSpace;
+};
+struct FromDataContext {
+    RemoteResourceCache& resourceCache;
+    RemoteRenderingBackend& renderingBackend;
+};
+
+}
+
+static LightSourceData toData(LightSource& value)
+{
+    return LightSourceData {
+
+    };
+}
+
+static std::optional<Vector<FilterEffectData>> serializeFilterEffectsToFilterEffectDatas(std::span<const Ref<FilterEffect>> effects, const ToDataContext&);
+
+static std::optional<SVGFilterData> toData(const SVGFilter& svgFilter, const ToDataContext& context)
+{
+    auto effects = serializeFilterEffectsToFilterEffectDatas(svgFilter.effects(), context);
+    if (!effects)
+        return std::nullopt;
+    return SVGFilterData {
+        .filterRenderingModes = svgFilter.filterRenderingModes(),
+        .filterScale = svgFilter.filterScale(),
+        .filterRegion = svgFilter.filterRegion(),
+        .targetBoundingBox = svgFilter.targetBoundingBox(),
+        .primitiveUnits = svgFilter.primitiveUnits(),
+        .expression = svgFilter.expression(),
+        .effects = WTFMove(*effects),
+        .renderingResourceIdentifier = svgFilter.renderingResourceIdentifier()
+    };
+}
+
+template<typename FilterFunctionDataVariant>
+static std::optional<FilterFunctionDataVariant> toData(const FilterFunction& function, const ToDataContext& context)
+{
+    switch (function.filterType()) {
+    case FilterFunction::Type::FEBlend: {
+        RefPtr f = dynamicDowncast<FEBlend>(function);
+        if (!f)
+            return std::nullopt;
+        return FEBlendData {
+            .blendMode = f->blendMode(),
+            .operatingColorSpace = f->operatingColorSpace()
+        };
+    }
+    case FilterFunction::Type::FEColorMatrix: {
+        RefPtr f = dynamicDowncast<FEColorMatrix>(function);
+        if (!f)
+            return std::nullopt;
+        return FEColorMatrixData {
+            .type = f->type(),
+            .values = f->values(),
+            .operatingColorSpace = f->operatingColorSpace()
+        };
+    }
+    case FilterFunction::Type::FEComponentTransfer: {
+        RefPtr f = dynamicDowncast<FEComponentTransfer>(function);
+        if (!f)
+            return std::nullopt;
+        return FEComponentTransferData {
+            .redFunction = f->redFunction(),
+            .greenFunction = f->greenFunction(),
+            .blueFunction = f->blueFunction(),
+            .alphaFunction = f->alphaFunction(),
+            .operatingColorSpace = f->operatingColorSpace()
+        };
+    }
+    case FilterFunction::Type::FEComposite: {
+        RefPtr f = dynamicDowncast<FEComposite>(function);
+        if (!f)
+            return std::nullopt;
+        return FECompositeData {
+            .operation = f->operation(),
+            .k1 = f->k1(),
+            .k2 = f->k2(),
+            .k3 = f->k3(),
+            .k4 = f->k4(),
+            .operatingColorSpace = f->operatingColorSpace()
+        };
+    }
+    case FilterFunction::Type::FEConvolveMatrix: {
+        RefPtr f = dynamicDowncast<FEConvolveMatrix>(function);
+        if (!f)
+            return std::nullopt;
+        return FEConvolveMatrixData {
+            .kernelSize = f->kernelSize(),
+            .divisor = f->divisor(),
+            .bias = f->bias(),
+            .targetOffset = f->targetOffset(),
+            .edgeMode = f->edgeMode(),
+            .kernelUnitLength = f->kernelUnitLength(),
+            .preserveAlpha = f->preserveAlpha(),
+            .kernel = f->kernel(),
+            .operatingColorSpace = f->operatingColorSpace()
+        };
+    }
+    case FilterFunction::Type::FEDiffuseLighting: {
+        RefPtr f = dynamicDowncast<FEDiffuseLighting>(function);
+        if (!f)
+            return std::nullopt;
+        return FEDiffuseLightingData {
+            .lightingColor = f->lightingColor(),
+            .surfaceScale = f->surfaceScale(),
+            .diffuseConstant = f->diffuseConstant(),
+            .kernelUnitLengthX = f->kernelUnitLengthX(),
+            .kernelUnitLengthY = f->kernelUnitLengthY(),
+            .lightSource = toData(f->lightSource()),
+            .operatingColorSpace = f->operatingColorSpace()
+        };
+    }
+    case FilterFunction::Type::FEDisplacementMap: {
+        RefPtr f = dynamicDowncast<FEDisplacementMap>(function);
+        if (!f)
+            return std::nullopt;
+        return FEDisplacementMapData {
+            .xChannelSelector = f->xChannelSelector(),
+            .yChannelSelector = f->yChannelSelector(),
+            .scale = f->scale(),
+            .operatingColorSpace = f->operatingColorSpace()
+        };
+    }
+    case FilterFunction::Type::FEDropShadow: {
+        RefPtr f = dynamicDowncast<FEDropShadow>(function);
+        if (!f)
+            return std::nullopt;
+        return FEDropShadowData {
+            .stdDeviationX = f->stdDeviationX(),
+            .stdDeviationY = f->stdDeviationY(),
+            .dx = f->dx(),
+            .dy = f->dy(),
+            .shadowColor = f->shadowColor(),
+            .shadowOpacity = f->shadowOpacity(),
+            .operatingColorSpace = f->operatingColorSpace()
+        };
+    }
+    case FilterFunction::Type::FEFlood: {
+        RefPtr f = dynamicDowncast<FEFlood>(function);
+        if (!f)
+            return std::nullopt;
+        return FEFloodData {
+            .floodColor = f->floodColor(),
+            .floodOpacity = f->floodOpacity(),
+            .operatingColorSpace = f->operatingColorSpace()
+        };
+    }
+    case FilterFunction::Type::FEGaussianBlur: {
+        RefPtr f = dynamicDowncast<FEGaussianBlur>(function);
+        if (!f)
+            return std::nullopt;
+        return FEGaussianBlurData {
+            .stdDeviationX = f->stdDeviationX(),
+            .stdDeviationY = f->stdDeviationY(),
+            .edgeMode = f->edgeMode(),
+            .operatingColorSpace = f->operatingColorSpace()
+        };
+    }
+    case FilterFunction::Type::FEImage: {
+        RefPtr f = dynamicDowncast<FEImage>(function);
+        if (!f)
+            return std::nullopt;
+        const auto& sourceImage = f->sourceImage();
+        std::optional<RenderingResourceIdentifier> sourceImageIdentifier;
+        if (RefPtr nativeImage = sourceImage.nativeImageIfExists()) {
+            context.renderingBackend.remoteResourceCacheProxy().recordNativeImageUse(*nativeImage, context.fallbackColorSpace);
+            sourceImageIdentifier = nativeImage->renderingResourceIdentifier();
+        } else if (RefPtr imageBuffer = sourceImage.imageBufferIfExists()) {
+            if (context.renderingBackend.isCached(*imageBuffer))
+                sourceImageIdentifier = imageBuffer->renderingResourceIdentifier();
+        }
+        if (!sourceImageIdentifier)
+            return std::nullopt;
+        return FEImageData {
+            .sourceImageIdentifier = *sourceImageIdentifier,
+            .sourceImageRect = f->sourceImageRect()
+        };
+    }
+    case FilterFunction::Type::FEMerge: {
+        RefPtr f = dynamicDowncast<FEMerge>(function);
+        if (!f)
+            return std::nullopt;
+        return FEMergeData {
+            .numberOfEffectInputs = f->numberOfEffectInputs(),
+            .operatingColorSpace = f->operatingColorSpace()
+        };
+    }
+    case FilterFunction::Type::FEMorphology: {
+        RefPtr f = dynamicDowncast<FEMorphology>(function);
+        if (!f)
+            return std::nullopt;
+        return FEMorphologyData {
+            .morphologyOperator = f->morphologyOperator(),
+            .radiusX = f->radiusX(),
+            .radiusY = f->radiusY(),
+            .operatingColorSpace = f->operatingColorSpace()
+        };
+    }
+    case FilterFunction::Type::FEOffset: {
+        RefPtr f = dynamicDowncast<FEOffset>(function);
+        if (!f)
+            return std::nullopt;
+        return FEOffsetData {
+            .dx = f->dx(),
+            .dy = f->dy(),
+            .operatingColorSpace = f->operatingColorSpace()
+        };
+    }
+    case FilterFunction::Type::FETile: {
+        RefPtr f = dynamicDowncast<FETile>(function);
+        if (!f)
+            return std::nullopt;
+        return FETileData {
+            .operatingColorSpace = f->operatingColorSpace()
+        };
+    }
+    case FilterFunction::Type::FESpecularLighting: {
+        RefPtr f = dynamicDowncast<FESpecularLighting>(function);
+        if (!f)
+            return std::nullopt;
+        return FESpecularLightingData {
+            .lightingColor = f->lightingColor(),
+            .surfaceScale = f->surfaceScale(),
+            .specularConstant = f->specularConstant(),
+            .specularExponent = f->specularExponent(),
+            .kernelUnitLengthX = f->kernelUnitLengthX(),
+            .kernelUnitLengthY = f->kernelUnitLengthY(),
+            .lightSource = toData(f->lightSource()),
+            .operatingColorSpace = f->operatingColorSpace()
+        };
+    }
+    case FilterFunction::Type::FETurbulence: {
+        RefPtr f = dynamicDowncast<FETurbulence>(function);
+        if (!f)
+            return std::nullopt;
+        return FETurbulenceData {
+            .type = f->type(),
+            .baseFrequencyX = f->baseFrequencyX(),
+            .baseFrequencyY = f->baseFrequencyY(),
+            .numOctaves = f->numOctaves(),
+            .seed = f->seed(),
+            .stitchTiles = f->stitchTiles(),
+            .operatingColorSpace = f->operatingColorSpace()
+        };
+    }
+    case FilterFunction::Type::SourceAlpha: {
+        RefPtr f = dynamicDowncast<SourceAlpha>(function);
+        if (!f)
+            return std::nullopt;
+        return SourceAlphaData {
+            .operatingColorSpace = f->operatingColorSpace()
+        };
+    }
+    case FilterFunction::Type::SourceGraphic: {
+        RefPtr f = dynamicDowncast<SourceGraphic>(function);
+        if (!f)
+            return std::nullopt;
+        return SourceGraphicData {
+            .operatingColorSpace = f->operatingColorSpace()
+        };
+    }
+    default:
+    }
+    ASSERT_NOT_REACHED();
+    return std::nullopt;
+}
+
+std::optional<Vector<FilterEffectData>> serializeFilterEffectsToFilterEffectDatas(std::span<const Ref<FilterEffect>> effects, const ToDataContext& context)
+{
+    Vector<FilterEffectData> result;
+    result.reserveCapacity(effects.size());
+    for (auto& effect : effects) {
+        auto effectData = toData<FilterEffectData>(effect, context);
+        if (!effectData)
+            return std::nullopt;
+        result.append(WTFMove(*effectData));
+    }
+    return result;
+}
+
+static std::optional<Vector<FilterFunctionData>> serializeFilterFunctionsToFilterFunctionDatas(std::span<const Ref<FilterFunction>> functions, const ToDataContext& context)
+{
+    Vector<FilterFunctionData> result;
+    result.reserveCapacity(functions.size());
+    for (auto& function : functions) {
+        std::optional<FilterFunctionData> functionData;
+        if (RefPtr svgFilter = dynamicDowncast<SVGFilter>(function))
+            functionData = toData(*svgFilter, context);
+        else
+            functionData = toData<FilterFunctionData>(function, context);
+        if (!functionData)
+            return std::nullopt;
+        result.append(WTFMove(*functionData));
+    }
+    return result;
+}
+
+std::optional<FilterData> serializeFilterToFilterData(Filter& filter, RemoteRenderingBackendProxy& renderingBackend, const DestinationColorSpace& fallbackColorSpace)
+{
+    ToDataContext context { renderingBackend, fallbackColorSpace };
+    if (RefPtr svgFilter = dynamicDowncast<SVGFilter>(filter))
+        return toData(*svgFilter, context);
+    if (RefPtr cssFilter = dynamicDowncast<CSSFilter>(filter)) {
+        auto functions = serializeFilterFunctionsToFilterFunctionDatas(cssFilter->functions(), context);
+        if (!functions)
+            return std::nullopt;
+        return CSSFilterData {
+            .filterRenderingModes = cssFilter->filterRenderingModes(),
+            .filterScale = cssFilter->filterScale(),
+            .filterRegion = cssFilter->filterRegion(),
+            .functions = WTFMove(*functions)
+        };
+    }
+    ASSERT_NOT_REACHED();
+    return std::nullopt;
+}
+
+#if 0
+static Vector<Ref<FilterEffect>> fromData(std::span<const FilterEffectData> effectDatas, const FromDataContext& context)
+{
+    Vector<Ref<FilterEffect>> result;
+    return result;
+}
+
+static Vector<Ref<FilterFunction>> fromData(std::span<const FilterFunctionData> functionDatas, const FromDataContext& context)
+{
+    Vector<Ref<FilterFunction>> result;
+    return result;
+}
+#endif
+
+RefPtr<Filter> createFilterFromFilterData(FilterData&& filterData, RemoteRenderingBackend& renderingBackend)
+{
+#if 0
+    FromDataContext context { resourceCache, renderingBackend };
+    return WTF::switchOn(filterData,
+        [&](CSSFilterData&& data) -> RefPtr<Filter> {
+            return CSSFilter::create(fromData(data.functions, context), data.filterRenderingModes, data.filterScale, data.filterRegion);
+        },
+        [&](SVGFilterData&& data) -> RefPtr<Filter> {
+            return SVGFilter::create(data.targetBoundingBox, data.primitiveUnits, WTFMove(data.expression), fromData(data.effects, context), data.renderingResourceIdentifier, data.filterRenderingModes, data.filterScale, data.filterRegion);
+        });
+#else
+    return nullptr;
+#endif
+}
+
+bool isValidSVGFilterExpression(const WebCore::SVGFilterExpression&, const Vector<FilterEffectData>&)
+{
+    // FIXME: implement.
+    return false;
+}
+
+}
+
+#endif

--- a/Source/WebKit/GPUProcess/graphics/FilterData.h
+++ b/Source/WebKit/GPUProcess/graphics/FilterData.h
@@ -1,0 +1,252 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(GPU_PROCESS)
+
+#include <WebCore/Color.h>
+#include <WebCore/FEColorMatrix.h>
+#include <WebCore/FEComponentTransfer.h>
+#include <WebCore/FEComposite.h>
+#include <WebCore/FEConvolveMatrix.h>
+#include <WebCore/FEDisplacementMap.h>
+#include <WebCore/FEMorphology.h>
+#include <WebCore/FETurbulence.h>
+#include <WebCore/LightSource.h>
+#include <WebCore/SVGFilter.h>
+#include <WebCore/SVGPreserveAspectRatioValue.h>
+
+namespace WebCore {
+
+class Filter;
+
+}
+
+namespace WebKit {
+
+class RemoteResourceCache;
+class RemoteResourceCacheProxy;
+class RemoteRenderingBackend;
+class RemoteRenderingBackendProxy;
+
+struct DistantLightSourceData {
+    float azimuth;
+    float elevation;
+};
+
+struct PointLightSourceData {
+    WebCore::FloatPoint3D position;
+};
+
+struct SpotLightSourceData {
+    WebCore::FloatPoint3D position;
+    WebCore::FloatPoint3D direction;
+    float specularExponent;
+    float limitingConeAngle;
+};
+
+using LightSourceData = Variant<DistantLightSourceData, PointLightSourceData, SpotLightSourceData>;
+
+struct FEBlendData {
+    WebCore::BlendMode blendMode;
+    WebCore::DestinationColorSpace operatingColorSpace;
+};
+
+struct FEColorMatrixData {
+    WebCore::ColorMatrixType type;
+    Vector<float> values;
+    WebCore::DestinationColorSpace operatingColorSpace;
+};
+
+struct ComponentTransferFunctionData {
+    WebCore::ComponentTransferType type;
+    float slope;
+    float intercept;
+    float amplitude;
+    float exponent;
+    float offset;
+    Vector<float> tableValues;
+};
+
+struct FEComponentTransferData {
+    WebCore::ComponentTransferFunction redFunction;
+    WebCore::ComponentTransferFunction greenFunction;
+    WebCore::ComponentTransferFunction blueFunction;
+    WebCore::ComponentTransferFunction alphaFunction;
+    WebCore::DestinationColorSpace operatingColorSpace;
+};
+
+struct FECompositeData {
+    WebCore::CompositeOperationType operation;
+    float k1;
+    float k2;
+    float k3;
+    float k4;
+    WebCore::DestinationColorSpace operatingColorSpace;
+};
+
+struct FEConvolveMatrixData {
+    WebCore::IntSize kernelSize;
+    float divisor;
+    float bias;
+    WebCore::IntPoint targetOffset;
+    WebCore::EdgeModeType edgeMode;
+    WebCore::FloatPoint kernelUnitLength;
+    bool preserveAlpha;
+    Vector<float> kernel;
+    WebCore::DestinationColorSpace operatingColorSpace;
+};
+
+struct FEDiffuseLightingData {
+    WebCore::Color lightingColor;
+    float surfaceScale;
+    float diffuseConstant;
+    float kernelUnitLengthX;
+    float kernelUnitLengthY;
+    LightSourceData lightSource;
+    WebCore::DestinationColorSpace operatingColorSpace;
+};
+
+struct FEDisplacementMapData {
+    WebCore::ChannelSelectorType xChannelSelector;
+    WebCore::ChannelSelectorType yChannelSelector;
+    float scale;
+    WebCore::DestinationColorSpace operatingColorSpace;
+};
+
+struct FEDropShadowData {
+    float stdDeviationX;
+    float stdDeviationY;
+    float dx;
+    float dy;
+    WebCore::Color shadowColor;
+    float shadowOpacity;
+    WebCore::DestinationColorSpace operatingColorSpace;
+};
+
+struct FEFloodData {
+    WebCore::Color floodColor;
+    float floodOpacity;
+    WebCore::DestinationColorSpace operatingColorSpace;
+};
+
+struct FEGaussianBlurData {
+    float stdDeviationX;
+    float stdDeviationY;
+    WebCore::EdgeModeType edgeMode;
+    WebCore::DestinationColorSpace operatingColorSpace;
+};
+
+struct FEImageData {
+    WebCore::RenderingResourceIdentifier sourceImageIdentifier;
+    WebCore::FloatRect sourceImageRect;
+    WebCore::SVGPreserveAspectRatioValue preserveAspectRatio;
+};
+
+struct FEMergeData {
+    unsigned numberOfEffectInputs;
+    WebCore::DestinationColorSpace operatingColorSpace;
+};
+
+struct FEMorphologyData {
+    WebCore::MorphologyOperatorType morphologyOperator;
+    float radiusX;
+    float radiusY;
+    WebCore::DestinationColorSpace operatingColorSpace;
+};
+
+struct FEOffsetData {
+    float dx;
+    float dy;
+    WebCore::DestinationColorSpace operatingColorSpace;
+};
+
+struct FETileData {
+    WebCore::DestinationColorSpace operatingColorSpace;
+};
+
+struct FESpecularLightingData {
+    WebCore::Color lightingColor;
+    float surfaceScale;
+    float specularConstant;
+    float specularExponent;
+    float kernelUnitLengthX;
+    float kernelUnitLengthY;
+    LightSourceData lightSource;
+    WebCore::DestinationColorSpace operatingColorSpace;
+};
+
+struct FETurbulenceData {
+    WebCore::TurbulenceType type;
+    float baseFrequencyX;
+    float baseFrequencyY;
+    int numOctaves;
+    float seed;
+    bool stitchTiles;
+    WebCore::DestinationColorSpace operatingColorSpace;
+};
+
+struct SourceAlphaData {
+    WebCore::DestinationColorSpace operatingColorSpace;
+};
+
+struct SourceGraphicData {
+    WebCore::DestinationColorSpace operatingColorSpace;
+};
+
+using FilterEffectData = Variant<FEBlendData, FEColorMatrixData, FEComponentTransferData, FECompositeData, FEConvolveMatrixData, FEDiffuseLightingData, FEDisplacementMapData, FEDropShadowData, FEFloodData, FEGaussianBlurData, FEImageData, FEMergeData, FEMorphologyData, FEOffsetData, FETileData, FESpecularLightingData, FETurbulenceData, SourceAlphaData, SourceGraphicData>;
+
+struct SVGFilterData {
+    OptionSet<WebCore::FilterRenderingMode> filterRenderingModes;
+    WebCore::FloatSize filterScale;
+    WebCore::FloatRect filterRegion;
+    WebCore::FloatRect targetBoundingBox;
+    WebCore::SVGUnitTypes::SVGUnitType primitiveUnits;
+    WebCore::SVGFilterExpression expression;
+    Vector<FilterEffectData> effects;
+    std::optional<WebCore::RenderingResourceIdentifier> renderingResourceIdentifier;
+};
+
+using FilterFunctionData = Variant<SVGFilterData, FEBlendData, FEColorMatrixData, FEComponentTransferData, FECompositeData, FEConvolveMatrixData, FEDiffuseLightingData, FEDisplacementMapData, FEDropShadowData, FEFloodData, FEGaussianBlurData, FEImageData, FEMergeData, FEMorphologyData, FEOffsetData, FESpecularLightingData, FETileData, FETurbulenceData, SourceAlphaData, SourceGraphicData>;
+
+struct CSSFilterData {
+    OptionSet<WebCore::FilterRenderingMode> filterRenderingModes;
+    WebCore::FloatSize filterScale;
+    WebCore::FloatRect filterRegion;
+    Vector<FilterFunctionData> functions;
+};
+
+using FilterData = Variant<CSSFilterData, SVGFilterData>;
+
+std::optional<FilterData> serializeFilterToFilterData(WebCore::Filter&, RemoteRenderingBackendProxy&, const WebCore::DestinationColorSpace& fallbackColorSpace);
+
+RefPtr<WebCore::Filter> createFilterFromFilterData(FilterData&&, RemoteRenderingBackend&);
+
+bool isValidSVGFilterExpression(const WebCore::SVGFilterExpression&, const Vector<FilterEffectData>&);
+
+}
+
+#endif

--- a/Source/WebKit/GPUProcess/graphics/FilterData.serialization.in
+++ b/Source/WebKit/GPUProcess/graphics/FilterData.serialization.in
@@ -1,0 +1,207 @@
+
+# Copyright (C) 2025 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#if ENABLE(GPU_PROCESS)
+
+header: "FilterData.h"
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] struct WebKit::DistantLightSourceData {
+    float azimuth;
+    float elevation;
+};
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] struct WebKit::PointLightSourceData {
+    WebCore::FloatPoint3D position;
+};
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] struct WebKit::SpotLightSourceData {
+    WebCore::FloatPoint3D position;
+    WebCore::FloatPoint3D direction;
+    float specularExponent;
+    float limitingConeAngle;
+};
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] using WebKit::LightSourceData = Variant<WebKit::DistantLightSourceData, WebKit::PointLightSourceData, WebKit::SpotLightSourceData>;
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] struct WebKit::FEBlendData {
+    WebCore::BlendMode blendMode;
+    WebCore::DestinationColorSpace operatingColorSpace;
+};
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] struct WebKit::FEColorMatrixData {
+    WebCore::ColorMatrixType type;
+    Vector<float> values;
+    WebCore::DestinationColorSpace operatingColorSpace;
+};
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] struct WebKit::FEComponentTransferData {
+    WebCore::ComponentTransferFunction redFunction;
+    WebCore::ComponentTransferFunction greenFunction;
+    WebCore::ComponentTransferFunction blueFunction;
+    WebCore::ComponentTransferFunction alphaFunction;
+    WebCore::DestinationColorSpace operatingColorSpace;
+};
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] struct WebKit::FECompositeData {
+    WebCore::CompositeOperationType operation;
+    float k1;
+    float k2;
+    float k3;
+    float k4;
+    WebCore::DestinationColorSpace operatingColorSpace;
+};
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] struct WebKit::FEConvolveMatrixData {
+    [Validator='!kernelSize->isEmpty()'] WebCore::IntSize kernelSize;
+    [Validator='*divisor != 0'] float divisor;
+    float bias;
+    [Validator='WebCore::IntRect({ }, *kernelSize).contains(*targetOffset)'] WebCore::IntPoint targetOffset;
+    WebCore::EdgeModeType edgeMode;
+    [Validator='kernelUnitLength->x() > 0 && kernelUnitLength->y() > 0'] WebCore::FloatPoint kernelUnitLength;
+    bool preserveAlpha;
+    [Validator='kernelSize->area() == kernel->size()'] Vector<float> kernel;
+    WebCore::DestinationColorSpace operatingColorSpace;
+};
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] struct WebKit::FEDiffuseLightingData {
+    WebCore::Color lightingColor;
+    float surfaceScale;
+    float diffuseConstant;
+    float kernelUnitLengthX;
+    float kernelUnitLengthY;
+    WebKit::LightSourceData lightSource;
+    WebCore::DestinationColorSpace operatingColorSpace;
+};
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] struct WebKit::FEDisplacementMapData {
+    WebCore::ChannelSelectorType xChannelSelector;
+    WebCore::ChannelSelectorType yChannelSelector;
+    float scale;
+    WebCore::DestinationColorSpace operatingColorSpace;
+};
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] struct WebKit::FEDropShadowData {
+    float stdDeviationX;
+    float stdDeviationY;
+    float dx;
+    float dy;
+    WebCore::Color shadowColor;
+    float shadowOpacity;
+    WebCore::DestinationColorSpace operatingColorSpace;
+};
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] struct WebKit::FEFloodData {
+    WebCore::Color floodColor;
+    float floodOpacity;
+    WebCore::DestinationColorSpace operatingColorSpace;
+};
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] struct WebKit::FEGaussianBlurData {
+    float stdDeviationX;
+    float stdDeviationY;
+    WebCore::EdgeModeType edgeMode;
+    WebCore::DestinationColorSpace operatingColorSpace;
+};
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] struct WebKit::FEImageData {
+    WebCore::RenderingResourceIdentifier sourceImageIdentifier;
+    WebCore::FloatRect sourceImageRect;
+    WebCore::SVGPreserveAspectRatioValue preserveAspectRatio;
+};
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] struct WebKit::FEMergeData {
+    unsigned numberOfEffectInputs;
+    WebCore::DestinationColorSpace operatingColorSpace;
+};
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] struct WebKit::FEMorphologyData {
+    WebCore::MorphologyOperatorType morphologyOperator;
+    float radiusX;
+    float radiusY;
+    WebCore::DestinationColorSpace operatingColorSpace;
+};
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] struct WebKit::FEOffsetData {
+    float dx;
+    float dy;
+    WebCore::DestinationColorSpace operatingColorSpace;
+};
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] struct WebKit::FETileData {
+    WebCore::DestinationColorSpace operatingColorSpace;
+};
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] struct WebKit::FESpecularLightingData {
+    WebCore::Color lightingColor;
+    float surfaceScale;
+    float specularConstant;
+    float specularExponent;
+    float kernelUnitLengthX;
+    float kernelUnitLengthY;
+    WebKit::LightSourceData lightSource;
+    WebCore::DestinationColorSpace operatingColorSpace;
+};
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] struct WebKit::FETurbulenceData {
+    WebCore::TurbulenceType type;
+    float baseFrequencyX;
+    float baseFrequencyY;
+    int numOctaves;
+    float seed;
+    bool stitchTiles;
+    WebCore::DestinationColorSpace operatingColorSpace;
+};
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] struct WebKit::SourceAlphaData {
+    WebCore::DestinationColorSpace operatingColorSpace;
+};
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] struct WebKit::SourceGraphicData {
+    WebCore::DestinationColorSpace operatingColorSpace;
+};
+
+using WebKit::FilterEffectData = Variant<WebKit::FEBlendData, WebKit::FEColorMatrixData, WebKit::FEComponentTransferData, WebKit::FECompositeData, WebKit::FEConvolveMatrixData, WebKit::FEDiffuseLightingData, WebKit::FEDisplacementMapData, WebKit::FEDropShadowData, WebKit::FEFloodData, WebKit::FEGaussianBlurData, WebKit::FEImageData, WebKit::FEMergeData, WebKit::FEMorphologyData, WebKit::FEOffsetData, WebKit::FETileData, WebKit::FESpecularLightingData, WebKit::FETurbulenceData, WebKit::SourceAlphaData, WebKit::SourceGraphicData>;
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder, CreateWith=create] struct WebKit::SVGFilterData {
+    OptionSet<WebCore::FilterRenderingMode> filterRenderingModes;
+    WebCore::FloatSize filterScale;
+    WebCore::FloatRect filterRegion;
+    WebCore::FloatRect targetBoundingBox;
+    WebCore::SVGUnitTypes::SVGUnitType primitiveUnits;
+    WebCore::SVGFilterExpression expression;
+    [Validator='WebKit::isValidSVGFilterExpression(*expression, *effects)'] Vector<WebKit::FilterEffectData> effects;
+    std::optional<WebCore::RenderingResourceIdentifier> renderingResourceIdentifier;
+};
+
+using WebKit::FilterFunctionData = Variant<WebKit::SVGFilterData, WebKit::FEBlendData, WebKit::FEColorMatrixData, WebKit::FEComponentTransferData, WebKit::FECompositeData, WebKit::FEConvolveMatrixData, WebKit::FEDiffuseLightingData, WebKit::FEDisplacementMapData, WebKit::FEDropShadowData, WebKit::FEFloodData, WebKit::FEGaussianBlurData, WebKit::FEImageData, WebKit::FEMergeData, WebKit::FEMorphologyData, WebKit::FEOffsetData, WebKit::FESpecularLightingData, WebKit::FETileData, WebKit::FETurbulenceData, WebKit::SourceAlphaData, WebKit::SourceGraphicData>;
+
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] struct WebKit::CSSFilterData {
+    OptionSet<WebCore::FilterRenderingMode> filterRenderingModes;
+    WebCore::FloatSize filterScale;
+    WebCore::FloatRect filterRegion;
+    Vector<WebKit::FilterFunctionData> functions;
+};
+
+using WebKit::FilterData = Variant<WebKit::CSSFilterData, WebKit::SVGFilterData>;
+
+#endif

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.cpp
@@ -93,6 +93,25 @@ std::optional<SourceImage> RemoteGraphicsContext::sourceImage(RenderingResourceI
     return std::nullopt;
 }
 
+RefPtr<Filter> RemoteGraphicsContext::filter(FilterData&& filterData)
+{
+    RefPtr<Filter> filter = createFilterFromFilterData(WTFMove(filterData), m_renderingBackend);
+    if (!filter)
+        return nullptr;
+    RefPtr svgFilter = dynamicDowncast<SVGFilter>(filter);
+    if (!svgFilter || !svgFilter->hasValidRenderingResourceIdentifier())
+        return filter;
+
+    // FIXME: Filters are not immutable, each draw updates the filter instance even though
+    // they might be used for unrelated draws.
+    RefPtr cachedFilter = resourceCache().cachedFilter(filter->renderingResourceIdentifier());
+    if (!cachedFilter)
+        return nullptr;
+
+    cachedFilter->mergeEffects(svgFilter->effects());
+    return cachedFilter;
+}
+
 void RemoteGraphicsContext::save()
 {
     context().save();
@@ -332,48 +351,30 @@ void RemoteGraphicsContext::resetClip()
     context().resetClip();
 }
 
-void RemoteGraphicsContext::drawFilteredImageBufferInternal(std::optional<RenderingResourceIdentifier> sourceImageIdentifier, const FloatRect& sourceImageRect, Filter& filter, FilterResults& results)
+void RemoteGraphicsContext::drawFilteredImageBuffer(std::optional<RenderingResourceIdentifier> sourceImageIdentifier, const FloatRect& sourceImageRect, FilterData&& filterData)
 {
     RefPtr<ImageBuffer> sourceImageBuffer;
-
     if (sourceImageIdentifier) {
         sourceImageBuffer = imageBuffer(*sourceImageIdentifier);
         MESSAGE_CHECK(sourceImageBuffer);
     }
 
-    for (auto& effect : filter.effectsOfType(FilterEffect::Type::FEImage)) {
-        Ref feImage = downcast<FEImage>(effect.get());
+    RefPtr filter = this->filter(WTFMove(filterData));
+    MESSAGE_CHECK(filter);
 
-        auto effectImage = sourceImage(feImage->sourceImage().imageIdentifier());
-        MESSAGE_CHECK(effectImage);
-        feImage->setImageSource(WTFMove(*effectImage));
-    }
-
-    context().drawFilteredImageBuffer(sourceImageBuffer.get(), sourceImageRect, filter, results);
-}
-
-void RemoteGraphicsContext::drawFilteredImageBuffer(std::optional<RenderingResourceIdentifier> sourceImageIdentifier, const FloatRect& sourceImageRect, Ref<Filter>&& filter)
-{
     RefPtr svgFilter = dynamicDowncast<SVGFilter>(filter);
-
     if (!svgFilter || !svgFilter->hasValidRenderingResourceIdentifier()) {
         FilterResults results(makeUnique<ImageBufferShareableAllocator>(m_sharedResourceCache->resourceOwner()));
-        drawFilteredImageBufferInternal(sourceImageIdentifier, sourceImageRect, filter, results);
+        context().drawFilteredImageBuffer(sourceImageBuffer.get(), sourceImageRect, *filter, results);
         return;
     }
 
-    RefPtr cachedFilter = resourceCache().cachedFilter(filter->renderingResourceIdentifier());
-    RefPtr cachedSVGFilter = dynamicDowncast<SVGFilter>(WTFMove(cachedFilter));
-    MESSAGE_CHECK(cachedSVGFilter);
-
-    cachedSVGFilter->mergeEffects(svgFilter->effects());
-
-    auto& results = cachedSVGFilter->ensureResults([&]() {
+    auto& results = svgFilter->ensureResults([&]() {
         auto allocator = makeUnique<ImageBufferShareableAllocator>(m_sharedResourceCache->resourceOwner());
         return makeUnique<FilterResults>(WTFMove(allocator));
     });
 
-    drawFilteredImageBufferInternal(sourceImageIdentifier, sourceImageRect, *cachedSVGFilter, results);
+    context().drawFilteredImageBuffer(sourceImageBuffer.get(), sourceImageRect, *svgFilter, results);
 }
 
 void RemoteGraphicsContext::drawGlyphs(RenderingResourceIdentifier fontIdentifier, IPC::ArrayReferenceTuple<GlyphBufferGlyph, FloatSize> glyphsAdvances, FloatPoint localAnchor, FontSmoothingMode fontSmoothingMode)

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.h
@@ -28,6 +28,7 @@
 #if ENABLE(GPU_PROCESS)
 
 #include "ArrayReferenceTuple.h"
+#include "FilterData.h"
 #include "RemoteDisplayListIdentifier.h"
 #include "RemoteGradientIdentifier.h"
 #include "RemoteGraphicsContextIdentifier.h"
@@ -96,7 +97,7 @@ public:
     void resetClip();
     void drawGlyphs(WebCore::RenderingResourceIdentifier fontIdentifier, IPC::ArrayReferenceTuple<WebCore::GlyphBufferGlyph, WebCore::FloatSize>, WebCore::FloatPoint localAnchor, WebCore::FontSmoothingMode);
     void drawDisplayList(RemoteDisplayListIdentifier);
-    void drawFilteredImageBuffer(std::optional<WebCore::RenderingResourceIdentifier> sourceImageIdentifier, const WebCore::FloatRect& sourceImageRect, Ref<WebCore::Filter>&&);
+    void drawFilteredImageBuffer(std::optional<WebCore::RenderingResourceIdentifier> sourceImageIdentifier, const WebCore::FloatRect& sourceImageRect, FilterData&&);
     void drawImageBuffer(WebCore::RenderingResourceIdentifier imageBufferIdentifier, const WebCore::FloatRect& destinationRect, const WebCore::FloatRect& srcRect, WebCore::ImagePaintingOptions);
     void drawNativeImage(WebCore::RenderingResourceIdentifier imageIdentifier, const WebCore::FloatRect& destRect, const WebCore::FloatRect& srcRect, WebCore::ImagePaintingOptions);
     void drawSystemImage(Ref<WebCore::SystemImage>&&, const WebCore::FloatRect&);
@@ -164,12 +165,11 @@ protected:
 
     Ref<WebCore::ControlFactory> controlFactory();
 
-    void drawFilteredImageBufferInternal(std::optional<WebCore::RenderingResourceIdentifier> sourceImageIdentifier, const WebCore::FloatRect& sourceImageRect, WebCore::Filter&, WebCore::FilterResults&);
-
     RemoteResourceCache& resourceCache() const;
     WebCore::GraphicsContext& context() { return m_context; }
     RefPtr<WebCore::ImageBuffer> imageBuffer(WebCore::RenderingResourceIdentifier) const;
     std::optional<WebCore::SourceImage> sourceImage(WebCore::RenderingResourceIdentifier) const;
+    RefPtr<WebCore::Filter> filter(FilterData&&);
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.messages.in
@@ -74,7 +74,7 @@ messages -> RemoteGraphicsContext Stream {
     ResetClip()
     DrawGlyphs(WebCore::RenderingResourceIdentifier fontIdentifier, IPC::ArrayReferenceTuple<WebCore::GlyphBufferGlyph, WebCore::FloatSize> glyphsAdvances, WebCore::FloatPoint localAnchor, enum:uint8_t WebCore::FontSmoothingMode smoothingMode)
     DrawDisplayList(WebKit::RemoteDisplayListIdentifier identifier)
-    DrawFilteredImageBuffer(std::optional<WebCore::RenderingResourceIdentifier> sourceImageIdentifier, WebCore::FloatRect sourceImageRect, Ref<WebCore::Filter> filter)
+    DrawFilteredImageBuffer(std::optional<WebCore::RenderingResourceIdentifier> sourceImageIdentifier, WebCore::FloatRect sourceImageRect, WebKit::FilterData filter)
     DrawImageBuffer(WebCore::RenderingResourceIdentifier imageBufferIdentifier, WebCore::FloatRect destinationRect, WebCore::FloatRect srcRect, struct WebCore::ImagePaintingOptions options)
     DrawNativeImage(WebCore::RenderingResourceIdentifier imageIdentifier, WebCore::FloatRect destRect, WebCore::FloatRect srcRect, struct WebCore::ImagePaintingOptions options)
     DrawSystemImage(Ref<WebCore::SystemImage> systemImage, WebCore::FloatRect destinationRect)

--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.cpp
@@ -157,12 +157,16 @@ void RemoteImageBuffer::getShareableBitmap(WebCore::PreserveResolution preserveR
     completionHandler(WTFMove(handle));
 }
 
-void RemoteImageBuffer::filteredNativeImage(Ref<WebCore::Filter> filter, CompletionHandler<void(std::optional<WebCore::ShareableBitmap::Handle>&&)>&& completionHandler)
+void RemoteImageBuffer::filteredNativeImage(FilterData&& filterData, CompletionHandler<void(std::optional<WebCore::ShareableBitmap::Handle>&&)>&& completionHandler)
 {
     assertIsCurrent(workQueue());
+    RefPtr<Filter> filter = createFilterFromFilterData(WTFMove(filterData), m_renderingBackend);
+    if (RefPtr svgFilter = dynamicDowncast<SVGFilter>(filter); svgFilter && svgFilter->hasValidRenderingResourceIdentifier())
+        filter = m_renderingBackend->remoteResourceCache().cachedFilter(filter->renderingResourceIdentifier());
+    MESSAGE_CHECK(filter, "Invalid filter.");
     std::optional<WebCore::ShareableBitmap::Handle> handle = [&]() -> std::optional<WebCore::ShareableBitmap::Handle> {
         Ref imageBuffer = m_imageBuffer;
-        auto image = imageBuffer->filteredNativeImage(filter);
+        auto image = imageBuffer->filteredNativeImage(*filter);
         if (!image)
             return std::nullopt;
         auto imageSize = image->size();

--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(GPU_PROCESS)
 
+#include "FilterData.h"
 #include "IPCEvent.h"
 #include "RemoteGraphicsContextIdentifier.h"
 #include "ScopedActiveMessageReceiveQueue.h"
@@ -70,7 +71,7 @@ private:
     void getPixelBufferWithNewMemory(WebCore::SharedMemory::Handle&&, WebCore::PixelBufferFormat, WebCore::IntPoint srcPoint, WebCore::IntSize srcSize, CompletionHandler<void()>&&);
     void putPixelBuffer(const WebCore::PixelBufferSourceView&, WebCore::IntPoint srcPoint, WebCore::IntSize srcSize, WebCore::IntPoint destPoint, WebCore::AlphaPremultiplication destFormat);
     void getShareableBitmap(WebCore::PreserveResolution, CompletionHandler<void(std::optional<WebCore::ShareableBitmap::Handle>&&)>&&);
-    void filteredNativeImage(Ref<WebCore::Filter>, CompletionHandler<void(std::optional<WebCore::ShareableBitmap::Handle>&&)>&&);
+    void filteredNativeImage(WebKit::FilterData&&, CompletionHandler<void(std::optional<WebCore::ShareableBitmap::Handle>&&)>&&);
     void convertToLuminanceMask();
     void transformToColorSpace(const WebCore::DestinationColorSpace&);
     void flushContext();

--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.messages.in
@@ -33,7 +33,7 @@ messages -> RemoteImageBuffer Stream {
     GetPixelBufferWithNewMemory(WebCore::SharedMemory::Handle handle, struct WebCore::PixelBufferFormat outputFormat, WebCore::IntPoint srcPoint, WebCore::IntSize srcSize) -> () Synchronous NotStreamEncodable
     PutPixelBuffer(WebCore::PixelBufferSourceView pixelBuffer, WebCore::IntPoint srcPoint, WebCore::IntSize srcSize, WebCore::IntPoint destPoint, enum:uint8_t WebCore::AlphaPremultiplication destFormat) StreamBatched
     GetShareableBitmap(enum:bool WebCore::PreserveResolution preserveResolution) -> (std::optional<WebCore::ShareableBitmapHandle> handle) Synchronous NotStreamEncodableReply
-    FilteredNativeImage(Ref<WebCore::Filter> filter) -> (std::optional<WebCore::ShareableBitmapHandle> handle) Synchronous NotStreamEncodableReply
+    FilteredNativeImage(WebKit::FilterData filter) -> (std::optional<WebCore::ShareableBitmapHandle> handle) Synchronous NotStreamEncodableReply
     ConvertToLuminanceMask()
     TransformToColorSpace(WebCore::DestinationColorSpace colorSpace)
     FlushContext()

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
@@ -29,6 +29,7 @@
 #if ENABLE(GPU_PROCESS)
 
 #include "BufferIdentifierSet.h"
+#include "FilterData.h"
 #include "GPUConnectionToWebProcess.h"
 #include "GPUProcess.h"
 #include "GPUProcessProxyMessages.h"
@@ -413,13 +414,14 @@ void RemoteRenderingBackend::releaseGradient(RemoteGradientIdentifier identifier
 }
 
 
-void RemoteRenderingBackend::cacheFilter(Ref<Filter>&& filter)
+void RemoteRenderingBackend::cacheFilter(FilterData&& filterData)
 {
-    ASSERT(!RunLoop::isMain());
-    if (filter->hasValidRenderingResourceIdentifier())
-        m_remoteResourceCache.cacheFilter(WTFMove(filter));
-    else
-        LOG_WITH_STREAM(DisplayLists, stream << "Received a Filter without a valid resource identifier");
+    assertIsCurrent(workQueue());
+    RefPtr<Filter> filter = createFilterFromFilterData(WTFMove(filterData), *this);
+    RefPtr<SVGFilter> svgFilter = dynamicDowncast<SVGFilter>(filter);
+    MESSAGE_CHECK(svgFilter && svgFilter->hasValidRenderingResourceIdentifier(), "Invalid filter.");
+    bool success = m_remoteResourceCache.cacheFilter(svgFilter.releaseNonNull());
+    MESSAGE_CHECK(success, "Filter already cached.");
 }
 
 void RemoteRenderingBackend::releaseFilter(RenderingResourceIdentifier identifier)

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
@@ -29,6 +29,7 @@
 
 #include "BufferIdentifierSet.h"
 #include "Connection.h"
+#include "FilterData.h"
 #include "IPCEvent.h"
 #include "ImageBufferBackendHandle.h"
 #include "MarkSurfacesAsVolatileRequestIdentifier.h"
@@ -161,7 +162,7 @@ private:
     void releaseNativeImage(WebCore::RenderingResourceIdentifier);
     void cacheGradient(Ref<WebCore::Gradient>&&, RemoteGradientIdentifier);
     void releaseGradient(RemoteGradientIdentifier);
-    void cacheFilter(Ref<WebCore::Filter>&&);
+    void cacheFilter(FilterData&&);
     void releaseFilter(WebCore::RenderingResourceIdentifier);
     void cacheFont(const WebCore::Font::Attributes&, WebCore::FontPlatformDataAttributes, std::optional<WebCore::RenderingResourceIdentifier>);
     void releaseFont(WebCore::RenderingResourceIdentifier);

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in
@@ -43,7 +43,7 @@ messages -> RemoteRenderingBackend Stream {
     ReleaseFontCustomPlatformData(WebCore::RenderingResourceIdentifier identifier)
     CacheGradient(Ref<WebCore::Gradient> gradient, WebKit::RemoteGradientIdentifier identifier)
     ReleaseGradient(WebKit::RemoteGradientIdentifier identifier)
-    CacheFilter(Ref<WebCore::Filter> filter) NotStreamEncodable
+    CacheFilter(WebKit::FilterData filter)
     ReleaseFilter(WebCore::RenderingResourceIdentifier identifier)
     ReleaseMemory()
     ReleaseNativeImages()

--- a/Source/WebKit/GPUProcess/graphics/RemoteResourceCache.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteResourceCache.cpp
@@ -73,10 +73,10 @@ RefPtr<Gradient> RemoteResourceCache::cachedGradient(RemoteGradientIdentifier id
     return m_gradients.get(identifier);
 }
 
-void RemoteResourceCache::cacheFilter(Ref<Filter>&& filter)
+bool RemoteResourceCache::cacheFilter(Ref<SVGFilter>&& filter)
 {
     auto identifier = filter->renderingResourceIdentifier();
-    m_filters.add(identifier, WTFMove(filter));
+    return m_filters.add(identifier, WTFMove(filter)).isNewEntry;
 }
 
 bool RemoteResourceCache::releaseFilter(RenderingResourceIdentifier identifier)
@@ -84,7 +84,7 @@ bool RemoteResourceCache::releaseFilter(RenderingResourceIdentifier identifier)
     return m_filters.remove(identifier);
 }
 
-RefPtr<Filter> RemoteResourceCache::cachedFilter(RenderingResourceIdentifier identifier) const
+RefPtr<SVGFilter> RemoteResourceCache::cachedFilter(RenderingResourceIdentifier identifier) const
 {
     return m_filters.get(identifier);
 }

--- a/Source/WebKit/GPUProcess/graphics/RemoteResourceCache.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteResourceCache.h
@@ -36,7 +36,7 @@
 
 namespace WebCore {
 
-class Filter;
+class SVGFilter;
 class Font;
 class Gradient;
 class ImageBuffer;
@@ -60,9 +60,9 @@ public:
     bool releaseGradient(RemoteGradientIdentifier);
     RefPtr<WebCore::Gradient> cachedGradient(RemoteGradientIdentifier) const;
 
-    void cacheFilter(Ref<WebCore::Filter>&&);
+    bool cacheFilter(Ref<WebCore::SVGFilter>&&);
     bool releaseFilter(WebCore::RenderingResourceIdentifier);
-    RefPtr<WebCore::Filter> cachedFilter(WebCore::RenderingResourceIdentifier) const;
+    RefPtr<WebCore::SVGFilter> cachedFilter(WebCore::RenderingResourceIdentifier) const;
 
     void cacheFont(Ref<WebCore::Font>&&);
     bool releaseFont(WebCore::RenderingResourceIdentifier);
@@ -84,7 +84,7 @@ private:
     HashMap<WebCore::RenderingResourceIdentifier, Ref<WebCore::ImageBuffer>> m_imageBuffers;
     HashMap<WebCore::RenderingResourceIdentifier, Ref<WebCore::NativeImage>> m_nativeImages;
     HashMap<RemoteGradientIdentifier, Ref<WebCore::Gradient>> m_gradients;
-    HashMap<WebCore::RenderingResourceIdentifier, Ref<WebCore::Filter>> m_filters;
+    HashMap<WebCore::RenderingResourceIdentifier, Ref<WebCore::SVGFilter>> m_filters;
     HashMap<WebCore::RenderingResourceIdentifier, Ref<WebCore::Font>> m_fonts;
     HashMap<WebCore::RenderingResourceIdentifier, Ref<WebCore::FontCustomPlatformData>> m_fontCustomPlatformDatas;
     HashMap<RemoteDisplayListIdentifier, Ref<const WebCore::DisplayList::DisplayList>> m_displayLists;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.cpp
@@ -34,6 +34,7 @@
 #include "StreamServerConnection.h"
 #include "WebGPUObjectHeap.h"
 #include <WebCore/WebGPUCompositorIntegration.h>
+#include <WebCore/WebGPUDevice.h>
 #include <wtf/TZoneMallocInlines.h>
 
 #define MESSAGE_CHECK_COMPLETION(assertion, completion) MESSAGE_CHECK_COMPLETION_BASE(assertion, m_streamConnection, completion)

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -598,6 +598,7 @@ def types_that_cannot_be_forward_declared():
         'WebKit::EditorStateIdentifier',
         'WebKit::FileSystemStorageError',
         'WebKit::FileSystemSyncAccessHandleInfo',
+        'WebKit::FilterData',
         'WebKit::FocusedElementInformation',
         'WebKit::GPUProcessConnectionInfo',
         'WebKit::LayerHostingContextID',

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -4051,35 +4051,6 @@ enum class WebCore::ApplePayButtonStyle : uint8_t {
     [Validator='progress >= 0.0f && progress <= 1.0f'] float progress();
 };
 
-[RefCounted, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DistantLightSource {
-    float azimuth();
-    float elevation();
-};
-
-[RefCounted, AdditionalEncoder=StreamConnectionEncoder] class WebCore::PointLightSource {
-    WebCore::FloatPoint3D position();
-};
-
-[RefCounted, AdditionalEncoder=StreamConnectionEncoder] class WebCore::SpotLightSource {
-    WebCore::FloatPoint3D position();
-    WebCore::FloatPoint3D direction();
-    float specularExponent();
-    float limitingConeAngle();
-};
-
-[RefCounted, AdditionalEncoder=StreamConnectionEncoder] class WebCore::FEBlend {
-    WebCore::BlendMode blendMode();
-
-    WebCore::DestinationColorSpace operatingColorSpace();
-};
-
-[RefCounted, AdditionalEncoder=StreamConnectionEncoder] class WebCore::FEColorMatrix {
-    WebCore::ColorMatrixType type();
-    Vector<float> values();
-
-    WebCore::DestinationColorSpace operatingColorSpace();
-};
-
 header: <WebCore/FEComponentTransfer.h>
 [CustomHeader, AdditionalEncoder=StreamConnectionEncoder] struct WebCore::ComponentTransferFunction {
     WebCore::ComponentTransferType type;
@@ -4090,145 +4061,6 @@ header: <WebCore/FEComponentTransfer.h>
     float offset;
     Vector<float> tableValues;
 };
-
-[RefCounted, AdditionalEncoder=StreamConnectionEncoder] class WebCore::FEComponentTransfer {
-    WebCore::ComponentTransferFunction redFunction();
-    WebCore::ComponentTransferFunction greenFunction();
-    WebCore::ComponentTransferFunction blueFunction();
-    WebCore::ComponentTransferFunction alphaFunction();
-
-    WebCore::DestinationColorSpace operatingColorSpace();
-};
-
-[RefCounted, AdditionalEncoder=StreamConnectionEncoder] class WebCore::FEComposite {
-    WebCore::CompositeOperationType operation();
-    float k1();
-    float k2();
-    float k3();
-    float k4();
-
-    WebCore::DestinationColorSpace operatingColorSpace();
-};
-
-[RefCounted, AdditionalEncoder=StreamConnectionEncoder] class WebCore::FEConvolveMatrix {
-    [Validator='!kernelSize->isEmpty()'] WebCore::IntSize kernelSize();
-    [Validator='*divisor != 0'] float divisor();
-    float bias();
-    [Validator='WebCore::IntRect({ }, *kernelSize).contains(*targetOffset)'] WebCore::IntPoint targetOffset();
-    WebCore::EdgeModeType edgeMode();
-    [Validator='kernelUnitLength->x() > 0 && kernelUnitLength->y() > 0'] WebCore::FloatPoint kernelUnitLength();
-    bool preserveAlpha();
-    [Validator='kernelSize->area() == kernel->size()'] Vector<float> kernel();
-
-    WebCore::DestinationColorSpace operatingColorSpace();
-};
-
-[RefCounted, AdditionalEncoder=StreamConnectionEncoder] class WebCore::FEDiffuseLighting {
-    WebCore::Color lightingColor();
-    float surfaceScale();
-    float diffuseConstant();
-    float kernelUnitLengthX();
-    float kernelUnitLengthY();
-    WebCore::LightSource lightSource();
-
-    WebCore::DestinationColorSpace operatingColorSpace();
-};
-
-[RefCounted, AdditionalEncoder=StreamConnectionEncoder] class WebCore::FEDisplacementMap {
-    WebCore::ChannelSelectorType xChannelSelector();
-    WebCore::ChannelSelectorType yChannelSelector();
-    float scale();
-
-    WebCore::DestinationColorSpace operatingColorSpace();
-};
-
-[RefCounted, AdditionalEncoder=StreamConnectionEncoder] class WebCore::FEDropShadow {
-    float stdDeviationX();
-    float stdDeviationY();
-    float dx();
-    float dy();
-    WebCore::Color shadowColor();
-    float shadowOpacity()
-
-    WebCore::DestinationColorSpace operatingColorSpace();
-};
-
-[RefCounted, AdditionalEncoder=StreamConnectionEncoder] class WebCore::FEFlood {
-    WebCore::Color floodColor();
-    float floodOpacity();
-
-    WebCore::DestinationColorSpace operatingColorSpace();
-};
-
-[RefCounted, AdditionalEncoder=StreamConnectionEncoder] class WebCore::FEGaussianBlur {
-    float stdDeviationX();
-    float stdDeviationY();
-    WebCore::EdgeModeType edgeMode();
-
-    WebCore::DestinationColorSpace operatingColorSpace();
-};
-
-[RefCounted, AdditionalEncoder=StreamConnectionEncoder] class WebCore::FEImage {
-    WebCore::SourceImage sourceImage();
-    WebCore::FloatRect sourceImageRect();
-    WebCore::SVGPreserveAspectRatioValue preserveAspectRatio();
-};
-
-[RefCounted, AdditionalEncoder=StreamConnectionEncoder] class WebCore::FEMerge {
-    unsigned numberOfEffectInputs();
-
-    WebCore::DestinationColorSpace operatingColorSpace();
-};
-
-[RefCounted, AdditionalEncoder=StreamConnectionEncoder] class WebCore::FEMorphology {
-    WebCore::MorphologyOperatorType morphologyOperator();
-    float radiusX();
-    float radiusY();
-
-    WebCore::DestinationColorSpace operatingColorSpace();
-};
-
-[RefCounted, AdditionalEncoder=StreamConnectionEncoder] class WebCore::FEOffset {
-    float dx();
-    float dy();
-
-    WebCore::DestinationColorSpace operatingColorSpace();
-};
-
-[RefCounted, AdditionalEncoder=StreamConnectionEncoder] class WebCore::FETile {
-    WebCore::DestinationColorSpace operatingColorSpace();
-}
-
-[RefCounted, AdditionalEncoder=StreamConnectionEncoder] class WebCore::FESpecularLighting {
-    WebCore::Color lightingColor();
-    float surfaceScale();
-    float specularConstant();
-    float specularExponent();
-    float kernelUnitLengthX();
-    float kernelUnitLengthY();
-    WebCore::LightSource lightSource();
-
-    WebCore::DestinationColorSpace operatingColorSpace();
-};
-
-[RefCounted, AdditionalEncoder=StreamConnectionEncoder] class WebCore::FETurbulence {
-    WebCore::TurbulenceType type();
-    float baseFrequencyX();
-    float baseFrequencyY();
-    int numOctaves();
-    float seed();
-    bool stitchTiles();
-
-    WebCore::DestinationColorSpace operatingColorSpace();
-};
-
-[RefCounted, AdditionalEncoder=StreamConnectionEncoder] class WebCore::SourceAlpha {
-    WebCore::DestinationColorSpace operatingColorSpace();
-}
-
-[RefCounted, AdditionalEncoder=StreamConnectionEncoder] class WebCore::SourceGraphic {
-    WebCore::DestinationColorSpace operatingColorSpace();
-}
 
 [Nested, OptionSet] enum class WebCore::FilterEffectGeometry::Flags : uint8_t {
     HasX,
@@ -7912,31 +7744,6 @@ class WebCore::FilterOperations {
 }
 #endif // !USE(COORDINATED_GRAPHICS)
 
-[AdditionalEncoder=StreamConnectionEncoder, RefCounted] class WebCore::Filter subclasses {
-    WebCore::CSSFilter
-    WebCore::SVGFilter
-}
-
-[AdditionalEncoder=StreamConnectionEncoder, RefCounted] class WebCore::CSSFilter {
-    Vector<Ref<WebCore::FilterFunction>> functions();
-
-    OptionSet<WebCore::FilterRenderingMode> filterRenderingModes();
-    WebCore::FloatSize filterScale();
-    WebCore::FloatRect filterRegion();
-}
-
-[AdditionalEncoder=StreamConnectionEncoder, RefCounted] class WebCore::SVGFilter {
-    WebCore::FloatRect targetBoundingBox();
-    WebCore::SVGUnitTypes::SVGUnitType primitiveUnits();
-    WebCore::SVGFilterExpression expression();
-    [Validator='WebCore::SVGFilter::isValidSVGFilterExpression(*expression, *effects)'] Vector<Ref<WebCore::FilterEffect>> effects();
-    std::optional<WebCore::RenderingResourceIdentifier> renderingResourceIdentifierIfExists();
-
-    OptionSet<WebCore::FilterRenderingMode> filterRenderingModes();
-    WebCore::FloatSize filterScale();
-    WebCore::FloatRect filterRegion();
-}
-
 [Nested] enum class WebCore::UserStyleLevel : bool;
 
 header: <WebCore/WheelEventTestMonitor.h>
@@ -8296,28 +8103,6 @@ header: <WebCore/SharedBuffer.h>
 };
 #endif // !USE(COORDINATED_GRAPHICS)
 
-[AdditionalEncoder=StreamConnectionEncoder, RefCounted] class WebCore::FilterEffect subclasses {
-    WebCore::FEBlend
-    WebCore::FEColorMatrix
-    WebCore::FEComponentTransfer
-    WebCore::FEComposite
-    WebCore::FEConvolveMatrix
-    WebCore::FEDiffuseLighting
-    WebCore::FEDisplacementMap
-    WebCore::FEDropShadow
-    WebCore::FEFlood
-    WebCore::FEGaussianBlur
-    WebCore::FEImage
-    WebCore::FEMerge
-    WebCore::FEMorphology
-    WebCore::FEOffset
-    WebCore::FETile
-    WebCore::FESpecularLighting
-    WebCore::FETurbulence
-    WebCore::SourceAlpha
-    WebCore::SourceGraphic
-}
-
 #if HAVE(CORE_MATERIAL)
 
 header: <WebCore/AppleVisualEffect.h>
@@ -8437,12 +8222,6 @@ header: <WebCore/DOMCacheEngine.h>
     uint64_t responseBodySize;
 };
 
-[AdditionalEncoder=StreamConnectionEncoder, RefCounted] class WebCore::LightSource subclasses {
-    WebCore::DistantLightSource
-    WebCore::PointLightSource
-    WebCore::SpotLightSource
-}
-
 enum class WebCore::WindowProxyProperty : uint8_t {
     Other,
     Closed,
@@ -8501,29 +8280,6 @@ struct WebCore::Length {
 };
 [Nested] struct WebCore::Length::UndefinedData {
 };
-
-[AdditionalEncoder=StreamConnectionEncoder, RefCounted] class WebCore::FilterFunction subclasses {
-    WebCore::SVGFilter
-    WebCore::FEBlend
-    WebCore::FEColorMatrix
-    WebCore::FEComponentTransfer
-    WebCore::FEComposite
-    WebCore::FEConvolveMatrix
-    WebCore::FEDiffuseLighting
-    WebCore::FEDisplacementMap
-    WebCore::FEDropShadow
-    WebCore::FEFlood
-    WebCore::FEGaussianBlur
-    WebCore::FEImage
-    WebCore::FEMerge
-    WebCore::FEMorphology
-    WebCore::FEOffset
-    WebCore::FESpecularLighting
-    WebCore::FETile
-    WebCore::FETurbulence
-    WebCore::SourceAlpha
-    WebCore::SourceGraphic
-}
 
 struct WebCore::OrganizationStorageAccessPromptQuirk {
     String organizationName;

--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -29,6 +29,7 @@ GPUProcess/ShapeDetection/RemoteBarcodeDetector.cpp
 GPUProcess/ShapeDetection/RemoteFaceDetector.cpp
 GPUProcess/ShapeDetection/RemoteTextDetector.cpp
 GPUProcess/ShapeDetection/ShapeDetectionObjectHeap.cpp
+GPUProcess/graphics/FilterData.cpp
 GPUProcess/graphics/ImageBufferShareableAllocator.cpp
 GPUProcess/graphics/RemoteDisplayListRecorder.cpp
 GPUProcess/graphics/RemoteGraphicsContext.cpp

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -6757,6 +6757,8 @@
 		7B73123725CC8524003B2796 /* StreamServerConnection.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StreamServerConnection.cpp; sourceTree = "<group>"; };
 		7B73123825CC8524003B2796 /* StreamServerConnection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StreamServerConnection.h; sourceTree = "<group>"; };
 		7B73123925CC8525003B2796 /* StreamConnectionEncoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StreamConnectionEncoder.h; sourceTree = "<group>"; };
+		7B73C1B52E78633E00675366 /* FilterData.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FilterData.h; sourceTree = "<group>"; };
+		7B73C1B62E78633E00675366 /* FilterData.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = FilterData.cpp; sourceTree = "<group>"; };
 		7B8679072C2D3D9D00268208 /* GPUProcessConnectionIdentifier.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GPUProcessConnectionIdentifier.h; sourceTree = "<group>"; };
 		7B904165254AFDEA006EEB8C /* RemoteGraphicsContextGLProxy.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteGraphicsContextGLProxy.cpp; sourceTree = "<group>"; };
 		7B904166254AFDEB006EEB8C /* RemoteGraphicsContextGLProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteGraphicsContextGLProxy.h; sourceTree = "<group>"; };
@@ -13502,6 +13504,8 @@
 			isa = PBXGroup;
 			children = (
 				1C98C01C27446926002CCB78 /* WebGPU */,
+				7B73C1B62E78633E00675366 /* FilterData.cpp */,
+				7B73C1B52E78633E00675366 /* FilterData.h */,
 				724DCF22284862FC0026ACF4 /* ImageBufferShareableAllocator.cpp */,
 				724DCF21284862FC0026ACF4 /* ImageBufferShareableAllocator.h */,
 				723C90A22A377AB400038126 /* PathSegment.serialization.in */,

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.cpp
@@ -238,17 +238,11 @@ void RemoteGraphicsContextProxy::drawFilteredImageBuffer(ImageBuffer* sourceImag
 {
     appendStateChangeItemIfNecessary();
 
-    for (auto& effect : filter.effectsOfType(FilterEffect::Type::FEImage)) {
-        Ref feImage = downcast<FEImage>(effect.get());
-        if (!recordResourceUse(feImage->sourceImage())) {
-            GraphicsContext::drawFilteredImageBuffer(sourceImage, sourceImageRect, filter, results);
-            return;
-        }
+    auto filterData = recordResourceUse(filter);
+    if (!filterData) {
+        GraphicsContext::drawFilteredImageBuffer(sourceImage, sourceImageRect, filter, results);
+        return;
     }
-
-    RefPtr svgFilter = dynamicDowncast<SVGFilter>(filter);
-    if (svgFilter && svgFilter->hasValidRenderingResourceIdentifier())
-        recordResourceUse(filter);
 
     std::optional<RenderingResourceIdentifier> identifier;
     if (sourceImage) {
@@ -259,7 +253,7 @@ void RemoteGraphicsContextProxy::drawFilteredImageBuffer(ImageBuffer* sourceImag
         identifier = sourceImage->renderingResourceIdentifier();
     }
 
-    send(Messages::RemoteGraphicsContext::DrawFilteredImageBuffer(WTFMove(identifier), sourceImageRect, filter));
+    send(Messages::RemoteGraphicsContext::DrawFilteredImageBuffer(WTFMove(identifier), sourceImageRect, *filterData));
 }
 
 void RemoteGraphicsContextProxy::drawGlyphs(const Font& font, std::span<const GlyphBufferGlyph> glyphs, std::span<const GlyphBufferAdvance> advances, const FloatPoint& localAnchor, FontSmoothingMode smoothingMode)
@@ -704,16 +698,15 @@ std::optional<RemoteGradientIdentifier> RemoteGraphicsContextProxy::recordResour
     return renderingBackend->remoteResourceCacheProxy().recordGradientUse(gradient);
 }
 
-bool RemoteGraphicsContextProxy::recordResourceUse(Filter& filter)
+std::optional<FilterData> RemoteGraphicsContextProxy::recordResourceUse(Filter& filter)
 {
     RefPtr renderingBackend = m_renderingBackend.get();
     if (!renderingBackend) [[unlikely]] {
         ASSERT_NOT_REACHED();
-        return false;
+        return std::nullopt;
     }
-
-    renderingBackend->remoteResourceCacheProxy().recordFilterUse(filter);
-    return true;
+    // FIXME: The fallback is incorrect.
+    return renderingBackend->remoteResourceCacheProxy().recordFilterUse(filter, DestinationColorSpace::SRGB());
 }
 
 std::optional<RemoteDisplayListIdentifier> RemoteGraphicsContextProxy::recordResourceUse(const DisplayList::DisplayList& displayList)

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(GPU_PROCESS)
 
+#include "FilterData.h"
 #include "RemoteDisplayListIdentifier.h"
 #include "RemoteGradientIdentifier.h"
 #include "RemoteGraphicsContextIdentifier.h"
@@ -147,7 +148,7 @@ private:
     bool recordResourceUse(const WebCore::SourceImage&);
     bool recordResourceUse(WebCore::Font&);
     std::optional<RemoteGradientIdentifier> recordResourceUse(WebCore::Gradient&);
-    bool recordResourceUse(WebCore::Filter&);
+    std::optional<FilterData> recordResourceUse(WebCore::Filter&);
     std::optional<RemoteDisplayListIdentifier> recordResourceUse(const WebCore::DisplayList::DisplayList&);
 
     // Synchronizes draw state.

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp
@@ -260,17 +260,22 @@ RefPtr<ImageBuffer> RemoteImageBufferProxy::sinkIntoBufferForDifferentThread()
 
 RefPtr<NativeImage> RemoteImageBufferProxy::filteredNativeImage(Filter& filter)
 {
-    if (!m_renderingBackend) [[unlikely]]
+    RefPtr renderingBackend = m_renderingBackend.get();
+    if (!renderingBackend) [[unlikely]]
         return nullptr;
-    auto sendResult = sendSync(Messages::RemoteImageBuffer::FilteredNativeImage(filter));
-    if (!sendResult.succeeded())
+    // FIXME: The fallback is incorrect.
+    auto filterData = renderingBackend->remoteResourceCacheProxy().recordFilterUse(filter, DestinationColorSpace::SRGB());
+    if (!filterData) [[unlikely]]
+        return nullptr;
+    auto sendResult = sendSync(Messages::RemoteImageBuffer::FilteredNativeImage(*filterData));
+    if (!sendResult.succeeded()) [[unlikely]]
         return nullptr;
     auto [handle] = sendResult.takeReply();
-    if (!handle)
+    if (!handle) [[unlikely]]
         return nullptr;
     handle->takeOwnershipOfMemory(MemoryLedger::Graphics);
     auto bitmap = ShareableBitmap::create(WTFMove(*handle));
-    if (!bitmap)
+    if (!bitmap) [[unlikely]]
         return nullptr;
     return NativeImage::create(bitmap->createPlatformImage(DontCopyBackingStore, ShouldInterpolate::No));
 }

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
@@ -450,9 +450,9 @@ void RemoteRenderingBackendProxy::releaseGradient(RemoteGradientIdentifier ident
     send(Messages::RemoteRenderingBackend::ReleaseGradient(identifier));
 }
 
-void RemoteRenderingBackendProxy::cacheFilter(Ref<Filter>&& filter)
+void RemoteRenderingBackendProxy::cacheFilter(const FilterData& filter)
 {
-    send(Messages::RemoteRenderingBackend::CacheFilter(WTFMove(filter)));
+    send(Messages::RemoteRenderingBackend::CacheFilter(filter));
 }
 
 void RemoteRenderingBackendProxy::releaseFilter(RenderingResourceIdentifier identifier)

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
@@ -116,7 +116,7 @@ public:
     void releaseFontCustomPlatformData(WebCore::RenderingResourceIdentifier);
     void cacheGradient(Ref<WebCore::Gradient>&&, RemoteGradientIdentifier);
     void releaseGradient(RemoteGradientIdentifier);
-    void cacheFilter(Ref<WebCore::Filter>&&);
+    void cacheFilter(const FilterData&);
     void releaseFilter(WebCore::RenderingResourceIdentifier);
     void cacheDisplayList(RemoteDisplayListIdentifier, const WebCore::DisplayList::DisplayList&);
     void releaseDisplayList(RemoteDisplayListIdentifier);

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp
@@ -61,12 +61,21 @@ RemoteGradientIdentifier RemoteResourceCacheProxy::recordGradientUse(Gradient& g
     return identifier;
 }
 
-void RemoteResourceCacheProxy::recordFilterUse(Filter& filter)
+std::optional<FilterData> RemoteResourceCacheProxy::recordFilterUse(Filter& filter, const DestinationColorSpace& fallbackColorSpace)
 {
-    if (m_filters.add(filter.renderingResourceIdentifier()).isNewEntry) {
-        filter.addObserver(m_resourceObserverWeakFactory.createWeakPtr(static_cast<RenderingResourceObserver&>(*this)).releaseNonNull());
-        m_remoteRenderingBackendProxy->cacheFilter(filter);
+    auto filterData = serializeFilterToFilterData(filter, m_remoteRenderingBackendProxy, fallbackColorSpace);
+    if (!filterData)
+        return std::nullopt;
+
+    RefPtr svgFilter = dynamicDowncast<SVGFilter>(filter);
+    if (svgFilter && svgFilter->hasValidRenderingResourceIdentifier())
+        return filterData;
+
+    if (m_filters.add(svgFilter->renderingResourceIdentifier()).isNewEntry) {
+        svgFilter->addObserver(m_resourceObserverWeakFactory.createWeakPtr(static_cast<RenderingResourceObserver&>(*this)).releaseNonNull());
+        m_remoteRenderingBackendProxy->cacheFilter(*filterData);
     }
+    return filterData;
 }
 
 void RemoteResourceCacheProxy::recordNativeImageUse(NativeImage& image, const DestinationColorSpace& colorSpace)

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(GPU_PROCESS)
 
+#include "FilterData.h"
 #include "RemoteDisplayListIdentifier.h"
 #include "RemoteGradientIdentifier.h"
 #include "RenderingUpdateID.h"
@@ -57,10 +58,10 @@ public:
     RemoteResourceCacheProxy(RemoteRenderingBackendProxy&);
     ~RemoteResourceCacheProxy();
 
-    void recordNativeImageUse(WebCore::NativeImage&, const WebCore::DestinationColorSpace&);
+    void recordNativeImageUse(WebCore::NativeImage&, const WebCore::DestinationColorSpace& fallbackColorSpace);
     void recordFontUse(WebCore::Font&);
     RemoteGradientIdentifier recordGradientUse(WebCore::Gradient&);
-    void recordFilterUse(WebCore::Filter&);
+    std::optional<FilterData> recordFilterUse(WebCore::Filter&, const WebCore::DestinationColorSpace& fallbackColorSpace);
     void recordFontCustomPlatformDataUse(const WebCore::FontCustomPlatformData&);
     RemoteDisplayListIdentifier recordDisplayListUse(const WebCore::DisplayList::DisplayList&);
     void didPaintLayers();


### PR DESCRIPTION
#### 4624da7b645bf2fe1384f4f4c9da2d17c4939054
<pre>
GPUP: Filters are not encoded in stateful manner
<a href="https://bugs.webkit.org/show_bug.cgi?id=298933">https://bugs.webkit.org/show_bug.cgi?id=298933</a>
<a href="https://rdar.apple.com/160679185">rdar://160679185</a>

Reviewed by NOBODY (OOPS!).

Before, filters were serialized to IPC messages as Ref&lt;Filter&gt;. This
means &quot;serialize contents as data and create instances in receiving
side&quot;. However, this is impossible, as the filters contain FEImage
instances that refer to NativeImages or ImageBuffers via SourceImage.
These types are not serialized as data, rather they are serialized as
identifiers that need to be looked up from remote rendering backend
resource cache. Naturally IPC encoding and decoding system does not have
context from which to navigate to the cache, rather the system deals
with data only.

The above problem was worked around by looking in the filter at encoding
site and manually caching the resources needed. On the receiving side,
the receiver would receive identifiers. WebCore::SourceImage would be
added a third held variant, ReenderingResourceIdentifier that was
used to construct non-functional SourceImages. After the decoding,
the FEImage SourceImages would be backfilled from the cache manually.

This creates problem that it ties the WebCore Filter implementation with
GPUP specific requirements and ties GPUP graphics subsystem implementation
with WebCore SourceImage structure:
- It prevents separation of ImageBuffers and NativeImages identifier
  types. Currently both are identified by the same identifier type,
  even though they are different types.
- It forces that both identifier types exist in WebCore.
- Forces unwanted ASSERT_NOT_REACHED() codepaths in WebCore,
  since WebCore and SourceImage clients do not have use for GPUP
  identifiers or identifier types.

Fix the above by correctly serializing the Filter data as plain data.
This is represented by WebKit::FilterData. The RRBP caching process
converts Filter into FilterData that can be sent through IPC and
serialized back to FilterData. Then FilterData can be converted
back to Filter via RRB cache lookup process. This is consistent with
other non-data references, such as ImageBuffers and NativeImages.

This way
SourceImage::ImageVariant&lt;..,..,ReenderingResourceIdentifier&gt; can be
removed in later commits, along with the ASSERT_NOT_REACHED() codepaths.

Fixes bugs in RemoteImageBufferProxy::filteredNativeImage, which failed
to do the manual caching / image reference backfill process, and as
such would fail to render FEImages.

Note: the filter caching / uncaching by identifier code signature is
a bit unconventional compared to other GPUP instances, because the
item in the cache is updated at the same time as being referenced by
identifier. There is no plain &quot;use filter by id&quot; messages, all messages
use filters by data currently. This is part of the existing code and not
changed. This could change later to be more conventional &quot;cache by
data&quot; and &quot;use by id&quot; messages.

* Source/WebCore/platform/graphics/SourceImage.h:
* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/GPUProcess/graphics/FilterData.cpp: Added.
(WebKit::serializeFilterToFilterData):
(WebKit::createFilterFromFilterData):
(WebKit::isValidSVGFilterExpression):
* Source/WebKit/GPUProcess/graphics/FilterData.h: Added.
* Source/WebKit/GPUProcess/graphics/FilterData.serialization.in: Added.
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.cpp:
(WebKit::RemoteGraphicsContext::filter):
(WebKit::RemoteGraphicsContext::drawFilteredImageBuffer):
(WebKit::RemoteGraphicsContext::drawFilteredImageBufferInternal): Deleted.
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.h:
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.messages.in:
* Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.cpp:
(WebKit::RemoteImageBuffer::filteredNativeImage):
* Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.h:
* Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.messages.in:
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp:
(WebKit::RemoteRenderingBackend::cacheFilter):
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h:
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in:
* Source/WebKit/GPUProcess/graphics/RemoteResourceCache.cpp:
(WebKit::RemoteResourceCache::cacheFilter):
(WebKit::RemoteResourceCache::cachedFilter const):
* Source/WebKit/GPUProcess/graphics/RemoteResourceCache.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.cpp:
* Source/WebKit/Scripts/webkit/messages.py:
(types_that_cannot_be_forward_declared):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/Sources.txt:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.cpp:
(WebKit::RemoteGraphicsContextProxy::drawFilteredImageBuffer):
(WebKit::RemoteGraphicsContextProxy::recordResourceUse):
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp:
(WebKit::RemoteImageBufferProxy::filteredNativeImage):
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp:
(WebKit::RemoteRenderingBackendProxy::cacheFilter):
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp:
(WebKit::RemoteResourceCacheProxy::recordFilterUse):
* Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4624da7b645bf2fe1384f4f4c9da2d17c4939054

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121558 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41255 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31914 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128020 "Hash 4624da7b for PR 50797 does not build (failure)") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73643 "Hash 4624da7b for PR 50797 does not build (failure)") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/30b5dc30-0395-48a6-b254-5f3f8bbabdf3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123434 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41996 "Failed to checkout and rebase branch from PR 50797") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49874 "Failed to checkout and rebase branch from PR 50797") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/128020 "Hash 4624da7b for PR 50797 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/73643 "Hash 4624da7b for PR 50797 does not build (failure)") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/04ecef4b-6a10-4bfb-8755-79354c6d3d3e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124510 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33502 "Unexpected infrastructure issue, retrying build") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108886 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/128020 "Hash 4624da7b for PR 50797 does not build (failure)") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/03786236-5339-4061-aabe-5c623b4d5e18) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/120915 "Passed tests") | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32512 "Exiting early after 60 failures. 28147 tests run. 1 new passes 60 failures") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27051 "Passed tests") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71588 "Hash 4624da7b for PR 50797 does not build (failure)") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102990 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27225 "Exiting early after 60 failures. 43181 tests run. 60 failures") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130837 "Hash 4624da7b for PR 50797 does not build (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48486 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36875 "Unexpected infrastructure issue, retrying build") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/130837 "Hash 4624da7b for PR 50797 does not build (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48854 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105108 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/130837 "Hash 4624da7b for PR 50797 does not build (failure)") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46234 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24320 "Found unexpected failure with change (failure)") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45184 "Hash 4624da7b for PR 50797 does not build (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48345 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54057 "Found 6 new failures in GPUProcess/graphics/FilterData.cpp") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47816 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51163 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49498 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->