### PR TITLE
[css-anchor-position-1] Invalidate last-successful position option when referenced @position-try rules are modified

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/last-successful-change-try-rule-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/last-successful-change-try-rule-expected.txt
@@ -1,5 +1,8 @@
 
-PASS Starts rendering with --try
-PASS No successful position, keep --try
-FAIL No successful position, last successful invalidated by @position-try change assert_equals: expected 0 but got 200
+PASS Sanity check: setup function works
+PASS Last successful position option is invalidated: mutating referenced @position-try
+PASS Last successful position option is invalidated: removing referenced @position-try
+PASS Last successful position option is invalidated: adding referenced @position-try
+PASS Last successful position option not invalidated: changing property value @position-try to same value
+PASS Last successful position option not invalidated: add then remove unreferenced @position-try rule
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/last-successful-change-try-rule.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/last-successful-change-try-rule.html
@@ -22,7 +22,7 @@
   }
   #anchored {
     position-anchor: --a;
-    position-try-fallbacks: --try;
+    position-try-fallbacks: --try, --try2, --try3;
     position: absolute;
     width: 100px;
     height: 200px;
@@ -32,30 +32,109 @@
   @position-try --try {
     position-area: bottom center;
   }
+  @position-try --try2 {
+    /* This makes this option always fail */
+    top: 999999px;
+  }
 </style>
 <div id="container">
   <div id="anchor"></div>
   <div id="anchored"></div>
 </div>
 <script>
-  promise_test(async () => {
+  // Sets up the testing scenario such that when the function returns,
+  // the last successful position option is --try, and no options are successful
+  // (hence the last successful position option --try is used)
+  async function setUpLastSuccessfulPositionOption() {
+    anchor.style.top = "0px";
     await waitUntilNextAnimationFrame();
     await waitUntilNextAnimationFrame();
-    assert_equals(anchored.offsetTop, 200);
-  }, "Starts rendering with --try");
+    // --try is the successful option, --try is remembered as last successful position option.
 
-  promise_test(async () => {
     anchor.style.top = "150px";
     await waitUntilNextAnimationFrame();
     await waitUntilNextAnimationFrame();
-    assert_equals(anchored.offsetTop, 200);
-  }, "No successful position, keep --try");
+    // No options are successful, use --try since it's the last successful position option.
+    // If something causes invalidation of last-successful position option,
+    // since no options are successful, the original style should be used.
+  }
 
   promise_test(async () => {
-    // Changing @position-try --try {}
+    await setUpLastSuccessfulPositionOption();
+    assert_equals(anchored.offsetTop, 200);
+  }, "Sanity check: setup function works");
+
+  // Test situations that invalidate the last-successful position option.
+
+  // Change @position-try --try to a different value
+  promise_test(async () => {
+    await setUpLastSuccessfulPositionOption();
+
     anchor_sheet.sheet.cssRules[3].style.positionArea = "bottom";
     await waitUntilNextAnimationFrame();
     await waitUntilNextAnimationFrame();
+
     assert_equals(anchored.offsetTop, 0);
-  }, "No successful position, last successful invalidated by @position-try change");
+
+    // Change it back to the original value so subsequent tests don't have to
+    // account for the new value.
+    anchor_sheet.sheet.cssRules[3].style.positionArea = "bottom center";
+    await waitUntilNextAnimationFrame();
+    await waitUntilNextAnimationFrame();
+  }, "Last successful position option is invalidated: mutating referenced @position-try");
+
+  // Remove @position-try --try2
+  promise_test(async () => {
+    await setUpLastSuccessfulPositionOption();
+
+    anchor_sheet.sheet.deleteRule(4);
+    await waitUntilNextAnimationFrame();
+    await waitUntilNextAnimationFrame();
+
+    assert_equals(anchored.offsetTop, 0);
+  }, "Last successful position option is invalidated: removing referenced @position-try");
+
+  // Add @position-try --try3
+  promise_test(async () => {
+    await setUpLastSuccessfulPositionOption();
+    await setUpLastSuccessfulPositionOption();
+    assert_equals(anchored.offsetTop, 200);
+
+    // This position option is guaranteed to always overflow and will never be selected.
+    anchor_sheet.sheet.insertRule("@position-try --try3 { bottom: 999999px; }");
+    await waitUntilNextAnimationFrame();
+    await waitUntilNextAnimationFrame();
+
+    assert_equals(anchored.offsetTop, 0);
+  }, "Last successful position option is invalidated: adding referenced @position-try");
+
+  // Testing changes that should not invalidate the last-successful position option
+
+  // Change @position-try --try to the same value
+  promise_test(async () => {
+    await setUpLastSuccessfulPositionOption();
+
+    anchor_sheet.sheet.cssRules[3].style.positionArea = "bottom center";
+    await waitUntilNextAnimationFrame();
+    await waitUntilNextAnimationFrame();
+
+    assert_equals(anchored.offsetTop, 200);
+  }, "Last successful position option not invalidated: changing property value @position-try to same value");
+
+  // Add and remove a new @position-try that's not referenced
+  promise_test(async () => {
+    await setUpLastSuccessfulPositionOption();
+
+    // Add rule
+    const newRuleIndex = anchor_sheet.sheet.insertRule("@position-try --unused { position-area: center; }");
+    await waitUntilNextAnimationFrame();
+    await waitUntilNextAnimationFrame();
+    assert_equals(anchored.offsetTop, 200);
+
+    // Delete rule
+    anchor_sheet.sheet.deleteRule(newRuleIndex);
+    await waitUntilNextAnimationFrame();
+    await waitUntilNextAnimationFrame();
+    assert_equals(anchored.offsetTop, 200);
+  }, "Last successful position option not invalidated: add then remove unreferenced @position-try rule");
 </script>

--- a/Source/WebCore/css/StyleProperties.h
+++ b/Source/WebCore/css/StyleProperties.h
@@ -147,6 +147,8 @@ public:
     inline int findPropertyIndex(CSSPropertyID) const;
     inline int findCustomPropertyIndex(StringView propertyName) const;
 
+    inline unsigned hash() const;
+
 protected:
     inline explicit StyleProperties(CSSParserMode);
     inline StyleProperties(CSSParserMode, unsigned immutableArraySize);

--- a/Source/WebCore/css/StylePropertiesInlines.h
+++ b/Source/WebCore/css/StylePropertiesInlines.h
@@ -96,6 +96,33 @@ inline unsigned StyleProperties::size() const
     return propertyCount();
 }
 
+inline unsigned StyleProperties::hash() const
+{
+    static std::optional<unsigned> hashCacheIfImmutable;
+
+    if (!m_isMutable && hashCacheIfImmutable)
+        return *hashCacheIfImmutable;
+
+    Hasher hasher;
+
+    add(hasher, m_cssParserMode);
+
+    for (auto property : *this) {
+        if (!property.protectedValue()->addHash(hasher)) {
+            ASSERT_NOT_REACHED();
+        }
+
+        add(hasher, property.id(), property.isImportant());
+    }
+
+    if (!m_isMutable) {
+        ASSERT(!hashCacheIfImmutable);
+        hashCacheIfImmutable = hasher.hash();
+    }
+
+    return hasher.hash();
+}
+
 inline String serializeLonghandValue(const CSS::SerializationContext& context, CSSPropertyID property, const CSSValue* value)
 {
     return value ? serializeLonghandValue(context, property, *value) : String();

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -2922,6 +2922,9 @@ void Document::resolveStyle(ResolveStyleType type)
     if (CheckedPtr styleOriginatedTimelinesController = this->styleOriginatedTimelinesController())
         styleOriginatedTimelinesController->documentDidResolveStyle();
 
+    if (m_styleScope->changedPositionTryRules())
+        m_styleScope->changedPositionTryRules()->clear();
+
     // Re-evaluate speculation rules after DOM changes that trigger style recalculation.
     // That helps ensure CSS selector matching works correctly.
     considerSpeculationRules();

--- a/Source/WebCore/style/RuleSet.h
+++ b/Source/WebCore/style/RuleSet.h
@@ -134,6 +134,7 @@ public:
     bool hasScopeRules() const { return !m_scopeRules.isEmpty(); }
     Vector<Ref<const StyleRuleScope>> scopeRulesFor(const RuleData&) const;
 
+    const HashMap<AtomString, RefPtr<const StyleRulePositionTry>>& positionTryRules() const { return m_positionTryRules; };
     const RefPtr<const StyleRulePositionTry> positionTryRuleForName(const AtomString&) const;
 
     String selectorsForDebugging() const;

--- a/Source/WebCore/style/StyleScope.h
+++ b/Source/WebCore/style/StyleScope.h
@@ -180,6 +180,9 @@ public:
 
     bool invalidateForAnchorDependencies(LayoutDependencyUpdateContext&);
 
+    std::optional<HashSet<AtomString>>& changedPositionTryRules() { return m_changedPositionTryRules; }
+    const std::optional<HashSet<AtomString>>& changedPositionTryRules() const { return m_changedPositionTryRules; }
+
 private:
     Scope& documentScope();
     bool isForUserAgentShadowTree() const;
@@ -203,6 +206,7 @@ private:
     };
 
     ActiveStyleSheetCollection collectActiveStyleSheets();
+    void positionTryRuleUpdates(const ActiveStyleSheetCollection&, const ActiveStyleSheetCollection&);
 
     enum class ResolverUpdateType {
         Reconstruct,
@@ -291,6 +295,16 @@ private:
     HashMap<ResolverSharingKey, Ref<Resolver>> m_sharedShadowTreeResolvers;
 
     AnchorPositionedToAnchorMap m_anchorPositionedToAnchorMap;
+
+    // When the resolver is cleared in clearResolver(), this stores the hash of
+    // the StyleProperties of @position-try rules in the document. When the resolver
+    // is rebuilt with new stylesheets, we use this to compute the @position-try
+    // rules that changes in the new resolver.
+    std::optional<HashMap<AtomString, unsigned>> m_oldPositionTryRuleHashes;
+
+    // After a new resolver is built, we compute the list of @position-try rules
+    // that have changed since the last resolver and store it here.
+    std::optional<HashSet<AtomString>> m_changedPositionTryRules;
 };
 
 HTMLSlotElement* assignedSlotForScopeOrdinal(const Element&, ScopeOrdinal);


### PR DESCRIPTION
#### db5ac72939d325848602d848bce0b7b1252a6e05
<pre>
[css-anchor-position-1] Invalidate last-successful position option when referenced @position-try rules are modified
<a href="https://rdar.apple.com/160901294">rdar://160901294</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=299141">https://bugs.webkit.org/show_bug.cgi?id=299141</a>

Reviewed by NOBODY (OOPS!).

This patch implements invalidating last-successful position option if a @position-try
rule referenced by the element is modified (added/removed/mutated). This is done by
remembering the list of @position-try rules when the style resolver is torn down.
Then when the resolver is rebuilt with new stylesheet information, we can compare
the new rules with the old rules, to figure out which rules are modified.

Test: LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/last-successful-change-try-rule.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/last-successful-change-try-rule-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/last-successful-change-try-rule.html:
* Source/WebCore/css/StyleProperties.h:
* Source/WebCore/css/StylePropertiesInlines.h:
(WebCore::StyleProperties::hash const):
* Source/WebCore/style/RuleSet.h:
(WebCore::Style::RuleSet::positionTryRules const):
* Source/WebCore/style/StyleScope.cpp:
(WebCore::Style::computeChangedPositionTryRules):
(WebCore::Style::Scope::createDocumentResolver):
(WebCore::Style::Scope::clearResolver):
* Source/WebCore/style/StyleScope.h:
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::lastSuccessfulPositionTryFallbackIndex):
(WebCore::Style::TreeResolver::styleForStyleable):
(WebCore::Style::TreeResolver::resolvePseudoElement):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/db5ac72939d325848602d848bce0b7b1252a6e05

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124990 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44659 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35396 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131839 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77250 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4a7f3cd3-a71e-483d-93d7-5fe97df4e1fa) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/126867 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45351 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53225 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95141 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/63389 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cd51d1b3-a410-43f6-b446-463140eea223) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127944 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36194 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111784 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75679 "Found 1 new API test failure: WPE/TestWebKitWebContext:/webkit/WebKitWebContext/no-web-process-leak (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5148d12e-b6b0-4241-a233-4fa0d7d03502) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35121 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29936 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75320 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105957 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30167 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134514 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51813 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39613 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103608 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52238 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107996 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103384 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48726 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27014 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48843 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51697 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57492 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51071 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54428 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52763 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->