### PR TITLE
Address safer cpp warnings in platform/graphics/coretext

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
@@ -57,7 +57,6 @@ platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.h
 platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.mm
 platform/graphics/ca/TileController.h
 platform/graphics/controls/PlatformControl.h
-platform/graphics/coretext/DrawGlyphsRecorder.h
 platform/graphics/filters/software/FEConvolveMatrixSoftwareApplier.h
 platform/graphics/filters/software/FELightingSoftwareApplier.h
 platform/graphics/filters/software/FEMorphologySoftwareApplier.h

--- a/Source/WebCore/SaferCPPExpectations/RetainPtrCtorAdoptCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/RetainPtrCtorAdoptCheckerExpectations
@@ -10,7 +10,6 @@ platform/graphics/cg/GraphicsContextCG.cpp
 platform/graphics/cg/ImageDecoderCG.cpp
 platform/graphics/cg/PatternCG.cpp
 platform/graphics/cocoa/VideoMediaSampleRenderer.mm
-platform/graphics/coretext/ComplexTextControllerCoreText.mm
 platform/graphics/cv/PixelBufferConformerCV.cpp
 platform/graphics/mac/GraphicsChecksMac.cpp
 platform/mac/CursorMac.mm

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -347,7 +347,6 @@ platform/graphics/ca/TileGrid.cpp
 platform/graphics/coreimage/FEColorMatrixCoreImageApplier.mm
 platform/graphics/coreimage/FEComponentTransferCoreImageApplier.mm
 platform/graphics/coreimage/SourceGraphicCoreImageApplier.mm
-platform/graphics/coretext/ComplexTextControllerCoreText.mm
 platform/graphics/filters/FilterOperations.cpp
 platform/graphics/filters/software/FEBlendSoftwareApplier.cpp
 platform/graphics/filters/software/FEColorMatrixSoftwareApplier.cpp

--- a/Source/WebCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
@@ -94,11 +94,6 @@ platform/graphics/cocoa/VideoMediaSampleRenderer.mm
 platform/graphics/cocoa/WebCoreCALayerExtras.mm
 platform/graphics/coreimage/FilterImageCoreImage.mm
 platform/graphics/coreimage/SourceGraphicCoreImageApplier.mm
-platform/graphics/coretext/ComplexTextControllerCoreText.mm
-platform/graphics/coretext/DrawGlyphsRecorder.cpp
-platform/graphics/coretext/FontCoreText.cpp
-platform/graphics/coretext/FontPlatformDataCoreText.cpp
-platform/graphics/coretext/GlyphPageCoreText.cpp
 platform/graphics/cv/CVUtilities.mm
 platform/graphics/cv/GraphicsContextGLCVCocoa.mm
 platform/graphics/cv/ImageTransferSessionVT.mm

--- a/Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
@@ -58,10 +58,6 @@ platform/graphics/cocoa/GraphicsContextCocoa.mm
 platform/graphics/cocoa/ImageAdapterCocoa.mm
 platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
 platform/graphics/cocoa/VideoMediaSampleRenderer.mm
-platform/graphics/coretext/ComplexTextControllerCoreText.mm
-platform/graphics/coretext/DrawGlyphsRecorder.cpp
-platform/graphics/coretext/FontCoreText.cpp
-platform/graphics/coretext/FontPlatformDataCoreText.cpp
 platform/graphics/cv/CVUtilities.mm
 platform/graphics/cv/ImageRotationSessionVT.mm
 platform/graphics/cv/ImageTransferSessionVT.mm

--- a/Source/WebCore/accessibility/cocoa/AccessibilityObjectCocoa.mm
+++ b/Source/WebCore/accessibility/cocoa/AccessibilityObjectCocoa.mm
@@ -189,7 +189,7 @@ RetainPtr<NSAttributedString> AccessibilityObject::attributedStringForRange(cons
 
 RetainPtr<CTFontRef> fontFrom(const RenderStyle& style)
 {
-    return style.fontCascade().primaryFont()->getCTFont();
+    return style.fontCascade().primaryFont()->ctFont();
 }
 
 Color textColorFrom(const RenderStyle& style)

--- a/Source/WebCore/accessibility/ios/AccessibilityObjectIOS.mm
+++ b/Source/WebCore/accessibility/ios/AccessibilityObjectIOS.mm
@@ -268,7 +268,7 @@ static void attributeStringSetStyle(NSMutableAttributedString *attrString, Rende
     auto& style = renderer->style();
 
     // Set basic font info.
-    attributedStringSetFont(attrString, style.fontCascade().primaryFont()->getCTFont(), range);
+    attributedStringSetFont(attrString, style.fontCascade().primaryFont()->ctFont(), range);
 
     if (style.textDecorationLineInEffect().hasUnderline())
         attributedStringSetNumber(attrString, AccessibilityTokenUnderline, @YES, range);

--- a/Source/WebCore/editing/cocoa/AttributedString.mm
+++ b/Source/WebCore/editing/cocoa/AttributedString.mm
@@ -383,7 +383,7 @@ static RetainPtr<id> toNSObject(const AttributedString::AttributeValue& value, I
     }, [] (const RetainPtr<NSDate>& value) -> RetainPtr<id> {
         return value;
     }, [] (const Ref<Font>& font) -> RetainPtr<id> {
-        return (__bridge PlatformFont *)(font->getCTFont());
+        return (__bridge PlatformFont *)font->ctFont();
     }, [] (const AttributedString::ColorFromPlatformColor& value) -> RetainPtr<id> {
         return cocoaColor(value.color);
     }, [] (const AttributedString::ColorFromCGColor& value) -> RetainPtr<id> {

--- a/Source/WebCore/editing/cocoa/EditingHTMLConverter.mm
+++ b/Source/WebCore/editing/cocoa/EditingHTMLConverter.mm
@@ -354,7 +354,7 @@ static void updateAttributes(const Node* node, const RenderStyle& style, OptionS
     else
         [attributes removeObjectForKey:NSStrikethroughStyleAttributeName];
 
-    if (auto ctFont = style.fontCascade().primaryFont()->getCTFont())
+    if (auto ctFont = style.fontCascade().primaryFont()->ctFont())
         [attributes setObject:(__bridge PlatformFont *)ctFont forKey:NSFontAttributeName];
     else {
         auto size = style.fontCascade().primaryFont()->platformData().size();

--- a/Source/WebCore/editing/cocoa/FontAttributeChangesCocoa.mm
+++ b/Source/WebCore/editing/cocoa/FontAttributeChangesCocoa.mm
@@ -52,7 +52,7 @@ const String& FontChanges::platformFontFamilyNameForCSS() const
     description.setIsItalic(m_italic.value_or(false));
     description.setWeight(FontSelectionValue { m_bold.value_or(false) ? 900 : 500 });
     if (auto font = FontCache::forCurrentThread()->fontForFamily(description, m_fontFamily))
-        fontNameFromDescription = adoptCF(CTFontCopyPostScriptName(font->getCTFont()));
+        fontNameFromDescription = adoptCF(CTFontCopyPostScriptName(font->ctFont()));
 
     if (fontNameFromDescription && CFStringCompare(cfFontName.get(), fontNameFromDescription.get(), 0) == kCFCompareEqualTo)
         return m_fontFamily;

--- a/Source/WebCore/editing/cocoa/FontAttributesCocoa.mm
+++ b/Source/WebCore/editing/cocoa/FontAttributesCocoa.mm
@@ -115,7 +115,7 @@ RetainPtr<NSTextList> TextList::createTextList() const
 RetainPtr<NSDictionary> FontAttributes::createDictionary() const
 {
     NSMutableDictionary *attributes = [NSMutableDictionary dictionary];
-    if (RetainPtr cocoaFont = font ? bridge_cast(font->getCTFont()) : nil)
+    if (RetainPtr cocoaFont = font ? bridge_cast(font->ctFont()) : nil)
         attributes[NSFontAttributeName] = cocoaFont.get();
 
     if (foregroundColor.isValid())

--- a/Source/WebCore/editing/cocoa/NodeHTMLConverter.mm
+++ b/Source/WebCore/editing/cocoa/NodeHTMLConverter.mm
@@ -877,7 +877,7 @@ static PlatformFont *_font(Element& element)
     Ref primaryFont = renderer->style().fontCascade().primaryFont();
     if (primaryFont->attributes().origin == FontOrigin::Remote)
         return [PlatformFontClass systemFontOfSize:defaultFontSize];
-    return (__bridge PlatformFont *)primaryFont->getCTFont();
+    return (__bridge PlatformFont *)primaryFont->ctFont();
 }
 
 NSDictionary *HTMLConverter::computedAttributesForElement(Element& element)

--- a/Source/WebCore/platform/graphics/Font.h
+++ b/Source/WebCore/platform/graphics/Font.h
@@ -228,7 +228,8 @@ public:
     bool shouldNotBeUsedForArabic() const { return m_shouldNotBeUsedForArabic; };
 #endif
 #if USE(CORE_TEXT)
-    CTFontRef getCTFont() const { return m_platformData.ctFont(); }
+    CTFontRef ctFont() const { return m_platformData.ctFont(); }
+    RetainPtr<CTFontRef> protectedCTFont() const { return ctFont(); }
     RetainPtr<CFDictionaryRef> getCFStringAttributes(bool enableKerning, FontOrientation, const AtomString& locale) const;
     bool supportsSmallCaps() const;
     bool supportsAllSmallCaps() const;

--- a/Source/WebCore/platform/graphics/FontPlatformData.h
+++ b/Source/WebCore/platform/graphics/FontPlatformData.h
@@ -332,12 +332,13 @@ public:
     WEBCORE_EXPORT IPCData toIPCData() const;
 
 #if USE(CORE_TEXT)
-    WEBCORE_EXPORT CTFontRef registeredFont() const; // Returns nullptr iff the font is not registered, such as web fonts (otherwise returns font()).
+    WEBCORE_EXPORT RetainPtr<CTFontRef> registeredFont() const; // Returns nullptr iff the font is not registered, such as web fonts (otherwise returns font()).
     static RetainPtr<CFTypeRef> objectForEqualityCheck(CTFontRef);
     RetainPtr<CFTypeRef> objectForEqualityCheck() const;
     bool hasCustomTracking() const { return isSystemFont(); }
 
     CTFontRef ctFont() const { return m_font.get(); }
+    RetainPtr<CTFontRef> protectedCTFont() const { return ctFont(); }
 #endif
 
 #if PLATFORM(COCOA)

--- a/Source/WebCore/platform/graphics/GraphicsContext.h
+++ b/Source/WebCore/platform/graphics/GraphicsContext.h
@@ -86,6 +86,12 @@ public:
 
     virtual bool hasPlatformContext() const { return false; }
     virtual PlatformGraphicsContext* platformContext() const { return nullptr; }
+#if USE(CG)
+    RetainPtr<CGContextRef> protectedPlatformContext() const { return platformContext(); }
+#else
+    // On other platforms, the PlatformGraphicsContext type is not refcounted.
+    PlatformGraphicsContext* protectedPlatformContext() const { return platformContext(); }
+#endif
 
     virtual const DestinationColorSpace& colorSpace() const { return DestinationColorSpace::SRGB(); }
 

--- a/Source/WebCore/platform/graphics/cocoa/GraphicsContextCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/GraphicsContextCocoa.mm
@@ -86,7 +86,7 @@ ImageDrawResult GraphicsContext::drawMultiRepresentationHEIC(Image& image, const
     // FIXME (rdar://123044459): This needs to account for vertical writing modes.
     CGContextSetTextPosition(cgContext, 0, font.metricsForMultiRepresentationHEIC().descent);
 
-    CTFontDrawImageFromAdaptiveImageProviderAtPoint(font.getCTFont(), multiRepresentationHEIC.get(), CGContextGetTextPosition(cgContext), cgContext);
+    CTFontDrawImageFromAdaptiveImageProviderAtPoint(font.ctFont(), multiRepresentationHEIC.get(), CGContextGetTextPosition(cgContext), cgContext);
 
     auto orientation = options.orientation();
     if (orientation == ImageOrientation::Orientation::FromImage)

--- a/Source/WebCore/platform/graphics/coretext/DrawGlyphsRecorder.cpp
+++ b/Source/WebCore/platform/graphics/coretext/DrawGlyphsRecorder.cpp
@@ -133,16 +133,16 @@ void DrawGlyphsRecorder::populateInternalContext(const GraphicsContextState& con
 
 void DrawGlyphsRecorder::recordInitialColors()
 {
-    CGContextRef cgContext = m_internalContext->platformContext();
-    m_initialFillColor = CGContextGetFillColorAsColor(cgContext);
-    m_initialStrokeColor = CGContextGetStrokeColorAsColor(cgContext);
+    RetainPtr cgContext = m_internalContext->platformContext();
+    m_initialFillColor = CGContextGetFillColorAsColor(cgContext.get());
+    m_initialStrokeColor = CGContextGetStrokeColorAsColor(cgContext.get());
 }
 
 void DrawGlyphsRecorder::prepareInternalContext(const Font& font, FontSmoothingMode smoothingMode)
 {
     ASSERT(CGAffineTransformIsIdentity(CTFontGetMatrix(font.platformData().ctFont())));
 
-    m_originalFont = &font;
+    m_originalFont = font;
     m_smoothingMode = smoothingMode;
 
     m_originalTextMatrix = computeOverallTextMatrix(font);
@@ -224,10 +224,10 @@ void DrawGlyphsRecorder::updateShadow(CGStyleRef style)
     auto rad = deg2rad(shadowStyle.azimuth - 180);
     auto shadowOffset = FloatSize(std::cos(rad), std::sin(rad)) * shadowStyle.height;
     auto shadowRadius = static_cast<float>(shadowStyle.radius);
-    auto shadowColor = CGStyleGetColor(style);
+    RetainPtr shadowColor = CGStyleGetColor(style);
     // Note: due to bugs in GraphicsContext interface and GraphicsContextCG, we have to set this first.
     m_owner.setShadowsIgnoreTransforms(true);
-    m_owner.setDropShadow({ shadowOffset, shadowRadius, Color::createAndPreserveColorSpace(shadowColor) });
+    m_owner.setDropShadow({ shadowOffset, shadowRadius, Color::createAndPreserveColorSpace(shadowColor.get()) });
 }
 
 void DrawGlyphsRecorder::recordBeginLayer(CGRenderingStateRef, CGGStateRef gstate, CGRect)
@@ -294,13 +294,13 @@ static AdvancesAndInitialPosition computeVerticalAdvancesFromPositions(std::span
 
 void DrawGlyphsRecorder::recordDrawGlyphs(CGRenderingStateRef, CGGStateRef gstate, const CGAffineTransform*, std::span<const CGGlyph> glyphs, std::span<const CGPoint> positions)
 {
-    ASSERT_IMPLIES(m_deriveFontFromContext == DeriveFontFromContext::No, m_originalFont);
+    ASSERT_IMPLIES(m_deriveFontFromContext == DeriveFontFromContext::No, m_originalFont.get());
 
     if (glyphs.empty())
         return;
 
-    CGFontRef usedFont = CGGStateGetFont(gstate);
-    if (m_deriveFontFromContext == DeriveFontFromContext::No && usedFont != adoptCF(CTFontCopyGraphicsFont(m_originalFont->platformData().ctFont(), nullptr)).get())
+    RetainPtr usedFont = CGGStateGetFont(gstate);
+    if (m_deriveFontFromContext == DeriveFontFromContext::No && usedFont != adoptCF(CTFontCopyGraphicsFont(m_originalFont->platformData().protectedCTFont().get(), nullptr)).get())
         return;
 
     updateCTM(*CGGStateGetCTM(gstate));
@@ -317,7 +317,7 @@ void DrawGlyphsRecorder::recordDrawGlyphs(CGRenderingStateRef, CGGStateRef gstat
     // If you set these two equal to each other, and solve for X, you get
     // CTM * currentTextMatrix = CTM * X * m_originalTextMatrix
     // currentTextMatrix * inverse(m_originalTextMatrix) = X
-    AffineTransform currentTextMatrix = CGContextGetTextMatrix(m_internalContext->platformContext());
+    AffineTransform currentTextMatrix = CGContextGetTextMatrix(m_internalContext->protectedPlatformContext().get());
     AffineTransform ctmFixup;
     if (auto invertedOriginalTextMatrix = m_originalTextMatrix.inverse())
         ctmFixup = currentTextMatrix * invertedOriginalTextMatrix.value();
@@ -328,12 +328,12 @@ void DrawGlyphsRecorder::recordDrawGlyphs(CGRenderingStateRef, CGGStateRef gstat
         ctmFixup = AffineTransform();
     m_owner.concatCTM(ctmFixup);
 
-    updateFillColor(CGGStateGetFillColor(gstate));
-    updateStrokeColor(CGGStateGetStrokeColor(gstate));
+    updateFillColor(RetainPtr { CGGStateGetFillColor(gstate) }.get());
+    updateStrokeColor(RetainPtr { CGGStateGetStrokeColor(gstate) }.get());
     updateShadow(CGGStateGetStyle(gstate));
 
     auto fontSize = CGGStateGetFontSize(gstate);
-    Ref font = m_deriveFontFromContext == DeriveFontFromContext::No ? *m_originalFont : Font::create(FontPlatformData(adoptCF(CTFontCreateWithGraphicsFont(usedFont, fontSize, nullptr, nullptr)), fontSize));
+    Ref font = m_deriveFontFromContext == DeriveFontFromContext::No ? *m_originalFont : Font::create(FontPlatformData(adoptCF(CTFontCreateWithGraphicsFont(usedFont.get(), fontSize, nullptr, nullptr)), fontSize));
 
     // The above does the work of ensuring the right CTM (which is the combination of CG's CTM and
     // CG's text matrix) is set for the replayer, but in order to provide the right values to
@@ -344,7 +344,7 @@ void DrawGlyphsRecorder::recordDrawGlyphs(CGRenderingStateRef, CGGStateRef gstat
     AdvancesAndInitialPosition advances;
     if (font->platformData().orientation() == FontOrientation::Vertical) {
         Vector<CGSize, 256> translations(glyphs.size());
-        CTFontGetVerticalTranslationsForGlyphs(font->platformData().ctFont(), glyphs.data(), translations.mutableSpan().data(), glyphs.size());
+        CTFontGetVerticalTranslationsForGlyphs(font->platformData().protectedCTFont().get(), glyphs.data(), translations.mutableSpan().data(), glyphs.size());
         auto ascentDelta = font->fontMetrics().ascent(FontBaseline::Ideographic) - font->fontMetrics().ascent();
         advances = computeVerticalAdvancesFromPositions(translations.span(), positions, ascentDelta, textMatrix);
     } else
@@ -391,27 +391,27 @@ void DrawGlyphsRecorder::recordDrawPath(CGRenderingStateRef, CGGStateRef gstate,
 
     switch (drawingMode) {
     case CGPathDrawingMode::kCGPathEOFill:
-        updateFillColor(CGGStateGetFillColor(gstate));
+        updateFillColor(RetainPtr { CGGStateGetFillColor(gstate) }.get());
         m_owner.setFillRule(WindRule::EvenOdd);
         m_owner.fillPath(path);
         break;
     case CGPathDrawingMode::kCGPathFill:
-        updateFillColor(CGGStateGetFillColor(gstate));
+        updateFillColor(RetainPtr { CGGStateGetFillColor(gstate) }.get());
         m_owner.setFillRule(WindRule::NonZero);
         m_owner.fillPath(path);
         break;
     case CGPathDrawingMode::kCGPathStroke:
-        updateStrokeColor(CGGStateGetStrokeColor(gstate));
+        updateStrokeColor(RetainPtr { CGGStateGetStrokeColor(gstate) }.get());
         m_owner.strokePath(path);
         break;
     case CGPathDrawingMode::kCGPathFillStroke:
-        updateStrokeColor(CGGStateGetStrokeColor(gstate));
-        updateFillColor(CGGStateGetFillColor(gstate));
+        updateStrokeColor(RetainPtr { CGGStateGetStrokeColor(gstate) }.get());
+        updateFillColor(RetainPtr { CGGStateGetFillColor(gstate) }.get());
         m_owner.setFillRule(WindRule::NonZero);
         m_owner.drawPath(path);
         break;
     case CGPathDrawingMode::kCGPathEOFillStroke:
-        updateStrokeColor(CGGStateGetStrokeColor(gstate));
+        updateStrokeColor(RetainPtr { CGGStateGetStrokeColor(gstate) }.get());
         m_owner.setFillRule(WindRule::EvenOdd);
         m_owner.drawPath(path);
         break;
@@ -506,8 +506,9 @@ void DrawGlyphsRecorder::drawNativeText(CTFontRef font, CGFloat fontSize, CTLine
     m_owner.scale(FloatSize(1, -1));
 
     prepareInternalContext(Font::create(FontPlatformData(font, fontSize)), FontSmoothingMode::SubpixelAntialiased);
-    CGContextSetTextPosition(m_internalContext->platformContext(), 0, 0);
-    CTLineDraw(line, m_internalContext->platformContext());
+    RetainPtr context = m_internalContext->platformContext();
+    CGContextSetTextPosition(context.get(), 0, 0);
+    CTLineDraw(line, context.get());
     concludeInternalContext();
 }
 

--- a/Source/WebCore/platform/graphics/coretext/DrawGlyphsRecorder.h
+++ b/Source/WebCore/platform/graphics/coretext/DrawGlyphsRecorder.h
@@ -84,7 +84,7 @@ private:
     void updateShadow(CGStyleRef);
 
     GraphicsContext& m_owner;
-    const Font* m_originalFont { nullptr };
+    SingleThreadWeakPtr<const Font> m_originalFont;
     AffineTransform m_originalTextMatrix;
     struct State {
         SourceBrush fillBrush;

--- a/Source/WebCore/platform/graphics/coretext/FontCascadeCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/FontCascadeCoreText.cpp
@@ -401,7 +401,7 @@ void FontCascade::drawGlyphs(GraphicsContext& context, const Font& font, std::sp
 bool FontCascade::primaryFontIsSystemFont() const
 {
     Ref fontData = primaryFont();
-    return isSystemFont(RetainPtr { fontData->getCTFont() }.get());
+    return isSystemFont(RetainPtr { fontData->ctFont() }.get());
 }
 
 RefPtr<const Font> FontCascade::fontForCombiningCharacterSequence(StringView stringView) const

--- a/Source/WebCore/platform/graphics/coretext/GlyphPageCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/GlyphPageCoreText.cpp
@@ -57,9 +57,9 @@ bool GlyphPage::fill(std::span<const char16_t> buffer)
     unsigned glyphStep = buffer.size() / GlyphPage::size;
 
     if (shouldFillWithVerticalGlyphs(buffer, font))
-        CTFontGetVerticalGlyphsForCharacters(font->platformData().ctFont(), reinterpret_cast<const UniChar*>(buffer.data()), glyphs.mutableSpan().data(), buffer.size());
+        CTFontGetVerticalGlyphsForCharacters(font->platformData().protectedCTFont().get(), reinterpret_cast<const UniChar*>(buffer.data()), glyphs.mutableSpan().data(), buffer.size());
     else
-        CTFontGetGlyphsForCharacters(font->platformData().ctFont(), reinterpret_cast<const UniChar*>(buffer.data()), glyphs.mutableSpan().data(), buffer.size());
+        CTFontGetGlyphsForCharacters(font->platformData().protectedCTFont().get(), reinterpret_cast<const UniChar*>(buffer.data()), glyphs.mutableSpan().data(), buffer.size());
 
     bool haveGlyphs = false;
     for (unsigned i = 0; i < GlyphPage::size; ++i) {

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -2959,7 +2959,7 @@ void WebViewImpl::updateFontManagerIfNeeded()
         if (!attributes.font)
             return;
 
-        RetainPtr nsFont = (__bridge NSFont *)attributes.font->getCTFont();
+        RetainPtr nsFont = (__bridge NSFont *)attributes.font->ctFont();
         if (!nsFont)
             return;
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/mac/WebPopupMenuMac.mm
+++ b/Source/WebKit/WebProcess/WebCoreSupport/mac/WebPopupMenuMac.mm
@@ -38,7 +38,7 @@ void WebPopupMenu::setUpPlatformData(const IntRect&, PlatformPopupMenuData& data
 {
 #if USE(APPKIT)
     // FIXME: font will be nil here for custom fonts, we should fix that.
-    RetainPtr font = m_popupClient->menuStyle().font().primaryFont()->getCTFont();
+    RetainPtr font = m_popupClient->menuStyle().font().primaryFont()->ctFont();
     if (!font)
         return;
 

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -3142,7 +3142,7 @@ void WebPage::requestAutocorrectionData(const String& textForAutocorrection, Com
     bool multipleFonts = false;
     CTFontRef font = nil;
     if (auto coreFont = frame->editor().fontForSelection(multipleFonts))
-        font = coreFont->getCTFont();
+        font = coreFont->ctFont();
 
     reply({ WTFMove(rootViewSelectionRects) , (__bridge UIFont *)font });
 }

--- a/Source/WebKitLegacy/mac/DOM/DOM.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOM.mm
@@ -650,7 +650,7 @@ id <DOMEventTarget> kit(EventTarget* target)
     auto* renderer = core(self)->renderer();
     if (!renderer)
         return nil;
-    return renderer->style().fontCascade().primaryFont()->getCTFont();
+    return renderer->style().fontCascade().primaryFont()->ctFont();
 }
 
 #if PLATFORM(MAC)

--- a/Source/WebKitLegacy/mac/WebCoreSupport/PopupMenuMac.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/PopupMenuMac.mm
@@ -84,7 +84,7 @@ void PopupMenuMac::populate()
         PopupMenuStyle style = m_client->itemStyle(i);
         RetainPtr<NSMutableDictionary> attributes = adoptNS([[NSMutableDictionary alloc] init]);
         if (style.font() != FontCascade()) {
-            RetainPtr<CTFontRef> font = style.font().primaryFont()->getCTFont();
+            RetainPtr<CTFontRef> font = style.font().primaryFont()->ctFont();
             if (!font) {
                 CGFloat size = style.font().primaryFont()->platformData().size();
                 font = adoptCF(CTFontCreateUIFontForLanguage(isFontWeightBold(style.font().weight()) ? kCTFontUIFontEmphasizedSystem : kCTFontUIFontSystem, size, nullptr));
@@ -155,7 +155,7 @@ void PopupMenuMac::show(const IntRect& r, LocalFrameView& frameView, int selecte
     [menu setUserInterfaceLayoutDirection:textDirection == TextDirection::LTR ? NSUserInterfaceLayoutDirectionLeftToRight : NSUserInterfaceLayoutDirectionRightToLeft];
 
     NSPoint location;
-    CTFontRef font = m_client->menuStyle().font().primaryFont()->getCTFont();
+    CTFontRef font = m_client->menuStyle().font().primaryFont()->ctFont();
 
     // These values were borrowed from AppKit to match their placement of the menu.
     const int popOverHorizontalAdjust = -13;

--- a/Source/WebKitLegacy/mac/WebView/WebFrame.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebFrame.mm
@@ -1824,7 +1824,7 @@ static WebFrameLoadType toWebFrameLoadType(WebCore::FrameLoadType frameLoadType)
     CTFontRef font = nil;
     if (_private->coreFrame) {
         if (auto coreFont = _private->coreFrame->editor().fontForSelection(multipleFonts))
-            font = coreFont->getCTFont();
+            font = coreFont->ctFont();
     }
     
     if (hasMultipleFonts)

--- a/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
@@ -5727,22 +5727,22 @@ static BOOL writingDirectionKeyBindingsEnabled()
         return;
 
     bool multipleFonts = false;
-    NSFont *font = nil;
+    RetainPtr<NSFont> font;
     RetainPtr<NSDictionary> attributes;
     if (auto* coreFrame = core([self _frame])) {
         if (auto coreFont = coreFrame->editor().fontForSelection(multipleFonts))
-            font = (NSFont *)coreFont->platformData().registeredFont();
+            font = (NSFont *)coreFont->platformData().registeredFont().get();
         attributes = coreFrame->editor().fontAttributesAtSelectionStart().createDictionary();
     }
 
     // FIXME: for now, return a bogus font that distinguishes the empty selection from the non-empty
     // selection. We should be able to remove this once the rest of this code works properly.
-    if (font == nil)
+    if (!font)
         font = [self _hasSelection] ? [NSFont menuFontOfSize:23] : [NSFont toolTipsFontOfSize:17];
-    ASSERT(font != nil);
+    ASSERT(font);
 
     NSFontManager *fontManager = [NSFontManager sharedFontManager];
-    [fontManager setSelectedFont:font isMultiple:multipleFonts];
+    [fontManager setSelectedFont:font.get() isMultiple:multipleFonts];
     [fontManager setSelectedAttributes:(attributes ? attributes.get() : @{ }) isMultiple:multipleFonts];
 }
 


### PR DESCRIPTION
#### e980cbd147631cfd2a7e33c395c4cc84f4537d2d
<pre>
Address safer cpp warnings in platform/graphics/coretext
<a href="https://bugs.webkit.org/show_bug.cgi?id=299070">https://bugs.webkit.org/show_bug.cgi?id=299070</a>

Reviewed by Darin Adler.

* Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/RetainPtrCtorAdoptCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations:
* Source/WebCore/accessibility/cocoa/AccessibilityObjectCocoa.mm:
(WebCore::fontFrom):
* Source/WebCore/accessibility/ios/AccessibilityObjectIOS.mm:
(WebCore::attributeStringSetStyle):
* Source/WebCore/editing/cocoa/AttributedString.mm:
(WebCore::toNSObject):
* Source/WebCore/editing/cocoa/EditingHTMLConverter.mm:
(WebCore::updateAttributes):
* Source/WebCore/editing/cocoa/FontAttributeChangesCocoa.mm:
(WebCore::FontChanges::platformFontFamilyNameForCSS const):
* Source/WebCore/editing/cocoa/FontAttributesCocoa.mm:
(WebCore::FontAttributes::createDictionary const):
* Source/WebCore/editing/cocoa/NodeHTMLConverter.mm:
(_font):
* Source/WebCore/platform/graphics/Font.h:
(WebCore::Font::ctFont const):
(WebCore::Font::protectedCTFont const):
(WebCore::Font::getCTFont const): Deleted.
* Source/WebCore/platform/graphics/FontPlatformData.h:
(WebCore::FontPlatformData::protectedCTFont const):
* Source/WebCore/platform/graphics/GraphicsContext.h:
(WebCore::GraphicsContext::protectedPlatformContext const):
* Source/WebCore/platform/graphics/cocoa/GraphicsContextCocoa.mm:
(WebCore::GraphicsContext::drawMultiRepresentationHEIC):
* Source/WebCore/platform/graphics/coretext/ComplexTextControllerCoreText.mm:
(WebCore::buildCoreTextTypesetterEmbeddingLevelDictionary):
(WebCore::typesetterOptionsSingleton):
(WebCore::ComplexTextController::collectComplexTextRunsForCharacters):
(WebCore::typesetterOptions): Deleted.
* Source/WebCore/platform/graphics/coretext/DrawGlyphsRecorder.cpp:
(WebCore::DrawGlyphsRecorder::recordInitialColors):
(WebCore::DrawGlyphsRecorder::prepareInternalContext):
(WebCore::DrawGlyphsRecorder::updateShadow):
(WebCore::DrawGlyphsRecorder::recordDrawGlyphs):
(WebCore::DrawGlyphsRecorder::recordDrawPath):
(WebCore::DrawGlyphsRecorder::drawNativeText):
* Source/WebCore/platform/graphics/coretext/DrawGlyphsRecorder.h:
* Source/WebCore/platform/graphics/coretext/FontCascadeCoreText.cpp:
(WebCore::FontCascade::primaryFontIsSystemFont const):
* Source/WebCore/platform/graphics/coretext/FontCoreText.cpp:
(WebCore::Font::platformInit):
(WebCore::Font::platformCharWidthInit):
(WebCore::Font::supportsOpenTypeAlternateHalfWidths const):
(WebCore::Font::supportsSmallCaps const):
(WebCore::Font::supportsAllSmallCaps const):
(WebCore::Font::supportsPetiteCaps const):
(WebCore::Font::supportsAllPetiteCaps const):
(WebCore::openTypeFeature):
(WebCore::trueTypeFeature):
(WebCore::defaultSelectorForTrueTypeFeature):
(WebCore::removedFeature):
(WebCore::createCTFontWithoutSynthesizableFeatures):
(WebCore::Font::createFontWithoutSynthesizableFeatures const):
(WebCore::Font::platformCreateScaledFont const):
(WebCore::supportsOpenTypeFeature):
(WebCore::Font::platformCreateHalfWidthFont const):
(WebCore::Font::platformWidthForGlyph const):
(WebCore::Font::applyTransforms const):
(WebCore::Font::determinePitch):
(WebCore::Font::platformBoundsForGlyph const):
(WebCore::Font::platformBoundsForGlyphs const):
(WebCore::Font::platformPathForGlyph const):
(WebCore::Font::platformSupportsCodePoint const):
(WebCore::Font::isProbablyOnlyUsedToRenderIcons const):
(WebCore::Font::otSVGTable const):
(WebCore::Font::hasComplexColorFormatTables const):
(WebCore::Font::glyphsWithComplexColorFormat const):
(WebCore::Font::glyphHasComplexColorFormat const):
(WebCore::Font::metricsForMultiRepresentationHEIC const):
* Source/WebCore/platform/graphics/coretext/FontPlatformDataCoreText.cpp:
(WebCore::FontPlatformData::FontPlatformData):
(WebCore::findFontDescriptor):
(WebCore::createCTFont):
(WebCore::FontPlatformData::create):
(WebCore::FontPlatformData::registeredFont const):
(WebCore::FontPlatformData::objectForEqualityCheck const):
(WebCore::FontPlatformData::openTypeTable const):
(WebCore::FontPlatformData::familyName const):
(WebCore::FontPlatformData::attributes const):
(WebCore::FontPlatformData::fromIPCData):
(WebCore::FontPlatformData::toIPCData const):
(WebCore::FontPlatformSerializedAttributes::fromCF):
(WebCore::FontPlatformOpticalSize::fromCF):
* Source/WebCore/platform/graphics/coretext/GlyphPageCoreText.cpp:
(WebCore::GlyphPage::fill):
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::updateFontManagerIfNeeded):
* Source/WebKit/WebProcess/WebCoreSupport/mac/WebPopupMenuMac.mm:
(WebKit::WebPopupMenu::setUpPlatformData):
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::requestAutocorrectionData):
* Source/WebKitLegacy/mac/DOM/DOM.mm:
(-[DOMElement _font]):
* Source/WebKitLegacy/mac/WebCoreSupport/PopupMenuMac.mm:
(PopupMenuMac::populate):
(PopupMenuMac::show):
* Source/WebKitLegacy/mac/WebView/WebFrame.mm:
(-[WebFrame fontForSelection:]):
* Source/WebKitLegacy/mac/WebView/WebHTMLView.mm:
(-[WebHTMLView _updateFontPanel]):

Canonical link: <a href="https://commits.webkit.org/300214@main">https://commits.webkit.org/300214@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aaa24f152c6f0b99cde50fac0be801703cc0abec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121687 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41388 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32052 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128208 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73777 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1c841cad-3093-4e9d-ad97-a02bebcd132f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123563 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42100 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49979 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92464 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/61477 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/32c1be8c-ba26-4c6d-9bca-5e9abac9e4fd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124639 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33588 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108992 "Found 1 new API test failure: TestIPC.ConnectionTest/ConnectionRunLoopTest.SendAsyncAndInvalidate/ClientIsA (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73125 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4d39c011-d410-4001-acf2-d4088357cfc5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32598 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27153 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71727 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103086 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27339 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131002 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48622 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36982 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101033 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48994 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105208 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100924 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25596 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46299 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24411 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45322 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48480 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54207 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47949 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51298 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49632 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->