### PR TITLE
[WPE] Missing null checks on gerror before accessing the message

### DIFF
--- a/Source/WebKit/UIProcess/wpe/AcceleratedBackingStore.cpp
+++ b/Source/WebKit/UIProcess/wpe/AcceleratedBackingStore.cpp
@@ -163,7 +163,7 @@ void AcceleratedBackingStore::renderPendingBuffer()
 
     GUniqueOutPtr<GError> error;
     if (!wpe_view_render_buffer(m_wpeView.get(), m_pendingBuffer.get(), rects, m_pendingDamageRects.size(), &error.outPtr())) {
-        g_warning("Failed to render frame: %s", error->message);
+        g_warning("Failed to render frame: %s", error ? error->message : "unknown error");
         frameDone();
         m_pendingBuffer = nullptr;
     }

--- a/Source/WebKit/UIProcess/wpe/SystemSettingsManagerProxyWPE.cpp
+++ b/Source/WebKit/UIProcess/wpe/SystemSettingsManagerProxyWPE.cpp
@@ -39,7 +39,7 @@ static String getString(WPESettings* settings, const char* key, const String& de
     GUniqueOutPtr<GError> error;
     const char* value;
     if (!(value = wpe_settings_get_string(settings, key, &error.outPtr()))) {
-        g_warning("Failed to access %s setting: %s", key, error->message);
+        g_warning("Failed to access %s setting: %s", key, error ? error->message : "unknown error");
         return defaultValue;
     }
 

--- a/Source/WebKit/WPEPlatform/wpe/WPEBufferAndroid.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEBufferAndroid.cpp
@@ -104,7 +104,7 @@ static gpointer wpeBufferAndroidImportToEGLImage(WPEBuffer* buffer, GError** err
     GUniqueOutPtr<GError> eglError;
     auto* eglDisplay = wpe_display_get_egl_display(display, &eglError.outPtr());
     if (eglDisplay == EGL_NO_DISPLAY) {
-        g_set_error(error, WPE_BUFFER_ERROR, WPE_BUFFER_ERROR_IMPORT_FAILED, "Failed to get EGLDisplay when importing buffer to EGL image: %s", eglError->message);
+        g_set_error(error, WPE_BUFFER_ERROR, WPE_BUFFER_ERROR_IMPORT_FAILED, "Failed to get EGLDisplay when importing buffer to EGL image: %s", eglError ? eglError->message : "unknown error");
         return nullptr;
     }
 

--- a/Source/WebKit/WPEPlatform/wpe/WPEBufferDMABuf.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEBufferDMABuf.cpp
@@ -116,7 +116,7 @@ static gpointer wpeBufferDMABufImportToEGLImage(WPEBuffer* buffer, GError** erro
     GUniqueOutPtr<GError> eglError;
     auto* eglDisplay = wpe_display_get_egl_display(display, &eglError.outPtr());
     if (eglDisplay == EGL_NO_DISPLAY) {
-        g_set_error(error, WPE_BUFFER_ERROR, WPE_BUFFER_ERROR_IMPORT_FAILED, "Failed to get EGLDisplay when importing buffer to EGL image: %s", eglError->message);
+        g_set_error(error, WPE_BUFFER_ERROR, WPE_BUFFER_ERROR_IMPORT_FAILED, "Failed to get EGLDisplay when importing buffer to EGL image: %s", eglError ? eglError->message : "unknown error");
         return nullptr;
     }
 

--- a/Source/WebKit/WPEPlatform/wpe/WPEDisplay.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEDisplay.cpp
@@ -256,7 +256,7 @@ WPEDisplay* wpe_display_get_default(void)
                     s_defaultDisplay = WTFMove(display);
                     return;
                 }
-                g_error("Failed to connect to display of type %s: %s", extensionName, error->message);
+                g_error("Failed to connect to display of type %s: %s", extensionName, error ? error->message : "unknown error");
             } else
                 g_error("Display of type %s was not found", extensionName);
             return;

--- a/Source/WebKit/WPEPlatform/wpe/WPESettings.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPESettings.cpp
@@ -238,7 +238,7 @@ gboolean wpe_settings_load_from_keyfile(WPESettings* settingsObject, GKeyFile* k
             GUniqueOutPtr<GError> innerError;
             GRefPtr<GVariant> parsedValue = adoptGRef(g_variant_parse(iter->value.type.get(), value.get(), nullptr, nullptr, &innerError.outPtr()));
             if (!parsedValue) {
-                g_set_error(error, WPE_SETTINGS_ERROR, WPE_SETTINGS_ERROR_INVALID_VALUE, "Failed to parse value for key %s: %s", path.data(), innerError->message);
+                g_set_error(error, WPE_SETTINGS_ERROR, WPE_SETTINGS_ERROR_INVALID_VALUE, "Failed to parse value for key %s: %s", path.data(), innerError ? innerError->message : "unknown error");
                 return FALSE;
             }
 

--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEDRMSessionLogind.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEDRMSessionLogind.cpp
@@ -69,7 +69,7 @@ SessionLogind::SessionLogind(GRefPtr<GDBusProxy>&& sessionProxy, GUniquePtr<char
     GRefPtr<GVariant> result = adoptGRef(g_dbus_proxy_call_sync(m_sessionProxy.get(), "TakeControl", g_variant_new("(b)", FALSE),
         G_DBUS_CALL_FLAGS_NONE, -1, nullptr, &error.outPtr()));
     if (!result) {
-        g_warning("Failed to take control of session: %s", error->message);
+        g_warning("Failed to take control of session: %s", error ? error->message : "unknown error");
         return;
     }
 
@@ -105,7 +105,7 @@ int SessionLogind::openDevice(const char* path, int flags)
     GRefPtr<GVariant> result = adoptGRef(g_dbus_proxy_call_with_unix_fd_list_sync(m_sessionProxy.get(), "TakeDevice", g_variant_new("(uu)", major(st.st_rdev), minor(st.st_rdev)),
         G_DBUS_CALL_FLAGS_NONE, -1, nullptr, &fdList.outPtr(), nullptr, &error.outPtr()));
     if (!result) {
-        g_warning("Session failed to take device %s: %s", path, error->message);
+        g_warning("Session failed to take device %s: %s", path, error ? error->message : "unknown error");
         errno = ENODEV;
         return -1;
     }
@@ -134,7 +134,7 @@ int SessionLogind::closeDevice(int deviceID)
     GRefPtr<GVariant> result = adoptGRef(g_dbus_proxy_call_sync(m_sessionProxy.get(), "ReleaseDevice", g_variant_new("(uu)", major(st.st_rdev), minor(st.st_rdev)),
         G_DBUS_CALL_FLAGS_NONE, -1, nullptr, &error.outPtr()));
     if (!result) {
-        g_warning("Session failed to release device %d: %s", deviceID, error->message);
+        g_warning("Session failed to release device %d: %s", deviceID, error ? error->message : "unknown error");
         errno = ENODEV;
         return -1;
     }

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEViewWayland.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEViewWayland.cpp
@@ -261,13 +261,13 @@ static DMABufBuffer* createWaylandBufferFromEGLImage(WPEView* view, WPEBuffer* b
     GUniqueOutPtr<GError> bufferError;
     auto* eglDisplay = wpe_display_get_egl_display(wpe_view_get_display(view), &bufferError.outPtr());
     if (!eglDisplay) {
-        g_set_error(error, WPE_VIEW_ERROR, WPE_VIEW_ERROR_RENDER_FAILED, "Failed to render buffer: can't create Wayland buffer because failed to get EGL display: %s", bufferError->message);
+        g_set_error(error, WPE_VIEW_ERROR, WPE_VIEW_ERROR_RENDER_FAILED, "Failed to render buffer: can't create Wayland buffer because failed to get EGL display: %s", bufferError ? bufferError->message : "unknown error");
         return nullptr;
     }
 
     auto eglImage = wpe_buffer_import_to_egl_image(buffer, &bufferError.outPtr());
     if (!eglImage) {
-        g_set_error(error, WPE_VIEW_ERROR, WPE_VIEW_ERROR_RENDER_FAILED, "Failed to render buffer: failed to import buffer to EGL image: %s", bufferError->message);
+        g_set_error(error, WPE_VIEW_ERROR, WPE_VIEW_ERROR_RENDER_FAILED, "Failed to render buffer: failed to import buffer to EGL image: %s", bufferError ? bufferError->message : "unknown error");
         return nullptr;
     }
 


### PR DESCRIPTION
#### 49a2ecd311f2fc435aaa494183d0d6748bad5e81
<pre>
[WPE] Missing null checks on gerror before accessing the message
<a href="https://bugs.webkit.org/show_bug.cgi?id=298958">https://bugs.webkit.org/show_bug.cgi?id=298958</a>

Reviewed by NOBODY (OOPS!).

There are a few cases where gerror could be null and the code is not
checking for that before accessing gerror-&gt;message.

* Source/WebKit/UIProcess/wpe/AcceleratedBackingStore.cpp:
(WebKit::AcceleratedBackingStore::renderPendingBuffer):
* Source/WebKit/UIProcess/wpe/SystemSettingsManagerProxyWPE.cpp:
(WebKit::getString):
* Source/WebKit/WPEPlatform/wpe/WPEBufferAndroid.cpp:
(wpeBufferAndroidImportToEGLImage):
* Source/WebKit/WPEPlatform/wpe/WPEBufferDMABuf.cpp:
(wpeBufferDMABufImportToEGLImage):
* Source/WebKit/WPEPlatform/wpe/WPEDisplay.cpp:
(wpe_display_get_default):
* Source/WebKit/WPEPlatform/wpe/WPESettings.cpp:
(wpe_settings_load_from_keyfile):
* Source/WebKit/WPEPlatform/wpe/drm/WPEDRMSessionLogind.cpp:
(WPE::DRM::SessionLogind::SessionLogind):
(WPE::DRM::SessionLogind::openDevice):
(WPE::DRM::SessionLogind::closeDevice):
* Source/WebKit/WPEPlatform/wpe/wayland/WPEViewWayland.cpp:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/49a2ecd311f2fc435aaa494183d0d6748bad5e81

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121127 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40823 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31481 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127546 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73208 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41525 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49402 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/92019 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/61217 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124079 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33161 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108573 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72694 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/32185 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71138 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/102665 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26855 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130399 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48054 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36523 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100617 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48422 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104740 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100520 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45922 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23973 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/44748 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47912 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53625 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47383 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50730 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49067 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->