### PR TITLE
`lostpointercapture` may not be fired before other subsequent events for the pointer after capture is lost

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_lostpointercapture_for_disconnected_node-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_lostpointercapture_for_disconnected_node-expected.txt
@@ -6,11 +6,11 @@ Pointer Events Capture Test
 
 The following pointer types were detected: mouse.
 
-The following events were logged: pointerover@btnCapture, pointerenter@BODY, pointermove@btnCapture, pointerdown@btnCapture, pointerout@btnCapture, pointerover@target0, pointerenter@target0, gotpointercapture@target0, pointerover@target0, pointerenter@target0, pointermove@target0, lostpointercapture@document, pointerout@target0, pointerleave@target0, pointerover@btnCapture, pointerenter@BODY, pointermove@btnCapture, pointermove@btnCapture, pointermove@btnCapture.
+The following events were logged: pointerover@btnCapture, pointerenter@BODY, pointermove@btnCapture, pointerdown@btnCapture, pointerout@btnCapture, pointerover@target0, pointerenter@target0, gotpointercapture@target0, lostpointercapture@document, pointerover@btnCapture, pointerenter@BODY, pointermove@btnCapture, pointermove@btnCapture, pointermove@btnCapture.
 
 
 PASS lostpointercapture event received
 PASS Lostpointercapture fires on document when target is removed
-FAIL lostpointercapture must be received before the next pointerevent after the node is disconnected assert_equals: No pointerevents should be received before lost capture is resolved expected "" but got "pointerover@target0, pointerenter@target0, pointermove@target0"
+PASS lostpointercapture must be received before the next pointerevent after the node is disconnected
 PASS lostpointercapture is dispatched on the document
 

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/pointerevents/pointerevent_lostpointercapture_for_disconnected_node-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/pointerevents/pointerevent_lostpointercapture_for_disconnected_node-expected.txt
@@ -1,0 +1,16 @@
+Pointer Events - lostpointercapture when capturing element is removed
+
+
+
+Pointer Events Capture Test
+
+The following pointer types were detected: mouse.
+
+The following events were logged: pointerover@btnCapture, pointerenter@BODY, pointermove@btnCapture, pointerdown@btnCapture, pointerout@btnCapture, pointerover@target0, pointerenter@target0, gotpointercapture@target0, pointerover@btnCapture, pointerenter@BODY, pointermove@btnCapture, lostpointercapture@document, pointermove@btnCapture, pointermove@btnCapture, pointermove@btnCapture.
+
+
+PASS lostpointercapture event received
+PASS Lostpointercapture fires on document when target is removed
+FAIL lostpointercapture must be received before the next pointerevent after the node is disconnected assert_equals: No pointerevents should be received before lost capture is resolved expected "" but got "pointerover@btnCapture, pointerenter@BODY, pointermove@btnCapture"
+PASS lostpointercapture is dispatched on the document
+

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -5404,6 +5404,11 @@ MouseEventWithHitTestResults Document::prepareMouseEvent(const HitTestRequest& r
             auto& pointerCaptureController = page->pointerCaptureController();
             RefPtr previousCaptureElement = pointerCaptureController.pointerCaptureElement(this, event.pointerId());
             pointerCaptureController.processPendingPointerCapture(event.pointerId());
+
+            // Check if event processing should be suppressed due to the possible removal of the captured element.
+            if (pointerCaptureController.shouldSuppressEventProcessing(event.pointerId()))
+                return MouseEventWithHitTestResults(event, HitTestResult(LayoutPoint()));
+
             RefPtr captureElement = pointerCaptureController.pointerCaptureElement(this, event.pointerId());
             // If the capture element has changed while running the Process Pending Capture Element steps then
             // we need to indicate that when calling updateHoverActiveState to be sure that the :active and :hover

--- a/Source/WebCore/dom/EventDispatcher.cpp
+++ b/Source/WebCore/dom/EventDispatcher.cpp
@@ -40,6 +40,9 @@
 #include "LocalFrameView.h"
 #include "Logging.h"
 #include "MouseEvent.h"
+#include "Page.h"
+#include "PointerCaptureController.h"
+#include "PointerEvent.h"
 #include "ScopedEventQueue.h"
 #include "ScriptDisallowedScope.h"
 #include "ShadowRoot.h"
@@ -170,6 +173,12 @@ void EventDispatcher::dispatchEvent(Node& node, Event& event)
     ASSERT_WITH_SECURITY_IMPLICATION(ScriptDisallowedScope::InMainThread::isEventDispatchAllowedInSubtree(node));
 
     LOG_WITH_STREAM(Events, stream << "EventDispatcher::dispatchEvent " << event << " on node " << node);
+
+    // Clear pointer event suppression when lostpointercapture is dispatched.
+    if (RefPtr pointerEvent = dynamicDowncast<PointerEvent>(event); pointerEvent && pointerEvent->type() == eventNames().lostpointercaptureEvent) {
+        if (RefPtr page = node.document().page())
+            page->pointerCaptureController().clearEventSuppression(pointerEvent->pointerId());
+    }
 
     Ref protectedNode { node };
     Ref document = node.document();

--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -757,6 +757,8 @@ public:
 
     virtual bool usePluginRendererScrollableArea(LocalFrame&) const { return true; }
 
+    virtual bool supportsEventSuppression() { return true; }
+
     WEBCORE_EXPORT virtual ~ChromeClient();
 
 protected:

--- a/Source/WebCore/page/PointerCaptureController.h
+++ b/Source/WebCore/page/PointerCaptureController.h
@@ -73,6 +73,8 @@ public:
     void dispatchEvent(PointerEvent&, EventTarget*);
     WEBCORE_EXPORT void cancelPointer(PointerID, const IntPoint&, PointerEvent* existingCancelEvent = nullptr);
     void processPendingPointerCapture(PointerID);
+    void clearEventSuppression(PointerID);
+    bool shouldSuppressEventProcessing(PointerID) const;
 
 private:
     struct CapturingData : public RefCounted<CapturingData> {
@@ -104,6 +106,7 @@ private:
         bool isPrimary { false };
         bool preventsCompatibilityMouseEvents { false };
         bool pointerIsPressed { false };
+        bool suppressEventProcessing { false };
         MouseButton previousMouseButton { MouseButton::PointerHasNotChanged };
 
     private:

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.h
@@ -254,6 +254,8 @@ private:
 
     void requestCookieConsent(CompletionHandler<void(WebCore::CookieConsentDecisionResult)>&&) final;
 
+    bool supportsEventSuppression() final { return false; }
+
 #if ENABLE(VIDEO_PRESENTATION_MODE)
     bool m_mockVideoPresentationModeEnabled { false };
 #endif


### PR DESCRIPTION
#### 54f983fffa579931c6ae07460a6c20835818d524
<pre>
`lostpointercapture` may not be fired before other subsequent events for the pointer after capture is lost
<a href="https://bugs.webkit.org/show_bug.cgi?id=299000">https://bugs.webkit.org/show_bug.cgi?id=299000</a>
<a href="https://rdar.apple.com/160752786">rdar://160752786</a>

Reviewed by Abrar Rahman Protyasha.

According to <a href="https://w3c.github.io/pointerevents/#dfn-lostpointercapture">https://w3c.github.io/pointerevents/#dfn-lostpointercapture</a>:
`lostpointercapture` &quot;MUST be fired prior to any subsequent events for the
pointer after capture was released.&quot; This is not always the case in WebKit;
we fail the third subtest of the wpt test
pointerevents/pointerevent_lostpointercapture_for_disconnected_node.html
as a result.

The cause of this bug is that, when an element with pointer capture is removed,
PointerCaptureController::elementWasRemovedSlow is called, and it queues the
dispatch of a `lostpointercaptureEvent` rather than immediately dispatching
due to it being in a script disallowed context. This results in a timing issue
where other pointer events may fire before `lostpointercaptureEvent`. To resolve
this, immediately clear the pointer capture target and pending target in
`lostpointercaptureEvent`, and begin suppressing event processing until the
`lostpointercaptureEvent` is received.

Event suppression works on a per-pointer basis, and is synchronously enabled in
`PointerCaptureController::elementWasRemovedSlow`. In `Document::prepareMouseEvent,`
we now return an empty result when the suppression flag is result to prevent
events from processing. When the `lostpointercapture` event is actually dispatched,
we detect it in `EventDispatcher::dispatchEvent`, and clear event suppression
accordingly.

* LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_lostpointercapture_for_disconnected_node-expected.txt:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/pointerevents/pointerevent_lostpointercapture_for_disconnected_node-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_lostpointercapture_for_disconnected_node-expected.txt.
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::prepareMouseEvent):
* Source/WebCore/dom/EventDispatcher.cpp:
(WebCore::EventDispatcher::dispatchEvent):
* Source/WebCore/page/ChromeClient.h:
(WebCore::ChromeClient::supportsEventSuppression):
* Source/WebCore/page/PointerCaptureController.cpp:
(WebCore::PointerCaptureController::elementWasRemovedSlow):
(WebCore::PointerCaptureController::clearEventSuppression):
(WebCore::PointerCaptureController::shouldSuppressEventProcessing const):
* Source/WebCore/page/PointerCaptureController.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.h:

Canonical link: <a href="https://commits.webkit.org/300168@main">https://commits.webkit.org/300168@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/21337d704263d564d28b17ed3bed7e3278b9ff87

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121520 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41217 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31876 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127977 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73603 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5d504037-65b0-44b8-b1c1-472e82be75a9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123396 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41919 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49796 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92297 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61408 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/52fc34ae-cfab-4132-a8e6-fab2ca6dfd3c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124472 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33471 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108848 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72973 "Found 1 new API test failure: WPE/TestWebKitWebContext:/webkit/WebKitWebContext/no-web-process-leak (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/366b16a2-cae4-4623-a02c-956d852e1f1f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32479 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27018 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71545 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102954 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27191 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130795 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48448 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36839 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100888 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48816 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105076 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100794 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25564 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46204 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24286 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45144 "Built successfully") | | 
| [  ~~🛠 🧪 unsafe-merge~~](https://ews-build.webkit.org/#/builders/22/builds/19258 "The change is no longer eligible for processing.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48307 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54019 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47778 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51124 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49460 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->