### PR TITLE
Improve memory safety in WebProcess/WebCoreSupport/* part 1

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -96,9 +96,6 @@ WebProcess/InjectedBundle/InjectedBundleDOMWindowExtension.cpp
 WebProcess/InjectedBundle/InjectedBundleHitTestResult.cpp
 WebProcess/Inspector/WebInspectorUI.cpp
 WebProcess/Inspector/WebInspectorUIExtensionController.cpp
-WebProcess/WebCoreSupport/ShareableBitmapUtilities.cpp
-WebProcess/WebCoreSupport/WebBroadcastChannelRegistry.cpp
-WebProcess/WebCoreSupport/WebCaptionPreferencesDelegate.cpp
 WebProcess/WebCoreSupport/WebChromeClient.cpp
 WebProcess/WebCoreSupport/mac/WebDragClientMac.mm
 WebProcess/WebPage/Cocoa/TextAnimationController.mm

--- a/Source/WebKit/WebProcess/WebCoreSupport/ShareableBitmapUtilities.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/ShareableBitmapUtilities.cpp
@@ -47,7 +47,7 @@ using namespace WebCore;
 RefPtr<ShareableBitmap> createShareableBitmap(RenderImage& renderImage, CreateShareableBitmapFromImageOptions&& options)
 {
     Ref frame = renderImage.frame();
-    auto colorSpaceForBitmap = screenColorSpace(frame->protectedMainFrame()->virtualView());
+    auto colorSpaceForBitmap = screenColorSpace(frame->protectedMainFrame()->protectedVirtualView().get());
     if (!renderImage.isRenderMedia() && !renderImage.opacity() && options.useSnapshotForTransparentImages == UseSnapshotForTransparentImages::Yes) {
         auto snapshotRect = renderImage.absoluteBoundingBoxRect();
         if (snapshotRect.isEmpty())

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebBroadcastChannelRegistry.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebBroadcastChannelRegistry.cpp
@@ -41,6 +41,11 @@ static inline IPC::Connection& networkProcessConnection()
     return WebProcess::singleton().ensureNetworkProcessConnection().connection();
 }
 
+static inline Ref<IPC::Connection> protectedNetworkProcessConnection()
+{
+    return networkProcessConnection();
+}
+
 // Opaque origins are only stored in process in m_channelsPerOrigin and never sent to the NetworkProcess as a ClientOrigin.
 // The identity of opaque origins wouldn't be preserved when serializing them as a SecurityOriginData (via ClientOrigin).
 // Since BroadcastChannels from an opaque origin can only communicate with other BroadcastChannels from the same opaque origin,
@@ -62,7 +67,7 @@ void WebBroadcastChannelRegistry::registerChannel(const WebCore::PartitionedSecu
 
     if (channelsForName.size() == 1) {
         if (auto clientOrigin = toClientOrigin(origin))
-            networkProcessConnection().send(Messages::NetworkBroadcastChannelRegistry::RegisterChannel { *clientOrigin, name }, 0);
+            protectedNetworkProcessConnection()->send(Messages::NetworkBroadcastChannelRegistry::RegisterChannel { *clientOrigin, name }, 0);
     }
 }
 
@@ -85,7 +90,7 @@ void WebBroadcastChannelRegistry::unregisterChannel(const WebCore::PartitionedSe
 
     channelsForOrigin.remove(channelsForOriginIterator);
     if (auto clientOrigin = toClientOrigin(origin))
-        networkProcessConnection().send(Messages::NetworkBroadcastChannelRegistry::UnregisterChannel { *clientOrigin, name }, 0);
+        protectedNetworkProcessConnection()->send(Messages::NetworkBroadcastChannelRegistry::UnregisterChannel { *clientOrigin, name }, 0);
 
     if (channelsForOrigin.isEmpty())
         m_channelsPerOrigin.remove(channelsPerOriginIterator);
@@ -96,7 +101,7 @@ void WebBroadcastChannelRegistry::postMessage(const WebCore::PartitionedSecurity
     auto callbackAggregator = CallbackAggregator::create(WTFMove(completionHandler));
     postMessageLocally(origin, name, source, message.copyRef(), callbackAggregator.copyRef());
     if (auto clientOrigin = toClientOrigin(origin))
-        networkProcessConnection().sendWithAsyncReply(Messages::NetworkBroadcastChannelRegistry::PostMessage { *clientOrigin, name, WebCore::MessageWithMessagePorts { WTFMove(message), { } } }, [callbackAggregator] { }, 0);
+        protectedNetworkProcessConnection()->sendWithAsyncReply(Messages::NetworkBroadcastChannelRegistry::PostMessage { *clientOrigin, name, WebCore::MessageWithMessagePorts { WTFMove(message), { } } }, [callbackAggregator] { }, 0);
 }
 
 void WebBroadcastChannelRegistry::postMessageLocally(const WebCore::PartitionedSecurityOrigin& origin, const String& name, std::optional<WebCore::BroadcastChannelIdentifier> sourceInProcess, Ref<WebCore::SerializedScriptValue>&& message, Ref<WTF::CallbackAggregator>&& callbackAggregator)
@@ -135,7 +140,7 @@ void WebBroadcastChannelRegistry::networkProcessCrashed()
         if (!clientOrigin)
             continue;
         for (auto& name : channelsForOrigin.keys())
-            networkProcessConnection().send(Messages::NetworkBroadcastChannelRegistry::RegisterChannel { *clientOrigin, name }, 0);
+            protectedNetworkProcessConnection()->send(Messages::NetworkBroadcastChannelRegistry::RegisterChannel { *clientOrigin, name }, 0);
     }
 
 }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebCaptionPreferencesDelegate.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebCaptionPreferencesDelegate.cpp
@@ -39,13 +39,13 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(WebCaptionPreferencesDelegate);
 
 void WebCaptionPreferencesDelegate::setDisplayMode(WebCore::CaptionUserPreferences::CaptionDisplayMode displayMode)
 {
-    WebProcess::singleton().parentProcessConnection()->send(Messages::WebProcessProxy::SetCaptionDisplayMode(displayMode), 0);
+    WebProcess::singleton().protectedParentProcessConnection()->send(Messages::WebProcessProxy::SetCaptionDisplayMode(displayMode), 0);
     WebCore::CaptionUserPreferencesMediaAF::setCachedCaptionDisplayMode(displayMode);
 }
 
 void WebCaptionPreferencesDelegate::setPreferredLanguage(const String& language)
 {
-    WebProcess::singleton().parentProcessConnection()->send(Messages::WebProcessProxy::SetCaptionLanguage(language), 0);
+    WebProcess::singleton().protectedParentProcessConnection()->send(Messages::WebProcessProxy::SetCaptionLanguage(language), 0);
 }
 
 } // namespace WebKit


### PR DESCRIPTION
#### 26483474601f5d1156255dcb87dc29c59458ed26
<pre>
Improve memory safety in WebProcess/WebCoreSupport/* part 1
<a href="https://bugs.webkit.org/show_bug.cgi?id=299112">https://bugs.webkit.org/show_bug.cgi?id=299112</a>
<a href="https://rdar.apple.com/160876054">rdar://160876054</a>

Reviewed by Chris Dumez.

Improve memory safety in WebCoreSupport/ files.

* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKit/WebProcess/WebCoreSupport/ShareableBitmapUtilities.cpp:
(WebKit::createShareableBitmap):
* Source/WebKit/WebProcess/WebCoreSupport/WebBroadcastChannelRegistry.cpp:
(WebKit::protectedNetworkProcessConnection):
(WebKit::WebBroadcastChannelRegistry::registerChannel):
(WebKit::WebBroadcastChannelRegistry::unregisterChannel):
(WebKit::WebBroadcastChannelRegistry::postMessage):
(WebKit::WebBroadcastChannelRegistry::networkProcessCrashed):
* Source/WebKit/WebProcess/WebCoreSupport/WebCaptionPreferencesDelegate.cpp:
(WebKit::WebCaptionPreferencesDelegate::setDisplayMode):
(WebKit::WebCaptionPreferencesDelegate::setPreferredLanguage):

Canonical link: <a href="https://commits.webkit.org/300852@main">https://commits.webkit.org/300852@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/68a5cbfe263c324a277862ad898a942f4c72087a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122763 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42475 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33165 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/129388 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74867 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43194 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51068 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93302 "5 flakes 15 failures") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61938 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/862b8711-c919-422a-9127-6f53947b1cb0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125715 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34439 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109900 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73941 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cc525859-12e6-460c-acc0-68286ee29224) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33423 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72892 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104139 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28267 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132115 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49708 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37842 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101816 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50085 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106114 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101688 "Found 3 new API test failures: WebKitGTK/TestInspector:/webkit/WebKitWebInspector/manual-attach-detach, TestWTF:CompletionHandlerDeathTest.MainThreadHandlerOnThreadAssertsDeathTest, TestWTF:CompletionHandlerDeathTest.ConstructionThreadHandlerOnThreadAssertsDeathTest (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26114 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47062 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25245 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/46478 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49565 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/55318 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49032 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/52384 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50715 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->