### PR TITLE
Crash in EventTarget::innerInvokeEventListeners

### DIFF
--- a/Source/WebCore/dom/ActiveDOMObject.cpp
+++ b/Source/WebCore/dom/ActiveDOMObject.cpp
@@ -185,7 +185,7 @@ void ActiveDOMObject::queueTaskToDispatchEventInternal(EventTarget& target, Task
 {
     ASSERT(!event->target() || &target == event->target());
     RefPtr context = scriptExecutionContext();
-    if (!context)
+    if (!context || isContextStopped())
         return;
     auto& eventLoopTaskGroup = context->eventLoop();
     auto task = makeUnique<ActiveDOMObjectEventDispatchTask>(source, eventLoopTaskGroup, *this, [target = Ref { target }, event = WTFMove(event)] {
@@ -198,7 +198,7 @@ void ActiveDOMObject::queueCancellableTaskToDispatchEventInternal(EventTarget& t
 {
     ASSERT(!event->target() || &target == event->target());
     RefPtr context = scriptExecutionContext();
-    if (!context)
+    if (!context || isContextStopped())
         return;
     auto& eventLoopTaskGroup = context->eventLoop();
     auto task = makeUnique<ActiveDOMObjectEventDispatchTask>(source, eventLoopTaskGroup, *this, CancellableTask(cancellationGroup, [target = Ref { target }, event = WTFMove(event)] {

--- a/Source/WebCore/dom/ActiveDOMObject.h
+++ b/Source/WebCore/dom/ActiveDOMObject.h
@@ -112,6 +112,9 @@ public:
         // Calls the template member function outside of lambda init-captures to work around a MSVC bug.
         auto activity = object.ActiveDOMObject::makePendingActivity(object);
         object.queueTaskInEventLoop(source, [protectedObject = Ref { object }, activity = WTFMove(activity), task = WTFMove(task)]() mutable {
+            if (protectedObject->ActiveDOMObject::isContextStopped())
+                return;
+
             task(protectedObject.get());
         });
     }
@@ -120,6 +123,8 @@ public:
     static void queueCancellableTaskKeepingObjectAlive(T& object, TaskSource source, TaskCancellationGroup& cancellationGroup, Task&& task)
     {
         CancellableTask cancellableTask(cancellationGroup, [task = WTFMove(task), protectedObject = Ref { object }]() mutable {
+            if (protectedObject->ActiveDOMObject::isContextStopped())
+                return;
             task(protectedObject.get());
         });
         // Calls the template member function outside of lambda init-captures to work around a MSVC bug.


### PR DESCRIPTION
#### 76b75a38344a3c295d90245aded90add528cfd2b
<pre>
Crash in EventTarget::innerInvokeEventListeners
<a href="https://bugs.webkit.org/show_bug.cgi?id=299001">https://bugs.webkit.org/show_bug.cgi?id=299001</a>

Reviewed by NOBODY (OOPS!).

The crash was caused by ActiveDOMObject::queueTaskKeepingObjectAlive calling the callback
after the active DOM objects have been stopped. Avoid the crash by exiting early in various
active DOM object member functions when the script execution content has been stopped.

Unfortunately, no new tests since we can&apos;t make a reliable test case.

* Source/WebCore/dom/ActiveDOMObject.cpp:
(WebCore::ActiveDOMObject::queueTaskToDispatchEventInternal):
(WebCore::ActiveDOMObject::queueCancellableTaskToDispatchEventInternal):
* Source/WebCore/dom/ActiveDOMObject.h:
(WebCore::ActiveDOMObject::queueTaskKeepingObjectAlive):
(WebCore::ActiveDOMObject::queueCancellableTaskKeepingObjectAlive):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/76b75a38344a3c295d90245aded90add528cfd2b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121280 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40977 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31635 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127716 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73361 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/210cb30a-bd8f-4688-9fb2-2b6fa30827ce) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123156 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41679 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49556 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92122 "Found 2 new test failures: gamepad/gamepad-vibration-document-no-longer-fully-active.html imported/w3c/web-platform-tests/screen-orientation/non-fully-active.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61286 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d52cd0c9-79ca-4aa5-85c6-f3703f17125c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124232 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33274 "Found 2 new test failures: http/tests/paymentrequest/payment-response-rejects-if-not-active.https.html http/tests/paymentrequest/rejects_if_not_active.https.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108679 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72799 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a8c7cdc9-e38d-42ca-97ab-389980eea75f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32290 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26808 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71298 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102768 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26984 "Found 4 new test failures: gamepad/gamepad-vibration-document-no-longer-fully-active.html http/tests/paymentrequest/payment-response-rejects-if-not-active.https.html http/tests/paymentrequest/rejects_if_not_active.https.html imported/w3c/web-platform-tests/screen-orientation/non-fully-active.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130554 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48208 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36643 "Found 5 new test failures: gamepad/gamepad-vibration-document-no-longer-fully-active.html http/tests/paymentrequest/payment-response-rejects-if-not-active.https.html http/tests/paymentrequest/rejects_if_not_active.https.html imported/w3c/web-platform-tests/screen-orientation/non-fully-active.html webaudio/require-transient-activation.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100721 "Found 1 new test failure: imported/w3c/web-platform-tests/screen-orientation/non-fully-active.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48575 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104869 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100626 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46029 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24092 "Found 4 new test failures: gamepad/gamepad-vibration-document-no-longer-fully-active.html http/tests/paymentrequest/payment-response-rejects-if-not-active.https.html http/tests/paymentrequest/rejects_if_not_active.https.html imported/w3c/web-platform-tests/screen-orientation/non-fully-active.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44901 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48066 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53779 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47537 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50884 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49220 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->