### PR TITLE
Avoid unsafe on early Swift 6

### DIFF
--- a/Tools/SwiftBrowser/Source/Views/ContentView.swift
+++ b/Tools/SwiftBrowser/Source/Views/ContentView.swift
@@ -121,10 +121,16 @@ struct ContentView: View {
                 .findNavigator(isPresented: $findNavigatorIsPresented)
                 .task {
                     do {
+                        #if compiler(>=6.2)
                         // Safety: this is actually safe; false positive is rdar://154775389
                         for try await unsafe event in viewModel.page.navigations {
                             print(event)
                         }
+                        #else
+                        for try await event in viewModel.page.navigations {
+                            print(event)
+                        }
+                        #endif
                     } catch {
                         print(error)
                     }

--- a/Tools/TestWebKitAPI/Tests/WebKit Swift/URLSchemeHandlerTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit Swift/URLSchemeHandlerTests.swift
@@ -21,7 +21,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
-#if ENABLE_SWIFTUI && canImport(Testing) && compiler(>=6.0)
+#if ENABLE_SWIFTUI && canImport(Testing) && compiler(>=6.2)
 
 import Testing
 import WebKit

--- a/Tools/TestWebKitAPI/Tests/WebKit Swift/WKWebViewSwiftOverlayTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit Swift/WKWebViewSwiftOverlayTests.swift
@@ -21,7 +21,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
-#if canImport(Testing) && compiler(>=6.0)
+#if canImport(Testing) && compiler(>=6.2)
 
 import Testing
 import WebKit

--- a/Tools/TestWebKitAPI/Tests/WebKit Swift/WebPageNavigationTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit Swift/WebPageNavigationTests.swift
@@ -21,7 +21,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
-#if ENABLE_SWIFTUI && canImport(Testing) && compiler(>=6.0)
+#if ENABLE_SWIFTUI && canImport(Testing) && compiler(>=6.2)
 
 import Testing
 @_spi(Testing) import WebKit
@@ -168,4 +168,4 @@ struct WebPageNavigationTests {
     }
 }
 
-#endif // ENABLE_SWIFTUI && canImport(Testing) && compiler(>=6.0)
+#endif // ENABLE_SWIFTUI && canImport(Testing) && compiler(>=6.2)

--- a/Tools/TestWebKitAPI/Tests/WebKit Swift/WebPageTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit Swift/WebPageTests.swift
@@ -21,7 +21,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
-#if ENABLE_SWIFTUI && canImport(Testing) && compiler(>=6.0)
+#if ENABLE_SWIFTUI && canImport(Testing) && compiler(>=6.2)
 
 import SwiftUI
 import Observation

--- a/Tools/TestWebKitAPI/Tests/WebKit Swift/WebPageTransferableTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit Swift/WebPageTransferableTests.swift
@@ -21,7 +21,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
-#if ENABLE_SWIFTUI && canImport(Testing) && compiler(>=6.0)
+#if ENABLE_SWIFTUI && canImport(Testing) && compiler(>=6.2)
 
 import Testing
 @_spi(Testing) import WebKit


### PR DESCRIPTION
#### 7c011bbd7964df82dcc95cf5048b8ef55283910f
<pre>
Avoid unsafe on early Swift 6
<a href="https://bugs.webkit.org/show_bug.cgi?id=299002">https://bugs.webkit.org/show_bug.cgi?id=299002</a>
<a href="https://rdar.apple.com/160755507">rdar://160755507</a>

Reviewed by Richard Robinson.

This disables the relevant tests on compilers earlier than 6.2,
and for the one instance of this in production code we use an #if.

This does not make a change to Foundation+Extras.swift as a
equivalent change is about to land in

<a href="https://github.com/WebKit/WebKit/pull/50711/">https://github.com/WebKit/WebKit/pull/50711/</a>
Canonical link: <a href="https://commits.webkit.org/300144@main">https://commits.webkit.org/300144@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/340c46f2426b80e5f229f6bc8cf7a646e1aae8fd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121380 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41077 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31736 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127820 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73463 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6b2fe0ca-70a3-4ce0-b64c-d039ec4b2c5b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123256 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41779 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49656 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92197 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61347 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8c44822f-dbf9-4b13-a3ad-1a08c4f65cd2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124332 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108758 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72873 "Found 1 new API test failure: WPE/TestWebKitWebContext:/webkit/WebKitWebContext/no-web-process-leak (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2f45babc-e97b-4221-a3d2-b549fc464dcb) 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26903 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71399 "Built successfully") | | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27077 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130654 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48308 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36732 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100795 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48676 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104962 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100700 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25547 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46106 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24179 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45004 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48166 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47638 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50984 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49320 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->