### PR TITLE
[JSC] WASM IPInt SIMD: x86_64: implement bitwise instructions

### DIFF
--- a/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
@@ -4335,7 +4335,7 @@ ipintOp(_simd_i8x16_swizzle, macro()
     # i8x16.swizzle - swizzle bytes from first vector using indices from second vector
     popVec(v1)
     popVec(v0)
-    
+
     if ARM64 or ARM64E
         emit "tbl v16.16b, {v16.16b}, v17.16b"
     elsif X86_64
@@ -4343,7 +4343,7 @@ ipintOp(_simd_i8x16_swizzle, macro()
     else
         break # Not implemented
     end
-    
+
     pushVec(v0)
     advancePC(2)
     nextIPIntInstruction()
@@ -4352,7 +4352,7 @@ end)
 ipintOp(_simd_i8x16_splat, macro()
     # i8x16.splat - splat i32 value to all 16 8-bit lanes
     popInt32(t0, t1)
-    
+
     if ARM64 or ARM64E
         emit "dup v16.16b, w0"
     elsif X86_64
@@ -4361,7 +4361,7 @@ ipintOp(_simd_i8x16_splat, macro()
     else
         break # Not implemented
     end
-    
+
     pushVec(v0)
     advancePC(2)
     nextIPIntInstruction()
@@ -4370,7 +4370,7 @@ end)
 ipintOp(_simd_i16x8_splat, macro()
     # i16x8.splat - splat i32 value to all 8 16-bit lanes
     popInt32(t0, t1)
-    
+
     if ARM64 or ARM64E
         emit "dup v16.8h, w0"
     elsif X86_64
@@ -4379,7 +4379,7 @@ ipintOp(_simd_i16x8_splat, macro()
     else
         break # Not implemented
     end
-    
+
     pushVec(v0)
     advancePC(2)
     nextIPIntInstruction()
@@ -4388,7 +4388,7 @@ end)
 ipintOp(_simd_i32x4_splat, macro()
     # i32x4.splat - splat i32 value to all 4 32-bit lanes
     popInt32(t0, t1)
-    
+
     if ARM64 or ARM64E
         emit "dup v16.4s, w0"
     elsif X86_64
@@ -4397,7 +4397,7 @@ ipintOp(_simd_i32x4_splat, macro()
     else
         break # Not implemented
     end
-    
+
     pushVec(v0)
     advancePC(2)
     nextIPIntInstruction()
@@ -4406,7 +4406,7 @@ end)
 ipintOp(_simd_i64x2_splat, macro()
     # i64x2.splat - splat i64 value to all 2 64-bit lanes
     popInt64(t0, t1)
-    
+
     if ARM64 or ARM64E
         emit "dup v16.2d, x0"
     elsif X86_64
@@ -4415,7 +4415,7 @@ ipintOp(_simd_i64x2_splat, macro()
     else
         break # Not implemented
     end
-    
+
     pushVec(v0)
     advancePC(2)
     nextIPIntInstruction()
@@ -4424,7 +4424,7 @@ end)
 ipintOp(_simd_f32x4_splat, macro()
     # f32x4.splat - splat f32 value to all 4 32-bit float lanes
     popFloat32(ft0)
-    
+
     if ARM64 or ARM64E
         emit "dup v16.4s, v0.s[0]"
     elsif X86_64
@@ -4433,7 +4433,7 @@ ipintOp(_simd_f32x4_splat, macro()
     else
         break # Not implemented
     end
-    
+
     pushVec(v0)
     advancePC(2)
     nextIPIntInstruction()
@@ -4442,7 +4442,7 @@ end)
 ipintOp(_simd_f64x2_splat, macro()
     # f64x2.splat - splat f64 value to all 2 64-bit float lanes
     popFloat64(ft0)
-    
+
     if ARM64 or ARM64E
         emit "dup v16.2d, v0.d[0]"
     elsif X86_64
@@ -4451,7 +4451,7 @@ ipintOp(_simd_f64x2_splat, macro()
     else
         break # Not implemented
     end
-    
+
     pushVec(v0)
     advancePC(2)
     nextIPIntInstruction()
@@ -5379,6 +5379,9 @@ ipintOp(_simd_v128_not, macro()
     popVec(v0)
     if ARM64 or ARM64E
         emit "mvn v16.16b, v16.16b"
+    elsif X86_64
+        emit "vpcmpeqb %xmm1, %xmm1, %xmm1"  # Set all bits to 1
+        emit "vpxor %xmm1, %xmm0, %xmm0"     # Invert all bits
     else
         break # Not implemented
     end
@@ -5393,6 +5396,8 @@ ipintOp(_simd_v128_and, macro()
     popVec(v0)
     if ARM64 or ARM64E
         emit "and v16.16b, v16.16b, v17.16b"
+    elsif X86_64
+        emit "vpand %xmm1, %xmm0, %xmm0"
     else
         break # Not implemented
     end
@@ -5407,6 +5412,8 @@ ipintOp(_simd_v128_andnot, macro()
     popVec(v0)
     if ARM64 or ARM64E
         emit "bic v16.16b, v16.16b, v17.16b"
+    elsif X86_64
+        emit "vpandn %xmm0, %xmm1, %xmm0"
     else
         break # Not implemented
     end
@@ -5421,6 +5428,8 @@ ipintOp(_simd_v128_or, macro()
     popVec(v0)
     if ARM64 or ARM64E
         emit "orr v16.16b, v16.16b, v17.16b"
+    elsif X86_64
+        emit "vpor %xmm1, %xmm0, %xmm0"
     else
         break # Not implemented
     end
@@ -5435,6 +5444,8 @@ ipintOp(_simd_v128_xor, macro()
     popVec(v0)
     if ARM64 or ARM64E
         emit "eor v16.16b, v16.16b, v17.16b"
+    elsif X86_64
+        emit "vpxor %xmm1, %xmm0, %xmm0"
     else
         break # Not implemented
     end
@@ -5456,6 +5467,10 @@ ipintOp(_simd_v128_bitselect, macro()
         emit "mov v18.16b, v18.16b"  # v2 -> v18 (selector)
         emit "bsl v18.16b, v16.16b, v17.16b"  # (c & a) | (~c & b)
         emit "mov v16.16b, v18.16b"  # result -> v0
+    elsif X86_64
+        emit "vpand %xmm2, %xmm0, %xmm3"     # xmm3 = a & c
+        emit "vpandn %xmm1, %xmm2, %xmm2"    # xmm2 = b & ~c (vpandn does ~src1 & src2)
+        emit "vpor %xmm2, %xmm3, %xmm0"      # xmm0 = (a & c) | (b & ~c)
     else
         break # Not implemented
     end
@@ -5475,6 +5490,10 @@ ipintOp(_simd_v128_any_true, macro()
         # Convert non-zero to 1
         emit "cmp w0, #0"
         emit "cset w0, ne"
+    elsif X86_64
+        emit "vptest %xmm0, %xmm0"
+        emit "setne %al"                  # Set AL to 1 if ZF=0 (any bit set), 0 if ZF=1 (all zero)
+        emit "movzbl %al, %eax"           # Zero-extend AL to EAX
     else
         break # Not implemented
     end
@@ -5506,7 +5525,7 @@ ipintOp(_simd_v128_load8_lane_mem, macro()
     # Push the result and then replace one lane of the result with the loaded value
     pushVec(v0)
     storeb t0, [sp, t1]
-    
+
     advanceMC(constexpr (sizeof(IPInt::Const32Metadata)))
     nextIPIntInstruction()
 end)
@@ -5532,7 +5551,7 @@ ipintOp(_simd_v128_load16_lane_mem, macro()
     # Push the result and then replace one lane of the result with the loaded value
     pushVec(v0)
     storeh t0, [sp, t1, 2]
-    
+
     advanceMC(constexpr (sizeof(IPInt::Const32Metadata)))
     nextIPIntInstruction()
 end)
@@ -5558,7 +5577,7 @@ ipintOp(_simd_v128_load32_lane_mem, macro()
     # Push the result and then replace one lane of the result with the loaded value
     pushVec(v0)
     storei t0, [sp, t1, 4]
-    
+
     advanceMC(constexpr (sizeof(IPInt::Const32Metadata)))
     nextIPIntInstruction()
 end)
@@ -5584,7 +5603,7 @@ ipintOp(_simd_v128_load64_lane_mem, macro()
     # Push the result and then replace one lane of the result with the loaded value
     pushVec(v0)
     storeq t0, [sp, t1, 8]
-    
+
     advanceMC(constexpr (sizeof(IPInt::Const32Metadata)))
     nextIPIntInstruction()
 end)
@@ -5607,9 +5626,9 @@ ipintOp(_simd_v128_store8_lane_mem, macro()
     loadi IPInt::Const32Metadata::value[MC], t2
     addp t2, t0
     ipintCheckMemoryBound(t0, t2, 1)
-       
+
     storeb t1, [memoryBase, t0]
-    
+
     advanceMC(constexpr (sizeof(IPInt::Const32Metadata)))
     nextIPIntInstruction()
 end)
@@ -5632,9 +5651,9 @@ ipintOp(_simd_v128_store16_lane_mem, macro()
     loadi IPInt::Const32Metadata::value[MC], t2
     addp t2, t0
     ipintCheckMemoryBound(t0, t2, 2)
-       
+
     storeh t1, [memoryBase, t0]
-    
+
     advanceMC(constexpr (sizeof(IPInt::Const32Metadata)))
     nextIPIntInstruction()
 end)
@@ -5657,9 +5676,9 @@ ipintOp(_simd_v128_store32_lane_mem, macro()
     loadi IPInt::Const32Metadata::value[MC], t2
     addp t2, t0
     ipintCheckMemoryBound(t0, t2, 4)
-       
+
     storei t1, [memoryBase, t0]
-    
+
     advanceMC(constexpr (sizeof(IPInt::Const32Metadata)))
     nextIPIntInstruction()
 end)
@@ -5681,9 +5700,9 @@ ipintOp(_simd_v128_store64_lane_mem, macro()
     loadi IPInt::Const32Metadata::value[MC], t2
     addp t2, t0
     ipintCheckMemoryBound(t0, t2, 8)
-       
+
     storeq t1, [memoryBase, t0]
-    
+
     advanceMC(constexpr (sizeof(IPInt::Const32Metadata)))
     nextIPIntInstruction()
 end)
@@ -5692,7 +5711,7 @@ ipintOp(_simd_v128_load32_zero_mem, macro()
     # v128.load32_zero - load 32-bit value from memory and zero-pad to 128 bits
     simdMemoryOp(4, macro()
         loadi [memoryBase, t0], t0
-        
+
         subp V128ISize, sp
         storei t0, [sp]
         storei 0, 4[sp]
@@ -5775,6 +5794,35 @@ ipintOp(_simd_i8x16_popcnt, macro()
     popVec(v0)
     if ARM64 or ARM64E
         emit "cnt v16.16b, v16.16b"
+    elsif X86_64
+        # x86_64 does not natively support vector lanewise popcount, so we emulate it using
+        # lookup tables, similar to BBQ JIT implementation
+
+        # Create bottom nibble mask (0x0f repeated 16 times)
+        emit "movabsq $0x0f0f0f0f0f0f0f0f, %rax"
+        emit "vmovq %rax, %xmm1"
+        emit "vmovq %rax, %xmm4"
+        emit "vpunpcklqdq %xmm4, %xmm1, %xmm1"  # xmm1 = bottom nibble mask
+
+        # Create popcount lookup table
+        emit "movabsq $0x0302020102010100, %rax"   # Low 64 bits of lookup table
+        emit "vmovq %rax, %xmm2"
+        emit "movabsq $0x0403030203020201, %rax"   # High 64 bits of lookup table
+        emit "vmovq %rax, %xmm4"
+        emit "vpunpcklqdq %xmm4, %xmm2, %xmm2"  # xmm2 = popcount lookup table
+
+        # Split input into low and high nibbles
+        emit "vmovdqa %xmm0, %xmm3"              # xmm3 = copy of input
+        emit "vpand %xmm1, %xmm0, %xmm0"         # xmm0 = low nibbles (input & mask)
+        emit "vpsrlw $4, %xmm3, %xmm3"           # Shift right 4 bits
+        emit "vpand %xmm1, %xmm3, %xmm3"         # xmm3 = high nibbles ((input >> 4) & mask)
+
+        # Lookup popcount for both nibbles using pshufb
+        emit "vpshufb %xmm0, %xmm2, %xmm0"       # Lookup low nibbles
+        emit "vpshufb %xmm3, %xmm2, %xmm3"       # Lookup high nibbles
+
+        # Add the results
+        emit "vpaddb %xmm3, %xmm0, %xmm0"        # Add popcount of low and high nibbles
     else
         break # Not implemented
     end
@@ -5792,6 +5840,14 @@ ipintOp(_simd_i8x16_all_true, macro()
         emit "fmov w0, s17"               # Move to general register
         emit "cmp w0, #0"                 # Compare with 0
         emit "cset w0, eq"                # Set to 1 if equal (all lanes non-zero), 0 otherwise
+    elsif X86_64
+        # Compare each byte with zero to create mask of zero lanes
+        emit "vpxor %xmm1, %xmm1, %xmm1"      # Create zero vector
+        emit "vpcmpeqb %xmm1, %xmm0, %xmm0"   # Compare each byte with 0 (0xFF if zero, 0x00 if non-zero)
+        emit "vpmovmskb %xmm0, %eax"          # Extract sign bits to create 16-bit mask
+        emit "test %eax, %eax"                # Test if any bit is set (any lane was zero)
+        emit "sete %al"                       # Set AL to 1 if no bits set (all lanes non-zero), 0 otherwise
+        emit "movzbl %al, %eax"               # Zero-extend to full 32-bit register
     else
         break # Not implemented
     end
@@ -5803,26 +5859,25 @@ end)
 ipintOp(_simd_i8x16_bitmask, macro()
     # i8x16.bitmask - extract most significant bit from each 8-bit lane into a 16-bit integer
     # Simple loop over the 16 bytes on the stack
-    
+
     move 0, t0          # Initialize result
-    move 0, t1          # Byte counter
-    move sp, t2         # Pointer to vector data
-    
+    move 0, t3          # Byte counter
+
 .bitmask_i8x16_loop:
     # Load byte and check sign bit
-    loadb [t2, t1], t3
-    andq 0x80, t3       # Extract sign bit
-    btiz t3, .bitmask_i8x16_next
-    
+    loadb [sp, t3], t1
+    andq 0x80, t1       # Extract sign bit
+    btiz t1, .bitmask_i8x16_next
+
     # Set corresponding bit in result
-    move 1, t3
-    lshiftq t1, t3      # Shift to bit position
-    orq t3, t0
-    
+    move 1, t1
+    lshiftq t3, t1      # Shift to bit position
+    orq t1, t0
+
 .bitmask_i8x16_next:
-    addq 1, t1          # Next byte
-    bilt t1, 16, .bitmask_i8x16_loop
-    
+    addq 1, t3          # Next byte
+    bilt t3, 16, .bitmask_i8x16_loop
+
     addp V128ISize, sp  # Pop the vector
     pushInt32(t0)
     advancePC(2)
@@ -6353,6 +6408,16 @@ ipintOp(_simd_i16x8_all_true, macro()
         emit "fmov w0, s17"              # Move to general register
         emit "cmp w0, #0"                # Compare with 0
         emit "cset w0, eq"               # Set to 1 if equal (all lanes non-zero), 0 otherwise
+    elsif X86_64
+        # Compare each 16-bit lane with zero
+        emit "vpxor %xmm1, %xmm1, %xmm1"     # Create zero vector
+        emit "vpcmpeqw %xmm1, %xmm0, %xmm1"  # Compare each word with 0 (1 if zero, 0 if non-zero)
+
+        # Test if any lane is zero
+        emit "vpmovmskb %xmm1, %eax"         # Extract sign bits
+        emit "testl %eax, %eax"              # Test if any bits are set
+        emit "sete %al"                      # Set AL to 1 if no bits set (all lanes non-zero), 0 otherwise
+        emit "movzbl %al, %eax"              # Zero-extend to 32-bit
     else
         break # Not implemented
     end
@@ -6364,26 +6429,25 @@ end)
 ipintOp(_simd_i16x8_bitmask, macro()
     # i16x8.bitmask - extract most significant bit from each 16-bit lane into an 8-bit integer
     # Simple loop over the 8 16-bit values on the stack
-    
+
     move 0, t0          # Initialize result
-    move 0, t1          # Lane counter
-    move sp, t2         # Pointer to vector data
-    
+    move 0, t3          # Lane counter
+
 .bitmask_i16x8_loop:
     # Load 16-bit value and check sign bit
-    loadh [t2, t1, 2], t3  # Load 16-bit value at offset t1*2
-    andq 0x8000, t3     # Extract sign bit (bit 15)
-    btiz t3, .bitmask_i16x8_next
-    
+    loadh [sp, t3, 2], t1  # Load 16-bit value at offset t1*2
+    andq 0x8000, t1     # Extract sign bit (bit 15)
+    btiz t1, .bitmask_i16x8_next
+
     # Set corresponding bit in result
-    move 1, t3
-    lshiftq t1, t3      # Shift to bit position
-    orq t3, t0
-    
+    move 1, t1
+    lshiftq t3, t1      # Shift to bit position
+    orq t1, t0
+
 .bitmask_i16x8_next:
-    addq 1, t1          # Next lane
-    bilt t1, 8, .bitmask_i16x8_loop
-    
+    addq 1, t3          # Next lane
+    bilt t3, 8, .bitmask_i16x8_loop
+
     addp V128ISize, sp  # Pop the vector
     pushInt32(t0)
     advancePC(2)
@@ -6832,6 +6896,16 @@ ipintOp(_simd_i32x4_all_true, macro()
         emit "fmov w0, s17"              # Move to general register
         emit "cmp w0, #0"                # Compare with 0
         emit "cset w0, eq"               # Set to 1 if equal (all lanes non-zero), 0 otherwise
+    elsif X86_64
+        # Compare each 32-bit lane with zero
+        emit "vpxor %xmm1, %xmm1, %xmm1"     # Create zero vector
+        emit "vpcmpeqd %xmm1, %xmm0, %xmm1"  # Compare each dword with 0 (1 if zero, 0 if non-zero)
+
+        # Test if any lane is zero
+        emit "vpmovmskb %xmm1, %eax"         # Extract sign bits
+        emit "testl %eax, %eax"              # Test if any bits are set
+        emit "sete %al"                      # Set AL to 1 if no bits set (all lanes non-zero), 0 otherwise
+        emit "movzbl %al, %eax"              # Zero-extend to 32-bit
     else
         break # Not implemented
     end
@@ -6843,26 +6917,25 @@ end)
 ipintOp(_simd_i32x4_bitmask, macro()
     # i32x4.bitmask - extract most significant bit from each 32-bit lane into a 4-bit integer
     # Simple loop over the 4 32-bit values on the stack
-    
+
     move 0, t0          # Initialize result
-    move 0, t1          # Lane counter
-    move sp, t2         # Pointer to vector data
-    
+    move 0, t3          # Lane counter
+
 .bitmask_i32x4_loop:
     # Load 32-bit value and check sign bit
-    loadi [t2, t1, 4], t3  # Load 32-bit value at offset t1*4
-    andq 0x80000000, t3 # Extract sign bit (bit 31)
-    btiz t3, .bitmask_i32x4_next
-    
+    loadi [sp, t3, 4], t1  # Load 32-bit value at offset t1*4
+    andq 0x80000000, t1 # Extract sign bit (bit 31)
+    btiz t1, .bitmask_i32x4_next
+
     # Set corresponding bit in result
-    move 1, t3
-    lshiftq t1, t3      # Shift to bit position
-    orq t3, t0
-    
+    move 1, t1
+    lshiftq t3, t1      # Shift to bit position
+    orq t1, t0
+
 .bitmask_i32x4_next:
-    addq 1, t1          # Next lane
-    bilt t1, 4, .bitmask_i32x4_loop
-    
+    addq 1, t3          # Next lane
+    bilt t3, 4, .bitmask_i32x4_loop
+
     addp V128ISize, sp  # Pop the vector
     pushInt32(t0)
     advancePC(2)
@@ -7217,6 +7290,16 @@ ipintOp(_simd_i64x2_all_true, macro()
         emit "fmov x0, d17"              # Move to general register
         emit "cmp x0, #0"                # Compare with 0
         emit "cset w0, eq"               # Set to 1 if equal (all lanes non-zero), 0 otherwise
+    elsif X86_64
+        # Compare each 64-bit lane with zero
+        emit "vpxor %xmm1, %xmm1, %xmm1"     # Create zero vector
+        emit "vpcmpeqq %xmm1, %xmm0, %xmm1"  # Compare each qword with 0 (1 if zero, 0 if non-zero)
+
+        # Test if any lane is zero
+        emit "vpmovmskb %xmm1, %eax"         # Extract sign bits
+        emit "testl %eax, %eax"              # Test if any bits are set
+        emit "sete %al"                      # Set AL to 1 if no bits set (all lanes non-zero), 0 otherwise
+        emit "movzbl %al, %eax"              # Zero-extend to 32-bit
     else
         break # Not implemented
     end
@@ -7228,27 +7311,27 @@ end)
 ipintOp(_simd_i64x2_bitmask, macro()
     # i64x2.bitmask - extract most significant bit from each 64-bit lane into a 2-bit integer
     # Handle both 64-bit values directly
-    
+
     # Load both 64-bit values
     loadq [sp], t0      # Load lane 0
     loadq 8[sp], t1     # Load lane 1
     addp V128ISize, sp  # Pop the vector
-    
+
     # Initialize result
     move 0, t2
-    
+
     # Check lane 0 sign bit (bit 63)
     move 0x8000000000000000, t3
     andq t3, t0
     btqz t0, .bitmask_i64x2_lane1
     orq 1, t2           # Set bit 0
-    
+
 .bitmask_i64x2_lane1:
     # Check lane 1 sign bit (bit 63)
     andq t3, t1
     btqz t1, .bitmask_i64x2_done
     orq 2, t2           # Set bit 1
-    
+
 .bitmask_i64x2_done:
     pushInt32(t2)
     advancePC(2)


### PR DESCRIPTION
#### 9fa5cdb6436307773a42aec6a126e384b2fcf47a
<pre>
[JSC] WASM IPInt SIMD: x86_64: implement bitwise instructions
<a href="https://bugs.webkit.org/show_bug.cgi?id=298956">https://bugs.webkit.org/show_bug.cgi?id=298956</a>
<a href="https://rdar.apple.com/160694776">rdar://160694776</a>

Reviewed by Yusuke Suzuki.

Implement x86_64 IPInt bitwise instructions.

For bitmask, which is already emulated, rearrange register assignments
so that t3, which is %rcx on x86_64, is the shift-by. That avoids
offlineasm having to insert xchg before/after the shift to get more
efficient code. Also, there is no need to move sp to another register.

This allows simd-instructions-bitwise.js test to pass on x86_64.

Testing: On Intel and ARM:
    jsc --validateOptions=1 --useDollarVM=true  --useConcurrentJIT=false
        --useWasmIPIntSIMD=1 -m simd-instructions-bitwise.js

Canonical link: <a href="https://commits.webkit.org/300043@main">https://commits.webkit.org/300043@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cca0400e615143d8199d16b9a408b05eac3718f4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121121 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40817 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31475 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127540 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73202 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3b3433b7-ca98-40f1-b04e-b40afb42452f) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41519 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49396 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92007 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/61212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/365854d9-20bd-440e-a3bf-f87c16570573) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124073 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33152 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108572 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72690 "Found 1 new API test failure: WPE/TestWebsiteData:/webkit/WebKitWebsiteData/cache (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7bbb160f-c0e0-42c1-a315-98bc24af654b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32176 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26675 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71132 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/113251 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/102657 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26854 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130393 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/119641 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48048 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36524 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100615 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48416 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104739 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100518 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45921 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23972 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44742 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19215 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47906 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53619 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/149803 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47377 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/38034 "Found 1 new JSC stress test failure: stress/dont-link-virtual-calls-on-compiler-thread.js.no-llint (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50724 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49061 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->