### PR TITLE
Unreviewed, adopt XPC_RETURNS_RETAINED in XPCSPI.h

### DIFF
--- a/Source/WTF/wtf/spi/darwin/XPCSPI.h
+++ b/Source/WTF/wtf/spi/darwin/XPCSPI.h
@@ -103,13 +103,17 @@ typedef void (*xpc_connection_handler_t)(xpc_connection_t connection);
 #define XPC_TYPE_ERROR (&_xpc_type_error)
 #define XPC_TYPE_STRING (&_xpc_type_string)
 
+#ifndef XPC_RETURNS_RETAINED
+#define XPC_RETURNS_RETAINED
+#endif
+
 extern const char * const _xpc_error_key_description;
 
 extern "C" void xpc_connection_activate(xpc_connection_t connection);
 extern "C" const void* xpc_dictionary_get_data(xpc_object_t xdict, const char* key, size_t* length);
 extern "C" xpc_object_t xpc_data_create_with_dispatch_data(dispatch_data_t ddata);
 extern "C" xpc_activity_state_t xpc_activity_get_state(xpc_activity_t activity);
-extern "C" xpc_object_t xpc_activity_copy_criteria(xpc_activity_t activity);
+extern "C" XPC_RETURNS_RETAINED xpc_object_t xpc_activity_copy_criteria(xpc_activity_t activity);
 extern "C" void xpc_activity_set_criteria(xpc_activity_t activity, xpc_object_t criteria);
 #if COMPILER_SUPPORTS(BLOCKS)
 typedef void (^xpc_activity_handler_t)(xpc_activity_t activity);
@@ -160,7 +164,7 @@ extern const struct _xpc_type_s _xpc_type_endpoint;
 extern const struct _xpc_type_s _xpc_type_error;
 extern const struct _xpc_type_s _xpc_type_string;
 
-xpc_object_t xpc_array_create(const xpc_object_t*, size_t count);
+XPC_RETURNS_RETAINED xpc_object_t xpc_array_create(const xpc_object_t*, size_t count);
 #if COMPILER_SUPPORTS(BLOCKS)
 bool xpc_array_apply(xpc_object_t, XPC_NOESCAPE xpc_array_applier_t);
 bool xpc_dictionary_apply(xpc_object_t xdict, XPC_NOESCAPE xpc_dictionary_applier_t applier);
@@ -170,10 +174,10 @@ const char* xpc_array_get_string(xpc_object_t, size_t index);
 void xpc_array_set_string(xpc_object_t, size_t index, const char* string);
 bool xpc_bool_get_value(xpc_object_t);
 void xpc_connection_cancel(xpc_connection_t);
-xpc_connection_t xpc_connection_create(const char* name, dispatch_queue_t);
-xpc_endpoint_t xpc_endpoint_create(xpc_connection_t);
-xpc_connection_t xpc_connection_create_from_endpoint(xpc_endpoint_t);
-xpc_connection_t xpc_connection_create_mach_service(const char* name, dispatch_queue_t, uint64_t flags);
+XPC_RETURNS_RETAINED xpc_connection_t xpc_connection_create(const char* name, dispatch_queue_t);
+XPC_RETURNS_RETAINED xpc_endpoint_t xpc_endpoint_create(xpc_connection_t);
+XPC_RETURNS_RETAINED xpc_connection_t xpc_connection_create_from_endpoint(xpc_endpoint_t);
+XPC_RETURNS_RETAINED xpc_connection_t xpc_connection_create_mach_service(const char* name, dispatch_queue_t, uint64_t flags);
 pid_t xpc_connection_get_pid(xpc_connection_t);
 void xpc_connection_resume(xpc_connection_t);
 void xpc_connection_suspend(xpc_connection_t);
@@ -181,8 +185,8 @@ void xpc_connection_send_message(xpc_connection_t, xpc_object_t);
 void xpc_connection_send_message_with_reply(xpc_connection_t, xpc_object_t, dispatch_queue_t, xpc_handler_t);
 void xpc_connection_set_event_handler(xpc_connection_t, xpc_handler_t);
 void xpc_connection_set_target_queue(xpc_connection_t, dispatch_queue_t);
-xpc_object_t xpc_dictionary_create(const char*  const* keys, const xpc_object_t*, size_t count);
-xpc_object_t xpc_dictionary_create_reply(xpc_object_t);
+XPC_RETURNS_RETAINED xpc_object_t xpc_dictionary_create(const char*  const* keys, const xpc_object_t*, size_t count);
+XPC_RETURNS_RETAINED xpc_object_t xpc_dictionary_create_reply(xpc_object_t);
 int xpc_dictionary_dup_fd(xpc_object_t, const char* key);
 xpc_connection_t xpc_dictionary_get_remote_connection(xpc_object_t);
 bool xpc_dictionary_get_bool(xpc_object_t, const char* key);
@@ -199,14 +203,14 @@ void xpc_dictionary_set_value(xpc_object_t, const char* key, xpc_object_t value)
 xpc_type_t xpc_get_type(xpc_object_t);
 const char* xpc_type_get_name(xpc_type_t);
 void xpc_main(xpc_connection_handler_t);
-xpc_object_t xpc_string_create(const char *string);
+XPC_RETURNS_RETAINED xpc_object_t xpc_string_create(const char *string);
 const char* xpc_string_get_string_ptr(xpc_object_t);
 size_t xpc_string_get_length(xpc_object_t);
-os_transaction_t os_transaction_create(const char *description);
+XPC_RETURNS_RETAINED os_transaction_t os_transaction_create(const char *description);
 void xpc_transaction_exit_clean(void);
 void xpc_track_activity(void);
 
-xpc_object_t xpc_connection_copy_entitlement_value(xpc_connection_t, const char* entitlement);
+XPC_RETURNS_RETAINED xpc_object_t xpc_connection_copy_entitlement_value(xpc_connection_t, const char* entitlement);
 void xpc_connection_get_audit_token(xpc_connection_t, audit_token_t*);
 void xpc_connection_kill(xpc_connection_t, int);
 void xpc_connection_set_instance(xpc_connection_t, uuid_t);
@@ -214,12 +218,12 @@ mach_port_t xpc_dictionary_copy_mach_send(xpc_object_t, const char*);
 void xpc_dictionary_set_mach_send(xpc_object_t, const char*, mach_port_t);
 
 void xpc_connection_set_bootstrap(xpc_connection_t, xpc_object_t);
-xpc_object_t xpc_copy_bootstrap();
+XPC_RETURNS_RETAINED xpc_object_t xpc_copy_bootstrap();
 void xpc_connection_set_oneshot_instance(xpc_connection_t, uuid_t instance);
 
 void xpc_array_append_value(xpc_object_t xarray, xpc_object_t value);
 xpc_object_t xpc_array_get_value(xpc_object_t xarray, size_t index);
-xpc_object_t xpc_data_create(const void* bytes, size_t length);
+XPC_RETURNS_RETAINED xpc_object_t xpc_data_create(const void* bytes, size_t length);
 const void * xpc_data_get_bytes_ptr(xpc_object_t xdata);
 size_t xpc_data_get_length(xpc_object_t xdata);
 xpc_object_t xpc_dictionary_get_array(xpc_object_t xdict, const char* key);

--- a/Source/WebKit/SaferCPPExpectations/RetainPtrCtorAdoptCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/RetainPtrCtorAdoptCheckerExpectations
@@ -9,7 +9,6 @@ Shared/API/c/cg/WKImageCG.cpp
 Shared/Cocoa/APIObject.mm
 Shared/Cocoa/WKNSString.mm
 Shared/Daemon/DaemonUtilities.mm
-Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm
 Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
 UIProcess/API/Cocoa/NSAttributedString.mm
 UIProcess/API/Cocoa/WKBackForwardListItem.mm
@@ -23,5 +22,4 @@ UIProcess/WebAuthentication/Mock/MockLocalConnection.mm
 UIProcess/WebAuthentication/Virtual/VirtualAuthenticatorUtils.mm
 UIProcess/mac/ServicesController.mm
 UIProcess/mac/WebViewImpl.mm
-webpushd/WebPushDaemon.mm
 webpushd/_WKMockUserNotificationCenter.mm


### PR DESCRIPTION
#### b806ed1b107922bc2dc4daa9d01f9e371e4dd195
<pre>
Unreviewed, adopt XPC_RETURNS_RETAINED in XPCSPI.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=299163">https://bugs.webkit.org/show_bug.cgi?id=299163</a>

Reviewed by Ryosuke Niwa.

* Source/WTF/wtf/spi/darwin/XPCSPI.h:
* Source/WebKit/SaferCPPExpectations/RetainPtrCtorAdoptCheckerExpectations:

Canonical link: <a href="https://commits.webkit.org/300228@main">https://commits.webkit.org/300228@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f6388995230e442eb2fcecc3a83aff41d0069702

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121798 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41499 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32163 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128337 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/73888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/de45ec96-b550-4eec-87e5-b38a6781f43c) 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/42211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50090 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/92551 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/73888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cc128893-93f6-4a4c-b003-4f8e6a6253b9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124750 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/42211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/109079 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73210 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7e49cc3d-2c07-4885-ab36-936faffe053c) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/42211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/27242 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71847 "Built successfully") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/113940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/42211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/27427 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131113 "Failed to checkout and rebase branch from PR 50993") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/120320 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48733 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/37057 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/131113 "Failed to checkout and rebase branch from PR 50993") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49105 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/105296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/131113 "Failed to checkout and rebase branch from PR 50993") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25613 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/46378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/24480 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/45434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48591 "Failed to checkout and rebase branch from PR 50993") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/54318 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/150481 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/48061 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/38466 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/51410 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/49743 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->