### PR TITLE
EditorState should only support system fonts

### DIFF
--- a/Source/WebCore/editing/FontAttributes.h
+++ b/Source/WebCore/editing/FontAttributes.h
@@ -48,12 +48,30 @@ struct TextList {
 #endif
 };
 
-struct FontAttributes {
+struct WEBCORE_EXPORT FontAttributes {
     enum class SubscriptOrSuperscript : uint8_t { None, Subscript, Superscript };
     enum class HorizontalAlignment : uint8_t { Left, Center, Right, Justify, Natural };
 
 #if PLATFORM(COCOA)
-    WEBCORE_EXPORT RetainPtr<NSDictionary> createDictionary() const;
+    RetainPtr<NSDictionary> createDictionary() const;
+    static std::optional<FontAttributes> fromSerializedData(String postScriptName,
+                                                            double pointSize,
+                                                            bool hasBold,
+                                                            bool hasItalics,
+                                                            Color backgroundColor,
+                                                            Color foregroundColor,
+                                                            FontShadow,
+                                                            FontAttributes::SubscriptOrSuperscript,
+                                                            FontAttributes::HorizontalAlignment,
+                                                            Vector<TextList> textLists,
+                                                            bool hasUnderline,
+                                                            bool hasStrikeThrough,
+                                                            bool hasMultipleFonts);
+
+    String postScriptName() const;
+    double pointSize() const;
+    bool hasBold() const;
+    bool hasItalics() const;
 #endif
 
     RefPtr<Font> font;

--- a/Source/WebCore/editing/cocoa/FontAttributesCocoa.mm
+++ b/Source/WebCore/editing/cocoa/FontAttributesCocoa.mm
@@ -29,6 +29,8 @@
 #import "CSSValueKeywords.h"
 #import "ColorCocoa.h"
 #import "FontCocoa.h"
+#import <CoreText/CTFont.h>
+#import <CoreText/CoreText.h>
 #import <pal/spi/cocoa/NSAttributedStringSPI.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
 #import <wtf/cocoa/VectorCocoa.h>
@@ -172,6 +174,71 @@ RetainPtr<NSDictionary> FontAttributes::createDictionary() const
         attributes[NSStrikethroughStyleAttributeName] = @(NSUnderlineStyleSingle);
 
     return attributes;
+}
+
+String FontAttributes::postScriptName() const
+{
+    return font ? String(adoptCF(CTFontCopyPostScriptName(font->getCTFont())).get()) : String();
+}
+
+double FontAttributes::pointSize() const
+{
+    return font ? CTFontGetSize(font->getCTFont()) : 0.0;
+}
+
+bool FontAttributes::hasBold() const
+{
+    if (!font)
+        return false;
+    CTFontSymbolicTraits traits = CTFontGetSymbolicTraits(font->getCTFont());
+    return traits & kCTFontTraitBold;
+}
+
+bool FontAttributes::hasItalics() const
+{
+    if (!font)
+        return false;
+    CTFontSymbolicTraits traits = CTFontGetSymbolicTraits(font->getCTFont());
+    return traits & kCTFontTraitItalic;
+}
+
+std::optional<FontAttributes> FontAttributes::fromSerializedData(
+    String postScriptName,
+    double pointSize,
+    bool hasBold,
+    bool hasItalics,
+    Color backgroundColor,
+    Color foregroundColor,
+    FontShadow fontShadow,
+    SubscriptOrSuperscript subscriptOrSuperscript,
+    HorizontalAlignment horizontalAlignment,
+    Vector<TextList> textLists,
+    bool hasUnderline,
+    bool hasStrikeThrough,
+    bool hasMultipleFonts)
+{
+    auto descriptor = adoptCF(CTFontDescriptorCreateWithNameAndSize(postScriptName.createCFString().get(), pointSize));
+
+    CTFontSymbolicTraits traits = 0;
+    if (hasBold)
+        traits |= kCTFontTraitBold;
+    if (hasItalics)
+        traits |= kCTFontTraitItalic;
+
+    auto traitsDescriptor = adoptCF(CTFontDescriptorCreateCopyWithSymbolicTraits(descriptor.get(), traits, traits));
+
+    return { {
+        Font::create(FontPlatformData(adoptCF(CTFontCreateWithFontDescriptor(traitsDescriptor.get(), CGFloat(pointSize), NULL)), pointSize)),
+        backgroundColor,
+        foregroundColor,
+        fontShadow,
+        subscriptOrSuperscript,
+        horizontalAlignment,
+        textLists,
+        hasUnderline,
+        hasStrikeThrough,
+        hasMultipleFonts
+    } };
 }
 
 } // namespace WebCore

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -4376,6 +4376,7 @@ struct WebKit::RunJavaScriptParameters {
     WebCore::RemoveTransientActivation removeTransientActivation;
 }
 
+
 header: <WebCore/FontAttributes.h>
 [CustomHeader] struct WebCore::TextList {
     WebCore::Style::ListStyleType styleType;
@@ -4397,6 +4398,23 @@ header: <WebCore/FontAttributes.h>
     Natural
 };
 
+#if PLATFORM(COCOA)
+[CustomHeader, CreateUsing=fromSerializedData] struct WebCore::FontAttributes {
+    String postScriptName();
+    double pointSize();
+    bool hasBold();
+    bool hasItalics();
+    WebCore::Color backgroundColor
+    WebCore::Color foregroundColor
+    WebCore::FontShadow fontShadow
+    WebCore::FontAttributes::SubscriptOrSuperscript subscriptOrSuperscript
+    WebCore::FontAttributes::HorizontalAlignment horizontalAlignment
+    Vector<WebCore::TextList> textLists
+    bool hasUnderline
+    bool hasStrikeThrough
+    bool hasMultipleFonts
+};
+#else
 [CustomHeader] struct WebCore::FontAttributes {
     RefPtr<WebCore::Font> font
     WebCore::Color backgroundColor
@@ -4409,6 +4427,7 @@ header: <WebCore/FontAttributes.h>
     bool hasStrikeThrough
     bool hasMultipleFonts
 };
+#endif
 
 header: <WebCore/WritingDirection.h>
 enum class WebCore::WritingDirection : uint8_t {


### PR DESCRIPTION
#### b0fe32d73dc525b03a968a2ce578034b5ef1eeb5
<pre>
EditorState should only support system fonts
<a href="https://bugs.webkit.org/show_bug.cgi?id=299027">https://bugs.webkit.org/show_bug.cgi?id=299027</a>

EditorState only needs to support system fonts. As a result, we
can just serialize the individual font attributes that are needed
across CoreIPC.

Explanation of why this fixes the bug (OOPS!).

* Source/WebCore/editing/FontAttributes.h:
* Source/WebCore/editing/cocoa/FontAttributesCocoa.mm:
(WebCore::FontAttributes::postScriptName const):
(WebCore::FontAttributes::pointSize const):
(WebCore::FontAttributes::hasBold const):
(WebCore::FontAttributes::hasItalics const):
(WebCore::FontAttributes::fromSerializedData):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b0fe32d73dc525b03a968a2ce578034b5ef1eeb5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121367 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41064 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31723 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127807 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73450 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/480c1fef-9dd7-410b-81ab-0ffc08c91f95) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123243 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41766 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49643 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92190 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61346 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8ac62230-4f6d-41c4-8573-d251862cc611) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124319 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33354 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108752 "Found 1 new API test failure: TestWebKitAPI.FontAttributes.FontTextStyle (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72887 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f04d122c-3c7f-44cd-8c13-d60a43a9caa0) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32371 "Found 1 new test failure: imported/w3c/web-platform-tests/html/dom/idlharness.https.html?exclude=(Document\|Window\|HTML.*) (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26893 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71386 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102848 "Found 1 new API test failure: TestWebKitAPI.FontAttributes.FontTextStyle (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27067 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130641 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48295 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36720 "Found 60 new test failures: accessibility/content-editable-set-inner-text-generates-axvalue-notification.html accessibility/mac/attributed-string/attributed-string-for-range.html accessibility/mac/br-element-text-selection.html accessibility/mac/replace-text-with-empty-range.html accessibility/mac/replaced-element-text-selection.html accessibility/mac/text-operation/text-operation-capitalize.html accessibility/mac/text-operation/text-operation-lowercase.html accessibility/mac/text-operation/text-operation-replace-preserve-case.html accessibility/mac/text-operation/text-operation-replace.html accessibility/mac/text-operation/text-operation-select.html ... (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100785 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48663 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104952 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100690 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46101 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24172 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44991 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48153 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53866 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47625 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50971 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49307 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->