### PR TITLE
[WebRTC] Split most generic parts of LibWebRTCNetwork into a reusable WebRTCNetwork super class

### DIFF
--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -848,6 +848,7 @@ WebProcess/Network/webrtc/LibWebRTCSocketFactory.cpp
 WebProcess/Network/webrtc/RTCDataChannelRemoteManager.cpp
 WebProcess/Network/webrtc/WebMDNSRegister.cpp
 WebProcess/Network/webrtc/WebRTCMonitor.cpp
+WebProcess/Network/webrtc/WebRTCNetworkBase.cpp
 WebProcess/Network/webrtc/WebRTCResolver.cpp
 
 WebProcess/Notifications/NotificationPermissionRequestManager.cpp

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetwork.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetwork.cpp
@@ -41,9 +41,8 @@ namespace WebKit {
 WTF_MAKE_TZONE_ALLOCATED_IMPL(LibWebRTCNetwork);
 
 LibWebRTCNetwork::LibWebRTCNetwork(WebProcess& webProcess)
-    : m_webProcess(webProcess)
+    : WebRTCNetworkBase(webProcess)
     , m_webNetworkMonitor(*this)
-    , m_mdnsRegister(*this)
 {
 }
 
@@ -52,20 +51,9 @@ LibWebRTCNetwork::~LibWebRTCNetwork()
     ASSERT_NOT_REACHED();
 }
 
-void LibWebRTCNetwork::ref() const
-{
-    m_webProcess->ref();
-}
-
-void LibWebRTCNetwork::deref() const
-{
-    m_webProcess->deref();
-}
-
 void LibWebRTCNetwork::setAsActive()
 {
-    ASSERT(!m_isActive);
-    m_isActive = true;
+    WebRTCNetworkBase::setAsActive();
     if (m_connection)
         setSocketFactoryConnection();
 }
@@ -84,7 +72,7 @@ void LibWebRTCNetwork::setConnection(RefPtr<IPC::Connection>&& connection)
 
     m_connection = WTFMove(connection);
 
-    if (m_isActive)
+    if (isActive())
         setSocketFactoryConnection();
     if (RefPtr connection = m_connection)
         connection->addMessageReceiver(*this, *this, Messages::LibWebRTCNetwork::messageReceiverName());
@@ -111,7 +99,7 @@ void LibWebRTCNetwork::setSocketFactoryConnection()
 
 void LibWebRTCNetwork::dispatch(Function<void()>&& callback)
 {
-    if (!m_isActive) {
+    if (!isActive()) {
         RELEASE_LOG_ERROR(WebRTC, "Received WebRTCSocket message while libWebRTCNetwork is not active");
         return;
     }

--- a/Source/WebKit/WebProcess/Network/webrtc/WebMDNSRegister.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/WebMDNSRegister.cpp
@@ -26,30 +26,30 @@
 #include "config.h"
 #include "WebMDNSRegister.h"
 
-#if ENABLE(WEB_RTC) && USE(LIBWEBRTC)
+#if ENABLE(WEB_RTC)
 
-#include "LibWebRTCNetwork.h"
 #include "NetworkMDNSRegisterMessages.h"
 #include "NetworkProcessConnection.h"
 #include "WebProcess.h"
+#include "WebRTCNetworkBase.h"
 #include <WebCore/Document.h>
 
 namespace WebKit {
 using namespace WebCore;
 
-WebMDNSRegister::WebMDNSRegister(LibWebRTCNetwork& libWebRTCNetwork)
-    : m_libWebRTCNetwork(libWebRTCNetwork)
+WebMDNSRegister::WebMDNSRegister(WebRTCNetworkBase& webRTCNetwork)
+    : m_webRTCNetwork(webRTCNetwork)
 {
 }
 
 void WebMDNSRegister::ref() const
 {
-    m_libWebRTCNetwork->ref();
+    m_webRTCNetwork->ref();
 }
 
 void WebMDNSRegister::deref() const
 {
-    m_libWebRTCNetwork->deref();
+    m_webRTCNetwork->deref();
 }
 
 void WebMDNSRegister::finishedRegisteringMDNSName(WebCore::ScriptExecutionContextIdentifier documentIdentifier, const String& ipAddress, String&& name, std::optional<MDNSRegisterError> error, CompletionHandler<void(const String&, std::optional<MDNSRegisterError>)>&& completionHandler)
@@ -96,4 +96,4 @@ void WebMDNSRegister::registerMDNSName(ScriptExecutionContextIdentifier identifi
 
 } // namespace WebKit
 
-#endif // ENABLE(WEB_RTC) && USE(LIBWEBRTC)
+#endif // ENABLE(WEB_RTC)

--- a/Source/WebKit/WebProcess/Network/webrtc/WebRTCNetworkBase.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/WebRTCNetworkBase.cpp
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2020-2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WebRTCNetworkBase.h"
+
+#if USE(LIBWEBRTC)
+
+#include "WebProcess.h"
+#include <wtf/TZoneMallocInlines.h>
+
+namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebRTCNetworkBase);
+
+WebRTCNetworkBase::WebRTCNetworkBase(WebProcess& webProcess)
+    : m_webProcess(webProcess)
+    , m_mdnsRegister(*this)
+{
+}
+
+WebRTCNetworkBase::~WebRTCNetworkBase()
+{
+    ASSERT_NOT_REACHED();
+}
+
+void WebRTCNetworkBase::ref() const
+{
+    m_webProcess->ref();
+}
+
+void WebRTCNetworkBase::deref() const
+{
+    m_webProcess->deref();
+}
+
+void WebRTCNetworkBase::setAsActive()
+{
+    ASSERT(!m_isActive);
+    m_isActive = true;
+}
+
+} // namespace WebKit
+
+#endif // USE(LIBWEBRTC)


### PR DESCRIPTION
#### 4bdca5ffb3004a9b79b0b7b383417b8e6d21021d
<pre>
[WebRTC] Split most generic parts of LibWebRTCNetwork into a reusable WebRTCNetwork super class
<a href="https://bugs.webkit.org/show_bug.cgi?id=299094">https://bugs.webkit.org/show_bug.cgi?id=299094</a>

Reviewed by Youenn Fablet.

Refactor the libwebrtc-agnostic code from LibWebRTCNetwork into a WebRTCNetworkBase
class (WebRTCNetwork is used for a namespace already) and remove USE(LIBWEBRTC) ifdefs from
WebMDNSRegister, making it usable later on for the WPE and GTK ports when GstWebRTC is enabled.

Covered by existing tests.

* Source/WebKit/Sources.txt:
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetwork.cpp:
(WebKit::LibWebRTCNetwork::LibWebRTCNetwork):
(WebKit::LibWebRTCNetwork::setAsActive):
(WebKit::LibWebRTCNetwork::setConnection):
(WebKit::LibWebRTCNetwork::dispatch):
(WebKit::LibWebRTCNetwork::ref const): Deleted.
(WebKit::LibWebRTCNetwork::deref const): Deleted.
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetwork.h:
* Source/WebKit/WebProcess/Network/webrtc/WebMDNSRegister.cpp:
(WebKit::WebMDNSRegister::WebMDNSRegister):
(WebKit::WebMDNSRegister::ref const):
(WebKit::WebMDNSRegister::deref const):
* Source/WebKit/WebProcess/Network/webrtc/WebMDNSRegister.h:
* Source/WebKit/WebProcess/Network/webrtc/WebRTCNetworkBase.cpp: Added.
(WebKit::WebRTCNetworkBase::WebRTCNetworkBase):
(WebKit::WebRTCNetworkBase::~WebRTCNetworkBase):
(WebKit::WebRTCNetworkBase::ref const):
(WebKit::WebRTCNetworkBase::deref const):
(WebKit::WebRTCNetworkBase::setAsActive):
* Source/WebKit/WebProcess/Network/webrtc/WebRTCNetworkBase.h: Copied from Source/WebKit/WebProcess/Network/webrtc/WebMDNSRegister.h.
(WebKit::WebRTCNetworkBase::networkProcessCrashed):
(WebKit::WebRTCNetworkBase::isActive const):
(WebKit::WebRTCNetworkBase::mdnsRegister):
(WebKit::WebRTCNetworkBase::protectedMDNSRegister):

Canonical link: <a href="https://commits.webkit.org/300740@main">https://commits.webkit.org/300740@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b3e896f201c6ab506e127aab93c8a1d77a9ae2a5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121769 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41470 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32134 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128303 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73859 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42182 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50061 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92531 "Failed to checkout and rebase branch from PR 50994") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61509 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124721 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33647 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109056 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73190 "Found 1 new API test failure: WPE/TestWebKitWebContext:/webkit/WebKitWebContext/no-web-process-leak (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32659 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71816 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103147 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27404 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131084 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48704 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37037 "Found 1 new test failure: compositing/visible-rect/flipped-preserve-3d.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101116 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49076 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105273 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100988 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26029 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46353 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24465 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45405 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48562 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54289 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48032 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51381 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49714 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->