### PR TITLE
Inline nesting selector when possible

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nesting-basic-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nesting-basic-expected.html
@@ -27,4 +27,5 @@
   <div class="test"></div>
   <div class="test"></div>
   <div class="test"></div>
+  <div class="test"></div>
 </body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nesting-basic.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nesting-basic.html
@@ -88,6 +88,17 @@
     background-color: red !important;
   }
 
+  .test-13::before {
+    background-color: green;
+    color: green;
+    content: "text";
+  }
+  .test-13::before {
+    & {
+      background-color: red;
+    }
+  }
+
   body * + * {
     margin-top: 8px;
   }
@@ -109,4 +120,5 @@
   <div class="test test-10"><div></div></div>
   <div class="test test-11"><div></div></div>
   <div class="test test-12"></div>
+  <div class="test test-13"></div>
 </body>

--- a/Source/WebCore/css/CSSSelector.h
+++ b/Source/WebCore/css/CSSSelector.h
@@ -55,6 +55,8 @@ class CSSSelector {
 public:
     CSSSelector() = default;
     CSSSelector(const CSSSelector&);
+    enum MutableSelectorCopyTag { MutableSelectorCopy };
+    CSSSelector(const CSSSelector&, MutableSelectorCopyTag);
     explicit CSSSelector(const QualifiedName&, bool tagIsForNamespaceRule = false);
 
     ~CSSSelector();
@@ -137,6 +139,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     const CSSSelector* precedingInComplexSelector() const { return m_isFirstInComplexSelector ? nullptr : this + 1; }
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
+    const CSSSelector* firstInCompound() const;
     const CSSSelector* lastInCompound() const;
 
     const QualifiedName& tagQName() const;
@@ -269,6 +272,8 @@ private:
         RareData* rareData;
     } m_data;
 };
+
+bool complexSelectorCanMatchPseudoElement(const CSSSelector&);
 
 inline bool operator==(const PossiblyQuotedIdentifier& a, const AtomString& b) { return a.identifier == b; }
 

--- a/Source/WebCore/css/parser/MutableCSSSelector.cpp
+++ b/Source/WebCore/css/parser/MutableCSSSelector.cpp
@@ -100,18 +100,15 @@ MutableCSSSelector::MutableCSSSelector(const QualifiedName& tagQName)
 }
 
 MutableCSSSelector::MutableCSSSelector(const CSSSelector& selector)
-    : m_selector(makeUnique<CSSSelector>(selector))
+    : m_selector(makeUnique<CSSSelector>(selector, CSSSelector::MutableSelectorCopy))
 {
     if (auto preceding = selector.precedingInComplexSelector())
         m_precedingInComplexSelector = makeUnique<MutableCSSSelector>(*preceding);
 }
 
 MutableCSSSelector::MutableCSSSelector(const CSSSelector& selector, SimpleSelectorTag)
-    : m_selector(makeUnique<CSSSelector>(selector))
+    : m_selector(makeUnique<CSSSelector>(selector, CSSSelector::MutableSelectorCopy))
 {
-    m_selector->m_isLastInSelectorList = false;
-    m_selector->m_isFirstInComplexSelector = true;
-    m_selector->m_isLastInComplexSelector = true;
 }
 
 

--- a/Source/WebCore/style/RuleData.cpp
+++ b/Source/WebCore/style/RuleData.cpp
@@ -86,25 +86,6 @@ static inline MatchBasedOnRuleHash computeMatchBasedOnRuleHash(const CSSSelector
     return MatchBasedOnRuleHash::None;
 }
 
-static bool selectorCanMatchPseudoElement(const CSSSelector& rootSelector)
-{
-    const CSSSelector* selector = &rootSelector;
-    do {
-        if (selector->matchesPseudoElement())
-            return true;
-
-        if (const CSSSelectorList* selectorList = selector->selectorList()) {
-            for (auto& subSelector : *selectorList) {
-                if (selectorCanMatchPseudoElement(subSelector))
-                    return true;
-            }
-        }
-
-        selector = selector->precedingInComplexSelector();
-    } while (selector);
-    return false;
-}
-
 static inline PropertyAllowlist determinePropertyAllowlist(const CSSSelector* selector)
 {
     for (const CSSSelector* component = selector; component; component = component->precedingInComplexSelector()) {
@@ -138,7 +119,7 @@ RuleData::RuleData(const StyleRule& styleRule, unsigned selectorIndex, unsigned 
     , m_selectorListIndex(selectorListIndex)
     , m_position(position)
     , m_matchBasedOnRuleHash(enumToUnderlyingType(computeMatchBasedOnRuleHash(*selector())))
-    , m_canMatchPseudoElement(selectorCanMatchPseudoElement(*selector()))
+    , m_canMatchPseudoElement(complexSelectorCanMatchPseudoElement(*selector()))
     , m_propertyAllowlist(enumToUnderlyingType(determinePropertyAllowlist(selector())))
     , m_isStartingStyle(enumToUnderlyingType(isStartingStyle))
     , m_isEnabled(true)


### PR DESCRIPTION
#### 4a6e51b91b8ef0d6a31cd1a6342a5941425209a5
<pre>
Inline nesting selector when possible
<a href="https://bugs.webkit.org/show_bug.cgi?id=299168">https://bugs.webkit.org/show_bug.cgi?id=299168</a>
<a href="https://rdar.apple.com/160927950">rdar://160927950</a>

Reviewed by Matthieu Dubet.

Currently we always wrap the parent selector list to :is(). This is unneeded in many common cases. For example

.foo { &amp; .bar {...} }

currently resolves to

:is(.foo) .bar {...}

with this patch it resolves to

.foo .bar {...}

Removing unnecessary :is() improves selector performance.

* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nesting-basic-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nesting-basic.html:

Add a test for the pseudo-element case where we can&apos;t inline.

* Source/WebCore/css/CSSSelector.cpp:
(WebCore::CSSSelector::firstInCompound const):
(WebCore::CSSSelector::CSSSelector):

Add a copy-constructor that resets the selector list bits to the initial state for MutableCSSSelector use.

(WebCore::complexSelectorCanMatchPseudoElement):

Move the function here from RuleData so we can use it from resolveNestingParent.

* Source/WebCore/css/CSSSelector.h:
* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::CSSSelectorParser::resolveNestingParent):

Inline the resolved nesting selectors when possible.

* Source/WebCore/css/parser/MutableCSSSelector.cpp:
(WebCore::MutableCSSSelector::MutableCSSSelector):
* Source/WebCore/style/RuleData.cpp:
(WebCore::Style::RuleData::RuleData):
(WebCore::Style::selectorCanMatchPseudoElement): Deleted.

Canonical link: <a href="https://commits.webkit.org/300297@main">https://commits.webkit.org/300297@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1fdbad78482c4e1ac4af55d58ad9668b4b929b3d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122004 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41706 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32376 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128564 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74097 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e505b56c-73ba-4759-9a4c-80451203a8fc) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123880 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42421 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50300 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92723 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61606 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/61f5bf63-16fd-4bd5-bebb-738a199607a8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124956 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33824 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109256 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73377 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32836 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27417 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72061 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103331 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27613 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131328 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48943 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37216 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101282 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49317 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105470 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101153 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25659 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46523 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24640 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45646 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48800 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54534 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48270 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51620 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49950 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->