### PR TITLE
Add privacyProxyStrictFailClosed to CoreIPCNSURLRequestData

### DIFF
--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.h
@@ -137,6 +137,7 @@ struct CoreIPCNSURLRequestData {
     bool privacyProxyFailClosed { false };
     bool privacyProxyFailClosedForUnreachableNonMainHosts { false };
     bool privacyProxyFailClosedForUnreachableHosts { false };
+    bool privacyProxyStrictFailClosed { false };
     std::optional<bool> requiresDNSSECValidation;
     bool allowsPersistentDNS { false };
     bool prohibitPrivacyProxy { false };

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.mm
@@ -192,6 +192,7 @@ CoreIPCNSURLRequest::CoreIPCNSURLRequest(NSURLRequest *request)
     SET_NSURLREQUESTDATA_PRIMITIVE(privacyProxyFailClosed, NSNumber, bool);
     SET_NSURLREQUESTDATA_PRIMITIVE(privacyProxyFailClosedForUnreachableNonMainHosts, NSNumber, bool);
     SET_NSURLREQUESTDATA_PRIMITIVE(privacyProxyFailClosedForUnreachableHosts, NSNumber, bool);
+    SET_NSURLREQUESTDATA_PRIMITIVE(privacyProxyStrictFailClosed, NSNumber, bool);
     SET_NSURLREQUESTDATA_PRIMITIVE(requiresDNSSECValidation, NSNumber, bool);
     SET_NSURLREQUESTDATA_PRIMITIVE(allowsPersistentDNS, NSNumber, bool);
     SET_NSURLREQUESTDATA_PRIMITIVE(prohibitPrivacyProxy, NSNumber, bool);
@@ -312,6 +313,7 @@ RetainPtr<id> CoreIPCNSURLRequest::toID() const
     SET_DICT_FROM_PRIMITIVE(privacyProxyFailClosed, NSInteger, Bool);
     SET_DICT_FROM_PRIMITIVE(privacyProxyFailClosedForUnreachableNonMainHosts, NSInteger, Bool);
     SET_DICT_FROM_PRIMITIVE(privacyProxyFailClosedForUnreachableHosts, NSInteger, Bool);
+    SET_DICT_FROM_PRIMITIVE(privacyProxyStrictFailClosed, NSInteger, Bool);
     SET_DICT_FROM_OPTIONAL_PRIMITIVE(requiresDNSSECValidation, NSInteger, Bool);
     SET_DICT_FROM_PRIMITIVE(allowsPersistentDNS, NSInteger, Bool);
     SET_DICT_FROM_PRIMITIVE(prohibitPrivacyProxy, NSInteger, Bool);

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.serialization.in
@@ -133,6 +133,7 @@ header: "CoreIPCNSURLRequest.h"
     bool privacyProxyFailClosed;
     bool privacyProxyFailClosedForUnreachableNonMainHosts;
     bool privacyProxyFailClosedForUnreachableHosts;
+    bool privacyProxyStrictFailClosed;
     std::optional<bool> requiresDNSSECValidation;
     bool allowsPersistentDNS;
     bool prohibitPrivacyProxy;


### PR DESCRIPTION
#### baec7ad5c81bd070d9affeb29623838bf9e5c499
<pre>
Add privacyProxyStrictFailClosed to CoreIPCNSURLRequestData
<a href="https://bugs.webkit.org/show_bug.cgi?id=299029">https://bugs.webkit.org/show_bug.cgi?id=299029</a>
<a href="https://rdar.apple.com/155294001">rdar://155294001</a>

Reviewed by Per Arne Vollan.

We need to the new property to recreate NSURLRequest.

* Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.h:
* Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.mm:
(WebKit::CoreIPCNSURLRequest::CoreIPCNSURLRequest):
(WebKit::CoreIPCNSURLRequest::toID const):
* Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.serialization.in:

Canonical link: <a href="https://commits.webkit.org/300187@main">https://commits.webkit.org/300187@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f629e3c906838246ad61bd3c44e9b8ba6c5217b7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121374 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41071 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31730 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127814 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73457 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9fb62342-8f78-4aa1-adb0-c1a8bdcd1774) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41773 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49650 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92196 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61345 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/170caa9a-603b-4b98-8b49-9884c89be3bb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124326 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33356 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108753 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72872 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6338ee0c-c212-44ed-a676-12e8ca8e21d9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32373 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71393 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102851 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27068 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130648 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48302 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36726 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100791 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48670 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104953 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100696 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25582 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46104 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24173 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44998 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48160 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53873 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47632 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50978 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49314 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->