### PR TITLE
Remove Ref<MediaPromise> MediaSourcePrivateClient::seekToTime(const MediaTime& time)

### DIFF
--- a/Source/WebCore/Modules/mediasource/MediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSource.cpp
@@ -165,17 +165,6 @@ private:
         return promise;
     }
 
-    Ref<MediaPromise> seekToTime(const MediaTime& time) final
-    {
-        MediaPromise::AutoRejectProducer producer(PlatformMediaError::SourceRemoved);
-        auto promise = producer.promise();
-
-        ensureWeakOnDispatcher([producer = WTFMove(producer), time](MediaSource& parent) mutable {
-            parent.seekToTime(time)->chainTo(WTFMove(producer));
-        });
-        return promise;
-    }
-
     RefPtr<MediaSourcePrivate> mediaSourcePrivate() const final
     {
         Locker locker { m_lock };
@@ -470,13 +459,6 @@ void MediaSource::completeSeek()
     });
     promise->chainTo(WTFMove(*m_seekTargetPromise));
     m_seekTargetPromise.reset();
-}
-
-Ref<MediaPromise> MediaSource::seekToTime(const MediaTime& time)
-{
-    for (Ref sourceBuffer : m_activeSourceBuffers.get())
-        sourceBuffer->seekToTime(time);
-    return MediaPromise::createAndResolve();
 }
 
 PlatformTimeRanges MediaSource::seekable()

--- a/Source/WebCore/Modules/mediasource/MediaSource.h
+++ b/Source/WebCore/Modules/mediasource/MediaSource.h
@@ -206,7 +206,6 @@ private:
     void removeSourceBufferWithOptionalDestruction(SourceBuffer&, bool withDestruction);
 
     Ref<MediaTimePromise> waitForTarget(const SeekTarget&);
-    Ref<MediaPromise> seekToTime(const MediaTime&);
     using RendererType = MediaSourcePrivateClient::RendererType;
     void failedToCreateRenderer(RendererType);
 

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
@@ -599,12 +599,6 @@ Ref<SourceBuffer::ComputeSeekPromise> SourceBuffer::computeSeekTime(const SeekTa
     return m_private->computeSeekTime(target);
 }
 
-void SourceBuffer::seekToTime(const MediaTime& time)
-{
-    ALWAYS_LOG(LOGIDENTIFIER, time);
-    m_private->seekToTime(time);
-}
-
 bool SourceBuffer::virtualHasPendingActivity() const
 {
     return !!m_source;

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.h
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.h
@@ -113,7 +113,6 @@ public:
     void removedFromMediaSource();
     using ComputeSeekPromise = SourceBufferPrivate::ComputeSeekPromise;
     Ref<ComputeSeekPromise> computeSeekTime(const SeekTarget&);
-    void seekToTime(const MediaTime&);
 
     bool hasVideo() const;
 

--- a/Source/WebCore/platform/graphics/MediaSourcePrivate.cpp
+++ b/Source/WebCore/platform/graphics/MediaSourcePrivate.cpp
@@ -104,11 +104,10 @@ Ref<MediaTimePromise> MediaSourcePrivate::waitForTarget(const SeekTarget& target
     return MediaTimePromise::createAndReject(PlatformMediaError::ClientDisconnected);
 }
 
-Ref<MediaPromise> MediaSourcePrivate::seekToTime(const MediaTime& time)
+void MediaSourcePrivate::seekToTime(const MediaTime& seekTime)
 {
-    if (RefPtr client = this->client())
-        return client->seekToTime(time);
-    return MediaPromise::createAndReject(PlatformMediaError::ClientDisconnected);
+    for (RefPtr sourceBuffer : m_activeSourceBuffers)
+        sourceBuffer->seekToTime(seekTime);
 }
 
 void MediaSourcePrivate::removeSourceBuffer(SourceBufferPrivate& sourceBuffer)

--- a/Source/WebCore/platform/graphics/MediaSourcePrivate.h
+++ b/Source/WebCore/platform/graphics/MediaSourcePrivate.h
@@ -101,7 +101,7 @@ public:
     MediaTime currentTime() const;
 
     Ref<MediaTimePromise> waitForTarget(const SeekTarget&);
-    Ref<MediaPromise> seekToTime(const MediaTime&);
+    void seekToTime(const MediaTime&);
 
     virtual void setTimeFudgeFactor(const MediaTime& fudgeFactor) { m_timeFudgeFactor = fudgeFactor; }
     MediaTime timeFudgeFactor() const { return m_timeFudgeFactor; }

--- a/Source/WebCore/platform/graphics/MediaSourcePrivateClient.h
+++ b/Source/WebCore/platform/graphics/MediaSourcePrivateClient.h
@@ -45,7 +45,6 @@ public:
     virtual void setPrivateAndOpen(Ref<MediaSourcePrivate>&&) = 0;
     virtual void reOpen() = 0;
     virtual Ref<MediaTimePromise> waitForTarget(const SeekTarget&) = 0;
-    virtual Ref<MediaPromise> seekToTime(const MediaTime&) = 0;
     virtual RefPtr<MediaSourcePrivate> mediaSourcePrivate() const = 0;
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
@@ -294,7 +294,7 @@ void SourceBufferPrivate::provideMediaData(TrackID trackID)
 
 void SourceBufferPrivate::provideMediaData(TrackBuffer& trackBuffer, TrackID trackID)
 {
-    if (isSeeking())
+    if (trackBuffer.needsReenqueueing() || isSeeking())
         return;
     RefPtr client = this->client();
     if (!client)

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -534,10 +534,7 @@ void MediaPlayerPrivateMediaSourceAVFObjC::seekInternal()
         mediaSourcePrivate->willSeek();
         [protectedThis->m_synchronizer setRate:0 time:PAL::toCMTime(seekedTime)];
 
-        mediaSourcePrivate->seekToTime(seekedTime)->whenSettled(RunLoop::currentSingleton(), [weakThis = WTFMove(weakThis)]() mutable {
-            if (RefPtr protectedThis = weakThis.get())
-                protectedThis->maybeCompleteSeek();
-        });
+        mediaSourcePrivate->seekToTime(seekedTime);
     });
 }
 

--- a/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.cpp
+++ b/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.cpp
@@ -242,24 +242,21 @@ void MockMediaPlayerMediaSource::seekToTarget(const SeekTarget& target)
         if (!protectedThis || !result)
             return;
 
-        protectedThis->protectedMediaSourcePrivate()->seekToTime(*result)->whenSettled(RunLoop::currentSingleton(), [weakThis, seekTime = *result] {
-            RefPtr protectedThis = weakThis.get();
-            if (!protectedThis)
-                return;
-            protectedThis->m_lastSeekTarget.reset();
-            protectedThis->m_currentTime = seekTime;
+        const auto seekTime = *result;
+        protectedThis->protectedMediaSourcePrivate()->seekToTime(seekTime);
+        protectedThis->m_lastSeekTarget.reset();
+        protectedThis->m_currentTime = seekTime;
 
-            if (RefPtr player = protectedThis->m_player.get()) {
-                player->seeked(seekTime);
-                player->timeChanged();
-            }
+        if (RefPtr player = protectedThis->m_player.get()) {
+            player->seeked(seekTime);
+            player->timeChanged();
+        }
 
-            if (protectedThis->m_playing) {
-                callOnMainThread([protectedThis = WTFMove(protectedThis)] {
-                    protectedThis->advanceCurrentTime();
-                });
-            }
-        });
+        if (protectedThis->m_playing) {
+            callOnMainThread([protectedThis = WTFMove(protectedThis)] {
+                protectedThis->advanceCurrentTime();
+            });
+        }
     });
 }
 

--- a/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.cpp
@@ -100,14 +100,6 @@ Ref<MediaTimePromise> RemoteMediaSourceProxy::waitForTarget(const SeekTarget& ta
     return MediaTimePromise::createAndReject(PlatformMediaError::IPCError);
 }
 
-Ref<MediaPromise> RemoteMediaSourceProxy::seekToTime(const MediaTime& time)
-{
-    if (RefPtr connection = connectionToWebProcess())
-        return connection->connection().sendWithPromisedReply<MediaPromiseConverter>(Messages::MediaSourcePrivateRemoteMessageReceiver::ProxySeekToTime(time), m_identifier);
-
-    return MediaPromise::createAndReject(PlatformMediaError::IPCError);
-}
-
 #if !RELEASE_LOG_DISABLED
 void RemoteMediaSourceProxy::setLogIdentifier(uint64_t)
 {

--- a/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.h
@@ -70,7 +70,6 @@ public:
     void setPrivateAndOpen(Ref<WebCore::MediaSourcePrivate>&&) final;
     void reOpen() final;
     Ref<WebCore::MediaTimePromise> waitForTarget(const WebCore::SeekTarget&) final;
-    Ref<WebCore::MediaPromise> seekToTime(const MediaTime&) final;
     RefPtr<WebCore::MediaSourcePrivate> mediaSourcePrivate() const final { return m_private; }
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.cpp
@@ -308,11 +308,6 @@ void RemoteSourceBufferProxy::computeSeekTime(const SeekTarget& target, Completi
     protectedSourceBufferPrivate()->computeSeekTime(target)->whenSettled(RunLoop::currentSingleton(), WTFMove(completionHandler));
 }
 
-void RemoteSourceBufferProxy::seekToTime(const MediaTime& time)
-{
-    protectedSourceBufferPrivate()->seekToTime(time);
-}
-
 void RemoteSourceBufferProxy::updateTrackIds(Vector<std::pair<TrackID, TrackID>>&& trackIdPairs)
 {
     if (!trackIdPairs.isEmpty())

--- a/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.h
@@ -116,7 +116,6 @@ private:
     void setAppendWindowEnd(const MediaTime&);
     void setMaximumBufferSize(uint64_t, CompletionHandler<void()>&&);
     void computeSeekTime(const WebCore::SeekTarget&, CompletionHandler<void(WebCore::SourceBufferPrivate::ComputeSeekPromise::Result&&)>&&);
-    void seekToTime(const MediaTime&);
     void updateTrackIds(Vector<std::pair<TrackID, TrackID>>&&);
     void bufferedSamplesForTrackId(TrackID, CompletionHandler<void(WebCore::SourceBufferPrivate::SamplesPromise::Result&&)>&&);
     void enqueuedSamplesForTrackID(TrackID, CompletionHandler<void(WebCore::SourceBufferPrivate::SamplesPromise::Result&&)>&&);

--- a/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.messages.in
@@ -57,7 +57,6 @@ messages -> RemoteSourceBufferProxy {
     SetAppendWindowEnd(MediaTime appendWindowEnd)
     SetMaximumBufferSize(uint64_t size) -> ()
     ComputeSeekTime(struct WebCore::SeekTarget target) -> (Expected<MediaTime, WebCore::PlatformMediaError> seekedTime)
-    SeekToTime(MediaTime time)
     UpdateTrackIds(Vector<std::pair<WebCore::TrackID, WebCore::TrackID>> identifierPairs)
     BufferedSamplesForTrackId(WebCore::TrackID trackID) -> (WebCore::SourceBufferPrivate::SamplesPromise::Result samples)
     EnqueuedSamplesForTrackID(WebCore::TrackID trackID) -> (WebCore::SourceBufferPrivate::SamplesPromise::Result samples)

--- a/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.cpp
@@ -279,17 +279,6 @@ void MediaSourcePrivateRemote::MessageReceiver::proxyWaitForTarget(const WebCore
     completionHandler(makeUnexpected(PlatformMediaError::ClientDisconnected));
 }
 
-void MediaSourcePrivateRemote::MessageReceiver::proxySeekToTime(const MediaTime& time, CompletionHandler<void(MediaPromise::Result&&)>&& completionHandler)
-{
-    assertIsCurrent(MediaSourcePrivateRemote::queueSingleton());
-
-    if (auto client = this->client()) {
-        client->seekToTime(time)->whenSettled(MediaSourcePrivateRemote::queueSingleton(), WTFMove(completionHandler));
-        return;
-    }
-    completionHandler(makeUnexpected(PlatformMediaError::SourceRemoved));
-}
-
 MediaSourcePrivateRemote::MessageReceiver::MessageReceiver(MediaSourcePrivateRemote& parent)
     : m_parent(parent)
 {

--- a/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.h
@@ -98,7 +98,6 @@ public:
         MessageReceiver(MediaSourcePrivateRemote&);
         void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
         void proxyWaitForTarget(const WebCore::SeekTarget&, CompletionHandler<void(WebCore::MediaTimePromise::Result&&)>&&);
-        void proxySeekToTime(const MediaTime&, CompletionHandler<void(WebCore::MediaPromise::Result&&)>&&);
 
         RefPtr<WebCore::MediaSourcePrivateClient> client() const;
         ThreadSafeWeakPtr<MediaSourcePrivateRemote> m_parent;

--- a/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemoteMessageReceiver.messages.in
+++ b/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemoteMessageReceiver.messages.in
@@ -31,7 +31,6 @@
 ]
 messages -> MediaSourcePrivateRemoteMessageReceiver {
     ProxyWaitForTarget(struct WebCore::SeekTarget target) -> (Expected<MediaTime, WebCore::PlatformMediaError> seekedTime);
-    ProxySeekToTime(MediaTime time) -> (Expected<void, WebCore::PlatformMediaError> result);
 }
 
 #endif

--- a/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.cpp
@@ -386,9 +386,7 @@ Ref<SourceBufferPrivate::ComputeSeekPromise> SourceBufferPrivateRemote::computeS
 
 void SourceBufferPrivateRemote::seekToTime(const MediaTime& time)
 {
-    ensureWeakOnDispatcher([time](auto& buffer) {
-        buffer.sendToProxy(Messages::RemoteSourceBufferProxy::SeekToTime(time));
-    });
+    ASSERT_NOT_REACHED();
 }
 
 void SourceBufferPrivateRemote::updateTrackIds(Vector<std::pair<TrackID, TrackID>>&& trackIDPairs)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ClipboardTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ClipboardTests.mm
@@ -148,7 +148,8 @@ static RetainPtr<NSString> readMarkupFromPasteboard()
 }
 
 // rdar://138144869
-#if PLATFORM(IOS) && !defined(NDEBUG)
+// rdar://159421461 (Release)
+#if PLATFORM(IOS)
 TEST(ClipboardTests, DISABLED_ReadMultipleItems)
 #else
 TEST(ClipboardTests, ReadMultipleItems)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/PasteHTML.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/PasteHTML.mm
@@ -73,7 +73,12 @@ static RetainPtr<TestWKWebView> createWebViewWithCustomPasteboardDataSetting(boo
     return webView;
 }
 
+// rdar://159421461
+#if PLATFORM(IOS)
+TEST(PasteHTML, DISABLED_ExposesHTMLTypeInDataTransfer)
+#else
 TEST(PasteHTML, ExposesHTMLTypeInDataTransfer)
+#endif
 {
     auto webView = createWebViewWithCustomPasteboardDataSetting(true);
     [webView synchronouslyLoadTestPageNamed:@"paste-rtfd"];
@@ -90,7 +95,8 @@ TEST(PasteHTML, ExposesHTMLTypeInDataTransfer)
 }
 
 // rdar://138144869
-#if PLATFORM(IOS) && !defined(NDEBUG)
+// rdar://159421461 (Release)
+#if PLATFORM(IOS)
 TEST(PasteHTML, DISABLED_SanitizesHTML)
 #else
 TEST(PasteHTML, SanitizesHTML)
@@ -111,7 +117,7 @@ TEST(PasteHTML, SanitizesHTML)
 }
 
 // rdar://138144869
-#if PLATFORM(IOS) && !defined(NDEBUG)
+#if PLATFORM(IOS)
 TEST(PasteHTML, DISABLED_DoesNotSanitizeHTMLWhenCustomPasteboardDataIsDisabled)
 #else
 TEST(PasteHTML, DoesNotSanitizeHTMLWhenCustomPasteboardDataIsDisabled)
@@ -132,7 +138,8 @@ TEST(PasteHTML, DoesNotSanitizeHTMLWhenCustomPasteboardDataIsDisabled)
 }
 
 // rdar://138144869
-#if PLATFORM(IOS) && !defined(NDEBUG)
+// rdar://159421461 (Release)
+#if PLATFORM(IOS)
 TEST(PasteHTML, DISABLED_StripsFileAndJavaScriptURLs)
 #else
 TEST(PasteHTML, StripsFileAndJavaScriptURLs)
@@ -157,7 +164,7 @@ TEST(PasteHTML, StripsFileAndJavaScriptURLs)
 }
 
 // rdar://138144869
-#if PLATFORM(IOS) && !defined(NDEBUG)
+#if PLATFORM(IOS)
 TEST(PasteHTML, DISABLED_DoesNotStripFileURLsWhenCustomPasteboardDataIsDisabled)
 #else
 TEST(PasteHTML, DoesNotStripFileURLsWhenCustomPasteboardDataIsDisabled)
@@ -176,7 +183,8 @@ TEST(PasteHTML, DoesNotStripFileURLsWhenCustomPasteboardDataIsDisabled)
 }
 
 // rdar://138144869
-#if PLATFORM(IOS) && !defined(NDEBUG)
+// rdar://159421461 (Release)
+#if PLATFORM(IOS)
 TEST(PasteHTML, DISABLED_KeepsHTTPURLs)
 #else
 TEST(PasteHTML, KeepsHTTPURLs)
@@ -195,7 +203,8 @@ TEST(PasteHTML, KeepsHTTPURLs)
 }
 
 // rdar://138144869
-#if PLATFORM(IOS) && !defined(NDEBUG)
+// rdar://159421461 (Release)
+#if PLATFORM(IOS)
 TEST(PasteHTML, DISABLED_PreservesMSOList)
 #else
 TEST(PasteHTML, PreservesMSOList)
@@ -251,7 +260,12 @@ TEST(PasteHTML, PreservesMSOList)
     EXPECT_WK_STREQ("rgb(255, 0, 0)", [webView stringByEvaluatingJavaScript:@"document.queryCommandValue('foreColor')"]);
 }
 
+// rdar://159421461
+#if PLATFORM(IOS)
+TEST(PasteHTML, DISABLED_PreservesMSOListInCompatibilityMode)
+#else
 TEST(PasteHTML, PreservesMSOListInCompatibilityMode)
+#endif
 {
     writeHTMLToPasteboard([NSString stringWithContentsOfFile:[NSBundle.test_resourcesBundle pathForResource:@"mso-list-compat-mode" ofType:@"html"]
         encoding:NSUTF8StringEncoding error:NULL]);
@@ -288,7 +302,8 @@ TEST(PasteHTML, PreservesMSOListInCompatibilityMode)
 }
 
 // rdar://138144869
-#if PLATFORM(IOS) && !defined(NDEBUG)
+// rdar://159421461 (Release)
+#if PLATFORM(IOS)
 TEST(PasteHTML, DISABLED_PreservesMSOListOnH4)
 #else
 TEST(PasteHTML, PreservesMSOListOnH4)
@@ -329,7 +344,8 @@ TEST(PasteHTML, PreservesMSOListOnH4)
 }
 
 // rdar://138144869
-#if PLATFORM(IOS) && !defined(NDEBUG)
+// rdar://159421461 (Release)
+#if PLATFORM(IOS)
 TEST(PasteHTML, DISABLED_StripsMSOListWhenMissingMSOHTMLElement)
 #else
 TEST(PasteHTML, StripsMSOListWhenMissingMSOHTMLElement)
@@ -381,7 +397,8 @@ TEST(PasteHTML, StripsMSOListWhenMissingMSOHTMLElement)
 }
 
 // rdar://138144869
-#if PLATFORM(IOS) && !defined(NDEBUG)
+// rdar://159421461 (Release)
+#if PLATFORM(IOS)
 TEST(PasteHTML, DISABLED_StripsSystemFontNames)
 #else
 TEST(PasteHTML, StripsSystemFontNames)
@@ -416,7 +433,7 @@ TEST(PasteHTML, StripsSystemFontNames)
 }
 
 // rdar://138144869
-#if PLATFORM(IOS) && !defined(NDEBUG)
+#if PLATFORM(IOS)
 TEST(PasteHTML, DISABLED_DoesNotAddStandardFontFamily)
 #else
 TEST(PasteHTML, DoesNotAddStandardFontFamily)


### PR DESCRIPTION
#### 22ce46ae753c8f5c0458c10943ecc25f2539b0b8
<pre>
Remove Ref&lt;MediaPromise&gt; MediaSourcePrivateClient::seekToTime(const MediaTime&amp; time)
<a href="https://bugs.webkit.org/show_bug.cgi?id=298908">https://bugs.webkit.org/show_bug.cgi?id=298908</a>
<a href="https://rdar.apple.com/160652035">rdar://160652035</a>

Reviewed by Youenn Fablet.

There is no need to jump back to the content process only to go back to GPUP;
re-enqueueing sample to the SourceBufferPrivate is new a synchronous operation
in all implementations, so we can remove this asynchronous API.

Covered by existings tests. No change in JS observable behaviour other than
seeking operations will be faster.

* Source/WebCore/Modules/mediasource/MediaSource.cpp:
(WebCore::MediaSource::seekToTime): Deleted.
* Source/WebCore/Modules/mediasource/MediaSource.h:
* Source/WebCore/Modules/mediasource/SourceBuffer.cpp:
(WebCore::SourceBuffer::seekToTime): Deleted.
* Source/WebCore/Modules/mediasource/SourceBuffer.h:
* Source/WebCore/platform/graphics/MediaSourcePrivate.cpp:
(WebCore::MediaSourcePrivate::seekToTime):
* Source/WebCore/platform/graphics/MediaSourcePrivate.h:
* Source/WebCore/platform/graphics/MediaSourcePrivateClient.h:
* Source/WebCore/platform/graphics/SourceBufferPrivate.cpp:
(WebCore::SourceBufferPrivate::provideMediaData):
* Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.cpp:
(WebCore::MockMediaPlayerMediaSource::seekToTarget):
* Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.cpp:
(WebKit::RemoteMediaSourceProxy::seekToTime): Deleted.
* Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.h:
* Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.messages.in:
* Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.cpp:
(WebKit::MediaSourcePrivateRemote::MessageReceiver::proxySeekToTime): Deleted.
* Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.h:
* Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemoteMessageReceiver.messages.in:
* Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.cpp:
(WebKit::SourceBufferPrivateRemote::seekToTime): Deleted.
* Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h:

Canonical link: <a href="https://commits.webkit.org/300147@main">https://commits.webkit.org/300147@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/85f413769b02b93492c94679c2e4d60e40a407d6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121513 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41210 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31869 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127975 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73596 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c5379f19-9ddc-493e-a6f0-4856b64fe53f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123389 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41912 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49789 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92295 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/61398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9b595692-f53b-40d5-a9c9-b656b96c65ab) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124465 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33463 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108841 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72971 "Found 1 new API test failure: WPE/TestWebKitWebContext:/webkit/WebKitWebContext/no-web-process-leak (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a70b28fa-a198-494d-b470-61b5e3232c11) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32470 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27011 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71537 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102946 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27184 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130788 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48441 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36834 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100882 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48809 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105069 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100789 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25550 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46200 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24279 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/45137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48300 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54012 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47771 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51117 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49453 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->