### PR TITLE
Make WebUserContentController creation consistently apply all properties

### DIFF
--- a/Source/WebKit/Shared/RemoteWorkerInitializationData.h
+++ b/Source/WebKit/Shared/RemoteWorkerInitializationData.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include "UserContentControllerIdentifier.h"
+#include "UserContentControllerParameters.h"
 #include <wtf/Forward.h>
 
 namespace WebKit {
@@ -33,10 +33,7 @@ namespace WebKit {
 class WebCompiledContentRuleListData;
 
 struct RemoteWorkerInitializationData {
-    UserContentControllerIdentifier userContentControllerIdentifier;
-#if ENABLE(CONTENT_EXTENSIONS)
-    Vector<std::pair<WebCompiledContentRuleListData, URL>> contentRuleLists;
-#endif
+    UserContentControllerParameters userContentControllerParameters;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/RemoteWorkerInitializationData.serialization.in
+++ b/Source/WebKit/Shared/RemoteWorkerInitializationData.serialization.in
@@ -21,8 +21,5 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 struct WebKit::RemoteWorkerInitializationData {
-    WebKit::UserContentControllerIdentifier userContentControllerIdentifier;
-#if ENABLE(CONTENT_EXTENSIONS)
-    Vector<std::pair<WebKit::WebCompiledContentRuleListData, URL>> contentRuleLists;
-#endif
+    WebKit::UserContentControllerParameters userContentControllerParameters;
 };

--- a/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.cpp
+++ b/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.cpp
@@ -95,13 +95,10 @@ void WebUserContentControllerProxy::removeNetworkProcess(NetworkProcessProxy& pr
 }
 #endif
 
-void WebUserContentControllerProxy::addProcess(WebProcessProxy& webProcessProxy)
-{
-    m_processes.add(webProcessProxy);
-}
-
 UserContentControllerParameters WebUserContentControllerProxy::parametersForProcess(WebProcessProxy& process) const
 {
+    m_processes.add(process);
+
     Vector<WebUserScriptData> userScripts;
     for (RefPtr userScript : m_userScripts->elementsOfType<API::UserScript>())
         userScripts.append({ userScript->identifier(), Ref { userScript->contentWorld() }->worldDataForProcess(process), userScript->userScript() });

--- a/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.h
+++ b/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.h
@@ -82,8 +82,6 @@ public:
 
     UserContentControllerParameters parametersForProcess(WebProcessProxy&) const;
 
-    void addProcess(WebProcessProxy&);
-
     API::Array& userScripts() { return m_userScripts.get(); }
     void addUserScript(API::UserScript&, InjectUserScriptImmediately);
     void removeUserScript(API::UserScript&);
@@ -131,7 +129,7 @@ public:
     void didPostMessage(WebPageProxy&, FrameInfoData&&, ScriptMessageHandlerIdentifier, JavaScriptEvaluationResult&&, CompletionHandler<void(Expected<JavaScriptEvaluationResult, String>&&)>&&) const;
 
 private:
-    WeakHashSet<WebProcessProxy> m_processes;
+    mutable WeakHashSet<WebProcessProxy> m_processes;
     const Ref<API::Array> m_userScripts;
     const Ref<API::Array> m_userStyleSheets;
     HashMap<ScriptMessageHandlerIdentifier, Ref<WebScriptMessageHandler>> m_scriptMessageHandlers;

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -11897,7 +11897,6 @@ WebPageCreationParameters WebPageProxy::creationParameters(WebProcessProxy& proc
     Ref userContentController = m_userContentController;
     if (RefPtr userContentControllerFromWebsitePolicies = websitePolicies ? websitePolicies->userContentController() : nullptr)
         userContentController = userContentControllerFromWebsitePolicies.releaseNonNull();
-    userContentController->addProcess(process);
 
     if (m_sessionStateWasRestoredByAPIRequest)
         m_backForwardList->setItemsAsRestoredFromSession();

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -711,7 +711,7 @@ void WebProcessPool::establishRemoteWorkerContextConnectionToNetworkProcess(Remo
 
     auto useProcessForRemoteWorkers = [&](WebProcessProxy& process) {
         remoteWorkerProcessProxy = process;
-        process.enableRemoteWorkers(workerType, processPool->userContentControllerIdentifierForRemoteWorkers());
+        process.enableRemoteWorkers(workerType, processPool->userContentControllerForRemoteWorkers());
         if (process.isInProcessCache()) {
             processPool->webProcessCache().removeProcess(process, WebProcessCache::ShouldShutDownProcess::No);
             ASSERT(!process.isInProcessCache());
@@ -1277,12 +1277,12 @@ Ref<WebProcessProxy> WebProcessPool::processForSite(WebsiteDataStore& websiteDat
     return createNewWebProcess(&websiteDataStore, lockdownMode);
 }
 
-UserContentControllerIdentifier WebProcessPool::userContentControllerIdentifierForRemoteWorkers()
+Ref<WebUserContentControllerProxy> WebProcessPool::userContentControllerForRemoteWorkers()
 {
     if (!m_userContentControllerForRemoteWorkers)
         m_userContentControllerForRemoteWorkers = WebUserContentControllerProxy::create();
 
-    return m_userContentControllerForRemoteWorkers->identifier();
+    return *m_userContentControllerForRemoteWorkers;
 }
 
 Ref<WebPageProxy> WebProcessPool::createWebPage(PageClient& pageClient, Ref<API::PageConfiguration>&& pageConfiguration)

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -423,7 +423,7 @@ public:
     void serviceWorkerProcessCrashed(WebProcessProxy&, ProcessTerminationReason);
 
     void updateRemoteWorkerUserAgent(const String& userAgent);
-    UserContentControllerIdentifier userContentControllerIdentifierForRemoteWorkers();
+    Ref<WebUserContentControllerProxy> userContentControllerForRemoteWorkers();
     static void establishRemoteWorkerContextConnectionToNetworkProcess(RemoteWorkerType, WebCore::Site&&, std::optional<WebCore::ProcessIdentifier> requestingProcessIdentifier, std::optional<WebCore::ScriptExecutionContextIdentifier> serviceWorkerPageIdentifier, PAL::SessionID, CompletionHandler<void(WebCore::ProcessIdentifier)>&&);
 
 #if PLATFORM(COCOA)

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -222,7 +222,7 @@ public:
     void setIsInProcessCache(bool, WillShutDown = WillShutDown::No);
     bool isInProcessCache() const { return m_isInProcessCache; }
 
-    void enableRemoteWorkers(RemoteWorkerType, const UserContentControllerIdentifier&);
+    void enableRemoteWorkers(RemoteWorkerType, const WebUserContentControllerProxy&);
     void disableRemoteWorkers(OptionSet<RemoteWorkerType>);
 
     WebsiteDataStore* websiteDataStore() const { ASSERT(m_websiteDataStore); return m_websiteDataStore.get(); }

--- a/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp
@@ -97,13 +97,9 @@ WebSWContextManagerConnection::WebSWContextManagerConnection(Ref<IPC::Connection
 #else
     , m_userAgent(standardUserAgent())
 #endif
-    , m_userContentController(WebUserContentController::getOrCreate(initializationData.userContentControllerIdentifier))
+    , m_userContentController(WebUserContentController::getOrCreate(WTFMove(initializationData.userContentControllerParameters)))
     , m_queue(WorkQueue::create("WebSWContextManagerConnection queue"_s, WorkQueue::QOS::UserInitiated))
 {
-#if ENABLE(CONTENT_EXTENSIONS)
-    m_userContentController->addContentRuleLists(WTFMove(initializationData.contentRuleLists));
-#endif
-
     WebPage::updatePreferencesGenerated(store);
     m_preferencesStore = store;
 

--- a/Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.cpp
@@ -78,12 +78,8 @@ WebSharedWorkerContextManagerConnection::WebSharedWorkerContextManagerConnection
 #else
     , m_userAgent(WebCore::standardUserAgent())
 #endif
-    , m_userContentController(WebUserContentController::getOrCreate(initializationData.userContentControllerIdentifier))
+    , m_userContentController(WebUserContentController::getOrCreate(WTFMove(initializationData.userContentControllerParameters)))
 {
-#if ENABLE(CONTENT_EXTENSIONS)
-    m_userContentController->addContentRuleLists(WTFMove(initializationData.contentRuleLists));
-#endif
-
     updatePreferencesStore(preferencesStore);
     WebProcess::singleton().disableTermination();
 }

--- a/Source/WebKit/WebProcess/UserContent/WebUserContentController.h
+++ b/Source/WebKit/WebProcess/UserContent/WebUserContentController.h
@@ -39,22 +39,19 @@
 #include <WebCore/ContentExtensionsBackend.h>
 #endif
 
-namespace WebCore {
-namespace ContentExtensions {
-class CompiledContentExtension;
-}
-}
-
 namespace WebKit {
 
 class InjectedBundleScriptWorld;
 class WebCompiledContentRuleListData;
 class WebUserMessageHandlerDescriptorProxy;
+
+struct UserContentControllerParameters;
+
 enum class InjectUserScriptImmediately : bool;
 
 class WebUserContentController final : public WebCore::UserContentProvider, public IPC::MessageReceiver {
 public:
-    static Ref<WebUserContentController> getOrCreate(UserContentControllerIdentifier);
+    static Ref<WebUserContentController> getOrCreate(UserContentControllerParameters&&);
     virtual ~WebUserContentController();
 
     void ref() const final { WebCore::UserContentProvider::ref(); }
@@ -74,8 +71,8 @@ public:
 
     void addContentWorldIfNecessary(const ContentWorldData&);
     void addUserScripts(Vector<WebUserScriptData>&&, InjectUserScriptImmediately);
-    void addUserStyleSheets(const Vector<WebUserStyleSheetData>&);
-    void addUserScriptMessageHandlers(const Vector<WebScriptMessageHandlerData>&);
+    void addUserStyleSheets(Vector<WebUserStyleSheetData>&&);
+    void addUserScriptMessageHandlers(Vector<WebScriptMessageHandlerData>&&);
 #if ENABLE(CONTENT_EXTENSIONS)
     void addContentRuleLists(Vector<std::pair<WebCompiledContentRuleListData, URL>>&&);
 #endif

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -633,7 +633,7 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
     , m_findController(makeUniqueRef<FindController>(this))
     , m_foundTextRangeController(makeUniqueRef<WebFoundTextRangeController>(*this))
     , m_inspectorTargetController(makeUniqueRef<WebPageInspectorTargetController>(*this))
-    , m_userContentController(WebUserContentController::getOrCreate(parameters.userContentControllerParameters.identifier))
+    , m_userContentController(WebUserContentController::getOrCreate(WTFMove(parameters.userContentControllerParameters)))
     , m_screenOrientationManager(makeUniqueRefWithoutRefCountedCheck<WebScreenOrientationManager>(*this))
 #if ENABLE(GEOLOCATION)
     , m_geolocationPermissionRequestManager(makeUniqueRefWithoutRefCountedCheck<GeolocationPermissionRequestManager>(*this))
@@ -1120,13 +1120,6 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
         registerURLSchemeHandler(iterator.value, iterator.key);
     for (auto& scheme : parameters.urlSchemesWithLegacyCustomProtocolHandlers)
         LegacySchemeRegistry::registerURLSchemeAsHandledBySchemeHandler({ scheme });
-
-    m_userContentController->addUserScripts(WTFMove(parameters.userContentControllerParameters.userScripts), InjectUserScriptImmediately::No);
-    m_userContentController->addUserStyleSheets(parameters.userContentControllerParameters.userStyleSheets);
-    m_userContentController->addUserScriptMessageHandlers(parameters.userContentControllerParameters.messageHandlers);
-#if ENABLE(CONTENT_EXTENSIONS)
-    m_userContentController->addContentRuleLists(WTFMove(parameters.userContentControllerParameters.contentRuleLists));
-#endif
 
 #if PLATFORM(IOS_FAMILY)
     setViewportConfigurationViewLayoutSize(parameters.viewportConfigurationViewLayoutSize, parameters.viewportConfigurationLayoutSizeScaleFactorFromClient, parameters.viewportConfigurationMinimumEffectiveDeviceWidth);


### PR DESCRIPTION
#### 8dcaa756107b725c38efc50175abc8f6b01e6750
<pre>
Make WebUserContentController creation consistently apply all properties
<a href="https://bugs.webkit.org/show_bug.cgi?id=299135">https://bugs.webkit.org/show_bug.cgi?id=299135</a>
<a href="https://rdar.apple.com/160893408">rdar://160893408</a>

Reviewed by Ryosuke Niwa.

Before this PR, we called WebUserContentController::getOrCreate then populated
its fields with whatever parameters we happened to have, which leads to inconsistently
initialized WebUserContentControllers.  This passes all needed parameters to
WebUserContentController::getOrCreate, and it will return the object if it
exists, or it will fully populate the object if it doesn&apos;t.  This makes it so
all processes get the same representation of the WebUserContentControllerProxy.

I also replace WebUserContentControllerProxy::addProcess with the
WebUserContentControllerProxy keeping track of which processes it has
sent its parameters to, like we do in ContentWorld::worldDataForProcess.

* Source/WebKit/Shared/RemoteWorkerInitializationData.h:
* Source/WebKit/Shared/RemoteWorkerInitializationData.serialization.in:
* Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.cpp:
(WebKit::WebUserContentControllerProxy::parametersForProcess const):
(WebKit::WebUserContentControllerProxy::addProcess): Deleted.
* Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::creationParameters):
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::establishRemoteWorkerContextConnectionToNetworkProcess):
(WebKit::WebProcessPool::userContentControllerForRemoteWorkers):
(WebKit::WebProcessPool::userContentControllerIdentifierForRemoteWorkers): Deleted.
* Source/WebKit/UIProcess/WebProcessPool.h:
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::createForRemoteWorkers):
(WebKit::WebProcessProxy::enableRemoteWorkers):
(WebKit::contentRuleListsFromIdentifier): Deleted.
* Source/WebKit/UIProcess/WebProcessProxy.h:
* Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp:
(WebKit::m_queue):
* Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.cpp:
(WebKit::m_userContentController):
* Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp:
(WebKit::WebUserContentController::getOrCreate):
(WebKit::WebUserContentController::addUserStyleSheets):
(WebKit::WebUserContentController::addUserScriptMessageHandlers):
* Source/WebKit/WebProcess/UserContent/WebUserContentController.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::m_toolbarsAreVisible):

Canonical link: <a href="https://commits.webkit.org/300243@main">https://commits.webkit.org/300243@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/16fef67228e3cc845cedbe3b222a04a6490d451c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121712 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41413 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32077 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128241 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73802 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/11866d32-58de-4a7a-8a64-dd45975bbcf2) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42125 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50004 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92482 "16 failures") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61486 "Found 1 new test failure: imported/w3c/web-platform-tests/event-timing/duration-with-target-low.html (failure)") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fbeba20f-242b-4241-a1ab-58476143c8e2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124664 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33609 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109011 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73144 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/10d85e7f-a847-4d68-8245-122f642923e5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32620 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71757 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103107 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27359 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131027 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48647 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37000 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101052 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49019 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105228 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100944 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46315 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24429 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45348 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19291 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48505 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54232 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47974 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51324 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49657 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->