### PR TITLE
[WPT] Re-import event timing tests

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/event-timing/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/event-timing/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: event-timing
+  files: "**"

--- a/LayoutTests/imported/w3c/web-platform-tests/event-timing/click-timing.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/event-timing/click-timing.html
@@ -58,8 +58,10 @@
     })
 
     timeBeforeFirstClick = performance.now();
+    mainThreadBusy(2);
     await clickAndBlockMain('button');
     timeAfterFirstClick = performance.now();
+    mainThreadBusy(2);
     await clickAndBlockMain('button');
     timeAfterSecondClick = performance.now();
 

--- a/LayoutTests/imported/w3c/web-platform-tests/event-timing/crossiframe.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/event-timing/crossiframe.html
@@ -53,6 +53,7 @@
     });
 
     clickTimeMin = performance.now();
+    mainThreadBusy(2);
 
     let observedPointerDown = false;
     const observerPromise = new Promise(resolve => {

--- a/LayoutTests/imported/w3c/web-platform-tests/event-timing/interactionid-keyboard-event-simulated-click-button-space.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/event-timing/interactionid-keyboard-event-simulated-click-button-space.html
@@ -13,7 +13,7 @@
 
 <script>
   promise_test(async t => {
-
+    assert_implements(window.PerformanceEventTiming, 'Event Timing is not supported.');
     let map = new Map();
 
     const button = document.getElementById('button');

--- a/LayoutTests/imported/w3c/web-platform-tests/event-timing/interactionid-keyboard-event-simulated-click-checkbox-space.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/event-timing/interactionid-keyboard-event-simulated-click-checkbox-space.html
@@ -13,7 +13,7 @@
 
 <script>
   promise_test(async t => {
-
+    assert_implements(window.PerformanceEventTiming, 'Event Timing is not supported.');
     let map = new Map();
 
     const checkbox = document.querySelector('input[type="checkbox"]');

--- a/LayoutTests/imported/w3c/web-platform-tests/event-timing/interactionid-keyboard-event-simulated-click-link-enter.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/event-timing/interactionid-keyboard-event-simulated-click-link-enter.html
@@ -13,7 +13,7 @@
 
 <script>
   promise_test(async t => {
-
+    assert_implements(window.PerformanceEventTiming, 'Event Timing is not supported.');
     let map = new Map();
 
     const link = document.getElementById('lnk');

--- a/LayoutTests/imported/w3c/web-platform-tests/event-timing/interactionid-orphan-pointerup.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/event-timing/interactionid-orphan-pointerup.html
@@ -13,7 +13,8 @@
 <script>
   let observedEntries = [];
   const map = new Map();
-  const events = ['pointerup'];
+  // keydown is being sent right after a pointerup to see if pointerup is present.
+  const events = ['pointerup', 'keydown'];
 
   promise_test(async t => {
     assert_implements(window.PerformanceEventTiming, 'Event Timing is not supported.');
@@ -23,7 +24,11 @@
     const observerPromise = createPerformanceObserverPromise(['event'], callback, readyToResolve);
 
     await interactAndObserve('orphan-pointerup', document.getElementById('testButtonId'), observerPromise);
-    assert_equals(map.get('pointerup'), 0, 'Should have a trivial interactionId for orphan pointerup event.');
+
+    // This test passes when either:
+    // - There is no orphan pointerup triggered by the browser.
+    // - The orphan pointerup doesn't have an interactionId.
+    assert_true(!map.has('pointerup') || map.get('pointerup') === 0, 'Should either have no triggered orphan pointerup event or have a trivial interactionId for orphan pointerup event.');
   }, "Event Timing: Orphan pointerup should not be measured as an interaction.");
 
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/event-timing/orphan-keydown-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/event-timing/orphan-keydown-expected.txt
@@ -1,0 +1,4 @@
+Click me
+
+FAIL Event Timing: Orphan keydown should be measured as an interaction. promise_test: Unhandled rejection with value: object "Error: testdriver-vendor.js for WebKit does not yet support mixing key and pointer sources"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/event-timing/orphan-keydown.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/event-timing/orphan-keydown.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<meta charset=utf-8 />
+<title>Event Timing: orphan keydown.</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=/resources/testdriver.js></script>
+<script src=/resources/testdriver-actions.js></script>
+<script src=/resources/testdriver-vendor.js></script>
+<script src=resources/event-timing-test-utils.js></script>
+
+<body>
+  <button id='target'>Click me</button>
+
+  <script>
+    let observedEntries = [];
+    const map = new Map();
+    const events = ['keydown'];
+
+    promise_test(async t => {
+      assert_implements(window.PerformanceEventTiming, 'Event Timing is not supported.');
+
+      const callback = (entryList) => {observedEntries = observedEntries.concat(entryList.getEntries().filter(filterAndAddToMap(events, map))); };
+      const readyToResolve = () => { return observedEntries.length >= 1; };
+      const observerPromise = createPerformanceObserverPromise(['event'], callback, readyToResolve);
+
+      await interactAndObserve('orphan-keydown', document.getElementById('target'), observerPromise);
+
+      assert_equals(observedEntries.length, 1, "Keydown without a keyup should be fired properly.");
+      assert_greater_than(map.get('keydown'), 0, "Should have a non-trivial interactionId.")
+    }, "Event Timing: Orphan keydown should be measured as an interaction.");
+  </script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/event-timing/timingconditions.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/event-timing/timingconditions.html
@@ -16,6 +16,7 @@
   let trustedClickStart;
   function trustedClickAndBlockMain(id) {
     trustedClickStart = performance.now();
+    mainThreadBusy(2);
     return clickAndBlockMain(id);
   }
 

--- a/LayoutTests/imported/w3c/web-platform-tests/event-timing/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/event-timing/w3c-import.log
@@ -16,6 +16,7 @@ None
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/event-timing/META.yml
 /LayoutTests/imported/w3c/web-platform-tests/event-timing/TapToStopFling.html
+/LayoutTests/imported/w3c/web-platform-tests/event-timing/WEB_FEATURES.yml
 /LayoutTests/imported/w3c/web-platform-tests/event-timing/auxclick.html
 /LayoutTests/imported/w3c/web-platform-tests/event-timing/buffered-and-duration-threshold.html
 /LayoutTests/imported/w3c/web-platform-tests/event-timing/buffered-flag.html
@@ -64,6 +65,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/event-timing/mouseover.html
 /LayoutTests/imported/w3c/web-platform-tests/event-timing/mouseup.html
 /LayoutTests/imported/w3c/web-platform-tests/event-timing/only-observe-firstInput.html
+/LayoutTests/imported/w3c/web-platform-tests/event-timing/orphan-keydown.html
 /LayoutTests/imported/w3c/web-platform-tests/event-timing/pointerdown.html
 /LayoutTests/imported/w3c/web-platform-tests/event-timing/pointerenter.html
 /LayoutTests/imported/w3c/web-platform-tests/event-timing/pointerleave.html


### PR DESCRIPTION
#### dc9098420ce7b023cdf08ff565e6c9d532e2bf46
<pre>
[WPT] Re-import event timing tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=299041">https://bugs.webkit.org/show_bug.cgi?id=299041</a>
<a href="https://rdar.apple.com/160803568">rdar://160803568</a>

Reviewed by Tim Nguyen.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/a70ffb696b479ffece1df0fe9f75767ad6f81c1d">https://github.com/web-platform-tests/wpt/commit/a70ffb696b479ffece1df0fe9f75767ad6f81c1d</a>

* LayoutTests/imported/w3c/web-platform-tests/event-timing/WEB_FEATURES.yml: Added.
* LayoutTests/imported/w3c/web-platform-tests/event-timing/click-timing.html:
* LayoutTests/imported/w3c/web-platform-tests/event-timing/crossiframe.html:
* LayoutTests/imported/w3c/web-platform-tests/event-timing/interactionid-keyboard-event-simulated-click-button-space.html:
* LayoutTests/imported/w3c/web-platform-tests/event-timing/interactionid-keyboard-event-simulated-click-checkbox-space.html:
* LayoutTests/imported/w3c/web-platform-tests/event-timing/interactionid-keyboard-event-simulated-click-link-enter.html:
* LayoutTests/imported/w3c/web-platform-tests/event-timing/interactionid-orphan-pointerup.html:
* LayoutTests/imported/w3c/web-platform-tests/event-timing/orphan-keydown-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/event-timing/orphan-keydown.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/event-timing/resources/event-timing-test-utils.js:
* LayoutTests/imported/w3c/web-platform-tests/event-timing/timingconditions.html:
* LayoutTests/imported/w3c/web-platform-tests/event-timing/w3c-import.log:

Canonical link: <a href="https://commits.webkit.org/300206@main">https://commits.webkit.org/300206@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1f5e692da811f87d2190fb5e6c277858f9a143ff

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121619 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41316 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31975 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128116 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73709 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42032 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49907 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92404 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61460 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124571 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33544 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108946 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73066 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32558 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27100 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71652 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103040 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27275 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130920 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48553 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36944 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100979 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48925 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105148 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100868 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25591 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46267 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24365 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/45254 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48410 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47881 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51230 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49564 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->