### PR TITLE
[visionOS] The overlayRegionsEnabled preference should apply instantly without waiting for the next layer tree commit

### DIFF
--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
@@ -94,7 +94,7 @@ enum class TapHandlingResult : uint8_t;
 - (void)_didFinishLoadingDataForCustomContentProviderWithSuggestedFilename:(const WTF::String&)suggestedFilename data:(NSData *)data;
 
 #if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
-- (void)_updateOverlayRegionsForCustomContentView;
+- (void)_updateOverlayRegions;
 #endif
 
 - (void)_willInvokeUIScrollViewDelegateCallback;

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -286,7 +286,12 @@ void PageClientImpl::modelProcessDidExit()
 
 void PageClientImpl::preferencesDidChange()
 {
+#if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
+    if (RetainPtr webView = this->webView())
+        [webView _updateOverlayRegions];
+#else
     notImplemented();
+#endif
 }
 
 void PageClientImpl::toolTipChanged(const String&, const String& newToolTip)


### PR DESCRIPTION
#### bda4f2c6e17982921429a9c256ffd42c9d93d801
<pre>
[visionOS] The overlayRegionsEnabled preference should apply instantly without waiting for the next layer tree commit
<a href="https://bugs.webkit.org/show_bug.cgi?id=298961">https://bugs.webkit.org/show_bug.cgi?id=298961</a>
&lt;<a href="https://rdar.apple.com/160387469">rdar://160387469</a>&gt;

Reviewed by Mike Wyrzykowski.

This preference can be toggled on or off on a live web view and we want
it to take effect instantly.
Extract an `_updateOverlayRegions` method we can call from the
PageClient when preferences change instead of relying on the
`_didComitLayerTree` path.

* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h:
Expose `_updateOverlayRegions`.
Remove `_updateOverlayRegionsForCutomContentView` since it&apos;s not used
anymore.
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _didCommitLayerTree:]):
Always remove destroyed layers from the ScrollCoordinatorProxy tracking
regardless of the value of the preference (adding them isn&apos;t dependent on
the pref).
Call `_updateOverlayRegions` when needed.
(-[WKWebView _updateOverlayRegions]):
New method.
(-[WKWebView _resetOverlayRegions]):
No change, re-ordered.
(-[WKWebView _updateScrollCoordinatorProxyForOverlayRegions:]):
(-[WKWebView _updateOverlayRegions:destroyedLayers:]): Deleted.
(-[WKWebView _updateOverlayRegionsForCustomContentView]): Deleted.
* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
(WebKit::PageClientImpl::preferencesDidChange):
Trigger `_udpateOverlayRegions` when the preferences change.

Canonical link: <a href="https://commits.webkit.org/300175@main">https://commits.webkit.org/300175@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7abc34e328ffa5cf48fb651eb762f51cce57e9a2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121318 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41015 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31674 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127754 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73399 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f2d52b3d-f330-488c-a77d-e45c734bee16) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41717 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49594 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92156 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61315 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9c567199-c1ca-49a6-a9d4-d5feb7fd9da0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124270 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33309 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108712 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72832 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/887df11d-2594-44d4-a3a2-78c7bc5a614c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32327 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71337 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102802 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27016 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130592 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48246 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36677 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100750 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48614 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104901 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100655 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25570 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46063 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24124 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44940 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48104 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53817 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47576 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50922 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49258 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->