### PR TITLE
[Length Deprecation] Remove unnecessary use of Length in BlurFilterOperation

### DIFF
--- a/Source/WebCore/platform/graphics/ca/cocoa/PlatformCAFiltersCocoa.mm
+++ b/Source/WebCore/platform/graphics/ca/cocoa/PlatformCAFiltersCocoa.mm
@@ -111,7 +111,7 @@ static const FilterOperation& passthroughFilter(const FilterOperation::Type type
         static NeverDestroyed<Ref<BasicColorMatrixFilterOperation>> passthroughContrastFilter = BasicColorMatrixFilterOperation::create(0, typeToMatch);
         return passthroughContrastFilter.get();
     case FilterOperation::Type::Blur:
-        static NeverDestroyed<Ref<BlurFilterOperation>> passthroughBlurFilter = BlurFilterOperation::create({ 0, LengthType::Fixed });
+        static NeverDestroyed<Ref<BlurFilterOperation>> passthroughBlurFilter = BlurFilterOperation::create(0);
         return passthroughBlurFilter.get();
     default:
         ASSERT_NOT_REACHED();
@@ -332,7 +332,7 @@ void PlatformCAFilters::setFiltersOnLayer(PlatformLayer* layer, const FilterOper
         case FilterOperation::Type::Blur: {
             const auto& blurOperation = downcast<BlurFilterOperation>(filterOperation);
             CAFilter *filter = [CAFilter filterWithType:kCAFilterGaussianBlur];
-            [filter setValue:[NSNumber numberWithFloat:floatValueForLength(blurOperation.stdDeviation(), 0)] forKey:@"inputRadius"];
+            [filter setValue:@(blurOperation.stdDeviation()) forKey:@"inputRadius"];
             if (is_objc<CABackdropLayer>(layer)) {
 #if PLATFORM(VISION)
                 // FIXME: https://bugs.webkit.org/show_bug.cgi?id=275965
@@ -442,7 +442,7 @@ RetainPtr<NSValue> PlatformCAFilters::filterValueForOperation(const FilterOperat
         // CAFilter: inputRadius
         double amount = 0;
         if (operation)
-            amount = floatValueForLength(downcast<BlurFilterOperation>(*operation).stdDeviation(), 0);
+            amount = downcast<BlurFilterOperation>(*operation).stdDeviation();
 
         value = @(amount);
         break;

--- a/Source/WebCore/platform/graphics/filters/FilterOperation.h
+++ b/Source/WebCore/platform/graphics/filters/FilterOperation.h
@@ -25,9 +25,9 @@
 
 #pragma once
 
+#include <WebCore/BoxExtents.h>
 #include <WebCore/Color.h>
-#include <WebCore/LayoutSize.h>
-#include <WebCore/LengthBox.h>
+#include <WebCore/IntPoint.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/TypeCasts.h>
 #include <wtf/text/WTFString.h>
@@ -37,6 +37,7 @@ namespace WebCore {
 // CSS Filters
 
 struct BlendingContext;
+using IntOutsets = IntBoxExtent;
 
 class FilterOperation : public ThreadSafeRefCounted<FilterOperation> {
 public:
@@ -272,7 +273,7 @@ private:
 
 class WEBCORE_EXPORT BlurFilterOperation : public FilterOperation {
 public:
-    static Ref<BlurFilterOperation> create(Length stdDeviation)
+    static Ref<BlurFilterOperation> create(float stdDeviation)
     {
         return adoptRef(*new BlurFilterOperation(WTFMove(stdDeviation)));
     }
@@ -282,7 +283,7 @@ public:
         return adoptRef(*new BlurFilterOperation(stdDeviation()));
     }
 
-    const Length& stdDeviation() const { return m_stdDeviation; }
+    float stdDeviation() const { return m_stdDeviation; }
 
     bool affectsOpacity() const override { return true; }
     bool movesPixels() const override { return true; }
@@ -292,16 +293,16 @@ public:
 private:
     bool operator==(const FilterOperation&) const override;
 
-    BlurFilterOperation(Length stdDeviation)
+    BlurFilterOperation(float stdDeviation)
         : FilterOperation(Type::Blur)
-        , m_stdDeviation(WTFMove(stdDeviation))
+        , m_stdDeviation(stdDeviation)
     {
     }
 
     bool isIdentity() const override;
     IntOutsets outsets() const override;
 
-    Length m_stdDeviation;
+    float m_stdDeviation;
 };
 
 class WEBCORE_EXPORT DropShadowFilterOperationBase : public FilterOperation {
@@ -329,8 +330,8 @@ protected:
     bool isIdentity() const override;
     IntOutsets outsets() const override;
 
-    IntPoint m_location; // FIXME: should location be in Lengths?
-    int m_stdDeviation;
+    IntPoint m_location; // FIXME: Should m_location be a FloatPoint?
+    int m_stdDeviation; // FIXME: Should m_stdDeviation be a float?
 };
 
 class WEBCORE_EXPORT DropShadowFilterOperation : public DropShadowFilterOperationBase {

--- a/Source/WebCore/platform/graphics/filters/FilterOperations.cpp
+++ b/Source/WebCore/platform/graphics/filters/FilterOperations.cpp
@@ -76,7 +76,7 @@ IntOutsets FilterOperations::outsets() const
         switch (operation->type()) {
         case FilterOperation::Type::Blur: {
             auto& blurOperation = downcast<BlurFilterOperation>(operation.get());
-            float stdDeviation = floatValueForLength(blurOperation.stdDeviation(), 0);
+            float stdDeviation = blurOperation.stdDeviation();
             IntSize outsetSize = FEGaussianBlur::calculateOutsetSize({ stdDeviation, stdDeviation });
             IntOutsets outsets(outsetSize.height(), outsetSize.width(), outsetSize.height(), outsetSize.width());
             totalOutsets += outsets;

--- a/Source/WebCore/platform/graphics/texmap/TextureMapper.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapper.cpp
@@ -34,7 +34,6 @@
 #include "GraphicsContext.h"
 #include "GraphicsTypesGL.h"
 #include "Image.h"
-#include "LengthFunctions.h"
 #include "TextureMapperFlags.h"
 #include "TextureMapperShaderProgram.h"
 #include <wtf/HashMap.h>
@@ -982,8 +981,8 @@ void TextureMapper::drawBlurred(const BitmapTexture& sourceTexture, const FloatR
 RefPtr<BitmapTexture> TextureMapper::applyBlurFilter(RefPtr<BitmapTexture>& sourceTexture, const BlurFilterOperation& blurFilter)
 {
     const auto& textureSize = sourceTexture->size();
-    float radiusX = floatValueForLength(blurFilter.stdDeviation(), textureSize.width());
-    float radiusY = floatValueForLength(blurFilter.stdDeviation(), textureSize.height());
+    float radiusX = blurFilter.stdDeviation();
+    float radiusY = blurFilter.stdDeviation();
 
     if (radiusX < MinBlurRadius && radiusY < MinBlurRadius)
         return sourceTexture;

--- a/Source/WebCore/rendering/CSSFilter.cpp
+++ b/Source/WebCore/rendering/CSSFilter.cpp
@@ -103,7 +103,7 @@ CSSFilter::CSSFilter(Vector<Ref<FilterFunction>>&& functions, const FloatSize& f
 
 static RefPtr<FilterEffect> createBlurEffect(const BlurFilterOperation& blurOperation)
 {
-    float stdDeviation = floatValueForLength(blurOperation.stdDeviation(), 0);
+    float stdDeviation = blurOperation.stdDeviation();
     return FEGaussianBlur::create(stdDeviation, stdDeviation, EdgeModeType::None);
 }
 

--- a/Source/WebCore/style/values/filter-effects/StyleBlurFunction.cpp
+++ b/Source/WebCore/style/values/filter-effects/StyleBlurFunction.cpp
@@ -35,18 +35,18 @@ namespace Style {
 
 CSS::Blur toCSSBlur(Ref<BlurFilterOperation> operation, const RenderStyle& style)
 {
-    return { CSS::Blur::Parameter { toCSS(Length<CSS::Nonnegative> { operation->stdDeviation().value() }, style) } };
+    return { CSS::Blur::Parameter { toCSS(Length<CSS::Nonnegative> { operation->stdDeviation() }, style) } };
 }
 
 Ref<FilterOperation> createFilterOperation(const CSS::Blur& filter, const Document&, RenderStyle&, const CSSToLengthConversionData& conversionData)
 {
-    WebCore::Length stdDeviation;
+    float stdDeviation = 0;
     if (auto parameter = filter.value)
-        stdDeviation = WebCore::Length { toStyle(*parameter, conversionData).value, LengthType::Fixed };
+        stdDeviation = toStyle(*parameter, conversionData).value;
     else
-        stdDeviation = WebCore::Length { filterFunctionDefaultValue<CSS::BlurFunction::name>().value, LengthType::Fixed };
+        stdDeviation = filterFunctionDefaultValue<CSS::BlurFunction::name>().value;
 
-    return BlurFilterOperation::create(WTFMove(stdDeviation));
+    return BlurFilterOperation::create(stdDeviation);
 }
 
 } // namespace Style

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -8281,7 +8281,7 @@ header: <WebCore/SharedBuffer.h>
     [Validator='WebCore::FilterOperation::isBasicComponentTransferFilterOperationType(*type)'] WebCore::FilterOperation::Type type();
 };
 [CustomHeader, RefCounted] class WebCore::BlurFilterOperation {
-    WebCore::Length stdDeviation();
+    float stdDeviation();
 };
 [CustomHeader, RefCounted] class WebCore::DropShadowFilterOperation {
     WebCore::IntPoint location();


### PR DESCRIPTION
#### fbbdbcc9001022de46b54d9848f6a29243421666
<pre>
[Length Deprecation] Remove unnecessary use of Length in BlurFilterOperation
<a href="https://bugs.webkit.org/show_bug.cgi?id=299098">https://bugs.webkit.org/show_bug.cgi?id=299098</a>

Reviewed by Darin Adler.

`BlurFilterOperation` uses a `Length`, but it is only ever `LengthType::Fixed`.
This changes it to use a a float instead.

* Source/WebCore/platform/graphics/ca/cocoa/PlatformCAFiltersCocoa.mm:
* Source/WebCore/platform/graphics/filters/FilterOperation.cpp:
* Source/WebCore/platform/graphics/filters/FilterOperation.h:
* Source/WebCore/platform/graphics/filters/FilterOperations.cpp:
* Source/WebCore/platform/graphics/texmap/TextureMapper.cpp:
* Source/WebCore/rendering/CSSFilter.cpp:
* Source/WebCore/style/values/filter-effects/StyleBlurFunction.cpp:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/300209@main">https://commits.webkit.org/300209@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/194a8040167915f73178dd0d78522038fddee047

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121683 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41384 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32048 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128205 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/73773 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123559 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42096 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49975 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92463 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/73773 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124635 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33585 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108987 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73124 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32595 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27149 "Found 2 new test failures: fast/scrolling/anchor-overscroll-fixed.html imported/w3c/web-platform-tests/css/css-font-loading/idlharness.https.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71724 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103083 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27335 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130998 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48618 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36977 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101031 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48990 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105204 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100922 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25594 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46297 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24408 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/45318 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48476 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54203 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47945 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51294 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49628 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->