### PR TITLE
Resync `webaudio` from WPT Upstream

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/active-processing.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/active-processing.https-expected.txt
@@ -1,16 +1,4 @@
 
-PASS # AUDIT TASK RUNNER STARTED.
-PASS Executing "Setup graph"
-PASS Executing "verify count change"
-PASS Audit report
-PASS > [Setup graph]
-PASS   AudioWorklet and graph construction resolved correctly.
-PASS < [Setup graph] All assertions passed. (total 1 assertions)
-PASS > [verify count change]
-PASS   Number of channels changed is true.
-PASS   Index where input channel count changed is less than or equal to 1280.
-PASS   Number of channels in input[0:255] contains only the constant 7.
-PASS   Number of channels in input[256:] contains only the constant 0.
-PASS < [verify count change] All assertions passed. (total 4 assertions)
-PASS # AUDIT TASK RUNNER FINISHED: 2 tasks ran successfully.
+PASS Setup graph with AudioWorklet and AudioBufferSourceNode
+PASS Verify input channel count change after AudioBufferSourceNode stops
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/active-processing.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/active-processing.https.html
@@ -1,100 +1,84 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
-  <head>
-    <title>
-      Test Active Processing for AudioBufferSourceNode
-    </title>
-    <script src="/resources/testharness.js"></script>
-    <script src="/resources/testharnessreport.js"></script>
-    <script src="/webaudio/resources/audit-util.js"></script>
-    <script src="/webaudio/resources/audit.js"></script>
-  </head>
+<head>
+  <title>
+    Test Active Processing for AudioBufferSourceNode
+  </title>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/webaudio/resources/audit-util.js"></script>
+</head>
+<body>
+  <script>
+    // Arbitrary sample rate. And we only new a few blocks for rendering to
+    // see if things are working.
+    const sampleRate = 8000;
+    const renderLength = 10 * RENDER_QUANTUM_FRAMES;
 
-  <body>
-    <script id="layout-test-code">
-      let audit = Audit.createTaskRunner();
+    // Offline context used for the tests.
+    let context;
 
-      // Arbitrary sample rate. And we only new a few blocks for rendering to
-      // see if things are working.
-      let sampleRate = 8000;
-      let renderLength = 10 * RENDER_QUANTUM_FRAMES;
+    // Number of channels for the AudioBufferSource. Fairly arbitrary, but
+    // should be more than 2.
+    const numberOfChannels = 7;
 
-      // Offline context used for the tests.
-      let context;
+    // Number of frames in the AudioBuffer.  Fairly arbitrary, but should
+    // probably be more than one render quantum and significantly less than
+    // |renderLength|.
+    const bufferFrames = 131;
 
-      // Number of channels for the AudioBufferSource. Fairly arbitrary, but
-      // should be more than 2.
-      let numberOfChannels = 7;
+    const filePath =
+        '../the-audioworklet-interface/processors/input-count-processor.js';
 
-      // Number of frames in the AudioBuffer.  Fairly arbitrary, but should
-      // probably be more than one render quantum and significantly less than
-      // |renderLength|.
-      let bufferFrames = 131;
+    promise_test(async (t) => {
+      context = new OfflineAudioContext(
+          numberOfChannels, renderLength, sampleRate);
 
-      let filePath =
-          '../the-audioworklet-interface/processors/input-count-processor.js';
-
-      audit.define('Setup graph', (task, should) => {
-        context =
-            new OfflineAudioContext(numberOfChannels, renderLength, sampleRate);
-
-        should(
-            context.audioWorklet.addModule(filePath).then(() => {
-              let buffer = new AudioBuffer({
-                numberOfChannels: numberOfChannels,
-                length: bufferFrames,
-                sampleRate: context.sampleRate
-              });
-
-              src = new AudioBufferSourceNode(context, {buffer: buffer});
-              let counter = new AudioWorkletNode(context, 'counter');
-
-              src.connect(counter).connect(context.destination);
-              src.start();
-            }),
-            'AudioWorklet and graph construction')
-            .beResolved()
-            .then(() => task.done());
+      await context.audioWorklet.addModule(filePath);
+      const buffer = new AudioBuffer({
+        numberOfChannels: numberOfChannels,
+        length: bufferFrames,
+        sampleRate: context.sampleRate
       });
 
-      audit.define('verify count change', (task, should) => {
-        context.startRendering()
-            .then(renderedBuffer => {
-              let output = renderedBuffer.getChannelData(0);
+      const src = new AudioBufferSourceNode(context, {buffer});
+      const counter = new AudioWorkletNode(context, 'counter');
 
-              // Find the first time the number of channels changes to 0.
-              let countChangeIndex = output.findIndex(x => x == 0);
+      src.connect(counter).connect(context.destination);
+      src.start();
+    }, 'Setup graph with AudioWorklet and AudioBufferSourceNode');
 
-              // Verify that the count did change.  If it didn't there's a bug
-              // in the implementation, or it takes longer than the render
-              // length to change.  For the latter case, increase the render
-              // length, but it can't be arbitrarily large.  The change needs to
-              // happen at some reasonable time after the source stops.
-              should(countChangeIndex >= 0, 'Number of channels changed')
-                  .beTrue();
-              should(
-                  countChangeIndex, 'Index where input channel count changed')
-                  .beLessThanOrEqualTo(renderLength);
+    promise_test(async () => {
+      const renderedBuffer = await context.startRendering();
+      const output = renderedBuffer.getChannelData(0);
 
-              // Verify the number of channels at the beginning matches the
-              // number of channels in the AudioBuffer.
-              should(
-                  output.slice(0, countChangeIndex),
-                  `Number of channels in input[0:${countChangeIndex - 1}]`)
-                  .beConstantValueOf(numberOfChannels);
+      // Find the first time the number of channels changes to 0.
+      const countChangeIndex = output.findIndex(x => x == 0);
 
-              // Verify that after the source has stopped, the number of
-              // channels is 0.
-              should(
-                  output.slice(countChangeIndex),
-                  `Number of channels in input[${countChangeIndex}:]`)
-                  .beConstantValueOf(0);
-            })
-            .then(() => task.done());
-      });
+      // Verify that the count did change.  If it didn't there's a bug
+      // in the implementation, or it takes longer than the render
+      // length to change.  For the latter case, increase the render
+      // length, but it can't be arbitrarily large.  The change needs to
+      // happen at some reasonable time after the source stops.
+      assert_greater_than_equal(countChangeIndex, 0,
+          'Number of channels changed');
+      assert_less_than_equal(countChangeIndex, renderLength,
+          'Index where input channel count changed');
 
-      audit.run();
-    </script>
+      // Verify the number of channels at the beginning matches the
+      // number of channels in the AudioBuffer.
+      assert_array_equals(
+          output.slice(0, countChangeIndex),
+          new Float32Array(countChangeIndex).fill(numberOfChannels),
+          `Number of channels in input[0:${countChangeIndex - 1}]`);
 
-  </body>
+      // Verify that after the source has stopped, the number of
+      // channels is 0.
+      assert_array_equals(
+          output.slice(countChangeIndex),
+          new Float32Array(renderLength - countChangeIndex),
+          `Number of channels in input[${countChangeIndex}:]`);
+    }, 'Verify input channel count change after AudioBufferSourceNode stops');
+  </script>
+</body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/audiobuffersource-channels-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/audiobuffersource-channels-expected.txt
@@ -1,24 +1,3 @@
 
-PASS # AUDIT TASK RUNNER STARTED.
-PASS Executing "validate .buffer"
-PASS Audit report
-PASS > [validate .buffer] Validatation of AudioBuffer in .buffer attribute setter
-PASS   source.buffer = 57 threw TypeError: "The AudioBufferSourceNode.buffer attribute must be an instance of AudioBuffer".
-PASS   source.buffer = null did not throw an exception.
-PASS   source.buffer = buffer did not throw an exception.
-PASS   source.buffer = new buffer threw InvalidStateError: "The buffer was already set".
-PASS   source.buffer = null again did not throw an exception.
-PASS   source.buffer = buffer again threw InvalidStateError: "The buffer was already set".
-PASS   source.buffer = null after setting to null did not throw an exception.
-PASS   Setting source with mono buffer did not throw an exception.
-PASS   Setting source with stereo buffer did not throw an exception.
-PASS   Setting source with 3 channels buffer did not throw an exception.
-PASS   Setting source with 4 channels buffer did not throw an exception.
-PASS   Setting source with 5 channels buffer did not throw an exception.
-PASS   Setting source with 6 channels buffer did not throw an exception.
-PASS   Setting source with 7 channels buffer did not throw an exception.
-PASS   Setting source with 8 channels buffer did not throw an exception.
-PASS   Setting source with 9 channels buffer did not throw an exception.
-PASS < [validate .buffer] All assertions passed. (total 16 assertions)
-PASS # AUDIT TASK RUNNER FINISHED: 1 tasks ran successfully.
+PASS validate .buffer: Validation of AudioBuffer in .buffer attribute setter
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/audiobuffersource-channels.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/audiobuffersource-channels.html
@@ -1,97 +1,81 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <title>
-      audiobuffersource-channels.html
-    </title>
-    <script src="/resources/testharness.js"></script>
-    <script src="/resources/testharnessreport.js"></script>
-    <script src="/webaudio/resources/audit-util.js"></script>
-    <script src="/webaudio/resources/audit.js"></script>
-  </head>
-  <body>
-    <script id="layout-test-code">
-      let audit = Audit.createTaskRunner();
-      let context;
-      let source;
+<head>
+  <title>audiobuffersource-channels.html</title>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/webaudio/resources/audit-util.js"></script>
+</head>
+<body>
+  <script>
+    test(() => {
+      const context = new AudioContext();
+      const source = new AudioBufferSourceNode(context);
 
-      audit.define(
-          {
-            label: 'validate .buffer',
-            description:
-                'Validatation of AudioBuffer in .buffer attribute setter'
-          },
-          function(task, should) {
-            context = new AudioContext();
-            source = context.createBufferSource();
+      // Make sure we can't set to something which isn't an AudioBuffer.
+      assert_throws_js(TypeError, () => {
+        source.buffer = 57;
+      }, 'source.buffer = 57');
 
-            // Make sure we can't set to something which isn't an AudioBuffer.
-            should(function() {
-              source.buffer = 57;
-            }, 'source.buffer = 57').throw(TypeError);
+      // It's ok to set the buffer to null.
+      source.buffer = null;
 
-            // It's ok to set the buffer to null.
-            should(function() {
-              source.buffer = null;
-            }, 'source.buffer = null').notThrow();
+      // Set the buffer to a valid AudioBuffer
+      const buffer = new AudioBuffer({
+        length: 128,
+        sampleRate: context.sampleRate});
 
-            // Set the buffer to a valid AudioBuffer
-            let buffer =
-                new AudioBuffer({length: 128, sampleRate: context.sampleRate});
+      source.buffer = buffer;
 
-            should(function() {
-              source.buffer = buffer;
-            }, 'source.buffer = buffer').notThrow();
+      // The buffer has been set; we can't set it again.
+      assert_throws_dom('InvalidStateError', () => {
+        source.buffer = new AudioBuffer({
+          length: 128,
+          sampleRate: context.sampleRate});
+      }, 'source.buffer = new buffer');
 
-            // The buffer has been set; we can't set it again.
-            should(function() {
-              source.buffer =
-                  new AudioBuffer({length: 128, sampleRate: context.sampleRate})
-            }, 'source.buffer = new buffer').throw(DOMException, 'InvalidStateError');
+      // The buffer has been set; it's ok to set it to null.
+      source.buffer = null;
 
-            // The buffer has been set; it's ok to set it to null.
-            should(function() {
-              source.buffer = null;
-            }, 'source.buffer = null again').notThrow();
+      // The buffer was already set (and set to null). Can't set it again.
+      assert_throws_dom('InvalidStateError', () => {
+        source.buffer = buffer;
+      }, 'source.buffer = buffer again');
 
-            // The buffer was already set (and set to null).  Can't set it
-            // again.
-            should(function() {
-              source.buffer = buffer;
-            }, 'source.buffer = buffer again').throw(DOMException, 'InvalidStateError');
+      // But setting to null is ok.
+      source.buffer = null;
 
-            // But setting to null is ok.
-            should(function() {
-            }, 'source.buffer = null after setting to null').notThrow();
+      // Check that mono buffer can be set.
+      {
+        const monoBuffer = new AudioBuffer({
+          numberOfChannels: 1,
+          length: 1024,
+          sampleRate: context.sampleRate});
+        const testSource = new AudioBufferSourceNode(context);
+        testSource.buffer = monoBuffer;
+      }
 
-            // Check that mono buffer can be set.
-            should(function() {
-              let monoBuffer =
-                  context.createBuffer(1, 1024, context.sampleRate);
-              let testSource = context.createBufferSource();
-              testSource.buffer = monoBuffer;
-            }, 'Setting source with mono buffer').notThrow();
+      // Check that stereo buffer can be set.
+      {
+        const stereoBuffer = new AudioBuffer({
+          numberOfChannels: 2,
+          length: 1024,
+          sampleRate: context.sampleRate});
+        const testSource = new AudioBufferSourceNode(context);
+        testSource.buffer = stereoBuffer;
+      }
 
-            // Check that stereo buffer can be set.
-            should(function() {
-              let stereoBuffer =
-                  context.createBuffer(2, 1024, context.sampleRate);
-              let testSource = context.createBufferSource();
-              testSource.buffer = stereoBuffer;
-            }, 'Setting source with stereo buffer').notThrow();
-
-            // Check buffers with more than two channels.
-            for (let i = 3; i < 10; ++i) {
-              should(function() {
-                let buffer = context.createBuffer(i, 1024, context.sampleRate);
-                let testSource = context.createBufferSource();
-                testSource.buffer = buffer;
-              }, 'Setting source with ' + i + ' channels buffer').notThrow();
-            }
-            task.done();
-          });
-
-      audit.run();
-    </script>
-  </body>
+      // Check buffers with more than two channels.
+      for (let i = 3; i < 10; ++i) {
+        const buffer = new AudioBuffer({
+          numberOfChannels: i,
+          length: 1024,
+          sampleRate: context.sampleRate});
+        const testSource = new AudioBufferSourceNode(context);
+        testSource.buffer = buffer;
+      }
+    }, 'validate .buffer: Validation of AudioBuffer in ' +
+        '.buffer attribute setter');
+  </script>
+</body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/audiosource-onended-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/audiosource-onended-expected.txt
@@ -1,21 +1,6 @@
 
-PASS # AUDIT TASK RUNNER STARTED.
-PASS Executing "absn-set-onended"
-PASS Executing "absn-add-listener"
-PASS Executing "osc-set-onended"
-PASS Executing "osc-add-listener"
-PASS Audit report
-PASS > [absn-set-onended]
-PASS   AudioBufferSource.onended called when ended set directly is equal to true.
-PASS < [absn-set-onended] All assertions passed. (total 1 assertions)
-PASS > [absn-add-listener]
-PASS   AudioBufferSource.onended called when using addEventListener is equal to true.
-PASS < [absn-add-listener] All assertions passed. (total 1 assertions)
-PASS > [osc-set-onended]
-PASS   Oscillator.onended called when ended set directly is equal to true.
-PASS < [osc-set-onended] All assertions passed. (total 1 assertions)
-PASS > [osc-add-listener]
-PASS   Oscillator.onended called when using addEventListener is equal to true.
-PASS < [osc-add-listener] All assertions passed. (total 1 assertions)
-PASS # AUDIT TASK RUNNER FINISHED: 4 tasks ran successfully.
+PASS absn-set-onended: onended event fires for AudioBufferSourceNode when set directly
+PASS absn-add-listener: onended event fires for AudioBufferSourceNode when using addEventListener
+PASS osc-set-onended: onended event fires for OscillatorNode when set directly
+PASS osc-add-listener: onended event fires for OscillatorNode when using addEventListener
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/audiosource-onended.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/audiosource-onended.html
@@ -2,100 +2,95 @@
 <html>
   <head>
     <title>
-      Test Onended Event Listener
+      Test Onended Event Listener for AudioBufferSourceNode and OscillatorNode
     </title>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/webaudio/resources/audit-util.js"></script>
-    <script src="/webaudio/resources/audit.js"></script>
   </head>
   <body>
-    <script id="layout-test-code">
-      let sampleRate = 44100;
-      let renderLengthSeconds = 1;
-      let renderLengthFrames = renderLengthSeconds * sampleRate;
+    <script>
+      const sampleRate = 44100;
+      const renderLengthSeconds = 1;
+      const renderLengthFrames = renderLengthSeconds * sampleRate;
 
       // Length of the source buffer.  Anything less than the render length is
       // fine.
-      let sourceBufferLengthFrames = renderLengthFrames / 8;
+      const sourceBufferLengthFrames = renderLengthFrames / 8;
       // When to stop the oscillator.  Anything less than the render time is
       // fine.
-      let stopTime = renderLengthSeconds / 8;
+      const stopTime = renderLengthSeconds / 8;
 
-      let audit = Audit.createTaskRunner();
-
-      audit.define('absn-set-onended', (task, should) => {
+      promise_test(async (t) => {
         // Test that the onended event for an AudioBufferSourceNode is fired
         // when it is set directly.
-        let context =
-            new OfflineAudioContext(1, renderLengthFrames, sampleRate);
-        let buffer = context.createBuffer(
-            1, sourceBufferLengthFrames, context.sampleRate);
-        let source = context.createBufferSource();
-        source.buffer = buffer;
+        const context = new OfflineAudioContext(
+            1, renderLengthFrames, sampleRate);
+        const buffer = new AudioBuffer({length: sourceBufferLengthFrames,
+            numberOfChannels: 1, sampleRate: context.sampleRate});
+        const source = new AudioBufferSourceNode(context, {buffer: buffer});
         source.connect(context.destination);
-        source.onended = function(e) {
-          should(
-              true, 'AudioBufferSource.onended called when ended set directly')
-              .beEqualTo(true);
+        source.onended = (e) => {
+          assert_true(
+              true, 'AudioBufferSource.onended called when ended set directly');
         };
         source.start();
-        context.startRendering().then(() => task.done());
-      });
+        await context.startRendering();
+      }, 'absn-set-onended: onended event fires for AudioBufferSourceNode ' +
+          'when set directly');
 
-      audit.define('absn-add-listener', (task, should) => {
+      promise_test(async (t) => {
         // Test that the onended event for an AudioBufferSourceNode is fired
         // when addEventListener is used to set the handler.
-        let context =
-            new OfflineAudioContext(1, renderLengthFrames, sampleRate);
-        let buffer = context.createBuffer(
-            1, sourceBufferLengthFrames, context.sampleRate);
-        let source = context.createBufferSource();
-        source.buffer = buffer;
+        const context = new OfflineAudioContext(
+            1, renderLengthFrames, sampleRate);
+        const buffer = new AudioBuffer({length: sourceBufferLengthFrames,
+            numberOfChannels: 1, sampleRate: context.sampleRate});
+        const source = new AudioBufferSourceNode(context, {buffer: buffer});
         source.connect(context.destination);
-        source.addEventListener('ended', function(e) {
-          should(
+        source.addEventListener('ended', (e) => {
+          assert_true(
               true,
-              'AudioBufferSource.onended called when using addEventListener')
-              .beEqualTo(true);
+              'AudioBufferSource.onended called when using addEventListener');
         });
         source.start();
-        context.startRendering().then(() => task.done());
-      });
+        await context.startRendering();
+      }, 'absn-add-listener: onended event fires for AudioBufferSourceNode ' +
+          'when using addEventListener');
 
-      audit.define('osc-set-onended', (task, should) => {
+      promise_test(async (t) => {
         // Test that the onended event for an OscillatorNode is fired when it is
         // set directly.
-        let context =
-            new OfflineAudioContext(1, renderLengthFrames, sampleRate);
-        let source = context.createOscillator();
+        const context = new OfflineAudioContext(
+            1, renderLengthFrames, sampleRate);
+        const source = new OscillatorNode(context);
         source.connect(context.destination);
-        source.onended = function(e) {
-          should(true, 'Oscillator.onended called when ended set directly')
-              .beEqualTo(true);
+        source.onended = (e) => {
+          assert_true(
+              true, 'Oscillator.onended called when ended set directly');
         };
         source.start();
         source.stop(stopTime);
-        context.startRendering().then(() => task.done());
-      });
+        await context.startRendering();
+      }, 'osc-set-onended: onended event fires for OscillatorNode ' +
+          'when set directly');
 
-      audit.define('osc-add-listener', (task, should) => {
+      promise_test(async (t) => {
         // Test that the onended event for an OscillatorNode is fired when
         // addEventListener is used to set the handler.
-        let context =
-            new OfflineAudioContext(1, renderLengthFrames, sampleRate);
-        let source = context.createOscillator();
+        const context = new OfflineAudioContext(
+            1, renderLengthFrames, sampleRate);
+        const source = new OscillatorNode(context);
         source.connect(context.destination);
-        source.addEventListener('ended', function(e) {
-          should(true, 'Oscillator.onended called when using addEventListener')
-              .beEqualTo(true);
+        source.addEventListener('ended', (e) => {
+          assert_true(
+              true, 'Oscillator.onended called when using addEventListener');
         });
         source.start();
         source.stop(stopTime);
-        context.startRendering().then(() => task.done());
-      });
-
-      audit.run();
+        await context.startRendering();
+      }, 'osc-add-listener: onended event fires for OscillatorNode ' +
+          'when using addEventListener');
     </script>
   </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/buffer-resampling-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/buffer-resampling-expected.txt
@@ -1,10 +1,3 @@
 
-PASS # AUDIT TASK RUNNER STARTED.
-PASS Executing "interpolate"
-PASS Audit report
-PASS > [interpolate] Interpolation of AudioBuffers to context sample rate
-PASS   Interpolated sine wave equals [expected array] with an element-wise tolerance of {"absoluteThreshold":0.090348,"relativeThreshold":0}.
-PASS   SNR (37.18 dB) is greater than or equal to 37.17.
-PASS < [interpolate] All assertions passed. (total 2 assertions)
-PASS # AUDIT TASK RUNNER FINISHED: 1 tasks ran successfully.
+PASS Interpolation of AudioBuffers to context sample rate
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/buffer-resampling.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/buffer-resampling.html
@@ -5,18 +5,15 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/webaudio/resources/audit-util.js"></script>
-    <script src="/webaudio/resources/audit.js"></script>
   </head>
   <body>
     <script>
-      let audit = Audit.createTaskRunner();
-
       const sampleRate = 48000;
 
       // For testing we only need a few render quanta.
-      const renderSamples = 512
+      const renderSamples = 512;
 
-      // Sample rate for our buffers.  This is the lowest sample rate that is
+      // Sample rate for our buffers. This is the lowest sample rate that is
       // required to be supported.
       const bufferRate = 8000;
 
@@ -27,75 +24,67 @@
       // Frequency of the sine wave for testing.
       const frequency = 440;
 
-      audit.define(
-          {
-            label: 'interpolate',
-            description: 'Interpolation of AudioBuffers to context sample rate'
-          },
-          (task, should) => {
-            // The first channel is for the interpolated signal, and the second
-            // channel is for the reference signal from an oscillator.
-            let context = new OfflineAudioContext({
-              numberOfChannels: 2,
-              length: renderSamples,
-              sampleRate: sampleRate
-            });
+      promise_test(async t => {
+        // The first channel is for the interpolated signal, and the second
+        // channel is for the reference signal from an oscillator.
+        const context = new OfflineAudioContext({
+          numberOfChannels: 2,
+          length: renderSamples,
+          sampleRate: sampleRate
+        });
 
-            let merger = new ChannelMergerNode(
-                context, {numberOfChannels: context.destination.channelCount});
-            merger.connect(context.destination);
+        const merger = new ChannelMergerNode(
+            context, {numberOfChannels: context.destination.channelCount});
+        merger.connect(context.destination);
 
-            // Create a set of AudioBuffers which are samples from a pure sine
-            // wave with frequency |frequency|.
-            const nBuffers = Math.floor(context.length / bufferLength);
-            const omega = 2 * Math.PI * frequency / bufferRate;
+        // Create a set of AudioBuffers which are samples from a pure sine
+        // wave with frequency |frequency|.
+        const nBuffers = Math.floor(context.length / bufferLength);
+        const omega = 2 * Math.PI * frequency / bufferRate;
 
-            let frameNumber = 0;
-            let startTime = 0;
+        let frameNumber = 0;
+        let startTime = 0;
 
-            for (let k = 0; k < nBuffers; ++k) {
-              //          let buffer = context.createBuffer(1, bufferLength,
-              //          bufferRate);
-              let buffer = new AudioBuffer(
-                  {length: bufferLength, sampleRate: bufferRate});
-              let data = buffer.getChannelData(0);
-              for (let n = 0; n < bufferLength; ++n) {
-                data[n] = Math.sin(omega * frameNumber);
-                ++frameNumber;
-              }
-              // Create a source using this buffer and start it at the end of
-              // the previous buffer.
-              let src = new AudioBufferSourceNode(context, {buffer: buffer});
+        for (let k = 0; k < nBuffers; ++k) {
+          const buffer = new AudioBuffer(
+              {length: bufferLength, sampleRate: bufferRate});
+          const data = buffer.getChannelData(0);
 
-              src.connect(merger, 0, 0);
-              src.start(startTime);
-              startTime += buffer.duration;
-            }
+          for (let n = 0; n < bufferLength; ++n) {
+            data[n] = Math.sin(omega * frameNumber);
+            ++frameNumber;
+          }
 
-            // Create the reference sine signal using an oscillator.
-            let osc = new OscillatorNode(
-                context, {type: 'sine', frequency: frequency});
-            osc.connect(merger, 0, 1);
-            osc.start(0);
+          // Create a source using this buffer and start it at the end of
+          // the previous buffer.
+          const src = new AudioBufferSourceNode(context, {buffer: buffer});
+          src.connect(merger, 0, 0);
+          src.start(startTime);
+          startTime += buffer.duration;
+        }
 
-            context.startRendering()
-                .then(audioBuffer => {
-                  let actual = audioBuffer.getChannelData(0);
-                  let expected = audioBuffer.getChannelData(1);
+        // Create the reference sine signal using an oscillator.
+        const osc = new OscillatorNode(
+            context, {type: 'sine', frequency: frequency});
+        osc.connect(merger, 0, 1);
+        osc.start();
 
-                  should(actual, 'Interpolated sine wave')
-                      .beCloseToArray(expected, {absoluteThreshold: 9.0348e-2});
+        const audioBuffer = await context.startRendering();
 
-                  // Compute SNR between them.
-                  let snr = 10 * Math.log10(computeSNR(actual, expected));
+        const actual = audioBuffer.getChannelData(0);
+        const expected = audioBuffer.getChannelData(1);
 
-                  should(snr, `SNR (${snr.toPrecision(4)} dB)`)
-                      .beGreaterThanOrEqualTo(37.17);
-                })
-                .then(() => task.done());
-          });
+        // Verify that the interpolated sine wave closely matches the reference.
+        assert_array_approx_equals(
+            actual, expected, 9.0348e-2,
+            'Interpolated sine wave should match reference oscillator');
 
-      audit.run();
+        // Compute SNR between them.
+        const snr = 10 * Math.log10(computeSNR(actual, expected));
+        assert_greater_than_equal(
+            snr, 37.17,
+            `SNR (${snr.toPrecision(4)} dB) should be >= 37.17 dB`);
+      }, 'Interpolation of AudioBuffers to context sample rate');
     </script>
   </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/sub-sample-buffer-stitching.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/sub-sample-buffer-stitching.html
@@ -30,7 +30,7 @@
         const actual = resultBuffer.getChannelData(0);
         const expected = resultBuffer.getChannelData(1);
 
-        assert_array_approximately_equals(
+        assert_array_equal_within_eps(
             actual,
             expected,
             errorThreshold,
@@ -65,7 +65,7 @@
         const actual = resultBuffer.getChannelData(0);
         const expected = resultBuffer.getChannelData(1);
 
-        assert_array_approximately_equals(
+        assert_array_equal_within_eps(
             actual,
             expected,
             errorThreshold,

--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/adding-events-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/adding-events-expected.txt
@@ -1,21 +1,4 @@
 
-PASS # AUDIT TASK RUNNER STARTED.
-PASS Executing "linearRamp"
-PASS Executing "expoRamp"
-PASS Audit report
-PASS > [linearRamp] Insert linearRamp after running for some time
-PASS   linearRamp: setValueAtTime(1, 0.007813) did not throw an exception.
-PASS   linearRamp: At time 0.0625 scheduling linearRampToValueAtTime(2, 0.132813) did not throw an exception.
-PASS   linearRamp: output[0:511] contains only the constant 1.
-PASS   linearRamp: output[512:576] equals [...] with an element-wise tolerance of {"absoluteThreshold":0,"relativeThreshold":0}.
-PASS   linearRamp: output[1088:] contains only the constant 2.
-PASS < [linearRamp] All assertions passed. (total 5 assertions)
-PASS > [expoRamp] Insert expoRamp after running for some time
-PASS   expoRamp: setValueAtTime(1, 0.007813) did not throw an exception.
-PASS   expoRamp: At time 0.0625 scheduling exponentialRampToValueAtTime(2, 0.132813) did not throw an exception.
-PASS   expoRamp: output[0:511] contains only the constant 1.
-PASS   expoRamp: output[512:576] equals [...] with an element-wise tolerance of {"absoluteThreshold":0,"relativeThreshold":0}.
-PASS   expoRamp: output[1088:] contains only the constant 2.
-PASS < [expoRamp] All assertions passed. (total 5 assertions)
-PASS # AUDIT TASK RUNNER FINISHED: 2 tasks ran successfully.
+PASS linearRamp: Insert linearRamp after running for some time
+PASS exponentialRamp: Insert exponentialRamp after running for some time
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/adding-events.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/adding-events.html
@@ -5,140 +5,142 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/webaudio/resources/audit-util.js"></script>
-    <script src="/webaudio/resources/audit.js"></script>
     <script src="/webaudio/resources/audio-param.js"></script>
   </head>
 
   <body>
     <script>
-      let audit = Audit.createTaskRunner();
 
-      // Arbitrary power of two to eliminate round-off in computing time from
-      // frame.
+      // Arbitrary power of two to eliminate round-off in computing time from frame.
       const sampleRate = 8192;
-
-      audit.define(
-          {
-            label: 'linearRamp',
-            description: 'Insert linearRamp after running for some time'
-          },
-          (task, should) => {
-            testInsertion(should, {
-              method: 'linearRampToValueAtTime',
-              prefix: 'linearRamp'
-            }).then(() => task.done());
-          });
-
-      audit.define(
-          {
-            label: 'expoRamp',
-            description: 'Insert expoRamp after running for some time'
-          },
-          (task, should) => {
-            testInsertion(should, {
-              method: 'exponentialRampToValueAtTime',
-              prefix: 'expoRamp'
-            }).then(() => task.done());
-          });
 
       // Test insertion of an event in the middle of rendering.
       //
       // options dictionary:
       //   method - automation method to test
       //   prefix - string to use for prefixing messages
-      function testInsertion(should, options) {
-        let {method, prefix} = options;
+      async function testInsertion(options) {
+        const {method, prefix} = options;
 
         // Channel 0 is the output for the test, and channel 1 is the
         // reference output.
-        let context = new OfflineAudioContext(
-            {numberOfChannels: 2, length: sampleRate, sampleRate: sampleRate});
-        let merger = new ChannelMergerNode(
-            context, {numberOfChannels: context.destination.channelCount});
+        const context = new OfflineAudioContext({
+          numberOfChannels: 2,
+          length: sampleRate,
+          sampleRate: sampleRate
+        });
 
+        const merger = new ChannelMergerNode(
+            context, {numberOfChannels: context.destination.channelCount});
         merger.connect(context.destination);
 
         // Initial value and final values of the source node
-        let initialValue = 1;
-        let finalValue = 2;
+        const initialValue = 1;
+        const finalValue = 2;
 
         // Set up the node for the automations under test
-        let src = new ConstantSourceNode(context, {offset: initialValue});
+        const src = new ConstantSourceNode(context, { offset: initialValue });
         src.connect(merger, 0, 0);
 
         // Set initial event to occur at this time.  Keep it in the first
         // render quantum.
         const initialEventTime = 64 / context.sampleRate;
-        should(
-            () => src.offset.setValueAtTime(initialValue, initialEventTime),
-            `${prefix}: setValueAtTime(${initialValue}, ${initialEventTime})`)
-            .notThrow();
+        // Any exception will naturally fail the test.
+        src.offset.setValueAtTime(initialValue, initialEventTime);
 
         // Let time pass and then add a new event with time in the future.
-        let insertAtFrame = 512;
-        let insertTime = insertAtFrame / context.sampleRate;
-        let automationEndFrame = 1024 + 64;
-        let automationEndTime = automationEndFrame / context.sampleRate;
-        context.suspend(insertTime)
-            .then(() => {
-              should(
-                  () => src.offset[method](finalValue, automationEndTime),
-                  `${prefix}: At time ${insertTime} scheduling ${method}(${
-                      finalValue}, ${automationEndTime})`)
-                  .notThrow();
-            })
-            .then(() => context.resume());
+        const insertAtFrame = 512;
+        const insertTime = insertAtFrame / context.sampleRate;
+        const automationEndFrame = 1024 + 64;
+        const automationEndTime = automationEndFrame / context.sampleRate;
+
+        // Schedule the insertion while rendering is in progress.
+        context.suspend(insertTime).then(() => {
+          src.offset[method](finalValue, automationEndTime);
+          context.resume();
+        });
 
         // Set up graph for the reference result.  Automate the source with
         // the events scheduled from the beginning.  Let the gain node
         // simulate the insertion of the event above.  This is done by
         // setting the gain to 1 at the insertion time.
-        let srcRef = new ConstantSourceNode(context, {offset: 1});
-        let g = new GainNode(context, {gain: 0});
+        const srcRef = new ConstantSourceNode(context, {offset: 1});
+        const g = new GainNode(context, {gain: 0});
         srcRef.connect(g).connect(merger, 0, 1);
         srcRef.offset.setValueAtTime(initialValue, initialEventTime);
         srcRef.offset[method](finalValue, automationEndTime);
 
-        // Allow everything through after |insertFrame| frames.
+        // Allow everything through after |insertAtFrame| frames.
         g.gain.setValueAtTime(1, insertTime);
 
         // Go!
         src.start();
         srcRef.start();
 
-        return context.startRendering().then(audioBuffer => {
-          let actual = audioBuffer.getChannelData(0);
-          let expected = audioBuffer.getChannelData(1);
+        const audioBuffer = await context.startRendering();
 
-          // Verify that the output is 1 until we reach
-          // insertAtFrame. Ignore the expected data because that always
-          // produces 1.
-          should(
-              actual.slice(0, insertAtFrame),
-              `${prefix}: output[0:${insertAtFrame - 1}]`)
-              .beConstantValueOf(initialValue);
+        const actual = audioBuffer.getChannelData(0);
+        const expected = audioBuffer.getChannelData(1);
 
-          // Verify ramp is correct by comparing it to the expected
-          // data.
-          should(
-              actual.slice(
-                  insertAtFrame, automationEndFrame - insertAtFrame + 1),
-              `${prefix}: output[${insertAtFrame}:${
-                  automationEndFrame - insertAtFrame}]`)
-              .beCloseToArray(
-                  expected.slice(
-                      insertAtFrame, automationEndFrame - insertAtFrame + 1),
-                  {absoluteThreshold: 0, numberOfArrayElements: 0});
+        // Verify that the output is 1 until we reach
+        // insertAtFrame. Ignore the expected data because that always
+        // produces 1.
+        {
+          const actualBeforeInsert = actual.slice(0, insertAtFrame);
+          const expectedBeforeInsert = new Float32Array(insertAtFrame);
+          expectedBeforeInsert.fill(initialValue);
+          assert_array_equal_within_eps(
+              actualBeforeInsert,
+              expectedBeforeInsert,
+              0,
+              `${prefix}: output[0:${insertAtFrame - 1}]`);
+        }
 
-          // Verify final output has the expected value
-          should(
-              actual.slice(automationEndFrame),
-              `${prefix}: output[${automationEndFrame}:]`)
-              .beConstantValueOf(finalValue);
-        })
+        // Verify ramp is correct by comparing it to the expected
+        {
+          const rampStart = insertAtFrame;
+          const rampEndInclusive = automationEndFrame;
+          const rampEndExclusive = rampEndInclusive + 1;
+
+          const actualRamp = actual.slice(rampStart, rampEndExclusive);
+          const expectedRamp = expected.slice(rampStart, rampEndExclusive);
+
+          assert_array_equal_within_eps(
+              actualRamp,
+              expectedRamp,
+              {absoluteThreshold: 0},
+              `${prefix}: output[${rampStart}:${rampEndInclusive}]`);
+        }
+
+        // Verify final output has the expected value
+        {
+          const tailStart = automationEndFrame + 1;
+          const actualTail = actual.slice(tailStart);
+          const refTail = new Float32Array(actualTail.length);
+          refTail.fill(finalValue);
+
+          assert_array_equal_within_eps(
+              actualTail,
+              refTail,
+              0,
+              `${prefix}: output[${tailStart}:]`);
+        }
       }
 
-      audit.run();
+      // Define tests (replacing audit.define/audit.run with promise_test)
+      promise_test(async () => {
+        await testInsertion({
+          method: 'linearRampToValueAtTime',
+          prefix: 'linearRamp'
+        });
+      }, 'linearRamp: Insert linearRamp after running for some time');
+
+      promise_test(async () => {
+        await testInsertion({
+          method: 'exponentialRampToValueAtTime',
+          prefix: 'exponentialRamp'
+        });
+      }, 'exponentialRamp: Insert exponentialRamp after running for some time');
     </script>
   </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/audioparam-connect-audioratesignal-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/audioparam-connect-audioratesignal-expected.txt
@@ -1,10 +1,3 @@
 
-PASS # AUDIT TASK RUNNER STARTED.
-PASS Executing "test"
-PASS Audit report
-PASS > [test]
-PASS   Rendered signal length is equal to 44100.
-PASS   Rendered signal exactly matches the audio-rate gain changing signal is true.
-PASS < [test] All assertions passed. (total 2 assertions)
-PASS # AUDIT TASK RUNNER FINISHED: 1 tasks ran successfully.
+PASS AudioParam accepts an audio-rate signal from an AudioNode and scales a constant source exactly
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/audioparam-connect-audioratesignal.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/audioparam-connect-audioratesignal.html
@@ -16,25 +16,25 @@ to check that the resultant signal should be equal to the gain-scaling curve.
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/webaudio/resources/audit-util.js"></script>
-    <script src="/webaudio/resources/audit.js"></script>
   </head>
   <body>
-    <script id="layout-test-code">
-      let audit = Audit.createTaskRunner();
+    <script>
+      const sampleRate = 44100.0;
+      const lengthInSeconds = 1;
 
-      let sampleRate = 44100.0;
-      let lengthInSeconds = 1;
+      let context;
+      let constantOneBuffer;
+      let linearRampBuffer;
 
-      let context = 0;
-      let constantOneBuffer = 0;
-      let linearRampBuffer = 0;
+      function checkResult(renderedBuffer) {
+        const renderedData = renderedBuffer.getChannelData(0);
+        const expectedData = linearRampBuffer.getChannelData(0);
+        const n = renderedBuffer.length;
 
-      function checkResult(renderedBuffer, should) {
-        let renderedData = renderedBuffer.getChannelData(0);
-        let expectedData = linearRampBuffer.getChannelData(0);
-        let n = renderedBuffer.length;
-
-        should(n, 'Rendered signal length').beEqualTo(linearRampBuffer.length);
+        assert_equals(
+            n,
+            linearRampBuffer.length,
+            'Rendered signal length should match control buffer length');
 
         // Check that the rendered result exactly matches the buffer used to
         // control gain.  This is because we're changing the gain of a signal
@@ -47,14 +47,14 @@ to check that the resultant signal should be equal to the gain-scaling curve.
           }
         }
 
-        should(
+        assert_true(
             success,
-            'Rendered signal exactly matches the audio-rate gain changing signal')
-            .beTrue();
+            `Rendered signal exactly matches ` +
+                `the audio-rate gain changing signal`);
       }
 
-      audit.define('test', function(task, should) {
-        let sampleFrameLength = sampleRate * lengthInSeconds;
+      promise_test(async t => {
+        const sampleFrameLength = sampleRate * lengthInSeconds;
 
         // Create offline audio context.
         context = new OfflineAudioContext(1, sampleFrameLength, sampleRate);
@@ -67,37 +67,32 @@ to check that the resultant signal should be equal to the gain-scaling curve.
 
         // Create the two sources.
 
-        let constantSource = context.createBufferSource();
-        constantSource.buffer = constantOneBuffer;
+        const constantSource = new AudioBufferSourceNode(context, {
+          buffer: constantOneBuffer,
+        });
 
-        let gainChangingSource = context.createBufferSource();
-        gainChangingSource.buffer = linearRampBuffer;
+        const gainChangingSource = new AudioBufferSourceNode(context, {
+          buffer: linearRampBuffer,
+        });
 
         // Create a gain node controlling the gain of constantSource and make
         // the connections.
-        let gainNode = context.createGain();
+        const gainNode = new GainNode(context, {gain: 0});
 
-        // Intrinsic baseline gain of zero.
-        gainNode.gain.value = 0;
-
-        constantSource.connect(gainNode);
-        gainNode.connect(context.destination);
+        constantSource.connect(gainNode).connect(context.destination);
 
         // Connect an audio-rate signal to control the .gain AudioParam.
         // This is the heart of what is being tested.
         gainChangingSource.connect(gainNode.gain);
 
         // Start both sources at time 0.
-        constantSource.start(0);
-        gainChangingSource.start(0);
+        constantSource.start();
+        gainChangingSource.start();
 
-        context.startRendering().then(buffer => {
-          checkResult(buffer, should);
-          task.done();
-        });
-      });
-
-      audit.run();
+        const renderedBuffer = await context.startRendering();
+        checkResult(renderedBuffer);
+      }, `AudioParam accepts an audio-rate signal from an AudioNode` +
+          ` and scales a constant source exactly`);
     </script>
   </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/automation-rate-testing.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/automation-rate-testing.js
@@ -37,7 +37,7 @@
 // |options.automations|) is applied.  A simple oscillator is connected to each
 // node which in turn are connected to different channels of an offline context.
 // Channel 0 is the k-rate node output; channel 1, the a-rate output; and
-// channel 3, the difference between the outputs.
+// channel 2, the difference between the outputs.
 //
 // Success is declared if the difference signal is not exactly zero.  This means
 // the automations did different things, as expected.
@@ -149,6 +149,179 @@ function doTest(context, should, options) {
             kRateOutput.slice(k, k + 128),
             `${options.prefix} k-rate output [${k}: ${k + 127}]`)
             .beConstantValueOf(kRateOutput[k]);
+      }
+    }
+  });
+}
+
+// Test k-rate vs a-rate AudioParams.
+//
+// |options| describes how the testing of the AudioParam should be done:
+//
+//   sourceNodeName: name of source node to use for testing; defaults to
+//                   'OscillatorNode'.  If set to 'none', then no source node
+//                   is created for testing and it is assumed that the AudioNode
+//                   under test are sources and need to be started.
+//   verifyPieceWiseConstant: if true, verify that the k-rate output is
+//                            piecewise constant for each render quantum.
+//   nodeName:  name of the AudioNode to be tested
+//   nodeOptions:  options to be used in the AudioNode constructor
+//
+//   prefix: Prefix for all output messages (to make them unique for
+//           testharness)
+//
+//   rateSettings: A vector of dictionaries specifying how to set the automation
+//                 rate(s):
+//       name: Name of the AudioParam
+//       value: The automation rate for the AudioParam given by |name|.
+//
+//   automations: A vector of dictionaries specifying how to automate each
+//                AudioParam:
+//       name: Name of the AudioParam
+//
+//       methods: A vector of dictionaries specifying the automation methods to
+//                be used for testing:
+//           name: Automation method to call
+//           options: Arguments for the automation method
+//
+// Testing is somewhat rudimentary.  We create two nodes of the same type.  One
+// node uses the default automation rates for each AudioParam (expecting them to
+// be a-rate).  The second node sets the automation rate of AudioParams to
+// "k-rate".  The set is speciified by |options.rateSettings|.
+//
+// For both of these nodes, the same set of automation methods (given by
+// |options.automations|) is applied.  A simple oscillator is connected to each
+// node which in turn are connected to different channels of an offline context.
+// Channel 0 is the k-rate node output; channel 1, the a-rate output; and
+// channel 2, the difference between the outputs.
+//
+// Success is declared if the difference signal is not exactly zero.  This means
+// the automations did different things, as expected.
+//
+// The promise from |startRendering| is returned.
+function doTest_W3TH(context, options) {
+  const merger = new ChannelMergerNode(context, {
+    numberOfInputs: context.destination.channelCount
+  });
+  merger.connect(context.destination);
+
+  let src = null;
+
+  // Skip creating a source to drive the graph if |sourceNodeName| is 'none'.
+  // If |sourceNodeName| is given, use that, else default to OscillatorNode.
+  if (options.sourceNodeName !== 'none') {
+    src = new window[options.sourceNodeName || 'OscillatorNode'](context);
+  }
+
+  const kRateNode = new window[options.nodeName](context, options.nodeOptions);
+  const aRateNode = new window[options.nodeName](context, options.nodeOptions);
+  const inverter = new GainNode(context, { gain: -1 });
+
+  // Set kRateNode filter to use k-rate params.
+  options.rateSettings.forEach(setting => {
+    kRateNode[setting.name].automationRate = setting.value;
+    // Mostly for documentation in the output. These should always
+    // pass.
+    assert_equals(
+        kRateNode[setting.name].automationRate, setting.value,
+        `${options.prefix}: Setting ${setting.name}.automationRate ` +
+            `to "${setting.value}"`);
+  });
+
+  // Run through all automations for each node separately. (Mostly to keep
+  // output of automations together.)
+  options.automations.forEach(param => {
+    param.methods.forEach(method => {
+      // Mostly for documentation in the output.  These should never throw.
+      const message = `${param.name}.${method.name}(${method.options})`;
+      try {
+        kRateNode[param.name][method.name](...method.options);
+      } catch (e) {
+        assert_unreached(
+            `${options.prefix}: k-rate node: ${message} threw: ${e.message}`);
+      }
+    });
+  });
+  options.automations.forEach(param => {
+    param.methods.forEach(method => {
+      // Mostly for documentation in the output.  These should never throw.
+      const message = `${param.name}.${method.name}(${method.options})`;
+      try {
+        aRateNode[param.name][method.name](...method.options);
+      } catch (e) {
+        assert_unreached(
+            `${options.prefix}: a-rate node: ${message} threw: ${e.message}`);
+      }
+    });
+  });
+
+  // Connect the source, if specified.
+  if (src) {
+    src.connect(kRateNode);
+    src.connect(aRateNode);
+  }
+
+  // The k-rate result is channel 0, and the a-rate result is channel 1.
+  kRateNode.connect(merger, 0, 0);
+  aRateNode.connect(merger, 0, 1);
+
+  // Compute the difference between the a-rate and k-rate results and send
+  // that to channel 2.
+  kRateNode.connect(merger, 0, 2);
+  aRateNode.connect(inverter).connect(merger, 0, 2);
+
+  if (src) {
+    src.start();
+  } else {
+    // If there's no source, then assume the test nodes are sources and start
+    // them.
+    kRateNode.start();
+    aRateNode.start();
+  }
+
+  return context.startRendering().then(renderedBuffer => {
+    const kRateOutput = renderedBuffer.getChannelData(0);
+    const aRateOutput = renderedBuffer.getChannelData(1);
+    const diff = renderedBuffer.getChannelData(2);
+
+    // Some informative messages to print out values of the k-rate and
+    // a-rate outputs.  These should always pass.
+    // (In testharness, assertions only report on failure,
+    // so we sanity-check types.)
+    assert_true(
+        kRateOutput instanceof Float32Array,
+        `${options.prefix}: Output of k-rate `+
+            `${options.nodeName} is Float32Array`);
+    assert_true(
+        aRateOutput instanceof Float32Array,
+        `${options.prefix}: Output of a-rate `+
+            `${options.nodeName} is Float32Array`);
+
+    // The real test.  If k-rate AudioParam is working correctly, the
+    // k-rate result MUST differ from the a-rate result.
+    let allZero = true;
+    for (let i = 0; i < diff.length; ++i) {
+      if (diff[i] !== 0) {allZero = false; break;}
+    }
+    assert_false(
+        allZero,
+        `${options.prefix}: Difference between a-rate and k-rate` +
+            `${options.nodeName} must not be identically 0`);
+
+    if (options.verifyPieceWiseConstant) {
+      // Verify that the output from the k-rate parameter is step-wise
+      // constant.
+      for (let k = 0; k < kRateOutput.length; k += 128) {
+        const end = Math.min(k + 128, kRateOutput.length);
+        const v0 = kRateOutput[k];
+        for (let i = k + 1; i < end; ++i) {
+          assert_equals(
+              kRateOutput[i],
+              v0,
+              `${options.prefix} k-rate output [${k}: ${end - 1}]` +
+                  `should be piecewise constant`,
+          );
+        }
       }
     }
   });

--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/k-rate-biquad-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/k-rate-biquad-expected.txt
@@ -1,63 +1,7 @@
 
-PASS # AUDIT TASK RUNNER STARTED.
-PASS Executing "Biquad k-rate AudioParams (all)"
-PASS Executing "Biquad k-rate Q"
-PASS Executing "Biquad k-rate detune"
-PASS Executing "Biquad k-rate frequency"
-PASS Executing "Biquad k-rate gain"
-PASS Audit report
-PASS > [Biquad k-rate AudioParams (all)]
-PASS   All k-rate params: Setting Q.automationRate to "k-rate" is equal to k-rate.
-PASS   All k-rate params: Setting detune.automationRate to "k-rate" is equal to k-rate.
-PASS   All k-rate params: Setting frequency.automationRate to "k-rate" is equal to k-rate.
-PASS   All k-rate params: Setting gain.automationRate to "k-rate" is equal to k-rate.
-PASS   All k-rate params: k-rate node: frequency.setValueAtTime(350,0) did not throw an exception.
-PASS   All k-rate params: k-rate node: frequency.linearRampToValueAtTime(0,1) did not throw an exception.
-PASS   All k-rate params: a-rate node:frequency.setValueAtTime(350,0) did not throw an exception.
-PASS   All k-rate params: a-rate node:frequency.linearRampToValueAtTime(0,1) did not throw an exception.
-PASS   All k-rate params: Output of k-rate BiquadFilterNode is identical to the array [expected array].
-PASS   All k-rate params: Output of a-rate BiquadFilterNode is identical to the array [expected array].
-PASS   All k-rate params: Difference between a-rate and k-rate BiquadFilterNode is not constantly 0.
-PASS < [Biquad k-rate AudioParams (all)] All assertions passed. (total 11 assertions)
-PASS > [Biquad k-rate Q]
-PASS   k-rate Q: Setting Q.automationRate to "k-rate" is equal to k-rate.
-PASS   k-rate Q: k-rate node: Q.setValueAtTime(1,0) did not throw an exception.
-PASS   k-rate Q: k-rate node: Q.linearRampToValueAtTime(10,1) did not throw an exception.
-PASS   k-rate Q: a-rate node:Q.setValueAtTime(1,0) did not throw an exception.
-PASS   k-rate Q: a-rate node:Q.linearRampToValueAtTime(10,1) did not throw an exception.
-PASS   k-rate Q: Output of k-rate BiquadFilterNode is identical to the array [expected array].
-PASS   k-rate Q: Output of a-rate BiquadFilterNode is identical to the array [expected array].
-PASS   k-rate Q: Difference between a-rate and k-rate BiquadFilterNode is not constantly 0.
-PASS < [Biquad k-rate Q] All assertions passed. (total 8 assertions)
-PASS > [Biquad k-rate detune]
-PASS   k-rate detune: Setting detune.automationRate to "k-rate" is equal to k-rate.
-PASS   k-rate detune: k-rate node: detune.setValueAtTime(0,0) did not throw an exception.
-PASS   k-rate detune: k-rate node: detune.linearRampToValueAtTime(1200,1) did not throw an exception.
-PASS   k-rate detune: a-rate node:detune.setValueAtTime(0,0) did not throw an exception.
-PASS   k-rate detune: a-rate node:detune.linearRampToValueAtTime(1200,1) did not throw an exception.
-PASS   k-rate detune: Output of k-rate BiquadFilterNode is identical to the array [expected array].
-PASS   k-rate detune: Output of a-rate BiquadFilterNode is identical to the array [expected array].
-PASS   k-rate detune: Difference between a-rate and k-rate BiquadFilterNode is not constantly 0.
-PASS < [Biquad k-rate detune] All assertions passed. (total 8 assertions)
-PASS > [Biquad k-rate frequency]
-PASS   k-rate frequency: Setting frequency.automationRate to "k-rate" is equal to k-rate.
-PASS   k-rate frequency: k-rate node: frequency.setValueAtTime(350,0) did not throw an exception.
-PASS   k-rate frequency: k-rate node: frequency.linearRampToValueAtTime(0,1) did not throw an exception.
-PASS   k-rate frequency: a-rate node:frequency.setValueAtTime(350,0) did not throw an exception.
-PASS   k-rate frequency: a-rate node:frequency.linearRampToValueAtTime(0,1) did not throw an exception.
-PASS   k-rate frequency: Output of k-rate BiquadFilterNode is identical to the array [expected array].
-PASS   k-rate frequency: Output of a-rate BiquadFilterNode is identical to the array [expected array].
-PASS   k-rate frequency: Difference between a-rate and k-rate BiquadFilterNode is not constantly 0.
-PASS < [Biquad k-rate frequency] All assertions passed. (total 8 assertions)
-PASS > [Biquad k-rate gain]
-PASS   k-rate gain: Setting gain.automationRate to "k-rate" is equal to k-rate.
-PASS   k-rate gain: k-rate node: gain.setValueAtTime(10,0) did not throw an exception.
-PASS   k-rate gain: k-rate node: gain.linearRampToValueAtTime(0,1) did not throw an exception.
-PASS   k-rate gain: a-rate node:gain.setValueAtTime(10,0) did not throw an exception.
-PASS   k-rate gain: a-rate node:gain.linearRampToValueAtTime(0,1) did not throw an exception.
-PASS   k-rate gain: Output of k-rate BiquadFilterNode is identical to the array [expected array].
-PASS   k-rate gain: Output of a-rate BiquadFilterNode is identical to the array [expected array].
-PASS   k-rate gain: Difference between a-rate and k-rate BiquadFilterNode is not constantly 0.
-PASS < [Biquad k-rate gain] All assertions passed. (total 8 assertions)
-PASS # AUDIT TASK RUNNER FINISHED: 5 tasks ran successfully.
+PASS Biquad k-rate AudioParams (all)
+PASS Biquad k-rate Q
+PASS Biquad k-rate detune
+PASS Biquad k-rate frequency
+PASS Biquad k-rate gain
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/k-rate-biquad.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/k-rate-biquad.html
@@ -4,50 +4,43 @@
     <title>Test k-rate AudioParams of BiquadFilterNode</title>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
-    <script src="/webaudio/resources/audit-util.js"></script>
-    <script src="/webaudio/resources/audit.js"></script>
     <script src="automation-rate-testing.js"></script>
   </head>
 
   <body>
     <script>
-      let audit = Audit.createTaskRunner();
 
-      audit.define(
-          {task: 'BiquadFilter-0', label: 'Biquad k-rate AudioParams (all)'},
-          (task, should) => {
-            // Arbitrary sample rate and duration.
-            let sampleRate = 8000;
-            let testDuration = 1;
-            let context = new OfflineAudioContext({
-              numberOfChannels: 3,
-              sampleRate: sampleRate,
-              length: testDuration * sampleRate
-            });
+      promise_test(async () => {
+        // Arbitrary sample rate and duration.
+        const sampleRate = 8000;
+        const testDuration = 1;
+        const context = new OfflineAudioContext({
+          numberOfChannels: 3,
+          sampleRate: sampleRate,
+          length: testDuration * sampleRate,
+        });
 
-            doTest(context, should, {
-              nodeName: 'BiquadFilterNode',
-              nodeOptions: {type: 'lowpass'},
-              prefix: 'All k-rate params',
-              // Set all AudioParams to k-rate
-              rateSettings: [
-                {name: 'Q', value: 'k-rate'},
-                {name: 'detune', value: 'k-rate'},
-                {name: 'frequency', value: 'k-rate'},
-                {name: 'gain', value: 'k-rate'},
-              ],
-              // Automate just the frequency
-              automations: [{
-                name: 'frequency',
-                methods: [
-                  {name: 'setValueAtTime', options: [350, 0]}, {
-                    name: 'linearRampToValueAtTime',
-                    options: [0, testDuration]
-                  }
-                ]
-              }]
-            }).then(() => task.done());
-          });
+        await doTest_W3TH(context, {
+          nodeName: 'BiquadFilterNode',
+          nodeOptions: {type: 'lowpass'},
+          prefix: 'All k-rate params',
+          // Set all AudioParams to k-rate
+          rateSettings: [
+            {name: 'Q', value: 'k-rate'},
+            {name: 'detune', value: 'k-rate'},
+            {name: 'frequency', value: 'k-rate'},
+            {name: 'gain', value: 'k-rate'},
+          ],
+          // Automate just the frequency
+          automations: [{
+            name: 'frequency',
+            methods: [
+              {name: 'setValueAtTime', options: [350, 0]},
+              {name: 'linearRampToValueAtTime', options: [0, testDuration]}
+            ]
+          }]
+        });
+      }, 'Biquad k-rate AudioParams (all)');
 
       // Define a test where we verify that a k-rate audio param produces
       // different results from an a-rate audio param for each of the audio
@@ -55,7 +48,7 @@
       //
       // Each entry gives the name of the AudioParam, an initial value to be
       // used with setValueAtTime, and a final value to be used with
-      // linearRampToValueAtTime. (See |doTest| for details as well.)
+      // linearRampToValueAtTime. (See |doTest_W3TH| for details as well.)
 
       [{name: 'Q',
         initial: 1,
@@ -73,17 +66,17 @@
         initial: 10,
         final: 0
        }].forEach(paramProperty => {
-        audit.define('Biquad k-rate ' + paramProperty.name, (task, should) => {
+        promise_test(async () => {
           // Arbitrary sample rate and duration.
-          let sampleRate = 8000;
-          let testDuration = 1;
-          let context = new OfflineAudioContext({
+          const sampleRate = 8000;
+          const testDuration = 1;
+          const context = new OfflineAudioContext({
             numberOfChannels: 3,
             sampleRate: sampleRate,
             length: testDuration * sampleRate
           });
 
-          doTest(context, should, {
+          await doTest_W3TH(context, {
             nodeName: 'BiquadFilterNode',
             nodeOptions: {type: 'peaking', Q: 1, gain: 10},
             prefix: `k-rate ${paramProperty.name}`,
@@ -95,17 +88,16 @@
             automations: [{
               name: paramProperty.name,
               methods: [
-                {name: 'setValueAtTime', options: [paramProperty.initial, 0]}, {
+                {name: 'setValueAtTime', options: [paramProperty.initial, 0]},
+                {
                   name: 'linearRampToValueAtTime',
-                  options: [paramProperty.final, testDuration]
+                  options: [paramProperty.final, testDuration],
                 }
               ]
             }]
-          }).then(() => task.done());
-        });
+          });
+        }, `Biquad k-rate ${paramProperty.name}`);
       });
-
-      audit.run();
     </script>
   </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-channelmergernode-interface/active-processing.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-channelmergernode-interface/active-processing.https-expected.txt
@@ -1,15 +1,4 @@
 
-PASS # AUDIT TASK RUNNER STARTED.
-PASS Executing "initialize"
-PASS Executing "test"
-PASS Audit report
-PASS > [initialize]
-PASS   AudioWorklet module loading resolved correctly.
-PASS < [initialize] All assertions passed. (total 1 assertions)
-PASS > [test]
-PASS   Test 0: Number of convolver output channels is equal to 7.
-PASS   Test 1: Number of convolver output channels is equal to 0.
-PASS   Number of distinct values is equal to 2.
-PASS < [test] All assertions passed. (total 3 assertions)
-PASS # AUDIT TASK RUNNER FINISHED: 2 tasks ran successfully.
+PASS initialize: AudioWorklet module loading
+PASS test: Active processing emits expected channel-count changes
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-channelmergernode-interface/active-processing.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-channelmergernode-interface/active-processing.https.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
   <head>
     <title>
@@ -6,88 +6,83 @@
     </title>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
-    <script src="/webaudio/resources/audit.js"></script>
   </head>
 
   <body>
-    <script id="layout-test-code">
+    <script>
       // AudioProcessor that sends a message to its AudioWorkletNode whenver the
       // number of channels on its input changes.
-      let filePath =
+      const filePath =
           '../the-audioworklet-interface/processors/active-processing.js';
-
-      const audit = Audit.createTaskRunner();
 
       let context;
 
-      audit.define('initialize', (task, should) => {
+      // Keep one promise_test to load module
+      // and set up context (so ordering is explicit).
+      promise_test(() => {
         // Create context and load the module
         context = new AudioContext();
-        should(
-            context.audioWorklet.addModule(filePath),
-            'AudioWorklet module loading')
-            .beResolved()
-            .then(() => task.done());
-      });
+        return context.audioWorklet.addModule(filePath);
+      }, 'initialize: AudioWorklet module loading');
 
-      audit.define('test', (task, should) => {
-        const src = new OscillatorNode(context);
+      promise_test(() => {
+        return new Promise(resolve => {
+          const src = new OscillatorNode(context);
 
-        // Number of inputs for the ChannelMergerNode.  Pretty arbitrary, but
-        // should not be 1.
-        const numberOfInputs = 7;
-        const merger =
-            new ChannelMergerNode(context, {numberOfInputs: numberOfInputs});
+          // Number of inputs for the ChannelMergerNode.  Pretty arbitrary, but
+          // should not be 1.
+          const numberOfInputs = 7;
+          const merger =
+              new ChannelMergerNode(context, {numberOfInputs: numberOfInputs});
 
-        const testerNode =
-            new AudioWorkletNode(context, 'active-processing-tester', {
-              // Use as short a duration as possible to keep the test from
-              // taking too much time.
-              processorOptions: {testDuration: .5},
-            });
+          const testerNode =
+              new AudioWorkletNode(context, 'active-processing-tester', {
+                // Use as short a duration as possible to keep the test from
+                // taking too much time.
+                processorOptions: {testDuration: .5},
+              });
 
-        // Expected number of output channels from the merger node.  We should
-        // start with the number of inputs, because the source (oscillator) is
-        // actively processing.  When the source stops, the number of channels
-        // should change to 0.
-        const expectedValues = [numberOfInputs, 0];
-        let index = 0;
+          // Expected number of output channels from the merger node.  We should
+          // start with the number of inputs, because the source (oscillator) is
+          // actively processing.  When the source stops, the number of channels
+          // should change to 0.
+          const expectedValues = [numberOfInputs, 0];
+          let index = 0;
 
-        testerNode.port.onmessage = event => {
-          let count = event.data.channelCount;
-          let finished = event.data.finished;
+          testerNode.port.onmessage = event => {
+            const count = event.data.channelCount;
+            const finished = event.data.finished;
 
-          // If we're finished, end testing.
-          if (finished) {
-            // Verify that we got the expected number of changes.
-            should(index, 'Number of distinct values')
-                .beEqualTo(expectedValues.length);
+            // If we're finished, end testing.
+            if (finished) {
+              // Verify that we got the expected number of changes.
+              assert_equals(
+                  index, expectedValues.length, 'Number of distinct values');
+              resolve();
+              return;
+            }
 
-            task.done();
-            return;
-          }
+            if (index < expectedValues.length) {
+              // Verify that the number of channels matches the expected number
+              // of channels.
+              assert_equals(
+                  count, expectedValues[index],
+                  `Test ${index}: Number of convolver output channels`);
+            }
 
-          if (index < expectedValues.length) {
-            // Verify that the number of channels matches the expected number of
-            // channels.
-            should(count, `Test ${index}: Number of convolver output channels`)
-                .beEqualTo(expectedValues[index]);
-          }
+            ++index;
+          };
 
-          ++index;
-        };
+          // Create the graph and go
+          src.connect(merger).connect(testerNode).connect(context.destination);
+          src.start();
 
-        // Create the graph and go
-        src.connect(merger).connect(testerNode).connect(context.destination);
-        src.start();
-
-        // Stop the source after a short time so we can test that the channel
-        // merger changes to not actively processing and thus produces a single
-        // channel of silence.
-        src.stop(context.currentTime + .1);
-      });
-
-      audit.run();
+          // Stop the source after a short time so we can test that the channel
+          // merger changes to not actively processing and thus produces a
+          // single channel of silence.
+          src.stop(context.currentTime + .1);
+        });
+      }, 'test: Active processing emits expected channel-count changes');
     </script>
   </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-iirfilternode-interface/iirfilter-getFrequencyResponse.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-iirfilternode-interface/iirfilter-getFrequencyResponse.html
@@ -67,12 +67,12 @@
         iir.getFrequencyResponse(frequencies, iirMag, iirPhase);
 
         // Thresholds were experimentally determined.
-        assert_close_to_array(
+        assert_array_equal_within_eps(
             iirMag, trueMag, 2.8611e-6, '1‑pole IIR magnitude response ' +
-            'should be closed to calculated magnitude response');
-        assert_close_to_array(
+                'should be closed to calculated magnitude response');
+        assert_array_equal_within_eps(
             iirPhase, truePhase, 1.7882e-7, '1‑pole IIR phase response ' +
-            ' should be closed to calculated phase response');
+                ' should be closed to calculated phase response');
       }, '1‑pole IIR getFrequencyResponse() matches analytic response');
 
       test(t => {
@@ -101,12 +101,12 @@
         biquad.getFrequencyResponse(frequencies, biquadMag, biquadPhase);
         iir.getFrequencyResponse(frequencies, iirMag, iirPhase);
       // Thresholds were experimentally determined.
-        assert_close_to_array(
+        assert_array_equal_within_eps(
             iirMag, biquadMag, 2.7419e-5, 'IIR magnitude response should be' +
-            'close to Biquad magnitude response');
-        assert_close_to_array(
+                'close to Biquad magnitude response');
+        assert_array_equal_within_eps(
             iirPhase, biquadPhase, 2.7657e-5, 'IIR phase response should be' +
-            'close to Biquad phase response');
+                'close to Biquad phase response');
       }, 'IIR filter equivalent to biquad has matching frequency response');
 
       test(t => {

--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-oscillatornode-interface/detune-limiting.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-oscillatornode-interface/detune-limiting.html
@@ -49,7 +49,7 @@
             0,
             `Reference output (freq: ${refOsc.frequency.value}) must be zero`
         );
-        assert_array_approximately_equals(
+        assert_array_equal_within_eps(
             actual,
             expected,
             0,

--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-pannernode-interface/automation-changes-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-pannernode-interface/automation-changes-expected.txt
@@ -1,26 +1,5 @@
 
-PASS # AUDIT TASK RUNNER STARTED.
-PASS Executing "Set Listener.positionX.value"
-PASS Executing "Listener.positionX.setValue"
-PASS Executing "Listener.setPosition"
-PASS Audit report
-PASS > [Set Listener.positionX.value]
-PASS   listenr.positionX.value: output0[0:511] equals [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0...] with an element-wise tolerance of {"absoluteThreshold":1e-16,"relativeThreshold":0}.
-PASS   listenr.positionX.value: output1[0:511] is not constantly 0.
-PASS   listenr.positionX.value: output0[512:] is not constantly 0.
-PASS   listenr.positionX.value: output1[512:] equals [expected array] with an element-wise tolerance of {"absoluteThreshold":0,"relativeThreshold":0}.
-PASS < [Set Listener.positionX.value] All assertions passed. (total 4 assertions)
-PASS > [Listener.positionX.setValue]
-PASS   listener.positionX.setValueATTime: output0[0:511] equals [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0...] with an element-wise tolerance of {"absoluteThreshold":1e-16,"relativeThreshold":0}.
-PASS   listener.positionX.setValueATTime: output1[0:511] is not constantly 0.
-PASS   listener.positionX.setValueATTime: output0[512:] is not constantly 0.
-PASS   listener.positionX.setValueATTime: output1[512:] equals [expected array] with an element-wise tolerance of {"absoluteThreshold":0,"relativeThreshold":0}.
-PASS < [Listener.positionX.setValue] All assertions passed. (total 4 assertions)
-PASS > [Listener.setPosition]
-PASS   listener.setPostion: output0[0:511] equals [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0...] with an element-wise tolerance of {"absoluteThreshold":1e-16,"relativeThreshold":0}.
-PASS   listener.setPostion: output1[0:511] is not constantly 0.
-PASS   listener.setPostion: output0[512:] is not constantly 0.
-PASS   listener.setPostion: output1[512:] equals [expected array] with an element-wise tolerance of {"absoluteThreshold":0,"relativeThreshold":0}.
-PASS < [Listener.setPosition] All assertions passed. (total 4 assertions)
-PASS # AUDIT TASK RUNNER FINISHED: 3 tasks ran successfully.
+PASS Set Listener.positionX.value
+PASS Listener.positionX.setValue
+PASS Listener.setPosition
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-pannernode-interface/automation-changes.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-pannernode-interface/automation-changes.html
@@ -5,7 +5,6 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="../../resources/audit-util.js"></script>
-    <script src="../../resources/audit.js"></script>
   </head>
 
   <body>
@@ -20,68 +19,8 @@
       // Initial panner positionX and final positionX for listener.
       const positionX = 2000;
 
-      const audit = Audit.createTaskRunner();
-
-      // Test that listener.positionX.value setter does the right thing.
-      audit.define('Set Listener.positionX.value', (task, should) => {
-        const context = new OfflineAudioContext(2, renderFrames, sampleRate);
-
-        createGraph(context);
-
-        // Frame at which the listener instantaneously moves to a new location.
-        const moveFrame = 512;
-
-        context.suspend(moveFrame / context.sampleRate)
-            .then(() => {
-              context.listener.positionX.value = positionX;
-            })
-            .then(() => context.resume());
-
-        verifyOutput(context, moveFrame, should, 'listenr.positionX.value')
-            .then(() => task.done());
-      });
-
-      // Test that listener.positionX.setValueAtTime() does the right thing.
-      audit.define('Listener.positionX.setValue', (task, should) => {
-        const context = new OfflineAudioContext(2, renderFrames, sampleRate);
-
-        createGraph(context);
-
-        // Frame at which the listener instantaneously moves to a new location.
-        const moveFrame = 512;
-
-        context.listener.positionX.setValueAtTime(
-            positionX, moveFrame / context.sampleRate);
-
-        verifyOutput(
-            context, moveFrame, should, 'listener.positionX.setValueATTime')
-            .then(() => task.done());
-      });
-
-      // Test that listener.setPosition() does the right thing.
-      audit.define('Listener.setPosition', (task, should) => {
-        const context = new OfflineAudioContext(2, renderFrames, sampleRate);
-
-        createGraph(context);
-
-        // Frame at which the listener instantaneously moves to a new location.
-        const moveFrame = 512;
-
-        context.suspend(moveFrame / context.sampleRate)
-            .then(() => {
-              context.listener.setPosition(positionX, 0, 0);
-            })
-            .then(() => context.resume());
-
-        verifyOutput(context, moveFrame, should, 'listener.setPostion')
-            .then(() => task.done());
-      });
-
-      audit.run();
-
-
-      // Create the basic graph for testing which consists of an oscillator node
-      // connected to a panner node.
+      // Create the basic graph for testing which consists of an
+      // oscillator node connected to a panner node.
       function createGraph(context) {
         const listener = context.listener;
 
@@ -106,7 +45,7 @@
 
 
       // Verify the output from the panner is correct.
-      function verifyOutput(context, moveFrame, should, prefix) {
+      function verifyOutput(context, moveFrame, prefix) {
         return context.startRendering().then(resultBuffer => {
           // Get the outputs (left and right)
           const c0 = resultBuffer.getChannelData(0);
@@ -117,23 +56,79 @@
           // should be 0 (or very nearly 0).
           const zero = new Float32Array(moveFrame);
 
-          should(
-              c0.slice(0, moveFrame), `${prefix}: output0[0:${moveFrame - 1}]`)
-              .beCloseToArray(zero, {absoluteThreshold: 1e-16});
-          should(
-              c1.slice(0, moveFrame), `${prefix}: output1[0:${moveFrame - 1}]`)
-              .notBeConstantValueOf(0);
+          assert_array_equal_within_eps(
+              c0.slice(0, moveFrame),
+              zero,
+              {absoluteThreshold: 1e-16},
+              `${prefix}: output0[0:${moveFrame - 1}]`);
+          assert_not_constant_value(
+              c1.slice(0, moveFrame),
+              0,
+              `${prefix}: output1[0:${moveFrame - 1}]`);
 
           // At |moveFrame| and beyond, the listener and source are at the
           // same position, so the outputs from the left and right should be
           // identical, and the left channel should not be 0 anymore.
-
-          should(c0.slice(moveFrame), `${prefix}: output0[${moveFrame}:]`)
-              .notBeConstantValueOf(0);
-          should(c1.slice(moveFrame), `${prefix}: output1[${moveFrame}:]`)
-              .beCloseToArray(c0.slice(moveFrame));
+          assert_not_constant_value(
+              c0.slice(moveFrame),
+              0,
+              `${prefix}: output0[${moveFrame}:]`);
+          assert_array_equal_within_eps(
+              c1.slice(moveFrame),
+              c0.slice(moveFrame),
+              0,
+              `${prefix}: output1[${moveFrame}:]`);
         });
       }
+
+      // Test that listener.positionX.value setter does the right thing.
+      promise_test(async t => {
+        const context = new OfflineAudioContext(2, renderFrames, sampleRate);
+        createGraph(context);
+
+        // Frame at which the listener instantaneously moves to a new location.
+        const moveFrame = 512;
+
+        // Schedule a suspend; when it trips, set the value and resume.
+        context.suspend(moveFrame / context.sampleRate).then(() => {
+          context.listener.positionX.value = positionX;
+          context.resume();
+        });
+
+        await verifyOutput(context, moveFrame, 'listener.positionX.value');
+      }, 'Set Listener.positionX.value');
+
+      // Test that listener.positionX.setValueAtTime() does the right thing.
+      promise_test(async t => {
+        const context = new OfflineAudioContext(2, renderFrames, sampleRate);
+        createGraph(context);
+
+        // Frame at which the listener instantaneously moves to a new location.
+        const moveFrame = 512;
+
+        context.listener.positionX.setValueAtTime(
+            positionX, moveFrame / context.sampleRate);
+
+        await verifyOutput(
+            context, moveFrame, 'listener.positionX.setValueAtTime');
+      }, 'Listener.positionX.setValue');
+
+      // Test that listener.setPosition() does the right thing.
+      promise_test(async t => {
+        const context = new OfflineAudioContext(2, renderFrames, sampleRate);
+        createGraph(context);
+
+        // Frame at which the listener instantaneously moves to a new location.
+        const moveFrame = 512;
+
+        context.suspend(moveFrame / context.sampleRate).then(() => {
+          context.listener.setPosition(positionX, 0, 0);
+          context.resume();
+        });
+
+        await verifyOutput(
+            context, moveFrame, 'listener.setPosition');
+      }, 'Listener.setPosition');
     </script>
   </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-scriptprocessornode-interface/simple-input-output-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-scriptprocessornode-interface/simple-input-output-expected.txt
@@ -1,11 +1,3 @@
 
-PASS # AUDIT TASK RUNNER STARTED.
-PASS Executing "test"
-PASS Audit report
-PASS > [test] ScriptProcessor with stopped input source
-PASS   ScriptProcessor output[0:1023] contains only the constant 0.
-PASS   ScriptProcessor output[1024:1151] equals [expected array] with an element-wise tolerance of {"absoluteThreshold":0,"relativeThreshold":0}.
-PASS   ScriptProcessor output[1152:] contains only the constant 1.
-PASS < [test] All assertions passed. (total 3 assertions)
-PASS # AUDIT TASK RUNNER FINISHED: 1 tasks ran successfully.
+PASS ScriptProcessor with stopped input source
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-scriptprocessornode-interface/simple-input-output.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-scriptprocessornode-interface/simple-input-output.html
@@ -1,98 +1,84 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
-  <head>
-    <title>Test ScriptProcessorNode</title>
-    <script src="/resources/testharness.js"></script>
-    <script src="/resources/testharnessreport.js"></script>
-    <script src="/webaudio/resources/audit-util.js"></script>
-    <script src="/webaudio/resources/audit.js"></script>
-  </head>
+<head>
+  <title>Test ScriptProcessorNode</title>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/webaudio/resources/audit-util.js"></script>
+</head>
+<body>
+  <script>
+    // Arbitrary sample rate
+    const sampleRate = 48000;
 
-  <body>
-    <script>
-      // Arbitrary sample rate
-      const sampleRate = 48000;
-      let audit = Audit.createTaskRunner();
+    promise_test(async (t) => {
+      // Two channels for testing.  Channel 0 is the output of the
+      // scriptProcessor.  Channel 1 is the oscillator so we can compare
+      // the outputs.
+      const context = new OfflineAudioContext({
+        numberOfChannels: 2,
+        length: sampleRate,
+        sampleRate: sampleRate});
 
-      audit.define(
-          {
-            label: 'test',
-            description: 'ScriptProcessor with stopped input source'
-          },
-          (task, should) => {
-            // Two channels for testing.  Channel 0 is the output of the
-            // scriptProcessor.  Channel 1 is the oscillator so we can compare
-            // the outputs.
-            let context = new OfflineAudioContext({
-              numberOfChannels: 2,
-              length: sampleRate,
-              sampleRate: sampleRate
-            });
+      const merger = new ChannelMergerNode(
+          context, {numberOfChannels: context.destination.channelCount});
+      merger.connect(context.destination);
 
-            let merger = new ChannelMergerNode(
-                context, {numberOfChannels: context.destination.channelCount});
-            merger.connect(context.destination);
+      const src = new OscillatorNode(context);
 
-            let src = new OscillatorNode(context);
+      // Arbitrary buffer size for the ScriptProcessorNode.  Don't use 0;
+      // we need to know the actual size to know the latency of the node
+      // (easily).
+      const spnSize = 512;
+      const spn = context.createScriptProcessor(spnSize, 1, 1);
 
-            // Arbitrary buffer size for the ScriptProcessorNode.  Don't use 0;
-            // we need to know the actual size to know the latency of the node
-            // (easily).
-            const spnSize = 512;
-            let spn = context.createScriptProcessor(spnSize, 1, 1);
+      // Arrange for the ScriptProcessor to add |offset| to the input.
+      const offset = 1;
+      spn.onaudioprocess = (event) => {
+        const input = event.inputBuffer.getChannelData(0);
+        const output = event.outputBuffer.getChannelData(0);
+        for (let k = 0; k < output.length; ++k) {
+          output[k] = input[k] + offset;
+        }
+      };
 
-            // Arrange for the ScriptProcessor to add |offset| to the input.
-            const offset = 1;
-            spn.onaudioprocess = (event) => {
-              let input = event.inputBuffer.getChannelData(0);
-              let output = event.outputBuffer.getChannelData(0);
-              for (let k = 0; k < output.length; ++k) {
-                output[k] = input[k] + offset;
-              }
-            };
+      src.connect(spn).connect(merger, 0, 0);
+      src.connect(merger, 0, 1);
 
-            src.connect(spn).connect(merger, 0, 0);
-            src.connect(merger, 0, 1);
+      // Start and stop the source.  The stop time is fairly arbitrary,
+      // but use a render quantum boundary for simplicity.
+      const stopFrame = RENDER_QUANTUM_FRAMES;
+      src.start();
+      src.stop(stopFrame / context.sampleRate);
 
-            // Start and stop the source.  The stop time is fairly arbitrary,
-            // but use a render quantum boundary for simplicity.
-            const stopFrame = RENDER_QUANTUM_FRAMES;
-            src.start(0);
-            src.stop(stopFrame / context.sampleRate);
+      const buffer = await context.startRendering();
+      const ch0 = buffer.getChannelData(0);
+      const ch1 = buffer.getChannelData(1);
 
-            context.startRendering()
-                .then(buffer => {
-                  let ch0 = buffer.getChannelData(0);
-                  let ch1 = buffer.getChannelData(1);
+      const shifted = ch1.slice(0, stopFrame).map((x) => x + offset);
 
-                  let shifted = ch1.slice(0, stopFrame).map(x => x + offset);
+      // SPN has a basic latency of 2*|spnSize| fraems, so the
+      // beginning is silent.
+      assert_array_equals(
+          ch0.slice(0, 2 * spnSize - 1),
+          new Float32Array(2 * spnSize - 1),
+          `ScriptProcessor output[0:${2 * spnSize - 1}]`);
 
-                  // SPN has a basic latency of 2*|spnSize| fraems, so the
-                  // beginning is silent.
-                  should(
-                      ch0.slice(0, 2 * spnSize - 1),
-                      `ScriptProcessor output[0:${2 * spnSize - 1}]`)
-                      .beConstantValueOf(0);
+      // For the middle section (after adding latency), the output
+      // should be the source shifted by |offset|.
+      assert_array_equals(
+          ch0.slice(2 * spnSize, 2 * spnSize + stopFrame),
+          new Float32Array(shifted),
+          `ScriptProcessor output[${2 * spnSize}:` +
+              `${2 * spnSize + stopFrame - 1}]`);
 
-                  // For the middle section (after adding latency), the output
-                  // should be the source shifted by |offset|.
-                  should(
-                      ch0.slice(2 * spnSize, 2 * spnSize + stopFrame),
-                      `ScriptProcessor output[${2 * spnSize}:${
-                          2 * spnSize + stopFrame - 1}]`)
-                      .beCloseToArray(shifted, {absoluteThreshold: 0});
-
-                  // Output should be constant after the source has stopped.
-                  // Include the latency introduced by the node.
-                  should(
-                      ch0.slice(2 * spnSize + stopFrame),
-                      `ScriptProcessor output[${2 * spnSize + stopFrame}:]`)
-                      .beConstantValueOf(offset);
-                })
-                .then(() => task.done());
-          });
-
-      audit.run();
-    </script>
-  </body>
+      // Output should be constant after the source has stopped.
+      // Include the latency introduced by the node.
+      assert_array_equals(
+        ch0.slice(2 * spnSize + stopFrame),
+        new Float32Array(ch0.length - (2 * spnSize + stopFrame)).fill(offset),
+        `ScriptProcessor output[${2 * spnSize + stopFrame}:]`);
+    }, 'ScriptProcessor with stopped input source');
+  </script>
+</body>
 </html>


### PR DESCRIPTION
#### 1c475e349b607fc360805a33229120abcbca797c
<pre>
Resync `webaudio` from WPT Upstream
<a href="https://bugs.webkit.org/show_bug.cgi?id=299143">https://bugs.webkit.org/show_bug.cgi?id=299143</a>
<a href="https://rdar.apple.com/160904880">rdar://160904880</a>

Reviewed by Tim Nguyen.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/45cf78f9fd18a2c3eb0a49a43f2334a77ea9292e">https://github.com/web-platform-tests/wpt/commit/45cf78f9fd18a2c3eb0a49a43f2334a77ea9292e</a>

* LayoutTests/imported/w3c/web-platform-tests/webaudio/resources/audit-util.js:
(assert_array_equal_within_eps):
(assert_array_approximately_equals): Deleted.
(assert_close_to_array): Deleted.
* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/active-processing.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/active-processing.https.html:
* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/audiobuffersource-channels-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/audiobuffersource-channels.html:
* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/audiosource-onended-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/audiosource-onended.html:
* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/buffer-resampling-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/buffer-resampling.html:
* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/sub-sample-buffer-stitching.html:
* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/adding-events-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/adding-events.html:
* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/audioparam-connect-audioratesignal-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/audioparam-connect-audioratesignal.html:
* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/automation-rate-testing.js:
* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/k-rate-biquad-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/k-rate-biquad.html:
* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-channelmergernode-interface/active-processing.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-channelmergernode-interface/active-processing.https.html:
* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-iirfilternode-interface/iirfilter-getFrequencyResponse.html:
* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-oscillatornode-interface/detune-limiting.html:
* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-pannernode-interface/automation-changes-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-pannernode-interface/automation-changes.html:
* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-scriptprocessornode-interface/simple-input-output-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-scriptprocessornode-interface/simple-input-output.html:

Canonical link: <a href="https://commits.webkit.org/300213@main">https://commits.webkit.org/300213@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/09a857934751e912cfb4acc81da785e7a50d992e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121689 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41390 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32054 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128211 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/73779 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/39749b71-f001-4ce0-8030-84a870feaace) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42102 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49981 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92465 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/73779 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/769dc13c-d67c-4d1d-8919-052c63bd863f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124641 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33590 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108994 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73126 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/40b21f84-6431-41db-ad3f-2f2364f9aa37) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32601 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27155 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71730 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103088 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27341 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131004 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48624 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36983 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101034 "Passed tests") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48996 "Hash 09a85793 for PR 50970 does not build (failure)") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105210 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100925 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25595 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24413 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45325 "Failed to checkout and rebase branch from PR 50970") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48482 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47951 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51301 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49634 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->