### PR TITLE
Address safer cpp warnings in ColorCG.cpp

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
@@ -76,7 +76,6 @@ platform/graphics/ca/cocoa/PlatformCAAnimationCocoa.mm
 platform/graphics/ca/cocoa/PlatformCAFiltersCocoa.mm
 platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
 platform/graphics/cg/CGSubimageCacheWithTimer.cpp
-platform/graphics/cg/ColorCG.cpp
 platform/graphics/cg/GradientCG.cpp
 platform/graphics/cg/GradientRendererCG.cpp
 platform/graphics/cg/GraphicsContextCG.cpp

--- a/Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
@@ -46,7 +46,6 @@ platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.mm
 platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
 platform/graphics/ca/cocoa/PlatformCAAnimationCocoa.mm
 platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
-platform/graphics/cg/ColorCG.cpp
 platform/graphics/cg/GradientRendererCG.cpp
 platform/graphics/cg/GraphicsContextCG.cpp
 platform/graphics/cg/GraphicsContextGLCG.cpp

--- a/Source/WebCore/platform/graphics/cg/ColorSpaceCG.h
+++ b/Source/WebCore/platform/graphics/cg/ColorSpaceCG.h
@@ -38,7 +38,7 @@ template<ColorSpace> struct CGColorSpaceMapping;
 
 WEBCORE_EXPORT CGColorSpaceRef sRGBColorSpaceSingleton();
 template<> struct CGColorSpaceMapping<ColorSpace::SRGB> {
-    static CGColorSpaceRef colorSpace()
+    static CGColorSpaceRef colorSpaceSingleton()
     {
         return sRGBColorSpaceSingleton();
     }
@@ -46,7 +46,7 @@ template<> struct CGColorSpaceMapping<ColorSpace::SRGB> {
 
 WEBCORE_EXPORT CGColorSpaceRef adobeRGB1998ColorSpaceSingleton();
 template<> struct CGColorSpaceMapping<ColorSpace::A98RGB> {
-    static CGColorSpaceRef colorSpace()
+    static CGColorSpaceRef colorSpaceSingleton()
     {
         return adobeRGB1998ColorSpaceSingleton();
     }
@@ -54,7 +54,7 @@ template<> struct CGColorSpaceMapping<ColorSpace::A98RGB> {
 
 WEBCORE_EXPORT CGColorSpaceRef displayP3ColorSpaceSingleton();
 template<> struct CGColorSpaceMapping<ColorSpace::DisplayP3> {
-    static CGColorSpaceRef colorSpace()
+    static CGColorSpaceRef colorSpaceSingleton()
     {
         return displayP3ColorSpaceSingleton();
     }
@@ -62,7 +62,7 @@ template<> struct CGColorSpaceMapping<ColorSpace::DisplayP3> {
 
 WEBCORE_EXPORT CGColorSpaceRef extendedAdobeRGB1998ColorSpaceSingleton();
 template<> struct CGColorSpaceMapping<ColorSpace::ExtendedA98RGB> {
-    static CGColorSpaceRef colorSpace()
+    static CGColorSpaceRef colorSpaceSingleton()
     {
         return extendedAdobeRGB1998ColorSpaceSingleton();
     }
@@ -70,7 +70,7 @@ template<> struct CGColorSpaceMapping<ColorSpace::ExtendedA98RGB> {
 
 WEBCORE_EXPORT CGColorSpaceRef extendedDisplayP3ColorSpaceSingleton();
 template<> struct CGColorSpaceMapping<ColorSpace::ExtendedDisplayP3> {
-    static CGColorSpaceRef colorSpace()
+    static CGColorSpaceRef colorSpaceSingleton()
     {
         return extendedDisplayP3ColorSpaceSingleton();
     }
@@ -78,7 +78,7 @@ template<> struct CGColorSpaceMapping<ColorSpace::ExtendedDisplayP3> {
 
 WEBCORE_EXPORT CGColorSpaceRef extendedITUR_2020ColorSpaceSingleton();
 template<> struct CGColorSpaceMapping<ColorSpace::ExtendedRec2020> {
-    static CGColorSpaceRef colorSpace()
+    static CGColorSpaceRef colorSpaceSingleton()
     {
         return extendedITUR_2020ColorSpaceSingleton();
     }
@@ -86,7 +86,7 @@ template<> struct CGColorSpaceMapping<ColorSpace::ExtendedRec2020> {
 
 WEBCORE_EXPORT CGColorSpaceRef extendedLinearDisplayP3ColorSpaceSingleton();
 template<> struct CGColorSpaceMapping<ColorSpace::ExtendedLinearDisplayP3> {
-    static CGColorSpaceRef colorSpace()
+    static CGColorSpaceRef colorSpaceSingleton()
     {
         return extendedLinearDisplayP3ColorSpaceSingleton();
     }
@@ -94,7 +94,7 @@ template<> struct CGColorSpaceMapping<ColorSpace::ExtendedLinearDisplayP3> {
 
 WEBCORE_EXPORT CGColorSpaceRef extendedLinearSRGBColorSpaceSingleton();
 template<> struct CGColorSpaceMapping<ColorSpace::ExtendedLinearSRGB> {
-    static CGColorSpaceRef colorSpace()
+    static CGColorSpaceRef colorSpaceSingleton()
     {
         return extendedLinearSRGBColorSpaceSingleton();
     }
@@ -102,7 +102,7 @@ template<> struct CGColorSpaceMapping<ColorSpace::ExtendedLinearSRGB> {
 
 WEBCORE_EXPORT CGColorSpaceRef extendedROMMRGBColorSpaceSingleton();
 template<> struct CGColorSpaceMapping<ColorSpace::ExtendedProPhotoRGB> {
-    static CGColorSpaceRef colorSpace()
+    static CGColorSpaceRef colorSpaceSingleton()
     {
         return extendedROMMRGBColorSpaceSingleton();
     }
@@ -110,7 +110,7 @@ template<> struct CGColorSpaceMapping<ColorSpace::ExtendedProPhotoRGB> {
 
 WEBCORE_EXPORT CGColorSpaceRef extendedSRGBColorSpaceSingleton();
 template<> struct CGColorSpaceMapping<ColorSpace::ExtendedSRGB> {
-    static CGColorSpaceRef colorSpace()
+    static CGColorSpaceRef colorSpaceSingleton()
     {
         return extendedSRGBColorSpaceSingleton();
     }
@@ -118,7 +118,7 @@ template<> struct CGColorSpaceMapping<ColorSpace::ExtendedSRGB> {
 
 WEBCORE_EXPORT CGColorSpaceRef ITUR_2020ColorSpaceSingleton();
 template<> struct CGColorSpaceMapping<ColorSpace::Rec2020> {
-    static CGColorSpaceRef colorSpace()
+    static CGColorSpaceRef colorSpaceSingleton()
     {
         return ITUR_2020ColorSpaceSingleton();
     }
@@ -126,7 +126,7 @@ template<> struct CGColorSpaceMapping<ColorSpace::Rec2020> {
 
 WEBCORE_EXPORT CGColorSpaceRef linearDisplayP3ColorSpaceSingleton();
 template<> struct CGColorSpaceMapping<ColorSpace::LinearDisplayP3> {
-    static CGColorSpaceRef colorSpace()
+    static CGColorSpaceRef colorSpaceSingleton()
     {
         return linearDisplayP3ColorSpaceSingleton();
     }
@@ -134,7 +134,7 @@ template<> struct CGColorSpaceMapping<ColorSpace::LinearDisplayP3> {
 
 WEBCORE_EXPORT CGColorSpaceRef linearSRGBColorSpaceSingleton();
 template<> struct CGColorSpaceMapping<ColorSpace::LinearSRGB> {
-    static CGColorSpaceRef colorSpace()
+    static CGColorSpaceRef colorSpaceSingleton()
     {
         return linearSRGBColorSpaceSingleton();
     }
@@ -142,7 +142,7 @@ template<> struct CGColorSpaceMapping<ColorSpace::LinearSRGB> {
 
 WEBCORE_EXPORT CGColorSpaceRef ROMMRGBColorSpaceSingleton();
 template<> struct CGColorSpaceMapping<ColorSpace::ProPhotoRGB> {
-    static CGColorSpaceRef colorSpace()
+    static CGColorSpaceRef colorSpaceSingleton()
     {
         return ROMMRGBColorSpaceSingleton();
     }
@@ -150,7 +150,7 @@ template<> struct CGColorSpaceMapping<ColorSpace::ProPhotoRGB> {
 
 WEBCORE_EXPORT CGColorSpaceRef xyzD50ColorSpaceSingleton();
 template<> struct CGColorSpaceMapping<ColorSpace::XYZ_D50> {
-    static CGColorSpaceRef colorSpace()
+    static CGColorSpaceRef colorSpaceSingleton()
     {
         return xyzD50ColorSpaceSingleton();
     }
@@ -170,69 +170,69 @@ WEBCORE_EXPORT std::optional<ColorSpace> colorSpaceForCGColorSpace(CGColorSpaceR
 
 
 template<ColorSpace, typename = void> inline constexpr bool HasCGColorSpaceMapping = false;
-template<ColorSpace space> inline constexpr bool HasCGColorSpaceMapping<space, std::void_t<decltype(CGColorSpaceMapping<space>::colorSpace())>> = true;
+template<ColorSpace space> inline constexpr bool HasCGColorSpaceMapping<space, std::void_t<decltype(CGColorSpaceMapping<space>::colorSpaceSingleton())>> = true;
 static_assert(HasCGColorSpaceMapping<ColorSpace::SRGB>, "An SRGB color space mapping must be supported on all platforms.");
 
-template<ColorSpace space, bool = HasCGColorSpaceMapping<space>> struct CGColorSpaceMappingOrNullGetter { static CGColorSpaceRef colorSpace() { return nullptr; } };
-template<ColorSpace space> struct CGColorSpaceMappingOrNullGetter<space, true> { static CGColorSpaceRef colorSpace() { return CGColorSpaceMapping<space>::colorSpace(); } };
+template<ColorSpace space, bool = HasCGColorSpaceMapping<space>> struct CGColorSpaceMappingOrNullGetter { static CGColorSpaceRef colorSpaceSingleton() { return nullptr; } };
+template<ColorSpace space> struct CGColorSpaceMappingOrNullGetter<space, true> { static CGColorSpaceRef colorSpaceSingleton() { return CGColorSpaceMapping<space>::colorSpaceSingleton(); } };
 
-template<ColorSpace space> CGColorSpaceRef cachedCGColorSpace()
+template<ColorSpace space> CGColorSpaceRef cachedCGColorSpaceSingleton()
 {
-    return CGColorSpaceMapping<space>::colorSpace();
+    return CGColorSpaceMapping<space>::colorSpaceSingleton();
 }
 
-template<ColorSpace space> CGColorSpaceRef cachedNullableCGColorSpace()
+template<ColorSpace space> CGColorSpaceRef cachedNullableCGColorSpaceSingleton()
 {
-    return CGColorSpaceMappingOrNullGetter<space>::colorSpace();
+    return CGColorSpaceMappingOrNullGetter<space>::colorSpaceSingleton();
 }
 
-inline CGColorSpaceRef cachedNullableCGColorSpace(ColorSpace colorSpace)
+inline CGColorSpaceRef cachedNullableCGColorSpaceSingleton(ColorSpace colorSpace)
 {
     switch (colorSpace) {
     case ColorSpace::A98RGB:
-        return cachedNullableCGColorSpace<ColorSpace::A98RGB>();
+        return cachedNullableCGColorSpaceSingleton<ColorSpace::A98RGB>();
     case ColorSpace::DisplayP3:
-        return cachedNullableCGColorSpace<ColorSpace::DisplayP3>();
+        return cachedNullableCGColorSpaceSingleton<ColorSpace::DisplayP3>();
     case ColorSpace::ExtendedA98RGB:
-        return cachedNullableCGColorSpace<ColorSpace::ExtendedA98RGB>();
+        return cachedNullableCGColorSpaceSingleton<ColorSpace::ExtendedA98RGB>();
     case ColorSpace::ExtendedDisplayP3:
-        return cachedNullableCGColorSpace<ColorSpace::ExtendedDisplayP3>();
+        return cachedNullableCGColorSpaceSingleton<ColorSpace::ExtendedDisplayP3>();
     case ColorSpace::ExtendedLinearDisplayP3:
-        return cachedNullableCGColorSpace<ColorSpace::ExtendedLinearDisplayP3>();
+        return cachedNullableCGColorSpaceSingleton<ColorSpace::ExtendedLinearDisplayP3>();
     case ColorSpace::ExtendedLinearSRGB:
-        return cachedNullableCGColorSpace<ColorSpace::ExtendedLinearSRGB>();
+        return cachedNullableCGColorSpaceSingleton<ColorSpace::ExtendedLinearSRGB>();
     case ColorSpace::ExtendedProPhotoRGB:
-        return cachedNullableCGColorSpace<ColorSpace::ExtendedProPhotoRGB>();
+        return cachedNullableCGColorSpaceSingleton<ColorSpace::ExtendedProPhotoRGB>();
     case ColorSpace::ExtendedRec2020:
-        return cachedNullableCGColorSpace<ColorSpace::ExtendedRec2020>();
+        return cachedNullableCGColorSpaceSingleton<ColorSpace::ExtendedRec2020>();
     case ColorSpace::ExtendedSRGB:
-        return cachedNullableCGColorSpace<ColorSpace::ExtendedSRGB>();
+        return cachedNullableCGColorSpaceSingleton<ColorSpace::ExtendedSRGB>();
     case ColorSpace::HSL:
-        return cachedNullableCGColorSpace<ColorSpace::HSL>();
+        return cachedNullableCGColorSpaceSingleton<ColorSpace::HSL>();
     case ColorSpace::HWB:
-        return cachedNullableCGColorSpace<ColorSpace::HWB>();
+        return cachedNullableCGColorSpaceSingleton<ColorSpace::HWB>();
     case ColorSpace::LCH:
-        return cachedNullableCGColorSpace<ColorSpace::LCH>();
+        return cachedNullableCGColorSpaceSingleton<ColorSpace::LCH>();
     case ColorSpace::Lab:
-        return cachedNullableCGColorSpace<ColorSpace::Lab>();
+        return cachedNullableCGColorSpaceSingleton<ColorSpace::Lab>();
     case ColorSpace::LinearDisplayP3:
-        return cachedNullableCGColorSpace<ColorSpace::LinearDisplayP3>();
+        return cachedNullableCGColorSpaceSingleton<ColorSpace::LinearDisplayP3>();
     case ColorSpace::LinearSRGB:
-        return cachedNullableCGColorSpace<ColorSpace::LinearSRGB>();
+        return cachedNullableCGColorSpaceSingleton<ColorSpace::LinearSRGB>();
     case ColorSpace::OKLCH:
-        return cachedNullableCGColorSpace<ColorSpace::OKLCH>();
+        return cachedNullableCGColorSpaceSingleton<ColorSpace::OKLCH>();
     case ColorSpace::OKLab:
-        return cachedNullableCGColorSpace<ColorSpace::OKLab>();
+        return cachedNullableCGColorSpaceSingleton<ColorSpace::OKLab>();
     case ColorSpace::ProPhotoRGB:
-        return cachedNullableCGColorSpace<ColorSpace::ProPhotoRGB>();
+        return cachedNullableCGColorSpaceSingleton<ColorSpace::ProPhotoRGB>();
     case ColorSpace::Rec2020:
-        return cachedNullableCGColorSpace<ColorSpace::Rec2020>();
+        return cachedNullableCGColorSpaceSingleton<ColorSpace::Rec2020>();
     case ColorSpace::SRGB:
-        return cachedNullableCGColorSpace<ColorSpace::SRGB>();
+        return cachedNullableCGColorSpaceSingleton<ColorSpace::SRGB>();
     case ColorSpace::XYZ_D50:
-        return cachedNullableCGColorSpace<ColorSpace::XYZ_D50>();
+        return cachedNullableCGColorSpaceSingleton<ColorSpace::XYZ_D50>();
     case ColorSpace::XYZ_D65:
-        return cachedNullableCGColorSpace<ColorSpace::XYZ_D65>();
+        return cachedNullableCGColorSpaceSingleton<ColorSpace::XYZ_D65>();
     }
 
     ASSERT_NOT_REACHED();

--- a/Source/WebCore/platform/graphics/cg/GradientRendererCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/GradientRendererCG.cpp
@@ -168,7 +168,7 @@ GradientRendererCG::Strategy GradientRendererCG::makeGradient(ColorInterpolation
             if (destinationColorSpace)
                 return destinationColorSpace->platformColorSpace();
 
-            return cachedCGColorSpace<ColorSpaceFor<SRGBA<float>>>();
+            return cachedCGColorSpaceSingleton<ColorSpaceFor<SRGBA<float>>>();
         }
 
         using OutputSpaceColorType = std::conditional_t<HasCGColorSpaceMapping<ColorSpace::ExtendedSRGB>, ExtendedSRGBA<float>, SRGBA<float>>;
@@ -178,7 +178,7 @@ GradientRendererCG::Strategy GradientRendererCG::makeGradient(ColorInterpolation
 
             locations.append(stop.offset);
         }
-        return cachedCGColorSpace<ColorSpaceFor<OutputSpaceColorType>>();
+        return cachedCGColorSpaceSingleton<ColorSpaceFor<OutputSpaceColorType>>();
     }();
 
     // CoreGraphics has a bug where if the last two stops are at 1, it fails to extend the last stop's color. This can be visible in radial gradients.
@@ -357,7 +357,7 @@ GradientRendererCG::Strategy GradientRendererCG::makeShading(ColorInterpolationM
     auto function = makeFunction(colorInterpolationMethod, data);
 
     // FIXME: Investigate using bounded sRGB when the input stops are all bounded sRGB.
-    auto colorSpace = cachedCGColorSpace<ColorSpaceFor<OutputSpaceColorType>>();
+    auto colorSpace = cachedCGColorSpaceSingleton<ColorSpaceFor<OutputSpaceColorType>>();
 
     return Shading { WTFMove(data), WTFMove(function), colorSpace };
 }

--- a/Source/WebKit/Shared/cf/CoreIPCCGColorSpace.h
+++ b/Source/WebKit/Shared/cf/CoreIPCCGColorSpace.h
@@ -60,7 +60,7 @@ public:
     {
         auto colorSpace = WTF::switchOn(m_cgColorSpace,
             [](WebCore::ColorSpace colorSpace) -> RetainPtr<CGColorSpaceRef> {
-                return RetainPtr { cachedNullableCGColorSpace(colorSpace) };
+                return RetainPtr { cachedNullableCGColorSpaceSingleton(colorSpace) };
             },
             [](RetainPtr<CFStringRef> name) -> RetainPtr<CGColorSpaceRef> {
                 return adoptCF(CGColorSpaceCreateWithName(name.get()));


### PR DESCRIPTION
#### 29ef0ad6e105467f071d60d5751fe26736af95ed
<pre>
Address safer cpp warnings in ColorCG.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=299011">https://bugs.webkit.org/show_bug.cgi?id=299011</a>

Reviewed by Geoffrey Garen.

* Source/WebCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations:
* Source/WebCore/platform/graphics/DestinationColorSpace.h:
(WebCore::DestinationColorSpace::protectedPlatformColorSpace const):
* Source/WebCore/platform/graphics/cg/ColorCG.cpp:
(WebCore::cachedCGColorTransform):
(WebCore::Color::createAndLosslesslyConvertToSupportedColorSpace):
(WebCore::Color::createAndPreserveColorSpace):
(WebCore::convertToCGCompatibleComponents):
(WebCore::createSDRCGColorForColorspace):
(WebCore::platformConvertColorComponents):
* Source/WebCore/platform/graphics/cg/ColorSpaceCG.h:
(WebCore::CGColorSpaceMapping&lt;ColorSpace::SRGB&gt;::colorSpaceSingleton):
(WebCore::CGColorSpaceMapping&lt;ColorSpace::A98RGB&gt;::colorSpaceSingleton):
(WebCore::CGColorSpaceMapping&lt;ColorSpace::DisplayP3&gt;::colorSpaceSingleton):
(WebCore::CGColorSpaceMapping&lt;ColorSpace::ExtendedA98RGB&gt;::colorSpaceSingleton):
(WebCore::CGColorSpaceMapping&lt;ColorSpace::ExtendedDisplayP3&gt;::colorSpaceSingleton):
(WebCore::CGColorSpaceMapping&lt;ColorSpace::ExtendedRec2020&gt;::colorSpaceSingleton):
(WebCore::CGColorSpaceMapping&lt;ColorSpace::ExtendedLinearDisplayP3&gt;::colorSpaceSingleton):
(WebCore::CGColorSpaceMapping&lt;ColorSpace::ExtendedLinearSRGB&gt;::colorSpaceSingleton):
(WebCore::CGColorSpaceMapping&lt;ColorSpace::ExtendedProPhotoRGB&gt;::colorSpaceSingleton):
(WebCore::CGColorSpaceMapping&lt;ColorSpace::ExtendedSRGB&gt;::colorSpaceSingleton):
(WebCore::CGColorSpaceMapping&lt;ColorSpace::Rec2020&gt;::colorSpaceSingleton):
(WebCore::CGColorSpaceMapping&lt;ColorSpace::LinearDisplayP3&gt;::colorSpaceSingleton):
(WebCore::CGColorSpaceMapping&lt;ColorSpace::LinearSRGB&gt;::colorSpaceSingleton):
(WebCore::CGColorSpaceMapping&lt;ColorSpace::ProPhotoRGB&gt;::colorSpaceSingleton):
(WebCore::CGColorSpaceMapping&lt;ColorSpace::XYZ_D50&gt;::colorSpaceSingleton):
(WebCore::CGColorSpaceMappingOrNullGetter::colorSpaceSingleton):
(WebCore::cachedCGColorSpaceSingleton):
(WebCore::cachedNullableCGColorSpaceSingleton):
(WebCore::CGColorSpaceMapping&lt;ColorSpace::SRGB&gt;::colorSpace): Deleted.
(WebCore::CGColorSpaceMapping&lt;ColorSpace::A98RGB&gt;::colorSpace): Deleted.
(WebCore::CGColorSpaceMapping&lt;ColorSpace::DisplayP3&gt;::colorSpace): Deleted.
(WebCore::CGColorSpaceMapping&lt;ColorSpace::ExtendedA98RGB&gt;::colorSpace): Deleted.
(WebCore::CGColorSpaceMapping&lt;ColorSpace::ExtendedDisplayP3&gt;::colorSpace): Deleted.
(WebCore::CGColorSpaceMapping&lt;ColorSpace::ExtendedRec2020&gt;::colorSpace): Deleted.
(WebCore::CGColorSpaceMapping&lt;ColorSpace::ExtendedLinearDisplayP3&gt;::colorSpace): Deleted.
(WebCore::CGColorSpaceMapping&lt;ColorSpace::ExtendedLinearSRGB&gt;::colorSpace): Deleted.
(WebCore::CGColorSpaceMapping&lt;ColorSpace::ExtendedProPhotoRGB&gt;::colorSpace): Deleted.
(WebCore::CGColorSpaceMapping&lt;ColorSpace::ExtendedSRGB&gt;::colorSpace): Deleted.
(WebCore::CGColorSpaceMapping&lt;ColorSpace::Rec2020&gt;::colorSpace): Deleted.
(WebCore::CGColorSpaceMapping&lt;ColorSpace::LinearDisplayP3&gt;::colorSpace): Deleted.
(WebCore::CGColorSpaceMapping&lt;ColorSpace::LinearSRGB&gt;::colorSpace): Deleted.
(WebCore::CGColorSpaceMapping&lt;ColorSpace::ProPhotoRGB&gt;::colorSpace): Deleted.
(WebCore::CGColorSpaceMapping&lt;ColorSpace::XYZ_D50&gt;::colorSpace): Deleted.
(WebCore::CGColorSpaceMappingOrNullGetter::colorSpace): Deleted.
(WebCore::cachedCGColorSpace): Deleted.
(WebCore::cachedNullableCGColorSpace): Deleted.
* Source/WebCore/platform/graphics/cg/GradientRendererCG.cpp:
(WebCore::GradientRendererCG::makeGradient const):
(WebCore::GradientRendererCG::makeShading const):
* Source/WebKit/Shared/cf/CoreIPCCGColorSpace.h:
(WebKit::CoreIPCCGColorSpace::toCF const):

Canonical link: <a href="https://commits.webkit.org/300137@main">https://commits.webkit.org/300137@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/915fa2e7cff1387aea2932536628c4f5dba94f22

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121320 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41017 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31676 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127756 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73401 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0378307d-bb9c-43ae-a570-f1e751a74f2c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123196 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41719 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49596 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92159 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61325 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/edb194c6-9c7d-416d-ade0-2d0c7c773cfa) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124272 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33313 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108719 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72835 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/62c516cf-21ce-4b29-bc0f-c507f49170b7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32331 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26847 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71339 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102806 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27023 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130594 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48248 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36683 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100755 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48616 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104908 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100660 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25541 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46068 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24131 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44942 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48106 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53819 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47578 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50924 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49260 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->