### PR TITLE
Assertion failure in HTMLMediaElement::isSuspended()

### DIFF
--- a/LayoutTests/http/tests/lockdown-mode/media-element-is-suspended-crash-expected.txt
+++ b/LayoutTests/http/tests/lockdown-mode/media-element-is-suspended-crash-expected.txt
@@ -1,0 +1,4 @@
+This tests adopting a video elements to a disconnected iframe's content document. WebKit should not hit any assertions.
+
+PASS
+

--- a/LayoutTests/http/tests/lockdown-mode/media-element-is-suspended-crash.html
+++ b/LayoutTests/http/tests/lockdown-mode/media-element-is-suspended-crash.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<body>
+<p>This tests adopting a video elements to a disconnected iframe's content document. WebKit should not hit any assertions.</p>
+<div id="result"></div>
+<script>
+
+function addFrame() {
+    const iframe = document.createElement('iframe');
+    iframe.srcdoc = `<script>
+    function runTest() {
+        const span = document.querySelector("span");
+        const iframe = document.querySelector('iframe');
+        const domImpl = iframe.contentDocument.implementation;
+        const newDoc = domImpl.createHTMLDocument("foo");
+        iframe.remove();
+        newDoc.adoptNode(document.querySelector('section'));
+        span.replaceWith(document.querySelector('video'));
+        if (window.GCController)
+            GCController.collect();
+        top.postMessage({ }, '*');
+    }
+    </` + `script><body onload="runTest()"><iframe></iframe><video controls></video><section><span>`;
+    document.body.appendChild(iframe);
+}
+
+let frameCount = 2;
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+    let count = 0;
+    window.onmessage = () => {
+        ++count;
+        if (count < frameCount)
+            return;
+        result.textContent = 'PASS';
+        testRunner.notifyDone();
+    }
+}
+
+for (let i = 0; i < frameCount; ++i)
+    addFrame();
+
+</script>

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -8887,7 +8887,8 @@ bool HTMLMediaElement::canProduceAudio() const
 
 bool HTMLMediaElement::isSuspended() const
 {
-    ASSERT(Node::scriptExecutionContext() == ActiveDOMObject::scriptExecutionContext());
+    ASSERT(Node::scriptExecutionContext() == ActiveDOMObject::scriptExecutionContext()
+        || (!ActiveDOMObject::scriptExecutionContext() && document().activeDOMObjectsAreStopped()));
     return document().activeDOMObjectsAreSuspended() || document().activeDOMObjectsAreStopped();
 }
 


### PR DESCRIPTION
#### 598af3159ad48d2666c14981a6ec261bdca3b8bd
<pre>
Assertion failure in HTMLMediaElement::isSuspended()
<a href="https://bugs.webkit.org/show_bug.cgi?id=298998">https://bugs.webkit.org/show_bug.cgi?id=298998</a>

Reviewed by Chris Dumez.

The assertion failure was caused because this function was getting called between the time when
active DOM objects are stopped in Document::commonTeardown and when the document is destroyed.

Fixed the assertion by allowing this specific situation.

Test: http/tests/lockdown-mode/media-element-is-suspended-crash.html

* LayoutTests/http/tests/lockdown-mode/media-element-is-suspended-crash-expected.txt: Added.
* LayoutTests/http/tests/lockdown-mode/media-element-is-suspended-crash.html: Added.
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::isSuspended const):

Canonical link: <a href="https://commits.webkit.org/300070@main">https://commits.webkit.org/300070@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dff892dfa1bf1b6f41ed48aa5e031f26f6526971

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121272 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40969 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31627 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127708 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73353 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/15614c36-6087-4caf-aad1-5a2908abfb4d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123148 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41671 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49548 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92115 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/61280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3c0af188-50f4-4a4c-87da-6ecbf8e721d0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124224 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33267 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/108673 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72792 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5180b7f4-ecf1-4093-9966-4e7578f4aa9f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32283 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26801 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71290 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102761 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/26978 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130546 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48200 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/36636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/100713 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/48567 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104863 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100618 "Passed tests") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24086 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/44893 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19229 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48058 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53771 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47529 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50876 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/49212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->