### PR TITLE
Return fixedpos containing block (if any) for a fixedpos's offsetParent

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-multicol-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-multicol-002.html
@@ -87,10 +87,10 @@
         <div class="target target1-rb"
              data-offset-x=58 data-offset-y=215></div>
         <div class="target fixed target1"
-             data-offset-x=26 data-offset-y=140
+             data-offset-x=18 data-offset-y=135
              data-expected-width=50 data-expected-height=90></div>
         <div class="target fixed target1-rb"
-             data-offset-x=66 data-offset-y=220></div>
+             data-offset-x=58 data-offset-y=215></div>
       </div>
 
       <!-- The containing block of querying elements is a multi-column.  -->
@@ -100,10 +100,10 @@
       <div class="target target1-rb"
            data-offset-x=294 data-offset-y=95></div>
       <div class="target fixed target1"
-           data-offset-x=152 data-offset-y=10
+           data-offset-x=144 data-offset-y=5
            data-expected-width=160 data-expected-height=100></div>
       <div class="target fixed target1-rb"
-           data-offset-x=302 data-offset-y=100></div>
+           data-offset-x=294 data-offset-y=95></div>
     </div>
 
     <!-- The containing block of querying elements is not fragmented.  -->
@@ -113,9 +113,9 @@
     <div class="target target1-rb"
          data-offset-x=294 data-offset-y=95></div>
     <div class="target fixed target1"
-         data-offset-x=152 data-offset-y=10
+         data-offset-x=144 data-offset-y=5
          data-expected-width=160 data-expected-height=100></div>
     <div class="target fixed target1-rb"
-         data-offset-x=302 data-offset-y=100></div>
-    </div>
+         data-offset-x=294 data-offset-y=95></div>
+  </div>
 </body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-insets-fixed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-insets-fixed-expected.txt
@@ -5,322 +5,322 @@ PASS horizontal-tb ltr inside horizontal-tb ltr - Percentages are absolutized in
 PASS horizontal-tb ltr inside horizontal-tb ltr - calc() is absolutized into pixels
 PASS horizontal-tb ltr inside horizontal-tb ltr - Pixels resolve as-is when overconstrained
 PASS horizontal-tb ltr inside horizontal-tb ltr - Percentages absolutize the computed value when overconstrained
-FAIL horizontal-tb ltr inside horizontal-tb ltr - If start side is 'auto' and end side is not, 'auto' resolves to used value assert_equals: 'top' expected "297px" but got "425px"
-FAIL horizontal-tb ltr inside horizontal-tb ltr - If end side is 'auto' and start side is not, 'auto' resolves to used value assert_equals: 'bottom' expected "299px" but got "171px"
-FAIL horizontal-tb ltr inside horizontal-tb ltr - If opposite sides are 'auto', they resolve to used value assert_equals: 'top' expected "127px" but got "255px"
+PASS horizontal-tb ltr inside horizontal-tb ltr - If start side is 'auto' and end side is not, 'auto' resolves to used value
+PASS horizontal-tb ltr inside horizontal-tb ltr - If end side is 'auto' and start side is not, 'auto' resolves to used value
+PASS horizontal-tb ltr inside horizontal-tb ltr - If opposite sides are 'auto', they resolve to used value
 PASS horizontal-tb ltr inside horizontal-tb rtl - Pixels resolve as-is
 PASS horizontal-tb ltr inside horizontal-tb rtl - Relative lengths are absolutized into pixels
 PASS horizontal-tb ltr inside horizontal-tb rtl - Percentages are absolutized into pixels
 PASS horizontal-tb ltr inside horizontal-tb rtl - calc() is absolutized into pixels
 PASS horizontal-tb ltr inside horizontal-tb rtl - Pixels resolve as-is when overconstrained
 PASS horizontal-tb ltr inside horizontal-tb rtl - Percentages absolutize the computed value when overconstrained
-FAIL horizontal-tb ltr inside horizontal-tb rtl - If start side is 'auto' and end side is not, 'auto' resolves to used value assert_equals: 'top' expected "297px" but got "425px"
-FAIL horizontal-tb ltr inside horizontal-tb rtl - If end side is 'auto' and start side is not, 'auto' resolves to used value assert_equals: 'bottom' expected "299px" but got "171px"
-FAIL horizontal-tb ltr inside horizontal-tb rtl - If opposite sides are 'auto', they resolve to used value assert_equals: 'top' expected "127px" but got "255px"
+PASS horizontal-tb ltr inside horizontal-tb rtl - If start side is 'auto' and end side is not, 'auto' resolves to used value
+PASS horizontal-tb ltr inside horizontal-tb rtl - If end side is 'auto' and start side is not, 'auto' resolves to used value
+PASS horizontal-tb ltr inside horizontal-tb rtl - If opposite sides are 'auto', they resolve to used value
 PASS horizontal-tb ltr inside vertical-lr ltr - Pixels resolve as-is
 PASS horizontal-tb ltr inside vertical-lr ltr - Relative lengths are absolutized into pixels
 PASS horizontal-tb ltr inside vertical-lr ltr - Percentages are absolutized into pixels
 PASS horizontal-tb ltr inside vertical-lr ltr - calc() is absolutized into pixels
 PASS horizontal-tb ltr inside vertical-lr ltr - Pixels resolve as-is when overconstrained
 PASS horizontal-tb ltr inside vertical-lr ltr - Percentages absolutize the computed value when overconstrained
-FAIL horizontal-tb ltr inside vertical-lr ltr - If start side is 'auto' and end side is not, 'auto' resolves to used value assert_equals: 'top' expected "297px" but got "425px"
-FAIL horizontal-tb ltr inside vertical-lr ltr - If end side is 'auto' and start side is not, 'auto' resolves to used value assert_equals: 'bottom' expected "299px" but got "171px"
-FAIL horizontal-tb ltr inside vertical-lr ltr - If opposite sides are 'auto', they resolve to used value assert_equals: 'top' expected "127px" but got "255px"
+PASS horizontal-tb ltr inside vertical-lr ltr - If start side is 'auto' and end side is not, 'auto' resolves to used value
+PASS horizontal-tb ltr inside vertical-lr ltr - If end side is 'auto' and start side is not, 'auto' resolves to used value
+PASS horizontal-tb ltr inside vertical-lr ltr - If opposite sides are 'auto', they resolve to used value
 PASS horizontal-tb ltr inside vertical-lr rtl - Pixels resolve as-is
 PASS horizontal-tb ltr inside vertical-lr rtl - Relative lengths are absolutized into pixels
 PASS horizontal-tb ltr inside vertical-lr rtl - Percentages are absolutized into pixels
 PASS horizontal-tb ltr inside vertical-lr rtl - calc() is absolutized into pixels
 PASS horizontal-tb ltr inside vertical-lr rtl - Pixels resolve as-is when overconstrained
 PASS horizontal-tb ltr inside vertical-lr rtl - Percentages absolutize the computed value when overconstrained
-FAIL horizontal-tb ltr inside vertical-lr rtl - If start side is 'auto' and end side is not, 'auto' resolves to used value assert_equals: 'top' expected "297px" but got "425px"
-FAIL horizontal-tb ltr inside vertical-lr rtl - If end side is 'auto' and start side is not, 'auto' resolves to used value assert_equals: 'bottom' expected "299px" but got "171px"
-FAIL horizontal-tb ltr inside vertical-lr rtl - If opposite sides are 'auto', they resolve to used value assert_equals: 'top' expected "173px" but got "301px"
+PASS horizontal-tb ltr inside vertical-lr rtl - If start side is 'auto' and end side is not, 'auto' resolves to used value
+PASS horizontal-tb ltr inside vertical-lr rtl - If end side is 'auto' and start side is not, 'auto' resolves to used value
+PASS horizontal-tb ltr inside vertical-lr rtl - If opposite sides are 'auto', they resolve to used value
 PASS horizontal-tb ltr inside vertical-rl ltr - Pixels resolve as-is
 PASS horizontal-tb ltr inside vertical-rl ltr - Relative lengths are absolutized into pixels
 PASS horizontal-tb ltr inside vertical-rl ltr - Percentages are absolutized into pixels
 PASS horizontal-tb ltr inside vertical-rl ltr - calc() is absolutized into pixels
 PASS horizontal-tb ltr inside vertical-rl ltr - Pixels resolve as-is when overconstrained
 PASS horizontal-tb ltr inside vertical-rl ltr - Percentages absolutize the computed value when overconstrained
-FAIL horizontal-tb ltr inside vertical-rl ltr - If start side is 'auto' and end side is not, 'auto' resolves to used value assert_equals: 'top' expected "297px" but got "425px"
-FAIL horizontal-tb ltr inside vertical-rl ltr - If end side is 'auto' and start side is not, 'auto' resolves to used value assert_equals: 'bottom' expected "299px" but got "171px"
-FAIL horizontal-tb ltr inside vertical-rl ltr - If opposite sides are 'auto', they resolve to used value assert_equals: 'top' expected "127px" but got "255px"
+PASS horizontal-tb ltr inside vertical-rl ltr - If start side is 'auto' and end side is not, 'auto' resolves to used value
+PASS horizontal-tb ltr inside vertical-rl ltr - If end side is 'auto' and start side is not, 'auto' resolves to used value
+PASS horizontal-tb ltr inside vertical-rl ltr - If opposite sides are 'auto', they resolve to used value
 PASS horizontal-tb ltr inside vertical-rl rtl - Pixels resolve as-is
 PASS horizontal-tb ltr inside vertical-rl rtl - Relative lengths are absolutized into pixels
 PASS horizontal-tb ltr inside vertical-rl rtl - Percentages are absolutized into pixels
 PASS horizontal-tb ltr inside vertical-rl rtl - calc() is absolutized into pixels
 PASS horizontal-tb ltr inside vertical-rl rtl - Pixels resolve as-is when overconstrained
 PASS horizontal-tb ltr inside vertical-rl rtl - Percentages absolutize the computed value when overconstrained
-FAIL horizontal-tb ltr inside vertical-rl rtl - If start side is 'auto' and end side is not, 'auto' resolves to used value assert_equals: 'top' expected "297px" but got "425px"
-FAIL horizontal-tb ltr inside vertical-rl rtl - If end side is 'auto' and start side is not, 'auto' resolves to used value assert_equals: 'bottom' expected "299px" but got "171px"
-FAIL horizontal-tb ltr inside vertical-rl rtl - If opposite sides are 'auto', they resolve to used value assert_equals: 'top' expected "173px" but got "301px"
+PASS horizontal-tb ltr inside vertical-rl rtl - If start side is 'auto' and end side is not, 'auto' resolves to used value
+PASS horizontal-tb ltr inside vertical-rl rtl - If end side is 'auto' and start side is not, 'auto' resolves to used value
+PASS horizontal-tb ltr inside vertical-rl rtl - If opposite sides are 'auto', they resolve to used value
 PASS horizontal-tb rtl inside horizontal-tb ltr - Pixels resolve as-is
 PASS horizontal-tb rtl inside horizontal-tb ltr - Relative lengths are absolutized into pixels
 PASS horizontal-tb rtl inside horizontal-tb ltr - Percentages are absolutized into pixels
 PASS horizontal-tb rtl inside horizontal-tb ltr - calc() is absolutized into pixels
 PASS horizontal-tb rtl inside horizontal-tb ltr - Pixels resolve as-is when overconstrained
 PASS horizontal-tb rtl inside horizontal-tb ltr - Percentages absolutize the computed value when overconstrained
-FAIL horizontal-tb rtl inside horizontal-tb ltr - If start side is 'auto' and end side is not, 'auto' resolves to used value assert_equals: 'top' expected "297px" but got "425px"
-FAIL horizontal-tb rtl inside horizontal-tb ltr - If end side is 'auto' and start side is not, 'auto' resolves to used value assert_equals: 'bottom' expected "299px" but got "171px"
-FAIL horizontal-tb rtl inside horizontal-tb ltr - If opposite sides are 'auto', they resolve to used value assert_equals: 'top' expected "127px" but got "255px"
+PASS horizontal-tb rtl inside horizontal-tb ltr - If start side is 'auto' and end side is not, 'auto' resolves to used value
+PASS horizontal-tb rtl inside horizontal-tb ltr - If end side is 'auto' and start side is not, 'auto' resolves to used value
+PASS horizontal-tb rtl inside horizontal-tb ltr - If opposite sides are 'auto', they resolve to used value
 PASS horizontal-tb rtl inside horizontal-tb rtl - Pixels resolve as-is
 PASS horizontal-tb rtl inside horizontal-tb rtl - Relative lengths are absolutized into pixels
 PASS horizontal-tb rtl inside horizontal-tb rtl - Percentages are absolutized into pixels
 PASS horizontal-tb rtl inside horizontal-tb rtl - calc() is absolutized into pixels
 PASS horizontal-tb rtl inside horizontal-tb rtl - Pixels resolve as-is when overconstrained
 PASS horizontal-tb rtl inside horizontal-tb rtl - Percentages absolutize the computed value when overconstrained
-FAIL horizontal-tb rtl inside horizontal-tb rtl - If start side is 'auto' and end side is not, 'auto' resolves to used value assert_equals: 'top' expected "297px" but got "425px"
-FAIL horizontal-tb rtl inside horizontal-tb rtl - If end side is 'auto' and start side is not, 'auto' resolves to used value assert_equals: 'bottom' expected "299px" but got "171px"
-FAIL horizontal-tb rtl inside horizontal-tb rtl - If opposite sides are 'auto', they resolve to used value assert_equals: 'top' expected "127px" but got "255px"
+PASS horizontal-tb rtl inside horizontal-tb rtl - If start side is 'auto' and end side is not, 'auto' resolves to used value
+PASS horizontal-tb rtl inside horizontal-tb rtl - If end side is 'auto' and start side is not, 'auto' resolves to used value
+PASS horizontal-tb rtl inside horizontal-tb rtl - If opposite sides are 'auto', they resolve to used value
 PASS horizontal-tb rtl inside vertical-lr ltr - Pixels resolve as-is
 PASS horizontal-tb rtl inside vertical-lr ltr - Relative lengths are absolutized into pixels
 PASS horizontal-tb rtl inside vertical-lr ltr - Percentages are absolutized into pixels
 PASS horizontal-tb rtl inside vertical-lr ltr - calc() is absolutized into pixels
 PASS horizontal-tb rtl inside vertical-lr ltr - Pixels resolve as-is when overconstrained
 PASS horizontal-tb rtl inside vertical-lr ltr - Percentages absolutize the computed value when overconstrained
-FAIL horizontal-tb rtl inside vertical-lr ltr - If start side is 'auto' and end side is not, 'auto' resolves to used value assert_equals: 'top' expected "297px" but got "425px"
-FAIL horizontal-tb rtl inside vertical-lr ltr - If end side is 'auto' and start side is not, 'auto' resolves to used value assert_equals: 'bottom' expected "299px" but got "171px"
-FAIL horizontal-tb rtl inside vertical-lr ltr - If opposite sides are 'auto', they resolve to used value assert_equals: 'top' expected "127px" but got "255px"
+PASS horizontal-tb rtl inside vertical-lr ltr - If start side is 'auto' and end side is not, 'auto' resolves to used value
+PASS horizontal-tb rtl inside vertical-lr ltr - If end side is 'auto' and start side is not, 'auto' resolves to used value
+PASS horizontal-tb rtl inside vertical-lr ltr - If opposite sides are 'auto', they resolve to used value
 PASS horizontal-tb rtl inside vertical-lr rtl - Pixels resolve as-is
 PASS horizontal-tb rtl inside vertical-lr rtl - Relative lengths are absolutized into pixels
 PASS horizontal-tb rtl inside vertical-lr rtl - Percentages are absolutized into pixels
 PASS horizontal-tb rtl inside vertical-lr rtl - calc() is absolutized into pixels
 PASS horizontal-tb rtl inside vertical-lr rtl - Pixels resolve as-is when overconstrained
 PASS horizontal-tb rtl inside vertical-lr rtl - Percentages absolutize the computed value when overconstrained
-FAIL horizontal-tb rtl inside vertical-lr rtl - If start side is 'auto' and end side is not, 'auto' resolves to used value assert_equals: 'top' expected "297px" but got "425px"
-FAIL horizontal-tb rtl inside vertical-lr rtl - If end side is 'auto' and start side is not, 'auto' resolves to used value assert_equals: 'bottom' expected "299px" but got "171px"
-FAIL horizontal-tb rtl inside vertical-lr rtl - If opposite sides are 'auto', they resolve to used value assert_equals: 'top' expected "173px" but got "301px"
+PASS horizontal-tb rtl inside vertical-lr rtl - If start side is 'auto' and end side is not, 'auto' resolves to used value
+PASS horizontal-tb rtl inside vertical-lr rtl - If end side is 'auto' and start side is not, 'auto' resolves to used value
+PASS horizontal-tb rtl inside vertical-lr rtl - If opposite sides are 'auto', they resolve to used value
 PASS horizontal-tb rtl inside vertical-rl ltr - Pixels resolve as-is
 PASS horizontal-tb rtl inside vertical-rl ltr - Relative lengths are absolutized into pixels
 PASS horizontal-tb rtl inside vertical-rl ltr - Percentages are absolutized into pixels
 PASS horizontal-tb rtl inside vertical-rl ltr - calc() is absolutized into pixels
 PASS horizontal-tb rtl inside vertical-rl ltr - Pixels resolve as-is when overconstrained
 PASS horizontal-tb rtl inside vertical-rl ltr - Percentages absolutize the computed value when overconstrained
-FAIL horizontal-tb rtl inside vertical-rl ltr - If start side is 'auto' and end side is not, 'auto' resolves to used value assert_equals: 'top' expected "297px" but got "425px"
-FAIL horizontal-tb rtl inside vertical-rl ltr - If end side is 'auto' and start side is not, 'auto' resolves to used value assert_equals: 'bottom' expected "299px" but got "171px"
-FAIL horizontal-tb rtl inside vertical-rl ltr - If opposite sides are 'auto', they resolve to used value assert_equals: 'top' expected "127px" but got "255px"
+PASS horizontal-tb rtl inside vertical-rl ltr - If start side is 'auto' and end side is not, 'auto' resolves to used value
+PASS horizontal-tb rtl inside vertical-rl ltr - If end side is 'auto' and start side is not, 'auto' resolves to used value
+PASS horizontal-tb rtl inside vertical-rl ltr - If opposite sides are 'auto', they resolve to used value
 PASS horizontal-tb rtl inside vertical-rl rtl - Pixels resolve as-is
 PASS horizontal-tb rtl inside vertical-rl rtl - Relative lengths are absolutized into pixels
 PASS horizontal-tb rtl inside vertical-rl rtl - Percentages are absolutized into pixels
 PASS horizontal-tb rtl inside vertical-rl rtl - calc() is absolutized into pixels
 PASS horizontal-tb rtl inside vertical-rl rtl - Pixels resolve as-is when overconstrained
 PASS horizontal-tb rtl inside vertical-rl rtl - Percentages absolutize the computed value when overconstrained
-FAIL horizontal-tb rtl inside vertical-rl rtl - If start side is 'auto' and end side is not, 'auto' resolves to used value assert_equals: 'top' expected "297px" but got "425px"
-FAIL horizontal-tb rtl inside vertical-rl rtl - If end side is 'auto' and start side is not, 'auto' resolves to used value assert_equals: 'bottom' expected "299px" but got "171px"
-FAIL horizontal-tb rtl inside vertical-rl rtl - If opposite sides are 'auto', they resolve to used value assert_equals: 'top' expected "173px" but got "301px"
+PASS horizontal-tb rtl inside vertical-rl rtl - If start side is 'auto' and end side is not, 'auto' resolves to used value
+PASS horizontal-tb rtl inside vertical-rl rtl - If end side is 'auto' and start side is not, 'auto' resolves to used value
+PASS horizontal-tb rtl inside vertical-rl rtl - If opposite sides are 'auto', they resolve to used value
 PASS vertical-lr ltr inside horizontal-tb ltr - Pixels resolve as-is
 PASS vertical-lr ltr inside horizontal-tb ltr - Relative lengths are absolutized into pixels
 PASS vertical-lr ltr inside horizontal-tb ltr - Percentages are absolutized into pixels
 PASS vertical-lr ltr inside horizontal-tb ltr - calc() is absolutized into pixels
 PASS vertical-lr ltr inside horizontal-tb ltr - Pixels resolve as-is when overconstrained
 PASS vertical-lr ltr inside horizontal-tb ltr - Percentages absolutize the computed value when overconstrained
-FAIL vertical-lr ltr inside horizontal-tb ltr - If start side is 'auto' and end side is not, 'auto' resolves to used value assert_equals: 'top' expected "297px" but got "425px"
-FAIL vertical-lr ltr inside horizontal-tb ltr - If end side is 'auto' and start side is not, 'auto' resolves to used value assert_equals: 'bottom' expected "299px" but got "171px"
-FAIL vertical-lr ltr inside horizontal-tb ltr - If opposite sides are 'auto', they resolve to used value assert_equals: 'top' expected "127px" but got "255px"
+PASS vertical-lr ltr inside horizontal-tb ltr - If start side is 'auto' and end side is not, 'auto' resolves to used value
+PASS vertical-lr ltr inside horizontal-tb ltr - If end side is 'auto' and start side is not, 'auto' resolves to used value
+PASS vertical-lr ltr inside horizontal-tb ltr - If opposite sides are 'auto', they resolve to used value
 PASS vertical-lr ltr inside horizontal-tb rtl - Pixels resolve as-is
 PASS vertical-lr ltr inside horizontal-tb rtl - Relative lengths are absolutized into pixels
 PASS vertical-lr ltr inside horizontal-tb rtl - Percentages are absolutized into pixels
 PASS vertical-lr ltr inside horizontal-tb rtl - calc() is absolutized into pixels
 PASS vertical-lr ltr inside horizontal-tb rtl - Pixels resolve as-is when overconstrained
 PASS vertical-lr ltr inside horizontal-tb rtl - Percentages absolutize the computed value when overconstrained
-FAIL vertical-lr ltr inside horizontal-tb rtl - If start side is 'auto' and end side is not, 'auto' resolves to used value assert_equals: 'top' expected "297px" but got "425px"
-FAIL vertical-lr ltr inside horizontal-tb rtl - If end side is 'auto' and start side is not, 'auto' resolves to used value assert_equals: 'bottom' expected "299px" but got "171px"
-FAIL vertical-lr ltr inside horizontal-tb rtl - If opposite sides are 'auto', they resolve to used value assert_equals: 'top' expected "127px" but got "255px"
+PASS vertical-lr ltr inside horizontal-tb rtl - If start side is 'auto' and end side is not, 'auto' resolves to used value
+PASS vertical-lr ltr inside horizontal-tb rtl - If end side is 'auto' and start side is not, 'auto' resolves to used value
+PASS vertical-lr ltr inside horizontal-tb rtl - If opposite sides are 'auto', they resolve to used value
 PASS vertical-lr ltr inside vertical-lr ltr - Pixels resolve as-is
 PASS vertical-lr ltr inside vertical-lr ltr - Relative lengths are absolutized into pixels
 PASS vertical-lr ltr inside vertical-lr ltr - Percentages are absolutized into pixels
 PASS vertical-lr ltr inside vertical-lr ltr - calc() is absolutized into pixels
 PASS vertical-lr ltr inside vertical-lr ltr - Pixels resolve as-is when overconstrained
 PASS vertical-lr ltr inside vertical-lr ltr - Percentages absolutize the computed value when overconstrained
-FAIL vertical-lr ltr inside vertical-lr ltr - If start side is 'auto' and end side is not, 'auto' resolves to used value assert_equals: 'top' expected "297px" but got "425px"
-FAIL vertical-lr ltr inside vertical-lr ltr - If end side is 'auto' and start side is not, 'auto' resolves to used value assert_equals: 'bottom' expected "299px" but got "171px"
-FAIL vertical-lr ltr inside vertical-lr ltr - If opposite sides are 'auto', they resolve to used value assert_equals: 'top' expected "127px" but got "255px"
+PASS vertical-lr ltr inside vertical-lr ltr - If start side is 'auto' and end side is not, 'auto' resolves to used value
+PASS vertical-lr ltr inside vertical-lr ltr - If end side is 'auto' and start side is not, 'auto' resolves to used value
+PASS vertical-lr ltr inside vertical-lr ltr - If opposite sides are 'auto', they resolve to used value
 PASS vertical-lr ltr inside vertical-lr rtl - Pixels resolve as-is
 PASS vertical-lr ltr inside vertical-lr rtl - Relative lengths are absolutized into pixels
 PASS vertical-lr ltr inside vertical-lr rtl - Percentages are absolutized into pixels
 PASS vertical-lr ltr inside vertical-lr rtl - calc() is absolutized into pixels
 PASS vertical-lr ltr inside vertical-lr rtl - Pixels resolve as-is when overconstrained
 PASS vertical-lr ltr inside vertical-lr rtl - Percentages absolutize the computed value when overconstrained
-FAIL vertical-lr ltr inside vertical-lr rtl - If start side is 'auto' and end side is not, 'auto' resolves to used value assert_equals: 'top' expected "297px" but got "425px"
-FAIL vertical-lr ltr inside vertical-lr rtl - If end side is 'auto' and start side is not, 'auto' resolves to used value assert_equals: 'bottom' expected "299px" but got "171px"
-FAIL vertical-lr ltr inside vertical-lr rtl - If opposite sides are 'auto', they resolve to used value assert_equals: 'top' expected "173px" but got "301px"
+PASS vertical-lr ltr inside vertical-lr rtl - If start side is 'auto' and end side is not, 'auto' resolves to used value
+PASS vertical-lr ltr inside vertical-lr rtl - If end side is 'auto' and start side is not, 'auto' resolves to used value
+PASS vertical-lr ltr inside vertical-lr rtl - If opposite sides are 'auto', they resolve to used value
 PASS vertical-lr ltr inside vertical-rl ltr - Pixels resolve as-is
 PASS vertical-lr ltr inside vertical-rl ltr - Relative lengths are absolutized into pixels
 PASS vertical-lr ltr inside vertical-rl ltr - Percentages are absolutized into pixels
 PASS vertical-lr ltr inside vertical-rl ltr - calc() is absolutized into pixels
 PASS vertical-lr ltr inside vertical-rl ltr - Pixels resolve as-is when overconstrained
 PASS vertical-lr ltr inside vertical-rl ltr - Percentages absolutize the computed value when overconstrained
-FAIL vertical-lr ltr inside vertical-rl ltr - If start side is 'auto' and end side is not, 'auto' resolves to used value assert_equals: 'top' expected "297px" but got "425px"
-FAIL vertical-lr ltr inside vertical-rl ltr - If end side is 'auto' and start side is not, 'auto' resolves to used value assert_equals: 'bottom' expected "299px" but got "171px"
-FAIL vertical-lr ltr inside vertical-rl ltr - If opposite sides are 'auto', they resolve to used value assert_equals: 'top' expected "127px" but got "255px"
+PASS vertical-lr ltr inside vertical-rl ltr - If start side is 'auto' and end side is not, 'auto' resolves to used value
+PASS vertical-lr ltr inside vertical-rl ltr - If end side is 'auto' and start side is not, 'auto' resolves to used value
+PASS vertical-lr ltr inside vertical-rl ltr - If opposite sides are 'auto', they resolve to used value
 PASS vertical-lr ltr inside vertical-rl rtl - Pixels resolve as-is
 PASS vertical-lr ltr inside vertical-rl rtl - Relative lengths are absolutized into pixels
 PASS vertical-lr ltr inside vertical-rl rtl - Percentages are absolutized into pixels
 PASS vertical-lr ltr inside vertical-rl rtl - calc() is absolutized into pixels
 PASS vertical-lr ltr inside vertical-rl rtl - Pixels resolve as-is when overconstrained
 PASS vertical-lr ltr inside vertical-rl rtl - Percentages absolutize the computed value when overconstrained
-FAIL vertical-lr ltr inside vertical-rl rtl - If start side is 'auto' and end side is not, 'auto' resolves to used value assert_equals: 'top' expected "297px" but got "425px"
-FAIL vertical-lr ltr inside vertical-rl rtl - If end side is 'auto' and start side is not, 'auto' resolves to used value assert_equals: 'bottom' expected "299px" but got "171px"
-FAIL vertical-lr ltr inside vertical-rl rtl - If opposite sides are 'auto', they resolve to used value assert_equals: 'top' expected "173px" but got "301px"
+PASS vertical-lr ltr inside vertical-rl rtl - If start side is 'auto' and end side is not, 'auto' resolves to used value
+PASS vertical-lr ltr inside vertical-rl rtl - If end side is 'auto' and start side is not, 'auto' resolves to used value
+PASS vertical-lr ltr inside vertical-rl rtl - If opposite sides are 'auto', they resolve to used value
 PASS vertical-lr rtl inside horizontal-tb ltr - Pixels resolve as-is
 PASS vertical-lr rtl inside horizontal-tb ltr - Relative lengths are absolutized into pixels
 PASS vertical-lr rtl inside horizontal-tb ltr - Percentages are absolutized into pixels
 PASS vertical-lr rtl inside horizontal-tb ltr - calc() is absolutized into pixels
 PASS vertical-lr rtl inside horizontal-tb ltr - Pixels resolve as-is when overconstrained
 PASS vertical-lr rtl inside horizontal-tb ltr - Percentages absolutize the computed value when overconstrained
-FAIL vertical-lr rtl inside horizontal-tb ltr - If start side is 'auto' and end side is not, 'auto' resolves to used value assert_equals: 'top' expected "297px" but got "425px"
-FAIL vertical-lr rtl inside horizontal-tb ltr - If end side is 'auto' and start side is not, 'auto' resolves to used value assert_equals: 'bottom' expected "299px" but got "171px"
-FAIL vertical-lr rtl inside horizontal-tb ltr - If opposite sides are 'auto', they resolve to used value assert_equals: 'top' expected "127px" but got "255px"
+PASS vertical-lr rtl inside horizontal-tb ltr - If start side is 'auto' and end side is not, 'auto' resolves to used value
+PASS vertical-lr rtl inside horizontal-tb ltr - If end side is 'auto' and start side is not, 'auto' resolves to used value
+PASS vertical-lr rtl inside horizontal-tb ltr - If opposite sides are 'auto', they resolve to used value
 PASS vertical-lr rtl inside horizontal-tb rtl - Pixels resolve as-is
 PASS vertical-lr rtl inside horizontal-tb rtl - Relative lengths are absolutized into pixels
 PASS vertical-lr rtl inside horizontal-tb rtl - Percentages are absolutized into pixels
 PASS vertical-lr rtl inside horizontal-tb rtl - calc() is absolutized into pixels
 PASS vertical-lr rtl inside horizontal-tb rtl - Pixels resolve as-is when overconstrained
 PASS vertical-lr rtl inside horizontal-tb rtl - Percentages absolutize the computed value when overconstrained
-FAIL vertical-lr rtl inside horizontal-tb rtl - If start side is 'auto' and end side is not, 'auto' resolves to used value assert_equals: 'top' expected "297px" but got "425px"
-FAIL vertical-lr rtl inside horizontal-tb rtl - If end side is 'auto' and start side is not, 'auto' resolves to used value assert_equals: 'bottom' expected "299px" but got "171px"
-FAIL vertical-lr rtl inside horizontal-tb rtl - If opposite sides are 'auto', they resolve to used value assert_equals: 'top' expected "127px" but got "255px"
+PASS vertical-lr rtl inside horizontal-tb rtl - If start side is 'auto' and end side is not, 'auto' resolves to used value
+PASS vertical-lr rtl inside horizontal-tb rtl - If end side is 'auto' and start side is not, 'auto' resolves to used value
+PASS vertical-lr rtl inside horizontal-tb rtl - If opposite sides are 'auto', they resolve to used value
 PASS vertical-lr rtl inside vertical-lr ltr - Pixels resolve as-is
 PASS vertical-lr rtl inside vertical-lr ltr - Relative lengths are absolutized into pixels
 PASS vertical-lr rtl inside vertical-lr ltr - Percentages are absolutized into pixels
 PASS vertical-lr rtl inside vertical-lr ltr - calc() is absolutized into pixels
 PASS vertical-lr rtl inside vertical-lr ltr - Pixels resolve as-is when overconstrained
 PASS vertical-lr rtl inside vertical-lr ltr - Percentages absolutize the computed value when overconstrained
-FAIL vertical-lr rtl inside vertical-lr ltr - If start side is 'auto' and end side is not, 'auto' resolves to used value assert_equals: 'top' expected "297px" but got "425px"
-FAIL vertical-lr rtl inside vertical-lr ltr - If end side is 'auto' and start side is not, 'auto' resolves to used value assert_equals: 'bottom' expected "299px" but got "171px"
-FAIL vertical-lr rtl inside vertical-lr ltr - If opposite sides are 'auto', they resolve to used value assert_equals: 'top' expected "127px" but got "255px"
+PASS vertical-lr rtl inside vertical-lr ltr - If start side is 'auto' and end side is not, 'auto' resolves to used value
+PASS vertical-lr rtl inside vertical-lr ltr - If end side is 'auto' and start side is not, 'auto' resolves to used value
+PASS vertical-lr rtl inside vertical-lr ltr - If opposite sides are 'auto', they resolve to used value
 PASS vertical-lr rtl inside vertical-lr rtl - Pixels resolve as-is
 PASS vertical-lr rtl inside vertical-lr rtl - Relative lengths are absolutized into pixels
 PASS vertical-lr rtl inside vertical-lr rtl - Percentages are absolutized into pixels
 PASS vertical-lr rtl inside vertical-lr rtl - calc() is absolutized into pixels
 PASS vertical-lr rtl inside vertical-lr rtl - Pixels resolve as-is when overconstrained
 PASS vertical-lr rtl inside vertical-lr rtl - Percentages absolutize the computed value when overconstrained
-FAIL vertical-lr rtl inside vertical-lr rtl - If start side is 'auto' and end side is not, 'auto' resolves to used value assert_equals: 'top' expected "297px" but got "425px"
-FAIL vertical-lr rtl inside vertical-lr rtl - If end side is 'auto' and start side is not, 'auto' resolves to used value assert_equals: 'bottom' expected "299px" but got "171px"
-FAIL vertical-lr rtl inside vertical-lr rtl - If opposite sides are 'auto', they resolve to used value assert_equals: 'top' expected "173px" but got "301px"
+PASS vertical-lr rtl inside vertical-lr rtl - If start side is 'auto' and end side is not, 'auto' resolves to used value
+PASS vertical-lr rtl inside vertical-lr rtl - If end side is 'auto' and start side is not, 'auto' resolves to used value
+PASS vertical-lr rtl inside vertical-lr rtl - If opposite sides are 'auto', they resolve to used value
 PASS vertical-lr rtl inside vertical-rl ltr - Pixels resolve as-is
 PASS vertical-lr rtl inside vertical-rl ltr - Relative lengths are absolutized into pixels
 PASS vertical-lr rtl inside vertical-rl ltr - Percentages are absolutized into pixels
 PASS vertical-lr rtl inside vertical-rl ltr - calc() is absolutized into pixels
 PASS vertical-lr rtl inside vertical-rl ltr - Pixels resolve as-is when overconstrained
 PASS vertical-lr rtl inside vertical-rl ltr - Percentages absolutize the computed value when overconstrained
-FAIL vertical-lr rtl inside vertical-rl ltr - If start side is 'auto' and end side is not, 'auto' resolves to used value assert_equals: 'top' expected "297px" but got "425px"
-FAIL vertical-lr rtl inside vertical-rl ltr - If end side is 'auto' and start side is not, 'auto' resolves to used value assert_equals: 'bottom' expected "299px" but got "171px"
-FAIL vertical-lr rtl inside vertical-rl ltr - If opposite sides are 'auto', they resolve to used value assert_equals: 'top' expected "127px" but got "255px"
+PASS vertical-lr rtl inside vertical-rl ltr - If start side is 'auto' and end side is not, 'auto' resolves to used value
+PASS vertical-lr rtl inside vertical-rl ltr - If end side is 'auto' and start side is not, 'auto' resolves to used value
+PASS vertical-lr rtl inside vertical-rl ltr - If opposite sides are 'auto', they resolve to used value
 PASS vertical-lr rtl inside vertical-rl rtl - Pixels resolve as-is
 PASS vertical-lr rtl inside vertical-rl rtl - Relative lengths are absolutized into pixels
 PASS vertical-lr rtl inside vertical-rl rtl - Percentages are absolutized into pixels
 PASS vertical-lr rtl inside vertical-rl rtl - calc() is absolutized into pixels
 PASS vertical-lr rtl inside vertical-rl rtl - Pixels resolve as-is when overconstrained
 PASS vertical-lr rtl inside vertical-rl rtl - Percentages absolutize the computed value when overconstrained
-FAIL vertical-lr rtl inside vertical-rl rtl - If start side is 'auto' and end side is not, 'auto' resolves to used value assert_equals: 'top' expected "297px" but got "425px"
-FAIL vertical-lr rtl inside vertical-rl rtl - If end side is 'auto' and start side is not, 'auto' resolves to used value assert_equals: 'bottom' expected "299px" but got "171px"
-FAIL vertical-lr rtl inside vertical-rl rtl - If opposite sides are 'auto', they resolve to used value assert_equals: 'top' expected "173px" but got "301px"
+PASS vertical-lr rtl inside vertical-rl rtl - If start side is 'auto' and end side is not, 'auto' resolves to used value
+PASS vertical-lr rtl inside vertical-rl rtl - If end side is 'auto' and start side is not, 'auto' resolves to used value
+PASS vertical-lr rtl inside vertical-rl rtl - If opposite sides are 'auto', they resolve to used value
 PASS vertical-rl ltr inside horizontal-tb ltr - Pixels resolve as-is
 PASS vertical-rl ltr inside horizontal-tb ltr - Relative lengths are absolutized into pixels
 PASS vertical-rl ltr inside horizontal-tb ltr - Percentages are absolutized into pixels
 PASS vertical-rl ltr inside horizontal-tb ltr - calc() is absolutized into pixels
 PASS vertical-rl ltr inside horizontal-tb ltr - Pixels resolve as-is when overconstrained
 PASS vertical-rl ltr inside horizontal-tb ltr - Percentages absolutize the computed value when overconstrained
-FAIL vertical-rl ltr inside horizontal-tb ltr - If start side is 'auto' and end side is not, 'auto' resolves to used value assert_equals: 'top' expected "297px" but got "425px"
-FAIL vertical-rl ltr inside horizontal-tb ltr - If end side is 'auto' and start side is not, 'auto' resolves to used value assert_equals: 'bottom' expected "299px" but got "171px"
-FAIL vertical-rl ltr inside horizontal-tb ltr - If opposite sides are 'auto', they resolve to used value assert_equals: 'top' expected "127px" but got "255px"
+PASS vertical-rl ltr inside horizontal-tb ltr - If start side is 'auto' and end side is not, 'auto' resolves to used value
+PASS vertical-rl ltr inside horizontal-tb ltr - If end side is 'auto' and start side is not, 'auto' resolves to used value
+PASS vertical-rl ltr inside horizontal-tb ltr - If opposite sides are 'auto', they resolve to used value
 PASS vertical-rl ltr inside horizontal-tb rtl - Pixels resolve as-is
 PASS vertical-rl ltr inside horizontal-tb rtl - Relative lengths are absolutized into pixels
 PASS vertical-rl ltr inside horizontal-tb rtl - Percentages are absolutized into pixels
 PASS vertical-rl ltr inside horizontal-tb rtl - calc() is absolutized into pixels
 PASS vertical-rl ltr inside horizontal-tb rtl - Pixels resolve as-is when overconstrained
 PASS vertical-rl ltr inside horizontal-tb rtl - Percentages absolutize the computed value when overconstrained
-FAIL vertical-rl ltr inside horizontal-tb rtl - If start side is 'auto' and end side is not, 'auto' resolves to used value assert_equals: 'top' expected "297px" but got "425px"
-FAIL vertical-rl ltr inside horizontal-tb rtl - If end side is 'auto' and start side is not, 'auto' resolves to used value assert_equals: 'bottom' expected "299px" but got "171px"
-FAIL vertical-rl ltr inside horizontal-tb rtl - If opposite sides are 'auto', they resolve to used value assert_equals: 'top' expected "127px" but got "255px"
+PASS vertical-rl ltr inside horizontal-tb rtl - If start side is 'auto' and end side is not, 'auto' resolves to used value
+PASS vertical-rl ltr inside horizontal-tb rtl - If end side is 'auto' and start side is not, 'auto' resolves to used value
+PASS vertical-rl ltr inside horizontal-tb rtl - If opposite sides are 'auto', they resolve to used value
 PASS vertical-rl ltr inside vertical-lr ltr - Pixels resolve as-is
 PASS vertical-rl ltr inside vertical-lr ltr - Relative lengths are absolutized into pixels
 PASS vertical-rl ltr inside vertical-lr ltr - Percentages are absolutized into pixels
 PASS vertical-rl ltr inside vertical-lr ltr - calc() is absolutized into pixels
 PASS vertical-rl ltr inside vertical-lr ltr - Pixels resolve as-is when overconstrained
 PASS vertical-rl ltr inside vertical-lr ltr - Percentages absolutize the computed value when overconstrained
-FAIL vertical-rl ltr inside vertical-lr ltr - If start side is 'auto' and end side is not, 'auto' resolves to used value assert_equals: 'top' expected "297px" but got "425px"
-FAIL vertical-rl ltr inside vertical-lr ltr - If end side is 'auto' and start side is not, 'auto' resolves to used value assert_equals: 'bottom' expected "299px" but got "171px"
-FAIL vertical-rl ltr inside vertical-lr ltr - If opposite sides are 'auto', they resolve to used value assert_equals: 'top' expected "127px" but got "255px"
+PASS vertical-rl ltr inside vertical-lr ltr - If start side is 'auto' and end side is not, 'auto' resolves to used value
+PASS vertical-rl ltr inside vertical-lr ltr - If end side is 'auto' and start side is not, 'auto' resolves to used value
+PASS vertical-rl ltr inside vertical-lr ltr - If opposite sides are 'auto', they resolve to used value
 PASS vertical-rl ltr inside vertical-lr rtl - Pixels resolve as-is
 PASS vertical-rl ltr inside vertical-lr rtl - Relative lengths are absolutized into pixels
 PASS vertical-rl ltr inside vertical-lr rtl - Percentages are absolutized into pixels
 PASS vertical-rl ltr inside vertical-lr rtl - calc() is absolutized into pixels
 PASS vertical-rl ltr inside vertical-lr rtl - Pixels resolve as-is when overconstrained
 PASS vertical-rl ltr inside vertical-lr rtl - Percentages absolutize the computed value when overconstrained
-FAIL vertical-rl ltr inside vertical-lr rtl - If start side is 'auto' and end side is not, 'auto' resolves to used value assert_equals: 'top' expected "297px" but got "425px"
-FAIL vertical-rl ltr inside vertical-lr rtl - If end side is 'auto' and start side is not, 'auto' resolves to used value assert_equals: 'bottom' expected "299px" but got "171px"
-FAIL vertical-rl ltr inside vertical-lr rtl - If opposite sides are 'auto', they resolve to used value assert_equals: 'top' expected "173px" but got "301px"
+PASS vertical-rl ltr inside vertical-lr rtl - If start side is 'auto' and end side is not, 'auto' resolves to used value
+PASS vertical-rl ltr inside vertical-lr rtl - If end side is 'auto' and start side is not, 'auto' resolves to used value
+PASS vertical-rl ltr inside vertical-lr rtl - If opposite sides are 'auto', they resolve to used value
 PASS vertical-rl ltr inside vertical-rl ltr - Pixels resolve as-is
 PASS vertical-rl ltr inside vertical-rl ltr - Relative lengths are absolutized into pixels
 PASS vertical-rl ltr inside vertical-rl ltr - Percentages are absolutized into pixels
 PASS vertical-rl ltr inside vertical-rl ltr - calc() is absolutized into pixels
 PASS vertical-rl ltr inside vertical-rl ltr - Pixels resolve as-is when overconstrained
 PASS vertical-rl ltr inside vertical-rl ltr - Percentages absolutize the computed value when overconstrained
-FAIL vertical-rl ltr inside vertical-rl ltr - If start side is 'auto' and end side is not, 'auto' resolves to used value assert_equals: 'top' expected "297px" but got "425px"
-FAIL vertical-rl ltr inside vertical-rl ltr - If end side is 'auto' and start side is not, 'auto' resolves to used value assert_equals: 'bottom' expected "299px" but got "171px"
-FAIL vertical-rl ltr inside vertical-rl ltr - If opposite sides are 'auto', they resolve to used value assert_equals: 'top' expected "127px" but got "255px"
+PASS vertical-rl ltr inside vertical-rl ltr - If start side is 'auto' and end side is not, 'auto' resolves to used value
+PASS vertical-rl ltr inside vertical-rl ltr - If end side is 'auto' and start side is not, 'auto' resolves to used value
+PASS vertical-rl ltr inside vertical-rl ltr - If opposite sides are 'auto', they resolve to used value
 PASS vertical-rl ltr inside vertical-rl rtl - Pixels resolve as-is
 PASS vertical-rl ltr inside vertical-rl rtl - Relative lengths are absolutized into pixels
 PASS vertical-rl ltr inside vertical-rl rtl - Percentages are absolutized into pixels
 PASS vertical-rl ltr inside vertical-rl rtl - calc() is absolutized into pixels
 PASS vertical-rl ltr inside vertical-rl rtl - Pixels resolve as-is when overconstrained
 PASS vertical-rl ltr inside vertical-rl rtl - Percentages absolutize the computed value when overconstrained
-FAIL vertical-rl ltr inside vertical-rl rtl - If start side is 'auto' and end side is not, 'auto' resolves to used value assert_equals: 'top' expected "297px" but got "425px"
-FAIL vertical-rl ltr inside vertical-rl rtl - If end side is 'auto' and start side is not, 'auto' resolves to used value assert_equals: 'bottom' expected "299px" but got "171px"
-FAIL vertical-rl ltr inside vertical-rl rtl - If opposite sides are 'auto', they resolve to used value assert_equals: 'top' expected "173px" but got "301px"
+PASS vertical-rl ltr inside vertical-rl rtl - If start side is 'auto' and end side is not, 'auto' resolves to used value
+PASS vertical-rl ltr inside vertical-rl rtl - If end side is 'auto' and start side is not, 'auto' resolves to used value
+PASS vertical-rl ltr inside vertical-rl rtl - If opposite sides are 'auto', they resolve to used value
 PASS vertical-rl rtl inside horizontal-tb ltr - Pixels resolve as-is
 PASS vertical-rl rtl inside horizontal-tb ltr - Relative lengths are absolutized into pixels
 PASS vertical-rl rtl inside horizontal-tb ltr - Percentages are absolutized into pixels
 PASS vertical-rl rtl inside horizontal-tb ltr - calc() is absolutized into pixels
 PASS vertical-rl rtl inside horizontal-tb ltr - Pixels resolve as-is when overconstrained
 PASS vertical-rl rtl inside horizontal-tb ltr - Percentages absolutize the computed value when overconstrained
-FAIL vertical-rl rtl inside horizontal-tb ltr - If start side is 'auto' and end side is not, 'auto' resolves to used value assert_equals: 'top' expected "297px" but got "425px"
-FAIL vertical-rl rtl inside horizontal-tb ltr - If end side is 'auto' and start side is not, 'auto' resolves to used value assert_equals: 'bottom' expected "299px" but got "171px"
-FAIL vertical-rl rtl inside horizontal-tb ltr - If opposite sides are 'auto', they resolve to used value assert_equals: 'top' expected "127px" but got "255px"
+PASS vertical-rl rtl inside horizontal-tb ltr - If start side is 'auto' and end side is not, 'auto' resolves to used value
+PASS vertical-rl rtl inside horizontal-tb ltr - If end side is 'auto' and start side is not, 'auto' resolves to used value
+PASS vertical-rl rtl inside horizontal-tb ltr - If opposite sides are 'auto', they resolve to used value
 PASS vertical-rl rtl inside horizontal-tb rtl - Pixels resolve as-is
 PASS vertical-rl rtl inside horizontal-tb rtl - Relative lengths are absolutized into pixels
 PASS vertical-rl rtl inside horizontal-tb rtl - Percentages are absolutized into pixels
 PASS vertical-rl rtl inside horizontal-tb rtl - calc() is absolutized into pixels
 PASS vertical-rl rtl inside horizontal-tb rtl - Pixels resolve as-is when overconstrained
 PASS vertical-rl rtl inside horizontal-tb rtl - Percentages absolutize the computed value when overconstrained
-FAIL vertical-rl rtl inside horizontal-tb rtl - If start side is 'auto' and end side is not, 'auto' resolves to used value assert_equals: 'top' expected "297px" but got "425px"
-FAIL vertical-rl rtl inside horizontal-tb rtl - If end side is 'auto' and start side is not, 'auto' resolves to used value assert_equals: 'bottom' expected "299px" but got "171px"
-FAIL vertical-rl rtl inside horizontal-tb rtl - If opposite sides are 'auto', they resolve to used value assert_equals: 'top' expected "127px" but got "255px"
+PASS vertical-rl rtl inside horizontal-tb rtl - If start side is 'auto' and end side is not, 'auto' resolves to used value
+PASS vertical-rl rtl inside horizontal-tb rtl - If end side is 'auto' and start side is not, 'auto' resolves to used value
+PASS vertical-rl rtl inside horizontal-tb rtl - If opposite sides are 'auto', they resolve to used value
 PASS vertical-rl rtl inside vertical-lr ltr - Pixels resolve as-is
 PASS vertical-rl rtl inside vertical-lr ltr - Relative lengths are absolutized into pixels
 PASS vertical-rl rtl inside vertical-lr ltr - Percentages are absolutized into pixels
 PASS vertical-rl rtl inside vertical-lr ltr - calc() is absolutized into pixels
 PASS vertical-rl rtl inside vertical-lr ltr - Pixels resolve as-is when overconstrained
 PASS vertical-rl rtl inside vertical-lr ltr - Percentages absolutize the computed value when overconstrained
-FAIL vertical-rl rtl inside vertical-lr ltr - If start side is 'auto' and end side is not, 'auto' resolves to used value assert_equals: 'top' expected "297px" but got "425px"
-FAIL vertical-rl rtl inside vertical-lr ltr - If end side is 'auto' and start side is not, 'auto' resolves to used value assert_equals: 'bottom' expected "299px" but got "171px"
-FAIL vertical-rl rtl inside vertical-lr ltr - If opposite sides are 'auto', they resolve to used value assert_equals: 'top' expected "127px" but got "255px"
+PASS vertical-rl rtl inside vertical-lr ltr - If start side is 'auto' and end side is not, 'auto' resolves to used value
+PASS vertical-rl rtl inside vertical-lr ltr - If end side is 'auto' and start side is not, 'auto' resolves to used value
+PASS vertical-rl rtl inside vertical-lr ltr - If opposite sides are 'auto', they resolve to used value
 PASS vertical-rl rtl inside vertical-lr rtl - Pixels resolve as-is
 PASS vertical-rl rtl inside vertical-lr rtl - Relative lengths are absolutized into pixels
 PASS vertical-rl rtl inside vertical-lr rtl - Percentages are absolutized into pixels
 PASS vertical-rl rtl inside vertical-lr rtl - calc() is absolutized into pixels
 PASS vertical-rl rtl inside vertical-lr rtl - Pixels resolve as-is when overconstrained
 PASS vertical-rl rtl inside vertical-lr rtl - Percentages absolutize the computed value when overconstrained
-FAIL vertical-rl rtl inside vertical-lr rtl - If start side is 'auto' and end side is not, 'auto' resolves to used value assert_equals: 'top' expected "297px" but got "425px"
-FAIL vertical-rl rtl inside vertical-lr rtl - If end side is 'auto' and start side is not, 'auto' resolves to used value assert_equals: 'bottom' expected "299px" but got "171px"
-FAIL vertical-rl rtl inside vertical-lr rtl - If opposite sides are 'auto', they resolve to used value assert_equals: 'top' expected "173px" but got "301px"
+PASS vertical-rl rtl inside vertical-lr rtl - If start side is 'auto' and end side is not, 'auto' resolves to used value
+PASS vertical-rl rtl inside vertical-lr rtl - If end side is 'auto' and start side is not, 'auto' resolves to used value
+PASS vertical-rl rtl inside vertical-lr rtl - If opposite sides are 'auto', they resolve to used value
 PASS vertical-rl rtl inside vertical-rl ltr - Pixels resolve as-is
 PASS vertical-rl rtl inside vertical-rl ltr - Relative lengths are absolutized into pixels
 PASS vertical-rl rtl inside vertical-rl ltr - Percentages are absolutized into pixels
 PASS vertical-rl rtl inside vertical-rl ltr - calc() is absolutized into pixels
 PASS vertical-rl rtl inside vertical-rl ltr - Pixels resolve as-is when overconstrained
 PASS vertical-rl rtl inside vertical-rl ltr - Percentages absolutize the computed value when overconstrained
-FAIL vertical-rl rtl inside vertical-rl ltr - If start side is 'auto' and end side is not, 'auto' resolves to used value assert_equals: 'top' expected "297px" but got "425px"
-FAIL vertical-rl rtl inside vertical-rl ltr - If end side is 'auto' and start side is not, 'auto' resolves to used value assert_equals: 'bottom' expected "299px" but got "171px"
-FAIL vertical-rl rtl inside vertical-rl ltr - If opposite sides are 'auto', they resolve to used value assert_equals: 'top' expected "127px" but got "255px"
+PASS vertical-rl rtl inside vertical-rl ltr - If start side is 'auto' and end side is not, 'auto' resolves to used value
+PASS vertical-rl rtl inside vertical-rl ltr - If end side is 'auto' and start side is not, 'auto' resolves to used value
+PASS vertical-rl rtl inside vertical-rl ltr - If opposite sides are 'auto', they resolve to used value
 PASS vertical-rl rtl inside vertical-rl rtl - Pixels resolve as-is
 PASS vertical-rl rtl inside vertical-rl rtl - Relative lengths are absolutized into pixels
 PASS vertical-rl rtl inside vertical-rl rtl - Percentages are absolutized into pixels
 PASS vertical-rl rtl inside vertical-rl rtl - calc() is absolutized into pixels
 PASS vertical-rl rtl inside vertical-rl rtl - Pixels resolve as-is when overconstrained
 PASS vertical-rl rtl inside vertical-rl rtl - Percentages absolutize the computed value when overconstrained
-FAIL vertical-rl rtl inside vertical-rl rtl - If start side is 'auto' and end side is not, 'auto' resolves to used value assert_equals: 'top' expected "297px" but got "425px"
-FAIL vertical-rl rtl inside vertical-rl rtl - If end side is 'auto' and start side is not, 'auto' resolves to used value assert_equals: 'bottom' expected "299px" but got "171px"
-FAIL vertical-rl rtl inside vertical-rl rtl - If opposite sides are 'auto', they resolve to used value assert_equals: 'top' expected "173px" but got "301px"
+PASS vertical-rl rtl inside vertical-rl rtl - If start side is 'auto' and end side is not, 'auto' resolves to used value
+PASS vertical-rl rtl inside vertical-rl rtl - If end side is 'auto' and start side is not, 'auto' resolves to used value
+PASS vertical-rl rtl inside vertical-rl rtl - If opposite sides are 'auto', they resolve to used value
 

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -2267,7 +2267,7 @@ RenderBoxModelObject* RenderElement::offsetParent() const
     // A is the root element.
     // A is the HTML body element.
     // The computed value of the position property for element A is fixed.
-    if (isDocumentElementRenderer() || isBody() || isFixedPositioned())
+    if (isDocumentElementRenderer() || isBody() || (isFixedPositioned() && is<RenderView>(container())))
         return nullptr;
 
     // If A is an area HTML element which has a map HTML element somewhere in the ancestor
@@ -2278,6 +2278,7 @@ RenderBoxModelObject* RenderElement::offsetParent() const
     // true and stop this algorithm if such an ancestor is found:
     //     * The element is a containing block of absolutely-positioned descendants (regardless
     //       of whether there are any absolutely-positioned descendants).
+    //     * The element is a containing block of fixed-positioned descendants.
     //     * It is the HTML body element.
     //     * The computed value of the position property of A is static and the ancestor
     //       is one of the following HTML elements: td, th, or table.
@@ -2286,7 +2287,7 @@ RenderBoxModelObject* RenderElement::offsetParent() const
     bool skipTables = isPositioned();
     float currZoom = style().usedZoom();
     CheckedPtr current = parent();
-    while (current && (!current->element() || (!current->canContainAbsolutelyPositionedObjects() && !current->isBody()))) {
+    while (current && (!current->element() || (!current->isBody() && !(isFixedPositioned() ? current->canContainFixedPositionObjects() : current->canContainAbsolutelyPositionedObjects())))) {
         RefPtr element = current->element();
         if (!skipTables && element && (is<HTMLTableElement>(*element) || is<HTMLTableCellElement>(*element)))
             break;


### PR DESCRIPTION
#### 6cd7aec936678f8164131163770ae1f213bd10a9
<pre>
Return fixedpos containing block (if any) for a fixedpos&apos;s offsetParent
<a href="https://bugs.webkit.org/show_bug.cgi?id=212372">https://bugs.webkit.org/show_bug.cgi?id=212372</a>
<a href="https://rdar.apple.com/63739636">rdar://63739636</a>

Reviewed by Simon Fraser.

Sometimes an element (such as a transformed element) that is not the viewport
forms the containing block of fixed positioned descendants. In this case,
offsetParent should return that box.

See spec: <a href="https://www.w3.org/TR/cssom-view/#dom-htmlelement-offsetparent">https://www.w3.org/TR/cssom-view/#dom-htmlelement-offsetparent</a>

* LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-insets-fixed-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-multicol-002.html:
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::offsetParent const):

Canonical link: <a href="https://commits.webkit.org/300097@main">https://commits.webkit.org/300097@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/42d67aff462fb9b75ff2dabf44a2abcced9683f7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121373 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41070 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31729 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127813 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/73456 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fbefdd67-5cc9-411b-bdce-e6d255a52a7d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123249 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41772 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49649 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/92195 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/73456 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4d95b7f1-2bf4-4499-a0b5-7d855b0a1cb6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124325 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/33357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/108748 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/72871 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f724599e-5ff3-4c77-ae0f-d88446ddf197) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/32374 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26889 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71392 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/102852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27063 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/130647 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/48301 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/36727 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/130647 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/48669 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104948 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/130647 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25512 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24168 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/44997 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/48159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53872 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/47631 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/50977 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/49313 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->