### PR TITLE
Address Safer CPP warnings in PlatformPasteboardMac.mm

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
@@ -111,7 +111,6 @@ platform/mac/DataDetectorHighlight.mm
 platform/mac/PasteboardMac.mm
 platform/mac/PasteboardWriter.mm
 platform/mac/PlatformEventFactoryMac.mm
-platform/mac/PlatformPasteboardMac.mm
 platform/mac/PlatformScreenMac.mm
 platform/mac/PowerObserverMac.cpp
 platform/mac/ScrollViewMac.mm

--- a/Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
@@ -78,7 +78,6 @@ platform/mac/DataDetectorHighlight.mm
 platform/mac/HIDDevice.cpp
 platform/mac/PasteboardMac.mm
 platform/mac/PlatformEventFactoryMac.mm
-platform/mac/PlatformPasteboardMac.mm
 platform/mac/ScrollViewMac.mm
 platform/mac/ScrollbarThemeMac.mm
 platform/mac/ScrollbarsControllerMac.mm

--- a/Source/WebCore/editing/cocoa/EditorCocoa.mm
+++ b/Source/WebCore/editing/cocoa/EditorCocoa.mm
@@ -309,10 +309,10 @@ void Editor::takeFindStringFromSelection()
     auto stringFromSelection = document().frame()->displayStringModifiedByEncoding(selectedTextForDataTransfer());
 #if PLATFORM(MAC)
     Vector<String> types;
-    types.append(String(legacyStringPasteboardType()));
+    types.append(String(legacyStringPasteboardTypeSingleton()));
     auto context = PagePasteboardContext::create(document().pageID());
     platformStrategies()->pasteboardStrategy()->setTypes(types, NSPasteboardNameFind, context.get());
-    platformStrategies()->pasteboardStrategy()->setStringForType(WTFMove(stringFromSelection), legacyStringPasteboardType(), NSPasteboardNameFind, context.get());
+    platformStrategies()->pasteboardStrategy()->setStringForType(WTFMove(stringFromSelection), legacyStringPasteboardTypeSingleton(), NSPasteboardNameFind, context.get());
 #else
     if (auto* client = this->client()) {
         // Since the find pasteboard doesn't exist on iOS, WebKit maintains its own notion of the latest find string,

--- a/Source/WebCore/editing/mac/EditorMac.mm
+++ b/Source/WebCore/editing/mac/EditorMac.mm
@@ -97,7 +97,7 @@ void Editor::platformCopyFont()
 
     PasteboardBuffer pasteboardBuffer;
     pasteboardBuffer.contentOrigin = document().originIdentifierForPasteboard();
-    pasteboardBuffer.type = legacyFontPasteboardType();
+    pasteboardBuffer.type = legacyFontPasteboardTypeSingleton();
     pasteboardBuffer.data = SharedBuffer::create(fontData.get());
     pasteboard.write(pasteboardBuffer);
 }
@@ -109,7 +109,7 @@ void Editor::platformPasteFont()
     client()->setInsertionPasteboard(pasteboard.name());
 
     RetainPtr<NSData> fontData;
-    if (auto buffer = pasteboard.readBuffer(std::nullopt, legacyFontPasteboardType()))
+    if (auto buffer = pasteboard.readBuffer(std::nullopt, legacyFontPasteboardTypeSingleton()))
         fontData = buffer->createNSData();
     auto fontSampleString = adoptNS([[NSAttributedString alloc] initWithRTF:fontData.get() documentAttributes:nil]);
     auto fontAttributes = RetainPtr([fontSampleString fontAttributesInRange:NSMakeRange(0, 1)]);
@@ -184,10 +184,10 @@ RefPtr<SharedBuffer> Editor::dataSelectionForPasteboard(const String& pasteboard
     if (pasteboardType == WebArchivePboardType || pasteboardType == String(UTTypeWebArchive.identifier))
         return selectionInWebArchiveFormat();
 
-    if (pasteboardType == String(legacyRTFDPasteboardType()))
+    if (pasteboardType == String(legacyRTFDPasteboardTypeSingleton()))
         return dataInRTFDFormat(attributedString(*adjustedSelectionRange(), IgnoreUserSelectNone::Yes).nsAttributedString().get());
 
-    if (pasteboardType == String(legacyRTFPasteboardType())) {
+    if (pasteboardType == String(legacyRTFPasteboardTypeSingleton())) {
         auto string = attributedString(*adjustedSelectionRange(), IgnoreUserSelectNone::Yes).nsAttributedString();
         // FIXME: Why is this stripping needed here, but not in writeSelectionToPasteboard?
         if ([string containsAttachments])

--- a/Source/WebCore/platform/cocoa/DragDataCocoa.mm
+++ b/Source/WebCore/platform/cocoa/DragDataCocoa.mm
@@ -51,7 +51,7 @@ static inline String rtfPasteboardType()
 #if PLATFORM(IOS_FAMILY)
     return String(UTTypeRTF.identifier);
 #else
-    return String(legacyRTFPasteboardType());
+    return String(legacyRTFPasteboardTypeSingleton());
 #endif
 }
 
@@ -60,7 +60,7 @@ static inline String rtfdPasteboardType()
 #if PLATFORM(IOS_FAMILY)
     return String(UTTypeFlatRTFD.identifier);
 #else
-    return String(legacyRTFDPasteboardType());
+    return String(legacyRTFDPasteboardTypeSingleton());
 #endif
 }
 
@@ -69,7 +69,7 @@ static inline String stringPasteboardType()
 #if PLATFORM(IOS_FAMILY)
     return String(UTTypeText.identifier);
 #else
-    return String(legacyStringPasteboardType());
+    return String(legacyStringPasteboardTypeSingleton());
 #endif
 }
 
@@ -78,7 +78,7 @@ static inline String urlPasteboardType()
 #if PLATFORM(IOS_FAMILY)
     return String(UTTypeURL.identifier);
 #else
-    return String(legacyURLPasteboardType());
+    return String(legacyURLPasteboardTypeSingleton());
 #endif
 }
 
@@ -87,7 +87,7 @@ static inline String htmlPasteboardType()
 #if PLATFORM(IOS_FAMILY)
     return String(UTTypeHTML.identifier);
 #else
-    return String(legacyHTMLPasteboardType());
+    return String(legacyHTMLPasteboardTypeSingleton());
 #endif
 }
 
@@ -96,7 +96,7 @@ static inline String colorPasteboardType()
 #if PLATFORM(IOS_FAMILY)
     return String { UIColorPboardType };
 #else
-    return String(legacyColorPasteboardType());
+    return String(legacyColorPasteboardTypeSingleton());
 #endif
 }
 
@@ -105,7 +105,7 @@ static inline String pdfPasteboardType()
 #if PLATFORM(IOS_FAMILY)
     return String(UTTypePDF.identifier);
 #else
-    return String(legacyPDFPasteboardType());
+    return String(legacyPDFPasteboardTypeSingleton());
 #endif
 }
 
@@ -114,7 +114,7 @@ static inline String tiffPasteboardType()
 #if PLATFORM(IOS_FAMILY)
     return String(UTTypeTIFF.identifier);
 #else
-    return String(legacyTIFFPasteboardType());
+    return String(legacyTIFFPasteboardTypeSingleton());
 #endif
 }
 
@@ -212,11 +212,11 @@ Vector<String> DragData::asFilenames() const
 #if PLATFORM(MAC)
     Vector<String> types;
     platformStrategies()->pasteboardStrategy()->getTypes(types, m_pasteboardName, context.get());
-    if (types.contains(String(legacyFilesPromisePasteboardType())))
+    if (types.contains(String(legacyFilesPromisePasteboardTypeSingleton())))
         return fileNames();
 
     Vector<String> results;
-    platformStrategies()->pasteboardStrategy()->getPathnamesForType(results, String(legacyFilenamesPasteboardType()), m_pasteboardName, context.get());
+    platformStrategies()->pasteboardStrategy()->getPathnamesForType(results, String(legacyFilenamesPasteboardTypeSingleton()), m_pasteboardName, context.get());
     return results;
 #else
     return fileNames();
@@ -233,7 +233,7 @@ bool DragData::containsPlainText() const
         || types.contains(rtfdPasteboardType())
         || types.contains(rtfPasteboardType())
 #if PLATFORM(MAC)
-        || types.contains(String(legacyFilenamesPasteboardType()))
+        || types.contains(String(legacyFilenamesPasteboardTypeSingleton()))
 #endif
         || platformStrategies()->pasteboardStrategy()->containsStringSafeForDOMToReadForType(urlPasteboardType(), m_pasteboardName, context.get());
 }
@@ -278,8 +278,8 @@ bool DragData::containsCompatibleContent(DraggingPurpose purpose) const
         || types.contains(htmlPasteboardType())
         || types.contains(String(UTTypeWebArchive.identifier))
 #if PLATFORM(MAC)
-        || (!m_disallowFileAccess && types.contains(String(legacyFilenamesPasteboardType())))
-        || (!m_disallowFileAccess && types.contains(String(legacyFilesPromisePasteboardType())))
+        || (!m_disallowFileAccess && types.contains(String(legacyFilenamesPasteboardTypeSingleton())))
+        || (!m_disallowFileAccess && types.contains(String(legacyFilesPromisePasteboardTypeSingleton())))
 #endif
         || types.contains(tiffPasteboardType())
         || types.contains(pdfPasteboardType())
@@ -298,11 +298,11 @@ bool DragData::containsPromise() const
     if (m_disallowFileAccess)
         return false;
     auto context = createPasteboardContext();
-    // FIXME: legacyFilesPromisePasteboardType() contains UTIs, not path names. Also, why do we
+    // FIXME: legacyFilesPromisePasteboardTypeSingleton() contains UTIs, not path names. Also, why do we
     // think promises should only contain one file (or UTI)?
     Vector<String> files;
 #if PLATFORM(MAC)
-    platformStrategies()->pasteboardStrategy()->getPathnamesForType(files, String(legacyFilesPromisePasteboardType()), m_pasteboardName, context.get());
+    platformStrategies()->pasteboardStrategy()->getPathnamesForType(files, String(legacyFilesPromisePasteboardTypeSingleton()), m_pasteboardName, context.get());
 #endif
     return files.size() == 1;
 }
@@ -316,7 +316,7 @@ bool DragData::containsURL(FilenameConversionPolicy) const
 #if PLATFORM(MAC)
     Vector<String> types;
     platformStrategies()->pasteboardStrategy()->getTypes(types, m_pasteboardName, context.get());
-    if (types.contains(String(legacyFilesPromisePasteboardType())) && fileNames().size() == 1)
+    if (types.contains(String(legacyFilesPromisePasteboardTypeSingleton())) && fileNames().size() == 1)
         return !![NSURL fileURLWithPath:fileNames().first().createNSString().get()];
 #endif
 
@@ -339,7 +339,7 @@ String DragData::asURL(FilenameConversionPolicy, String* title) const
 #if PLATFORM(MAC)
     Vector<String> types;
     platformStrategies()->pasteboardStrategy()->getTypes(types, m_pasteboardName, context.get());
-    if (types.contains(String(legacyFilesPromisePasteboardType())) && fileNames().size() == 1)
+    if (types.contains(String(legacyFilesPromisePasteboardTypeSingleton())) && fileNames().size() == 1)
         return [URLByCanonicalizingURL([NSURL fileURLWithPath:fileNames()[0].createNSString().get()]) absoluteString];
 #endif
 

--- a/Source/WebCore/platform/cocoa/PasteboardCocoa.mm
+++ b/Source/WebCore/platform/cocoa/PasteboardCocoa.mm
@@ -59,13 +59,13 @@ enum class ImageType {
 static ImageType cocoaTypeToImageType(const String& cocoaType)
 {
 #if PLATFORM(MAC)
-    if (cocoaType == String(legacyTIFFPasteboardType()))
+    if (cocoaType == String(legacyTIFFPasteboardTypeSingleton()))
         return ImageType::TIFF;
 #endif
     if (cocoaType == String(UTTypeTIFF.identifier))
         return ImageType::TIFF;
 #if PLATFORM(MAC)
-    if (cocoaType == String(legacyPNGPasteboardType())) // NSPNGPboardType
+    if (cocoaType == String(legacyPNGPasteboardTypeSingleton())) // NSPNGPboardType
         return ImageType::PNG;
 #endif
     if (cocoaType == String(UTTypePNG.identifier))
@@ -159,7 +159,7 @@ Pasteboard::FileContentState Pasteboard::fileContentState()
 
         auto indexOfURL = cocoaTypes.findIf([](auto& cocoaType) {
 #if PLATFORM(MAC)
-            if (cocoaType == String(legacyURLPasteboardType()))
+            if (cocoaType == String(legacyURLPasteboardTypeSingleton()))
                 return true;
 #endif
             return cocoaType == String(UTTypeURL.identifier);

--- a/Source/WebCore/platform/cocoa/PlatformPasteboardCocoa.mm
+++ b/Source/WebCore/platform/cocoa/PlatformPasteboardCocoa.mm
@@ -78,8 +78,8 @@ String PlatformPasteboard::urlStringSuitableForLoading(String& title)
     String urlPasteboardType = UTTypeURL.identifier;
     String stringPasteboardType = UTTypeText.identifier;
 #else
-    String urlPasteboardType = legacyURLPasteboardType();
-    String stringPasteboardType = legacyStringPasteboardType();
+    String urlPasteboardType = legacyURLPasteboardTypeSingleton();
+    String stringPasteboardType = legacyStringPasteboardTypeSingleton();
 #endif
 
     if (types.contains(urlPasteboardType)) {
@@ -99,9 +99,9 @@ String PlatformPasteboard::urlStringSuitableForLoading(String& title)
     }
 
 #if PLATFORM(MAC)
-    if (types.contains(String(legacyFilenamesPasteboardType()))) {
+    if (types.contains(String(legacyFilenamesPasteboardTypeSingleton()))) {
         Vector<String> files;
-        getPathnamesForType(files, String(legacyFilenamesPasteboardType()));
+        getPathnamesForType(files, String(legacyFilenamesPasteboardTypeSingleton()));
         if (files.size() == 1) {
             RetainPtr firstFile = files[0].createNSString();
             BOOL isDirectory;

--- a/Source/WebCore/platform/mac/LegacyNSPasteboardTypes.h
+++ b/Source/WebCore/platform/mac/LegacyNSPasteboardTypes.h
@@ -32,62 +32,62 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
 
 namespace WebCore {
 
-inline NSString *legacyStringPasteboardType()
+inline NSString *legacyStringPasteboardTypeSingleton()
 {
     return NSStringPboardType;
 }
 
-inline NSString *legacyFilenamesPasteboardType()
+inline NSString *legacyFilenamesPasteboardTypeSingleton()
 {
     return NSFilenamesPboardType;
 }
 
-inline NSString *legacyTIFFPasteboardType()
+inline NSString *legacyTIFFPasteboardTypeSingleton()
 {
     return NSTIFFPboardType;
 }
 
-inline NSString *legacyRTFPasteboardType()
+inline NSString *legacyRTFPasteboardTypeSingleton()
 {
     return NSRTFPboardType;
 }
 
-inline NSString *legacyFontPasteboardType()
+inline NSString *legacyFontPasteboardTypeSingleton()
 {
     return NSFontPboardType;
 }
 
-inline NSString *legacyColorPasteboardType()
+inline NSString *legacyColorPasteboardTypeSingleton()
 {
     return NSColorPboardType;
 }
 
-inline NSString *legacyRTFDPasteboardType()
+inline NSString *legacyRTFDPasteboardTypeSingleton()
 {
     return NSRTFDPboardType;
 }
 
-inline NSString *legacyHTMLPasteboardType()
+inline NSString *legacyHTMLPasteboardTypeSingleton()
 {
     return NSHTMLPboardType;
 }
 
-inline NSString *legacyURLPasteboardType()
+inline NSString *legacyURLPasteboardTypeSingleton()
 {
     return NSURLPboardType;
 }
 
-inline NSString *legacyPDFPasteboardType()
+inline NSString *legacyPDFPasteboardTypeSingleton()
 {
     return NSPDFPboardType;
 }
 
-inline NSString *legacyFilesPromisePasteboardType()
+inline NSString *legacyFilesPromisePasteboardTypeSingleton()
 {
     return NSFilesPromisePboardType;
 }
 
-inline NSString *legacyPNGPasteboardType()
+inline NSString *legacyPNGPasteboardTypeSingleton()
 {
     return @"Apple PNG pasteboard type";
 }

--- a/Source/WebCore/platform/mac/PasteboardMac.mm
+++ b/Source/WebCore/platform/mac/PasteboardMac.mm
@@ -67,25 +67,25 @@ static const Vector<String> writableTypesForURL()
     Vector<String> types;
     
     types.append(WebURLsWithTitlesPboardType);
-    types.append(String(legacyURLPasteboardType()));
+    types.append(String(legacyURLPasteboardTypeSingleton()));
     types.append(WebURLPboardType);
     types.append(WebURLNamePboardType);
-    types.append(String(legacyStringPasteboardType()));
+    types.append(String(legacyStringPasteboardTypeSingleton()));
     return types;
 }
 
 static Vector<String> writableTypesForImage()
 {
     Vector<String> types;
-    types.append(String(legacyTIFFPasteboardType()));
+    types.append(String(legacyTIFFPasteboardTypeSingleton()));
     types.appendVector(writableTypesForURL());
-    types.append(String(legacyRTFDPasteboardType()));
+    types.append(String(legacyRTFDPasteboardTypeSingleton()));
     return types;
 }
 
 NSArray *Pasteboard::supportedFileUploadPasteboardTypes()
 {
-    return @[ legacyFilesPromisePasteboardType(), legacyFilenamesPasteboardType() ];
+    return @[ legacyFilesPromisePasteboardTypeSingleton(), legacyFilenamesPasteboardTypeSingleton() ];
 }
 
 Pasteboard::Pasteboard(std::unique_ptr<PasteboardContext>&& context)
@@ -148,13 +148,13 @@ void Pasteboard::write(const PasteboardWebContent& content)
         types.append(UTTypeWebArchive.identifier);
     }
     if (content.dataInRTFDFormat)
-        types.append(String(legacyRTFDPasteboardType()));
+        types.append(String(legacyRTFDPasteboardTypeSingleton()));
     if (content.dataInRTFFormat)
-        types.append(String(legacyRTFPasteboardType()));
+        types.append(String(legacyRTFPasteboardTypeSingleton()));
     if (!content.dataInHTMLFormat.isNull())
-        types.append(String(legacyHTMLPasteboardType()));
+        types.append(String(legacyHTMLPasteboardTypeSingleton()));
     if (!content.dataInStringFormat.isNull())
-        types.append(String(legacyStringPasteboardType()));
+        types.append(String(legacyStringPasteboardTypeSingleton()));
     types.appendVector(clientTypes);
     types.append(PasteboardCustomData::cocoaType());
 
@@ -174,13 +174,13 @@ void Pasteboard::write(const PasteboardWebContent& content)
         m_changeCount = platformStrategies()->pasteboardStrategy()->setBufferForType(content.dataInWebArchiveFormat.get(), UTTypeWebArchive.identifier, m_pasteboardName, context());
     }
     if (content.dataInRTFDFormat)
-        m_changeCount = platformStrategies()->pasteboardStrategy()->setBufferForType(content.dataInRTFDFormat.get(), legacyRTFDPasteboardType(), m_pasteboardName, context());
+        m_changeCount = platformStrategies()->pasteboardStrategy()->setBufferForType(content.dataInRTFDFormat.get(), legacyRTFDPasteboardTypeSingleton(), m_pasteboardName, context());
     if (content.dataInRTFFormat)
-        m_changeCount = platformStrategies()->pasteboardStrategy()->setBufferForType(content.dataInRTFFormat.get(), legacyRTFPasteboardType(), m_pasteboardName, context());
+        m_changeCount = platformStrategies()->pasteboardStrategy()->setBufferForType(content.dataInRTFFormat.get(), legacyRTFPasteboardTypeSingleton(), m_pasteboardName, context());
     if (!content.dataInHTMLFormat.isNull())
-        m_changeCount = platformStrategies()->pasteboardStrategy()->setStringForType(content.dataInHTMLFormat, legacyHTMLPasteboardType(), m_pasteboardName, context());
+        m_changeCount = platformStrategies()->pasteboardStrategy()->setStringForType(content.dataInHTMLFormat, legacyHTMLPasteboardTypeSingleton(), m_pasteboardName, context());
     if (!content.dataInStringFormat.isNull())
-        m_changeCount = platformStrategies()->pasteboardStrategy()->setStringForType(content.dataInStringFormat, legacyStringPasteboardType(), m_pasteboardName, context());
+        m_changeCount = platformStrategies()->pasteboardStrategy()->setStringForType(content.dataInStringFormat, legacyStringPasteboardTypeSingleton(), m_pasteboardName, context());
 
     PasteboardCustomData data;
     data.setOrigin(content.contentOrigin);
@@ -191,12 +191,12 @@ void Pasteboard::write(const PasteboardWebContent& content)
 void Pasteboard::writePlainText(const String& text, SmartReplaceOption smartReplaceOption)
 {
     Vector<String> types;
-    types.append(legacyStringPasteboardType());
+    types.append(legacyStringPasteboardTypeSingleton());
     if (smartReplaceOption == CanSmartReplace)
         types.append(WebSmartPastePboardType);
 
     platformStrategies()->pasteboardStrategy()->setTypes(types, m_pasteboardName, context());
-    m_changeCount = platformStrategies()->pasteboardStrategy()->setStringForType(text, legacyStringPasteboardType(), m_pasteboardName, context());
+    m_changeCount = platformStrategies()->pasteboardStrategy()->setStringForType(text, legacyStringPasteboardTypeSingleton(), m_pasteboardName, context());
     if (smartReplaceOption == CanSmartReplace)
         m_changeCount = platformStrategies()->pasteboardStrategy()->setBufferForType(0, WebSmartPastePboardType, m_pasteboardName, context());
 }
@@ -220,14 +220,14 @@ static long writeURLForTypes(const Vector<String>& types, const String& pasteboa
         PasteboardURL url = { pasteboardURL.url, String(title.get()).trim(deprecatedIsSpaceOrNewline), emptyString() };
         newChangeCount = platformStrategies()->pasteboardStrategy()->setURL(url, pasteboardName, context);
     }
-    if (types.contains(String(legacyURLPasteboardType())))
-        newChangeCount = platformStrategies()->pasteboardStrategy()->setStringForType([nsURL absoluteString], legacyURLPasteboardType(), pasteboardName, context);
+    if (types.contains(String(legacyURLPasteboardTypeSingleton())))
+        newChangeCount = platformStrategies()->pasteboardStrategy()->setStringForType([nsURL absoluteString], legacyURLPasteboardTypeSingleton(), pasteboardName, context);
     if (types.contains(WebURLPboardType))
         newChangeCount = platformStrategies()->pasteboardStrategy()->setStringForType(userVisibleString.get(), WebURLPboardType, pasteboardName, context);
     if (types.contains(WebURLNamePboardType))
         newChangeCount = platformStrategies()->pasteboardStrategy()->setStringForType(title.get(), WebURLNamePboardType, pasteboardName, context);
-    if (types.contains(String(legacyStringPasteboardType())))
-        newChangeCount = platformStrategies()->pasteboardStrategy()->setStringForType(userVisibleString.get(), legacyStringPasteboardType(), pasteboardName, context);
+    if (types.contains(String(legacyStringPasteboardTypeSingleton())))
+        newChangeCount = platformStrategies()->pasteboardStrategy()->setStringForType(userVisibleString.get(), legacyStringPasteboardTypeSingleton(), pasteboardName, context);
 
     return newChangeCount;
 }
@@ -245,7 +245,7 @@ void Pasteboard::writeTrustworthyWebURLsPboardType(const PasteboardURL& pasteboa
 
 void Pasteboard::write(const Color& color)
 {
-    Vector<String> types = { legacyColorPasteboardType() };
+    Vector<String> types = { legacyColorPasteboardTypeSingleton() };
     platformStrategies()->pasteboardStrategy()->setTypes(types, m_pasteboardName, context());
     m_changeCount = platformStrategies()->pasteboardStrategy()->setColor(color, m_pasteboardName, context());
 }
@@ -265,7 +265,7 @@ static void writeFileWrapperAsRTFDAttachment(NSFileWrapper *wrapper, const Strin
     if (!RTFDData)
         return;
 
-    newChangeCount = platformStrategies()->pasteboardStrategy()->setBufferForType(SharedBuffer::create(RTFDData).ptr(), legacyRTFDPasteboardType(), pasteboardName, context);
+    newChangeCount = platformStrategies()->pasteboardStrategy()->setBufferForType(SharedBuffer::create(RTFDData).ptr(), legacyRTFDPasteboardTypeSingleton(), pasteboardName, context);
 }
 
 void Pasteboard::write(const PasteboardImage& pasteboardImage)
@@ -284,13 +284,13 @@ void Pasteboard::write(const PasteboardImage& pasteboardImage)
     }
 
     m_changeCount = writeURLForTypes(types, m_pasteboardName, pasteboardImage.url, context());
-    m_changeCount = platformStrategies()->pasteboardStrategy()->setBufferForType(SharedBuffer::create(imageData).ptr(), legacyTIFFPasteboardType(), m_pasteboardName, context());
+    m_changeCount = platformStrategies()->pasteboardStrategy()->setBufferForType(SharedBuffer::create(imageData).ptr(), legacyTIFFPasteboardTypeSingleton(), m_pasteboardName, context());
     if (auto archiveData = pasteboardImage.dataInWebArchiveFormat) {
         m_changeCount = platformStrategies()->pasteboardStrategy()->setBufferForType(archiveData.get(), WebArchivePboardType, m_pasteboardName, context());
         m_changeCount = platformStrategies()->pasteboardStrategy()->setBufferForType(archiveData.get(), UTTypeWebArchive.identifier, m_pasteboardName, context());
     }
     if (!pasteboardImage.dataInHTMLFormat.isEmpty())
-        m_changeCount = platformStrategies()->pasteboardStrategy()->setStringForType(pasteboardImage.dataInHTMLFormat, legacyHTMLPasteboardType(), m_pasteboardName, context());
+        m_changeCount = platformStrategies()->pasteboardStrategy()->setStringForType(pasteboardImage.dataInHTMLFormat, legacyHTMLPasteboardTypeSingleton(), m_pasteboardName, context());
     writeFileWrapperAsRTFDAttachment(fileWrapper(pasteboardImage), m_pasteboardName, m_changeCount, context());
 }
 
@@ -364,14 +364,14 @@ void Pasteboard::read(PasteboardPlainText& text, PlainTextURLReadingPolicy allow
         return;
     }
 
-    if (types.contains(String(legacyStringPasteboardType()))) {
-        text.text = readStringAtPreferredItemIndex(legacyStringPasteboardType(), itemIndex, strategy.get(), m_pasteboardName, context());
+    if (types.contains(String(legacyStringPasteboardTypeSingleton()))) {
+        text.text = readStringAtPreferredItemIndex(legacyStringPasteboardTypeSingleton(), itemIndex, strategy.get(), m_pasteboardName, context());
         text.isURL = false;
         return;
     }
     
-    if (types.contains(String(legacyRTFDPasteboardType()))) {
-        if (auto data = readBufferAtPreferredItemIndex(legacyRTFDPasteboardType(), itemIndex, strategy.get(), m_pasteboardName, context())) {
+    if (types.contains(String(legacyRTFDPasteboardTypeSingleton()))) {
+        if (auto data = readBufferAtPreferredItemIndex(legacyRTFDPasteboardTypeSingleton(), itemIndex, strategy.get(), m_pasteboardName, context())) {
             if (auto attributedString = adoptNS([[NSAttributedString alloc] initWithRTFD:data->makeContiguous()->createNSData().get() documentAttributes:nil])) {
                 text.text = [attributedString string];
                 text.isURL = false;
@@ -390,8 +390,8 @@ void Pasteboard::read(PasteboardPlainText& text, PlainTextURLReadingPolicy allow
         }
     }
 
-    if (types.contains(String(legacyRTFPasteboardType()))) {
-        if (auto data = readBufferAtPreferredItemIndex(legacyRTFPasteboardType(), itemIndex, strategy, m_pasteboardName, context())) {
+    if (types.contains(String(legacyRTFPasteboardTypeSingleton()))) {
+        if (auto data = readBufferAtPreferredItemIndex(legacyRTFPasteboardTypeSingleton(), itemIndex, strategy, m_pasteboardName, context())) {
             if (auto attributedString = adoptNS([[NSAttributedString alloc] initWithRTF:data->createNSData().get() documentAttributes:nil])) {
                 text.text = [attributedString string];
                 text.isURL = false;
@@ -410,15 +410,15 @@ void Pasteboard::read(PasteboardPlainText& text, PlainTextURLReadingPolicy allow
         }
     }
 
-    if (types.contains(String(legacyFilesPromisePasteboardType()))) {
+    if (types.contains(String(legacyFilesPromisePasteboardTypeSingleton()))) {
         text.text = joinPathnames(m_promisedFilePaths);
         text.isURL = false;
         return;
     }
 
-    if (types.contains(String(legacyFilenamesPasteboardType()))) {
+    if (types.contains(String(legacyFilenamesPasteboardTypeSingleton()))) {
         Vector<String> pathnames;
-        strategy->getPathnamesForType(pathnames, legacyFilenamesPasteboardType(), m_pasteboardName, context());
+        strategy->getPathnamesForType(pathnames, legacyFilenamesPasteboardTypeSingleton(), m_pasteboardName, context());
         text.text = joinPathnames(pathnames);
         text.isURL = false;
         return;
@@ -426,7 +426,7 @@ void Pasteboard::read(PasteboardPlainText& text, PlainTextURLReadingPolicy allow
 
     // FIXME: The code above looks at the types vector first, but this just gets the string without checking. Why the difference?
     if (allowURL == PlainTextURLReadingPolicy::AllowURL) {
-        text.text = readStringAtPreferredItemIndex(legacyURLPasteboardType(), itemIndex, strategy.get(), m_pasteboardName, context());
+        text.text = readStringAtPreferredItemIndex(legacyURLPasteboardTypeSingleton(), itemIndex, strategy.get(), m_pasteboardName, context());
         text.isURL = !text.text.isNull();
     }
 }
@@ -472,20 +472,20 @@ void Pasteboard::read(PasteboardWebContentReader& reader, WebContentReadingPolic
         }
     }
 
-    if (policy == WebContentReadingPolicy::AnyType && types.contains(String(legacyFilesPromisePasteboardType()))) {
+    if (policy == WebContentReadingPolicy::AnyType && types.contains(String(legacyFilesPromisePasteboardTypeSingleton()))) {
         if (m_changeCount != changeCount() || reader.readFilePaths(m_promisedFilePaths))
             return;
     }
 
-    if (policy == WebContentReadingPolicy::AnyType && types.contains(String(legacyFilenamesPasteboardType()))) {
+    if (policy == WebContentReadingPolicy::AnyType && types.contains(String(legacyFilenamesPasteboardTypeSingleton()))) {
         Vector<String> paths;
-        strategy->getPathnamesForType(paths, legacyFilenamesPasteboardType(), m_pasteboardName, context());
+        strategy->getPathnamesForType(paths, legacyFilenamesPasteboardTypeSingleton(), m_pasteboardName, context());
         if (m_changeCount != changeCount() || reader.readFilePaths(paths))
             return;
     }
 
-    if (types.contains(String(legacyHTMLPasteboardType()))) {
-        String string = readStringAtPreferredItemIndex(legacyHTMLPasteboardType(), itemIndex, strategy.get(), m_pasteboardName, context());
+    if (types.contains(String(legacyHTMLPasteboardTypeSingleton()))) {
+        String string = readStringAtPreferredItemIndex(legacyHTMLPasteboardTypeSingleton(), itemIndex, strategy.get(), m_pasteboardName, context());
         if (m_changeCount != changeCount() || (!string.isNull() && reader.readHTML(string)))
             return;
     }
@@ -496,8 +496,8 @@ void Pasteboard::read(PasteboardWebContentReader& reader, WebContentReadingPolic
             return;
     }
 
-    if (types.contains(String(legacyRTFDPasteboardType()))) {
-        if (auto buffer = readBufferAtPreferredItemIndex(legacyRTFDPasteboardType(), itemIndex, strategy.get(), m_pasteboardName, context())) {
+    if (types.contains(String(legacyRTFDPasteboardTypeSingleton()))) {
+        if (auto buffer = readBufferAtPreferredItemIndex(legacyRTFDPasteboardTypeSingleton(), itemIndex, strategy.get(), m_pasteboardName, context())) {
             if (m_changeCount != changeCount() || reader.readRTFD(*buffer))
                 return;
         }
@@ -510,8 +510,8 @@ void Pasteboard::read(PasteboardWebContentReader& reader, WebContentReadingPolic
         }
     }
 
-    if (types.contains(String(legacyRTFPasteboardType()))) {
-        if (auto buffer = readBufferAtPreferredItemIndex(legacyRTFPasteboardType(), itemIndex, strategy.get(), m_pasteboardName, context())) {
+    if (types.contains(String(legacyRTFPasteboardTypeSingleton()))) {
+        if (auto buffer = readBufferAtPreferredItemIndex(legacyRTFPasteboardTypeSingleton(), itemIndex, strategy.get(), m_pasteboardName, context())) {
             if (m_changeCount != changeCount() || reader.readRTF(*buffer))
                 return;
         }
@@ -529,9 +529,9 @@ void Pasteboard::read(PasteboardWebContentReader& reader, WebContentReadingPolic
 
     using ImageReadingInfo = std::tuple<String, ASCIILiteral>;
     const std::array<ImageReadingInfo, 6> imageTypesToRead { {
-        { String(legacyTIFFPasteboardType()), "image/tiff"_s },
+        { String(legacyTIFFPasteboardTypeSingleton()), "image/tiff"_s },
         { String(NSPasteboardTypeTIFF), "image/tiff"_s },
-        { String(legacyPDFPasteboardType()), "application/pdf"_s },
+        { String(legacyPDFPasteboardTypeSingleton()), "application/pdf"_s },
         { String(NSPasteboardTypePDF), "application/pdf"_s },
         { String(UTTypePNG.identifier), "image/png"_s },
         { String(UTTypeJPEG.identifier), "image/jpeg"_s }
@@ -566,15 +566,15 @@ void Pasteboard::read(PasteboardWebContentReader& reader, WebContentReadingPolic
             return;
     }
 
-    if (types.contains(String(legacyURLPasteboardType()))) {
+    if (types.contains(String(legacyURLPasteboardTypeSingleton()))) {
         URL url = strategy->url(m_pasteboardName, context());
         String title = readStringAtPreferredItemIndex(WebURLNamePboardType, itemIndex, strategy.get(), m_pasteboardName, context());
         if (m_changeCount != changeCount() || (!url.isNull() && reader.readURL(url, title)))
             return;
     }
 
-    if (types.contains(String(legacyStringPasteboardType()))) {
-        String string = readStringAtPreferredItemIndex(legacyStringPasteboardType(), itemIndex, strategy.get(), m_pasteboardName, context());
+    if (types.contains(String(legacyStringPasteboardTypeSingleton()))) {
+        String string = readStringAtPreferredItemIndex(legacyStringPasteboardTypeSingleton(), itemIndex, strategy.get(), m_pasteboardName, context());
         if (m_changeCount != changeCount() || (!string.isNull() && reader.readPlainText(string)))
             return;
     }
@@ -632,7 +632,7 @@ Vector<String> Pasteboard::readPlatformValuesAsStrings(const String& domType, in
         return { };
 
     auto values = strategy->allStringsForType(cocoaType, pasteboardName, context());
-    if (cocoaType == String(legacyStringPasteboardType())) {
+    if (cocoaType == String(legacyStringPasteboardTypeSingleton())) {
         values = values.map([&] (auto& value) -> String {
             return [value.createNSString() precomposedStringWithCanonicalMapping];
         });
@@ -663,15 +663,15 @@ void Pasteboard::addHTMLClipboardTypesForCocoaType(ListHashSet<String>& resultTy
         return; // Skip this ancient type that gets auto-supplied by some system conversion.
 
     // UTI may not do these right, so make sure we get the right, predictable result
-    if (cocoaType == String(legacyStringPasteboardType()) || cocoaType == String(NSPasteboardTypeString)) {
+    if (cocoaType == String(legacyStringPasteboardTypeSingleton()) || cocoaType == String(NSPasteboardTypeString)) {
         resultTypes.add(textPlainContentTypeAtom());
         return;
     }
-    if (cocoaType == String(legacyURLPasteboardType())) {
+    if (cocoaType == String(legacyURLPasteboardTypeSingleton())) {
         resultTypes.add("text/uri-list"_s);
         return;
     }
-    if (cocoaType == String(legacyFilenamesPasteboardType()) || Pasteboard::shouldTreatCocoaTypeAsFile(cocoaType))
+    if (cocoaType == String(legacyFilenamesPasteboardTypeSingleton()) || Pasteboard::shouldTreatCocoaTypeAsFile(cocoaType))
         return;
     String utiType = utiTypeFromCocoaType(cocoaType);
     if (!utiType.isEmpty()) {
@@ -687,7 +687,7 @@ void Pasteboard::writeString(const String& type, const String& data)
     const String& cocoaType = cocoaTypeFromHTMLClipboardType(type);
     String cocoaData = data;
 
-    if (cocoaType == String(legacyURLPasteboardType()) || cocoaType == String(UTTypeFileURL.identifier)) {
+    if (cocoaType == String(legacyURLPasteboardTypeSingleton()) || cocoaType == String(UTTypeFileURL.identifier)) {
         RetainPtr url = adoptNS([[NSURL alloc] initWithString:cocoaData.createNSString().get()]);
         if ([url isFileURL])
             return;
@@ -711,12 +711,12 @@ Vector<String> Pasteboard::readFilePaths()
     Vector<String> types;
     strategy->getTypes(types, m_pasteboardName, context());
 
-    if (types.contains(String(legacyFilesPromisePasteboardType())))
+    if (types.contains(String(legacyFilesPromisePasteboardTypeSingleton())))
         return m_promisedFilePaths;
 
-    if (types.contains(String(legacyFilenamesPasteboardType()))) {
+    if (types.contains(String(legacyFilenamesPasteboardTypeSingleton()))) {
         Vector<String> filePaths;
-        strategy->getPathnamesForType(filePaths, legacyFilenamesPasteboardType(), m_pasteboardName, context());
+        strategy->getPathnamesForType(filePaths, legacyFilenamesPasteboardTypeSingleton(), m_pasteboardName, context());
         return filePaths;
     }
 
@@ -835,7 +835,7 @@ RefPtr<WebCore::SharedBuffer> Pasteboard::bufferConvertedToPasteboardType(const 
     if (pasteboardBuffer.type == pasteboardType)
         return pasteboardBuffer.data;
 
-    if (pasteboardType != String(legacyTIFFPasteboardType()))
+    if (pasteboardType != String(legacyTIFFPasteboardTypeSingleton()))
         return pasteboardBuffer.data;
 
     if (pasteboardBuffer.type == String(UTTypeTIFF.identifier))

--- a/Source/WebCore/platform/mac/PasteboardWriter.mm
+++ b/Source/WebCore/platform/mac/PasteboardWriter.mm
@@ -86,11 +86,11 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
         // NSURLPboardType.
         if (NSURL *baseCocoaURL = nsURL.get().baseURL)
-            [pasteboardItem setPropertyList:@[ nsURL.get().relativeString, baseCocoaURL.absoluteString ] forType:toUTI(WebCore::legacyURLPasteboardType()).get()];
+            [pasteboardItem setPropertyList:@[ nsURL.get().relativeString, baseCocoaURL.absoluteString ] forType:toUTI(WebCore::legacyURLPasteboardTypeSingleton()).get()];
         else if (nsURL)
-            [pasteboardItem setPropertyList:@[ nsURL.get().absoluteString, @"" ] forType:toUTI(WebCore::legacyURLPasteboardType()).get()];
+            [pasteboardItem setPropertyList:@[ nsURL.get().absoluteString, @"" ] forType:toUTI(WebCore::legacyURLPasteboardTypeSingleton()).get()];
         else
-            [pasteboardItem setPropertyList:@[ @"", @"" ] forType:toUTI(WebCore::legacyURLPasteboardType()).get()];
+            [pasteboardItem setPropertyList:@[ @"", @"" ] forType:toUTI(WebCore::legacyURLPasteboardTypeSingleton()).get()];
 
         if (nsURL.get().fileURL)
             [pasteboardItem setString:nsURL.get().absoluteString forType:UTTypeFileURL.identifier];

--- a/Source/WebKit/Shared/mac/PasteboardTypes.mm
+++ b/Source/WebKit/Shared/mac/PasteboardTypes.mm
@@ -45,15 +45,15 @@ NSArray* PasteboardTypes::forEditing()
     static NeverDestroyed<RetainPtr<NSArray>> types = @[
         WebArchivePboardType,
         UTTypeWebArchive.identifier,
-        WebCore::legacyHTMLPasteboardType(),
-        WebCore::legacyFilenamesPasteboardType(),
-        WebCore::legacyTIFFPasteboardType(),
-        WebCore::legacyPDFPasteboardType(),
-        WebCore::legacyURLPasteboardType(),
-        WebCore::legacyRTFDPasteboardType(),
-        WebCore::legacyRTFPasteboardType(),
-        WebCore::legacyStringPasteboardType(),
-        WebCore::legacyColorPasteboardType(),
+        WebCore::legacyHTMLPasteboardTypeSingleton(),
+        WebCore::legacyFilenamesPasteboardTypeSingleton(),
+        WebCore::legacyTIFFPasteboardTypeSingleton(),
+        WebCore::legacyPDFPasteboardTypeSingleton(),
+        WebCore::legacyURLPasteboardTypeSingleton(),
+        WebCore::legacyRTFDPasteboardTypeSingleton(),
+        WebCore::legacyRTFPasteboardTypeSingleton(),
+        WebCore::legacyStringPasteboardTypeSingleton(),
+        WebCore::legacyColorPasteboardTypeSingleton(),
         UTTypePNG.identifier
     ];
     return types.get().get();
@@ -63,12 +63,12 @@ NSArray* PasteboardTypes::forURL()
 {
     static NeverDestroyed<RetainPtr<NSArray>> types = @[
         WebURLsWithTitlesPboardType,
-        WebCore::legacyURLPasteboardType(),
+        WebCore::legacyURLPasteboardTypeSingleton(),
         WebURLPboardType,
         WebURLNamePboardType,
-        WebCore::legacyStringPasteboardType(),
-        WebCore::legacyFilenamesPasteboardType(),
-        WebCore::legacyFilesPromisePasteboardType()
+        WebCore::legacyStringPasteboardTypeSingleton(),
+        WebCore::legacyFilenamesPasteboardTypeSingleton(),
+        WebCore::legacyFilesPromisePasteboardTypeSingleton()
     ];
     return types.get().get();
 }
@@ -76,12 +76,12 @@ NSArray* PasteboardTypes::forURL()
 NSArray* PasteboardTypes::forImages()
 {
     static NeverDestroyed<RetainPtr<NSArray>> types = @[
-        WebCore::legacyTIFFPasteboardType(),
+        WebCore::legacyTIFFPasteboardTypeSingleton(),
         WebURLsWithTitlesPboardType,
-        WebCore::legacyURLPasteboardType(),
+        WebCore::legacyURLPasteboardTypeSingleton(),
         WebURLPboardType,
         WebURLNamePboardType,
-        WebCore::legacyStringPasteboardType()
+        WebCore::legacyStringPasteboardTypeSingleton()
     ];
     return types.get().get();
 }
@@ -89,13 +89,13 @@ NSArray* PasteboardTypes::forImages()
 NSArray* PasteboardTypes::forImagesWithArchive()
 {
     static NeverDestroyed<RetainPtr<NSArray>> types = @[
-        WebCore::legacyTIFFPasteboardType(),
+        WebCore::legacyTIFFPasteboardTypeSingleton(),
         WebURLsWithTitlesPboardType,
-        WebCore::legacyURLPasteboardType(),
+        WebCore::legacyURLPasteboardTypeSingleton(),
         WebURLPboardType,
         WebURLNamePboardType,
-        WebCore::legacyStringPasteboardType(),
-        WebCore::legacyRTFDPasteboardType(),
+        WebCore::legacyStringPasteboardTypeSingleton(),
+        WebCore::legacyRTFDPasteboardTypeSingleton(),
         WebArchivePboardType
     ];
     return types.get().get();
@@ -107,9 +107,9 @@ NSArray* PasteboardTypes::forSelection()
         WebArchivePboardType,
         UTTypeWebArchive.identifier,
         NSPasteboardTypeRTF,
-        WebCore::legacyRTFDPasteboardType(),
-        WebCore::legacyRTFPasteboardType(),
-        WebCore::legacyStringPasteboardType()
+        WebCore::legacyRTFDPasteboardTypeSingleton(),
+        WebCore::legacyRTFPasteboardTypeSingleton(),
+        WebCore::legacyStringPasteboardTypeSingleton()
     ];
     return types.get().get();
 }

--- a/Source/WebKit/UIProcess/Cocoa/GlobalFindInPageState.mm
+++ b/Source/WebKit/UIProcess/Cocoa/GlobalFindInPageState.mm
@@ -55,7 +55,7 @@ static String& globalStringForFind()
 void updateStringForFind(const String& string)
 {
 #if PLATFORM(MAC)
-    [findPasteboard() setString:string.createNSString().get() forType:WebCore::legacyStringPasteboardType()];
+    [findPasteboard() setString:string.createNSString().get() forType:WebCore::legacyStringPasteboardTypeSingleton()];
 #else
     globalStringForFind() = string;
 #endif
@@ -64,7 +64,7 @@ void updateStringForFind(const String& string)
 String stringForFind()
 {
 #if PLATFORM(MAC)
-    return [findPasteboard() stringForType:WebCore::legacyStringPasteboardType()];
+    return [findPasteboard() stringForType:WebCore::legacyStringPasteboardTypeSingleton()];
 #else
     return globalStringForFind();
 #endif

--- a/Source/WebKit/UIProcess/Cocoa/WebPasteboardProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPasteboardProxyCocoa.mm
@@ -83,7 +83,7 @@ std::optional<IPC::AsyncReplyID> WebPasteboardProxy::grantAccessToCurrentData(We
     }
 #if PLATFORM(MAC)
     if (!paths.size())
-        pasteboard.getPathnamesForType(paths, legacyFilenamesPasteboardType());
+        pasteboard.getPathnamesForType(paths, legacyFilenamesPasteboardTypeSingleton());
 #endif
 
     if (!paths.size()) {
@@ -212,7 +212,7 @@ void WebPasteboardProxy::getPasteboardPathnamesForType(IPC::Connection& connecti
             PlatformPasteboard(pasteboardName).getPathnamesForType(pathnames, pasteboardType);
             // On iOS, files are copied into app's container upon paste.
 #if PLATFORM(MAC)
-            bool needsExtensions = pasteboardType == String(WebCore::legacyFilenamesPasteboardType());
+            bool needsExtensions = pasteboardType == String(WebCore::legacyFilenamesPasteboardTypeSingleton());
             sandboxExtensions = pathnames.map([needsExtensions](auto& filename) {
                 if (!needsExtensions || ![[NSFileManager defaultManager] fileExistsAtPath:filename.createNSString().get()])
                     return SandboxExtension::Handle { };

--- a/Source/WebKit/UIProcess/mac/WKSharingServicePickerDelegate.mm
+++ b/Source/WebKit/UIProcess/mac/WKSharingServicePickerDelegate.mm
@@ -135,7 +135,7 @@
         dataReference = span(data.get());
 
         types.append(NSPasteboardTypeRTFD);
-        types.append(WebCore::legacyRTFDPasteboardType());
+        types.append(WebCore::legacyRTFDPasteboardTypeSingleton());
     } else if (RetainPtr data = dynamic_objc_cast<NSData>(item.get())) {
         RetainPtr<CGImageSourceRef> source = adoptCF(CGImageSourceCreateWithData(bridge_cast(data.get()), NULL));
         RetainPtr<CGImageRef> image = adoptCF(CGImageSourceCreateImageAtIndex(source.get(), 0, NULL));

--- a/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
@@ -181,8 +181,8 @@ void WebPageProxy::searchTheWeb(const String& string)
     [pasteboard clearContents];
     if (sessionID().isEphemeral())
         [pasteboard _setExpirationDate:[NSDate dateWithTimeIntervalSinceNow:pasteboardExpirationDelay.seconds()]];
-    [pasteboard addTypes:@[legacyStringPasteboardType()] owner:nil];
-    [pasteboard setString:string.createNSString().get() forType:legacyStringPasteboardType()];
+    [pasteboard addTypes:@[legacyStringPasteboardTypeSingleton()] owner:nil];
+    [pasteboard setString:string.createNSString().get() forType:legacyStringPasteboardTypeSingleton()];
 
     NSPerformService(@"Search With %WebSearchProvider@", pasteboard.get());
 }

--- a/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
@@ -1184,31 +1184,31 @@ static NSControlStateValue kit(TriState state)
     if ([types containsObject:WebArchivePboardType] && (fragment = [self _documentFragmentFromPasteboard:pasteboard forType:WebArchivePboardType inContext:context subresources:0]))
         return fragment;
 
-    if ([types containsObject:WebCore::legacyFilenamesPasteboardType()] && (fragment = [self _documentFragmentFromPasteboard:pasteboard forType:WebCore::legacyFilenamesPasteboardType() inContext:context subresources:0]))
+    if ([types containsObject:WebCore::legacyFilenamesPasteboardTypeSingleton()] && (fragment = [self _documentFragmentFromPasteboard:pasteboard forType:WebCore::legacyFilenamesPasteboardTypeSingleton() inContext:context subresources:0]))
         return fragment;
     
-    if ([types containsObject:WebCore::legacyHTMLPasteboardType()] && (fragment = [self _documentFragmentFromPasteboard:pasteboard forType:WebCore::legacyHTMLPasteboardType() inContext:context subresources:0]))
+    if ([types containsObject:WebCore::legacyHTMLPasteboardTypeSingleton()] && (fragment = [self _documentFragmentFromPasteboard:pasteboard forType:WebCore::legacyHTMLPasteboardTypeSingleton() inContext:context subresources:0]))
         return fragment;
     
-    if ([types containsObject:WebCore::legacyRTFDPasteboardType()] && (fragment = [self _documentFragmentFromPasteboard:pasteboard forType:WebCore::legacyRTFDPasteboardType() inContext:context subresources:0]))
+    if ([types containsObject:WebCore::legacyRTFDPasteboardTypeSingleton()] && (fragment = [self _documentFragmentFromPasteboard:pasteboard forType:WebCore::legacyRTFDPasteboardTypeSingleton() inContext:context subresources:0]))
         return fragment;
     
-    if ([types containsObject:WebCore::legacyRTFPasteboardType()] && (fragment = [self _documentFragmentFromPasteboard:pasteboard forType:WebCore::legacyRTFPasteboardType() inContext:context subresources:0]))
+    if ([types containsObject:WebCore::legacyRTFPasteboardTypeSingleton()] && (fragment = [self _documentFragmentFromPasteboard:pasteboard forType:WebCore::legacyRTFPasteboardTypeSingleton() inContext:context subresources:0]))
         return fragment;
 
-    if ([types containsObject:WebCore::legacyTIFFPasteboardType()] && (fragment = [self _documentFragmentFromPasteboard:pasteboard forType:WebCore::legacyTIFFPasteboardType() inContext:context subresources:0]))
+    if ([types containsObject:WebCore::legacyTIFFPasteboardTypeSingleton()] && (fragment = [self _documentFragmentFromPasteboard:pasteboard forType:WebCore::legacyTIFFPasteboardTypeSingleton() inContext:context subresources:0]))
         return fragment;
 
-    if ([types containsObject:WebCore::legacyPDFPasteboardType()] && (fragment = [self _documentFragmentFromPasteboard:pasteboard forType:WebCore::legacyPDFPasteboardType() inContext:context subresources:0]))
+    if ([types containsObject:WebCore::legacyPDFPasteboardTypeSingleton()] && (fragment = [self _documentFragmentFromPasteboard:pasteboard forType:WebCore::legacyPDFPasteboardTypeSingleton() inContext:context subresources:0]))
         return fragment;
 
     if ([types containsObject:UTTypePNG.identifier] && (fragment = [self _documentFragmentFromPasteboard:pasteboard forType:UTTypePNG.identifier inContext:context subresources:0]))
         return fragment;
 
-    if ([types containsObject:WebCore::legacyURLPasteboardType()] && (fragment = [self _documentFragmentFromPasteboard:pasteboard forType:WebCore::legacyURLPasteboardType() inContext:context subresources:0]))
+    if ([types containsObject:WebCore::legacyURLPasteboardTypeSingleton()] && (fragment = [self _documentFragmentFromPasteboard:pasteboard forType:WebCore::legacyURLPasteboardTypeSingleton() inContext:context subresources:0]))
         return fragment;
 
-    if (allowPlainText && [types containsObject:WebCore::legacyStringPasteboardType()] && (fragment = [self _documentFragmentFromPasteboard:pasteboard forType:WebCore::legacyStringPasteboardType() inContext:context subresources:0]))
+    if (allowPlainText && [types containsObject:WebCore::legacyStringPasteboardTypeSingleton()] && (fragment = [self _documentFragmentFromPasteboard:pasteboard forType:WebCore::legacyStringPasteboardTypeSingleton() inContext:context subresources:0]))
         return fragment;
     
     return nil;
@@ -1218,19 +1218,19 @@ static NSControlStateValue kit(TriState state)
 {
     NSArray *types = [pasteboard types];
     
-    if ([types containsObject:WebCore::legacyStringPasteboardType()])
-        return [[pasteboard stringForType:WebCore::legacyStringPasteboardType()] precomposedStringWithCanonicalMapping];
+    if ([types containsObject:WebCore::legacyStringPasteboardTypeSingleton()])
+        return [[pasteboard stringForType:WebCore::legacyStringPasteboardTypeSingleton()] precomposedStringWithCanonicalMapping];
 
     RetainPtr<NSAttributedString> attributedString;
-    if ([types containsObject:WebCore::legacyRTFDPasteboardType()])
-        attributedString = adoptNS([[NSAttributedString alloc] initWithRTFD:[pasteboard dataForType:WebCore::legacyRTFDPasteboardType()] documentAttributes:NULL]);
-    if (!attributedString && [types containsObject:WebCore::legacyRTFPasteboardType()])
-        attributedString = adoptNS([[NSAttributedString alloc] initWithRTF:[pasteboard dataForType:WebCore::legacyRTFPasteboardType()] documentAttributes:NULL]);
+    if ([types containsObject:WebCore::legacyRTFDPasteboardTypeSingleton()])
+        attributedString = adoptNS([[NSAttributedString alloc] initWithRTFD:[pasteboard dataForType:WebCore::legacyRTFDPasteboardTypeSingleton()] documentAttributes:NULL]);
+    if (!attributedString && [types containsObject:WebCore::legacyRTFPasteboardTypeSingleton()])
+        attributedString = adoptNS([[NSAttributedString alloc] initWithRTF:[pasteboard dataForType:WebCore::legacyRTFPasteboardTypeSingleton()] documentAttributes:NULL]);
     if (attributedString)
         return adoptNS([[attributedString string] copy]).autorelease();
 
-    if ([types containsObject:WebCore::legacyFilenamesPasteboardType()]) {
-        if (NSString *string = [[pasteboard propertyListForType:WebCore::legacyFilenamesPasteboardType()] componentsJoinedByString:@"\n"])
+    if ([types containsObject:WebCore::legacyFilenamesPasteboardTypeSingleton()]) {
+        if (NSString *string = [[pasteboard propertyListForType:WebCore::legacyFilenamesPasteboardTypeSingleton()] componentsJoinedByString:@"\n"])
             return string;
     }
 
@@ -1365,27 +1365,27 @@ static NSControlStateValue kit(TriState state)
     }
 
     // Put the attributed string on the pasteboard (RTF/RTFD format).
-    if ([types containsObject:WebCore::legacyRTFDPasteboardType()]) {
+    if ([types containsObject:WebCore::legacyRTFDPasteboardTypeSingleton()]) {
         if (attributedString == nil) {
             attributedString = [self selectedAttributedString];
         }        
         NSData *RTFDData = [attributedString RTFDFromRange:NSMakeRange(0, [attributedString length]) documentAttributes:@{ }];
-        [pasteboard setData:RTFDData forType:WebCore::legacyRTFDPasteboardType()];
+        [pasteboard setData:RTFDData forType:WebCore::legacyRTFDPasteboardTypeSingleton()];
     }        
-    if ([types containsObject:WebCore::legacyRTFPasteboardType()]) {
+    if ([types containsObject:WebCore::legacyRTFPasteboardTypeSingleton()]) {
         if (!attributedString)
             attributedString = [self selectedAttributedString];
         if ([attributedString containsAttachments])
             attributedString = WebCore::attributedStringByStrippingAttachmentCharacters(attributedString);
         NSData *RTFData = [attributedString RTFFromRange:NSMakeRange(0, [attributedString length]) documentAttributes:@{ }];
-        [pasteboard setData:RTFData forType:WebCore::legacyRTFPasteboardType()];
+        [pasteboard setData:RTFData forType:WebCore::legacyRTFPasteboardTypeSingleton()];
     }
 
     // Put plain string on the pasteboard.
-    if ([types containsObject:WebCore::legacyStringPasteboardType()]) {
+    if ([types containsObject:WebCore::legacyStringPasteboardTypeSingleton()]) {
         // Map &nbsp; to a plain old space because this is better for source code, other browsers do it, and
         // because HTML forces content creators and editors to use this character any time they want two spaces in a row.
-        [pasteboard setString:[[self selectedString] stringByReplacingOccurrencesOfString:@"\u00A0" withString:@" "] forType:WebCore::legacyStringPasteboardType()];
+        [pasteboard setString:[[self selectedString] stringByReplacingOccurrencesOfString:@"\u00A0" withString:@" "] forType:WebCore::legacyStringPasteboardTypeSingleton()];
     }
 
     if ([self _canSmartCopyOrDelete] && [types containsObject:WebSmartPastePboardType])
@@ -1963,9 +1963,9 @@ static bool mouseEventIsPartOfClickOrDrag(NSEvent *event)
 {
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     static NeverDestroyed<RetainPtr<NSArray>> types = @[
-        WebArchivePboardType, WebCore::legacyHTMLPasteboardType(), WebCore::legacyFilenamesPasteboardType(), WebCore::legacyTIFFPasteboardType(),
-        WebCore::legacyPDFPasteboardType(), WebCore::legacyURLPasteboardType(), WebCore::legacyRTFDPasteboardType(), WebCore::legacyRTFPasteboardType(),
-        WebCore::legacyStringPasteboardType(), WebCore::legacyColorPasteboardType(), UTTypePNG.identifier,
+        WebArchivePboardType, WebCore::legacyHTMLPasteboardTypeSingleton(), WebCore::legacyFilenamesPasteboardTypeSingleton(), WebCore::legacyTIFFPasteboardTypeSingleton(),
+        WebCore::legacyPDFPasteboardTypeSingleton(), WebCore::legacyURLPasteboardTypeSingleton(), WebCore::legacyRTFDPasteboardTypeSingleton(), WebCore::legacyRTFPasteboardTypeSingleton(),
+        WebCore::legacyStringPasteboardTypeSingleton(), WebCore::legacyColorPasteboardTypeSingleton(), UTTypePNG.identifier,
     ];
 ALLOW_DEPRECATED_DECLARATIONS_END
     return types.get().get();
@@ -1974,7 +1974,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 + (NSArray *)_selectionPasteboardTypes
 {
     // FIXME: We should put data for NSHTMLPboardType on the pasteboard but Microsoft Excel doesn't like our format of HTML (3640423).
-    return @[WebArchivePboardType, WebCore::legacyRTFDPasteboardType(), WebCore::legacyRTFPasteboardType(), WebCore::legacyStringPasteboardType()];
+    return @[WebArchivePboardType, WebCore::legacyRTFDPasteboardTypeSingleton(), WebCore::legacyRTFPasteboardTypeSingleton(), WebCore::legacyStringPasteboardTypeSingleton()];
 }
 
 ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
@@ -1988,12 +1988,12 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
 - (void)pasteboard:(NSPasteboard *)pasteboard provideDataForType:(NSString *)type
 ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 {
-    if ([type isEqualToString:WebCore::legacyRTFDPasteboardType()] && [[pasteboard types] containsObject:WebArchivePboardType]) {
+    if ([type isEqualToString:WebCore::legacyRTFDPasteboardTypeSingleton()] && [[pasteboard types] containsObject:WebArchivePboardType]) {
         auto archive = adoptNS([[WebArchive alloc] initWithData:[pasteboard dataForType:WebArchivePboardType]]);
-        [pasteboard _web_writePromisedRTFDFromArchive:archive.get() containsImage:[[pasteboard types] containsObject:WebCore::legacyTIFFPasteboardType()]];
-    } else if ([type isEqualToString:WebCore::legacyTIFFPasteboardType()] && _private->promisedDragTIFFDataSource) {
+        [pasteboard _web_writePromisedRTFDFromArchive:archive.get() containsImage:[[pasteboard types] containsObject:WebCore::legacyTIFFPasteboardTypeSingleton()]];
+    } else if ([type isEqualToString:WebCore::legacyTIFFPasteboardTypeSingleton()] && _private->promisedDragTIFFDataSource) {
         if (auto* image = _private->promisedDragTIFFDataSource->image())
-            [pasteboard setData:(__bridge NSData *)image->adapter().tiffRepresentation() forType:WebCore::legacyTIFFPasteboardType()];
+            [pasteboard setData:(__bridge NSData *)image->adapter().tiffRepresentation() forType:WebCore::legacyTIFFPasteboardTypeSingleton()];
         [self setPromisedDragTIFFDataSource:nullptr];
     }
 }
@@ -2232,7 +2232,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     RetainPtr<NSMutableArray> mutableTypes;
     if (![attributedString containsAttachments]) {
         mutableTypes = adoptNS([types mutableCopy]);
-        [mutableTypes removeObject:WebCore::legacyRTFDPasteboardType()];
+        [mutableTypes removeObject:WebCore::legacyRTFDPasteboardTypeSingleton()];
         types = mutableTypes.get();
     }
 
@@ -2297,11 +2297,11 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         return [[self _dataSource] _documentFragmentWithArchive:archive.get()];
     }
 
-    if ([pboardType isEqualToString:WebCore::legacyFilenamesPasteboardType()])
-        return [self _documentFragmentWithPaths:[pasteboard propertyListForType:WebCore::legacyFilenamesPasteboardType()]];
+    if ([pboardType isEqualToString:WebCore::legacyFilenamesPasteboardTypeSingleton()])
+        return [self _documentFragmentWithPaths:[pasteboard propertyListForType:WebCore::legacyFilenamesPasteboardTypeSingleton()]];
 
-    if ([pboardType isEqualToString:WebCore::legacyHTMLPasteboardType()]) {
-        NSString *HTMLString = [pasteboard stringForType:WebCore::legacyHTMLPasteboardType()];
+    if ([pboardType isEqualToString:WebCore::legacyHTMLPasteboardTypeSingleton()]) {
+        NSString *HTMLString = [pasteboard stringForType:WebCore::legacyHTMLPasteboardTypeSingleton()];
         // This is a hack to make Microsoft's HTML pasteboard data work. See 3778785.
         if ([HTMLString hasPrefix:@"Version:"]) {
             NSRange range = [HTMLString rangeOfString:@"<html" options:NSCaseInsensitiveSearch];
@@ -2313,12 +2313,12 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         return [[self _frame] _documentFragmentWithMarkupString:HTMLString baseURLString:nil];
     }
 
-    if ([pboardType isEqualToString:WebCore::legacyRTFPasteboardType()] || [pboardType isEqualToString:WebCore::legacyRTFDPasteboardType()]) {
+    if ([pboardType isEqualToString:WebCore::legacyRTFPasteboardTypeSingleton()] || [pboardType isEqualToString:WebCore::legacyRTFDPasteboardTypeSingleton()]) {
         RetainPtr<NSAttributedString> string;
-        if ([pboardType isEqualToString:WebCore::legacyRTFDPasteboardType()])
-            string = adoptNS([[NSAttributedString alloc] initWithRTFD:[pasteboard dataForType:WebCore::legacyRTFDPasteboardType()] documentAttributes:NULL]);
+        if ([pboardType isEqualToString:WebCore::legacyRTFDPasteboardTypeSingleton()])
+            string = adoptNS([[NSAttributedString alloc] initWithRTFD:[pasteboard dataForType:WebCore::legacyRTFDPasteboardTypeSingleton()] documentAttributes:NULL]);
         if (!string)
-            string = adoptNS([[NSAttributedString alloc] initWithRTF:[pasteboard dataForType:WebCore::legacyRTFPasteboardType()] documentAttributes:NULL]);
+            string = adoptNS([[NSAttributedString alloc] initWithRTF:[pasteboard dataForType:WebCore::legacyRTFPasteboardTypeSingleton()] documentAttributes:NULL]);
         if (!string)
             return nil;
 
@@ -2346,14 +2346,14 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         return fragment;
     }
 
-    if ([pboardType isEqualToString:WebCore::legacyTIFFPasteboardType()])
-        return [self _web_documentFragmentFromPasteboard:pasteboard pasteboardType:WebCore::legacyTIFFPasteboardType() imageMIMEType:@"image/tiff"];
-    if ([pboardType isEqualToString:WebCore::legacyPDFPasteboardType()])
-        return [self _web_documentFragmentFromPasteboard:pasteboard pasteboardType:WebCore::legacyPDFPasteboardType() imageMIMEType:@"application/pdf"];
+    if ([pboardType isEqualToString:WebCore::legacyTIFFPasteboardTypeSingleton()])
+        return [self _web_documentFragmentFromPasteboard:pasteboard pasteboardType:WebCore::legacyTIFFPasteboardTypeSingleton() imageMIMEType:@"image/tiff"];
+    if ([pboardType isEqualToString:WebCore::legacyPDFPasteboardTypeSingleton()])
+        return [self _web_documentFragmentFromPasteboard:pasteboard pasteboardType:WebCore::legacyPDFPasteboardTypeSingleton() imageMIMEType:@"application/pdf"];
     if ([pboardType isEqualToString:UTTypePNG.identifier])
         return [self _web_documentFragmentFromPasteboard:pasteboard pasteboardType:UTTypePNG.identifier imageMIMEType:@"image/png"];
 
-    if ([pboardType isEqualToString:WebCore::legacyURLPasteboardType()]) {
+    if ([pboardType isEqualToString:WebCore::legacyURLPasteboardTypeSingleton()]) {
         NSURL *URL = [NSURL URLFromPasteboard:pasteboard];
         DOMDocument* document = [[self _frame] DOMDocument];
         ASSERT(document);
@@ -2372,10 +2372,10 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         return fragment;
     }
 
-    if ([pboardType isEqualToString:WebCore::legacyStringPasteboardType()]) {
+    if ([pboardType isEqualToString:WebCore::legacyStringPasteboardTypeSingleton()]) {
         if (!context)
             return nil;
-        auto string = [[pasteboard stringForType:WebCore::legacyStringPasteboardType()] precomposedStringWithCanonicalMapping];
+        auto string = [[pasteboard stringForType:WebCore::legacyStringPasteboardTypeSingleton()] precomposedStringWithCanonicalMapping];
         return kit(createFragmentFromText(makeSimpleRange(*core(context)), string).ptr());
     }
 
@@ -2834,7 +2834,7 @@ WEBCORE_COMMAND(toggleUnderline)
         isReturnTypeOK = YES;
     else if ([[[self class] _insertablePasteboardTypes] containsObject:returnType] && [self _isEditable]) {
         // We can insert strings in any editable context.  We can insert other types, like images, only in rich edit contexts.
-        isReturnTypeOK = [returnType isEqualToString:WebCore::legacyStringPasteboardType()] || [self _canEditRichly];
+        isReturnTypeOK = [returnType isEqualToString:WebCore::legacyStringPasteboardTypeSingleton()] || [self _canEditRichly];
     }
     if (isSendTypeOK && isReturnTypeOK)
         return self;
@@ -5079,7 +5079,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     NSPasteboard *fontPasteboard = [NSPasteboard pasteboardWithName:NSPasteboardNameFont];
     if (fontPasteboard == nil)
         return nil;
-    NSData *data = [fontPasteboard dataForType:WebCore::legacyFontPasteboardType()];
+    NSData *data = [fontPasteboard dataForType:WebCore::legacyFontPasteboardTypeSingleton()];
     if (data == nil || [data length] == 0)
         return nil;
     // NSTextView does something more efficient by parsing the attributes only, but that's not available in API.
@@ -5284,8 +5284,8 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     // Put RTF with font attributes on the pasteboard.
     // Maybe later we should add a pasteboard type that contains CSS text for "native" copy and paste font.
     NSPasteboard *fontPasteboard = [NSPasteboard pasteboardWithName:NSPasteboardNameFont];
-    [fontPasteboard declareTypes:@[WebCore::legacyFontPasteboardType()] owner:nil];
-    [fontPasteboard setData:[self _selectionStartFontAttributesAsRTF] forType:WebCore::legacyFontPasteboardType()];
+    [fontPasteboard declareTypes:@[WebCore::legacyFontPasteboardTypeSingleton()] owner:nil];
+    [fontPasteboard setData:[self _selectionStartFontAttributesAsRTF] forType:WebCore::legacyFontPasteboardTypeSingleton()];
 }
 
 - (void)pasteFont:(id)sender

--- a/Source/WebKitLegacy/mac/WebView/WebPDFView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebPDFView.mm
@@ -905,28 +905,28 @@ static BOOL _PDFSelectionsAreEqual(PDFSelection *selectionA, PDFSelection *selec
 
 - (NSArray *)pasteboardTypesForSelection
 {
-    return @[WebCore::legacyRTFDPasteboardType(), WebCore::legacyRTFPasteboardType(), WebCore::legacyStringPasteboardType()];
+    return @[WebCore::legacyRTFDPasteboardTypeSingleton(), WebCore::legacyRTFPasteboardTypeSingleton(), WebCore::legacyStringPasteboardTypeSingleton()];
 }
 
 - (void)writeSelectionWithPasteboardTypes:(NSArray *)types toPasteboard:(NSPasteboard *)pasteboard
 {
     NSAttributedString *attributedString = [self selectedAttributedString];
     
-    if ([types containsObject:WebCore::legacyRTFDPasteboardType()]) {
+    if ([types containsObject:WebCore::legacyRTFDPasteboardTypeSingleton()]) {
         NSData *RTFDData = [attributedString RTFDFromRange:NSMakeRange(0, [attributedString length]) documentAttributes:@{ }];
-        [pasteboard setData:RTFDData forType:WebCore::legacyRTFDPasteboardType()];
+        [pasteboard setData:RTFDData forType:WebCore::legacyRTFDPasteboardTypeSingleton()];
     }        
     
-    if ([types containsObject:WebCore::legacyRTFPasteboardType()]) {
+    if ([types containsObject:WebCore::legacyRTFPasteboardTypeSingleton()]) {
         if ([attributedString containsAttachments])
             attributedString = WebCore::attributedStringByStrippingAttachmentCharacters(attributedString);
 
         NSData *RTFData = [attributedString RTFFromRange:NSMakeRange(0, [attributedString length]) documentAttributes:@{ }];
-        [pasteboard setData:RTFData forType:WebCore::legacyRTFPasteboardType()];
+        [pasteboard setData:RTFData forType:WebCore::legacyRTFPasteboardTypeSingleton()];
     }
     
-    if ([types containsObject:WebCore::legacyStringPasteboardType()])
-        [pasteboard setString:[self selectedString] forType:WebCore::legacyStringPasteboardType()];
+    if ([types containsObject:WebCore::legacyStringPasteboardTypeSingleton()])
+        [pasteboard setString:[self selectedString] forType:WebCore::legacyStringPasteboardTypeSingleton()];
 }
 
 // MARK: PDFView DELEGATE METHODS

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -6322,12 +6322,12 @@ static bool needsWebViewInitThreadWorkaround()
     auto* dragData = new WebCore::DragData(draggingInfo, client, global, coreDragOperationMask([draggingInfo draggingSourceOperationMask]), [self _applicationFlagsForDrag:draggingInfo]);
 
     NSArray* types = draggingInfo.draggingPasteboard.types;
-    if (![types containsObject:WebArchivePboardType] && [types containsObject:WebCore::legacyFilesPromisePasteboardType()]) {
+    if (![types containsObject:WebArchivePboardType] && [types containsObject:WebCore::legacyFilesPromisePasteboardTypeSingleton()]) {
 
-        // FIXME: legacyFilesPromisePasteboardType() contains UTIs, not path names. Also, it's not
+        // FIXME: legacyFilesPromisePasteboardTypeSingleton() contains UTIs, not path names. Also, it's not
         // guaranteed that the count of UTIs equals the count of files, since some clients only write
         // unique UTIs.
-        NSArray *files = [draggingInfo.draggingPasteboard propertyListForType:WebCore::legacyFilesPromisePasteboardType()];
+        NSArray *files = [draggingInfo.draggingPasteboard propertyListForType:WebCore::legacyFilesPromisePasteboardTypeSingleton()];
         if (![files isKindOfClass:[NSArray class]]) {
             delete dragData;
             return false;
@@ -8587,12 +8587,12 @@ FORWARD(toggleUnderline)
     }
 
     NSPasteboard *pasteboard = [NSPasteboard pasteboardWithUniqueName];
-    [pasteboard declareTypes:@[WebCore::legacyStringPasteboardType()] owner:nil];
+    [pasteboard declareTypes:@[WebCore::legacyStringPasteboardTypeSingleton()] owner:nil];
     auto s = adoptNS([selectedString mutableCopy]);
     const unichar nonBreakingSpaceCharacter = 0xA0;
     NSString *nonBreakingSpaceString = [NSString stringWithCharacters:&nonBreakingSpaceCharacter length:1];
     [s replaceOccurrencesOfString:nonBreakingSpaceString withString:@" " options:0 range:NSMakeRange(0, [s length])];
-    [pasteboard setString:s.get() forType:WebCore::legacyStringPasteboardType()];
+    [pasteboard setString:s.get() forType:WebCore::legacyStringPasteboardTypeSingleton()];
 
     // FIXME: seems fragile to use the service by name, but this is what AppKit does
     NSPerformService(@"Search With Google", pasteboard);

--- a/Tools/TestRunnerShared/mac/NSPasteboardAdditions.mm
+++ b/Tools/TestRunnerShared/mac/NSPasteboardAdditions.mm
@@ -41,31 +41,31 @@
             type = legacyType.bridgingAutorelease();
     }
 
-    if ([type isEqualToString:WebCore::legacyStringPasteboardType()])
+    if ([type isEqualToString:WebCore::legacyStringPasteboardTypeSingleton()])
         return NSPasteboardTypeString;
 
-    if ([type isEqualToString:WebCore::legacyHTMLPasteboardType()])
+    if ([type isEqualToString:WebCore::legacyHTMLPasteboardTypeSingleton()])
         return NSPasteboardTypeHTML;
 
-    if ([type isEqualToString:WebCore::legacyTIFFPasteboardType()])
+    if ([type isEqualToString:WebCore::legacyTIFFPasteboardTypeSingleton()])
         return NSPasteboardTypeTIFF;
 
-    if ([type isEqualToString:WebCore::legacyURLPasteboardType()])
+    if ([type isEqualToString:WebCore::legacyURLPasteboardTypeSingleton()])
         return NSPasteboardTypeURL;
 
-    if ([type isEqualToString:WebCore::legacyPDFPasteboardType()])
+    if ([type isEqualToString:WebCore::legacyPDFPasteboardTypeSingleton()])
         return NSPasteboardTypePDF;
 
-    if ([type isEqualToString:WebCore::legacyRTFDPasteboardType()])
+    if ([type isEqualToString:WebCore::legacyRTFDPasteboardTypeSingleton()])
         return NSPasteboardTypeRTFD;
 
-    if ([type isEqualToString:WebCore::legacyRTFPasteboardType()])
+    if ([type isEqualToString:WebCore::legacyRTFPasteboardTypeSingleton()])
         return NSPasteboardTypeRTF;
 
-    if ([type isEqualToString:WebCore::legacyColorPasteboardType()])
+    if ([type isEqualToString:WebCore::legacyColorPasteboardTypeSingleton()])
         return NSPasteboardTypeColor;
 
-    if ([type isEqualToString:WebCore::legacyFontPasteboardType()])
+    if ([type isEqualToString:WebCore::legacyFontPasteboardTypeSingleton()])
         return NSPasteboardTypeFont;
 
     return type;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ClipboardTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ClipboardTests.mm
@@ -140,7 +140,7 @@ static void writeMultipleObjectsToPlatformPasteboard()
 static RetainPtr<NSString> readMarkupFromPasteboard()
 {
 #if PLATFORM(MAC)
-    NSData *rawData = [NSPasteboard.generalPasteboard dataForType:WebCore::legacyHTMLPasteboardType()];
+    NSData *rawData = [NSPasteboard.generalPasteboard dataForType:WebCore::legacyHTMLPasteboardTypeSingleton()];
 #else
     NSData *rawData = [UIPasteboard.generalPasteboard dataForPasteboardType:UTTypeHTML.identifier];
 #endif

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/PasteHTML.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/PasteHTML.mm
@@ -51,8 +51,8 @@
 
 void writeHTMLToPasteboard(NSString *html)
 {
-    [[NSPasteboard generalPasteboard] declareTypes:@[WebCore::legacyHTMLPasteboardType()] owner:nil];
-    [[NSPasteboard generalPasteboard] setString:html forType:WebCore::legacyHTMLPasteboardType()];
+    [[NSPasteboard generalPasteboard] declareTypes:@[WebCore::legacyHTMLPasteboardTypeSingleton()] owner:nil];
+    [[NSPasteboard generalPasteboard] setString:html forType:WebCore::legacyHTMLPasteboardTypeSingleton()];
 }
 #else
 void writeHTMLToPasteboard(NSString *html)


### PR DESCRIPTION
#### bd8e8fcc81eb7b4bd6b5f11cc2eabc6d61f27940
<pre>
Address Safer CPP warnings in PlatformPasteboardMac.mm
<a href="https://bugs.webkit.org/show_bug.cgi?id=299153">https://bugs.webkit.org/show_bug.cgi?id=299153</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations:
* Source/WebCore/editing/cocoa/EditorCocoa.mm:
(WebCore::Editor::takeFindStringFromSelection):
* Source/WebCore/editing/mac/EditorMac.mm:
(WebCore::Editor::platformCopyFont):
(WebCore::Editor::platformPasteFont):
(WebCore::Editor::dataSelectionForPasteboard):
* Source/WebCore/platform/cocoa/DragDataCocoa.mm:
(WebCore::rtfPasteboardType):
(WebCore::rtfdPasteboardType):
(WebCore::stringPasteboardType):
(WebCore::urlPasteboardType):
(WebCore::htmlPasteboardType):
(WebCore::colorPasteboardType):
(WebCore::pdfPasteboardType):
(WebCore::tiffPasteboardType):
(WebCore::DragData::asFilenames const):
(WebCore::DragData::containsPlainText const):
(WebCore::DragData::containsCompatibleContent const):
(WebCore::DragData::containsPromise const):
(WebCore::DragData::containsURL const):
(WebCore::DragData::asURL const):
* Source/WebCore/platform/cocoa/PasteboardCocoa.mm:
(WebCore::cocoaTypeToImageType):
(WebCore::Pasteboard::fileContentState):
* Source/WebCore/platform/cocoa/PlatformPasteboardCocoa.mm:
(WebCore::PlatformPasteboard::urlStringSuitableForLoading):
* Source/WebCore/platform/mac/LegacyNSPasteboardTypes.h:
(WebCore::legacyStringPasteboardTypeSingleton):
(WebCore::legacyFilenamesPasteboardTypeSingleton):
(WebCore::legacyTIFFPasteboardTypeSingleton):
(WebCore::legacyRTFPasteboardTypeSingleton):
(WebCore::legacyFontPasteboardTypeSingleton):
(WebCore::legacyColorPasteboardTypeSingleton):
(WebCore::legacyRTFDPasteboardTypeSingleton):
(WebCore::legacyHTMLPasteboardTypeSingleton):
(WebCore::legacyURLPasteboardTypeSingleton):
(WebCore::legacyPDFPasteboardTypeSingleton):
(WebCore::legacyFilesPromisePasteboardTypeSingleton):
(WebCore::legacyPNGPasteboardTypeSingleton):
(WebCore::legacyStringPasteboardType): Deleted.
(WebCore::legacyFilenamesPasteboardType): Deleted.
(WebCore::legacyTIFFPasteboardType): Deleted.
(WebCore::legacyRTFPasteboardType): Deleted.
(WebCore::legacyFontPasteboardType): Deleted.
(WebCore::legacyColorPasteboardType): Deleted.
(WebCore::legacyRTFDPasteboardType): Deleted.
(WebCore::legacyHTMLPasteboardType): Deleted.
(WebCore::legacyURLPasteboardType): Deleted.
(WebCore::legacyPDFPasteboardType): Deleted.
(WebCore::legacyFilesPromisePasteboardType): Deleted.
(WebCore::legacyPNGPasteboardType): Deleted.
* Source/WebCore/platform/mac/PasteboardMac.mm:
(WebCore::writableTypesForURL):
(WebCore::writableTypesForImage):
(WebCore::Pasteboard::supportedFileUploadPasteboardTypes):
(WebCore::Pasteboard::write):
(WebCore::Pasteboard::writePlainText):
(WebCore::writeURLForTypes):
(WebCore::writeFileWrapperAsRTFDAttachment):
(WebCore::Pasteboard::read):
(WebCore::Pasteboard::readPlatformValuesAsStrings):
(WebCore::Pasteboard::addHTMLClipboardTypesForCocoaType):
(WebCore::Pasteboard::writeString):
(WebCore::Pasteboard::readFilePaths):
(WebCore::Pasteboard::bufferConvertedToPasteboardType):
* Source/WebCore/platform/mac/PasteboardWriter.mm:
(WebCore::createPasteboardWriter):
* Source/WebCore/platform/mac/PlatformPasteboardMac.mm:
(WebCore::isFilePasteboardType):
(WebCore::PlatformPasteboard::bufferForType const):
(WebCore::PlatformPasteboard::numberOfFiles const):
(WebCore::PlatformPasteboard::getPathnamesForType const):
(WebCore::pasteboardMayContainFilePaths):
(WebCore::PlatformPasteboard::stringForType const):
(WebCore::urlStringsFromPasteboard):
(WebCore::typeIdentifierForPasteboardType):
(WebCore::PlatformPasteboard::allStringsForType const):
(WebCore::safeTypeForDOMToReadAndWriteForPlatformType):
(WebCore::PlatformPasteboard::typesSafeForDOMToReadAndWrite const):
(WebCore::PlatformPasteboard::write):
(WebCore::PlatformPasteboard::platformPasteboardTypeForSafeTypeForDOMToReadAndWrite):
(WebCore::PlatformPasteboard::copy):
(WebCore::PlatformPasteboard::setURL):
(WebCore::PlatformPasteboard::setStringForType):
(WebCore::PlatformPasteboard::readBuffer const):
(WebCore::PlatformPasteboard::readString const):
(WebCore::PlatformPasteboard::readURL const):
(WebCore::createPasteboardItem):
(WebCore::PlatformPasteboard::informationForItemAtIndex):
* Source/WebKit/Shared/mac/PasteboardTypes.mm:
(WebKit::PasteboardTypes::forEditing):
(WebKit::PasteboardTypes::forURL):
(WebKit::PasteboardTypes::forImages):
(WebKit::PasteboardTypes::forImagesWithArchive):
(WebKit::PasteboardTypes::forSelection):
* Source/WebKit/UIProcess/Cocoa/GlobalFindInPageState.mm:
(WebKit::updateStringForFind):
(WebKit::stringForFind):
* Source/WebKit/UIProcess/Cocoa/WebPasteboardProxyCocoa.mm:
(WebKit::WebPasteboardProxy::grantAccessToCurrentData):
(WebKit::WebPasteboardProxy::getPasteboardPathnamesForType):
* Source/WebKit/UIProcess/mac/WKSharingServicePickerDelegate.mm:
(-[WKSharingServicePickerDelegate sharingService:didShareItems:]):
* Source/WebKit/UIProcess/mac/WebPageProxyMac.mm:
(WebKit::WebPageProxy::searchTheWeb):
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::writeSelectionToPasteboard):
(WebKit::WebViewImpl::validRequestorForSendAndReturnTypes):
(WebKit::handleLegacyFilesPromisePasteboard):
(WebKit::handleLegacyFilesPasteboard):
(WebKit::WebViewImpl::performDragOperation):
(WebKit::WebViewImpl::setFileAndURLTypes):
(WebKit::WebViewImpl::setPromisedDataForImage):
(WebKit::WebViewImpl::provideDataForPasteboard):
* Source/WebKitLegacy/mac/Misc/WebNSPasteboardExtras.mm:
(+[NSPasteboard _web_writableTypesForURL]):
(writableTypesForImageWithoutArchive):
(writableTypesForImageWithArchive):
(+[NSPasteboard _web_dragTypesForURL]):
(-[NSPasteboard _web_bestURL]):
(-[NSPasteboard _web_writeURL:andTitle:types:]):
(+[NSPasteboard _web_setFindPasteboardString:withOwner:]):
(-[NSPasteboard _web_writeFileWrapperAsRTFDAttachment:]):
(-[NSPasteboard _web_writeImage:element:URL:title:archive:types:source:]):
(-[NSPasteboard _web_declareAndWriteDragImageForElement:URL:title:archive:source:]):
* Source/WebKitLegacy/mac/WebView/WebHTMLView.mm:
(-[WebHTMLView _documentFragmentFromPasteboard:inContext:allowPlainText:]):
(-[WebHTMLView _plainTextFromPasteboard:]):
(-[WebHTMLView _writeSelectionWithPasteboardTypes:toPasteboard:cachedAttributedString:]):
(+[WebHTMLView _insertablePasteboardTypes]):
(+[WebHTMLView _selectionPasteboardTypes]):
(-[WebHTMLView pasteboard:provideDataForType:]):
(-[WebHTMLView _writeSelectionToPasteboard:]):
(-[WebHTMLView _documentFragmentFromPasteboard:forType:inContext:subresources:]):
(-[WebHTMLView validRequestorForSendType:returnType:]):
(-[WebHTMLView _fontAttributesFromFontPasteboard]):
(-[WebHTMLView copyFont:]):
* Source/WebKitLegacy/mac/WebView/WebPDFView.mm:
(-[WebPDFView pasteboardTypesForSelection]):
(-[WebPDFView writeSelectionWithPasteboardTypes:toPasteboard:]):
* Source/WebKitLegacy/mac/WebView/WebView.mm:
(-[WebView performDragOperation:]):
(-[WebView _searchWithGoogleFromMenu:]):
* Tools/TestRunnerShared/mac/NSPasteboardAdditions.mm:
(+[NSPasteboard _modernPasteboardType:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ClipboardTests.mm:
(readMarkupFromPasteboard):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/PasteHTML.mm:
(writeHTMLToPasteboard):

Canonical link: <a href="https://commits.webkit.org/300227@main">https://commits.webkit.org/300227@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3c61476a73d325f92461310e8caafa855a62ed04

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121799 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41500 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32164 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128338 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/73889 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6e0f5543-6562-4aea-ab30-1cfd5ede6f84) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123675 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/42212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50091 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/92552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/73889 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/48ead5a7-0a31-4168-b52a-5cfbe7730198) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124751 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/42212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109077 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73211 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/15cf7d2e-839f-4eb4-9f4f-dc7eeeb474e0) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/42212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/27240 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71848 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/42212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27425 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/131114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48734 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/37058 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/131114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/49106 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105294 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/131114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25614 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/24478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/45435 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/48592 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/54319 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/48062 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/51411 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/49744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->