### PR TITLE
[css-anchor-position-1] Change in used visibility should trigger repaint

### DIFF
--- a/LayoutTests/fast/css/css-anchor-position/position-visibility-add-no-overflow-expected.html
+++ b/LayoutTests/fast/css/css-anchor-position/position-visibility-add-no-overflow-expected.html
@@ -1,0 +1,10 @@
+<style>
+  #anchor {
+    width: 100px;
+    height: 100px;
+    background: green;
+  }
+</style>
+
+This test passes if there is only one green square.
+<div id="anchor"></div>

--- a/LayoutTests/fast/css/css-anchor-position/position-visibility-add-no-overflow.html
+++ b/LayoutTests/fast/css/css-anchor-position/position-visibility-add-no-overflow.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+
+<title>Tests that anchor-positioned element is hidden when adding position-visibility: no-overflow</title>
+
+<style>
+  #container {
+    position: relative;
+    width: 400px;
+    height: 150px;
+  }
+
+  #anchor {
+    width: 100px;
+    height: 100px;
+    background: green;
+    anchor-name: --a1;
+  }
+
+  #target {
+    position: absolute;
+    position-anchor: --a1;
+    position-area: block-end;
+
+    width: 100px;
+    height: 100px;
+    background: red;
+    top: 0;
+    left: 0;
+  }
+</style>
+
+<script src="../../../resources/ui-helper.js"></script>
+
+This test passes if there is only one green square.
+
+<div id="container">
+  <div id="anchor"></div>
+  <!-- #target should not be visible because it overflows the containing block. -->
+  <div id="target"></div>
+</div>
+
+<script>
+  if (window.testRunner) {
+    testRunner.waitUntilDone()
+
+    // This bug is about a missed repaint, so the force repaint at the end will negate it.
+    // Disable force repaint to reproduce the bug.
+    if (testRunner.dontForceRepaint)
+      testRunner.dontForceRepaint();
+  }
+
+  async function doTest() {
+    await UIHelper.renderingUpdate();
+    await UIHelper.renderingUpdate();
+
+    target.style.positionVisibility = 'no-overflow';
+
+    await UIHelper.renderingUpdate();
+    await UIHelper.renderingUpdate();
+
+    if (window.testRunner)
+      testRunner.notifyDone();
+  }
+  window.addEventListener('load', doTest, false);
+</script>

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -1336,7 +1336,7 @@ bool RenderStyle::changeRequiresRepaint(const RenderStyle& other, OptionSet<Styl
     if (!requiresPainting(*this) && !requiresPainting(other))
         return false;
 
-    if (m_inheritedFlags.visibility != other.m_inheritedFlags.visibility
+    if (usedVisibility() != other.usedVisibility()
         || m_inheritedFlags.printColorAdjust != other.m_inheritedFlags.printColorAdjust
         || m_inheritedFlags.insideLink != other.m_inheritedFlags.insideLink)
         return true;


### PR DESCRIPTION
#### 12d6cdfb97ad6ac9e5728bda3a456a09de62cae1
<pre>
[css-anchor-position-1] Change in used visibility should trigger repaint
<a href="https://rdar.apple.com/160719145">rdar://160719145</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=298975">https://bugs.webkit.org/show_bug.cgi?id=298975</a>

Reviewed by Antti Koivisto.

Changes to the visibility of the element should trigger repaint. However,
RenderStyle::changeRequiresRepaint only checks visibility(), which is the
value of the &apos;visibility&apos; property. Besides setting &apos;visibility&apos;, an element
can also be &quot;force hidden&quot; by calling RenderStyle::setIsForceHidden()
(which sets the isForceHidden bit in RenderStyle::StyleRareInheritedData).
Change it to check usedVisibility() instead, which accounts for &apos;visibility&apos;
and force hidden.

This was caught by
imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-add-no-overflow.html,
but only in Safari, not WKTR. WKTR forces a full repaint before taking
screenshot for comparison, hence why this wasn&apos;t caught (because this bug
is about a missed repaint). Adds a similar test that calls
testRunner.dontForceRepaint() to disable full repaint before taking screenshot,
which helps reproduce the issue in WKTR.

Test: fast/css/css-anchor-position/position-visibility-add-no-overflow.html

* LayoutTests/fast/css/css-anchor-position/position-visibility-add-no-overflow-expected.html: Added.
* LayoutTests/fast/css/css-anchor-position/position-visibility-add-no-overflow.html: Added.
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::changeRequiresRepaint const):

Canonical link: <a href="https://commits.webkit.org/300132@main">https://commits.webkit.org/300132@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/da7ae0becf6ffc6128708fc45ea215c3d5507470

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121481 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41178 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31837 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127931 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/73564 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e57523dc-cdda-40c1-be28-79aaf3abe37e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123357 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41880 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49757 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/92264 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/73564 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9aa316d3-5bf4-4538-933b-95d3fe1d8417) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124433 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/33437 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/108817 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72941 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/459ac4c4-85f9-44b1-9bed-52f5b14a9ebc) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/32446 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26979 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71502 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/102923 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27153 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/130756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/48409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36798 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/130756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/48777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105038 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/130756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25534 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/24249 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/45105 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/48268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53980 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/47739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/51085 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/49421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->