### PR TITLE
[JSC] WASM IPInt SIMD: support v128 in local.get, local.set, local.tee, global.get, global.set

### DIFF
--- a/JSTests/wasm/stress/simd-get-set.js
+++ b/JSTests/wasm/stress/simd-get-set.js
@@ -1,0 +1,181 @@
+//@ requireOptions("--useWasmSIMD=1")
+//@ skip if !$isSIMDPlatform
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat = `
+(module
+    (memory (export "memory") 1)
+
+    (global $embedded_global_ro v128 (v128.const i32x4 42 100 200 300))
+    (global $embedded_global_mut (mut v128) (v128.const i32x4 0 0 0 0))
+    (global $exported_global (export "exported_global") (mut v128) (v128.const i32x4 0 0 0 0))
+
+    ;; Basic test: read v128 from memory, store in local, then write to different memory location
+    (func (export "test_basic_copy") (param $src i32) (param $dst i32)
+        (local $temp v128)
+
+        ;; Load v128 from source address into local
+        (local.set $temp (v128.load (local.get $src)))
+
+        ;; Store local v128 to destination address
+        (v128.store (local.get $dst) (local.get $temp))
+    )
+
+    ;; Test multiple v128 locals
+    (func (export "test_multiple_locals") (param $src1 i32) (param $src2 i32) (param $dst1 i32) (param $dst2 i32)
+        (local $vec1 v128)
+        (local $vec2 v128)
+
+        ;; Load two vectors from memory
+        (local.set $vec1 (v128.load (local.get $src1)))
+        (local.set $vec2 (v128.load (local.get $src2)))
+
+        ;; Store results back to memory (swapped destinations)
+        (v128.store (local.get $dst1) (local.get $vec2))
+        (v128.store (local.get $dst2) (local.get $vec1))
+    )
+
+    ;; Test v128 local.tee operation
+    (func (export "test_local_tee") (param $src i32) (param $dst1 i32) (param $dst2 i32)
+        (local $vec v128)
+
+        ;; Load vector and use local.tee to both set local and leave value on stack
+        (v128.store (local.get $dst1)
+            (local.tee $vec (v128.load (local.get $src)))
+        )
+
+        ;; Use the local that was set by local.tee
+        (v128.store (local.get $dst2) (local.get $vec))
+    )
+
+    ;; Test global.get and global.set
+    (func (export "test_globals") (param $dst i32)
+        (local $temp v128)
+
+        (global.set $exported_global (global.get $embedded_global_ro))
+        (global.set $embedded_global_mut (global.get $exported_global))
+        (v128.store (local.get $dst) (global.get $embedded_global_mut))
+    )
+)
+`
+
+async function test() {
+    const instance = await instantiate(wat, {}, { simd: true });
+    const {
+        memory,
+        test_basic_copy,
+        test_multiple_locals,
+        test_local_tee,
+        test_globals,
+    } = instance.exports;
+
+    // Create typed array views for easy data manipulation
+    const i32View = new Int32Array(memory.buffer);
+
+    // Helper function to set i32x4 data at byte offset
+    function setI32x4(byteOffset, a, b, c, d) {
+        const i32Offset = byteOffset / 4;
+        i32View[i32Offset] = a;
+        i32View[i32Offset + 1] = b;
+        i32View[i32Offset + 2] = c;
+        i32View[i32Offset + 3] = d;
+    }
+
+    // Helper function to get i32x4 data at byte offset
+    function getI32x4(byteOffset) {
+        const i32Offset = byteOffset / 4;
+        return [i32View[i32Offset], i32View[i32Offset + 1], i32View[i32Offset + 2], i32View[i32Offset + 3]];
+    }
+
+    // Basic copy operation
+    {
+        const srcAddr = 0;
+        const dstAddr = 16;
+
+        // Set source data: [1, 2, 3, 4]
+        setI32x4(srcAddr, 1, 2, 3, 4);
+
+        // Call the function
+        test_basic_copy(srcAddr, dstAddr);
+
+        // Verify the copy
+        const result = getI32x4(dstAddr);
+        assert.eq(result[0], 1);
+        assert.eq(result[1], 2);
+        assert.eq(result[2], 3);
+        assert.eq(result[3], 4);
+    }
+
+    // Multiple locals
+    {
+        const src1Addr = 32;
+        const src2Addr = 48;
+        const dst1Addr = 64;
+        const dst2Addr = 80;
+
+        // Set source data
+        setI32x4(src1Addr, 10, 20, 30, 40);    // vec1
+        setI32x4(src2Addr, 100, 200, 300, 400); // vec2
+
+        // Call the function (swaps the vectors)
+        test_multiple_locals(src1Addr, src2Addr, dst1Addr, dst2Addr);
+
+        // Verify swapped results
+        const result1 = getI32x4(dst1Addr); // Should be vec2
+        const result2 = getI32x4(dst2Addr); // Should be vec1
+
+        assert.eq(result1[0], 100);
+        assert.eq(result1[1], 200);
+        assert.eq(result1[2], 300);
+        assert.eq(result1[3], 400);
+
+        assert.eq(result2[0], 10);
+        assert.eq(result2[1], 20);
+        assert.eq(result2[2], 30);
+        assert.eq(result2[3], 40);
+    }
+
+    // local.tee operation
+    {
+        const srcAddr = 224;
+        const dst1Addr = 240;
+        const dst2Addr = 256;
+
+        setI32x4(srcAddr, 100, 200, 300, 400);
+
+        // Call function (uses local.tee to set local and store to both destinations)
+        test_local_tee(srcAddr, dst1Addr, dst2Addr);
+
+        // Both destinations should have the same data
+        const result1 = getI32x4(dst1Addr);
+        const result2 = getI32x4(dst2Addr);
+
+        assert.eq(result1[0], 100);
+        assert.eq(result1[1], 200);
+        assert.eq(result1[2], 300);
+        assert.eq(result1[3], 400);
+
+        assert.eq(result2[0], 100);
+        assert.eq(result2[1], 200);
+        assert.eq(result2[2], 300);
+        assert.eq(result2[3], 400);
+    }
+
+    // Test globals operation
+    {
+        const dstAddr = 272;
+
+        // Call function (reads embedded global [42,100,200,300], writes to exported, reads back, writes to memory)
+        test_globals(dstAddr);
+
+        // Verify the result contains the embedded global value
+        const result = getI32x4(dstAddr);
+        assert.eq(result[0], 42);
+        assert.eq(result[1], 100);
+        assert.eq(result[2], 200);
+        assert.eq(result[3], 300);
+    }
+}
+
+await assert.asyncTest(test())


### PR DESCRIPTION
#### 67d7bf15139a2b28d915d7e59b557851d19944ce
<pre>
[JSC] WASM IPInt SIMD: support v128 in local.get, local.set, local.tee, global.get, global.set
<a href="https://bugs.webkit.org/show_bug.cgi?id=299044">https://bugs.webkit.org/show_bug.cgi?id=299044</a>
<a href="https://rdar.apple.com/160806182">rdar://160806182</a>

Reviewed by Keith Miller.

In order to support v128 in IPInt implementation of local.{get, set, tee}
and global.{get, set}, always load/store 16-bytes.

Test: JSTests/wasm/stress/simd-get-set.js
* JSTests/wasm/stress/simd-get-set.js: Added.
(Test.global.and.global.func.async test.setI32x4):
(Test.global.and.global.func.async test.getI32x4):
(Test.global.and.global.func.async test):
* Source/JavaScriptCore/llint/InPlaceInterpreter64.asm:

Canonical link: <a href="https://commits.webkit.org/300163@main">https://commits.webkit.org/300163@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8a6bee310d2eb9dd5582354e833fbf1fc6785cfc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121424 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41121 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31780 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127865 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73507 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fe4e171c-a4f7-4543-8d87-5a0df33213e2) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41823 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49700 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92232 "20 flakes 20 failures") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61364 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/19b98778-9c51-4025-a13f-264b344c1bc9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124376 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33390 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108784 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72908 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fa17ab72-b10d-41ca-9b45-2c697f6a84f6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32420 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26935 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71445 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/113554 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102886 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27109 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130699 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/119944 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48352 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36764 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100821 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48720 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104994 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100728 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46141 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24208 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45048 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19264 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48210 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53923 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/150106 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47682 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/38192 "Found 1 new JSC stress test failure: stress/dont-link-virtual-calls-on-compiler-thread.js.no-llint (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51028 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49364 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->