### PR TITLE
Use MutableCSSSelector for resolving nested selector lists

### DIFF
--- a/Source/WebCore/css/CSSSelector.h
+++ b/Source/WebCore/css/CSSSelector.h
@@ -68,14 +68,12 @@ public:
 
     enum class VisitFunctionalPseudoClasses { No, Yes };
     enum class VisitOnlySubject { No, Yes };
-    using VisitFunctor = WTF::Function<bool(CSSSelector&)>;
+    using VisitFunctor = WTF::Function<bool(const CSSSelector&)>;
     bool visitSimpleSelectors(VisitFunctor&&, VisitFunctionalPseudoClasses = VisitFunctionalPseudoClasses::No, VisitOnlySubject = VisitOnlySubject::No) const;
 
     bool hasExplicitNestingParent() const;
     bool hasExplicitPseudoClassScope() const;
     bool hasScope() const;
-    void resolveNestingParentSelectors(const CSSSelectorList& parent);
-    void replaceNestingSelectorByWhereScope();
 
     using PseudoClass = CSSSelectorPseudoClass;
     using PseudoElement = CSSSelectorPseudoElement;

--- a/Source/WebCore/css/parser/MutableCSSSelector.cpp
+++ b/Source/WebCore/css/parser/MutableCSSSelector.cpp
@@ -106,6 +106,14 @@ MutableCSSSelector::MutableCSSSelector(const CSSSelector& selector)
         m_precedingInComplexSelector = makeUnique<MutableCSSSelector>(*preceding);
 }
 
+MutableCSSSelector::MutableCSSSelector(const CSSSelector& selector, SimpleSelectorTag)
+    : m_selector(makeUnique<CSSSelector>(selector))
+{
+    m_selector->m_isLastInSelectorList = false;
+    m_selector->m_isFirstInComplexSelector = true;
+    m_selector->m_isLastInComplexSelector = true;
+}
+
 
 MutableCSSSelector::~MutableCSSSelector()
 {

--- a/Source/WebCore/css/parser/MutableCSSSelector.h
+++ b/Source/WebCore/css/parser/MutableCSSSelector.h
@@ -43,6 +43,10 @@ public:
     // Recursively copy the selector chain.
     MutableCSSSelector(const CSSSelector&);
 
+    // Only copy the simple selector.
+    enum SimpleSelectorTag { SimpleSelector };
+    MutableCSSSelector(const CSSSelector&, SimpleSelectorTag);
+
     explicit MutableCSSSelector(const QualifiedName&);
 
     ~MutableCSSSelector();


### PR DESCRIPTION
#### 290124606c2a9c70c255bd80361642fd1fff4e8a
<pre>
Use MutableCSSSelector for resolving nested selector lists
<a href="https://bugs.webkit.org/show_bug.cgi?id=299101">https://bugs.webkit.org/show_bug.cgi?id=299101</a>
<a href="https://rdar.apple.com/problem/160871018">rdar://problem/160871018</a>

Reviewed by Matthieu Dubet.

Mutating const CSSSelectors was pretty ugly. Also this will allow optimizing
nesting better in future.

* Source/WebCore/css/CSSSelector.cpp:
(WebCore::CSSSelector::resolveNestingParentSelectors): Deleted.
(WebCore::CSSSelector::replaceNestingParentByPseudoClassScope): Deleted.

Remove the mutating functions.

* Source/WebCore/css/CSSSelector.h:
* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::CSSSelectorParser::resolveNestingParent):

Construct the resolved elector list using MutableCSSSelectors which is how the parser works in general.

* Source/WebCore/css/parser/MutableCSSSelector.cpp:
(WebCore::MutableCSSSelector::MutableCSSSelector):

Add a new constructor that just wraps a simple selector.

* Source/WebCore/css/parser/MutableCSSSelector.h:

Canonical link: <a href="https://commits.webkit.org/300218@main">https://commits.webkit.org/300218@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/71a95e849546082bedfd8eb9c1bb9c936fda0c08

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121614 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41311 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31970 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128108 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73704 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f8b648f7-a86b-434f-889c-cf4a4c6100bf) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123490 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42030 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49900 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92399 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61462 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7edc3d67-8aef-4d90-966e-c63329c6ac45) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124566 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33545 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108943 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73058 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/68e00198-04f8-4c66-ad72-24ac6fb51415) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32559 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27103 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71647 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103041 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27279 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130914 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48548 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36938 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100983 "Found 1 new test failure: imported/w3c/web-platform-tests/service-workers/service-worker/redirected-response.https.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48920 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105152 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100872 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25600 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46264 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24368 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45249 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48405 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54126 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47876 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51225 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49559 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->