### PR TITLE
Migrate functions using postPageMessage from web content process to the UI process

### DIFF
--- a/Tools/WebKitTestRunner/DictionaryFunctions.h
+++ b/Tools/WebKitTestRunner/DictionaryFunctions.h
@@ -117,6 +117,11 @@ inline WKStringRef stringValue(WKDictionaryRef dictionary, const char* key)
     return stringValue(value(dictionary, key));
 }
 
+inline WKArrayRef arrayValue(WKDictionaryRef dictionary, const char* key)
+{
+    return arrayValue(value(dictionary, key));
+}
+
 inline uint64_t uint64Value(WKDictionaryRef dictionary, const char* key)
 {
     return uint64Value(value(dictionary, key));

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
@@ -135,7 +135,6 @@ interface TestRunner {
     attribute double databaseMaxQuota;
 
     // Text search testing.
-    undefined findStringMatchesInPage(DOMString target, object optionsArray);
     undefined replaceFindMatchesAtIndices(object matchIndicesArray, DOMString replacementText, boolean selectionOnly);
 
     // Evaluating script in a special context.
@@ -227,10 +226,6 @@ interface TestRunner {
     undefined queueLoadingScript(DOMString script);
     undefined queueNonLoadingScript(DOMString script);
 
-    // Authentication
-    undefined setAuthenticationUsername(DOMString username);
-    undefined setAuthenticationPassword(DOMString password);
-
     undefined setAllowsAnySSLCertificate(boolean value);
 
     undefined setShouldSwapToEphemeralSessionOnNextNavigation(boolean value);
@@ -238,9 +233,6 @@ interface TestRunner {
 
     // Secure text input mode (Mac only)
     readonly attribute boolean secureEventInputIsEnabled;
-    
-    // Override plugin load policy.
-    undefined setPluginSupportedMode(DOMString mode);
 
     // Hooks to the JSC compiler.
     object failNextNewCodeBlock();
@@ -250,9 +242,6 @@ interface TestRunner {
     unsigned long imageCountInGeneralPasteboard();
 
     undefined accummulateLogsForChannel(DOMString channel);
-
-    // Contextual menu actions
-    undefined setAllowedMenuActions(object actions);
 
     // Gamepad
     undefined setMockGamepadDetails(unsigned long index, DOMString id, DOMString mapping, unsigned long axisCount, unsigned long buttonCount, boolean supportsDualRumble, boolean wasConnected);
@@ -304,10 +293,6 @@ interface TestRunner {
 
     // Storage Access API
     undefined setRequestStorageAccessThrowsExceptionUntilReload(boolean enabled);
-
-    // Open panel
-    undefined setOpenPanelFiles(object filesArray);
-    undefined setOpenPanelFilesMediaIcon(object mediaIcon);
 
     // Modal alerts
     undefined setShouldDismissJavaScriptAlertsAsynchronously(boolean value);

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
@@ -181,7 +181,6 @@ public:
     void addUserStyleSheet(JSStringRef source, bool allFrames);
 
     // Text search testing.
-    void findStringMatchesInPage(JSContextRef, JSStringRef, JSValueRef optionsArray);
     void replaceFindMatchesAtIndices(JSContextRef, JSValueRef matchIndices, JSStringRef replacementText, bool selectionOnly);
 
     // Local storage
@@ -208,16 +207,10 @@ public:
     bool isPrinting() { return m_isPrinting; }
     void setPrinting() { m_isPrinting = true; }
 
-    // Authentication
-    void setAuthenticationUsername(JSStringRef);
-    void setAuthenticationPassword(JSStringRef);
-
     void setValueForUser(JSContextRef, JSValueRef element, JSStringRef value);
 
     // Audio testing.
     void setAudioResult(JSContextRef, JSValueRef data);
-
-    void setPluginSupportedMode(JSStringRef);
 
     WhatToDump whatToDump() const;
     void setWhatToDump(WhatToDump);
@@ -353,9 +346,6 @@ public:
     bool didCancelClientRedirect() const { return m_didCancelClientRedirect; }
     void setDidCancelClientRedirect(bool value) { m_didCancelClientRedirect = value; }
 
-    // Contextual menu actions
-    void setAllowedMenuActions(JSContextRef, JSValueRef);
-
     void clearTestRunnerCallbacks();
 
     void accummulateLogsForChannel(JSStringRef channel);
@@ -413,10 +403,6 @@ public:
 
     // Storage Access API
     void setRequestStorageAccessThrowsExceptionUntilReload(bool enabled);
-
-    // Open panel
-    void setOpenPanelFiles(JSContextRef, JSValueRef);
-    void setOpenPanelFilesMediaIcon(JSContextRef, JSValueRef);
 
     // Modal alerts
     void setShouldDismissJavaScriptAlertsAsynchronously(bool);

--- a/Tools/WebKitTestRunner/TestInvocation.cpp
+++ b/Tools/WebKitTestRunner/TestInvocation.cpp
@@ -534,47 +534,6 @@ void TestInvocation::didReceiveMessageFromInjectedBundle(WKStringRef messageName
         return;
     }
 
-    if (WKStringIsEqualToUTF8CString(messageName, "SetAuthenticationUsername")) {
-        WKStringRef username = stringValue(messageBody);
-        TestController::singleton().setAuthenticationUsername(toWTFString(username));
-        return;
-    }
-
-    if (WKStringIsEqualToUTF8CString(messageName, "SetAuthenticationPassword")) {
-        WKStringRef password = stringValue(messageBody);
-        TestController::singleton().setAuthenticationPassword(toWTFString(password));
-        return;
-    }
-
-    if (WKStringIsEqualToUTF8CString(messageName, "SetPluginSupportedMode")) {
-        WKStringRef mode = stringValue(messageBody);
-        TestController::singleton().setPluginSupportedMode(toWTFString(mode));
-        return;
-    }
-
-    if (WKStringIsEqualToUTF8CString(messageName, "SetAllowedMenuActions")) {
-        auto messageBodyArray = static_cast<WKArrayRef>(messageBody);
-        auto size = WKArrayGetSize(messageBodyArray);
-        Vector<String> actions;
-        actions.reserveInitialCapacity(size);
-        for (size_t index = 0; index < size; ++index)
-            actions.append(toWTFString(stringValue(WKArrayGetItemAtIndex(messageBodyArray, index))));
-        TestController::singleton().setAllowedMenuActions(actions);
-        return;
-    }
-
-    if (WKStringIsEqualToUTF8CString(messageName, "SetOpenPanelFileURLs")) {
-        TestController::singleton().setOpenPanelFileURLs(static_cast<WKArrayRef>(messageBody));
-        return;
-    }
-
-#if PLATFORM(IOS_FAMILY)
-    if (WKStringIsEqualToUTF8CString(messageName, "SetOpenPanelFileURLsMediaIcon")) {
-        TestController::singleton().setOpenPanelFileURLsMediaIcon(static_cast<WKDataRef>(messageBody));
-        return;
-    }
-#endif
-
     if (WKStringIsEqualToUTF8CString(messageName, "ReloadFromOrigin")) {
         TestController::singleton().setUseWorkQueue(true);
         TestController::singleton().reloadFromOrigin();
@@ -588,14 +547,6 @@ void TestInvocation::didReceiveMessageFromInjectedBundle(WKStringRef messageName
 
     if (WKStringIsEqualToUTF8CString(messageName, "SkipPolicyDelegateNotifyDone")) {
         TestController::singleton().skipPolicyDelegateNotifyDone();
-        return;
-    }
-
-    if (WKStringIsEqualToUTF8CString(messageName, "FindStringMatches")) {
-        auto messageBodyDictionary = dictionaryValue(messageBody);
-        auto string = stringValue(messageBodyDictionary, "String");
-        auto findOptions = static_cast<WKFindOptions>(uint64Value(messageBodyDictionary, "FindOptions"));
-        WKPageFindStringMatches(TestController::singleton().mainWebView()->page(), string, findOptions, 0);
         return;
     }
 
@@ -705,6 +656,7 @@ WKRetainPtr<WKTypeRef> TestInvocation::didReceiveSynchronousMessageFromInjectedB
         TestController::singleton().setBackgroundFetchPermission(booleanValue(messageBody));
         return nullptr;
     }
+
     if (WKStringIsEqualToUTF8CString(messageName, "GetBackgroundFetchIdentifier"))
         return TestController::singleton().getBackgroundFetchIdentifier();
 


### PR DESCRIPTION
#### f9b02c4a6d438a6314ae6ea6786403beccc67f99
<pre>
Migrate functions using postPageMessage from web content process to the UI process
<a href="https://bugs.webkit.org/show_bug.cgi?id=299060">https://bugs.webkit.org/show_bug.cgi?id=299060</a>
<a href="https://rdar.apple.com/160815925">rdar://160815925</a>

Reviewed by Alex Christensen.

Finish moving functions using postPageMessage from the web content process to the UI process.

* Tools/WebKitTestRunner/DictionaryFunctions.h:
(WTR::arrayValue):
* Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl:
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp:
(WTR::toWK): Deleted.
(WTR::findOptionsFromArray): Deleted.
(WTR::TestRunner::findStringMatchesInPage): Deleted.
(WTR::TestRunner::setAuthenticationUsername): Deleted.
(WTR::TestRunner::setAuthenticationPassword): Deleted.
(WTR::TestRunner::setPluginSupportedMode): Deleted.
(WTR::TestRunner::setAllowedMenuActions): Deleted.
(WTR::makeOpenPanelURL): Deleted.
(WTR::TestRunner::setOpenPanelFiles): Deleted.
(WTR::TestRunner::setOpenPanelFilesMediaIcon): Deleted.
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.h:
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::if):
(WTR::CompletionHandler&lt;void):
(WTR::WTF::Function&lt;void): Deleted.
* Tools/WebKitTestRunner/TestInvocation.cpp:
(WTR::TestInvocation::didReceiveMessageFromInjectedBundle):
(WTR::TestInvocation::didReceiveSynchronousMessageFromInjectedBundle):

Canonical link: <a href="https://commits.webkit.org/300777@main">https://commits.webkit.org/300777@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1280e7965c0b300a27678a176f8ad1905a9f9eec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123808 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43523 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34220 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130588 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/75958 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/125685 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44247 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52117 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94157 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/62483 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126761 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35256 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110757 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74757 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34211 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28917 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74070 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104982 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29140 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133283 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50760 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38657 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102631 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51135 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106976 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102460 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26051 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47805 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26059 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/47610 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50614 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50088 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53434 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51762 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->