### PR TITLE
fast/frames/lots-of-iframes.html and fast/frames/lots-of-objects.html are flaky timeouts

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2411,8 +2411,6 @@ webkit.org/b/283954 imported/w3c/web-platform-tests/svg/text/reftests/transform-
 [ Debug ] fast/loader/document-with-fragment-url-4.html [ Pass Timeout ]
 
 webkit.org/b/85902 [ Debug ] fast/overflow/lots-of-sibling-inline-boxes.html [ Slow ]
-webkit.org/b/298471 fast/frames/lots-of-objects.html [ Pass Timeout ]
-webkit.org/b/298471 fast/frames/lots-of-iframes.html [ Pass Timeout ]
 webkit.org/b/135053 [ Debug ] html5lib/webkit-resumer.html [ Slow ]
 [ Debug ] js/dfg-double-vote-fuzz.html [ Slow ]
 [ Debug ] js/array-sort-small-sparse-array-with-large-length.html [ Slow ]

--- a/LayoutTests/fast/frames/lots-of-iframes.html
+++ b/LayoutTests/fast/frames/lots-of-iframes.html
@@ -1,20 +1,15 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html>
 <html>
 <head>
 <title>Lots of iframes</title>
-<script type="text/javascript">
+<script>
   var maxNumberOfFrames = 1000;
 
   if (window.testRunner)
     testRunner.dumpAsText();
 
-  function createIFrames() {
-    var str = "<div id=\"status\"></div>";
-    for (var i = 0; i < maxNumberOfFrames + 1; i++) {
-      str += "<iframe id=\"i" + i + "\" src=\"data:text/html,iframe_" + i + "\"></iframe>";
-    }
-    document.getElementsByTagName("body")[0].innerHTML = str;
-
+function dumpResults()
+{
     var results = "";
 
     var f = document.getElementById("i" + (maxNumberOfFrames - 1));
@@ -28,13 +23,32 @@
     if (g && g.contentWindow) {
       results += "Failed to block creation of frame number " + (maxNumberOfFrames + 1) + ".";
     } else {
-      results += "Successfully blocked creation of frame number " + (maxNumberOfFrames + 1) + ".";
+      results += "Successfully blocked creation of frame number " + (maxNumberOfFrames + 1) + ".<br>";
     }
 
     document.getElementById("status").innerHTML = results;
-  }
+}
+
+function createIFrames()
+{
+    let fragment = document.createDocumentFragment();
+    for (var i = 0; i < maxNumberOfFrames + 1; ++i) {
+        let iframe = document.createElement("iframe");
+        iframe.id = `i${i}`;
+        iframe.style.display = "none"
+        iframe.style.position = "absolute";
+        iframe.style.top = "9999px";
+        iframe.loading = "lazy";
+        iframe.srcdoc = `iframe_${i}`;
+        fragment.appendChild(iframe);
+    }
+    document.body.appendChild(fragment);
+    dumpResults();
+}
+
 </script>
 </head>
 <body onLoad="createIFrames()">
+<div id="status"></div>
 </body>
 </html>

--- a/LayoutTests/fast/frames/lots-of-objects.html
+++ b/LayoutTests/fast/frames/lots-of-objects.html
@@ -1,35 +1,49 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html>
 <html>
 <head>
 <title>Lots of objects</title>
-<script type="text/javascript">
-  var maxNumberOfFrames = 1000;
+<script>
+var maxNumberOfFrames = 1000;
 
-  if (window.testRunner)
+if (window.testRunner)
     testRunner.dumpAsText();
 
-  var createdObjects = 0;
-  function count() {
-    createdObjects++;
+function dumpResult()
+{
+    let objects = document.getElementsByTagName("object");
+    let objectCount = objects.length;
+    var result = "";
 
-    if (createdObjects == maxNumberOfFrames) {
-      var str = "Created precisely " + maxNumberOfFrames + " objects.<br>PASS";
-      document.getElementById("status").innerHTML = str;
-    } else if (createdObjects > maxNumberOfFrames) {
-      var str = "Created " + createdObjects + " objects (max: " + maxNumberOfFrames + ").<br>FAIL";
-      document.getElementById("status").innerHTML = str;
-    }
-  }
+    if (objectCount != maxNumberOfFrames + 1)
+        result = `Created an invalid number of objects (${objectCount}).<br>FAIL`;
+    else if (objects[objectCount - 1].contentDocument)
+        result = `Created ${objectCount} objects (max: ${maxNumberOfFrames}).<br>FAIL`;
+    else
+        result = `Created precisely ${maxNumberOfFrames} objects.<br>PASS`;
 
-  function createObjects(nbr) {
-    var str = "<div id=\"status\"></div>";
+    document.getElementById("status").innerHTML = result
+}
+
+
+function createObjects()
+{
+    var observer = new MutationObserver(dumpResult);
+    var config = { childList: true, attributes: false, subtree: false };
+    observer.observe(document.body, config);
+
+    let fragment = document.createDocumentFragment();
     for (var i = 0; i < maxNumberOfFrames + 1; i++) {
-      str += "<object onLoad=\"count()\" data=\"data:text/html,object_" + i + "\"></object>";
+        let object = document.createElement("object");
+        object.type = 'text/html';
+        object.data = `data:text/html,object_${i}`;
+        object.style.visibility = 'hidden';
+        fragment.appendChild(object);
     }
-    document.getElementsByTagName("body")[0].innerHTML = str;
-  }
+    document.body.appendChild(fragment);
+}
 </script>
 </head>
 <body onLoad="createObjects()">
+<div id="status"></div>
 </body>
 </html>


### PR DESCRIPTION
#### 4b9d31c3a99905ac9d003167241760c57f757882
<pre>
fast/frames/lots-of-iframes.html and fast/frames/lots-of-objects.html are flaky timeouts
<a href="https://bugs.webkit.org/show_bug.cgi?id=298471">https://bugs.webkit.org/show_bug.cgi?id=298471</a>
<a href="https://rdar.apple.com/159964738">rdar://159964738</a>

Reviewed by Sammy Gill and Brent Fulgham.

fast/frames/lots-of* tests attempt to test the limit placed on &lt;iframe&gt; and &lt;object&gt;
element document creation by creating 1001 of each and testing that the 1001th was blocked.
This can be really slow in debug builds. I measured about 12 sec/test on average for
fast/frames/lots-of-iframes.html and a little under 11 sec/test for fast/frames/lots-of-objects.html
on a M4 Max MacBook Pro. The result of this is that we often see flaky timeouts of these tests in
our test infrastructure.

In an attempt to improve the situation I tried to optimize the tests to reduce runtime using some modern
web technologies. Things such as MutationObserver and lazy iframe loading.

On average I saw a 50% reduction in runtime on fast/frames/lots-of-iframes.html and a 20-25% reduction
in runtime on fast/frames/lots-of-objects.html in debug builds on the M4 Max.

Both use similar techniques. There exist more optimization opportunities for iframes so I was able to
get a better result from that test.

* LayoutTests/TestExpectations:
* LayoutTests/fast/frames/lots-of-iframes.html:
    When we create iframes we set the style of the element specifically to avoid layout (display: none)
    and to allow for lazy loading by forcing the frame to be off screen (position: absolute, top: 9999px).
* LayoutTests/fast/frames/lots-of-objects.html:
    &lt;object&gt; elements will not attempt to load their documents if they have display: none so we use
    visibility: hidden to avoid any extra work when we load the first 1k objects.

Canonical link: <a href="https://commits.webkit.org/300174@main">https://commits.webkit.org/300174@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/32e9cff954ceab2e8e873b304fa2988f591bc250

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121586 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41283 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31942 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128064 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/73675 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/12210e2a-3d50-41a2-82d7-f85561a10bfe) 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/41985 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49862 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92356 "") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/73675 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4471d7cf-6358-4b15-8f29-9c874fd495cd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124538 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/41985 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/108905 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/73028 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bc5003bd-183c-4b01-9543-be9dfaea97ca) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/41985 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/27072 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71619 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/41985 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27245 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130873 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/48514 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/36894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/100939 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/48882 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105128 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/100843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25566 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24339 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/45216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48373 "Built successfully") | | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/47844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/51191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/49526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->