### PR TITLE
Resolve Safer CPP warnings in LegacyDisplayRefreshMonitorMac.h

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
@@ -91,7 +91,6 @@ platform/graphics/ImageBufferContextSwitcher.h
 platform/graphics/StringTruncator.cpp
 platform/graphics/ca/PlatformCALayer.h
 platform/graphics/ca/TileController.cpp
-platform/graphics/mac/LegacyDisplayRefreshMonitorMac.h
 platform/mediastream/libwebrtc/LibWebRTCDav1dDecoder.cpp
 platform/mediastream/mac/CoreAudioSharedUnit.h
 platform/network/cocoa/CredentialCocoa.h

--- a/Source/WebCore/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations
@@ -6,7 +6,6 @@ platform/cocoa/WebAVPlayerLayer.h
 platform/graphics/ca/cocoa/WebVideoContainerLayer.h
 platform/graphics/cg/CGSubimageCacheWithTimer.cpp
 platform/graphics/cocoa/WebSampleBufferVideoRendering.h
-platform/graphics/mac/LegacyDisplayRefreshMonitorMac.h
 platform/ios/WebAVPlayerController.h
 platform/ios/WebAVPlayerController.mm
 platform/mac/WebCoreFullScreenPlaceholderView.h

--- a/Source/WebCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
@@ -99,7 +99,6 @@ platform/graphics/cv/GraphicsContextGLCVCocoa.mm
 platform/graphics/cv/ImageTransferSessionVT.mm
 platform/graphics/cv/VideoFrameCV.mm
 platform/graphics/mac/ColorMac.mm
-platform/graphics/mac/LegacyDisplayRefreshMonitorMac.cpp
 platform/graphics/mac/PDFDocumentImageMac.mm
 platform/graphics/mac/ScrollbarTrackCornerSystemImageMac.mm
 platform/graphics/mac/controls/InnerSpinButtonMac.mm

--- a/Source/WebCore/platform/cocoa/CoreVideoExtras.h
+++ b/Source/WebCore/platform/cocoa/CoreVideoExtras.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if PLATFORM(MAC)
+#include <CoreVideo/CVDisplayLink.h>
+
+namespace WTF {
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+template<> struct DefaultRefDerefTraits<__CVDisplayLink> {
+    static CVDisplayLinkRef refIfNotNull(CVDisplayLinkRef displayLink) { return CVDisplayLinkRetain(displayLink); }
+    static void derefIfNotNull(CVDisplayLinkRef displayLink) { CVDisplayLinkRelease(displayLink); }
+};
+}
+
+#endif // PLATFORM(MAC)

--- a/Source/WebCore/platform/graphics/mac/LegacyDisplayRefreshMonitorMac.h
+++ b/Source/WebCore/platform/graphics/mac/LegacyDisplayRefreshMonitorMac.h
@@ -27,10 +27,9 @@
 
 #if PLATFORM(MAC)
 
+#include "CoreVideoExtras.h"
 #include "DisplayRefreshMonitor.h"
 #include <wtf/WeakPtr.h>
-
-typedef struct __CVDisplayLink *CVDisplayLinkRef;
 
 namespace WebCore {
 
@@ -60,7 +59,7 @@ private:
 
     static FramesPerSecond nominalFramesPerSecondFromDisplayLink(CVDisplayLinkRef);
 
-    CVDisplayLinkRef m_displayLink { nullptr };
+    RefPtr<__CVDisplayLink> m_displayLink;
     
     DisplayUpdate m_currentUpdate;
     bool m_displayLinkIsActive { false };

--- a/Source/WebKit/UIProcess/DisplayLink.h
+++ b/Source/WebKit/UIProcess/DisplayLink.h
@@ -37,7 +37,7 @@
 #include <wtf/TZoneMalloc.h>
 
 #if PLATFORM(MAC)
-#include <CoreVideo/CVDisplayLink.h>
+#include <WebCore/CoreVideoExtras.h>
 #endif
 
 #if PLATFORM(GTK) || PLATFORM(WPE)
@@ -47,17 +47,6 @@
 #if USE(WPE_BACKEND_PLAYSTATION)
 struct wpe_playstation_display;
 #endif
-
-namespace WTF {
-#if PLATFORM(MAC)
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-template<> struct DefaultRefDerefTraits<__CVDisplayLink> {
-    static CVDisplayLinkRef refIfNotNull(CVDisplayLinkRef displayLink) { return CVDisplayLinkRetain(displayLink); }
-    static void derefIfNotNull(CVDisplayLinkRef displayLink) { CVDisplayLinkRelease(displayLink); }
-};
-ALLOW_DEPRECATED_DECLARATIONS_END
-#endif // PLATFORM(MAC)
-}
 
 namespace WebKit {
 


### PR DESCRIPTION
#### e3568c37e4cad5a0fbe4203ee38990651993bdcd
<pre>
Resolve Safer CPP warnings in LegacyDisplayRefreshMonitorMac.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=299142">https://bugs.webkit.org/show_bug.cgi?id=299142</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/cocoa/CoreVideoExtras.h: Added.
(WTF::DefaultRefDerefTraits&lt;__CVDisplayLink&gt;::refIfNotNull):
(WTF::DefaultRefDerefTraits&lt;__CVDisplayLink&gt;::derefIfNotNull):
* Source/WebCore/platform/graphics/mac/LegacyDisplayRefreshMonitorMac.cpp:
(WebCore::LegacyDisplayRefreshMonitorMac::stop):
(WebCore::LegacyDisplayRefreshMonitorMac::ensureDisplayLink):
(WebCore::LegacyDisplayRefreshMonitorMac::startNotificationMechanism):
(WebCore::LegacyDisplayRefreshMonitorMac::stopNotificationMechanism):
(WebCore::LegacyDisplayRefreshMonitorMac::displayNominalFramesPerSecond):
* Source/WebCore/platform/graphics/mac/LegacyDisplayRefreshMonitorMac.h:
* Source/WebKit/UIProcess/DisplayLink.h:
(WTF::DefaultRefDerefTraits&lt;__CVDisplayLink&gt;::refIfNotNull): Deleted.
(WTF::DefaultRefDerefTraits&lt;__CVDisplayLink&gt;::derefIfNotNull): Deleted.

Canonical link: <a href="https://commits.webkit.org/300224@main">https://commits.webkit.org/300224@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2b43e5ce7adf272d85742975b6b30abcf7c854e8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121714 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41415 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32079 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128243 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73804 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4ec89591-f957-4b7f-96ce-b25627cb4c01) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123590 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42127 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50006 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92483 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61487 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4005de5e-95c2-417e-aa20-f44f146bc17c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124666 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33607 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109017 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73145 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5597fd7f-ea60-48d6-b00a-34fdb08304e5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32617 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27180 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71759 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103105 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27365 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131029 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48649 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37001 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101051 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49021 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105234 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100943 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25610 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46314 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24435 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45350 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48507 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54234 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47976 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51326 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49659 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->