### PR TITLE
[Safer CPP] Use globalDispatchQueueSingleton() instead of dispatch_get_global_queue()

### DIFF
--- a/Source/JavaScriptCore/API/tests/ExecutionTimeLimitTest.cpp
+++ b/Source/JavaScriptCore/API/tests/ExecutionTimeLimitTest.cpp
@@ -39,7 +39,7 @@
 #include <wtf/text/StringBuilder.h>
 
 #if HAVE(MACH_EXCEPTIONS)
-#include <dispatch/dispatch.h>
+#include <wtf/darwin/DispatchExtras.h>
 #endif
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
@@ -533,7 +533,7 @@ int testExecutionTimeLimit()
             Seconds& endTimeRef = endTime;
 
             dispatch_group_t group = dispatch_group_create();
-            dispatch_group_async(group, dispatch_get_global_queue(0, 0), ^{
+            dispatch_group_async(group, globalDispatchQueueSingleton(0, 0), ^{
                 startTimeRef = CPUTime::forCurrentThread();
                 JSEvaluateScript(contextRef, scriptRef, nullptr, nullptr, 1, &exceptionRef);
                 endTimeRef = CPUTime::forCurrentThread();

--- a/Source/JavaScriptCore/API/tests/Regress141275.mm
+++ b/Source/JavaScriptCore/API/tests/Regress141275.mm
@@ -282,7 +282,7 @@ static void __JSTRunLoopSourceCancelCallBack(void* info, CFRunLoopRef rl, CFStri
 - (void)_callCompletionHandler:(void(^)(NSError* error))completionHandler ifNeededWithError:(NSError*)error
 {
     if (completionHandler) {
-        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        dispatch_async(globalDispatchQueueSingleton(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
             completionHandler(error);
         });
     }

--- a/Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorCocoa.mm
+++ b/Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorCocoa.mm
@@ -201,7 +201,7 @@ void RemoteInspector::updateAutomaticInspectionCandidate(RemoteInspectionTarget*
         // In case debuggers fail to respond, or we cannot connect to webinspectord, assume a rejection for
         // automatic inspection after a short period of time.
         int64_t debuggerTimeoutDelay = 10;
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, debuggerTimeoutDelay * NSEC_PER_SEC), dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, debuggerTimeoutDelay * NSEC_PER_SEC), globalDispatchQueueSingleton(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
             Locker locker { m_mutex };
             if (m_automaticInspectionCandidates.remove(targetIdentifier)) {
                 WTFLogAlways("Skipping Automatic Inspection Candidate with pageId(%u) because we failed to receive a response in time.", targetIdentifier);
@@ -457,7 +457,7 @@ void RemoteInspector::xpcConnectionFailed(RemoteInspectorXPCConnection* relayCon
     m_shouldReconnectToRelayOnFailure = false;
 
     // Schedule setting up a new connection, since we currently are holding a lock needed to create a new connection.
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 1 * NSEC_PER_SEC), dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 1 * NSEC_PER_SEC), globalDispatchQueueSingleton(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         RemoteInspector::singleton().setupXPCConnectionIfNeeded();
     });
 }
@@ -597,7 +597,7 @@ void RemoteInspector::pushListingsSoon()
         return;
 
     m_pushScheduled = true;
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0.2 * NSEC_PER_SEC), dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0.2 * NSEC_PER_SEC), globalDispatchQueueSingleton(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         Locker locker { m_mutex };
         if (m_pushScheduled)
             pushListingsNow();
@@ -761,7 +761,7 @@ void RemoteInspector::receivedProxyApplicationSetupMessage(NSDictionary *)
         // We are a proxy application without parent process information.
         // Wait a bit for the information, but give up after a second.
         m_shouldSendParentProcessInformation = true;
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 1 * NSEC_PER_SEC), dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 1 * NSEC_PER_SEC), globalDispatchQueueSingleton(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
             Locker locker { m_mutex };
             if (m_shouldSendParentProcessInformation)
                 stopInternal(StopSource::XPCMessage);

--- a/Source/WTF/wtf/ParallelJobsLibdispatch.h
+++ b/Source/WTF/wtf/ParallelJobsLibdispatch.h
@@ -29,7 +29,7 @@
 
 #if ENABLE(THREADING_LIBDISPATCH)
 
-#include <dispatch/dispatch.h>
+#include <wtf/darwin/DispatchExtras.h>
 
 namespace WTF {
 
@@ -54,7 +54,7 @@ public:
 
     void execute(unsigned char* parameters)
     {
-        static dispatch_queue_t globalQueue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
+        static dispatch_queue_t globalQueue = globalDispatchQueueSingleton(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         dispatch_apply(m_numberOfJobs, globalQueue, ^(size_t i) { (*m_threadFunction)(parameters + (m_sizeOfParameter * i)); });

--- a/Source/WTF/wtf/cocoa/WorkQueueCocoa.cpp
+++ b/Source/WTF/wtf/cocoa/WorkQueueCocoa.cpp
@@ -104,7 +104,7 @@ WorkQueue::WorkQueue(MainTag)
 
 void ConcurrentWorkQueue::apply(size_t iterations, WTF::Function<void(size_t index)>&& function)
 {
-    dispatch_apply(iterations, dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), makeBlockPtr([function = WTFMove(function)](size_t index) {
+    dispatch_apply(iterations, globalDispatchQueueSingleton(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), makeBlockPtr([function = WTFMove(function)](size_t index) {
         function(index);
     }).get());
 }

--- a/Source/WTF/wtf/darwin/LibraryPathDiagnostics.mm
+++ b/Source/WTF/wtf/darwin/LibraryPathDiagnostics.mm
@@ -35,6 +35,7 @@
 #include <wtf/StringPrintStream.h>
 #include <wtf/UUID.h>
 #include <wtf/cf/TypeCastsCF.h>
+#include <wtf/darwin/DispatchExtras.h>
 #include <wtf/spi/cf/CFPrivSPI.h>
 #include <wtf/spi/darwin/dyldSPI.h>
 
@@ -286,7 +287,7 @@ void initializeLibraryPathDiagnostics(void)
     static std::once_flag onceFlag;
     std::call_once(onceFlag, [] {
         int token = -1;
-        notify_register_dispatch(notificationName, &token, dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^(int token) {
+        notify_register_dispatch(notificationName, &token, globalDispatchQueueSingleton(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^(int token) {
             UNUSED_PARAM(token);
             logLibraryPathDiagnostics();
         });

--- a/Source/WTF/wtf/mac/FileSystemMac.mm
+++ b/Source/WTF/wtf/mac/FileSystemMac.mm
@@ -29,6 +29,7 @@
 #if PLATFORM(MAC)
 
 #import <wtf/cocoa/NSURLExtras.h>
+#import <wtf/darwin/DispatchExtras.h>
 #import <wtf/spi/mac/MetadataSPI.h>
 #import <wtf/text/WTFString.h>
 
@@ -43,7 +44,7 @@ void FileSystem::setMetadataURL(const String& path, const String& metadataURLStr
         urlString = metadataURLString;
 
     // Call Metadata API on a background queue because it can take some time.
-    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), [path = path.isolatedCopy(), urlString = WTFMove(urlString).isolatedCopy(), referrer = referrer.isolatedCopy()] {
+    dispatch_async(globalDispatchQueueSingleton(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), [path = path.isolatedCopy(), urlString = WTFMove(urlString).isolatedCopy(), referrer = referrer.isolatedCopy()] {
         auto item = adoptCF(MDItemCreate(kCFAllocatorDefault, path.createCFString().get()));
         if (!item)
             return;

--- a/Source/WebCore/crypto/cocoa/CryptoKeyRSAMac.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoKeyRSAMac.cpp
@@ -36,6 +36,7 @@
 #include <JavaScriptCore/HeapInlines.h>
 #include <JavaScriptCore/JSGenericTypedArrayViewInlines.h>
 #include <wtf/MainThread.h>
+#include <wtf/darwin/DispatchExtras.h>
 
 namespace WebCore {
 
@@ -283,7 +284,7 @@ void CryptoKeyRSA::generatePair(CryptoAlgorithmIdentifier algorithm, CryptoAlgor
     __block auto blockCallback(WTFMove(callback));
     __block auto blockFailureCallback(WTFMove(failureCallback));
     auto contextIdentifier = context->identifier();
-    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+    dispatch_async(globalDispatchQueueSingleton(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         CCRSACryptorRef ccPublicKey = nullptr;
         CCRSACryptorRef ccPrivateKey = nullptr;
         CCCryptorStatus status = CCRSACryptorGeneratePair(modulusLength, e, &ccPublicKey, &ccPrivateKey);

--- a/Source/WebCore/platform/cocoa/TelephoneNumberDetectorCocoa.cpp
+++ b/Source/WebCore/platform/cocoa/TelephoneNumberDetectorCocoa.cpp
@@ -29,6 +29,7 @@
 #if ENABLE(TELEPHONE_NUMBER_DETECTION)
 
 #include <wtf/SoftLinking.h>
+#include <wtf/darwin/DispatchExtras.h>
 
 #if USE(APPLE_INTERNAL_SDK)
 #include <DataDetectorsCore/DDDFAScanner.h>
@@ -61,7 +62,7 @@ static DDDFAScannerRef phoneNumbersScanner()
 void prewarm()
 {
     // Prewarm on a background queue to avoid hanging the main thread.
-    dispatch_async(dispatch_get_global_queue(0, 0), ^{
+    dispatch_async(globalDispatchQueueSingleton(0, 0), ^{
         phoneNumbersScanner();
     });
 }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/ImageDecoderAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/ImageDecoderAVFObjC.mm
@@ -56,6 +56,7 @@
 #import <wtf/TZoneMallocInlines.h>
 #import <wtf/Vector.h>
 #import <wtf/cf/TypeCastsCF.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 #import "CoreVideoSoftLink.h"
 #import "VideoToolboxSoftLink.h"
@@ -356,7 +357,7 @@ ImageDecoderAVFObjC::ImageDecoderAVFObjC(const FragmentedSharedBuffer& data, con
     m_decompressionSession->setResourceOwner(m_resourceOwner);
     [m_loader updateData:data.makeContiguous()->createNSData().get() complete:NO];
 
-    [m_asset.get().resourceLoader setDelegate:m_loader.get() queue:dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)];
+    [m_asset.get().resourceLoader setDelegate:m_loader.get() queue:globalDispatchQueueSingleton(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)];
     [m_asset loadValuesAsynchronouslyForKeys:@[@"tracks"] completionHandler:[protectedThis = Ref { *this }] () mutable {
         callOnMainThread([protectedThis = WTFMove(protectedThis)] {
             protectedThis->setTrack(protectedThis->firstEnabledTrack());

--- a/Source/WebCore/platform/ios/LegacyTileLayerPool.mm
+++ b/Source/WebCore/platform/ios/LegacyTileLayerPool.mm
@@ -33,6 +33,7 @@
 #import "Logging.h"
 #import <wtf/MemoryPressureHandler.h>
 #import <wtf/NeverDestroyed.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 namespace WebCore {
 
@@ -127,7 +128,7 @@ void LegacyTileLayerPool::schedulePrune()
         return;
     m_needsPrune = true;
     dispatch_time_t nextPruneTime = dispatch_time(DISPATCH_TIME_NOW, 1 * NSEC_PER_SEC);
-    dispatch_after(nextPruneTime, dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+    dispatch_after(nextPruneTime, globalDispatchQueueSingleton(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         prune();
     });
 }

--- a/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm
+++ b/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm
@@ -51,7 +51,8 @@
 #import <pal/spi/cocoa/AVFoundationSPI.h>
 #import <wtf/Scope.h>
 #import <wtf/WorkQueue.h>
-#include <wtf/cocoa/VectorCocoa.h>
+#import <wtf/cocoa/VectorCocoa.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 #import "CoreVideoSoftLink.h"
 #import <pal/cocoa/AVFoundationSoftLink.h>
@@ -106,7 +107,7 @@ static dispatch_queue_t globaVideoCaptureSerialQueue()
     static dispatch_queue_t globalQueue;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        globalQueue = dispatch_queue_create_with_target("WebCoreAVVideoCaptureSource video capture queue", DISPATCH_QUEUE_SERIAL, dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0));
+        globalQueue = dispatch_queue_create_with_target("WebCoreAVVideoCaptureSource video capture queue", DISPATCH_QUEUE_SERIAL, globalDispatchQueueSingleton(DISPATCH_QUEUE_PRIORITY_HIGH, 0));
     });
     return globalQueue;
 }

--- a/Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm
@@ -100,7 +100,7 @@ void NetworkStorageSession::deleteCookie(const Cookie& cookie, CompletionHandler
 
     if (m_isInMemoryCookieStore)
         return work();
-    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), makeBlockPtr(WTFMove(work)).get());
+    dispatch_async(globalDispatchQueueSingleton(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), makeBlockPtr(WTFMove(work)).get());
 }
 
 static Vector<Cookie> nsCookiesToCookieVector(NSArray<NSHTTPCookie *> *nsCookies, NOESCAPE const Function<bool(NSHTTPCookie *)>& filter = { })
@@ -265,7 +265,7 @@ void NetworkStorageSession::deleteHTTPCookie(CFHTTPCookieStorageRef cookieStorag
 
     if (m_isInMemoryCookieStore)
         return work();
-    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), makeBlockPtr(WTFMove(work)).get());
+    dispatch_async(globalDispatchQueueSingleton(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), makeBlockPtr(WTFMove(work)).get());
 }
 
 static RetainPtr<NSDictionary> policyProperties(const SameSiteInfo& sameSiteInfo, NSURL *url, NSString *partition, ThirdPartyCookieBlockingDecision thirdPartyCookieBlockingDecision)
@@ -664,7 +664,7 @@ void NetworkStorageSession::deleteAllCookies(CompletionHandler<void()>&& complet
     
     if (m_isInMemoryCookieStore)
         return work();
-    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), makeBlockPtr(WTFMove(work)).get());
+    dispatch_async(globalDispatchQueueSingleton(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), makeBlockPtr(WTFMove(work)).get());
 }
 
 void NetworkStorageSession::deleteCookiesMatching(NOESCAPE const Function<bool(NSHTTPCookie *)>& matches, CompletionHandler<void()>&& completionHandler)
@@ -748,7 +748,7 @@ void NetworkStorageSession::deleteAllCookiesModifiedSince(WallTime timePoint, Co
 
     if (m_isInMemoryCookieStore)
         return work();
-    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), makeBlockPtr(WTFMove(work)).get());
+    dispatch_async(globalDispatchQueueSingleton(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), makeBlockPtr(WTFMove(work)).get());
 }
 
 Vector<Cookie> NetworkStorageSession::domCookiesForHost(const URL& firstParty)

--- a/Source/WebCore/testing/Internals.mm
+++ b/Source/WebCore/testing/Internals.mm
@@ -287,7 +287,7 @@ bool Internals::emitWebCoreLogs(unsigned logCount, bool useMainThread) const
     if (useMainThread)
         dispatch_async(mainDispatchQueueSingleton(), blockPtr.get());
     else
-        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), blockPtr.get());
+        dispatch_async(globalDispatchQueueSingleton(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), blockPtr.get());
     return true;
 }
 
@@ -300,7 +300,7 @@ bool Internals::emitLogs(const String& logString, unsigned logCount, bool useMai
     if (useMainThread)
         dispatch_async(mainDispatchQueueSingleton(), blockPtr.get());
     else
-        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), blockPtr.get());
+        dispatch_async(globalDispatchQueueSingleton(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), blockPtr.get());
     return true;
 }
 #endif // ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheIOChannelCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheIOChannelCocoa.mm
@@ -28,7 +28,6 @@
 
 #import "Logging.h"
 #import "NetworkCacheFileSystem.h"
-#import <dispatch/dispatch.h>
 #import <mach/vm_param.h>
 #import <sys/mman.h>
 #import <sys/stat.h>

--- a/Source/WebKitLegacy/ios/Misc/WebUIKitSupport.mm
+++ b/Source/WebKitLegacy/ios/Misc/WebUIKitSupport.mm
@@ -41,6 +41,7 @@
 #import <WebCore/WebBackgroundTaskController.h>
 #import <WebCore/WebCoreThreadSystemInterface.h>
 #import <wtf/ObjCRuntimeExtras.h>
+#import <wtf/darwin/DispatchExtras.h>
 #import <wtf/spi/darwin/dyldSPI.h>
 
 using namespace WebCore;
@@ -48,7 +49,7 @@ using namespace WebCore;
 // See <rdar://problem/7902473> Optimize WebLocalizedString for why we do this on a background thread on a timer callback
 static void LoadWebLocalizedStringsTimerCallback(CFRunLoopTimerRef timer, void *info)
 {
-    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_LOW, 0), ^ {
+    dispatch_async(globalDispatchQueueSingleton(DISPATCH_QUEUE_PRIORITY_LOW, 0), ^{
         // We don't care if we find this string, but searching for it will load the plist and save the results.
         // FIXME: It would be nicer to do this in a more direct way.
         UI_STRING_KEY_INTERNAL("Typing", "Typing (Undo action name)", "Undo action name");

--- a/Source/WebKitLegacy/mac/Storage/WebDatabaseManager.mm
+++ b/Source/WebKitLegacy/mac/Storage/WebDatabaseManager.mm
@@ -36,6 +36,7 @@
 #import <WebCore/DatabaseTracker.h>
 #import <WebCore/SecurityOrigin.h>
 #import <wtf/cocoa/VectorCocoa.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 #if PLATFORM(IOS_FAMILY)
 #import "WebDatabaseManagerInternal.h"
@@ -208,7 +209,7 @@ static bool isFileHidden(NSString *file)
 {
     DatabaseTracker::emptyDatabaseFilesRemovalTaskWillBeScheduled();
     
-    dispatch_async(dispatch_get_global_queue(0, 0), ^{
+    dispatch_async(globalDispatchQueueSingleton(0, 0), ^{
         [WebDatabaseManager removeEmptyDatabaseFiles];
         DatabaseTracker::emptyDatabaseFilesRemovalTaskDidFinish();
     });

--- a/Tools/TestWebKitAPI/Tests/JavaScriptCore/JSRunLoopTimer.mm
+++ b/Tools/TestWebKitAPI/Tests/JavaScriptCore/JSRunLoopTimer.mm
@@ -33,6 +33,7 @@
 #import <wtf/Vector.h>
 #import <wtf/cocoa/NSURLExtras.h>
 #import <wtf/cocoa/VectorCocoa.h>
+#import <wtf/darwin/DispatchExtras.h>
 #import <wtf/text/WTFString.h>
 
 // JavaScriptCore's behavior at the time of writing is that destructors
@@ -106,7 +107,7 @@ TEST(JavaScriptCore, IncrementalSweeperSecondaryThread)
     s_expectedRunLoop = &RunLoop::currentSingleton();
 
     while (!s_done) {
-        dispatch_sync(dispatch_get_global_queue(QOS_CLASS_USER_INTERACTIVE, 0), ^{
+        dispatch_sync(globalDispatchQueueSingleton(QOS_CLASS_USER_INTERACTIVE, 0), ^{
             triggerGC(context.get());
             cycleRunLoop();
         });

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/NavigationAction.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/NavigationAction.mm
@@ -34,6 +34,7 @@
 #import "TestWKWebView.h"
 #import <WebKit/WKNavigationActionPrivate.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 @interface NavigationActionTestDelegate : NSObject <WKNavigationDelegate>
 
@@ -229,12 +230,12 @@ TEST(WKNavigationAction, NonMainThread)
     [webView setNavigationDelegate:delegate.get()];
     __block bool done = false;
     delegate.get().decidePolicyForNavigationAction = ^(WKNavigationAction *action, void (^completionHandler)(WKNavigationActionPolicy)) {
-        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        dispatch_async(globalDispatchQueueSingleton(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
             completionHandler(WKNavigationActionPolicyAllow);
         });
     };
     delegate.get().decidePolicyForNavigationResponse = ^(WKNavigationResponse *action, void (^completionHandler)(WKNavigationResponsePolicy)) {
-        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        dispatch_async(globalDispatchQueueSingleton(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
             completionHandler(WKNavigationResponsePolicyAllow);
         });
     };

--- a/Tools/TestWebKitAPI/cocoa/TestInspectorURLSchemeHandler.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestInspectorURLSchemeHandler.mm
@@ -52,7 +52,7 @@
 
     if (!_operationQueue) {
         _operationQueue = adoptNS([[NSOperationQueue alloc] init]);
-        _operationQueue.get().underlyingQueue = dispatch_get_global_queue(QOS_CLASS_USER_INTERACTIVE, 0);
+        _operationQueue.get().underlyingQueue = globalDispatchQueueSingleton(QOS_CLASS_USER_INTERACTIVE, 0);
         _operationQueue.get().qualityOfService = NSOperationQualityOfServiceUserInteractive;
 
         // The default value (NSOperationQueueDefaultMaxConcurrentOperationCount) results in a large number of threads


### PR DESCRIPTION
#### 80b2a1380485573eb16e36e15c6f3a9ce7258a82
<pre>
[Safer CPP] Use globalDispatchQueueSingleton() instead of dispatch_get_global_queue()
<a href="https://bugs.webkit.org/show_bug.cgi?id=299014">https://bugs.webkit.org/show_bug.cgi?id=299014</a>

Reviewed by Darin Adler.

Use globalDispatchQueueSingleton() instead of dispatch_get_global_queue() to
silence some safer cpp static analysis warnings.

* Source/JavaScriptCore/API/tests/ExecutionTimeLimitTest.cpp:
(testExecutionTimeLimit):
* Source/JavaScriptCore/API/tests/Regress141275.mm:
(-[JSTEvaluator _callCompletionHandler:ifNeededWithError:]):
* Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorCocoa.mm:
(Inspector::RemoteInspector::updateAutomaticInspectionCandidate):
(Inspector::RemoteInspector::xpcConnectionFailed):
(Inspector::RemoteInspector::pushListingsSoon):
(Inspector::RemoteInspector::receivedProxyApplicationSetupMessage):
* Source/WTF/wtf/ParallelJobsLibdispatch.h:
(WTF::ParallelEnvironment::execute):
* Source/WTF/wtf/cocoa/WorkQueueCocoa.cpp:
(WTF::ConcurrentWorkQueue::apply):
* Source/WTF/wtf/darwin/LibraryPathDiagnostics.mm:
(WTF::initializeLibraryPathDiagnostics):
* Source/WTF/wtf/mac/FileSystemMac.mm:
(WTF::FileSystem::setMetadataURL):
* Source/WebCore/crypto/cocoa/CryptoKeyRSAMac.cpp:
(WebCore::CryptoKeyRSA::generatePair):
* Source/WebCore/platform/cocoa/TelephoneNumberDetectorCocoa.cpp:
(WebCore::TelephoneNumberDetector::prewarm):
* Source/WebCore/platform/graphics/avfoundation/objc/ImageDecoderAVFObjC.mm:
(WebCore::ImageDecoderAVFObjC::ImageDecoderAVFObjC):
* Source/WebCore/platform/ios/LegacyTileLayerPool.mm:
(WebCore::LegacyTileLayerPool::schedulePrune):
* Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm:
(WebCore::globaVideoCaptureSerialQueue):
* Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm:
(WebCore::NetworkStorageSession::deleteCookie):
(WebCore::NetworkStorageSession::deleteHTTPCookie const):
(WebCore::NetworkStorageSession::deleteAllCookies):
(WebCore::NetworkStorageSession::deleteAllCookiesModifiedSince):
* Source/WebCore/testing/Internals.mm:
(WebCore::Internals::emitWebCoreLogs const):
(WebCore::Internals::emitLogs const):
* Source/WebKit/NetworkProcess/cache/NetworkCacheIOChannelCocoa.mm:
* Source/WebKitLegacy/ios/Misc/WebUIKitSupport.mm:
(LoadWebLocalizedStringsTimerCallback):
* Source/WebKitLegacy/mac/Storage/WebDatabaseManager.mm:
(+[WebDatabaseManager scheduleEmptyDatabaseRemoval]):
* Tools/TestWebKitAPI/Tests/JavaScriptCore/JSRunLoopTimer.mm:
(TestWebKitAPI::TEST(JavaScriptCore, IncrementalSweeperSecondaryThread)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/NavigationAction.mm:
(TEST(WKNavigationAction, NonMainThread)):
* Tools/TestWebKitAPI/cocoa/TestInspectorURLSchemeHandler.mm:
(-[TestInspectorURLSchemeHandler webView:startURLSchemeTask:]):

Canonical link: <a href="https://commits.webkit.org/300110@main">https://commits.webkit.org/300110@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b791bec3cbe5adcf0293d4406920a84956b475e3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121309 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41006 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31664 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127745 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73390 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/efad6fd1-ebf0-47eb-b775-aec5954a28a6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123185 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41708 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49585 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92147 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61305 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/43d37c96-8ae1-4b31-8433-61ca55339f6b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124261 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33303 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108703 "Found 1 new API test failure: TestIPC.StreamServerConnectionTests/StreamServerDidReceiveInvalidMessageTest.AsyncNotStreamEncodable/ValidationError (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72823 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fc8c8c8e-79b2-483c-a670-658e6612e21a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32321 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26831 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71328 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/113439 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102796 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27007 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130583 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/119829 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48237 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36671 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100741 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48605 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104892 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100646 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25523 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46052 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24115 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44931 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48095 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53808 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/149991 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47567 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/38128 "Found 1 new JSC stress test failure: stress/dont-link-virtual-calls-on-compiler-thread.js.no-llint (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50913 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49249 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->