### PR TITLE
Improve memory safety in WebProcess/WebCoreSupport/* part 2

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -32,7 +32,6 @@ WebProcess/Network/webrtc/LibWebRTCDnsResolverFactory.cpp
 WebProcess/Network/webrtc/LibWebRTCNetwork.h
 WebProcess/Network/webrtc/LibWebRTCProvider.cpp
 WebProcess/Network/webrtc/LibWebRTCResolver.cpp
-WebProcess/WebCoreSupport/WebChromeClient.cpp
 WebProcess/WebCoreSupport/mac/WebPopupMenuMac.mm
 WebProcess/WebPage/Cocoa/TextAnimationController.mm
 WebProcess/WebPage/Cocoa/WebPageCocoa.mm

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp
@@ -436,7 +436,7 @@ void WebEditorClient::textFieldDidEndEditing(Element& element)
     if (!inputElement)
         return;
 
-    auto webFrame = WebFrame::fromCoreFrame(*element.document().protectedFrame());
+    auto webFrame = WebFrame::fromCoreFrame(*element.protectedDocument()->protectedFrame());
     ASSERT(webFrame);
 
     if (RefPtr page = m_page.get())
@@ -451,7 +451,7 @@ void WebEditorClient::textDidChangeInTextField(Element& element)
 
     bool initiatedByUserTyping = UserTypingGestureIndicator::processingUserTypingGesture() && UserTypingGestureIndicator::focusedElementAtGestureStart() == inputElement;
 
-    auto webFrame = WebFrame::fromCoreFrame(*element.document().protectedFrame());
+    auto webFrame = WebFrame::fromCoreFrame(*element.protectedDocument()->protectedFrame());
     ASSERT(webFrame);
 
     if (RefPtr page = m_page.get())
@@ -464,7 +464,7 @@ void WebEditorClient::textDidChangeInTextArea(Element& element)
     if (!textAreaElement)
         return;
 
-    auto webFrame = WebFrame::fromCoreFrame(*element.document().protectedFrame());
+    auto webFrame = WebFrame::fromCoreFrame(*element.protectedDocument()->protectedFrame());
     ASSERT(webFrame);
 
     if (RefPtr page = m_page.get())
@@ -538,7 +538,7 @@ bool WebEditorClient::doTextFieldCommandFromEvent(Element& element, KeyboardEven
     if (!getActionTypeForKeyEvent(event, actionType))
         return false;
 
-    auto webFrame = WebFrame::fromCoreFrame(*element.document().protectedFrame());
+    auto webFrame = WebFrame::fromCoreFrame(*element.protectedDocument()->protectedFrame());
     ASSERT(webFrame);
 
     RefPtr page = m_page.get();
@@ -551,7 +551,7 @@ void WebEditorClient::textWillBeDeletedInTextField(Element& element)
     if (!inputElement)
         return;
 
-    auto webFrame = WebFrame::fromCoreFrame(*element.document().protectedFrame());
+    auto webFrame = WebFrame::fromCoreFrame(*element.protectedDocument()->protectedFrame());
     ASSERT(webFrame);
 
     if (RefPtr page = m_page.get())


### PR DESCRIPTION
#### e24f355cbdda0af3b17f0f1ce481072edb465bc0
<pre>
Improve memory safety in WebProcess/WebCoreSupport/* part 2
<a href="https://bugs.webkit.org/show_bug.cgi?id=299113">https://bugs.webkit.org/show_bug.cgi?id=299113</a>
<a href="https://rdar.apple.com/160876045">rdar://160876045</a>

Reviewed by Chris Dumez and Ryosuke Niwa.

Further improve memory safety in WebCoreSupport/*

* Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::windowRect const):
(WebKit::WebChromeClient::focusedFrameChanged):
(WebKit::WebChromeClient::createWindow):
(WebKit::WebChromeClient::closeWindow):
(WebKit::WebChromeClient::invalidateContentsAndRootView):
(WebKit::WebChromeClient::invalidateContentsForSlowScroll):
(WebKit::WebChromeClient::scroll):
(WebKit::WebChromeClient::contentsSizeChanged const):
(WebKit::WebChromeClient::createImageBuffer const):
(WebKit::WebChromeClient::sinkIntoImageBuffer):
(WebKit::WebChromeClient::createWorkerClient):
(WebKit::WebChromeClient::createScrollingCoordinator const):
(WebKit::WebChromeClient::ensureScrollbarsController const):
(WebKit::WebChromeClient::canEnterVideoFullscreen const):
(WebKit::WebChromeClient::supportsVideoFullscreen):
(WebKit::WebChromeClient::supportsVideoFullscreenStandby):
(WebKit::WebChromeClient::enterVideoFullscreenForVideoElement):
(WebKit::WebChromeClient::setPlayerIdentifierForVideoElement):
(WebKit::WebChromeClient::exitVideoFullscreenForVideoElement):
(WebKit::WebChromeClient::setUpPlaybackControlsManager):
(WebKit::WebChromeClient::clearPlaybackControlsManager):
(WebKit::WebChromeClient::mediaEngineChanged):
(WebKit::WebChromeClient::exitVideoFullscreenToModeWithoutAnimation):
(WebKit::WebChromeClient::setVideoFullscreenMode):
(WebKit::WebChromeClient::clearVideoFullscreenMode):
(WebKit::WebChromeClient::supportsFullScreenForElement):
(WebKit::WebChromeClient::enterFullScreenForElement):
(WebKit::WebChromeClient::exitFullScreenForElement):
(WebKit::WebChromeClient::shouldUseTiledBackingForFrameView const):
(WebKit::WebChromeClient::isUsingUISideCompositing const):
(WebKit::WebChromeClient::getImageBufferResourceLimitsForTesting const):
* Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp:
(WebKit::WebEditorClient::textFieldDidEndEditing):
(WebKit::WebEditorClient::textDidChangeInTextField):
(WebKit::WebEditorClient::textDidChangeInTextArea):
(WebKit::WebEditorClient::doTextFieldCommandFromEvent):
(WebKit::WebEditorClient::textWillBeDeletedInTextField):

Canonical link: <a href="https://commits.webkit.org/300857@main">https://commits.webkit.org/300857@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/399f19fe6f35c76fea47f877e2bc4f8605034bf2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124104 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43802 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34514 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130931 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/76226 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44540 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52402 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94403 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/76226 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e495cbe5-6ec0-46f4-b55f-8c07eb548af9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127058 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/35492 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111013 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74995 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/60fe6c3e-26c7-4c86-bb5f-98cfc3037526) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/34439 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74417 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105230 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29396 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133607 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/51040 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38889 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102873 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51418 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107232 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102682 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26119 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/48039 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26286 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/47919 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50896 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56667 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/50357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/53705 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/52031 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->