### PR TITLE
[Smart Lists] Availability of Smart Lists need not depend on `_editable` being true

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -7346,12 +7346,12 @@ SmartInsertDeleteEnabled:
     WebCore:
       default: true
 
-SmartListsEnabled:
+SmartListsAvailable:
   type: bool
   status: embedder
   category: dom
   humanReadableName: "Smart Lists"
-  humanReadableDescription: "Enable Smart Lists"
+  humanReadableDescription: "Allow Smart Lists to be enabled"
   defaultValue:
     WebKit:
       default: false

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -1993,11 +1993,7 @@ void Editor::toggleAutomaticSpellingCorrection()
 void Editor::toggleSmartLists()
 {
     Ref document = this->document();
-    RefPtr page = document->page();
-    if (!page || !page->isEditable())
-        return;
-
-    if (!document->settings().smartListsEnabled())
+    if (!document->settings().smartListsAvailable())
         return;
 
     if (client())
@@ -2010,11 +2006,7 @@ void Editor::toggleSmartLists()
 bool Editor::isSmartListsEnabled()
 {
     Ref document = this->document();
-    RefPtr page = document->page();
-    if (!page || !page->isEditable())
-        return false;
-
-    if (!document->settings().smartListsEnabled())
+    if (!document->settings().smartListsAvailable())
         return false;
 
 #if PLATFORM(MAC)

--- a/Source/WebCore/page/ContextMenuController.cpp
+++ b/Source/WebCore/page/ContextMenuController.cpp
@@ -876,7 +876,7 @@ void ContextMenuController::createAndAppendSubstitutionsSubMenu(ContextMenuItem&
     appendItem(smartCopyPaste, &substitutionsMenu);
     appendItem(smartQuotes, &substitutionsMenu);
 
-    if (m_page->settings().smartListsEnabled() && m_page->isEditable())
+    if (m_page->settings().smartListsAvailable())
         appendItem(smartLists, &substitutionsMenu);
 
     appendItem(smartDashes, &substitutionsMenu);

--- a/Source/WebKit/UIProcess/API/Swift/WebPage.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage.swift
@@ -393,14 +393,6 @@ final public class WebPage {
         return webView
     }()
 
-    // SPI for testing.
-    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
-    @_spi(Testing)
-    public var isEditable: Bool {
-        get { backingWebView._isEditable }
-        set { backingWebView._isEditable = newValue }
-    }
-
     #if os(macOS)
     // SPI for testing.
     // swift-format-ignore: AllPublicDeclarationsHaveDocumentation

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -3344,7 +3344,7 @@ void WebViewImpl::toggleAutomaticTextReplacement()
 
 bool WebViewImpl::isSmartListsEnabled()
 {
-    if (!m_page->protectedPreferences()->smartListsEnabled() || !isEditable())
+    if (!m_page->protectedPreferences()->smartListsAvailable())
         return false;
 
     return TextChecker::state().contains(TextCheckerState::SmartListsEnabled);
@@ -3352,7 +3352,7 @@ bool WebViewImpl::isSmartListsEnabled()
 
 void WebViewImpl::setSmartListsEnabled(bool flag)
 {
-    if (!m_page->protectedPreferences()->smartListsEnabled() || !isEditable())
+    if (!m_page->protectedPreferences()->smartListsAvailable())
         return;
 
     if (flag == TextChecker::state().contains(TextCheckerState::SmartListsEnabled))
@@ -3364,7 +3364,7 @@ void WebViewImpl::setSmartListsEnabled(bool flag)
 
 void WebViewImpl::toggleSmartLists()
 {
-    if (!m_page->protectedPreferences()->smartListsEnabled() || !isEditable())
+    if (!m_page->protectedPreferences()->smartListsAvailable())
         return;
 
     TextChecker::setSmartListsEnabled(!TextChecker::state().contains(TextCheckerState::SmartListsEnabled));

--- a/Source/WebKit/_WebKit_SwiftUI/API/WebView.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/API/WebView.swift
@@ -249,7 +249,7 @@ extension WebView {
     @_spi(Testing)
     public struct WebPreferenceFeature<Value>: Sendable where Value: Sendable, Value: Codable {
         public static var allowSmartLists: WebPreferenceFeature<Bool> {
-            .init(rawValue: "SmartListsEnabled")
+            .init(rawValue: "SmartListsAvailable")
         }
 
         let rawValue: String

--- a/Tools/SwiftBrowser/Source/SwiftBrowser.swift
+++ b/Tools/SwiftBrowser/Source/SwiftBrowser.swift
@@ -32,9 +32,6 @@ struct SwiftBrowserApp: App {
     @AppStorage(AppStorageKeys.homepage)
     private var homepage = "https://www.webkit.org"
 
-    @AppStorage(AppStorageKeys.isEditable)
-    private var isEditable = false
-
     @State
     private var smartListsEnabled = true
 
@@ -78,12 +75,6 @@ struct SwiftBrowserApp: App {
                     focusedBrowserViewModel!.exportAsPDF()
                 }
                 .disabled(focusedBrowserViewModel == nil)
-            }
-
-            CommandGroup(before: .undoRedo) {
-                Toggle(isOn: $isEditable) {
-                    Label("Editable", systemImage: "pencil")
-                }
             }
 
             TextEditingCommands()

--- a/Tools/SwiftBrowser/Source/ViewModel/AppStorageKeys.swift
+++ b/Tools/SwiftBrowser/Source/ViewModel/AppStorageKeys.swift
@@ -30,5 +30,4 @@ enum AppStorageKeys {
     static let scrollBounceBehaviorBasedOnSize = "scrollBounceBehaviorBasedOnSize"
     static let backgroundHidden = "backgroundHidden"
     static let showColorInTabBar = "showColorInTabBar"
-    static let isEditable = "isEditable"
 }

--- a/Tools/SwiftBrowser/Source/Views/BrowserView.swift
+++ b/Tools/SwiftBrowser/Source/Views/BrowserView.swift
@@ -31,9 +31,6 @@ struct BrowserView: View {
 
     let smartListsEnabled: Bool
 
-    @AppStorage(AppStorageKeys.isEditable)
-    private var isEditable = false
-
     let initialRequest: URLRequest
 
     @State
@@ -42,9 +39,6 @@ struct BrowserView: View {
     var body: some View {
         ContentView(url: $url, initialRequest: initialRequest)
             .environment(viewModel)
-            .onChange(of: isEditable, initial: true) {
-                viewModel.page.isEditable = isEditable
-            }
             .onChange(of: smartListsEnabled, initial: true) {
                 #if os(macOS)
                 viewModel.page.smartListsEnabled = smartListsEnabled

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SmartListsSupport.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SmartListsSupport.swift
@@ -80,11 +80,10 @@ extension SmartListsSupport {
         #if os(macOS)
         let page = WebPage()
 
-        page.setWebFeature("SmartListsEnabled", enabled: true)
-        page.isEditable = true
+        page.setWebFeature("SmartListsAvailable", enabled: true)
         page.smartListsEnabled = true
 
-        try await page.load(html: "<body></body>").wait()
+        try await page.load(html: "<body contenteditable></body>").wait()
 
         try await page.callJavaScript("document.body.focus()")
 


### PR DESCRIPTION
#### 48f9be2c1106fa791c69b7fe9e98ecf14d119267
<pre>
[Smart Lists] Availability of Smart Lists need not depend on `_editable` being true
<a href="https://bugs.webkit.org/show_bug.cgi?id=299056">https://bugs.webkit.org/show_bug.cgi?id=299056</a>
<a href="https://rdar.apple.com/160811291">rdar://160811291</a>

Reviewed by Ryosuke Niwa.

Checking both the web preference and the value of `_editable` is redundant, since the web preference value is sufficient by itself.

Also rename the preference to &quot;availability&quot; instead of &quot;enable&quot; to disambiguate it from when Smart Lists are actually enabled
(which is controlled by the user).

Canonical link: <a href="https://commits.webkit.org/300134@main">https://commits.webkit.org/300134@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/448c01b5879d16e7ed365c06a4a789b72b76f1ab

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121454 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41151 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31810 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127910 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73537 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fc002e17-c44a-4891-a80d-020c101eca5c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123330 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41853 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49730 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92252 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/61377 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ff96c278-12d9-4345-a02b-ca9dd59c52cf) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124406 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33411 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108804 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72928 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4b58a8f8-cdb6-4e7e-9686-724da789d451) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32423 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26965 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71475 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/113584 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102902 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27139 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130729 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/119974 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48382 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36784 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100841 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48750 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105024 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100748 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25538 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46157 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24236 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/45078 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48240 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53953 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/150136 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47712 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/38222 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51058 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49394 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->