### PR TITLE
[WebRTC] Exclude LibWebRTCNetwork from non-libwebrtc builds

### DIFF
--- a/Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp
+++ b/Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp
@@ -88,8 +88,10 @@ NetworkProcessConnection::NetworkProcessConnection(IPC::Connection::Identifier&&
 {
     m_connection->open(*this);
 
+#if USE(LIBWEBRTC)
     if (WebRTCProvider::webRTCAvailable())
         WebProcess::singleton().protectedLibWebRTCNetwork()->setConnection(m_connection.copyRef());
+#endif
 }
 
 NetworkProcessConnection::~NetworkProcessConnection()

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetwork.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetwork.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#if USE(LIBWEBRTC)
+
 #include "Connection.h"
 #include "LibWebRTCProvider.h"
 #include "LibWebRTCSocketFactory.h"
@@ -56,7 +58,6 @@ public:
 
     bool isActive() const { return m_isActive; }
 
-#if USE(LIBWEBRTC)
     WebRTCMonitor& monitor() { return m_webNetworkMonitor; }
     Ref<WebRTCMonitor> protectedMonitor() { return m_webNetworkMonitor; }
     LibWebRTCSocketFactory& socketFactory() { return m_socketFactory; }
@@ -64,17 +65,13 @@ public:
     void disableNonLocalhostConnections() { socketFactory().disableNonLocalhostConnections(); }
 
     Ref<WebRTCResolver> resolver(LibWebRTCResolverIdentifier identifier) { return WebRTCResolver::create(socketFactory(), identifier); }
-#endif
 
-#if ENABLE(WEB_RTC)
     WebMDNSRegister& mdnsRegister() { return m_mdnsRegister; }
     Ref<WebMDNSRegister> protectedMDNSRegister() { return m_mdnsRegister; }
-#endif
 
     void setAsActive();
 
 private:
-#if USE(LIBWEBRTC)
     void setSocketFactoryConnection();
 
     void signalReadPacket(WebCore::LibWebRTCSocketIdentifier, std::span<const uint8_t>, const RTCNetwork::IPAddress&, uint16_t port, int64_t, WebRTCNetwork::EcnMarking);
@@ -83,27 +80,24 @@ private:
     void signalConnect(WebCore::LibWebRTCSocketIdentifier);
     void signalClose(WebCore::LibWebRTCSocketIdentifier, int);
     void signalUsedInterface(WebCore::LibWebRTCSocketIdentifier, String&&);
-#endif
 
     // FunctionDispatcher
     void dispatch(Function<void()>&&) final;
 
-#if USE(LIBWEBRTC)
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
-#endif
 
     const CheckedRef<WebProcess> m_webProcess;
 
-#if USE(LIBWEBRTC)
     LibWebRTCSocketFactory m_socketFactory;
     WebRTCMonitor m_webNetworkMonitor;
-#endif
-#if ENABLE(WEB_RTC)
+
     WebMDNSRegister m_mdnsRegister;
-#endif
+
     bool m_isActive { false };
     RefPtr<IPC::Connection> m_connection;
 };
 
 } // namespace WebKit
+
+#endif // USE(LIBWEBRTC)

--- a/Source/WebKit/WebProcess/Network/webrtc/WebMDNSRegister.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/WebMDNSRegister.cpp
@@ -26,7 +26,7 @@
 #include "config.h"
 #include "WebMDNSRegister.h"
 
-#if ENABLE(WEB_RTC)
+#if ENABLE(WEB_RTC) && USE(LIBWEBRTC)
 
 #include "LibWebRTCNetwork.h"
 #include "NetworkMDNSRegisterMessages.h"
@@ -96,4 +96,4 @@ void WebMDNSRegister::registerMDNSName(ScriptExecutionContextIdentifier identifi
 
 } // namespace WebKit
 
-#endif // ENABLE(WEB_RTC)
+#endif // ENABLE(WEB_RTC) && USE(LIBWEBRTC)

--- a/Source/WebKit/WebProcess/Network/webrtc/WebMDNSRegister.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/WebMDNSRegister.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#if ENABLE(WEB_RTC)
+#if ENABLE(WEB_RTC) && USE(LIBWEBRTC)
 
 #include <WebCore/MDNSRegisterError.h>
 #include <WebCore/ProcessQualified.h>
@@ -67,4 +67,4 @@ private:
 
 } // namespace WebKit
 
-#endif // ENABLE(WEB_RTC)
+#endif // ENABLE(WEB_RTC) && USE(LIBWEBRTC)

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -1410,8 +1410,10 @@ void WebProcess::networkProcessConnectionClosed(NetworkProcessConnection* connec
     m_webSocketChannelManager.networkProcessCrashed();
     m_broadcastChannelRegistry->networkProcessCrashed();
 
+#if USE(LIBWEBRTC)
     if (m_libWebRTCNetwork)
         m_libWebRTCNetwork->networkProcessCrashed();
+#endif
 
     for (auto& page : m_pageMap.values()) {
         page->stopAllURLSchemeTasks();
@@ -2166,6 +2168,7 @@ void WebProcess::clearCachedPage(BackForwardItemIdentifier backForwardItemID, Co
     completionHandler();
 }
 
+#if USE(LIBWEBRTC)
 LibWebRTCNetwork& WebProcess::libWebRTCNetwork()
 {
     if (!m_libWebRTCNetwork)
@@ -2177,6 +2180,7 @@ Ref<LibWebRTCNetwork> WebProcess::protectedLibWebRTCNetwork()
 {
     return libWebRTCNetwork();
 }
+#endif
 
 void WebProcess::establishRemoteWorkerContextConnectionToNetworkProcess(RemoteWorkerType workerType, PageGroupIdentifier pageGroupID, WebPageProxyIdentifier webPageProxyID, PageIdentifier pageID, const WebPreferencesStore& store, Site&& site, std::optional<ScriptExecutionContextIdentifier> serviceWorkerPageIdentifier, RemoteWorkerInitializationData&& initializationData, CompletionHandler<void()>&& completionHandler)
 {

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -323,8 +323,10 @@ public:
     ModelProcessConnection* existingModelProcessConnection() { return m_modelProcessConnection.get(); }
 #endif // ENABLE(MODEL_PROCESS)
 
+#if USE(LIBWEBRTC)
     LibWebRTCNetwork& libWebRTCNetwork();
     Ref<LibWebRTCNetwork> protectedLibWebRTCNetwork();
+#endif
 
     void setCacheModel(CacheModel);
 
@@ -826,7 +828,9 @@ private:
     const Ref<WebCookieJar> m_cookieJar;
     WebSocketChannelManager m_webSocketChannelManager;
 
+#if USE(LIBWEBRTC)
     const std::unique_ptr<LibWebRTCNetwork> m_libWebRTCNetwork;
+#endif
 
     HashSet<String> m_dnsPrefetchedHosts;
     PAL::HysteresisActivity m_dnsPrefetchHystereris;


### PR DESCRIPTION
#### 9b456fb129cda9c94f5d9e74ccb39ad05c3dc267
<pre>
[WebRTC] Exclude LibWebRTCNetwork from non-libwebrtc builds
<a href="https://bugs.webkit.org/show_bug.cgi?id=299004">https://bugs.webkit.org/show_bug.cgi?id=299004</a>

Reviewed by Xabier Rodriguez-Calvar and Youenn Fablet.

Simplify ifdefs in LibWebRTCNetwork, this class is specific to LibWebRTC so reflect this in ifdef
guards. As a consequence the WebMDNSRegister usage of LibWebRTCNetwork now requires ifdefs. Support
for the upcoming librice backend will be added in WebMDNSRegister in a follow-up PR.

* Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp:
(WebKit::NetworkProcessConnection::NetworkProcessConnection):
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetwork.cpp:
(WebKit::LibWebRTCNetwork::LibWebRTCNetwork):
(WebKit::LibWebRTCNetwork::setAsActive):
(WebKit::LibWebRTCNetwork::networkProcessCrashed):
(WebKit::LibWebRTCNetwork::setConnection):
(WebKit::LibWebRTCNetwork::setSocketFactoryConnection):
(WebKit::LibWebRTCNetwork::dispatch):
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetwork.h:
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::networkProcessConnectionClosed):
* Source/WebKit/WebProcess/WebProcess.h:

Canonical link: <a href="https://commits.webkit.org/300150@main">https://commits.webkit.org/300150@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3819a4e128125c1840338d740c664fcbfcd5d3a6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121525 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41222 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31881 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127983 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73608 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41924 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49801 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/92301 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/61403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124477 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33476 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108852 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/72978 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32484 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71550 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102959 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27194 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130800 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48453 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36844 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/100892 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48821 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105079 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100798 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25553 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46209 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24289 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/45149 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48312 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54024 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47783 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51129 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49465 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->