### PR TITLE
Make image controls respect border radius

### DIFF
--- a/LayoutTests/fast/images/spatial-image-controls-expected.html
+++ b/LayoutTests/fast/images/spatial-image-controls-expected.html
@@ -4,11 +4,25 @@
         width: 200px;
         height: 200px;
         position: absolute;
+        border-radius: inherit;
     }
     div.image-container {
         width: 200px;
         height: 200px;
         position: relative;
+    }
+    div.rounded {
+        border-radius: 20px;
+    }
+    div.spatial-image-controls {
+        height: 100%;
+        display: flex;
+        flex-direction: column;
+        justify-content: space-between;
+        position: relative;
+        box-sizing: border-box;
+        padding: 20px;
+        border-radius: inherit;
     }
     button.spatial-image-controls-button {
         width: 45px;
@@ -67,6 +81,8 @@
         left: 0;
         height: 33%;
         width: 100%;
+        border-bottom-right-radius: inherit;
+        border-bottom-left-radius: inherit;
     }
 
     div.label {
@@ -92,7 +108,7 @@
 <body>
     <div class="image-container">
         <img src="resources/spatial.heic">
-        <div class="spatial-image-controls" contenteditable="false" style="height: 100%; display: flex; flex-direction: column; justify-content: space-between; position: relative; box-sizing: border-box; padding: 20px;">
+        <div class="spatial-image-controls" contenteditable="false">
             <button class="spatial-image-controls-button"></button>
             <div class="background-tint">
                 <div class="blur"></div>
@@ -105,7 +121,7 @@
     </div>
     <div class="image-container">
         <img src="resources/spatial.heic">
-            <div class="spatial-image-controls" contenteditable="false" style="width: 100%; height: 100%; display: flex; flex-direction: column; justify-content: space-between; position: relative; box-sizing: border-box; padding: 20px;">
+            <div class="spatial-image-controls" contenteditable="false">
                 <button class="spatial-image-controls-button"></button>
                 <div class="background-tint">
                     <div class="blur"></div>
@@ -115,6 +131,19 @@
                 <div class="label">
                     <span class="spatial-glyph"></span>SPATIAL</div>
             </div>
+    </div>
+    <div class="image-container rounded">
+        <img src="resources/spatial.heic">
+        <div class="spatial-image-controls" contenteditable="false">
+            <button class="spatial-image-controls-button"></button>
+            <div class="background-tint">
+                <div class="blur"></div>
+                <div class="tint"></div>
+            </div>
+            <div class="bottom-gradient"></div>
+            <div class="label">
+                <span class="spatial-glyph"></span>SPATIAL</div>
+        </div>
     </div>
     <img src="resources/green.jpg">
 </body>

--- a/LayoutTests/fast/images/spatial-image-controls.html
+++ b/LayoutTests/fast/images/spatial-image-controls.html
@@ -5,11 +5,15 @@
         width: 200px;
         height: 200px;
         position: absolute;
+        border-radius: inherit;
     }
     div.image-container {
         width: 200px;
         height: 200px;
         position: relative;
+    }
+    .rounded {
+        border-radius: 20px;
     }
 </style>
 <body>
@@ -20,6 +24,9 @@
         <template shadowrootmode="open">
             <img style="width: 200px; height: 200px" controls src="resources/spatial.heic">
         </template>
+    </div>
+    <div class="image-container rounded">
+        <img controls src="resources/spatial.heic">
     </div>
     <img controls src="resources/green.jpg">
             

--- a/Source/WebCore/html/shadow/SpatialImageControls.cpp
+++ b/Source/WebCore/html/shadow/SpatialImageControls.cpp
@@ -132,6 +132,7 @@ void ensureSpatialControls(HTMLImageElement& imageElement)
         controlLayer->setInlineStyleProperty(CSSPropertyJustifyContent, "space-between"_s);
         controlLayer->setInlineStyleProperty(CSSPropertyPosition, "relative"_s);
         controlLayer->setInlineStyleProperty(CSSPropertyBoxSizing, "border-box"_s);
+        controlLayer->setInlineStyleProperty(CSSPropertyBorderRadius, "inherit"_s);
         controlLayer->setInlineStyleProperty(CSSPropertyPadding, paddingValue, CSSUnitType::CSS_PX);
         shadowRoot->appendChild(controlLayer);
 

--- a/Source/WebCore/html/shadow/spatialImageControls.css
+++ b/Source/WebCore/html/shadow/spatialImageControls.css
@@ -81,6 +81,8 @@ div#bottom-gradient {
     left: 0;
     height: 33%;
     width: 100%;
+    border-bottom-right-radius: inherit;
+    border-bottom-left-radius: inherit;
 }
 
 div#label {


### PR DESCRIPTION
#### f717266f8c2809068ccd3242d299bbad933649d6
<pre>
Make image controls respect border radius
<a href="https://bugs.webkit.org/show_bug.cgi?id=298986">https://bugs.webkit.org/show_bug.cgi?id=298986</a>
&lt;<a href="https://rdar.apple.com/155253201">rdar://155253201</a>&gt;

Reviewed by Mike Wyrzykowski.

Make the label section of the controls inherit the border radius of the
parent image.

* LayoutTests/fast/images/spatial-image-controls-expected.html:
* LayoutTests/fast/images/spatial-image-controls.html:
Add new test coverage, and refactor existing controls tests.
* Source/WebCore/html/shadow/SpatialImageControls.cpp:
(WebCore::SpatialImageControls::ensureSpatialControls):
* Source/WebCore/html/shadow/spatialImageControls.css:
(div#bottom-gradient):
Make controls label inherit bottom border radius of image.

Canonical link: <a href="https://commits.webkit.org/300535@main">https://commits.webkit.org/300535@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/153114e0f65bdf4e4513124f9eb06986dee5d8de

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122979 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/42693 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33390 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/129633 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/75088 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/124856 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43416 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51287 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/93485 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/75088 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125930 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/34616 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/110080 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/74112 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/33593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/28233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/73142 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/104326 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/28448 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132361 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/49928 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/38019 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/101985 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/50305 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/106289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/101854 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25868 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/25411 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/46702 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/49784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/55544 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/49251 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/52604 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/50933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->