### PR TITLE
Address Safer CPP failures in PlaybackSessionInterfaceMac.mm

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -480,7 +480,6 @@ platform/graphics/ca/cocoa/WebTiledBackingLayer.mm
 platform/graphics/cg/CGSubimageCacheWithTimer.cpp
 platform/ios/PlaybackSessionInterfaceIOS.mm
 platform/ios/WebAVPlayerController.mm
-platform/mac/PlaybackSessionInterfaceMac.mm
 platform/mac/ScrollAnimatorMac.mm
 platform/mac/ScrollbarThemeMac.mm
 platform/mac/ScrollbarsControllerMac.mm

--- a/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
@@ -264,8 +264,8 @@ page/DeviceController.cpp
 page/DragController.cpp
 page/ElementTargetingController.cpp
 page/EventHandler.cpp
-page/FrameConsoleClient.cpp
 page/FocusController.cpp
+page/FrameConsoleClient.cpp
 page/FrameSnapshotting.cpp
 page/FrameView.cpp
 page/ImageAnalysisQueue.cpp
@@ -313,7 +313,6 @@ platform/graphics/cg/CGSubimageCacheWithTimer.cpp
 platform/graphics/mac/controls/ImageControlsButtonMac.mm
 platform/ios/PlaybackSessionInterfaceIOS.mm
 platform/ios/WebAVPlayerController.mm
-platform/mac/PlaybackSessionInterfaceMac.mm
 platform/mac/VideoPresentationInterfaceMac.mm
 platform/mac/WebPlaybackControlsManager.mm
 platform/network/mac/ResourceHandleMac.mm

--- a/Source/WebCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
@@ -114,7 +114,6 @@ platform/mac/PasteboardWriter.mm
 platform/mac/PlatformEventFactoryMac.mm
 platform/mac/PlatformPasteboardMac.mm
 platform/mac/PlatformScreenMac.mm
-platform/mac/PlaybackSessionInterfaceMac.mm
 platform/mac/PowerObserverMac.cpp
 platform/mac/ScrollViewMac.mm
 platform/mac/ScrollbarThemeMac.mm

--- a/Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
@@ -79,7 +79,6 @@ platform/mac/HIDDevice.cpp
 platform/mac/PasteboardMac.mm
 platform/mac/PlatformEventFactoryMac.mm
 platform/mac/PlatformPasteboardMac.mm
-platform/mac/PlaybackSessionInterfaceMac.mm
 platform/mac/ScrollViewMac.mm
 platform/mac/ScrollbarThemeMac.mm
 platform/mac/ScrollbarsControllerMac.mm

--- a/Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.h
+++ b/Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.h
@@ -74,6 +74,7 @@ public:
 #if ENABLE(WEB_PLAYBACK_CONTROLS_MANAGER)
     void setPlayBackControlsManager(WebPlaybackControlsManager *);
     WebPlaybackControlsManager *playBackControlsManager();
+    RetainPtr<WebPlaybackControlsManager> protectedPlayBackControlsManager();
 
     void updatePlaybackControlsManagerCanTogglePictureInPicture();
 #endif


### PR DESCRIPTION
#### de56a627803eb65054a2be948e507f4e7d9ba769
<pre>
Address Safer CPP failures in PlaybackSessionInterfaceMac.mm
<a href="https://bugs.webkit.org/show_bug.cgi?id=299159">https://bugs.webkit.org/show_bug.cgi?id=299159</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations:
* Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.h:
* Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.mm:
(WebCore::PlaybackSessionInterfaceMac::isInWindowFullscreenActive const):
(WebCore::PlaybackSessionInterfaceMac::enterInWindowFullscreen):
(WebCore::PlaybackSessionInterfaceMac::exitInWindowFullscreen):
(WebCore::PlaybackSessionInterfaceMac::durationChanged):
(WebCore::PlaybackSessionInterfaceMac::currentTimeChanged):
(WebCore::PlaybackSessionInterfaceMac::rateChanged):
(WebCore::PlaybackSessionInterfaceMac::willBeginScrubbing):
(WebCore::PlaybackSessionInterfaceMac::beginScrubbing):
(WebCore::PlaybackSessionInterfaceMac::endScrubbing):
(WebCore::PlaybackSessionInterfaceMac::skipAd):
(WebCore::PlaybackSessionInterfaceMac::seekableRangesChanged):
(WebCore::PlaybackSessionInterfaceMac::audioMediaSelectionOptionsChanged):
(WebCore::PlaybackSessionInterfaceMac::legibleMediaSelectionOptionsChanged):
(WebCore::PlaybackSessionInterfaceMac::audioMediaSelectionIndexChanged):
(WebCore::PlaybackSessionInterfaceMac::legibleMediaSelectionIndexChanged):
(WebCore::PlaybackSessionInterfaceMac::invalidate):
(WebCore::PlaybackSessionInterfaceMac::setPlayBackControlsManager):
(WebCore::PlaybackSessionInterfaceMac::updatePlaybackControlsManagerCanTogglePictureInPicture):
(WebCore::PlaybackSessionInterfaceMac::updatePlaybackControlsManagerTiming):
(WebCore::PlaybackSessionInterfaceMac::protectedPlayBackControlsManager):
(WebCore::PlaybackSessionInterfaceMac::logIdentifier const):
(WebCore::PlaybackSessionInterfaceMac::loggerPtr const):

Canonical link: <a href="https://commits.webkit.org/300222@main">https://commits.webkit.org/300222@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bc0f179e15d351b3a4709396018f723fd5a1fcb0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121765 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41466 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32130 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128298 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73855 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/67b771f9-3411-4a27-b164-59716250e64c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123641 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42178 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50057 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92524 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/61506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/80b2ac6a-81f1-4ace-bd53-1c91b891f84b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124717 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33642 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109057 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73188 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/927d49e4-45d2-4a14-960c-5b3abbf7cdfb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32654 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27220 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71812 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103142 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27405 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131080 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48700 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/37034 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101114 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49072 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105274 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100986 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25606 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46351 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/24466 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/45401 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48558 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54285 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48028 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51377 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49710 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->