### PR TITLE
Remove Postgresql command line option

### DIFF
--- a/Websites/bugs.webkit.org/Bugzilla/DB/Pg.pm
+++ b/Websites/bugs.webkit.org/Bugzilla/DB/Pg.pm
@@ -49,10 +49,6 @@ sub new {
     $dsn .= ";host=$host" if $host;
     $dsn .= ";port=$port" if $port;
 
-    # This stops Pg from printing out lots of "NOTICE" messages when
-    # creating tables.
-    $dsn .= ";options='-c client_min_messages=warning'";
-
     my $attrs = { pg_enable_utf8 => Bugzilla->params->{'utf8'} };
 
     my $self = $class->db_new({ dsn => $dsn, user => $user, 


### PR DESCRIPTION
#### 7b2a1e9e473fba1a70c7ea0ae3d6c3545bd47e6d
<pre>
Remove Postgresql command line option
<a href="https://rdar.apple.com/160828422">rdar://160828422</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=299068">https://bugs.webkit.org/show_bug.cgi?id=299068</a>

Reviewed by Dewei Zhu.

Setting command line options such as client_min_messages here is not supported by AWS Proxy for connection pooling. The client_min_messages=warning setting will be set in the cluster parameter.

* Websites/bugs.webkit.org/Bugzilla/DB/Pg.pm:
(new):

Canonical link: <a href="https://commits.webkit.org/300176@main">https://commits.webkit.org/300176@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/979e60419be32a7c9fc15c3e68a4e0eb74baef82

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121503 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41200 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31859 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127955 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73586 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/497bb923-b0c6-46bb-844e-48191b366c23) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41902 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49779 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92282 "18 flakes 22 failures") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61396 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/35e75374-3489-4ea9-9ba9-c0f9c571f3de) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124455 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33455 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108835 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72959 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2ed9df09-174a-40ee-adb4-bdb4d5d9651a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32463 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71527 "Built successfully") | | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27176 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130778 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48431 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36824 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100869 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48799 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105061 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100776 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25572 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46185 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24271 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45127 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48290 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47761 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51107 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49443 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->