### PR TITLE
Unreviewed. Suppress the remaining static analyzer warnings in WebKit.

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations
@@ -1,6 +1,7 @@
 Platform/spi/Cocoa/NearFieldSPI.h
 Shared/API/Cocoa/_WKHitTestResult.h
 Shared/API/Cocoa/_WKRemoteObjectInterface.h
+Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.h
 UIProcess/API/C/mac/WKInspectorPrivateMac.h
 UIProcess/API/C/mac/WKPagePrivateMac.h
 UIProcess/API/Cocoa/WKBackForwardList.h
@@ -12,11 +13,13 @@ UIProcess/API/Cocoa/WKFrameInfo.h
 UIProcess/API/Cocoa/WKNavigationAction.h
 UIProcess/API/Cocoa/WKNavigationData.h
 UIProcess/API/Cocoa/WKNavigationResponse.h
+UIProcess/API/Cocoa/WKProcessPoolPrivate.h
 UIProcess/API/Cocoa/WKScriptMessage.h
 UIProcess/API/Cocoa/WKSecurityOrigin.h
 UIProcess/API/Cocoa/WKSnapshotConfiguration.h
 UIProcess/API/Cocoa/WKURLSchemeTask.h
 UIProcess/API/Cocoa/WKURLSchemeTaskPrivate.h
+UIProcess/API/Cocoa/WKUserContentController.h
 UIProcess/API/Cocoa/WKUserScript.h
 UIProcess/API/Cocoa/WKView.h
 UIProcess/API/Cocoa/WKWebExtension.h
@@ -32,6 +35,7 @@ UIProcess/API/Cocoa/WKWebExtensionDataRecord.h
 UIProcess/API/Cocoa/WKWebExtensionMatchPattern.h
 UIProcess/API/Cocoa/WKWebExtensionMessagePort.h
 UIProcess/API/Cocoa/WKWebExtensionTabConfiguration.h
+UIProcess/API/Cocoa/WKWebExtensionWindowConfiguration.h
 UIProcess/API/Cocoa/WKWebView.h
 UIProcess/API/Cocoa/WKWebViewConfiguration.h
 UIProcess/API/Cocoa/WKWebViewConfigurationInternal.h
@@ -52,8 +56,10 @@ UIProcess/API/Cocoa/_WKAuthenticatorAssertionResponse.h
 UIProcess/API/Cocoa/_WKAuthenticatorAttestationResponse.h
 UIProcess/API/Cocoa/_WKAuthenticatorResponse.h
 UIProcess/API/Cocoa/_WKAutomationSession.h
+UIProcess/API/Cocoa/_WKContentRuleListAction.h
 UIProcess/API/Cocoa/_WKContentWorldConfiguration.h
 UIProcess/API/Cocoa/_WKContextMenuElementInfo.h
+UIProcess/API/Cocoa/_WKCustomHeaderFields.h
 UIProcess/API/Cocoa/_WKDataTask.h
 UIProcess/API/Cocoa/_WKDownload.h
 UIProcess/API/Cocoa/_WKFrameTreeNode.h
@@ -84,6 +90,7 @@ UIProcess/API/Cocoa/_WKSessionState.h
 UIProcess/API/Cocoa/_WKSpatialBackdropSource.h
 UIProcess/API/Cocoa/_WKTargetedElementInfo.h
 UIProcess/API/Cocoa/_WKTextExtractionInternal.h
+UIProcess/API/Cocoa/_WKTextManipulationConfiguration.h
 UIProcess/API/Cocoa/_WKTextManipulationExclusionRule.h
 UIProcess/API/Cocoa/_WKTextManipulationItem.h
 UIProcess/API/Cocoa/_WKTextManipulationToken.h
@@ -103,6 +110,7 @@ UIProcess/API/Cocoa/_WKWebPushMessage.h
 UIProcess/API/Cocoa/_WKWebPushSubscriptionData.h
 UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.h
 UIProcess/API/mac/WKViewInternal.h
+UIProcess/Inspector/mac/WKInspectorResourceURLSchemeHandler.h
 UIProcess/Inspector/mac/WKInspectorViewController.h
 UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm
 UIProcess/WebAuthentication/Cocoa/AuthenticationServicesForwardDeclarations.h

--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.h
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.h
@@ -101,7 +101,9 @@ void XPCServiceInitializer(OSObjectPtr<xpc_connection_t> connection, xpc_object_
     // so ensure that we have an outstanding transaction here. This is not needed when using
     // RunningBoard because the UIProcess takes process assertions on behalf of its child processes.
 #if !USE(RUNNINGBOARD)
-    setOSTransaction(adoptOSObject(os_transaction_create("WebKit XPC Service")));
+    // Supress this warning for when this header file is included in WKWebProcess.cpp
+    // since os_transaction_create's annotation is only effective in Objective-C files.
+    SUPPRESS_RETAINPTR_CTOR_ADOPT setOSTransaction(adoptOSObject(os_transaction_create("WebKit XPC Service")));
 #endif
 
     AuxiliaryProcessInitializationParameters parameters;


### PR DESCRIPTION
#### db14ab1f05e3e258d11a45e644edd53e29b95f4b
<pre>
Unreviewed. Suppress the remaining static analyzer warnings in WebKit.

* Source/WebKit/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations:
* Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.h:
(WebKit::XPCServiceInitializer):

Canonical link: <a href="https://commits.webkit.org/300249@main">https://commits.webkit.org/300249@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/053ee50da06ad75005dfcb5f353306bbf8fed8ba

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121871 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41573 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32243 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128423 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/73964 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e51179e6-41a2-459e-823b-368ac714618f) 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/42288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50167 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/92624 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/73964 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c13ee24b-60c8-4567-8860-dd83e00b716f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124823 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/42288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/109149 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/73282 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7c2f7bdb-1988-4b4b-bf57-a5699e570e4e) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/42288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71926 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/114019 "Build is in progress. Recent messages:") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/42288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/27502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/131195 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/48810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/37121 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/131195 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/49182 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/105360 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/131195 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/24544 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/45510 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19295 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/48667 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/54401 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/48137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/51487 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/49817 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->