### PR TITLE
[WebXR][GLib] WebXR compatible canvas created even if required GL extensions are not available

### DIFF
--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -2883,10 +2883,9 @@ void WebGLRenderingContextBase::makeXRCompatible(MakeXRCompatiblePromise&& promi
         //  Set context’s XR compatible boolean to true and resolve promise.
         // Otherwise: Queue a task on the WebGL task source to perform the following steps:
         // FIXME: add a way to verify that we're using a compatible graphics adapter.
-#if PLATFORM(COCOA)
         if (!m_context->enableRequiredWebXRExtensions())
             return;
-#endif
+
         m_attributes.xrCompatible = true;
         promise.resolve();
         rejectPromiseWithInvalidStateError.release();


### PR DESCRIPTION
#### d47deef8cb9ca01051bb246d8c83c672ec7d80f9
<pre>
[WebXR][GLib] WebXR compatible canvas created even if required GL extensions are not available
<a href="https://bugs.webkit.org/show_bug.cgi?id=298955">https://bugs.webkit.org/show_bug.cgi?id=298955</a>

Reviewed by NOBODY (OOPS!).

The code that checks whether the required GL extensions are available had
COCOA guards as it was the only port supporting WebXR. Removed the guard
as the call is available for all platforms supporting  WebXR.

* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::makeXRCompatible):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d47deef8cb9ca01051bb246d8c83c672ec7d80f9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121117 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40813 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31471 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127536 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73198 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122993 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41515 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49392 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92004 "Found 75 new test failures: http/tests/webxr/webxr-third-party-iframe-makexrcompatible-allowed-by-feature-policy.html http/wpt/webxr/events_transient_pointer_input_source.https.html http/wpt/webxr/xrDevice_requestSession_hand_tracking_feature.https.html http/wpt/webxr/xrDevice_requestSession_previously_enabled_feature_not_requested.https.html http/wpt/webxr/xrFrame_fillJointRadii.html http/wpt/webxr/xrFrame_fillJointRadii_missing_joint_pose.html http/wpt/webxr/xrFrame_fillPoses.html http/wpt/webxr/xrFrame_fillPoses_missing_joint_pose.html http/wpt/webxr/xrFrame_getJointPose.html http/wpt/webxr/xrFrame_getJointPose_missing_joint_pose.html ... (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61210 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124069 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33155 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108571 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72687 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32179 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26674 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71128 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102660 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26853 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130389 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48044 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36517 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100612 "Found 75 new test failures: http/tests/webxr/webxr-third-party-iframe-makexrcompatible-allowed-by-feature-policy.html http/wpt/webxr/events_transient_pointer_input_source.https.html http/wpt/webxr/xrDevice_requestSession_hand_tracking_feature.https.html http/wpt/webxr/xrDevice_requestSession_previously_enabled_feature_not_requested.https.html http/wpt/webxr/xrFrame_fillJointRadii.html http/wpt/webxr/xrFrame_fillJointRadii_missing_joint_pose.html http/wpt/webxr/xrFrame_fillPoses.html http/wpt/webxr/xrFrame_fillPoses_missing_joint_pose.html http/wpt/webxr/xrFrame_getJointPose.html http/wpt/webxr/xrFrame_getJointPose_missing_joint_pose.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48412 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104738 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100515 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45913 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23971 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44738 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47902 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53615 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47373 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50720 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49057 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->