### PR TITLE
[ews] Improve error logging while parsing layout tests json results

### DIFF
--- a/Tools/CISupport/ews-build/layout_test_failures.py
+++ b/Tools/CISupport/ews-build/layout_test_failures.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 Apple Inc. All rights reserved.
+# Copyright (C) 2019-2025 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -41,6 +41,7 @@ class LayoutTestFailures(object):
     @classmethod
     def results_from_string(cls, string):
         if not string:
+            print(f'Error while parsing layout-test json, empty json')
             return None
 
         content_string = cls._strip_json_wrapper(string.strip())
@@ -48,7 +49,8 @@ class LayoutTestFailures(object):
         content_string = ''.join(content_string.splitlines())
         try:
             json_dict = json.loads(content_string)
-        except json.JSONDecodeError:
+        except json.JSONDecodeError as e:
+            print(f'Exception while parsing layout-test json: {e}, json data being parsed: {string}')
             return None
 
         failing_tests = []


### PR DESCRIPTION
#### 73026bca11fab22794ceb7e54f9852735bd29734
<pre>
[ews] Improve error logging while parsing layout tests json results
<a href="https://rdar.apple.com/160867801">rdar://160867801</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=299100">https://bugs.webkit.org/show_bug.cgi?id=299100</a>

Reviewed by Brianna Fan.

* Tools/CISupport/ews-build/layout_test_failures.py:
(LayoutTestFailures.results_from_string):

Canonical link: <a href="https://commits.webkit.org/300178@main">https://commits.webkit.org/300178@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d2c9650ea03d40d60ae3bf5da5af9bc3de2375ee

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121576 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41273 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/138/builds/31932 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128043 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/73661 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/62c67565-ccb7-478f-b670-70bdaa3f6722) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123452 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/41975 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49852 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/92340 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/73661 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1ff540d8-0ded-41f3-aac9-9a6d2cf5f682) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124528 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/41975 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/138/builds/31932 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/73013 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5ed73acc-7475-49d2-985a-71c198b73278) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/41975 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/138/builds/31932 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71609 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/41975 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/31932 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/130859 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/48504 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/36886 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/130859 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/120997 "Passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/48872 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/138/builds/31932 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/130859 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/31932 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/45202 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19268 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/48363 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/47834 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/51181 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/49516 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->