### PR TITLE
WebCore: fix compilation if ENABLE(VIDEO) is not set

### DIFF
--- a/Source/WebCore/dom/DocumentFullscreen.cpp
+++ b/Source/WebCore/dom/DocumentFullscreen.cpp
@@ -160,6 +160,7 @@ void DocumentFullscreen::requestFullscreen(Ref<Element>&& element, FullscreenChe
             return;
         }
 
+#if ENABLE(VIDEO)
         Ref videoList = maybeVideoList.releaseReturnValue();
 
         RefPtr<HTMLVideoElement> largestVideo = nullptr;
@@ -182,6 +183,7 @@ void DocumentFullscreen::requestFullscreen(Ref<Element>&& element, FullscreenChe
         }
         if (largestVideo)
             largestVideo->webkitRequestFullscreen();
+#endif
 
         completionHandler({ });
         return;

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
@@ -3170,6 +3170,7 @@ Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::setAllowEditingUserA
     return { };
 }
 
+#if ENABLE(VIDEO)
 static Inspector::Protocol::DOM::VideoProjectionMetadataKind videoProjectionMetadataKind(VideoProjectionMetadataKind kind)
 {
     switch (kind) {
@@ -3191,6 +3192,7 @@ static Inspector::Protocol::DOM::VideoProjectionMetadataKind videoProjectionMeta
     ASSERT_NOT_REACHED();
     return Inspector::Protocol::DOM::VideoProjectionMetadataKind::Unknown;
 }
+#endif
 
 Inspector::Protocol::ErrorStringOr<Ref<Inspector::Protocol::DOM::MediaStats>> InspectorDOMAgent::getMediaStats(Inspector::Protocol::DOM::NodeId nodeId)
 {

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -3121,9 +3121,12 @@ void Page::setShouldSuppressHDR(bool shouldSuppressHDR)
         return;
 
     m_shouldSuppressHDR = shouldSuppressHDR;
+
+#if ENABLE(VIDEO)
     forEachDocument([](auto& document) {
         document.shouldSuppressHDRDidChange();
     });
+#endif
 }
 
 #if ENABLE(MEDIA_STREAM)

--- a/Source/WebCore/platform/MediaStrategy.h
+++ b/Source/WebCore/platform/MediaStrategy.h
@@ -74,9 +74,11 @@ protected:
     bool m_mockMediaSourceEnabled { false };
 };
 
+#if ENABLE(VIDEO)
 inline void MediaStrategy::nativeImageFromVideoFrame(const VideoFrame&, CompletionHandler<void(std::optional<RefPtr<NativeImage>>&&)>&& completionHandler)
 {
     completionHandler(std::nullopt);
 }
+#endif
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderReplaced.cpp
+++ b/Source/WebCore/rendering/RenderReplaced.cpp
@@ -128,8 +128,12 @@ static bool shouldRepaintOnSizeChange(RenderReplaced& renderer)
 {
     if (is<RenderHTMLCanvas>(renderer))
         return true;
+
+#if ENABLE(VIDEO)
     if (auto* renderImage = dynamicDowncast<RenderImage>(renderer); renderImage && !is<RenderMedia>(*renderImage) && !renderImage->isShowingMissingOrImageError())
         return true;
+#endif
+
     return false;
 }
 


### PR DESCRIPTION
#### f0d8991bbfe39c094e6e8662db8f7da51cc27bc7
<pre>
WebCore: fix compilation if ENABLE(VIDEO) is not set

<a href="https://bugs.webkit.org/show_bug.cgi?id=299089">https://bugs.webkit.org/show_bug.cgi?id=299089</a>

Reviewed by Michael Catanzaro.

Source/WebCore/dom/DocumentFullscreen.cpp: In member function ‘void WebCore::DocumentFullscreen::requestFullscreen(WTF::Ref&lt;WebCore::Element&gt;&amp;&amp;, FullscreenCheckType, WTF::CompletionHandler&lt;void(WebCore::ExceptionOr&lt;void&gt;)&gt;&amp;&amp;, WebCore::MediaPlayerEnums::VideoFullscreenMode)’:
Source/WebCore/dom/DocumentFullscreen.cpp:156:40: error: invalid use of incomplete type ‘class WebCore::HTMLVideoElement’
  156 |             CheckedPtr renderer = video-&gt;renderer();
      |                                        ^~

Source/WebCore/inspector/agents/InspectorDOMAgent.cpp:3171:90: error: ‘VideoProjectionMetadataKind’ was not declared in this scope; did you mean ‘Inspector::Protocol::DOM::VideoProjectionMetadataKind’?
 3171 | static Inspector::Protocol::DOM::VideoProjectionMetadataKind videoProjectionMetadataKind(VideoProjectionMetadataKind kind)
      |                                                                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                                                                          Inspector::Protocol::DOM::VideoProjectionMetadataKind

Source/WebCore/platform/MediaStrategy.h:73:13: error: no declaration matches ‘void WebCore::MediaStrategy::nativeImageFromVideoFrame(const WebCore::VideoFrame&amp;, WTF::CompletionHandler&lt;void(std::optional&lt;WTF::RefPtr&lt;WebCore::NativeImage&gt; &gt;&amp;&amp;)&gt;&amp;&amp;)’
   73 | inline void MediaStrategy::nativeImageFromVideoFrame(const VideoFrame&amp;, CompletionHandler&lt;void(std::optional&lt;RefPtr&lt;NativeImage&gt;&gt;&amp;&amp;)&gt;&amp;&amp; completionHandler)
      |             ^~~~~~~~~~~~~

Source/WebCore/page/Page.cpp:3105:18: error: ‘class WebCore::Document’ has no member named ‘shouldSuppressHDRDidChange’
 3105 |         document.shouldSuppressHDRDidChange();
      |         ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~

Source/WebCore/rendering/RenderReplaced.cpp: In function ‘bool WebCore::shouldRepaintOnSizeChange(RenderReplaced&amp;)’:
Source/WebCore/rendering/RenderReplaced.cpp:123:88: error: ‘RenderMedia’ was not declared in this scope; did you mean ‘RenderMeter’?
  123 |     if (auto* renderImage = dynamicDowncast&lt;RenderImage&gt;(renderer); renderImage &amp;&amp; !is&lt;RenderMedia&gt;(*renderImage) &amp;&amp; !renderImage-&gt;isShowingMissingOrImageError())
      |                                                                                        ^~~~~~~~~~~
      |                                                                                        RenderMeter

Signed-off-by: Thomas Devoogdt &lt;thomas.devoogdt@barco.com&gt;
Canonical link: <a href="https://commits.webkit.org/300185@main">https://commits.webkit.org/300185@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/48c8ba4c267b9b9f9a79c115a3b4f9a5e7e22d7a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121618 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41315 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31974 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128115 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/73708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123494 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42031 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49906 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/92405 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/73708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124570 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33548 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108930 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73067 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/32562 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27099 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71651 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/103044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27274 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130919 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/48552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/36942 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/100980 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/48924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105147 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100869 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25580 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24364 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/45253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48409 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54129 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/47880 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/51229 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/49563 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->