### PR TITLE
Only serialize installed fonts attributes for WebCore::AttributedString

### DIFF
--- a/Source/WebCore/Configurations/AllowedSPI.toml
+++ b/Source/WebCore/Configurations/AllowedSPI.toml
@@ -66,3 +66,10 @@ selectors = [
     { name = "_enumerateAllDeclaredTypesUsingBlock:", class = "UTType" },
     { name = "_parentTypes", class = "UTType" },
 ]
+
+[[temporary-usage]]
+request = "rdar://161241270"
+cleanup = "rdar://161241477"
+symbols = [
+    "CTFontDescriptorCreateMatchingFontDescriptorsWithOptions",
+]

--- a/Source/WebCore/PAL/pal/spi/cf/CoreTextSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cf/CoreTextSPI.h
@@ -109,6 +109,10 @@ typedef CF_ENUM(uint32_t, CTFontTextStylePlatform)
     kCTFontTextStylePlatformVision = (CTFontTextStylePlatform)5,
 };
 
+typedef CF_OPTIONS(CFOptionFlags, CTFontDescriptorMatchingOptions) {
+    kCTFontDescriptorMatchingOptionIncludeHiddenFonts = 1 << 16,
+};
+
 #endif
 
 WTF_EXTERN_C_BEGIN
@@ -240,6 +244,7 @@ bool CTFontIsAppleColorEmoji(CTFontRef);
 CTFontRef CTFontCreateForCharacters(CTFontRef currentFont, const UTF16Char *characters, CFIndex length, CFIndex *coveredLength);
 CGFloat CTFontGetSbixImageSizeForGlyphAndContentsScale(CTFontRef, const CGGlyph, CGFloat contentsScale);
 
+CFArrayRef _Nullable CTFontDescriptorCreateMatchingFontDescriptorsWithOptions(CTFontDescriptorRef, CFSetRef _Nullable, CTFontDescriptorMatchingOptions);
 CTFontDescriptorOptions CTFontDescriptorGetOptions(CTFontDescriptorRef);
 
 CFBitVectorRef CTFontCopyColorGlyphCoverage(CTFontRef);

--- a/Source/WebCore/editing/cocoa/AttributedString.h
+++ b/Source/WebCore/editing/cocoa/AttributedString.h
@@ -26,7 +26,9 @@
 #pragma once
 
 #import <WebCore/Color.h>
+#import <WebCore/FontPlatformData.h>
 #import <WebCore/TextAttachmentForSerialization.h>
+#import <pal/spi/cf/CoreTextSPI.h>
 #import <wtf/ObjectIdentifier.h>
 #import <wtf/Platform.h>
 #import <wtf/RetainPtr.h>
@@ -207,12 +209,23 @@ struct WEBCORE_EXPORT AttributedString {
         Color color;
     };
 
+    struct FontWrapper {
+        Ref<Font> font;
+
+        String postScriptName() const;
+        double pointSize() const;
+        CTFontDescriptorOptions fontDescriptorOptions() const;
+        std::optional<WebCore::FontPlatformSerializedAttributes> fontSerializedAttributes() const;
+        static std::optional<FontWrapper> createFromIPCData(const String& postScriptName, double pointSize, const CTFontDescriptorOptions&, const std::optional<WebCore::FontPlatformSerializedAttributes>&);
+    };
+
     struct AttributeValue {
-        Variant<
+
+        using AttributeType = Variant<
             double,
             String,
             URL,
-            Ref<Font>,
+            FontWrapper,
             Vector<String>,
             Vector<double>,
             ParagraphStyle,
@@ -226,7 +239,9 @@ struct WEBCORE_EXPORT AttributedString {
 #endif
             TextAttachmentFileWrapper,
             TextAttachmentMissingImage
-        > value;
+            >;
+
+        AttributeType value;
     };
 
     String string;

--- a/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
@@ -231,14 +231,24 @@ header: <WebCore/AttributedString.h>
     Vector<WebCore::TextTab> textTabs;
 }
 
-[Nested] struct WebCore::AttributedString::AttributeValue {
+[Nested, CreateUsing=createFromIPCData] struct WebCore::AttributedString::FontWrapper {
+    String postScriptName();
+    double pointSize();
+    CTFontDescriptorOptions fontDescriptorOptions();
+    std::optional<WebCore::FontPlatformSerializedAttributes> fontSerializedAttributes();
+}
+
 #if ENABLE(MULTI_REPRESENTATION_HEIC)
-    Variant<double, String, URL, Ref<WebCore::Font>, Vector<String>, Vector<double>, WebCore::ParagraphStyle, RetainPtr<NSPresentationIntent>, RetainPtr<NSShadow>, RetainPtr<NSDate>, WebCore::AttributedString::ColorFromCGColor, WebCore::AttributedString::ColorFromPlatformColor, WebCore::MultiRepresentationHEICAttachmentData, WebCore::TextAttachmentFileWrapper, WebCore::TextAttachmentMissingImage> value;
+[Nested] struct WebCore::AttributedString::AttributeValue {
+    Variant<double, String, URL, WebCore::AttributedString::FontWrapper, Vector<String>, Vector<double>, WebCore::ParagraphStyle, RetainPtr<NSPresentationIntent>, RetainPtr<NSShadow>, RetainPtr<NSDate>, WebCore::AttributedString::ColorFromCGColor, WebCore::AttributedString::ColorFromPlatformColor, WebCore::MultiRepresentationHEICAttachmentData, WebCore::TextAttachmentFileWrapper, WebCore::TextAttachmentMissingImage> value;
+}
 #endif
 #if !ENABLE(MULTI_REPRESENTATION_HEIC)
-    Variant<double, String, URL, Ref<WebCore::Font>, Vector<String>, Vector<double>, WebCore::ParagraphStyle, RetainPtr<NSPresentationIntent>, RetainPtr<NSShadow>, RetainPtr<NSDate>, WebCore::AttributedString::ColorFromCGColor, WebCore::AttributedString::ColorFromPlatformColor, WebCore::TextAttachmentFileWrapper, WebCore::TextAttachmentMissingImage> value;
-#endif
+[Nested] struct WebCore::AttributedString::AttributeValue {
+    Variant<double, String, URL, WebCore::AttributedString::FontWrapper, Vector<String>, Vector<double>, WebCore::ParagraphStyle, RetainPtr<NSPresentationIntent>, RetainPtr<NSShadow>, RetainPtr<NSDate>, WebCore::AttributedString::ColorFromCGColor, WebCore::AttributedString::ColorFromPlatformColor, WebCore::TextAttachmentFileWrapper, WebCore::TextAttachmentMissingImage> value;
 }
+#endif
+
 
 [Nested] struct WebCore::AttributedString::ColorFromPlatformColor {
     WebCore::Color color

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -6951,6 +6951,7 @@
 		849944302943E2550086CDBB /* iOS_Private.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = iOS_Private.modulemap; sourceTree = "<group>"; };
 		8623B1272ACE1B66002BA9EA /* WebPageNetworkParameters.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebPageNetworkParameters.serialization.in; sourceTree = "<group>"; };
 		8623B1282ACE1DE4002BA9EA /* ResourceLoadInfo.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = ResourceLoadInfo.serialization.in; sourceTree = "<group>"; };
+		862C44DE2E856922000DB57E /* WebCoreFont.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebCoreFont.serialization.in; sourceTree = "<group>"; };
 		863551D229647AB400C2BE98 /* NetworkResourceLoadParameters.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = NetworkResourceLoadParameters.serialization.in; sourceTree = "<group>"; };
 		8644890A27B47020007A1C66 /* _WKSystemPreferences.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKSystemPreferences.h; sourceTree = "<group>"; };
 		8644890C27B47045007A1C66 /* _WKSystemPreferences.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKSystemPreferences.mm; sourceTree = "<group>"; };
@@ -9994,6 +9995,7 @@
 				510FBB991288C95E00AFFDF4 /* WebContextMenuItemData.h */,
 				46F96C662B02A58100253A2B /* WebContextMenuItemData.serialization.in */,
 				5C426B5A28BEC8D200C695CF /* WebCoreArgumentCoders.serialization.in */,
+				862C44DE2E856922000DB57E /* WebCoreFont.serialization.in */,
 				7AF2361E1E79A3B400438A05 /* WebErrors.cpp */,
 				7AF2361F1E79A3D800438A05 /* WebErrors.h */,
 				C0337DAD127A24FE008FF4F4 /* WebEvent.cpp */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/NSAttributedStringWebKitAdditions.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/NSAttributedStringWebKitAdditions.mm
@@ -27,6 +27,7 @@
 
 #import "TestCocoa.h"
 #import "TestWKWebView.h"
+#import <WebCore/FontCocoa.h>
 #import <WebKit/NSAttributedString.h>
 #import <wtf/RetainPtr.h>
 
@@ -121,6 +122,33 @@ TEST(NSAttributedStringWebKitAdditions, FontDataURL)
         [attributedString enumerateAttributesInRange:NSMakeRange(0, attributedString.length) options:0 usingBlock:^(NSDictionary *attributes, NSRange attributeRange, BOOL *stop) {
             if (attributes[NSFontAttributeName])
                 foundFont = true;
+        }];
+        EXPECT_TRUE(foundFont);
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+}
+
+TEST(NSAttributedStringWebKitAdditions, InstalledFont)
+{
+    NSString *html = [NSString stringWithFormat:@""
+        "<html>"
+        "<head>"
+        "<style>"
+        "div { font-family: Helvetica; }"
+        "</style>"
+        "</head>"
+        "<body><div>hello!</div></body>"
+        "</html>"];
+
+    __block bool done = false;
+    [NSAttributedString loadFromHTMLWithString:html options:@{ } completionHandler:^(NSAttributedString *attributedString, NSDictionary<NSAttributedStringDocumentAttributeKey, id> *attributes, NSError *error) {
+        __block bool foundFont { false };
+        [attributedString enumerateAttributesInRange:NSMakeRange(0, attributedString.length) options:0 usingBlock:^(NSDictionary *attributes, NSRange attributeRange, BOOL *stop) {
+            if (attributes[NSFontAttributeName]) {
+                foundFont = true;
+                EXPECT_WK_STREQ(((WebCore::CocoaFont *)attributes[NSFontAttributeName]).fontName, "Helvetica"_s);
+            }
         }];
         EXPECT_TRUE(foundFont);
         done = true;


### PR DESCRIPTION
#### 4fc463d4e6296b020cf1243b712463b7a4b8b0da
<pre>
Only serialize installed fonts attributes for WebCore::AttributedString
<a href="https://bugs.webkit.org/show_bug.cgi?id=299174">https://bugs.webkit.org/show_bug.cgi?id=299174</a>
&lt;<a href="https://rdar.apple.com/problem/161175544">rdar://problem/161175544</a>&gt;

Reviewed by Alex Christensen.

This change modifies our WebCore::AttributedString serialzation to only support
installed fonts.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/NSAttributedStringWebKitAdditions.mm
* Source/WebCore/Configurations/AllowedSPI.toml:
* Source/WebCore/PAL/pal/spi/cf/CoreTextSPI.h:
* Source/WebCore/editing/cocoa/AttributedString.h:
* Source/WebCore/editing/cocoa/AttributedString.mm:
(WebCore::toNSObject):
(WebCore::extractValue):
(WebCore::AttributedString::FontWrapper::createFromIPCData):
(WebCore::AttributedString::FontWrapper::postScriptName const):
(WebCore::AttributedString::FontWrapper::pointSize const):
* Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/NSAttributedStringWebKitAdditions.mm:
(TEST(NSAttributedStringWebKitAdditions, InstalledFont)):

Canonical link: <a href="https://commits.webkit.org/300681@main">https://commits.webkit.org/300681@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/95b9760b5fabcfd402cc906cca98c795f2e0b0a0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122901 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42613 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33303 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/129539 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/75007 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e7a911b1-48bc-4499-9de4-6a6a983f40be) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/124777 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43332 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51206 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93449 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62012 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ceb63aed-b1bc-4f55-96f1-9fcb14739534) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125853 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34545 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110009 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74042 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/72aaf893-2c43-4178-b26a-813cc8b04636) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33524 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28166 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73030 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104247 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28378 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132269 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49846 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37946 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101937 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50223 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106222 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101801 "Found 4 new API test failures: TestWTF:CompletionHandlerDeathTest.MainThreadHandlerOnThreadAssertsDeathTest, WebKitGTK/TestInspector:/webkit/WebKitWebInspector/manual-attach-detach, TestWTF:CompletionHandlerDeathTest.ConstructionThreadHandlerOnThreadAssertsDeathTest, WebKitGTK/TestWebKitNetworkSession:/webkit/WebKitNetworkSession/proxy (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25982 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47160 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25349 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/46618 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49704 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/55456 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49174 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/52522 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50856 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->