### PR TITLE
Allow VideoLayerRemote to work with AudioVideoRendererRemote

### DIFF
--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
@@ -1089,7 +1089,7 @@ PlatformLayer* MediaPlayerPrivateRemote::platformLayer() const
 #if PLATFORM(COCOA)
     if (!m_videoLayer && m_layerHostingContext.contextID) {
         auto expandedVideoLayerSize = expandedIntSize(videoLayerSize());
-        m_videoLayer = createVideoLayerRemote(const_cast<MediaPlayerPrivateRemote*>(this), m_layerHostingContext.contextID, m_videoFullscreenGravity, expandedVideoLayerSize);
+        m_videoLayer = createVideoLayerRemote(const_cast<MediaPlayerPrivateRemote&>(*this), m_layerHostingContext.contextID, m_videoFullscreenGravity, expandedVideoLayerSize);
         m_videoLayerManager->setVideoLayer(m_videoLayer.get(), expandedVideoLayerSize);
     }
     return m_videoLayerManager->videoInlineLayer();
@@ -1570,16 +1570,14 @@ void MediaPlayerPrivateRemote::notifyActiveSourceBuffersChanged()
     connection().send(Messages::RemoteMediaPlayerProxy::NotifyActiveSourceBuffersChanged(), m_id);
 }
 
-#if PLATFORM(COCOA)
 bool MediaPlayerPrivateRemote::inVideoFullscreenOrPictureInPicture() const
 {
-#if ENABLE(VIDEO_PRESENTATION_MODE)
+#if PLATFORM(COCOA) && ENABLE(VIDEO_PRESENTATION_MODE)
     return !!m_videoLayerManager->videoFullscreenLayer();
 #else
     return false;
 #endif
 }
-#endif
 
 void MediaPlayerPrivateRemote::applicationWillResignActive()
 {

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
@@ -37,6 +37,7 @@
 #include "RemoteVideoFrameObjectHeapProxy.h"
 #include "RemoteVideoFrameProxy.h"
 #include "TextTrackPrivateRemote.h"
+#include "VideoLayerRemote.h"
 #include "VideoTrackPrivateRemote.h"
 #include <WebCore/MediaPlayerPrivate.h>
 #include <WebCore/PlatformLayer.h>
@@ -88,12 +89,15 @@ struct MediaTimeUpdateData {
 
 class MediaPlayerPrivateRemote final
     : public WebCore::MediaPlayerPrivateInterface
+    , public VideoLayerRemoteParent
     , public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<MediaPlayerPrivateRemote, WTF::DestructionThread::Main>
 #if !RELEASE_LOG_DISABLED
     , private LoggerHelper
 #endif
 {
 public:
+    WTF_ABSTRACT_THREAD_SAFE_REF_COUNTED_AND_CAN_MAKE_WEAK_PTR_IMPL;
+
     static Ref<MediaPlayerPrivateRemote> create(WebCore::MediaPlayer* player, WebCore::MediaPlayerEnums::MediaEngineIdentifier remoteEngineIdentifier, WebCore::MediaPlayerIdentifier identifier, RemoteMediaPlayerManager& manager)
     {
         return adoptRef(*new MediaPlayerPrivateRemote(player, remoteEngineIdentifier, identifier, manager));
@@ -103,9 +107,6 @@ public:
     ~MediaPlayerPrivateRemote();
 
     constexpr WebCore::MediaPlayerType mediaPlayerType() const final { return WebCore::MediaPlayerType::Remote; }
-
-    void ref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::ref(); }
-    void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref(); }
 
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&);
 
@@ -179,9 +180,7 @@ public:
 
     void activeSourceBuffersChanged();
 
-#if PLATFORM(COCOA)
-    bool inVideoFullscreenOrPictureInPicture() const;
-#endif
+    bool inVideoFullscreenOrPictureInPicture() const final;
 
 #if ENABLE(ENCRYPTED_MEDIA)
     void waitingForKeyChanged(bool);

--- a/Source/WebKit/WebProcess/GPU/media/VideoLayerRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/VideoLayerRemote.h
@@ -31,12 +31,26 @@
 #include <WebCore/IntSize.h>
 #include <WebCore/MediaPlayerEnums.h>
 #include <WebCore/PlatformLayer.h>
+#include <wtf/AbstractThreadSafeRefCountedAndCanMakeWeakPtr.h>
+
+#if PLATFORM(COCOA)
+namespace WTF {
+struct MachSendRightAnnotated;
+}
+#endif
 
 namespace WebKit {
 
-class MediaPlayerPrivateRemote;
+class VideoLayerRemoteParent : public AbstractThreadSafeRefCountedAndCanMakeWeakPtr {
+public:
+    virtual bool inVideoFullscreenOrPictureInPicture() const = 0;
+    virtual WebCore::FloatSize naturalSize() const = 0;
+#if PLATFORM(COCOA)
+    virtual void setVideoLayerSizeFenced(const WebCore::FloatSize&, WTF::MachSendRightAnnotated&&) = 0;
+#endif
+};
 
-PlatformLayerContainer createVideoLayerRemote(MediaPlayerPrivateRemote*, LayerHostingContextID, WebCore::MediaPlayerEnums::VideoGravity, WebCore::IntSize);
+PlatformLayerContainer createVideoLayerRemote(VideoLayerRemoteParent&, LayerHostingContextID, WebCore::MediaPlayerEnums::VideoGravity, WebCore::IntSize);
 
 } // namespace WebKit
 

--- a/Source/WebKit/WebProcess/GPU/media/cocoa/VideoLayerRemoteCocoa.h
+++ b/Source/WebKit/WebProcess/GPU/media/cocoa/VideoLayerRemoteCocoa.h
@@ -25,15 +25,16 @@
 
 #if ENABLE(GPU_PROCESS) && PLATFORM(COCOA)
 
-#import <QuartzCore/CALayer.h>
-#import <WebCore/MediaPlayerEnums.h>
+#include <QuartzCore/CALayer.h>
+#include <WebCore/FloatSize.h>
+#include <WebCore/MediaPlayerEnums.h>
 
 namespace WebKit {
-class MediaPlayerPrivateRemote;
+class VideoLayerRemoteParent;
 }
 
 @interface WKVideoLayerRemote : CALayer
-@property (nonatomic) WebKit::MediaPlayerPrivateRemote* mediaPlayerPrivateRemote;
+@property (nonatomic) WebKit::VideoLayerRemoteParent* parent;
 @property (nonatomic) CGRect videoLayerFrame;
 @property (nonatomic) WebCore::MediaPlayerEnums::VideoGravity videoGravity;
 @end

--- a/Source/WebKit/WebProcess/GPU/media/gstreamer/VideoLayerRemoteGStreamer.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/gstreamer/VideoLayerRemoteGStreamer.cpp
@@ -35,7 +35,7 @@
 
 namespace WebKit {
 
-PlatformLayerContainer createVideoLayerRemote(MediaPlayerPrivateRemote*, LayerHostingContextID, WebCore::MediaPlayerEnums::VideoGravity, WebCore::IntSize)
+PlatformLayerContainer createVideoLayerRemote(VideoLayerRemoteParent&, LayerHostingContextID, WebCore::MediaPlayerEnums::VideoGravity, WebCore::IntSize)
 {
     notImplemented();
     return nullptr;

--- a/Source/WebKit/WebProcess/GPU/media/playstation/VideoLayerRemotePlayStation.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/playstation/VideoLayerRemotePlayStation.cpp
@@ -32,7 +32,7 @@
 
 namespace WebKit {
 
-PlatformLayerContainer createVideoLayerRemote(MediaPlayerPrivateRemote*, LayerHostingContextID, WebCore::MediaPlayerEnums::VideoGravity, WebCore::IntSize)
+PlatformLayerContainer createVideoLayerRemote(VideoLayerRemoteParent&, LayerHostingContextID, WebCore::MediaPlayerEnums::VideoGravity, WebCore::IntSize)
 {
     notImplemented();
     return nullptr;

--- a/Source/WebKit/WebProcess/GPU/media/win/VideoLayerRemoteWin.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/win/VideoLayerRemoteWin.cpp
@@ -33,7 +33,7 @@
 
 namespace WebKit {
 
-PlatformLayerContainer createVideoLayerRemote(MediaPlayerPrivateRemote*, LayerHostingContextID, WebCore::MediaPlayerEnums::VideoGravity, WebCore::IntSize)
+PlatformLayerContainer createVideoLayerRemote(VideoLayerRemoteParent&, LayerHostingContextID, WebCore::MediaPlayerEnums::VideoGravity, WebCore::IntSize)
 {
     notImplemented();
     return nullptr;


### PR DESCRIPTION
#### 8159ad29772e53e827176bc5064eb385e65e1655
<pre>
Allow VideoLayerRemote to work with AudioVideoRendererRemote
<a href="https://bugs.webkit.org/show_bug.cgi?id=299078">https://bugs.webkit.org/show_bug.cgi?id=299078</a>
<a href="https://rdar.apple.com/160844908">rdar://160844908</a>

Reviewed by Youenn Fablet.

Make the VideoLayerRemote take a VideoLayerRemoteParent instead of a
MediaPlayerPrivateRemote.
In a follow-up change we will introduce an AudioVideoRendererRemote which
will be a VideoLayerRemoteParent too.

No change in behaviour.

* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h:
* Source/WebKit/WebProcess/GPU/media/VideoLayerRemote.h:
* Source/WebKit/WebProcess/GPU/media/cocoa/VideoLayerRemoteCocoa.h:
* Source/WebKit/WebProcess/GPU/media/cocoa/VideoLayerRemoteCocoa.mm:
(-[WKVideoLayerRemote parent]):
(-[WKVideoLayerRemote setParent:]):
(-[WKVideoLayerRemote resizePreservingGravity]):
(-[WKVideoLayerRemote layoutSublayers]):
(-[WKVideoLayerRemote resolveBounds]):
(WebKit::createVideoLayerRemote):
(-[WKVideoLayerRemote mediaPlayerPrivateRemote]): Deleted.
(-[WKVideoLayerRemote setMediaPlayerPrivateRemote:]): Deleted.
* Source/WebKit/WebProcess/GPU/media/gstreamer/VideoLayerRemoteGStreamer.cpp:
(WebKit::createVideoLayerRemote):
* Source/WebKit/WebProcess/GPU/media/playstation/VideoLayerRemotePlayStation.cpp:
(WebKit::createVideoLayerRemote):
* Source/WebKit/WebProcess/GPU/media/win/VideoLayerRemoteWin.cpp:
(WebKit::createVideoLayerRemote):

Canonical link: <a href="https://commits.webkit.org/300151@main">https://commits.webkit.org/300151@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7dbcb1865f9db935db9a5b97aee68d4dcf1de619

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121536 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41233 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31892 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127994 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73619 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ddf36c15-a3d0-4123-b61a-bb775b677be1) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41935 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49812 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92308 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/61412 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/dcfb07d3-af7e-4e62-a9fd-82f88db1f0d9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124488 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33487 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108864 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72984 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e3085865-b99b-432f-985e-45af6ac1099f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32495 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71562 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/102970 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27205 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130811 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48464 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36854 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100898 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48832 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105090 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100804 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25554 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46218 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24300 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45160 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48323 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54035 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47794 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51140 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49476 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->