### PR TITLE
[Length Deprecation] Remove unnecessary use of Length in PerspectiveTransformOperation

### DIFF
--- a/Source/WebCore/platform/graphics/transforms/PerspectiveTransformOperation.cpp
+++ b/Source/WebCore/platform/graphics/transforms/PerspectiveTransformOperation.cpp
@@ -32,16 +32,15 @@
 
 namespace WebCore {
 
-Ref<PerspectiveTransformOperation> PerspectiveTransformOperation::create(const std::optional<Length>& p)
+Ref<PerspectiveTransformOperation> PerspectiveTransformOperation::create(const std::optional<float>& p)
 {
     return adoptRef(*new PerspectiveTransformOperation(p));
 }
 
-PerspectiveTransformOperation::PerspectiveTransformOperation(const std::optional<Length>& p)
+PerspectiveTransformOperation::PerspectiveTransformOperation(const std::optional<float>& p)
     : TransformOperation(TransformOperation::Type::Perspective)
     , m_p(p)
 {
-    ASSERT(!p || (*p).isFixed());
 }
 
 bool PerspectiveTransformOperation::operator==(const TransformOperation& other) const
@@ -75,10 +74,9 @@ Ref<TransformOperation> PerspectiveTransformOperation::blend(const TransformOper
     }
 
     double pInverse = WebCore::blend(fromPInverse, toPInverse, context);
-    std::optional<Length> p;
-    if (pInverse > 0.0 && std::isnormal(pInverse)) {
-        p = Length(1.0 / pInverse, LengthType::Fixed);
-    }
+    std::optional<float> p;
+    if (pInverse > 0.0 && std::isnormal(pInverse))
+        p = 1.0 / pInverse;
     return PerspectiveTransformOperation::create(p);
 }
 

--- a/Source/WebCore/platform/graphics/transforms/PerspectiveTransformOperation.h
+++ b/Source/WebCore/platform/graphics/transforms/PerspectiveTransformOperation.h
@@ -25,8 +25,6 @@
 
 #pragma once
 
-#include <WebCore/Length.h>
-#include <WebCore/LengthFunctions.h>
 #include <WebCore/TransformOperation.h>
 #include <optional>
 #include <wtf/Ref.h>
@@ -37,15 +35,15 @@ struct BlendingContext;
 
 class PerspectiveTransformOperation final : public TransformOperation {
 public:
-    WEBCORE_EXPORT static Ref<PerspectiveTransformOperation> create(const std::optional<Length>&);
+    WEBCORE_EXPORT static Ref<PerspectiveTransformOperation> create(const std::optional<float>&);
 
     Ref<TransformOperation> clone() const override
     {
         return adoptRef(*new PerspectiveTransformOperation(m_p));
     }
 
-    std::optional<Length> perspective() const { return m_p; }
-    
+    std::optional<float> perspective() const { return m_p; }
+
 private:
     bool isIdentity() const override { return !m_p; }
     bool isAffectedByTransformOrigin() const override { return !isIdentity(); }
@@ -63,7 +61,7 @@ private:
         // "As very small <length> values can produce bizarre rendering results and stress the numerical accuracy of
         // transform calculations, values less than 1px must be treated as 1px for rendering purposes. (This clamping
         // does not affect the underlying value, so perspective: 0; in a stylesheet will still serialize back as 0.)"
-        return std::max(1.0f, floatValueForLength(*m_p, 1.0));
+        return std::max(1.0f, *m_p);
     }
 
     bool apply(TransformationMatrix& transform, const FloatSize&) const override
@@ -77,9 +75,9 @@ private:
 
     void dump(WTF::TextStream&) const final;
 
-    PerspectiveTransformOperation(const std::optional<Length>&);
+    PerspectiveTransformOperation(const std::optional<float>&);
 
-    std::optional<Length> m_p;
+    std::optional<float> m_p;
 };
 
 } // namespace WebCore

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -3004,7 +3004,7 @@ header: <WebCore/KeyboardScroll.h>
 }
 
 [RefCounted] class WebCore::PerspectiveTransformOperation {
-    std::optional<WebCore::Length> perspective();
+    std::optional<float> perspective();
 }
 
 [RefCounted] class WebCore::MatrixTransformOperation {


### PR DESCRIPTION
#### 4502a4306fb4f9a5729ee9b328dc089dec7bc08b
<pre>
[Length Deprecation] Remove unnecessary use of Length in PerspectiveTransformOperation
<a href="https://bugs.webkit.org/show_bug.cgi?id=299198">https://bugs.webkit.org/show_bug.cgi?id=299198</a>

Reviewed by Darin Adler.

`PerspectiveTransformOperation` uses a `Length`, but it is only ever `LengthType::Fixed`.
This changes it to use a a float instead.

* Source/WebCore/platform/graphics/transforms/PerspectiveTransformOperation.cpp:
* Source/WebCore/platform/graphics/transforms/PerspectiveTransformOperation.h:
* Source/WebCore/style/values/transforms/StyleTransformFunction.cpp:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/300265@main">https://commits.webkit.org/300265@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eb7e01ea14a71dba0dedc9c03856c150eefe86d3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121873 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41575 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32245 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128425 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73966 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123749 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42290 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50169 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92625 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/61560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124825 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33731 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109147 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73283 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32744 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27311 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71928 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103236 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27500 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131197 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48812 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37122 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101194 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49184 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105358 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101062 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25639 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46430 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24542 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45512 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48669 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54403 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48139 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51489 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49819 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->