### PR TITLE
Fix TestIPC flakiness exposed by running the tests in parallel

### DIFF
--- a/Tools/TestWebKitAPI/Tests/IPC/IPCTestUtilities.h
+++ b/Tools/TestWebKitAPI/Tests/IPC/IPCTestUtilities.h
@@ -77,6 +77,17 @@ public:
         ASSERT(m_invalidMessages.isEmpty()); // Received unexpected invalid message.
     }
 
+    testing::AssertionResult checkMessages()
+    {
+        auto messages = takeMessages();
+        if (!messages.isEmpty())
+            return testing::AssertionFailure() << "Unexpected messages: " << messages.size() << " first: " << static_cast<unsigned>(messages[0].messageName) << " to " << messages[0].destinationID;
+        auto invalidMessages = takeInvalidMessages();
+        if (!invalidMessages.isEmpty())
+            return testing::AssertionFailure() << "Unexpected invalid messages: " << invalidMessages.size() << " first:" << static_cast<unsigned>(invalidMessages[0]);
+        return testing::AssertionSuccess();
+    }
+
     Vector<MessageInfo> takeMessages()
     {
         Locker locker { m_lock };


### PR DESCRIPTION
#### d1a8274f96dac8a478fd412f1a62f53219e42858
<pre>
Fix TestIPC flakiness exposed by running the tests in parallel
<a href="https://bugs.webkit.org/show_bug.cgi?id=299167">https://bugs.webkit.org/show_bug.cgi?id=299167</a>
<a href="https://rdar.apple.com/160925533">rdar://160925533</a>

Reviewed by Mike Wyrzykowski.

TestIPC tests are prone to logic errors due to testing API contracts
related to parallelism.

Fix errors uncovered by running many tests in parallel to cause unusual
scheduling of the threads.

Fixes cases that were uncovered locally using:
run-api-tests --fully-parallel --repeat-each=30 TestIPC.&quot;*&quot;

* Tools/TestWebKitAPI/Tests/IPC/ConnectionTests.cpp:
(TestWebKitAPI::TEST_P):
* Tools/TestWebKitAPI/Tests/IPC/IPCTestUtilities.h:
(TestWebKitAPI::WaitForMessageMixin::checkMessages):
* Tools/TestWebKitAPI/Tests/IPC/StreamConnectionTests.cpp:

Canonical link: <a href="https://commits.webkit.org/300247@main">https://commits.webkit.org/300247@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/375ef81ade288f1d969b98f567dbb4594019c1ca

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121768 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41469 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32133 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128302 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73858 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f0502753-e8a3-491f-b151-41e16823d13c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123644 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42181 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50060 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92527 "") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61508 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f23e2411-6dc4-4fa8-971b-aeea4dad9a09) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124720 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33645 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109054 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73189 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/48e2ba13-93f9-4cad-a718-8441db044c7f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32657 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27217 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71815 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103145 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27402 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131083 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48703 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37039 "Found 1 new test failure: compositing/visible-rect/flipped-preserve-3d.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101117 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49075 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105271 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100989 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25626 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46352 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24463 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45404 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48561 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48031 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51380 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49713 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->