### PR TITLE
Access UserContentProvider through LocalFrame instead of Page

### DIFF
--- a/Source/WebCore/Modules/websockets/ThreadableWebSocketChannel.cpp
+++ b/Source/WebCore/Modules/websockets/ThreadableWebSocketChannel.cpp
@@ -78,8 +78,11 @@ std::optional<ThreadableWebSocketChannel::ValidatedURL> ThreadableWebSocketChann
             return { };
 
 #if ENABLE(CONTENT_EXTENSIONS)
-        if (RefPtr documentLoader = document.loader()) {
-            auto results = page->protectedUserContentProvider()->processContentRuleListsForLoad(*page, validatedURL.url, ContentExtensions::ResourceType::WebSocket, *documentLoader);
+        RefPtr frame = document.frame();
+        RefPtr userContentProvider = frame ? frame->userContentProvider() : nullptr;
+        RefPtr documentLoader = document.loader();
+        if (userContentProvider && documentLoader) {
+            auto results = userContentProvider->processContentRuleListsForLoad(*page, validatedURL.url, ContentExtensions::ResourceType::WebSocket, *documentLoader);
             if (results.shouldBlock())
                 return { };
 

--- a/Source/WebCore/contentextensions/ContentExtensionsBackend.cpp
+++ b/Source/WebCore/contentextensions/ContentExtensionsBackend.cpp
@@ -199,7 +199,7 @@ auto ContentExtensionsBackend::actionsForResourceLoad(const ResourceLoadInfo& re
     return actionsVector;
 }
 
-void ContentExtensionsBackend::forEach(NOESCAPE const Function<void(const String&, ContentExtension&)>& apply)
+void ContentExtensionsBackend::forEach(NOESCAPE const Function<void(const String&, ContentExtension&)>& apply) const
 {
     for (auto& pair : m_contentExtensions)
         apply(pair.key, pair.value);
@@ -240,7 +240,7 @@ std::optional<String> customTrackerBlockingMessageForConsole(const ContentRuleLi
 #endif
 }
 
-ContentRuleListResults ContentExtensionsBackend::processContentRuleListsForLoad(Page& page, const URL& url, OptionSet<ResourceType> resourceType, DocumentLoader& initiatingDocumentLoader, const URL& redirectFrom, const RuleListFilter& ruleListFilter)
+ContentRuleListResults ContentExtensionsBackend::processContentRuleListsForLoad(Page& page, const URL& url, OptionSet<ResourceType> resourceType, DocumentLoader& initiatingDocumentLoader, const URL& redirectFrom, const RuleListFilter& ruleListFilter) const
 {
     Document* currentDocument = nullptr;
     URL mainDocumentURL;

--- a/Source/WebCore/contentextensions/ContentExtensionsBackend.h
+++ b/Source/WebCore/contentextensions/ContentExtensionsBackend.h
@@ -75,13 +75,13 @@ public:
     WEBCORE_EXPORT Vector<ActionsFromContentRuleList> actionsForResourceLoad(const ResourceLoadInfo&, const RuleListFilter& = { [](const String&) { return ShouldSkipRuleList::No; } }) const;
     WEBCORE_EXPORT StyleSheetContents* globalDisplayNoneStyleSheet(const String& identifier) const;
 
-    ContentRuleListResults processContentRuleListsForLoad(Page&, const URL&, OptionSet<ResourceType>, DocumentLoader& initiatingDocumentLoader, const URL& redirectFrom, const RuleListFilter&);
+    ContentRuleListResults processContentRuleListsForLoad(Page&, const URL&, OptionSet<ResourceType>, DocumentLoader& initiatingDocumentLoader, const URL& redirectFrom, const RuleListFilter&) const;
     WEBCORE_EXPORT ContentRuleListResults processContentRuleListsForPingLoad(const URL&, const URL& mainDocumentURL, const URL& frameURL, const String& httpMethod);
     bool processContentRuleListsForResourceMonitoring(const URL&, const URL& mainDocumentURL, const URL& frameURL, OptionSet<ResourceType>);
 
     static const String& displayNoneCSSRule();
 
-    void forEach(NOESCAPE const Function<void(const String&, ContentExtension&)>&);
+    void forEach(NOESCAPE const Function<void(const String&, ContentExtension&)>&) const;
 
     WEBCORE_EXPORT static bool shouldBeMadeSecure(const URL&);
 

--- a/Source/WebCore/dom/ExtensionStyleSheets.cpp
+++ b/Source/WebCore/dom/ExtensionStyleSheets.cpp
@@ -153,7 +153,10 @@ void ExtensionStyleSheets::updateInjectedStyleSheetCache() const
     for (const auto& userStyleSheet : m_pageSpecificStyleSheets)
         addStyleSheet(userStyleSheet);
 
-    owningPage->protectedUserContentProvider()->forEachUserStyleSheet([&](const UserStyleSheet& userStyleSheet) {
+    RefPtr frame = m_document->frame();
+    RefPtr userContentProvider = frame ? frame->userContentProvider() : nullptr;
+
+    userContentProvider->forEachUserStyleSheet([&](const UserStyleSheet& userStyleSheet) {
         if (userStyleSheet.pageID())
             return;
 

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -1856,8 +1856,10 @@ void HTMLMediaElement::loadResource(const URL& initialURL, const ContentType& in
 #endif
 
 #if ENABLE(CONTENT_EXTENSIONS)
-    if (RefPtr documentLoader = frame->loader().documentLoader()) {
-        if (page->protectedUserContentProvider()->processContentRuleListsForLoad(*page, url, ContentExtensions::ResourceType::Media, *documentLoader).shouldBlock()) {
+    RefPtr documentLoader = frame->loader().documentLoader();
+    RefPtr userContentProvider = frame->userContentProvider();
+    if (documentLoader && userContentProvider) {
+        if (userContentProvider->processContentRuleListsForLoad(*page, url, ContentExtensions::ResourceType::Media, *documentLoader).shouldBlock()) {
             mediaLoadingFailed(MediaPlayer::NetworkState::FormatError);
             return;
         }

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -558,10 +558,13 @@ void DocumentLoader::handleSubstituteDataLoadNow()
         response = ResourceResponse(URL { m_request.url() }, String { m_substituteData.mimeType() }, m_substituteData.content()->size(), String { m_substituteData.textEncoding() });
 
 #if ENABLE(CONTENT_EXTENSIONS)
-    if (RefPtr page = m_frame ? m_frame->page() : nullptr) {
+    RefPtr frame = m_frame.get();
+    RefPtr page = frame ? frame->page() : nullptr;
+    RefPtr userContentProvider = frame ? frame->userContentProvider() : nullptr;
+    if (page && userContentProvider) {
         // We intentionally do nothing with the results of this call.
         // We want the CSS to be loaded for us, but we ignore any attempt to block or upgrade the connection since there is no connection.
-        page->protectedUserContentProvider()->processContentRuleListsForLoad(*page, response.url(), m_frame->isMainFrame() ? ContentExtensions::ResourceType::TopDocument : ContentExtensions::ResourceType::ChildDocument, *this);
+        userContentProvider->processContentRuleListsForLoad(*page, response.url(), frame->isMainFrame() ? ContentExtensions::ResourceType::TopDocument : ContentExtensions::ResourceType::ChildDocument, *this);
     }
 #endif
 

--- a/Source/WebCore/loader/EmptyClients.cpp
+++ b/Source/WebCore/loader/EmptyClients.cpp
@@ -591,7 +591,7 @@ class EmptyUserContentProvider final : public UserContentProvider {
     void forEachUserMessageHandler(NOESCAPE const Function<void(const UserMessageHandlerDescriptor&)>&) const final { }
 #endif
 #if ENABLE(CONTENT_EXTENSIONS)
-    ContentExtensions::ContentExtensionsBackend& userContentExtensionBackend() final { static NeverDestroyed<ContentExtensions::ContentExtensionsBackend> backend; return backend.get(); };
+    const ContentExtensions::ContentExtensionsBackend& userContentExtensionBackend() const final { static NeverDestroyed<ContentExtensions::ContentExtensionsBackend> backend; return backend.get(); };
 #endif
 };
 

--- a/Source/WebCore/loader/PingLoader.cpp
+++ b/Source/WebCore/loader/PingLoader.cpp
@@ -76,7 +76,11 @@ static bool processContentRuleListsForLoad(const LocalFrame& frame, ResourceRequ
     if (!page)
         return false;
 
-    auto results = page->protectedUserContentProvider()->processContentRuleListsForLoad(*page, request.url(), resourceType, *documentLoader);
+    RefPtr userContentProvider = frame.userContentProvider();
+    if (!userContentProvider)
+        return false;
+
+    auto results = userContentProvider->processContentRuleListsForLoad(*page, request.url(), resourceType, *documentLoader);
     ContentExtensions::applyResultsToRequest(WTFMove(results), page.get(), request);
     return results.shouldBlock();
 }

--- a/Source/WebCore/loader/SubframeLoader.cpp
+++ b/Source/WebCore/loader/SubframeLoader.cpp
@@ -349,9 +349,9 @@ RefPtr<LocalFrame> FrameLoader::SubframeLoader::loadSubframe(HTMLFrameOwnerEleme
     frame->loader().loadURLIntoChildFrame(url, referrerToUse, *subFrame);
 
 #if ENABLE(CONTENT_EXTENSIONS)
-    RefPtr subFramePage = subFrame->page();
-    if ((url.isAboutBlank() || url.isAboutSrcDoc()) && subFramePage) {
-        subFramePage->protectedUserContentProvider()->userContentExtensionBackend().forEach([&] (const String& identifier, ContentExtensions::ContentExtension& extension) {
+    RefPtr userContentProvider = frame->userContentProvider();
+    if ((url.isAboutBlank() || url.isAboutSrcDoc()) && userContentProvider) {
+        userContentProvider->userContentExtensionBackend().forEach([&] (const String& identifier, ContentExtensions::ContentExtension& extension) {
             if (RefPtr styleSheetContents = extension.globalDisplayNoneStyleSheet())
                 subFrame->protectedDocument()->extensionStyleSheets().maybeAddContentExtensionSheet(identifier, *styleSheetContents);
         });

--- a/Source/WebCore/loader/cache/CachedResourceLoader.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.cpp
@@ -1128,9 +1128,10 @@ ResourceErrorOr<CachedResourceHandle<CachedResource>> CachedResourceLoader::requ
         bool madeHTTPS { request.resourceRequest().wasSchemeOptimisticallyUpgraded() };
 #if ENABLE(CONTENT_EXTENSIONS)
         const auto& resourceRequest = request.resourceRequest();
-        if (request.options().shouldEnableContentExtensionsCheck == ShouldEnableContentExtensionsCheck::Yes) {
+        RefPtr userContentProvider = frame->userContentProvider();
+        if (request.options().shouldEnableContentExtensionsCheck == ShouldEnableContentExtensionsCheck::Yes && userContentProvider) {
             RegistrableDomain originalDomain { resourceRequest.url() };
-            auto results = page->protectedUserContentProvider()->processContentRuleListsForLoad(page, resourceRequest.url(), ContentExtensions::toResourceType(type, request.resourceRequest().requester(), frame->isMainFrame()), *documentLoader);
+            auto results = userContentProvider->processContentRuleListsForLoad(page, resourceRequest.url(), ContentExtensions::toResourceType(type, request.resourceRequest().requester(), frame->isMainFrame()), *documentLoader);
             madeHTTPS = results.summary.madeHTTPS;
             request.applyResults(WTFMove(results), page.ptr());
             if (results.shouldBlock()) {

--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -733,16 +733,35 @@ FloatSize LocalFrame::resizePageRectsKeepingRatio(const FloatSize& originalSize,
     return resultSize;
 }
 
+const UserContentProvider* LocalFrame::userContentProvider() const
+{
+    if (RefPtr page = this->page())
+        return page->protectedUserContentProviderForFrame().ptr();
+    return nullptr;
+}
+
+UserContentProvider* LocalFrame::userContentProvider()
+{
+    if (RefPtr page = this->page())
+        return page->protectedUserContentProviderForFrame().ptr();
+    return nullptr;
+}
+
+bool LocalFrame::hasUserContentProvider(const UserContentProvider& provider)
+{
+    return userContentProvider() == &provider;
+}
+
 void LocalFrame::injectUserScripts(UserScriptInjectionTime injectionTime)
 {
-    if (!page())
-        return;
-
     if (loader().stateMachine().creatingInitialEmptyDocument() && !settings().shouldInjectUserScriptsInInitialEmptyDocument())
         return;
 
-    RefPtr page = this->page();
-    page->protectedUserContentProvider()->forEachUserScript([this, injectionTime](DOMWrapperWorld& world, const UserScript& script) {
+    RefPtr userContentProvider = this->userContentProvider();
+    if (!userContentProvider)
+        return;
+
+    userContentProvider->forEachUserScript([this, injectionTime](DOMWrapperWorld& world, const UserScript& script) {
         if (script.injectionTime() == injectionTime)
             injectUserScriptImmediately(world, script);
     });

--- a/Source/WebCore/page/LocalFrame.h
+++ b/Source/WebCore/page/LocalFrame.h
@@ -92,6 +92,7 @@ class RenderWidget;
 class ResourceMonitor;
 class ScriptController;
 class SecurityOrigin;
+class UserContentProvider;
 class UserScript;
 class VisiblePosition;
 class Widget;
@@ -200,6 +201,9 @@ public:
 
     WEBCORE_EXPORT void injectUserScripts(UserScriptInjectionTime);
     WEBCORE_EXPORT void injectUserScriptImmediately(DOMWrapperWorld&, const UserScript&);
+    UserContentProvider* userContentProvider();
+    const UserContentProvider* userContentProvider() const;
+    WEBCORE_EXPORT bool hasUserContentProvider(const UserContentProvider&);
 
     WEBCORE_EXPORT String trackedRepaintRectsAsText() const;
 

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -472,7 +472,7 @@ Page::Page(PageConfiguration&& pageConfiguration)
     updateTimerThrottlingState();
 
     protectedPluginInfoProvider()->addPage(*this);
-    protectedUserContentProvider()->addPage(*this);
+    Ref { m_userContentProvider }->addPage(*this);
     protectedVisitedLinkStore()->addPage(*this);
 
     static bool firstTimeInitializationRan = false;
@@ -556,7 +556,7 @@ Page::~Page()
         BackForwardCache::singleton().removeAllItemsForPage(*this);
 
     protectedPluginInfoProvider()->removePage(*this);
-    protectedUserContentProvider()->removePage(*this);
+    Ref { m_userContentProvider }->removePage(*this);
     protectedVisitedLinkStore()->removePage(*this);
 }
 
@@ -3957,21 +3957,16 @@ Ref<PluginInfoProvider> Page::protectedPluginInfoProvider() const
     return m_pluginInfoProvider;
 }
 
-UserContentProvider& Page::userContentProvider()
+Ref<UserContentProvider> Page::protectedUserContentProviderForFrame()
 {
     return m_userContentProvider;
 }
 
-Ref<UserContentProvider> Page::protectedUserContentProvider()
+void Page::setUserContentProviderForWebKitLegacy(Ref<UserContentProvider>&& userContentProvider)
 {
-    return m_userContentProvider;
-}
-
-void Page::setUserContentProvider(Ref<UserContentProvider>&& userContentProvider)
-{
-    protectedUserContentProvider()->removePage(*this);
+    Ref { m_userContentProvider }->removePage(*this);
     m_userContentProvider = WTFMove(userContentProvider);
-    protectedUserContentProvider()->addPage(*this);
+    Ref { m_userContentProvider }->addPage(*this);
 
     invalidateInjectedStyleSheetCacheInAllFrames();
 }

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -1008,9 +1008,8 @@ public:
     PluginInfoProvider& pluginInfoProvider();
     Ref<PluginInfoProvider> protectedPluginInfoProvider() const;
 
-    WEBCORE_EXPORT UserContentProvider& userContentProvider();
-    WEBCORE_EXPORT Ref<UserContentProvider> protectedUserContentProvider();
-    WEBCORE_EXPORT void setUserContentProvider(Ref<UserContentProvider>&&);
+    WEBCORE_EXPORT Ref<UserContentProvider> protectedUserContentProviderForFrame();
+    WEBCORE_EXPORT void setUserContentProviderForWebKitLegacy(Ref<UserContentProvider>&&);
 
     ScreenOrientationManager* screenOrientationManager() const;
 

--- a/Source/WebCore/page/UserContentController.h
+++ b/Source/WebCore/page/UserContentController.h
@@ -56,7 +56,7 @@ private:
     void forEachUserMessageHandler(NOESCAPE const Function<void(const UserMessageHandlerDescriptor&)>&) const final;
 #endif
 #if ENABLE(CONTENT_EXTENSIONS)
-    ContentExtensions::ContentExtensionsBackend& userContentExtensionBackend() override { return m_contentExtensionBackend; }
+    const ContentExtensions::ContentExtensionsBackend& userContentExtensionBackend() const override { return m_contentExtensionBackend; }
 #endif
 
     UserScriptMap m_userScripts;

--- a/Source/WebCore/page/UserContentProvider.cpp
+++ b/Source/WebCore/page/UserContentProvider.cpp
@@ -147,7 +147,7 @@ static void applyLinkDecorationFilteringIfNeeded(ContentRuleListResults& results
         results.summary.redirectActions.append({ { ContentExtensions::RedirectAction::URLAction { adjustedURL.string() } }, adjustedURL });
 }
 
-ContentRuleListResults UserContentProvider::processContentRuleListsForLoad(Page& page, const URL& url, OptionSet<ContentExtensions::ResourceType> resourceType, DocumentLoader& initiatingDocumentLoader, const URL& redirectFrom)
+ContentRuleListResults UserContentProvider::processContentRuleListsForLoad(Page& page, const URL& url, OptionSet<ContentExtensions::ResourceType> resourceType, DocumentLoader& initiatingDocumentLoader, const URL& redirectFrom) const
 {
     auto results = userContentExtensionBackend().processContentRuleListsForLoad(page, url, resourceType, initiatingDocumentLoader, redirectFrom, ruleListFilter(initiatingDocumentLoader));
 

--- a/Source/WebCore/page/UserContentProvider.h
+++ b/Source/WebCore/page/UserContentProvider.h
@@ -75,7 +75,7 @@ public:
     virtual void forEachUserMessageHandler(NOESCAPE const Function<void(const UserMessageHandlerDescriptor&)>&) const = 0;
 #endif
 #if ENABLE(CONTENT_EXTENSIONS)
-    virtual ContentExtensions::ContentExtensionsBackend& userContentExtensionBackend() = 0;
+    virtual const ContentExtensions::ContentExtensionsBackend& userContentExtensionBackend() const = 0;
 #endif
 
     void registerForUserMessageHandlerInvalidation(UserContentProviderInvalidationClient&);
@@ -85,7 +85,7 @@ public:
     void removePage(Page&);
 
 #if ENABLE(CONTENT_EXTENSIONS)
-    ContentRuleListResults processContentRuleListsForLoad(Page&, const URL&, OptionSet<ContentExtensions::ResourceType>, DocumentLoader& initiatingDocumentLoader, const URL& redirectFrom = { });
+    ContentRuleListResults processContentRuleListsForLoad(Page&, const URL&, OptionSet<ContentExtensions::ResourceType>, DocumentLoader& initiatingDocumentLoader, const URL& redirectFrom = { }) const;
 #endif
 
 protected:

--- a/Source/WebCore/page/UserMessageHandlersNamespace.cpp
+++ b/Source/WebCore/page/UserMessageHandlersNamespace.cpp
@@ -85,15 +85,15 @@ UserMessageHandler* UserMessageHandlersNamespace::namedItem(DOMWrapperWorld& wor
     if (!frame)
         return nullptr;
 
-    RefPtr page = frame->page();
-    if (!page)
+    RefPtr userContentProvider = frame->userContentProvider();
+    if (!userContentProvider)
         return nullptr;
 
     RefPtr handler = m_messageHandlers.get({ name, &world });
     if (handler)
         return handler.get();
 
-    page->protectedUserContentProvider()->forEachUserMessageHandler([&](const UserMessageHandlerDescriptor& descriptor) {
+    userContentProvider->forEachUserMessageHandler([&](const UserMessageHandlerDescriptor& descriptor) {
         if (descriptor.name() != name || &descriptor.world() != &world)
             return;
         

--- a/Source/WebKit/WebProcess/UserContent/WebUserContentController.h
+++ b/Source/WebKit/WebProcess/UserContent/WebUserContentController.h
@@ -91,7 +91,7 @@ private:
     void forEachUserMessageHandler(NOESCAPE const Function<void(const WebCore::UserMessageHandlerDescriptor&)>&) const final;
 #endif
 #if ENABLE(CONTENT_EXTENSIONS)
-    WebCore::ContentExtensions::ContentExtensionsBackend& userContentExtensionBackend() override { return m_contentExtensionBackend; }
+    const WebCore::ContentExtensions::ContentExtensionsBackend& userContentExtensionBackend() const override { return m_contentExtensionBackend; }
 #endif
 
     // IPC::MessageReceiver.

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -6494,7 +6494,7 @@ static WebFrame *incrementFrame(WebFrame *frame, WebFindOptions options = 0)
     if (!_private->page)
         return;
 
-    _private->page->setUserContentProvider(_private->group->userContentController());
+    _private->page->setUserContentProviderForWebKitLegacy(_private->group->userContentController());
     _private->page->setVisitedLinkStore(_private->group->visitedLinkStore());
     _private->page->setGroupName(groupName);
 }


### PR DESCRIPTION
#### 33c60f6f41c4979d4240c9ef09fbc90ad3ca1daa
<pre>
Access UserContentProvider through LocalFrame instead of Page
<a href="https://bugs.webkit.org/show_bug.cgi?id=298999">https://bugs.webkit.org/show_bug.cgi?id=298999</a>
<a href="https://rdar.apple.com/160751956">rdar://160751956</a>

Reviewed by Brady Eidson.

This is preparation for having different frames have different WKUserContentControllers.

* Source/WebCore/Modules/websockets/ThreadableWebSocketChannel.cpp:
(WebCore::ThreadableWebSocketChannel::validateURL):
* Source/WebCore/contentextensions/ContentExtensionsBackend.cpp:
(WebCore::ContentExtensions::ContentExtensionsBackend::forEach const):
(WebCore::ContentExtensions::ContentExtensionsBackend::processContentRuleListsForLoad const):
(WebCore::ContentExtensions::ContentExtensionsBackend::forEach): Deleted.
(WebCore::ContentExtensions::ContentExtensionsBackend::processContentRuleListsForLoad): Deleted.
* Source/WebCore/contentextensions/ContentExtensionsBackend.h:
* Source/WebCore/css/StyleSheetContents.cpp:
(WebCore::StyleSheetContents::subresourcesAllowReuse const):
* Source/WebCore/dom/ExtensionStyleSheets.cpp:
(WebCore::ExtensionStyleSheets::updateInjectedStyleSheetCache const):
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::loadResource):
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::handleSubstituteDataLoadNow):
* Source/WebCore/loader/DocumentLoader.h:
* Source/WebCore/loader/EmptyClients.cpp:
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::loadResourceSynchronously):
(WebCore::FrameLoader::prefetchDNSIfNeeded):
* Source/WebCore/loader/LinkLoader.cpp:
(WebCore::LinkLoader::preconnectIfNeeded):
* Source/WebCore/loader/PingLoader.cpp:
(WebCore::processContentRuleListsForLoad):
* Source/WebCore/loader/PolicyChecker.cpp:
(WebCore::PolicyChecker::checkNavigationPolicy):
* Source/WebCore/loader/ResourceLoader.cpp:
(WebCore::ResourceLoader::willSendRequestInternal):
* Source/WebCore/loader/SubframeLoader.cpp:
(WebCore::FrameLoader::SubframeLoader::loadSubframe):
* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::CachedResourceLoader::requestResource):
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::shouldHaveWebKitNamespaceForWorld):
(WebCore::LocalDOMWindow::webkitNamespace):
(WebCore::LocalDOMWindow::open):
* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::userContentProvider const):
(WebCore::LocalFrame::userContentProvider):
(WebCore::LocalFrame::hasUserContentProvider):
(WebCore::LocalFrame::injectUserScripts):
* Source/WebCore/page/LocalFrame.h:
* Source/WebCore/page/Page.cpp:
(WebCore::m_mediaSessionManagerFactory):
(WebCore::Page::~Page):
(WebCore::Page::protectedUserContentProviderForFrame):
(WebCore::Page::setUserContentProviderForWebKitLegacy):
(WebCore::Page::userContentProvider): Deleted.
(WebCore::Page::protectedUserContentProvider): Deleted.
(WebCore::Page::setUserContentProvider): Deleted.
* Source/WebCore/page/Page.h:
* Source/WebCore/page/UserContentController.h:
* Source/WebCore/page/UserContentProvider.cpp:
(WebCore::UserContentProvider::processContentRuleListsForLoad const):
(WebCore::UserContentProvider::processContentRuleListsForLoad): Deleted.
* Source/WebCore/page/UserContentProvider.h:
(WebCore::UserContentProvider::processContentRuleListsForLoad):
* Source/WebCore/page/UserMessageHandlersNamespace.cpp:
(WebCore::UserMessageHandlersNamespace::namedItem):
* Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp:
(WebKit::WebUserContentController::addContentWorlds):
(WebKit::WebUserContentController::addUserScriptInternal):
* Source/WebKit/WebProcess/UserContent/WebUserContentController.h:
* Source/WebKitLegacy/mac/WebView/WebView.mm:
(-[WebView setGroupName:]):

Canonical link: <a href="https://commits.webkit.org/300095@main">https://commits.webkit.org/300095@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/61d5f0a5469057621b2dc6666de21a9df5c9cc9f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121340 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41037 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31696 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127779 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73421 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/90f9253d-dd22-4495-867a-03858e1f84b8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123216 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41739 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49616 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92174 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/61328 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/058298a1-7b0a-44c4-9935-b0c989ed0c97) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124292 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33336 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/108731 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72851 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f999afc1-71f7-4ec6-965b-84552adbb933) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32353 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26866 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71359 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102829 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27041 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130615 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48268 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36700 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100774 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48636 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104926 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100679 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46085 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24147 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44962 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19238 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48126 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53839 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47598 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50944 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49280 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->