### PR TITLE
[CSS] nesting selector & directly inside @scope behaves like :where(:scope)

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-invalidation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-invalidation-expected.txt
@@ -24,5 +24,5 @@ PASS :nth-child() in scope root
 PASS :nth-child() in scope limit
 PASS Modifying selectorText invalidates affected elements
 PASS Modifying selectorText invalidates affected elements (>)
-FAIL Relative selectors set with selectorText are relative to :scope and & assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
+PASS Relative selectors set with selectorText are relative to :scope and &
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-nesting-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-nesting-expected.txt
@@ -17,7 +17,7 @@ PASS :scope within nested and scoped rule (relative)
 PASS Scoped nested group rule
 PASS Scoped nested within another scope
 PASS Implicit (prelude-less) @scope as a nested group rule
-FAIL Insert a nested style rule within @scope, & assert_equals: expected "rgb(255, 0, 0)" but got "rgb(0, 128, 0)"
+PASS Insert a nested style rule within @scope, &
 PASS Insert a nested style rule within @scope, :scope
 PASS Insert a CSSNestedDeclarations rule directly in top-level @scope
 PASS Mutating selectorText on outer style rule causes correct inner specificity

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-specificity-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-specificity-expected.txt
@@ -4,7 +4,7 @@ PASS @scope (#main) to (.b) { .a {  } } and .a
 PASS @scope (#main, .foo, .bar) { #a {  } } and #a
 PASS @scope (#main) { div.b {  } } and div.b
 PASS @scope (#main) { :scope .b {  } } and .a .b
-FAIL @scope (#main) { & .b {  } } and :where(#main) .b assert_equals: unscoped + scoped expected "2" but got "1"
+PASS @scope (#main) { & .b {  } } and :where(#main) .b
 PASS @scope (#main) { div .b {  } } and div .b
 PASS @scope (#main) { @scope (.a) { .b {  } } } and .b
 PASS @scope (#main) { :scope .b {  } } and :scope .b

--- a/Source/WebCore/css/CSSSelector.h
+++ b/Source/WebCore/css/CSSSelector.h
@@ -75,7 +75,7 @@ public:
     bool hasExplicitPseudoClassScope() const;
     bool hasScope() const;
     void resolveNestingParentSelectors(const CSSSelectorList& parent);
-    void replaceNestingParentByPseudoClassScope();
+    void replaceNestingSelectorByWhereScope();
 
     using PseudoClass = CSSSelectorPseudoClass;
     using PseudoElement = CSSSelectorPseudoElement;

--- a/Source/WebCore/css/parser/CSSSelectorParser.h
+++ b/Source/WebCore/css/parser/CSSSelectorParser.h
@@ -61,7 +61,7 @@ public:
     WEBCORE_EXPORT static std::optional<CSSSelectorList> parseSelectorList(const String&, const CSSParserContext&, StyleSheetContents* = nullptr, CSSParserEnum::NestedContext = { });
 
     static bool supportsComplexSelector(CSSParserTokenRange, const CSSSelectorParserContext&);
-    static CSSSelectorList resolveNestingParent(const CSSSelectorList& nestedSelectorList, const CSSSelectorList* parentResolvedSelectorList);
+    static CSSSelectorList resolveNestingParent(const CSSSelectorList& nestedSelectorList, const CSSSelectorList* parentResolvedSelectorList, bool parentRuleIsScope = false);
     static std::pair<bool, std::optional<Style::PseudoElementIdentifier>> parsePseudoElement(const String&, const CSSSelectorParserContext&);
 
 private:

--- a/Source/WebCore/style/RuleSetBuilder.cpp
+++ b/Source/WebCore/style/RuleSetBuilder.cpp
@@ -279,9 +279,13 @@ void RuleSetBuilder::addRulesFromSheetContents(const StyleSheetContents& sheet)
 void RuleSetBuilder::resolveSelectorListWithNesting(StyleRuleWithNesting& rule)
 {
     const CSSSelectorList* parentResolvedSelectorList = nullptr;
-    if (m_selectorListStack.size())
+    bool parentIsScopeRule = false;
+    if (m_selectorListStack.size()) {
         parentResolvedSelectorList = m_selectorListStack.last();
-    auto resolvedSelectorList = CSSSelectorParser::resolveNestingParent(rule.originalSelectorList(), parentResolvedSelectorList);
+        parentIsScopeRule = m_ancestorStack.last() == CSSParserEnum::NestedContextType::Scope;
+    }
+
+    auto resolvedSelectorList = CSSSelectorParser::resolveNestingParent(rule.originalSelectorList(), parentResolvedSelectorList, parentIsScopeRule);
     rule.wrapperAdoptSelectorList(WTFMove(resolvedSelectorList));
 }
 


### PR DESCRIPTION
#### 4d5ebef83e17f6201e006f379de304fac6d196b4
<pre>
[CSS] nesting selector &amp; directly inside @scope behaves like :where(:scope)
<a href="https://bugs.webkit.org/show_bug.cgi?id=299017">https://bugs.webkit.org/show_bug.cgi?id=299017</a>
<a href="https://rdar.apple.com/160769736">rdar://160769736</a>

Reviewed by Antti Koivisto.

<a href="https://github.com/w3c/csswg-drafts/issues/9740">https://github.com/w3c/csswg-drafts/issues/9740</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-invalidation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-nesting-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-specificity-expected.txt:
* Source/WebCore/css/CSSSelector.cpp:
(WebCore::CSSSelector::replaceNestingSelectorByWhereScope):
(WebCore::CSSSelector::replaceNestingParentByPseudoClassScope): Deleted.
* Source/WebCore/css/CSSSelector.h:
* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::CSSSelectorParser::resolveNestingParent):
* Source/WebCore/css/parser/CSSSelectorParser.h:
* Source/WebCore/style/RuleSetBuilder.cpp:
(WebCore::Style::RuleSetBuilder::resolveSelectorListWithNesting):

Canonical link: <a href="https://commits.webkit.org/300153@main">https://commits.webkit.org/300153@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7a426ec579cb7b7b3f98eafcd0bd2cfa3046752a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121324 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41021 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31680 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127763 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73405 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/76480c75-984c-4065-856d-7d851bc0a71f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123200 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41723 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49600 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92161 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61319 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9cba5eb5-b88e-46f9-8d92-f2671f2f062c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124276 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33314 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108718 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72837 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5b4204a2-dba6-4d5f-9360-8f4d923146df) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32333 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26846 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71343 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102814 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27022 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130598 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48252 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36682 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100757 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48620 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104907 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100662 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25555 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46070 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24130 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44946 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48110 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53823 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47582 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50928 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49264 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->