### PR TITLE
Clean up UserContentController a little

### DIFF
--- a/Source/WebCore/page/UserMessageHandler.cpp
+++ b/Source/WebCore/page/UserMessageHandler.cpp
@@ -35,7 +35,7 @@
 
 namespace WebCore {
 
-UserMessageHandler::UserMessageHandler(LocalFrame& frame, UserMessageHandlerDescriptor& descriptor)
+UserMessageHandler::UserMessageHandler(LocalFrame& frame, const UserMessageHandlerDescriptor& descriptor)
     : FrameDestructionObserver(&frame)
     , m_descriptor(&descriptor)
 {

--- a/Source/WebCore/page/UserMessageHandler.h
+++ b/Source/WebCore/page/UserMessageHandler.h
@@ -42,7 +42,7 @@ template<typename> class ExceptionOr;
 
 class UserMessageHandler : public RefCounted<UserMessageHandler>, public FrameDestructionObserver {
 public:
-    static Ref<UserMessageHandler> create(LocalFrame& frame, UserMessageHandlerDescriptor& descriptor)
+    static Ref<UserMessageHandler> create(LocalFrame& frame, const UserMessageHandlerDescriptor& descriptor)
     {
         return adoptRef(*new UserMessageHandler(frame, descriptor));
     }
@@ -51,13 +51,13 @@ public:
     ExceptionOr<void> postMessage(JSC::JSGlobalObject&, JSC::JSValue, Ref<DeferredPromise>&&);
     JSC::JSValue postLegacySynchronousMessage(JSC::JSGlobalObject&, JSC::JSValue);
 
-    UserMessageHandlerDescriptor* descriptor() { return m_descriptor.get(); }
+    const UserMessageHandlerDescriptor* descriptor() { return m_descriptor.get(); }
     void invalidateDescriptor() { m_descriptor = nullptr; }
 
 private:
-    UserMessageHandler(LocalFrame&, UserMessageHandlerDescriptor&);
+    UserMessageHandler(LocalFrame&, const UserMessageHandlerDescriptor&);
     
-    RefPtr<UserMessageHandlerDescriptor> m_descriptor;
+    RefPtr<const UserMessageHandlerDescriptor> m_descriptor;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/UserMessageHandlerDescriptor.cpp
+++ b/Source/WebCore/page/UserMessageHandlerDescriptor.cpp
@@ -45,11 +45,6 @@ const AtomString& UserMessageHandlerDescriptor::name() const
     return m_name;
 }
 
-DOMWrapperWorld& UserMessageHandlerDescriptor::world()
-{
-    return m_world.get();
-}
-
 const DOMWrapperWorld& UserMessageHandlerDescriptor::world() const
 {
     return m_world.get();

--- a/Source/WebCore/page/UserMessageHandlerDescriptor.h
+++ b/Source/WebCore/page/UserMessageHandlerDescriptor.h
@@ -48,13 +48,12 @@ public:
     WEBCORE_EXPORT virtual ~UserMessageHandlerDescriptor();
 
     WEBCORE_EXPORT const AtomString& name() const;
-    WEBCORE_EXPORT DOMWrapperWorld& world();
     WEBCORE_EXPORT const DOMWrapperWorld& world() const;
 
-    virtual void didPostMessage(UserMessageHandler&, JSC::JSGlobalObject&, JSC::JSValue, Function<void(JSC::JSValue, const String&)>&&) = 0;
-    virtual JSC::JSValue didPostLegacySynchronousMessage(UserMessageHandler&, JSC::JSGlobalObject&, JSC::JSValue) = 0;
+    virtual void didPostMessage(UserMessageHandler&, JSC::JSGlobalObject&, JSC::JSValue, Function<void(JSC::JSValue, const String&)>&&) const = 0;
+    virtual JSC::JSValue didPostLegacySynchronousMessage(UserMessageHandler&, JSC::JSGlobalObject&, JSC::JSValue) const = 0;
 private:
-    AtomString m_name;
+    const AtomString m_name;
     const Ref<DOMWrapperWorld> m_world;
 };
 

--- a/Source/WebCore/page/UserMessageHandlersNamespace.h
+++ b/Source/WebCore/page/UserMessageHandlersNamespace.h
@@ -62,7 +62,10 @@ private:
     void didInvalidate(UserContentProvider&) override;
 
     const Ref<UserContentProvider> m_userContentProvider;
-    HashMap<std::pair<AtomString, RefPtr<DOMWrapperWorld>>, RefPtr<UserMessageHandler>> m_messageHandlers;
+
+    // FIXME: This could be a Ref<const DOMWrapperWorld> but PairHashTraits doesn't have hasIsEmptyValueFunction,
+    // so HashTraitsEmptyValueChecker calls operator== with a null Ref which asserts.
+    HashMap<std::pair<AtomString, RefPtr<const DOMWrapperWorld>>, Ref<UserMessageHandler>> m_messageHandlers;
 };
 
 } // namespace WebCore

--- a/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.cpp
+++ b/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.cpp
@@ -381,7 +381,7 @@ void WebUserContentControllerProxy::removeAllUserMessageHandlers()
     m_scriptMessageHandlers.clear();
 }
 
-void WebUserContentControllerProxy::didPostMessage(WebPageProxyIdentifier pageProxyID, FrameInfoData&& frameInfoData, ScriptMessageHandlerIdentifier messageHandlerID, JavaScriptEvaluationResult&& message, CompletionHandler<void(Expected<WebKit::JavaScriptEvaluationResult, String>&&)>&& reply)
+void WebUserContentControllerProxy::didPostMessage(WebPageProxyIdentifier pageProxyID, FrameInfoData&& frameInfoData, ScriptMessageHandlerIdentifier messageHandlerID, JavaScriptEvaluationResult&& message, CompletionHandler<void(Expected<WebKit::JavaScriptEvaluationResult, String>&&)>&& reply) const
 {
     auto page = WebProcessProxy::webPage(pageProxyID);
     if (!page)
@@ -397,7 +397,7 @@ void WebUserContentControllerProxy::didPostMessage(WebPageProxyIdentifier pagePr
     handler->client().didPostMessage(*page, WTFMove(frameInfoData), handler->world(), WTFMove(message), WTFMove(reply));
 }
 
-void WebUserContentControllerProxy::didPostLegacySynchronousMessage(WebPageProxyIdentifier webPageProxyID, FrameInfoData&& frameInfoData, ScriptMessageHandlerIdentifier messageHandlerID, JavaScriptEvaluationResult&& message, CompletionHandler<void(Expected<JavaScriptEvaluationResult, String>&&)>&& reply)
+void WebUserContentControllerProxy::didPostLegacySynchronousMessage(WebPageProxyIdentifier webPageProxyID, FrameInfoData&& frameInfoData, ScriptMessageHandlerIdentifier messageHandlerID, JavaScriptEvaluationResult&& message, CompletionHandler<void(Expected<JavaScriptEvaluationResult, String>&&)>&& reply) const
 {
     didPostMessage(webPageProxyID, WTFMove(frameInfoData), messageHandlerID, WTFMove(message), WTFMove(reply));
 }

--- a/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.h
+++ b/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.h
@@ -143,8 +143,8 @@ private:
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
     void didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) override;
 
-    void didPostMessage(WebPageProxyIdentifier, FrameInfoData&&, ScriptMessageHandlerIdentifier, JavaScriptEvaluationResult&&, CompletionHandler<void(Expected<JavaScriptEvaluationResult, String>&&)>&&);
-    void didPostLegacySynchronousMessage(WebPageProxyIdentifier, FrameInfoData&&, ScriptMessageHandlerIdentifier, JavaScriptEvaluationResult&&, CompletionHandler<void(Expected<JavaScriptEvaluationResult, String>&&)>&&);
+    void didPostMessage(WebPageProxyIdentifier, FrameInfoData&&, ScriptMessageHandlerIdentifier, JavaScriptEvaluationResult&&, CompletionHandler<void(Expected<JavaScriptEvaluationResult, String>&&)>&&) const;
+    void didPostLegacySynchronousMessage(WebPageProxyIdentifier, FrameInfoData&&, ScriptMessageHandlerIdentifier, JavaScriptEvaluationResult&&, CompletionHandler<void(Expected<JavaScriptEvaluationResult, String>&&)>&&) const;
 
     void addContentWorld(API::ContentWorld&);
 

--- a/Source/WebKit/WebProcess/UserContent/WebUserContentController.h
+++ b/Source/WebKit/WebProcess/UserContent/WebUserContentController.h
@@ -123,16 +123,16 @@ private:
     void removeUserScriptMessageHandlerInternal(InjectedBundleScriptWorld&, ScriptMessageHandlerIdentifier);
 #endif
 
-    UserContentControllerIdentifier m_identifier;
+    const UserContentControllerIdentifier m_identifier;
 
-    typedef HashMap<RefPtr<InjectedBundleScriptWorld>, Vector<std::pair<std::optional<UserScriptIdentifier>, WebCore::UserScript>>> WorldToUserScriptMap;
+    using WorldToUserScriptMap = HashMap<Ref<InjectedBundleScriptWorld>, Vector<std::pair<std::optional<UserScriptIdentifier>, WebCore::UserScript>>>;
     WorldToUserScriptMap m_userScripts;
 
-    typedef HashMap<RefPtr<InjectedBundleScriptWorld>, Vector<std::pair<std::optional<UserStyleSheetIdentifier>, WebCore::UserStyleSheet>>> WorldToUserStyleSheetMap;
+    using WorldToUserStyleSheetMap = HashMap<Ref<InjectedBundleScriptWorld>, Vector<std::pair<std::optional<UserStyleSheetIdentifier>, WebCore::UserStyleSheet>>>;
     WorldToUserStyleSheetMap m_userStyleSheets;
 
 #if ENABLE(USER_MESSAGE_HANDLERS)
-    typedef HashMap<RefPtr<InjectedBundleScriptWorld>, Vector<std::pair<ScriptMessageHandlerIdentifier, RefPtr<WebUserMessageHandlerDescriptorProxy>>>> WorldToUserMessageHandlerVectorMap;
+    using WorldToUserMessageHandlerVectorMap = HashMap<Ref<InjectedBundleScriptWorld>, Vector<std::pair<ScriptMessageHandlerIdentifier, Ref<WebUserMessageHandlerDescriptorProxy>>>>;
     WorldToUserMessageHandlerVectorMap m_userMessageHandlers;
 #endif
 #if ENABLE(CONTENT_EXTENSIONS)


### PR DESCRIPTION
#### 663bf6c94a79fa71dfad436a294be9a7af1f3c9c
<pre>
Clean up UserContentController a little
<a href="https://bugs.webkit.org/show_bug.cgi?id=298982">https://bugs.webkit.org/show_bug.cgi?id=298982</a>
<a href="https://rdar.apple.com/160725426">rdar://160725426</a>

Reviewed by Simon Fraser.

Use Ref instead of RefPtr where possible.
Use initializer lists instead of std::make_pair where possible.
Use const where possible.
Remove const_cast where possible.

No change in behavior.

* Source/WebCore/loader/EmptyClients.cpp:
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::shouldHaveWebKitNamespaceForWorld):
* Source/WebCore/page/UserContentController.cpp:
(WebCore::UserContentController::forEachUserMessageHandler const):
* Source/WebCore/page/UserContentController.h:
* Source/WebCore/page/UserContentProvider.h:
* Source/WebCore/page/UserMessageHandlersNamespace.cpp:
(WebCore::UserMessageHandlersNamespace::didInvalidate):
(WebCore::UserMessageHandlersNamespace::namedItem):
* Source/WebCore/page/UserMessageHandlersNamespace.h:
* Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp:
(WebKit::WebUserMessageHandlerDescriptorProxy::create):
(WebKit::WebUserMessageHandlerDescriptorProxy::WebUserMessageHandlerDescriptorProxy):
(WebKit::WebUserContentController::addUserScriptMessageHandlerInternal):
(WebKit::WebUserContentController::forEachUserMessageHandler const):
* Source/WebKit/WebProcess/UserContent/WebUserContentController.h:

Canonical link: <a href="https://commits.webkit.org/300069@main">https://commits.webkit.org/300069@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aa0063fe7a4e4918d7c4178a6d13f96b1e2abd59

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121262 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40959 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31617 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127698 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73343 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/91520f28-0fea-40f1-9cc4-7ab29e18b370) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123138 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41661 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49538 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92109 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/61277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124214 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33262 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/108668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72786 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9ce389b1-d122-45a4-9d5d-d5fcd4dd3951) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32278 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/26796 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71280 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102755 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26973 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130536 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48190 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36628 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/100706 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48557 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104858 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100611 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46020 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24081 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/44883 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19228 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48048 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53761 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47519 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50866 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49202 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->