### PR TITLE
[AutoFill Debugging] Remove more types of quotes when normalizing text in interaction descriptions

### DIFF
--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -1271,10 +1271,10 @@ static constexpr auto maxDescriptionLength = 512;
 
 static String normalizeText(const String& string)
 {
-    auto result = makeStringByReplacingAll(string, '\'', ""_s);
-    result = makeStringByReplacingAll(string, '\"', ""_s);
+    auto result = foldQuoteMarks(string);
+    for (auto character : { '"', '\'', '\r' })
+        result = makeStringByReplacingAll(result, character, ""_s);
     result = makeStringByReplacingAll(result, '\n', " "_s);
-    result = makeStringByReplacingAll(result, '\r', ""_s);
     result = result.trim(isASCIIWhitespace<char16_t>);
     if (result.length() <= maxDescriptionLength)
         return result;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/TextExtractionTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/TextExtractionTests.mm
@@ -180,7 +180,7 @@ TEST(TextExtractionTests, InteractionDebugDescription)
 
         [interaction setNodeIdentifier:composeID.get()];
         description = [interaction debugDescriptionInWebView:webView.get() error:&error];
-        EXPECT_WK_STREQ("Click on editable div labeled 'Compose a new message', with rendered text 'Subject  Hello world.', containing child labeled 'Heading'", description);
+        EXPECT_WK_STREQ("Click on editable div labeled 'Compose a new message', with rendered text 'Subject  The quick brown fox jumped over the lazy dog', containing child labeled 'Heading'", description);
         EXPECT_NULL(error);
     }
     {
@@ -194,10 +194,10 @@ TEST(TextExtractionTests, InteractionDebugDescription)
         EXPECT_NULL(error);
 
         [interaction setNodeIdentifier:composeID.get()];
-        [interaction setText:@"Hello world"];
+        [interaction setText:@"«Testing»"];
         [interaction setReplaceAll:NO];
         description = [interaction debugDescriptionInWebView:webView.get() error:&error];
-        EXPECT_WK_STREQ("Enter text 'Hello world' into editable div labeled 'Compose a new message', with rendered text 'Subject  Hello world.', containing child labeled 'Heading'", description);
+        EXPECT_WK_STREQ("Enter text 'Testing' into editable div labeled 'Compose a new message', with rendered text 'Subject  The quick brown fox jumped over the lazy dog', containing child labeled 'Heading'", description);
         EXPECT_NULL(error);
     }
     {

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/debug-text-extraction.html
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/debug-text-extraction.html
@@ -14,7 +14,7 @@
     </select>
     <div aria-label="Compose a new message" contenteditable="plaintext-only">
         <h3 aria-label="Heading">Subject</h3>
-        <p>Hello world.</p>
+        <p>“The quick brown fox jumped over the lazy dog”</p>
     </div>
     <h1 class="click-count">0</h1>
     <script>


### PR DESCRIPTION
#### e79afb7015aed8c884f7f6d2168b135551e80a19
<pre>
[AutoFill Debugging] Remove more types of quotes when normalizing text in interaction descriptions
<a href="https://bugs.webkit.org/show_bug.cgi?id=299187">https://bugs.webkit.org/show_bug.cgi?id=299187</a>
<a href="https://rdar.apple.com/160947861">rdar://160947861</a>

Reviewed by Abrar Rahman Protyasha.

Normalize more types of single/double quotes by first folding all quotation marks in the raw text.

Tests: TextExtractionTests.InteractionDebugDescription

* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::normalizeText):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/TextExtractionTests.mm:
(TestWebKitAPI::TEST(TextExtractionTests, InteractionDebugDescription)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/debug-text-extraction.html:

Augment an existing API test to include quoted text.

Canonical link: <a href="https://commits.webkit.org/300256@main">https://commits.webkit.org/300256@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/edcdb8f769a6c506ccd0c5f7e8cb66451485ab0d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121855 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41556 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32220 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128406 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73948 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5e3089c7-3d9e-4f5a-998a-ef72c95c638d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123731 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42268 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50149 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92602 "") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/61544 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b2ca2061-21a0-41f3-b930-69ef47c558ac) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124807 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33725 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109136 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73263 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3e44ef2d-4d24-45b7-9987-a97304dc58d9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32738 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27293 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71910 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103230 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27478 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131179 "Failed to compile WebKit") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48790 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37111 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101184 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49169 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105346 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101052 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25632 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46424 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24531 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/45494 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48648 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54386 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48121 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51471 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49801 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->