### PR TITLE
[OpenXR] Use AHardwareBuffer for buffer sharing on Android

### DIFF
--- a/Source/WebCore/PlatformWPE.cmake
+++ b/Source/WebCore/PlatformWPE.cmake
@@ -28,6 +28,7 @@ list(APPEND WebCore_PRIVATE_INCLUDE_DIRECTORIES
     "${WEBCORE_DIR}/crypto/openssl"
     "${WEBCORE_DIR}/platform/audio/glib"
     "${WEBCORE_DIR}/platform/glib"
+    "${WEBCORE_DIR}/platform/graphics/android"
     "${WEBCORE_DIR}/platform/graphics/egl"
     "${WEBCORE_DIR}/platform/graphics/epoxy"
     "${WEBCORE_DIR}/platform/graphics/gbm"
@@ -54,6 +55,8 @@ list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/glib/ApplicationGLib.h
     platform/glib/SelectionData.h
     platform/glib/SystemSettings.h
+
+    platform/graphics/android/GraphicsContextGLTextureMapperAndroid.h
 
     platform/graphics/egl/PlatformDisplaySurfaceless.h
 

--- a/Source/WebCore/SourcesWPE.txt
+++ b/Source/WebCore/SourcesWPE.txt
@@ -69,6 +69,9 @@ platform/graphics/glib/ImageAdapterGLib.cpp
 
 platform/graphics/wpe/SystemFontDatabaseWPE.cpp
 
+platform/graphics/android/GraphicsContextGLTextureMapperAndroid.h @no-unify
+platform/graphics/android/GraphicsContextGLTextureMapperAndroid.cpp @no-unify
+
 platform/graphics/egl/GLContext.cpp @no-unify
 platform/graphics/egl/GLContextLibWPE.cpp @no-unify
 platform/graphics/egl/GLContextWrapper.cpp @no-unify

--- a/Source/WebCore/platform/graphics/GraphicsContextGL.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextGL.h
@@ -43,6 +43,10 @@
 #include <wtf/RefCounted.h>
 #include <wtf/text/WTFString.h>
 
+#if OS(ANDROID)
+#include <wtf/android/RefPtrAndroid.h>
+#endif
+
 #if PLATFORM(COCOA)
 #include <wtf/MachSendRight.h>
 #endif
@@ -91,11 +95,15 @@ using GraphicsContextGLExternalSyncSource = std::tuple<MachSendRight, uint64_t>;
 #elif PLATFORM(GTK) || PLATFORM(WPE)
 
 struct GraphicsContextGLExternalImageSource {
+#if OS(ANDROID)
+    RefPtr<AHardwareBuffer> hardwareBuffer;
+#else
     Vector<WTF::UnixFileDescriptor> fds;
     Vector<uint32_t> strides;
     Vector<uint32_t> offsets;
     uint32_t fourcc;
     uint64_t modifier;
+#endif // OS(ANDROID)
     WebCore::IntSize size;
 };
 using GraphicsContextGLExternalSyncSource = int;

--- a/Source/WebCore/platform/graphics/android/GraphicsContextGLTextureMapperAndroid.cpp
+++ b/Source/WebCore/platform/graphics/android/GraphicsContextGLTextureMapperAndroid.cpp
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2025 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "config.h"
+#include "GraphicsContextGLTextureMapperAndroid.h"
+
+#if ENABLE(WEBGL) && USE(COORDINATED_GRAPHICS) && OS(ANDROID)
+#include "ANGLEHeaders.h"
+#include "GLFence.h"
+#include "Logging.h"
+#include "PlatformDisplay.h"
+#include "TextureMapperFlags.h"
+#include <android/hardware_buffer.h>
+
+namespace WebCore {
+
+RefPtr<GraphicsContextGLTextureMapperAndroid> GraphicsContextGLTextureMapperAndroid::create(GraphicsContextGLAttributes&& attributes)
+{
+    auto context = adoptRef(new GraphicsContextGLTextureMapperAndroid(WTFMove(attributes)));
+    if (!context->initialize())
+        return nullptr;
+    return context;
+}
+
+bool GraphicsContextGLTextureMapperAndroid::platformInitializeExtensions()
+{
+    if (!enableExtension("GL_OES_EGL_image"_s))
+        return false;
+
+    const auto& eglExtensions = PlatformDisplay::sharedDisplay().eglExtensions();
+    return eglExtensions.KHR_image_base && eglExtensions.ANDROID_get_native_client_buffer && eglExtensions.ANDROID_image_native_buffer;
+}
+
+#if ENABLE(WEBXR)
+GCGLExternalImage GraphicsContextGLTextureMapperAndroid::createExternalImage(ExternalImageSource&& source, GCGLenum, GCGLint)
+{
+    if (m_displayObj == EGL_NO_DISPLAY) {
+        addError(GCGLErrorCode::InvalidOperation);
+        RELEASE_LOG_ERROR(XR, "Invalid display %#06x", EGL_GetError());
+        return { };
+    }
+
+    static PFNEGLGETNATIVECLIENTBUFFERANDROIDPROC s_eglGetNativeClientBufferANDROID { nullptr };
+    if (!s_eglGetNativeClientBufferANDROID) [[unlikely]] {
+        s_eglGetNativeClientBufferANDROID = reinterpret_cast<PFNEGLGETNATIVECLIENTBUFFERANDROIDPROC>(EGL_GetProcAddress("eglGetNativeClientBufferANDROID"));
+        RELEASE_ASSERT(s_eglGetNativeClientBufferANDROID);
+    }
+
+    static constexpr EGLint attributes[] = { EGL_IMAGE_PRESERVED, EGL_TRUE, EGL_NONE };
+
+    auto clientBuffer = s_eglGetNativeClientBufferANDROID(source.hardwareBuffer.get());
+    auto eglImage = EGL_CreateImageKHR(m_displayObj, EGL_NO_CONTEXT, EGL_NATIVE_BUFFER_ANDROID, clientBuffer, attributes);
+    if (eglImage == EGL_NO_IMAGE_KHR) {
+        RELEASE_LOG_ERROR(XR, "Failed to bind AHardwareBuffer to an EGLImage (%#06x). This is typically caused by "
+            "a version mismatch between the gralloc implementation and the OpenGL/EGL driver. Please contact your "
+            "GPU vendor to resolve this problem.", EGL_GetError());
+        addError(GCGLErrorCode::InvalidOperation);
+        return { };
+    }
+
+    auto newName = ++m_nextExternalImageName;
+    m_eglImages.add(newName, eglImage);
+    return newName;
+}
+
+void GraphicsContextGLTextureMapperAndroid::bindExternalImage(GCGLenum target, GCGLExternalImage image)
+{
+    if (!makeContextCurrent())
+        return;
+
+    EGLImage eglImage = EGL_NO_IMAGE_KHR;
+    if (image) {
+        eglImage = m_eglImages.get(image);
+        if (eglImage == EGL_NO_IMAGE_KHR) {
+            addError(GCGLErrorCode::InvalidOperation);
+            return;
+        }
+    }
+
+    if (target == RENDERBUFFER)
+        GL_EGLImageTargetRenderbufferStorageOES(RENDERBUFFER, eglImage);
+    else
+        GL_EGLImageTargetTexture2DOES(target, eglImage);
+}
+
+bool GraphicsContextGLTextureMapperAndroid::enableRequiredWebXRExtensions()
+{
+    if (!makeContextCurrent())
+        return false;
+
+    return enableExtension("GL_OES_EGL_image"_s)
+        && enableExtension("GL_OES_EGL_image_external"_s)
+        && enableExtension("EGL_KHR_image_base"_s)
+        && enableExtension("EGL_KHR_surfaceless_context"_s)
+        && enableExtension("EGL_ANDROID_get_native_client_buffer"_s)
+        && enableExtension("EGL_ANDROID_image_native_buffer"_s);
+}
+#endif // ENABLE(WEBXR)
+
+} // namespace WebCore
+
+#endif // ENABLE(WEBGL) && USE(COORDINATED_GRAPHICS) && OS(ANDROID)

--- a/Source/WebCore/platform/graphics/android/GraphicsContextGLTextureMapperAndroid.h
+++ b/Source/WebCore/platform/graphics/android/GraphicsContextGLTextureMapperAndroid.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2025 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#pragma once
+
+#if ENABLE(WEBGL) && USE(COORDINATED_GRAPHICS) && OS(ANDROID)
+#include "GraphicsContextGLTextureMapperANGLE.h"
+#include <wtf/android/RefPtrAndroid.h>
+
+namespace WebCore {
+
+class GraphicsContextGLTextureMapperAndroid final : public GraphicsContextGLTextureMapperANGLE {
+public:
+    static RefPtr<GraphicsContextGLTextureMapperAndroid> create(GraphicsContextGLAttributes&&);
+
+#if ENABLE(WEBXR)
+    GCGLExternalImage createExternalImage(ExternalImageSource&&, GCGLenum internalFormat, GCGLint layer) final;
+    void bindExternalImage(GCGLenum target, GCGLExternalImage) final;
+    bool enableRequiredWebXRExtensions() final;
+#endif // ENABLE(WEBXR)
+
+private:
+    explicit GraphicsContextGLTextureMapperAndroid(GraphicsContextGLAttributes&& attributes)
+        : GraphicsContextGLTextureMapperANGLE(WTFMove(attributes))
+    {
+    }
+
+    bool platformInitializeExtensions() override;
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(WEBGL) && USE(COORDINATED_GRAPHICS) && OS(ANDROID)

--- a/Source/WebCore/platform/graphics/egl/GLDisplay.cpp
+++ b/Source/WebCore/platform/graphics/egl/GLDisplay.cpp
@@ -85,6 +85,11 @@ GLDisplay::GLDisplay(EGLDisplay eglDisplay)
     m_extensions.EXT_image_dma_buf_import = findExtension("EGL_EXT_image_dma_buf_import"_s);
     m_extensions.EXT_image_dma_buf_import_modifiers = findExtension("EGL_EXT_image_dma_buf_import_modifiers"_s);
     m_extensions.MESA_image_dma_buf_export = findExtension("EGL_MESA_image_dma_buf_export"_s);
+
+#if OS(ANDROID)
+    m_extensions.ANDROID_get_native_client_buffer = findExtension("EGL_ANDROID_get_native_client_buffer"_s);
+    m_extensions.ANDROID_image_native_buffer = findExtension("EGL_ANDROID_image_native_buffer"_s);
+#endif
 }
 
 void GLDisplay::terminate()

--- a/Source/WebCore/platform/graphics/egl/GLDisplay.h
+++ b/Source/WebCore/platform/graphics/egl/GLDisplay.h
@@ -60,6 +60,10 @@ public:
         bool EXT_image_dma_buf_import_modifiers { false };
         bool MESA_image_dma_buf_export { false };
         bool ANDROID_native_fence_sync { false };
+#if OS(ANDROID)
+        bool ANDROID_get_native_client_buffer { false };
+        bool ANDROID_image_native_buffer { false };
+#endif
     };
     const Extensions& extensions() const { return m_extensions; }
 

--- a/Source/WebCore/platform/xr/PlatformXR.h
+++ b/Source/WebCore/platform/xr/PlatformXR.h
@@ -38,6 +38,10 @@
 #include <wtf/unix/UnixFileDescriptor.h>
 #endif
 
+#if OS(ANDROID)
+#include <wtf/android/RefPtrAndroid.h>
+#endif
+
 #if PLATFORM(COCOA)
 #include <WebCore/IOSurface.h>
 #include <WebCore/XRGPUProjectionLayerInit.h>
@@ -301,6 +305,9 @@ struct FrameData {
 #endif
     };
 
+#if OS(ANDROID)
+    using ExternalTexture = RefPtr<AHardwareBuffer>;
+#else
     struct ExternalTexture {
 #if PLATFORM(COCOA)
         MachSendRight handle;
@@ -311,8 +318,11 @@ struct FrameData {
         Vector<uint32_t> offsets;
         uint32_t fourcc;
         uint64_t modifier;
+
+        explicit operator bool() const { return !fds.isEmpty(); }
 #endif
     };
+#endif
 
     struct ExternalTextureData {
         uint64_t reusableTextureIndex = 0;

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -8935,11 +8935,15 @@ using WebCore::GraphicsContextGL::ExternalSyncSource = std::tuple<MachSendRight,
 #if (PLATFORM(GTK) || PLATFORM(WPE))
 header: <WebCore/GraphicsContextGL.h>
 [CustomHeader] struct WebCore::GraphicsContextGLExternalImageSource {
+#if OS(ANDROID)
+    RefPtr<AHardwareBuffer> hardwareBuffer;
+#else
     Vector<WTF::UnixFileDescriptor> fds;
     Vector<uint32_t> strides;
     Vector<uint32_t> offsets;
     uint32_t fourcc;
     uint64_t modifier;
+#endif
     WebCore::IntSize size;
 };
 using WebCore::GraphicsContextGL::ExternalImageSource = WebCore::GraphicsContextGLExternalImageSource;

--- a/Source/WebKit/Shared/XR/PlatformXR.serialization.in
+++ b/Source/WebKit/Shared/XR/PlatformXR.serialization.in
@@ -129,6 +129,7 @@ header: <WebCore/PlatformXR.h>
 #endif
 };
 
+#if !OS(ANDROID)
 [Nested, RValue] struct PlatformXR::FrameData::ExternalTexture {
 #if PLATFORM(COCOA)
     MachSendRight handle;
@@ -142,6 +143,7 @@ header: <WebCore/PlatformXR.h>
     uint64_t modifier;
 #endif
 };
+#endif // !OS(ANDROID)
 
 [Nested, RValue] struct PlatformXR::FrameData::ExternalTextureData {
     uint64_t reusableTextureIndex;

--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRExtensions.cpp
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRExtensions.cpp
@@ -29,7 +29,6 @@
 #else
 #include <EGL/egl.h>
 #endif
-#include <openxr/openxr_platform.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/WTFString.h>

--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRExtensions.h
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRExtensions.h
@@ -30,6 +30,12 @@ typedef unsigned EGLenum;
 #if defined(XR_USE_PLATFORM_EGL)
 typedef void (*(*PFNEGLGETPROCADDRESSPROC)(const char *))(void);
 #endif
+
+// The JNI types need to be defined before including openxr_platform.h
+#if OS(ANDROID)
+#include <jni.h>
+#endif
+
 #include <openxr/openxr_platform.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/TZoneMalloc.h>

--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRLayer.cpp
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRLayer.cpp
@@ -30,9 +30,14 @@
 #include <WebCore/FourCC.h>
 #include <WebCore/GLContext.h>
 #include <WebCore/GLDisplay.h>
+#include <wtf/SafeStrerror.h>
 #include <wtf/Scope.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/unix/UnixFileDescriptor.h>
+
+#if OS(ANDROID)
+#include <android/hardware_buffer.h>
+#endif
 
 #if USE(GBM)
 #include <WebCore/GBMDevice.h>
@@ -63,6 +68,92 @@ OpenXRLayer::~OpenXRLayer()
 #endif
 }
 
+#if OS(ANDROID)
+std::optional<PlatformXR::FrameData::ExternalTexture> OpenXRLayer::exportOpenXRTextureAndroid(WebCore::GLDisplay& display, PlatformGLObject openxrTexture)
+{
+    static constexpr auto kHardwareBufferUsage = AHARDWAREBUFFER_USAGE_GPU_FRAMEBUFFER | AHARDWAREBUFFER_USAGE_GPU_SAMPLED_IMAGE;
+
+    RefPtr<AHardwareBuffer> hardwareBuffer;
+    {
+        RELEASE_ASSERT(m_swapchain->width() > 0);
+        RELEASE_ASSERT(m_swapchain->height() > 0);
+
+        AHardwareBuffer_Desc bufferDesc = { };
+        bufferDesc.width = static_cast<uint32_t>(m_swapchain->width());
+        bufferDesc.height = static_cast<uint32_t>(m_swapchain->height());
+        bufferDesc.usage = kHardwareBufferUsage;
+        bufferDesc.layers = 1;
+
+        switch (m_swapchain->format()) {
+        case GL_RGBA8:
+            bufferDesc.format = AHARDWAREBUFFER_FORMAT_R8G8B8A8_UNORM;
+            break;
+        case GL_RGB8:
+            bufferDesc.format = AHARDWAREBUFFER_FORMAT_R8G8B8X8_UNORM;
+            if (!AHardwareBuffer_isSupported(&bufferDesc))
+                bufferDesc.format = AHARDWAREBUFFER_FORMAT_R8G8B8_UNORM;
+            break;
+        case GL_RGB565:
+            bufferDesc.format = AHARDWAREBUFFER_FORMAT_R5G6B5_UNORM;
+            break;
+        case GL_RGBA16F:
+            bufferDesc.format = AHARDWAREBUFFER_FORMAT_R16G16B16A16_FLOAT;
+            break;
+        case GL_RGB10_A2:
+            bufferDesc.format = AHARDWAREBUFFER_FORMAT_R10G10B10A2_UNORM;
+            break;
+        }
+
+        if (!bufferDesc.format || !AHardwareBuffer_isSupported(&bufferDesc)) {
+            RELEASE_LOG_INFO(XR, "AHardwareBuffer format %#" PRIX32 " not supported, using"
+                " RGBA8888 fallback that may result in slow blits", bufferDesc.format);
+            bufferDesc.format = AHARDWAREBUFFER_FORMAT_R8G8B8A8_UNORM;
+        }
+
+        AHardwareBuffer* buffer { nullptr };
+        if (auto error = AHardwareBuffer_allocate(&bufferDesc, &buffer)) {
+            if (error < 0)
+                RELEASE_LOG_ERROR(XR, "Failed to allocate AHardwareBuffer for OpenXR texture: %s", safeStrerror(-error).data());
+            else
+                RELEASE_LOG_ERROR(XR, "Failed to allocate AHardwareBuffer for OpenXR texture: %" PRIi32, error);
+            return { };
+        }
+        hardwareBuffer = adoptRef(buffer);
+    }
+
+    static PFNEGLGETNATIVECLIENTBUFFERANDROIDPROC s_eglGetNativeClientBufferANDROID { nullptr };
+    if (!s_eglGetNativeClientBufferANDROID) [[unlikely]] {
+        s_eglGetNativeClientBufferANDROID = reinterpret_cast<PFNEGLGETNATIVECLIENTBUFFERANDROIDPROC>(eglGetProcAddress("eglGetNativeClientBufferANDROID"));
+        RELEASE_ASSERT(s_eglGetNativeClientBufferANDROID);
+    }
+
+    static const Vector<EGLAttrib> attributes = { EGL_IMAGE_PRESERVED, EGL_TRUE, EGL_NONE };
+    auto clientBuffer = s_eglGetNativeClientBufferANDROID(hardwareBuffer.get());
+    auto image = display.createImage(EGL_NO_CONTEXT, EGL_NATIVE_BUFFER_ANDROID, clientBuffer, attributes);
+    if (image == EGL_NO_IMAGE_KHR) {
+        RELEASE_LOG(XR, "Failed to create EGL image for OpenXR texture (%#06x)", eglGetError());
+        return { };
+    }
+
+    GLint boundTexture = 0;
+    glGetIntegerv(GL_TEXTURE_BINDING_2D, &boundTexture);
+    PlatformGLObject exportedTexture;
+    glGenTextures(1, &exportedTexture);
+    glBindTexture(GL_TEXTURE_2D, exportedTexture);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+    glEGLImageTargetTexture2DOES(GL_TEXTURE_2D, image);
+    glBindTexture(GL_TEXTURE_2D, boundTexture);
+
+    display.destroyImage(image);
+
+    m_exportedTexturesMap.add(openxrTexture, exportedTexture);
+
+    return hardwareBuffer;
+}
+#else
 std::optional<PlatformXR::FrameData::ExternalTexture> OpenXRLayer::exportOpenXRTextureDMABuf(WebCore::GLDisplay& display, WebCore::GLContext& context, PlatformGLObject openxrTexture)
 {
     // Texture must be bound to be exported.
@@ -121,6 +212,7 @@ std::optional<PlatformXR::FrameData::ExternalTexture> OpenXRLayer::exportOpenXRT
         .modifier = modifier,
     };
 }
+#endif // !OS(ANDROID)
 
 #if USE(GBM)
 void OpenXRLayer::setGBMDevice(RefPtr<WebCore::GBMDevice> gbmDevice)
@@ -229,7 +321,9 @@ std::optional<PlatformXR::FrameData::ExternalTexture> OpenXRLayer::exportOpenXRT
         .modifier = modifier
     };
 }
+#endif // USE(GBM)
 
+#if USE(GBM) || OS(ANDROID)
 void OpenXRLayer::blitTexture() const
 {
     auto openxrTexture = m_swapchain->acquiredTexture();
@@ -249,7 +343,7 @@ void OpenXRLayer::blitTexture() const
     glBlitFramebuffer(0, 0, width, height, 0, 0, width, height, GL_COLOR_BUFFER_BIT, GL_NEAREST);
     glBindFramebuffer(GL_FRAMEBUFFER, 0);
 }
-#endif
+#endif // USE(GBM) || OS(ANDROID)
 
 std::optional<PlatformXR::FrameData::ExternalTexture> OpenXRLayer::exportOpenXRTexture(PlatformGLObject openxrTexture)
 {
@@ -259,8 +353,12 @@ std::optional<PlatformXR::FrameData::ExternalTexture> OpenXRLayer::exportOpenXRT
     auto display = glContext->display();
     ASSERT(display);
 
+#if OS(ANDROID)
+    return exportOpenXRTextureAndroid(*display, openxrTexture);
+#else
     if (display->extensions().MESA_image_dma_buf_export)
         return exportOpenXRTextureDMABuf(*display, *glContext, openxrTexture);
+#endif
 
 #if USE(GBM)
     if (m_gbmDevice)
@@ -325,8 +423,8 @@ std::optional<PlatformXR::FrameData::LayerData> OpenXRLayerProjection::startFram
 
 XrCompositionLayerBaseHeader* OpenXRLayerProjection::endFrame(const XRDeviceLayer& layer, XrSpace space, const Vector<XrView>& frameViews)
 {
-#if USE(GBM)
-    if (m_gbmDevice) {
+#if OS(ANDROID) || USE(GBM)
+    if (needsBlitTexture()) {
         if (!m_fbosForBlitting[0])
             glGenFramebuffers(2, m_fbosForBlitting);
         blitTexture();

--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRLayer.h
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRLayer.h
@@ -55,10 +55,17 @@ public:
 
 protected:
     OpenXRLayer(UniqueRef<OpenXRSwapchain>&&);
+#if OS(ANDROID)
+    std::optional<PlatformXR::FrameData::ExternalTexture> exportOpenXRTextureAndroid(WebCore::GLDisplay&, PlatformGLObject);
+    void blitTexture() const;
+    inline bool needsBlitTexture() const { return true; }
+#else
     std::optional<PlatformXR::FrameData::ExternalTexture> exportOpenXRTextureDMABuf(WebCore::GLDisplay&, WebCore::GLContext&, PlatformGLObject);
+#endif
 #if USE(GBM)
     std::optional<PlatformXR::FrameData::ExternalTexture> exportOpenXRTextureGBM(WebCore::GLDisplay&, PlatformGLObject);
     void blitTexture() const;
+    inline bool needsBlitTexture() const { return m_gbmDevice; }
 #endif
     std::optional<PlatformXR::FrameData::ExternalTexture> exportOpenXRTexture(PlatformGLObject);
 
@@ -68,10 +75,13 @@ protected:
     using ReusableTextureIndex = uint64_t;
     HashMap<PlatformGLObject, ReusableTextureIndex> m_exportedTextures;
     ReusableTextureIndex m_nextReusableTextureIndex { 0 };
-#if USE(GBM)
-    RefPtr<WebCore::GBMDevice> m_gbmDevice;
+
+#if USE(GBM) || OS(ANDROID)
     HashMap<PlatformGLObject, PlatformGLObject> m_exportedTexturesMap;
     PlatformGLObject m_fbosForBlitting[2] { 0, 0 };
+#endif
+#if USE(GBM)
+    RefPtr<WebCore::GBMDevice> m_gbmDevice;
 #endif
 };
 

--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRSwapchain.h
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRSwapchain.h
@@ -24,13 +24,21 @@
 #include "OpenXRUtils.h"
 #include <WebCore/GraphicsTypesGL.h>
 #include <WebCore/IntSize.h>
+
 typedef void* EGLDisplay;
 typedef void* EGLContext;
 typedef void* EGLConfig;
 typedef unsigned EGLenum;
+
 #if defined(XR_USE_PLATFORM_EGL)
 typedef void (*(*PFNEGLGETPROCADDRESSPROC)(const char *))(void);
 #endif
+
+// The JNI types need to be defined before including openxr_platform.h
+#if OS(ANDROID)
+#include <jni.h>
+#endif
+
 #include <openxr/openxr_platform.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/TZoneMalloc.h>

--- a/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.cpp
+++ b/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.cpp
@@ -38,7 +38,6 @@
 #include <WebCore/GLContext.h>
 #include <WebCore/GLDisplay.h>
 #include <WebCore/GLFence.h>
-#include <openxr/openxr_platform.h>
 #include <wtf/RunLoop.h>
 #include <wtf/WorkQueue.h>
 
@@ -46,6 +45,13 @@
 #include "DRMMainDevice.h"
 #include <WebCore/DRMDevice.h>
 #include <WebCore/GBMDevice.h>
+#endif
+
+#if OS(ANDROID)
+#include <dlfcn.h>
+using WPEAndroidRuntimeGetJavaVMFunction = JavaVM* (*)();
+using WPEAndroidRuntimeGetActivityFunction = jobject (*)();
+#undef jobject
 #endif
 
 namespace WebKit {
@@ -339,7 +345,7 @@ void OpenXRCoordinator::createInstance()
     ASSERT(RunLoop::isMain());
     ASSERT(m_instance == XR_NULL_HANDLE);
 
-    Vector<char *, 2> extensions;
+    Vector<char *> extensions;
 #if defined(XR_USE_PLATFORM_EGL)
     if (OpenXRExtensions::singleton().isExtensionSupported(XR_MNDX_EGL_ENABLE_EXTENSION_NAME ""_span))
         extensions.append(const_cast<char*>(XR_MNDX_EGL_ENABLE_EXTENSION_NAME));
@@ -355,12 +361,36 @@ void OpenXRCoordinator::createInstance()
     if (OpenXRExtensions::singleton().isExtensionSupported(XR_EXT_HAND_TRACKING_EXTENSION_NAME ""_span))
         extensions.append(const_cast<char*>(XR_EXT_HAND_TRACKING_EXTENSION_NAME));
 #endif
+#if OS(ANDROID)
+    extensions.append(const_cast<char*>(XR_KHR_ANDROID_CREATE_INSTANCE_EXTENSION_NAME));
+#endif
 
     XrInstanceCreateInfo createInfo = createOpenXRStruct<XrInstanceCreateInfo, XR_TYPE_INSTANCE_CREATE_INFO >();
     createInfo.applicationInfo = { "WebKit", 1, "WebKit", 1, XR_CURRENT_API_VERSION };
     createInfo.enabledApiLayerCount = 0;
     createInfo.enabledExtensionCount = static_cast<uint32_t>(extensions.size());
     createInfo.enabledExtensionNames = extensions.mutableSpan().data();
+
+#if OS(ANDROID)
+    static WPEAndroidRuntimeGetJavaVMFunction s_wpeAndroidRuntimeGetJavaVM =
+        reinterpret_cast<WPEAndroidRuntimeGetJavaVMFunction>(dlsym(RTLD_DEFAULT, "wpe_android_runtime_get_current_java_vm"));
+    if (!s_wpeAndroidRuntimeGetJavaVM) [[unlikely]] {
+        RELEASE_LOG_ERROR(XR, "Cannot resolve wpe_android_runtime_get_current_java_vm(): %s.", dlerror());
+        return;
+    }
+
+    static WPEAndroidRuntimeGetActivityFunction s_wpeAndroidRuntimeGetActivity =
+        reinterpret_cast<WPEAndroidRuntimeGetActivityFunction>(dlsym(RTLD_DEFAULT, "wpe_android_runtime_get_current_activity"));
+    if (!s_wpeAndroidRuntimeGetActivity) [[unlikely]] {
+        RELEASE_LOG_ERROR(XR, "Cannot resolve wpe_android_runtime_get_current_activity(): %s.", dlerror());
+        return;
+    }
+
+    auto java = createOpenXRStruct<XrInstanceCreateInfoAndroidKHR, XR_TYPE_INSTANCE_CREATE_INFO_ANDROID_KHR>();
+    java.applicationVM = s_wpeAndroidRuntimeGetJavaVM();
+    java.applicationActivity = s_wpeAndroidRuntimeGetActivity();
+    createInfo.next = reinterpret_cast<XrBaseInStructure*>(&java);
+#endif
 
     CHECK_XRCMD(xrCreateInstance(&createInfo, &m_instance));
 }
@@ -380,6 +410,17 @@ RefPtr<WebCore::GLDisplay> OpenXRCoordinator::createGLDisplay() const
     };
 
     RefPtr<WebCore::GLDisplay> glDisplay;
+
+#if OS(ANDROID)
+    if (WebCore::GLContext::isExtensionSupported(extensions, "EGL_KHR_platform_android")) {
+        glDisplay = tryCreateDisplay(EGL_PLATFORM_ANDROID_KHR, EGL_DEFAULT_DISPLAY);
+        if (!glDisplay)
+            glDisplay = WebCore::GLDisplay::create(eglGetDisplay(EGL_DEFAULT_DISPLAY));
+        if (glDisplay && !(glDisplay->extensions().ANDROID_get_native_client_buffer && glDisplay->extensions().ANDROID_image_native_buffer))
+            glDisplay = nullptr;
+    }
+#endif // OS(ANDROID)
+
     if (WebCore::GLContext::isExtensionSupported(extensions, "EGL_MESA_platform_surfaceless")) {
         glDisplay = tryCreateDisplay(EGL_PLATFORM_SURFACELESS_MESA, EGL_DEFAULT_DISPLAY);
         if (glDisplay && !glDisplay->extensions().MESA_image_dma_buf_export)
@@ -506,10 +547,12 @@ void OpenXRCoordinator::initializeBlendModes()
 
 void OpenXRCoordinator::tryInitializeGraphicsBinding()
 {
+#if !OS(ANDROID)
     if (!OpenXRExtensions::singleton().isExtensionSupported(XR_MNDX_EGL_ENABLE_EXTENSION_NAME ""_span)) {
         LOG(XR, "OpenXR MNDX_EGL_ENABLE extension is not supported.");
         return;
     }
+#endif
 
     if (!m_glContext) {
 #if USE(GBM)
@@ -524,11 +567,15 @@ void OpenXRCoordinator::tryInitializeGraphicsBinding()
         }
     }
 
+#if OS(ANDROID)
+    m_graphicsBinding = createOpenXRStruct<XrGraphicsBindingOpenGLESAndroidKHR, XR_TYPE_GRAPHICS_BINDING_OPENGL_ES_ANDROID_KHR>();
+#else
     m_graphicsBinding = createOpenXRStruct<XrGraphicsBindingEGLMNDX, XR_TYPE_GRAPHICS_BINDING_EGL_MNDX>();
+    m_graphicsBinding.getProcAddress = OpenXRExtensions::singleton().methods().getProcAddressFunc;
+#endif
     m_graphicsBinding.display = m_glDisplay->eglDisplay();
     m_graphicsBinding.context = m_glContext->platformContext();
     m_graphicsBinding.config = m_glContext->config();
-    m_graphicsBinding.getProcAddress = OpenXRExtensions::singleton().methods().getProcAddressFunc;
 }
 
 void OpenXRCoordinator::createSessionIfNeeded()

--- a/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.h
+++ b/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.h
@@ -112,7 +112,11 @@ private:
     Vector<XrView> m_views;
     HashMap<PlatformXR::LayerHandle, std::unique_ptr<OpenXRLayer>> m_layers;
     Vector<int64_t> m_supportedSwapchainFormats;
+#if OS(ANDROID)
+    XrGraphicsBindingOpenGLESAndroidKHR m_graphicsBinding;
+#else
     XrGraphicsBindingEGLMNDX m_graphicsBinding;
+#endif
     std::unique_ptr<WebCore::GLContext> m_glContext;
     XrSpace m_localSpace { XR_NULL_HANDLE };
     XrSpace m_floorSpace { XR_NULL_HANDLE };


### PR DESCRIPTION
#### f59489c669a20aededb0e299e54d3ed448424b9b
<pre>
[OpenXR] Use AHardwareBuffer for buffer sharing on Android
<a href="https://bugs.webkit.org/show_bug.cgi?id=298312">https://bugs.webkit.org/show_bug.cgi?id=298312</a>

Reviewed by Carlos Garcia Campos.

Add a new GraphicsContextGLTextureMapperAndroid class, which mostly
reuses the functionality from the GraphicsContextGLTextureMapperANGLE;
but adds its own implementation of methods used by the WebXR machinery
to use GCGLExternalImage instances backed by AHardwareBuffer that can be
shared with the rendering process (currently WebProcess, but could be
GPUProcess). Buffer sharing across processes uses the support added
in 299311@main.

It is not possible to extract the AHardwareBuffer backing an existing
texture provided by the OpenXR runtime as part of its swapchain (and
textures may not even use one), so instead new compatible buffers are
created where the actual rendering is done, and then the result blitted
onto the OpenXR-provided textures. This reuses the existing blitting
mechanism used as fallback when the MESA_image_dma_buf_export is not
available, which was introduced in introduced in 299044@main.

The last bit of the piece is handling XrInstanceCreateInfoAndroidKHR
during OpenXR initialization: the runtime needs to know which JavaVM
instance for the application, and the Activity from the Android UI
framework to associate with the XrInstance. To obtain these, the code
expects the following two functions to be defined and resolvable at
run time via dlsym(RTLD_DEFAULT, ...):

  JavaVM* wpe_android_runtime_get_current_java_vm()
  jobject wpe_android_runtime_get_current_activity()

The WPE-Android project has incorporated those in the following patch:

  <a href="https://github.com/Igalia/wpe-android/pull/214">https://github.com/Igalia/wpe-android/pull/214</a>

* Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp:
(WebCore::makeExternalImageSource):
(WebCore::WebXROpaqueFramebuffer::reusableDisplayAttachments const):
(WebCore::WebXROpaqueFramebuffer::bindCompositorTexturesForDisplay):
* Source/WebCore/PlatformWPE.cmake:
* Source/WebCore/SourcesWPE.txt:
* Source/WebCore/platform/graphics/GraphicsContextGL.h:
* Source/WebCore/platform/graphics/android/GraphicsContextGLTextureMapperAndroid.cpp: Added.
(WebCore::GraphicsContextGLTextureMapperAndroid::create):
(WebCore::GraphicsContextGLTextureMapperAndroid::platformInitializeExtensions):
(WebCore::GraphicsContextGLTextureMapperAndroid::createExternalImage):
(WebCore::GraphicsContextGLTextureMapperAndroid::bindExternalImage):
(WebCore::GraphicsContextGLTextureMapperAndroid::enableRequiredWebXRExtensions):
* Source/WebCore/platform/graphics/android/GraphicsContextGLTextureMapperAndroid.h: Added.
* Source/WebCore/platform/graphics/egl/GLDisplay.cpp:
(WebCore::GLDisplay::GLDisplay):
* Source/WebCore/platform/graphics/egl/GLDisplay.h:
* Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp:
(WebCore::createWebProcessGraphicsContextGL):
* Source/WebCore/platform/xr/PlatformXR.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/Shared/XR/PlatformXR.serialization.in:
* Source/WebKit/UIProcess/XR/openxr/OpenXRLayer.cpp:
(WebKit::OpenXRLayer::exportOpenXRTextureAndroid):
(WebKit::OpenXRLayer::exportOpenXRTexture):
(WebKit::OpenXRLayerProjection::endFrame):
* Source/WebKit/UIProcess/XR/openxr/OpenXRLayer.h:
(WebKit::OpenXRLayer::needsBlitTexture const):
* Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.cpp:
(WebKit::OpenXRCoordinator::createInstance):
(WebKit::OpenXRCoordinator::createGLDisplay const):
(WebKit::OpenXRCoordinator::tryInitializeGraphicsBinding):
* Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.h:

Canonical link: <a href="https://commits.webkit.org/300466@main">https://commits.webkit.org/300466@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9bbb2fb77663cac163c8358e657115d42c49e9f9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122652 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42364 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33054 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/129270 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74756 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/124528 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43083 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50957 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93223 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/61907 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125604 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34345 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109803 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73867 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33332 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27959 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72756 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104042 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28170 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131993 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49597 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37747 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/101756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49973 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106019 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/101621 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25805 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46986 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25154 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/46367 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49454 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/55207 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48921 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/52273 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50604 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->