### PR TITLE
REGRESSION (Safari 26): Crash in WebProcess due to checkTopOrigin called from WebSWServerConnection::registerServiceWorkerClient with blob urls

### DIFF
--- a/Source/WebCore/fileapi/BlobURL.h
+++ b/Source/WebCore/fileapi/BlobURL.h
@@ -50,7 +50,7 @@ public:
     static URL createPublicURL(SecurityOrigin*);
     static URL createInternalURL();
 
-    static URL getOriginURL(const URL&);
+    WEBCORE_EXPORT static URL getOriginURL(const URL&);
     static bool isSecureBlobURL(const URL&);
 #if ASSERT_ENABLED
     static bool isInternalURL(const URL&);

--- a/Source/WebCore/platform/RegistrableDomain.h
+++ b/Source/WebCore/platform/RegistrableDomain.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <WebCore/BlobURL.h>
 #include <WebCore/PublicSuffixStore.h>
 #include <WebCore/SecurityOriginData.h>
 #include <wtf/HashTraits.h>
@@ -42,7 +43,7 @@ public:
     RegistrableDomain() = default;
 
     explicit RegistrableDomain(const URL& url)
-        : RegistrableDomain(registrableDomainFromHost(url.host().toString()))
+        : RegistrableDomain(registrableDomainFromHost(url))
     {
     }
 
@@ -114,6 +115,14 @@ private:
         if (host.length() == m_registrableDomain.length())
             return true;
         return host[host.length() - m_registrableDomain.length() - 1] == '.';
+    }
+
+    static inline String registrableDomainFromHost(const URL& url)
+    {
+        if (url.protocolIsBlob())
+            return registrableDomainFromHost(BlobURL::getOriginURL(url).host().toString());
+
+        return registrableDomainFromHost(url.host().toString());
     }
 
     static inline String registrableDomainFromHost(const String& host)

--- a/Tools/TestWebKitAPI/Tests/WebCore/RegistrableDomain.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/RegistrableDomain.cpp
@@ -52,6 +52,12 @@ TEST(RegistrableDomain, StringVsURL)
     auto fileDomainFromString = RegistrableDomain::uncheckedCreateFromRegistrableDomainString(emptyString());
     
     ASSERT_EQ(fileDomainFromURL, fileDomainFromString);
+
+    URL blobURL { "blob:http://example.com/ABCD"_str };
+    RegistrableDomain blobDomainFromURL { blobURL };
+    auto blobDomainFromString = RegistrableDomain::uncheckedCreateFromRegistrableDomainString("example.com"_s);
+
+    ASSERT_EQ(blobDomainFromURL, blobDomainFromString);
 }
 
 TEST(RegistrableDomain, MatchesURLs)


### PR DESCRIPTION
#### 6e06607704287078292effe9430556d93c905f1a
<pre>
REGRESSION (Safari 26): Crash in WebProcess due to checkTopOrigin called from WebSWServerConnection::registerServiceWorkerClient with blob urls
<a href="https://rdar.apple.com/160421211">rdar://160421211</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=298697">https://bugs.webkit.org/show_bug.cgi?id=298697</a>

Reviewed by Brady Eidson.

The UIProcess is responsible to notify the network process whether a given web process can access cookies for a given top origin.
This logic is used when doing navigation, for instance in WebProcessPool::processForNavigation.
The principle is to get a Site from a request URL and allow the origin.

But the computation of RegistrableDomain for a blob URL was leading to nullOrigin.
This would lead WebProcessPool::processForNavigation to register nullOrigin instead of the actual origin of the blob URL.
This woudl then trigger termination of the web process loading the blob page.

We fix the blob URL logic and add an API test to verify that computation is correct.

* Source/WebCore/fileapi/BlobURL.h:
* Source/WebCore/platform/RegistrableDomain.h:
(WebCore::RegistrableDomain::RegistrableDomain):
(WebCore::RegistrableDomain::registrableDomainFromHost):
* Tools/TestWebKitAPI/Tests/WebCore/RegistrableDomain.cpp:
(TestWebKitAPI::TEST(RegistrableDomain, StringVsURL)):

Canonical link: <a href="https://commits.webkit.org/300071@main">https://commits.webkit.org/300071@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2a65554decb17ae2f38f99b6567952cbc0afb446

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121175 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40871 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31529 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127599 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73256 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123051 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41573 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49450 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92054 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61246 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124127 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33197 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108615 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72730 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32223 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26721 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71188 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102697 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26901 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130447 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48102 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36564 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100653 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48470 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104786 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100557 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25496 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45961 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24016 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44796 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47960 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53673 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47431 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50778 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49115 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->