### PR TITLE
[JSC] Do not elide atomic and with -1 on x86

### DIFF
--- a/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
@@ -4062,13 +4062,15 @@ public:
     void atomicAnd32(TrustedImm32 imm, Address address)
     {
         m_assembler.lock();
-        and32(imm, address);
+        // Do not use and32 as it may be optimized out when imm is -1.
+        m_assembler.andl_im(imm.m_value, address.offset, address.base);
     }
 
     void atomicAnd32(TrustedImm32 imm, BaseIndex address)
     {
         m_assembler.lock();
-        and32(imm, address);
+        // Do not use and32 as it may be optimized out when imm is -1.
+        m_assembler.andl_im(imm.m_value, address.offset, address.base, address.index, address.scale);
     }
 
     void atomicAnd32(RegisterID reg, Address address)
@@ -6864,13 +6866,15 @@ public:
     void atomicAnd64(TrustedImm32 imm, Address address)
     {
         m_assembler.lock();
-        and64(imm, address);
+        // Do not use and64 as it may be optimized out when imm is -1.
+        m_assembler.andq_im(imm.m_value, address.offset, address.base);
     }
     
     void atomicAnd64(TrustedImm32 imm, BaseIndex address)
     {
         m_assembler.lock();
-        and64(imm, address);
+        // Do not use and64 as it may be optimized out when imm is -1.
+        m_assembler.andq_im(imm.m_value, address.offset, address.base, address.index, address.scale);
     }
     
     void atomicAnd64(RegisterID reg, Address address)


### PR DESCRIPTION
#### e8e09d0cc146d3fcc254a10d37eb1d2b10a4d2b3
<pre>
[JSC] Do not elide atomic and with -1 on x86

<a href="https://bugs.webkit.org/show_bug.cgi?id=298099">https://bugs.webkit.org/show_bug.cgi?id=298099</a>
<a href="https://rdar.apple.com/159443883">rdar://159443883</a>

Reviewed by Yusuke Suzuki.

Seq-cst and with -1 cannot be optimized out on x86. Seq-cst stores must exist
for the seq-cst ordering guarantee. This PR disables the microoptimization if
the bitwise and is atomic.

This also fixes an issue with generating a dangling LOCK prefix.

Test: Source/JavaScriptCore/assembler/testmasm.cpp
Canonical link: <a href="https://commits.webkit.org/300245@main">https://commits.webkit.org/300245@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/09a49af5c06cad75e9634ec2b397216f19b0a259

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121847 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41548 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32212 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128398 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/73940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/aba7ff2f-f2bf-4947-aa6d-a9bcd77758d8) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42260 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50141 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/92600 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/73940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c12d2714-56fb-4456-8eab-221c9a74847f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124799 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33701 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/109124 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/73261 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b68195ea-e02d-4bed-9a28-5044fc7d85c1) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/32724 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/27288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71900 "Built successfully") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/114009 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/103216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27473 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/131169 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/120369 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48782 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/37096 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/131169 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49154 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105341 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/131169 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25625 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46409 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/24523 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/45486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48640 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/54367 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/150530 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/48110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/38513 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/51459 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/49793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->