### PR TITLE
Properly obtain an IOSurface pool to use with CIImage

### DIFF
--- a/Source/WebCore/platform/graphics/coreimage/FilterImageCoreImage.mm
+++ b/Source/WebCore/platform/graphics/coreimage/FilterImageCoreImage.mm
@@ -28,7 +28,6 @@
 
 #if USE(CORE_IMAGE)
 
-#import "ImageBufferIOSurfaceBackend.h"
 #import <CoreImage/CIContext.h>
 #import <CoreImage/CoreImage.h>
 #import <wtf/NeverDestroyed.h>
@@ -61,10 +60,7 @@ ImageBuffer* FilterImage::imageBufferFromCIImage()
     if (m_imageBuffer)
         return m_imageBuffer.get();
 
-    ImageBufferCreationContext creationContext;
-    creationContext.surfacePool = IOSurfacePool::sharedPoolSingleton();
-
-    RefPtr imageBuffer = ImageBuffer::create<ImageBufferIOSurfaceBackend>(m_absoluteImageRect.size(), 1, m_colorSpace, { PixelFormat::BGRA8 }, RenderingPurpose::Unspecified, creationContext);
+    RefPtr imageBuffer = m_allocator.createImageBuffer(m_absoluteImageRect.size(), m_colorSpace, RenderingMode::Accelerated);
     m_imageBuffer = imageBuffer;
     if (!imageBuffer)
         return nullptr;

--- a/Source/WebKit/GPUProcess/graphics/ImageBufferShareableAllocator.h
+++ b/Source/WebKit/GPUProcess/graphics/ImageBufferShareableAllocator.h
@@ -32,12 +32,20 @@
 #include <WebCore/SharedMemory.h>
 #include <wtf/TZoneMalloc.h>
 
+#if HAVE(IOSURFACE)
+#include <WebCore/IOSurfacePool.h>
+#endif
+
 namespace WebKit {
 
 class ImageBufferShareableAllocator final : public WebCore::ImageBufferAllocator {
     WTF_MAKE_TZONE_ALLOCATED(ImageBufferShareableAllocator);
 public:
+#if HAVE(IOSURFACE)
+    ImageBufferShareableAllocator(const WebCore::ProcessIdentity&, WebCore::IOSurfacePool*);
+#else
     ImageBufferShareableAllocator(const WebCore::ProcessIdentity&);
+#endif
 
 private:
     RefPtr<WebCore::ImageBuffer> createImageBuffer(const WebCore::FloatSize&, const WebCore::DestinationColorSpace&, WebCore::RenderingMode) const final;
@@ -46,6 +54,9 @@ private:
     void transferMemoryOwnership(WebCore::SharedMemory::Handle&&) const;
 
     const WebCore::ProcessIdentity m_resourceOwner;
+#if HAVE(IOSURFACE)
+    RefPtr<WebCore::IOSurfacePool> m_ioSurfacePool;
+#endif
 };
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.cpp
@@ -357,7 +357,11 @@ void RemoteGraphicsContext::drawFilteredImageBuffer(std::optional<RenderingResou
     RefPtr svgFilter = dynamicDowncast<SVGFilterRenderer>(filter);
 
     if (!svgFilter || !svgFilter->hasValidRenderingResourceIdentifier()) {
+#if HAVE(IOSURFACE)
+        FilterResults results(makeUnique<ImageBufferShareableAllocator>(m_sharedResourceCache->resourceOwner(), &m_sharedResourceCache->ioSurfacePool()));
+#else
         FilterResults results(makeUnique<ImageBufferShareableAllocator>(m_sharedResourceCache->resourceOwner()));
+#endif
         drawFilteredImageBufferInternal(sourceImageIdentifier, sourceImageRect, filter, results);
         return;
     }
@@ -369,7 +373,11 @@ void RemoteGraphicsContext::drawFilteredImageBuffer(std::optional<RenderingResou
     cachedSVGFilter->mergeEffects(svgFilter->effects());
 
     auto& results = cachedSVGFilter->ensureResults([&]() {
+#if HAVE(IOSURFACE)
+        auto allocator = makeUnique<ImageBufferShareableAllocator>(m_sharedResourceCache->resourceOwner(), &m_sharedResourceCache->ioSurfacePool());
+#else
         auto allocator = makeUnique<ImageBufferShareableAllocator>(m_sharedResourceCache->resourceOwner());
+#endif
         return makeUnique<FilterResults>(WTFMove(allocator));
     });
 


### PR DESCRIPTION
#### 6fdd8c93864a00eacad38e40d14bec1029cd5c2b
<pre>
Properly obtain an IOSurface pool to use with CIImage
<a href="https://bugs.webkit.org/show_bug.cgi?id=299093">https://bugs.webkit.org/show_bug.cgi?id=299093</a>
<a href="https://rdar.apple.com/160861257">rdar://160861257</a>

Reviewed by Simon Fraser.

After 298654@main, pages using CoreImage-backed filters trigger a isMainThread
assertion. The issue occurs because filter code running on RRB (non-main thread
in GPUP) was directly accessing IOSurfacePool via sharedPoolSingleton(), which
requires main thread execution.

We fix by creating ImageBuffer through the allocator, which uses the correct pool
from RRB&apos;s SharedResourceCache.

* Source/WebCore/platform/graphics/coreimage/FilterImageCoreImage.mm:
(WebCore::FilterImage::imageBufferFromCIImage):
* Source/WebKit/GPUProcess/graphics/ImageBufferShareableAllocator.cpp:
(WebKit::ImageBufferShareableAllocator::ImageBufferShareableAllocator):
(WebKit::ImageBufferShareableAllocator::createImageBuffer const):
* Source/WebKit/GPUProcess/graphics/ImageBufferShareableAllocator.h:
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.cpp:
(WebKit::RemoteGraphicsContext::drawFilteredImageBuffer):

Canonical link: <a href="https://commits.webkit.org/300275@main">https://commits.webkit.org/300275@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/45124d284d228926a596779c6f78ece827bfa0d7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121672 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41373 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32037 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128190 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73762 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ad5597fc-9573-4c3b-98dd-3f49883241c2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123548 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42085 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49964 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92452 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61475 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6319d216-ea8c-41f3-a8c0-5f71b106e921) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124624 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33575 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108976 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73114 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9d656239-5022-433e-baec-e31a64b5f796) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32587 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27138 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71710 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103071 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27324 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130987 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48606 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36972 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101020 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48978 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105193 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100911 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25645 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46288 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24398 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45307 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48465 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54192 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47934 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51283 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49617 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->