### PR TITLE
REGRESSION(298715@main): SVG animation with finite 'max' and indefinite 'repeatDur` causes the web page to jetsam

### DIFF
--- a/LayoutTests/svg/animations/smil-max-finite-repeatDur-indefinite-crash-expected.txt
+++ b/LayoutTests/svg/animations/smil-max-finite-repeatDur-indefinite-crash-expected.txt
@@ -1,0 +1,3 @@
+Passes if it does not crash.
+
+

--- a/LayoutTests/svg/animations/smil-max-finite-repeatDur-indefinite-crash.html
+++ b/LayoutTests/svg/animations/smil-max-finite-repeatDur-indefinite-crash.html
@@ -1,0 +1,21 @@
+<body>
+    <p>Passes if it does not crash.</p>
+    <svg id="svg">
+        <rect width="100" height="100" fill="green">
+            <set attributeName="transform" begin="200ms" max="200ms" dur="2s" repeatDur="indefinite" onend="handleEndEvent()"/>
+        </rect>
+    </svg>
+    <script>
+        if (window.testRunner) {
+            testRunner.dumpAsText();
+            testRunner.waitUntilDone();
+        }
+
+        svg.setCurrentTime(0.5);
+
+        function handleEndEvent(event) {
+            if (window.testRunner)
+                testRunner.notifyDone();
+        }
+    </script>
+</body>


### PR DESCRIPTION
#### 19a1347c71e0731cda80f988622c19ecadd32d86
<pre>
REGRESSION(298715@main): SVG animation with finite &apos;max&apos; and indefinite &apos;repeatDur` causes the web page to jetsam
<a href="https://bugs.webkit.org/show_bug.cgi?id=299047">https://bugs.webkit.org/show_bug.cgi?id=299047</a>
<a href="https://rdar.apple.com/160099991">rdar://160099991</a>

Reviewed by Nikolas Zimmermann.

When the SMIL ends because the elapsed time is greater than the intervalEnd, we
should not use repeatingDuration to calculate &apos;repeat&apos; value unless its value is
finite. If it is value isIndefinite, we should use the duration since the begin
of the animation.

Test: svg/animations/smil-max-finite-repeatDur-indefinite-crash.html
* LayoutTests/svg/animations/smil-max-finite-repeatDur-indefinite-crash-expected.txt: Added.
* LayoutTests/svg/animations/smil-max-finite-repeatDur-indefinite-crash.html: Added.
* Source/WebCore/svg/animation/SVGSMILElement.cpp:
(WebCore::SVGSMILElement::calculateAnimationPercentAndRepeat const):

Canonical link: <a href="https://commits.webkit.org/300165@main">https://commits.webkit.org/300165@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2ea95a5b20bd54eb5f916da2435136261cf8dee8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121442 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41139 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31798 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127886 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73525 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cb830a2d-1d3b-43f7-8610-b4690ba615ae) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123318 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41841 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49718 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92240 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61372 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/27e29520-4ea7-4aed-827c-91c3fb2b6b33) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124394 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33406 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108796 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72916 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bab3381f-fcd5-4c50-b081-b71cebb5263c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32419 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26954 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71463 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102898 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27128 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130717 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48370 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36776 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100833 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48738 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105013 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100740 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25562 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46150 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24225 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45066 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48228 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53941 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47700 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51046 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49382 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->