### PR TITLE
[GFC] Build Layout::ElementBox tree from RenderGrid.

### DIFF
--- a/Source/WebCore/layout/integration/LayoutIntegrationBoxTreeUpdater.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationBoxTreeUpdater.cpp
@@ -328,7 +328,15 @@ void BoxTreeUpdater::buildTreeForFlexContent()
 
 void BoxTreeUpdater::buildTreeForGridContent()
 {
-    // FIXME: Implement this
+    for (auto& gridItemRenderer : childrenOfType<RenderElement>(m_rootRenderer)) {
+        if (auto existingChildBox = gridItemRenderer.layoutBox()) {
+            insertChild(existingChildBox->removeFromParent(), gridItemRenderer, gridItemRenderer.previousSibling());
+            continue;
+        }
+        auto style = RenderStyle::clone(gridItemRenderer.style());
+        auto gridItemBox = makeUniqueRef<Layout::ElementBox>(elementAttributes(gridItemRenderer), WTFMove(style));
+        insertChild(WTFMove(gridItemBox), gridItemRenderer, gridItemRenderer.previousSibling());
+    }
 }
 
 void BoxTreeUpdater::insertChild(UniqueRef<Layout::Box> childBox, RenderObject& childRenderer, const RenderObject* beforeChild)
@@ -558,5 +566,3 @@ void showInlineContent(TextStream& stream, const InlineContent& inlineContent, s
 
 }
 }
-
-

--- a/Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.cpp
+++ b/Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.cpp
@@ -26,8 +26,12 @@
 #include "config.h"
 #include "LayoutIntegrationGridLayout.h"
 
+#include "FormattingContextBoxIterator.h"
 #include "LayoutIntegrationBoxTreeUpdater.h"
 #include "RenderGrid.h"
+#include <wtf/CheckedPtr.h>
+#include <wtf/CheckedRef.h>
+#include <wtf/text/TextStream.h>
 
 namespace WebCore {
 
@@ -41,7 +45,25 @@ GridLayout::GridLayout(RenderGrid& renderGrid)
 
 void GridLayout::layout()
 {
-    // FIXME implement this
+    // FIXME: implement this.
+}
+
+TextStream& operator<<(TextStream& stream, const GridLayout& layout)
+{
+    stream << "GridLayout@" << &layout;
+    stream << " gridBox=" << &layout.gridBox();
+    size_t index = 0;
+    for (CheckedRef box : Layout::formattingContextBoxes(layout.gridBox())) {
+        stream << "\n  [" << index++ << "] box=" << box.ptr();
+        stream << " anonymous=" << (box->isAnonymous() ? "yes" : "no");
+        stream << " establishesContext=" << (box->establishesFormattingContext() ? "yes" : "no");
+        stream << " display=" << box->style().display();
+        if (CheckedPtr renderer = box->rendererForIntegration())
+            stream << " renderer=" << renderer->renderName() << '@' << renderer.get();
+        else
+            stream << " renderer=<null>";
+    }
+    return stream;
 }
 
 } // namespace LayoutIntegration

--- a/Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.h
+++ b/Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.h
@@ -28,6 +28,10 @@
 #include "LayoutState.h"
 #include <wtf/CheckedPtr.h>
 
+namespace WTF {
+class TextStream;
+}
+
 namespace WebCore {
 
 class RenderGrid;
@@ -44,6 +48,8 @@ public:
 
     void layout();
 
+    friend WTF::TextStream& operator<<(WTF::TextStream&, const GridLayout&);
+
 private:
     const Layout::ElementBox& gridBox() const { return *m_gridBox; }
     Layout::ElementBox& gridBox() { return *m_gridBox; }
@@ -56,6 +62,8 @@ private:
     const CheckedPtr<Layout::ElementBox> m_gridBox;
     CheckedRef<Layout::LayoutState> m_layoutState;
 };
+
+WTF::TextStream& operator<<(WTF::TextStream&, const GridLayout&);
 
 } // namespace LayoutIntegration
 


### PR DESCRIPTION
#### c1c037979677818a2d80a6386b4a2d381b8de45e
<pre>
[GFC] Build Layout::ElementBox tree from RenderGrid.
<a href="https://bugs.webkit.org/show_bug.cgi?id=299053">https://bugs.webkit.org/show_bug.cgi?id=299053</a>
&lt;<a href="https://rdar.apple.com/160810280">rdar://160810280</a>&gt;

Reviewed by Sammy Gill.

This PR implements BoxTreeUpdater::buildTreeForGridContent() to convert a
RenderGrid and its children into a tree of Layout::ElementBox and populate
LayoutIntegrationGridLayout&apos;s m_gridBox.

This PR also adds a utility function to LayoutIntegrationGridLayout to support

WTF_ALWAYS_LOG(&lt;LayoutIntegration::GridLayout object&gt;);

This is a QOL function to streamline development and debugging.

Example debug output:

gridLayoutGridLayout@0x16cf378f8 gridBox=0x135310270
  [0] box=0x135310340 anonymous=no establishesContext=yes display=1 renderer=RenderBlock@0x1352fc230
  [1] box=0x135310410 anonymous=no establishesContext=yes display=1 renderer=RenderBlock@0x1352fc510
  [2] box=0x1353104e0 anonymous=no establishesContext=yes display=1 renderer=RenderBlock@0x1352fc680
  [3] box=0x1353105b0 anonymous=no establishesContext=yes display=1 renderer=RenderBlock@0x1352fc7f0
  [4] box=0x135310680 anonymous=no establishesContext=yes display=1 renderer=RenderBlock@0x1352fc960
  [5] box=0x135310750 anonymous=no establishesContext=yes display=1 renderer=RenderBlock@0x1352fcad0

* Source/WebCore/layout/integration/LayoutIntegrationBoxTreeUpdater.cpp:
(WebCore::LayoutIntegration::BoxTreeUpdater::buildTreeForGridContent):
* Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.cpp:
(WebCore::LayoutIntegration::GridLayout::layout):
(WebCore::LayoutIntegration::operator&lt;&lt;):
* Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.h:

Canonical link: <a href="https://commits.webkit.org/300208@main">https://commits.webkit.org/300208@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a4be3a6e1f8c1eb6138e77fc419d88e9532c6974

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121642 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41343 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32007 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128159 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73732 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/61e5aef9-5088-4af7-89dc-82f6a9d187f5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123518 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42055 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49934 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92436 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/61469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a7029680-c4dc-413d-bf67-1fd25976133f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124594 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33557 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108958 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73097 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/22a32073-3458-428b-b167-bf1efedd0904) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32573 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27118 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71676 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103054 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27301 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130957 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48576 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36955 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101009 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48948 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105170 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100898 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25593 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46278 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24383 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45277 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48435 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54162 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47904 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51253 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49587 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->