### PR TITLE
Resync `webrtc-stats` from WPT Upstream

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc-stats/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc-stats/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: webrtc-stats
+  files: "**"

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc-stats/hardware-capability-stats.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc-stats/hardware-capability-stats.https.html
@@ -14,23 +14,25 @@
  */
 'use strict';
 
-function getStatEntry(report, type, kind) {
+function getStatEntry(report, type, kind, assertStatsExists = true) {
   const values = [...report.values()];
   const for_kind = values.filter(
     stat => stat.type == type && stat.kind == kind);
 
-  assert_equals(1, for_kind.length,
-                "Expected report to have only 1 entry with type '" + type +
-                "' and kind '" + kind + "'. Found values " + for_kind);
-  return for_kind[0];
+  if (assertStatsExists) {
+    assert_equals(1, for_kind.length,
+                  "Expected report to have only 1 entry with type '" + type +
+                  "' and kind '" + kind + "'. Found values " + for_kind);
+  }
+  return for_kind.length > 0 ? for_kind[0] : null;
 }
 
 async function hasEncodedAndDecodedFrames(pc, t) {
   while (true) {
     const report = await pc.getStats();
-    const inboundRtp = getStatEntry(report, 'inbound-rtp', 'video');
-    const outboundRtp = getStatEntry(report, 'outbound-rtp', 'video');
-    if (inboundRtp.framesDecoded > 0 && outboundRtp.framesEncoded > 0) {
+    const inboundRtp = getStatEntry(report, 'inbound-rtp', 'video', false);
+    const outboundRtp = getStatEntry(report, 'outbound-rtp', 'video', false);
+    if (inboundRtp?.framesDecoded > 0 && outboundRtp?.framesEncoded > 0) {
       return;
     }
     // Avoid any stats caching, which can otherwise make this an infinite loop.

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc-stats/outbound-rtp.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc-stats/outbound-rtp.https-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL setting an encoding to false is reflected in outbound-rtp stats assert_true: expected true got undefined
+PASS setting an encoding to false is reflected in outbound-rtp stats
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc-stats/outbound-rtp.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc-stats/outbound-rtp.https.html
@@ -6,14 +6,21 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="../webrtc/RTCPeerConnection-helper.js"></script>
 <script>
-function extractOutboundRtpStats(stats) {
-  const wantedStats = [];
-  stats.forEach(report => {
-    if (report.type === 'outbound-rtp') {
-     wantedStats.push(report);
+async function extractOutboundRtpStats(pc, expected) {
+  // If remote stats are never reported, return after 5 seconds.
+  const startTime = performance.now();
+  let stats;
+  while (true) {
+    const report = await pc.getStats();
+    stats = [...report.values()].filter(({type}) => type === 'outbound-rtp');
+    if (stats.length && stats.every(({active}) => active == expected)) {
+      break;
     }
-  });
-  return wantedStats;
+    if (performance.now() > startTime + 5000) {
+      break;
+    }
+  }
+  return stats;
 }
 
 promise_test(async (test) => {
@@ -26,9 +33,8 @@ promise_test(async (test) => {
   stream.getTracks().forEach(t => pc1.addTrack(t, stream));
   exchangeIceCandidates(pc1, pc2);
   exchangeOfferAnswer(pc1, pc2);
-  const {track} = await new Promise(r => pc2.ontrack = r);
-  await new Promise(r => track.onunmute = r);
-  let outboundStats = extractOutboundRtpStats(await pc1.getStats());
+  await waitForRtpAndRtcpStats(pc1);
+  let outboundStats = await extractOutboundRtpStats(pc1, true);
   assert_equals(outboundStats.length, 2);
   assert_true(outboundStats[0].active);
   assert_true(outboundStats[1].active);
@@ -41,7 +47,7 @@ promise_test(async (test) => {
   // Avoid any stats caching.
   await (new Promise(r => test.step_timeout(r, 100)));
 
-  outboundStats = extractOutboundRtpStats(await pc1.getStats());
+  outboundStats = await extractOutboundRtpStats(pc1, false);
   assert_equals(outboundStats.length, 2);
   assert_false(outboundStats[0].active);
   assert_false(outboundStats[1].active);

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc-stats/rtp-stats-creation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc-stats/rtp-stats-creation-expected.txt
@@ -1,7 +1,7 @@
 
 FAIL No RTCRtpStreamStats exist when only remote description is set assert_equals: no rtp stats with only remote description expected 0 but got 2
 FAIL No RTCRtpStreamStats exist when only local description is set assert_equals: no rtp stats with only local description expected 0 but got 2
-FAIL No RTCOutboundRtpStreamStats exist until packets have been sent assert_true: no outbound rtp stats before packets sent expected true got false
+FAIL No RTCRtpOutboundStreamStats should exist before negotiation completes assert_equals: No outbound rtp stats after setLocalDescription but before setRemoteDescription expected 0 but got 2
 FAIL No RTCInboundRtpStreamStats exist until packets have been received assert_true: no inbound rtp stats before packets received expected true got false
 FAIL RTCAudioPlayoutStats should be present assert_unreached: Audio playout stats should become available Reached unreachable code
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc-stats/rtp-stats-creation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc-stats/rtp-stats-creation.html
@@ -38,18 +38,26 @@ promise_test(async (test) => {
   localPc.addTrack(...await createTrackAndStreamWithCleanup(test, "audio"));
   localPc.addTrack(...await createTrackAndStreamWithCleanup(test, "video"));
   exchangeIceCandidates(localPc, remotePc);
-  await Promise.all([
-    exchangeOfferAnswer(localPc, remotePc),
-    new Promise(r => remotePc.ontrack = e => e.track.onunmute = r)
-  ]);
+
+  async function countOutboundRtp() {
+    const stats = await localPc.getStats();
+    return [...stats.values()]
+        .filter(({ type }) => type == "outbound-rtp").length;
+  }
+
+  assert_equals(await countOutboundRtp(), 0,
+    "No outbound rtp stats before setLocalDescription");
+  await localPc.setLocalDescription();
+  const p = remotePc.setRemoteDescription(localPc.localDescription);
+  assert_equals(await countOutboundRtp(), 0,
+    "No outbound rtp stats after setLocalDescription but before setRemoteDescription");
+  await p;
+  await remotePc.setLocalDescription();
+  await localPc.setRemoteDescription(remotePc.localDescription);
+
   const start = performance.now();
   while (true) {
-    const report = await localPc.getStats();
-    const outbound =
-      [...report.values()].filter(({type}) => type == "outbound-rtp");
-    assert_true(outbound.every(({packetsSent}) => packetsSent > 0),
-      "no outbound rtp stats before packets sent");
-    if (outbound.length == 2) {
+    if (await countOutboundRtp() == 2) {
       // One outbound stat for each track is present. We're done.
       break;
     }
@@ -58,7 +66,7 @@ promise_test(async (test) => {
     }
     await new Promise(r => test.step_timeout(r, 100));
   }
-}, "No RTCOutboundRtpStreamStats exist until packets have been sent");
+}, "No RTCRtpOutboundStreamStats should exist before negotiation completes");
 
 promise_test(async (test) => {
   const localPc = createPeerConnectionWithCleanup(test);

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc-stats/supported-stats.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc-stats/supported-stats.https-expected.txt
@@ -3,7 +3,6 @@ PASS getStats succeeds
 PASS All references resolve
 PASS Validating stats
 PASS codec's payloadType
-FAIL codec's codecType assert_true: Is codecType present expected true got false
 PASS codec's transportId
 PASS codec's mimeType
 PASS codec's clockRate
@@ -12,40 +11,41 @@ PASS codec's sdpFmtpLine
 PASS codec's timestamp
 PASS codec's type
 PASS codec's id
-FAIL inbound-rtp's receiverId assert_true: Is receiverId present expected true got false
+PASS inbound-rtp's trackIdentifier
+PASS inbound-rtp's mid
 PASS inbound-rtp's remoteId
 PASS inbound-rtp's framesDecoded
 PASS inbound-rtp's keyFramesDecoded
+FAIL inbound-rtp's framesRendered assert_true: Is framesRendered present expected true got false
+PASS inbound-rtp's framesDropped
 PASS inbound-rtp's frameWidth
 PASS inbound-rtp's frameHeight
-FAIL inbound-rtp's frameBitDepth assert_true: Is frameBitDepth present expected true got false
 PASS inbound-rtp's framesPerSecond
 FAIL inbound-rtp's qpSum assert_true: Is qpSum present expected true got false
 PASS inbound-rtp's totalDecodeTime
 PASS inbound-rtp's totalInterFrameDelay
 PASS inbound-rtp's totalSquaredInterFrameDelay
-FAIL inbound-rtp's voiceActivityFlag assert_true: Is voiceActivityFlag present expected true got false
+PASS inbound-rtp's pauseCount
+PASS inbound-rtp's totalPausesDuration
+PASS inbound-rtp's freezeCount
+PASS inbound-rtp's totalFreezesDuration
 PASS inbound-rtp's lastPacketReceivedTimestamp
-FAIL inbound-rtp's averageRtcpInterval assert_true: Is averageRtcpInterval present expected true got false
 PASS inbound-rtp's headerBytesReceived
+PASS inbound-rtp's packetsDiscarded
+NOTRUN inbound-rtp's fecBytesReceived inbound-rtp.fecBytesReceived marked as not testable.
 PASS inbound-rtp's fecPacketsReceived
 PASS inbound-rtp's fecPacketsDiscarded
 PASS inbound-rtp's bytesReceived
-FAIL inbound-rtp's packetsFailedDecryption assert_true: Is packetsFailedDecryption present expected true got false
-FAIL inbound-rtp's packetsDuplicated assert_true: Is packetsDuplicated present expected true got false
-FAIL inbound-rtp's perDscpPacketsReceived assert_true: Is perDscpPacketsReceived present expected true got false
 PASS inbound-rtp's nackCount
 PASS inbound-rtp's firCount
 PASS inbound-rtp's pliCount
-FAIL inbound-rtp's sliCount assert_true: Is sliCount present expected true got false
 PASS inbound-rtp's totalProcessingDelay
 PASS inbound-rtp's estimatedPlayoutTimestamp
 PASS inbound-rtp's jitterBufferDelay
+PASS inbound-rtp's jitterBufferTargetDelay
 PASS inbound-rtp's jitterBufferEmittedCount
+PASS inbound-rtp's jitterBufferMinimumDelay
 PASS inbound-rtp's totalSamplesReceived
-FAIL inbound-rtp's totalSamplesDecoded assert_true: Is totalSamplesDecoded present expected true got false
-FAIL inbound-rtp's samplesDecodedWithSilk assert_true: Is samplesDecodedWithSilk present expected true got false
-FAIL inbound-rtp's samplesDecodedWithCelt assert_true: Is samplesDecodedWithCelt present expected true got false
 PASS inbound-rtp's concealedSamples
 PASS inbound-rtp's silentConcealedSamples
 PASS inbound-rtp's concealmentEvents
@@ -56,22 +56,24 @@ PASS inbound-rtp's totalAudioEnergy
 PASS inbound-rtp's totalSamplesDuration
 PASS inbound-rtp's framesReceived
 FAIL inbound-rtp's decoderImplementation assert_true: Is decoderImplementation present expected true got false
+FAIL inbound-rtp's playoutId assert_true: Is playoutId present expected true got false
+FAIL inbound-rtp's powerEfficientDecoder assert_true: Is powerEfficientDecoder present expected true got false
+PASS inbound-rtp's framesAssembledFromMultiplePackets
+PASS inbound-rtp's totalAssemblyTime
+PASS inbound-rtp's retransmittedPacketsReceived
+PASS inbound-rtp's retransmittedBytesReceived
+PASS inbound-rtp's rtxSsrc
+NOTRUN inbound-rtp's fecSsrc inbound-rtp.fecSsrc marked as not testable.
+FAIL inbound-rtp's totalCorruptionProbability assert_true: Is totalCorruptionProbability present expected true got false
+FAIL inbound-rtp's totalSquaredCorruptionProbability assert_true: Is totalSquaredCorruptionProbability present expected true got false
+FAIL inbound-rtp's corruptionMeasurements assert_true: Is corruptionMeasurements present expected true got false
 PASS inbound-rtp's packetsReceived
+FAIL inbound-rtp's packetsReceivedWithEct1 assert_true: Is packetsReceivedWithEct1 present expected true got false
+FAIL inbound-rtp's packetsReceivedWithCe assert_true: Is packetsReceivedWithCe present expected true got false
+FAIL inbound-rtp's packetsReportedAsLost assert_true: Is packetsReportedAsLost present expected true got false
+FAIL inbound-rtp's packetsReportedAsLostButRecovered assert_true: Is packetsReportedAsLostButRecovered present expected true got false
 PASS inbound-rtp's packetsLost
 PASS inbound-rtp's jitter
-PASS inbound-rtp's packetsDiscarded
-FAIL inbound-rtp's packetsRepaired assert_true: Is packetsRepaired present expected true got false
-FAIL inbound-rtp's burstPacketsLost assert_true: Is burstPacketsLost present expected true got false
-FAIL inbound-rtp's burstPacketsDiscarded assert_true: Is burstPacketsDiscarded present expected true got false
-FAIL inbound-rtp's burstLossCount assert_true: Is burstLossCount present expected true got false
-FAIL inbound-rtp's burstDiscardCount assert_true: Is burstDiscardCount present expected true got false
-FAIL inbound-rtp's burstLossRate assert_true: Is burstLossRate present expected true got false
-FAIL inbound-rtp's burstDiscardRate assert_true: Is burstDiscardRate present expected true got false
-FAIL inbound-rtp's gapLossRate assert_true: Is gapLossRate present expected true got false
-FAIL inbound-rtp's gapDiscardRate assert_true: Is gapDiscardRate present expected true got false
-PASS inbound-rtp's framesDropped
-FAIL inbound-rtp's partialFramesLost assert_true: Is partialFramesLost present expected true got false
-FAIL inbound-rtp's fullFramesLost assert_true: Is fullFramesLost present expected true got false
 PASS inbound-rtp's ssrc
 PASS inbound-rtp's kind
 PASS inbound-rtp's transportId
@@ -79,48 +81,42 @@ PASS inbound-rtp's codecId
 PASS inbound-rtp's timestamp
 PASS inbound-rtp's type
 PASS inbound-rtp's id
-PASS outbound-rtp's rtxSsrc
+PASS outbound-rtp's mid
 PASS outbound-rtp's mediaSourceId
-FAIL outbound-rtp's senderId assert_true: Is senderId present expected true got false
 PASS outbound-rtp's remoteId
 NOTRUN outbound-rtp's rid outbound-rtp.rid marked as not testable.
-FAIL outbound-rtp's lastPacketSentTimestamp assert_true: Is lastPacketSentTimestamp present expected true got false
+FAIL outbound-rtp's encodingIndex assert_true: Is encodingIndex present expected true got false
 PASS outbound-rtp's headerBytesSent
-FAIL outbound-rtp's packetsDiscardedOnSend assert_true: Is packetsDiscardedOnSend present expected true got false
-FAIL outbound-rtp's bytesDiscardedOnSend assert_true: Is bytesDiscardedOnSend present expected true got false
-FAIL outbound-rtp's fecPacketsSent assert_true: Is fecPacketsSent present expected true got false
 PASS outbound-rtp's retransmittedPacketsSent
 PASS outbound-rtp's retransmittedBytesSent
+PASS outbound-rtp's rtxSsrc
 PASS outbound-rtp's targetBitrate
 PASS outbound-rtp's totalEncodedBytesTarget
 PASS outbound-rtp's frameWidth
 PASS outbound-rtp's frameHeight
-FAIL outbound-rtp's frameBitDepth assert_true: Is frameBitDepth present expected true got false
 PASS outbound-rtp's framesPerSecond
 PASS outbound-rtp's framesSent
 PASS outbound-rtp's hugeFramesSent
 PASS outbound-rtp's framesEncoded
 PASS outbound-rtp's keyFramesEncoded
-FAIL outbound-rtp's framesDiscardedOnSend assert_true: Is framesDiscardedOnSend present expected true got false
 PASS outbound-rtp's qpSum
-FAIL outbound-rtp's totalSamplesSent assert_true: Is totalSamplesSent present expected true got false
-FAIL outbound-rtp's samplesEncodedWithSilk assert_true: Is samplesEncodedWithSilk present expected true got false
-FAIL outbound-rtp's samplesEncodedWithCelt assert_true: Is samplesEncodedWithCelt present expected true got false
-FAIL outbound-rtp's voiceActivityFlag assert_true: Is voiceActivityFlag present expected true got false
+FAIL outbound-rtp's psnrSum assert_true: Is psnrSum present expected true got false
+FAIL outbound-rtp's psnrMeasurements assert_true: Is psnrMeasurements present expected true got false
 PASS outbound-rtp's totalEncodeTime
 PASS outbound-rtp's totalPacketSendDelay
-FAIL outbound-rtp's averageRtcpInterval assert_true: Is averageRtcpInterval present expected true got false
 PASS outbound-rtp's qualityLimitationReason
 PASS outbound-rtp's qualityLimitationDurations
 PASS outbound-rtp's qualityLimitationResolutionChanges
-FAIL outbound-rtp's perDscpPacketsSent assert_true: Is perDscpPacketsSent present expected true got false
 PASS outbound-rtp's nackCount
 PASS outbound-rtp's firCount
 PASS outbound-rtp's pliCount
-FAIL outbound-rtp's sliCount assert_true: Is sliCount present expected true got false
 FAIL outbound-rtp's encoderImplementation assert_true: Is encoderImplementation present expected true got false
+FAIL outbound-rtp's powerEfficientEncoder assert_true: Is powerEfficientEncoder present expected true got false
+PASS outbound-rtp's active
+FAIL outbound-rtp's scalabilityMode assert_true: Is scalabilityMode present expected true got false
 PASS outbound-rtp's packetsSent
 PASS outbound-rtp's bytesSent
+FAIL outbound-rtp's packetsSentWithEct1 assert_true: Is packetsSentWithEct1 present expected true got false
 PASS outbound-rtp's ssrc
 PASS outbound-rtp's kind
 PASS outbound-rtp's transportId
@@ -132,24 +128,15 @@ PASS remote-inbound-rtp's localId
 PASS remote-inbound-rtp's roundTripTime
 PASS remote-inbound-rtp's totalRoundTripTime
 PASS remote-inbound-rtp's fractionLost
-FAIL remote-inbound-rtp's reportsReceived assert_true: Is reportsReceived present expected true got false
 PASS remote-inbound-rtp's roundTripTimeMeasurements
+FAIL remote-inbound-rtp's packetsWithBleachedEct1Marking assert_true: Is packetsWithBleachedEct1Marking present expected true got false
 FAIL remote-inbound-rtp's packetsReceived assert_true: Is packetsReceived present expected true got false
+FAIL remote-inbound-rtp's packetsReceivedWithEct1 assert_true: Is packetsReceivedWithEct1 present expected true got false
+FAIL remote-inbound-rtp's packetsReceivedWithCe assert_true: Is packetsReceivedWithCe present expected true got false
+FAIL remote-inbound-rtp's packetsReportedAsLost assert_true: Is packetsReportedAsLost present expected true got false
+FAIL remote-inbound-rtp's packetsReportedAsLostButRecovered assert_true: Is packetsReportedAsLostButRecovered present expected true got false
 PASS remote-inbound-rtp's packetsLost
 PASS remote-inbound-rtp's jitter
-FAIL remote-inbound-rtp's packetsDiscarded assert_true: Is packetsDiscarded present expected true got false
-FAIL remote-inbound-rtp's packetsRepaired assert_true: Is packetsRepaired present expected true got false
-FAIL remote-inbound-rtp's burstPacketsLost assert_true: Is burstPacketsLost present expected true got false
-FAIL remote-inbound-rtp's burstPacketsDiscarded assert_true: Is burstPacketsDiscarded present expected true got false
-FAIL remote-inbound-rtp's burstLossCount assert_true: Is burstLossCount present expected true got false
-FAIL remote-inbound-rtp's burstDiscardCount assert_true: Is burstDiscardCount present expected true got false
-FAIL remote-inbound-rtp's burstLossRate assert_true: Is burstLossRate present expected true got false
-FAIL remote-inbound-rtp's burstDiscardRate assert_true: Is burstDiscardRate present expected true got false
-FAIL remote-inbound-rtp's gapLossRate assert_true: Is gapLossRate present expected true got false
-FAIL remote-inbound-rtp's gapDiscardRate assert_true: Is gapDiscardRate present expected true got false
-FAIL remote-inbound-rtp's framesDropped assert_true: Is framesDropped present expected true got false
-FAIL remote-inbound-rtp's partialFramesLost assert_true: Is partialFramesLost present expected true got false
-FAIL remote-inbound-rtp's fullFramesLost assert_true: Is fullFramesLost present expected true got false
 PASS remote-inbound-rtp's ssrc
 PASS remote-inbound-rtp's kind
 PASS remote-inbound-rtp's transportId
@@ -165,6 +152,7 @@ PASS remote-outbound-rtp's totalRoundTripTime
 PASS remote-outbound-rtp's roundTripTimeMeasurements
 PASS remote-outbound-rtp's packetsSent
 PASS remote-outbound-rtp's bytesSent
+FAIL remote-outbound-rtp's packetsSentWithEct1 assert_true: Is packetsSentWithEct1 present expected true got false
 PASS remote-outbound-rtp's ssrc
 PASS remote-outbound-rtp's kind
 PASS remote-outbound-rtp's transportId
@@ -172,17 +160,8 @@ PASS remote-outbound-rtp's codecId
 PASS remote-outbound-rtp's timestamp
 PASS remote-outbound-rtp's type
 PASS remote-outbound-rtp's id
-FAIL csrc's contributorSsrc assert_true: Is contributorSsrc present expected true got false
-FAIL csrc's inboundRtpStreamId assert_true: Is inboundRtpStreamId present expected true got false
-FAIL csrc's packetsContributedTo assert_true: Is packetsContributedTo present expected true got false
-FAIL csrc's audioLevel assert_true: Is audioLevel present expected true got false
-FAIL csrc's timestamp assert_true: Is timestamp present expected true got false
-FAIL csrc's type assert_true: Is type present expected true got false
-FAIL csrc's id assert_true: Is id present expected true got false
 PASS peer-connection's dataChannelsOpened
 PASS peer-connection's dataChannelsClosed
-FAIL peer-connection's dataChannelsRequested assert_true: Is dataChannelsRequested present expected true got false
-FAIL peer-connection's dataChannelsAccepted assert_true: Is dataChannelsAccepted present expected true got false
 PASS peer-connection's timestamp
 PASS peer-connection's type
 PASS peer-connection's id
@@ -204,33 +183,26 @@ NOTRUN media-source's echoReturnLoss media-source.echoReturnLoss marked as not t
 NOTRUN media-source's echoReturnLossEnhancement media-source.echoReturnLossEnhancement marked as not testable.
 FAIL media-source's width assert_true: Is width present expected true got false
 FAIL media-source's height assert_true: Is height present expected true got false
-FAIL media-source's bitDepth assert_true: Is bitDepth present expected true got false
 PASS media-source's frames
 PASS media-source's framesPerSecond
 PASS media-source's trackIdentifier
 PASS media-source's kind
-FAIL media-source's relayedSource assert_true: Is relayedSource present expected true got false
 PASS media-source's timestamp
 PASS media-source's type
 PASS media-source's id
-FAIL sender's mediaSourceId assert_true: Is mediaSourceId present expected true got false
-FAIL sender's trackIdentifier assert_true: Is trackIdentifier present expected true got false
-FAIL sender's ended assert_true: Is ended present expected true got false
-FAIL sender's kind assert_true: Is kind present expected true got false
-FAIL sender's timestamp assert_true: Is timestamp present expected true got false
-FAIL sender's type assert_true: Is type present expected true got false
-FAIL sender's id assert_true: Is id present expected true got false
-FAIL receiver's trackIdentifier assert_true: Is trackIdentifier present expected true got false
-FAIL receiver's ended assert_true: Is ended present expected true got false
-FAIL receiver's kind assert_true: Is kind present expected true got false
-FAIL receiver's timestamp assert_true: Is timestamp present expected true got false
-FAIL receiver's type assert_true: Is type present expected true got false
-FAIL receiver's id assert_true: Is id present expected true got false
+FAIL media-playout's kind assert_true: Is kind present expected true got false
+FAIL media-playout's synthesizedSamplesDuration assert_true: Is synthesizedSamplesDuration present expected true got false
+FAIL media-playout's synthesizedSamplesEvents assert_true: Is synthesizedSamplesEvents present expected true got false
+FAIL media-playout's totalSamplesDuration assert_true: Is totalSamplesDuration present expected true got false
+FAIL media-playout's totalPlayoutDelay assert_true: Is totalPlayoutDelay present expected true got false
+FAIL media-playout's totalSamplesCount assert_true: Is totalSamplesCount present expected true got false
+FAIL media-playout's timestamp assert_true: Is timestamp present expected true got false
+FAIL media-playout's type assert_true: Is type present expected true got false
+FAIL media-playout's id assert_true: Is id present expected true got false
 PASS transport's packetsSent
 PASS transport's packetsReceived
 PASS transport's bytesSent
 PASS transport's bytesReceived
-FAIL transport's rtcpTransportStatsId assert_true: Is rtcpTransportStatsId present expected true got false
 PASS transport's iceRole
 PASS transport's iceLocalUsernameFragment
 PASS transport's dtlsState
@@ -240,9 +212,11 @@ PASS transport's localCertificateId
 PASS transport's remoteCertificateId
 PASS transport's tlsVersion
 PASS transport's dtlsCipher
+PASS transport's dtlsRole
 PASS transport's srtpCipher
-FAIL transport's tlsGroup assert_true: Is tlsGroup present expected true got false
 PASS transport's selectedCandidatePairChanges
+FAIL transport's ccfbMessagesSent assert_true: Is ccfbMessagesSent present expected true got false
+FAIL transport's ccfbMessagesReceived assert_true: Is ccfbMessagesReceived present expected true got false
 PASS transport's timestamp
 PASS transport's type
 PASS transport's id
@@ -257,27 +231,17 @@ PASS candidate-pair's bytesSent
 PASS candidate-pair's bytesReceived
 PASS candidate-pair's lastPacketSentTimestamp
 PASS candidate-pair's lastPacketReceivedTimestamp
-FAIL candidate-pair's firstRequestTimestamp assert_true: Is firstRequestTimestamp present expected true got false
-FAIL candidate-pair's lastRequestTimestamp assert_true: Is lastRequestTimestamp present expected true got false
-FAIL candidate-pair's lastResponseTimestamp assert_true: Is lastResponseTimestamp present expected true got false
 PASS candidate-pair's totalRoundTripTime
 PASS candidate-pair's currentRoundTripTime
 PASS candidate-pair's availableOutgoingBitrate
 NOTRUN candidate-pair's availableIncomingBitrate candidate-pair.availableIncomingBitrate marked as not testable.
-FAIL candidate-pair's circuitBreakerTriggerCount assert_true: Is circuitBreakerTriggerCount present expected true got false
 PASS candidate-pair's requestsReceived
 PASS candidate-pair's requestsSent
 PASS candidate-pair's responsesReceived
 PASS candidate-pair's responsesSent
-FAIL candidate-pair's retransmissionsReceived assert_true: Is retransmissionsReceived present expected true got false
-FAIL candidate-pair's retransmissionsSent assert_true: Is retransmissionsSent present expected true got false
 PASS candidate-pair's consentRequestsSent
-FAIL candidate-pair's consentExpiredTimestamp assert_true: Is consentExpiredTimestamp present expected true got false
 PASS candidate-pair's packetsDiscardedOnSend
 PASS candidate-pair's bytesDiscardedOnSend
-FAIL candidate-pair's requestBytesSent assert_true: Is requestBytesSent present expected true got false
-FAIL candidate-pair's consentRequestBytesSent assert_true: Is consentRequestBytesSent present expected true got false
-FAIL candidate-pair's responseBytesSent assert_true: Is responseBytesSent present expected true got false
 PASS candidate-pair's timestamp
 PASS candidate-pair's type
 PASS candidate-pair's id
@@ -289,6 +253,11 @@ PASS local-candidate's candidateType
 PASS local-candidate's priority
 NOTRUN local-candidate's url local-candidate.url marked as not testable.
 NOTRUN local-candidate's relayProtocol local-candidate.relayProtocol marked as not testable.
+PASS local-candidate's foundation
+NOTRUN local-candidate's relatedAddress local-candidate.relatedAddress marked as not testable.
+NOTRUN local-candidate's relatedPort local-candidate.relatedPort marked as not testable.
+PASS local-candidate's usernameFragment
+FAIL local-candidate's tcpType assert_true: Is tcpType present expected true got false
 PASS local-candidate's timestamp
 PASS local-candidate's type
 PASS local-candidate's id
@@ -300,6 +269,11 @@ PASS remote-candidate's candidateType
 PASS remote-candidate's priority
 NOTRUN remote-candidate's url remote-candidate.url marked as not testable.
 NOTRUN remote-candidate's relayProtocol remote-candidate.relayProtocol marked as not testable.
+PASS remote-candidate's foundation
+NOTRUN remote-candidate's relatedAddress remote-candidate.relatedAddress marked as not testable.
+NOTRUN remote-candidate's relatedPort remote-candidate.relatedPort marked as not testable.
+PASS remote-candidate's usernameFragment
+NOTRUN remote-candidate's tcpType remote-candidate.tcpType marked as not testable.
 PASS remote-candidate's timestamp
 PASS remote-candidate's type
 PASS remote-candidate's id

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc-stats/supported-stats.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc-stats/supported-stats.https.html
@@ -69,6 +69,7 @@ function isPropertyTestable(type, property) {
     ],
     'inbound-rtp': [
       'fecSsrc', // requires FlexFEC to be negotiated.
+      'fecBytesReceived', // requires FlexFEC to be negotiated.
     ],
     'media-source': [
       'echoReturnLoss', // requires gUM with an audio input device.

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc-stats/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc-stats/w3c-import.log
@@ -16,6 +16,7 @@ None
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/webrtc-stats/META.yml
 /LayoutTests/imported/w3c/web-platform-tests/webrtc-stats/README.md
+/LayoutTests/imported/w3c/web-platform-tests/webrtc-stats/WEB_FEATURES.yml
 /LayoutTests/imported/w3c/web-platform-tests/webrtc-stats/getStats-remote-candidate-address.html
 /LayoutTests/imported/w3c/web-platform-tests/webrtc-stats/getStats-remote-candidate-ufrag.html
 /LayoutTests/imported/w3c/web-platform-tests/webrtc-stats/hardware-capability-stats.https.html

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webrtc-stats/outbound-rtp.https-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webrtc-stats/outbound-rtp.https-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL setting an encoding to false is reflected in outbound-rtp stats assert_true: expected true got undefined
+


### PR DESCRIPTION
#### 3d92230ada8e4aef74899f5dd94f1c3be052c85a
<pre>
Resync `webrtc-stats` from WPT Upstream
<a href="https://bugs.webkit.org/show_bug.cgi?id=299145">https://bugs.webkit.org/show_bug.cgi?id=299145</a>
<a href="https://rdar.apple.com/160905893">rdar://160905893</a>

Reviewed by Darin Adler.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/611eeeaf5144cc732b63b68a716bc1d1cbd96cbf">https://github.com/web-platform-tests/wpt/commit/611eeeaf5144cc732b63b68a716bc1d1cbd96cbf</a>

* LayoutTests/imported/w3c/web-platform-tests/webrtc-stats/hardware-capability-stats.https.html:
* LayoutTests/imported/w3c/web-platform-tests/webrtc-stats/outbound-rtp.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webrtc-stats/outbound-rtp.https.html:
* LayoutTests/imported/w3c/web-platform-tests/webrtc-stats/rtp-stats-creation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webrtc-stats/rtp-stats-creation.html:
* LayoutTests/imported/w3c/web-platform-tests/webrtc-stats/supported-stats.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webrtc-stats/supported-stats.https.html:
* LayoutTests/imported/w3c/web-platform-tests/webrtc-stats/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/webrtc-stats/WEB_FEATURES.yml:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/webrtc-stats/outbound-rtp.https-expected.txt:

Canonical link: <a href="https://commits.webkit.org/300397@main">https://commits.webkit.org/300397@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6d059d2c5106ae9e3b2b8091b084399f485b8911

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121822 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41523 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32187 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128367 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73912 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7fdede6e-3510-409e-80bc-27e884cd40f9) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42235 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50116 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92578 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61530 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b573c823-69b4-4553-a08d-62a729bc941a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124774 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33685 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109100 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73237 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2e7ad551-1bcd-40cb-96c2-196c93527ab1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32697 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27263 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71873 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103185 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27448 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131142 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48757 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37074 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101165 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49129 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105317 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101037 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25734 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46394 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24499 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45458 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48615 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48085 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51434 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49767 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->