### PR TITLE
Remove all uses of PUBLIC_IN_WEBGPU_SWIFT

### DIFF
--- a/Configurations/CommonBase.xcconfig
+++ b/Configurations/CommonBase.xcconfig
@@ -130,6 +130,6 @@ WK_LIBCPP_ASSERTIONS_CFLAGS[sdk=watch*10*] = -D_LIBCPP_ENABLE_ASSERTIONS=1;
 // Enable strict memory safety in Swift, and treat any such warnings as errors.
 // Enable for sufficiently recent Xcode only.
 WK_SWIFT_MEMORY_SAFETY_FLAGS = $(WK_SWIFT_MEMORY_SAFETY_FLAGS_$(WK_XCODE_BEFORE_17));
-WK_SWIFT_MEMORY_SAFETY_FLAGS_ = -Werror StrictMemorySafety -strict-memory-safety -enable-experimental-feature Lifetimes -enable-experimental-feature LifetimeDependence;
+WK_SWIFT_MEMORY_SAFETY_FLAGS_ = -Werror StrictMemorySafety -strict-memory-safety -enable-experimental-feature Lifetimes -enable-experimental-feature LifetimeDependence -enable-experimental-feature ImportNonPublicCxxMembers;
 
 OTHER_SWIFT_FLAGS = $(inherited) $(WK_SWIFT_MEMORY_SAFETY_FLAGS);

--- a/Source/WebGPU/WebGPU/Buffer.h
+++ b/Source/WebGPU/WebGPU/Buffer.h
@@ -139,11 +139,7 @@ private:
     Buffer(id<MTLBuffer>, uint64_t initialSize, WGPUBufferUsageFlags, State initialState, MappingRange initialMappingRange, Device&);
     Buffer(Device&);
 
-
-private PUBLIC_IN_WEBGPU_SWIFT:
     bool validateGetMappedRange(size_t offset, size_t rangeSize) const;
-
-private:
     NSString* errorValidatingMapAsync(WGPUMapModeFlags, size_t offset, size_t rangeSize) const;
     bool validateUnmap() const;
     void setState(State);
@@ -152,9 +148,7 @@ private:
     void takeSlowIndirectIndexValidationPath(CommandBuffer&, Buffer&, MTLIndexType, uint32_t indexBufferOffsetInBytes, uint32_t indirectOffset, uint32_t minVertexCount, uint32_t minInstanceCount, MTLPrimitiveType);
     void takeSlowIndirectValidationPath(CommandBuffer&, uint64_t indirectOffset, uint32_t minVertexCount, uint32_t minInstanceCount);
 
-private PUBLIC_IN_WEBGPU_SWIFT:
     id<MTLBuffer> m_buffer { nil };
-private:
     id<MTLBuffer> m_indirectBuffer { nil };
     id<MTLBuffer> m_indirectIndexedBuffer { nil };
 
@@ -166,9 +160,7 @@ private:
     // [[mapping]] is unnecessary; we can just use m_device.contents.
     MappingRange m_mappingRange { 0, 0 };
     using MappedRanges = RangeSet<Range<size_t>>;
-private PUBLIC_IN_WEBGPU_SWIFT:
     MappedRanges m_mappedRanges;
-private:
     WGPUMapModeFlags m_mapMode { WGPUMapMode_None };
     uint32_t m_maxUnsignedIndex { 0 };
     uint16_t m_maxUshortIndex { 0 };
@@ -197,7 +189,7 @@ private:
     bool m_mappedAtCreation { false };
 #endif
     HashMap<uint64_t, bool, DefaultHash<uint64_t>, WTF::UnsignedWithZeroKeyHashTraits<uint64_t>> m_didReadOOB;
-} SWIFT_SHARED_REFERENCE(refBuffer, derefBuffer);
+} SWIFT_SHARED_REFERENCE(refBuffer, derefBuffer) SWIFT_PRIVATE_FILEID("WebGPU/Buffer.swift");
 
 } // namespace WebGPU
 

--- a/Source/WebGPU/WebGPU/CommandEncoder.h
+++ b/Source/WebGPU/WebGPU/CommandEncoder.h
@@ -167,14 +167,10 @@ private:
     NSString* errorValidatingCopyTextureToBuffer(const WGPUImageCopyTexture&, const WGPUImageCopyBuffer&, const WGPUExtent3D&) const;
     NSString* errorValidatingCopyTextureToTexture(const WGPUImageCopyTexture& source, const WGPUImageCopyTexture& destination, const WGPUExtent3D& copySize) const;
 
-private PUBLIC_IN_WEBGPU_SWIFT:
     void discardCommandBuffer();
-private:
-
     RefPtr<CommandBuffer> protectedCachedCommandBuffer() const { return m_cachedCommandBuffer.get(); }
     void retainTimestampsForOneUpdateLoop();
 
-private PUBLIC_IN_WEBGPU_SWIFT:
     id<MTLCommandBuffer> m_commandBuffer { nil };
     id<MTLCommandEncoder> m_existingCommandEncoder { nil };
     id<MTLBlitCommandEncoder> m_blitCommandEncoder { nil };
@@ -194,7 +190,6 @@ private:
     Vector<Function<bool(CommandBuffer&, CommandEncoder&)>> m_onCommitHandlers;
     HashMap<uint64_t, Vector<DrawIndexCacheContainerValue>, DefaultHash<uint64_t>, WTF::UnsignedWithZeroKeyHashTraits<uint64_t>> m_skippedDrawIndexedValidationKeys;
     Vector<RefPtr<const BindGroup>> m_bindGroups;
-private PUBLIC_IN_WEBGPU_SWIFT:
     int m_bufferMapCount { 0 };
     bool m_makeSubmitInvalid { false };
     id<MTLSharedEvent> m_sharedEvent { nil };
@@ -204,8 +199,7 @@ private PUBLIC_IN_WEBGPU_SWIFT:
 #if ENABLE(WEBGPU_BY_DEFAULT)
     uint32_t m_currentResidencySetCount { 0 };
 #endif
-private:
-} SWIFT_SHARED_REFERENCE(refCommandEncoder, derefCommandEncoder);
+} SWIFT_SHARED_REFERENCE(refCommandEncoder, derefCommandEncoder) SWIFT_PRIVATE_FILEID("WebGPU/CommandEncoder.swift");
 
 } // namespace WebGPU
 

--- a/Source/WebGPU/WebGPU/CommandsMixin.h
+++ b/Source/WebGPU/WebGPU/CommandsMixin.h
@@ -32,14 +32,15 @@ class Device;
 
 // https://gpuweb.github.io/gpuweb/#gpucommandsmixin
 class CommandsMixin {
-protected PUBLIC_IN_WEBGPU_SWIFT:
+public:
     enum class EncoderState : uint8_t {
         Open,
         Locked,
         Ended
     };
-    bool prepareTheEncoderState() const;
+
 protected:
+    bool prepareTheEncoderState() const;
     NSString* encoderStateName() const;
     static bool computedSizeOverflows(const Buffer&, uint64_t offset, uint64_t& size);
 

--- a/Source/WebGPU/WebGPU/Device.h
+++ b/Source/WebGPU/WebGPU/Device.h
@@ -294,7 +294,6 @@ private:
         std::optional<Error> error;
         const WGPUErrorFilter filter;
     };
-private:
     id<MTLDevice> m_device { nil };
     const Ref<Queue> m_defaultQueue;
 

--- a/Source/WebGPU/WebGPU/Queue.h
+++ b/Source/WebGPU/WebGPU/Queue.h
@@ -117,16 +117,12 @@ private:
 
     NSString* errorValidatingWriteTexture(const WGPUImageCopyTexture&, const WGPUTextureDataLayout&, const WGPUExtent3D&, size_t, const Texture&) const;
 
-private PUBLIC_IN_WEBGPU_SWIFT:
     std::pair<id<MTLBuffer>, uint64_t> newTemporaryBufferWithBytes(const std::span<uint8_t> data, bool noCopy);
 
-private:
     id<MTLCommandQueue> m_commandQueue { nil };
     id<MTLCommandBuffer> m_commandBuffer { nil };
     id<MTLBlitCommandEncoder> m_blitCommandEncoder { nil };
-private PUBLIC_IN_WEBGPU_SWIFT:
     ThreadSafeWeakPtr<Device> m_device; // The only kind of queues that exist right now are default queues, which are owned by Devices.
-private:
     uint64_t m_submittedCommandBufferCount { 0 };
     uint64_t m_completedCommandBufferCount { 0 };
     uint64_t m_scheduledCommandBufferCount { 0 };
@@ -142,7 +138,7 @@ private:
     const ThreadSafeWeakPtr<Instance> m_instance;
     id<MTLBuffer> m_temporaryBuffer;
     uint64_t m_temporaryBufferOffset;
-} SWIFT_SHARED_REFERENCE(refQueue, derefQueue);
+} SWIFT_SHARED_REFERENCE(refQueue, derefQueue) SWIFT_PRIVATE_FILEID("WebGPU/Queue.swift");
 
 } // namespace WebGPU
 

--- a/Source/WebGPU/WebGPU/WebGPUExt.h
+++ b/Source/WebGPU/WebGPU/WebGPUExt.h
@@ -129,17 +129,6 @@ WGPU_EXPORT void wgpuDeviceClearUncapturedErrorCallback(WGPUDevice device) WGPU_
 
 WGPU_EXPORT String wgpuAdapterFeatureName(WGPUFeatureName feature) WGPU_FUNCTION_ATTRIBUTE;
 
-// Current Swift-C++ encapsulation rules prevent Swift from accessing non-public data members,
-// even in extensions. When building WebGPU, use these macros to allow our Swift module to break
-// encapsulation.
-#if defined(__swift__) && __swift__ && \
-    defined(__WEBGPU__) && __WEBGPU__ && \
-    defined(ENABLE_WEBGPU_SWIFT) && ENABLE_WEBGPU_SWIFT
-#define PUBLIC_IN_WEBGPU_SWIFT  : public
-#else
-#define PUBLIC_IN_WEBGPU_SWIFT
-#endif
-
 #endif
 
 #endif // WEBGPUEXT_H_


### PR DESCRIPTION
#### 1d2530a18d24e4f56c87e4bcd3f3d716e944cca6
<pre>
Remove all uses of PUBLIC_IN_WEBGPU_SWIFT
<a href="https://bugs.webkit.org/show_bug.cgi?id=299042">https://bugs.webkit.org/show_bug.cgi?id=299042</a>
<a href="https://rdar.apple.com/160803645">rdar://160803645</a>

Reviewed by Mike Wyrzykowski and Elliott Williams.

PUBLIC_IN_WEBGPU_SWIFT was a glorious hack to enable implementing parts of a C++
class in Swift despite name lookup rules making private and protected members
invisible.

Now that <a href="https://rdar.apple.com/137764620">rdar://137764620</a> is fixed, we can use SWIFT_PRIVATE_FILEID instead.

I consider this a subtask of removing un-safety in this code because making
private fields public is... not a great way to uphold essential invariants.

* Configurations/CommonBase.xcconfig: Enable SWIFT_PRIVATE_FILEID
* Source/WebGPU/WebGPU/Buffer.h: Use SWIFT_PRIVATE_FILEID instead of public.
* Source/WebGPU/WebGPU/CommandEncoder.h: Use SWIFT_PRIVATE_FILEID instead of public.
* Source/WebGPU/WebGPU/CommandsMixin.h: Declare our enum public because it
doesn&apos;t hold any private state, and all subclasses inherit this class publicly
anyway. (Also, we can&apos;t support protected enum declarations until
<a href="https://rdar.apple.com/160803362">rdar://160803362</a> is fixed.)
* Source/WebGPU/WebGPU/Device.h: No need for double `private` anymore since
there&apos;s no interstitial `public`.
(WebGPU::Device::nopVertexFunction const):
* Source/WebGPU/WebGPU/Queue.h: Use SWIFT_PRIVATE_FILEID instead of public.
* Source/WebGPU/WebGPU/WebGPUExt.h: No need for SWIFT_PRIVATE_FILEID anymore!

Canonical link: <a href="https://commits.webkit.org/300128@main">https://commits.webkit.org/300128@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/34ea499922424e68b607dd42f760aa394df17996

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121464 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41161 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31820 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127913 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/73547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5bebc2b6-8f2c-4110-a23b-6115211d5679) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41863 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49740 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92253 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/73547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/36abafc9-5772-44b8-81db-de41b6e6e6b0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124416 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33424 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/108810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72929 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/32433 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71485 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/102912 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27146 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130739 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48392 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36790 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/100843 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48760 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105031 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100750 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46162 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24242 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/45088 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19253 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48251 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53963 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/47722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/51068 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/49404 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->