### PR TITLE
Improve security key PIN re-entry flow

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.h
@@ -54,6 +54,7 @@ typedef NS_ENUM(NSInteger, _WKWebAuthenticationPanelUpdate) {
     _WKWebAuthenticationPanelUpdateKeyStoreFull,
     _WKWebAuthenticationPanelUpdatePINTooShort,
     _WKWebAuthenticationPanelUpdatePINTooLong,
+    _WKWebAuthenticationPanelUpdatePINSuccessful,
 } WK_API_AVAILABLE(macos(10.15.4), ios(13.4));
 
 typedef NS_ENUM(NSInteger, _WKWebAuthenticationResult) {

--- a/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.cpp
@@ -331,9 +331,11 @@ void AuthenticatorManager::downgrade(Authenticator& id, Ref<Authenticator>&& dow
 
 void AuthenticatorManager::authenticatorStatusUpdated(WebAuthenticationStatus status)
 {
-    // Immediately invalidate the cache if the PIN is incorrect. A status update often means
-    // an error. We don't really care what kind of error it really is.
-    m_pendingRequestData.cachedPin = String();
+    if (status != WebAuthenticationStatus::PINSuccessful) {
+        // Immediately invalidate the cache if the PIN is incorrect. A status update often means
+        // an error. We don't really care what kind of error it really is.
+        m_pendingRequestData.cachedPin = String();
+    }
 
     // This is for the new UI.
     if (RefPtr presenter = m_presenter) {

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticationPanelClient.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticationPanelClient.mm
@@ -88,6 +88,8 @@ static _WKWebAuthenticationPanelUpdate wkWebAuthenticationPanelUpdate(WebAuthent
         return _WKWebAuthenticationPanelUpdatePINTooShort;
     if (status == WebAuthenticationStatus::PINTooLong)
         return _WKWebAuthenticationPanelUpdatePINTooLong;
+    if (status == WebAuthenticationStatus::PINSuccessful)
+        return _WKWebAuthenticationPanelUpdatePINSuccessful;
     ASSERT_NOT_REACHED();
     return _WKWebAuthenticationPanelUpdateMultipleNFCTagsPresent;
 }

--- a/Source/WebKit/UIProcess/WebAuthentication/WebAuthenticationFlags.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/WebAuthenticationFlags.h
@@ -52,6 +52,7 @@ enum class WebAuthenticationStatus : uint8_t {
     KeyStoreFull,
     PINTooShort,
     PINTooLong,
+    PINSuccessful,
 };
 
 enum class LocalAuthenticatorPolicy : bool {

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp
@@ -84,6 +84,8 @@ WebAuthenticationStatus toStatus(const CtapDeviceResponseCode& error)
         return WebAuthenticationStatus::PinAuthBlocked;
     case CtapDeviceResponseCode::kCtap2ErrPinBlocked:
         return WebAuthenticationStatus::PinBlocked;
+    case CtapDeviceResponseCode::kSuccess:
+        return WebAuthenticationStatus::PINSuccessful;
     default:
         ASSERT_NOT_REACHED();
         return WebAuthenticationStatus::PinInvalid;
@@ -545,9 +547,15 @@ void CtapAuthenticator::continueRequestAfterGetPinToken(Vector<uint8_t>&& data, 
                 return;
         }
 
+        if (RefPtr observer = this->observer())
+            observer->authenticatorStatusUpdated(toStatus(CtapDeviceResponseCode::kSuccess));
+
         receiveRespond(ExceptionData { ExceptionCode::UnknownError, makeString("Unknown internal error. Error code: "_s, static_cast<uint8_t>(error)) });
         return;
     }
+
+    if (RefPtr observer = this->observer())
+        observer->authenticatorStatusUpdated(toStatus(CtapDeviceResponseCode::kSuccess));
 
     m_pinAuth = token->pinAuth(requestData().hash);
     WTF::switchOn(requestData().options, [&](const PublicKeyCredentialCreationOptions& options) {


### PR DESCRIPTION
#### e10b0d93ce7b98efa25ad94db116f0079e98acea
<pre>
Improve security key PIN re-entry flow
<a href="https://bugs.webkit.org/show_bug.cgi?id=299119">https://bugs.webkit.org/show_bug.cgi?id=299119</a>
<a href="https://rdar.apple.com/160881460">rdar://160881460</a>

Reviewed by Pascoe.

We need to add a new status update to send to AuthenticationServices to signal
that a PIN was successful. This allows AuthenticationServices to correctly determine
the sequence and timing to present UI in both the success and failure cases.

* Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.h:
* Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.cpp:
(WebKit::AuthenticatorManager::authenticatorStatusUpdated):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticationPanelClient.mm:
(WebKit::wkWebAuthenticationPanelUpdate):
* Source/WebKit/UIProcess/WebAuthentication/WebAuthenticationFlags.h:
* Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp:
(WebKit::CtapAuthenticator::continueRequestAfterGetPinToken):

Canonical link: <a href="https://commits.webkit.org/300411@main">https://commits.webkit.org/300411@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/530079ed4474381e6a3bf62b8d9429e861e36ee0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122426 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42132 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32818 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/129018 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/74525 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bad9aec6-cb90-457d-9340-79fa3f9771ef) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42851 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50725 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93059 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/74525 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6d82a444-a49b-4e29-a937-ee5d049cd2fb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125378 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34175 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109617 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73712 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/db0f6af6-2736-403b-abc8-f436a86a87f0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33163 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72509 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103801 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27984 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131754 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49367 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37571 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101600 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49741 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105837 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101470 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25749 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46846 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24980 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/46132 "The change is no longer eligible for processing.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49225 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54969 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48692 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/52042 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50374 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->