### PR TITLE
Some page elements have a blue flicker (caused by @starting-style)

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/parent-after-change-style-pseudo-element-flicker-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/parent-after-change-style-pseudo-element-flicker-expected.html
@@ -1,0 +1,20 @@
+<style>
+div {
+    position: absolute;
+    width: 100px;
+    height: 100px;
+}
+
+.child:after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background-color: black;
+}
+
+</style>
+
+<div class="parent">
+    <div class="child"></div>
+</div>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/parent-after-change-style-pseudo-element-flicker-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/parent-after-change-style-pseudo-element-flicker-ref.html
@@ -1,0 +1,20 @@
+<style>
+div {
+    position: absolute;
+    width: 100px;
+    height: 100px;
+}
+
+.child:after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background-color: black;
+}
+
+</style>
+
+<div class="parent">
+    <div class="child"></div>
+</div>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/parent-after-change-style-pseudo-element-flicker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/parent-after-change-style-pseudo-element-flicker.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<title>Test that resolving after-change style does not cause flicker in descendant pseudo-elements</title>
+<link rel="match" href="parent-after-change-style-pseudo-element-flicker-ref.html">
+
+<style>
+div {
+    position: absolute;
+    width: 100px;
+    height: 100px;
+}
+
+@keyframes animation {
+    from, to { margin-left: 0 }
+}
+
+@starting-style {
+    .parent:after { }
+}
+
+.parent {
+    animation: animation 10000s;
+}
+
+.child:after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background-color: black;
+    animation: animation 10000s;
+}
+
+</style>
+<body onload="test()">
+<div class="parent">
+    <div class="child"></div>
+</div>
+<script>
+async function test() {
+    await new Promise(requestAnimationFrame);
+    await new Promise(requestAnimationFrame);
+    await new Promise(requestAnimationFrame);
+    await new Promise(requestAnimationFrame);
+}
+</script>

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -914,8 +914,9 @@ std::unique_ptr<RenderStyle> TreeResolver::resolveAgainInDifferentContext(const 
     auto newStyle = RenderStyle::createPtr();
     newStyle->inheritFrom(parentStyle);
 
-    if (styleable.pseudoElementIdentifier)
-        newStyle->setPseudoElementType(styleable.pseudoElementIdentifier->pseudoId);
+    newStyle->setPseudoElementType(resolvedStyle.style->pseudoElementType());
+    newStyle->setPseudoElementNameArgument(resolvedStyle.style->pseudoElementNameArgument());
+    newStyle->copyPseudoElementBitsFrom(*resolvedStyle.style);
 
     auto builderContext = BuilderContext {
         m_document.get(),


### PR DESCRIPTION
#### 27e097a3c04dc90b851283cd526f59f150a825d4
<pre>
Some page elements have a blue flicker (caused by @starting-style)
<a href="https://bugs.webkit.org/show_bug.cgi?id=299073">https://bugs.webkit.org/show_bug.cgi?id=299073</a>
<a href="https://rdar.apple.com/154228431">rdar://154228431</a>

Reviewed by Alan Baradlay.

Seen in <a href="https://merlyndesignworks.co.uk/">https://merlyndesignworks.co.uk/</a>

Tests: imported/w3c/web-platform-tests/css/css-animations/parent-after-change-style-pseudo-element-flicker-ref.html
       imported/w3c/web-platform-tests/css/css-animations/parent-after-change-style-pseudo-element-flicker.html
* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/parent-after-change-style-pseudo-element-flicker-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/parent-after-change-style-pseudo-element-flicker-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/parent-after-change-style-pseudo-element-flicker.html: Added.
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::resolveAgainInDifferentContext):

We lose the pseudo-element bits when resolving after-change style via TreeResolver::resolveAfterChangeStyleForNonAnimated.

Fix by transferring the bits over to the new style when doing another round of resolving.
They are set by selector matching but here we are doing just style building.

As a drive-by fix, also transfer the pseudo-element name argument.

Canonical link: <a href="https://commits.webkit.org/300169@main">https://commits.webkit.org/300169@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5fb075ad3e87f26a0e4b8d6444224fc1bc0184c5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121531 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41228 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31887 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127989 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73614 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123407 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41930 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49807 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92304 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61409 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124483 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33479 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108861 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72981 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32487 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27029 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71557 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102962 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27202 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130806 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48459 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36849 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100894 "Passed tests") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48827 "Failed to checkout and rebase branch from PR 50921") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105087 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100800 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25563 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24297 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45155 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48318 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54030 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47789 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51135 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49471 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->