### PR TITLE
REGRESSION(299383@main): [ iOS Release, macOS wk2 ] webrtc/video-rotation-black.html is a flaky text failure

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -311,6 +311,8 @@ imported/w3c/web-platform-tests/video-rvfc [ Skip ]
 fast/mediastream/getUserMedia-rvfc.html [ Skip ]
 webrtc/peerConnection-rvfc.html [ Skip ]
 
+[ Debug ] webrtc/video-rotation-black.html [ Slow ]
+
 # Our implementation of pc.setLocalDescription() is not fully spec compliant, steps 4.2 and 4.3 are
 # not implemented.
 imported/w3c/web-platform-tests/webrtc/legacy/munge-dont.html [ Failure ]

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8263,8 +8263,6 @@ fast/images/low-memory-decode.html [ Pass Timeout ]
 
 webkit.org/b/298608 imported/w3c/web-platform-tests/digital-credentials/create.tentative.https.html [ Pass Failure ]
 
-webkit.org/b/298903 [ Release ] webrtc/video-rotation-black.html [ Pass Failure ]
-
 webkit.org/b/298905 imported/w3c/web-platform-tests/html/semantics/popovers/label-in-invoker.html [ Pass Failure ]
 
 webkit.org/b/298962 imported/w3c/web-platform-tests/html/browsers/browsing-the-web/overlapping-navigations-and-traversals/cross-document-traversal-cross-document-traversal.html [ Pass Failure ]

--- a/LayoutTests/webrtc/video-rotation-black.html
+++ b/LayoutTests/webrtc/video-rotation-black.html
@@ -42,7 +42,7 @@ function checkVideoBlack(expected, video, canvasId)
 {
     return new Promise((resolve, reject) => {
         pollVideoBlackCheck(expected, video, canvasId, resolve);
-        setTimeout(() => reject("checkVideoBlack timed out for '" + canvasId + "', expected " + expected), 15000);
+        setTimeout(() => reject("checkVideoBlack timed out for '" + canvasId + "', expected " + expected), 30000);
     });
 }
 


### PR DESCRIPTION
#### 94ae61ff0973ee9f726dcc0a38fec23c7b5802a4
<pre>
REGRESSION(299383@main): [ iOS Release, macOS wk2 ] webrtc/video-rotation-black.html is a flaky text failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=298903">https://bugs.webkit.org/show_bug.cgi?id=298903</a>

Reviewed by Jean-Yves Avenard.

We increase the timeout value since a passing test takes 14 seconds to run and failing test runs take 16 seconds.
We go from 15 seconds to 30 seconds.

* LayoutTests/TestExpectations:
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/webrtc/video-rotation-black.html:

Canonical link: <a href="https://commits.webkit.org/300148@main">https://commits.webkit.org/300148@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a4c09ac06b62d4aa035f706d124ff4e2ba9e030a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121142 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40838 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31496 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127567 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73223 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c0b5752d-bc48-4263-ac6e-b3633b19ea19) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41540 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49417 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92030 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61222 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fdf4e95f-d998-4444-84b6-ccd81546228b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124094 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33169 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108588 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72706 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e192939f-ae4b-4e6a-a677-4ee0c0872461) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32194 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26691 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71153 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102673 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26870 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130414 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48069 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36536 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100628 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48437 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104755 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100532 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25551 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45934 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23988 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44763 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47927 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47398 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50745 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49082 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->