### PR TITLE
[Site Isolation] Image in cross-site iframe isn't translated if frame is added after user translates page

### DIFF
--- a/Source/WebCore/page/ImageAnalysisQueue.cpp
+++ b/Source/WebCore/page/ImageAnalysisQueue.cpp
@@ -130,11 +130,11 @@ void ImageAnalysisQueue::enqueueAllImagesIfNeeded(Frame& frame, const String& so
 
     m_analysisOfAllImagesOnPageHasStarted = true;
 
-    if (sourceLanguageIdentifier != m_sourceLanguageIdentifier || targetLanguageIdentifier != m_targetLanguageIdentifier)
+    if (sourceLanguageIdentifier != m_languageIdentifiers.source || targetLanguageIdentifier != m_languageIdentifiers.target)
         clear();
 
-    m_sourceLanguageIdentifier = sourceLanguageIdentifier;
-    m_targetLanguageIdentifier = targetLanguageIdentifier;
+    m_languageIdentifiers.source = sourceLanguageIdentifier;
+    m_languageIdentifiers.target = targetLanguageIdentifier;
     enqueueAllImagesRecursive(frame);
 }
 
@@ -168,8 +168,8 @@ void ImageAnalysisQueue::resumeProcessing()
         if (auto* image = element->cachedImage(); image && !image->errorOccurred())
             m_queuedElements.set(*element, image->url());
 
-        auto allowSnapshots = m_targetLanguageIdentifier.isEmpty() ? TextRecognitionOptions::AllowSnapshots::Yes : TextRecognitionOptions::AllowSnapshots::No;
-        m_page->chrome().client().requestTextRecognition(*element, { m_sourceLanguageIdentifier, m_targetLanguageIdentifier, allowSnapshots }, [this, page = m_page] (auto&&) {
+        auto allowSnapshots = m_languageIdentifiers.target.isEmpty() ? TextRecognitionOptions::AllowSnapshots::Yes : TextRecognitionOptions::AllowSnapshots::No;
+        m_page->chrome().client().requestTextRecognition(*element, { m_languageIdentifiers.source, m_languageIdentifiers.target, allowSnapshots }, [this, page = m_page] (auto&&) {
             if (!page || page->imageAnalysisQueueIfExists() != this)
                 return;
 
@@ -204,8 +204,7 @@ void ImageAnalysisQueue::clear()
     m_resumeProcessingTimer.stop();
     m_queue = { };
     m_queuedElements.clear();
-    m_sourceLanguageIdentifier = { };
-    m_targetLanguageIdentifier = { };
+    m_languageIdentifiers = { };
     m_currentTaskNumber = 0;
     m_analysisOfAllImagesOnPageHasStarted = false;
     m_imageQueueEmptyHysteresis = nullptr;

--- a/Source/WebCore/page/ImageAnalysisQueue.h
+++ b/Source/WebCore/page/ImageAnalysisQueue.h
@@ -48,6 +48,11 @@ class Page;
 class Timer;
 class WeakPtrImplWithEventTargetData;
 
+struct ImageTranslationLanguageIdentifiers {
+    String source;
+    String target;
+};
+
 class ImageAnalysisQueue final : public RefCountedAndCanMakeWeakPtr<ImageAnalysisQueue> {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(ImageAnalysisQueue, WEBCORE_EXPORT);
 public:
@@ -61,6 +66,8 @@ public:
 
     WEBCORE_EXPORT void setDidBecomeEmptyCallback(Function<void()>&&);
     WEBCORE_EXPORT void clearDidBecomeEmptyCallback();
+
+    void setTranslationLanguageIdentifiers(ImageTranslationLanguageIdentifiers&& identifiers) { m_languageIdentifiers = WTFMove(identifiers); }
 
 private:
     explicit ImageAnalysisQueue(Page&);
@@ -80,9 +87,7 @@ private:
     static bool firstIsHigherPriority(const Task&, const Task&);
     unsigned nextTaskNumber() { return ++m_currentTaskNumber; }
 
-    // FIXME: Refactor the source and target LIDs into either a std::pair<> of strings, or its own named struct.
-    String m_sourceLanguageIdentifier;
-    String m_targetLanguageIdentifier;
+    ImageTranslationLanguageIdentifiers m_languageIdentifiers;
     WeakPtr<Page> m_page;
     Timer m_resumeProcessingTimer;
     WeakHashMap<HTMLImageElement, URL, WeakPtrImplWithEventTargetData> m_queuedElements;

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -528,6 +528,11 @@ Page::Page(PageConfiguration&& pageConfiguration)
         m_throttlingReasons.add(ThrottlingReason::ThermalMitigation);
         m_throttlingReasons.set(ThrottlingReason::AggressiveThermalMitigation, settings().respondToThermalPressureAggressively());
     }
+
+#if ENABLE(IMAGE_ANALYSIS)
+    if (pageConfiguration.imageTranslationLanguageIdentifiers)
+        imageAnalysisQueue().setTranslationLanguageIdentifiers(WTFMove(*pageConfiguration.imageTranslationLanguageIdentifiers));
+#endif
 }
 
 Page::~Page()

--- a/Source/WebCore/page/PageConfiguration.h
+++ b/Source/WebCore/page/PageConfiguration.h
@@ -53,6 +53,10 @@
 #include <WebCore/ShouldRequireExplicitConsentForGamepadAccess.h>
 #endif
 
+#if ENABLE(IMAGE_ANALYSIS)
+#include <WebCore/ImageAnalysisQueue.h>
+#endif
+
 namespace WebCore {
 
 class AlternativeTextClient;
@@ -247,6 +251,10 @@ public:
 #endif
 
     std::optional<MediaSessionManagerFactory> mediaSessionManagerFactory;
+
+#if ENABLE(IMAGE_ANALYSIS)
+    std::optional<ImageTranslationLanguageIdentifiers> imageTranslationLanguageIdentifiers;
+#endif
 };
 
 }

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -9398,3 +9398,11 @@ struct WebCore::ParentalControlsURLFilterParameters {
 #endif
 };
 #endif
+
+#if ENABLE(IMAGE_ANALYSIS)
+header: <WebCore/ImageAnalysisQueue.h>
+[CustomHeader] struct WebCore::ImageTranslationLanguageIdentifiers {
+    String source;
+    String target;
+};
+#endif

--- a/Source/WebKit/Shared/WebPageCreationParameters.h
+++ b/Source/WebKit/Shared/WebPageCreationParameters.h
@@ -89,6 +89,10 @@
 #include "CoreIPCAuditToken.h"
 #endif
 
+#if ENABLE(IMAGE_ANALYSIS)
+#include <WebCore/ImageAnalysisQueue.h>
+#endif
+
 namespace WebCore {
 enum class SandboxFlag : uint16_t;
 using SandboxFlags = OptionSet<SandboxFlag>;
@@ -362,6 +366,10 @@ struct WebPageCreationParameters {
     String presentingApplicationBundleIdentifier;
 #endif
     bool shouldSendConsoleLogsToUIProcessForTesting { false };
+
+#if ENABLE(IMAGE_ANALYSIS)
+    std::optional<WebCore::ImageTranslationLanguageIdentifiers> imageTranslationLanguageIdentifiers;
+#endif
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
+++ b/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
@@ -284,6 +284,10 @@ enum class WebCore::UserInterfaceLayoutDirection : bool;
 #endif
 
     bool shouldSendConsoleLogsToUIProcessForTesting;
+
+#if ENABLE(IMAGE_ANALYSIS)
+    std::optional<WebCore::ImageTranslationLanguageIdentifiers> imageTranslationLanguageIdentifiers;
+#endif
 }
 
 [Nested] struct WebKit::RemotePageParameters {

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -7377,6 +7377,11 @@ void WebPageProxy::didCommitLoadForFrame(IPC::Connection& connection, FrameIdent
     if (frame->isMainFrame())
         resetMediaCapability();
 #endif
+
+#if ENABLE(IMAGE_ANALYSIS)
+    if (frame->isMainFrame())
+        m_internals->imageTranslationLanguageIdentifiers = std::nullopt;
+#endif
 }
 
 void WebPageProxy::didFinishDocumentLoadForFrame(IPC::Connection& connection, FrameIdentifier frameID, std::optional<WebCore::NavigationIdentifier> navigationID, const UserData& userData, WallTime timestamp)
@@ -12190,6 +12195,10 @@ WebPageCreationParameters WebPageProxy::creationParameters(WebProcessProxy& proc
     parameters.presentingApplicationBundleIdentifier = presentingApplicationBundleIdentifier();
 #endif
 
+#if ENABLE(IMAGE_ANALYSIS)
+    parameters.imageTranslationLanguageIdentifiers = m_internals->imageTranslationLanguageIdentifiers;
+#endif
+
     return parameters;
 }
 
@@ -12902,6 +12911,8 @@ void WebPageProxy::updateWithTextRecognitionResult(TextRecognitionResult&& resul
 
 void WebPageProxy::startVisualTranslation(const String& sourceLanguageIdentifier, const String& targetLanguageIdentifier)
 {
+    m_internals->imageTranslationLanguageIdentifiers = { sourceLanguageIdentifier, targetLanguageIdentifier };
+
     forEachWebContentProcess([&](auto& webProcess, auto pageID) {
         if (hasRunningProcess())
             webProcess.send(Messages::WebPage::StartVisualTranslation(sourceLanguageIdentifier, targetLanguageIdentifier), pageID);

--- a/Source/WebKit/UIProcess/WebPageProxyInternals.h
+++ b/Source/WebKit/UIProcess/WebPageProxyInternals.h
@@ -97,6 +97,10 @@
 #include "ModelPresentationManagerProxy.h"
 #endif
 
+#if ENABLE(IMAGE_ANALYSIS)
+#include <WebCore/ImageAnalysisQueue.h>
+#endif
+
 namespace WebKit {
 
 #if ENABLE(WINDOW_PROXY_PROPERTY_ACCESS_NOTIFICATION)
@@ -422,6 +426,10 @@ public:
 #endif
 
     bool allowsLayoutViewportHeightExpansion { true };
+
+#if ENABLE(IMAGE_ANALYSIS)
+    std::optional<WebCore::ImageTranslationLanguageIdentifiers> imageTranslationLanguageIdentifiers { std::nullopt };
+#endif
 
     explicit Internals(WebPageProxy&);
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -901,6 +901,10 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
     pageConfiguration.presentingApplicationBundleIdentifier = WTFMove(parameters.presentingApplicationBundleIdentifier);
 #endif
 
+#if ENABLE(IMAGE_ANALYSIS)
+    pageConfiguration.imageTranslationLanguageIdentifiers = WTFMove(parameters.imageTranslationLanguageIdentifiers);
+#endif
+
     Ref page = Page::create(WTFMove(pageConfiguration));
     m_page = page.copyRef();
 


### PR DESCRIPTION
#### 7c36bd3c403e26c44c730d77c5225a8416499648
<pre>
[Site Isolation] Image in cross-site iframe isn&apos;t translated if frame is added after user translates page
<a href="https://bugs.webkit.org/show_bug.cgi?id=299158">https://bugs.webkit.org/show_bug.cgi?id=299158</a>
<a href="https://rdar.apple.com/160917894">rdar://160917894</a>

Reviewed by Wenson Hsieh.

If the user translates a page, and then a cross-site iframe is added later, the
images in this iframe should be translated automatically as well. This happens
with site isolation off, but not with site isolation on.

There are two issues:

1. When loading an image into a page, Page::didFinishLoadingImageForElement()
   will add the image to the ImageAnalysisQueue to be translated. But only if
   this queue already exists. This queue is only created when the user requests
   translation and WKWebView::_startImageAnalysis is called.

   In our case where a cross-site iframe is loaded after page translation, a
   new Page will be created but will not have an ImageAnalysisQueue. And so the
   images in the frame will not be translated.

   To fix this, we keep a flag on WebPageProxy which indicates if translation
   has been requested. If a new Page is created, it will be passed this flag.
   If it&apos;s true, the Page will create an ImageAnalysisQueue so that when the
   images are loaded and Page::didFinishLoadingImageForElement() is called, the
   images will be translated.

2. Now the images are being added to the queue to be translated. But translation
   only occurs if a source and target language are specified. These are set by
   the call to WKWebView::_startImageAnalysis. This call won&apos;t occur after the
   cross-site iframe is loaded. So the images are queued for translation, but
   aren&apos;t actually translated.

   To fix this, we store the two languages on WebPageProxy as well.

These three bits of information are stored on WebPageProxy like so:

std::optional&lt;ImageTranslationLanguageIdentifiers&gt; imageTranslationLanguageIdentifiers;
Where struct ImageTranslationLanguageIdentifiers contains the two languages.

If the struct is present, it means translation was requested. This struct will
be plumbed from WebPageProxy to WebPage to PageConfiguration to Page where it&apos;s
used to create the ImageAnalysisQueue with the two languages if needed.

If a new document is loaded in the main frame, this is nulled since translation
on one page must not cause translation on the next. This is done in
WebPageProxy::didCommitLoadForFrame().

New API test: SiteIsolation.IframeImageTranslationIfIframeIsAddedAfterTranslationCall

* Source/WebCore/page/ImageAnalysisQueue.cpp:
(WebCore::ImageAnalysisQueue::enqueueAllImagesIfNeeded):
(WebCore::ImageAnalysisQueue::resumeProcessing):
(WebCore::ImageAnalysisQueue::clear):
* Source/WebCore/page/ImageAnalysisQueue.h:
* Source/WebCore/page/Page.cpp:

If the flag is set, create the ImageAnalysisQueue and set the two languages.

(WebCore::m_mediaSessionManagerFactory):
* Source/WebCore/page/PageConfiguration.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/Shared/WebPageCreationParameters.h:
* Source/WebKit/Shared/WebPageCreationParameters.serialization.in:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didCommitLoadForFrame):

Unset the flag and the two languages if a new load was done in the main frame.

(WebKit::WebPageProxy::creationParameters):
(WebKit::WebPageProxy::startVisualTranslation):

Set the flag and the two languages.

* Source/WebKit/UIProcess/WebPageProxyInternals.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::m_toolbarsAreVisible):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::(SiteIsolation, IframeImageTranslation)):
(TestWebKitAPI::(SiteIsolation, IframeImageTranslationIfIframeIsAddedAfterTranslationCall)):

Canonical link: <a href="https://commits.webkit.org/300305@main">https://commits.webkit.org/300305@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/812f4ae2c87d534f8cf245dbb943161a084b8248

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122068 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41770 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32440 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128632 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74162 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/244372a0-2bb1-434a-9428-ad36ea82e92f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123944 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42485 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50364 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92782 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61665 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/82e08aa6-7001-4290-99b8-4f44a5273d56) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125020 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33883 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109314 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73438 "Found 1 new API test failure: WPE/TestWebKitWebContext:/webkit/WebKitWebContext/no-web-process-leak (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/108071cd-b9b5-4545-bd31-39fea657023a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32896 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27480 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72125 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103390 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27671 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131392 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49007 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37274 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101343 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49381 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105528 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101214 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46581 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24698 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45744 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19313 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48864 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54598 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48334 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51684 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50014 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->