### PR TITLE
[GFC] Initial implementation of grid item placement.

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1920,6 +1920,8 @@ layout/formattingContexts/flex/FlexFormattingUtils.cpp
 layout/formattingContexts/flex/FlexLayout.cpp
 layout/formattingContexts/grid/GridFormattingContext.cpp
 layout/formattingContexts/grid/GridLayout.cpp
+layout/formattingContexts/grid/ImplicitGrid.cpp
+layout/formattingContexts/grid/PlacedGridItem.cpp
 layout/formattingContexts/grid/UnplacedGridItem.cpp
 layout/formattingContexts/inline/AbstractLineBuilder.cpp
 layout/formattingContexts/inline/InlineContentAligner.cpp

--- a/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp
@@ -28,6 +28,7 @@
 
 #include "GridLayout.h"
 #include "LayoutChildIterator.h"
+#include "RenderStyleInlines.h"
 #include "StylePrimitiveNumeric.h"
 #include "UnplacedGridItem.h"
 
@@ -59,9 +60,25 @@ UnplacedGridItems GridFormattingContext::constructUnplacedGridItems() const
 
     std::ranges::stable_sort(gridItems, { }, &GridItem::order);
 
-    return gridItems.map([](const GridItem& gridItem) -> UnplacedGridItem {
-        return UnplacedGridItem { gridItem.layoutBox.get() };
-    });
+    UnplacedGridItems unplacedGridItems;
+    for (auto& gridItem : gridItems) {
+        CheckedRef gridItemStyle = gridItem.layoutBox->style();
+
+        auto gridItemColumnStart = gridItemStyle->gridItemColumnStart();
+        auto gridItemColumnEnd = gridItemStyle->gridItemColumnEnd();
+        auto gridItemRowStart = gridItemStyle->gridItemRowStart();
+        auto gridItemRowEnd = gridItemStyle->gridItemRowEnd();
+
+        if (!gridItemColumnStart.isExplicit() || !gridItemColumnEnd.isExplicit()
+            || !gridItemRowStart.isExplicit() || !gridItemRowEnd.isExplicit()) {
+            ASSERT_NOT_IMPLEMENTED_YET();
+            return { };
+        }
+
+        unplacedGridItems.nonAutoPositionedItems.constructAndAppend(gridItem.layoutBox, gridItemStyle->gridItemColumnStart(), gridItemStyle->gridItemColumnEnd(),
+    gridItemStyle->gridItemRowStart(), gridItemStyle->gridItemRowEnd());
+    }
+    return unplacedGridItems;
 }
 
 void GridFormattingContext::layout(GridLayoutConstraints layoutConstraints)

--- a/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "LayoutState.h"
 #include "LayoutUnit.h"
 #include <wtf/CheckedRef.h>
 
@@ -32,10 +33,9 @@ namespace WebCore {
 namespace Layout {
 
 class ElementBox;
-class LayoutState;
 
 class UnplacedGridItem;
-using UnplacedGridItems = Vector<UnplacedGridItem>;
+struct UnplacedGridItems;
 
 class GridFormattingContext : public CanMakeCheckedPtr<GridFormattingContext> {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(GridFormattingContext);
@@ -50,6 +50,9 @@ public:
     GridFormattingContext(const ElementBox& gridBox, LayoutState&);
 
     void layout(GridLayoutConstraints);
+
+    const ElementBox& root() const { return m_gridBox; }
+
 private:
     UnplacedGridItems constructUnplacedGridItems() const;
 

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayout.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayout.h
@@ -28,17 +28,26 @@
 #include "GridFormattingContext.h"
 
 namespace WebCore {
+class RenderStyle;
+
 namespace Layout {
 
+class PlacedGridItem;
 class UnplacedGridItem;
-using UnplacedGridItems = Vector<UnplacedGridItem>;
+struct UnplacedGridItems;
 
 class GridLayout {
 public:
     GridLayout(const GridFormattingContext&);
 
-    void layout(GridFormattingContext::GridLayoutConstraints, UnplacedGridItems);
+    void layout(GridFormattingContext::GridLayoutConstraints, const UnplacedGridItems&);
 private:
+    using PlacedGridItems = Vector<PlacedGridItem>;
+    static PlacedGridItems placeGridItems(const UnplacedGridItems&, size_t gridTemplateColumnsTracksCount, size_t gridTemplateRowsTracksCount);
+
+    const ElementBox& gridContainer() const;
+    const RenderStyle& gridContainerStyle() const;
+
     const CheckedRef<const GridFormattingContext> m_gridFormattingContext;
 };
 

--- a/Source/WebCore/layout/formattingContexts/grid/ImplicitGrid.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/ImplicitGrid.cpp
@@ -1,0 +1,123 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ImplicitGrid.h"
+
+#include "PlacedGridItem.h"
+#include "UnplacedGridItem.h"
+#include <wtf/Range.h>
+
+namespace WebCore {
+namespace Layout {
+
+// The implicit grid is created from the explicit grid + items that are placed outside
+// of the explicit grid. Since we know the explicit tracks from style we start the
+// implicit grid as exactly the explicit grid and allow placement to add implicit
+// tracks and grow the grid.
+ImplicitGrid::ImplicitGrid(size_t gridTemplateColumnsCount, size_t gridTemplateRowsCount)
+    : m_gridMatrix(Vector(gridTemplateRowsCount, Vector<CheckedPtr<const UnplacedGridItem>>(gridTemplateColumnsCount)))
+{
+}
+
+void ImplicitGrid::insertUnplacedGridItem(const UnplacedGridItem& unplacedGridItem)
+{
+    // https://drafts.csswg.org/css-grid/#common-uses-numeric
+    auto explicitColumnStart = unplacedGridItem.explicitColumnStart();
+    auto explicitColumnEnd = unplacedGridItem.explicitColumnEnd();
+    if (explicitColumnStart < 0 || explicitColumnEnd < 0) {
+        ASSERT_NOT_IMPLEMENTED_YET();
+        return;
+    }
+
+    if (explicitColumnEnd <= explicitColumnStart) {
+        ASSERT_NOT_IMPLEMENTED_YET();
+        return;
+    }
+
+    auto columnsCount = static_cast<int>(this->columnsCount());
+    if (explicitColumnStart > columnsCount || explicitColumnEnd > columnsCount) {
+        ASSERT_NOT_IMPLEMENTED_YET();
+        return;
+    }
+
+    auto explicitRowStart = unplacedGridItem.explicitRowStart();
+    auto explicitRowEnd = unplacedGridItem.explicitRowEnd();
+    if (explicitRowStart < 0 || explicitRowEnd < 0) {
+        ASSERT_NOT_IMPLEMENTED_YET();
+        return;
+    }
+
+    if (explicitRowEnd <= explicitRowStart) {
+        ASSERT_NOT_IMPLEMENTED_YET();
+        return;
+    }
+
+    auto rowsCount = static_cast<int>(this->rowsCount());
+    if (explicitRowStart > rowsCount || explicitRowEnd > rowsCount) {
+        ASSERT_NOT_IMPLEMENTED_YET();
+        return;
+    }
+
+    if (explicitColumnEnd - explicitColumnStart > 1) {
+        ASSERT_NOT_IMPLEMENTED_YET();
+        return;
+    }
+
+    if (explicitRowEnd - explicitRowStart > 1) {
+        ASSERT_NOT_IMPLEMENTED_YET();
+        return;
+    }
+
+    auto columnsRange = WTF::Range(explicitColumnStart, explicitColumnEnd);
+    auto rowsRange = WTF::Range(explicitRowStart, explicitRowEnd);
+    for (auto rowIndex = rowsRange.begin(); rowIndex < rowsRange.end(); ++rowIndex) {
+        for (auto columnIndex = columnsRange.begin(); columnIndex < columnsRange.end(); ++columnIndex)
+            m_gridMatrix[rowIndex].insert(columnIndex, unplacedGridItem);
+    }
+
+}
+
+PlacedGridItems ImplicitGrid::placedGridItems() const
+{
+    HashSet<CheckedRef<const UnplacedGridItem>> processedUnplacedGridItems;
+    PlacedGridItems placedGridItems;
+
+    for (size_t rowIndex = 0; rowIndex < m_gridMatrix.size(); ++rowIndex) {
+        for (size_t columnIndex = 0; columnIndex < m_gridMatrix[rowIndex].size(); ++columnIndex) {
+
+            CheckedPtr unplacedGridItem = m_gridMatrix[rowIndex][columnIndex];
+            if (!unplacedGridItem || processedUnplacedGridItems.contains(*unplacedGridItem))
+                continue;
+
+            processedUnplacedGridItems.add(*unplacedGridItem);
+            placedGridItems.append({ *unplacedGridItem, { columnIndex, columnIndex + 1, rowIndex, rowIndex + 1 } });
+        }
+    }
+    return placedGridItems;
+}
+
+} // namespace Layout
+} // namespace WebCore

--- a/Source/WebCore/layout/formattingContexts/grid/ImplicitGrid.h
+++ b/Source/WebCore/layout/formattingContexts/grid/ImplicitGrid.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/Forward.h>
+
+namespace WebCore {
+namespace Layout {
+
+class PlacedGridItem;
+class UnplacedGridItem;
+
+using PlacedGridItems = Vector<PlacedGridItem>;
+
+// https://drafts.csswg.org/css-grid-1/#implicit-grids
+class ImplicitGrid {
+public:
+    ImplicitGrid(size_t explicitColumnsCount, size_t explicitRowsCount);
+
+    size_t rowsCount() const { return m_gridMatrix.size(); }
+    size_t columnsCount() const { return rowsCount() ? m_gridMatrix[0].size() : 0; }
+
+    void insertUnplacedGridItem(const UnplacedGridItem&);
+
+    PlacedGridItems placedGridItems() const;
+
+private:
+    using GridMatrix = Vector<Vector<WTF::CheckedPtr<const UnplacedGridItem>>>;
+    GridMatrix m_gridMatrix;
+};
+
+} // namespace Layout
+} // namespace WebCore

--- a/Source/WebCore/layout/formattingContexts/grid/PlacedGridItem.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/PlacedGridItem.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "PlacedGridItem.h"
+
+#include "UnplacedGridItem.h"
+
+namespace WebCore {
+namespace Layout {
+
+PlacedGridItem::PlacedGridItem(const UnplacedGridItem& unplacedGridItem, GridAreaLines gridAreaLines)
+    : m_layoutBox(unplacedGridItem.m_layoutBox)
+    , m_gridAreaLines(gridAreaLines)
+{
+}
+
+} // namespace Layout
+} // namespace WebCore

--- a/Source/WebCore/layout/formattingContexts/grid/PlacedGridItem.h
+++ b/Source/WebCore/layout/formattingContexts/grid/PlacedGridItem.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "LayoutElementBox.h"
+#include <wtf/HashTraits.h>
+
+namespace WebCore {
+namespace Layout {
+
+class UnplacedGridItem;
+
+class PlacedGridItem {
+public:
+    // https://drafts.csswg.org/css-grid-1/#grid-area
+    struct GridAreaLines {
+        size_t columnStartLine;
+        size_t columnEndLine;
+        size_t rowStartLine;
+        size_t rowEndLine;
+    };
+
+    PlacedGridItem(const UnplacedGridItem&, GridAreaLines);
+
+    size_t columnStartLine() const { return m_gridAreaLines.columnStartLine; }
+    size_t columnEndLine() const { return m_gridAreaLines.columnEndLine; }
+    size_t rowStartLine() const { return m_gridAreaLines.rowStartLine; }
+    size_t rowEndLine() const { return m_gridAreaLines.rowEndLine; }
+
+private:
+    const CheckedRef<const ElementBox> m_layoutBox;
+
+    GridAreaLines m_gridAreaLines;
+};
+
+} // namespace Layout
+} // namespace WebCore

--- a/Source/WebCore/layout/formattingContexts/grid/UnplacedGridItem.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/UnplacedGridItem.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -28,9 +28,56 @@
 
 namespace WebCore {
 namespace Layout {
-UnplacedGridItem::UnplacedGridItem(const ElementBox& layoutBox)
+UnplacedGridItem::UnplacedGridItem(const ElementBox& layoutBox, Style::GridPosition columnStart, Style::GridPosition columnEnd,
+    Style::GridPosition rowStart, Style::GridPosition rowEnd)
     : m_layoutBox(layoutBox)
+    , m_columnPosition({ columnStart, columnEnd })
+    , m_rowPosition({ rowStart, rowEnd })
 {
+}
+
+int UnplacedGridItem::explicitColumnStart() const
+{
+    ASSERT(m_columnPosition.first.isExplicit());
+    auto explicitColumnStart = m_columnPosition.first.explicitPosition();
+    if (explicitColumnStart > 0)
+        return explicitColumnStart - 1;
+
+    ASSERT_NOT_IMPLEMENTED_YET();
+    return { };
+}
+
+int UnplacedGridItem::explicitColumnEnd() const
+{
+    ASSERT(m_columnPosition.second.isExplicit());
+    auto explicitColumnEnd = m_columnPosition.second.explicitPosition();
+    if (explicitColumnEnd > 0)
+        return explicitColumnEnd - 1;
+
+    ASSERT_NOT_IMPLEMENTED_YET();
+    return { };
+}
+
+int UnplacedGridItem::explicitRowStart() const
+{
+    ASSERT(m_rowPosition.first.isExplicit());
+    auto explicitRowStart = m_rowPosition.first.explicitPosition();
+    if (explicitRowStart > 0)
+        return explicitRowStart - 1;
+
+    ASSERT_NOT_IMPLEMENTED_YET();
+    return { };
+}
+
+int UnplacedGridItem::explicitRowEnd() const
+{
+    ASSERT(m_rowPosition.second.isExplicit());
+    auto explicitRowEnd = m_rowPosition.second.explicitPosition();
+    if (explicitRowEnd > 0)
+        return explicitRowEnd - 1;
+
+    ASSERT_NOT_IMPLEMENTED_YET();
+    return { };
 }
 
 } // namespace Layout

--- a/Source/WebCore/layout/formattingContexts/grid/UnplacedGridItem.h
+++ b/Source/WebCore/layout/formattingContexts/grid/UnplacedGridItem.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -25,17 +25,42 @@
 
 #pragma once
 
-#include "LayoutElementBox.h"
 #include "StyleGridPosition.h"
 
 namespace WebCore {
 namespace Layout {
 
-class UnplacedGridItem {
+class ElementBox;
+
+class UnplacedGridItem : public CanMakeCheckedPtr<UnplacedGridItem> {
+    WTF_MAKE_TZONE_OR_ISO_ALLOCATED(UnplacedGridItem);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(UnplacedGridItem);
 public:
-    UnplacedGridItem(const ElementBox&);
+    UnplacedGridItem(const ElementBox&, Style::GridPosition columnStart, Style::GridPosition columnEnd, Style::GridPosition rowStart, Style::GridPosition rowEnd);
+
+    // The grammar for <grid-line>, which is used by the grid-{column, row}-{start-end}
+    // placement properties is 1-index in regards to line numbers. To allow for easy
+    // indexing from these line numbers into our structures we subtract 1 from them
+    // into these helper functions to make them 0-index. For example, grid-column-start: 1
+    // and grid-column-end: 2 would make to [0, 1] and place the grid item into
+    // Grid[rowIndex][0].
+    int explicitColumnStart() const;
+    int explicitColumnEnd() const;
+    int explicitRowStart() const;
+    int explicitRowEnd() const;
+
 private:
     const CheckedRef<const ElementBox> m_layoutBox;
+
+    // https://drafts.csswg.org/css-grid-1/#typedef-grid-row-start-grid-line
+    std::pair<Style::GridPosition, Style::GridPosition> m_columnPosition;
+    std::pair<Style::GridPosition, Style::GridPosition> m_rowPosition;
+
+    friend class PlacedGridItem;
+};
+
+struct UnplacedGridItems {
+    Vector<UnplacedGridItem> nonAutoPositionedItems;
 };
 
 }


### PR DESCRIPTION
#### 5063ef34f4f66ebb467473eb9ed62e5a40cdbe7b
<pre>
[GFC] Initial implementation of grid item placement.
<a href="https://bugs.webkit.org/show_bug.cgi?id=298989">https://bugs.webkit.org/show_bug.cgi?id=298989</a>
<a href="https://rdar.apple.com/problem/160729099">rdar://problem/160729099</a>

Reviewed by Sam Weinig and Alan Baradlay.

This patch introduces the initial implementation of grid item placement
by implementing some overall logic around simple content. In this case,
simple content refers to grid content in which all items are explicitly
placed, span only a single track, and other placement constraints which
should be documented through the code. In addition, we only support
placement by placing items within columns and grids that are explicitly
defined via the grid-template-{columns, rows} properties.

The overall purpose of this patch is not to implement all of the logic
required to satisfy item placement in all scenarios but rather provide
some overall scaffolding in which we can build upon one at a time. We
liberally use ASSERT_NOT_IMPLEMENTED to help identify these areas in which
we can and will need to build upon in future work.

* Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp:
(WebCore::Layout::GridFormattingContext::constructUnplacedGridItems const):
* Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.h:
(WebCore::Layout::GridFormattingContext::root const):
* Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp:
(WebCore::Layout::GridLayout::layout):
(WebCore::Layout::GridLayout::placeGridItems):
* Source/WebCore/layout/formattingContexts/grid/GridLayout.h:
(WebCore::Layout::GridLayout::gridContainer const):
(WebCore::Layout::GridLayout::gridContainerStyle const):

* Source/WebCore/layout/formattingContexts/grid/ImplicitGrid.cpp: Added.
(WebCore::Layout::ImplicitGrid::ImplicitGrid):
The main purpose of ImplicitGrid is to serve as a helper structure to
keep track of some state during item placement. Since an implicit grid
is constructed from the explicit grid, as described in the spec, the
idea is that the constructor takes in the number of explicit columns and
rows that are specified in the style. For now, we only take in the
columns and rows that are specified by grid-template-{columns, rows}, but
eventually, we will also need to take into consideration the fact
that the number of explicit tracks can also be influenced by the
grid-template-areas property.

(WebCore::Layout::ImplicitGrid::insertUnplacedGridItem):
Users of ImplicitGrid will insert unplaced items through this API, and
the ImplicitGrid will handle resizing the grid (i.e. adding implicit
columns and rows) as necessary to fit the items. This logic isn&apos;t
implemented currently since we are only worrying about items that fit
within the explicitly sized grid, and as a result, we should not need to
expect to resize the grid.

* Source/WebCore/layout/formattingContexts/grid/PlacedGridItem.cpp:
(WebCore::Layout::PlacedGridItem::PlacedGridItem):
* Source/WebCore/layout/formattingContexts/grid/PlacedGridItem.h:
A PlacedGridItem is the result of resolving the placement (i.e. the grid
area) of an UnplacedGridItem. This structure is very similar to
UnplacedGridItem, with the main difference being that the positions are
typed by size_t wthin a GridAreaLines struct to indicate the fact that
the location is resolved within the implicit grid.

(WebCore::Layout::UnplacedGridItem::explicitColumnStart const):
(WebCore::Layout::UnplacedGridItem::explicitColumnEnd const):
(WebCore::Layout::UnplacedGridItem::explicitRowStart const):
(WebCore::Layout::UnplacedGridItem::explicitRowEnd const):
Some straightforward helper functions to access the item&apos;s explicit
column/row positions. Since the grid lines in the properties&apos; grammar are
1-indexed, we also subtract 1 from these values so that they map nicely
to our 0 indexed structures. For example, grid-column-start: 1 and
grid-column-end: 2 would return [0, 1] which would map the item to be
placed into GridMatrix[rowIndex][0]. We also leave negative line numbers
to be handled in a future patch to maintain simplicity.

* Source/WebCore/layout/formattingContexts/grid/UnplacedGridItem.h:
In order to place an UnplacedGridItem we need to know its placement
(position and span) which are given from the grid-{column, row}-{start, end}
properties. Any information that is needed to resolve a grid item&apos;s
placement should be stored on this class and be accessed through a
dedicated API, such as the explicit position helper functions above.

Also, we change PlacedGridItems from being a simple Vector&lt;PlacedGridItem&gt;
to a struct instead. This is because it will organize the different
unplaced grid items into a way that is easily accessible to the
placement logic in a manner that is similar to how the spec reads. For
example, the first step in placement is to place all non-auto positioned
items so this will be a collection of items in UnplacedGridItems that
the code can get to perform that step.

Canonical link: <a href="https://commits.webkit.org/300141@main">https://commits.webkit.org/300141@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cd4f215e29d31aa460c91fe3bfa69d9b4caf7e06

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121366 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41063 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31722 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127806 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73449 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/95ed812b-dbcb-4ddb-ba4a-0781a487c315) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123242 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41765 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49642 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92189 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61340 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/840e987a-52ea-4af7-b7c6-1db3bfd8d040) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124318 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33351 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108744 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72865 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a0e6e155-69c9-4860-b309-a229e624584d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32368 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26883 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71385 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102845 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27058 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130640 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48294 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36718 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100784 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48662 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104943 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100689 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25544 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46099 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24164 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44990 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48152 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53865 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47624 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50970 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49306 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->