### PR TITLE
Adjust display type of ::first-letter pseudo-element

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-display/display-first-letter-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-display/display-first-letter-001-expected.txt
@@ -1,0 +1,7 @@
+First letter is float and flex.
+First letter is float but not flex.
+First letter is flex but not float.
+First letter not float or flex.
+
+PASS display of first-letter
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-display/display-first-letter-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-display/display-first-letter-001.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Display: first-letter pseudo-element</title>
+<link rel="help" href="https://www.w3.org/TR/css-display-3/#placement">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+  #t1::first-letter { float: left; display: flex; font-size: 30px }
+  #t2::first-letter { float: left; font-size: 30px }
+  #t3::first-letter { display: flex; font-size: 30px }
+  #t4::first-letter { font-size: 30px }
+</style>
+<div id="t1">First letter is float and flex.</div>
+<div id="t2">First letter is float but not flex.</div>
+<div id="t3">First letter is flex but not float.</div>
+<div id="t4">First letter not float or flex.</div>
+<script>
+  function getFirstLetterDisplayFor(id) {
+    return window.getComputedStyle(document.getElementById(id), "::first-letter").display;
+  }
+  test(function() {
+    assert_equals(getFirstLetterDisplayFor("t1"), "block");
+    assert_equals(getFirstLetterDisplayFor("t2"), "block");
+    assert_equals(getFirstLetterDisplayFor("t3"), "inline");
+    assert_equals(getFirstLetterDisplayFor("t4"), "inline");
+  }, "display of first-letter");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-display/display-first-line-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-display/display-first-line-001-expected.txt
@@ -1,11 +1,7 @@
-First letter is float and flex.
-First letter is float but not flex.
-First letter is flex but not float.
-First letter not float or flex.
 First line is float and flex.
 First line is float but not flex.
 First line is flex but not float.
 First line is not float or flex.
 
-FAIL display of first-letter and first-line assert_equals: expected "block" but got "flex"
+FAIL display of first-line assert_equals: expected "inline" but got "flex"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-display/display-first-line-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-display/display-first-line-001.html
@@ -1,42 +1,27 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<title>CSS Display: first-line and first-letter pseudo-elements</title>
+<title>CSS Display: first-line pseudo-element</title>
 <link rel="help" href="https://www.w3.org/TR/css-display-3/#placement">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <style>
-  #t1::first-letter { float: left; display: flex; font-size: 30px }
-  #t2::first-letter { float: left; font-size: 30px }
-  #t3::first-letter { display: flex; font-size: 30px }
-  #t4::first-letter { font-size: 30px }
-  #t5::first-line { float: left; display: flex; font-size: 30px }
-  #t6::first-line { float: left; font-size: 30px }
-  #t7::first-line { display: flex; font-size: 30px }
-  #t8::first-line { font-size: 30px }
+  #t1::first-line { float: left; display: flex; font-size: 30px }
+  #t2::first-line { float: left; font-size: 30px }
+  #t3::first-line { display: flex; font-size: 30px }
+  #t4::first-line { font-size: 30px }
 </style>
-<div id="t1">First letter is float and flex.</div>
-<div id="t2">First letter is float but not flex.</div>
-<div id="t3">First letter is flex but not float.</div>
-<div id="t4">First letter not float or flex.</div>
-<div id="t5">First line is float and flex.</div>
-<div id="t6">First line is float but not flex.</div>
-<div id="t7">First line is flex but not float.</div>
-<div id="t8">First line is not float or flex.</div>
+<div id="t1">First line is float and flex.</div>
+<div id="t2">First line is float but not flex.</div>
+<div id="t3">First line is flex but not float.</div>
+<div id="t4">First line is not float or flex.</div>
 <script>
-  function getFirstLetterDisplayFor(id) {
-    return window.getComputedStyle(document.getElementById(id), "::first-letter").display;
-  }
   function getFirstLineDisplayFor(id) {
     return window.getComputedStyle(document.getElementById(id), "::first-line").display;
   }
   test(function() {
-    assert_equals(getFirstLetterDisplayFor("t1"), "block");
-    assert_equals(getFirstLetterDisplayFor("t2"), "block");
-    assert_equals(getFirstLetterDisplayFor("t3"), "inline");
-    assert_equals(getFirstLetterDisplayFor("t4"), "inline");
-    assert_equals(getFirstLineDisplayFor("t5"), "inline");
-    assert_equals(getFirstLineDisplayFor("t6"), "inline");
-    assert_equals(getFirstLineDisplayFor("t7"), "inline");
-    assert_equals(getFirstLineDisplayFor("t8"), "inline");
-  }, "display of first-letter and first-line");
+    assert_equals(getFirstLineDisplayFor("t1"), "inline");
+    assert_equals(getFirstLineDisplayFor("t2"), "inline");
+    assert_equals(getFirstLineDisplayFor("t3"), "inline");
+    assert_equals(getFirstLineDisplayFor("t4"), "inline");
+  }, "display of first-line");
 </script>

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -475,6 +475,15 @@ void Adjuster::adjustFromBuilder(RenderStyle& style)
     style.adjustViewTimelines();
 }
 
+void Adjuster::adjustFirstLetterStyle(RenderStyle& style)
+{
+    if (style.pseudoElementType() != PseudoId::FirstLetter)
+        return;
+
+    // Force inline display (except for floating first-letters).
+    style.setEffectiveDisplay(style.isFloating() ? DisplayType::Block : DisplayType::Inline);
+}
+
 void Adjuster::adjust(RenderStyle& style) const
 {
     if (style.display() == DisplayType::Contents)
@@ -514,6 +523,8 @@ void Adjuster::adjust(RenderStyle& style) const
         // Absolute/fixed positioned elements, floating elements and the document element need block-like outside display.
         if (style.hasOutOfFlowPosition() || style.isFloating() || (m_element && m_document->documentElement() == m_element.get()))
             style.setEffectiveDisplay(equivalentBlockDisplay(style));
+
+        adjustFirstLetterStyle(style);
 
         // FIXME: Don't support this mutation for pseudo styles like first-letter or first-line, since it's not completely
         // clear how that should work.

--- a/Source/WebCore/style/StyleAdjuster.h
+++ b/Source/WebCore/style/StyleAdjuster.h
@@ -54,6 +54,7 @@ public:
     void adjustAnimatedStyle(RenderStyle&, OptionSet<AnimationImpact>) const;
 
     static void adjustVisibilityForPseudoElement(RenderStyle&, const Element& host);
+    static void adjustFirstLetterStyle(RenderStyle&);
     static void adjustSVGElementStyle(RenderStyle&, const SVGElement&);
     static bool adjustEventListenerRegionTypesForRootStyle(RenderStyle&, const Document&);
     static void propagateToDocumentElementAndInitialContainingBlock(Update&, const Document&);


### PR DESCRIPTION
#### 4ccbdab29e67826e6b314f09a9399c9157203982
<pre>
Adjust display type of ::first-letter pseudo-element
<a href="https://bugs.webkit.org/show_bug.cgi?id=298972">https://bugs.webkit.org/show_bug.cgi?id=298972</a>
<a href="https://rdar.apple.com/160710650">rdar://160710650</a>

Reviewed by Antti Koivisto.

This patch aligns WebKit with Gecko / Firefox and Blink / Firefox.

According to web specification [1]. we cannot set the display on first-letter
pseudo element and we should force display type inline except in case of
float. This patch adds this case.

Additonally, we segregate test case from combined of ::first-letter and
::first-line into separate to show progression and make it more clear.

[1] <a href="https://www.w3.org/TR/css-display-3/#placement">https://www.w3.org/TR/css-display-3/#placement</a>

* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::Adjuster::adjustFirstLetterStyle):
(WebCore::Style::Adjuster::adjust const):
* Source/WebCore/style/StyleAdjuster.h:
* LayoutTests/imported/w3c/web-platform-tests/css/css-display/display-first-letter-001-expected.txt: Added + Progression.
* LayoutTests/imported/w3c/web-platform-tests/css/css-display/display-first-letter-001.html: Copied from LayoutTests/imported/w3c/web-platform-tests/css/css-display/display-first-line-001.html.
* LayoutTests/imported/w3c/web-platform-tests/css/css-display/display-first-line-001.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-display/display-first-line-001-expected.txt:

Canonical link: <a href="https://commits.webkit.org/300073@main">https://commits.webkit.org/300073@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6760a0b0a46399db78417af774699e0c19435a1c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121172 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40868 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31526 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127596 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73253 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5f9692ba-dc72-4574-b27f-ca62647cca49) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123048 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41570 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49447 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92052 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61243 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bf846783-715d-4fd9-a3ac-9bf824cf7957) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124124 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33194 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108613 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72728 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5d534c00-921a-47d1-b7fb-f44375553575) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32220 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26718 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71185 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102695 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26898 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130444 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48099 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36561 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100650 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48467 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104783 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100554 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25498 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45956 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24013 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44793 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47957 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53670 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47428 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50775 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49112 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->