### PR TITLE
Address some Safer CPP warnings found by the newer version of the static analyser

### DIFF
--- a/Source/JavaScriptCore/SaferCPPExpectations/RetainPtrCtorAdoptCheckerExpectations
+++ b/Source/JavaScriptCore/SaferCPPExpectations/RetainPtrCtorAdoptCheckerExpectations
@@ -5,4 +5,3 @@ API/ObjCCallbackFunction.mm
 API/tests/Regress141275.mm
 API/tests/testapi.c
 inspector/remote/cocoa/RemoteConnectionToTargetCocoa.mm
-inspector/remote/cocoa/RemoteInspectorCocoa.mm

--- a/Source/JavaScriptCore/inspector/remote/RemoteInspector.h
+++ b/Source/JavaScriptCore/inspector/remote/RemoteInspector.h
@@ -301,7 +301,7 @@ private:
     std::optional<RemoteInspector::Client::Capabilities> m_clientCapabilities;
 
 #if PLATFORM(COCOA)
-    dispatch_queue_t m_xpcQueue;
+    OSObjectPtr<dispatch_queue_t> m_xpcQueue;
 #endif
     TargetID m_nextAvailableTargetIdentifier { 1 };
     int m_notifyToken { 0 };

--- a/Source/WebKit/SaferCPPExpectations/RetainPtrCtorAdoptCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/RetainPtrCtorAdoptCheckerExpectations
@@ -20,6 +20,5 @@ UIProcess/WebAuthentication/Cocoa/LocalConnection.mm
 UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm
 UIProcess/WebAuthentication/Mock/MockLocalConnection.mm
 UIProcess/WebAuthentication/Virtual/VirtualAuthenticatorUtils.mm
-UIProcess/mac/ServicesController.mm
 UIProcess/mac/WebViewImpl.mm
 webpushd/_WKMockUserNotificationCenter.mm

--- a/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
@@ -38,7 +38,6 @@ Shared/Cocoa/RevealItem.mm
 Shared/Cocoa/WKNSError.mm
 Shared/Cocoa/WKNSURLRequest.mm
 Shared/EntryPointUtilities/Cocoa/Daemon/PCMDaemonEntryPoint.mm
-Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.mm
 Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm
 Shared/JavaScriptEvaluationResult.mm
 Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
@@ -136,7 +135,6 @@ UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
 UIProcess/mac/DisplayCaptureSessionManager.mm
 UIProcess/mac/PageClientImplMac.mm
 UIProcess/mac/SecItemShimProxy.cpp
-UIProcess/mac/ServicesController.mm
 UIProcess/mac/TiledCoreAnimationDrawingAreaProxy.mm
 UIProcess/mac/ViewGestureControllerMac.mm
 UIProcess/mac/WKFullScreenWindowController.mm

--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.h
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.h
@@ -74,7 +74,7 @@ protected:
     bool isClientSandboxed();
 
     OSObjectPtr<xpc_connection_t> m_connection;
-    xpc_object_t m_initializerMessage;
+    OSObjectPtr<xpc_object_t> m_initializerMessage;
 };
 
 template<typename XPCServiceType>

--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.mm
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.mm
@@ -71,7 +71,7 @@ bool XPCServiceInitializerDelegate::checkEntitlements()
 
 bool XPCServiceInitializerDelegate::getConnectionIdentifier(IPC::Connection::Identifier& identifier)
 {
-    mach_port_t port = xpc_dictionary_copy_mach_send(m_initializerMessage, "server-port");
+    mach_port_t port = xpc_dictionary_copy_mach_send(m_initializerMessage.get(), "server-port");
     if (!MACH_PORT_VALID(port))
         return false;
 
@@ -81,19 +81,19 @@ bool XPCServiceInitializerDelegate::getConnectionIdentifier(IPC::Connection::Ide
 
 bool XPCServiceInitializerDelegate::getClientIdentifier(String& clientIdentifier)
 {
-    clientIdentifier = xpcDictionaryGetString(m_initializerMessage, "client-identifier"_s);
+    clientIdentifier = xpcDictionaryGetString(m_initializerMessage.get(), "client-identifier"_s);
     return !clientIdentifier.isEmpty();
 }
 
 bool XPCServiceInitializerDelegate::getClientBundleIdentifier(String& clientBundleIdentifier)
 {
-    clientBundleIdentifier = xpcDictionaryGetString(m_initializerMessage, "client-bundle-identifier"_s);
+    clientBundleIdentifier = xpcDictionaryGetString(m_initializerMessage.get(), "client-bundle-identifier"_s);
     return !clientBundleIdentifier.isEmpty();
 }
 
 bool XPCServiceInitializerDelegate::getClientSDKAlignedBehaviors(SDKAlignedBehaviors& behaviors)
 {
-    auto behaviorData = xpcDictionaryGetData(m_initializerMessage, "client-sdk-aligned-behaviors"_s);
+    auto behaviorData = xpcDictionaryGetData(m_initializerMessage.get(), "client-sdk-aligned-behaviors"_s);
     if (behaviorData.empty())
         return false;
     auto storageBytes = behaviors.storageBytes();
@@ -107,7 +107,7 @@ bool XPCServiceInitializerDelegate::getClientSDKAlignedBehaviors(SDKAlignedBehav
 
 bool XPCServiceInitializerDelegate::getProcessIdentifier(std::optional<WebCore::ProcessIdentifier>& identifier)
 {
-    auto parsedIdentifier = parseInteger<uint64_t>(xpcDictionaryGetString(m_initializerMessage, "process-identifier"_s));
+    auto parsedIdentifier = parseInteger<uint64_t>(xpcDictionaryGetString(m_initializerMessage.get(), "process-identifier"_s));
     if (!parsedIdentifier)
         return false;
     if (!ObjectIdentifier<WebCore::ProcessIdentifierType>::isValidIdentifier(*parsedIdentifier))
@@ -119,13 +119,13 @@ bool XPCServiceInitializerDelegate::getProcessIdentifier(std::optional<WebCore::
 
 bool XPCServiceInitializerDelegate::getClientProcessName(String& clientProcessName)
 {
-    clientProcessName = xpcDictionaryGetString(m_initializerMessage, "ui-process-name"_s);
+    clientProcessName = xpcDictionaryGetString(m_initializerMessage.get(), "ui-process-name"_s);
     return !clientProcessName.isEmpty();
 }
 
 bool XPCServiceInitializerDelegate::getExtraInitializationData(HashMap<String, String>& extraInitializationData)
 {
-    RetainPtr extraDataInitializationDataObject = xpc_dictionary_get_value(m_initializerMessage, "extra-initialization-data");
+    RetainPtr extraDataInitializationDataObject = xpc_dictionary_get_value(m_initializerMessage.get(), "extra-initialization-data");
 
     auto inspectorProcess = xpcDictionaryGetString(extraDataInitializationDataObject.get(), "inspector-process"_s);
     if (!inspectorProcess.isEmpty())

--- a/Source/WebKit/UIProcess/mac/ServicesController.h
+++ b/Source/WebKit/UIProcess/mac/ServicesController.h
@@ -49,7 +49,7 @@ public:
 private:
     ServicesController();
 
-    dispatch_queue_t m_refreshQueue;
+    OSObjectPtr<dispatch_queue_t> m_refreshQueue;
     std::atomic_bool m_hasPendingRefresh;
 
     std::atomic<bool> m_hasImageServices;

--- a/Source/WebKit/UIProcess/mac/ServicesController.mm
+++ b/Source/WebKit/UIProcess/mac/ServicesController.mm
@@ -46,7 +46,7 @@ ServicesController& ServicesController::singleton()
 }
 
 ServicesController::ServicesController()
-    : m_refreshQueue(dispatch_queue_create("com.apple.WebKit.ServicesController", DISPATCH_QUEUE_SERIAL))
+    : m_refreshQueue(adoptOSObject(dispatch_queue_create("com.apple.WebKit.ServicesController", DISPATCH_QUEUE_SERIAL)))
     , m_hasPendingRefresh(false)
     , m_hasImageServices(false)
     , m_hasSelectionServices(false)
@@ -84,7 +84,7 @@ void ServicesController::refreshExistingServices(bool refreshImmediately)
     m_hasPendingRefresh = true;
 
     auto refreshTime = dispatch_time(DISPATCH_TIME_NOW, refreshImmediately ? 0 : (int64_t)(1 * NSEC_PER_SEC));
-    dispatch_after(refreshTime, m_refreshQueue, ^{
+    dispatch_after(refreshTime, m_refreshQueue.get(), ^{
         auto serviceLookupGroup = adoptOSObject(dispatch_group_create());
 
         static NeverDestroyed<RetainPtr<NSImage>> image = adoptNS([[NSImage alloc] init]);


### PR DESCRIPTION
#### 67e53aecf711a6803f12e2a603828c5f70a2e4cb
<pre>
Address some Safer CPP warnings found by the newer version of the static analyser
<a href="https://bugs.webkit.org/show_bug.cgi?id=299165">https://bugs.webkit.org/show_bug.cgi?id=299165</a>

Reviewed by Ryosuke Niwa.

* Source/JavaScriptCore/SaferCPPExpectations/RetainPtrCtorAdoptCheckerExpectations:
* Source/JavaScriptCore/inspector/remote/RemoteInspector.h:
* Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorCocoa.mm:
(Inspector::RemoteInspector::RemoteInspector):
(Inspector::RemoteInspector::start):
(Inspector::RemoteInspector::setupXPCConnectionIfNeeded):
(Inspector::RemoteInspector::connectToWebInspector):
* Source/WebKit/SaferCPPExpectations/RetainPtrCtorAdoptCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations:
* Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.h:
* Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.mm:
(WebKit::XPCServiceInitializerDelegate::getConnectionIdentifier):
(WebKit::XPCServiceInitializerDelegate::getClientIdentifier):
(WebKit::XPCServiceInitializerDelegate::getClientBundleIdentifier):
(WebKit::XPCServiceInitializerDelegate::getClientSDKAlignedBehaviors):
(WebKit::XPCServiceInitializerDelegate::getProcessIdentifier):
(WebKit::XPCServiceInitializerDelegate::getClientProcessName):
(WebKit::XPCServiceInitializerDelegate::getExtraInitializationData):
* Source/WebKit/UIProcess/mac/ServicesController.h:
* Source/WebKit/UIProcess/mac/ServicesController.mm:
(WebKit::ServicesController::ServicesController):
(WebKit::ServicesController::refreshExistingServices):
* Source/WebKit/webpushd/_WKMockUserNotificationCenter.mm:
(-[_WKMockUserNotificationCenter _internalInitWithBundleIdentifier:]):
(-[_WKMockUserNotificationCenter addNotificationRequest:withCompletionHandler:]):
(-[_WKMockUserNotificationCenter getDeliveredNotificationsWithCompletionHandler:]):
(-[_WKMockUserNotificationCenter getNotificationSettingsWithCompletionHandler:]):
(-[_WKMockUserNotificationCenter requestAuthorizationWithOptions:completionHandler:]):

Canonical link: <a href="https://commits.webkit.org/300230@main">https://commits.webkit.org/300230@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de6977295564360fe090eb7e74f97520265c6df2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121801 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41502 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32166 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128340 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/73891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b68040aa-02b2-45f1-839e-20c6dcb86c01) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42214 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50093 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/92553 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/73891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9f9d0710-409d-42cf-bf53-849846864b15) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124753 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/33666 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/109082 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73212 "Found 1 new API test failure: TestWTF:WTF_Condition.OneProducerOneConsumerOneSlotTimeout (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1688e2ef-adf0-4ca6-ba16-086dfbce276d) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/32677 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/27245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71850 "Built successfully") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/113943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/103166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/27430 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131116 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/120323 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48736 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/37059 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/101139 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49108 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/105299 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101011 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25615 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/46376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/24483 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/45437 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48594 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/54321 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/150484 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/48064 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/38468 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51413 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/49746 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->