### PR TITLE
[Site Isolation] Minor MediaSessionManager restructuring

### DIFF
--- a/Source/WebCore/Modules/audiosession/DOMAudioSession.cpp
+++ b/Source/WebCore/Modules/audiosession/DOMAudioSession.cpp
@@ -103,8 +103,10 @@ ExceptionOr<void> DOMAudioSession::setType(Type type)
     auto categoryOverride = fromDOMAudioSessionType(type);
     AudioSession::singleton().setCategoryOverride(categoryOverride);
 
-    if (categoryOverride == AudioSessionCategory::None)
-        Ref { page->mediaSessionManager() }->updateAudioSessionCategoryIfNecessary();
+    if (categoryOverride == AudioSessionCategory::None) {
+        if (RefPtr manager = page->mediaSessionManager())
+            manager->updateAudioSessionCategoryIfNecessary();
+    }
 
     return { };
 }

--- a/Source/WebCore/Modules/mediasession/MediaSession.cpp
+++ b/Source/WebCore/Modules/mediasession/MediaSession.cpp
@@ -416,7 +416,7 @@ RefPtr<MediaSessionManagerInterface> MediaSession::sessionManager() const
     if (!page)
         return nullptr;
 
-    return &page->mediaSessionManager();
+    return page->mediaSessionManager();
 }
 
 void MediaSession::metadataUpdated(const MediaMetadata& metadata)

--- a/Source/WebCore/Modules/mediastream/MediaStream.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaStream.cpp
@@ -424,7 +424,7 @@ RefPtr<MediaSessionManagerInterface> MediaStream::mediaSessionManager() const
     if (!page)
         return nullptr;
 
-    return &page->mediaSessionManager();
+    return page->mediaSessionManager();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
@@ -671,7 +671,7 @@ RefPtr<MediaSessionManagerInterface> MediaStreamTrack::mediaSessionManager() con
     if (!page)
         return nullptr;
 
-    return &page->mediaSessionManager();
+    return page->mediaSessionManager();
 }
 
 ScriptExecutionContext* MediaStreamTrack::scriptExecutionContext() const

--- a/Source/WebCore/Modules/webaudio/BaseAudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/BaseAudioContext.cpp
@@ -996,7 +996,7 @@ RefPtr<MediaSessionManagerInterface> BaseAudioContext::mediaSessionManager() con
     if (!page)
         return nullptr;
 
-    return &page->mediaSessionManager();
+    return page->mediaSessionManager();
 }
 
 

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -10054,7 +10054,7 @@ bool HTMLMediaElement::limitedMatroskaSupportEnabled() const
 RefPtr<MediaSessionManagerInterface> HTMLMediaElement::sessionManager() const
 {
     if (RefPtr page = document().page())
-        return &page->mediaSessionManager();
+        return page->mediaSessionManager();
 
     return nullptr;
 }

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -466,6 +466,7 @@ public:
 
     WEBCORE_EXPORT static void forEachPage(NOESCAPE const Function<void(Page&)>&);
     WEBCORE_EXPORT static unsigned nonUtilityPageCount();
+    static Page* fromPageIdentifier(PageIdentifier);
 
     unsigned subframeCount() const;
 
@@ -1355,10 +1356,9 @@ public:
 
     WEBCORE_EXPORT RefPtr<HTMLMediaElement> bestMediaElementForRemoteControls(PlatformMediaSessionPlaybackControlsPurpose, Document*);
 
-    WEBCORE_EXPORT MediaSessionManagerInterface& mediaSessionManager();
-    WEBCORE_EXPORT Ref<MediaSessionManagerInterface> protectedMediaSessionManager();
+    WEBCORE_EXPORT RefPtr<MediaSessionManagerInterface> mediaSessionManager();
     WEBCORE_EXPORT MediaSessionManagerInterface* mediaSessionManagerIfExists() const;
-    WEBCORE_EXPORT static MediaSessionManagerInterface* mediaSessionManagerForPageIdentifier(PageIdentifier);
+    WEBCORE_EXPORT static RefPtr<MediaSessionManagerInterface> mediaSessionManagerForPageIdentifier(PageIdentifier);
 
 #if ENABLE(MODEL_ELEMENT)
     bool shouldDisableModelLoadDelaysForTesting() const { return m_modelLoadDelaysDisabledForTesting; }
@@ -1837,7 +1837,7 @@ private:
     String m_presentingApplicationBundleIdentifier;
 #endif
 
-    using MediaSessionManagerFactory = Function<RefPtr<MediaSessionManagerInterface> (std::optional<PageIdentifier>)>;
+    using MediaSessionManagerFactory = Function<RefPtr<MediaSessionManagerInterface> (PageIdentifier)>;
     std::optional<MediaSessionManagerFactory> m_mediaSessionManagerFactory;
     RefPtr<MediaSessionManagerInterface> m_mediaSessionManager;
 

--- a/Source/WebCore/page/PageConfiguration.h
+++ b/Source/WebCore/page/PageConfiguration.h
@@ -99,7 +99,7 @@ class WebRTCProvider;
 
 enum class SandboxFlag : uint16_t;
 using SandboxFlags = OptionSet<SandboxFlag>;
-using MediaSessionManagerFactory = Function<RefPtr<MediaSessionManagerInterface> (std::optional<PageIdentifier>)>;
+using MediaSessionManagerFactory = Function<RefPtr<MediaSessionManagerInterface> (PageIdentifier)>;
 
 class PageConfiguration {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(PageConfiguration, WEBCORE_EXPORT);

--- a/Source/WebCore/page/cocoa/PageCocoa.mm
+++ b/Source/WebCore/page/cocoa/PageCocoa.mm
@@ -136,7 +136,8 @@ const String& Page::presentingApplicationBundleIdentifier() const
 void Page::setPresentingApplicationBundleIdentifier(String&& bundleIdentifier)
 {
     m_presentingApplicationBundleIdentifier = WTFMove(bundleIdentifier);
-    mediaSessionManager().updateNowPlayingInfoIfNecessary();
+    if (RefPtr manager = mediaSessionManager())
+        manager->updateNowPlayingInfoIfNecessary();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/audio/MediaSessionManagerInterface.cpp
+++ b/Source/WebCore/platform/audio/MediaSessionManagerInterface.cpp
@@ -44,9 +44,10 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(MediaSessionManagerInterface);
 
-MediaSessionManagerInterface::MediaSessionManagerInterface()
+MediaSessionManagerInterface::MediaSessionManagerInterface(PageIdentifier pageIdentifier)
+    : m_pageIdentifier(pageIdentifier)
 #if !RELEASE_LOG_DISABLED
-    : m_stateLogTimer(makeUniqueRef<Timer>(*this, &MediaSessionManagerInterface::dumpSessionStates))
+    , m_stateLogTimer(makeUniqueRef<Timer>(*this, &MediaSessionManagerInterface::dumpSessionStates))
     , m_logger(AggregateLogger::create(this))
 #endif
 {
@@ -577,11 +578,11 @@ int MediaSessionManagerInterface::countActiveAudioCaptureSources()
 void MediaSessionManagerInterface::processDidReceiveRemoteControlCommand(PlatformMediaSession::RemoteControlCommandType command, const PlatformMediaSession::RemoteCommandArgument& argument)
 {
 #if ENABLE(VIDEO) || ENABLE(audio)
-    auto activeSession = firstSessionMatching([](auto& session) {
+    WeakPtr weakActiveSession = firstSessionMatching([](auto& session) {
         return session.canReceiveRemoteControlCommands();
     });
 
-    if (activeSession)
+    if (RefPtr activeSession = weakActiveSession.get())
         activeSession->didReceiveRemoteControlCommand(command, argument);
 #else
     UNUSED_PARAM(command);

--- a/Source/WebCore/platform/audio/MediaSessionManagerInterface.h
+++ b/Source/WebCore/platform/audio/MediaSessionManagerInterface.h
@@ -29,6 +29,7 @@
 #include <WebCore/MediaUniqueIdentifier.h>
 #include <WebCore/NowPlayingInfo.h>
 #include <WebCore/NowPlayingMetadataObserver.h>
+#include <WebCore/PageIdentifier.h>
 #include <WebCore/PlatformMediaSessionTypes.h>
 #include <wtf/AggregateLogger.h>
 #include <wtf/CancellableTask.h>
@@ -167,7 +168,7 @@ public:
     virtual void resetSessionState() { };
 
 protected:
-    MediaSessionManagerInterface();
+    MediaSessionManagerInterface(PageIdentifier);
 
     virtual WeakListHashSet<PlatformMediaSessionInterface>& sessions() const = 0;
     virtual Vector<WeakPtr<PlatformMediaSessionInterface>> copySessionsToVector() const = 0;
@@ -192,6 +193,8 @@ protected:
 
     void scheduleUpdateSessionState();
     virtual void updateSessionState() { }
+
+    PageIdentifier pageIdentifier() const { return m_pageIdentifier; }
 
 #if !RELEASE_LOG_DISABLED
     void scheduleStateLog();
@@ -219,6 +222,7 @@ private:
     WeakHashSet<NowPlayingMetadataObserver> m_nowPlayingMetadataObservers;
     TaskCancellationGroup m_taskGroup;
 
+    PageIdentifier m_pageIdentifier;
 #if !RELEASE_LOG_DISABLED
     UniqueRef<Timer> m_stateLogTimer;
     const Ref<AggregateLogger> m_logger;

--- a/Source/WebCore/platform/audio/PlatformMediaSession.cpp
+++ b/Source/WebCore/platform/audio/PlatformMediaSession.cpp
@@ -409,7 +409,6 @@ void PlatformMediaSession::setActiveNowPlayingSession(bool isActiveNowPlayingSes
         return;
 
     m_isActiveNowPlayingSession = isActiveNowPlayingSession;
-    client().isActiveNowPlayingSessionChanged();
 }
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebCore/platform/audio/PlatformMediaSessionManager.cpp
+++ b/Source/WebCore/platform/audio/PlatformMediaSessionManager.cpp
@@ -55,14 +55,14 @@ namespace WebCore {
 WTF_MAKE_TZONE_ALLOCATED_IMPL(PlatformMediaSessionManager);
 
 #if !PLATFORM(COCOA) && (!USE(GLIB) || !ENABLE(MEDIA_SESSION))
-RefPtr<PlatformMediaSessionManager> PlatformMediaSessionManager::create(std::optional<PageIdentifier>)
+RefPtr<PlatformMediaSessionManager> PlatformMediaSessionManager::create(PageIdentifier pageIdentifier)
 {
-    return adoptRef(new PlatformMediaSessionManager);
+    return adoptRef(new PlatformMediaSessionManager(pageIdentifier));
 }
 #endif // !PLATFORM(COCOA) && (!USE(GLIB) || !ENABLE(MEDIA_SESSION))
 
-PlatformMediaSessionManager::PlatformMediaSessionManager()
-    : MediaSessionManagerInterface()
+PlatformMediaSessionManager::PlatformMediaSessionManager(PageIdentifier pageIdentifier)
+    : MediaSessionManagerInterface(pageIdentifier)
 {
 }
 

--- a/Source/WebCore/platform/audio/PlatformMediaSessionManager.h
+++ b/Source/WebCore/platform/audio/PlatformMediaSessionManager.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include <WebCore/MediaSessionManagerInterface.h>
-#include <WebCore/PageIdentifier.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakListHashSet.h>
 
@@ -40,12 +39,12 @@ class PlatformMediaSessionManager : public MediaSessionManagerInterface
 {
     WTF_MAKE_TZONE_ALLOCATED(PlatformMediaSessionManager);
 public:
-    static RefPtr<PlatformMediaSessionManager> create(std::optional<PageIdentifier>);
+    static RefPtr<PlatformMediaSessionManager> create(PageIdentifier);
 
     void forEachMatchingSession(NOESCAPE const Function<bool(const PlatformMediaSessionInterface&)>& predicate, NOESCAPE const Function<void(PlatformMediaSessionInterface&)>& matchingCallback) final;
 
 protected:
-    PlatformMediaSessionManager();
+    PlatformMediaSessionManager(PageIdentifier);
 
     void addSession(PlatformMediaSessionInterface&) override;
     void removeSession(PlatformMediaSessionInterface&) override;

--- a/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.h
+++ b/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.h
@@ -48,7 +48,7 @@ class MediaSessionManagerCocoa
     , private AudioHardwareListener::Client {
     WTF_MAKE_TZONE_ALLOCATED(MediaSessionManagerCocoa);
 public:
-    MediaSessionManagerCocoa();
+    MediaSessionManagerCocoa(PageIdentifier);
     
     void updateSessionState() final;
     void beginInterruption(PlatformMediaSession::InterruptionType) final;

--- a/Source/WebCore/platform/audio/glib/MediaSessionManagerGLib.cpp
+++ b/Source/WebCore/platform/audio/glib/MediaSessionManagerGLib.cpp
@@ -115,7 +115,7 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(MediaSessionManagerGLib);
 
-RefPtr<PlatformMediaSessionManager> PlatformMediaSessionManager::create(std::optional<PageIdentifier>)
+RefPtr<PlatformMediaSessionManager> PlatformMediaSessionManager::create(PageIdentifier pageIdentifier)
 {
     GUniqueOutPtr<GError> error;
     auto mprisInterface = adoptGRef(g_dbus_node_info_new_for_xml(s_mprisInterface, &error.outPtr()));
@@ -123,11 +123,12 @@ RefPtr<PlatformMediaSessionManager> PlatformMediaSessionManager::create(std::opt
         g_warning("Failed at parsing XML Interface definition: %s", error->message);
         return nullptr;
     }
-    return adoptRef(new MediaSessionManagerGLib(WTFMove(mprisInterface)));
+    return adoptRef(new MediaSessionManagerGLib(WTFMove(mprisInterface), pageIdentifier));
 }
 
-MediaSessionManagerGLib::MediaSessionManagerGLib(GRefPtr<GDBusNodeInfo>&& mprisInterface)
-    : m_mprisInterface(WTFMove(mprisInterface))
+MediaSessionManagerGLib::MediaSessionManagerGLib(GRefPtr<GDBusNodeInfo>&& mprisInterface, PageIdentifier pageIdentifier)
+    : PlatformMediaSessionManager(pageIdentifier)
+    , m_mprisInterface(WTFMove(mprisInterface))
     , m_nowPlayingManager(platformStrategies()->mediaStrategy()->createNowPlayingManager())
 {
 }

--- a/Source/WebCore/platform/audio/glib/MediaSessionManagerGLib.h
+++ b/Source/WebCore/platform/audio/glib/MediaSessionManagerGLib.h
@@ -36,7 +36,7 @@ class MediaSessionManagerGLib
     , private NowPlayingManagerClient {
     WTF_MAKE_TZONE_ALLOCATED(MediaSessionManagerGLib);
 public:
-    MediaSessionManagerGLib(GRefPtr<GDBusNodeInfo>&&);
+    MediaSessionManagerGLib(GRefPtr<GDBusNodeInfo>&&, PageIdentifier);
     ~MediaSessionManagerGLib();
 
     void beginInterruption(PlatformMediaSession::InterruptionType) final;

--- a/Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.h
+++ b/Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.h
@@ -51,7 +51,7 @@ class MediaSessionManageriOS
     , public AudioSessionInterruptionObserver {
     WTF_MAKE_TZONE_ALLOCATED(MediaSessionManageriOS);
 public:
-    MediaSessionManageriOS();
+    MediaSessionManageriOS(PageIdentifier);
     virtual ~MediaSessionManageriOS();
 
     bool hasWirelessTargetsAvailable() final;

--- a/Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.mm
+++ b/Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.mm
@@ -45,15 +45,15 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(MediaSessionManageriOS);
 
-RefPtr<PlatformMediaSessionManager> PlatformMediaSessionManager::create(std::optional<PageIdentifier>)
+RefPtr<PlatformMediaSessionManager> PlatformMediaSessionManager::create(PageIdentifier pageIdentifier)
 {
-    auto manager = adoptRef(new MediaSessionManageriOS);
+    auto manager = adoptRef(new MediaSessionManageriOS(pageIdentifier));
     MediaSessionHelper::sharedHelper().addClient(*manager);
     return manager;
 }
 
-MediaSessionManageriOS::MediaSessionManageriOS()
-    : MediaSessionManagerCocoa()
+MediaSessionManageriOS::MediaSessionManageriOS(PageIdentifier pageIdentifier)
+    : MediaSessionManagerCocoa(pageIdentifier)
 {
     AudioSession::addInterruptionObserver(*this);
 }

--- a/Source/WebCore/testing/InternalSettings.cpp
+++ b/Source/WebCore/testing/InternalSettings.cpp
@@ -67,8 +67,10 @@ InternalSettings::Backup::Backup(Settings& settings)
 #endif
 {
 #if ENABLE(VIDEO) || ENABLE(WEB_AUDIO)
-    if (RefPtr page = settings.page().get())
-        m_shouldDeactivateAudioSession = page->mediaSessionManager().shouldDeactivateAudioSession();
+    if (RefPtr page = settings.page().get()) {
+        if (RefPtr manager = page->mediaSessionManager())
+            m_shouldDeactivateAudioSession = manager->shouldDeactivateAudioSession();
+    }
 #endif
 }
 
@@ -121,8 +123,10 @@ void InternalSettings::Backup::restoreTo(Settings& settings)
 #endif
 
 #if ENABLE(VIDEO) || ENABLE(WEB_AUDIO)
-    if (RefPtr page = settings.page().get())
-        page->mediaSessionManager().setShouldDeactivateAudioSession(m_shouldDeactivateAudioSession);
+    if (RefPtr page = settings.page().get()) {
+        if (RefPtr manager = page->mediaSessionManager())
+            manager->setShouldDeactivateAudioSession(m_shouldDeactivateAudioSession);
+    }
 #endif
 
 #if ENABLE(WEB_AUDIO)
@@ -539,7 +543,10 @@ ExceptionOr<void>  InternalSettings::setShouldDeactivateAudioSession(bool should
         return Exception { ExceptionCode::InvalidAccessError };
 
 #if ENABLE(VIDEO) || ENABLE(WEB_AUDIO)
-    m_page->mediaSessionManager().setShouldDeactivateAudioSession(should);
+    if (RefPtr page = m_page.get()) {
+        if (RefPtr manager = page->mediaSessionManager())
+            manager->setShouldDeactivateAudioSession(should);
+    }
 #else
     UNUSED_PARAM(should);
 #endif

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -620,21 +620,21 @@ void Internals::resetToConsistentState(Page& page)
         localMainFrame->editor().toggleOverwriteModeEnabled();
     localMainFrame->loader().clearTestingOverrides();
 
-    auto& sessionManager = page.mediaSessionManager();
+    RefPtr sessionManager = page.mediaSessionManager();
 #if ENABLE(VIDEO)
     page.group().ensureCaptionPreferences().setCaptionDisplayMode(CaptionUserPreferences::CaptionDisplayMode::ForcedOnly);
     page.group().ensureCaptionPreferences().setCaptionsStyleSheetOverride(emptyString());
 
-    sessionManager.resetHaveEverRegisteredAsNowPlayingApplicationForTesting();
-    sessionManager.resetRestrictions();
-    sessionManager.resetSessionState();
-    sessionManager.setWillIgnoreSystemInterruptions(true);
-    sessionManager.applicationWillEnterForeground(false);
+    sessionManager->resetHaveEverRegisteredAsNowPlayingApplicationForTesting();
+    sessionManager->resetRestrictions();
+    sessionManager->resetSessionState();
+    sessionManager->setWillIgnoreSystemInterruptions(true);
+    sessionManager->applicationWillEnterForeground(false);
     if (page.mediaPlaybackIsSuspended())
         page.resumeAllMediaPlayback();
 #endif
 #if ENABLE(VIDEO) || ENABLE(WEB_AUDIO)
-    sessionManager.setIsPlayingToAutomotiveHeadUnit(false);
+    sessionManager->setIsPlayingToAutomotiveHeadUnit(false);
 #endif
     AXObjectCache::setEnhancedUserInterfaceAccessibility(false);
     AXObjectCache::disableAccessibility();
@@ -8021,7 +8021,7 @@ RefPtr<MediaSessionManagerInterface> Internals::sessionManager() const
     if (!page)
         return nullptr;
 
-    return &page->mediaSessionManager();
+    return page->mediaSessionManager();
 }
 
 #if ENABLE(MODEL_ELEMENT)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -10562,7 +10562,7 @@ void WebPage::frameViewLayoutOrVisualViewportChanged(const LocalFrameView& frame
 RefPtr<MediaSessionManagerInterface> WebPage::mediaSessionManager() const
 {
     RefPtr page { corePage() };
-    return page ? &page->mediaSessionManager() : nullptr;
+    return page ? page->mediaSessionManager() : nullptr;
 
 }
 


### PR DESCRIPTION
#### 66cd692a2422b6b3e491ebc8f47c6cb03a2945b9
<pre>
[Site Isolation] Minor MediaSessionManager restructuring
<a href="https://bugs.webkit.org/show_bug.cgi?id=299095">https://bugs.webkit.org/show_bug.cgi?id=299095</a>
<a href="https://rdar.apple.com/160861881">rdar://160861881</a>

Reviewed by Andy Estes.

Just restructuring existing code, no change in behavior.

* Source/WebCore/Modules/audiosession/DOMAudioSession.cpp:
(WebCore::DOMAudioSession::setType):
* Source/WebCore/Modules/mediasession/MediaSession.cpp:
(WebCore::MediaSession::sessionManager const):
* Source/WebCore/Modules/mediastream/MediaStream.cpp:
(WebCore::MediaStream::mediaSessionManager const):
* Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp:
(WebCore::MediaStreamTrack::mediaSessionManager const):
* Source/WebCore/Modules/webaudio/BaseAudioContext.cpp:
(WebCore::BaseAudioContext::mediaSessionManager const):
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::sessionManager const):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::fromPageIdentifier):
(WebCore::Page::bestMediaElementForRemoteControls):
(WebCore::Page::setActivityState):
(WebCore::Page::updateActiveNowPlayingSessionNow):
(WebCore::Page::mediaSessionManager):
(WebCore::Page::mediaSessionManagerForPageIdentifier):
(WebCore::Page::protectedMediaSessionManager): Deleted.
* Source/WebCore/page/Page.h:
* Source/WebCore/page/PageConfiguration.h:
* Source/WebCore/page/cocoa/PageCocoa.mm:
(WebCore::Page::setPresentingApplicationBundleIdentifier):
* Source/WebCore/platform/audio/MediaSessionManagerInterface.cpp:
(WebCore::MediaSessionManagerInterface::MediaSessionManagerInterface):
(WebCore::MediaSessionManagerInterface::processDidReceiveRemoteControlCommand):
* Source/WebCore/platform/audio/MediaSessionManagerInterface.h:
(WebCore::MediaSessionManagerInterface::pageIdentifier const):
* Source/WebCore/platform/audio/PlatformMediaSession.cpp:
(WebCore::PlatformMediaSession::setActiveNowPlayingSession):
* Source/WebCore/platform/audio/PlatformMediaSessionManager.cpp:
(WebCore::PlatformMediaSessionManager::create):
(WebCore::PlatformMediaSessionManager::PlatformMediaSessionManager):
* Source/WebCore/platform/audio/PlatformMediaSessionManager.h:
* Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.h:
* Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm:
(WebCore::PlatformMediaSessionManager::create):
(WebCore::MediaSessionManagerCocoa::MediaSessionManagerCocoa):
(WebCore::MediaSessionManagerCocoa::removeSession):
(WebCore::MediaSessionManagerCocoa::updateActiveNowPlayingSession):
* Source/WebCore/platform/audio/glib/MediaSessionManagerGLib.cpp:
(WebCore::PlatformMediaSessionManager::create):
(WebCore::MediaSessionManagerGLib::MediaSessionManagerGLib):
* Source/WebCore/platform/audio/glib/MediaSessionManagerGLib.h:
* Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.h:
* Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.mm:
(WebCore::PlatformMediaSessionManager::create):
(WebCore::MediaSessionManageriOS::MediaSessionManageriOS):
* Source/WebCore/testing/InternalSettings.cpp:
(WebCore::InternalSettings::Backup::Backup):
(WebCore::InternalSettings::Backup::restoreTo):
(WebCore::InternalSettings::setShouldDeactivateAudioSession):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::resetToConsistentState):
(WebCore::Internals::sessionManager const):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::mediaSessionManager const):

Canonical link: <a href="https://commits.webkit.org/300263@main">https://commits.webkit.org/300263@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e851830054aeab8671c1830cc13a77fa353fbd01

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121888 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41590 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32260 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128440 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73981 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/21410954-adbb-44f4-9303-0942e750f612) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123764 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42305 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50184 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92637 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/61562 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/418e8a22-1110-4564-9ff5-c79824540963) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124840 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33741 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109164 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73296 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32754 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27332 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71944 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103247 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27521 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131212 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48827 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37130 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101206 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49199 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105379 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101074 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25636 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46441 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24558 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/45527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48684 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54418 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48154 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51504 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49834 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->