### PR TITLE
Split writing mode propagation computed style and rendering tests

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-032.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-032.html
@@ -41,31 +41,9 @@
       height: 100px;
       width: 100px;
     }
-
-  h1#second-test-condition
-    {
-      background-color: red;
-      color: yellow;
-    }
   </style>
 
-  <script>
-  function verifyComputedValueDocRoot()
-  {
-  if(getComputedStyle(document.documentElement)["writing-mode"] == "horizontal-tb")
-    {
-    document.getElementById("second-test-condition").style.display = "none";
-    };
-
-    /*
-    If the computed value of 'writing-mode' of the root element
-    itself is not affected by such propagation, then the big FAIL
-    word will not be displayed.
-    */
-  }
-  </script>
-
- <body onload="verifyComputedValueDocRoot();">
+ <body>
 
   <div></div>
 
@@ -76,5 +54,3 @@
   Test passes if there is a blue square in the
   <strong>upper-right corner</strong> of the page.
   -->
-
-  <h1 id="second-test-condition">FAIL</h1>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-033.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-033.html
@@ -46,31 +46,9 @@
     {
       writing-mode: vertical-lr;
     }
-
-  h1#second-test-condition
-    {
-      background-color: red;
-      color: yellow;
-    }
   </style>
 
-  <script>
-  function verifyComputedValueDocRoot()
-  {
-  if(getComputedStyle(document.documentElement)["writing-mode"] == "horizontal-tb")
-    {
-    document.getElementById("second-test-condition").style.display = "none";
-    };
-
-    /*
-    If the computed value of 'writing-mode' of the root element
-    itself is not affected by such propagation, then the big FAIL
-    word will not be displayed.
-    */
-  }
-  </script>
-
- <body onload="verifyComputedValueDocRoot();">
+ <body>
 
   <div><img src="support/wm-propagation-body-003-exp-res.png" width="340" height="37" alt="Image download support must be enabled"></div>
 
@@ -79,5 +57,3 @@
   Test passes if there is an orange square
   in the <strong>upper-left corner</strong> of the page.
   -->
-
-  <h1 id="second-test-condition">FAIL</h1>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-034.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-034.html
@@ -41,31 +41,9 @@
       height: 100px;
       width: 100px;
     }
-
-  h1#second-test-condition
-    {
-      background-color: red;
-      color: yellow;
-    }
   </style>
 
-  <script>
-  function verifyComputedValueDocRoot()
-  {
-  if(getComputedStyle(document.documentElement)["writing-mode"] == "horizontal-tb")
-    {
-    document.getElementById("second-test-condition").style.display = "none";
-    };
-
-    /*
-    If the computed value of 'writing-mode' of the root element
-    itself is not affected by such propagation, then the big FAIL
-    word will not be displayed.
-    */
-  }
-  </script>
-
- <body onload="verifyComputedValueDocRoot();">
+ <body>
 
   <div></div>
 
@@ -76,5 +54,3 @@
   Test passes if there is a blue square in the
   <strong>upper-right corner</strong> of the page.
   -->
-
-  <h1 id="second-test-condition">FAIL</h1>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-035.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-035.html
@@ -41,31 +41,9 @@
       height: 100px;
       width: 100px;
     }
-
-  h1#second-test-condition
-    {
-      background-color: red;
-      color: yellow;
-    }
   </style>
 
-  <script>
-  function verifyComputedValueDocRoot()
-  {
-  if(getComputedStyle(document.documentElement)["writing-mode"] == "horizontal-tb")
-    {
-    document.getElementById("second-test-condition").style.display = "none";
-    };
-
-    /*
-    If the computed value of 'writing-mode' of the root element
-    itself is not affected by such propagation, then the big FAIL
-    word will not be displayed.
-    */
-  }
-  </script>
-
- <body onload="verifyComputedValueDocRoot();">
+<body>
 
   <div></div>
 
@@ -76,5 +54,3 @@
   Test passes if there is a teal square in
   the <strong>lower-left corner</strong> of the page.
   -->
-
-  <h1 id="second-test-condition">FAIL</h1>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-036.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-036.html
@@ -47,31 +47,9 @@
       height: 100px;
       width: 100px;
     }
-
-  h1#second-test-condition
-    {
-      background-color: red;
-      color: yellow;
-    }
   </style>
 
-  <script>
-  function verifyComputedValueDocRoot()
-  {
-  if(getComputedStyle(document.documentElement)["writing-mode"] == "horizontal-tb")
-    {
-    document.getElementById("second-test-condition").style.display = "none";
-    };
-
-    /*
-    If the computed value of 'writing-mode' of the root element
-    itself is not affected by such propagation, then the big FAIL
-    word will not be displayed.
-    */
-  }
-  </script>
-
- <body onload="verifyComputedValueDocRoot();">
+ <body>
 
   <div></div>
 
@@ -82,5 +60,3 @@
   Test passes if there is a blue square in the
   <strong>upper-right corner</strong> of the page.
   -->
-
-  <h1 id="second-test-condition">FAIL</h1>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-037.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-037.html
@@ -51,31 +51,9 @@
     {
       writing-mode: vertical-lr;
     }
-
-  h1#second-test-condition
-    {
-      background-color: red;
-      color: yellow;
-    }
   </style>
 
-  <script>
-  function verifyComputedValueDocRoot()
-  {
-  if(getComputedStyle(document.documentElement)["writing-mode"] == "horizontal-tb")
-    {
-    document.getElementById("second-test-condition").style.display = "none";
-    };
-
-    /*
-    If the computed value of 'writing-mode' of the root element
-    itself is not affected by such propagation, then the big FAIL
-    word will not be displayed.
-    */
-  }
-  </script>
-
- <body onload="verifyComputedValueDocRoot();">
+<body>
 
   <div><img src="support/wm-propagation-body-003-exp-res.png" width="340" height="37" alt="Image download support must be enabled"></div>
 
@@ -84,5 +62,3 @@
   Test passes if there is an orange square
   in the <strong>upper-left corner</strong> of the page.
   -->
-
-  <h1 id="second-test-condition">FAIL</h1>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-038.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-038.html
@@ -46,31 +46,9 @@
       height: 100px;
       width: 100px;
     }
-
-  h1#second-test-condition
-    {
-      background-color: red;
-      color: yellow;
-    }
   </style>
 
-  <script>
-  function verifyComputedValueDocRoot()
-  {
-  if(getComputedStyle(document.documentElement)["writing-mode"] == "horizontal-tb")
-    {
-    document.getElementById("second-test-condition").style.display = "none";
-    };
-
-    /*
-    If the computed value of 'writing-mode' of the root element
-    itself is not affected by such propagation, then the big FAIL
-    word will not be displayed.
-    */
-  }
-  </script>
-
- <body onload="verifyComputedValueDocRoot();">
+<body>
 
   <div></div>
 
@@ -81,5 +59,3 @@
   Test passes if there is a blue square in the
   <strong>upper-right corner</strong> of the page.
   -->
-
-  <h1 id="second-test-condition">FAIL</h1>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-039.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-039.html
@@ -46,31 +46,9 @@
       height: 100px;
       width: 100px;
     }
-
-  h1#second-test-condition
-    {
-      background-color: red;
-      color: yellow;
-    }
   </style>
 
-  <script>
-  function verifyComputedValueDocRoot()
-  {
-  if(getComputedStyle(document.documentElement)["writing-mode"] == "horizontal-tb")
-    {
-    document.getElementById("second-test-condition").style.display = "none";
-    };
-
-    /*
-    If the computed value of 'writing-mode' of the root element
-    itself is not affected by such propagation, then the big FAIL
-    word will not be displayed.
-    */
-  }
-  </script>
-
- <body onload="verifyComputedValueDocRoot();">
+<body>
 
   <div></div>
 
@@ -81,5 +59,3 @@
   Test passes if there is a teal square in
   the <strong>lower-left corner</strong> of the page.
   -->
-
-  <h1 id="second-test-condition">FAIL</h1>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-040.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-040.html
@@ -47,31 +47,9 @@
       vertical-align: top;
       width: 100px;
     }
-
-  h1#second-test-condition
-    {
-      background-color: red;
-      color: yellow;
-    }
   </style>
 
-  <script>
-  function verifyComputedValueDocRoot()
-  {
-  if(getComputedStyle(document.documentElement)["writing-mode"] == "vertical-rl")
-    {
-    document.getElementById("second-test-condition").style.display = "none";
-    };
-
-    /*
-    If the computed value of 'writing-mode' of the root element
-    itself is not affected by such propagation, then the big FAIL
-    word will not be displayed.
-    */
-  }
-  </script>
-
- <body onload="verifyComputedValueDocRoot();">
+ <body>
 
   <div><img id="orange-square" src="support/swatch-orange.png" alt="Image download support must be enabled"><img src="support/wm-propagation-body-003-exp-res.png" width="340" height="37" alt="Image download support must be enabled"></div>
 
@@ -80,5 +58,3 @@
   Test passes if there is an orange square
   in the <strong>upper-left corner</strong> of the page.
   -->
-
-  <h1 id="second-test-condition">FAIL</h1>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-041.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-041.html
@@ -46,31 +46,9 @@
       height: 100px;
       width: 100px;
     }
-
-  h1#second-test-condition
-    {
-      background-color: red;
-      color: yellow;
-    }
   </style>
 
-  <script>
-  function verifyComputedValueDocRoot()
-  {
-  if(getComputedStyle(document.documentElement)["writing-mode"] == "vertical-rl")
-    {
-    document.getElementById("second-test-condition").style.display = "none";
-    };
-
-    /*
-    If the computed value of 'writing-mode' of the root element
-    itself is not affected by such propagation, then the big FAIL
-    word will not be displayed.
-    */
-  }
-  </script>
-
- <body onload="verifyComputedValueDocRoot();">
+ <body>
 
   <div></div>
 
@@ -81,5 +59,3 @@
   Test passes if there is an orange square
   in the <strong>upper-left corner</strong> of the page.
   -->
-
-  <h1 id="second-test-condition">FAIL</h1>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-042.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-042.html
@@ -53,31 +53,9 @@
       height: 100px;
       width: 100px;
     }
-
-  h1#second-test-condition
-    {
-      background-color: red;
-      color: yellow;
-    }
   </style>
 
-  <script>
-  function verifyComputedValueDocRoot()
-  {
-  if(getComputedStyle(document.documentElement)["writing-mode"] == "vertical-rl")
-    {
-    document.getElementById("second-test-condition").style.display = "none";
-    };
-
-    /*
-    If the computed value of 'writing-mode' of the root element
-    itself is not affected by such propagation, then the big FAIL
-    word will not be displayed.
-    */
-  }
-  </script>
-
- <body onload="verifyComputedValueDocRoot();">
+ <body>
 
   <div></div>
 
@@ -88,5 +66,3 @@
   Test passes if there is a blue square in the
   <strong>upper-right corner</strong> of the page.
   -->
-
-  <h1 id="second-test-condition">FAIL</h1>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-043.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-043.html
@@ -46,31 +46,9 @@
       height: 100px;
       width: 100px;
     }
-
-  h1#second-test-condition
-    {
-      background-color: red;
-      color: yellow;
-    }
   </style>
 
-  <script>
-  function verifyComputedValueDocRoot()
-  {
-  if(getComputedStyle(document.documentElement)["writing-mode"] == "vertical-rl")
-    {
-    document.getElementById("second-test-condition").style.display = "none";
-    };
-
-    /*
-    If the computed value of 'writing-mode' of the root element
-    itself is not affected by such propagation, then the big FAIL
-    word will not be displayed.
-    */
-  }
-  </script>
-
- <body onload="verifyComputedValueDocRoot();">
+ <body>
 
   <div></div>
 
@@ -81,5 +59,3 @@
   Test passes if there is a teal square in
   the <strong>lower-left corner</strong> of the page.
   -->
-
-  <h1 id="second-test-condition">FAIL</h1>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-044.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-044.html
@@ -53,31 +53,9 @@
       vertical-align: top;
       width: 100px;
     }
-
-  h1#second-test-condition
-    {
-      background-color: red;
-      color: yellow;
-    }
   </style>
 
-  <script>
-  function verifyComputedValueDocRoot()
-  {
-  if(getComputedStyle(document.documentElement)["writing-mode"] == "vertical-lr")
-    {
-    document.getElementById("second-test-condition").style.display = "none";
-    };
-
-    /*
-    If the computed value of 'writing-mode' of the root element
-    itself is not affected by such propagation, then the big FAIL
-    word will not be displayed.
-    */
-  }
-  </script>
-
- <body onload="verifyComputedValueDocRoot();">
+ <body>
 
   <p><img id="orange-square" src="support/swatch-orange.png" alt="Image download support must be enabled"><img src="support/wm-propagation-body-003-exp-res.png" width="340" height="37" alt="Image download support must be enabled"></p>
 
@@ -86,5 +64,3 @@
   Test passes if there is an orange square
   in the <strong>upper-left corner</strong> of the page.
   -->
-
-  <h1 id="second-test-condition">FAIL</h1>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-045.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-045.html
@@ -46,31 +46,9 @@
       height: 100px;
       width: 100px;
     }
-
-  h1#second-test-condition
-    {
-      background-color: red;
-      color: yellow;
-    }
   </style>
 
-  <script>
-  function verifyComputedValueDocRoot()
-  {
-  if(getComputedStyle(document.documentElement)["writing-mode"] == "vertical-lr")
-    {
-    document.getElementById("second-test-condition").style.display = "none";
-    };
-
-    /*
-    If the computed value of 'writing-mode' of the root element
-    itself is not affected by such propagation, then the big FAIL
-    word will not be displayed.
-    */
-  }
-  </script>
-
- <body onload="verifyComputedValueDocRoot();">
+ <body>
 
   <div></div>
 
@@ -81,5 +59,3 @@
   Test passes if there is a blue square in the
   <strong>upper-right corner</strong> of the page.
   -->
-
-  <h1 id="second-test-condition">FAIL</h1>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-046.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-046.html
@@ -46,31 +46,9 @@
       height: 100px;
       width: 100px;
     }
-
-  h1#second-test-condition
-    {
-      background-color: red;
-      color: yellow;
-    }
   </style>
 
-  <script>
-  function verifyComputedValueDocRoot()
-  {
-  if(getComputedStyle(document.documentElement)["writing-mode"] == "vertical-lr")
-    {
-    document.getElementById("second-test-condition").style.display = "none";
-    };
-
-    /*
-    If the computed value of 'writing-mode' of the root element
-    itself is not affected by such propagation, then the big FAIL
-    word will not be displayed.
-    */
-  }
-  </script>
-
- <body onload="verifyComputedValueDocRoot();">
+ <body>
 
   <div></div>
 
@@ -81,5 +59,3 @@
   Test passes if there is a blue square in the
   <strong>upper-right corner</strong> of the page.
   -->
-
-  <h1 id="second-test-condition">FAIL</h1>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-047.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-047.html
@@ -59,31 +59,9 @@
       margin-right: 1em;
     }
 
-
-  h1#second-test-condition
-    {
-      background-color: red;
-      color: yellow;
-    }
   </style>
 
-  <script>
-  function verifyComputedValueDocRoot()
-  {
-  if(getComputedStyle(document.documentElement)["writing-mode"] == "vertical-lr")
-    {
-    document.getElementById("second-test-condition").style.display = "none";
-    };
-
-    /*
-    If the computed value of 'writing-mode' of the root element
-    itself is not affected by such propagation, then the big FAIL
-    word will not be displayed.
-    */
-  }
-  </script>
-
- <body onload="verifyComputedValueDocRoot();">
+ <body>
 
   <div></div>
 
@@ -94,5 +72,3 @@
   Test passes if there is a teal square in
   the <strong>lower-left corner</strong> of the page.
   -->
-
-  <h1 id="second-test-condition">FAIL</h1>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-048.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-048.html
@@ -47,31 +47,9 @@
       vertical-align: top;
       width: 100px;
     }
-
-  h1#second-test-condition
-    {
-      background-color: red;
-      color: yellow;
-    }
   </style>
 
-  <script>
-  function verifyComputedValueDocRoot()
-  {
-  if(getComputedStyle(document.documentElement)["writing-mode"] == "sideways-rl")
-    {
-    document.getElementById("second-test-condition").style.display = "none";
-    };
-
-    /*
-    If the computed value of 'writing-mode' of the root element
-    itself is not affected by such propagation, then the big FAIL
-    word will not be displayed.
-    */
-  }
-  </script>
-
- <body onload="verifyComputedValueDocRoot();">
+ <body>
 
   <div><img id="orange-square" src="support/swatch-orange.png" alt="Image download support must be enabled"><img src="support/wm-propagation-body-003-exp-res.png" width="340" height="37" alt="Image download support must be enabled"></div>
 
@@ -80,5 +58,3 @@
   Test passes if there is an orange square
   in the <strong>upper-left corner</strong> of the page.
   -->
-
-  <h1 id="second-test-condition">FAIL</h1>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-049.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-049.html
@@ -53,31 +53,9 @@
       height: 100px;
       width: 100px;
     }
-
-  h1#second-test-condition
-    {
-      background-color: red;
-      color: yellow;
-    }
   </style>
 
-  <script>
-  function verifyComputedValueDocRoot()
-  {
-  if(getComputedStyle(document.documentElement)["writing-mode"] == "sideways-rl")
-    {
-    document.getElementById("second-test-condition").style.display = "none";
-    };
-
-    /*
-    If the computed value of 'writing-mode' of the root element
-    itself is not affected by such propagation, then the big FAIL
-    word will not be displayed.
-    */
-  }
-  </script>
-
- <body onload="verifyComputedValueDocRoot();">
+ <body>
 
   <div></div>
 
@@ -88,5 +66,3 @@
   Test passes if there is a blue square in the
   <strong>upper-right corner</strong> of the page.
   -->
-
-  <h1 id="second-test-condition">FAIL</h1>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-050.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-050.html
@@ -46,31 +46,9 @@
       height: 100px;
       width: 100px;
     }
-
-  h1#second-test-condition
-    {
-      background-color: red;
-      color: yellow;
-    }
   </style>
 
-  <script>
-  function verifyComputedValueDocRoot()
-  {
-  if(getComputedStyle(document.documentElement)["writing-mode"] == "sideways-rl")
-    {
-    document.getElementById("second-test-condition").style.display = "none";
-    };
-
-    /*
-    If the computed value of 'writing-mode' of the root element
-    itself is not affected by such propagation, then the big FAIL
-    word will not be displayed.
-    */
-  }
-  </script>
-
- <body onload="verifyComputedValueDocRoot();">
+ <body>
 
   <div></div>
 
@@ -81,5 +59,3 @@
   Test passes if there is an orange square
   in the <strong>upper-left corner</strong> of the page.
   -->
-
-  <h1 id="second-test-condition">FAIL</h1>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-051.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-051.html
@@ -46,31 +46,9 @@
       height: 100px;
       width: 100px;
     }
-
-  h1#second-test-condition
-    {
-      background-color: red;
-      color: yellow;
-    }
   </style>
 
-  <script>
-  function verifyComputedValueDocRoot()
-  {
-  if(getComputedStyle(document.documentElement)["writing-mode"] == "sideways-rl")
-    {
-    document.getElementById("second-test-condition").style.display = "none";
-    };
-
-    /*
-    If the computed value of 'writing-mode' of the root element
-    itself is not affected by such propagation, then the big FAIL
-    word will not be displayed.
-    */
-  }
-  </script>
-
- <body onload="verifyComputedValueDocRoot();">
+ <body>
 
   <div></div>
 
@@ -81,5 +59,3 @@
   Test passes if there is a teal square in
   the <strong>lower-left corner</strong> of the page.
   -->
-
-  <h1 id="second-test-condition">FAIL</h1>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-052.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-052.html
@@ -47,31 +47,9 @@
       vertical-align: top;
       width: 100px;
     }
-
-  h1#second-test-condition
-    {
-      background-color: red;
-      color: yellow;
-    }
   </style>
 
-  <script>
-  function verifyComputedValueDocRoot()
-  {
-  if(getComputedStyle(document.documentElement)["writing-mode"] == "sideways-lr")
-    {
-    document.getElementById("second-test-condition").style.display = "none";
-    };
-
-    /*
-    If the computed value of 'writing-mode' of the root element
-    itself is not affected by such propagation, then the big FAIL
-    word will not be displayed.
-    */
-  }
-  </script>
-
- <body onload="verifyComputedValueDocRoot();">
+ <body>
 
   <div><img id="orange-square" src="support/swatch-orange.png" alt="Image download support must be enabled"><img src="support/wm-propagation-body-003-exp-res.png" width="340" height="37" alt="Image download support must be enabled"></div>
 
@@ -80,5 +58,3 @@
   Test passes if there is an orange square
   in the <strong>upper-left corner</strong> of the page.
   -->
-
-  <h1 id="second-test-condition">FAIL</h1>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-053.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-053.html
@@ -46,31 +46,9 @@
       height: 100px;
       width: 100px;
     }
-
-  h1#second-test-condition
-    {
-      background-color: red;
-      color: yellow;
-    }
   </style>
 
-  <script>
-  function verifyComputedValueDocRoot()
-  {
-  if(getComputedStyle(document.documentElement)["writing-mode"] == "sideways-lr")
-    {
-    document.getElementById("second-test-condition").style.display = "none";
-    };
-
-    /*
-    If the computed value of 'writing-mode' of the root element
-    itself is not affected by such propagation, then the big FAIL
-    word will not be displayed.
-    */
-  }
-  </script>
-
- <body onload="verifyComputedValueDocRoot();">
+ <body>
 
   <div></div>
 
@@ -81,5 +59,3 @@
   Test passes if there is a blue square in the
   <strong>upper-right corner</strong> of the page.
   -->
-
-  <h1 id="second-test-condition">FAIL</h1>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-054.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-054.html
@@ -54,31 +54,9 @@
       height: 100px;
       width: 100px;
     }
-
-  h1#second-test-condition
-    {
-      background-color: red;
-      color: yellow;
-    }
   </style>
 
-  <script>
-  function verifyComputedValueDocRoot()
-  {
-  if(getComputedStyle(document.documentElement)["writing-mode"] == "sideways-lr")
-    {
-    document.getElementById("second-test-condition").style.display = "none";
-    };
-
-    /*
-    If the computed value of 'writing-mode' of the root element
-    itself is not affected by such propagation, then the big FAIL
-    word will not be displayed.
-    */
-  }
-  </script>
-
- <body onload="verifyComputedValueDocRoot();">
+ <body>
 
   <div></div>
 
@@ -89,5 +67,3 @@
   Test passes if there is an orange square
   in the <strong>upper-left corner</strong> of the page.
   -->
-
-  <h1 id="second-test-condition">FAIL</h1>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-055.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-055.html
@@ -46,31 +46,9 @@
       height: 100px;
       width: 100px;
     }
-
-  h1#second-test-condition
-    {
-      background-color: red;
-      color: yellow;
-    }
   </style>
 
-  <script>
-  function verifyComputedValueDocRoot()
-  {
-  if(getComputedStyle(document.documentElement)["writing-mode"] == "sideways-lr")
-    {
-    document.getElementById("second-test-condition").style.display = "none";
-    };
-
-    /*
-    If the computed value of 'writing-mode' of the root element
-    itself is not affected by such propagation, then the big FAIL
-    word will not be displayed.
-    */
-  }
-  </script>
-
- <body onload="verifyComputedValueDocRoot();">
+ <body>
 
   <div></div>
 
@@ -81,5 +59,3 @@
   Test passes if there is a blue square in the
   <strong>upper-right corner</strong> of the page.
   -->
-
-  <h1 id="second-test-condition">FAIL</h1>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-computed-writing-mode-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-computed-writing-mode-expected.txt
@@ -1,0 +1,27 @@
+
+PASS Computed style is as specified with horizontal-tb on body & horizontal-tb on html
+PASS Computed style is as specified with vertical-lr on body & horizontal-tb on html
+PASS Computed style is as specified with vertical-rl on body & horizontal-tb on html
+PASS Computed style is as specified with sideways-lr on body & horizontal-tb on html
+PASS Computed style is as specified with sideways-rl on body & horizontal-tb on html
+PASS Computed style is as specified with horizontal-tb on body & vertical-lr on html
+PASS Computed style is as specified with vertical-lr on body & vertical-lr on html
+PASS Computed style is as specified with vertical-rl on body & vertical-lr on html
+PASS Computed style is as specified with sideways-lr on body & vertical-lr on html
+PASS Computed style is as specified with sideways-rl on body & vertical-lr on html
+PASS Computed style is as specified with horizontal-tb on body & vertical-rl on html
+PASS Computed style is as specified with vertical-lr on body & vertical-rl on html
+PASS Computed style is as specified with vertical-rl on body & vertical-rl on html
+PASS Computed style is as specified with sideways-lr on body & vertical-rl on html
+PASS Computed style is as specified with sideways-rl on body & vertical-rl on html
+PASS Computed style is as specified with horizontal-tb on body & sideways-lr on html
+PASS Computed style is as specified with vertical-lr on body & sideways-lr on html
+PASS Computed style is as specified with vertical-rl on body & sideways-lr on html
+PASS Computed style is as specified with sideways-lr on body & sideways-lr on html
+PASS Computed style is as specified with sideways-rl on body & sideways-lr on html
+PASS Computed style is as specified with horizontal-tb on body & sideways-rl on html
+PASS Computed style is as specified with vertical-lr on body & sideways-rl on html
+PASS Computed style is as specified with vertical-rl on body & sideways-rl on html
+PASS Computed style is as specified with sideways-lr on body & sideways-rl on html
+PASS Computed style is as specified with sideways-rl on body & sideways-rl on html
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-computed-writing-mode.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-computed-writing-mode.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+
+<title>Computed root element writing-mode style when propagating writing-mode from body</title>
+<link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#principal-flow">
+
+<body>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script>
+        const writingModes = ["horizontal-tb", "vertical-lr", "vertical-rl", "sideways-lr", "sideways-rl"];
+        for (const rootWM of writingModes) {
+            for (const bodyWM of writingModes) {
+                test(function(t) {
+                    t.add_cleanup(() => {
+                        document.documentElement.style.removeProperty("writing-mode");
+                        document.body.style.removeProperty("writing-mode");
+                    });
+                    document.documentElement.style.writingMode = rootWM;
+                    document.body.style.writingMode = bodyWM;
+                    assert_equals(getComputedStyle(document.documentElement).writingMode, rootWM, "root computed writing mode should be correct");
+                    assert_equals(getComputedStyle(document.body).writingMode, bodyWM, "body computed writing mode should be correct");
+                }, `Computed style is as specified with ${bodyWM} on body & ${rootWM} on html`);
+            }
+        }
+    </script>
+</body>
+
+</html>


### PR DESCRIPTION
#### 5ff89e50d172ece535b3f7b3548501d00270fad6
<pre>
Split writing mode propagation computed style and rendering tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=299040">https://bugs.webkit.org/show_bug.cgi?id=299040</a>
<a href="https://rdar.apple.com/160802205">rdar://160802205</a>

Reviewed by Alan Baradlay.

See:
- <a href="https://github.com/web-platform-tests/interop/issues/1035">https://github.com/web-platform-tests/interop/issues/1035</a>
- <a href="https://github.com/w3c/csswg-drafts/issues/12586">https://github.com/w3c/csswg-drafts/issues/12586</a>

Split the tests to unblock progress on bug 297248.

* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-032.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-033.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-034.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-035.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-036.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-037.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-038.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-039.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-040.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-041.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-042.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-043.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-044.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-045.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-046.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-047.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-048.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-049.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-050.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-051.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-052.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-053.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-054.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-055.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-computed-writing-mode-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-computed-writing-mode.html: Added.

Canonical link: <a href="https://commits.webkit.org/300135@main">https://commits.webkit.org/300135@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/343e25ee8f1f69d1c76ba0e93e674a397751aaf3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121421 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41118 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31777 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127862 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73504 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b0b8fdce-c21a-43a2-8fe0-d5276e3a1794) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41820 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49697 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92230 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/61362 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/70d58507-e63c-48d9-9d9b-3c1a2110c015) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124373 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33397 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108781 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72905 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3b012aaf-8fa4-456d-834d-c6c3b2cf8363) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32412 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26932 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71442 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102892 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27106 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130696 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48349 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36761 "Passed tests") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48717 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104991 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100726 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46139 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24205 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45045 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19255 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48207 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47679 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51025 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49361 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->