### PR TITLE
[JSC] Introduce WasmInstanceAnchor

### DIFF
--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -1400,7 +1400,7 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
 
     wasm/WasmBaselineData.h
     wasm/WasmBranchHints.h
-    wasm/WasmCallSlot.h
+    wasm/WasmCallProfile.h
     wasm/WasmCallee.h
     wasm/WasmCalleeGroup.h
     wasm/WasmCallingConvention.h
@@ -1414,8 +1414,9 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     wasm/WasmFunctionIPIntMetadataGenerator.h
     wasm/WasmHandlerInfo.h
     wasm/WasmIPIntGenerator.h
-    wasm/WasmIndexOrName.h
     wasm/WasmIPIntTierUpCounter.h
+    wasm/WasmIndexOrName.h
+    wasm/WasmInstanceAnchor.h
     wasm/WasmJS.h
     wasm/WasmLimits.h
     wasm/WasmMemory.h
@@ -1428,7 +1429,6 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     wasm/WasmOpcodeOrigin.h
     wasm/WasmParser.h
     wasm/WasmPlan.h
-    wasm/WasmProfileCollection.h
     wasm/WasmSIMDOpcodes.h
     wasm/WasmSections.h
     wasm/WasmSIMDOpcodes.h

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -1994,6 +1994,7 @@
 		E33637A61B63220200EE0840 /* ReflectObject.h in Headers */ = {isa = PBXBuildFile; fileRef = E33637A41B63220200EE0840 /* ReflectObject.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E3369129296EEBFE00324FD7 /* WasmOperationsInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = E3369128296EEBFE00324FD7 /* WasmOperationsInlines.h */; };
 		E337B967224324EA0093A820 /* WasmCapabilities.h in Headers */ = {isa = PBXBuildFile; fileRef = E337B966224324E50093A820 /* WasmCapabilities.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		E338C4A92E7B23D500C039A5 /* WasmInstanceAnchor.h in Headers */ = {isa = PBXBuildFile; fileRef = E338C4A62E7B23D500C039A5 /* WasmInstanceAnchor.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E339700523210E0B00B0AE21 /* JSInternalFieldObjectImplInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = E339700423210E0A00B0AE21 /* JSInternalFieldObjectImplInlines.h */; };
 		E33A94962255323000D42B06 /* RandomizingFuzzerAgent.h in Headers */ = {isa = PBXBuildFile; fileRef = E33A94942255322900D42B06 /* RandomizingFuzzerAgent.h */; };
 		E33A94972255323300D42B06 /* FuzzerAgent.h in Headers */ = {isa = PBXBuildFile; fileRef = E33A94922255322900D42B06 /* FuzzerAgent.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -2040,7 +2041,6 @@
 		E378DC8D2727629400427B0B /* IntlNumberFormat.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A1D792F61B43864B004516F5 /* IntlNumberFormat.cpp */; };
 		E379006628F8F4E100206FD8 /* DFGValidateUnlinked.h in Headers */ = {isa = PBXBuildFile; fileRef = E379006428F8F4E100206FD8 /* DFGValidateUnlinked.h */; };
 		E3794E761B77EB97005543AE /* ModuleAnalyzer.h in Headers */ = {isa = PBXBuildFile; fileRef = E3794E741B77EB97005543AE /* ModuleAnalyzer.h */; };
-		E37986372E6FA60E008B5EA6 /* WasmProfileCollection.h in Headers */ = {isa = PBXBuildFile; fileRef = E37986352E6FA60E008B5EA6 /* WasmProfileCollection.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E379B59029834EC5007C4C0E /* SIMDShuffle.h in Headers */ = {isa = PBXBuildFile; fileRef = E379B58F29834EC5007C4C0E /* SIMDShuffle.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E37F44C72A13088000E56D8D /* KeyAtomStringCacheInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = E37F44C52A13088000E56D8D /* KeyAtomStringCacheInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E37F44C82A13088000E56D8D /* KeyAtomStringCache.h in Headers */ = {isa = PBXBuildFile; fileRef = E37F44C62A13088000E56D8D /* KeyAtomStringCache.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -2052,7 +2052,7 @@
 		E386FD7E26E867B800E4C28B /* TemporalPlainTime.h in Headers */ = {isa = PBXBuildFile; fileRef = E386FD7826E867B800E4C28B /* TemporalPlainTime.h */; };
 		E386FD7F26E867B800E4C28B /* TemporalPlainTimePrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = E386FD7926E867B800E4C28B /* TemporalPlainTimePrototype.h */; };
 		E389D854291226BC0085C3DC /* PageCount.h in Headers */ = {isa = PBXBuildFile; fileRef = E389D852291226BC0085C3DC /* PageCount.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		E38CA06F2E614C0C00041A0C /* WasmCallSlot.h in Headers */ = {isa = PBXBuildFile; fileRef = E38CA06E2E614C0C00041A0C /* WasmCallSlot.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		E38CA06F2E614C0C00041A0C /* WasmCallProfile.h in Headers */ = {isa = PBXBuildFile; fileRef = E38CA06E2E614C0C00041A0C /* WasmCallProfile.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E38DAB532A95D23A0050B7A8 /* PerfLog.h in Headers */ = {isa = PBXBuildFile; fileRef = E38DAB512A95D23A0050B7A8 /* PerfLog.h */; };
 		E38DB2E727F588F80027BD3F /* ScriptExecutableInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = E38DB2E627F588F70027BD3F /* ScriptExecutableInlines.h */; };
 		E38DE55C2C4A11C700EF7055 /* CharacterPropertyDataGenerator.h in Headers */ = {isa = PBXBuildFile; fileRef = E38DE55A2C4A11AD00EF7055 /* CharacterPropertyDataGenerator.h */; };
@@ -5747,6 +5747,8 @@
 		E33637A41B63220200EE0840 /* ReflectObject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ReflectObject.h; sourceTree = "<group>"; };
 		E3369128296EEBFE00324FD7 /* WasmOperationsInlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WasmOperationsInlines.h; sourceTree = "<group>"; };
 		E337B966224324E50093A820 /* WasmCapabilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WasmCapabilities.h; sourceTree = "<group>"; };
+		E338C4A62E7B23D500C039A5 /* WasmInstanceAnchor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WasmInstanceAnchor.h; sourceTree = "<group>"; };
+		E338C4A72E7B23D500C039A5 /* WasmInstanceAnchor.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WasmInstanceAnchor.cpp; sourceTree = "<group>"; };
 		E339700423210E0A00B0AE21 /* JSInternalFieldObjectImplInlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSInternalFieldObjectImplInlines.h; sourceTree = "<group>"; };
 		E33A94922255322900D42B06 /* FuzzerAgent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FuzzerAgent.h; sourceTree = "<group>"; };
 		E33A94932255322900D42B06 /* RandomizingFuzzerAgent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RandomizingFuzzerAgent.cpp; sourceTree = "<group>"; };
@@ -5820,8 +5822,6 @@
 		E379006428F8F4E100206FD8 /* DFGValidateUnlinked.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DFGValidateUnlinked.h; path = dfg/DFGValidateUnlinked.h; sourceTree = "<group>"; };
 		E3794E731B77EB97005543AE /* ModuleAnalyzer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ModuleAnalyzer.cpp; sourceTree = "<group>"; };
 		E3794E741B77EB97005543AE /* ModuleAnalyzer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ModuleAnalyzer.h; sourceTree = "<group>"; };
-		E37986352E6FA60E008B5EA6 /* WasmProfileCollection.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WasmProfileCollection.h; sourceTree = "<group>"; };
-		E37986362E6FA60E008B5EA6 /* WasmProfileCollection.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WasmProfileCollection.cpp; sourceTree = "<group>"; };
 		E379B58F29834EC5007C4C0E /* SIMDShuffle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SIMDShuffle.h; sourceTree = "<group>"; };
 		E37CFB2D22F27C57009A7B38 /* WasmCompilationMode.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WasmCompilationMode.cpp; sourceTree = "<group>"; };
 		E37F44C52A13088000E56D8D /* KeyAtomStringCacheInlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KeyAtomStringCacheInlines.h; sourceTree = "<group>"; };
@@ -5842,7 +5842,7 @@
 		E3893A1C2203A7C600E79A74 /* AsyncFromSyncIteratorPrototype.lut.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AsyncFromSyncIteratorPrototype.lut.h; sourceTree = "<group>"; };
 		E389D851291226BC0085C3DC /* PageCount.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PageCount.cpp; sourceTree = "<group>"; };
 		E389D852291226BC0085C3DC /* PageCount.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PageCount.h; sourceTree = "<group>"; };
-		E38CA06E2E614C0C00041A0C /* WasmCallSlot.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WasmCallSlot.h; sourceTree = "<group>"; };
+		E38CA06E2E614C0C00041A0C /* WasmCallProfile.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WasmCallProfile.h; sourceTree = "<group>"; };
 		E38D060B1F8E814100649CF2 /* JSScriptFetchParameters.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSScriptFetchParameters.h; sourceTree = "<group>"; };
 		E38D060C1F8E814100649CF2 /* ScriptFetchParameters.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ScriptFetchParameters.h; sourceTree = "<group>"; };
 		E38D060D1F8E814100649CF2 /* JSScriptFetchParameters.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSScriptFetchParameters.cpp; sourceTree = "<group>"; };
@@ -7938,7 +7938,7 @@
 				526AC4B51E977C5D003500E1 /* WasmCalleeGroup.h */,
 				53FD04D11D7AB187003287D3 /* WasmCallingConvention.cpp */,
 				53FD04D21D7AB187003287D3 /* WasmCallingConvention.h */,
-				E38CA06E2E614C0C00041A0C /* WasmCallSlot.h */,
+				E38CA06E2E614C0C00041A0C /* WasmCallProfile.h */,
 				E337B966224324E50093A820 /* WasmCapabilities.h */,
 				E32D51A52C6D0FD600B013D1 /* WasmCompilationContext.h */,
 				E37CFB2D22F27C57009A7B38 /* WasmCompilationMode.cpp */,
@@ -7964,6 +7964,8 @@
 				148521D726EAEBFE00CC1D1A /* WasmHandlerInfo.h */,
 				AD8FF3961EB5BD850087FF82 /* WasmIndexOrName.cpp */,
 				AD8FF3951EB5BD850087FF82 /* WasmIndexOrName.h */,
+				E338C4A72E7B23D500C039A5 /* WasmInstanceAnchor.cpp */,
+				E338C4A62E7B23D500C039A5 /* WasmInstanceAnchor.h */,
 				F3D9C2382A426CB7006EE152 /* WasmIPIntGenerator.cpp */,
 				F3D9C2352A426CB7006EE152 /* WasmIPIntGenerator.h */,
 				F3D9C2362A426CB7006EE152 /* WasmIPIntPlan.cpp */,
@@ -8007,8 +8009,6 @@
 				53F40E8C1D5901F20099A1B6 /* WasmParser.h */,
 				531374BE1D5CE95000AF7A0B /* WasmPlan.cpp */,
 				531374BC1D5CE67600AF7A0B /* WasmPlan.h */,
-				E37986362E6FA60E008B5EA6 /* WasmProfileCollection.cpp */,
-				E37986352E6FA60E008B5EA6 /* WasmProfileCollection.h */,
 				E3A0531721342B660022EC14 /* WasmSectionParser.cpp */,
 				E3A0531821342B670022EC14 /* WasmSectionParser.h */,
 				53F40E841D58F9770099A1B6 /* WasmSections.h */,
@@ -12116,7 +12116,7 @@
 				525C0DDA1E935847002184CD /* WasmCallee.h in Headers */,
 				526AC4B71E977C5D003500E1 /* WasmCalleeGroup.h in Headers */,
 				53FD04D41D7AB291003287D3 /* WasmCallingConvention.h in Headers */,
-				E38CA06F2E614C0C00041A0C /* WasmCallSlot.h in Headers */,
+				E38CA06F2E614C0C00041A0C /* WasmCallProfile.h in Headers */,
 				E337B967224324EA0093A820 /* WasmCapabilities.h in Headers */,
 				E32D51AF2C6D0FF200B013D1 /* WasmCompilationContext.h in Headers */,
 				E3BD2B7622F275020011765C /* WasmCompilationMode.h in Headers */,
@@ -12132,6 +12132,7 @@
 				E383500A2390D93B0036316D /* WasmGlobal.h in Headers */,
 				148521D826EAEBFE00CC1D1A /* WasmHandlerInfo.h in Headers */,
 				AD8FF3981EB5BDB20087FF82 /* WasmIndexOrName.h in Headers */,
+				E338C4A92E7B23D500C039A5 /* WasmInstanceAnchor.h in Headers */,
 				F3D9C2392A426CB8006EE152 /* WasmIPIntGenerator.h in Headers */,
 				F3D9C23B2A426CB8006EE152 /* WasmIPIntPlan.h in Headers */,
 				53091F9A2ABE1F570076CBC4 /* WasmIPIntSlowPaths.h in Headers */,
@@ -12159,7 +12160,6 @@
 				527E6CEC2772B9CB005E0782 /* WasmOSREntryPlan.h in Headers */,
 				53F40E8D1D5901F20099A1B6 /* WasmParser.h in Headers */,
 				531374BD1D5CE67600AF7A0B /* WasmPlan.h in Headers */,
-				E37986372E6FA60E008B5EA6 /* WasmProfileCollection.h in Headers */,
 				E3A0531C21342B680022EC14 /* WasmSectionParser.h in Headers */,
 				53F40E851D58F9770099A1B6 /* WasmSections.h in Headers */,
 				641DF80E2890C7D500F9895F /* WasmSIMDOpcodes.h in Headers */,

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -1146,6 +1146,7 @@ wasm/WasmFunctionIPIntMetadataGenerator.cpp
 wasm/WasmGlobal.cpp
 wasm/WasmHandlerInfo.cpp
 wasm/WasmIndexOrName.cpp
+wasm/WasmInstanceAnchor.cpp
 wasm/WasmIPIntGenerator.cpp
 wasm/WasmIPIntPlan.cpp
 wasm/WasmIPIntSlowPaths.cpp @no-unify
@@ -1161,7 +1162,6 @@ wasm/WasmOSREntryPlan.cpp
 wasm/WasmOpcodeOrigin.cpp
 wasm/WasmOperations.cpp
 wasm/WasmPlan.cpp
-wasm/WasmProfileCollection.cpp
 wasm/WasmSectionParser.cpp
 wasm/WasmTypeDefinition.cpp
 wasm/WasmOpcodeCounter.cpp

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.h
@@ -2045,7 +2045,7 @@ public:
     void emitTailCall(FunctionSpaceIndex, const TypeDefinition& signature, ArgumentList& arguments);
     PartialResult WARN_UNUSED_RETURN addCall(unsigned, FunctionSpaceIndex, const TypeDefinition& signature, ArgumentList& arguments, ResultList& results, CallType = CallType::Call);
 
-    void emitIndirectCall(const char* opcode, unsigned callSlotIndex, const Value& callee, GPRReg boxedCallee, GPRReg calleeInstance, GPRReg calleeCode, const TypeDefinition& signature, ArgumentList& arguments, ResultList& results);
+    void emitIndirectCall(const char* opcode, unsigned callProfileIndex, const Value& callee, GPRReg boxedCallee, GPRReg calleeInstance, GPRReg calleeCode, const TypeDefinition& signature, ArgumentList& arguments, ResultList& results);
     void emitIndirectTailCall(const char* opcode, const Value& callee, GPRReg calleeInstance, GPRReg calleeCode, const TypeDefinition& signature, ArgumentList& arguments);
 
     PartialResult WARN_UNUSED_RETURN addCallIndirect(unsigned, unsigned tableIndex, const TypeDefinition& originalSignature, ArgumentList& args, ResultList& results, CallType = CallType::Call);
@@ -2226,7 +2226,7 @@ private:
 
     bool canTierUpToOMG() const;
 
-    void emitIncrementCallSlotCount(unsigned callSlotIndex);
+    void emitIncrementCallProfileCount(unsigned callProfileIndex);
 
     void emitSaveCalleeSaves();
     void emitRestoreCalleeSaves();

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT32_64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT32_64.cpp
@@ -3576,9 +3576,9 @@ void BBQJIT::emitLoad(TypeKind type, Location src, Location dst)
     }
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addCallRef(unsigned callSlotIndex, const TypeDefinition& originalSignature, ArgumentList& args, ResultList& results, CallType callType)
+PartialResult WARN_UNUSED_RETURN BBQJIT::addCallRef(unsigned callProfileIndex, const TypeDefinition& originalSignature, ArgumentList& args, ResultList& results, CallType callType)
 {
-    emitIncrementCallSlotCount(callSlotIndex);
+    emitIncrementCallProfileCount(callProfileIndex);
     Value callee = args.takeLast();
     const TypeDefinition& signature = originalSignature.expand();
     ASSERT(signature.as<FunctionSignature>()->argumentCount() == args.size());
@@ -3621,7 +3621,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addCallRef(unsigned callSlotIndex, cons
     }
 
     if (callType == CallType::Call)
-        emitIndirectCall("CallRef", callSlotIndex, callee, boxedCallee, calleeInstance, calleeCode, signature, args, results);
+        emitIndirectCall("CallRef", callProfileIndex, callee, boxedCallee, calleeInstance, calleeCode, signature, args, results);
     else
         emitIndirectTailCall("ReturnCallRef", callee, calleeInstance, calleeCode, signature, args);
     return { };

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
@@ -5294,9 +5294,9 @@ void BBQJIT::emitMove(StorageType type, Value src, Address dst)
         emitStore(type, srcLocation, dst);
 }
 
-PartialResult WARN_UNUSED_RETURN BBQJIT::addCallRef(unsigned callSlotIndex, const TypeDefinition& originalSignature, ArgumentList& args, ResultList& results, CallType callType)
+PartialResult WARN_UNUSED_RETURN BBQJIT::addCallRef(unsigned callProfileIndex, const TypeDefinition& originalSignature, ArgumentList& args, ResultList& results, CallType callType)
 {
-    emitIncrementCallSlotCount(callSlotIndex);
+    emitIncrementCallProfileCount(callProfileIndex);
     Value callee = args.takeLast();
     const TypeDefinition& signature = originalSignature.expand();
     ASSERT(signature.as<FunctionSignature>()->argumentCount() == args.size());
@@ -5339,7 +5339,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addCallRef(unsigned callSlotIndex, cons
     }
 
     if (callType == CallType::Call)
-        emitIndirectCall("CallRef", callSlotIndex, callee, boxedCallee, calleeInstance, calleeCode, signature, args, results);
+        emitIndirectCall("CallRef", callProfileIndex, callee, boxedCallee, calleeInstance, calleeCode, signature, args, results);
     else
         emitIndirectTailCall("ReturnCallRef", callee, calleeInstance, calleeCode, signature, args);
     return { };

--- a/Source/JavaScriptCore/wasm/WasmBaselineData.h
+++ b/Source/JavaScriptCore/wasm/WasmBaselineData.h
@@ -27,7 +27,7 @@
 
 #if ENABLE(WEBASSEMBLY)
 
-#include <JavaScriptCore/WasmCallSlot.h>
+#include <JavaScriptCore/WasmCallProfile.h>
 #include <JavaScriptCore/WasmCallee.h>
 #include <JavaScriptCore/WasmCallingConvention.h>
 #include <wtf/text/WTFString.h>
@@ -36,18 +36,16 @@ namespace JSC::Wasm {
 
 // Per-instance side data for wasm baseline execution (IPInt and BBQ).
 // Mainly for profiling / IC.
-class BaselineData final : public ThreadSafeRefCounted<BaselineData>, public TrailingArray<BaselineData, CallSlot> {
+class BaselineData final : public ThreadSafeRefCounted<BaselineData>, public TrailingArray<BaselineData, CallProfile> {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(BaselineData);
     WTF_MAKE_NONMOVABLE(BaselineData);
-    using TrailingArrayType = TrailingArray<BaselineData, CallSlot>;
+    using TrailingArrayType = TrailingArray<BaselineData, CallProfile>;
     friend TrailingArrayType;
 public:
 
     static Ref<BaselineData> create(const IPIntCallee& callee)
     {
-        auto result = adoptRef(*new (fastMalloc(allocationSize(callee.numCallSlots()))) BaselineData(callee.numCallSlots()));
-        WTF::storeStoreFence();
-        return result;
+        return adoptRef(*new (fastMalloc(allocationSize(callee.numCallProfiles()))) BaselineData(callee.numCallProfiles()));
     }
 
 private:

--- a/Source/JavaScriptCore/wasm/WasmCallee.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCallee.cpp
@@ -38,7 +38,7 @@
 #include "PCToCodeOriginMap.h"
 #include "VMManager.h"
 #include "WasmBaselineData.h"
-#include "WasmCallSlot.h"
+#include "WasmCallProfile.h"
 #include "WasmCallingConvention.h"
 #include "WasmModuleInformation.h"
 #include "WebAssemblyBuiltin.h"
@@ -238,7 +238,7 @@ IPIntCallee::IPIntCallee(FunctionIPIntMetadataGenerator& generator, FunctionSpac
     , m_numLocals(generator.m_numLocals)
     , m_numArgumentsOnStack(generator.m_numArgumentsOnStack)
     , m_maxFrameSizeInV128(generator.m_maxFrameSizeInV128)
-    , m_numCallSlots(generator.m_numCallSlots)
+    , m_numCallProfiles(generator.m_numCallProfiles)
     , m_tierUpCounter(WTFMove(generator.m_tierUpCounter))
 {
     if (size_t count = generator.m_exceptionHandlers.size()) {
@@ -289,7 +289,7 @@ const RegisterAtOffsetList* IPIntCallee::calleeSaveRegistersImpl()
 
 bool IPIntCallee::needsProfiling() const
 {
-    return m_numCallSlots;
+    return m_numCallProfiles;
 }
 
 #if ENABLE(WEBASSEMBLY_OMGJIT)

--- a/Source/JavaScriptCore/wasm/WasmCallee.h
+++ b/Source/JavaScriptCore/wasm/WasmCallee.h
@@ -58,7 +58,7 @@ class PCToOriginMap;
 namespace Wasm {
 
 class BaselineData;
-class CallSlot;
+class CallProfile;
 class CalleeGroup;
 
 class Callee : public NativeCallee {
@@ -442,7 +442,7 @@ public:
     unsigned localSizeToAlloc() const { return m_localSizeToAlloc; }
     unsigned rethrowSlots() const { return m_numRethrowSlotsToAlloc; }
 
-    unsigned numCallSlots() const { return m_numCallSlots; }
+    unsigned numCallProfiles() const { return m_numCallProfiles; }
 
     bool needsProfiling() const;
 
@@ -473,7 +473,7 @@ private:
     unsigned m_numLocals;
     unsigned m_numArgumentsOnStack;
     unsigned m_maxFrameSizeInV128;
-    unsigned m_numCallSlots;
+    unsigned m_numCallProfiles;
 
     IPIntTierUpCounter m_tierUpCounter;
 };

--- a/Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.h
@@ -132,7 +132,7 @@ private:
     unsigned m_numArguments { 0 };
     unsigned m_numArgumentsOnStack { 0 };
     unsigned m_nonArgLocalOffset { 0 };
-    unsigned m_numCallSlots { 0 };
+    unsigned m_numCallProfiles { 0 };
     Vector<uint8_t, 16> m_argumINTBytecode { };
 
     UncheckedKeyHashMap<IPIntPC, IPIntTierUpCounter::OSREntryData> m_tierUpCounter;

--- a/Source/JavaScriptCore/wasm/WasmFunctionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionParser.h
@@ -195,7 +195,7 @@ public:
         return result;
     }
 
-    uint32_t numCallSlots() const { return m_callSlotIndex; }
+    uint32_t numCallProfiles() const { return m_callProfileIndex; }
 
 private:
     static constexpr bool verbose = false;
@@ -388,7 +388,7 @@ private:
 
     unsigned m_unreachableBlocks { 0 };
     unsigned m_loopIndex { 0 };
-    unsigned m_callSlotIndex { 0 };
+    unsigned m_callProfileIndex { 0 };
 };
 
 WTF_MAKE_TZONE_ALLOCATED_TEMPLATE_IMPL(template<typename Context>, FunctionParser<Context>);
@@ -3068,14 +3068,14 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             for (unsigned i = 0; i < calleeSignature.returnCount(); ++i)
                 WASM_VALIDATOR_FAIL_IF(!isSubtype(calleeSignature.returnType(i), callerSignature.returnType(i)), "tail call function index "_s, functionIndex, " return type mismatch: "_s , "expected "_s, callerSignature.returnType(i), ", got "_s, calleeSignature.returnType(i));
 
-            WASM_TRY_ADD_TO_CONTEXT(addCall(m_callSlotIndex++, functionIndex, typeDefinition, args, results, CallType::TailCall));
+            WASM_TRY_ADD_TO_CONTEXT(addCall(m_callProfileIndex++, functionIndex, typeDefinition, args, results, CallType::TailCall));
 
             m_unreachableBlocks = 1;
 
             return { };
         }
 
-        WASM_TRY_ADD_TO_CONTEXT(addCall(m_callSlotIndex++, functionIndex, typeDefinition, args, results));
+        WASM_TRY_ADD_TO_CONTEXT(addCall(m_callProfileIndex++, functionIndex, typeDefinition, args, results));
         RELEASE_ASSERT(calleeSignature.returnCount() == results.size());
 
         for (unsigned i = 0; i < calleeSignature.returnCount(); ++i) {
@@ -3136,14 +3136,14 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             for (unsigned i = 0; i < calleeSignature.returnCount(); ++i)
                 WASM_VALIDATOR_FAIL_IF(!isSubtype(calleeSignature.returnType(i), callerSignature.returnType(i)), "tail call indirect return type mismatch: "_s , "expected "_s, callerSignature.returnType(i), ", got "_s, calleeSignature.returnType(i));
 
-            WASM_TRY_ADD_TO_CONTEXT(addCallIndirect(m_callSlotIndex++, tableIndex, typeDefinition, args, results, CallType::TailCall));
+            WASM_TRY_ADD_TO_CONTEXT(addCallIndirect(m_callProfileIndex++, tableIndex, typeDefinition, args, results, CallType::TailCall));
 
             m_unreachableBlocks = 1;
 
             return { };
         }
 
-        WASM_TRY_ADD_TO_CONTEXT(addCallIndirect(m_callSlotIndex++, tableIndex, typeDefinition, args, results));
+        WASM_TRY_ADD_TO_CONTEXT(addCallIndirect(m_callProfileIndex++, tableIndex, typeDefinition, args, results));
 
         for (unsigned i = 0; i < calleeSignature.returnCount(); ++i) {
             Type returnType = calleeSignature.returnType(i);
@@ -3201,14 +3201,14 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             for (unsigned i = 0; i < calleeSignature.returnCount(); ++i)
                 WASM_VALIDATOR_FAIL_IF(!isSubtype(calleeSignature.returnType(i), callerSignature.returnType(i)), "tail call ref return type mismatch: "_s , "expected "_s, callerSignature.returnType(i), ", got "_s, calleeSignature.returnType(i));
 
-            WASM_TRY_ADD_TO_CONTEXT(addCallRef(m_callSlotIndex++, typeDefinition, args, results, CallType::TailCall));
+            WASM_TRY_ADD_TO_CONTEXT(addCallRef(m_callProfileIndex++, typeDefinition, args, results, CallType::TailCall));
 
             m_unreachableBlocks = 1;
 
             return { };
         }
 
-        WASM_TRY_ADD_TO_CONTEXT(addCallRef(m_callSlotIndex++, typeDefinition, args, results));
+        WASM_TRY_ADD_TO_CONTEXT(addCallRef(m_callProfileIndex++, typeDefinition, args, results));
 
         for (unsigned i = 0; i < calleeSignature.returnCount(); ++i) {
             Type returnType = calleeSignature.returnType(i);

--- a/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
@@ -2906,7 +2906,7 @@ void IPIntGenerator::addTailCallCommonData(const FunctionSignature& signature)
     m_metadata->appendMetadata(numStackValues);
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addCall(unsigned callSlotIndex, FunctionSpaceIndex index, const TypeDefinition& type, ArgumentList&, ResultList& results, CallType callType)
+PartialResult WARN_UNUSED_RETURN IPIntGenerator::addCall(unsigned callProfileIndex, FunctionSpaceIndex index, const TypeDefinition& type, ArgumentList&, ResultList& results, CallType callType)
 {
     const FunctionSignature& signature = *type.as<FunctionSignature>();
     if (callType == CallType::TailCall) {
@@ -2924,7 +2924,7 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addCall(unsigned callSlotIndex,
 
         IPInt::TailCallMetadata functionIndexMetadata {
             .length = safeCast<uint8_t>(getCurrentInstructionLength()),
-            .callSlotIndex = callSlotIndex,
+            .callProfileIndex = callProfileIndex,
             .functionIndex = index,
             .callerStackArgSize = static_cast<int32_t>(callerStackArgs * sizeof(Register)),
             .argumentBytecode = { }
@@ -2940,7 +2940,7 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addCall(unsigned callSlotIndex,
 
     IPInt::CallMetadata functionIndexMetadata {
         .length = safeCast<uint8_t>(getCurrentInstructionLength()),
-        .callSlotIndex = callSlotIndex,
+        .callProfileIndex = callProfileIndex,
         .functionIndex = index,
         .signature = {
             static_cast<uint32_t>(callConvention.headerAndArgumentStackSizeInBytes),
@@ -2954,7 +2954,7 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addCall(unsigned callSlotIndex,
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addCallIndirect(unsigned callSlotIndex, unsigned tableIndex, const TypeDefinition& originalSignature, ArgumentList&, ResultList& results, CallType callType)
+PartialResult WARN_UNUSED_RETURN IPIntGenerator::addCallIndirect(unsigned callProfileIndex, unsigned tableIndex, const TypeDefinition& originalSignature, ArgumentList&, ResultList& results, CallType callType)
 {
     const FunctionSignature& signature = *originalSignature.expand().as<FunctionSignature>();
     if (callType == CallType::TailCall) {
@@ -2974,7 +2974,7 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addCallIndirect(unsigned callSl
 
         IPInt::TailCallIndirectMetadata functionIndexMetadata {
             .length = safeCast<uint8_t>(getCurrentInstructionLength()),
-            .callSlotIndex = callSlotIndex,
+            .callProfileIndex = callProfileIndex,
             .tableIndex = tableIndex,
             .rtt = m_metadata->addSignature(originalSignature),
             .callerStackArgSize = static_cast<int32_t>(callerStackArgs * sizeof(Register)),
@@ -2992,7 +2992,7 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addCallIndirect(unsigned callSl
 
     IPInt::CallIndirectMetadata functionIndexMetadata {
         .length = safeCast<uint8_t>(getCurrentInstructionLength()),
-        .callSlotIndex = callSlotIndex,
+        .callProfileIndex = callProfileIndex,
         .tableIndex = tableIndex,
         .rtt = m_metadata->addSignature(originalSignature),
         .signature = {
@@ -3008,7 +3008,7 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addCallIndirect(unsigned callSl
     return { };
 }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addCallRef(unsigned callSlotIndex, const TypeDefinition& originalSignature, ArgumentList&, ResultList& results, CallType callType)
+PartialResult WARN_UNUSED_RETURN IPIntGenerator::addCallRef(unsigned callProfileIndex, const TypeDefinition& originalSignature, ArgumentList&, ResultList& results, CallType callType)
 {
     const FunctionSignature& signature = *originalSignature.expand().as<FunctionSignature>();
     if (callType == CallType::TailCall) {
@@ -3028,7 +3028,7 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addCallRef(unsigned callSlotInd
 
         IPInt::TailCallRefMetadata callMetadata {
             .length = safeCast<uint8_t>(getCurrentInstructionLength()),
-            .callSlotIndex = callSlotIndex,
+            .callProfileIndex = callProfileIndex,
             .callerStackArgSize = static_cast<int32_t>(callerStackArgs * sizeof(Register)),
             .argumentBytecode = { }
         };
@@ -3044,7 +3044,7 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addCallRef(unsigned callSlotInd
 
     IPInt::CallRefMetadata callMetadata {
         .length = safeCast<uint8_t>(getCurrentInstructionLength()),
-        .callSlotIndex = callSlotIndex,
+        .callProfileIndex = callProfileIndex,
         .signature = {
             static_cast<uint32_t>(callConvention.headerAndArgumentStackSizeInBytes),
             static_cast<uint16_t>(signature.returnCount() > signature.argumentCount() ? signature.returnCount() - signature.argumentCount() : 0),
@@ -3087,7 +3087,7 @@ std::unique_ptr<FunctionIPIntMetadataGenerator> IPIntGenerator::finalize()
     m_metadata->m_maxFrameSizeInV128 = roundUpToMultipleOf<2>(m_metadata->m_numLocals) / 2;
     m_metadata->m_maxFrameSizeInV128 += m_metadata->m_numAlignedRethrowSlots / 2;
     m_metadata->m_maxFrameSizeInV128 += m_maxStackSize;
-    m_metadata->m_numCallSlots = m_parser->numCallSlots();
+    m_metadata->m_numCallProfiles = m_parser->numCallProfiles();
 
     return WTFMove(m_metadata);
 }

--- a/Source/JavaScriptCore/wasm/WasmIPIntGenerator.h
+++ b/Source/JavaScriptCore/wasm/WasmIPIntGenerator.h
@@ -195,7 +195,7 @@ enum class CallArgumentBytecode : uint8_t { // (mINT)
 
 struct CallMetadata {
     uint8_t length; // 1B for instruction length
-    uint32_t callSlotIndex; // 4B for call slot index
+    uint32_t callProfileIndex; // 4B for call profile index
     Wasm::FunctionSpaceIndex functionIndex; // 4B for decoded index
     CallSignatureMetadata signature;
     CallArgumentBytecode argumentBytecode[0];
@@ -203,7 +203,7 @@ struct CallMetadata {
 
 struct TailCallMetadata {
     uint8_t length; // 1B for instruction length
-    uint32_t callSlotIndex; // 4B for call slot index
+    uint32_t callProfileIndex; // 4B for call profile index
     Wasm::FunctionSpaceIndex functionIndex; // 4B for decoded index
     int32_t callerStackArgSize; // 4B for caller stack size
     CallArgumentBytecode argumentBytecode[0];
@@ -211,7 +211,7 @@ struct TailCallMetadata {
 
 struct CallIndirectMetadata {
     uint8_t length; // 1B for length
-    uint32_t callSlotIndex; // 4B for call slot index
+    uint32_t callProfileIndex; // 4B for call profile index
     uint32_t tableIndex; // 4B for table index
     SUPPRESS_UNCOUNTED_MEMBER const Wasm::RTT* rtt; // 8B for RTT
     CallSignatureMetadata signature;
@@ -220,7 +220,7 @@ struct CallIndirectMetadata {
 
 struct TailCallIndirectMetadata {
     uint8_t length; // 1B for instruction length
-    uint32_t callSlotIndex; // 4B for call slot index
+    uint32_t callProfileIndex; // 4B for call profile index
     uint32_t tableIndex; // 4B for table index
     SUPPRESS_UNCOUNTED_MEMBER const Wasm::RTT* rtt; // 8B for RTT
     int32_t callerStackArgSize; // 4B for caller stack size
@@ -229,14 +229,14 @@ struct TailCallIndirectMetadata {
 
 struct CallRefMetadata {
     uint8_t length; // 1B for length
-    uint32_t callSlotIndex; // 4B for call slot index
+    uint32_t callProfileIndex; // 4B for call profile index
     CallSignatureMetadata signature;
     CallArgumentBytecode argumentBytecode[0];
 };
 
 struct TailCallRefMetadata {
     uint8_t length; // 1B for length
-    uint32_t callSlotIndex; // 4B for call slot index
+    uint32_t callProfileIndex; // 4B for call profile index
     int32_t callerStackArgSize; // 4B for caller stack size
     CallArgumentBytecode argumentBytecode[0];
 };

--- a/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
@@ -40,7 +40,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 #include "LLIntExceptions.h"
 #include "WasmBBQPlan.h"
 #include "WasmBaselineData.h"
-#include "WasmCallSlot.h"
+#include "WasmCallProfile.h"
 #include "WasmCallee.h"
 #include "WasmCallingConvention.h"
 #include "WasmIPIntGenerator.h"
@@ -913,7 +913,7 @@ WASM_IPINT_EXTERN_CPP_DECL(ref_cast, int32_t heapType, bool allowNull, EncodedJS
 WASM_IPINT_EXTERN_CPP_DECL(prepare_call, CallFrame* callFrame, CallMetadata* call, Register* calleeAndWasmInstanceReturn)
 {
     auto* callee = IPINT_CALLEE(callFrame);
-    instance->ensureBaselineData(callee->functionIndex()).at(call->callSlotIndex).incrementCount();
+    instance->ensureBaselineData(callee->functionIndex()).at(call->callProfileIndex).incrementCount();
 
     Wasm::FunctionSpaceIndex functionIndex = call->functionIndex;
 
@@ -946,8 +946,8 @@ WASM_IPINT_EXTERN_CPP_DECL(prepare_call, CallFrame* callFrame, CallMetadata* cal
 WASM_IPINT_EXTERN_CPP_DECL(prepare_call_indirect, CallFrame* callFrame, Wasm::FunctionSpaceIndex* functionIndex, CallIndirectMetadata* call)
 {
     auto* callee = IPINT_CALLEE(callFrame);
-    auto& callSlot = instance->ensureBaselineData(callee->functionIndex()).at(call->callSlotIndex);
-    callSlot.incrementCount();
+    auto& callProfile = instance->ensureBaselineData(callee->functionIndex()).at(call->callProfileIndex);
+    callProfile.incrementCount();
 
     unsigned tableIndex = call->tableIndex;
     const Wasm::FuncRefTable::Function* function = nullptr;
@@ -979,9 +979,9 @@ WASM_IPINT_EXTERN_CPP_DECL(prepare_call_indirect, CallFrame* callFrame, Wasm::Fu
         auto* targetInstance = function->m_function.targetInstance.get();
         functionInfoSlot = targetInstance;
         if (instance != targetInstance)
-            callSlot.observeCrossInstanceCall();
+            callProfile.observeCrossInstanceCall();
         else
-            callSlot.observeCallIndirect(boxedCallee);
+            callProfile.observeCallIndirect(boxedCallee);
     }
 
     auto callTarget = *function->m_function.entrypointLoadLocation;
@@ -991,8 +991,8 @@ WASM_IPINT_EXTERN_CPP_DECL(prepare_call_indirect, CallFrame* callFrame, Wasm::Fu
 WASM_IPINT_EXTERN_CPP_DECL(prepare_call_ref, CallFrame* callFrame, CallRefMetadata* call, IPIntStackEntry* sp)
 {
     auto* callee = IPINT_CALLEE(callFrame);
-    auto& callSlot = instance->ensureBaselineData(callee->functionIndex()).at(call->callSlotIndex);
-    callSlot.incrementCount();
+    auto& callProfile = instance->ensureBaselineData(callee->functionIndex()).at(call->callProfileIndex);
+    callProfile.incrementCount();
 
     JSValue targetReference = JSValue::decode(sp->ref);
 
@@ -1015,9 +1015,9 @@ WASM_IPINT_EXTERN_CPP_DECL(prepare_call_ref, CallFrame* callFrame, CallRefMetada
         auto* targetInstance = function.targetInstance.get();
         functionInfoSlot = targetInstance;
         if (instance != targetInstance)
-            callSlot.observeCrossInstanceCall();
+            callProfile.observeCrossInstanceCall();
         else
-            callSlot.observeCallIndirect(boxedCallee);
+            callProfile.observeCallIndirect(boxedCallee);
     }
 
     auto callTarget = *function.entrypointLoadLocation;

--- a/Source/JavaScriptCore/wasm/WasmMergedProfile.cpp
+++ b/Source/JavaScriptCore/wasm/WasmMergedProfile.cpp
@@ -36,16 +36,16 @@ namespace JSC::Wasm {
 WTF_MAKE_TZONE_ALLOCATED_IMPL(MergedProfile);
 
 MergedProfile::MergedProfile(const IPIntCallee& callee)
-    : m_callSites(callee.numCallSlots())
+    : m_callSites(callee.numCallProfiles())
 {
 }
 
-void MergedProfile::CallSite::merge(const CallSlot& slot)
+void MergedProfile::CallSite::merge(const CallProfile& slot)
 {
     m_count += slot.count();
 
     auto bits = slot.boxedCallee();
-    if (bits == CallSlot::megamorphicCallee) {
+    if (bits == CallProfile::megamorphicCallee) {
         m_callee = megamorphic;
         return;
     }

--- a/Source/JavaScriptCore/wasm/WasmMergedProfile.h
+++ b/Source/JavaScriptCore/wasm/WasmMergedProfile.h
@@ -28,7 +28,7 @@
 #if ENABLE(WEBASSEMBLY)
 
 #include <JavaScriptCore/WasmBaselineData.h>
-#include <JavaScriptCore/WasmCallSlot.h>
+#include <JavaScriptCore/WasmCallProfile.h>
 #include <JavaScriptCore/WasmCallee.h>
 #include <wtf/text/WTFString.h>
 
@@ -43,7 +43,7 @@ class MergedProfile {
 public:
     class CallSite {
     public:
-        void merge(const CallSlot&);
+        void merge(const CallProfile&);
         uint32_t count() const { return m_count; }
 
         Callee* callee() const

--- a/Source/JavaScriptCore/wasm/WasmModule.h
+++ b/Source/JavaScriptCore/wasm/WasmModule.h
@@ -32,10 +32,10 @@
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 #include <JavaScriptCore/WasmCalleeGroup.h>
+#include <JavaScriptCore/WasmInstanceAnchor.h>
 #include <JavaScriptCore/WasmJS.h>
 #include <JavaScriptCore/WasmMemory.h>
 #include <JavaScriptCore/WasmOps.h>
-#include <JavaScriptCore/WasmProfileCollection.h>
 #include <wtf/Expected.h>
 #include <wtf/Lock.h>
 #include <wtf/SharedTask.h>
@@ -87,7 +87,7 @@ public:
 
     IPIntCallees& ipintCallees() const { return m_ipintCallees.get(); }
 
-    Ref<Wasm::ProfileCollection> createProfiles();
+    Ref<Wasm::InstanceAnchor> registerAnchor(JSWebAssemblyInstance*);
 
     std::unique_ptr<MergedProfile> createMergedProfile(IPIntCallee&);
 
@@ -99,7 +99,7 @@ private:
     RefPtr<CalleeGroup> m_calleeGroups[numberOfMemoryModes];
     const Ref<IPIntCallees> m_ipintCallees;
     FixedVector<MacroAssemblerCodeRef<WasmEntryPtrTag>> m_wasmToJSExitStubs;
-    ThreadSafeWeakHashSet<ProfileCollection> m_profiles;
+    ThreadSafeWeakHashSet<InstanceAnchor> m_anchors;
     Lock m_lock;
 };
 

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp
@@ -754,7 +754,7 @@ public:
     auto createCallPatchpoint(BasicBlock*, const TypeDefinition&, const CallInformation&, const ArgumentList& tmpArgs) -> CallPatchpointData;
     auto createTailCallPatchpoint(BasicBlock*, const TypeDefinition&, const CallInformation& wasmCallerInfoAsCallee, const CallInformation& wasmCalleeInfoAsCallee, const ArgumentList& tmpArgSourceLocations, Vector<B3::ConstrainedValue> patchArgs) -> CallPatchpointData;
 
-    bool canInline(FunctionSpaceIndex functionIndexSpace, unsigned callSlotIndex) const;
+    bool canInline(FunctionSpaceIndex functionIndexSpace, unsigned callProfileIndex) const;
     PartialResult WARN_UNUSED_RETURN emitInlineDirectCall(FunctionCodeIndex calleeIndex, const TypeDefinition&, ArgumentList& args, ResultList& results);
 
     void dump(const ControlStack&, const Stack* expressionStack);
@@ -5828,7 +5828,7 @@ auto OMGIRGenerator::emitInlineDirectCall(FunctionCodeIndex calleeFunctionIndex,
     return { };
 }
 
-auto OMGIRGenerator::addCall(unsigned callSlotIndex, FunctionSpaceIndex functionIndexSpace, const TypeDefinition& signature, ArgumentList& args, ResultList& results, CallType callType) -> PartialResult
+auto OMGIRGenerator::addCall(unsigned callProfileIndex, FunctionSpaceIndex functionIndexSpace, const TypeDefinition& signature, ArgumentList& args, ResultList& results, CallType callType) -> PartialResult
 {
     if (!m_info.isImportedFunctionFromFunctionIndexSpace(functionIndexSpace)) {
         // Record the callee so the callee knows to look for it in updateCallsitesToCallUs.
@@ -5971,7 +5971,7 @@ auto OMGIRGenerator::addCall(unsigned callSlotIndex, FunctionSpaceIndex function
         return { };
     }
 
-    if (callType == CallType::Call && canInline(functionIndexSpace, callSlotIndex)) {
+    if (callType == CallType::Call && canInline(functionIndexSpace, callProfileIndex)) {
         auto functionIndex = m_info.toCodeIndex(functionIndexSpace);
         dataLogLnIf(WasmOMGIRGeneratorInternal::verboseInlining, " inlining call to ", functionIndex, " from ", m_functionIndex, " depth ", m_inlineDepth);
         m_inlineRoot->m_inlinedBytes += m_info.functionWasmSizeImportSpace(functionIndexSpace);
@@ -6010,9 +6010,9 @@ auto OMGIRGenerator::addCall(unsigned callSlotIndex, FunctionSpaceIndex function
     return { };
 }
 
-auto OMGIRGenerator::addCallIndirect(unsigned callSlotIndex, unsigned tableIndex, const TypeDefinition& originalSignature, ArgumentList& args, ResultList& results, CallType callType) -> PartialResult
+auto OMGIRGenerator::addCallIndirect(unsigned callProfileIndex, unsigned tableIndex, const TypeDefinition& originalSignature, ArgumentList& args, ResultList& results, CallType callType) -> PartialResult
 {
-    UNUSED_PARAM(callSlotIndex);
+    UNUSED_PARAM(callProfileIndex);
     Value* calleeIndex = get(args.takeLast());
     const TypeDefinition& signature = originalSignature.expand();
     ASSERT(signature.as<FunctionSignature>()->argumentCount() == args.size());

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h
@@ -37,10 +37,10 @@
 #include "WasmCreationMode.h"
 #include "WasmFormat.h"
 #include "WasmGlobal.h"
+#include "WasmInstanceAnchor.h"
 #include "WasmMemory.h"
 #include "WasmModule.h"
 #include "WasmModuleInformation.h"
-#include "WasmProfileCollection.h"
 #include "WasmTable.h"
 #include "WebAssemblyBuiltin.h"
 #include "WebAssemblyFunction.h"
@@ -405,7 +405,7 @@ private:
     uint32_t m_cachedTable0Length { 0 };
     const Ref<Wasm::Module> m_module;
     const Ref<const Wasm::ModuleInformation> m_moduleInformation;
-    const Ref<Wasm::ProfileCollection> m_profiles;
+    RefPtr<Wasm::InstanceAnchor> m_anchor;
     RefPtr<SourceProvider> m_sourceProvider;
 
     CallFrame* m_temporaryCallFrame { nullptr };


### PR DESCRIPTION
#### f9f1ed183bf72d7d7e5f17a5d4929845a302def2
<pre>
[JSC] Introduce WasmInstanceAnchor
<a href="https://bugs.webkit.org/show_bug.cgi?id=299024">https://bugs.webkit.org/show_bug.cgi?id=299024</a>
<a href="https://rdar.apple.com/160786381">rdar://160786381</a>

Reviewed by Yijia Huang.

We found that WasmProfileCollection&apos;s lock is taken frequently, and
sometimes it is blocking the main thread. So this patch is taking a
different approach. In this patch, we introduce Wasm::InstanceAnchor,
which is registered to Wasm::Module and offering a way to access to
JSWebAssemblyInstance. It is
ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr, and keeping a lock &amp;
JSWebAssemblyInstance*. When JSWebAssemblyInstance is destroyed, it is
taking a lock and nullifying the pointer. So the concurrent compiler can
ensure that JSWebAssemblyInstance* is accessible while taking a lock of
this anchor.

We also rename Wasm::CallSlot to Wasm::CallProfile, which represents
what it is more reasonably.

* Source/JavaScriptCore/CMakeLists.txt:
* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/Sources.txt:
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::emitIncrementCallProfileCount):
(JSC::Wasm::BBQJITImpl::BBQJIT::addCall):
(JSC::Wasm::BBQJITImpl::BBQJIT::emitIndirectCall):
(JSC::Wasm::BBQJITImpl::BBQJIT::addCallIndirect):
(JSC::Wasm::BBQJITImpl::BBQJIT::emitIncrementCallSlotCount): Deleted.
* Source/JavaScriptCore/wasm/WasmBBQJIT.h:
* Source/JavaScriptCore/wasm/WasmBBQJIT32_64.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::addCallRef):
* Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::addCallRef):
* Source/JavaScriptCore/wasm/WasmBaselineData.h:
* Source/JavaScriptCore/wasm/WasmCallProfile.h: Renamed from Source/JavaScriptCore/wasm/WasmCallSlot.h.
(JSC::Wasm::CallProfile::offsetOfCount):
(JSC::Wasm::CallProfile::offsetOfBoxedCallee):
* Source/JavaScriptCore/wasm/WasmCallee.cpp:
(JSC::Wasm::IPIntCallee::IPIntCallee):
(JSC::Wasm::IPIntCallee::needsProfiling const):
* Source/JavaScriptCore/wasm/WasmCallee.h:
* Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.h:
* Source/JavaScriptCore/wasm/WasmFunctionParser.h:
(JSC::Wasm::FunctionParser::numCallProfiles const):
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseExpression):
(JSC::Wasm::FunctionParser::numCallSlots const): Deleted.
* Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp:
(JSC::Wasm::IPIntGenerator::addCall):
(JSC::Wasm::IPIntGenerator::addCallIndirect):
(JSC::Wasm::IPIntGenerator::addCallRef):
(JSC::Wasm::IPIntGenerator::finalize):
* Source/JavaScriptCore/wasm/WasmIPIntGenerator.h:
* Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp:
(JSC::IPInt::WASM_IPINT_EXTERN_CPP_DECL):
* Source/JavaScriptCore/wasm/WasmInstanceAnchor.cpp: Renamed from Source/JavaScriptCore/wasm/WasmProfileCollection.cpp.
(JSC::Wasm::InstanceAnchor::create):
* Source/JavaScriptCore/wasm/WasmInstanceAnchor.h: Renamed from Source/JavaScriptCore/wasm/WasmProfileCollection.h.
* Source/JavaScriptCore/wasm/WasmMergedProfile.cpp:
(JSC::Wasm::MergedProfile::MergedProfile):
(JSC::Wasm::MergedProfile::CallSite::merge):
* Source/JavaScriptCore/wasm/WasmMergedProfile.h:
* Source/JavaScriptCore/wasm/WasmModule.cpp:
(JSC::Wasm::Module::registerAnchor):
(JSC::Wasm::Module::createMergedProfile):
(JSC::Wasm::Module::createProfiles): Deleted.
* Source/JavaScriptCore/wasm/WasmModule.h:
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::OMGIRGenerator::canInline const):
(JSC::Wasm::OMGIRGenerator::addCall):
(JSC::Wasm::OMGIRGenerator::emitDirectCall):
(JSC::Wasm::OMGIRGenerator::addCallIndirect):
(JSC::Wasm::OMGIRGenerator::addCallRef):
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp:
(JSC::Wasm::OMGIRGenerator::addCall):
(JSC::Wasm::OMGIRGenerator::addCallIndirect):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp:
(JSC::JSWebAssemblyInstance::JSWebAssemblyInstance):
(JSC::JSWebAssemblyInstance::finishCreation):
(JSC::JSWebAssemblyInstance::~JSWebAssemblyInstance):
(JSC::JSWebAssemblyInstance::ensureBaselineData):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h:

Canonical link: <a href="https://commits.webkit.org/300108@main">https://commits.webkit.org/300108@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/73862f24f02514a9b46fd63987cc3e409037c3fd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121360 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41057 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31716 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127800 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73443 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2f2e96e7-3436-49e5-a32b-42b7226d80b8) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41759 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49636 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92183 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/61337 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ea825c5e-70b3-44fa-bb4d-7ab63085e3b3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124312 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33344 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72861 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4fa8dd92-069b-4111-8194-d28e3a386979) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32361 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26882 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71379 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/113490 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102838 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27057 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130634 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/119880 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48288 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36712 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100781 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48656 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104942 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100686 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46092 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24163 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44985 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19246 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48146 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53859 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/150042 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47618 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/38169 "Found 1 new JSC stress test failure: stress/dont-link-virtual-calls-on-compiler-thread.js.no-llint (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50964 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49300 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->