### PR TITLE
[GFC] Stop using CanMakeCheckedPtr with UnplacedGridItem

### DIFF
--- a/Source/WebCore/css/values/CSSValueAggregates.cpp
+++ b/Source/WebCore/css/values/CSSValueAggregates.cpp
@@ -34,4 +34,9 @@ WTF::TextStream& operator<<(WTF::TextStream& ts, const CustomIdentifier& value)
     return ts << value.value;
 }
 
+void add(Hasher& hasher, const CustomIdentifier& customIdentifier)
+{
+    add(hasher, customIdentifier.value);
+}
+
 } // namespace WebCore

--- a/Source/WebCore/css/values/CSSValueAggregates.h
+++ b/Source/WebCore/css/values/CSSValueAggregates.h
@@ -178,6 +178,8 @@ struct CustomIdentifier {
 };
 TextStream& operator<<(TextStream&, const CustomIdentifier&);
 
+void add(Hasher&, const CustomIdentifier&);
+
 template<CSSValueID C> TextStream& operator<<(TextStream& ts, const Constant<C>&)
 {
     return ts << nameLiteral(C);

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
@@ -59,7 +59,7 @@ GridLayout::PlacedGridItems GridLayout::placeGridItems(const UnplacedGridItems& 
 
     // 1. Position anything that’s not auto-positioned.
     auto& nonAutoPositionedGridItems = unplacedGridItems.nonAutoPositionedItems;
-    for (CheckedRef nonAutoPositionedItem : nonAutoPositionedGridItems)
+    for (auto& nonAutoPositionedItem : nonAutoPositionedGridItems)
         implicitGrid.insertUnplacedGridItem(nonAutoPositionedItem);
     return implicitGrid.placedGridItems();
 }

--- a/Source/WebCore/layout/formattingContexts/grid/ImplicitGrid.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/ImplicitGrid.cpp
@@ -38,7 +38,7 @@ namespace Layout {
 // implicit grid as exactly the explicit grid and allow placement to add implicit
 // tracks and grow the grid.
 ImplicitGrid::ImplicitGrid(size_t gridTemplateColumnsCount, size_t gridTemplateRowsCount)
-    : m_gridMatrix(Vector(gridTemplateRowsCount, Vector<CheckedPtr<const UnplacedGridItem>>(gridTemplateColumnsCount)))
+    : m_gridMatrix(Vector(gridTemplateRowsCount, Vector<std::optional<const UnplacedGridItem>>(gridTemplateColumnsCount)))
 {
 }
 
@@ -102,13 +102,13 @@ void ImplicitGrid::insertUnplacedGridItem(const UnplacedGridItem& unplacedGridIt
 
 PlacedGridItems ImplicitGrid::placedGridItems() const
 {
-    HashSet<CheckedRef<const UnplacedGridItem>> processedUnplacedGridItems;
+    HashSet<UnplacedGridItem> processedUnplacedGridItems;
     PlacedGridItems placedGridItems;
 
     for (size_t rowIndex = 0; rowIndex < m_gridMatrix.size(); ++rowIndex) {
         for (size_t columnIndex = 0; columnIndex < m_gridMatrix[rowIndex].size(); ++columnIndex) {
 
-            CheckedPtr unplacedGridItem = m_gridMatrix[rowIndex][columnIndex];
+            auto unplacedGridItem = m_gridMatrix[rowIndex][columnIndex];
             if (!unplacedGridItem || processedUnplacedGridItems.contains(*unplacedGridItem))
                 continue;
 

--- a/Source/WebCore/layout/formattingContexts/grid/ImplicitGrid.h
+++ b/Source/WebCore/layout/formattingContexts/grid/ImplicitGrid.h
@@ -48,7 +48,7 @@ public:
     PlacedGridItems placedGridItems() const;
 
 private:
-    using GridMatrix = Vector<Vector<WTF::CheckedPtr<const UnplacedGridItem>>>;
+    using GridMatrix = Vector<Vector<std::optional<const UnplacedGridItem>>>;
     GridMatrix m_gridMatrix;
 };
 

--- a/Source/WebCore/layout/formattingContexts/grid/UnplacedGridItem.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/UnplacedGridItem.cpp
@@ -36,6 +36,13 @@ UnplacedGridItem::UnplacedGridItem(const ElementBox& layoutBox, Style::GridPosit
 {
 }
 
+UnplacedGridItem::UnplacedGridItem(WTF::HashTableEmptyValueType)
+    : m_layoutBox(WTF::HashTableEmptyValue)
+    , m_columnPosition({ RenderStyle::initialGridItemColumnStart(), RenderStyle::initialGridItemColumnEnd() })
+    , m_rowPosition({ RenderStyle::initialGridItemRowStart(), RenderStyle::initialGridItemRowEnd() })
+{
+}
+
 int UnplacedGridItem::explicitColumnStart() const
 {
     ASSERT(m_columnPosition.first.isExplicit());
@@ -80,5 +87,25 @@ int UnplacedGridItem::explicitRowEnd() const
     return { };
 }
 
+bool UnplacedGridItem::operator==(const UnplacedGridItem& other) const
+{
+    // Since the hash table empty value uses CheckedRef's empty value,
+    // we need to check if either |this| or |other| are the empty value
+    // so we do not compare the uninitialized ref.
+    bool isEmpty = isHashTableEmptyValue();
+    if (isEmpty)
+        return other.isHashTableEmptyValue();
+    if (other.isHashTableEmptyValue())
+        return isEmpty;
+
+    return m_layoutBox.ptr() == other.m_layoutBox.ptr() && m_columnPosition == other.m_columnPosition && m_rowPosition == other.m_rowPosition;
+}
+
+void add(Hasher& hasher, const WebCore::Layout::UnplacedGridItem& unplacedGridItem)
+{
+    addArgs(hasher, unplacedGridItem.m_layoutBox.ptr(), unplacedGridItem.m_columnPosition, unplacedGridItem.m_rowPosition);
+}
+
 } // namespace Layout
 } // namespace WebCore
+

--- a/Source/WebCore/style/values/grid/StyleGridPosition.cpp
+++ b/Source/WebCore/style/values/grid/StyleGridPosition.cpp
@@ -49,6 +49,11 @@ static int clampGridIntegerPosition(int integerPosition)
     return clampTo(integerPosition, GridPosition::min(), GridPosition::max());
 }
 
+void add(Hasher& hasher, const GridPosition& gridPosition)
+{
+    addArgs(hasher, gridPosition.m_type, gridPosition.m_integerPosition, gridPosition.m_namedGridLine);
+}
+
 GridPosition::GridPosition(GridPosition::Explicit&& explicitPosition)
     : m_type { GridPositionType::Explicit }
     , m_integerPosition { clampGridIntegerPosition(explicitPosition.position.value) }

--- a/Source/WebCore/style/values/grid/StyleGridPosition.h
+++ b/Source/WebCore/style/values/grid/StyleGridPosition.h
@@ -130,6 +130,8 @@ struct GridPosition {
     WEBCORE_EXPORT static void setMaxPositionForTesting(unsigned);
 
 private:
+    friend void add(Hasher&, const GridPosition&);
+
     enum class GridPositionType : uint8_t {
         Auto,
         Explicit,


### PR DESCRIPTION
#### 10a9a51814343bd5b14c7b478ba019448c2cafc9
<pre>
[GFC] Stop using CanMakeCheckedPtr with UnplacedGridItem
<a href="https://bugs.webkit.org/show_bug.cgi?id=299069">https://bugs.webkit.org/show_bug.cgi?id=299069</a>
<a href="https://rdar.apple.com/160832323">rdar://160832323</a>

Reviewed by Alan Baradlay.

UnplacedGridItem currently inherits from CanMakeCheckedPtr but seems a
bit unnecessary given how we are currently using it alongside the fact
that it is not designed to be a long-lived object. Instead, we can
achieve the same functionality with two main changes:

1.) Use std::optional&lt;UnplacedGridItem&gt; inside the GridMatrix to
indicate whether an item is within a particular cell or if it is empty.
2.) Add some HashTraits to UnplacedGridItem to allow it to be used
within a HashSet that we use to keep track of which UnplacedGridItems
have been processed when computing ProcessedGridItems.

Canonical link: <a href="https://commits.webkit.org/300160@main">https://commits.webkit.org/300160@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ea2c6693b659023072d71c9ddc6959c4ff343f3d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121517 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41214 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31873 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127970 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73600 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/70eb27d1-5861-49b4-a89c-3e3e43816b01) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123393 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41916 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49793 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92291 "") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61402 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/68748074-227b-4969-b456-986bc8f7e7ff) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124469 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33469 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108847 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72967 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b57a67e1-f312-4b1e-93e1-001f01d022da) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32478 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27017 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71542 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102952 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27190 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130792 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48445 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36836 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100881 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48813 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105075 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100788 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25561 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46201 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24285 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45141 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48304 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54016 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47775 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51121 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49457 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->