### PR TITLE
AX: accessibilityDetailsElement should return containers on iOS

### DIFF
--- a/LayoutTests/accessibility/ios-simulator/aria-details-expected.txt
+++ b/LayoutTests/accessibility/ios-simulator/aria-details-expected.txt
@@ -1,3 +1,12 @@
+This verifies the exposure of aria-details.
+
+PASS: details.length === 2
+PASS: details[0].childAtIndex(0).childAtIndex(0).description === 'AXLabel: Details example'
+PASS: details[1].description === 'AXLabel: Application of the Pythagorean Theorem'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
 
 Details example
 The Pythagorean Theorem is a relationship in Euclidean Geometry between the three sides of a right triangle, where the square of the hypotenuse is the sum of the squares of the two opposing sides.
@@ -7,17 +16,3 @@ The following drawing illustrates an application of the Pythagorean Theorem when
 In this example you will notice a skateboard ramp with a base and vertical board whose width is the width of the ramp. To compute how long the ramp must be, simply calculate the base length, square it, sum it with the square of the height of the ramp, and take the square root of the sum.
 
 See an Application of the Pythagorean Theorem.
-
-This verifies the exposure of aria-details.
-
-On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
-
-
-PASS details.length is 5
-PASS details[0].description is 'AXLabel: Details example'
-PASS details[2].description is 'AXLabel: The following drawing illustrates an application of the Pythagorean Theorem when used to construct a skateboard ramp.'
-PASS details[4].description is 'AXLabel: Application of the Pythagorean Theorem'
-PASS successfullyParsed is true
-
-TEST COMPLETE
-

--- a/LayoutTests/accessibility/ios-simulator/aria-details.html
+++ b/LayoutTests/accessibility/ios-simulator/aria-details.html
@@ -1,7 +1,8 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/accessibility-helper.js"></script>
 </head>
 <body>
 
@@ -26,21 +27,17 @@
 </details>
 <p>See an <a href="http://foo.com/pt.html" id="details2">Application of the Pythagorean Theorem</a>.</p>
 
-<p id="description"></p>
-<div id="console"></div>
-
 <script>
-    description("This verifies the exposure of aria-details.");
+    var output = "This verifies the exposure of aria-details.\n\n";
 
     if (window.accessibilityController) {
         image1 = accessibilityController.accessibleElementById("image1");
         details = image1.detailsElements();
-        shouldBe("details.length", "5");
-        shouldBe("details[0].description", "'AXLabel: Details example'");
-        shouldBe("details[2].description", "'AXLabel: The following drawing illustrates an application of the Pythagorean Theorem when used to construct a skateboard ramp.'");
-        shouldBe("details[4].description", "'AXLabel: Application of the Pythagorean Theorem'");
+        output += expect("details.length", "2");
+        output += expect("details[0].childAtIndex(0).childAtIndex(0).description", "'AXLabel: Details example'");
+        output += expect("details[1].description", "'AXLabel: Application of the Pythagorean Theorem'");
+        debug(output);
     }
 </script>
-<script src="../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
+++ b/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
@@ -2000,7 +2000,12 @@ static NSArray *accessibleElementsForObjects(const AXCoreObject::AccessibilityCh
 {
     if (![self _prepareAccessibilityCall])
         return nil;
-    return accessibleElementsForObjects(self.axBackingObject->detailedByObjects());
+
+    return createNSArray(self.axBackingObject->detailedByObjects(), [] (auto&& detailedByObject) -> id {
+        auto wrapper = detailedByObject->wrapper();
+        ASSERT(wrapper);
+        return wrapper;
+    }).autorelease();
 }
 
 - (NSArray *)accessibilityErrorMessageElements


### PR DESCRIPTION
#### 759d61308c4bdd1bb5482ee28f3ed282a61e8e1f
<pre>
AX: accessibilityDetailsElement should return containers on iOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=299121">https://bugs.webkit.org/show_bug.cgi?id=299121</a>
<a href="https://rdar.apple.com/160884055">rdar://160884055</a>

Reviewed by Tyler Wilcock.

This PR updates accessibilityDetailsElements to return the details element container,
rather than its accessible descendants. This allows ATs to query the accessible descendants
as-needed, instead of not having that information up front.

Our iOS-specific layout test was updated to reflect this change.

* LayoutTests/accessibility/ios-simulator/aria-details-expected.txt:
* LayoutTests/accessibility/ios-simulator/aria-details.html:
* Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm:
(-[WebAccessibilityObjectWrapper accessibilityDetailsElements]):

Canonical link: <a href="https://commits.webkit.org/300416@main">https://commits.webkit.org/300416@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a9f95016bd385a3b20ecb34fea291ecf5d7149e3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122436 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42144 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32829 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/129036 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74535 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fc58fd94-ae02-4d89-89a2-d7ed9c8e79a6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/124312 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42862 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50735 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93071 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61818 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bad37621-bffb-4677-b08a-85b6f31b2955) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125388 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34184 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109627 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73720 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c43bf13e-8314-4917-8312-9f20cb92fb29) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33173 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27784 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72521 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103816 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27995 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131764 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49377 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37578 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101608 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49751 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105848 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101477 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25754 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46855 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24990 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/46142 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49235 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54979 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48702 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/52052 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50384 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->