### PR TITLE
[Smart Lists] Smart Lists should be able to be identified by their type

### DIFF
--- a/Source/WebCore/editing/InsertTextCommand.cpp
+++ b/Source/WebCore/editing/InsertTextCommand.cpp
@@ -157,6 +157,20 @@ static AtomString inlineStyleForListStyleType(StyledElement& element, Style::Lis
     return inlineStyle->asTextAtom(CSS::defaultSerializationContext());
 }
 
+static AtomString classNameForSmartList(const TextList& textList)
+{
+    if (textList.ordered) {
+        ASSERT(textList.styleType.isDecimal());
+        return "Apple-decimal-list"_s;
+    }
+
+    if (textList.styleType.isDisc())
+        return "Apple-disc-list"_s;
+
+    ASSERT(textList.styleType.isString());
+    return "Apple-dash-list"_s;
+}
+
 bool InsertTextCommand::applySmartListsIfNeeded()
 {
     if (!document().editor().isSmartListsEnabled())
@@ -228,6 +242,9 @@ bool InsertTextCommand::applySmartListsIfNeeded()
 
     if (auto style = inlineStyleForListStyleType(*listElement, smartList->styleType); !style.isNull())
         setNodeAttribute(*listElement, HTMLNames::styleAttr, style);
+
+    if (auto className = classNameForSmartList(*smartList); !className.isNull())
+        setNodeAttribute(*listElement, HTMLNames::classAttr, className);
 
     deleteSelection();
     return true;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SmartListsSupport.h
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SmartListsSupport.h
@@ -51,7 +51,7 @@ NS_SWIFT_UI_ACTOR
 NS_SWIFT_UI_ACTOR
 @interface SmartListsTestConfiguration : NSObject
 
-- (instancetype)initWithExpectedHTML:(NSString *)expectedHTML expectedSelection:(SmartListsTestSelectionConfiguration *)expectedSelection input:(NSString *)input;
+- (instancetype)initWithExpectedHTML:(NSString *)expectedHTML expectedSelection:(SmartListsTestSelectionConfiguration *)expectedSelection input:(NSString *)input stylesheet:(nullable NSString *)stylesheet;
 
 @end
 


### PR DESCRIPTION
#### 42adc93b64e57e5364bbf7652fbc9be87899a1b0
<pre>
[Smart Lists] Smart Lists should be able to be identified by their type
<a href="https://bugs.webkit.org/show_bug.cgi?id=299123">https://bugs.webkit.org/show_bug.cgi?id=299123</a>
<a href="https://rdar.apple.com/160885297">rdar://160885297</a>

Reviewed by Abrar Rahman Protyasha.

When a Smart List is created, set a specific class name depending on the type of list it is, so that clients can be able to identify these.

Also adds a test with some minor refactoring

Canonical link: <a href="https://commits.webkit.org/300200@main">https://commits.webkit.org/300200@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c869bc6e9a0130323dcc6b10f2e34c56d3346ed

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121639 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41338 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31999 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128155 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/73729 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fd0febcd-9886-444e-9539-84158706fab4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123515 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42052 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49931 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/92435 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/73729 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/755dde8d-7dcb-4c4e-a4bf-9a0f48f41958) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124591 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33556 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/108952 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73096 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/90275818-8ddc-40ab-a6b0-b5c18e02c97b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32572 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27112 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71673 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103053 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27293 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130954 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48573 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/36952 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/101005 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48945 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105162 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100894 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25588 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/46275 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24377 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/45274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48432 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54159 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/47901 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/51250 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/49584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->