### PR TITLE
[GLib][WebRTC] MDNS address registration support using Avahi

### DIFF
--- a/Source/WebKit/NetworkProcess/glib/NetworkMDNSRegisterGLib.cpp
+++ b/Source/WebKit/NetworkProcess/glib/NetworkMDNSRegisterGLib.cpp
@@ -1,0 +1,166 @@
+/*
+ * Copyright (C) 2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Comcast Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "NetworkMDNSRegister.h"
+
+#if ENABLE(WEB_RTC) && USE(GLIB)
+
+#include "NetworkConnectionToWebProcess.h"
+#include <WebCore/MDNSRegisterError.h>
+#include <gio/gio.h>
+#include <wtf/Markable.h>
+#include <wtf/UUID.h>
+#include <wtf/glib/GRefPtr.h>
+#include <wtf/glib/GUniquePtr.h>
+#include <wtf/text/MakeString.h>
+
+namespace WebKit {
+
+NetworkMDNSRegister::NetworkMDNSRegister(NetworkConnectionToWebProcess& connection)
+    : m_connection(connection)
+{
+    m_cancellable = adoptGRef(g_cancellable_new());
+    g_dbus_proxy_new_for_bus(G_BUS_TYPE_SYSTEM, G_DBUS_PROXY_FLAGS_NONE, nullptr, "org.freedesktop.Avahi", "/", "org.freedesktop.Avahi.Server", m_cancellable.get(), [](GObject*, GAsyncResult* result, gpointer userData) {
+        GUniqueOutPtr<GError> error;
+        auto self = reinterpret_cast<NetworkMDNSRegister*>(userData);
+        self->m_dbusProxy = adoptGRef(g_dbus_proxy_new_for_bus_finish(result, &error.outPtr()));
+        if (!error)
+            return;
+
+#if PLATFORM(GTK)
+        // Check if the connection to the system bus was refused, don't log an error when that
+        // happens because it is expected when running as a Flatpak app.
+        if (g_error_matches(error.get(), G_IO_ERROR, G_IO_ERROR_NOT_FOUND))
+            return;
+#endif
+        if (!g_error_matches(error.get(), G_IO_ERROR, G_IO_ERROR_CANCELLED))
+            LOG_ERROR("Unable to connect to the Avahi daemon: %s", error->message);
+    }, this);
+}
+
+NetworkMDNSRegister::~NetworkMDNSRegister()
+{
+    g_cancellable_cancel(m_cancellable.get());
+}
+
+void NetworkMDNSRegister::registerMDNSName(WebCore::ScriptExecutionContextIdentifier documentIdentifier, const String& ipAddress, CompletionHandler<void(const String&, std::optional<WebCore::MDNSRegisterError>)>&& completionHandler)
+{
+    auto name = makeString(WTF::UUID::createVersion4(), ".local"_s);
+
+    if (ipAddress == "0.0.0.0"_s || ipAddress == "::"_s) {
+        completionHandler(name, WebCore::MDNSRegisterError::BadParameter);
+        return;
+    }
+
+    if (!m_dbusProxy) {
+        completionHandler(name, WebCore::MDNSRegisterError::Internal);
+        return;
+    }
+
+    m_registeredNames.add(name);
+    m_perDocumentRegisteredNames.ensure(documentIdentifier, [] {
+        return Vector<String>();
+    }).iterator->value.append(name);
+
+    Ref connection = m_connection.get();
+    auto request = makeUnique<PendingRegistrationRequest>(connection.get(), WTFMove(name), ipAddress, sessionID(), WTFMove(completionHandler));
+
+    request->cancellable = m_cancellable;
+
+    g_dbus_proxy_call(m_dbusProxy.get(), "EntryGroupNew", g_variant_new("()"), G_DBUS_CALL_FLAGS_NONE, -1, m_cancellable.get(), [](GObject* object, GAsyncResult* result, gpointer userData) {
+        std::unique_ptr<PendingRegistrationRequest> request;
+        request.reset(reinterpret_cast<PendingRegistrationRequest*>(userData));
+
+        GUniqueOutPtr<GError> error;
+        auto variant = adoptGRef(g_dbus_proxy_call_finish(G_DBUS_PROXY(object), result, &error.outPtr()));
+        if (error) {
+            // We might have access to the system bus but Avahi is not activatable/installed, don't
+            // log an error when that is the case.
+            if (!g_error_matches(error.get(), G_IO_ERROR, G_IO_ERROR_CANCELLED)
+                && !g_error_matches(error.get(), G_DBUS_ERROR, G_DBUS_ERROR_SERVICE_UNKNOWN)) {
+                LOG_ERROR("Unable to add Avahi entry group: %s", error->message);
+            }
+            request->completionHandler(request->name, WebCore::MDNSRegisterError::Internal);
+            return;
+        }
+        GUniqueOutPtr<char> objectPath;
+        g_variant_get(variant.get(), "(o)", &objectPath.outPtr());
+
+        g_dbus_proxy_new_for_bus(G_BUS_TYPE_SYSTEM, G_DBUS_PROXY_FLAGS_NONE, nullptr, "org.freedesktop.Avahi", objectPath.get(), "org.freedesktop.Avahi.EntryGroup", request->cancellable.get(), [](GObject*, GAsyncResult* result, gpointer userData) {
+            std::unique_ptr<PendingRegistrationRequest> request;
+            request.reset(reinterpret_cast<PendingRegistrationRequest*>(userData));
+
+            GUniqueOutPtr<GError> error;
+            auto dbusProxy = adoptGRef(g_dbus_proxy_new_for_bus_finish(result, &error.outPtr()));
+
+            if (error) {
+                if (!g_error_matches(error.get(), G_IO_ERROR, G_IO_ERROR_CANCELLED))
+                    LOG_ERROR("Unable to create DBus proxy for Avahi entry group: %s", error->message);
+                request->completionHandler(request->name, WebCore::MDNSRegisterError::Internal);
+                return;
+            }
+
+            int interface = -1;
+            int protocol = -1;
+            uint32_t flags = 16; // AVAHI_PUBLISH_NO_REVERSE
+
+            g_dbus_proxy_call(dbusProxy.get(), "AddAddress", g_variant_new("(iiuss)", interface, protocol, flags, request->name.ascii().data(), request->address.ascii().data()), G_DBUS_CALL_FLAGS_NONE, -1, request->cancellable.get(), [](GObject* object, GAsyncResult* result, gpointer userData) {
+                std::unique_ptr<PendingRegistrationRequest> request;
+                request.reset(reinterpret_cast<PendingRegistrationRequest*>(userData));
+
+                GUniqueOutPtr<GError> error;
+                auto proxy = G_DBUS_PROXY(object);
+                auto finalResult = adoptGRef(g_dbus_proxy_call_finish(proxy, result, &error.outPtr()));
+                if (!finalResult) {
+                    if (!g_error_matches(error.get(), G_IO_ERROR, G_IO_ERROR_CANCELLED))
+                        LOG_ERROR("Unable to register MDNS address %s to Avahi: %s", request->name.ascii().data(), error->message);
+                    request->completionHandler(request->name, WebCore::MDNSRegisterError::Internal);
+                    return;
+                }
+
+                g_dbus_proxy_call(proxy, "Commit", g_variant_new("()"), G_DBUS_CALL_FLAGS_NONE, -1, request->cancellable.get(), [](GObject* object, GAsyncResult* result, gpointer userData) {
+                    std::unique_ptr<PendingRegistrationRequest> request;
+                    request.reset(reinterpret_cast<PendingRegistrationRequest*>(userData));
+
+                    GUniqueOutPtr<GError> error;
+                    auto finalResult = adoptGRef(g_dbus_proxy_call_finish(G_DBUS_PROXY(object), result, &error.outPtr()));
+                    if (!finalResult) {
+                        if (!g_error_matches(error.get(), G_IO_ERROR, G_IO_ERROR_CANCELLED))
+                            LOG_ERROR("Unable to commit MDNS address %s to Avahi: %s", request->name.ascii().data(), error->message);
+                        request->completionHandler(request->name, WebCore::MDNSRegisterError::Internal);
+                        return;
+                    }
+                    request->completionHandler(request->name, { });
+                }, request.release());
+            }, request.release());
+        }, request.release());
+    }, request.release());
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(WEB_RTC) && USE(GLIB)

--- a/Source/WebKit/SourcesGTK.txt
+++ b/Source/WebKit/SourcesGTK.txt
@@ -40,6 +40,7 @@ NetworkProcess/cache/NetworkCacheDataGLib.cpp
 NetworkProcess/cache/NetworkCacheIOChannelGLib.cpp
 
 NetworkProcess/glib/DNSCache.cpp
+NetworkProcess/glib/NetworkMDNSRegisterGLib.cpp
 NetworkProcess/glib/WebKitCachedResolver.cpp
 NetworkProcess/glib/WebKitOverridingResolver.cpp
 

--- a/Source/WebKit/SourcesWPE.txt
+++ b/Source/WebKit/SourcesWPE.txt
@@ -40,6 +40,7 @@ NetworkProcess/cache/NetworkCacheDataGLib.cpp
 NetworkProcess/cache/NetworkCacheIOChannelGLib.cpp
 
 NetworkProcess/glib/DNSCache.cpp
+NetworkProcess/glib/NetworkMDNSRegisterGLib.cpp
 NetworkProcess/glib/WebKitCachedResolver.cpp
 NetworkProcess/glib/WebKitOverridingResolver.cpp
 

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.cpp
@@ -138,11 +138,7 @@ void LibWebRTCNetworkManager::StopUpdating()
 
 webrtc::MdnsResponderInterface* LibWebRTCNetworkManager::GetMdnsResponder() const
 {
-#if PLATFORM(GTK) || PLATFORM(WPE)
-    return nullptr;
-#else
     return m_useMDNSCandidates ? const_cast<LibWebRTCNetworkManager*>(this) : nullptr;
-#endif
 }
 
 void LibWebRTCNetworkManager::networksChanged(const Vector<RTCNetwork>& networks, const RTCNetwork::IPAddress& ipv4, const RTCNetwork::IPAddress& ipv6)


### PR DESCRIPTION
#### 2c02cea6d045a29d1f73dafc9b7e8e529ee6c6b8
<pre>
[GLib][WebRTC] MDNS address registration support using Avahi
<a href="https://bugs.webkit.org/show_bug.cgi?id=299005">https://bugs.webkit.org/show_bug.cgi?id=299005</a>

Reviewed by Michael Catanzaro.

Use DBus to register/unregister MDNS addresses of local network interfaces in Avahi. As this works,
enable it in WPE/GTK LibWebRTC builds.

* Source/WebKit/NetworkProcess/glib/NetworkMDNSRegisterGLib.cpp: Added.
(WebKit::NetworkMDNSRegister::NetworkMDNSRegister):
(WebKit::NetworkMDNSRegister::~NetworkMDNSRegister):
(WebKit::NetworkMDNSRegister::registerMDNSName):
* Source/WebKit/NetworkProcess/webrtc/NetworkMDNSRegister.cpp:
(WebKit::NetworkMDNSRegister::PendingRegistrationRequest::PendingRegistrationRequest):
(WebKit::pendingRegistrationRequestMap):
(WebKit::NetworkMDNSRegister::registerMDNSName):
(WebKit::NetworkMDNSRegister::unregisterMDNSNames):
(WebKit::PendingRegistrationRequest::PendingRegistrationRequest): Deleted.
* Source/WebKit/NetworkProcess/webrtc/NetworkMDNSRegister.h:
* Source/WebKit/SourcesGTK.txt:
* Source/WebKit/SourcesWPE.txt:
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.cpp:
(WebKit::LibWebRTCNetworkManager::GetMdnsResponder const):

Canonical link: <a href="https://commits.webkit.org/301397@main">https://commits.webkit.org/301397@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6ff0bebfb0320f3d4629df367d4c8a56b3776cfb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125792 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45454 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36205 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132660 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77668 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46137 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54013 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95827 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/63943 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128740 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36885 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112484 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76320 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35787 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76130 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106664 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30881 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135339 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52579 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40325 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104293 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53027 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108694 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104021 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26504 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49390 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27707 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49918 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52474 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58283 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51822 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55171 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53516 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->