### PR TITLE
AX: Expose orientation on iOS

### DIFF
--- a/Source/WebCore/accessibility/AXCoreObject.cpp
+++ b/Source/WebCore/accessibility/AXCoreObject.cpp
@@ -932,6 +932,31 @@ bool AXCoreObject::selfOrAncestorLinkHasPopup() const
     return false;
 }
 
+std::optional<AccessibilityOrientation> AXCoreObject::defaultOrientation() const
+{
+    switch (role()) {
+    case AccessibilityRole::DescriptionList:
+    case AccessibilityRole::List:
+    case AccessibilityRole::ListBox:
+    case AccessibilityRole::Menu:
+    case AccessibilityRole::ScrollBar:
+    case AccessibilityRole::Tree:
+        return { AccessibilityOrientation::Vertical };
+    case AccessibilityRole::MenuBar:
+    case AccessibilityRole::Slider:
+    case AccessibilityRole::Splitter:
+    case AccessibilityRole::TabList:
+    case AccessibilityRole::Toolbar:
+        return { AccessibilityOrientation::Horizontal };
+    case AccessibilityRole::ComboBox:
+    case AccessibilityRole::RadioGroup:
+    case AccessibilityRole::TreeGrid:
+        return { AccessibilityOrientation::Undefined };
+    default:
+        return std::nullopt;
+    }
+}
+
 AccessibilityOrientation AXCoreObject::orientation() const
 {
     if (std::optional orientation = explicitOrientation())
@@ -940,14 +965,8 @@ AccessibilityOrientation AXCoreObject::orientation() const
     // In ARIA 1.1, the implicit value of aria-orientation changed from horizontal
     // to undefined on all roles that don't have their own role-specific values. In
     // addition, the implicit value of combobox became undefined.
-    if (isComboBox() || isRadioGroup() || isTreeGrid())
-        return AccessibilityOrientation::Undefined;
-
-    if (isScrollbar() || isList() || isListBox() || isMenu() || isTree())
-        return AccessibilityOrientation::Vertical;
-
-    if (isMenuBar() || isSplitter() || isTabList() || isToolbar() || isSlider())
-        return AccessibilityOrientation::Horizontal;
+    if (std::optional defaultOrientation = this->defaultOrientation())
+        return *defaultOrientation;
 
     // Lacking concrete evidence of orientation, horizontal means width > height. vertical is height > width;
     auto size = this->size();

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -244,8 +244,8 @@ struct AccessibilityTextOperation {
 
 enum class AccessibilityOrientation : uint8_t {
     Undefined,
-    Horizontal,
-    Vertical
+    Vertical,
+    Horizontal
 };
 
 enum class DidTimeout : bool { No, Yes };
@@ -955,6 +955,7 @@ public:
     // which inherently are horizontal or vertical.
     virtual std::optional<AccessibilityOrientation> explicitOrientation() const = 0;
     AccessibilityOrientation orientation() const;
+    std::optional<AccessibilityOrientation> defaultOrientation() const;
 
     virtual void increment() = 0;
     virtual void decrement() = 0;

--- a/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
+++ b/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
@@ -3246,6 +3246,21 @@ static RenderObject* rendererForView(WAKView* view)
     return [NSString stringWithFormat:@"%@: %@", [self class], [self accessibilityLabel]];
 }
 
+- (AccessibilityOrientation)accessibilityOrientation
+{
+    if (![self _prepareAccessibilityCall])
+        return AccessibilityOrientation::Undefined;
+
+    std::optional defaultOrientation = self.axBackingObject->defaultOrientation();
+    // If we don't have a default orientation (unknown or otherwise), don't expose anything.
+    if (!defaultOrientation)
+        return AccessibilityOrientation::Undefined;
+
+    // If the orientation is the default, we don't need to share that with ATs.
+    std::optional orientation = self.axBackingObject->orientation();
+    return orientation && *orientation == *defaultOrientation ? AccessibilityOrientation::Undefined : *orientation;
+}
+
 @end
 
 #endif // PLATFORM(IOS_FAMILY)


### PR DESCRIPTION
#### 44a63befef09f0f6755ed771051826780cde1fb2
<pre>
AX: Expose orientation on iOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=299043">https://bugs.webkit.org/show_bug.cgi?id=299043</a>
<a href="https://rdar.apple.com/160805653">rdar://160805653</a>

Reviewed by Chris Fleizach.

Begin exposing the accessibility orientation of objects (when supported) on iOS. This
PR explicitly only will expose an non-undefined orientation when the object (a) supports
aria-orientation and (b) has a non-default value.

* Source/WebCore/accessibility/AXCoreObject.cpp:
(WebCore::AXCoreObject::defaultOrientation const):
(WebCore::AXCoreObject::orientation const):
* Source/WebCore/accessibility/AXCoreObject.h:
* Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm:
(-[WebAccessibilityObjectWrapper accessibilityOrientation]):

Canonical link: <a href="https://commits.webkit.org/300166@main">https://commits.webkit.org/300166@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/29b023c7fbe77c2fada1a6437d8fbf763e62711c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121477 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41174 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31833 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127927 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73560 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4c133af7-aed6-4fa7-9e33-5f65b32463f3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123353 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41876 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49753 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92262 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61383 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/62b3e12a-a1ca-44dd-9e35-ae55f34894d6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124429 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33435 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108814 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72939 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/30e5c8b9-7c6a-4782-9473-4f6e4b4e3721) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32444 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26990 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71498 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102921 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27150 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130752 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48405 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36802 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100852 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48773 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105035 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100759 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25565 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46168 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24246 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45101 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48264 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53976 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47735 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51081 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49417 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->