### PR TITLE
[WebXR] Add support for passthroughFullyObscured

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webxr/idlharness.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webxr/idlharness.https.window-expected.txt
@@ -98,14 +98,14 @@ PASS XRRenderState interface: existence and properties of interface prototype ob
 PASS XRRenderState interface: existence and properties of interface prototype object's @@unscopables property
 PASS XRRenderState interface: attribute depthNear
 PASS XRRenderState interface: attribute depthFar
-FAIL XRRenderState interface: attribute passthroughFullyObscured assert_true: The prototype object must have a property "passthroughFullyObscured" expected true got false
+PASS XRRenderState interface: attribute passthroughFullyObscured
 PASS XRRenderState interface: attribute inlineVerticalFieldOfView
 PASS XRRenderState interface: attribute baseLayer
 PASS XRRenderState must be primary interface of xrRenderState
 PASS Stringification of xrRenderState
 PASS XRRenderState interface: xrRenderState must inherit property "depthNear" with the proper type
 PASS XRRenderState interface: xrRenderState must inherit property "depthFar" with the proper type
-FAIL XRRenderState interface: xrRenderState must inherit property "passthroughFullyObscured" with the proper type assert_inherits: property "passthroughFullyObscured" not found in prototype chain
+PASS XRRenderState interface: xrRenderState must inherit property "passthroughFullyObscured" with the proper type
 PASS XRRenderState interface: xrRenderState must inherit property "inlineVerticalFieldOfView" with the proper type
 PASS XRRenderState interface: xrRenderState must inherit property "baseLayer" with the proper type
 PASS XRFrame interface: existence and properties of interface object

--- a/Source/WebCore/Modules/webxr/WebXRRenderState.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRRenderState.cpp
@@ -39,7 +39,7 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(WebXRRenderState);
 Ref<WebXRRenderState> WebXRRenderState::create(XRSessionMode mode)
 {
     // https://immersive-web.github.io/webxr/#initialize-the-render-state
-    // depthNear, depthFar and baseLayer are initialized in the class definition
+    // depthNear, depthFar, passthroughFullyObscured and baseLayer are initialized in the class definition
     return adoptRef(*new WebXRRenderState(mode == XRSessionMode::Inline ? std::make_optional(piOverTwoDouble) : std::nullopt));
 }
 
@@ -57,6 +57,7 @@ Ref<WebXRRenderState> WebXRRenderState::clone() const
 
 WebXRRenderState::WebXRRenderState(const WebXRRenderState& other)
     : m_depth(other.m_depth)
+    , m_passthroughFullyObscured(other.m_passthroughFullyObscured)
     , m_inlineVerticalFieldOfView(other.m_inlineVerticalFieldOfView)
     , m_baseLayer(other.baseLayer())
 {

--- a/Source/WebCore/Modules/webxr/WebXRRenderState.h
+++ b/Source/WebCore/Modules/webxr/WebXRRenderState.h
@@ -50,6 +50,9 @@ public:
     double depthFar() const { return m_depth.far; }
     void setDepthFar(double far) { m_depth.far = far; };
 
+    std::optional<bool> passthroughFullyObscured() const { return m_passthroughFullyObscured; }
+    void setPassthroughFullyObscured(bool passthroughFullyObscured) { m_passthroughFullyObscured = passthroughFullyObscured; }
+
     std::optional<double> inlineVerticalFieldOfView() const { return m_inlineVerticalFieldOfView; }
     void setInlineVerticalFieldOfView(double fieldOfView) { m_inlineVerticalFieldOfView = fieldOfView; }
 
@@ -76,6 +79,7 @@ private:
         double near { 0.1 }; // in meters
         double far { 1000 }; // in meters
     } m_depth;
+    std::optional<bool> m_passthroughFullyObscured { false };
     std::optional<double> m_inlineVerticalFieldOfView; // in radians
     RefPtr<WebXRWebGLLayer> m_baseLayer;
 #if ENABLE(WEBXR_LAYERS)

--- a/Source/WebCore/Modules/webxr/WebXRRenderState.idl
+++ b/Source/WebCore/Modules/webxr/WebXRRenderState.idl
@@ -33,6 +33,7 @@
 ] interface WebXRRenderState {
     readonly attribute double depthNear;
     readonly attribute double depthFar;
+    readonly attribute boolean? passthroughFullyObscured;
     readonly attribute double? inlineVerticalFieldOfView;
     readonly attribute WebXRWebGLLayer? baseLayer;
 };

--- a/Source/WebCore/Modules/webxr/WebXRSession.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRSession.cpp
@@ -175,6 +175,9 @@ ExceptionOr<void> WebXRSession::updateRenderState(const XRRenderStateInit& newSt
     }
 #endif
 
+    if (newState.passthroughFullyObscured)
+        m_pendingRenderState->setPassthroughFullyObscured(newState.passthroughFullyObscured.value());
+
     // 9. If newState's depthNear value is set, set session's pending render state's depthNear to newState's depthNear.
     if (newState.depthNear)
         m_pendingRenderState->setDepthNear(newState.depthNear.value());
@@ -552,7 +555,9 @@ void WebXRSession::applyPendingRenderState()
         m_activeRenderState->setOutputCanvas(nullptr);
     }
 
-    m_requestData = {{ .depthRange = PlatformXR::DepthRange { static_cast<float>(m_activeRenderState->depthNear()), static_cast<float>(m_activeRenderState->depthFar()) } }}; // NOLINT
+    m_requestData = { {
+        .isPassthroughFullyObscured = m_activeRenderState->passthroughFullyObscured().value_or(false),
+        .depthRange = PlatformXR::DepthRange { static_cast<float>(m_activeRenderState->depthNear()), static_cast<float>(m_activeRenderState->depthFar()) } }}; // NOLINT
 }
 
 void WebXRSession::minimalUpdateRendering()

--- a/Source/WebCore/Modules/webxr/XRRenderStateInit.h
+++ b/Source/WebCore/Modules/webxr/XRRenderStateInit.h
@@ -36,6 +36,7 @@ namespace WebCore {
 struct XRRenderStateInit {
     std::optional<double> depthNear;
     std::optional<double> depthFar;
+    std::optional<bool> passthroughFullyObscured;
     std::optional<double> inlineVerticalFieldOfView;
     RefPtr<WebXRWebGLLayer> baseLayer;
     std::optional<Vector<Ref<WebXRLayer>>> layers;

--- a/Source/WebCore/Modules/webxr/XRRenderStateInit.idl
+++ b/Source/WebCore/Modules/webxr/XRRenderStateInit.idl
@@ -30,6 +30,7 @@
 ] dictionary XRRenderStateInit {
     double depthNear;
     double depthFar;
+    boolean passthroughFullyObscured;
     double inlineVerticalFieldOfView;
     WebXRWebGLLayer? baseLayer;
     sequence<WebXRLayer>? layers;

--- a/Source/WebCore/platform/xr/PlatformXR.h
+++ b/Source/WebCore/platform/xr/PlatformXR.h
@@ -243,6 +243,7 @@ struct DepthRange {
 };
 
 struct RequestData {
+    bool isPassthroughFullyObscured;
     DepthRange depthRange;
 };
 

--- a/Source/WebKit/Shared/XR/PlatformXR.serialization.in
+++ b/Source/WebKit/Shared/XR/PlatformXR.serialization.in
@@ -79,6 +79,7 @@ enum class PlatformXR::XRTargetRayMode : uint8_t {
 
 header: <WebCore/PlatformXR.h>
 [CustomHeader] struct PlatformXR::RequestData {
+    bool isPassthroughFullyObscured;
     PlatformXR::DepthRange depthRange;
 };
 


### PR DESCRIPTION
#### e12952fd429be8f3fad8a448739f2655dc8b4bf4
<pre>
[WebXR] Add support for passthroughFullyObscured
<a href="https://bugs.webkit.org/show_bug.cgi?id=299012">https://bugs.webkit.org/show_bug.cgi?id=299012</a>

Reviewed by Dan Glastonbury.

Added passthroughFullyObscured attribute to the render state object.
It&apos;s a hint for the XR system to switch of passthrough (if needed)
because the WebXR experience is going to render the whole viewport
with XR content.

So far it only does something meaningful in the OpenXR backend where
it switches from an AR blend mode to a VR blend mode.

Some sub tests in the WPT suite PASS now.

* LayoutTests/imported/w3c/web-platform-tests/webxr/idlharness.https.window-expected.txt:
* Source/WebCore/Modules/webxr/WebXRRenderState.cpp:
(WebCore::WebXRRenderState::create):
(WebCore::WebXRRenderState::WebXRRenderState):
* Source/WebCore/Modules/webxr/WebXRRenderState.h:
(WebCore::WebXRRenderState::passthroughFullyObscured const):
(WebCore::WebXRRenderState::setPassthroughFullyObscured):
* Source/WebCore/Modules/webxr/WebXRRenderState.idl:
* Source/WebCore/Modules/webxr/WebXRSession.cpp:
(WebCore::WebXRSession::updateRenderState):
(WebCore::WebXRSession::applyPendingRenderState):
* Source/WebCore/Modules/webxr/XRRenderStateInit.h:
* Source/WebCore/Modules/webxr/XRRenderStateInit.idl:
* Source/WebCore/platform/xr/PlatformXR.h:
* Source/WebKit/Shared/XR/PlatformXR.serialization.in:
* Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.cpp:
(WebKit::OpenXRCoordinator::scheduleAnimationFrame):
(WebKit::OpenXRCoordinator::endFrame):

Canonical link: <a href="https://commits.webkit.org/300376@main">https://commits.webkit.org/300376@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1282369f92c9fb7b9b84c46a5b7d1c8bb2f0f269

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122375 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42081 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32767 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128962 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/74474 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/124251 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42800 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50674 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/93016 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/74474 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125327 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34135 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109575 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73675 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/33123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/27733 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72454 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/103735 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27942 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131703 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49316 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37528 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/101564 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49690 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105795 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101435 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25719 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46808 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24941 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/46077 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49174 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54917 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/48641 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51991 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50323 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->