### PR TITLE
[WPT] Resync largest-contentful-paint tests

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/largest-contentful-paint/resized-image-not-reconsidered.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/largest-contentful-paint/resized-image-not-reconsidered.html
@@ -1,45 +1,48 @@
-<!DOCTYPE HTML>
-<meta charset=utf-8>
+<!doctype html>
+<meta charset="utf-8" />
 <title>Resized Image Is Not Reconsidered as LCP.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 
 <body>
-  <img src='/images/lcp-256x256.png' id='image_id' height="100" width="50" />
+  <img src="/images/lcp-256x256.png" id="testpic" height="100" width="50" />
   <script>
-    let image_id = 'image_id';
-
-    // Create a promise that resolves when an LCP is observed.
-    const lcp_observation_promise = image_src => {
-      return new Promise(resolve => {
-        new PerformanceObserver((entryList) => {
-          let lcpEntries = entryList.getEntries().filter(e => e.id == image_id);
-
-          if (lcpEntries) {
-            resolve(lcpEntries);
-          }
-        }).observe({ type: 'largest-contentful-paint', buffered: true });
+    promise_test(async (t) => {
+      // Set up an observer that looks for LCP entries for the testpic,
+      // identified by its id.
+      const entries = [];
+      const observer = new PerformanceObserver((l) => {
+        entries.push(...l.getEntries().filter((e) => e.id == "testpic"));
       });
-    }
+      observer.observe({ type: "largest-contentful-paint", buffered: true });
 
-    promise_test(async t => {
-      const lcpEntriesInitial = await lcp_observation_promise();
-      assert_equals(lcpEntriesInitial.length, 1);
+      // Wait for the initial LCP entry to be emitted, and verify it's as expected.
+      await t.step_wait(() => entries.length > 0, "Waiting for initial LCP entry to be emitted.");
+      assert_equals(entries.length, 1);
+      assert_equals(entries[0].id, "testpic");
+      assert_equals(entries[0].size, 100 * 50);
 
-      // Resize image.
-      document.getElementById('image_id').height = 150;
+      // Now resize image, then wait, then observe that no additional
+      // entries are emitted.
+      document.getElementById("testpic").height = 150;
 
-      // Wait for a repaint.
-      const lcpEntriesAfterImageResizing =
-        await new Promise(resolve => {
-          t.step_timeout(window.requestAnimationFrame(async () => {
-            resolve(await lcp_observation_promise());
-          }), 100);
+      // Wait for the image to be resized - after a requestAnimationFrame
+      // cycle and 1 second, disconnect the observer.
+      await new Promise((resolve) => {
+        requestAnimationFrame(() => {
+          t.step_timeout(() => {
+            observer.disconnect();
+            resolve();
+          }, 1000);
         });
+      });
 
-      // No additional LCP entry is emitted after the image is resized to be larger.
-      assert_equals(lcpEntriesAfterImageResizing.length, 1);
-      assert_true(lcpEntriesInitial[0] === lcpEntriesAfterImageResizing[0]);
+      // Verify that the image was not reconsidered as LCP: it's still
+      // the same entry, reflecting the initial size with width and height from
+      // the img tag.
+      assert_equals(entries.length, 1);
+      assert_equals(entries[0].id, "testpic");
+      assert_equals(entries[0].size, 100 * 50);
     }, "Resized image should not be reconsidered as LCP");
   </script>
 </body>


### PR DESCRIPTION
#### 7a42ea919eaa20b3b97b890e913558e777867247
<pre>
[WPT] Resync largest-contentful-paint tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=299147">https://bugs.webkit.org/show_bug.cgi?id=299147</a>
<a href="https://rdar.apple.com/160908767">rdar://160908767</a>

Reviewed by Tim Nguyen.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/611eeeaf5144cc732b63b68a716bc1d1cbd96cbf">https://github.com/web-platform-tests/wpt/commit/611eeeaf5144cc732b63b68a716bc1d1cbd96cbf</a>

* LayoutTests/imported/w3c/web-platform-tests/largest-contentful-paint/resized-image-not-reconsidered.html:

Canonical link: <a href="https://commits.webkit.org/300215@main">https://commits.webkit.org/300215@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bb5469d58bfd9e088fb53d4c456b8bea809b991e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121702 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41403 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32067 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128230 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/73792 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2b964e86-0839-441b-8559-fc1c18520bb5) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42115 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49994 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92474 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/73792 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f30b77ab-5157-43e9-8be8-f7de6318fd0a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124654 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33601 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109006 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73135 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/11d9f26d-8a6f-4849-9cc8-05f2215cc123) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32611 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27168 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71746 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103099 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27354 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131017 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48637 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36993 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101041 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49009 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105223 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100933 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25597 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46309 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24424 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/45338 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48495 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47964 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51314 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49647 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->