### PR TITLE
Gradients in operations in  DisplayList might be mutated after put to the list

### DIFF
--- a/Source/WebCore/html/canvas/CanvasGradient.cpp
+++ b/Source/WebCore/html/canvas/CanvasGradient.cpp
@@ -34,17 +34,17 @@
 namespace WebCore {
 
 CanvasGradient::CanvasGradient(const FloatPoint& p0, const FloatPoint& p1)
-    : m_gradient(Gradient::create(Gradient::LinearData { p0, p1 }, { ColorInterpolationMethod::SRGB { }, AlphaPremultiplication::Unpremultiplied }))
+    : m_storage(Data { Gradient::LinearData { p0, p1 }, { } })
 {
 }
 
 CanvasGradient::CanvasGradient(const FloatPoint& p0, float r0, const FloatPoint& p1, float r1)
-    : m_gradient(Gradient::create(Gradient::RadialData { p0, p1, r0, r1, 1 }, { ColorInterpolationMethod::SRGB { }, AlphaPremultiplication::Unpremultiplied }))
+    : m_storage(Data { Gradient::RadialData { p0, p1, r0, r1, 1 }, { } })
 {
 }
 
 CanvasGradient::CanvasGradient(const FloatPoint& centerPoint, float angleInRadians)
-    : m_gradient(Gradient::create(Gradient::ConicData { centerPoint, angleInRadians }, { ColorInterpolationMethod::SRGB { }, AlphaPremultiplication::Unpremultiplied }))
+    : m_storage(Data { Gradient::ConicData { centerPoint, angleInRadians }, { } })
 {
 }
 
@@ -73,8 +73,11 @@ ExceptionOr<void> CanvasGradient::addColorStop(ScriptExecutionContext& scriptExe
     auto color = parseColor(colorString, scriptExecutionContext);
     if (!color.isValid())
         return Exception { ExceptionCode::SyntaxError };
-
-    m_gradient->addColorStop({ static_cast<float>(value), WTFMove(color) });
+    if (std::holds_alternative<Ref<const Gradient>>(m_storage)) {
+        Ref gradient = std::get<Ref<const Gradient>>(WTFMove(m_storage));
+        m_storage = Data { gradient->data(), gradient->stops() };
+    }
+    std::get<Data>(m_storage).stops.constructAndAppend(static_cast<float>(value), WTFMove(color));
     return { };
 }
 

--- a/Source/WebCore/html/canvas/CanvasGradient.h
+++ b/Source/WebCore/html/canvas/CanvasGradient.h
@@ -27,10 +27,10 @@
 #pragma once
 
 #include "FloatPoint.h"
+#include "Gradient.h"
 
 namespace WebCore {
 
-class Gradient;
 class ScriptExecutionContext;
 template<typename> class ExceptionOr;
 
@@ -41,8 +41,7 @@ public:
     static Ref<CanvasGradient> create(const FloatPoint& centerPoint, float angleInRadians);
     ~CanvasGradient();
 
-    Gradient& gradient() { return m_gradient; }
-    const Gradient& gradient() const { return m_gradient; }
+    const Gradient& gradient() const;
 
     ExceptionOr<void> addColorStop(ScriptExecutionContext&, double value, const String& color);
 
@@ -51,7 +50,20 @@ private:
     CanvasGradient(const FloatPoint& p0, float r0, const FloatPoint& p1, float r1);
     CanvasGradient(const FloatPoint& centerPoint, float angleInRadians);
 
-    const Ref<Gradient> m_gradient;
+    struct Data {
+        Gradient::Data data;
+        GradientColorStops stops;
+    };
+    mutable Variant<Data, Ref<const Gradient>> m_storage;
 };
+
+inline const Gradient& CanvasGradient::gradient() const
+{
+    if (std::holds_alternative<Ref<const Gradient>>(m_storage))
+        return std::get<Ref<const Gradient>>(m_storage);
+    auto& data = std::get<Data>(m_storage);
+    m_storage = Gradient::create(WTFMove(data.data), { ColorInterpolationMethod::SRGB { }, AlphaPremultiplication::Unpremultiplied }, GradientSpreadMethod::Pad, WTFMove(data.stops));
+    return std::get<Ref<const Gradient>>(m_storage);
+}
 
 } // namespace WebCore

--- a/Source/WebCore/page/DebugPageOverlays.cpp
+++ b/Source/WebCore/page/DebugPageOverlays.cpp
@@ -531,19 +531,18 @@ void InteractionRegionOverlay::drawRect(PageOverlay&, GraphicsContext& context, 
         };
 
         auto makeGradient = [&] (Gradient::RadialData gradientData) {
-            auto gradient = Gradient::create(WTFMove(gradientData), { ColorInterpolationMethod::SRGB { }, AlphaPremultiplication::Unpremultiplied });
+            GradientColorStops stops;
             if (region && valueForSetting("wash"_s) && valueForSetting("clip"_s)) {
-                gradient->addColorStop({ 0.1, Color(Color::white).colorWithAlpha(0.5) });
-                gradient->addColorStop({ 1, Color(Color::white).colorWithAlpha(0.1) });
+                stops.constructAndAppend(0.1, Color(Color::white).colorWithAlpha(0.5));
+                stops.constructAndAppend(1, Color(Color::white).colorWithAlpha(0.1));
             } else if (!valueForSetting("clip"_s) || !valueForSetting("constrain"_s)) {
-                gradient->addColorStop({ 0.1, Color(Color::white).colorWithAlpha(0.2) });
-                gradient->addColorStop({ 1, Color(Color::white).colorWithAlpha(0) });
+                stops.constructAndAppend(0.1, Color(Color::white).colorWithAlpha(0.2));
+                stops.constructAndAppend(1, Color(Color::white).colorWithAlpha(0));
             } else {
-                gradient->addColorStop({ 0.1, Color(Color::white).colorWithAlpha(0.5) });
-                gradient->addColorStop({ 1, Color(Color::white).colorWithAlpha(0) });
+                stops.constructAndAppend(0.1, Color(Color::white).colorWithAlpha(0.5));
+                stops.constructAndAppend(1, Color(Color::white).colorWithAlpha(0));
             }
-
-            return gradient;
+            return Gradient::create(WTFMove(gradientData), { ColorInterpolationMethod::SRGB { }, AlphaPremultiplication::Unpremultiplied }, GradientSpreadMethod::Pad, SortedGradientColorStops { WTFMove(stops) });
         };
         
         constexpr float defaultRadius = 50;
@@ -583,19 +582,19 @@ void InteractionRegionOverlay::drawRect(PageOverlay&, GraphicsContext& context, 
             if (shouldClip) {
                 for (const auto& path : clipPaths) {
                     float radius = valueForSetting("contextualSize"_s) ? 1.5 * path.boundingRect().size().minDimension() : defaultRadius;
-                    auto backdropGradient = Gradient::create(gradientData(radius * 1.5), { ColorInterpolationMethod::SRGB { }, AlphaPremultiplication::Unpremultiplied });
-                    backdropGradient->addColorStop({ 0.1, Color(Color::black).colorWithAlpha(0.2) });
-                    backdropGradient->addColorStop({ 1, Color(Color::black).colorWithAlpha(0) });
-
-                    context.setFillGradient(WTFMove(backdropGradient));
+                    GradientColorStops stops;
+                    stops.reserveCapacity(2);
+                    stops.constructAndAppend(0.1, Color(Color::black).colorWithAlpha(0.2));
+                    stops.constructAndAppend(1, Color(Color::black).colorWithAlpha(0));
+                    context.setFillGradient(Gradient::create(gradientData(radius * 1.5), { ColorInterpolationMethod::SRGB { }, AlphaPremultiplication::Unpremultiplied }, GradientSpreadMethod::Pad, WTFMove(stops)));
                     context.fillPath(path);
                 }
             } else {
-                auto backdropGradient = Gradient::create(gradientData(defaultRadius * 2), { ColorInterpolationMethod::SRGB { }, AlphaPremultiplication::Unpremultiplied });
-                backdropGradient->addColorStop({ 0.1, Color(Color::black).colorWithAlpha(0.2) });
-                backdropGradient->addColorStop({ 1, Color(Color::black).colorWithAlpha(0) });
-
-                context.setFillGradient(WTFMove(backdropGradient));
+                GradientColorStops stops;
+                stops.reserveCapacity(2);
+                stops.constructAndAppend(0.1, Color(Color::black).colorWithAlpha(0.2));
+                stops.constructAndAppend(1, Color(Color::black).colorWithAlpha(0));
+                context.setFillGradient(Gradient::create(gradientData(defaultRadius * 2), { ColorInterpolationMethod::SRGB { }, AlphaPremultiplication::Unpremultiplied },  GradientSpreadMethod::Pad, WTFMove(stops)));
                 context.fillRect(dirtyRect);    
             }
         }

--- a/Source/WebCore/platform/DictationCaretAnimator.cpp
+++ b/Source/WebCore/platform/DictationCaretAnimator.cpp
@@ -263,11 +263,12 @@ void DictationCaretAnimator::fillCaretTail(const FloatRect& rect, GraphicsContex
     float width = rect.width();
     float midY = rect.y() + 0.5f * height;
 
-    auto gradient = Gradient::create(Gradient::LinearData { FloatPoint(rect.x(), midY), FloatPoint(rect.x() + width, midY) }, { ColorInterpolationMethod::SRGB { }, AlphaPremultiplication::Unpremultiplied });
     constexpr auto glowOpacity = .75f;
     bool isLTR = isLeftToRightLayout();
-    gradient->addColorStop({ isLTR ? 0.f : 1.f, tailColor.colorWithAlpha(0.1f * glowOpacity) });
-    gradient->addColorStop({ isLTR ? 1.f : 0.f, tailColor.colorWithAlpha(0.35f * glowOpacity) });
+    GradientColorStops stops;
+    stops.constructAndAppend(isLTR ? 0.f : 1.f, tailColor.colorWithAlpha(0.1f * glowOpacity));
+    stops.constructAndAppend(isLTR ? 1.f : 0.f, tailColor.colorWithAlpha(0.35f * glowOpacity));
+    Ref gradient = Gradient::create(Gradient::LinearData { FloatPoint(rect.x(), midY), FloatPoint(rect.x() + width, midY) }, { ColorInterpolationMethod::SRGB { }, AlphaPremultiplication::Unpremultiplied }, GradientSpreadMethod::Pad, WTFMove(stops));
     // FIXME: https://bugs.webkit.org/show_bug.cgi?id=253139 - this should be computed based on the render area
     constexpr auto shadowOffset = 10000.f;
     GraphicsDropShadow dropShadow = {

--- a/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.cpp
+++ b/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.cpp
@@ -208,7 +208,7 @@ void BifurcatedGraphicsContext::fillRect(const FloatRect& rect, const Color& col
     VERIFY_STATE_SYNCHRONIZATION();
 }
 
-void BifurcatedGraphicsContext::fillRect(const FloatRect& rect, Gradient& gradient)
+void BifurcatedGraphicsContext::fillRect(const FloatRect& rect, const Gradient&gradient)
 {
     m_primaryContext.fillRect(rect, gradient);
     m_secondaryContext.fillRect(rect, gradient);
@@ -216,7 +216,7 @@ void BifurcatedGraphicsContext::fillRect(const FloatRect& rect, Gradient& gradie
     VERIFY_STATE_SYNCHRONIZATION();
 }
 
-void BifurcatedGraphicsContext::fillRect(const FloatRect& rect, Gradient& gradient, const AffineTransform& gradientSpaceTransform, RequiresClipToRect requiresClipToRect)
+void BifurcatedGraphicsContext::fillRect(const FloatRect& rect, const Gradient&gradient, const AffineTransform& gradientSpaceTransform, RequiresClipToRect requiresClipToRect)
 {
     m_primaryContext.fillRect(rect, gradient, gradientSpaceTransform, requiresClipToRect);
     m_secondaryContext.fillRect(rect, gradient, gradientSpaceTransform, requiresClipToRect);

--- a/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.h
+++ b/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.h
@@ -71,8 +71,8 @@ public:
     using GraphicsContext::fillRect;
     void fillRect(const FloatRect&, RequiresClipToRect) final;
     void fillRect(const FloatRect&, const Color&) final;
-    void fillRect(const FloatRect&, Gradient&) final;
-    void fillRect(const FloatRect&, Gradient&, const AffineTransform&, RequiresClipToRect) final;
+    void fillRect(const FloatRect&, const Gradient&) final;
+    void fillRect(const FloatRect&, const Gradient&, const AffineTransform&, RequiresClipToRect) final;
     void fillRoundedRectImpl(const FloatRoundedRect&, const Color&) final;
     void fillRectWithRoundedHole(const FloatRect&, const FloatRoundedRect& roundedHoleRect, const Color&) final;
     void clearRect(const FloatRect&) final;

--- a/Source/WebCore/platform/graphics/Gradient.cpp
+++ b/Source/WebCore/platform/graphics/Gradient.cpp
@@ -35,7 +35,7 @@
 
 namespace WebCore {
 
-Ref<Gradient> Gradient::create(Data&& data, ColorInterpolationMethod colorInterpolationMethod, GradientSpreadMethod spreadMethod, GradientColorStops&& stops, bool isTransient)
+Ref<const Gradient> Gradient::create(Data&& data, ColorInterpolationMethod colorInterpolationMethod, GradientSpreadMethod spreadMethod, SortedGradientColorStops&& stops, bool isTransient)
 {
     return adoptRef(*new Gradient(WTFMove(data), colorInterpolationMethod, spreadMethod, WTFMove(stops), isTransient));
 }
@@ -55,7 +55,7 @@ Gradient::~Gradient()
         observer.willDestroyGradient(*this);
 }
 
-void Gradient::adjustParametersForTiledDrawing(FloatSize& size, FloatRect& srcRect, const FloatSize& spacing)
+void Gradient::adjustParametersForTiledDrawing(FloatSize& size, FloatRect& srcRect, const FloatSize& spacing) const
 {
     if (srcRect.isEmpty())
         return;
@@ -100,13 +100,6 @@ bool Gradient::isZeroSize() const
     );
 }
 
-void Gradient::addColorStop(GradientColorStop&& stop)
-{
-    m_stops.addColorStop(WTFMove(stop));
-    m_cachedHash = 0;
-    stopsChanged();
-}
-
 static void add(Hasher& hasher, const Gradient::LinearData& data)
 {
     add(hasher, data.point0, data.point1);
@@ -125,7 +118,7 @@ static void add(Hasher& hasher, const Gradient::ConicData& data)
 unsigned Gradient::hash() const
 {
     if (!m_cachedHash)
-        m_cachedHash = computeHash(m_data, m_colorInterpolationMethod, m_spreadMethod, m_stops.sorted());
+        m_cachedHash = computeHash(m_data, m_colorInterpolationMethod, m_spreadMethod, m_stops);
     return m_cachedHash;
 }
 

--- a/Source/WebCore/platform/graphics/Gradient.h
+++ b/Source/WebCore/platform/graphics/Gradient.h
@@ -33,6 +33,7 @@
 #include <WebCore/GradientColorStops.h>
 #include <WebCore/GraphicsTypes.h>
 #include <WebCore/RenderingResource.h>
+#include <atomic>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/Vector.h>
 
@@ -42,6 +43,7 @@
 
 #if USE(CG)
 #include <WebCore/GradientRendererCG.h>
+#include <wtf/Lock.h>
 #endif
 
 #if USE(CG)
@@ -88,33 +90,34 @@ public:
     // isTransient may affect backend rendering implementation caching decisions.
     // Transient instances may be assumed to be drawn only few times or seldomly and as such the backend
     // may not persist caches related to the instance.
-    WEBCORE_EXPORT static Ref<Gradient> create(Data&&, ColorInterpolationMethod, GradientSpreadMethod = GradientSpreadMethod::Pad, GradientColorStops&& = { }, bool isTransient = true);
+    static Ref<const Gradient> create(Data&&, ColorInterpolationMethod, GradientSpreadMethod = GradientSpreadMethod::Pad, GradientColorStops&& = { }, bool isTransient = true);
+    WEBCORE_EXPORT static Ref<const Gradient> create(Data&&, ColorInterpolationMethod, GradientSpreadMethod, SortedGradientColorStops&&, bool isTransient = true);
+
     WEBCORE_EXPORT ~Gradient();
 
     const Data& data() const { return m_data; }
     ColorInterpolationMethod colorInterpolationMethod() const { return m_colorInterpolationMethod; }
     GradientSpreadMethod spreadMethod() const { return m_spreadMethod; }
+    // Returns stops as sorted.
     const GradientColorStops& stops() const { return m_stops; }
     bool isTransient() const { return m_isTransient; }
 
-    WEBCORE_EXPORT void addColorStop(GradientColorStop&&);
-
     bool isZeroSize() const;
 
-    void fill(GraphicsContext&, const FloatRect&);
-    void adjustParametersForTiledDrawing(FloatSize&, FloatRect&, const FloatSize& spacing);
+    void fill(GraphicsContext&, const FloatRect&) const;
+    void adjustParametersForTiledDrawing(FloatSize&, FloatRect&, const FloatSize& spacing) const;
 
     unsigned hash() const;
 
 #if USE(CAIRO)
-    RefPtr<cairo_pattern_t> createPattern(float globalAlpha, const AffineTransform&);
+    RefPtr<cairo_pattern_t> createPattern(float globalAlpha, const AffineTransform&) const;
 #endif
 
 #if USE(CG)
-    void paint(GraphicsContext&);
+    void paint(GraphicsContext&) const;
     // If the DestinationColorSpace is present, the gradient may cache a platform renderer using colors converted into this colorspace,
     // which can be more efficient to render since it avoids colorspace conversions when lower level frameworks render the gradient.
-    void paint(CGContextRef, std::optional<DestinationColorSpace> = { });
+    void paint(CGContextRef, std::optional<DestinationColorSpace> = { }) const;
 #endif
 
 #if USE(SKIA)
@@ -129,16 +132,15 @@ public:
 private:
     Gradient(Data&&, ColorInterpolationMethod, GradientSpreadMethod, GradientColorStops&&, bool isTransient);
 
-    void stopsChanged();
-
     Data m_data;
     ColorInterpolationMethod m_colorInterpolationMethod;
     GradientSpreadMethod m_spreadMethod;
     GradientColorStops m_stops;
-    mutable unsigned m_cachedHash { 0 };
+    mutable std::atomic<unsigned> m_cachedHash { 0 };
 
 #if USE(CG)
-    std::optional<GradientRendererCG> m_platformRenderer;
+    mutable Lock m_lock;
+    mutable std::optional<GradientRendererCG> m_platformRenderer WTF_GUARDED_BY_LOCK(m_lock);
 #endif
 
     mutable WeakHashSet<RenderingResourceObserver> m_observers;
@@ -146,5 +148,11 @@ private:
 };
 
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const Gradient&);
+
+inline Ref<const Gradient> Gradient::create(Data&& data, ColorInterpolationMethod colorInterpolationMethod, GradientSpreadMethod spreadMethod, GradientColorStops&& stops, bool isTransient)
+{
+    std::ranges::stable_sort(stops, { }, &GradientColorStop::offset);
+    return create(WTFMove(data), colorInterpolationMethod, spreadMethod, SortedGradientColorStops { WTFMove(stops) }, isTransient);
+}
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/GradientColorStops.cpp
+++ b/Source/WebCore/platform/graphics/GradientColorStops.cpp
@@ -30,10 +30,4 @@
 
 namespace WebCore {
 
-TextStream& operator<<(TextStream& ts, const GradientColorStops& stops)
-{
-    ts << stops.stops();
-    return ts;
-}
-
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/GradientColorStops.h
+++ b/Source/WebCore/platform/graphics/GradientColorStops.h
@@ -34,90 +34,28 @@
 
 namespace WebCore {
 
-class GradientColorStops {
+using GradientColorStops = Vector<GradientColorStop, 2>;
+
+class SortedGradientColorStops {
 public:
-    using StopVector = Vector<GradientColorStop, 2>;
-
-    struct Sorted {
-        StopVector stops;
-    };
-
-    GradientColorStops()
-        : m_isSorted { true }
+    explicit SortedGradientColorStops(GradientColorStops&& stops)
+        : m_stops(stops)
     {
+        ASSERT(std::ranges::is_sorted(m_stops, { }, &GradientColorStop::offset));
     }
-
-    GradientColorStops(StopVector stops)
-        : m_stops { WTFMove(stops) }
-        , m_isSorted { false }
-    {
-    }
-
-    GradientColorStops(Sorted sortedStops)
-        : m_stops { WTFMove(sortedStops.stops) }
-        , m_isSorted { true }
-    {
-        ASSERT(validateIsSorted());
-    }
-
-    void addColorStop(GradientColorStop stop)
-    {
-        if (!m_stops.isEmpty() && m_stops.last().offset > stop.offset)
-            m_isSorted = false;
-        m_stops.append(WTFMove(stop));
-    }
-
-    void sort()
-    {
-        if (m_isSorted)
-            return;
-
-        std::ranges::stable_sort(m_stops, { }, &GradientColorStop::offset);
-        m_isSorted = true;
-    }
-
-    const GradientColorStops& sorted() const
-    {
-        const_cast<GradientColorStops*>(this)->sort();
-        return *this;
-    }
-
-    size_t size() const { return m_stops.size(); }
-    bool isEmpty() const { return m_stops.isEmpty(); }
-
-    StopVector::const_iterator begin() const LIFETIME_BOUND { return m_stops.begin(); }
-    StopVector::const_iterator end() const LIFETIME_BOUND { return m_stops.end(); }
-
-    template<typename MapFunction> GradientColorStops mapColors(MapFunction&& mapFunction) const
-    {
-        return {
-            m_stops.map<StopVector>([&] (const GradientColorStop& stop) -> GradientColorStop {
-                return { stop.offset, mapFunction(stop.color) };
-            }),
-            m_isSorted
-        };
-    }
-
-    const StopVector& stops() const { return m_stops; }
-
+    SortedGradientColorStops(SortedGradientColorStops&&) = default;
+    SortedGradientColorStops& operator=(SortedGradientColorStops&&) = default;
+    operator GradientColorStops() && { return WTFMove(m_stops); }
 private:
-    GradientColorStops(StopVector stops, bool isSorted)
-        : m_stops { WTFMove(stops) }
-        , m_isSorted { isSorted }
-    {
-    }
-
-#if ASSERT_ENABLED
-    bool validateIsSorted() const
-    {
-        return std::ranges::is_sorted(m_stops, { }, &GradientColorStop::offset);
-    }
-#endif
-
-    StopVector m_stops;
-    bool m_isSorted;
+    GradientColorStops m_stops;
 };
 
-TextStream& operator<<(TextStream&, const GradientColorStops&);
+template<typename MapFunction>
+GradientColorStops mapGradientColors(const GradientColorStops& stops, NOESCAPE MapFunction&& mapFunction)
+{
+    return stops.map<GradientColorStops>([&] (const GradientColorStop& stop) -> GradientColorStop {
+        return { stop.offset, mapFunction(stop.color) };
+    });
+}
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/GradientImage.cpp
+++ b/Source/WebCore/platform/graphics/GradientImage.cpp
@@ -32,7 +32,7 @@
 
 namespace WebCore {
 
-GradientImage::GradientImage(Gradient& generator, const FloatSize& size)
+GradientImage::GradientImage(const Gradient& generator, const FloatSize& size)
     : m_gradient(generator)
 {
     setContainerSize(size);

--- a/Source/WebCore/platform/graphics/GradientImage.h
+++ b/Source/WebCore/platform/graphics/GradientImage.h
@@ -34,7 +34,7 @@ class ImageBuffer;
 
 class GradientImage final : public GeneratedImage {
 public:
-    static Ref<GradientImage> create(Gradient& generator, const FloatSize& size)
+    static Ref<GradientImage> create(const Gradient& generator, const FloatSize& size)
     {
         return adoptRef(*new GradientImage(generator, size));
     }
@@ -44,14 +44,14 @@ public:
     const Gradient& gradient() const { return m_gradient.get(); }
 
 private:
-    WEBCORE_EXPORT GradientImage(Gradient&, const FloatSize&);
+    WEBCORE_EXPORT GradientImage(const Gradient&, const FloatSize&);
 
     ImageDrawResult draw(GraphicsContext&, const FloatRect& dstRect, const FloatRect& srcRect, ImagePaintingOptions = { }) final;
     void drawPattern(GraphicsContext&, const FloatRect& destRect, const FloatRect& srcRect, const AffineTransform& patternTransform, const FloatPoint& phase, const FloatSize& spacing, ImagePaintingOptions = { }) final;
     bool isGradientImage() const final { return true; }
     void dump(WTF::TextStream&) const final;
     
-    const Ref<Gradient> m_gradient;
+    const Ref<const Gradient> m_gradient;
     RefPtr<ImageBuffer> m_cachedImage;
     FloatSize m_cachedAdjustedSize;
     unsigned m_cachedGeneratorHash { 0 };

--- a/Source/WebCore/platform/graphics/GraphicsContext.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContext.cpp
@@ -471,7 +471,7 @@ IntRect GraphicsContext::clipBounds() const
     return IntRect();
 }
 
-void GraphicsContext::fillRect(const FloatRect& rect, Gradient& gradient)
+void GraphicsContext::fillRect(const FloatRect& rect, const Gradient&gradient)
 {
     gradient.fill(*this, rect);
 }

--- a/Source/WebCore/platform/graphics/GraphicsContext.h
+++ b/Source/WebCore/platform/graphics/GraphicsContext.h
@@ -99,12 +99,12 @@ public:
 
     const SourceBrush& fillBrush() const { return m_state.fillBrush(); }
     const Color& fillColor() const { return fillBrush().color(); }
-    Gradient* fillGradient() const { return fillBrush().gradient(); }
+    const Gradient* fillGradient() const { return fillBrush().gradient(); }
     const AffineTransform& fillGradientSpaceTransform() const { return fillBrush().gradientSpaceTransform(); }
     Pattern* fillPattern() const { return fillBrush().pattern(); }
     void setFillBrush(const SourceBrush& brush) { m_state.setFillBrush(brush); didUpdateSingleState(m_state, GraphicsContextState::toIndex(GraphicsContextState::Change::FillBrush)); }
     void setFillColor(const Color& color) { m_state.setFillColor(color); didUpdateSingleState(m_state, GraphicsContextState::toIndex(GraphicsContextState::Change::FillBrush)); }
-    void setFillGradient(Ref<Gradient>&& gradient, const AffineTransform& spaceTransform = { }) { m_state.setFillGradient(WTFMove(gradient), spaceTransform); didUpdateSingleState(m_state, GraphicsContextState::toIndex(GraphicsContextState::Change::FillBrush)); }
+    void setFillGradient(Ref<const Gradient>&& gradient, const AffineTransform& spaceTransform = { }) { m_state.setFillGradient(WTFMove(gradient), spaceTransform); didUpdateSingleState(m_state, GraphicsContextState::toIndex(GraphicsContextState::Change::FillBrush)); }
     void setFillPattern(Ref<Pattern>&& pattern) { m_state.setFillPattern(WTFMove(pattern)); didUpdateSingleState(m_state, GraphicsContextState::toIndex(GraphicsContextState::Change::FillBrush)); }
 
     WindRule fillRule() const { return m_state.fillRule(); }
@@ -112,12 +112,12 @@ public:
 
     const SourceBrush& strokeBrush() const { return m_state.strokeBrush(); }
     const Color& strokeColor() const { return strokeBrush().color(); }
-    Gradient* strokeGradient() const { return strokeBrush().gradient(); }
+    const Gradient* strokeGradient() const { return strokeBrush().gradient(); }
     const AffineTransform& strokeGradientSpaceTransform() const { return strokeBrush().gradientSpaceTransform(); }
     Pattern* strokePattern() const { return strokeBrush().pattern(); }
     void setStrokeBrush(const SourceBrush& brush) { m_state.setStrokeBrush(brush); didUpdateSingleState(m_state, GraphicsContextState::toIndex(GraphicsContextState::Change::StrokeBrush)); }
     void setStrokeColor(const Color& color) { m_state.setStrokeColor(color); didUpdateSingleState(m_state, GraphicsContextState::toIndex(GraphicsContextState::Change::StrokeBrush)); }
-    void setStrokeGradient(Ref<Gradient>&& gradient, const AffineTransform& spaceTransform = { }) { m_state.setStrokeGradient(WTFMove(gradient), spaceTransform); didUpdateSingleState(m_state, GraphicsContextState::toIndex(GraphicsContextState::Change::StrokeBrush)); }
+    void setStrokeGradient(Ref<const Gradient>&& gradient, const AffineTransform& spaceTransform = { }) { m_state.setStrokeGradient(WTFMove(gradient), spaceTransform); didUpdateSingleState(m_state, GraphicsContextState::toIndex(GraphicsContextState::Change::StrokeBrush)); }
     void setStrokePattern(Ref<Pattern>&& pattern) { m_state.setStrokePattern(WTFMove(pattern)); didUpdateSingleState(m_state, GraphicsContextState::toIndex(GraphicsContextState::Change::StrokeBrush)); }
 
     float strokeThickness() const { return m_state.strokeThickness(); }
@@ -219,8 +219,8 @@ public:
     using RequiresClipToRect = WebCore::RequiresClipToRect;
     virtual void fillRect(const FloatRect&, RequiresClipToRect = RequiresClipToRect::Yes) = 0;
     virtual void fillRect(const FloatRect&, const Color&) = 0;
-    virtual void fillRect(const FloatRect&, Gradient&, const AffineTransform&, RequiresClipToRect = RequiresClipToRect::Yes) = 0;
-    WEBCORE_EXPORT virtual void fillRect(const FloatRect&, Gradient&);
+    virtual void fillRect(const FloatRect&, const Gradient&, const AffineTransform&, RequiresClipToRect = RequiresClipToRect::Yes) = 0;
+    WEBCORE_EXPORT virtual void fillRect(const FloatRect&, const Gradient&);
     WEBCORE_EXPORT virtual void fillRect(const FloatRect&, const Color&, CompositeOperator, BlendMode = BlendMode::Normal);
     virtual void fillRoundedRectImpl(const FloatRoundedRect&, const Color&) = 0;
     WEBCORE_EXPORT virtual void fillRoundedRect(const FloatRoundedRect&, const Color&, BlendMode = BlendMode::Normal);

--- a/Source/WebCore/platform/graphics/GraphicsContextState.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextState.h
@@ -89,7 +89,7 @@ public:
     const SourceBrush& fillBrush() const { return m_fillBrush; }
     void setFillBrush(const SourceBrush& brush) { setProperty(Change::FillBrush, &GraphicsContextState::m_fillBrush, brush); }
     void setFillColor(const Color& color) { setProperty(Change::FillBrush, &GraphicsContextState::m_fillBrush, { color }); }
-    void setFillGradient(Ref<Gradient>&& gradient, const AffineTransform& spaceTransform) { m_fillBrush.setGradient(WTFMove(gradient), spaceTransform); m_changeFlags.add(Change::FillBrush); }
+    void setFillGradient(Ref<const Gradient>&& gradient, const AffineTransform& spaceTransform) { m_fillBrush.setGradient(WTFMove(gradient), spaceTransform); m_changeFlags.add(Change::FillBrush); }
     void setFillPattern(Ref<Pattern>&& pattern) { m_fillBrush.setPattern(WTFMove(pattern)); m_changeFlags.add(Change::FillBrush); }
 
     WindRule fillRule() const { return m_fillRule; }
@@ -99,7 +99,7 @@ public:
     const SourceBrush& strokeBrush() const { return m_strokeBrush; }
     void setStrokeBrush(const SourceBrush& brush) { setProperty(Change::StrokeBrush, &GraphicsContextState::m_strokeBrush, brush); }
     void setStrokeColor(const Color& color) { setProperty(Change::StrokeBrush, &GraphicsContextState::m_strokeBrush, { color }); }
-    void setStrokeGradient(Ref<Gradient>&& gradient, const AffineTransform& spaceTransform) { m_strokeBrush.setGradient(WTFMove(gradient), spaceTransform); m_changeFlags.add(Change::StrokeBrush); }
+    void setStrokeGradient(Ref<const Gradient>&& gradient, const AffineTransform& spaceTransform) { m_strokeBrush.setGradient(WTFMove(gradient), spaceTransform); m_changeFlags.add(Change::StrokeBrush); }
     void setStrokePattern(Ref<Pattern>&& pattern) { m_strokeBrush.setPattern(WTFMove(pattern)); m_changeFlags.add(Change::StrokeBrush); }
 
     float strokeThickness() const { return m_strokeThickness; }

--- a/Source/WebCore/platform/graphics/NullGraphicsContext.h
+++ b/Source/WebCore/platform/graphics/NullGraphicsContext.h
@@ -82,7 +82,7 @@ private:
     void fillPath(const Path&) final { }
     void strokePath(const Path&) final { }
     void fillRect(const FloatRect&, RequiresClipToRect) final { }
-    void fillRect(const FloatRect&, Gradient&, const AffineTransform&, RequiresClipToRect) final { }
+    void fillRect(const FloatRect&, const Gradient&, const AffineTransform&, RequiresClipToRect) final { }
     void fillRect(const FloatRect&, const Color&) final { }
     void fillRoundedRectImpl(const FloatRoundedRect&, const Color&) final { }
     void strokeRect(const FloatRect&, float) final { }
@@ -132,7 +132,7 @@ private:
     void clipOutRoundedRect(const FloatRoundedRect&) final { }
     void clipToImageBuffer(ImageBuffer&, const FloatRect&) final { }
 
-    void fillRect(const FloatRect&, Gradient&) final { }
+    void fillRect(const FloatRect&, const Gradient&) final { }
     void fillRect(const FloatRect&, const Color&, CompositeOperator, BlendMode = BlendMode::Normal) final { }
 
     void fillRoundedRect(const FloatRoundedRect&, const Color&, BlendMode = BlendMode::Normal) final { }

--- a/Source/WebCore/platform/graphics/SourceBrush.cpp
+++ b/Source/WebCore/platform/graphics/SourceBrush.cpp
@@ -35,7 +35,7 @@ const AffineTransform& SourceBrush::gradientSpaceTransform() const
     return identity;
 }
 
-Gradient* SourceBrush::gradient() const
+const Gradient* SourceBrush::gradient() const
 {
     if (auto* logicalGradient = std::get_if<SourceBrushLogicalGradient>(&m_patternGradient))
         return logicalGradient->gradient.ptr();
@@ -49,7 +49,7 @@ Pattern* SourceBrush::pattern() const
     return nullptr;
 }
 
-void SourceBrush::setGradient(Ref<Gradient>&& gradient, const AffineTransform& spaceTransform)
+void SourceBrush::setGradient(Ref<const Gradient>&& gradient, const AffineTransform& spaceTransform)
 {
     m_patternGradient = SourceBrushLogicalGradient { WTFMove(gradient), spaceTransform };
 }

--- a/Source/WebCore/platform/graphics/SourceBrush.h
+++ b/Source/WebCore/platform/graphics/SourceBrush.h
@@ -50,12 +50,12 @@ public:
     // Packed color accessor takes into account the discrimination between color, gradient, pattern.
     std::optional<PackedColor::RGBA> packedColor() const;
 
-    WEBCORE_EXPORT Gradient* gradient() const;
+    WEBCORE_EXPORT const Gradient* gradient() const;
     WEBCORE_EXPORT Pattern* pattern() const;
     WEBCORE_EXPORT const AffineTransform& gradientSpaceTransform() const;
     WEBCORE_EXPORT std::optional<RenderingResourceIdentifier> gradientIdentifier() const;
 
-    WEBCORE_EXPORT void setGradient(Ref<Gradient>&&, const AffineTransform& spaceTransform = { });
+    WEBCORE_EXPORT void setGradient(Ref<const Gradient>&&, const AffineTransform& spaceTransform = { });
     WEBCORE_EXPORT void setPattern(Ref<Pattern>&&);
 
     bool isVisible() const { return hasPatternOrGradient() || m_color.isVisible(); }

--- a/Source/WebCore/platform/graphics/SourceBrushLogicalGradient.h
+++ b/Source/WebCore/platform/graphics/SourceBrushLogicalGradient.h
@@ -30,7 +30,7 @@
 namespace WebCore {
 
 struct SourceBrushLogicalGradient {
-    Ref<Gradient> gradient;
+    Ref<const Gradient> gradient;
     AffineTransform spaceTransform;
 
     friend bool operator==(const SourceBrushLogicalGradient&, const SourceBrushLogicalGradient&);

--- a/Source/WebCore/platform/graphics/cairo/CairoOperationRecorder.cpp
+++ b/Source/WebCore/platform/graphics/cairo/CairoOperationRecorder.cpp
@@ -274,7 +274,7 @@ void OperationRecorder::fillRect(const FloatRect& rect, const Color& color)
     append(createCommand<FillRect>(rect, color, Cairo::ShadowState(state())));
 }
 
-void OperationRecorder::fillRect(const FloatRect& rect, Gradient& gradient)
+void OperationRecorder::fillRect(const FloatRect& rect, const Gradient&gradient)
 {
     struct FillRect final : PaintingOperation, OperationData<FloatRect, RefPtr<cairo_pattern_t>> {
         virtual ~FillRect() = default;
@@ -297,7 +297,7 @@ void OperationRecorder::fillRect(const FloatRect& rect, Gradient& gradient)
     append(createCommand<FillRect>(rect, gradient.createPattern(1.0, state.fillBrush().gradientSpaceTransform())));
 }
 
-void OperationRecorder::fillRect(const FloatRect& rect, Gradient& gradient, const AffineTransform& gradientSpaceTransform, RequiresClipToRect)
+void OperationRecorder::fillRect(const FloatRect& rect, const Gradient&gradient, const AffineTransform& gradientSpaceTransform, RequiresClipToRect)
 {
     struct FillRect final : PaintingOperation, OperationData<FloatRect, Cairo::FillSource, Cairo::ShadowState> {
         virtual ~FillRect() = default;

--- a/Source/WebCore/platform/graphics/cairo/CairoOperationRecorder.h
+++ b/Source/WebCore/platform/graphics/cairo/CairoOperationRecorder.h
@@ -53,8 +53,8 @@ private:
 
     void fillRect(const WebCore::FloatRect&, WebCore::GraphicsContext::RequiresClipToRect = WebCore::GraphicsContext::RequiresClipToRect::Yes) override;
     void fillRect(const WebCore::FloatRect&, const WebCore::Color&) override;
-    void fillRect(const WebCore::FloatRect&, WebCore::Gradient&) override;
-    void fillRect(const WebCore::FloatRect&, WebCore::Gradient&, const WebCore::AffineTransform&, WebCore::GraphicsContext::RequiresClipToRect = WebCore::GraphicsContext::RequiresClipToRect::Yes) override;
+    void fillRect(const WebCore::FloatRect&, const WebCore::Gradient&) override;
+    void fillRect(const WebCore::FloatRect&, const WebCore::Gradient&, const WebCore::AffineTransform&, WebCore::GraphicsContext::RequiresClipToRect = WebCore::GraphicsContext::RequiresClipToRect::Yes) override;
     void fillRect(const WebCore::FloatRect&, const WebCore::Color&, WebCore::CompositeOperator, WebCore::BlendMode) override;
     void fillRoundedRectImpl(const WebCore::FloatRoundedRect&, const WebCore::Color&) override { ASSERT_NOT_REACHED(); }
     void fillRoundedRect(const WebCore::FloatRoundedRect&, const WebCore::Color&, WebCore::BlendMode) override;

--- a/Source/WebCore/platform/graphics/cairo/CairoOperations.cpp
+++ b/Source/WebCore/platform/graphics/cairo/CairoOperations.cpp
@@ -536,7 +536,7 @@ FillSource::FillSource(const GraphicsContextState& state)
         color = state.fillBrush().color();
 }
 
-FillSource::FillSource(const GraphicsContextState& state, Gradient& useGradient, const AffineTransform& gradientSpaceTransform)
+FillSource::FillSource(const GraphicsContextState& state, const Gradient&useGradient, const AffineTransform& gradientSpaceTransform)
     : globalAlpha(state.alpha())
     , fillRule(state.fillRule())
 {

--- a/Source/WebCore/platform/graphics/cairo/CairoOperations.h
+++ b/Source/WebCore/platform/graphics/cairo/CairoOperations.h
@@ -77,7 +77,7 @@ enum class OrientationSizing {
 struct FillSource {
     FillSource() = default;
     explicit FillSource(const GraphicsContextState&);
-    FillSource(const GraphicsContextState&, Gradient&, const AffineTransform&);
+    FillSource(const GraphicsContextState&, const Gradient&, const AffineTransform&);
 
     float globalAlpha { 0 };
     struct {

--- a/Source/WebCore/platform/graphics/cairo/GradientCairo.cpp
+++ b/Source/WebCore/platform/graphics/cairo/GradientCairo.cpp
@@ -40,10 +40,6 @@
 
 namespace WebCore {
 
-void Gradient::stopsChanged()
-{
-}
-
 static void addColorStopRGBA(cairo_pattern_t *gradient, GradientColorStop stop, float globalAlpha)
 {
     auto [r, g, b, a] = stop.color.toColorTypeLossy<SRGBA<float>>().resolved();
@@ -150,7 +146,7 @@ static void addConicSector(cairo_pattern_t *gradient, float cx, float cy, float 
 }
 
 static RefPtr<cairo_pattern_t> createConic(float xo, float yo, float r, float angleRadians,
-    GradientColorStops::StopVector stops, float globalAlpha)
+    const GradientColorStops& stops, float globalAlpha)
 {
     // Locate last stop with offset 0.
     size_t i = stops.size() - 1;
@@ -160,7 +156,7 @@ static RefPtr<cairo_pattern_t> createConic(float xo, float yo, float r, float an
     }
     // Remove stops with offset zero before last one.
     if (i > 0) {
-        GradientColorStops::StopVector newStops;
+        GradientColorStops newStops;
         for (; i < stops.size(); i++)
             newStops.append(stops[i]);
         stops = newStops;
@@ -208,7 +204,7 @@ static RefPtr<cairo_pattern_t> createConic(float xo, float yo, float r, float an
     return gradient;
 }
 
-RefPtr<cairo_pattern_t> Gradient::createPattern(float globalAlpha, const AffineTransform& gradientSpaceTransform)
+RefPtr<cairo_pattern_t> Gradient::createPattern(float globalAlpha, const AffineTransform& gradientSpaceTransform) const
 {
     cairo_matrix_t matrix = toCairoMatrix(gradientSpaceTransform);
     cairo_matrix_invert(&matrix);
@@ -260,7 +256,7 @@ RefPtr<cairo_pattern_t> Gradient::createPattern(float globalAlpha, const AffineT
     return gradient;
 }
 
-void Gradient::fill(GraphicsContext& context, const FloatRect& rect)
+void Gradient::fill(GraphicsContext& context, const FloatRect& rect) const
 {
     auto pattern = createPattern(1.0, context.fillGradientSpaceTransform());
     if (!pattern)

--- a/Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.cpp
+++ b/Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.cpp
@@ -187,7 +187,7 @@ void GraphicsContextCairo::fillRect(const FloatRect& rect, RequiresClipToRect)
     Cairo::fillRect(*this, rect, Cairo::FillSource(state), Cairo::ShadowState(state));
 }
 
-void GraphicsContextCairo::fillRect(const FloatRect& rect, Gradient& gradient, const AffineTransform& gradientSpaceTransform, RequiresClipToRect)
+void GraphicsContextCairo::fillRect(const FloatRect& rect, const Gradient&gradient, const AffineTransform& gradientSpaceTransform, RequiresClipToRect)
 {
     auto& state = this->state();
     Cairo::fillRect(*this, rect, Cairo::FillSource(state, gradient, gradientSpaceTransform), Cairo::ShadowState(state));

--- a/Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.h
+++ b/Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.h
@@ -60,7 +60,7 @@ public:
 
     using GraphicsContext::fillRect;
     void fillRect(const FloatRect&, RequiresClipToRect = RequiresClipToRect::Yes) final;
-    void fillRect(const FloatRect&, Gradient&, const AffineTransform&, RequiresClipToRect = RequiresClipToRect::Yes) final;
+    void fillRect(const FloatRect&, const Gradient&, const AffineTransform&, RequiresClipToRect = RequiresClipToRect::Yes) final;
     void fillRect(const FloatRect&, const Color&) final;
     void fillRoundedRectImpl(const FloatRoundedRect&, const Color&) final;
     void fillRectWithRoundedHole(const FloatRect&, const FloatRoundedRect&, const Color&) final;

--- a/Source/WebCore/platform/graphics/cg/GradientCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/GradientCG.cpp
@@ -32,39 +32,31 @@
 #include "GradientRendererCG.h"
 #include "GraphicsContextCG.h"
 #include <pal/spi/cg/CoreGraphicsSPI.h>
+#include <wtf/Locker.h>
 #include <wtf/MathExtras.h>
 
 namespace WebCore {
 
-void Gradient::stopsChanged()
-{
-    m_platformRenderer = { };
-}
-
-void Gradient::fill(GraphicsContext& context, const FloatRect& rect)
+void Gradient::fill(GraphicsContext& context, const FloatRect& rect) const
 {
     context.clip(rect);
     paint(context);
 }
 
-void Gradient::paint(GraphicsContext& context)
+void Gradient::paint(GraphicsContext& context) const
 {
     paint(context.platformContext(), context.colorSpace());
 }
 
-void Gradient::paint(CGContextRef platformContext, std::optional<DestinationColorSpace> colorSpace)
+void Gradient::paint(CGContextRef platformContext, std::optional<DestinationColorSpace> colorSpace) const
 {
-    auto ensurePlatformRenderer = [&] {
-        if (m_platformRenderer && m_platformRenderer->colorSpace() == colorSpace)
-            return;
-
-        m_platformRenderer = GradientRendererCG { m_colorInterpolationMethod, m_stops.sorted(), colorSpace };
-    };
-
-    ensurePlatformRenderer();
+    Locker locker { m_lock };
+    if (!m_platformRenderer && m_platformRenderer->colorSpace() != colorSpace)
+        m_platformRenderer = GradientRendererCG { m_colorInterpolationMethod, m_stops, colorSpace };
 
     WTF::switchOn(m_data,
         [&] (const LinearData& data) {
+            assertIsHeld(m_lock);
             switch (m_spreadMethod) {
             case GradientSpreadMethod::Repeat:
             case GradientSpreadMethod::Reflect: {
@@ -88,13 +80,6 @@ void Gradient::paint(CGContextRef platformContext, std::optional<DestinationColo
                 CGFloat pixelSize = CGFAbs(CGContextConvertSizeToUserSpace(platformContext, CGSizeMake(1, 1)).width);
                 if (CGFAbs(dx) < pixelSize)
                     dx = dx < 0 ? -pixelSize : pixelSize;
-
-                auto drawLinearGradient = [&](CGFloat start, CGFloat end, bool flip) {
-                    CGPoint left = CGPointMake(flip ? end : start, 0);
-                    CGPoint right = CGPointMake(flip ? start : end, 0);
-
-                    m_platformRenderer->drawLinearGradient(platformContext, left, right, extendOptions);
-                };
 
                 auto isLeftOf = [](CGFloat start, CGFloat end, CGRect boundingBox) -> bool {
                     return std::max(start, end) <= CGRectGetMinX(boundingBox);
@@ -120,7 +105,11 @@ void Gradient::paint(CGContextRef platformContext, std::optional<DestinationColo
 
                 // Draw gradient forward till the points are outside boundingBox.
                 for (; isIntersecting(start, start + dx, boundingBox); start += dx) {
-                    drawLinearGradient(start, start + dx, flip);
+                    CGPoint left = CGPointMake(start, 0);
+                    CGPoint right = CGPointMake(start + dx, 0);
+                    if (flip)
+                        std::swap(left, right);
+                    m_platformRenderer->drawLinearGradient(platformContext, left, right, extendOptions);
                     flip = !flip && m_spreadMethod == GradientSpreadMethod::Reflect;
                 }
 
@@ -136,7 +125,11 @@ void Gradient::paint(CGContextRef platformContext, std::optional<DestinationColo
 
                 // Draw gradient backward till the points are outside boundingBox.
                 for (; isIntersecting(end, end - dx, boundingBox); end -= dx) {
-                    drawLinearGradient(end - dx, end, flip);
+                    CGPoint left = CGPointMake(end - dx, 0);
+                    CGPoint right = CGPointMake(end, 0);
+                    if (flip)
+                        std::swap(left, right);
+                    m_platformRenderer->drawLinearGradient(platformContext, left, right, extendOptions);
                     flip = !flip && m_spreadMethod == GradientSpreadMethod::Reflect;
                 }
                 break;
@@ -149,6 +142,7 @@ void Gradient::paint(CGContextRef platformContext, std::optional<DestinationColo
             }
         },
         [&] (const RadialData& data) {
+            assertIsHeld(m_lock);
             bool needScaling = data.aspectRatio != 1;
             if (needScaling) {
                 CGContextSaveGState(platformContext);
@@ -167,6 +161,7 @@ void Gradient::paint(CGContextRef platformContext, std::optional<DestinationColo
                 CGContextRestoreGState(platformContext);
         },
         [&] (const ConicData& data) {
+            assertIsHeld(m_lock);
             CGContextSaveGState(platformContext);
             CGContextTranslateCTM(platformContext, data.point0.x(), data.point0.y());
             CGContextRotateCTM(platformContext, (CGFloat)-piOverTwoDouble);

--- a/Source/WebCore/platform/graphics/cg/GradientRendererCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/GradientRendererCG.cpp
@@ -367,7 +367,7 @@ GradientRendererCG::Strategy GradientRendererCG::makeShading(ColorInterpolationM
 void GradientRendererCG::drawLinearGradient(CGContextRef platformContext, CGPoint startPoint, CGPoint endPoint, CGGradientDrawingOptions options)
 {
     WTF::switchOn(m_strategy,
-        [&] (Gradient& gradient) {
+        [&] (const Gradient& gradient) {
             CGContextDrawLinearGradient(platformContext, gradient.gradient.get(), startPoint, endPoint, options);
         },
         [&] (Shading& shading) {
@@ -382,7 +382,7 @@ void GradientRendererCG::drawLinearGradient(CGContextRef platformContext, CGPoin
 void GradientRendererCG::drawRadialGradient(CGContextRef platformContext, CGPoint startCenter, CGFloat startRadius, CGPoint endCenter, CGFloat endRadius, CGGradientDrawingOptions options)
 {
     WTF::switchOn(m_strategy,
-        [&] (Gradient& gradient) {
+        [&] (const Gradient& gradient) {
             CGContextDrawRadialGradient(platformContext, gradient.gradient.get(), startCenter, startRadius, endCenter, endRadius, options);
         },
         [&] (Shading& shading) {
@@ -397,7 +397,7 @@ void GradientRendererCG::drawRadialGradient(CGContextRef platformContext, CGPoin
 void GradientRendererCG::drawConicGradient(CGContextRef platformContext, CGPoint center, CGFloat angle)
 {
     WTF::switchOn(m_strategy,
-        [&] (Gradient& gradient) {
+        [&] (const Gradient& gradient) {
             CGContextDrawConicGradient(platformContext, gradient.gradient.get(), center, angle);
         },
         [&] (Shading& shading) {

--- a/Source/WebCore/platform/graphics/cg/GradientRendererCG.h
+++ b/Source/WebCore/platform/graphics/cg/GradientRendererCG.h
@@ -29,13 +29,12 @@
 #include <WebCore/ColorComponents.h>
 #include <WebCore/ColorInterpolationMethod.h>
 #include <WebCore/DestinationColorSpace.h>
+#include <WebCore/GradientColorStops.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/Vector.h>
 
 namespace WebCore {
-
-class GradientColorStops;
 
 struct ColorConvertedToInterpolationColorSpaceStop {
     float offset;

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
@@ -841,7 +841,7 @@ void GraphicsContextCG::fillRect(const FloatRect& rect, RequiresClipToRect requi
     CGContextFillRect(context, rect);
 }
 
-void GraphicsContextCG::fillRect(const FloatRect& rect, Gradient& gradient, const AffineTransform& gradientSpaceTransform, RequiresClipToRect requiresClipToRect)
+void GraphicsContextCG::fillRect(const FloatRect& rect, const Gradient&gradient, const AffineTransform& gradientSpaceTransform, RequiresClipToRect requiresClipToRect)
 {
     CGContextRef context = platformContext();
 

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.h
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.h
@@ -73,7 +73,7 @@ public:
     using GraphicsContext::fillRect;
     void fillRect(const FloatRect&, RequiresClipToRect = RequiresClipToRect::Yes) final;
     void fillRect(const FloatRect&, const Color&) final;
-    void fillRect(const FloatRect&, Gradient&, const AffineTransform&, RequiresClipToRect = RequiresClipToRect::Yes) final;
+    void fillRect(const FloatRect&, const Gradient&, const AffineTransform&, RequiresClipToRect = RequiresClipToRect::Yes) final;
     void fillRoundedRectImpl(const FloatRoundedRect&, const Color&) final;
     void fillRectWithRoundedHole(const FloatRect&, const FloatRoundedRect& roundedHoleRect, const Color&) final;
     void clearRect(const FloatRect&) final;

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp
@@ -503,13 +503,13 @@ void FillRectWithColor::dump(TextStream& ts, OptionSet<AsTextFlag>) const
     ts.dumpProperty("color"_s, color());
 }
 
-FillRectWithGradient::FillRectWithGradient(const FloatRect& rect, Gradient& gradient)
+FillRectWithGradient::FillRectWithGradient(const FloatRect& rect, const Gradient&gradient)
     : m_rect(rect)
     , m_gradient(gradient)
 {
 }
 
-FillRectWithGradient::FillRectWithGradient(FloatRect&& rect, Ref<Gradient>&& gradient)
+FillRectWithGradient::FillRectWithGradient(FloatRect&& rect, Ref<const Gradient>&& gradient)
     : m_rect(WTFMove(rect))
     , m_gradient(WTFMove(gradient))
 {
@@ -526,7 +526,7 @@ void FillRectWithGradient::dump(TextStream& ts, OptionSet<AsTextFlag>) const
     ts.dumpProperty("gradient"_s, m_gradient);
 }
 
-FillRectWithGradientAndSpaceTransform::FillRectWithGradientAndSpaceTransform(const FloatRect& rect, Gradient& gradient, const AffineTransform& gradientSpaceTransform, GraphicsContext::RequiresClipToRect requiresClipToRect)
+FillRectWithGradientAndSpaceTransform::FillRectWithGradientAndSpaceTransform(const FloatRect& rect, const Gradient&gradient, const AffineTransform& gradientSpaceTransform, GraphicsContext::RequiresClipToRect requiresClipToRect)
     : m_rect(rect)
     , m_gradient(gradient)
     , m_gradientSpaceTransform(gradientSpaceTransform)
@@ -534,7 +534,7 @@ FillRectWithGradientAndSpaceTransform::FillRectWithGradientAndSpaceTransform(con
 {
 }
 
-FillRectWithGradientAndSpaceTransform::FillRectWithGradientAndSpaceTransform(FloatRect&& rect, Ref<Gradient>&& gradient, AffineTransform&& gradientSpaceTransform, GraphicsContext::RequiresClipToRect requiresClipToRect)
+FillRectWithGradientAndSpaceTransform::FillRectWithGradientAndSpaceTransform(FloatRect&& rect, Ref<const Gradient>&& gradient, AffineTransform&& gradientSpaceTransform, GraphicsContext::RequiresClipToRect requiresClipToRect)
     : m_rect(WTFMove(rect))
     , m_gradient(WTFMove(gradient))
     , m_gradientSpaceTransform(WTFMove(gradientSpaceTransform))

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItems.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItems.h
@@ -967,8 +967,8 @@ class FillRectWithGradient {
 public:
     static constexpr char name[] = "fill-rect-with-gradient";
 
-    WEBCORE_EXPORT FillRectWithGradient(const FloatRect&, Gradient&);
-    WEBCORE_EXPORT FillRectWithGradient(FloatRect&&, Ref<Gradient>&&);
+    WEBCORE_EXPORT FillRectWithGradient(const FloatRect&, const Gradient&);
+    WEBCORE_EXPORT FillRectWithGradient(FloatRect&&, Ref<const Gradient>&&);
 
     const FloatRect& rect() const { return m_rect; }
     const Gradient& gradient() const { return m_gradient; }
@@ -978,15 +978,15 @@ public:
 
 private:
     FloatRect m_rect;
-    const Ref<Gradient> m_gradient;
+    const Ref<const Gradient> m_gradient;
 };
 
 class FillRectWithGradientAndSpaceTransform {
 public:
     static constexpr char name[] = "fill-rect-with-gradient-and-space-transform";
 
-    WEBCORE_EXPORT FillRectWithGradientAndSpaceTransform(const FloatRect&, Gradient&, const AffineTransform&, GraphicsContext::RequiresClipToRect);
-    WEBCORE_EXPORT FillRectWithGradientAndSpaceTransform(FloatRect&&, Ref<Gradient>&&, AffineTransform&&, GraphicsContext::RequiresClipToRect);
+    WEBCORE_EXPORT FillRectWithGradientAndSpaceTransform(const FloatRect&, const Gradient&, const AffineTransform&, GraphicsContext::RequiresClipToRect);
+    WEBCORE_EXPORT FillRectWithGradientAndSpaceTransform(FloatRect&&, Ref<const Gradient>&&, AffineTransform&&, GraphicsContext::RequiresClipToRect);
 
     const FloatRect& rect() const { return m_rect; }
     const Gradient& gradient() const { return m_gradient; }
@@ -998,7 +998,7 @@ public:
 
 private:
     FloatRect m_rect;
-    const Ref<Gradient> m_gradient;
+    const Ref<const Gradient> m_gradient;
     AffineTransform m_gradientSpaceTransform;
     GraphicsContext::RequiresClipToRect m_requiresClipToRect;
 };

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp
@@ -322,13 +322,13 @@ void RecorderImpl::fillRect(const FloatRect& rect, const Color& color)
     m_items.append(FillRectWithColor(rect, color));
 }
 
-void RecorderImpl::fillRect(const FloatRect& rect, Gradient& gradient)
+void RecorderImpl::fillRect(const FloatRect& rect, const Gradient&gradient)
 {
     appendStateChangeItemIfNecessary();
     m_items.append(FillRectWithGradient(rect, gradient));
 }
 
-void RecorderImpl::fillRect(const FloatRect& rect, Gradient& gradient, const AffineTransform& gradientSpaceTransform, RequiresClipToRect requiresClipToRect)
+void RecorderImpl::fillRect(const FloatRect& rect, const Gradient&gradient, const AffineTransform& gradientSpaceTransform, RequiresClipToRect requiresClipToRect)
 {
     appendStateChangeItemIfNecessary();
     m_items.append(FillRectWithGradientAndSpaceTransform(rect, gradient, gradientSpaceTransform, requiresClipToRect));

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.h
@@ -88,8 +88,8 @@ public:
     void fillPath(const Path&) final;
     void fillRect(const FloatRect&, RequiresClipToRect) final;
     void fillRect(const FloatRect&, const Color&) final;
-    void fillRect(const FloatRect&, Gradient&) final;
-    void fillRect(const FloatRect&, Gradient&, const AffineTransform&, RequiresClipToRect) final;
+    void fillRect(const FloatRect&, const Gradient&) final;
+    void fillRect(const FloatRect&, const Gradient&, const AffineTransform&, RequiresClipToRect) final;
     void fillRect(const FloatRect&, const Color&, CompositeOperator, BlendMode) final;
     void fillRoundedRect(const FloatRoundedRect&, const Color&, BlendMode) final;
     void fillRectWithRoundedHole(const FloatRect&, const FloatRoundedRect&, const Color&) final;

--- a/Source/WebCore/platform/graphics/skia/GradientSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/GradientSkia.cpp
@@ -40,10 +40,6 @@ WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 
 namespace WebCore {
 
-void Gradient::stopsChanged()
-{
-}
-
 inline SkScalar webCoreDoubleToSkScalar(double d)
 {
     return SkDoubleToScalar(std::isfinite(d) ? d : 0);
@@ -106,7 +102,7 @@ sk_sp<SkShader> Gradient::shader(float globalAlpha, const AffineTransform& gradi
     colors.reserveInitialCapacity(stops().size());
     Vector<SkScalar, 8> positions;
     positions.reserveInitialCapacity(stops().size());
-    auto fillStops = [&](const GradientColorStops::StopVector& stops) {
+    auto fillStops = [&](const GradientColorStops& stops) {
         if (stops.isEmpty()) {
             positions.append(webCoreDoubleToSkScalar(0));
             colors.append(SkColors::kTransparent);
@@ -125,7 +121,7 @@ sk_sp<SkShader> Gradient::shader(float globalAlpha, const AffineTransform& gradi
             colors.append(colors.last());
         }
     };
-    fillStops(stops().sorted().stops());
+    fillStops(stops());
 
     SkTileMode tileMode = SkTileMode::kClamp;
     switch (m_spreadMethod) {

--- a/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp
@@ -579,7 +579,7 @@ void GraphicsContextSkia::fillRect(const FloatRect& boundaries, const Color& fil
     drawSkiaRect(boundaries, paint);
 }
 
-void GraphicsContextSkia::fillRect(const FloatRect& boundaries, Gradient& gradient, const AffineTransform& gradientSpaceTransform, RequiresClipToRect)
+void GraphicsContextSkia::fillRect(const FloatRect& boundaries, const Gradient&gradient, const AffineTransform& gradientSpaceTransform, RequiresClipToRect)
 {
     if (!makeGLContextCurrentIfNeeded())
         return;

--- a/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.h
+++ b/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.h
@@ -67,7 +67,7 @@ public:
     using GraphicsContext::fillRect;
     void fillRect(const FloatRect&, RequiresClipToRect = RequiresClipToRect::Yes) final;
     void fillRect(const FloatRect&, const Color&) final;
-    void fillRect(const FloatRect&, Gradient&, const AffineTransform&, RequiresClipToRect = RequiresClipToRect::Yes) final;
+    void fillRect(const FloatRect&, const Gradient&, const AffineTransform&, RequiresClipToRect = RequiresClipToRect::Yes) final;
     void fillRoundedRectImpl(const FloatRoundedRect&, const Color&) final;
     void fillRectWithRoundedHole(const FloatRect&, const FloatRoundedRect&, const Color&) final;
     void fillPath(const Path&) final;

--- a/Source/WebCore/rendering/TextBoxPainter.cpp
+++ b/Source/WebCore/rendering/TextBoxPainter.cpp
@@ -1191,15 +1191,15 @@ static void drawWritingToolsUnderline(GraphicsContext& context, const FloatRect&
 
     auto xOffset = frameX * fmod(animationProgress + midY / frameY, 1.0);
     constexpr std::array colorList { purpleColor, redColor, yellowColor, redColor, purpleColor, purpleColor, redColor, yellowColor, redColor, purpleColor };
-
-    Ref gradient = Gradient::create(Gradient::LinearData { FloatPoint(0 - xOffset, 0), FloatPoint(frameX * 2 - xOffset, frameY) }, { ColorInterpolationMethod::SRGB { }, AlphaPremultiplication::Unpremultiplied });
-
     auto colorStop = 0.f;
     auto colorIncrement = 1.0 / colorList.size();
+    GradientColorStops stops;
+    stops.reserveCapacity(colorList.size());
     for (auto color : colorList) {
-        gradient->addColorStop({ colorStop, color });
+        stops.constructAndAppend(colorStop, color);
         colorStop += colorIncrement;
     }
+    Ref gradient = Gradient::create(Gradient::LinearData { FloatPoint(0 - xOffset, 0), FloatPoint(frameX * 2 - xOffset, frameY) }, { ColorInterpolationMethod::SRGB { }, AlphaPremultiplication::Unpremultiplied }, GradientSpreadMethod::Pad, SortedGradientColorStops { WTFMove(stops) });
 
     context.save();
     context.setFillGradient(WTFMove(gradient));

--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
@@ -774,18 +774,17 @@ static void drawShapeWithBorder(GraphicsContext& context, float deviceScaleFacto
     context.strokePath(path);
 }
 
-static RefPtr<Gradient> checkboxRadioBackgroundGradientForVectorBasedControls(const FloatRect& rect, OptionSet<ControlStyle::State> states)
+static RefPtr<const Gradient> checkboxRadioBackgroundGradientForVectorBasedControls(const FloatRect& rect, OptionSet<ControlStyle::State> states)
 {
     // FIXME: This is just a copy of RenderThemeIOS::checkboxRadioBackgroundGradient(...). Refactor to remove this duplicate code.
     bool isPressed = states.contains(ControlStyle::State::Pressed);
     if (isPressed)
         return nullptr;
-
+    GradientColorStops stops;
     bool isEmpty = !states.containsAny({ ControlStyle::State::Checked, ControlStyle::State::Indeterminate });
-    auto gradient = Gradient::create(Gradient::LinearData { rect.minXMinYCorner(), rect.maxXMaxYCorner() }, { ColorInterpolationMethod::SRGB { }, AlphaPremultiplication::Unpremultiplied });
-    gradient->addColorStop({ 0.0f, DisplayP3<float> { 0, 0, 0, isEmpty ? 0.05f : 0.125f } });
-    gradient->addColorStop({ 1.0f, DisplayP3<float> { 0, 0, 0, 0 } });
-    return gradient;
+    stops.constructAndAppend(0.0f, DisplayP3<float> { 0, 0, 0, isEmpty ? 0.05f : 0.125f });
+    stops.constructAndAppend(1.0f, DisplayP3<float> { 0, 0, 0, 0 });
+    return Gradient::create(Gradient::LinearData { rect.minXMinYCorner(), rect.maxXMaxYCorner() }, { ColorInterpolationMethod::SRGB { }, AlphaPremultiplication::Unpremultiplied }, GradientSpreadMethod::Pad, SortedGradientColorStops { WTFMove(stops) });
 }
 
 constexpr auto checkboxCornerRadiusRatio = 5.5f / checkboxRadioSizeForVectorBasedControls;
@@ -1532,9 +1531,11 @@ bool RenderThemeCocoa::paintColorWellDecorationsForVectorBasedControls(const Ren
     };
     constexpr int numColorStops = std::size(colorStops);
 
-    Ref gradient = Gradient::create(Gradient::ConicData { rect.center(), 0 }, { ColorInterpolationMethod::SRGB { }, AlphaPremultiplication::Unpremultiplied });
+    GradientColorStops stops;
+    stops.reserveCapacity(numColorStops);
     for (int i = 0; i < numColorStops; ++i)
-        gradient->addColorStop({ i * 1.0f / (numColorStops - 1), colorStops[i] });
+        stops.constructAndAppend(i * 1.0f / (numColorStops - 1), colorStops[i]);
+    Ref gradient = Gradient::create(Gradient::ConicData { rect.center(), 0 }, { ColorInterpolationMethod::SRGB { }, AlphaPremultiplication::Unpremultiplied }, GradientSpreadMethod::Pad);
 
     FloatRect strokeRect = rect;
     strokeRect.inflate(-strokeThickness / 2.0f);

--- a/Source/WebCore/rendering/ios/RenderThemeIOS.h
+++ b/Source/WebCore/rendering/ios/RenderThemeIOS.h
@@ -112,7 +112,7 @@ private:
 
     Color checkboxRadioBorderColor(OptionSet<ControlStyle::State>, OptionSet<StyleColorOptions>);
     Color checkboxRadioBackgroundColor(const RenderStyle&, OptionSet<ControlStyle::State>, OptionSet<StyleColorOptions>);
-    RefPtr<Gradient> checkboxRadioBackgroundGradient(const FloatRect&, OptionSet<ControlStyle::State>);
+    RefPtr<const Gradient> checkboxRadioBackgroundGradient(const FloatRect&, OptionSet<ControlStyle::State>);
     Color checkboxRadioIndicatorColor(OptionSet<ControlStyle::State>, OptionSet<StyleColorOptions>);
 
     bool paintCheckbox(const RenderObject&, const PaintInfo&, const FloatRect&) override;

--- a/Source/WebCore/rendering/ios/RenderThemeIOS.mm
+++ b/Source/WebCore/rendering/ios/RenderThemeIOS.mm
@@ -1456,17 +1456,17 @@ Color RenderThemeIOS::checkboxRadioBackgroundColor(const RenderStyle& style, Opt
     return enabledBackgroundColor;
 }
 
-RefPtr<Gradient> RenderThemeIOS::checkboxRadioBackgroundGradient(const FloatRect& rect, OptionSet<ControlStyle::State> states)
+RefPtr<const Gradient> RenderThemeIOS::checkboxRadioBackgroundGradient(const FloatRect& rect, OptionSet<ControlStyle::State> states)
 {
     bool isPressed = states.contains(ControlStyle::State::Pressed);
     if (isPressed)
         return nullptr;
 
     bool isEmpty = !states.containsAny({ ControlStyle::State::Checked, ControlStyle::State::Indeterminate });
-    auto gradient = Gradient::create(Gradient::LinearData { rect.minXMinYCorner(), rect.maxXMaxYCorner() }, { ColorInterpolationMethod::SRGB { }, AlphaPremultiplication::Unpremultiplied });
-    gradient->addColorStop({ 0.0f, DisplayP3<float> { 0, 0, 0, isEmpty ? 0.05f : 0.125f }});
-    gradient->addColorStop({ 1.0f, DisplayP3<float> { 0, 0, 0, 0 }});
-    return gradient;
+    GradientColorStops stops;
+    stops.constructAndAppend(0.0f, DisplayP3<float> { 0, 0, 0, isEmpty ? 0.05f : 0.125f });
+    stops.constructAndAppend(1.0f, DisplayP3<float> { 0, 0, 0, 0 });
+    return Gradient::create(Gradient::LinearData { rect.minXMinYCorner(), rect.maxXMaxYCorner() }, { ColorInterpolationMethod::SRGB { }, AlphaPremultiplication::Unpremultiplied }, GradientSpreadMethod::Pad, WTFMove(stops));
 }
 
 Color RenderThemeIOS::checkboxRadioIndicatorColor(OptionSet<ControlStyle::State> states, OptionSet<StyleColorOptions> styleColorOptions)
@@ -1863,9 +1863,11 @@ void RenderThemeIOS::paintColorWellDecorations(const RenderObject& renderer, con
     };
     constexpr int numColorStops = std::size(colorStops);
 
-    auto gradient = Gradient::create(Gradient::ConicData { rect.center(), 0 }, { ColorInterpolationMethod::SRGB { }, AlphaPremultiplication::Unpremultiplied });
+    GradientColorStops stops;
+    stops.reserveCapacity(numColorStops);
     for (int i = 0; i < numColorStops; ++i)
-        gradient->addColorStop({ i * 1.0f / (numColorStops - 1), colorStops[i] });
+        stops.constructAndAppend(i * 1.0f / (numColorStops - 1), colorStops[i]);
+    auto gradient = Gradient::create(Gradient::ConicData { rect.center(), 0 }, { ColorInterpolationMethod::SRGB { }, AlphaPremultiplication::Unpremultiplied }, GradientSpreadMethod::Pad, WTFMove(stops));
 
     auto& context = paintInfo.context();
     GraphicsContextStateSaver stateSaver(context);

--- a/Source/WebCore/rendering/style/StyleGradientImage.h
+++ b/Source/WebCore/rendering/style/StyleGradientImage.h
@@ -31,9 +31,6 @@
 
 namespace WebCore {
 
-class Gradient;
-class GradientColorStops;
-
 class StyleGradientImage final : public StyleGeneratedImage {
 public:
     static Ref<StyleGradientImage> create(Style::Gradient gradient)

--- a/Source/WebCore/rendering/svg/RenderSVGResourceGradient.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceGradient.cpp
@@ -42,7 +42,7 @@ GradientColorStops RenderSVGResourceGradient::stopsByApplyingColorFilter(const G
     if (!style.hasAppleColorFilter())
         return stops;
 
-    return stops.mapColors([&] (auto& color) {
+    return mapGradientColors(stops, [&] (auto& color) {
         return style.colorByApplyingColorFilter(color);
     });
 }

--- a/Source/WebCore/rendering/svg/RenderSVGResourceGradient.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceGradient.h
@@ -45,7 +45,7 @@ protected:
     RenderSVGResourceGradient(Type, SVGElement&, RenderStyle&&);
 
     virtual void collectGradientAttributesIfNeeded() = 0;
-    virtual RefPtr<Gradient> createGradient(const RenderStyle&) = 0;
+    virtual RefPtr<const Gradient> createGradient(const RenderStyle&) = 0;
 
     virtual AffineTransform gradientTransform() const = 0;
 
@@ -53,7 +53,7 @@ protected:
     GradientColorStops stopsByApplyingColorFilter(const GradientColorStops&, const RenderStyle&) const;
     GradientSpreadMethod platformSpreadMethodFromSVGType(SVGSpreadMethodType) const;
 
-    RefPtr<Gradient> m_gradient;
+    RefPtr<const Gradient> m_gradient;
 };
 
 }

--- a/Source/WebCore/rendering/svg/RenderSVGResourceLinearGradient.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceLinearGradient.cpp
@@ -51,7 +51,7 @@ void RenderSVGResourceLinearGradient::collectGradientAttributesIfNeeded()
         m_attributes = WTFMove(attributes);
 }
 
-RefPtr<Gradient> RenderSVGResourceLinearGradient::createGradient(const RenderStyle& style)
+RefPtr<const Gradient> RenderSVGResourceLinearGradient::createGradient(const RenderStyle& style)
 {
     if (!m_attributes)
         return nullptr;
@@ -64,7 +64,8 @@ RefPtr<Gradient> RenderSVGResourceLinearGradient::createGradient(const RenderSty
         Gradient::LinearData { startPoint, endPoint },
         { ColorInterpolationMethod::SRGB { }, AlphaPremultiplication::Unpremultiplied },
         platformSpreadMethodFromSVGType(m_attributes->spreadMethod()),
-        stopsByApplyingColorFilter(m_attributes->stops(), style));
+        stopsByApplyingColorFilter(m_attributes->stops(), style),
+        false);
 }
 
 }

--- a/Source/WebCore/rendering/svg/RenderSVGResourceLinearGradient.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceLinearGradient.h
@@ -52,7 +52,7 @@ public:
 
 private:
     void collectGradientAttributesIfNeeded() final;
-    RefPtr<Gradient> createGradient(const RenderStyle&) final;
+    RefPtr<const Gradient> createGradient(const RenderStyle&) final;
 
     void element() const = delete;
     ASCIILiteral renderName() const final { return "RenderSVGResourceLinearGradient"_s; }

--- a/Source/WebCore/rendering/svg/RenderSVGResourceRadialGradient.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceRadialGradient.cpp
@@ -52,7 +52,7 @@ void RenderSVGResourceRadialGradient::collectGradientAttributesIfNeeded()
         m_attributes = WTFMove(attributes);
 }
 
-RefPtr<Gradient> RenderSVGResourceRadialGradient::createGradient(const RenderStyle& style)
+RefPtr<const Gradient> RenderSVGResourceRadialGradient::createGradient(const RenderStyle& style)
 {
     if (!m_attributes)
         return nullptr;
@@ -68,7 +68,8 @@ RefPtr<Gradient> RenderSVGResourceRadialGradient::createGradient(const RenderSty
         Gradient::RadialData { focalPoint, centerPoint, focalRadius, radius, 1 },
         { ColorInterpolationMethod::SRGB { }, AlphaPremultiplication::Unpremultiplied },
         platformSpreadMethodFromSVGType(m_attributes->spreadMethod()),
-        stopsByApplyingColorFilter(m_attributes->stops(), style));
+        stopsByApplyingColorFilter(m_attributes->stops(), style),
+        false);
 }
 
 }

--- a/Source/WebCore/rendering/svg/RenderSVGResourceRadialGradient.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceRadialGradient.h
@@ -51,7 +51,7 @@ public:
 
 private:
     void collectGradientAttributesIfNeeded() final;
-    RefPtr<Gradient> createGradient(const RenderStyle&) final;
+    RefPtr<const Gradient> createGradient(const RenderStyle&) final;
 
     void element() const = delete;
     ASCIILiteral renderName() const final { return "RenderSVGResourceRadialGradient"_s; }

--- a/Source/WebCore/rendering/svg/SVGTextBoxPainter.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextBoxPainter.cpp
@@ -575,7 +575,7 @@ void SVGTextBoxPainter<TextBoxPath>::paintTextWithShadows(const RenderStyle& sty
 
         {
             // Optimized code path to support gradient/pattern fill/stroke on text without using temporary ImageBuffers / masking.
-            RefPtr<Gradient> gradient;
+            RefPtr<const Gradient> gradient;
             RefPtr<Pattern> pattern;
             if (renderer().document().settings().layerBasedSVGEngineEnabled()) {
                 auto* textRootBlock = RenderSVGText::locateRenderSVGTextAncestor(renderer());

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceGradient.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceGradient.cpp
@@ -360,7 +360,9 @@ GradientColorStops LegacyRenderSVGResourceGradient::stopsByApplyingColorFilter(c
     if (!style.hasAppleColorFilter())
         return stops;
 
-    return stops.mapColors([&] (auto& color) { return style.colorByApplyingColorFilter(color); });
+    return mapGradientColors(stops, [&] (auto& color) {
+        return style.colorByApplyingColorFilter(color);
+    });
 }
 
 GradientSpreadMethod LegacyRenderSVGResourceGradient::platformSpreadMethodFromSVGType(SVGSpreadMethodType method)

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceGradient.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceGradient.h
@@ -52,7 +52,7 @@ struct GradientData {
         return !gradient;
     }
 
-    RefPtr<Gradient> gradient;
+    RefPtr<const Gradient> gradient;
     AffineTransform userspaceTransform;
     Inputs inputs;
 };
@@ -97,7 +97,7 @@ private:
     virtual SVGUnitTypes::SVGUnitType gradientUnits() const = 0;
     virtual AffineTransform gradientTransform() const = 0;
     virtual bool collectGradientAttributes() = 0;
-    virtual Ref<Gradient> buildGradient(const RenderStyle&) const = 0;
+    virtual Ref<const Gradient> buildGradient(const RenderStyle&) const = 0;
 
     HashMap<RenderObject*, std::unique_ptr<GradientData>> m_gradientMap;
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceLinearGradient.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceLinearGradient.cpp
@@ -51,13 +51,14 @@ FloatPoint LegacyRenderSVGResourceLinearGradient::endPoint(const LinearGradientA
     return SVGLengthContext::resolvePoint(protectedLinearGradientElement().ptr(), attributes.gradientUnits(), attributes.x2(), attributes.y2());
 }
 
-Ref<Gradient> LegacyRenderSVGResourceLinearGradient::buildGradient(const RenderStyle& style) const
+Ref<const Gradient> LegacyRenderSVGResourceLinearGradient::buildGradient(const RenderStyle& style) const
 {
     return Gradient::create(
         Gradient::LinearData { startPoint(m_attributes), endPoint(m_attributes) },
         { ColorInterpolationMethod::SRGB { }, AlphaPremultiplication::Unpremultiplied },
         platformSpreadMethodFromSVGType(m_attributes.spreadMethod()),
-        stopsByApplyingColorFilter(m_attributes.stops(), style));
+        stopsByApplyingColorFilter(m_attributes.stops(), style),
+        false);
 }
 
 }

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceLinearGradient.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceLinearGradient.h
@@ -46,7 +46,7 @@ private:
     SVGUnitTypes::SVGUnitType gradientUnits() const final { return m_attributes.gradientUnits(); }
     AffineTransform gradientTransform() const final { return m_attributes.gradientTransform(); }
     bool collectGradientAttributes() final;
-    Ref<Gradient> buildGradient(const RenderStyle&) const final;
+    Ref<const Gradient> buildGradient(const RenderStyle&) const final;
 
     void gradientElement() const = delete;
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceRadialGradient.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceRadialGradient.cpp
@@ -62,7 +62,7 @@ float LegacyRenderSVGResourceRadialGradient::focalRadius(const RadialGradientAtt
     return SVGLengthContext::resolveLength(protectedRadialGradientElement().ptr(), attributes.gradientUnits(), attributes.fr());
 }
 
-Ref<Gradient> LegacyRenderSVGResourceRadialGradient::buildGradient(const RenderStyle& style) const
+Ref<const Gradient> LegacyRenderSVGResourceRadialGradient::buildGradient(const RenderStyle& style) const
 {
     return Gradient::create(
         Gradient::RadialData { focalPoint(m_attributes), centerPoint(m_attributes), focalRadius(m_attributes), radius(m_attributes), 1 },

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceRadialGradient.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceRadialGradient.h
@@ -47,7 +47,7 @@ private:
 
     SVGUnitTypes::SVGUnitType gradientUnits() const final { return m_attributes.gradientUnits(); }
     AffineTransform gradientTransform() const final { return m_attributes.gradientTransform(); }
-    Ref<Gradient> buildGradient(const RenderStyle&) const final;
+    Ref<const Gradient> buildGradient(const RenderStyle&) const final;
 
     void gradientElement() const = delete;
 

--- a/Source/WebCore/style/values/images/StyleGradient.cpp
+++ b/Source/WebCore/style/values/images/StyleGradient.cpp
@@ -353,10 +353,10 @@ public:
     }
 };
 
-template<typename GradientAdapter, typename StyleGradient> GradientColorStops computeStopsForDeprecatedVariants(GradientAdapter&, const StyleGradient& styleGradient, const RenderStyle& style)
+template<typename GradientAdapter, typename StyleGradient> SortedGradientColorStops computeStopsForDeprecatedVariants(GradientAdapter&, const StyleGradient& styleGradient, const RenderStyle& style)
 {
     bool hasColorFilter = style.hasAppleColorFilter();
-    auto result = styleGradient.parameters.stops.value.template map<GradientColorStops::StopVector>([&](auto& stop) -> WebCore::GradientColorStop {
+    auto result = styleGradient.parameters.stops.value.template map<GradientColorStops>([&](auto& stop) -> WebCore::GradientColorStop {
         return {
             resolveColorStopPosition(stop.position),
             resolveColorStopColor(stop.color, style, hasColorFilter)
@@ -365,10 +365,10 @@ template<typename GradientAdapter, typename StyleGradient> GradientColorStops co
 
     std::ranges::stable_sort(result, { }, &WebCore::GradientColorStop::offset);
 
-    return GradientColorStops::Sorted { WTFMove(result) };
+    return SortedGradientColorStops { WTFMove(result) };
 }
 
-template<typename GradientAdapter, typename StyleGradient> GradientColorStops computeStops(GradientAdapter& gradientAdapter, const StyleGradient& styleGradient, const RenderStyle& style)
+template<typename GradientAdapter, typename StyleGradient> SortedGradientColorStops computeStops(GradientAdapter& gradientAdapter, const StyleGradient& styleGradient, const RenderStyle& style)
 {
     bool hasColorFilter = style.hasAppleColorFilter();
 
@@ -635,8 +635,8 @@ template<typename GradientAdapter, typename StyleGradient> GradientColorStops co
     if (stops.size() > 1 && (*stops.first().offset < 0 || *stops.last().offset > 1))
         gradientAdapter.normalizeStopsAndEndpointsOutsideRange(stops, styleGradient.parameters.colorInterpolationMethod.method);
 
-    return GradientColorStops::Sorted {
-        stops.template map<GradientColorStops::StopVector>([](auto& stop) -> WebCore::GradientColorStop {
+    return SortedGradientColorStops {
+        stops.template map<GradientColorStops>([](auto& stop) -> WebCore::GradientColorStop {
             return { *stop.offset, stop.color };
         })
     };
@@ -811,7 +811,7 @@ static inline float horizontalEllipseRadius(const FloatSize& p, float aspectRati
 
 // MARK: - Linear create.
 
-template<CSSValueID Name> static Ref<WebCore::Gradient> createPlatformGradient(const FunctionNotation<Name, LinearGradient>& linear, const FloatSize& size, const RenderStyle& style)
+template<CSSValueID Name> static Ref<const WebCore::Gradient> createPlatformGradient(const FunctionNotation<Name, LinearGradient>& linear, const FloatSize& size, const RenderStyle& style)
 {
     ASSERT(!size.isEmpty());
 
@@ -861,7 +861,7 @@ template<CSSValueID Name> static Ref<WebCore::Gradient> createPlatformGradient(c
 
 // MARK: - Prefixed Linear create.
 
-template<CSSValueID Name> static Ref<WebCore::Gradient> createPlatformGradient(const FunctionNotation<Name, PrefixedLinearGradient>& linear, const FloatSize& size, const RenderStyle& style)
+template<CSSValueID Name> static Ref<const WebCore::Gradient> createPlatformGradient(const FunctionNotation<Name, PrefixedLinearGradient>& linear, const FloatSize& size, const RenderStyle& style)
 {
     ASSERT(!size.isEmpty());
 
@@ -916,7 +916,7 @@ template<CSSValueID Name> static Ref<WebCore::Gradient> createPlatformGradient(c
 
 // MARK: - Deprecated Linear create.
 
-template<CSSValueID Name> static Ref<WebCore::Gradient> createPlatformGradient(const FunctionNotation<Name, DeprecatedLinearGradient>& linear, const FloatSize& size, const RenderStyle& style)
+template<CSSValueID Name> static Ref<const WebCore::Gradient> createPlatformGradient(const FunctionNotation<Name, DeprecatedLinearGradient>& linear, const FloatSize& size, const RenderStyle& style)
 {
     ASSERT(!size.isEmpty());
 
@@ -932,7 +932,7 @@ template<CSSValueID Name> static Ref<WebCore::Gradient> createPlatformGradient(c
 
 // MARK: - Radial create.
 
-template<CSSValueID Name> static Ref<WebCore::Gradient> createPlatformGradient(const FunctionNotation<Name, RadialGradient>& radial, const FloatSize& size, const RenderStyle& style)
+template<CSSValueID Name> static Ref<const WebCore::Gradient> createPlatformGradient(const FunctionNotation<Name, RadialGradient>& radial, const FloatSize& size, const RenderStyle& style)
 {
     ASSERT(!size.isEmpty());
 
@@ -1027,7 +1027,7 @@ template<CSSValueID Name> static Ref<WebCore::Gradient> createPlatformGradient(c
 
 // MARK: - Prefixed Radial create.
 
-template<CSSValueID Name> static Ref<WebCore::Gradient> createPlatformGradient(const FunctionNotation<Name, PrefixedRadialGradient>& radial, const FloatSize& size, const RenderStyle& style)
+template<CSSValueID Name> static Ref<const WebCore::Gradient> createPlatformGradient(const FunctionNotation<Name, PrefixedRadialGradient>& radial, const FloatSize& size, const RenderStyle& style)
 {
     ASSERT(!size.isEmpty());
 
@@ -1134,7 +1134,7 @@ template<CSSValueID Name> static Ref<WebCore::Gradient> createPlatformGradient(c
 
 // MARK: - Deprecated Radial create.
 
-template<CSSValueID Name> static Ref<WebCore::Gradient> createPlatformGradient(const FunctionNotation<Name, DeprecatedRadialGradient>& radial, const FloatSize& size, const RenderStyle& style)
+template<CSSValueID Name> static Ref<const WebCore::Gradient> createPlatformGradient(const FunctionNotation<Name, DeprecatedRadialGradient>& radial, const FloatSize& size, const RenderStyle& style)
 {
     ASSERT(!size.isEmpty());
 
@@ -1154,7 +1154,7 @@ template<CSSValueID Name> static Ref<WebCore::Gradient> createPlatformGradient(c
 
 // MARK: - Conic create.
 
-template<CSSValueID Name> static Ref<WebCore::Gradient> createPlatformGradient(const FunctionNotation<Name, ConicGradient>& conic, const FloatSize& size, const RenderStyle& style)
+template<CSSValueID Name> static Ref<const WebCore::Gradient> createPlatformGradient(const FunctionNotation<Name, ConicGradient>& conic, const FloatSize& size, const RenderStyle& style)
 {
     ASSERT(!size.isEmpty());
 
@@ -1174,7 +1174,7 @@ template<CSSValueID Name> static Ref<WebCore::Gradient> createPlatformGradient(c
 
 // MARK: - createPlatformGradient
 
-Ref<WebCore::Gradient> createPlatformGradient(const Gradient& gradient, const FloatSize& size, const RenderStyle& style)
+Ref<const WebCore::Gradient> createPlatformGradient(const Gradient& gradient, const FloatSize& size, const RenderStyle& style)
 {
     return WTF::switchOn(gradient, [&](auto& gradient) { return createPlatformGradient(gradient, size, style); });
 }

--- a/Source/WebCore/style/values/images/StyleGradient.h
+++ b/Source/WebCore/style/values/images/StyleGradient.h
@@ -387,7 +387,7 @@ using Gradient = Variant<
 >;
 
 // Creates a platform gradient from the style representation.
-Ref<WebCore::Gradient> createPlatformGradient(const Gradient&, const FloatSize&, const RenderStyle&);
+Ref<const WebCore::Gradient> createPlatformGradient(const Gradient&, const FloatSize&, const RenderStyle&);
 
 // Returns whether it caching based on the gradient's stops is allowed.
 WEBCORE_EXPORT bool stopsAreCacheable(const Gradient&);

--- a/Source/WebCore/svg/SVGGradientElement.cpp
+++ b/Source/WebCore/svg/SVGGradientElement.cpp
@@ -117,7 +117,7 @@ GradientColorStops SVGGradientElement::buildStops()
     for (auto& stop : childrenOfType<SVGStopElement>(*this)) {
         auto monotonicallyIncreasingOffset = std::clamp(stop.offset(), previousOffset, 1.0f);
         previousOffset = monotonicallyIncreasingOffset;
-        stops.addColorStop({ monotonicallyIncreasingOffset, stop.stopColorIncludingOpacity() });
+        stops.constructAndAppend(monotonicallyIncreasingOffset, stop.stopColorIncludingOpacity());
     }
     return stops;
 }

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.cpp
@@ -145,7 +145,7 @@ void RemoteGraphicsContext::setFillCachedGradient(RemoteGradientIdentifier ident
     context().setFillGradient(gradient.releaseNonNull(), spaceTransform);
 }
 
-void RemoteGraphicsContext::setFillGradient(Ref<Gradient>&& gradient, const AffineTransform& spaceTransform)
+void RemoteGraphicsContext::setFillGradient(Ref<const Gradient>&& gradient, const AffineTransform& spaceTransform)
 {
     context().setFillGradient(WTFMove(gradient), spaceTransform);
 }
@@ -179,7 +179,7 @@ void RemoteGraphicsContext::setStrokeCachedGradient(RemoteGradientIdentifier ide
     context().setStrokeGradient(gradient.releaseNonNull(), spaceTransform);
 }
 
-void RemoteGraphicsContext::setStrokeGradient(Ref<Gradient>&& gradient, const AffineTransform& spaceTransform)
+void RemoteGraphicsContext::setStrokeGradient(Ref<const Gradient>&& gradient, const AffineTransform& spaceTransform)
 {
     context().setStrokeGradient(WTFMove(gradient), spaceTransform);
 }
@@ -496,12 +496,12 @@ void RemoteGraphicsContext::fillRectWithColor(const FloatRect& rect, const Color
     context().fillRect(rect, color);
 }
 
-void RemoteGraphicsContext::fillRectWithGradient(const FloatRect& rect, Ref<Gradient>&& gradient)
+void RemoteGraphicsContext::fillRectWithGradient(const FloatRect& rect, Ref<const Gradient>&& gradient)
 {
     context().fillRect(rect, gradient);
 }
 
-void RemoteGraphicsContext::fillRectWithGradientAndSpaceTransform(const FloatRect& rect, Ref<Gradient>&& gradient, const AffineTransform& transform, GraphicsContext::RequiresClipToRect requiresClipToRect)
+void RemoteGraphicsContext::fillRectWithGradientAndSpaceTransform(const FloatRect& rect, Ref<const Gradient>&& gradient, const AffineTransform& transform, GraphicsContext::RequiresClipToRect requiresClipToRect)
 {
     context().fillRect(rect, gradient, transform, requiresClipToRect);
 }

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.h
@@ -60,13 +60,13 @@ public:
     void setFillPackedColor(WebCore::PackedColor::RGBA);
     void setFillColor(const WebCore::Color&);
     void setFillCachedGradient(RemoteGradientIdentifier, const WebCore::AffineTransform&);
-    void setFillGradient(Ref<WebCore::Gradient>&&, const WebCore::AffineTransform&);
+    void setFillGradient(Ref<const WebCore::Gradient>&&, const WebCore::AffineTransform&);
     void setFillPattern(WebCore::RenderingResourceIdentifier tileImageIdentifier, const WebCore::PatternParameters&);
     void setFillRule(WebCore::WindRule);
     void setStrokePackedColor(WebCore::PackedColor::RGBA);
     void setStrokeColor(const WebCore::Color&);
     void setStrokeCachedGradient(RemoteGradientIdentifier, const WebCore::AffineTransform&);
-    void setStrokeGradient(Ref<WebCore::Gradient>&&, const WebCore::AffineTransform&);
+    void setStrokeGradient(Ref<const WebCore::Gradient>&&, const WebCore::AffineTransform&);
     void setStrokePattern(WebCore::RenderingResourceIdentifier tileImageIdentifier, const WebCore::PatternParameters&);
     void setStrokePackedColorAndThickness(WebCore::PackedColor::RGBA, float);
     void setStrokeThickness(float);
@@ -118,8 +118,8 @@ public:
     void drawFocusRingRects(const Vector<WebCore::FloatRect>&, float outlineOffset, float outlineWidth, const WebCore::Color&);
     void fillRect(const WebCore::FloatRect&, WebCore::RequiresClipToRect);
     void fillRectWithColor(const WebCore::FloatRect&, const WebCore::Color&);
-    void fillRectWithGradient(const WebCore::FloatRect&, Ref<WebCore::Gradient>&&);
-    void fillRectWithGradientAndSpaceTransform(const WebCore::FloatRect&, Ref<WebCore::Gradient>&&, const WebCore::AffineTransform&, WebCore::RequiresClipToRect);
+    void fillRectWithGradient(const WebCore::FloatRect&, Ref<const WebCore::Gradient>&&);
+    void fillRectWithGradientAndSpaceTransform(const WebCore::FloatRect&, Ref<const WebCore::Gradient>&&, const WebCore::AffineTransform&, WebCore::RequiresClipToRect);
     void fillCompositedRect(const WebCore::FloatRect&, const WebCore::Color&, WebCore::CompositeOperator, WebCore::BlendMode);
     void fillRoundedRect(const WebCore::FloatRoundedRect&, const WebCore::Color&, WebCore::BlendMode);
     void fillRectWithRoundedHole(const WebCore::FloatRect&, const WebCore::FloatRoundedRect&, const WebCore::Color&);

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.messages.in
@@ -38,13 +38,13 @@ messages -> RemoteGraphicsContext Stream {
     SetFillPackedColor(struct WebCore::PackedColor::RGBA color) StreamBatched
     SetFillColor(WebCore::Color color) StreamBatched
     SetFillCachedGradient(WebKit::RemoteGradientIdentifier identifier, WebCore::AffineTransform spaceTransform) StreamBatched
-    SetFillGradient(Ref<WebCore::Gradient> gradient, WebCore::AffineTransform spaceTransform) StreamBatched
+    SetFillGradient(Ref<const WebCore::Gradient> gradient, WebCore::AffineTransform spaceTransform) StreamBatched
     SetFillPattern(WebCore::RenderingResourceIdentifier tileImageIdentifier, WebCore::PatternParameters pattern) StreamBatched
     SetFillRule(enum:bool WebCore::WindRule rule) StreamBatched
     SetStrokePackedColor(WebCore::PackedColor::RGBA color) StreamBatched
     SetStrokeColor(WebCore::Color color) StreamBatched
     SetStrokeCachedGradient(WebKit::RemoteGradientIdentifier identifier, WebCore::AffineTransform spaceTransform) StreamBatched
-    SetStrokeGradient(Ref<WebCore::Gradient> gradient, WebCore::AffineTransform spaceTransform) StreamBatched
+    SetStrokeGradient(Ref<const WebCore::Gradient> gradient, WebCore::AffineTransform spaceTransform) StreamBatched
     SetStrokePattern(WebCore::RenderingResourceIdentifier tileImageIdentifier, WebCore::PatternParameters pattern) StreamBatched
     SetStrokePackedColorAndThickness(WebCore::PackedColor::RGBA color, float thickness) StreamBatched
     SetStrokeThickness(float thickness) StreamBatched
@@ -93,8 +93,8 @@ messages -> RemoteGraphicsContext Stream {
     DrawFocusRingRects(Vector<WebCore::FloatRect> rects, float outlineOffset, float outlineWidth, WebCore::Color color)
     FillRect(WebCore::FloatRect rect, enum:bool WebCore::RequiresClipToRect requiresClipToRect)
     FillRectWithColor(WebCore::FloatRect rect, WebCore::Color color)
-    FillRectWithGradient(WebCore::FloatRect rect, Ref<WebCore::Gradient> gradient)
-    FillRectWithGradientAndSpaceTransform(WebCore::FloatRect rect, Ref<WebCore::Gradient> gradient, WebCore::AffineTransform transform, enum:bool WebCore::RequiresClipToRect requiresClipToRect)
+    FillRectWithGradient(WebCore::FloatRect rect, Ref<const WebCore::Gradient> gradient)
+    FillRectWithGradientAndSpaceTransform(WebCore::FloatRect rect, Ref<const WebCore::Gradient> gradient, WebCore::AffineTransform transform, enum:bool WebCore::RequiresClipToRect requiresClipToRect)
     FillCompositedRect(WebCore::FloatRect rect, WebCore::Color color, enum:uint8_t WebCore::CompositeOperator op, enum:uint8_t WebCore::BlendMode blendMode)
     FillRoundedRect(WebCore::FloatRoundedRect rect, WebCore::Color color, enum:uint8_t WebCore::BlendMode blendMode)
     FillRectWithRoundedHole(WebCore::FloatRect rect, WebCore::FloatRoundedRect roundedHoleRect, WebCore::Color color)

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
@@ -398,7 +398,7 @@ void RemoteRenderingBackend::releaseFontCustomPlatformData(WebCore::RenderingRes
     MESSAGE_CHECK(success, "FontCustomPlatformData released before being cached.");
 }
 
-void RemoteRenderingBackend::cacheGradient(Ref<Gradient>&& gradient, RemoteGradientIdentifier identifier)
+void RemoteRenderingBackend::cacheGradient(Ref<const Gradient>&& gradient, RemoteGradientIdentifier identifier)
 {
     assertIsCurrent(workQueue());
     bool success = m_remoteResourceCache.cacheGradient(identifier, WTFMove(gradient));

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
@@ -159,7 +159,7 @@ private:
     void destroyGetPixelBufferSharedMemory();
     void cacheNativeImage(WebCore::ShareableBitmap::Handle&&, WebCore::RenderingResourceIdentifier);
     void releaseNativeImage(WebCore::RenderingResourceIdentifier);
-    void cacheGradient(Ref<WebCore::Gradient>&&, RemoteGradientIdentifier);
+    void cacheGradient(Ref<const WebCore::Gradient>&&, RemoteGradientIdentifier);
     void releaseGradient(RemoteGradientIdentifier);
     void cacheFilter(Ref<WebCore::Filter>&&);
     void releaseFilter(WebCore::RenderingResourceIdentifier);

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in
@@ -41,7 +41,7 @@ messages -> RemoteRenderingBackend Stream {
     ReleaseFont(WebCore::RenderingResourceIdentifier identifier)
     CacheFontCustomPlatformData(struct WebCore::FontCustomPlatformSerializedData fontCustomPlatformData) NotStreamEncodable
     ReleaseFontCustomPlatformData(WebCore::RenderingResourceIdentifier identifier)
-    CacheGradient(Ref<WebCore::Gradient> gradient, WebKit::RemoteGradientIdentifier identifier)
+    CacheGradient(Ref<const WebCore::Gradient> gradient, WebKit::RemoteGradientIdentifier identifier)
     ReleaseGradient(WebKit::RemoteGradientIdentifier identifier)
     CacheFilter(Ref<WebCore::Filter> filter) NotStreamEncodable
     ReleaseFilter(WebCore::RenderingResourceIdentifier identifier)

--- a/Source/WebKit/GPUProcess/graphics/RemoteResourceCache.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteResourceCache.cpp
@@ -58,7 +58,7 @@ RefPtr<NativeImage> RemoteResourceCache::cachedNativeImage(RenderingResourceIden
     return m_nativeImages.get(identifier);
 }
 
-bool RemoteResourceCache::cacheGradient(RemoteGradientIdentifier identifier, Ref<Gradient>&& gradient)
+bool RemoteResourceCache::cacheGradient(RemoteGradientIdentifier identifier, Ref<const Gradient>&& gradient)
 {
     return m_gradients.add(identifier, WTFMove(gradient)).isNewEntry;
 }
@@ -68,7 +68,7 @@ bool RemoteResourceCache::releaseGradient(RemoteGradientIdentifier identifier)
     return m_gradients.remove(identifier);
 }
 
-RefPtr<Gradient> RemoteResourceCache::cachedGradient(RemoteGradientIdentifier identifier) const
+RefPtr<const Gradient> RemoteResourceCache::cachedGradient(RemoteGradientIdentifier identifier) const
 {
     return m_gradients.get(identifier);
 }

--- a/Source/WebKit/GPUProcess/graphics/RemoteResourceCache.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteResourceCache.h
@@ -56,9 +56,9 @@ public:
     bool releaseNativeImage(WebCore::RenderingResourceIdentifier);
     RefPtr<WebCore::NativeImage> cachedNativeImage(WebCore::RenderingResourceIdentifier) const;
 
-    bool cacheGradient(RemoteGradientIdentifier, Ref<WebCore::Gradient>&&);
+    bool cacheGradient(RemoteGradientIdentifier, Ref<const WebCore::Gradient>&&);
     bool releaseGradient(RemoteGradientIdentifier);
-    RefPtr<WebCore::Gradient> cachedGradient(RemoteGradientIdentifier) const;
+    RefPtr<const WebCore::Gradient> cachedGradient(RemoteGradientIdentifier) const;
 
     void cacheFilter(Ref<WebCore::Filter>&&);
     bool releaseFilter(WebCore::RenderingResourceIdentifier);
@@ -83,7 +83,7 @@ public:
 private:
     HashMap<WebCore::RenderingResourceIdentifier, Ref<WebCore::ImageBuffer>> m_imageBuffers;
     HashMap<WebCore::RenderingResourceIdentifier, Ref<WebCore::NativeImage>> m_nativeImages;
-    HashMap<RemoteGradientIdentifier, Ref<WebCore::Gradient>> m_gradients;
+    HashMap<RemoteGradientIdentifier, Ref<const WebCore::Gradient>> m_gradients;
     HashMap<WebCore::RenderingResourceIdentifier, Ref<WebCore::Filter>> m_filters;
     HashMap<WebCore::RenderingResourceIdentifier, Ref<WebCore::Font>> m_fonts;
     HashMap<WebCore::RenderingResourceIdentifier, Ref<WebCore::FontCustomPlatformData>> m_fontCustomPlatformDatas;

--- a/Source/WebKit/Platform/IPC/ArgumentCoders.h
+++ b/Source/WebKit/Platform/IPC/ArgumentCoders.h
@@ -296,7 +296,7 @@ template<typename T> struct ArgumentCoder<Ref<T>> {
         // std::optional<Ref<U>>.
         // We cannot use `decoder.template decode<U>()`
         // Currently expect "modern decoder" -like decode function.
-        return ArgumentCoder<U>::decode(decoder);
+        return ArgumentCoder<std::remove_cvref_t<U>>::decode(decoder);
     }
 };
 

--- a/Source/WebKit/Scripts/generate-serializers.py
+++ b/Source/WebKit/Scripts/generate-serializers.py
@@ -38,6 +38,7 @@ import sys
 # Alias - this type is not a struct or class, but a typedef.
 # Nested - this type is only serialized as a member of its parent, so work around the need for http://wg21.link/P0289 and don't forward declare it in the header.
 # RefCounted - deserializer returns a std::optional<Ref<T>> instead of a std::optional<T>.
+# ConstRefCounted - deserializer returns a std::optional<Ref<const T>> instead of a std::optional<T>.
 # LegacyPopulateFromEmptyConstructor - instead of calling a constructor with the members, call the empty constructor then insert the members one at a time.
 # OptionSet - for enum classes, instead of only allowing deserialization of the exact values, allow deserialization of any bit combination of the values.
 # RValue - serializer takes an rvalue reference, instead of an lvalue.
@@ -92,6 +93,7 @@ class SerializedType(object):
         self.condition = condition
         self.encoders = ['Encoder']
         self.return_ref = False
+        self.return_const_ref = False
         self.construct_subclass = None
         self.create_using = False
         self.populate_from_empty_constructor = False
@@ -131,6 +133,8 @@ class SerializedType(object):
                         self.nested = True
                     elif attribute == 'RefCounted':
                         self.return_ref = True
+                    elif attribute == 'ConstRefCounted':
+                        self.return_const_ref = True
                     elif attribute == 'DisableMissingMemberCheck':
                         self.disableMissingMemberCheck = True
                     elif attribute == 'RValue':
@@ -496,23 +500,43 @@ _license_header = """/*
 """
 
 
+def coder_encode_decode_type_declarations(type, name_with_template):
+    """Returns tuple containing type declaraations for ArgumentCoder<> specilization, encode function type,
+       decode function."""
+    if type.cf_type:
+        return (f'{name_with_template}', f'{name_with_template}', f'std::optional<RetainPtr<{name_with_template}>>')
+    if type.rvalue:
+        return (f'{name_with_template}', f'{name_with_template}&&', f'std::optional<{name_with_template}>')
+    if type.return_ref:
+        return (f'{name_with_template}', f'const {name_with_template}&', f'std::optional<Ref<{name_with_template}>>')
+    if type.return_const_ref:
+        return (f'{name_with_template}', f'const {name_with_template}&', f'std::optional<Ref<const {name_with_template}>>')
+    return (f'{name_with_template}', f'const {name_with_template}&', f'std::optional<{name_with_template}>')
+
+
 def one_argument_coder_declaration_cf(type):
     result = []
     result.append('')
     if type.condition is not None:
         result.append(f'#if {type.condition}')
     name_with_template = type.namespace_and_name()
-    result.append(f'template<> struct ArgumentCoder<{name_with_template}> {{')
+    (specialization_type, encode_type, decode_type) = coder_encode_decode_type_declarations(type, name_with_template)
+    result.append(f'template<> struct ArgumentCoder<{specialization_type}> {{')
     for encoder in type.encoders:
-        result.append(f'    static void encode({encoder}&, {name_with_template});')
+        result.append(f'    static void encode({encoder}&, {encode_type});')
+    result.append(f'    static {decode_type} decode(Decoder&);')
     result.append('};')
-    result.append(f'template<> struct ArgumentCoder<RetainPtr<{name_with_template}>> {{')
+    # FIXME: template<> ArgumentCoder<RetainPtr<T>> missing.
+    result.append(f'template<> struct ArgumentCoder<RetainPtr<{specialization_type}>> {{')
     for encoder in type.encoders:
         result.append(f'    static void encode({encoder}& encoder, const RetainPtr<{name_with_template}>& retainPtr)')
         result.append('    {')
         result.append(f'        ArgumentCoder<{name_with_template}>::encode(encoder, retainPtr.get());')
         result.append('    }')
-    result.append(f'    static std::optional<RetainPtr<{name_with_template}>> decode(Decoder&);')
+    result.append(f'    static {decode_type} decode(Decoder& decoder)')
+    result.append('    {')
+    result.append(f'        return ArgumentCoder<{specialization_type}>::decode(decoder);')
+    result.append('    }')
     result.append('};')
     if type.condition is not None:
         result.append('#endif')
@@ -529,16 +553,11 @@ def one_argument_coder_declaration(type, template_argument):
     name_with_template = type.namespace_and_name()
     if template_argument is not None:
         name_with_template = f'{name_with_template}<{template_argument.namespace}::{template_argument.name}>'
-    result.append(f'template<> struct ArgumentCoder<{name_with_template}> {{')
+    [specialization_type_decl, encode_type_decl, decode_type_decl] = coder_encode_decode_type_declarations(type, name_with_template)
+    result.append(f'template<> struct ArgumentCoder<{specialization_type_decl}> {{')
     for encoder in type.encoders:
-        if type.rvalue:
-            result.append(f'    static void encode({encoder}&, {name_with_template}&&);')
-        else:
-            result.append(f'    static void encode({encoder}&, const {name_with_template}&);')
-    if type.return_ref:
-        result.append(f'    static std::optional<Ref<{name_with_template}>> decode(Decoder&);')
-    else:
-        result.append(f'    static std::optional<{name_with_template}> decode(Decoder&);')
+        result.append(f'    static void encode({encoder}&, {encode_type_decl});')
+    result.append(f'    static {decode_type_decl} decode(Decoder&);')
     result.append('};')
     if type.condition is not None:
         result.append('#endif')
@@ -743,7 +762,7 @@ def check_type_members(type, checking_parent_class):
     if type.can_assert_member_order_is_correct():
         # FIXME: Add this check for types with parent classes, too.
         if type.parent_class is None and not checking_parent_class:
-            result.append(f'    struct ShouldBeSameSizeAs{type.name_as_identifier()} : public VirtualTableAndRefCountOverhead<std::is_polymorphic_v<{type.namespace_and_name()}>, {"true" if type.return_ref else "false"}> {{')
+            result.append(f'    struct ShouldBeSameSizeAs{type.name_as_identifier()} : public VirtualTableAndRefCountOverhead<std::is_polymorphic_v<{type.namespace_and_name()}>, {"true" if type.return_ref or type.return_const_ref else "false"}> {{')
             for member in type.members:
                 if member.condition is not None:
                     result.append(f'#if {member.condition}')
@@ -991,7 +1010,7 @@ def construct_type(type, specialization, indentation):
     fulltype = type.namespace_and_name_for_construction(specialization)
     if type.create_using:
         result.append(f'{indent(indentation)}{fulltype}::{type.create_using}(')
-    elif type.return_ref:
+    elif type.return_ref or type.return_const_ref:
         result.append(f'{indent(indentation)}{fulltype}::create(')
     else:
         result.append(f'{indent(indentation)}{fulltype} {{')
@@ -1010,7 +1029,7 @@ def construct_type(type, specialization, indentation):
     for i in range(len(type.dictionary_members)):
         member = type.dictionary_members[i]
         result.append(f'{indent(indentation + 1)}WTFMove(*{member.type}){"," if i < len(type.dictionary_members) - 1 else ""}')
-    if type.create_using or type.return_ref:
+    if type.create_using or type.return_ref or type.return_const_ref:
         result.append(indent(indentation) + ')')
     else:
         result.append(indent(indentation) + '}')
@@ -1022,6 +1041,8 @@ def generate_one_impl(type, template_argument, serialized_types):
     name_with_template = type.namespace_and_name()
     if template_argument is not None:
         name_with_template = f'{name_with_template}<{template_argument.namespace}::{template_argument.name}>'
+    [specialization_type_decl, encode_type_decl, decode_type_decl] = coder_encode_decode_type_declarations(type, name_with_template)
+
     if type.condition is not None:
         result.append(f'#if {type.condition}')
 
@@ -1045,12 +1066,7 @@ def generate_one_impl(type, template_argument, serialized_types):
         if type.members_are_subclasses:
             result.append('IGNORE_WARNINGS_BEGIN("missing-noreturn")')
         instanceArgName = 'instance' if type.generic_wrapper is None else 'passedInstance'
-        if type.cf_type is not None:
-            result.append(f'void ArgumentCoder<{name_with_template}>::encode({encoder}& encoder, {name_with_template} {instanceArgName})')
-        elif type.rvalue:
-            result.append(f'void ArgumentCoder<{name_with_template}>::encode({encoder}& encoder, {name_with_template}&& {instanceArgName})')
-        else:
-            result.append(f'void ArgumentCoder<{name_with_template}>::encode({encoder}& encoder, const {name_with_template}& {instanceArgName})')
+        result.append(f'void ArgumentCoder<{specialization_type_decl}>::encode({encoder}& encoder, {encode_type_decl} {instanceArgName})')
         result.append('{')
         if type.generic_wrapper is not None:
             if type.rvalue:
@@ -1066,12 +1082,7 @@ def generate_one_impl(type, template_argument, serialized_types):
         if type.members_are_subclasses:
             result.append('IGNORE_WARNINGS_END')
         result.append('')
-    if type.cf_type is not None:
-        result.append(f'std::optional<RetainPtr<{name_with_template}>> ArgumentCoder<RetainPtr<{name_with_template}>>::decode(Decoder& decoder)')
-    elif type.return_ref:
-        result.append(f'std::optional<Ref<{name_with_template}>> ArgumentCoder<{name_with_template}>::decode(Decoder& decoder)')
-    else:
-        result.append(f'std::optional<{name_with_template}> ArgumentCoder<{name_with_template}>::decode(Decoder& decoder)')
+    result.append(f'{decode_type_decl} ArgumentCoder<{specialization_type_decl}>::decode(Decoder& decoder)')
     result.append('{')
     result = result + decode_type(type, serialized_types)
     if type.cf_type is None:

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
@@ -60,6 +60,7 @@
 #include <WebCore/AppKitControlSystemImage.h>
 #endif
 #include <WebCore/FloatBoxExtent.h>
+#include <WebCore/Gradient.h>
 #include <WebCore/InheritanceGrandchild.h>
 #include <WebCore/InheritsFrom.h>
 #include <WebCore/MoveOnlyBaseClass.h>
@@ -1240,7 +1241,7 @@ void ArgumentCoder<CFFooRef>::encode(Encoder& encoder, CFFooRef instance)
     encoder << WebKit::FooWrapper { instance };
 }
 
-std::optional<RetainPtr<CFFooRef>> ArgumentCoder<RetainPtr<CFFooRef>>::decode(Decoder& decoder)
+std::optional<RetainPtr<CFFooRef>> ArgumentCoder<CFFooRef>::decode(Decoder& decoder)
 {
     auto result = decoder.decode<WebKit::FooWrapper>();
     if (!decoder.isValid()) [[unlikely]]
@@ -1259,7 +1260,7 @@ void ArgumentCoder<CFBarRef>::encode(StreamConnectionEncoder& encoder, CFBarRef 
     encoder << WebKit::BarWrapper::createFromCF(instance);
 }
 
-std::optional<RetainPtr<CFBarRef>> ArgumentCoder<RetainPtr<CFBarRef>>::decode(Decoder& decoder)
+std::optional<RetainPtr<CFBarRef>> ArgumentCoder<CFBarRef>::decode(Decoder& decoder)
 {
     auto result = decoder.decode<WebKit::BarWrapper>();
     if (!decoder.isValid()) [[unlikely]]
@@ -1534,6 +1535,25 @@ std::optional<WebCore::RectEdges<bool>> ArgumentCoder<WebCore::RectEdges<bool>>:
             WTFMove(*bottom),
             WTFMove(*left)
         }
+    };
+}
+
+void ArgumentCoder<WebCore::Gradient>::encode(Encoder& encoder, const WebCore::Gradient& instance)
+{
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.zz())>, int>);
+
+    encoder << instance.zz();
+}
+
+std::optional<Ref<const WebCore::Gradient>> ArgumentCoder<WebCore::Gradient>::decode(Decoder& decoder)
+{
+    auto zz = decoder.decode<int>();
+    if (!decoder.isValid()) [[unlikely]]
+        return std::nullopt;
+    return {
+        WebCore::Gradient::create(
+            WTFMove(*zz)
+        )
     };
 }
 

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h
@@ -99,6 +99,7 @@ class ScrollingStateFrameHostingNodeWithStuffAfterTuple;
 class AppKitControlSystemImage;
 #endif
 template<typename> class RectEdges;
+class Gradient;
 struct Amazing;
 }
 
@@ -331,19 +332,24 @@ template<> struct ArgumentCoder<WebKit::CoreIPCDDScannerResult> {
 
 template<> struct ArgumentCoder<CFFooRef> {
     static void encode(Encoder&, CFFooRef);
+    static std::optional<RetainPtr<CFFooRef>> decode(Decoder&);
 };
 template<> struct ArgumentCoder<RetainPtr<CFFooRef>> {
     static void encode(Encoder& encoder, const RetainPtr<CFFooRef>& retainPtr)
     {
         ArgumentCoder<CFFooRef>::encode(encoder, retainPtr.get());
     }
-    static std::optional<RetainPtr<CFFooRef>> decode(Decoder&);
+    static std::optional<RetainPtr<CFFooRef>> decode(Decoder& decoder)
+    {
+        return ArgumentCoder<CFFooRef>::decode(decoder);
+    }
 };
 
 #if USE(CFBAR)
 template<> struct ArgumentCoder<CFBarRef> {
     static void encode(Encoder&, CFBarRef);
     static void encode(StreamConnectionEncoder&, CFBarRef);
+    static std::optional<RetainPtr<CFBarRef>> decode(Decoder&);
 };
 template<> struct ArgumentCoder<RetainPtr<CFBarRef>> {
     static void encode(Encoder& encoder, const RetainPtr<CFBarRef>& retainPtr)
@@ -354,7 +360,10 @@ template<> struct ArgumentCoder<RetainPtr<CFBarRef>> {
     {
         ArgumentCoder<CFBarRef>::encode(encoder, retainPtr.get());
     }
-    static std::optional<RetainPtr<CFBarRef>> decode(Decoder&);
+    static std::optional<RetainPtr<CFBarRef>> decode(Decoder& decoder)
+    {
+        return ArgumentCoder<CFBarRef>::decode(decoder);
+    }
 };
 #endif
 
@@ -362,6 +371,7 @@ template<> struct ArgumentCoder<RetainPtr<CFBarRef>> {
 template<> struct ArgumentCoder<CFStringRef> {
     static void encode(Encoder&, CFStringRef);
     static void encode(StreamConnectionEncoder&, CFStringRef);
+    static std::optional<RetainPtr<CFStringRef>> decode(Decoder&);
 };
 template<> struct ArgumentCoder<RetainPtr<CFStringRef>> {
     static void encode(Encoder& encoder, const RetainPtr<CFStringRef>& retainPtr)
@@ -372,7 +382,10 @@ template<> struct ArgumentCoder<RetainPtr<CFStringRef>> {
     {
         ArgumentCoder<CFStringRef>::encode(encoder, retainPtr.get());
     }
-    static std::optional<RetainPtr<CFStringRef>> decode(Decoder&);
+    static std::optional<RetainPtr<CFStringRef>> decode(Decoder& decoder)
+    {
+        return ArgumentCoder<CFStringRef>::decode(decoder);
+    }
 };
 #endif
 
@@ -426,6 +439,11 @@ template<> struct ArgumentCoder<WebCore::AppKitControlSystemImage> {
 template<> struct ArgumentCoder<WebCore::RectEdges<bool>> {
     static void encode(Encoder&, const WebCore::RectEdges<bool>&);
     static std::optional<WebCore::RectEdges<bool>> decode(Decoder&);
+};
+
+template<> struct ArgumentCoder<WebCore::Gradient> {
+    static void encode(Encoder&, const WebCore::Gradient&);
+    static std::optional<Ref<const WebCore::Gradient>> decode(Decoder&);
 };
 
 } // namespace IPC

--- a/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
@@ -61,6 +61,7 @@
 #include <WebCore/AppKitControlSystemImage.h>
 #endif
 #include <WebCore/FloatBoxExtent.h>
+#include <WebCore/Gradient.h>
 #include <WebCore/InheritanceGrandchild.h>
 #include <WebCore/InheritsFrom.h>
 #include <WebCore/MoveOnlyBaseClass.h>
@@ -558,6 +559,12 @@ Vector<SerializedTypeInfo> allSerializedTypes()
             {
                 "bool"_s,
                 "left()"_s
+            },
+        } },
+        { "WebCore::Gradient"_s, {
+            {
+                "int"_s,
+                "zz()"_s
             },
         } },
 #if USE(PASSKIT)

--- a/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
@@ -364,3 +364,7 @@ using WebCore::ConditionalVariant = Variant<
 >;
 
 using WebCore::NonConditionalVariant = Variant<int, double>
+
+[ConstRefCounted] class WebCore::Gradient {
+    int zz();
+}

--- a/Source/WebKit/Scripts/webkit/tests/WebKitPlatformGeneratedSerializers.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/WebKitPlatformGeneratedSerializers.cpp
@@ -381,7 +381,7 @@ void ArgumentCoder<CFStringRef>::encode(StreamConnectionEncoder& encoder, CFStri
     encoder << WTF::String { instance };
 }
 
-std::optional<RetainPtr<CFStringRef>> ArgumentCoder<RetainPtr<CFStringRef>>::decode(Decoder& decoder)
+std::optional<RetainPtr<CFStringRef>> ArgumentCoder<CFStringRef>::decode(Decoder& decoder)
 {
     auto result = decoder.decode<WTF::String>();
     if (!decoder.isValid()) [[unlikely]]

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -3055,7 +3055,7 @@ class WebCore::TransformOperations {
     float angleRadians;
 };
 
-[RefCounted, AdditionalEncoder=StreamConnectionEncoder] class WebCore::Gradient {
+[ConstRefCounted, AdditionalEncoder=StreamConnectionEncoder] class WebCore::Gradient {
     Variant<WebCore::Gradient::LinearData, WebCore::Gradient::RadialData, WebCore::Gradient::ConicData> data();
     WebCore::ColorInterpolationMethod colorInterpolationMethod();
     WebCore::GradientSpreadMethod spreadMethod();
@@ -5045,9 +5045,7 @@ enum class WebCore::VideoFrameRotation : uint16_t {
     WebCore::Color color;
 };
 
-[AdditionalEncoder=StreamConnectionEncoder] class WebCore::GradientColorStops {
-    Vector<WebCore::GradientColorStop, 2> stops();
-};
+using WebCore::GradientColorStops = Vector<WebCore::GradientColorStop, 2>;
 
 header: <WebCore/ImageBuffer.h>
 [CustomHeader] struct WebCore::ImageBufferParameters {

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.cpp
@@ -465,13 +465,13 @@ void RemoteGraphicsContextProxy::fillRect(const FloatRect& rect, const Color& co
     send(Messages::RemoteGraphicsContext::FillRectWithColor(rect, color));
 }
 
-void RemoteGraphicsContextProxy::fillRect(const FloatRect& rect, Gradient& gradient)
+void RemoteGraphicsContextProxy::fillRect(const FloatRect& rect, const Gradient& gradient)
 {
     appendStateChangeItemIfNecessary();
     send(Messages::RemoteGraphicsContext::FillRectWithGradient(rect, gradient));
 }
 
-void RemoteGraphicsContextProxy::fillRect(const FloatRect& rect, Gradient& gradient, const AffineTransform& gradientSpaceTransform, RequiresClipToRect requiresClipToRect)
+void RemoteGraphicsContextProxy::fillRect(const FloatRect& rect, const Gradient& gradient, const AffineTransform& gradientSpaceTransform, RequiresClipToRect requiresClipToRect)
 {
     appendStateChangeItemIfNecessary();
     send(Messages::RemoteGraphicsContext::FillRectWithGradientAndSpaceTransform(rect, gradient, gradientSpaceTransform, requiresClipToRect));
@@ -691,7 +691,7 @@ bool RemoteGraphicsContextProxy::recordResourceUse(Font& font)
     return true;
 }
 
-std::optional<RemoteGradientIdentifier> RemoteGraphicsContextProxy::recordResourceUse(Gradient& gradient)
+std::optional<RemoteGradientIdentifier> RemoteGraphicsContextProxy::recordResourceUse(const Gradient& gradient)
 {
     if (gradient.isTransient())
         return std::nullopt;

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.h
@@ -115,8 +115,8 @@ private:
     void fillPath(const WebCore::Path&) final;
     void fillRect(const WebCore::FloatRect&, RequiresClipToRect) final;
     void fillRect(const WebCore::FloatRect&, const WebCore::Color&) final;
-    void fillRect(const WebCore::FloatRect&, WebCore::Gradient&) final;
-    void fillRect(const WebCore::FloatRect&, WebCore::Gradient&, const WebCore::AffineTransform&, RequiresClipToRect) final;
+    void fillRect(const WebCore::FloatRect&, const WebCore::Gradient&) final;
+    void fillRect(const WebCore::FloatRect&, const WebCore::Gradient&, const WebCore::AffineTransform&, RequiresClipToRect) final;
     void fillRect(const WebCore::FloatRect&, const WebCore::Color&, WebCore::CompositeOperator, WebCore::BlendMode) final;
     void fillRoundedRect(const WebCore::FloatRoundedRect&, const WebCore::Color&, WebCore::BlendMode) final;
     void fillRectWithRoundedHole(const WebCore::FloatRect&, const WebCore::FloatRoundedRect&, const WebCore::Color&) final;
@@ -146,7 +146,7 @@ private:
     bool recordResourceUse(WebCore::ImageBuffer&);
     bool recordResourceUse(const WebCore::SourceImage&);
     bool recordResourceUse(WebCore::Font&);
-    std::optional<RemoteGradientIdentifier> recordResourceUse(WebCore::Gradient&);
+    std::optional<RemoteGradientIdentifier> recordResourceUse(const WebCore::Gradient&);
     bool recordResourceUse(WebCore::Filter&);
     std::optional<RemoteDisplayListIdentifier> recordResourceUse(const WebCore::DisplayList::DisplayList&);
 

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
@@ -438,7 +438,7 @@ void RemoteRenderingBackendProxy::releaseFontCustomPlatformData(RenderingResourc
     send(Messages::RemoteRenderingBackend::ReleaseFontCustomPlatformData(identifier));
 }
 
-void RemoteRenderingBackendProxy::cacheGradient(Ref<Gradient>&& gradient, RemoteGradientIdentifier identifier)
+void RemoteRenderingBackendProxy::cacheGradient(Ref<const Gradient>&& gradient, RemoteGradientIdentifier identifier)
 {
     send(Messages::RemoteRenderingBackend::CacheGradient(WTFMove(gradient), identifier));
 }

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
@@ -114,7 +114,7 @@ public:
     void releaseFont(WebCore::RenderingResourceIdentifier);
     void cacheFontCustomPlatformData(Ref<const WebCore::FontCustomPlatformData>&&);
     void releaseFontCustomPlatformData(WebCore::RenderingResourceIdentifier);
-    void cacheGradient(Ref<WebCore::Gradient>&&, RemoteGradientIdentifier);
+    void cacheGradient(Ref<const WebCore::Gradient>&&, RemoteGradientIdentifier);
     void releaseGradient(RemoteGradientIdentifier);
     void cacheFilter(Ref<WebCore::Filter>&&);
     void releaseFilter(WebCore::RenderingResourceIdentifier);

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp
@@ -48,7 +48,7 @@ RemoteResourceCacheProxy::~RemoteResourceCacheProxy()
 {
 }
 
-RemoteGradientIdentifier RemoteResourceCacheProxy::recordGradientUse(Gradient& gradient)
+RemoteGradientIdentifier RemoteResourceCacheProxy::recordGradientUse(const Gradient& gradient)
 {
     auto result = m_gradients.ensure(&gradient, [] {
         return RemoteGradientIdentifier::generate();

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h
@@ -59,7 +59,7 @@ public:
 
     void recordNativeImageUse(WebCore::NativeImage&, const WebCore::DestinationColorSpace&);
     void recordFontUse(WebCore::Font&);
-    RemoteGradientIdentifier recordGradientUse(WebCore::Gradient&);
+    RemoteGradientIdentifier recordGradientUse(const WebCore::Gradient&);
     void recordFilterUse(WebCore::Filter&);
     void recordFontCustomPlatformDataUse(const WebCore::FontCustomPlatformData&);
     RemoteDisplayListIdentifier recordDisplayListUse(const WebCore::DisplayList::DisplayList&);

--- a/Tools/TestWebKitAPI/Tests/WebCore/cg/BifurcatedGraphicsContextTestsCG.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cg/BifurcatedGraphicsContextTestsCG.cpp
@@ -122,8 +122,9 @@ TEST(BifurcatedGraphicsContextTests, DrawTiledGradientImage)
     GraphicsContextCG secondaryContext(secondaryCGContext.get());
     BifurcatedGraphicsContext ctx(primaryContext, secondaryContext);
 
-    auto gradient = Gradient::create(Gradient::LinearData { { 0, 0 }, { 1, 1 } }, { ColorInterpolationMethod::SRGB { }, AlphaPremultiplication::Unpremultiplied });
-    gradient->addColorStop({ 0, Color::red });
+    GradientColorStops stops;
+    stops.constructAndAppend(0, Color::red);
+    auto gradient = Gradient::create(Gradient::LinearData { { 0, 0 }, { 1, 1 } }, { ColorInterpolationMethod::SRGB { }, AlphaPremultiplication::Unpremultiplied }, GradientSpreadMethod::Pad, WTFMove(stops));
 
     auto gradientImage = GradientImage::create(gradient, FloatSize { 1, 1 });
 
@@ -154,8 +155,9 @@ TEST(BifurcatedGraphicsContextTests, DrawGradientImage)
     GraphicsContextCG secondaryContext(secondaryCGContext.get());
     BifurcatedGraphicsContext ctx(primaryContext, secondaryContext);
 
-    auto gradient = Gradient::create(Gradient::LinearData { { 0, 0 }, { 1, 1 } }, { ColorInterpolationMethod::SRGB { }, AlphaPremultiplication::Unpremultiplied });
-    gradient->addColorStop({ 0, Color::red });
+    GradientColorStops stops;
+    stops.constructAndAppend(0, Color::red);
+    auto gradient = Gradient::create(Gradient::LinearData { { 0, 0 }, { 1, 1 } }, { ColorInterpolationMethod::SRGB { }, AlphaPremultiplication::Unpremultiplied }, GradientSpreadMethod::Pad, WTFMove(stops));
 
     auto gradientImage = GradientImage::create(gradient, FloatSize { 1, 1 });
 


### PR DESCRIPTION
#### 52c6f78b5a23873fe28b2a3a8b0cfb45e1470e57
<pre>
Gradients in operations in  DisplayList might be mutated after put to the list
<a href="https://bugs.webkit.org/show_bug.cgi?id=299072">https://bugs.webkit.org/show_bug.cgi?id=299072</a>
<a href="https://rdar.apple.com/160838934">rdar://160838934</a>

Reviewed by NOBODY (OOPS!).

Make Gradient immutable, so that it can be used from different threads
and so that DisplayList objects with gradients work.

WIP: requires a change to CanvasRenderingContext2D base to flush
fill/stroke settings on need.

* Source/WebCore/html/canvas/CanvasGradient.cpp:
(WebCore::CanvasGradient::CanvasGradient):
(WebCore::CanvasGradient::addColorStop):
* Source/WebCore/html/canvas/CanvasGradient.h:
(WebCore::CanvasGradient::gradient const):
(WebCore::CanvasGradient::gradient): Deleted.
* Source/WebCore/page/DebugPageOverlays.cpp:
(WebCore::InteractionRegionOverlay::drawRect):
* Source/WebCore/platform/DictationCaretAnimator.cpp:
(WebCore::DictationCaretAnimator::fillCaretTail const):
* Source/WebCore/platform/graphics/BifurcatedGraphicsContext.cpp:
(WebCore::BifurcatedGraphicsContext::fillRect):
* Source/WebCore/platform/graphics/BifurcatedGraphicsContext.h:
* Source/WebCore/platform/graphics/Gradient.cpp:
(WebCore::Gradient::create):
(WebCore::Gradient::adjustParametersForTiledDrawing const):
(WebCore::Gradient::hash const):
(WebCore::Gradient::adjustParametersForTiledDrawing): Deleted.
(WebCore::Gradient::addColorStop): Deleted.
* Source/WebCore/platform/graphics/Gradient.h:
(WebCore::Gradient::create):
* Source/WebCore/platform/graphics/GradientColorStops.cpp:
(WebCore::operator&lt;&lt;): Deleted.
* Source/WebCore/platform/graphics/GradientColorStops.h:
(WebCore::SortedGradientColorStops::SortedGradientColorStops):
(WebCore::SortedGradientColorStops::operator GradientColorStops):
(WebCore::mapGradientColors):
(WebCore::GradientColorStops::GradientColorStops): Deleted.
(): Deleted.
(WebCore::GradientColorStops::addColorStop): Deleted.
(WebCore::GradientColorStops::sort): Deleted.
(WebCore::GradientColorStops::sorted const): Deleted.
(WebCore::GradientColorStops::size const): Deleted.
(WebCore::GradientColorStops::isEmpty const): Deleted.
(WebCore::GradientColorStops::mapColors const): Deleted.
(WebCore::GradientColorStops::stops const): Deleted.
(WebCore::GradientColorStops::validateIsSorted const): Deleted.
* Source/WebCore/platform/graphics/GradientImage.cpp:
(WebCore::GradientImage::GradientImage):
* Source/WebCore/platform/graphics/GradientImage.h:
* Source/WebCore/platform/graphics/GraphicsContext.cpp:
(WebCore::GraphicsContext::fillRect):
* Source/WebCore/platform/graphics/GraphicsContext.h:
(WebCore::GraphicsContext::fillGradient const):
(WebCore::GraphicsContext::setFillGradient):
(WebCore::GraphicsContext::strokeGradient const):
(WebCore::GraphicsContext::setStrokeGradient):
* Source/WebCore/platform/graphics/GraphicsContextState.h:
(WebCore::GraphicsContextState::setFillGradient):
(WebCore::GraphicsContextState::setStrokeGradient):
* Source/WebCore/platform/graphics/NullGraphicsContext.h:
* Source/WebCore/platform/graphics/SourceBrush.cpp:
(WebCore::SourceBrush::gradient const):
(WebCore::SourceBrush::setGradient):
* Source/WebCore/platform/graphics/SourceBrush.h:
(WebCore::SourceBrush::setGradient):
* Source/WebCore/platform/graphics/SourceBrushLogicalGradient.h:
* Source/WebCore/platform/graphics/cairo/CairoOperationRecorder.cpp:
(WebCore::Cairo::OperationRecorder::fillRect):
* Source/WebCore/platform/graphics/cairo/CairoOperationRecorder.h:
* Source/WebCore/platform/graphics/cairo/CairoOperations.cpp:
(WebCore::Cairo::FillSource::FillSource):
* Source/WebCore/platform/graphics/cairo/CairoOperations.h:
* Source/WebCore/platform/graphics/cairo/GradientCairo.cpp:
(WebCore::createConic):
(WebCore::Gradient::createPattern const):
(WebCore::Gradient::fill const):
(WebCore::Gradient::stopsChanged): Deleted.
(WebCore::Gradient::createPattern): Deleted.
(WebCore::Gradient::fill): Deleted.
* Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.cpp:
(WebCore::GraphicsContextCairo::fillRect):
* Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.h:
* Source/WebCore/platform/graphics/cg/GradientCG.cpp:
(WebCore::Gradient::fill const):
(WebCore::Gradient::paint const):
(WebCore::Gradient::stopsChanged): Deleted.
(WebCore::Gradient::fill): Deleted.
(WebCore::Gradient::paint): Deleted.
* Source/WebCore/platform/graphics/cg/GradientRendererCG.cpp:
(WebCore::GradientRendererCG::drawLinearGradient):
(WebCore::GradientRendererCG::drawRadialGradient):
(WebCore::GradientRendererCG::drawConicGradient):
* Source/WebCore/platform/graphics/cg/GradientRendererCG.h:
* Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp:
(WebCore::GraphicsContextCG::fillRect):
* Source/WebCore/platform/graphics/cg/GraphicsContextCG.h:
* Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp:
(WebCore::DisplayList::FillRectWithGradient::FillRectWithGradient):
(WebCore::DisplayList::FillRectWithGradientAndSpaceTransform::FillRectWithGradientAndSpaceTransform):
* Source/WebCore/platform/graphics/displaylists/DisplayListItems.h:
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp:
(WebCore::DisplayList::RecorderImpl::fillRect):
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.h:
* Source/WebCore/platform/graphics/skia/GradientSkia.cpp:
(WebCore::Gradient::shader):
(WebCore::Gradient::stopsChanged): Deleted.
* Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp:
(WebCore::GraphicsContextSkia::fillRect):
* Source/WebCore/platform/graphics/skia/GraphicsContextSkia.h:
* Source/WebCore/rendering/TextBoxPainter.cpp:
(WebCore::drawWritingToolsUnderline):
* Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm:
(WebCore::checkboxRadioBackgroundGradientForVectorBasedControls):
(WebCore::RenderThemeCocoa::paintColorWellDecorationsForVectorBasedControls):
* Source/WebCore/rendering/ios/RenderThemeIOS.h:
* Source/WebCore/rendering/ios/RenderThemeIOS.mm:
(WebCore::RenderThemeIOS::checkboxRadioBackgroundGradient):
(WebCore::RenderThemeIOS::paintColorWellDecorations):
* Source/WebCore/rendering/style/StyleGradientImage.h:
* Source/WebCore/rendering/svg/RenderSVGResourceGradient.cpp:
(WebCore::RenderSVGResourceGradient::stopsByApplyingColorFilter const):
* Source/WebCore/rendering/svg/RenderSVGResourceGradient.h:
* Source/WebCore/rendering/svg/RenderSVGResourceLinearGradient.cpp:
(WebCore::RenderSVGResourceLinearGradient::createGradient):
* Source/WebCore/rendering/svg/RenderSVGResourceLinearGradient.h:
* Source/WebCore/rendering/svg/RenderSVGResourceRadialGradient.cpp:
(WebCore::RenderSVGResourceRadialGradient::createGradient):
* Source/WebCore/rendering/svg/RenderSVGResourceRadialGradient.h:
* Source/WebCore/rendering/svg/SVGTextBoxPainter.cpp:
(WebCore::SVGTextBoxPainter&lt;TextBoxPath&gt;::paintTextWithShadows):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceGradient.cpp:
(WebCore::LegacyRenderSVGResourceGradient::stopsByApplyingColorFilter):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceGradient.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceLinearGradient.cpp:
(WebCore::LegacyRenderSVGResourceLinearGradient::buildGradient const):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceLinearGradient.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceRadialGradient.cpp:
(WebCore::LegacyRenderSVGResourceRadialGradient::buildGradient const):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceRadialGradient.h:
* Source/WebCore/style/values/images/StyleGradient.cpp:
(WebCore::Style::computeStopsForDeprecatedVariants):
(WebCore::Style::computeStops):
(WebCore::Style::createPlatformGradient):
* Source/WebCore/style/values/images/StyleGradient.h:
* Source/WebCore/svg/SVGGradientElement.cpp:
(WebCore::SVGGradientElement::buildStops):
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.cpp:
(WebKit::RemoteGraphicsContext::setFillGradient):
(WebKit::RemoteGraphicsContext::setStrokeGradient):
(WebKit::RemoteGraphicsContext::fillRectWithGradient):
(WebKit::RemoteGraphicsContext::fillRectWithGradientAndSpaceTransform):
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.h:
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.messages.in:
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp:
(WebKit::RemoteRenderingBackend::cacheGradient):
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h:
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in:
* Source/WebKit/GPUProcess/graphics/RemoteResourceCache.cpp:
(WebKit::RemoteResourceCache::cacheGradient):
(WebKit::RemoteResourceCache::cachedGradient const):
* Source/WebKit/GPUProcess/graphics/RemoteResourceCache.h:
* Source/WebKit/Platform/IPC/ArgumentCoders.h:
(IPC::ArgumentCoder&lt;Ref&lt;T&gt;&gt;::decode):
* Source/WebKit/Scripts/generate-serializers.py:
(SerializedType.__init__):
(coder_encode_decode_type_declarations):
(one_argument_coder_declaration_cf):
(one_argument_coder_declaration):
(check_type_members.is):
(construct_type):
(generate_one_impl):
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp:
(IPC::ArgumentCoder&lt;CFFooRef&gt;::decode):
(IPC::ArgumentCoder&lt;CFBarRef&gt;::decode):
(IPC::ArgumentCoder&lt;WebCore::Gradient&gt;::encode):
(IPC::ArgumentCoder&lt;WebCore::Gradient&gt;::decode):
(IPC::ArgumentCoder&lt;RetainPtr&lt;CFFooRef&gt;&gt;::decode): Deleted.
(IPC::ArgumentCoder&lt;RetainPtr&lt;CFBarRef&gt;&gt;::decode): Deleted.
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h:
(IPC::ArgumentCoder&lt;RetainPtr&lt;CFFooRef&gt;&gt;::decode):
(IPC::ArgumentCoder&lt;RetainPtr&lt;CFBarRef&gt;&gt;::decode):
(IPC::ArgumentCoder&lt;RetainPtr&lt;CFStringRef&gt;&gt;::decode):
* Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp:
(WebKit::allSerializedTypes):
* Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in:
* Source/WebKit/Scripts/webkit/tests/WebKitPlatformGeneratedSerializers.cpp:
(IPC::ArgumentCoder&lt;CFStringRef&gt;::decode):
(IPC::ArgumentCoder&lt;RetainPtr&lt;CFStringRef&gt;&gt;::decode): Deleted.
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.cpp:
(WebKit::RemoteGraphicsContextProxy::fillRect):
(WebKit::RemoteGraphicsContextProxy::recordResourceUse):
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp:
(WebKit::RemoteRenderingBackendProxy::cacheGradient):
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp:
(WebKit::RemoteResourceCacheProxy::recordGradientUse):
* Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h:
* Tools/TestWebKitAPI/Tests/WebCore/cg/BifurcatedGraphicsContextTestsCG.cpp:
(TestWebKitAPI::TEST(BifurcatedGraphicsContextTests, DrawTiledGradientImage)):
(TestWebKitAPI::TEST(BifurcatedGraphicsContextTests, DrawGradientImage)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/52c6f78b5a23873fe28b2a3a8b0cfb45e1470e57

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121523 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41220 "Hash 52c6f78b for PR 50920 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31879 "Hash 52c6f78b for PR 50920 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127981 "Hash 52c6f78b for PR 50920 does not build (failure)") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73606 "Hash 52c6f78b for PR 50920 does not build (failure)") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/229e1c02-9b2f-4fb3-9aaa-c3ca17f60f1c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123399 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41922 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49799 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/127981 "Hash 52c6f78b for PR 50920 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/73606 "Hash 52c6f78b for PR 50920 does not build (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/add8dea9-c9e8-4c1e-b9e9-1d3615a07a8d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124475 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33474 "Found 60 new test failures: accessibility/ios-simulator/color-well.html accessibility/ios-simulator/suggestion-insertion-deletion-attributes.html animations/background-position.html apple-visual-effects/apple-visual-effect-automatic-vibrancy.html apple-visual-effects/apple-visual-effect-blur-material-chrome.html apple-visual-effects/apple-visual-effect-blur-material-thick-dark.html apple-visual-effects/apple-visual-effect-blur-material-thin-dark.html apple-visual-effects/apple-visual-effect-blur-material-ultra-thin-dark.html apple-visual-effects/apple-visual-effect-blur-material.html apple-visual-effects/apple-visual-effect-dark-mode.html ... (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/138/builds/31879 "Hash 52c6f78b for PR 50920 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/127981 "Hash 52c6f78b for PR 50920 does not build (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7b43b5f8-5096-4f85-b9a1-5d8b3eb734d9) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/120880 "Passed tests") | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32482 "Found 60 new test failures: imported/w3c/web-platform-tests/accname/name/comp_label.html imported/w3c/web-platform-tests/compat/webkit-background-origin-text.html imported/w3c/web-platform-tests/compat/webkit-linear-gradient-diff-unprefixed.html imported/w3c/web-platform-tests/compat/webkit-linear-gradient-line-bottom.html imported/w3c/web-platform-tests/compat/webkit-linear-gradient-line-left.html imported/w3c/web-platform-tests/compat/webkit-linear-gradient-line-right.html imported/w3c/web-platform-tests/compat/webkit-linear-gradient-line-top.html imported/w3c/web-platform-tests/css/compositing/background-blending/background-blend-mode-gradient-image.html imported/w3c/web-platform-tests/css/css-backgrounds/background-attachment-margin-root-002.html imported/w3c/web-platform-tests/css/css-backgrounds/background-gradient-interpolation-001.html ... (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/138/builds/31879 "Hash 52c6f78b for PR 50920 does not build (failure)") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71548 "Hash 52c6f78b for PR 50920 does not build (failure)") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102957 "Found 27 new API test failures: TestWebKitAPI.WritingTools.ProofreadingShowOriginalWithMultiwordSuggestions, TestWebKitAPI.WritingTools.IntelligenceTextEffectCoordinatorDelegate_RectsForProofreadingSuggestionsInRange, TestWebKitAPI.SampledPageTopColor.SolidColor, TestWebKitAPI.SampledPageTopColor.DifferentColorsWithLeftOutlierAboveMaxDifference, TestWebKitAPI.WritingTools.ShowDetailsForSuggestions, TestWebKitAPI.BifurcatedGraphicsContextTests.DrawTiledGradientImage, TestWebKitAPI.WritingTools.ProofreadingAcceptReject, TestWebKitAPI.DrawingToPDF.GradientIntoPDF, TestWebKitAPI.AdvancedPrivacyProtections.NoiseInjectionForOffscreenCanvasInSharedWorker, TestWebKitAPI.WritingTools.ProofreadingRevertWithMultiwordSuggestions ... (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/138/builds/31879 "Hash 52c6f78b for PR 50920 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130798 "Hash 52c6f78b for PR 50920 does not build (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48451 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36842 "Found 60 new test failures: accessibility/appearance-none-meter-and-progress-elements.html apple-visual-effects/apple-visual-effect-automatic-vibrancy.html apple-visual-effects/apple-visual-effect-blur-material-chrome.html apple-visual-effects/apple-visual-effect-blur-material-thick-dark.html apple-visual-effects/apple-visual-effect-blur-material-thick.html apple-visual-effects/apple-visual-effect-blur-material-thin.html apple-visual-effects/apple-visual-effect-blur-material-ultra-thin.html apple-visual-effects/apple-visual-effect-dark-mode.html apple-visual-effects/apple-visual-effect-vibrancy-effects.html apple-visual-effects/backdrop-filter-with-apple-visual-effect.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/130798 "Hash 52c6f78b for PR 50920 does not build (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48819 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/138/builds/31879 "Hash 52c6f78b for PR 50920 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/130798 "Hash 52c6f78b for PR 50920 does not build (failure)") | | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46207 "Found 2 new test failures: interaction-region/content-hint.html interaction-region/display-table.html (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/138/builds/31879 "Hash 52c6f78b for PR 50920 does not build (failure)") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45147 "Hash 52c6f78b for PR 50920 does not build (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48310 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54022 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47781 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51127 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49463 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->