### PR TITLE
Fix `field-sizing-placeholder-stretch.html` to upstream later

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-placeholder-stretch-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-placeholder-stretch-expected.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<link rel="stylesheet" href="/fonts/ahem.css">
 <style>
 input {
   padding: 0px;

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-placeholder-stretch-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-placeholder-stretch-ref.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
+<link rel="stylesheet" href="/fonts/ahem.css">
 <style>
 input {
   padding: 0px;
   border: none;
-  font-size: 30px;
+  font: 30px Ahem;
   color: green;
-  font-family: Ahem;
 }
 </style>
 <input value="PASS if not clipped">

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-placeholder-stretch.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-placeholder-stretch.html
@@ -6,9 +6,8 @@
 
 <style>
 ::placeholder {
-  font-size: 30px;
+  font: 30px Ahem;
   color: green;
-  font-family: Ahem;
 }
 input {
   field-sizing: content;


### PR DESCRIPTION
#### c05f080cd02b95b75db098c07662c16eced8e9b8
<pre>
Fix `field-sizing-placeholder-stretch.html` to upstream later
<a href="https://bugs.webkit.org/show_bug.cgi?id=299062">https://bugs.webkit.org/show_bug.cgi?id=299062</a>

Reviewed by Tim Nguyen and Alan Baradlay.

This is just to make it easier to upstream and fix any linting errors.

* LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-placeholder-stretch-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-placeholder-stretch-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-placeholder-stretch.html:

Canonical link: <a href="https://commits.webkit.org/300149@main">https://commits.webkit.org/300149@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cab1ac000e85a4d69916ba72de14d8c0212d873f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121482 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41179 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31838 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127932 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73565 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bc22b7ef-ec77-4a2a-bebc-026ea8065093) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41881 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49758 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92265 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61384 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/976bfdc8-5c5e-4806-87b2-04ea17e1423e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124434 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33438 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108820 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72942 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/86931837-e1ca-4a98-b42d-8d8462a1652d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32447 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26982 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71503 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102924 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27156 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130757 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48410 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36800 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100851 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48778 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105041 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100758 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25552 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46173 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24252 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45106 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48269 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47740 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51086 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49422 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->