### PR TITLE
JITOperationAnnotationInitializers should have SUPPRESS_ASAN

### DIFF
--- a/Source/WTF/wtf/PlatformCallingConventions.h
+++ b/Source/WTF/wtf/PlatformCallingConventions.h
@@ -96,7 +96,7 @@
 
 #define JSC_ANNOTATE_JIT_OPERATION_INTERNAL(function, decltypeInfo) \
     static_assert(sizeof(JSC::JITOperationAnnotationInitializer<decltypeInfo>) == sizeof(JSC::JITOperationAnnotation)); \
-    constexpr JSC::JITOperationAnnotationInitializer<decltypeInfo> _JITTargetID_##function __attribute__((used, section("__DATA_CONST,__jsc_ops"))) = { function, JSC_ANNOTATE_JIT_OPERATION_EXTRAS(function##Validate) };
+    SUPPRESS_ASAN constexpr JSC::JITOperationAnnotationInitializer<decltypeInfo> _JITTargetID_##function __attribute__((used, section("__DATA_CONST,__jsc_ops"))) = { function, JSC_ANNOTATE_JIT_OPERATION_EXTRAS(function##Validate) };
 
 #define JSC_ANNOTATE_JIT_OPERATION(function) \
     JSC_ANNOTATE_JIT_OPERATION_WITH_DECLTYPE_INFO(function, decltype(function))


### PR DESCRIPTION
#### 95031bd05fd29c0dfc4fa7d02672dc96518c145b
<pre>
JITOperationAnnotationInitializers should have SUPPRESS_ASAN
<a href="https://bugs.webkit.org/show_bug.cgi?id=299191">https://bugs.webkit.org/show_bug.cgi?id=299191</a>
<a href="https://rdar.apple.com/160871360">rdar://160871360</a>

Reviewed by Yusuke Suzuki and David Kilzer.

Currently, JITOperationAnnotationInitializers aren&apos;t marked SUPPRESS_ASAN, which
leads to global redzones being placed between them when we don&apos;t intend to. This
patch adds SUPPRESS_ASAN to stop those redzones from being added.

No new tests as this fixes a crash on startup on ASAN builds.
* Source/WTF/wtf/PlatformCallingConventions.h:

Canonical link: <a href="https://commits.webkit.org/300292@main">https://commits.webkit.org/300292@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/93879af4b3f225e294241e003d2b02968afd1f51

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121856 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41557 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32221 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128407 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73949 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ef37c2cf-366e-4d25-9766-8a64a0bb35d4) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42269 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50150 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92612 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61547 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/38636644-22e7-4329-8b3f-32cc6fc0959b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124808 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33721 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109140 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73264 "Found 1 new API test failure: TestWTF:WTF_Condition.OneProducerOneConsumerOneSlotTimeout (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8dfcc5be-a3a3-4cb6-ae82-25964abfc74e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32733 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27304 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71911 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/114012 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103225 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27493 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131180 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/120378 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48803 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37113 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101191 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49209 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105351 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101059 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46446 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24535 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45495 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19309 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48653 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54387 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/150539 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48122 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/38516 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51472 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49802 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->