### PR TITLE
Convert WebPage::drawPagesToPDFImpl to use GraphicsContext.

### DIFF
--- a/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.cpp
+++ b/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.cpp
@@ -570,10 +570,10 @@ void BifurcatedGraphicsContext::drawDotsForDocumentMarker(const FloatRect& rect,
     VERIFY_STATE_SYNCHRONIZATION();
 }
 
-void BifurcatedGraphicsContext::beginPage(const IntSize& pageSize)
+void BifurcatedGraphicsContext::beginPage(const FloatRect& pageRect)
 {
-    m_primaryContext.beginPage(pageSize);
-    m_secondaryContext.beginPage(pageSize);
+    m_primaryContext.beginPage(pageRect);
+    m_secondaryContext.beginPage(pageRect);
 
     VERIFY_STATE_SYNCHRONIZATION();
 }

--- a/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.h
+++ b/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.h
@@ -140,7 +140,7 @@ public:
 
     void drawDotsForDocumentMarker(const FloatRect&, DocumentMarkerLineStyle) final;
 
-    void beginPage(const IntSize&) final;
+    void beginPage(const FloatRect&) final;
     void endPage() final;
 
     void setURLForRect(const URL&, const FloatRect&) final;

--- a/Source/WebCore/platform/graphics/GraphicsContext.h
+++ b/Source/WebCore/platform/graphics/GraphicsContext.h
@@ -351,7 +351,7 @@ public:
     WEBCORE_EXPORT FloatSize scaleFactorForDrawing(const FloatRect& destRect, const FloatRect& srcRect) const;
 
     // PDF, printing and snapshotting
-    virtual void beginPage(const IntSize&) { }
+    virtual void beginPage(const FloatRect&) { }
     virtual void endPage() { }
 
     // Links

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
@@ -1480,7 +1480,7 @@ void GraphicsContextCG::strokeEllipse(const FloatRect& ellipse)
     CGContextStrokeEllipseInRect(context, ellipse);
 }
 
-void GraphicsContextCG::beginPage(const IntSize& pageSize)
+void GraphicsContextCG::beginPage(const FloatRect& pageRect)
 {
     CGContextRef context = platformContext();
 
@@ -1489,7 +1489,7 @@ void GraphicsContextCG::beginPage(const IntSize& pageSize)
         return;
     }
 
-    auto mediaBox = CGRectMake(0, 0, pageSize.width(), pageSize.height());
+    auto mediaBox = CGRectMake(pageRect.x(), pageRect.y(), pageRect.width(), pageRect.height());
     auto mediaBoxData = adoptCF(CFDataCreate(nullptr, (const UInt8 *)&mediaBox, sizeof(CGRect)));
 
     const void* key = kCGPDFContextMediaBox;

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.h
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.h
@@ -122,7 +122,7 @@ public:
 
     void drawDotsForDocumentMarker(const FloatRect&, DocumentMarkerLineStyle) final;
 
-    void beginPage(const IntSize& pageSize) final;
+    void beginPage(const FloatRect& pageRect) final;
     void endPage() final;
 
     void setURLForRect(const URL&, const FloatRect&) final;

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp
@@ -728,12 +728,12 @@ void ApplyDeviceScaleFactor::dump(TextStream& ts, OptionSet<AsTextFlag>) const
 
 void BeginPage::apply(GraphicsContext& context) const
 {
-    context.beginPage(m_pageSize);
+    context.beginPage(m_pageRect);
 }
 
 void BeginPage::dump(TextStream& ts, OptionSet<AsTextFlag>) const
 {
-    ts.dumpProperty("page-size"_s, pageSize());
+    ts.dumpProperty("page-rect"_s, pageRect());
 }
 
 void EndPage::apply(GraphicsContext& context) const

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItems.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItems.h
@@ -1263,18 +1263,18 @@ class BeginPage {
 public:
     static constexpr char name[] = "begin-page";
 
-    BeginPage(const IntSize& pageSize)
-        : m_pageSize(pageSize)
+    BeginPage(const FloatRect& pageRect)
+        : m_pageRect(pageRect)
     {
     }
 
-    const IntSize& pageSize() const { return m_pageSize; }
+    const FloatRect& pageRect() const { return m_pageRect; }
 
     WEBCORE_EXPORT void apply(GraphicsContext&) const;
     void dump(TextStream&, OptionSet<AsTextFlag>) const;
 
 private:
-    IntSize m_pageSize;
+    FloatRect m_pageRect;
 };
 
 class EndPage {

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp
@@ -424,10 +424,10 @@ void RecorderImpl::applyDeviceScaleFactor(float scaleFactor)
     m_items.append(ApplyDeviceScaleFactor(scaleFactor));
 }
 
-void RecorderImpl::beginPage(const IntSize& pageSize)
+void RecorderImpl::beginPage(const FloatRect& pageRect)
 {
     appendStateChangeItemIfNecessary();
-    m_items.append(BeginPage({ pageSize }));
+    m_items.append(BeginPage({ pageRect }));
 }
 
 void RecorderImpl::endPage()

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.h
@@ -110,7 +110,7 @@ public:
 #endif
     void applyDeviceScaleFactor(float) final;
 
-    void beginPage(const IntSize&) final;
+    void beginPage(const FloatRect&) final;
     void endPage() final;
 
     void setURLForRect(const URL&, const FloatRect&) final;

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.cpp
@@ -688,9 +688,9 @@ void RemoteGraphicsContext::applyDeviceScaleFactor(float scaleFactor)
     context().applyDeviceScaleFactor(scaleFactor);
 }
 
-void RemoteGraphicsContext::beginPage(const IntSize& pageSize)
+void RemoteGraphicsContext::beginPage(const FloatRect& pageRect)
 {
-    context().beginPage(pageSize);
+    context().beginPage(pageRect);
 }
 
 void RemoteGraphicsContext::endPage()

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.h
@@ -154,7 +154,7 @@ public:
     void applyDeviceScaleFactor(float);
     std::optional<WebKit::SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const;
 
-    void beginPage(const WebCore::IntSize& pageSize);
+    void beginPage(const WebCore::FloatRect&);
     void endPage();
 
     void setURLForRect(const URL&, const WebCore::FloatRect&);

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.messages.in
@@ -128,7 +128,7 @@ messages -> RemoteGraphicsContext Stream {
 #endif
     ApplyDeviceScaleFactor(float scaleFactor)
 
-    BeginPage(WebCore::IntSize pageSize)
+    BeginPage(WebCore::FloatRect pageRect)
     EndPage()
     SetURLForRect(URL link, WebCore::FloatRect destRect)
 

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.cpp
@@ -609,10 +609,10 @@ void RemoteGraphicsContextProxy::applyDeviceScaleFactor(float scaleFactor)
     send(Messages::RemoteGraphicsContext::ApplyDeviceScaleFactor(scaleFactor));
 }
 
-void RemoteGraphicsContextProxy::beginPage(const IntSize& pageSize)
+void RemoteGraphicsContextProxy::beginPage(const FloatRect& pageRect)
 {
     appendStateChangeItemIfNecessary();
-    send(Messages::RemoteGraphicsContext::BeginPage(pageSize));
+    send(Messages::RemoteGraphicsContext::BeginPage(pageRect));
 }
 
 void RemoteGraphicsContextProxy::endPage()

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.h
@@ -138,7 +138,7 @@ private:
 #endif
     void applyDeviceScaleFactor(float) final;
 
-    void beginPage(const WebCore::IntSize& pageSize) final;
+    void beginPage(const WebCore::FloatRect&) final;
     void endPage() final;
     void setURLForRect(const URL&, const WebCore::FloatRect&) final;
 

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -610,7 +610,7 @@ void WebPage::pdfSnapshotAtSize(LocalFrame& localMainFrame, GraphicsContext& con
         rect.setHeight(bitmapSize.height());
         rect.setY(nextRectY);
 
-        context.beginPage(bitmapSize);
+        context.beginPage(FloatRect { { }, bitmapSize });
         context.scale({ 1, -1 });
         context.translate(0, -bitmapSize.height());
 
@@ -1359,18 +1359,16 @@ void WebPage::drawPDFDocument(CGContextRef context, PDFDocument *pdfDocument, co
     }
 }
 
-void WebPage::drawPagesToPDFFromPDFDocument(CGContextRef context, PDFDocument *pdfDocument, const PrintInfo& printInfo, uint32_t first, uint32_t count)
+void WebPage::drawPagesToPDFFromPDFDocument(GraphicsContext& context, PDFDocument *pdfDocument, const PrintInfo& printInfo, const WebCore::FloatRect& mediaBox, uint32_t first, uint32_t count)
 {
     NSUInteger pageCount = [pdfDocument pageCount];
     for (uint32_t page = first; page < first + count; ++page) {
         if (page >= pageCount)
             break;
 
-        RetainPtr pageInfo = adoptCF(CFDictionaryCreateMutable(0, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
-
-        CGPDFContextBeginPage(context, pageInfo.get());
-        drawPDFPage(pdfDocument, page, context, printInfo.pageSetupScaleFactor, CGSizeMake(printInfo.availablePaperWidth, printInfo.availablePaperHeight));
-        CGPDFContextEndPage(context);
+        context.beginPage(mediaBox);
+        drawPDFPage(pdfDocument, page, context.platformContext(), printInfo.pageSetupScaleFactor, CGSizeMake(printInfo.availablePaperWidth, printInfo.availablePaperHeight));
+        context.endPage();
     }
 }
 
@@ -1386,7 +1384,7 @@ void WebPage::computePagesForPrintingPDFDocument(WebCore::FrameIdentifier, const
     notImplemented();
 }
 
-void WebPage::drawPagesToPDFFromPDFDocument(CGContextRef, PDFDocument *, const PrintInfo&, uint32_t, uint32_t)
+void WebPage::drawPagesToPDFFromPDFDocument(GraphicsContext&, PDFDocument *, const PrintInfo&, const WebCore::FloatRect&, uint32_t, uint32_t)
 {
     notImplemented();
 }

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1363,7 +1363,9 @@ public:
     void drawRectToImageDuringDOMPrintOperation(WebCore::FrameIdentifier frameID, const PrintInfo& printInfo, const WebCore::IntRect& rect, const WebCore::IntSize& imageSize, CompletionHandler<void(std::optional<WebCore::ShareableBitmap::Handle>&&)>&& completionHandler) { drawRectToImage(frameID, printInfo, rect, imageSize, WTFMove(completionHandler)); }
     void drawPagesToPDF(WebCore::FrameIdentifier, const PrintInfo&, uint32_t first, uint32_t count, CompletionHandler<void(RefPtr<WebCore::SharedBuffer>&&)>&&);
     void drawPagesToPDFDuringDOMPrintOperation(WebCore::FrameIdentifier frameID, const PrintInfo& printInfo, uint32_t first, uint32_t count, CompletionHandler<void(RefPtr<WebCore::SharedBuffer>&&)>&& completionHandler) { drawPagesToPDF(frameID, printInfo, first, count, WTFMove(completionHandler)); }
-    void drawPagesToPDFImpl(WebCore::FrameIdentifier, const PrintInfo&, uint32_t first, uint32_t count, RetainPtr<CFMutableDataRef>& pdfPageData);
+    void drawPagesToPDFImpl(WebCore::FrameIdentifier, const PrintInfo&, uint32_t first, uint32_t count, RefPtr<WebCore::SharedBuffer>& pdfPageData);
+
+    void drawPrintContextPagesToGraphicsContext(WebCore::GraphicsContext&, const WebCore::FloatRect& pageRect, uint32_t first, uint32_t count);
 #endif
 
 #if PLATFORM(IOS_FAMILY)
@@ -2328,7 +2330,7 @@ private:
     RetainPtr<PDFDocument> pdfDocumentForPrintingFrame(WebCore::LocalFrame*);
     void computePagesForPrintingPDFDocument(WebCore::FrameIdentifier, const PrintInfo&, Vector<WebCore::IntRect>& resultPageRects);
     void drawPDFDocument(CGContextRef, PDFDocument *, const PrintInfo&, const WebCore::IntRect&);
-    void drawPagesToPDFFromPDFDocument(CGContextRef, PDFDocument *, const PrintInfo&, uint32_t first, uint32_t count);
+    void drawPagesToPDFFromPDFDocument(WebCore::GraphicsContext&, PDFDocument *, const PrintInfo&, const WebCore::FloatRect&, uint32_t first, uint32_t count);
 #endif
 
     void endPrintingImmediately();

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -5454,9 +5454,9 @@ void WebPage::drawToPDFiOS(FrameIdentifier frameID, const PrintInfo& printInfo, 
         return;
     }
 
-    RetainPtr<CFMutableDataRef> pdfPageData;
+    RefPtr<SharedBuffer> pdfPageData;
     drawPagesToPDFImpl(frameID, printInfo, 0, pageCount, pdfPageData);
-    reply(SharedBuffer::create(pdfPageData.get()));
+    reply(WTFMove(pdfPageData));
 
     endPrinting();
 }


### PR DESCRIPTION
#### 4417fcbc469169d01d5bc7dea493deb1c3eb98d4
<pre>
Convert WebPage::drawPagesToPDFImpl to use GraphicsContext.
<a href="https://bugs.webkit.org/show_bug.cgi?id=299050">https://bugs.webkit.org/show_bug.cgi?id=299050</a>
&lt;<a href="https://rdar.apple.com/problem/160809008">rdar://problem/160809008</a>&gt;

Reviewed by Abrar Rahman Protyasha.

This currently uses CGContext, but needs to use a GraphicsContext so that we can
write a snapshot (display list) recording version for site-isolation.

Change GraphicsContext::beginPage to take a rect instead of a size, more closely
matching the CG API undernearth.

Convert drawPagesToPDFImpl over to using the platform-agnostic
GraphicsContext/ImageBuffer APIs. This is largely a direct conversion, except
that the media is now specified per-page instead of on context creation (where
it became the default used for pages).

* Source/WebCore/platform/graphics/BifurcatedGraphicsContext.cpp:
(WebCore::BifurcatedGraphicsContext::beginPage):
* Source/WebCore/platform/graphics/BifurcatedGraphicsContext.h:
* Source/WebCore/platform/graphics/GraphicsContext.h:
(WebCore::GraphicsContext::beginPage):
* Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp:
(WebCore::GraphicsContextCG::beginPage):
* Source/WebCore/platform/graphics/cg/GraphicsContextCG.h:
* Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp:
(WebCore::DisplayList::BeginPage::apply const):
(WebCore::DisplayList::BeginPage::dump const):
* Source/WebCore/platform/graphics/displaylists/DisplayListItems.h:
(WebCore::DisplayList::BeginPage::BeginPage):
(WebCore::DisplayList::BeginPage::pageRect const):
(WebCore::DisplayList::BeginPage::pageSize const): Deleted.
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp:
(WebCore::DisplayList::RecorderImpl::beginPage):
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.h:
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.cpp:
(WebKit::RemoteGraphicsContext::beginPage):
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.h:
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.messages.in:
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.cpp:
(WebKit::RemoteGraphicsContextProxy::beginPage):
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.h:
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::pdfSnapshotAtSize):
(WebKit::WebPage::drawPagesToPDFFromPDFDocument):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::drawPagesToPDF):
(WebKit::WebPage::drawPagesToPDFImpl):
(WebKit::WebPage::drawPrintContextPagesToGraphicsContext):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::drawToPDFiOS):

Canonical link: <a href="https://commits.webkit.org/300136@main">https://commits.webkit.org/300136@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/64e3e09d6f1b395185cfb7d44da1a0cfcc0cd338

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121440 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41137 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31796 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127885 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73523 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3c9eed55-ec9b-470c-881e-11053d843ab5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123316 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41839 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49716 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92241 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/61371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f0d420e3-212a-4337-873f-68064082d49c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124392 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33402 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108795 "Found 1 new API test failure: TestIPC.ConnectionTest/ConnectionRunLoopTest.SendAsyncAndInvalidate/ServerIsA (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72917 "Found 1 new API test failure: WPE/TestWebsiteData:/webkit/WebKitWebsiteData/cache (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d96d3035-d86d-4da3-a3c8-75ad886ac724) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32416 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26952 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71461 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102896 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27126 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130715 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48368 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36775 "Found 1 new test failure: ipc/invalid-path-segments-crash.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100834 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48736 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105011 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100741 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25540 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46149 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24223 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45064 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48226 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53939 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47698 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51044 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49380 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->