### PR TITLE
Improve memory safety in WebProcess/GPU/ part 1

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -67,8 +67,6 @@ WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsEventCocoa.mm
 WebProcess/FullScreen/WebFullScreenManager.cpp
 WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
 WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
-WebProcess/GPU/media/RemoteLegacyCDMFactory.cpp
-WebProcess/GPU/media/RemoteLegacyCDMSession.cpp
 WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInCSSStyleDeclarationHandle.mm
 WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInFrame.mm
 WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInHitTestResult.mm

--- a/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDM.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDM.cpp
@@ -55,7 +55,7 @@ Ref<RemoteLegacyCDMFactory> RemoteLegacyCDM::protectedFactory() const
 
 bool RemoteLegacyCDM::supportsMIMEType(const String& mimeType) const
 {
-    auto sendResult = protectedFactory()->gpuProcessConnection().connection().sendSync(Messages::RemoteLegacyCDMProxy::SupportsMIMEType(mimeType), m_identifier);
+    auto sendResult = protectedFactory()->gpuProcessConnectionSingleton().connection().sendSync(Messages::RemoteLegacyCDMProxy::SupportsMIMEType(mimeType), m_identifier);
     auto [supported] = sendResult.takeReplyOr(false);
     return supported;
 }
@@ -68,7 +68,7 @@ RefPtr<WebCore::LegacyCDMSession> RemoteLegacyCDM::createSession(WebCore::Legacy
 #endif
 
     Ref factory = m_factory.get();
-    auto sendResult = factory->gpuProcessConnection().connection().sendSync(Messages::RemoteLegacyCDMProxy::CreateSession(logIdentifier), m_identifier);
+    auto sendResult = factory->gpuProcessConnectionSingleton().connection().sendSync(Messages::RemoteLegacyCDMProxy::CreateSession(logIdentifier), m_identifier);
     auto [identifier] = sendResult.takeReplyOr(std::nullopt);
     if (!identifier)
         return nullptr;
@@ -77,7 +77,7 @@ RefPtr<WebCore::LegacyCDMSession> RemoteLegacyCDM::createSession(WebCore::Legacy
 
 void RemoteLegacyCDM::setPlayerId(std::optional<MediaPlayerIdentifier> identifier)
 {
-    protectedFactory()->gpuProcessConnection().connection().send(Messages::RemoteLegacyCDMProxy::SetPlayerId(identifier), m_identifier);
+    protectedFactory()->gpuProcessConnectionSingleton().connection().send(Messages::RemoteLegacyCDMProxy::SetPlayerId(identifier), m_identifier);
 }
 
 void RemoteLegacyCDM::ref() const

--- a/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMFactory.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMFactory.cpp
@@ -83,7 +83,7 @@ ASCIILiteral RemoteLegacyCDMFactory::supplementName()
     return "RemoteLegacyCDMFactory"_s;
 }
 
-GPUProcessConnection& RemoteLegacyCDMFactory::gpuProcessConnection()
+GPUProcessConnection& RemoteLegacyCDMFactory::gpuProcessConnectionSingleton()
 {
     return WebProcess::singleton().ensureGPUProcessConnection();
 }
@@ -94,7 +94,7 @@ bool RemoteLegacyCDMFactory::supportsKeySystem(const String& keySystem)
     if (foundInCache != m_supportsKeySystemCache.end())
         return foundInCache->value;
 
-    auto sendResult = gpuProcessConnection().connection().sendSync(Messages::RemoteLegacyCDMFactoryProxy::SupportsKeySystem(keySystem, std::nullopt), { });
+    auto sendResult = gpuProcessConnectionSingleton().connection().sendSync(Messages::RemoteLegacyCDMFactoryProxy::SupportsKeySystem(keySystem, std::nullopt), { });
     auto [supported] = sendResult.takeReplyOr(false);
     m_supportsKeySystemCache.set(keySystem, supported);
     return supported;
@@ -107,7 +107,7 @@ bool RemoteLegacyCDMFactory::supportsKeySystemAndMimeType(const String& keySyste
     if (foundInCache != m_supportsKeySystemAndMimeTypeCache.end())
         return foundInCache->value;
 
-    auto sendResult = gpuProcessConnection().connection().sendSync(Messages::RemoteLegacyCDMFactoryProxy::SupportsKeySystem(keySystem, mimeType), { });
+    auto sendResult = gpuProcessConnectionSingleton().connection().sendSync(Messages::RemoteLegacyCDMFactoryProxy::SupportsKeySystem(keySystem, mimeType), { });
     auto [supported] = sendResult.takeReplyOr(false);
     m_supportsKeySystemAndMimeTypeCache.set(key, supported);
     return supported;
@@ -117,9 +117,9 @@ std::unique_ptr<CDMPrivateInterface> RemoteLegacyCDMFactory::createCDM(WebCore::
 {
     std::optional<MediaPlayerIdentifier> playerId;
     if (auto player = cdm.mediaPlayer())
-        playerId = gpuProcessConnection().protectedMediaPlayerManager()->findRemotePlayerId(player->protectedPlayerPrivate().get());
+        playerId = gpuProcessConnectionSingleton().protectedMediaPlayerManager()->findRemotePlayerId(player->protectedPlayerPrivate().get());
 
-    auto sendResult = gpuProcessConnection().connection().sendSync(Messages::RemoteLegacyCDMFactoryProxy::CreateCDM(cdm.keySystem(), WTFMove(playerId)), { });
+    auto sendResult = gpuProcessConnectionSingleton().connection().sendSync(Messages::RemoteLegacyCDMFactoryProxy::CreateCDM(cdm.keySystem(), WTFMove(playerId)), { });
     auto [identifier] = sendResult.takeReplyOr(std::nullopt);
     if (!identifier)
         return nullptr;
@@ -133,17 +133,17 @@ void RemoteLegacyCDMFactory::addSession(RemoteLegacyCDMSessionIdentifier identif
     ASSERT(!m_sessions.contains(identifier));
     m_sessions.set(identifier, WeakPtr { session });
 
-    gpuProcessConnection().messageReceiverMap().addMessageReceiver(Messages::RemoteLegacyCDMSession::messageReceiverName(), identifier.toUInt64(), session);
+    gpuProcessConnectionSingleton().messageReceiverMap().addMessageReceiver(Messages::RemoteLegacyCDMSession::messageReceiverName(), identifier.toUInt64(), session);
 }
 
 void RemoteLegacyCDMFactory::removeSession(RemoteLegacyCDMSessionIdentifier identifier)
 {
     ASSERT(m_sessions.contains(identifier));
     RefPtr session = m_sessions.get(identifier).get();
-    gpuProcessConnection().connection().sendWithAsyncReply(Messages::RemoteLegacyCDMFactoryProxy::RemoveSession(identifier), [protectedThis = Ref { *this }, identifier, session = WTFMove(session)] {
+    gpuProcessConnectionSingleton().connection().sendWithAsyncReply(Messages::RemoteLegacyCDMFactoryProxy::RemoveSession(identifier), [protectedThis = Ref { *this }, identifier, session = WTFMove(session)] {
         ASSERT(protectedThis->m_sessions.contains(identifier));
         protectedThis->m_sessions.remove(identifier);
-        protectedThis->gpuProcessConnection().messageReceiverMap().removeMessageReceiver(Messages::RemoteLegacyCDMSession::messageReceiverName(), identifier.toUInt64());
+        protectedThis->gpuProcessConnectionSingleton().messageReceiverMap().removeMessageReceiver(Messages::RemoteLegacyCDMSession::messageReceiverName(), identifier.toUInt64());
         UNUSED_PARAM(session);
     }, { });
 }

--- a/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMFactory.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMFactory.h
@@ -69,7 +69,7 @@ public:
 
     static ASCIILiteral supplementName();
 
-    GPUProcessConnection& gpuProcessConnection();
+    GPUProcessConnection& gpuProcessConnectionSingleton();
 
     void addSession(RemoteLegacyCDMSessionIdentifier, RemoteLegacyCDMSession&);
     void removeSession(RemoteLegacyCDMSessionIdentifier);


### PR DESCRIPTION
#### f8d2bb071564b6ae0b62e2ffe0c20186f0e1e741
<pre>
Improve memory safety in WebProcess/GPU/ part 1
<a href="https://bugs.webkit.org/show_bug.cgi?id=299111">https://bugs.webkit.org/show_bug.cgi?id=299111</a>
<a href="https://rdar.apple.com/160875899">rdar://160875899</a>

Reviewed by NOBODY (OOPS!).

Improve memory safety in WebProcess/GPU.

No new tests (OOPS!).
* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDM.cpp:
(WebKit::RemoteLegacyCDM::supportsMIMEType const):
(WebKit::RemoteLegacyCDM::createSession):
(WebKit::RemoteLegacyCDM::setPlayerId):
* Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMFactory.cpp:
(WebKit::RemoteLegacyCDMFactory::gpuProcessConnectionSingleton):
(WebKit::RemoteLegacyCDMFactory::supportsKeySystem):
(WebKit::RemoteLegacyCDMFactory::supportsKeySystemAndMimeType):
(WebKit::RemoteLegacyCDMFactory::createCDM):
(WebKit::RemoteLegacyCDMFactory::addSession):
(WebKit::RemoteLegacyCDMFactory::removeSession):
(WebKit::RemoteLegacyCDMFactory::gpuProcessConnection): Deleted.
* Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMFactory.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f8d2bb071564b6ae0b62e2ffe0c20186f0e1e741

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121611 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41308 "Hash f8d2bb07 for PR 50942 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31967 "Hash f8d2bb07 for PR 50942 does not build (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128104 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73701 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/740574ad-6e4b-4d2e-ad0f-cd5e46cefaad) 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42029 "Hash f8d2bb07 for PR 50942 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49897 "Hash f8d2bb07 for PR 50942 does not build (failure)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92396 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61457 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/43e74a2e-3ba4-4eca-bc6b-591224ee5b48) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124563 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/130/builds/42029 "Hash f8d2bb07 for PR 50942 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/138/builds/31967 "Hash f8d2bb07 for PR 50942 does not build (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73055 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/749fb413-b36c-4722-8455-1da356577cb2) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/130/builds/42029 "Hash f8d2bb07 for PR 50942 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/138/builds/31967 "Hash f8d2bb07 for PR 50942 does not build (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71644 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/130/builds/42029 "Hash f8d2bb07 for PR 50942 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/138/builds/31967 "Hash f8d2bb07 for PR 50942 does not build (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130911 "Built successfully") | | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48545 "Hash f8d2bb07 for PR 50942 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/123/builds/49897 "Hash f8d2bb07 for PR 50942 does not build (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100973 "Passed tests") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48917 "Hash f8d2bb07 for PR 50942 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/138/builds/31967 "Hash f8d2bb07 for PR 50942 does not build (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100861 "Passed tests") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/138/builds/31967 "Hash f8d2bb07 for PR 50942 does not build (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45246 "Built successfully") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48414 "Hash f8d2bb07 for PR 50942 does not build (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54110 "Failed to build and analyze WebKit") | | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47873 "Hash f8d2bb07 for PR 50942 does not build (failure)") | | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51222 "Hash f8d2bb07 for PR 50942 does not build (failure)") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49556 "Hash f8d2bb07 for PR 50942 does not build (failure)") | | | | 
<!--EWS-Status-Bubble-End-->