### PR TITLE
[AutoFill Debugging] Include `canvas` elements in text extraction output

### DIFF
--- a/LayoutTests/fast/text-extraction/debug-text-extraction-basic-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-basic-expected.txt
@@ -25,6 +25,8 @@ root
             role='region'
                 role='status','Ready',[…]
                 button,uid=…,events=[click],'Update Status',[…]
+            aria-label='Figure 1'
+                canvas,uid=…,[…]
     role='contentinfo'
         '    \nFooter content with ',[…]
         role='img',aria-label='copyright symbol','©',[…]

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-basic.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-basic.html
@@ -26,6 +26,16 @@ body {
     background-color: lightyellow;
     padding: 8px;
 }
+
+canvas {
+    width: 200px;
+    height: 200px;
+}
+
+.canvas-container {
+    border: 1px dashed gray;
+    padding: 1em;
+}
 </style>
 <script src="../../resources/ui-helper.js"></script>
 </head>
@@ -65,6 +75,9 @@ body {
             <div role="status" aria-live="polite" id="status-msg">Ready</div>
             <button onclick="document.getElementById('status-msg').textContent = 'Updated!'">Update Status</button>
         </div>
+        <div class="canvas-container" aria-label="Figure 1">
+            <canvas width="400" height="400"></canvas>
+        </div>
     </section>
 </main>
 <footer role="contentinfo">
@@ -75,7 +88,40 @@ body {
 </div>
 
 <script>
+function paintIntoCanvas() {
+    const context = document.querySelector("canvas").getContext("2d");
+    context.save();
+    context.clearRect(0, 0, 400, 400);
+    context.beginPath();
+    context.strokeStyle = "black";
+    context.rect(20, 20, 160, 160);
+    context.stroke();
+
+    context.beginPath();
+    context.strokeStyle = "red";
+    context.rect(220, 20, 160, 160);
+    context.stroke();
+    context.fillStyle = "red";
+    context.fill();
+
+    context.beginPath();
+    context.rect(20, 220, 160, 160);
+    context.fillStyle = "green";
+    context.fill();
+
+    context.beginPath();
+    context.strokeStyle = "black";
+    context.lineWidth = 20;
+    context.rect(230, 230, 140, 140);
+    context.stroke();
+    context.fillStyle = "gray";
+    context.fill();
+    context.restore();
+}
+
 addEventListener("load", async () => {
+    paintIntoCanvas();
+
     if (!window.testRunner)
         return;
 

--- a/Source/WebCore/page/text-extraction/TextExtractionTypes.h
+++ b/Source/WebCore/page/text-extraction/TextExtractionTypes.h
@@ -128,6 +128,7 @@ enum class ContainerType : uint8_t {
     Section,
     Nav,
     Button,
+    Canvas,
     Generic,
 };
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -7141,6 +7141,7 @@ header: <WebCore/TextExtractionTypes.h>
     Section,
     Nav,
     Button,
+    Canvas,
     Generic
 };
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.swift
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.swift
@@ -208,6 +208,8 @@ extension WKTextExtractionContainerItem {
             containerString = "navigation"
         case .button:
             containerString = "button"
+        case .canvas:
+            containerString = "canvas"
         case .generic:
             break
         @unknown default:

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtractionInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtractionInternal.h
@@ -79,6 +79,7 @@ typedef NS_ENUM(NSInteger, WKTextExtractionContainer) {
     WKTextExtractionContainerSection,
     WKTextExtractionContainerNav,
     WKTextExtractionContainerButton,
+    WKTextExtractionContainerCanvas,
     WKTextExtractionContainerGeneric
 };
 

--- a/Source/WebKit/UIProcess/Cocoa/TextExtraction/WKTextExtractionUtilities.mm
+++ b/Source/WebKit/UIProcess/Cocoa/TextExtraction/WKTextExtractionUtilities.mm
@@ -59,6 +59,8 @@ inline static WKTextExtractionContainer containerType(TextExtraction::ContainerT
         return WKTextExtractionContainerNav;
     case TextExtraction::ContainerType::Button:
         return WKTextExtractionContainerButton;
+    case TextExtraction::ContainerType::Canvas:
+        return WKTextExtractionContainerCanvas;
     case TextExtraction::ContainerType::Generic:
         return WKTextExtractionContainerGeneric;
     }

--- a/Tools/WebKitTestRunner/cocoa/WKTextExtractionTestingHelpers.mm
+++ b/Tools/WebKitTestRunner/cocoa/WKTextExtractionTestingHelpers.mm
@@ -60,6 +60,8 @@ ASCIILiteral description(WKTextExtractionContainer container)
         return "NAV"_s;
     case WKTextExtractionContainerButton:
         return "BUTTON"_s;
+    case WKTextExtractionContainerCanvas:
+        return "CANVAS"_s;
     case WKTextExtractionContainerGeneric:
         return "GENERIC"_s;
     }


### PR DESCRIPTION
#### 6062b4cd7c816cf152fd967202be957eeb90406b
<pre>
[AutoFill Debugging] Include `canvas` elements in text extraction output
<a href="https://bugs.webkit.org/show_bug.cgi?id=299034">https://bugs.webkit.org/show_bug.cgi?id=299034</a>
<a href="https://rdar.apple.com/160795452">rdar://160795452</a>

Reviewed by Abrar Rahman Protyasha and Timothy Hatcher.

Add `.canvas` as a text extraction container type, and include `uid` for canvas elements.

* LayoutTests/fast/text-extraction/debug-text-extraction-basic-expected.txt:
* LayoutTests/fast/text-extraction/debug-text-extraction-basic.html:

Augment an existing layout test to include a canvas element.

* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::extractItemData):
(WebCore::TextExtraction::shouldIncludeNodeIdentifier):
(WebCore::TextExtraction::pruneEmptyContainersRecursive):

Avoid pruning `canvas` elements when post-processing (similar to how buttons are treated).

* Source/WebCore/page/text-extraction/TextExtractionTypes.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.swift:
(WKTextExtractionContainerItem.textRepresentationParts):
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtractionInternal.h:
* Source/WebKit/UIProcess/Cocoa/TextExtraction/WKTextExtractionUtilities.mm:
(WebKit::containerType):
* Tools/WebKitTestRunner/cocoa/WKTextExtractionTestingHelpers.mm:
(WTR::description):

Canonical link: <a href="https://commits.webkit.org/300104@main">https://commits.webkit.org/300104@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aa19ba5f0ff799922558f12c2b244badbae6e00a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121385 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41082 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31741 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127826 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/73468 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/98132cdd-f2ac-47d6-81de-68ddba88fcc6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123261 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41784 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49661 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92203 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/73468 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f32f89ee-0386-4b9c-9a5d-4ee5f4cccc84) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124337 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33365 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/108761 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72878 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1bf41840-70b7-44e9-a5fc-95d635f471a5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32382 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26906 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71406 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102860 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27080 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130659 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48313 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36736 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100798 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48681 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104965 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100703 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25517 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46114 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24182 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/45009 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48171 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53884 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47643 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50989 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/49325 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->