### PR TITLE
[Site Isolation] Translation does not work for images in cross-site iframes

### DIFF
--- a/Source/WebCore/page/ImageAnalysisQueue.h
+++ b/Source/WebCore/page/ImageAnalysisQueue.h
@@ -42,7 +42,7 @@ class HysteresisActivity;
 
 namespace WebCore {
 
-class Document;
+class Frame;
 class HTMLImageElement;
 class Page;
 class Timer;
@@ -54,7 +54,7 @@ public:
     static Ref<ImageAnalysisQueue> create(Page&);
     WEBCORE_EXPORT ~ImageAnalysisQueue();
 
-    WEBCORE_EXPORT void enqueueAllImagesIfNeeded(Document&, const String& sourceLanguageIdentifier, const String& targetLanguageIdentifier);
+    WEBCORE_EXPORT void enqueueAllImagesIfNeeded(Frame&, const String& sourceLanguageIdentifier, const String& targetLanguageIdentifier);
     void clear();
 
     void enqueueIfNeeded(HTMLImageElement&);
@@ -68,7 +68,7 @@ private:
     void resumeProcessingSoon();
     void resumeProcessing();
 
-    void enqueueAllImagesRecursive(Document&);
+    void enqueueAllImagesRecursive(Frame&);
 
     enum class Priority : bool { Low, High };
     struct Task {

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -1232,9 +1232,7 @@ void Page::analyzeImagesForFindInPage(Function<void()>&& callback)
     if (settings().imageAnalysisDuringFindInPageEnabled()) {
         Ref imageAnalysisQueue = this->imageAnalysisQueue();
         imageAnalysisQueue->setDidBecomeEmptyCallback(WTFMove(callback));
-        RefPtr localMainFrame = dynamicDowncast<LocalFrame>(m_mainFrame.get());
-        if (RefPtr mainDocument = localMainFrame ? localMainFrame->document() : nullptr)
-            imageAnalysisQueue->enqueueAllImagesIfNeeded(*mainDocument, { }, { });
+        imageAnalysisQueue->enqueueAllImagesIfNeeded(m_mainFrame.get(), { }, { });
     }
 }
 #endif

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -12895,8 +12895,10 @@ void WebPageProxy::updateWithTextRecognitionResult(TextRecognitionResult&& resul
 
 void WebPageProxy::startVisualTranslation(const String& sourceLanguageIdentifier, const String& targetLanguageIdentifier)
 {
-    if (hasRunningProcess())
-        send(Messages::WebPage::StartVisualTranslation(sourceLanguageIdentifier, targetLanguageIdentifier));
+    forEachWebContentProcess([&](auto& webProcess, auto pageID) {
+        if (hasRunningProcess())
+            webProcess.send(Messages::WebPage::StartVisualTranslation(sourceLanguageIdentifier, targetLanguageIdentifier), pageID);
+    });
 }
 
 #endif // ENABLE(IMAGE_ANALYSIS)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -9377,8 +9377,11 @@ void WebPage::updateWithTextRecognitionResult(const TextRecognitionResult& resul
 
 void WebPage::startVisualTranslation(const String& sourceLanguageIdentifier, const String& targetLanguageIdentifier)
 {
-    if (RefPtr document = m_mainFrame->coreLocalFrame()->document())
-        protectedCorePage()->protectedImageAnalysisQueue()->enqueueAllImagesIfNeeded(*document, sourceLanguageIdentifier, targetLanguageIdentifier);
+    RefPtr frame = m_mainFrame->coreFrame();
+    if (!frame)
+        return;
+
+    protectedCorePage()->protectedImageAnalysisQueue()->enqueueAllImagesIfNeeded(*frame, sourceLanguageIdentifier, targetLanguageIdentifier);
 }
 
 #endif // ENABLE(IMAGE_ANALYSIS)


### PR DESCRIPTION
#### 8943706e7394a34d007f9b7b3bb50cb4e4ec8def
<pre>
[Site Isolation] Translation does not work for images in cross-site iframes
<a href="https://bugs.webkit.org/show_bug.cgi?id=299051">https://bugs.webkit.org/show_bug.cgi?id=299051</a>
<a href="https://rdar.apple.com/160809446">rdar://160809446</a>

Reviewed by Brady Eidson and Wenson Hsieh.

With site-isolation off, translating a page will translate images that are in
cross-site iframes. With site-isolation on, those images are not translated.

There are two issues:

1. WebPageProxy::startVisualTranslation() starts the image translation only in
   the current-process&apos; document. So translation occurs only in the main frame
   and any same-origin iframes.

   We update this to start the image translation in all web content processes.

2. Now the image translation is starting in all processes. But we see that
   WebPage::startVisualTranslation() only enqueues images to be translated if
   it&apos;s able to access the main frame&apos;s document. For remote frames, this is
   not possible, so the remote frames&apos; images won&apos;t get translated.

   We update this to start the translation regardless of if the main frame
   is local or not. Instead of doing a document traversal (which doesn&apos;t work
   with site-isolation), we will do a frame traversal.

   Each process will enqueue (and then translate) the images of any frame in
   the frame tree that is local to the process. Since all web content processes
   are doing this, all frames will be translated.

This is tested by a new API test: SiteIsolation.IframeImageTranslation.

With site isolation off, if the page is translated, then a new cross-site iframe
is added, that iframe&apos;s images should also be translated. This doesn&apos;t happen
with site isolation on but will be fixed in subsequent patches.

* Source/WebCore/page/ImageAnalysisQueue.cpp:
(WebCore::ImageAnalysisQueue::enqueueAllImagesIfNeeded):
(WebCore::ImageAnalysisQueue::enqueueAllImagesRecursive):
* Source/WebCore/page/ImageAnalysisQueue.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::analyzeImagesForFindInPage):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::startVisualTranslation):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::startVisualTranslation):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(processRequestWithResults):
(makeFakeRequest):
(makeImageAnalysisRequestSwizzler):
(-[TestWKWebViewImageAnalysisTests waitForImageAnalysisRequests:]):
(TestWebKitAPI::(SiteIsolation, IframeImageTranslation)):

Canonical link: <a href="https://commits.webkit.org/300199@main">https://commits.webkit.org/300199@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/efa1ea1aa4b17f84d5279e3ddeb6250ba18a9667

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121571 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41268 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31927 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128148 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73656 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2b444eca-2d73-4216-afdf-ffe514c7e8e7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123447 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41970 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49847 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/92429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61441 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1953c468-7a52-45d6-9625-c1d9239494ad) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124523 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33509 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108894 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73090 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a66acd54-38bc-4061-95dd-ad3c26473956) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32524 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27059 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71603 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102997 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27233 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130947 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48499 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36918 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/101001 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48867 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105116 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100890 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46243 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24328 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45206 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19277 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48358 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54070 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47829 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51176 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49511 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->