### PR TITLE
[JSC] DFG ASSERTION FAILED: Generating OSR exit while node says DoesNotExit

### DIFF
--- a/JSTests/stress/invalidate-state-based-on-edge-filter-result.js
+++ b/JSTests/stress/invalidate-state-based-on-edge-filter-result.js
@@ -1,0 +1,17 @@
+//@ runDefault("--forceEagerCompilation=true")
+function foo(){
+  const v1 = [0];
+  let v2 = 0;
+
+  while (v2 !== 2) {
+      v1.a ||= v2;
+      v2++;
+  }
+
+  return v1;
+}
+
+
+for(let i = 0; i < 32; i++) {
+  foo(42);
+}

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreter.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreter.h
@@ -172,12 +172,12 @@ public:
 
     void executeKnownEdgeTypes(Node*);
     
-    ALWAYS_INLINE void filterEdgeByUse(Edge& edge)
+    ALWAYS_INLINE FiltrationResult filterEdgeByUse(Edge& edge)
     {
         UseKind useKind = edge.useKind();
         if (useKind == UntypedUse)
-            return;
-        filterByType(edge, typeFilterFor(useKind));
+            return FiltrationOK;
+        return filterByType(edge, typeFilterFor(useKind));
     }
     
     // Abstractly execute the effects of the given node. This changes the abstract
@@ -266,8 +266,8 @@ private:
         abstractValue.fixTypeForRepresentation(m_graph, node);
     }
 
-    ALWAYS_INLINE void filterByType(Edge& edge, SpeculatedType type);
-    
+    ALWAYS_INLINE FiltrationResult filterByType(Edge&, SpeculatedType);
+
     void verifyEdge(Node*, Edge);
     void verifyEdges(Node*);
     void executeDoubleUnaryOpEffects(Node*, const auto& functor);

--- a/Source/JavaScriptCore/dfg/DFGAtTailAbstractState.h
+++ b/Source/JavaScriptCore/dfg/DFGAtTailAbstractState.h
@@ -71,9 +71,9 @@ public:
         return forNode(edge);
     }
     
-    ALWAYS_INLINE void fastForwardAndFilterUnproven(AbstractValue& value, SpeculatedType type)
+    ALWAYS_INLINE FiltrationResult fastForwardAndFilterUnproven(AbstractValue& value, SpeculatedType type)
     {
-        value.filter(type);
+        return value.filter(type);
     }
     
     ALWAYS_INLINE void clearForNode(NodeFlowProjection node)

--- a/Source/JavaScriptCore/dfg/DFGInPlaceAbstractState.h
+++ b/Source/JavaScriptCore/dfg/DFGInPlaceAbstractState.h
@@ -59,9 +59,9 @@ public:
         return value;
     }
     
-    ALWAYS_INLINE void fastForwardAndFilterUnproven(AbstractValue& value, SpeculatedType type)
+    ALWAYS_INLINE FiltrationResult fastForwardAndFilterUnproven(AbstractValue& value, SpeculatedType type)
     {
-        value.fastForwardToAndFilterUnproven(m_effectEpoch, type);
+        return value.fastForwardToAndFilterUnproven(m_effectEpoch, type);
     }
     
     ALWAYS_INLINE AbstractValue& forNodeWithoutFastForward(NodeFlowProjection node)


### PR DESCRIPTION
#### f24db23749f4549857680d70e77cbe9e4c7e7a52
<pre>
[JSC] DFG ASSERTION FAILED: Generating OSR exit while node says DoesNotExit
<a href="https://bugs.webkit.org/show_bug.cgi?id=298850">https://bugs.webkit.org/show_bug.cgi?id=298850</a>
<a href="https://rdar.apple.com/160593061">rdar://160593061</a>

Reviewed by Justin Michaud.

This is not an actual issue because this happens only when the input is
already None. This means that we will never reach here at runtime. So
whether we generate OSR exit code or not does not matter. But let&apos;s make
this verification correct by making abstract state invalid when edge
filtering contradicts.

Test: JSTests/stress/invalidate-state-based-on-edge-filter-result.js

Test: JSTests/stress/invalidate-state-based-on-edge-filter-result.js
* JSTests/stress/invalidate-state-based-on-edge-filter-result.js: Added.
(foo):
* Source/JavaScriptCore/dfg/DFGAbstractInterpreter.h:
(JSC::DFG::AbstractInterpreter::filterEdgeByUse):
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEdges):
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeKnownEdgeTypes):
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::filterByType):
(JSC::DFG::AbstractInterpreterExecuteEdgesFunc::AbstractInterpreterExecuteEdgesFunc): Deleted.
(JSC::DFG::AbstractInterpreterExecuteEdgesFunc::operator() const): Deleted.
* Source/JavaScriptCore/dfg/DFGAtTailAbstractState.h:
(JSC::DFG::AtTailAbstractState::fastForwardAndFilterUnproven):
* Source/JavaScriptCore/dfg/DFGInPlaceAbstractState.h:
(JSC::DFG::InPlaceAbstractState::fastForwardAndFilterUnproven):

Canonical link: <a href="https://commits.webkit.org/300085@main">https://commits.webkit.org/300085@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/11918ef07446b9d3d021f51117f5b52d09ebbf8b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121260 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40957 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31615 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127696 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73341 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8585f28e-096f-491c-b26e-e422e8becf60) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41659 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49536 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92108 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61282 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8ee7f895-08e3-4e58-afdb-b1c1dbeb9843) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124212 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33259 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108662 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72785 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5802f8dc-9874-47ff-a233-ec662db688b4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32275 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26789 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71278 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/113390 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102752 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26967 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130534 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/119780 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48188 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36626 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100705 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48555 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104852 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100610 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46015 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24075 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44881 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19233 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48046 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53759 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/149942 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47517 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/38112 "Found 1 new JSC stress test failure: stress/dont-link-virtual-calls-on-compiler-thread.js.no-llint (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50864 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49200 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->