### PR TITLE
Disable TestWebKitAPI.WebKit.MobileAssetSandboxCheck on macOS26+

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKit/MobileAssetSandboxCheck.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/MobileAssetSandboxCheck.mm
@@ -31,11 +31,9 @@
 #import "TestWKWebView.h"
 #import <WebKit/WKWebViewPrivate.h>
 
-#if PLATFORM(MAC) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 260000
+// This test no longer makes sense on macOS26+ as we no longer allow com.apple.mobileassetd.v2 access.
+#if !PLATFORM(MAC) || __MAC_OS_X_VERSION_MIN_REQUIRED < 260000
 TEST(WebKit, DISABLED_MobileAssetSandboxCheck)
-#else
-TEST(WebKit, MobileAssetSandboxCheck)
-#endif
 {
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     auto context = adoptWK(TestWebKitAPI::Util::createContextForInjectedBundleTest("InternalsInjectedBundleTest"));
@@ -52,5 +50,6 @@ TEST(WebKit, MobileAssetSandboxCheck)
 
     ASSERT_TRUE(sandboxAccess());
 }
+#endif
 
 #endif // WK_HAVE_C_SPI


### PR DESCRIPTION
#### aac5510791f65667be41e5103631cc4d04f9efd3
<pre>
Disable TestWebKitAPI.WebKit.MobileAssetSandboxCheck on macOS26+
<a href="https://bugs.webkit.org/show_bug.cgi?id=299054">https://bugs.webkit.org/show_bug.cgi?id=299054</a>
<a href="https://rdar.apple.com/153227385">rdar://153227385</a>

Reviewed by Per Arne Vollan.

Disable TestWebKitAPI.WebKit.MobileAssetSandboxCheck on macOS26+.
The test no longer makes sense there since we no longer allow access
to com.apple.mobileassetd.v2.

* Tools/TestWebKitAPI/Tests/WebKit/MobileAssetSandboxCheck.mm:
(TEST(WebKit, DISABLED_MobileAssetSandboxCheck)):
(TEST(WebKit, MobileAssetSandboxCheck)): Deleted.

Canonical link: <a href="https://commits.webkit.org/300130@main">https://commits.webkit.org/300130@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7e65669b9fa8e9ca3c53b2c4387d836fb6ec1e6e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121449 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41146 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31805 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127893 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/73532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/725f1c8b-eb9c-4e8f-9f39-bfc65308bbd0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123325 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41848 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49725 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92243 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/73532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1b355dbc-c7d2-4f4b-8ca2-c98685ca238d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124401 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33413 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/108799 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72919 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7b19ee39-d7ea-4447-850d-a97a987b4e59) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32424 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26958 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71470 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/102903 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27132 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130724 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48377 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36783 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100836 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48745 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105017 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100743 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25533 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46155 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24229 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/45073 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48235 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47707 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51053 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49389 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->