### PR TITLE
Address safer CPP warnings in UI process

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
@@ -89,17 +89,10 @@ UIProcess/API/Cocoa/_WKWebPushAction.mm
 UIProcess/API/mac/WKWebViewMac.mm
 UIProcess/API/mac/WKWebViewTestingMac.mm
 UIProcess/Authentication/cocoa/AuthenticationChallengeProxyCocoa.mm
-UIProcess/Authentication/cocoa/SecKeyProxyStore.mm
 UIProcess/Automation/mac/WebAutomationSessionMac.mm
-UIProcess/Cocoa/AutomationClient.mm
-UIProcess/Cocoa/AutomationSessionClient.mm
 UIProcess/Cocoa/BrowsingWarningCocoa.mm
 UIProcess/Cocoa/DiagnosticLoggingClient.mm
-UIProcess/Cocoa/FindClient.mm
 UIProcess/Cocoa/GlobalFindInPageState.mm
-UIProcess/Cocoa/GroupActivities/GroupActivitiesCoordinator.mm
-UIProcess/Cocoa/IconLoadingDelegate.mm
-UIProcess/Cocoa/LegacyDownloadClient.mm
 UIProcess/Cocoa/MediaPermissionUtilities.mm
 UIProcess/Cocoa/NavigationState.mm
 UIProcess/Cocoa/PageClientImplCocoa.mm

--- a/Source/WebKit/UIProcess/Authentication/cocoa/SecKeyProxyStore.mm
+++ b/Source/WebKit/UIProcess/Authentication/cocoa/SecKeyProxyStore.mm
@@ -35,8 +35,11 @@ namespace WebKit {
 
 bool SecKeyProxyStore::initialize(const WebCore::Credential& credential)
 {
-    if (!credential.isEmpty() && credential.nsCredential().identity)
-        m_secKeyProxy = adoptNS([[SecKeyProxy alloc] initWithIdentity:credential.nsCredential().identity]);
+    if (!credential.isEmpty()) {
+        RetainPtr nsCredential = credential.nsCredential();
+        if (RetainPtr identity = [nsCredential.get() identity])
+            m_secKeyProxy = adoptNS([[SecKeyProxy alloc] initWithIdentity:identity.get()]);
+    }
     return isInitialized();
 }
 

--- a/Source/WebKit/UIProcess/Cocoa/AutomationClient.mm
+++ b/Source/WebKit/UIProcess/Cocoa/AutomationClient.mm
@@ -110,7 +110,7 @@ void AutomationClient::requestedDebuggablesToWakeUp()
 String AutomationClient::browserName() const
 {
     if (m_delegateMethods.browserNameForAutomation)
-        return [m_delegate _processPoolBrowserNameForAutomation:m_processPool.get().get()];
+        return [m_delegate.get() _processPoolBrowserNameForAutomation:m_processPool.get().get()];
 
     // Fall back to using the unlocalized app name (i.e., 'Safari').
     RetainPtr appBundle = [NSBundle mainBundle];
@@ -122,7 +122,7 @@ String AutomationClient::browserName() const
 String AutomationClient::browserVersion() const
 {
     if (m_delegateMethods.browserVersionForAutomation)
-        return [m_delegate _processPoolBrowserVersionForAutomation:m_processPool.get().get()];
+        return [m_delegate.get() _processPoolBrowserVersionForAutomation:m_processPool.get().get()];
 
     // Fall back to using the app short version (i.e., '11.1.1').
     RetainPtr appBundle = [NSBundle mainBundle];

--- a/Source/WebKit/UIProcess/Cocoa/AutomationSessionClient.mm
+++ b/Source/WebKit/UIProcess/Cocoa/AutomationSessionClient.mm
@@ -67,7 +67,7 @@ AutomationSessionClient::AutomationSessionClient(id <_WKAutomationSessionDelegat
 void AutomationSessionClient::didDisconnectFromRemote(WebAutomationSession& session)
 {
     if (m_delegateMethods.didDisconnectFromRemote)
-        [m_delegate.get() _automationSessionDidDisconnectFromRemote:wrapper(session)];
+        [m_delegate.get() _automationSessionDidDisconnectFromRemote:RetainPtr { wrapper(session) }.get()];
 }
 
 static inline _WKAutomationSessionBrowsingContextOptions toAPI(API::AutomationSessionBrowsingContextOptions options)
@@ -99,7 +99,7 @@ static inline _WKAutomationSessionWebExtensionResourceOptions toAPI(API::Automat
 void AutomationSessionClient::requestNewPageWithOptions(WebAutomationSession& session, API::AutomationSessionBrowsingContextOptions options, CompletionHandler<void(WebKit::WebPageProxy*)>&& completionHandler)
 {
     if (m_delegateMethods.requestNewWebViewWithOptions) {
-        [m_delegate.get() _automationSession:wrapper(session) requestNewWebViewWithOptions:toAPI(options) completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler)](WKWebView *webView) mutable {
+        [m_delegate.get() _automationSession:RetainPtr { wrapper(session) }.get() requestNewWebViewWithOptions:toAPI(options) completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler)](WKWebView *webView) mutable {
             completionHandler(webView->_page.get());
         }).get()];
     } else
@@ -109,7 +109,7 @@ void AutomationSessionClient::requestNewPageWithOptions(WebAutomationSession& se
 void AutomationSessionClient::requestSwitchToPage(WebAutomationSession& session, WebPageProxy& page, CompletionHandler<void()>&& completionHandler)
 {
     if (auto webView = page.cocoaView(); webView && m_delegateMethods.requestSwitchToWebView)
-        [m_delegate.get() _automationSession:wrapper(session) requestSwitchToWebView:webView.get() completionHandler:makeBlockPtr(WTFMove(completionHandler)).get()];
+        [m_delegate.get() _automationSession:RetainPtr { wrapper(session) }.get() requestSwitchToWebView:webView.get() completionHandler:makeBlockPtr(WTFMove(completionHandler)).get()];
     else
         completionHandler();
 }
@@ -117,7 +117,7 @@ void AutomationSessionClient::requestSwitchToPage(WebAutomationSession& session,
 void AutomationSessionClient::requestHideWindowOfPage(WebAutomationSession& session, WebPageProxy& page, CompletionHandler<void()>&& completionHandler)
 {
     if (auto webView = page.cocoaView(); webView && m_delegateMethods.requestHideWindowOfWebView)
-        [m_delegate.get() _automationSession:wrapper(session) requestHideWindowOfWebView:webView.get() completionHandler:makeBlockPtr(WTFMove(completionHandler)).get()];
+        [m_delegate.get() _automationSession:RetainPtr { wrapper(session) }.get() requestHideWindowOfWebView:webView.get() completionHandler:makeBlockPtr(WTFMove(completionHandler)).get()];
     else
         completionHandler();
 }
@@ -125,7 +125,7 @@ void AutomationSessionClient::requestHideWindowOfPage(WebAutomationSession& sess
 void AutomationSessionClient::requestRestoreWindowOfPage(WebAutomationSession& session, WebPageProxy& page, CompletionHandler<void()>&& completionHandler)
 {
     if (auto webView = page.cocoaView(); webView && m_delegateMethods.requestRestoreWindowOfWebView)
-        [m_delegate.get() _automationSession:wrapper(session) requestRestoreWindowOfWebView:webView.get() completionHandler:makeBlockPtr(WTFMove(completionHandler)).get()];
+        [m_delegate.get() _automationSession:RetainPtr { wrapper(session) }.get() requestRestoreWindowOfWebView:webView.get() completionHandler:makeBlockPtr(WTFMove(completionHandler)).get()];
     else
         completionHandler();
 }
@@ -133,7 +133,7 @@ void AutomationSessionClient::requestRestoreWindowOfPage(WebAutomationSession& s
 void AutomationSessionClient::requestMaximizeWindowOfPage(WebAutomationSession& session, WebPageProxy& page, CompletionHandler<void()>&& completionHandler)
 {
     if (auto webView = page.cocoaView(); webView && m_delegateMethods.requestMaximizeWindowOfWebView)
-        [m_delegate.get() _automationSession:wrapper(session) requestMaximizeWindowOfWebView:webView.get() completionHandler:makeBlockPtr(WTFMove(completionHandler)).get()];
+        [m_delegate.get() _automationSession:RetainPtr { wrapper(session) }.get() requestMaximizeWindowOfWebView:webView.get() completionHandler:makeBlockPtr(WTFMove(completionHandler)).get()];
     else
         completionHandler();
 }
@@ -146,7 +146,7 @@ void AutomationSessionClient::loadWebExtensionWithOptions(WebKit::WebAutomationS
         return;
     }
 
-    [m_delegate.get() _automationSession:wrapper(session) loadWebExtensionWithOptions:toAPI(options) resource:resource.createNSString().get() completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler)](NSString *extensionId) mutable {
+    [m_delegate.get() _automationSession:RetainPtr { wrapper(session) }.get() loadWebExtensionWithOptions:toAPI(options) resource:resource.createNSString().get() completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler)](NSString *extensionId) mutable {
         completionHandler(extensionId);
     }).get()];
 }
@@ -158,7 +158,7 @@ void AutomationSessionClient::unloadWebExtension(WebKit::WebAutomationSession& s
         return;
     }
 
-    [m_delegate.get() _automationSession:wrapper(session) unloadWebExtensionWithIdentifier:identifier.createNSString().get() completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler)](BOOL success) mutable {
+    [m_delegate.get() _automationSession:RetainPtr { wrapper(session) }.get() unloadWebExtensionWithIdentifier:identifier.createNSString().get() completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler)](BOOL success) mutable {
         completionHandler(success);
     }).get()];
 }
@@ -167,7 +167,7 @@ void AutomationSessionClient::unloadWebExtension(WebKit::WebAutomationSession& s
 bool AutomationSessionClient::isShowingJavaScriptDialogOnPage(WebAutomationSession& session, WebPageProxy& page)
 {
     if (auto webView = page.cocoaView(); webView && m_delegateMethods.isShowingJavaScriptDialogForWebView)
-        return [m_delegate.get() _automationSession:wrapper(session) isShowingJavaScriptDialogForWebView:webView.get()];
+        return [m_delegate.get() _automationSession:RetainPtr { wrapper(session) }.get() isShowingJavaScriptDialogForWebView:webView.get()];
     
     return false;
 }
@@ -175,19 +175,19 @@ bool AutomationSessionClient::isShowingJavaScriptDialogOnPage(WebAutomationSessi
 void AutomationSessionClient::dismissCurrentJavaScriptDialogOnPage(WebAutomationSession& session, WebPageProxy& page)
 {
     if (auto webView = page.cocoaView(); webView && m_delegateMethods.dismissCurrentJavaScriptDialogForWebView)
-        [m_delegate.get() _automationSession:wrapper(session) dismissCurrentJavaScriptDialogForWebView:webView.get()];
+        [m_delegate.get() _automationSession:RetainPtr { wrapper(session) }.get() dismissCurrentJavaScriptDialogForWebView:webView.get()];
 }
 
 void AutomationSessionClient::acceptCurrentJavaScriptDialogOnPage(WebAutomationSession& session, WebPageProxy& page)
 {
     if (auto webView = page.cocoaView(); webView && m_delegateMethods.acceptCurrentJavaScriptDialogForWebView)
-        [m_delegate.get() _automationSession:wrapper(session) acceptCurrentJavaScriptDialogForWebView:webView.get()];
+        [m_delegate.get() _automationSession:RetainPtr { wrapper(session) }.get() acceptCurrentJavaScriptDialogForWebView:webView.get()];
 }
 
 std::optional<String> AutomationSessionClient::messageOfCurrentJavaScriptDialogOnPage(WebAutomationSession& session, WebPageProxy& page)
 {
     if (auto webView = page.cocoaView(); webView && m_delegateMethods.messageOfCurrentJavaScriptDialogForWebView)
-        return [m_delegate.get() _automationSession:wrapper(session) messageOfCurrentJavaScriptDialogForWebView:webView.get()];
+        return [m_delegate.get() _automationSession:RetainPtr { wrapper(session) }.get() messageOfCurrentJavaScriptDialogForWebView:webView.get()];
 
     return std::nullopt;
 }
@@ -195,7 +195,7 @@ std::optional<String> AutomationSessionClient::messageOfCurrentJavaScriptDialogO
 std::optional<String> AutomationSessionClient::defaultTextOfCurrentJavaScriptDialogOnPage(WebAutomationSession& session, WebPageProxy& page)
 {
     if (auto webView = page.cocoaView(); webView && m_delegateMethods.defaultTextOfCurrentJavaScriptDialogForWebView)
-        return [m_delegate.get() _automationSession:wrapper(session) defaultTextOfCurrentJavaScriptDialogForWebView:webView.get()];
+        return [m_delegate.get() _automationSession:RetainPtr { wrapper(session) }.get() defaultTextOfCurrentJavaScriptDialogForWebView:webView.get()];
 
     return std::nullopt;
 }
@@ -203,7 +203,7 @@ std::optional<String> AutomationSessionClient::defaultTextOfCurrentJavaScriptDia
 std::optional<String> AutomationSessionClient::userInputOfCurrentJavaScriptDialogOnPage(WebAutomationSession& session, WebPageProxy& page)
 {
     if (auto webView = page.cocoaView(); webView && m_delegateMethods.userInputOfCurrentJavaScriptDialogForWebView)
-        return [m_delegate.get() _automationSession:wrapper(session) userInputOfCurrentJavaScriptDialogForWebView:webView.get()];
+        return [m_delegate.get() _automationSession:RetainPtr { wrapper(session) }.get() userInputOfCurrentJavaScriptDialogForWebView:webView.get()];
 
     return std::nullopt;
 }
@@ -211,7 +211,7 @@ std::optional<String> AutomationSessionClient::userInputOfCurrentJavaScriptDialo
 void AutomationSessionClient::setUserInputForCurrentJavaScriptPromptOnPage(WebAutomationSession& session, WebPageProxy& page, const String& value)
 {
     if (auto webView = page.cocoaView(); webView && m_delegateMethods.setUserInputForCurrentJavaScriptPromptForWebView)
-        [m_delegate.get() _automationSession:wrapper(session) setUserInput:value.createNSString().get() forCurrentJavaScriptDialogForWebView:webView.get()];
+        [m_delegate.get() _automationSession:RetainPtr { wrapper(session) }.get() setUserInput:value.createNSString().get() forCurrentJavaScriptDialogForWebView:webView.get()];
 }
 
 static std::optional<API::AutomationSessionClient::JavaScriptDialogType> toImpl(_WKAutomationSessionJavaScriptDialogType type)
@@ -241,7 +241,7 @@ static API::AutomationSessionClient::BrowsingContextPresentation toImpl(_WKAutom
 std::optional<API::AutomationSessionClient::JavaScriptDialogType> AutomationSessionClient::typeOfCurrentJavaScriptDialogOnPage(WebAutomationSession& session, WebPageProxy& page)
 {
     if (auto webView = page.cocoaView(); webView && m_delegateMethods.typeOfCurrentJavaScriptDialogForWebView)
-        return toImpl([m_delegate.get() _automationSession:wrapper(session) typeOfCurrentJavaScriptDialogForWebView:webView.get()]);
+        return toImpl([m_delegate.get() _automationSession:RetainPtr { wrapper(session) }.get() typeOfCurrentJavaScriptDialogForWebView:webView.get()]);
 
     return API::AutomationSessionClient::JavaScriptDialogType::Prompt;
 }
@@ -249,7 +249,7 @@ std::optional<API::AutomationSessionClient::JavaScriptDialogType> AutomationSess
 API::AutomationSessionClient::BrowsingContextPresentation AutomationSessionClient::currentPresentationOfPage(WebAutomationSession& session, WebPageProxy& page)
 {
     if (auto webView = page.cocoaView(); webView && m_delegateMethods.currentPresentationForWebView)
-        return toImpl([m_delegate.get() _automationSession:wrapper(session) currentPresentationForWebView:webView.get()]);
+        return toImpl([m_delegate.get() _automationSession:RetainPtr { wrapper(session) }.get() currentPresentationForWebView:webView.get()]);
 
     return API::AutomationSessionClient::BrowsingContextPresentation::Window;
 }

--- a/Source/WebKit/UIProcess/Cocoa/FindClient.mm
+++ b/Source/WebKit/UIProcess/Cocoa/FindClient.mm
@@ -75,13 +75,13 @@ void FindClient::didFailToFindString(WebPageProxy*, const String& string)
 void FindClient::didAddLayerForFindOverlay(WebKit::WebPageProxy*, PlatformLayer* layer)
 {
     if (m_delegateMethods.webviewDidAddLayerForFindOverlay)
-        [m_delegate _webView:m_webView.get().get() didAddLayerForFindOverlay:layer];
+        [m_delegate.get() _webView:m_webView.get().get() didAddLayerForFindOverlay:layer];
 }
 
 void FindClient::didRemoveLayerForFindOverlay(WebKit::WebPageProxy*)
 {
     if (m_delegateMethods.webviewDidRemoveLayerForFindOverlay)
-        [m_delegate _webViewDidRemoveLayerForFindOverlay:m_webView.get().get()];
+        [m_delegate.get() _webViewDidRemoveLayerForFindOverlay:m_webView.get().get()];
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesCoordinator.mm
+++ b/Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesCoordinator.mm
@@ -137,14 +137,14 @@ GroupActivitiesCoordinator::GroupActivitiesCoordinator(GroupActivitiesSession& s
     , m_playbackCoordinator(adoptNS([PAL::allocAVDelegatingPlaybackCoordinatorInstance() initWithPlaybackControlDelegate:m_delegate.get()]))
     , m_stateChangeObserver([this] (auto& session, auto state) { sessionStateChanged(session, state); })
 {
-    [session.groupSession() coordinateWithCoordinator:m_playbackCoordinator.get()];
+    [session.protectedGroupSession() coordinateWithCoordinator:m_playbackCoordinator.get()];
     session.addStateChangeObserver(m_stateChangeObserver);
 }
 
 GroupActivitiesCoordinator::~GroupActivitiesCoordinator()
 {
-    m_session->groupSession().newActivityCallback = nil;
-    m_session->groupSession().stateChangedCallback = nil;
+    m_session->protectedGroupSession().get().newActivityCallback = nil;
+    m_session->protectedGroupSession().get().stateChangedCallback = nil;
 }
 
 void GroupActivitiesCoordinator::sessionStateChanged(const GroupActivitiesSession& session, GroupActivitiesSession::State state)

--- a/Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesSession.h
+++ b/Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesSession.h
@@ -69,6 +69,7 @@ private:
     friend class GroupActivitiesCoordinator;
     GroupActivitiesSession(RetainPtr<WKGroupSession>&&);
     WKGroupSession* groupSession() { return m_groupSession.get(); }
+    RetainPtr<WKGroupSession> protectedGroupSession() { return m_groupSession; }
 
     RetainPtr<WKGroupSession> m_groupSession;
     WeakHashSet<StateChangeObserver> m_stateChangeObservers;

--- a/Source/WebKit/UIProcess/Cocoa/IconLoadingDelegate.mm
+++ b/Source/WebKit/UIProcess/Cocoa/IconLoadingDelegate.mm
@@ -100,7 +100,7 @@ void IconLoadingDelegate::IconLoadingClient::getLoadDecisionForIcon(const WebCor
         ASSERT(RunLoop::isMain());
         if (loadCompletionHandler) {
             completionHandler([loadCompletionHandler = makeBlockPtr(loadCompletionHandler)](API::Data* data) {
-                loadCompletionHandler(wrapper(data));
+                loadCompletionHandler(RetainPtr { wrapper(data) }.get());
             });
         } else
             completionHandler(nullptr);


### PR DESCRIPTION
#### 428c03aa284e353ec705dda15c85ba1315eb0a83
<pre>
Address safer CPP warnings in UI process
<a href="https://bugs.webkit.org/show_bug.cgi?id=299177">https://bugs.webkit.org/show_bug.cgi?id=299177</a>

Reviewed by Ryosuke Niwa.

Mainly address unretained call args warnings.

* Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations:
* Source/WebKit/UIProcess/Authentication/cocoa/SecKeyProxyStore.mm:
(WebKit::SecKeyProxyStore::initialize):
* Source/WebKit/UIProcess/Cocoa/AutomationClient.mm:
(WebKit::AutomationClient::browserName const):
(WebKit::AutomationClient::browserVersion const):
* Source/WebKit/UIProcess/Cocoa/AutomationSessionClient.mm:
(WebKit::AutomationSessionClient::didDisconnectFromRemote):
(WebKit::AutomationSessionClient::requestNewPageWithOptions):
(WebKit::AutomationSessionClient::requestSwitchToPage):
(WebKit::AutomationSessionClient::requestHideWindowOfPage):
(WebKit::AutomationSessionClient::requestRestoreWindowOfPage):
(WebKit::AutomationSessionClient::requestMaximizeWindowOfPage):
(WebKit::AutomationSessionClient::loadWebExtensionWithOptions):
(WebKit::AutomationSessionClient::unloadWebExtension):
(WebKit::AutomationSessionClient::isShowingJavaScriptDialogOnPage):
(WebKit::AutomationSessionClient::dismissCurrentJavaScriptDialogOnPage):
(WebKit::AutomationSessionClient::acceptCurrentJavaScriptDialogOnPage):
(WebKit::AutomationSessionClient::messageOfCurrentJavaScriptDialogOnPage):
(WebKit::AutomationSessionClient::defaultTextOfCurrentJavaScriptDialogOnPage):
(WebKit::AutomationSessionClient::userInputOfCurrentJavaScriptDialogOnPage):
(WebKit::AutomationSessionClient::setUserInputForCurrentJavaScriptPromptOnPage):
(WebKit::AutomationSessionClient::typeOfCurrentJavaScriptDialogOnPage):
(WebKit::AutomationSessionClient::currentPresentationOfPage):
* Source/WebKit/UIProcess/Cocoa/FindClient.mm:
(WebKit::FindClient::didAddLayerForFindOverlay):
(WebKit::FindClient::didRemoveLayerForFindOverlay):
* Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesCoordinator.mm:
(WebKit::GroupActivitiesCoordinator::~GroupActivitiesCoordinator):
* Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesSession.h:
(WebKit::GroupActivitiesSession::protectedGroupSession):
* Source/WebKit/UIProcess/Cocoa/IconLoadingDelegate.mm:
(WebKit::IconLoadingDelegate::IconLoadingClient::getLoadDecisionForIcon):
* Source/WebKit/UIProcess/Cocoa/LegacyDownloadClient.mm:
(WebKit::LegacyDownloadClient::legacyDidStart):
(WebKit::LegacyDownloadClient::didReceiveResponse):
(WebKit::LegacyDownloadClient::didReceiveData):
(WebKit::LegacyDownloadClient::didReceiveAuthenticationChallenge):
(WebKit::LegacyDownloadClient::didCreateDestination):
(WebKit::LegacyDownloadClient::processDidCrash):
(WebKit::LegacyDownloadClient::decideDestinationWithSuggestedFilename):
(WebKit::LegacyDownloadClient::didFinish):
(WebKit::LegacyDownloadClient::didFail):
(WebKit::LegacyDownloadClient::legacyDidCancel):
(WebKit::LegacyDownloadClient::willSendRequest):

Canonical link: <a href="https://commits.webkit.org/300254@main">https://commits.webkit.org/300254@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/63062526d91088ade18ebedccb89fb48f031f7ca

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121817 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41518 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32182 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128359 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73907 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42230 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50110 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92569 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/61533 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124769 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33676 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109094 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73228 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32688 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71868 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103176 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27442 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131134 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48752 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37070 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101151 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49124 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105311 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101023 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25630 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46389 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24493 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45453 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48610 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54337 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48080 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51429 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49762 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->