### PR TITLE
Fire scroll/scrollend events on text input instead of the input inner element

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-fires-to-text-input-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-fires-to-text-input-expected.txt
@@ -2,6 +2,6 @@
 
 Harness Error (TIMEOUT), message = null
 
-TIMEOUT scrolled input field should receive scrollend. Test timed out
-NOTRUN scrolled input field should receive scrollend for animated scroll.
+PASS scrolled input field should receive scrollend.
+TIMEOUT scrolled input field should receive scrollend for animated scroll. Test timed out
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-fires-to-text-input.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-fires-to-text-input.html
@@ -3,7 +3,6 @@
   <head>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
-    <script src="scroll_support.js"></script>
   </head>
   <body>
     <style>
@@ -15,14 +14,19 @@
     <input type="text" id="inputscroller"
     value="qwertyuiopasddfghjklzxcvbnmqwertyuiopasddfghjklzxcvbnmqwer">
     <script>
-      promise_test(async(t) => {
+      promise_test(async t => {
         const inputscroller = document.getElementById("inputscroller");
-        await waitForScrollReset(t, inputscroller);
+        t.add_cleanup(() => {
+          return new Promise(resolve => {
+            inputscroller.addEventListener("scrollend", resolve, { once: true });
+            inputscroller.scrollLeft = 0;
+          });
+        });
         assert_equals(inputscroller.scrollLeft, 0,
           "text input field is not initially scrolled.");
 
         const scrollend_promise = new Promise((resolve) => {
-          inputscroller.addEventListener("scrollend", resolve);
+          inputscroller.addEventListener("scrollend", resolve, { once: true });
         });
         inputscroller.scrollLeft = 10;
         await scrollend_promise;
@@ -30,16 +34,21 @@
           "text input field is scrolled by the correct amount");
       }, "scrolled input field should receive scrollend.");
 
-      promise_test(async(t) => {
+      promise_test(async t => {
         const inputscroller = document.getElementById("inputscroller");
-        await waitForScrollReset(t, inputscroller);
+        t.add_cleanup(() => {
+          return new Promise(resolve => {
+            inputscroller.addEventListener("scrollend", resolve, { once: true });
+            inputscroller.scrollLeft = 0;
+          });
+        });
         assert_equals(inputscroller.scrollLeft, 0,
           "text input field is not initially scrolled.");
 
         const scrollend_promise = new Promise((resolve) => {
-          inputscroller.addEventListener("scrollend", resolve);
+          inputscroller.addEventListener("scrollend", resolve, { once: true });
         });
-        inputscroller.scrollBy({left:10, behavior: 'smooth'});
+        inputscroller.scrollBy({ left: 10, behavior: "smooth" });
         await scrollend_promise;
         assert_equals(inputscroller.scrollLeft, 10,
           "text input field is scrolled by the correct amount");

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2140,7 +2140,6 @@ webkit.org/b/291966 [ Sequoia+ ] http/tests/webgpu/webgpu/api/validation/render_
 [ Sonoma+ Debug ] imported/w3c/web-platform-tests/webcodecs/video-encoder-rescaling.https.any.worker.html?vp9_p0 [ Skip ]
 
 webkit.org/b/296195 imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-event-fired-to-element-with-overscroll-behavior.html [ Skip ]
-webkit.org/b/296195 imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-fires-to-text-input.html [ Skip ]
 
 webkit.org/b/292203 [ Debug ] imported/w3c/web-platform-tests/css/css-view-transitions/transition-in-hidden-page.html [ Pass Crash ]
 


### PR DESCRIPTION
#### 70738317c8836ab637cfdcb4446c8d40e4c07e4a
<pre>
Fire scroll/scrollend events on text input instead of the input inner element
<a href="https://bugs.webkit.org/show_bug.cgi?id=297138">https://bugs.webkit.org/show_bug.cgi?id=297138</a>
<a href="https://rdar.apple.com/157880733">rdar://157880733</a>

Reviewed by Simon Fraser.

Just like we forward calls to scrollLeft/scrollTop to the input inner element, we should forward the events back to the input element.

The remaining timeout is due to <a href="https://bugs.webkit.org/show_bug.cgi?id=299192">https://bugs.webkit.org/show_bug.cgi?id=299192</a>

Also clean up test to use cleanup functions instead of cleaning up as part of the following test.

* LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-fires-to-text-input-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-fires-to-text-input.html:
* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::addPendingScrollEventTarget):

Canonical link: <a href="https://commits.webkit.org/300260@main">https://commits.webkit.org/300260@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8320d3df8911627f2a99de35f92bac7e02e3d0a1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121917 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/41619 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/138/builds/32289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/128470 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/74010 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123793 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/42334 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/50213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/128470 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/74010 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124869 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/42334 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/138/builds/32289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/128470 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/42334 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/138/builds/32289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/71973 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/42334 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/32289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/131241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/48856 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/50213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/131241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/49230 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/138/builds/32289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/131241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/32289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/45557 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19300 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/48713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/54447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/48183 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/51533 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/49863 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->