### PR TITLE
Add support for using SF Symbols as Web Extension icons.

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/WebExtension.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtension.cpp
@@ -526,6 +526,11 @@ String WebExtension::resourceMIMETypeForPath(const String& path)
         return defaultMIMEType();
     }
 
+#if PLATFORM(COCOA)
+    if (path.startsWith("symbol:"_s))
+        return defaultMIMEType();
+#endif
+
     return MIMETypeRegistry::mimeTypeForPath(path);
 }
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIActionCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIActionCocoa.mm
@@ -390,8 +390,8 @@ bool WebExtensionAPIAction::isValidDimensionKey(NSString *dimension)
 
 NSString *WebExtensionAPIAction::parseIconPath(NSString *path, const URL& baseURL)
 {
-    // Resolve paths as relative against the base URL, unless it is a data URL.
-    if ([path hasPrefix:@"data:"])
+    // Resolve paths as relative against the base URL, unless it is a data or symbol URL.
+    if ([path hasPrefix:@"data:"] || [path hasPrefix:@"symbol:"])
         return path;
     return URL { baseURL, path }.path().createNSString().autorelease();
 }

--- a/Tools/TestWebKitAPI/Tests/TestWebKitAPI/mac/AppKitSPI.h
+++ b/Tools/TestWebKitAPI/Tests/TestWebKitAPI/mac/AppKitSPI.h
@@ -31,6 +31,7 @@ DECLARE_SYSTEM_HEADER
 
 #if USE(APPLE_INTERNAL_SDK)
 
+#import <AppKit/NSImage_Private.h>
 #import <AppKit/NSInspectorBar.h>
 #import <AppKit/NSInspectorBarItemController.h>
 #import <AppKit/NSInspectorBar_Private.h>
@@ -109,6 +110,10 @@ NSString * const NSInspectorBarTextAlignmentItemIdentifier = @"NSInspectorBarTex
 
 @interface NSScrollPocket : NSView
 @property (copy, nullable) NSColor *captureColor;
+@end
+
+@interface NSImage (SPI)
+@property (readonly, getter=_isSymbolImage) BOOL _symbolImage;
 @end
 
 #endif


### PR DESCRIPTION
#### e533155ab7c237c95febdc0cdafd526d752faacc
<pre>
Add support for using SF Symbols as Web Extension icons.
<a href="https://webkit.org/b/298978">https://webkit.org/b/298978</a>
<a href="https://rdar.apple.com/problem/160723485">rdar://problem/160723485</a>

Reviewed by Brian Weinstein.

Allow `&quot;symbol:name&quot;` to be used where any image path is allowed to use a system SF Symbol.

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm:
(WebKit::WebExtension::resourceDataForPath):
(WebKit::WebExtension::iconForPath):
* Source/WebKit/UIProcess/Extensions/WebExtension.cpp:
(WebKit::WebExtension::resourceMIMETypeForPath):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIActionCocoa.mm:
(WebKit::WebExtensionAPIAction::parseIconPath):
* Tools/TestWebKitAPI/Tests/TestWebKitAPI/mac/AppKitSPI.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtension.mm:
(TestWebKitAPI::TEST(WKWebExtension, SymbolImageIcon)): Added.
(TestWebKitAPI::TEST(WKWebExtension, SymbolImageIconVariant)): Added.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIAction.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIAction, SetIconSymbolSinglePath)): Added.
(TestWebKitAPI::TEST(WKWebExtensionAPIAction, SetIconSymbolIconsDictionary)): Added.
(TestWebKitAPI::TEST(WKWebExtensionAPIAction, SetIconWithSymbolVariants)): Added.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIMenus.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIMenus, MenuItemWithSymbolImageIconVariants)): Added.
(TestWebKitAPI::TEST(WKWebExtensionAPIMenus, MenuItemWithSymbolImageIcon)): Added.

Canonical link: <a href="https://commits.webkit.org/300080@main">https://commits.webkit.org/300080@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6fd67b7f1eff5176f5eab9b31001cb14e0a4d40b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121200 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40896 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31554 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127630 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73281 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/972785fb-5146-4d76-8b31-e3cbe84262c0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123076 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41598 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49475 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92064 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61254 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/375cc5b3-b908-4fb8-ad75-c06ac71b8c42) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124152 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33213 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108629 "Found 1 new API test failure: TestIPC.ConnectionTest/ConnectionRunLoopTest.SendAndInvalidate/ServerIsA (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72742 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c6cb0157-2374-4bfe-be76-34edee73f05e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32236 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26738 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71214 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102710 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26917 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130474 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48127 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36581 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100662 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48495 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104802 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100566 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45985 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24032 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44821 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19230 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47985 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53698 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47456 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50803 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49140 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->