### PR TITLE
Anchoring a pseudo element to a slotted element in a Shadow DOM causes browser crash

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/pseudo-element-with-slotted-anchor-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/pseudo-element-with-slotted-anchor-expected.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<style>
+my-anchor {
+  display: block;
+}
+
+span {
+  display: block;
+  anchor-name: --anchor;
+  padding: 2rem;
+  background: red;
+  color: white;
+  inline-size: fit-content;
+}
+
+my-anchor::after {
+  content: 'target';
+  position: absolute;
+  position-anchor: --anchor;
+  position-area: bottom center;
+  background: lightblue;
+  padding: 1rem;
+}
+</style>
+<my-anchor>
+  <span>anchor</span>
+</my-anchor>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/pseudo-element-with-slotted-anchor-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/pseudo-element-with-slotted-anchor-ref.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<style>
+my-anchor {
+  display: block;
+}
+
+span {
+  display: block;
+  anchor-name: --anchor;
+  padding: 2rem;
+  background: red;
+  color: white;
+  inline-size: fit-content;
+}
+
+my-anchor::after {
+  content: 'target';
+  position: absolute;
+  position-anchor: --anchor;
+  position-area: bottom center;
+  background: lightblue;
+  padding: 1rem;
+}
+</style>
+<my-anchor>
+  <span>anchor</span>
+</my-anchor>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/pseudo-element-with-slotted-anchor.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/pseudo-element-with-slotted-anchor.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<title>Slotted anchor with anchored pseudo-element</title>
+<link rel="help" href="https://drafts.csswg.org/css-anchor-1/#target-anchor-element">
+<link rel="match" href="pseudo-element-with-slotted-anchor-ref.html">
+<my-anchor>
+  <template shadowrootmode="open">
+    <style>
+    :host {
+      display: block;
+    }
+
+    ::slotted(*) {
+      display: block;
+      anchor-name: --anchor;
+      padding: 2rem;
+      background: red;
+      color: white;
+      inline-size: fit-content;
+    }
+
+    :host::after {
+      content: 'target';
+      position: absolute;
+      position-anchor: --anchor;
+      position-area: bottom center;
+      background: lightblue;
+      padding: 1rem;
+    }
+    </style>
+    <slot></slot>
+  </template>
+  <span>anchor</span>
+</my-anchor>

--- a/Source/WebCore/style/StyleScope.cpp
+++ b/Source/WebCore/style/StyleScope.cpp
@@ -238,6 +238,9 @@ const Scope& Scope::forNode(const Node& node)
 
 Scope* Scope::forOrdinal(Element& element, ScopeOrdinal ordinal)
 {
+    if (CheckedPtr pseudoElement = dynamicDowncast<PseudoElement>(element))
+        return forOrdinal(*pseudoElement->hostElement(), ordinal);
+
     if (ordinal == ScopeOrdinal::Element)
         return &forNode(element);
     if (ordinal == ScopeOrdinal::Shadow) {


### PR DESCRIPTION
#### ec6791966b1e356505e689cd37860f45fdce449c
<pre>
Anchoring a pseudo element to a slotted element in a Shadow DOM causes browser crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=298646">https://bugs.webkit.org/show_bug.cgi?id=298646</a>
<a href="https://rdar.apple.com/160291579">rdar://160291579</a>

Reviewed by Simon Fraser and Alan Baradlay.

Tests: imported/w3c/web-platform-tests/css/css-anchor-position/pseudo-element-with-slotted-anchor-ref.html
       imported/w3c/web-platform-tests/css/css-anchor-position/pseudo-element-with-slotted-anchor.html
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/pseudo-element-with-slotted-anchor-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/pseudo-element-with-slotted-anchor-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/pseudo-element-with-slotted-anchor.html: Added.
* Source/WebCore/style/StyleScope.cpp:
(WebCore::Style::Scope::forOrdinal):

For PseudoElements use the scope of the host element.

Canonical link: <a href="https://commits.webkit.org/300086@main">https://commits.webkit.org/300086@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/77ef53b2acac6424b431a2514c4135acb4e27868

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121291 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40988 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31646 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127727 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73372 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123167 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41690 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49567 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92132 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61294 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124243 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33286 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108692 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72809 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32303 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26820 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71309 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102780 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26996 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130565 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48219 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36656 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100730 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48587 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104881 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100635 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25507 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46039 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24104 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44912 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48077 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53790 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47548 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50895 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49231 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->