### PR TITLE
Simplify WebUserContentController and ContentWorld lifetime management

### DIFF
--- a/Source/WebKit/Platform/Logging.h
+++ b/Source/WebKit/Platform/Logging.h
@@ -173,6 +173,7 @@ extern "C" {
     M(TextInteraction) \
     M(Translation) \
     M(UIHitTesting) \
+    M(UserContentController) \
     M(ViewGestures) \
     M(ViewState) \
     M(ViewportSizing) \

--- a/Source/WebKit/Shared/UserContentControllerParameters.h
+++ b/Source/WebKit/Shared/UserContentControllerParameters.h
@@ -34,7 +34,6 @@ namespace WebKit {
 
 struct UserContentControllerParameters {
     UserContentControllerIdentifier identifier;
-    Vector<ContentWorldData> userContentWorlds;
     Vector<WebUserScriptData> userScripts;
     Vector<WebUserStyleSheetData> userStyleSheets;
     Vector<WebScriptMessageHandlerData> messageHandlers;

--- a/Source/WebKit/Shared/UserContentControllerParameters.serialization.in
+++ b/Source/WebKit/Shared/UserContentControllerParameters.serialization.in
@@ -22,7 +22,6 @@
 
 [DebugDecodingFailure] struct WebKit::UserContentControllerParameters {
     WebKit::UserContentControllerIdentifier identifier;
-    Vector<WebKit::ContentWorldData> userContentWorlds;
     Vector<WebKit::WebUserScriptData> userScripts;
     Vector<WebKit::WebUserStyleSheetData> userStyleSheets;
     Vector<WebKit::WebScriptMessageHandlerData> messageHandlers;

--- a/Source/WebKit/Shared/WebUserContentControllerDataTypes.h
+++ b/Source/WebKit/Shared/WebUserContentControllerDataTypes.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "ContentWorldData.h"
 #include "ContentWorldShared.h"
 #include "ScriptMessageHandlerIdentifier.h"
 #include "UserScriptIdentifier.h"
@@ -32,28 +33,23 @@
 #include <WebCore/UserScript.h>
 #include <WebCore/UserStyleSheet.h>
 
-namespace IPC {
-class Decoder;
-class Encoder;
-}
-
 namespace WebKit {
 
 struct WebUserScriptData {
     UserScriptIdentifier identifier;
-    ContentWorldIdentifier worldIdentifier;
+    ContentWorldData worldData;
     WebCore::UserScript userScript;
 };
 
 struct WebUserStyleSheetData {
     UserStyleSheetIdentifier identifier;
-    ContentWorldIdentifier worldIdentifier;
+    ContentWorldData worldData;
     WebCore::UserStyleSheet userStyleSheet;
 };
 
 struct WebScriptMessageHandlerData {
     ScriptMessageHandlerIdentifier identifier;
-    ContentWorldIdentifier worldIdentifier;
+    ContentWorldData worldData;
     String name;
 };
 

--- a/Source/WebKit/Shared/WebUserContentControllerDataTypes.serialization.in
+++ b/Source/WebKit/Shared/WebUserContentControllerDataTypes.serialization.in
@@ -23,20 +23,20 @@
 header: "WebUserContentControllerDataTypes.h"
 [CustomHeader, DebugDecodingFailure] struct WebKit::WebUserScriptData {
     WebKit::UserScriptIdentifier identifier;
-    WebKit::ContentWorldIdentifier worldIdentifier;
+    WebKit::ContentWorldData worldData;
     WebCore::UserScript userScript;
 }
 
 header: "WebUserContentControllerDataTypes.h"
 [CustomHeader, DebugDecodingFailure] struct WebKit::WebUserStyleSheetData {
     WebKit::UserStyleSheetIdentifier identifier;
-    WebKit::ContentWorldIdentifier worldIdentifier;
+    WebKit::ContentWorldData worldData;
     WebCore::UserStyleSheet userStyleSheet;
 }
 
 header: "WebUserContentControllerDataTypes.h"
 [CustomHeader, DebugDecodingFailure] struct WebKit::WebScriptMessageHandlerData {
     WebKit::ScriptMessageHandlerIdentifier identifier;
-    WebKit::ContentWorldIdentifier worldIdentifier;
+    WebKit::ContentWorldData worldData;
     String name;
 }

--- a/Source/WebKit/UIProcess/API/APIContentWorld.cpp
+++ b/Source/WebKit/UIProcess/API/APIContentWorld.cpp
@@ -27,6 +27,8 @@
 #include "APIContentWorld.h"
 
 #include "ContentWorldShared.h"
+#include "WebProcessMessages.h"
+#include "WebProcessProxy.h"
 #include "WebUserContentControllerProxy.h"
 #include <wtf/HashMap.h>
 #include <wtf/WeakRef.h>
@@ -112,20 +114,14 @@ ContentWorld::~ContentWorld()
         ASSERT_UNUSED(taken, taken.get() == this);
     }
 
-    for (Ref proxy : m_associatedContentControllerProxies)
-        proxy->contentWorldDestroyed(*this);
+    for (auto& process : m_processes)
+        process.send(Messages::WebProcess::ContentWorldDestroyed(m_identifier), 0);
 }
 
-void ContentWorld::addAssociatedUserContentControllerProxy(WebKit::WebUserContentControllerProxy& proxy)
+WebKit::ContentWorldData ContentWorld::worldDataForProcess(WebKit::WebProcessProxy& process) const
 {
-    auto addResult = m_associatedContentControllerProxies.add(proxy);
-    ASSERT_UNUSED(addResult, addResult.isNewEntry);
-}
-
-void ContentWorld::userContentControllerProxyDestroyed(WebKit::WebUserContentControllerProxy& proxy)
-{
-    bool removed = m_associatedContentControllerProxies.remove(proxy);
-    ASSERT_UNUSED(removed, removed);
+    m_processes.add(process);
+    return { m_identifier, m_name, m_options };
 }
 
 } // namespace API

--- a/Source/WebKit/UIProcess/API/APIContentWorld.h
+++ b/Source/WebKit/UIProcess/API/APIContentWorld.h
@@ -32,6 +32,7 @@
 #include <wtf/text/WTFString.h>
 
 namespace WebKit {
+class WebProcessProxy;
 class WebUserContentControllerProxy;
 }
 
@@ -48,7 +49,7 @@ public:
 
     WebKit::ContentWorldIdentifier identifier() const { return m_identifier; }
     const WTF::String& name() const { return m_name; }
-    WebKit::ContentWorldData worldData() const { return { m_identifier, m_name, m_options }; }
+    WebKit::ContentWorldData worldDataForProcess(WebKit::WebProcessProxy&) const;
 
     bool allowAccessToClosedShadowRoots() const { return m_options.contains(WebKit::ContentWorldOption::AllowAccessToClosedShadowRoots); }
     void setAllowAccessToClosedShadowRoots(bool value) { m_options.add(WebKit::ContentWorldOption::AllowAccessToClosedShadowRoots); }
@@ -69,7 +70,6 @@ public:
     void setAllowNodeSerialization() { m_options.add(WebKit::ContentWorldOption::AllowNodeSerialization); }
 
     void addAssociatedUserContentControllerProxy(WebKit::WebUserContentControllerProxy&);
-    void userContentControllerProxyDestroyed(WebKit::WebUserContentControllerProxy&);
 
 private:
     explicit ContentWorld(const WTF::String&, OptionSet<WebKit::ContentWorldOption>);
@@ -78,7 +78,7 @@ private:
     WebKit::ContentWorldIdentifier m_identifier;
     WTF::String m_name;
     OptionSet<WebKit::ContentWorldOption> m_options;
-    WeakHashSet<WebKit::WebUserContentControllerProxy> m_associatedContentControllerProxies;
+    mutable WeakHashSet<WebKit::WebProcessProxy> m_processes;
 };
 
 } // namespace API

--- a/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.cpp
+++ b/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.cpp
@@ -76,12 +76,6 @@ WebUserContentControllerProxy::WebUserContentControllerProxy()
 
 WebUserContentControllerProxy::~WebUserContentControllerProxy()
 {
-    for (const auto& identifier : m_associatedContentWorlds) {
-        RefPtr world = API::ContentWorld::worldForIdentifier(identifier);
-        RELEASE_ASSERT(world);
-        world->userContentControllerProxyDestroyed(*this);
-    }
-    
     webUserContentControllerProxies().remove(identifier());
 #if ENABLE(CONTENT_EXTENSIONS)
     for (Ref process : m_networkProcesses)
@@ -106,29 +100,22 @@ void WebUserContentControllerProxy::addProcess(WebProcessProxy& webProcessProxy)
     m_processes.add(webProcessProxy);
 }
 
-UserContentControllerParameters WebUserContentControllerProxy::parameters() const
+UserContentControllerParameters WebUserContentControllerProxy::parametersForProcess(WebProcessProxy& process) const
 {
-    auto userContentWorlds = WTF::map(m_associatedContentWorlds, [](auto& identifier) {
-        auto* world = API::ContentWorld::worldForIdentifier(identifier);
-        RELEASE_ASSERT(world);
-        return world->worldData();
-    });
-
     Vector<WebUserScriptData> userScripts;
     for (RefPtr userScript : m_userScripts->elementsOfType<API::UserScript>())
-        userScripts.append({ userScript->identifier(), userScript->contentWorld().identifier(), userScript->userScript() });
+        userScripts.append({ userScript->identifier(), userScript->contentWorld().worldDataForProcess(process), userScript->userScript() });
 
     Vector<WebUserStyleSheetData> userStyleSheets;
     for (RefPtr userStyleSheet : m_userStyleSheets->elementsOfType<API::UserStyleSheet>())
-        userStyleSheets.append({ userStyleSheet->identifier(), userStyleSheet->contentWorld().identifier(), userStyleSheet->userStyleSheet() });
+        userStyleSheets.append({ userStyleSheet->identifier(), userStyleSheet->contentWorld().worldDataForProcess(process), userStyleSheet->userStyleSheet() });
 
-    auto messageHandlers = WTF::map(m_scriptMessageHandlers, [](auto entry) {
-        return WebScriptMessageHandlerData { entry.value->identifier(), entry.value->world().identifier(), entry.value->name() };
+    auto messageHandlers = WTF::map(m_scriptMessageHandlers, [&](auto entry) {
+        return WebScriptMessageHandlerData { entry.value->identifier(), entry.value->world().worldDataForProcess(process), entry.value->name() };
     });
 
     return {
         identifier()
-        , WTFMove(userContentWorlds)
         , WTFMove(userScripts)
         , WTFMove(userStyleSheets)
         , WTFMove(messageHandlers)
@@ -147,39 +134,14 @@ Vector<std::pair<WebCompiledContentRuleListData, URL>> WebUserContentControllerP
 }
 #endif
 
-void WebUserContentControllerProxy::addContentWorld(API::ContentWorld& world)
-{
-    if (world.identifier() == pageContentWorldIdentifier())
-        return;
-
-    auto addResult = m_associatedContentWorlds.add(world.identifier());
-    if (!addResult.isNewEntry)
-        return;
-
-    world.addAssociatedUserContentControllerProxy(*this);
-    for (Ref process : m_processes)
-        process->send(Messages::WebUserContentController::AddContentWorlds({ world.worldData() }), identifier());
-}
-
-void WebUserContentControllerProxy::contentWorldDestroyed(API::ContentWorld& world)
-{
-    bool result = m_associatedContentWorlds.remove(world.identifier());
-    ASSERT_UNUSED(result, result);
-
-    for (Ref process : m_processes)
-        process->send(Messages::WebUserContentController::RemoveContentWorlds({ world.identifier() }), identifier());
-}
-
 void WebUserContentControllerProxy::addUserScript(API::UserScript& userScript, InjectUserScriptImmediately immediately)
 {
     Ref<API::ContentWorld> world = userScript.contentWorld();
 
-    addContentWorld(world.get());
-
     m_userScripts->elements().append(&userScript);
 
     for (Ref process : m_processes)
-        process->send(Messages::WebUserContentController::AddUserScripts({ { userScript.identifier(), world->identifier(), userScript.userScript() } }, immediately), identifier());
+        process->send(Messages::WebUserContentController::AddUserScripts({ { userScript.identifier(), world->worldDataForProcess(process), userScript.userScript() } }, immediately), identifier());
 }
 
 void WebUserContentControllerProxy::removeUserScript(API::UserScript& userScript)
@@ -247,12 +209,10 @@ void WebUserContentControllerProxy::addUserStyleSheet(API::UserStyleSheet& userS
 {
     Ref<API::ContentWorld> world = userStyleSheet.contentWorld();
 
-    addContentWorld(world.get());
-
     m_userStyleSheets->elements().append(&userStyleSheet);
 
     for (Ref process : m_processes)
-        process->send(Messages::WebUserContentController::AddUserStyleSheets({ { userStyleSheet.identifier(), world->identifier(), userStyleSheet.userStyleSheet() } }), identifier());
+        process->send(Messages::WebUserContentController::AddUserStyleSheets({ { userStyleSheet.identifier(), world->worldDataForProcess(process), userStyleSheet.userStyleSheet() } }), identifier());
 }
 
 void WebUserContentControllerProxy::removeUserStyleSheet(API::UserStyleSheet& userStyleSheet)
@@ -325,12 +285,10 @@ bool WebUserContentControllerProxy::addUserScriptMessageHandler(WebScriptMessage
             return false;
     }
 
-    addContentWorld(world);
-
     m_scriptMessageHandlers.add(handler.identifier(), handler);
 
     for (Ref process : m_processes)
-        process->send(Messages::WebUserContentController::AddUserScriptMessageHandlers({ { handler.identifier(), world->identifier(), handler.name() } }), identifier());
+        process->send(Messages::WebUserContentController::AddUserScriptMessageHandlers({ { handler.identifier(), world->worldDataForProcess(process), handler.name() } }), identifier());
     
     return true;
 }

--- a/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.h
+++ b/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.h
@@ -80,7 +80,7 @@ public:
 
     static WebUserContentControllerProxy* get(UserContentControllerIdentifier);
 
-    UserContentControllerParameters parameters() const;
+    UserContentControllerParameters parametersForProcess(WebProcessProxy&) const;
 
     void addProcess(WebProcessProxy&);
 
@@ -126,20 +126,15 @@ public:
     Vector<std::pair<WebCompiledContentRuleListData, URL>> contentRuleListData() const;
 #endif
 
-    void contentWorldDestroyed(API::ContentWorld&);
-
     bool operator==(const WebUserContentControllerProxy& other) const { return (this == &other); }
 
     void didPostMessage(WebPageProxy&, FrameInfoData&&, ScriptMessageHandlerIdentifier, JavaScriptEvaluationResult&&, CompletionHandler<void(Expected<JavaScriptEvaluationResult, String>&&)>&&) const;
 
 private:
-    void addContentWorld(API::ContentWorld&);
-
     WeakHashSet<WebProcessProxy> m_processes;
     const Ref<API::Array> m_userScripts;
     const Ref<API::Array> m_userStyleSheets;
     HashMap<ScriptMessageHandlerIdentifier, Ref<WebScriptMessageHandler>> m_scriptMessageHandlers;
-    HashSet<ContentWorldIdentifier> m_associatedContentWorlds;
 
 #if ENABLE(CONTENT_EXTENSIONS)
     WeakHashSet<NetworkProcessProxy> m_networkProcesses;

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -6368,7 +6368,7 @@ void WebPageProxy::runJavaScriptInFrameInScriptWorld(RunJavaScriptParameters&& p
         activity = processContainingFrame(frameID)->protectedThrottler()->foregroundActivity("WebPageProxy::runJavaScriptInFrameInScriptWorld"_s);
 #endif
 
-    sendWithAsyncReplyToProcessContainingFrame(frameID, Messages::WebPage::RunJavaScriptInFrameInScriptWorld(parameters, frameID, world.worldData(), wantsResult), [activity = WTFMove(activity), callbackFunction = WTFMove(callbackFunction)] (auto&& result) mutable {
+    sendWithAsyncReplyToProcessContainingFrame(frameID, Messages::WebPage::RunJavaScriptInFrameInScriptWorld(parameters, frameID, world.worldDataForProcess(processContainingFrame(frameID)), wantsResult), [activity = WTFMove(activity), callbackFunction = WTFMove(callbackFunction)] (auto&& result) mutable {
         callbackFunction(WTFMove(result));
     });
 }
@@ -11915,7 +11915,7 @@ WebPageCreationParameters WebPageProxy::creationParameters(WebProcessProxy& proc
         .pageGroupData = m_pageGroup->data(),
         .visitedLinkTableID = m_visitedLinkStore->identifier(),
         .overrideReferrerForAllRequests = m_configuration->overrideReferrerForAllRequests(),
-        .userContentControllerParameters = userContentController->parameters(),
+        .userContentControllerParameters = userContentController->parametersForProcess(process),
         .mainFrameIdentifier = mainFrameIdentifier,
         .openedMainFrameName = m_openedMainFrameName,
         .initialSandboxFlags = m_mainFrame ? m_mainFrame->effectiveSandboxFlags() : SandboxFlags { },

--- a/Source/WebKit/WebProcess/UserContent/WebUserContentController.h
+++ b/Source/WebKit/WebProcess/UserContent/WebUserContentController.h
@@ -72,14 +72,15 @@ public:
 
     InjectedBundleScriptWorld* worldForIdentifier(ContentWorldIdentifier);
 
-    void addContentWorlds(const Vector<ContentWorldData>&);
-    InjectedBundleScriptWorld* addContentWorld(const ContentWorldData&);
+    void addContentWorldIfNecessary(const ContentWorldData&);
     void addUserScripts(Vector<WebUserScriptData>&&, InjectUserScriptImmediately);
     void addUserStyleSheets(const Vector<WebUserStyleSheetData>&);
     void addUserScriptMessageHandlers(const Vector<WebScriptMessageHandlerData>&);
 #if ENABLE(CONTENT_EXTENSIONS)
     void addContentRuleLists(Vector<std::pair<WebCompiledContentRuleListData, URL>>&&);
 #endif
+
+    static void removeContentWorld(ContentWorldIdentifier);
 
 private:
     explicit WebUserContentController(UserContentControllerIdentifier);
@@ -96,8 +97,6 @@ private:
 
     // IPC::MessageReceiver.
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
-
-    void removeContentWorlds(const Vector<ContentWorldIdentifier>&);
 
     void removeUserScript(ContentWorldIdentifier, UserScriptIdentifier);
     void removeAllUserScripts(const Vector<ContentWorldIdentifier>&);

--- a/Source/WebKit/WebProcess/UserContent/WebUserContentController.messages.in
+++ b/Source/WebKit/WebProcess/UserContent/WebUserContentController.messages.in
@@ -28,9 +28,6 @@
     DispatchedTo=WebContent
 ]
 messages -> WebUserContentController {
-    AddContentWorlds(Vector<WebKit::ContentWorldData> worlds);
-    RemoveContentWorlds(Vector<WebKit::ContentWorldIdentifier> worldIdentifiers);
-
     AddUserScripts(Vector<WebKit::WebUserScriptData> userScripts, enum:bool WebKit::InjectUserScriptImmediately immediately);
     RemoveUserScript(WebKit::ContentWorldIdentifier worldIdentifier, WebKit::UserScriptIdentifier identifier);
     RemoveAllUserScripts(Vector<WebKit::ContentWorldIdentifier> worldIdentifiers);

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -90,6 +90,7 @@
 #include "WebSharedWorkerContextManagerConnectionMessages.h"
 #include "WebSharedWorkerProvider.h"
 #include "WebTransportSession.h"
+#include "WebUserContentController.h"
 #include "WebsiteData.h"
 #include "WebsiteDataStoreParameters.h"
 #include "WebsiteDataType.h"
@@ -2669,6 +2670,11 @@ void WebProcess::didReceiveRemoteCommand(PlatformMediaSession::RemoteControlComm
 {
     for (auto& page : m_pageMap.values())
         page->didReceiveRemoteCommand(type, argument);
+}
+
+void WebProcess::contentWorldDestroyed(ContentWorldIdentifier identifier)
+{
+    WebUserContentController::removeContentWorld(identifier);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -160,6 +160,7 @@ class WebTransportSession;
 
 struct AccessibilityPreferences;
 struct AdditionalFonts;
+struct ContentWorldIdentifierType;
 struct RemoteWorkerInitializationData;
 struct UserMessage;
 struct WebProcessCreationParameters;
@@ -174,6 +175,7 @@ struct WebsiteDataStoreParameters;
 enum class RemoteWorkerType : uint8_t;
 enum class WebsiteDataType : uint32_t;
 
+using ContentWorldIdentifier = ObjectIdentifier<ContentWorldIdentifierType>;
 using WebTransportSessionIdentifier = AtomicObjectIdentifier<WebTransportSessionIdentifierType>;
 
 #if PLATFORM(IOS_FAMILY)
@@ -242,6 +244,8 @@ public:
     WebCore::ThirdPartyCookieBlockingMode thirdPartyCookieBlockingMode() const { return m_thirdPartyCookieBlockingMode; }
 
     bool fullKeyboardAccessEnabled() const { return m_fullKeyboardAccessEnabled; }
+
+    void contentWorldDestroyed(ContentWorldIdentifier);
 
 #if HAVE(MOUSE_DEVICE_OBSERVATION)
     bool hasMouseDevice() const { return m_hasMouseDevice; }

--- a/Source/WebKit/WebProcess/WebProcess.messages.in
+++ b/Source/WebKit/WebProcess/WebProcess.messages.in
@@ -252,4 +252,6 @@ messages -> WebProcess : AuxiliaryProcess WantsAsyncDispatchMessage {
 #if ENABLE(INITIALIZE_ACCESSIBILITY_ON_DEMAND)
     InitializeAccessibility(Vector<WebKit::SandboxExtensionHandle> handles);
 #endif
+
+    ContentWorldDestroyed(WebKit::ContentWorldIdentifier identifier)
 }


### PR DESCRIPTION
#### 022c9f84d64993ed580b44bca9558dbfc19149b6
<pre>
Simplify WebUserContentController and ContentWorld lifetime management
<a href="https://bugs.webkit.org/show_bug.cgi?id=299114">https://bugs.webkit.org/show_bug.cgi?id=299114</a>
<a href="https://rdar.apple.com/160876340">rdar://160876340</a>

Reviewed by Brady Eidson.

Before this PR, WebUserContentControllerProxy was trying to manage the lifetimes of
InjectedBundleScriptWorlds in different processes, but it was doing so in a complex
and incomplete manner.  This untangles the code a bit by making the ContentWorld
keep track of which processes it has been injected into and cleaning up in those
processes when it is done.

This should have no change in behavior, except for the case where a WKContentWorld
is used for WKWebView.evaluateJavaScript or callAsyncJavaScript but not a WKUserScript
or a _WKUserStyleSheet.  In that case, the InjectedBundleScriptWorld was not destroyed
when the WKContentWorld was destroyed because the WebUserContentControllerProxy had
not been informed of its existence.  Now it is cleaned up, which should only result
in memory savings.

* Source/WebKit/Shared/UserContentControllerParameters.h:
* Source/WebKit/Shared/UserContentControllerParameters.serialization.in:
* Source/WebKit/Shared/WebUserContentControllerDataTypes.h:
* Source/WebKit/Shared/WebUserContentControllerDataTypes.serialization.in:
* Source/WebKit/UIProcess/API/APIContentWorld.cpp:
(API::ContentWorld::~ContentWorld):
(API::ContentWorld::worldDataForProcess const):
(API::ContentWorld::addAssociatedUserContentControllerProxy): Deleted.
(API::ContentWorld::userContentControllerProxyDestroyed): Deleted.
* Source/WebKit/UIProcess/API/APIContentWorld.h:
* Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.cpp:
(WebKit::WebUserContentControllerProxy::~WebUserContentControllerProxy):
(WebKit::WebUserContentControllerProxy::parametersForProcess const):
(WebKit::WebUserContentControllerProxy::addUserScript):
(WebKit::WebUserContentControllerProxy::addUserStyleSheet):
(WebKit::WebUserContentControllerProxy::addUserScriptMessageHandler):
(WebKit::WebUserContentControllerProxy::parameters const): Deleted.
(WebKit::WebUserContentControllerProxy::addContentWorld): Deleted.
(WebKit::WebUserContentControllerProxy::contentWorldDestroyed): Deleted.
* Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::runJavaScriptInFrameInScriptWorld):
(WebKit::WebPageProxy::creationParameters):
* Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp:
(WebKit::worldMap):
(WebKit::WebUserContentController::worldForIdentifier):
(WebKit::WebUserContentController::addContentWorldIfNecessary):
(WebKit::WebUserContentController::removeContentWorld):
(WebKit::WebUserContentController::addUserScripts):
(WebKit::WebUserContentController::removeUserScript):
(WebKit::WebUserContentController::removeAllUserScripts):
(WebKit::WebUserContentController::addUserStyleSheets):
(WebKit::WebUserContentController::removeUserStyleSheet):
(WebKit::WebUserContentController::removeAllUserStyleSheets):
(WebKit::WebUserContentController::addUserScriptMessageHandlers):
(WebKit::WebUserContentController::removeUserScriptMessageHandler):
(WebKit::WebUserContentController::removeAllUserScriptMessageHandlersForWorlds):
(WebKit::WebUserContentController::addContentWorld): Deleted.
(WebKit::WebUserContentController::addContentWorlds): Deleted.
(WebKit::WebUserContentController::removeContentWorlds): Deleted.
* Source/WebKit/WebProcess/UserContent/WebUserContentController.h:
* Source/WebKit/WebProcess/UserContent/WebUserContentController.messages.in:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::m_toolbarsAreVisible):
(WebKit::WebPage::runJavaScriptInFrameInScriptWorld):
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::contentWorldDestroyed):
* Source/WebKit/WebProcess/WebProcess.h:
* Source/WebKit/WebProcess/WebProcess.messages.in:

Canonical link: <a href="https://commits.webkit.org/300192@main">https://commits.webkit.org/300192@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8cbd7e24d454542597c3933eedafe12f0f34ba4e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121612 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41310 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31969 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128106 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/73702 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d5ef2227-eea4-4eee-85e5-f5f45e17408c) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42021 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49898 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92401 "19 flakes 22 failures") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/73702 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/511ff39d-7d87-43ad-a5f0-2b19dd43f072) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124564 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33541 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/108941 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73060 "Found 1 new API test failure: WPE/TestWebKitWebContext:/webkit/WebKitWebContext/no-web-process-leak (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/96cf3bf7-ed09-4ae4-9d18-a9ae8f1c30a0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32555 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71645 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103037 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27276 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130913 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48547 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/36935 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/100976 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48918 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105149 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100864 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46262 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24366 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/45248 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19273 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48403 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54148 "Found 4 new failures in UIProcess/UserContent/WebUserContentControllerProxy.cpp, UIProcess/API/APIContentWorld.cpp") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47874 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51224 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49557 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->