### PR TITLE
[Filters] Enable CoreGraphics GaussianBlur filter for layout tests

### DIFF
--- a/LayoutTests/css3/filters/effect-blur.html
+++ b/LayoutTests/css3/filters/effect-blur.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta name="fuzzy" content="maxDifference=0-50; totalPixels=0-5000">
+    <meta name="fuzzy" content="maxDifference=0-50; totalPixels=0-61883">
     <link rel="stylesheet" href="resources/filter-helpers.css">
 </head>
 <body>

--- a/LayoutTests/css3/filters/effect-combined.html
+++ b/LayoutTests/css3/filters/effect-combined.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta name="fuzzy" content="maxDifference=0-20; totalPixels=0-26400" />
+    <meta name="fuzzy" content="maxDifference=0-31; totalPixels=0-62774" />
     <link rel="stylesheet" href="resources/filter-helpers.css">
     <script src="resources/filter-helpers.js"></script>
 </head>

--- a/LayoutTests/fast/canvas/canvas-filter-drawing.html
+++ b/LayoutTests/fast/canvas/canvas-filter-drawing.html
@@ -1,4 +1,4 @@
-<meta name="fuzzy" content="maxDifference=0-3; totalPixels=0-4920" />
+<meta name="fuzzy" content="maxDifference=0-3; totalPixels=0-7862" />
 <style>
      canvas {
          width: 350px;

--- a/LayoutTests/fast/filter-image/filter-image-blur.html
+++ b/LayoutTests/fast/filter-image/filter-image-blur.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta name="fuzzy" content="maxDifference=0-10; totalPixels=0-500">
+    <meta name="fuzzy" content="maxDifference=0-23; totalPixels=0-3538">
     <style>
         div {
             position: absolute;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-captures-different-size.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-captures-different-size.html
@@ -5,7 +5,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:vmpstr@chromium.org">
 <link rel="match" href="new-content-captures-different-size-ref.html">
-<meta name=fuzzy content="maxDifference=0-100; totalPixels=0-15393">
+<meta name=fuzzy content="maxDifference=0-100; totalPixels=0-15518">
 <script src="/common/reftest-wait.js"></script>
 <style>
   html {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-edge-pixels-2.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-edge-pixels-2.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<meta name=fuzzy content="maxDifference=0-25;totalPixels=0-30000">
+<meta name=fuzzy content="maxDifference=0-28;totalPixels=0-30000">
 <link rel="author" href="mailto:masonf@chromium.org">
 <link rel="author" href="mailto:flackr@chromium.org">
 <link rel="help" href="https://drafts.fxtf.org/filter-effects-2/#BackdropFilterProperty">

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/fixed-pos-filter-clip-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/fixed-pos-filter-clip-001.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<meta name="fuzzy" content="maxDifference=0-2; totalPixels=0-399">
 <title>filter + fixed pos clipping</title>
 <link rel="author" title="Emilio Cobos Álvarez" href="mailto:emilio@crisal.io">
 <link rel="author" title="Mozilla" href="https://mozilla.org">

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -3266,7 +3266,7 @@ GoogleAntiFlickerOptimizationQuirkEnabled:
 
 GraphicsContextBlurFilterEnabled:
    type: bool
-   status: unstable
+   status: testable
    category: media
    webcoreOnChange: setNeedsRelayoutAllFrames
    humanReadableName: "GraphicsContext Blur Filter Rendering"


### PR DESCRIPTION
#### 931fd9a048adf383ae849eda49230a533bbb1c52
<pre>
[Filters] Enable CoreGraphics GaussianBlur filter for layout tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=298965">https://bugs.webkit.org/show_bug.cgi?id=298965</a>
<a href="https://rdar.apple.com/160702870">rdar://160702870</a>

Reviewed by Simon Fraser.

The pixel tolerance for some layout tests needs to be adjusted.

* LayoutTests/css3/filters/effect-blur.html:
* LayoutTests/css3/filters/effect-combined.html:
* LayoutTests/fast/canvas/canvas-filter-drawing.html:
* LayoutTests/fast/filter-image/filter-image-blur.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-captures-different-size.html:
* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-edge-pixels-2.html:
* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/fixed-pos-filter-clip-001.html:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:

Canonical link: <a href="https://commits.webkit.org/300062@main">https://commits.webkit.org/300062@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9978b45e35ec9ecc7e4b80790ea00963b57440d4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121214 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40910 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31568 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127645 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73295 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/befcaa12-a5d4-4e9e-ae32-c79028baf977) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41612 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49489 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92079 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/61263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d113699b-a5eb-46ca-9505-6d5b14e4f0e8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124166 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33230 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/108637 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72757 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bb2ce16c-a33d-4626-bbc2-271474f7532d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32248 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26757 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71229 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/113344 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102723 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26936 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130488 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/119734 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48141 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36591 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100676 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48509 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104821 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100580 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25488 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45990 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24044 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44835 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47999 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53712 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/149896 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47470 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/38092 "Found 1 new JSC stress test failure: stress/dont-link-virtual-calls-on-compiler-thread.js.no-llint (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50817 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49154 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->