### PR TITLE
[Safer CPP] Rename singleton functions from `shared()` to `singleton()`

### DIFF
--- a/Source/WebCore/Modules/airplay/WebMediaSessionManager.h
+++ b/Source/WebCore/Modules/airplay/WebMediaSessionManager.h
@@ -51,7 +51,7 @@ class WebMediaSessionManager : public MediaPlaybackTargetPicker::Client, public 
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebMediaSessionManager);
 public:
 
-    WEBCORE_EXPORT static WebMediaSessionManager& shared();
+    WEBCORE_EXPORT static WebMediaSessionManager& singleton();
 
     WEBCORE_EXPORT void setMockMediaPlaybackTargetPickerEnabled(bool);
     WEBCORE_EXPORT void setMockMediaPlaybackTargetPickerState(const String&, MediaPlaybackTargetContext::MockState);

--- a/Source/WebCore/Modules/encryptedmedia/CDM.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/CDM.cpp
@@ -141,7 +141,7 @@ bool CDM::supportsInitDataType(const AtomString& initDataType) const
 
 RefPtr<SharedBuffer> CDM::sanitizeInitData(const AtomString& initDataType, const SharedBuffer& initData)
 {
-    return InitDataRegistry::shared().sanitizeInitData(initDataType, initData);
+    return InitDataRegistry::singleton().sanitizeInitData(initDataType, initData);
 }
 
 bool CDM::supportsInitData(const AtomString& initDataType, const SharedBuffer& initData)

--- a/Source/WebCore/Modules/encryptedmedia/InitDataRegistry.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/InitDataRegistry.cpp
@@ -288,7 +288,7 @@ static std::optional<Vector<Ref<SharedBuffer>>> extractKeyIDsWebM(const SharedBu
     return keyIDs;
 }
 
-InitDataRegistry& InitDataRegistry::shared()
+InitDataRegistry& InitDataRegistry::singleton()
 {
     static NeverDestroyed<InitDataRegistry> registry;
     return registry.get();

--- a/Source/WebCore/Modules/encryptedmedia/InitDataRegistry.h
+++ b/Source/WebCore/Modules/encryptedmedia/InitDataRegistry.h
@@ -42,7 +42,7 @@ class SharedBuffer;
 
 class InitDataRegistry {
 public:
-    WEBCORE_EXPORT static InitDataRegistry& shared();
+    WEBCORE_EXPORT static InitDataRegistry& singleton();
     friend class NeverDestroyed<InitDataRegistry>;
 
     RefPtr<SharedBuffer> sanitizeInitData(const AtomString& initDataType, const SharedBuffer&);

--- a/Source/WebCore/Modules/websockets/WebSocket.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocket.cpp
@@ -311,7 +311,7 @@ ExceptionOr<void> WebSocket::connect(const String& url, const Vector<String>& pr
     }
 
     RunLoop::mainSingleton().dispatch([targetURL = m_url.isolatedCopy(), mainFrameURL = context->url().isolatedCopy()]() {
-        ResourceLoadObserver::shared().logWebSocketLoading(targetURL, mainFrameURL);
+        ResourceLoadObserver::singleton().logWebSocketLoading(targetURL, mainFrameURL);
     });
 
     if (RefPtr document = dynamicDowncast<Document>(context)) {

--- a/Source/WebCore/PAL/pal/system/ios/SleepDisablerIOS.mm
+++ b/Source/WebCore/PAL/pal/system/ios/SleepDisablerIOS.mm
@@ -37,7 +37,7 @@ namespace PAL {
 
 class ScreenSleepDisabler {
 public:
-    static ScreenSleepDisabler& shared()
+    static ScreenSleepDisabler& singleton()
     {
         static MainThreadNeverDestroyed<ScreenSleepDisabler> screenSleepDisabler;
         return screenSleepDisabler;
@@ -79,12 +79,12 @@ private:
 
 void SleepDisablerCocoa::takeScreenSleepDisablingAssertion(const String&)
 {
-    m_screenSleepDisablerToken = ScreenSleepDisabler::shared().takeAssertion();
+    m_screenSleepDisablerToken = ScreenSleepDisabler::singleton().takeAssertion();
 }
 
 void SleepDisablerCocoa::setScreenWakeLockHandler(Function<bool(bool shouldKeepScreenAwake)>&& screenWakeLockHandler)
 {
-    ScreenSleepDisabler::shared().setScreenWakeLockHandler(WTFMove(screenWakeLockHandler));
+    ScreenSleepDisabler::singleton().setScreenWakeLockHandler(WTFMove(screenWakeLockHandler));
 }
 
 } // namespace PAL

--- a/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
@@ -310,7 +310,6 @@ platform/graphics/ca/GraphicsLayerCA.cpp
 platform/graphics/ca/PlatformCALayer.mm
 platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
 platform/graphics/cg/CGSubimageCacheWithTimer.cpp
-platform/graphics/mac/controls/ImageControlsButtonMac.mm
 platform/ios/PlaybackSessionInterfaceIOS.mm
 platform/ios/WebAVPlayerController.mm
 platform/mac/VideoPresentationInterfaceMac.mm

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -277,8 +277,8 @@ page/DeviceController.cpp
 page/DragController.cpp
 page/ElementTargetingController.cpp
 page/EventHandler.cpp
-page/FrameConsoleClient.cpp
 page/FocusController.cpp
+page/FrameConsoleClient.cpp
 page/FrameSnapshotting.cpp
 page/FrameView.cpp
 page/ImageAnalysisQueue.cpp
@@ -365,7 +365,6 @@ platform/graphics/filters/software/FETileSoftwareApplier.cpp
 platform/graphics/filters/software/FETurbulenceSoftwareApplier.cpp
 platform/graphics/filters/software/SourceAlphaSoftwareApplier.cpp
 platform/graphics/filters/software/SourceGraphicSoftwareApplier.cpp
-platform/graphics/mac/controls/ImageControlsButtonMac.mm
 platform/graphics/mac/controls/MeterMac.mm
 platform/graphics/mac/controls/ProgressBarMac.mm
 platform/graphics/mac/controls/SliderTrackMac.mm

--- a/Source/WebCore/css/CSSFontFaceSource.cpp
+++ b/Source/WebCore/css/CSSFontFaceSource.cpp
@@ -187,7 +187,7 @@ void CSSFontFaceSource::load(Document* document)
             fontDescription.setShouldAllowUserInstalledFonts(protectedCSSFontFace()->allowUserInstalledFonts());
             success = FontCache::forCurrentThread()->fontForFamily(fontDescription, m_fontFaceName, { }, FontLookupOptions::ExactFamilyNameMatch);
             if (document && document->settings().webAPIStatisticsEnabled())
-                ResourceLoadObserver::shared().logFontLoad(*document, m_fontFaceName.string(), success);
+                ResourceLoadObserver::singleton().logFontLoad(*document, m_fontFaceName.string(), success);
         }
         setStatus(success ? Status::Success : Status::Failure);
     }

--- a/Source/WebCore/css/CSSFontSelector.cpp
+++ b/Source/WebCore/css/CSSFontSelector.cpp
@@ -465,7 +465,7 @@ FontRanges CSSFontSelector::fontRangesForFamily(const FontDescription& fontDescr
     RefPtr document = dynamicDowncast<Document>(m_context.get());
     if (RefPtr face = m_cssFontFaceSet->fontFace(fontDescriptionForLookup->fontSelectionRequest(), familyForLookup)) {
         if (document && document->settings().webAPIStatisticsEnabled())
-            ResourceLoadObserver::shared().logFontLoad(*document, familyForLookup.string(), true);
+            ResourceLoadObserver::singleton().logFontLoad(*document, familyForLookup.string(), true);
         return { face->fontRanges(*fontDescriptionForLookup, fontPaletteValues, fontFeatureValues), isGenericFontFamily };
     }
 
@@ -474,7 +474,7 @@ FontRanges CSSFontSelector::fontRangesForFamily(const FontDescription& fontDescr
 
     auto font = FontCache::forCurrentThread()->fontForFamily(*fontDescriptionForLookup, familyForLookup, { { }, { }, fontPaletteValues, fontFeatureValues, 1.0 });
     if (document && document->settings().webAPIStatisticsEnabled())
-        ResourceLoadObserver::shared().logFontLoad(*document, familyForLookup.string(), !!font);
+        ResourceLoadObserver::singleton().logFontLoad(*document, familyForLookup.string(), !!font);
     return { FontRanges { WTFMove(font) }, isGenericFontFamily };
 }
 
@@ -506,7 +506,7 @@ RefPtr<Font> CSSFontSelector::fallbackFontAt(const FontDescription& fontDescript
     auto& pictographFontFamily = context->settingsValues().fontGenericFamilies.pictographFontFamily();
     RefPtr font = FontCache::forCurrentThread()->fontForFamily(fontDescription, pictographFontFamily);
     if (RefPtr document = dynamicDowncast<Document>(context.get()); document && document->settingsValues().webAPIStatisticsEnabled)
-        ResourceLoadObserver::shared().logFontLoad(*document, pictographFontFamily, !!font);
+        ResourceLoadObserver::singleton().logFontLoad(*document, pictographFontFamily, !!font);
 
     return font;
 }

--- a/Source/WebCore/dom/UserGestureIndicator.cpp
+++ b/Source/WebCore/dom/UserGestureIndicator.cpp
@@ -128,7 +128,7 @@ UserGestureIndicator::UserGestureIndicator(std::optional<IsProcessingUserGesture
         if (processInteractionStyle == ProcessInteractionStyle::Immediate) {
             RefPtr mainFrameDocument = document->mainFrameDocument();
             if (mainFrameDocument)
-                ResourceLoadObserver::shared().logUserInteractionWithReducedTimeResolution(*mainFrameDocument);
+                ResourceLoadObserver::singleton().logUserInteractionWithReducedTimeResolution(*mainFrameDocument);
             else
                 LOG_ONCE(SiteIsolation, "Unable to properly construct UserGestureIndicator::UserGestureIndicator() without access to the main frame document ");
         }

--- a/Source/WebCore/html/HTMLCanvasElement.cpp
+++ b/Source/WebCore/html/HTMLCanvasElement.cpp
@@ -723,7 +723,7 @@ ExceptionOr<UncachedString> HTMLCanvasElement::toDataURL(const String& mimeType,
         return UncachedString { "data:,"_s };
     Ref document = this->document();
     if (document->settings().webAPIStatisticsEnabled())
-        ResourceLoadObserver::shared().logCanvasRead(document);
+        ResourceLoadObserver::singleton().logCanvasRead(document);
 
     auto encodingMIMEType = toEncodingMimeType(mimeType);
     auto quality = qualityFromJSValue(qualityValue);
@@ -769,7 +769,7 @@ ExceptionOr<void> HTMLCanvasElement::toBlob(Ref<BlobCallback>&& callback, const 
         return { };
     }
     if (document->settings().webAPIStatisticsEnabled())
-        ResourceLoadObserver::shared().logCanvasRead(document);
+        ResourceLoadObserver::singleton().logCanvasRead(document);
 
     auto encodingMIMEType = toEncodingMimeType(mimeType);
     auto quality = qualityFromJSValue(qualityValue);
@@ -826,7 +826,7 @@ RefPtr<ImageData> HTMLCanvasElement::getImageData()
 
     Ref document = this->document();
     if (document->settings().webAPIStatisticsEnabled())
-        ResourceLoadObserver::shared().logCanvasRead(document.get());
+        ResourceLoadObserver::singleton().logCanvasRead(document.get());
 
     RefPtr pixelBuffer = context->drawingBufferToPixelBuffer();
     if (!pixelBuffer)
@@ -848,13 +848,13 @@ RefPtr<VideoFrame> HTMLCanvasElement::toVideoFrame()
 #if ENABLE(WEBGL)
     if (RefPtr context = dynamicDowncast<WebGLRenderingContextBase>(m_context.get())) {
         if (document->settings().webAPIStatisticsEnabled())
-            ResourceLoadObserver::shared().logCanvasRead(document.get());
+            ResourceLoadObserver::singleton().logCanvasRead(document.get());
         return context->surfaceBufferToVideoFrame(CanvasRenderingContext::SurfaceBuffer::DrawingBuffer);
     }
 #endif
 
     if (document->settings().webAPIStatisticsEnabled())
-        ResourceLoadObserver::shared().logCanvasRead(document.get());
+        ResourceLoadObserver::singleton().logCanvasRead(document.get());
 
     RefPtr imageBuffer = makeRenderingResultsAvailable();
     if (!imageBuffer)
@@ -884,7 +884,7 @@ ExceptionOr<Ref<MediaStream>> HTMLCanvasElement::captureStream(std::optional<dou
         return Exception(ExceptionCode::SecurityError, "Canvas is tainted"_s);
     Ref document = this->document();
     if (document->settings().webAPIStatisticsEnabled())
-        ResourceLoadObserver::shared().logCanvasRead(document.get());
+        ResourceLoadObserver::singleton().logCanvasRead(document.get());
 
     if (frameRequestRate && frameRequestRate.value() < 0)
         return Exception(ExceptionCode::NotSupportedError, "frameRequestRate is negative"_s);

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -1527,7 +1527,7 @@ void HTMLInputElement::logUserInteraction()
     if (!document().frame() || !document().frame()->localMainFrame())
         return;
     if (RefPtr mainFrameDocument = document().frame()->localMainFrame()->document())
-        ResourceLoadObserver::shared().logUserInteractionWithReducedTimeResolution(*mainFrameDocument);
+        ResourceLoadObserver::singleton().logUserInteractionWithReducedTimeResolution(*mainFrameDocument);
 }
 
 void HTMLInputElement::setAutofilled(bool autoFilled)

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp
@@ -270,8 +270,8 @@ Ref<TextMetrics> CanvasRenderingContext2D::measureText(const String& text)
     ScriptDisallowedScope::InMainThread scriptDisallowedScope;
 
     if (document->settings().webAPIStatisticsEnabled()) {
-        ResourceLoadObserver::shared().logCanvasWriteOrMeasure(document, text);
-        ResourceLoadObserver::shared().logCanvasRead(document);
+        ResourceLoadObserver::singleton().logCanvasWriteOrMeasure(document, text);
+        ResourceLoadObserver::singleton().logCanvasRead(document);
     }
 
     String normalizedText = normalizeSpaces(text);
@@ -303,7 +303,7 @@ void CanvasRenderingContext2D::drawTextInternal(const String& text, double x, do
     ScriptDisallowedScope::InMainThread scriptDisallowedScope;
 
     if (document->settings().webAPIStatisticsEnabled())
-        ResourceLoadObserver::shared().logCanvasWriteOrMeasure(document, text);
+        ResourceLoadObserver::singleton().logCanvasWriteOrMeasure(document, text);
 
     if (!canDrawText(x, y, fill, maxWidth))
         return;

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -3670,7 +3670,7 @@ ResourceLoaderIdentifier FrameLoader::loadResourceSynchronously(const ResourceRe
         Vector<uint8_t> buffer;
         platformStrategies()->loaderStrategy()->loadResourceSynchronously(*this, identifier, newRequest, clientCredentialPolicy, options, originalRequestHeaders, error, response, buffer);
         data = SharedBuffer::create(WTFMove(buffer));
-        ResourceLoadObserver::shared().logSubresourceLoading(protectedFrame().ptr(), newRequest, response,
+        ResourceLoadObserver::singleton().logSubresourceLoading(protectedFrame().ptr(), newRequest, response,
             (isScriptLikeDestination(options.destination) ? ResourceLoadObserver::FetchDestinationIsScriptLike::Yes : ResourceLoadObserver::FetchDestinationIsScriptLike::No));
     }
 

--- a/Source/WebCore/loader/ResourceLoadObserver.cpp
+++ b/Source/WebCore/loader/ResourceLoadObserver.cpp
@@ -41,7 +41,7 @@ void ResourceLoadObserver::setShared(ResourceLoadObserver& observer)
     sharedObserver() = &observer;
 }
 
-ResourceLoadObserver& ResourceLoadObserver::shared()
+ResourceLoadObserver& ResourceLoadObserver::singleton()
 {
     static NeverDestroyed<ResourceLoadObserver> emptyObserver;
     if (!sharedObserver())
@@ -49,7 +49,7 @@ ResourceLoadObserver& ResourceLoadObserver::shared()
     return *sharedObserver();
 }
 
-ResourceLoadObserver* ResourceLoadObserver::sharedIfExists()
+ResourceLoadObserver* ResourceLoadObserver::singletonIfExists()
 {
     return sharedObserver();
 }

--- a/Source/WebCore/loader/ResourceLoadObserver.h
+++ b/Source/WebCore/loader/ResourceLoadObserver.h
@@ -46,8 +46,8 @@ public:
     // https://fetch.spec.whatwg.org/#request-destination-script-like
     enum class FetchDestinationIsScriptLike : bool { No, Yes };
 
-    WEBCORE_EXPORT static ResourceLoadObserver& shared();
-    WEBCORE_EXPORT static ResourceLoadObserver* sharedIfExists();
+    WEBCORE_EXPORT static ResourceLoadObserver& singleton();
+    WEBCORE_EXPORT static ResourceLoadObserver* singletonIfExists();
     WEBCORE_EXPORT static void setShared(ResourceLoadObserver&);
     
     virtual ~ResourceLoadObserver() { }

--- a/Source/WebCore/loader/SubresourceLoader.cpp
+++ b/Source/WebCore/loader/SubresourceLoader.cpp
@@ -209,7 +209,7 @@ void SubresourceLoader::willSendRequestInternal(ResourceRequest&& newRequest, co
     }
 
     if (newRequest.requester() != ResourceRequestRequester::Main) {
-        ResourceLoadObserver::shared().logSubresourceLoading(protectedFrame().get(), newRequest, redirectResponse,
+        ResourceLoadObserver::singleton().logSubresourceLoading(protectedFrame().get(), newRequest, redirectResponse,
             (isScriptLikeDestination(options().destination) ? ResourceLoadObserver::FetchDestinationIsScriptLike::Yes : ResourceLoadObserver::FetchDestinationIsScriptLike::No));
     }
 

--- a/Source/WebCore/page/DOMWindow.cpp
+++ b/Source/WebCore/page/DOMWindow.cpp
@@ -130,7 +130,7 @@ void DOMWindow::close()
     if (localFrame && !localFrame->loader().shouldClose())
         return;
 
-    ResourceLoadObserver::shared().updateCentralStatisticsStore([] { });
+    ResourceLoadObserver::singleton().updateCentralStatisticsStore([] { });
 
     page->setIsClosing();
     closePage();

--- a/Source/WebCore/page/DeprecatedGlobalSettings.cpp
+++ b/Source/WebCore/page/DeprecatedGlobalSettings.cpp
@@ -40,7 +40,7 @@
 
 namespace WebCore {
 
-DeprecatedGlobalSettings& DeprecatedGlobalSettings::shared()
+DeprecatedGlobalSettings& DeprecatedGlobalSettings::singleton()
 {
     static NeverDestroyed<DeprecatedGlobalSettings> deprecatedGlobalSettings;
     return deprecatedGlobalSettings;
@@ -49,10 +49,10 @@ DeprecatedGlobalSettings& DeprecatedGlobalSettings::shared()
 #if USE(AVFOUNDATION)
 void DeprecatedGlobalSettings::setAVFoundationEnabled(bool enabled)
 {
-    if (shared().m_AVFoundationEnabled == enabled)
+    if (singleton().m_AVFoundationEnabled == enabled)
         return;
 
-    shared().m_AVFoundationEnabled = enabled;
+    singleton().m_AVFoundationEnabled = enabled;
     platformStrategies()->mediaStrategy()->resetMediaEngines();
 }
 #endif
@@ -60,10 +60,10 @@ void DeprecatedGlobalSettings::setAVFoundationEnabled(bool enabled)
 #if USE(GSTREAMER)
 void DeprecatedGlobalSettings::setGStreamerEnabled(bool enabled)
 {
-    if (shared().m_GStreamerEnabled == enabled)
+    if (singleton().m_GStreamerEnabled == enabled)
         return;
 
-    shared().m_GStreamerEnabled = enabled;
+    singleton().m_GStreamerEnabled = enabled;
 
 #if ENABLE(VIDEO)
     platformStrategies()->mediaStrategy()->resetMediaEngines();
@@ -77,19 +77,19 @@ void DeprecatedGlobalSettings::setGStreamerEnabled(bool enabled)
 // correctly, which may cause the platform to follow dangling pointers.
 void DeprecatedGlobalSettings::setMockScrollbarsEnabled(bool flag)
 {
-    shared().m_mockScrollbarsEnabled = flag;
+    singleton().m_mockScrollbarsEnabled = flag;
     // FIXME: This should update scroll bars in existing pages.
 }
 
 void DeprecatedGlobalSettings::setUsesOverlayScrollbars(bool flag)
 {
-    shared().m_usesOverlayScrollbars = flag;
+    singleton().m_usesOverlayScrollbars = flag;
     // FIXME: This should update scroll bars in existing pages.
 }
 
 void DeprecatedGlobalSettings::setTrackingPreventionEnabled(bool flag)
 {
-    shared().m_trackingPreventionEnabled = flag;
+    singleton().m_trackingPreventionEnabled = flag;
 }
 
 #if PLATFORM(IOS_FAMILY)
@@ -105,7 +105,7 @@ unsigned DeprecatedGlobalSettings::audioSessionCategoryOverride()
 
 void DeprecatedGlobalSettings::setNetworkInterfaceName(const String& networkInterfaceName)
 {
-    shared().m_networkInterfaceName = networkInterfaceName;
+    singleton().m_networkInterfaceName = networkInterfaceName;
 }
 #endif
 
@@ -123,19 +123,19 @@ bool DeprecatedGlobalSettings::shouldManageAudioSessionCategory()
 
 void DeprecatedGlobalSettings::setAllowsAnySSLCertificate(bool allowAnySSLCertificate)
 {
-    shared().m_allowsAnySSLCertificate = allowAnySSLCertificate;
+    singleton().m_allowsAnySSLCertificate = allowAnySSLCertificate;
 }
 
 bool DeprecatedGlobalSettings::allowsAnySSLCertificate()
 {
-    return shared().m_allowsAnySSLCertificate;
+    return singleton().m_allowsAnySSLCertificate;
 }
 
 #if ENABLE(WEB_PUSH_NOTIFICATIONS)
 
 bool DeprecatedGlobalSettings::builtInNotificationsEnabled()
 {
-    return shared().m_builtInNotificationsEnabled;
+    return singleton().m_builtInNotificationsEnabled;
 }
 
 #endif

--- a/Source/WebCore/page/DeprecatedGlobalSettings.h
+++ b/Source/WebCore/page/DeprecatedGlobalSettings.h
@@ -36,24 +36,24 @@ class DeprecatedGlobalSettings {
 public:
 #if USE(AVFOUNDATION)
     WEBCORE_EXPORT static void setAVFoundationEnabled(bool);
-    static bool isAVFoundationEnabled() { return shared().m_AVFoundationEnabled; }
+    static bool isAVFoundationEnabled() { return singleton().m_AVFoundationEnabled; }
 #endif
 
 #if USE(GSTREAMER)
     WEBCORE_EXPORT static void setGStreamerEnabled(bool);
-    static bool isGStreamerEnabled() { return shared().m_GStreamerEnabled; }
+    static bool isGStreamerEnabled() { return singleton().m_GStreamerEnabled; }
 #endif
 
     WEBCORE_EXPORT static void setMockScrollbarsEnabled(bool);
-    static bool mockScrollbarsEnabled() { return shared().m_mockScrollbarsEnabled; }
+    static bool mockScrollbarsEnabled() { return singleton().m_mockScrollbarsEnabled; }
 
     WEBCORE_EXPORT static void setUsesOverlayScrollbars(bool);
-    static bool usesOverlayScrollbars() { return shared().m_usesOverlayScrollbars; }
+    static bool usesOverlayScrollbars() { return singleton().m_usesOverlayScrollbars; }
 
-    static bool lowPowerVideoAudioBufferSizeEnabled() { return shared().m_lowPowerVideoAudioBufferSizeEnabled; }
-    static void setLowPowerVideoAudioBufferSizeEnabled(bool flag) { shared().m_lowPowerVideoAudioBufferSizeEnabled = flag; }
+    static bool lowPowerVideoAudioBufferSizeEnabled() { return singleton().m_lowPowerVideoAudioBufferSizeEnabled; }
+    static void setLowPowerVideoAudioBufferSizeEnabled(bool flag) { singleton().m_lowPowerVideoAudioBufferSizeEnabled = flag; }
 
-    static bool trackingPreventionEnabled() { return shared().m_trackingPreventionEnabled; }
+    static bool trackingPreventionEnabled() { return singleton().m_trackingPreventionEnabled; }
     WEBCORE_EXPORT static void setTrackingPreventionEnabled(bool);
 
 #if PLATFORM(IOS_FAMILY)
@@ -61,13 +61,13 @@ public:
     static unsigned audioSessionCategoryOverride();
 
     WEBCORE_EXPORT static void setNetworkInterfaceName(const String&);
-    static const String& networkInterfaceName() { return shared().m_networkInterfaceName; }
+    static const String& networkInterfaceName() { return singleton().m_networkInterfaceName; }
 
-    static void setDisableScreenSizeOverride(bool flag) { shared().m_disableScreenSizeOverride = flag; }
-    static bool disableScreenSizeOverride() { return shared().m_disableScreenSizeOverride; }
+    static void setDisableScreenSizeOverride(bool flag) { singleton().m_disableScreenSizeOverride = flag; }
+    static bool disableScreenSizeOverride() { return singleton().m_disableScreenSizeOverride; }
 
-    static void setShouldOptOutOfNetworkStateObservation(bool flag) { shared().m_shouldOptOutOfNetworkStateObservation = flag; }
-    static bool shouldOptOutOfNetworkStateObservation() { return shared().m_shouldOptOutOfNetworkStateObservation; }
+    static void setShouldOptOutOfNetworkStateObservation(bool flag) { singleton().m_shouldOptOutOfNetworkStateObservation = flag; }
+    static bool shouldOptOutOfNetworkStateObservation() { return singleton().m_shouldOptOutOfNetworkStateObservation; }
 #endif
 
 #if USE(AUDIO_SESSION)
@@ -78,56 +78,56 @@ public:
     WEBCORE_EXPORT static void setAllowsAnySSLCertificate(bool);
     WEBCORE_EXPORT static bool allowsAnySSLCertificate();
 
-    static void setCustomPasteboardDataEnabled(bool isEnabled) { shared().m_isCustomPasteboardDataEnabled = isEnabled; }
-    static bool customPasteboardDataEnabled() { return shared().m_isCustomPasteboardDataEnabled; }
+    static void setCustomPasteboardDataEnabled(bool isEnabled) { singleton().m_isCustomPasteboardDataEnabled = isEnabled; }
+    static bool customPasteboardDataEnabled() { return singleton().m_isCustomPasteboardDataEnabled; }
 
-    static void setAttrStyleEnabled(bool isEnabled) { shared().m_attrStyleEnabled = isEnabled; }
-    static bool attrStyleEnabled() { return shared().m_attrStyleEnabled; }
+    static void setAttrStyleEnabled(bool isEnabled) { singleton().m_attrStyleEnabled = isEnabled; }
+    static bool attrStyleEnabled() { return singleton().m_attrStyleEnabled; }
 
-    static void setWebSQLEnabled(bool isEnabled) { shared().m_webSQLEnabled = isEnabled; }
-    static bool webSQLEnabled() { return shared().m_webSQLEnabled; }
+    static void setWebSQLEnabled(bool isEnabled) { singleton().m_webSQLEnabled = isEnabled; }
+    static bool webSQLEnabled() { return singleton().m_webSQLEnabled; }
 
 #if ENABLE(ATTACHMENT_ELEMENT)
-    static void setAttachmentElementEnabled(bool areEnabled) { shared().m_isAttachmentElementEnabled = areEnabled; }
-    static bool attachmentElementEnabled() { return shared().m_isAttachmentElementEnabled; }
+    static void setAttachmentElementEnabled(bool areEnabled) { singleton().m_isAttachmentElementEnabled = areEnabled; }
+    static bool attachmentElementEnabled() { return singleton().m_isAttachmentElementEnabled; }
 #endif
 
-    static bool webRTCAudioLatencyAdaptationEnabled() { return shared().m_isWebRTCAudioLatencyAdaptationEnabled; }
-    static void setWebRTCAudioLatencyAdaptationEnabled(bool isEnabled) { shared().m_isWebRTCAudioLatencyAdaptationEnabled = isEnabled; }
+    static bool webRTCAudioLatencyAdaptationEnabled() { return singleton().m_isWebRTCAudioLatencyAdaptationEnabled; }
+    static void setWebRTCAudioLatencyAdaptationEnabled(bool isEnabled) { singleton().m_isWebRTCAudioLatencyAdaptationEnabled = isEnabled; }
 
-    static void setReadableByteStreamAPIEnabled(bool isEnabled) { shared().m_isReadableByteStreamAPIEnabled = isEnabled; }
-    static bool readableByteStreamAPIEnabled() { return shared().m_isReadableByteStreamAPIEnabled; }
+    static void setReadableByteStreamAPIEnabled(bool isEnabled) { singleton().m_isReadableByteStreamAPIEnabled = isEnabled; }
+    static bool readableByteStreamAPIEnabled() { return singleton().m_isReadableByteStreamAPIEnabled; }
 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
-    static void setIsAccessibilityIsolatedTreeEnabled(bool isEnabled) { shared().m_accessibilityIsolatedTree = isEnabled; }
-    static bool isAccessibilityIsolatedTreeEnabled() { return shared().m_accessibilityIsolatedTree; }
+    static void setIsAccessibilityIsolatedTreeEnabled(bool isEnabled) { singleton().m_accessibilityIsolatedTree = isEnabled; }
+    static bool isAccessibilityIsolatedTreeEnabled() { return singleton().m_accessibilityIsolatedTree; }
 #endif
 
 #if ENABLE(AX_THREAD_TEXT_APIS)
-    static void setAccessibilityThreadTextApisEnabled(bool isEnabled) { shared().m_accessibilityThreadTextApis = isEnabled; }
-    static bool accessibilityThreadTextApisEnabled() { return shared().m_accessibilityThreadTextApis; }
+    static void setAccessibilityThreadTextApisEnabled(bool isEnabled) { singleton().m_accessibilityThreadTextApis = isEnabled; }
+    static bool accessibilityThreadTextApisEnabled() { return singleton().m_accessibilityThreadTextApis; }
 #endif
 
-    static void setArePDFImagesEnabled(bool isEnabled) { shared().m_arePDFImagesEnabled = isEnabled; }
-    static bool arePDFImagesEnabled() { return shared().m_arePDFImagesEnabled; }
+    static void setArePDFImagesEnabled(bool isEnabled) { singleton().m_arePDFImagesEnabled = isEnabled; }
+    static bool arePDFImagesEnabled() { return singleton().m_arePDFImagesEnabled; }
 
 #if ENABLE(WEB_PUSH_NOTIFICATIONS)
-    static void setBuiltInNotificationsEnabled(bool isEnabled) { shared().m_builtInNotificationsEnabled = isEnabled; }
+    static void setBuiltInNotificationsEnabled(bool isEnabled) { singleton().m_builtInNotificationsEnabled = isEnabled; }
     WEBCORE_EXPORT static bool builtInNotificationsEnabled();
 #endif
 
 #if ENABLE(MODEL_ELEMENT)
-    static void setModelDocumentEnabled(bool isEnabled) { shared().m_modelDocumentEnabled = isEnabled; }
-    static bool modelDocumentEnabled() { return shared().m_modelDocumentEnabled; }
+    static void setModelDocumentEnabled(bool isEnabled) { singleton().m_modelDocumentEnabled = isEnabled; }
+    static bool modelDocumentEnabled() { return singleton().m_modelDocumentEnabled; }
 #endif
 
 #if HAVE(WEBCONTENTRESTRICTIONS)
-    static void setUsesWebContentRestrictionsForFilter(bool uses) { shared().m_usesWebContentRestrictionsForFilter = uses; }
-    static bool usesWebContentRestrictionsForFilter() { return shared().m_usesWebContentRestrictionsForFilter; };
+    static void setUsesWebContentRestrictionsForFilter(bool uses) { singleton().m_usesWebContentRestrictionsForFilter = uses; }
+    static bool usesWebContentRestrictionsForFilter() { return singleton().m_usesWebContentRestrictionsForFilter; };
 #endif
 
 private:
-    WEBCORE_EXPORT static DeprecatedGlobalSettings& shared();
+    WEBCORE_EXPORT static DeprecatedGlobalSettings& singleton();
     DeprecatedGlobalSettings() = default;
     ~DeprecatedGlobalSettings() = default;
 

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -3969,7 +3969,7 @@ bool EventHandler::keyEvent(const PlatformKeyboardEvent& keyEvent)
             if (page)
                 page->setUserDidInteractWithPage(savedUserDidInteractWithPage);
         } else
-            ResourceLoadObserver::shared().logUserInteractionWithReducedTimeResolution(*mainFrameDocument);
+            ResourceLoadObserver::singleton().logUserInteractionWithReducedTimeResolution(*mainFrameDocument);
     }
 
     if (!wasHandled && frame->document())

--- a/Source/WebCore/page/Navigator.cpp
+++ b/Source/WebCore/page/Navigator.cpp
@@ -83,7 +83,7 @@ String Navigator::appVersion() const
     if (!frame)
         return String();
     if (frame->settings().webAPIStatisticsEnabled())
-        ResourceLoadObserver::shared().logNavigatorAPIAccessed(*frame->protectedDocument(), NavigatorAPIsAccessed::AppVersion);
+        ResourceLoadObserver::singleton().logNavigatorAPIAccessed(*frame->protectedDocument(), NavigatorAPIsAccessed::AppVersion);
     return NavigatorBase::appVersion();
 }
 
@@ -93,7 +93,7 @@ const String& Navigator::userAgent() const
     if (!frame || !frame->page())
         return m_userAgent;
     if (frame->settings().webAPIStatisticsEnabled())
-        ResourceLoadObserver::shared().logNavigatorAPIAccessed(*frame->protectedDocument(), NavigatorAPIsAccessed::UserAgent);
+        ResourceLoadObserver::singleton().logNavigatorAPIAccessed(*frame->protectedDocument(), NavigatorAPIsAccessed::UserAgent);
     if (m_userAgent.isNull())
         m_userAgent = frame->loader().userAgent(frame->document()->url());
     return m_userAgent;
@@ -307,7 +307,7 @@ void Navigator::initializePluginAndMimeTypeArrays()
 DOMPluginArray& Navigator::plugins()
 {
     if (RefPtr frame = this->frame(); frame && frame->settings().webAPIStatisticsEnabled())
-        ResourceLoadObserver::shared().logNavigatorAPIAccessed(*frame->protectedDocument(), NavigatorAPIsAccessed::Plugins);
+        ResourceLoadObserver::singleton().logNavigatorAPIAccessed(*frame->protectedDocument(), NavigatorAPIsAccessed::Plugins);
 
     initializePluginAndMimeTypeArrays();
     return *m_plugins;
@@ -316,7 +316,7 @@ DOMPluginArray& Navigator::plugins()
 DOMMimeTypeArray& Navigator::mimeTypes()
 {
     if (RefPtr frame = this->frame(); frame && frame->settings().webAPIStatisticsEnabled())
-        ResourceLoadObserver::shared().logNavigatorAPIAccessed(*frame->protectedDocument(), NavigatorAPIsAccessed::MimeTypes);
+        ResourceLoadObserver::singleton().logNavigatorAPIAccessed(*frame->protectedDocument(), NavigatorAPIsAccessed::MimeTypes);
 
     initializePluginAndMimeTypeArrays();
     return *m_mimeTypes;
@@ -336,7 +336,7 @@ bool Navigator::cookieEnabled() const
         return false;
 
     if (frame->settings().webAPIStatisticsEnabled())
-        ResourceLoadObserver::shared().logNavigatorAPIAccessed(*frame->protectedDocument(), NavigatorAPIsAccessed::CookieEnabled);
+        ResourceLoadObserver::singleton().logNavigatorAPIAccessed(*frame->protectedDocument(), NavigatorAPIsAccessed::CookieEnabled);
 
     RefPtr page = frame->page();
     if (!page)

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -5727,7 +5727,7 @@ void Page::setLastAuthentication(LoginStatus::AuthenticationType authType)
     m_lastAuthentication = loginStatus.releaseReturnValue().moveToUniquePtr();
 
     if (RefPtr document = localMainFrame() ? localMainFrame()->document() : nullptr)
-        ResourceLoadObserver::shared().logUserInteractionWithReducedTimeResolution(*document);
+        ResourceLoadObserver::singleton().logUserInteractionWithReducedTimeResolution(*document);
 }
 
 #if ENABLE(FULLSCREEN_API)

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -1073,7 +1073,7 @@ static bool isStorageAccessQuirkDomainAndElement(const URL& url, const Element& 
 bool Quirks::hasStorageAccessForAllLoginDomains(const HashSet<RegistrableDomain>& loginDomains, const RegistrableDomain& topFrameDomain)
 {
     for (auto& loginDomain : loginDomains) {
-        if (!ResourceLoadObserver::shared().hasCrossPageStorageAccess(loginDomain, topFrameDomain))
+        if (!ResourceLoadObserver::singleton().hasCrossPageStorageAccess(loginDomain, topFrameDomain))
             return false;
     }
     return true;
@@ -1108,7 +1108,7 @@ Quirks::StorageAccessResult Quirks::requestStorageAccessAndHandleClick(Completio
             return;
         }
 
-        ResourceLoadObserver::shared().setDomainsWithCrossPageStorageAccess({ { firstPartyDomain, Vector<RegistrableDomain> { domainInNeedOfStorageAccess } } }, [completionHandler = WTFMove(completionHandler)] () mutable {
+        ResourceLoadObserver::singleton().setDomainsWithCrossPageStorageAccess({ { firstPartyDomain, Vector<RegistrableDomain> { domainInNeedOfStorageAccess } } }, [completionHandler = WTFMove(completionHandler)] () mutable {
             completionHandler(ShouldDispatchClick::Yes);
         });
     });
@@ -1174,9 +1174,9 @@ Quirks::StorageAccessResult Quirks::triggerOptionalStorageAccessQuirk(Element& e
             return Quirks::StorageAccessResult::ShouldNotCancelEvent;
 
         // Embedded YouTube case.
-        if (element.hasClass() && domain == youTubeDomain && !document->isTopDocument() && ResourceLoadObserver::shared().hasHadUserInteraction(youTubeDomain)) {
+        if (element.hasClass() && domain == youTubeDomain && !document->isTopDocument() && ResourceLoadObserver::singleton().hasHadUserInteraction(youTubeDomain)) {
             if (element.hasClassName("ytp-watch-later-icon"_s) || element.hasClassName("ytp-watch-later-icon"_s)) {
-                if (ResourceLoadObserver::shared().hasHadUserInteraction(youTubeDomain)) {
+                if (ResourceLoadObserver::singleton().hasHadUserInteraction(youTubeDomain)) {
                     DocumentStorageAccess::requestStorageAccessForDocumentQuirk(*document, [](StorageAccessWasGranted) { });
                     return Quirks::StorageAccessResult::ShouldNotCancelEvent;
                 }
@@ -1186,7 +1186,7 @@ Quirks::StorageAccessResult Quirks::triggerOptionalStorageAccessQuirk(Element& e
 
         // Kinja login case.
         if (kinjaQuirks.get().contains(domain) && isKinjaLoginAvatarElement(element)) {
-            if (ResourceLoadObserver::shared().hasHadUserInteraction(kinjaDomain)) {
+            if (ResourceLoadObserver::singleton().hasHadUserInteraction(kinjaDomain)) {
                 DocumentStorageAccess::requestStorageAccessForNonDocumentQuirk(*document, kinjaDomain.get().isolatedCopy(), [](StorageAccessWasGranted) { });
                 return Quirks::StorageAccessResult::ShouldNotCancelEvent;
             }

--- a/Source/WebCore/page/Screen.cpp
+++ b/Source/WebCore/page/Screen.cpp
@@ -81,7 +81,7 @@ int Screen::height() const
     if (!frame)
         return 0;
     if (frame->settings().webAPIStatisticsEnabled())
-        ResourceLoadObserver::shared().logScreenAPIAccessed(*frame->protectedDocument(), ScreenAPIsAccessed::Height);
+        ResourceLoadObserver::singleton().logScreenAPIAccessed(*frame->protectedDocument(), ScreenAPIsAccessed::Height);
 
     if (shouldFlipScreenDimensions(*frame))
         return static_cast<int>(frame->screenSize().width());
@@ -95,7 +95,7 @@ int Screen::width() const
     if (!frame)
         return 0;
     if (frame->settings().webAPIStatisticsEnabled())
-        ResourceLoadObserver::shared().logScreenAPIAccessed(*frame->protectedDocument(), ScreenAPIsAccessed::Width);
+        ResourceLoadObserver::singleton().logScreenAPIAccessed(*frame->protectedDocument(), ScreenAPIsAccessed::Width);
 
     if (shouldFlipScreenDimensions(*frame))
         return static_cast<int>(frame->screenSize().height());
@@ -109,7 +109,7 @@ unsigned Screen::colorDepth() const
     if (!frame)
         return 24;
     if (frame->settings().webAPIStatisticsEnabled())
-        ResourceLoadObserver::shared().logScreenAPIAccessed(*frame->protectedDocument(), ScreenAPIsAccessed::ColorDepth);
+        ResourceLoadObserver::singleton().logScreenAPIAccessed(*frame->protectedDocument(), ScreenAPIsAccessed::ColorDepth);
     return static_cast<unsigned>(screenDepth(frame->protectedView().get()));
 }
 
@@ -120,7 +120,7 @@ int Screen::availLeft() const
         return 0;
 
     if (frame->settings().webAPIStatisticsEnabled())
-        ResourceLoadObserver::shared().logScreenAPIAccessed(*frame->protectedDocument(), ScreenAPIsAccessed::AvailLeft);
+        ResourceLoadObserver::singleton().logScreenAPIAccessed(*frame->protectedDocument(), ScreenAPIsAccessed::AvailLeft);
 
     if (shouldApplyScreenFingerprintingProtections(*frame))
         return 0;
@@ -135,7 +135,7 @@ int Screen::availTop() const
         return 0;
 
     if (frame->settings().webAPIStatisticsEnabled())
-        ResourceLoadObserver::shared().logScreenAPIAccessed(*frame->protectedDocument(), ScreenAPIsAccessed::AvailTop);
+        ResourceLoadObserver::singleton().logScreenAPIAccessed(*frame->protectedDocument(), ScreenAPIsAccessed::AvailTop);
 
     if (shouldApplyScreenFingerprintingProtections(*frame))
         return 0;
@@ -150,7 +150,7 @@ int Screen::availHeight() const
         return 0;
 
     if (frame->settings().webAPIStatisticsEnabled())
-        ResourceLoadObserver::shared().logScreenAPIAccessed(*frame->protectedDocument(), ScreenAPIsAccessed::AvailHeight);
+        ResourceLoadObserver::singleton().logScreenAPIAccessed(*frame->protectedDocument(), ScreenAPIsAccessed::AvailHeight);
 
     if (shouldApplyScreenFingerprintingProtections(*frame))
         return static_cast<int>(frame->screenSize().height());
@@ -165,7 +165,7 @@ int Screen::availWidth() const
         return 0;
 
     if (frame->settings().webAPIStatisticsEnabled())
-        ResourceLoadObserver::shared().logScreenAPIAccessed(*frame->protectedDocument(), ScreenAPIsAccessed::AvailWidth);
+        ResourceLoadObserver::singleton().logScreenAPIAccessed(*frame->protectedDocument(), ScreenAPIsAccessed::AvailWidth);
 
     if (shouldApplyScreenFingerprintingProtections(*frame))
         return static_cast<int>(frame->screenSize().width());

--- a/Source/WebCore/platform/graphics/GraphicsContext.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContext.cpp
@@ -557,7 +557,7 @@ void GraphicsContext::drawLineForText(const FloatRect& rect, bool isPrinting, bo
 
 void GraphicsContext::drawDisplayList(const DisplayList::DisplayList& displayList)
 {
-    Ref controlFactory = ControlFactory::shared();
+    Ref controlFactory = ControlFactory::singleton();
     drawDisplayList(displayList, controlFactory);
 }
 

--- a/Source/WebCore/platform/graphics/ImageBufferDisplayListBackend.cpp
+++ b/Source/WebCore/platform/graphics/ImageBufferDisplayListBackend.cpp
@@ -33,7 +33,7 @@ namespace WebCore {
 
 std::unique_ptr<ImageBufferDisplayListBackend> ImageBufferDisplayListBackend::create(const Parameters& parameters, const ImageBufferCreationContext&)
 {
-    return std::unique_ptr<ImageBufferDisplayListBackend>(new ImageBufferDisplayListBackend(parameters, ControlFactory::shared()));
+    return std::unique_ptr<ImageBufferDisplayListBackend>(new ImageBufferDisplayListBackend(parameters, ControlFactory::singleton()));
 }
 
 

--- a/Source/WebCore/platform/graphics/adwaita/ControlFactoryAdwaita.cpp
+++ b/Source/WebCore/platform/graphics/adwaita/ControlFactoryAdwaita.cpp
@@ -57,9 +57,9 @@ Ref<ControlFactory> ControlFactory::create()
     return adoptRef(*new ControlFactoryAdwaita());
 }
 
-ControlFactoryAdwaita& ControlFactoryAdwaita::shared()
+ControlFactoryAdwaita& ControlFactoryAdwaita::singleton()
 {
-    return downcast<ControlFactoryAdwaita>(ControlFactory::shared());
+    return downcast<ControlFactoryAdwaita>(ControlFactory::singleton());
 }
 
 #if ENABLE(APPLE_PAY)

--- a/Source/WebCore/platform/graphics/adwaita/ControlFactoryAdwaita.h
+++ b/Source/WebCore/platform/graphics/adwaita/ControlFactoryAdwaita.h
@@ -33,7 +33,7 @@ namespace WebCore {
 
 class ControlFactoryAdwaita final : public ControlFactory {
 public:
-    static ControlFactoryAdwaita& shared();
+    static ControlFactoryAdwaita& singleton();
 
 private:
     std::unique_ptr<PlatformControl> createPlatformButton(ButtonPart&) final;

--- a/Source/WebCore/platform/graphics/avfoundation/CDMFairPlayStreaming.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/CDMFairPlayStreaming.cpp
@@ -280,10 +280,10 @@ void CDMFactory::platformRegisterFactories(Vector<CDMFactory*>& factories)
 
     static std::once_flag onceFlag;
     std::call_once(onceFlag, [] {
-        InitDataRegistry::shared().registerInitDataType(CDMPrivateFairPlayStreaming::sinfName(), { CDMPrivateFairPlayStreaming::sanitizeSinf, CDMPrivateFairPlayStreaming::extractKeyIDsSinf });
-        InitDataRegistry::shared().registerInitDataType(CDMPrivateFairPlayStreaming::skdName(), { CDMPrivateFairPlayStreaming::sanitizeSkd, CDMPrivateFairPlayStreaming::extractKeyIDsSkd });
+        InitDataRegistry::singleton().registerInitDataType(CDMPrivateFairPlayStreaming::sinfName(), { CDMPrivateFairPlayStreaming::sanitizeSinf, CDMPrivateFairPlayStreaming::extractKeyIDsSinf });
+        InitDataRegistry::singleton().registerInitDataType(CDMPrivateFairPlayStreaming::skdName(), { CDMPrivateFairPlayStreaming::sanitizeSkd, CDMPrivateFairPlayStreaming::extractKeyIDsSkd });
 #if HAVE(FAIRPLAYSTREAMING_MTPS_INITDATA)
-        InitDataRegistry::shared().registerInitDataType(CDMPrivateFairPlayStreaming::mptsName(), { CDMPrivateFairPlayStreaming::sanitizeMpts, CDMPrivateFairPlayStreaming::extractKeyIDsMpts });
+        InitDataRegistry::singleton().registerInitDataType(CDMPrivateFairPlayStreaming::mptsName(), { CDMPrivateFairPlayStreaming::sanitizeMpts, CDMPrivateFairPlayStreaming::extractKeyIDsMpts });
 #endif
     });
 }

--- a/Source/WebCore/platform/graphics/avfoundation/WebMediaSessionManagerMac.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/WebMediaSessionManagerMac.cpp
@@ -33,7 +33,7 @@
 
 namespace WebCore {
 
-WebMediaSessionManager& WebMediaSessionManager::shared()
+WebMediaSessionManager& WebMediaSessionManager::singleton()
 {
     static NeverDestroyed<WebMediaSessionManagerMac> sharedManager;
     return sharedManager;

--- a/Source/WebCore/platform/graphics/controls/ControlFactory.cpp
+++ b/Source/WebCore/platform/graphics/controls/ControlFactory.cpp
@@ -41,7 +41,7 @@ Ref<ControlFactory> ControlFactory::create()
 }
 #endif
 
-ControlFactory& ControlFactory::shared()
+ControlFactory& ControlFactory::singleton()
 {
     static MainThreadNeverDestroyed<RefPtr<ControlFactory>> shared { create() };
     return *shared.get();

--- a/Source/WebCore/platform/graphics/controls/ControlFactory.h
+++ b/Source/WebCore/platform/graphics/controls/ControlFactory.h
@@ -58,7 +58,7 @@ public:
     virtual ~ControlFactory() = default;
 
     WEBCORE_EXPORT static Ref<ControlFactory> create();
-    WEBCORE_EXPORT static ControlFactory& shared();
+    WEBCORE_EXPORT static ControlFactory& singleton();
 
 #if ENABLE(APPLE_PAY)
     virtual std::unique_ptr<PlatformControl> createPlatformApplePayButton(ApplePayButtonPart&) = 0;

--- a/Source/WebCore/platform/graphics/controls/ControlPart.cpp
+++ b/Source/WebCore/platform/graphics/controls/ControlPart.cpp
@@ -38,7 +38,7 @@ ControlPart::ControlPart(StyleAppearance type)
 
 ControlFactory& ControlPart::controlFactory() const
 {
-    return m_overrideControlFactory ? *m_overrideControlFactory : ControlFactory::shared();
+    return m_overrideControlFactory ? *m_overrideControlFactory : ControlFactory::singleton();
 }
 
 Ref<ControlFactory> ControlPart::protectedControlFactory() const

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
@@ -68,7 +68,7 @@ Recorder::~Recorder()
 
 void Recorder::appendDisplayList(const DisplayList& displayList)
 {
-    GraphicsContext::drawDisplayList(displayList, Ref { ControlFactory::shared() });
+    GraphicsContext::drawDisplayList(displayList, Ref { ControlFactory::singleton() });
 }
 
 const GraphicsContextState& Recorder::state() const

--- a/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.h
@@ -45,7 +45,7 @@ class ControlFactoryMac final : public ControlFactoryCocoa, public CanMakeChecke
 public:
     using ControlFactoryCocoa::ControlFactoryCocoa;
 
-    static ControlFactoryMac& shared();
+    static ControlFactoryMac& singleton();
 
     NSView *drawingView(const FloatRect&, const ControlStyle&) const;
 

--- a/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.mm
@@ -65,9 +65,9 @@ Ref<ControlFactory> ControlFactory::create()
     return adoptRef(*new ControlFactoryMac());
 }
 
-ControlFactoryMac& ControlFactoryMac::shared()
+ControlFactoryMac& ControlFactoryMac::singleton()
 {
-    return downcast<ControlFactoryMac>(ControlFactory::shared());
+    return downcast<ControlFactoryMac>(ControlFactory::singleton());
 }
 
 NSView *ControlFactoryMac::drawingView(const FloatRect& rect, const ControlStyle& style) const

--- a/Source/WebCore/platform/graphics/mac/controls/ImageControlsButtonMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ImageControlsButtonMac.mm
@@ -50,7 +50,7 @@ ImageControlsButtonMac::~ImageControlsButtonMac() = default;
 
 IntSize ImageControlsButtonMac::servicesRolloverButtonCellSize()
 {
-    auto& controlFactory = ControlFactoryMac::shared();
+    auto& controlFactory = ControlFactoryMac::singleton();
     if (auto* servicesRolloverButtonCell = controlFactory.servicesRolloverButtonCell())
         return IntSize { [servicesRolloverButtonCell cellSize] };
     return { };

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -5901,7 +5901,7 @@ JSValue Internals::cloneArrayBuffer(JSC::JSGlobalObject& lexicalGlobalObject, JS
 
 String Internals::resourceLoadStatisticsForURL(const DOMURL& url)
 {
-    return ResourceLoadObserver::shared().statisticsForURL(url.href());
+    return ResourceLoadObserver::singleton().statisticsForURL(url.href());
 }
 
 void Internals::setTrackingPreventionEnabled(bool enable)
@@ -6922,7 +6922,7 @@ ExceptionOr<unsigned> Internals::pluginScrollPositionY(Element& element)
 
 void Internals::notifyResourceLoadObserver()
 {
-    ResourceLoadObserver::shared().updateCentralStatisticsStore([] { });
+    ResourceLoadObserver::singleton().updateCentralStatisticsStore([] { });
 }
 
 unsigned Internals::primaryScreenDisplayID()

--- a/Source/WebCore/testing/MockCDMFactory.cpp
+++ b/Source/WebCore/testing/MockCDMFactory.cpp
@@ -324,7 +324,7 @@ void MockCDMInstanceSession::requestLicense(LicenseType licenseType, KeyGrouping
         return;
     }
 
-    auto keyIDs = InitDataRegistry::shared().extractKeyIDs(initDataType, initData);
+    auto keyIDs = InitDataRegistry::singleton().extractKeyIDs(initDataType, initData);
     if (!keyIDs || keyIDs.value().isEmpty()) {
         callback(SharedBuffer::create(), emptyString(), false, SuccessValue::Failed);
         return;

--- a/Source/WebCore/workers/service/context/ServiceWorkerThread.cpp
+++ b/Source/WebCore/workers/service/context/ServiceWorkerThread.cpp
@@ -68,7 +68,7 @@ class DummyServiceWorkerThreadProxy final : public WorkerObjectProxy, public Can
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(DummyServiceWorkerThreadProxy);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DummyServiceWorkerThreadProxy);
 public:
-    static DummyServiceWorkerThreadProxy& shared()
+    static DummyServiceWorkerThreadProxy& singleton()
     {
         static NeverDestroyed<DummyServiceWorkerThreadProxy> proxy;
         return proxy;
@@ -129,12 +129,12 @@ static WorkerThreadStartMode threadStartModeFromSettings()
 }
 
 ServiceWorkerThread::ServiceWorkerThread(ServiceWorkerContextData&& contextData, ServiceWorkerData&& workerData, String&& userAgent, WorkerThreadMode workerThreadMode, const SettingsValues& settingsValues, WorkerLoaderProxy& loaderProxy, WorkerDebuggerProxy& debuggerProxy, WorkerBadgeProxy& badgeProxy, IDBClient::IDBConnectionProxy* idbConnectionProxy, SocketProvider* socketProvider, std::unique_ptr<NotificationClient>&& notificationClient, PAL::SessionID sessionID, std::optional<uint64_t> noiseInjectionHashSalt, OptionSet<AdvancedPrivacyProtections> advancedPrivacyProtections)
-    : WorkerThread(generateWorkerParameters(contextData, WTFMove(userAgent), workerThreadMode, settingsValues, sessionID, advancedPrivacyProtections, noiseInjectionHashSalt), contextData.script, loaderProxy, debuggerProxy, DummyServiceWorkerThreadProxy::shared(), badgeProxy, threadStartModeFromSettings(), contextData.registration.key.topOrigin().securityOrigin().get(), idbConnectionProxy, socketProvider, JSC::RuntimeFlags::createAllEnabled())
+    : WorkerThread(generateWorkerParameters(contextData, WTFMove(userAgent), workerThreadMode, settingsValues, sessionID, advancedPrivacyProtections, noiseInjectionHashSalt), contextData.script, loaderProxy, debuggerProxy, DummyServiceWorkerThreadProxy::singleton(), badgeProxy, threadStartModeFromSettings(), contextData.registration.key.topOrigin().securityOrigin().get(), idbConnectionProxy, socketProvider, JSC::RuntimeFlags::createAllEnabled())
     , m_serviceWorkerIdentifier(contextData.serviceWorkerIdentifier)
     , m_jobDataIdentifier(contextData.jobDataIdentifier)
     , m_contextData(crossThreadCopy(WTFMove(contextData)))
     , m_workerData(crossThreadCopy(WTFMove(workerData)))
-    , m_workerObjectProxy(DummyServiceWorkerThreadProxy::shared())
+    , m_workerObjectProxy(DummyServiceWorkerThreadProxy::singleton())
     , m_heartBeatTimeout(settingsValues.shouldUseServiceWorkerShortTimeout ? heartBeatTimeoutForTest : heartBeatTimeout)
     , m_heartBeatTimer { *this, &ServiceWorkerThread::heartBeatTimerFired }
     , m_notificationClient(WTFMove(notificationClient))

--- a/Source/WebKit/ModelProcess/ModelProcess.cpp
+++ b/Source/WebKit/ModelProcess/ModelProcess.cpp
@@ -93,7 +93,7 @@ void ModelProcess::createModelConnectionToWebProcess(
         return;
 
 #if PLATFORM(VISION) && ENABLE(GPU_PROCESS)
-    WKREEngine::shared().initializeWithSharedSimulationConnectionGetterIfNeeded([identifier, weakThis = WeakPtr { *this }] (CompletionHandler<void(std::optional<IPC::SharedFileHandle>)>&& completionHandler) {
+    WKREEngine::singleton().initializeWithSharedSimulationConnectionGetterIfNeeded([identifier, weakThis = WeakPtr { *this }] (CompletionHandler<void(std::optional<IPC::SharedFileHandle>)>&& completionHandler) {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis) {
             completionHandler(std::nullopt);

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
@@ -679,7 +679,7 @@ void ModelProcessModelPlayerProxy::load(WebCore::Model& model, WebCore::LayoutSi
     RELEASE_LOG(ModelElement, "%p - ModelProcessModelPlayerProxy::load size=%zu id=%" PRIu64, this, model.data()->size(), m_id.toUInt64());
     sizeDidChange(layoutSize);
 
-    WKREEngine::shared().runWithSharedScene([this, protectedThis = Ref { *this }, model = Ref { model }] (RESceneRef scene) {
+    WKREEngine::singleton().runWithSharedScene([this, protectedThis = Ref { *this }, model = Ref { model }] (RESceneRef scene) {
         m_scene = scene;
         if ([getWKRKEntityClassSingleton() isLoadFromDataAvailable])
             m_loader = RKUSDModelLoadScheduler::singleton().scheduleModelLoad(model.get(), m_attributionTaskID, m_debugEntityMemoryLimit ? *m_debugEntityMemoryLimit : defaultEntityMemoryLimit, *this);

--- a/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.h
+++ b/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.h
@@ -172,7 +172,7 @@ private:
 
 class RestrictedOpenerDomainsController {
 public:
-    static RestrictedOpenerDomainsController& shared();
+    static RestrictedOpenerDomainsController& singleton();
 
     RestrictedOpenerType lookup(const WebCore::RegistrableDomain&) const;
 

--- a/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm
+++ b/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm
@@ -334,7 +334,7 @@ void StorageAccessUserAgentStringQuirkController::updateList(CompletionHandler<v
     }];
 }
 
-RestrictedOpenerDomainsController& RestrictedOpenerDomainsController::shared()
+RestrictedOpenerDomainsController& RestrictedOpenerDomainsController::singleton()
 {
     static MainRunLoopNeverDestroyed<RestrictedOpenerDomainsController> sharedInstance;
     return sharedInstance.get();

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -367,7 +367,7 @@ void WebProcessPool::platformInitialize(NeedsGlobalStaticInitialization needsGlo
 
 #if ENABLE(ADVANCED_PRIVACY_PROTECTIONS)
     PAL::registerNotifyCallback("com.apple.WebKit.restrictedDomains"_s, ^{
-        RestrictedOpenerDomainsController::shared();
+        RestrictedOpenerDomainsController::singleton();
     });
 #endif
 

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -1427,7 +1427,7 @@ void WebProcessPool::postMessageToInjectedBundle(const String& messageName, API:
 static void loadRestrictedOpenerTypeDataIfNeeded()
 {
 #if ENABLE(ADVANCED_PRIVACY_PROTECTIONS)
-    RestrictedOpenerDomainsController::shared();
+    RestrictedOpenerDomainsController::singleton();
 #endif
 }
 

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -2834,7 +2834,7 @@ RestrictedOpenerType WebsiteDataStore::openerTypeForDomain(const WebCore::Regist
     }
 
 #if ENABLE(ADVANCED_PRIVACY_PROTECTIONS)
-    return RestrictedOpenerDomainsController::shared().lookup(domain);
+    return RestrictedOpenerDomainsController::singleton().lookup(domain);
 #else
     return RestrictedOpenerType::Unrestricted;
 #endif

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
@@ -971,7 +971,7 @@ void PageClientImpl::showPlatformContextMenu(NSMenu *menu, IntPoint location)
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
 WebCore::WebMediaSessionManager& PageClientImpl::mediaSessionManager()
 {
-    return WebMediaSessionManager::shared();
+    return WebMediaSessionManager::singleton();
 }
 #endif
 

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundle.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundle.cpp
@@ -208,15 +208,15 @@ void WKBundleSetTabKeyCyclesThroughElements(WKBundleRef bundleRef, WKBundlePageR
 
 void WKBundleClearResourceLoadStatistics(WKBundleRef)
 {
-    WebCore::ResourceLoadObserver::shared().clearState();
+    WebCore::ResourceLoadObserver::singleton().clearState();
 }
 
 void WKBundleResourceLoadStatisticsNotifyObserver(WKBundleRef, void* context, NotifyObserverCallback callback)
 {
-    if (!WebCore::ResourceLoadObserver::shared().hasStatistics())
+    if (!WebCore::ResourceLoadObserver::singleton().hasStatistics())
         return callback(context);
 
-    WebCore::ResourceLoadObserver::shared().updateCentralStatisticsStore([context, callback] {
+    WebCore::ResourceLoadObserver::singleton().updateCentralStatisticsStore([context, callback] {
         callback(context);
     });
 }

--- a/Source/WebKitLegacy/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebKitLegacy/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -103,7 +103,6 @@ mac/WebView/WebFullScreenController.mm
 mac/WebView/WebHTMLRepresentation.mm
 mac/WebView/WebHTMLView.mm
 mac/WebView/WebImmediateActionController.mm
-mac/WebView/WebMediaPlaybackTargetPicker.mm
 mac/WebView/WebPDFView.mm
 mac/WebView/WebPreferences.mm
 mac/WebView/WebScriptDebugger.mm

--- a/Source/WebKitLegacy/mac/WebView/WebMediaPlaybackTargetPicker.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebMediaPlaybackTargetPicker.mm
@@ -48,37 +48,37 @@ WebMediaPlaybackTargetPicker::WebMediaPlaybackTargetPicker(WebView *webView, Web
 
 void WebMediaPlaybackTargetPicker::addPlaybackTargetPickerClient(WebCore::PlaybackTargetClientContextIdentifier contextId)
 {
-    WebCore::WebMediaSessionManager::shared().addPlaybackTargetPickerClient(*this, contextId);
+    WebCore::WebMediaSessionManager::singleton().addPlaybackTargetPickerClient(*this, contextId);
 }
 
 void WebMediaPlaybackTargetPicker::removePlaybackTargetPickerClient(WebCore::PlaybackTargetClientContextIdentifier contextId)
 {
-    WebCore::WebMediaSessionManager::shared().removePlaybackTargetPickerClient(*this, contextId);
+    WebCore::WebMediaSessionManager::singleton().removePlaybackTargetPickerClient(*this, contextId);
 }
 
 void WebMediaPlaybackTargetPicker::showPlaybackTargetPicker(WebCore::PlaybackTargetClientContextIdentifier contextId, const WebCore::FloatRect& rect, bool hasVideo)
 {
-    WebCore::WebMediaSessionManager::shared().showPlaybackTargetPicker(*this, contextId, WebCore::IntRect(rect), hasVideo, m_page ? m_page->useDarkAppearance() : false);
+    WebCore::WebMediaSessionManager::singleton().showPlaybackTargetPicker(*this, contextId, WebCore::IntRect(rect), hasVideo, m_page ? m_page->useDarkAppearance() : false);
 }
 
 void WebMediaPlaybackTargetPicker::playbackTargetPickerClientStateDidChange(WebCore::PlaybackTargetClientContextIdentifier contextId, WebCore::MediaProducerMediaStateFlags state)
 {
-    WebCore::WebMediaSessionManager::shared().clientStateDidChange(*this, contextId, state);
+    WebCore::WebMediaSessionManager::singleton().clientStateDidChange(*this, contextId, state);
 }
 
 void WebMediaPlaybackTargetPicker::setMockMediaPlaybackTargetPickerEnabled(bool enabled)
 {
-    WebCore::WebMediaSessionManager::shared().setMockMediaPlaybackTargetPickerEnabled(enabled);
+    WebCore::WebMediaSessionManager::singleton().setMockMediaPlaybackTargetPickerEnabled(enabled);
 }
 
 void WebMediaPlaybackTargetPicker::setMockMediaPlaybackTargetPickerState(const String& name, WebCore::MediaPlaybackTargetContext::MockState state)
 {
-    WebCore::WebMediaSessionManager::shared().setMockMediaPlaybackTargetPickerState(name, state);
+    WebCore::WebMediaSessionManager::singleton().setMockMediaPlaybackTargetPickerState(name, state);
 }
 
 void WebMediaPlaybackTargetPicker::mockMediaPlaybackTargetPickerDismissPopup()
 {
-    WebCore::WebMediaSessionManager::shared().mockMediaPlaybackTargetPickerDismissPopup();
+    WebCore::WebMediaSessionManager::singleton().mockMediaPlaybackTargetPickerDismissPopup();
 }
 
 void WebMediaPlaybackTargetPicker::setPlaybackTarget(WebCore::PlaybackTargetClientContextIdentifier contextId, Ref<WebCore::MediaPlaybackTarget>&& target)
@@ -115,7 +115,7 @@ void WebMediaPlaybackTargetPicker::invalidate()
 {
     m_page = nullptr;
     m_webView = nil;
-    WebCore::WebMediaSessionManager::shared().removeAllPlaybackTargetPickerClients(*this);
+    WebCore::WebMediaSessionManager::singleton().removeAllPlaybackTargetPickerClients(*this);
 }
 
 RetainPtr<CocoaView> WebMediaPlaybackTargetPicker::platformView() const


### PR DESCRIPTION
#### dd82ba7dac94951ec0a791f9bd9cef72c98e498c
<pre>
[Safer CPP] Rename singleton functions from `shared()` to `singleton()`
<a href="https://bugs.webkit.org/show_bug.cgi?id=299144">https://bugs.webkit.org/show_bug.cgi?id=299144</a>

Reviewed by Ryosuke Niwa.

Rename singleton functions from `shared()` to `singleton()` to help
Safer CPP static analysis understand lifetime.

* Source/WebCore/Modules/airplay/WebMediaSessionManager.h:
* Source/WebCore/Modules/encryptedmedia/CDM.cpp:
(WebCore::CDM::sanitizeInitData):
* Source/WebCore/Modules/encryptedmedia/InitDataRegistry.cpp:
(WebCore::InitDataRegistry::singleton):
(WebCore::InitDataRegistry::shared): Deleted.
* Source/WebCore/Modules/encryptedmedia/InitDataRegistry.h:
* Source/WebCore/Modules/websockets/WebSocket.cpp:
(WebCore::WebSocket::connect):
* Source/WebCore/PAL/pal/system/ios/SleepDisablerIOS.mm:
(PAL::ScreenSleepDisabler::singleton):
(PAL::SleepDisablerCocoa::takeScreenSleepDisablingAssertion):
(PAL::SleepDisablerCocoa::setScreenWakeLockHandler):
(PAL::ScreenSleepDisabler::shared): Deleted.
* Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebCore/css/CSSFontFaceSource.cpp:
(WebCore::CSSFontFaceSource::load):
* Source/WebCore/css/CSSFontSelector.cpp:
(WebCore::CSSFontSelector::fontRangesForFamily):
(WebCore::CSSFontSelector::fallbackFontAt):
* Source/WebCore/dom/UserGestureIndicator.cpp:
* Source/WebCore/html/HTMLCanvasElement.cpp:
(WebCore::HTMLCanvasElement::toDataURL):
(WebCore::HTMLCanvasElement::toBlob):
(WebCore::HTMLCanvasElement::getImageData):
(WebCore::HTMLCanvasElement::toVideoFrame):
(WebCore::HTMLCanvasElement::captureStream):
* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::HTMLInputElement::logUserInteraction):
* Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp:
(WebCore::CanvasRenderingContext2D::measureText):
(WebCore::CanvasRenderingContext2D::drawTextInternal):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::loadResourceSynchronously):
* Source/WebCore/loader/ResourceLoadObserver.cpp:
(WebCore::ResourceLoadObserver::singleton):
(WebCore::ResourceLoadObserver::singletonIfExists):
(WebCore::ResourceLoadObserver::shared): Deleted.
(WebCore::ResourceLoadObserver::sharedIfExists): Deleted.
* Source/WebCore/loader/ResourceLoadObserver.h:
* Source/WebCore/loader/SubresourceLoader.cpp:
(WebCore::SubresourceLoader::willSendRequestInternal):
* Source/WebCore/page/DOMWindow.cpp:
(WebCore::DOMWindow::close):
* Source/WebCore/page/DeprecatedGlobalSettings.cpp:
(WebCore::DeprecatedGlobalSettings::singleton):
(WebCore::DeprecatedGlobalSettings::setAVFoundationEnabled):
(WebCore::DeprecatedGlobalSettings::setGStreamerEnabled):
(WebCore::DeprecatedGlobalSettings::setMockScrollbarsEnabled):
(WebCore::DeprecatedGlobalSettings::setUsesOverlayScrollbars):
(WebCore::DeprecatedGlobalSettings::setTrackingPreventionEnabled):
(WebCore::DeprecatedGlobalSettings::setNetworkInterfaceName):
(WebCore::DeprecatedGlobalSettings::setAllowsAnySSLCertificate):
(WebCore::DeprecatedGlobalSettings::allowsAnySSLCertificate):
(WebCore::DeprecatedGlobalSettings::builtInNotificationsEnabled):
(WebCore::DeprecatedGlobalSettings::shared): Deleted.
* Source/WebCore/page/DeprecatedGlobalSettings.h:
(WebCore::DeprecatedGlobalSettings::isAVFoundationEnabled):
(WebCore::DeprecatedGlobalSettings::isGStreamerEnabled):
(WebCore::DeprecatedGlobalSettings::mockScrollbarsEnabled):
(WebCore::DeprecatedGlobalSettings::usesOverlayScrollbars):
(WebCore::DeprecatedGlobalSettings::lowPowerVideoAudioBufferSizeEnabled):
(WebCore::DeprecatedGlobalSettings::setLowPowerVideoAudioBufferSizeEnabled):
(WebCore::DeprecatedGlobalSettings::trackingPreventionEnabled):
(WebCore::DeprecatedGlobalSettings::networkInterfaceName):
(WebCore::DeprecatedGlobalSettings::setDisableScreenSizeOverride):
(WebCore::DeprecatedGlobalSettings::disableScreenSizeOverride):
(WebCore::DeprecatedGlobalSettings::setShouldOptOutOfNetworkStateObservation):
(WebCore::DeprecatedGlobalSettings::shouldOptOutOfNetworkStateObservation):
(WebCore::DeprecatedGlobalSettings::setCustomPasteboardDataEnabled):
(WebCore::DeprecatedGlobalSettings::customPasteboardDataEnabled):
(WebCore::DeprecatedGlobalSettings::setAttrStyleEnabled):
(WebCore::DeprecatedGlobalSettings::attrStyleEnabled):
(WebCore::DeprecatedGlobalSettings::setWebSQLEnabled):
(WebCore::DeprecatedGlobalSettings::webSQLEnabled):
(WebCore::DeprecatedGlobalSettings::setAttachmentElementEnabled):
(WebCore::DeprecatedGlobalSettings::attachmentElementEnabled):
(WebCore::DeprecatedGlobalSettings::webRTCAudioLatencyAdaptationEnabled):
(WebCore::DeprecatedGlobalSettings::setWebRTCAudioLatencyAdaptationEnabled):
(WebCore::DeprecatedGlobalSettings::setReadableByteStreamAPIEnabled):
(WebCore::DeprecatedGlobalSettings::readableByteStreamAPIEnabled):
(WebCore::DeprecatedGlobalSettings::setIsAccessibilityIsolatedTreeEnabled):
(WebCore::DeprecatedGlobalSettings::isAccessibilityIsolatedTreeEnabled):
(WebCore::DeprecatedGlobalSettings::setAccessibilityThreadTextApisEnabled):
(WebCore::DeprecatedGlobalSettings::accessibilityThreadTextApisEnabled):
(WebCore::DeprecatedGlobalSettings::setArePDFImagesEnabled):
(WebCore::DeprecatedGlobalSettings::arePDFImagesEnabled):
(WebCore::DeprecatedGlobalSettings::setBuiltInNotificationsEnabled):
(WebCore::DeprecatedGlobalSettings::setModelDocumentEnabled):
(WebCore::DeprecatedGlobalSettings::modelDocumentEnabled):
(WebCore::DeprecatedGlobalSettings::setUsesWebContentRestrictionsForFilter):
(WebCore::DeprecatedGlobalSettings::usesWebContentRestrictionsForFilter):
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::keyEvent):
* Source/WebCore/page/Navigator.cpp:
(WebCore::Navigator::appVersion const):
(WebCore::Navigator::userAgent const):
(WebCore::Navigator::plugins):
(WebCore::Navigator::mimeTypes):
(WebCore::Navigator::cookieEnabled const):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::setLastAuthentication):
* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::hasStorageAccessForAllLoginDomains):
(WebCore::Quirks::requestStorageAccessAndHandleClick const):
(WebCore::Quirks::triggerOptionalStorageAccessQuirk const):
* Source/WebCore/page/Screen.cpp:
(WebCore::Screen::height const):
(WebCore::Screen::width const):
(WebCore::Screen::colorDepth const):
(WebCore::Screen::availLeft const):
(WebCore::Screen::availTop const):
(WebCore::Screen::availHeight const):
(WebCore::Screen::availWidth const):
* Source/WebCore/platform/graphics/GraphicsContext.cpp:
(WebCore::GraphicsContext::drawDisplayList):
* Source/WebCore/platform/graphics/ImageBufferDisplayListBackend.cpp:
(WebCore::ImageBufferDisplayListBackend::create):
* Source/WebCore/platform/graphics/adwaita/ControlFactoryAdwaita.cpp:
(WebCore::ControlFactoryAdwaita::singleton):
(WebCore::ControlFactoryAdwaita::shared): Deleted.
* Source/WebCore/platform/graphics/adwaita/ControlFactoryAdwaita.h:
* Source/WebCore/platform/graphics/avfoundation/CDMFairPlayStreaming.cpp:
(WebCore::CDMFactory::platformRegisterFactories):
* Source/WebCore/platform/graphics/avfoundation/WebMediaSessionManagerMac.cpp:
(WebCore::WebMediaSessionManager::singleton):
(WebCore::WebMediaSessionManager::shared): Deleted.
* Source/WebCore/platform/graphics/controls/ControlFactory.cpp:
(WebCore::ControlFactory::singleton):
(WebCore::ControlFactory::shared): Deleted.
* Source/WebCore/platform/graphics/controls/ControlFactory.h:
* Source/WebCore/platform/graphics/controls/ControlPart.cpp:
(WebCore::ControlPart::controlFactory const):
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp:
(WebCore::DisplayList::Recorder::appendDisplayList):
* Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.h:
* Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.mm:
(WebCore::ControlFactoryMac::singleton):
(WebCore::ControlFactoryMac::shared): Deleted.
* Source/WebCore/platform/graphics/mac/controls/ImageControlsButtonMac.mm:
(WebCore::ImageControlsButtonMac::servicesRolloverButtonCellSize):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::resourceLoadStatisticsForURL):
(WebCore::Internals::notifyResourceLoadObserver):
* Source/WebCore/testing/MockCDMFactory.cpp:
(WebCore::MockCDMInstanceSession::requestLicense):
* Source/WebCore/workers/service/context/ServiceWorkerThread.cpp:
(WebCore::ServiceWorkerThread::ServiceWorkerThread):
* Source/WebKit/ModelProcess/ModelProcess.cpp:
(WebKit::ModelProcess::createModelConnectionToWebProcess):
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm:
(WebKit::ModelProcessModelPlayerProxy::load):
* Source/WebKit/Platform/cocoa/WebPrivacyHelpers.h:
* Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm:
(WebKit::RestrictedOpenerDomainsController::singleton):
(WebKit::RestrictedOpenerDomainsController::shared): Deleted.
* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(WebKit::WebProcessPool::platformInitialize):
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::loadRestrictedOpenerTypeDataIfNeeded):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::openerTypeForDomain const):
* Source/WebKit/UIProcess/mac/PageClientImplMac.mm:
(WebKit::PageClientImpl::mediaSessionManager):
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundle.cpp:
(WKBundleClearResourceLoadStatistics):
(WKBundleResourceLoadStatisticsNotifyObserver):
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::setWebsiteDataStoreParameters):
(WebKit::WebProcess::setTrackingPreventionEnabled):
(WebKit::WebProcess::clearResourceLoadStatistics):
(WebKit::WebProcess::flushResourceLoadStatistics):
(WebKit::WebProcess::seedResourceLoadStatisticsForTesting):
(WebKit::WebProcess::setDomainsWithUserInteraction):
(WebKit::WebProcess::setDomainsWithCrossPageStorageAccess):
(WebKit::WebProcess::sendResourceLoadStatisticsDataImmediately):
* Source/WebKitLegacy/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebKitLegacy/mac/WebView/WebMediaPlaybackTargetPicker.mm:
(WebMediaPlaybackTargetPicker::addPlaybackTargetPickerClient):
(WebMediaPlaybackTargetPicker::removePlaybackTargetPickerClient):
(WebMediaPlaybackTargetPicker::showPlaybackTargetPicker):
(WebMediaPlaybackTargetPicker::playbackTargetPickerClientStateDidChange):
(WebMediaPlaybackTargetPicker::setMockMediaPlaybackTargetPickerEnabled):
(WebMediaPlaybackTargetPicker::setMockMediaPlaybackTargetPickerState):
(WebMediaPlaybackTargetPicker::mockMediaPlaybackTargetPickerDismissPopup):
(WebMediaPlaybackTargetPicker::invalidate):

Canonical link: <a href="https://commits.webkit.org/300229@main">https://commits.webkit.org/300229@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9a095dafebb789e142ff3989a2097baf5c978e1c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121792 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41493 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32157 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128330 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/73882 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/32b30ff4-da30-4b0d-9f8b-c221444cc8f9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123668 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42205 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50084 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/92550 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/73882 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bf3ac437-11e1-4299-9b2e-5a15c9f45cdf) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124744 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/33665 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109074 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73208 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/79b99483-0556-44ab-b34c-4086bcaddc07) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/32676 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/27237 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71856 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/103165 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27422 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131107 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48727 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/37054 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/101138 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49099 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105291 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/101010 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46372 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/24476 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/45428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19288 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48585 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/54312 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48055 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51404 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49737 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->