### PR TITLE
[Smart Lists] Smart Lists should not be activated if selection is already within a list

### DIFF
--- a/Source/WebCore/editing/InsertTextCommand.cpp
+++ b/Source/WebCore/editing/InsertTextCommand.cpp
@@ -172,6 +172,11 @@ bool InsertTextCommand::applySmartListsIfNeeded()
         return false;
     }
 
+    if (enclosingList(endingSelection().base().anchorNode())) {
+        // Smart Lists can not be "activated" if the selection is already within a list.
+        return false;
+    }
+
     auto lineStart = startOfLine(endingSelection().visibleBase());
     if (lineStart.isNull() || lineStart.isOrphan()) {
         ASSERT_NOT_REACHED();

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SmartLists.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SmartLists.mm
@@ -223,10 +223,10 @@ TEST(SmartLists, InsertingSpaceAndTextAfterBulletPointGeneratesListWithText)
     </body>
     )"""_s;
 
-    runTest(@"* Hello", expectedHTML.createNSString().get(), @"//body/ul/li/text()", [@"Hello" length]);
+    runTest(@"* Hello", expectedHTML.createNSString().get(), @"//body/ul/li/text()", @"Hello".length);
 
     RetainPtr inputWithBullet = makeString(WTF::Unicode::bullet, " Hello"_s).createNSString();
-    runTest(inputWithBullet.get(), expectedHTML.createNSString().get(), @"//body/ul/li/text()", [@"Hello" length]);
+    runTest(inputWithBullet.get(), expectedHTML.createNSString().get(), @"//body/ul/li/text()", @"Hello".length);
 }
 
 TEST(SmartLists, InsertingSpaceAndTextAfterHyphenGeneratesDashedList)
@@ -243,7 +243,7 @@ TEST(SmartLists, InsertingSpaceAndTextAfterHyphenGeneratesDashedList)
 
     RetainPtr expectedHTML = WTF::makeStringByReplacingAll(expectedHTMLTemplate, "<MARKER>"_s, marker).createNSString();
 
-    runTest(@"- Hello", expectedHTML.get(), @"//body/ul/li/text()", [@"Hello" length]);
+    runTest(@"- Hello", expectedHTML.get(), @"//body/ul/li/text()", @"Hello".length);
 }
 
 TEST(SmartLists, InsertingSpaceAfterBulletPointGeneratesEmptyList)
@@ -267,7 +267,7 @@ TEST(SmartLists, InsertingSpaceAfterBulletPointInMiddleOfSentenceDoesNotGenerate
     </body>
     )"""_s;
 
-    runTest(@"ABC * DEF", expectedHTML.createNSString().get(), @"//body/text()", [@"ABC * DEF" length]);
+    runTest(@"ABC * DEF", expectedHTML.createNSString().get(), @"//body/text()", @"ABC * DEF".length);
 }
 
 TEST(SmartLists, InsertingSpaceAfterPeriodAtStartOfSentenceDoesNotGenerateList)
@@ -278,7 +278,7 @@ TEST(SmartLists, InsertingSpaceAfterPeriodAtStartOfSentenceDoesNotGenerateList)
     </body>
     )"""_s;
 
-    runTest(@". Hi", expectedHTML.createNSString().get(), @"//body/text()", [@". Hi" length]);
+    runTest(@". Hi", expectedHTML.createNSString().get(), @"//body/text()", @". Hi".length);
 }
 
 TEST(SmartLists, InsertingSpaceAfterNumberGeneratesOrderedList)
@@ -291,9 +291,9 @@ TEST(SmartLists, InsertingSpaceAfterNumberGeneratesOrderedList)
     </body>
     )"""_s;
 
-    runTest(@"1. Hello", expectedHTML.createNSString().get(), @"//body/ol/li/text()", [@"Hello" length]);
+    runTest(@"1. Hello", expectedHTML.createNSString().get(), @"//body/ol/li/text()", @"Hello".length);
 
-    runTest(@"1) Hello", expectedHTML.createNSString().get(), @"//body/ol/li/text()", [@"Hello" length]);
+    runTest(@"1) Hello", expectedHTML.createNSString().get(), @"//body/ol/li/text()", @"Hello".length);
 }
 
 TEST(SmartLists, InsertingSpaceAfterMultipleDigitNumberGeneratesOrderedList)
@@ -306,7 +306,7 @@ TEST(SmartLists, InsertingSpaceAfterMultipleDigitNumberGeneratesOrderedList)
     </body>
     )"""_s;
 
-    runTest(@"1234. Hello", expectedHTML.createNSString().get(), @"//body/ol/li/text()", [@"Hello" length]);
+    runTest(@"1234. Hello", expectedHTML.createNSString().get(), @"//body/ol/li/text()", @"Hello".length);
 }
 
 TEST(SmartLists, InsertingSpaceAfterInvalidNumberDoesNotGenerateOrderedList)
@@ -350,6 +350,20 @@ TEST(SmartLists, InsertingListMergesWithPreviousListIfPossible)
     "";
 
     runTest(input.get(), expectedHTML.createNSString().get(), @"//body/ol/li[3]/text()", 1);
+}
+
+TEST(SmartLists, InsertingSpaceInsideListElementDoesNotActivateSmartLists)
+{
+    static constexpr auto expectedHTML = R"""(
+    <body>
+        <ul>
+            <li>A</li>
+            <li>1. Hi</li>
+        </ul>
+    </body>
+    )"""_s;
+
+    runTest(@"* A\n1. Hi", expectedHTML.createNSString().get(), @"//body/ul/li[2]/text()", @"1. Hi".length);
 }
 
 #endif // PLATFORM(MAC)


### PR DESCRIPTION
#### d4cc14a231eab87f2ff577f2a8c50a6f74ce7366
<pre>
[Smart Lists] Smart Lists should not be activated if selection is already within a list
<a href="https://bugs.webkit.org/show_bug.cgi?id=299066">https://bugs.webkit.org/show_bug.cgi?id=299066</a>
<a href="https://rdar.apple.com/160826918">rdar://160826918</a>

Reviewed by Abrar Rahman Protyasha and Lily Spiniolas.

Before allowing a Smart List to be created, first check if the selection is already within a list and exit early if so.

* Source/WebCore/editing/InsertTextCommand.cpp:
(WebCore::InsertTextCommand::applySmartListsIfNeeded):

Add new guard condition to check for an enclosing list.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/SmartLists.mm:
(TEST(SmartLists, InsertingSpaceAndTextAfterBulletPointGeneratesListWithText)):
(InsertingSpaceAndTextAfterHyphenGeneratesDashedList)):
((SmartLists, InsertingSpaceAfterBulletPointInMiddleOfSentenceDoesNotGenerateList)):
((SmartLists, InsertingSpaceAfterPeriodAtStartOfSentenceDoesNotGenerateList)):
((SmartLists, InsertingSpaceAfterNumberGeneratesOrderedList)):
((SmartLists, InsertingSpaceAfterMultipleDigitNumberGeneratesOrderedList)):

Drive-by formatting fix for consistency

((SmartLists, InsertingSpaceInsideListElementDoesNotActivateSmartLists)):

New test added

Canonical link: <a href="https://commits.webkit.org/300158@main">https://commits.webkit.org/300158@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4e43c1c0cc3ace003040ce170c6e8a672475d6b9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121498 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41195 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31854 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127950 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73581 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123374 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41897 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49774 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92280 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61393 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124450 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33449 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108833 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72957 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/04d568b3-684a-485b-834c-faf00c9535a4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32458 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26999 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71522 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102936 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27172 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130773 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48426 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36819 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100866 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48794 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105057 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100773 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25560 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46180 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24267 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45122 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48285 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53997 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47756 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51102 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49438 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->