### PR TITLE
Address Safer CPP warning in GraphicsContextGLANGLE.cpp and ANGLEUtilities.cpp

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
@@ -89,8 +89,6 @@ platform/Scrollbar.h
 platform/cocoa/TelephoneNumberDetectorCocoa.cpp
 platform/graphics/ImageBufferContextSwitcher.h
 platform/graphics/StringTruncator.cpp
-platform/graphics/angle/ANGLEUtilities.cpp
-platform/graphics/angle/GraphicsContextGLANGLE.cpp
 platform/graphics/ca/PlatformCALayer.h
 platform/graphics/ca/TileController.cpp
 platform/graphics/mac/LegacyDisplayRefreshMonitorMac.h

--- a/Source/WebCore/platform/graphics/angle/ANGLEUtilities.cpp
+++ b/Source/WebCore/platform/graphics/angle/ANGLEUtilities.cpp
@@ -135,21 +135,6 @@ ScopedFramebuffer::~ScopedFramebuffer()
     GL_DeleteFramebuffers(1, &m_object);
 }
 
-void ScopedGLFence::reset()
-{
-    if (m_object) {
-        GL_DeleteSync(static_cast<GLsync>(m_object));
-        m_object = { };
-    }
-}
-
-void ScopedGLFence::fenceSync()
-{
-    reset();
-    m_object = GL_FenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0);
-}
-
-
 ScopedGLCapability::ScopedGLCapability(GCGLenum capability, bool enable)
     : m_capability(capability)
     , m_original(GL_IsEnabled(m_capability) == enable ? std::nullopt : std::optional<bool>(!enable))

--- a/Source/WebCore/platform/graphics/angle/ANGLEUtilities.h
+++ b/Source/WebCore/platform/graphics/angle/ANGLEUtilities.h
@@ -143,35 +143,6 @@ private:
     GCGLuint m_object { 0 };
 };
 
-class ScopedGLFence {
-    WTF_MAKE_NONCOPYABLE(ScopedGLFence);
-
-public:
-    ScopedGLFence() = default;
-    ScopedGLFence(ScopedGLFence&& other)
-        : m_object(std::exchange(other.m_object, { }))
-    {
-    }
-    ~ScopedGLFence() { reset(); }
-    ScopedGLFence& operator=(ScopedGLFence&& other)
-    {
-        if (this != &other) {
-            reset();
-            m_object = std::exchange(other.m_object, { });
-        }
-        return *this;
-    }
-    void reset();
-    void abandon() { m_object = { }; }
-    void fenceSync();
-    GCGLsync get() const { return m_object; }
-    operator GCGLsync() const { return m_object; }
-    operator bool() const { return m_object; }
-
-private:
-    GCGLsync m_object { };
-};
-
 class ScopedGLCapability {
     WTF_MAKE_NONCOPYABLE(ScopedGLCapability);
 public:

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
@@ -32,6 +32,7 @@
 #include "ANGLEHeaders.h"
 #include "ANGLEUtilities.h"
 #include "ByteArrayPixelBuffer.h"
+#include "GraphicsContext.h"
 #include "ImageBuffer.h"
 #include "IntRect.h"
 #include "IntSize.h"


### PR DESCRIPTION
#### e9f64d4350a80d38e6ef06041894328887505240
<pre>
Address Safer CPP warning in GraphicsContextGLANGLE.cpp and ANGLEUtilities.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=298950">https://bugs.webkit.org/show_bug.cgi?id=298950</a>

Reviewed by Darin Adler.

* Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations:
* Source/WebCore/platform/graphics/angle/ANGLEUtilities.cpp:
(WebCore::ScopedGLFence::reset): Deleted.
(WebCore::ScopedGLFence::fenceSync): Deleted.
* Source/WebCore/platform/graphics/angle/ANGLEUtilities.h:
(WebCore::ScopedGLFence::ScopedGLFence): Deleted.
(WebCore::ScopedGLFence::~ScopedGLFence): Deleted.
(WebCore::ScopedGLFence::operator=): Deleted.
(WebCore::ScopedGLFence::abandon): Deleted.
(WebCore::ScopedGLFence::get const): Deleted.
(WebCore::ScopedGLFence::operator GCGLsync const): Deleted.
(WebCore::ScopedGLFence::operator bool const): Deleted.
* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp:

Canonical link: <a href="https://commits.webkit.org/300112@main">https://commits.webkit.org/300112@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7c1214c7062a035b23903a620a2900ebeef9fa78

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121296 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40993 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31651 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127732 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73377 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1db1f873-daa5-4e4c-855b-25dbe072770c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123172 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41695 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49572 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92139 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61299 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a7271a54-9f15-4f4f-a311-f47b55fb3003) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124248 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33291 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108696 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72815 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a18bde0e-d23d-4698-bccf-e3a8760ec007) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32308 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26824 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71314 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102784 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27000 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130570 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48224 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36668 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100734 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48592 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104885 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100639 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25525 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46045 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24108 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44918 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48082 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53795 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47553 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50900 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49236 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->