### PR TITLE
Address Safer CPP warnings in ControlFactoryMac.mm

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -92,7 +92,6 @@ platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.h
 platform/graphics/avfoundation/objc/CDMSessionMediaSourceAVFObjC.h
 platform/graphics/ca/GraphicsLayerCA.cpp
 platform/graphics/ca/cocoa/PlatformCAAnimationCocoa.mm
-platform/graphics/mac/controls/ControlFactoryMac.mm
 platform/graphics/mac/controls/ControlMac.mm
 platform/mac/PasteboardMac.mm
 platform/mac/ScrollbarsControllerMac.mm

--- a/Source/WebCore/platform/graphics/adwaita/ControlFactoryAdwaita.cpp
+++ b/Source/WebCore/platform/graphics/adwaita/ControlFactoryAdwaita.cpp
@@ -59,7 +59,7 @@ Ref<ControlFactory> ControlFactory::create()
 
 ControlFactoryAdwaita& ControlFactoryAdwaita::shared()
 {
-    return static_cast<ControlFactoryAdwaita&>(ControlFactory::shared());
+    return downcast<ControlFactoryAdwaita>(ControlFactory::shared());
 }
 
 #if ENABLE(APPLE_PAY)

--- a/Source/WebCore/platform/graphics/adwaita/ControlFactoryAdwaita.h
+++ b/Source/WebCore/platform/graphics/adwaita/ControlFactoryAdwaita.h
@@ -56,8 +56,14 @@ private:
     std::unique_ptr<PlatformControl> createPlatformTextArea(TextAreaPart&) final;
     std::unique_ptr<PlatformControl> createPlatformTextField(TextFieldPart&) final;
     std::unique_ptr<PlatformControl> createPlatformToggleButton(ToggleButtonPart&) final;
+
+    Type type() const final { return Type::Adwaita; }
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::ControlFactoryAdwaita)
+    static bool isType(const WebCore::ControlFactory& factory) { return factory.type() == WebCore::ControlFactory::Type::Adwaita; }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // USE(THEME_ADWAITA)

--- a/Source/WebCore/platform/graphics/controls/ControlFactory.h
+++ b/Source/WebCore/platform/graphics/controls/ControlFactory.h
@@ -84,6 +84,14 @@ public:
     virtual std::unique_ptr<PlatformControl> createPlatformTextField(TextFieldPart&) = 0;
     virtual std::unique_ptr<PlatformControl> createPlatformToggleButton(ToggleButtonPart&) = 0;
 
+    enum class Type : uint8_t {
+        Adwaita,
+        Empty,
+        IOS,
+        Mac,
+    };
+    virtual Type type() const = 0;
+
 protected:
     ControlFactory() = default;
 };

--- a/Source/WebCore/platform/graphics/controls/EmptyControlFactory.h
+++ b/Source/WebCore/platform/graphics/controls/EmptyControlFactory.h
@@ -59,6 +59,7 @@ private:
     std::unique_ptr<PlatformControl> createPlatformTextArea(TextAreaPart&) final;
     std::unique_ptr<PlatformControl> createPlatformTextField(TextFieldPart&) final;
     std::unique_ptr<PlatformControl> createPlatformToggleButton(ToggleButtonPart&) final;
+    Type type() const final { return Type::Empty; }
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/ios/controls/ControlFactoryIOS.h
+++ b/Source/WebCore/platform/graphics/ios/controls/ControlFactoryIOS.h
@@ -55,8 +55,13 @@ private:
     std::unique_ptr<PlatformControl> createPlatformTextArea(TextAreaPart&) final;
     std::unique_ptr<PlatformControl> createPlatformTextField(TextFieldPart&) final;
     std::unique_ptr<PlatformControl> createPlatformToggleButton(ToggleButtonPart&) final;
+    Type type() const final { return Type::IOS; }
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::ControlFactoryIOS)
+    static bool isType(const WebCore::ControlFactory& factory) { return factory.type() == WebCore::ControlFactory::Type::IOS; }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.h
@@ -74,6 +74,7 @@ private:
     std::unique_ptr<PlatformControl> createPlatformTextArea(TextAreaPart&) final;
     std::unique_ptr<PlatformControl> createPlatformTextField(TextFieldPart&) final;
     std::unique_ptr<PlatformControl> createPlatformToggleButton(ToggleButtonPart&) final;
+    Type type() const final { return Type::Mac; }
 
     NSButtonCell *buttonCell() const;
     NSButtonCell *defaultButtonCell() const;
@@ -104,5 +105,9 @@ private:
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::ControlFactoryMac)
+    static bool isType(const WebCore::ControlFactory& factory) { return factory.type() == WebCore::ControlFactory::Type::Mac; }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // PLATFORM(MAC)

--- a/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.mm
@@ -67,7 +67,7 @@ Ref<ControlFactory> ControlFactory::create()
 
 ControlFactoryMac& ControlFactoryMac::shared()
 {
-    return static_cast<ControlFactoryMac&>(ControlFactory::shared());
+    return downcast<ControlFactoryMac>(ControlFactory::shared());
 }
 
 NSView *ControlFactoryMac::drawingView(const FloatRect& rect, const ControlStyle& style) const


### PR DESCRIPTION
#### 2641e351db16194bf7857939a3553657810cf688
<pre>
Address Safer CPP warnings in ControlFactoryMac.mm
<a href="https://bugs.webkit.org/show_bug.cgi?id=299149">https://bugs.webkit.org/show_bug.cgi?id=299149</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations:
* Source/WebCore/platform/graphics/adwaita/ControlFactoryAdwaita.cpp:
(WebCore::ControlFactoryAdwaita::shared):
* Source/WebCore/platform/graphics/adwaita/ControlFactoryAdwaita.h:
(isType):
* Source/WebCore/platform/graphics/controls/ControlFactory.h:
* Source/WebCore/platform/graphics/controls/EmptyControlFactory.h:
* Source/WebCore/platform/graphics/ios/controls/ControlFactoryIOS.h:
(isType):
* Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.h:
(isType):
* Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.mm:
(WebCore::ControlFactoryMac::shared):

Canonical link: <a href="https://commits.webkit.org/300221@main">https://commits.webkit.org/300221@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b95ec086926efaee17babedc767370a3d3e04f6c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121718 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41419 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32083 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128247 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73808 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e998433d-f878-4fb5-a7c4-154b7da224b7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123594 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42131 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50010 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92489 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61491 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/51c99ce8-f392-49d2-8ec5-2e2b6ccc8a86) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124670 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33614 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109018 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73151 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b64b6450-324e-496f-84f9-34c7bd33127d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32625 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27181 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71763 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103113 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27366 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131033 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48653 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37006 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101056 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49025 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105235 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100947 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25607 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46325 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24436 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45354 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48511 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54238 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47980 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51330 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49663 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->