### PR TITLE
Draft: Align UA Stylesheet with MathML Core for maction and semantics.

### DIFF
--- a/Source/WebCore/css/mathml.css
+++ b/Source/WebCore/css/mathml.css
@@ -94,40 +94,30 @@ math[display="inline" i] {
     math-style: compact;
 }
 
-ms, mtext, mi, mn, mo, annotation, mtd {
-    white-space: nowrap !important;
+/* <mrow>-like elements */
+semantics > :not(:first-child) {
+    display: none;
 }
 
-/* Fractions */
-mfrac {
-    padding-inline: 1px;
+maction > :not(:first-child) {
+    display: none;
 }
 
-mfrac > * {
-    math-style: compact;
-}
-
-msub > * + *, msup > * + *, msubsup > * + *, mmultiscripts > * + *, munder > * + *, mover > * + *, munderover > * + * {
-    font-size: 0.71em;
-    math-style: compact;
-}
-
-mroot > *:last-child {
-    font-size: 0.5041em; /* This 0.71^2 since the scriptlevel is incremented by 2 in the index. */
-    math-style: compact;
+merror {
+    border: 1px solid red;
+    background-color: lightYellow;
 }
 
 mphantom {
     visibility: hidden;
 }
 
-/* This is a special style for erroneous markup. */
-/* https://w3c.github.io/mathml-core/#error-message-merror */
-merror {
-    border: 1px solid red;
-    background-color: lightYellow;
+/* Token elements */
+ms, mtext, mi, mn, mo, annotation, mtd {
+    white-space: nowrap !important;
 }
 
+/* Tables */
 mtable {
     display: inline-table;
     text-align: center;
@@ -195,7 +185,34 @@ mtable[columnlines="dashed"] > mtr > mtd + mtd {
     border-left: dashed thin;
 }
 
+/* Fractions */
+mfrac {
+    padding-inline: 1px;
+}
+
+mfrac > * {
+    math-style: compact;
+}
+
+mfrac > :nth-child(2) {
+    math-shift: compact;
+}
+
 /* Other rules for scriptlevel, displaystyle and math-shift */
+mroot > *:last-child {
+    font-size: 0.5041em; /* This 0.71^2 since the scriptlevel is incremented by 2 in the index. */
+    math-style: compact;
+}
+
+mroot, msqrt {
+    math-shift: compact;
+}
+
+msub > * + *, msup > * + *, msubsup > * + *, mmultiscripts > * + *, munder > * + *, mover > * + *, munderover > * + * {
+    font-size: 0.71em;
+    math-style: compact;
+}
+
 munder[accentunder="true" i] > :nth-child(2),
 mover[accent="true" i] > :nth-child(2),
 munderover[accentunder="true" i] > :nth-child(2),
@@ -203,9 +220,6 @@ munderover[accent="true" i] > :nth-child(3) {
   font-size: inherit;
 }
 
-mfrac > :nth-child(2),
-mroot,
-msqrt,
 msub > :nth-child(2),
 msubsup > :nth-child(2),
 mmultiscripts > :nth-child(even),

--- a/Source/WebCore/mathml/mathtags.in
+++ b/Source/WebCore/mathml/mathtags.in
@@ -6,7 +6,7 @@ fallbackJSInterfaceName="MathMLElement"
 
 annotation interfaceName=MathMLAnnotationElement, JSInterfaceName=MathMLElement
 annotation-xml interfaceName=MathMLAnnotationElement, JSInterfaceName=MathMLElement
-maction interfaceName=MathMLSelectElement, JSInterfaceName=MathMLElement
+maction interfaceName=MathMLRowElement, JSInterfaceName=MathMLElement
 math
 mfrac interfaceName=MathMLFractionElement, JSInterfaceName=MathMLElement
 mfenced interfaceName=MathMLRowElement, JSInterfaceName=MathMLElement
@@ -36,7 +36,7 @@ mmultiscripts interfaceName=MathMLScriptsElement, JSInterfaceName=MathMLElement
 mprescripts interfaceName=MathMLPresentationElement, JSInterfaceName=MathMLElement
 menclose interfaceName=MathMLMencloseElement, JSInterfaceName=MathMLElement
 none interfaceName=MathMLPresentationElement, JSInterfaceName=MathMLElement
-semantics interfaceName=MathMLSelectElement, JSInterfaceName=MathMLElement
+semantics interfaceName=MathMLRowElement, JSInterfaceName=MathMLElement
 
 maligngroup interfaceName=MathMLPresentationElement, JSInterfaceName=MathMLElement
 malignmark interfaceName=MathMLPresentationElement, JSInterfaceName=MathMLElement


### PR DESCRIPTION
#### cded5d0e51a96a9161bed09c89bc9198e2df6018
<pre>
Align semantics and maction with MathML Core
<a href="https://bugs.webkit.org/show_bug.cgi?id=262696">https://bugs.webkit.org/show_bug.cgi?id=262696</a>

Reviewed by NOBODY (OOPS!).

The MathML Core spec says that semantics
(<a href="https://w3c.github.io/mathml-core/#semantics-and-presentation)">https://w3c.github.io/mathml-core/#semantics-and-presentation)</a> and
maction (<a href="https://w3c.github.io/mathml-core/#dfn-maction)">https://w3c.github.io/mathml-core/#dfn-maction)</a> have the same
layout algorithm than then mrow element.

Additionally, it adds some rules for the UA stylesheet to properly render
these elements. This patch also makes the stylesheet align more closely
with the one defined in the spec
(<a href="https://w3c.github.io/mathml-core/#user-agent-stylesheet)">https://w3c.github.io/mathml-core/#user-agent-stylesheet)</a>

* LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/legacy-mrow-like-elements-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/default-properties-on-semantics-and-maction-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/writing-mode/writing-mode-002-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/mathml/relations/css-styling/ignored-properties-001-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/mathml/relations/html5-tree/dynamic-childlist-002-expected.txt:
* Source/WebCore/css/mathml.css:
(semantics &gt; :not(:first-child)):
(maction &gt; :not(:first-child)):
(merror):
(ms, mtext, mi, mn, mo, annotation, mtd):
(mfrac):
(mfrac &gt; *):
(mfrac &gt; :nth-child(2)):
(mroot &gt; *:last-child):
(mroot, msqrt):
(msub &gt; * + *, msup &gt; * + *, msubsup &gt; * + *, mmultiscripts &gt; * + *, munder &gt; * + *, mover &gt; * + *, munderover &gt; * + *):
(mfrac &gt; :nth-child(2),): Deleted.
* Source/WebCore/mathml/MathMLAnnotationElement.cpp:
(WebCore::MathMLAnnotationElement::createElementRenderer):
(WebCore::MathMLAnnotationElement::childShouldCreateRenderer const):
* Source/WebCore/mathml/MathMLSelectElement.cpp:
(WebCore::MathMLSelectElement::childShouldCreateRenderer const):
(WebCore::MathMLSelectElement::updateSelectedChild):
(WebCore::MathMLSelectElement::defaultEventHandler):
(WebCore::MathMLSelectElement::willRespondToMouseClickEventsWithEditability const):
</pre>