### PR TITLE
[GStreamer][WebRTC] Fix several mem leaks reported by the GStreamer leak tracer

### DIFF
--- a/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
@@ -1247,6 +1247,12 @@ void RTCPeerConnection::stopGatheringStatLogs()
     protectedBackend()->stopGatheringStatLogs();
 }
 
+void RTCPeerConnection::clearTransports()
+{
+    m_dtlsTransports.clear();
+    m_iceTransports.clear();
+}
+
 } // namespace WebCore
 
 #endif // ENABLE(WEB_RTC)

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnection.h
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnection.h
@@ -215,6 +215,8 @@ public:
     void startGatheringStatLogs(Function<void(String&&)>&&);
     void stopGatheringStatLogs();
 
+    void clearTransports();
+
 private:
     RTCPeerConnection(Document&);
 

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerDtlsTransportBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerDtlsTransportBackend.cpp
@@ -25,6 +25,7 @@
 #include "GStreamerIceTransportBackend.h"
 #include "GStreamerWebRTCUtils.h"
 #include <JavaScriptCore/ArrayBuffer.h>
+#include <wtf/Noncopyable.h>
 #include <wtf/glib/GUniquePtr.h>
 
 namespace WebCore {
@@ -33,6 +34,7 @@ GST_DEBUG_CATEGORY(webkit_webrtc_dtls_transport_debug);
 #define GST_CAT_DEFAULT webkit_webrtc_dtls_transport_debug
 
 class GStreamerDtlsTransportBackendObserver final : public ThreadSafeRefCounted<GStreamerDtlsTransportBackendObserver> {
+    WTF_MAKE_NONCOPYABLE(GStreamerDtlsTransportBackendObserver);
 public:
     static Ref<GStreamerDtlsTransportBackendObserver> create(RTCDtlsTransportBackendClient& client, GRefPtr<GstWebRTCDTLSTransport>&& backend) { return adoptRef(*new GStreamerDtlsTransportBackendObserver(client, WTFMove(backend))); }
 

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
@@ -337,6 +337,7 @@ void GStreamerMediaEndpoint::teardownPipeline()
     m_remoteStreamsById.clear();
     m_webrtcBin = nullptr;
     m_pipeline = nullptr;
+    m_peerConnectionBackend = nullptr;
 }
 
 bool GStreamerMediaEndpoint::handleMessage(GstMessage* message)
@@ -1485,11 +1486,11 @@ void GStreamerMediaEndpoint::connectIncomingTrack(WebRTCTrackData& data)
     auto& source = track.privateTrack().source();
     if (source.isIncomingAudioSource()) {
         auto& audioSource = static_cast<RealtimeIncomingAudioSourceGStreamer&>(source);
-        if (!audioSource.setBin(mediaStreamBin))
+        if (!audioSource.setBin(WTFMove(mediaStreamBin)))
             return;
     } else if (source.isIncomingVideoSource()) {
         auto& videoSource = static_cast<RealtimeIncomingVideoSourceGStreamer&>(source);
-        if (!videoSource.setBin(mediaStreamBin))
+        if (!videoSource.setBin(WTFMove(mediaStreamBin)))
             return;
     }
 

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpReceiverBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpReceiverBackend.cpp
@@ -50,6 +50,12 @@ GStreamerRtpReceiverBackend::GStreamerRtpReceiverBackend(GRefPtr<GstWebRTCRTPTra
     g_object_get(m_rtcTransceiver.get(), "receiver", &m_rtcReceiver.outPtr(), nullptr);
 }
 
+void GStreamerRtpReceiverBackend::tearDown()
+{
+    m_rtcReceiver = nullptr;
+    m_rtcTransceiver = nullptr;
+}
+
 RTCRtpParameters GStreamerRtpReceiverBackend::getParameters()
 {
     RTCRtpParameters parameters;

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpReceiverBackend.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpReceiverBackend.h
@@ -36,6 +36,8 @@ public:
     GstWebRTCRTPReceiver* rtcReceiver() { return m_rtcReceiver.get(); }
     Ref<RealtimeMediaSource> createSource(const String& trackKind, const String& trackId);
 
+    void tearDown();
+
 private:
     RTCRtpParameters getParameters() final;
     Vector<RTCRtpContributingSource> getContributingSources() const final;

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpSenderBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpSenderBackend.cpp
@@ -135,6 +135,8 @@ void GStreamerRtpSenderBackend::tearDown()
         source->teardown();
     }, [&](std::nullptr_t&) {
     });
+
+    m_rtcSender = nullptr;
 }
 
 bool GStreamerRtpSenderBackend::replaceTrack(RTCRtpSender& sender, MediaStreamTrack* track)

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingSourceGStreamer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingSourceGStreamer.h
@@ -31,7 +31,9 @@ public:
     WTF_ABSTRACT_THREAD_SAFE_REF_COUNTED_AND_CAN_MAKE_WEAK_PTR_IMPL;
 
     GstElement* bin() const { return m_bin.get(); }
-    bool setBin(const GRefPtr<GstElement>&);
+    bool setBin(GRefPtr<GstElement> &&);
+
+    void tearDown();
 
     bool hasClient(const GRefPtr<GstElement>&);
     int registerClient(GRefPtr<GstElement>&&);
@@ -39,7 +41,7 @@ public:
 
     void handleUpstreamEvent(GRefPtr<GstEvent>&&);
     bool handleUpstreamQuery(GstQuery*);
-    GstPadProbeReturn handleDownstreamEvent(GstElement* sink, GRefPtr<GstEvent>&&);
+    GstPadProbeReturn handleDownstreamEvent(GRefPtr<GstEvent>&&);
 
 protected:
     RealtimeIncomingSourceGStreamer(const CaptureDevice&);
@@ -54,6 +56,7 @@ private:
 
     GRefPtr<GstElement> m_bin;
     GRefPtr<GstElement> m_sink;
+    unsigned long m_sinkPadProbeId;
     Lock m_clientLock;
     HashMap<int, GRefPtr<GstElement>> m_clients WTF_GUARDED_BY_LOCK(m_clientLock);
     MonotonicTime m_lastTagUpdate;


### PR DESCRIPTION
#### 8cf7c05ce072132dae6505122ec9a448526aa29a
<pre>
[GStreamer][WebRTC] Fix several mem leaks reported by the GStreamer leak tracer
<a href="https://bugs.webkit.org/show_bug.cgi?id=299006">https://bugs.webkit.org/show_bug.cgi?id=299006</a>

Reviewed by Xabier Rodriguez-Calvar.

Clear some more GStreamer-related objects during WebRTC pipeline teardown, before gst_deinit() is
called so that the leak tracer doesn&apos;t account for these as leaked.

* Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp:
(WebCore::RTCPeerConnection::clearTransports):
* Source/WebCore/Modules/mediastream/RTCPeerConnection.h:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerDtlsTransportBackend.cpp:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp:
(WebCore::GStreamerMediaEndpoint::teardownPipeline):
(WebCore::GStreamerMediaEndpoint::connectIncomingTrack):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.cpp:
(WebCore::GStreamerPeerConnectionBackend::tearDown):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpReceiverBackend.cpp:
(WebCore::GStreamerRtpReceiverBackend::tearDown):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpReceiverBackend.h:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpSenderBackend.cpp:
(WebCore::GStreamerRtpSenderBackend::tearDown):
* Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingSourceGStreamer.cpp:
(WebCore::RealtimeIncomingSourceGStreamer::setBin):
(WebCore::RealtimeIncomingSourceGStreamer::tearDown):
(WebCore::RealtimeIncomingSourceGStreamer::handleDownstreamEvent):
* Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingSourceGStreamer.h:

Canonical link: <a href="https://commits.webkit.org/300145@main">https://commits.webkit.org/300145@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/155c6ed65d59e305c8a1f5e3ca3c92e69d2ca7c5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121289 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40986 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31644 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127725 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73370 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123165 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41688 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49565 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92131 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61290 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124241 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33283 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108690 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72808 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32300 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26818 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71307 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102777 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26994 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130563 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48217 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36650 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100727 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48585 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104879 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100632 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25549 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46041 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24102 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44910 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48075 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53788 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47546 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50893 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49229 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->