### PR TITLE
[JSC] Use signal handling for null check in wasm

### DIFF
--- a/JSTests/wasm/gc/arrays.js
+++ b/JSTests/wasm/gc/arrays.js
@@ -324,7 +324,7 @@ function testArrayGet() {
     assert.throws(
       () => { m.exports.f(); },
       WebAssembly.RuntimeError,
-      "array.get to a null reference"
+      "access to a null reference"
     );
   }
 
@@ -342,7 +342,7 @@ function testArrayGet() {
     assert.throws(
       () => { m.exports.f(); },
       WebAssembly.RuntimeError,
-      "array.get to a null reference"
+      "access to a null reference"
     );
   }
 
@@ -515,7 +515,7 @@ function testArraySet() {
     assert.throws(
       () => { m.exports.f(); },
       WebAssembly.RuntimeError,
-      "array.set to a null reference"
+      "access to a null reference"
     );
   }
 
@@ -531,7 +531,7 @@ function testArraySet() {
     assert.throws(
       () => { m.exports.f(); },
       WebAssembly.RuntimeError,
-      "array.set to a null reference"
+      "access to a null reference"
     );
   }
 
@@ -593,7 +593,7 @@ function testArrayLen() {
     assert.throws(
       () => { m.exports.f(); },
       WebAssembly.RuntimeError,
-      "array.len to a null reference"
+      "access to a null reference"
     );
   }
 
@@ -610,7 +610,7 @@ function testArrayLen() {
     assert.throws(
       () => { m.exports.f(); },
       WebAssembly.RuntimeError,
-      "array.len to a null reference"
+      "access to a null reference"
     );
   }
 }
@@ -630,7 +630,7 @@ function testArrayTable() {
     `);
     m.exports.set(5);
     assert.eq(m.exports.get(5, 1), 42);
-    assert.throws(() => m.exports.get(2, 2), WebAssembly.RuntimeError, "array.get to a null");
+    assert.throws(() => m.exports.get(2, 2), WebAssembly.RuntimeError, "access to a null");
   }
 
   // Test arrayref table storing arrays of different types.
@@ -650,7 +650,7 @@ function testArrayTable() {
     m.exports.set(5, 6);
     assert.eq(m.exports.len(5), 5);
     assert.eq(m.exports.len(6), 7);
-    assert.throws(() => m.exports.len(9), WebAssembly.RuntimeError, "array.len to a null");
+    assert.throws(() => m.exports.len(9), WebAssembly.RuntimeError, "access to a null");
   }
 
   // Invalid array.get, needs a downcast.

--- a/JSTests/wasm/gc/bug252299.js
+++ b/JSTests/wasm/gc/bug252299.js
@@ -35,10 +35,10 @@ function arrayGetUninitializedLocal() {
       )`);
 
 
-    for (var p of [["arrayGetNull", "array.get"],
-                   ["arraySetNull", "array.set"],
-                   ["structGetNull", "struct.get"],
-                   ["structSetNull", "struct.set"],
+    for (var p of [["arrayGetNull", "access"],
+                   ["arraySetNull", "access"],
+                   ["structGetNull", "access"],
+                   ["structSetNull", "access"],
                    ["i31GetNull", "i31.get_<sx>"]]) {
         assert.throws(() => m.exports[p[0]](), WebAssembly.RuntimeError, p[1] + " to a null reference");
     }

--- a/JSTests/wasm/gc/packed-arrays.js
+++ b/JSTests/wasm/gc/packed-arrays.js
@@ -335,7 +335,7 @@ function testTrapsNull(type) {
         (i32.const 0)))`);
     assert.throws(() => { m.exports.f(); },
                   WebAssembly.RuntimeError,
-                  "array.set to a null reference");
+                  "access to a null reference");
 }
 
 // Tests that setting `index` in a `type` array of length `len` is a runtime error

--- a/JSTests/wasm/gc/structs.js
+++ b/JSTests/wasm/gc/structs.js
@@ -761,7 +761,7 @@ function testStructGet() {
       )
     `).exports.f(),
     WebAssembly.RuntimeError,
-    "struct.get to a null reference"
+    "access to a null reference"
   );
 
   // Bottom is type valid but throws due to null.
@@ -774,7 +774,7 @@ function testStructGet() {
       )
     `).exports.f(),
     WebAssembly.RuntimeError,
-    "struct.get to a null reference"
+    "access to a null reference"
   );
 }
 
@@ -1186,7 +1186,7 @@ function testStructSet() {
       )
     `).exports.f(),
     WebAssembly.RuntimeError,
-    "struct.set to a null reference"
+    "access to a null reference"
   );
 
   // Bottom is type valid but throws on null.
@@ -1199,7 +1199,7 @@ function testStructSet() {
       )
     `).exports.f(),
     WebAssembly.RuntimeError,
-    "struct.set to a null reference"
+    "access to a null reference"
   );
 }
 
@@ -1218,7 +1218,7 @@ function testStructTable() {
     `);
     m.exports.set(2);
     assert.eq(m.exports.get(2), 42);
-    assert.throws(() => m.exports.get(4), WebAssembly.RuntimeError, "struct.get to a null");
+    assert.throws(() => m.exports.get(4), WebAssembly.RuntimeError, "access to a null");
   }
 
   // Invalid struct.get, needs a downcast.

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
@@ -1267,7 +1267,7 @@ op(wasm_throw_from_fault_handler_trampoline_reg_instance, macro ()
 
     move cfr, a0
     move a2, a1
-    move constexpr Wasm::ExceptionType::OutOfBoundsMemoryAccess, a2
+    loadi JSWebAssemblyInstance::m_exception[a1], a2
 
     storei 0, CallSiteIndex[cfr]
     cCall3(_slow_path_wasm_throw_exception)

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
@@ -3471,7 +3471,7 @@ ipintOp(_array_len, macro()
     nextIPIntInstruction()
 
 .nullArray:
-    throwException(NullArrayLen)
+    throwException(NullAccess)
 end)
 
 ipintOp(_array_fill, macro()

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.h
@@ -1449,7 +1449,8 @@ public:
 
     PartialResult WARN_UNUSED_RETURN addStructSet(TypedExpression structValue, const StructType& structType, uint32_t fieldIndex, Value value);
 
-    void emitRefTestOrCast(const TypedExpression&, GPRReg, bool allowNull, int32_t toHeapType, JumpList& failureCases);
+    enum class CastKind { Test, Cast };
+    void emitRefTestOrCast(CastKind, const TypedExpression&, GPRReg, bool allowNull, int32_t toHeapType, JumpList& failureCases);
 
     PartialResult WARN_UNUSED_RETURN addRefTest(TypedExpression reference, bool allowNull, int32_t heapType, bool shouldNegate, ExpressionType& result);
 
@@ -1619,6 +1620,7 @@ public:
     void recordJumpToThrowException(ExceptionType, const JumpList&);
 
     void emitThrowOnNullReference(ExceptionType type, Location ref);
+    void emitThrowOnNullReferenceBeforeAccess(Location ref, ptrdiff_t offset);
 
     template<typename IntType, bool IsMod>
     void emitModOrDiv(Value& lhs, Location lhsLocation, Value& rhs, Location rhsLocation, Value& result, Location resultLocation);

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT32_64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT32_64.cpp
@@ -1404,14 +1404,14 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addArrayGet(ExtGCOpType arrayGetKind, u
 
     if (arrayref.isConst()) {
         ASSERT(arrayref.asI64() == JSValue::encode(jsNull()));
-        emitThrowException(ExceptionType::NullArrayGet);
+        emitThrowException(ExceptionType::NullAccess);
         result = topValue(resultType.kind);
         return { };
     }
 
     Location arrayLocation = loadIfNecessary(arrayref);
     if (typedArray.type().isNullable())
-        emitThrowOnNullReference(ExceptionType::NullArrayGet, arrayLocation);
+        emitThrowOnNullReference(ExceptionType::NullAccess, arrayLocation);
 
     Location indexLocation;
     if (index.isConst()) {
@@ -1657,13 +1657,13 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addArraySet(uint32_t typeIndex, TypedEx
 
         LOG_INSTRUCTION("ArraySet", typeIndex, arrayref, index, value);
         consume(value);
-        emitThrowException(ExceptionType::NullArraySet);
+        emitThrowException(ExceptionType::NullAccess);
         return { };
     }
 
     Location arrayLocation = loadIfNecessary(arrayref);
     if (typedArray.type().isNullable())
-        emitThrowOnNullReference(ExceptionType::NullArraySet, arrayLocation);
+        emitThrowOnNullReference(ExceptionType::NullAccess, arrayLocation);
 
     if (index.isConst()) {
         m_jit.load32(MacroAssembler::Address(arrayLocation.asGPRlo(), JSWebAssemblyArray::offsetOfSize()), wasmScratchGPR);
@@ -1690,7 +1690,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addArrayLen(TypedExpression typedArray,
     auto arrayref = typedArray.value();
     if (arrayref.isConst()) {
         ASSERT(arrayref.asI64() == JSValue::encode(jsNull()));
-        emitThrowException(ExceptionType::NullArrayLen);
+        emitThrowException(ExceptionType::NullAccess);
         result = Value::fromI32(0);
         LOG_INSTRUCTION("ArrayLen", arrayref, RESULT(result), "Exception");
         return { };
@@ -1699,7 +1699,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addArrayLen(TypedExpression typedArray,
     Location arrayLocation = loadIfNecessary(arrayref);
     consume(arrayref);
     if (typedArray.type().isNullable())
-        emitThrowOnNullReference(ExceptionType::NullArrayLen, arrayLocation);
+        emitThrowOnNullReference(ExceptionType::NullAccess, arrayLocation);
 
     result = topValue(TypeKind::I32);
     Location resultLocation = allocateWithHint(result, arrayLocation);
@@ -1896,7 +1896,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addStructGet(ExtGCOpType structGetKind,
     if (structValue.isConst()) {
         // This is the only constant struct currently possible.
         ASSERT(JSValue::decode(structValue.asRef()).isNull());
-        emitThrowException(ExceptionType::NullStructGet);
+        emitThrowException(ExceptionType::NullAccess);
         result = topValue(resultKind);
         LOG_INSTRUCTION("StructGet", structValue, fieldIndex, "Exception");
         return { };
@@ -1904,7 +1904,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addStructGet(ExtGCOpType structGetKind,
 
     Location structLocation = loadIfNecessary(structValue);
     if (typedStruct.type().isNullable())
-        emitThrowOnNullReference(ExceptionType::NullStructGet, structLocation);
+        emitThrowOnNullReference(ExceptionType::NullAccess, structLocation);
 
     unsigned fieldOffset = JSWebAssemblyStruct::offsetOfData() + structType.offsetOfFieldInPayload(fieldIndex);
     RELEASE_ASSERT((std::numeric_limits<int32_t>::max() & fieldOffset) == fieldOffset);
@@ -1969,13 +1969,13 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addStructSet(TypedExpression typedStruc
 
         LOG_INSTRUCTION("StructSet", structValue, fieldIndex, value, "Exception");
         consume(value);
-        emitThrowException(ExceptionType::NullStructSet);
+        emitThrowException(ExceptionType::NullAccess);
         return { };
     }
 
     Location structLocation = loadIfNecessary(structValue);
     if (typedStruct.type().isNullable())
-        emitThrowOnNullReference(ExceptionType::NullStructSet, structLocation);
+        emitThrowOnNullReference(ExceptionType::NullAccess, structLocation);
 
     bool needsWriteBarrier = emitStructSet(structLocation.asGPRlo(), structType, fieldIndex, value);
     if (needsWriteBarrier)

--- a/Source/JavaScriptCore/wasm/WasmBBQPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQPlan.cpp
@@ -36,6 +36,7 @@
 #include "WasmCallee.h"
 #include "WasmCalleeGroup.h"
 #include "WasmCompilationContext.h"
+#include "WasmFaultSignalHandler.h"
 #include "WasmIRGeneratorHelpers.h"
 #include "WasmTierUpCount.h"
 #include "WasmTypeDefinitionInlines.h"
@@ -59,6 +60,7 @@ BBQPlan::BBQPlan(VM& vm, Ref<ModuleInformation>&& moduleInformation, FunctionCod
 {
     ASSERT(Options::useBBQJIT());
     setMode(m_calleeGroup->mode());
+    Wasm::activateSignalingMemory();
     dataLogLnIf(WasmBBQPlanInternal::verbose, "Starting BBQ plan for ", functionIndex);
 }
 

--- a/Source/JavaScriptCore/wasm/WasmExceptionType.h
+++ b/Source/JavaScriptCore/wasm/WasmExceptionType.h
@@ -59,15 +59,11 @@ namespace Wasm {
     macro(BadArrayNew, "Failed to allocate new array"_s) \
     macro(BadArrayNewInitElem, "Out of bounds or failed to allocate in array.new_elem"_s) \
     macro(BadArrayNewInitData, "Out of bounds or failed to allocate in array.new_data"_s) \
-    macro(NullArrayGet, "array.get to a null reference"_s) \
-    macro(NullArraySet, "array.set to a null reference"_s) \
-    macro(NullArrayLen, "array.len to a null reference"_s) \
+    macro(NullAccess, "access to a null reference"_s) \
     macro(NullArrayFill, "array.fill to a null reference"_s) \
     macro(NullArrayCopy, "array.copy to a null reference"_s) \
     macro(NullArrayInitElem, "array.init_elem to a null reference"_s) \
     macro(NullArrayInitData, "array.init_data to a null reference"_s) \
-    macro(NullStructGet, "struct.get to a null reference"_s) \
-    macro(NullStructSet, "struct.set to a null reference"_s) \
     macro(TypeErrorInvalidValueUse, "an exported wasm function cannot contain an invalid parameter or return value"_s) \
     macro(TypeErrorV128TagAccessInJS, "a v128 parameter of a tag may not be accessed from JS"_s) \
     macro(NullRefAsNonNull, "ref.as_non_null to a null reference"_s) \
@@ -130,15 +126,11 @@ ALWAYS_INLINE bool isTypeErrorExceptionType(ExceptionType type)
     case ExceptionType::BadArrayNew:
     case ExceptionType::BadArrayNewInitElem:
     case ExceptionType::BadArrayNewInitData:
-    case ExceptionType::NullArrayGet:
-    case ExceptionType::NullArraySet:
-    case ExceptionType::NullArrayLen:
+    case ExceptionType::NullAccess:
     case ExceptionType::NullArrayFill:
     case ExceptionType::NullArrayCopy:
     case ExceptionType::NullArrayInitElem:
     case ExceptionType::NullArrayInitData:
-    case ExceptionType::NullStructGet:
-    case ExceptionType::NullStructSet:
     case ExceptionType::NullRefAsNonNull:
     case ExceptionType::CastFailure:
     case ExceptionType::OutOfMemory:

--- a/Source/JavaScriptCore/wasm/WasmFaultSignalHandler.h
+++ b/Source/JavaScriptCore/wasm/WasmFaultSignalHandler.h
@@ -36,4 +36,6 @@ inline void activateSignalingMemory() { }
 inline void prepareSignalingMemory() { }
 #endif // ENABLE(WEBASSEMBLY)
 
+ptrdiff_t maxAcceptableOffsetForNullReference();
+
 } } // namespace JSC::Wasm

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp
@@ -3295,7 +3295,7 @@ auto OMGIRGenerator::addArrayGet(ExtGCOpType arrayGetKind, uint32_t typeIndex, T
 
     // Ensure arrayref is non-null.
     if (arrayref.type().isNullable())
-        emitNullCheck(arrayValue, ExceptionType::NullArrayGet);
+        emitNullCheck(arrayValue, ExceptionType::NullAccess);
 
     // Check array bounds.
     Value* arraySize = m_currentBlock->appendNew<MemoryValue>(m_proc, Load, Int32, origin(),
@@ -3421,7 +3421,7 @@ auto OMGIRGenerator::addArraySet(uint32_t typeIndex, TypedExpression arrayref, E
     auto valueValue = get(value);
 
     if (arrayref.type().isNullable())
-        emitNullCheck(arrayValue, ExceptionType::NullArraySet);
+        emitNullCheck(arrayValue, ExceptionType::NullAccess);
 
     // Check array bounds.
     Value* arraySize = m_currentBlock->appendNew<MemoryValue>(m_proc, Load, Int32, origin(),
@@ -3444,7 +3444,7 @@ auto OMGIRGenerator::addArrayLen(TypedExpression arrayref, ExpressionType& resul
     auto arrayValue = get(arrayref);
 
     if (arrayref.type().isNullable())
-        emitNullCheck(arrayValue, ExceptionType::NullArrayLen);
+        emitNullCheck(arrayValue, ExceptionType::NullAccess);
 
     result = push(m_currentBlock->appendNew<MemoryValue>(m_proc, Load, Int32, origin(), truncate(get(arrayref)), safeCast<int32_t>(JSWebAssemblyArray::offsetOfSize())));
 
@@ -3615,7 +3615,7 @@ auto OMGIRGenerator::addStructGet(ExtGCOpType structGetKind, TypedExpression str
     Value* structValue = get(structReference);
 
     if (structReference.type().isNullable())
-        emitNullCheck(structValue, ExceptionType::NullStructGet);
+        emitNullCheck(structValue, ExceptionType::NullAccess);
 
     structValue = truncate(structValue);
     int32_t fieldOffset = fixupPointerPlusOffset(structValue, JSWebAssemblyStruct::offsetOfData() + structType.offsetOfFieldInPayload(fieldIndex));
@@ -3660,7 +3660,7 @@ auto OMGIRGenerator::addStructSet(TypedExpression structReference, const StructT
     Value* valueValue = get(value);
 
     if (structReference.type().isNullable())
-        emitNullCheck(structValue, ExceptionType::NullStructSet);
+        emitNullCheck(structValue, ExceptionType::NullAccess);
 
     bool needsWriteBarrier = emitStructSet(structValue, fieldIndex, structType, valueValue);
     if (needsWriteBarrier)

--- a/Source/JavaScriptCore/wasm/WasmOMGPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGPlan.cpp
@@ -33,6 +33,7 @@
 #include "LinkBuffer.h"
 #include "NativeCalleeRegistry.h"
 #include "WasmCallee.h"
+#include "WasmFaultSignalHandler.h"
 #include "WasmIRGeneratorHelpers.h"
 #include "WasmNameSection.h"
 #include "WasmOMGIRGenerator.h"
@@ -59,6 +60,7 @@ OMGPlan::OMGPlan(VM& vm, Ref<Module>&& module, FunctionCodeIndex functionIndex, 
     setMode(mode);
     ASSERT(m_calleeGroup->runnable());
     ASSERT(m_calleeGroup.ptr() == m_module->calleeGroupFor(m_mode));
+    Wasm::activateSignalingMemory();
     dataLogLnIf(WasmOMGPlanInternal::verbose, "[", m_moduleInformation->toSpaceIndex(m_functionIndex), "]: Starting OMG plan for ", functionIndex, " of module: ", RawPointer(&m_module.get()));
 }
 

--- a/Source/JavaScriptCore/wasm/WasmOSREntryPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOSREntryPlan.cpp
@@ -32,6 +32,7 @@
 #include "LinkBuffer.h"
 #include "NativeCalleeRegistry.h"
 #include "WasmCallee.h"
+#include "WasmFaultSignalHandler.h"
 #include "WasmIRGeneratorHelpers.h"
 #include "WasmMachineThreads.h"
 #include "WasmNameSection.h"
@@ -60,6 +61,7 @@ OSREntryPlan::OSREntryPlan(VM& vm, Ref<Module>&& module, Ref<Callee>&& callee, F
     setMode(mode);
     ASSERT(m_calleeGroup->runnable());
     ASSERT(m_calleeGroup.ptr() == m_module->calleeGroupFor(m_mode));
+    Wasm::activateSignalingMemory();
     dataLogLnIf(WasmOSREntryPlanInternal::verbose, "Starting OMGForOSREntry plan for ", functionIndex, " of module: ", RawPointer(&m_module.get()));
 }
 

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h
@@ -381,7 +381,12 @@ public:
 
     void* softStackLimit() const { return m_stackMirror.softStackLimit(); }
 
-    void setFaultPC(void* pc) { m_faultPC = pc; };
+    void setFaultPC(Wasm::ExceptionType exception, void* pc)
+    {
+        m_exception = exception;
+        m_faultPC = pc;
+    }
+    Wasm::ExceptionType exception() const { return m_exception; }
     void* faultPC() const { return m_faultPC; }
 
 private:
@@ -422,6 +427,7 @@ private:
     // Used by builtin trampolines to quickly fetch callee bits to store in the call frame.
     // The actual callees are owned by builtins. Populated by WebAssemblyModuleRecord::initializeImports().
     CalleeBits m_builtinCalleeBits[WASM_BUILTIN_COUNT];
+    Wasm::ExceptionType m_exception { Wasm::ExceptionType::Termination };
 };
 
 } // namespace JSC


### PR DESCRIPTION
#### bf18b5b709f304bc51a760be984b1292df47475c
<pre>
[JSC] Use signal handling for null check in wasm
<a href="https://bugs.webkit.org/show_bug.cgi?id=299154">https://bugs.webkit.org/show_bug.cgi?id=299154</a>
<a href="https://rdar.apple.com/160915405">rdar://160915405</a>

Reviewed by Yijia Huang.

This is commonly used optimizations in many engines. When accessing null
(jsNull) as wasm GC object, we are emitting null check to throw an
exception. But since null is just 0x2, these accesses can be handled via
wasm fault signal handler. This patch leverages this,

When offset is within the allowed size (0 &lt;-&gt; lowestAccessibleAddress),
we do not emit null check. And let the access to cause a fault and wasm
fault handler will extract this information and throw an error.

* JSTests/wasm/gc/arrays.js:
(testArrayGet):
* JSTests/wasm/gc/bug252299.js:
(arrayGetUninitializedLocal):
* JSTests/wasm/gc/packed-arrays.js:
* JSTests/wasm/gc/structs.js:
* Source/JavaScriptCore/llint/InPlaceInterpreter.asm:
* Source/JavaScriptCore/llint/InPlaceInterpreter64.asm:
* Source/JavaScriptCore/wasm/WasmBBQJIT.h:
* Source/JavaScriptCore/wasm/WasmBBQJIT32_64.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::addArrayGet):
(JSC::Wasm::BBQJITImpl::BBQJIT::addArraySet):
(JSC::Wasm::BBQJITImpl::BBQJIT::addArrayLen):
(JSC::Wasm::BBQJITImpl::BBQJIT::addStructGet):
(JSC::Wasm::BBQJITImpl::BBQJIT::addStructSet):
* Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::addArrayGet):
(JSC::Wasm::BBQJITImpl::BBQJIT::addArraySet):
(JSC::Wasm::BBQJITImpl::BBQJIT::addArrayLen):
(JSC::Wasm::BBQJITImpl::BBQJIT::addStructGet):
(JSC::Wasm::BBQJITImpl::BBQJIT::addStructSet):
(JSC::Wasm::BBQJITImpl::BBQJIT::emitRefTestOrCast):
(JSC::Wasm::BBQJITImpl::BBQJIT::addRefCast):
(JSC::Wasm::BBQJITImpl::BBQJIT::addRefTest):
(JSC::Wasm::BBQJITImpl::BBQJIT::emitThrowOnNullReferenceBeforeAccess):
(JSC::Wasm::BBQJITImpl::BBQJIT::addCallRef):
* Source/JavaScriptCore/wasm/WasmBBQPlan.cpp:
(JSC::Wasm::BBQPlan::BBQPlan):
* Source/JavaScriptCore/wasm/WasmExceptionType.h:
(JSC::Wasm::isTypeErrorExceptionType):
* Source/JavaScriptCore/wasm/WasmFaultSignalHandler.cpp:
(JSC::Wasm::trapHandler):
(JSC::Wasm::maxAcceptableOffsetForNullReference):
* Source/JavaScriptCore/wasm/WasmFaultSignalHandler.h:
* Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp:
(JSC::IPInt::WASM_IPINT_EXTERN_CPP_DECL):
(JSC::IPInt::slow_path_wasm_throw_exception):
(JSC::IPInt::slow_path_wasm_unwind_exception):
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::OMGIRGenerator::emitStructSet):
(JSC::Wasm::OMGIRGenerator::addArrayGet):
(JSC::Wasm::OMGIRGenerator::emitNullCheckBeforeAccess):
(JSC::Wasm::OMGIRGenerator::addArraySet):
(JSC::Wasm::OMGIRGenerator::addArrayLen):
(JSC::Wasm::OMGIRGenerator::addStructNew):
(JSC::Wasm::OMGIRGenerator::addStructNewDefault):
(JSC::Wasm::OMGIRGenerator::addStructGet):
(JSC::Wasm::OMGIRGenerator::addStructSet):
(JSC::Wasm::OMGIRGenerator::emitRefTestOrCast):
(JSC::Wasm::OMGIRGenerator::addCallRef):
(JSC::Wasm::OMGIRGenerator::emitLoadRTTFromFuncref): Deleted.
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp:
(JSC::Wasm::OMGIRGenerator::addArrayGet):
(JSC::Wasm::OMGIRGenerator::addArraySet):
(JSC::Wasm::OMGIRGenerator::addArrayLen):
(JSC::Wasm::OMGIRGenerator::addStructGet):
(JSC::Wasm::OMGIRGenerator::addStructSet):
* Source/JavaScriptCore/wasm/WasmOMGPlan.cpp:
(JSC::Wasm::OMGPlan::OMGPlan):
* Source/JavaScriptCore/wasm/WasmOSREntryPlan.cpp:
(JSC::Wasm::OSREntryPlan::OSREntryPlan):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h:

Canonical link: <a href="https://commits.webkit.org/300258@main">https://commits.webkit.org/300258@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3981ea7b5dac82c8d39780857ea0a19b617032d5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121898 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41600 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32270 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128450 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/73991 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4446e3fb-a235-44c4-8f49-974f0ea4e7a4) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42315 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50194 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/92643 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/73991 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/335bd7d0-1455-49a9-97cd-62fb911d0d61) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124850 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/33746 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/109165 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/73302 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/346625f1-7879-4c62-bf89-f5291d27e16e) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/32757 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/27333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71954 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/114046 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/103252 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27522 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/131222 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/120424 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48837 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/37139 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/131222 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49211 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105380 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/131222 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/46447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/24559 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/45537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19298 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48694 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/54428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/150581 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/48164 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/38522 "Found 1 new JSC stress test failure: stress/dont-link-virtual-calls-on-compiler-thread.js.no-llint (failure)") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/51514 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/49844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->