### PR TITLE
Only serialize necessary font attributes when showing the popup menu

### DIFF
--- a/Source/WebKit/Shared/PlatformPopupMenuData.h
+++ b/Source/WebKit/Shared/PlatformPopupMenuData.h
@@ -34,7 +34,8 @@ namespace WebKit {
 
 struct PlatformPopupMenuData {
 #if PLATFORM(COCOA)
-    WebKit::PlatformFontInfo fontInfo;
+    String postScriptName;
+    double pointSize { 0.0 };
     bool shouldPopOver { false };
     bool hideArrows { false };
     WebCore::PopupMenuStyle::Size menuSize { WebCore::PopupMenuStyle::Size::Normal };

--- a/Source/WebKit/Shared/PlatformPopupMenuData.serialization.in
+++ b/Source/WebKit/Shared/PlatformPopupMenuData.serialization.in
@@ -22,7 +22,8 @@
 
 struct WebKit::PlatformPopupMenuData {
 #if PLATFORM(COCOA)
-    WebKit::PlatformFontInfo fontInfo;
+    String postScriptName;
+    double pointSize;
     bool shouldPopOver;
     bool hideArrows;
     WebCore::PopupMenuStyle::Size menuSize;

--- a/Source/WebKit/UIProcess/mac/WebPopupMenuProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebPopupMenuProxyMac.mm
@@ -109,17 +109,16 @@ void WebPopupMenuProxyMac::showPopupMenu(const IntRect& rect, TextDirection text
 
     BEGIN_BLOCK_OBJC_EXCEPTIONS
 
-    if (RetainPtr fontAttributes = bridge_cast(data.fontInfo.fontAttributeDictionary.get())) {
-        auto scaledFontSize = [fontAttributes.get()[NSFontSizeAttribute] floatValue] * pageScaleFactor;
-
-        font = fontWithAttributes(fontAttributes.get(), ((pageScaleFactor != 1) ? scaledFontSize : 0));
-        // font will be nil when using a custom font. However, we should still
-        // honor the font size, matching other browsers.
-        if (!font)
-            font = [NSFont menuFontOfSize:scaledFontSize];
-    } else
-        font = [NSFont menuFontOfSize:0];
+    auto scaledFontSize = data.pointSize * pageScaleFactor;
     
+    RetainPtr<NSFontDescriptor> descriptor = [NSFontDescriptor fontDescriptorWithName:data.postScriptName.createNSString().get() size:scaledFontSize];
+    font = [NSFont fontWithDescriptor:descriptor.get() size:scaledFontSize];
+
+    // font will be nil when using a custom font. However, we should still
+    // honor the font size, matching other browsers.
+    if (!font)
+        font = [NSFont menuFontOfSize:scaledFontSize];
+
     END_BLOCK_OBJC_EXCEPTIONS
 
     populate(items, font.get(), textDirection);

--- a/Source/WebKit/WebProcess/WebCoreSupport/mac/WebPopupMenuMac.mm
+++ b/Source/WebKit/WebProcess/WebCoreSupport/mac/WebPopupMenuMac.mm
@@ -27,6 +27,7 @@
 #import "WebPopupMenu.h"
 
 #import "PlatformPopupMenuData.h"
+#import <CoreText/CoreText.h>
 #import <WebCore/LocalFrame.h>
 #import <WebCore/LocalFrameView.h>
 #import <WebCore/PopupMenuClient.h>
@@ -42,15 +43,8 @@ void WebPopupMenu::setUpPlatformData(const IntRect&, PlatformPopupMenuData& data
     if (!font)
         return;
 
-    RetainPtr fontDescriptor = adoptCF(CTFontCopyFontDescriptor(font.get()));
-    if (!fontDescriptor)
-        return;
-
-    RetainPtr attributes = adoptCF(CTFontDescriptorCopyAttributes(fontDescriptor.get()));
-    if (!attributes)
-        return;
-    
-    data.fontInfo.fontAttributeDictionary = attributes.get();
+    data.postScriptName = font ? String(adoptCF(CTFontCopyPostScriptName(font.get())).get()) : String();
+    data.pointSize = font ? CTFontGetSize(font.get()) : 0.0;
     data.shouldPopOver = m_popupClient->shouldPopOver();
     data.hideArrows = !m_popupClient->menuStyle().hasDefaultAppearance();
     data.menuSize = m_popupClient->menuStyle().menuSize();


### PR DESCRIPTION
#### baec37f9d7c7ea1804288603933225b3106f12fb
<pre>
Only serialize necessary font attributes when showing the popup menu
<a href="https://bugs.webkit.org/show_bug.cgi?id=299170">https://bugs.webkit.org/show_bug.cgi?id=299170</a>
<a href="https://rdar.apple.com/76505928">rdar://76505928</a>

Reviewed by Alex Christensen.

Instead of serializing all font attributes when showing the popup menu,
instead just serialize the minimum set required to reconstruct the font.

* Source/WebKit/Shared/PlatformPopupMenuData.h:
* Source/WebKit/Shared/PlatformPopupMenuData.serialization.in:
* Source/WebKit/UIProcess/mac/WebPopupMenuProxyMac.mm:
(WebKit::WebPopupMenuProxyMac::showPopupMenu):
* Source/WebKit/WebProcess/WebCoreSupport/mac/WebPopupMenuMac.mm:
(WebKit::WebPopupMenu::setUpPlatformData):

Canonical link: <a href="https://commits.webkit.org/300337@main">https://commits.webkit.org/300337@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d8d90d2199a409e3daeb48dee0718c8c26be0f26

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122186 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41889 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32558 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128759 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74280 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b0b29222-2698-4b9c-a9f7-9cd8b942a105) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42603 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50482 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92868 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/61737 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4abbf367-0143-4e68-b800-93e832ef760e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125138 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33981 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109415 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73524 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ede54619-da58-43db-9c3d-f87a723e0f0a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32991 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72247 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103489 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27771 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131510 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49125 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37373 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101436 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49499 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105626 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101305 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25684 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46677 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24794 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/45876 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48982 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54716 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48452 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51802 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50132 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->