### PR TITLE
`element.scrollTo` / `element.scrollBy` don't work on text inputs

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-fires-to-text-input-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-fires-to-text-input-expected.txt
@@ -1,7 +1,8 @@
 
 
-Harness Error (TIMEOUT), message = null
-
-PASS scrolled input field should receive scrollend.
-TIMEOUT scrolled input field should receive scrollend for animated scroll. Test timed out
+PASS scrolled input field should receive scrollend when setting scrollLeft.
+PASS scrolled input field should receive scrollend with scrollBy({ behavior: 'smooth' }).
+PASS scrolled input field should receive scrollend with scrollBy({ behavior: 'instant' }).
+PASS scrolled input field should receive scrollend with scrollTo({ behavior: 'smooth' }).
+PASS scrolled input field should receive scrollend with scrollTo({ behavior: 'instant' }).
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-fires-to-text-input.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-fires-to-text-input.html
@@ -14,14 +14,19 @@
     <input type="text" id="inputscroller"
     value="qwertyuiopasddfghjklzxcvbnmqwertyuiopasddfghjklzxcvbnmqwer">
     <script>
-      promise_test(async t => {
-        const inputscroller = document.getElementById("inputscroller");
+      const inputscroller = document.getElementById("inputscroller");
+
+      function register_cleanup(t) {
         t.add_cleanup(() => {
           return new Promise(resolve => {
             inputscroller.addEventListener("scrollend", resolve, { once: true });
             inputscroller.scrollLeft = 0;
           });
         });
+      }
+
+      promise_test(async t => {
+        register_cleanup(t);
         assert_equals(inputscroller.scrollLeft, 0,
           "text input field is not initially scrolled.");
 
@@ -32,16 +37,10 @@
         await scrollend_promise;
         assert_equals(inputscroller.scrollLeft, 10,
           "text input field is scrolled by the correct amount");
-      }, "scrolled input field should receive scrollend.");
+      }, "scrolled input field should receive scrollend when setting scrollLeft.");
 
       promise_test(async t => {
-        const inputscroller = document.getElementById("inputscroller");
-        t.add_cleanup(() => {
-          return new Promise(resolve => {
-            inputscroller.addEventListener("scrollend", resolve, { once: true });
-            inputscroller.scrollLeft = 0;
-          });
-        });
+        register_cleanup(t);
         assert_equals(inputscroller.scrollLeft, 0,
           "text input field is not initially scrolled.");
 
@@ -52,7 +51,49 @@
         await scrollend_promise;
         assert_equals(inputscroller.scrollLeft, 10,
           "text input field is scrolled by the correct amount");
-      }, "scrolled input field should receive scrollend for animated scroll.");
+      }, "scrolled input field should receive scrollend with scrollBy({ behavior: 'smooth' }).");
+
+      promise_test(async t => {
+        register_cleanup(t);
+        assert_equals(inputscroller.scrollLeft, 0,
+          "text input field is not initially scrolled.");
+
+        const scrollend_promise = new Promise((resolve) => {
+          inputscroller.addEventListener("scrollend", resolve, { once: true });
+        });
+        inputscroller.scrollBy({ left: 10, behavior: "instant" });
+        await scrollend_promise;
+        assert_equals(inputscroller.scrollLeft, 10,
+          "text input field is scrolled by the correct amount");
+      }, "scrolled input field should receive scrollend with scrollBy({ behavior: 'instant' }).");
+
+      promise_test(async t => {
+        register_cleanup(t);
+        assert_equals(inputscroller.scrollLeft, 0,
+          "text input field is not initially scrolled.");
+
+        const scrollend_promise = new Promise((resolve) => {
+          inputscroller.addEventListener("scrollend", resolve, { once: true });
+        });
+        inputscroller.scrollTo({ left: 10, behavior: "smooth" });
+        await scrollend_promise;
+        assert_equals(inputscroller.scrollLeft, 10,
+          "text input field is scrolled by the correct amount");
+      }, "scrolled input field should receive scrollend with scrollTo({ behavior: 'smooth' }).");
+
+      promise_test(async t => {
+        register_cleanup(t);
+        assert_equals(inputscroller.scrollLeft, 0,
+          "text input field is not initially scrolled.");
+
+        const scrollend_promise = new Promise((resolve) => {
+          inputscroller.addEventListener("scrollend", resolve, { once: true });
+        });
+        inputscroller.scrollTo({ left: 10, behavior: "instant" });
+        await scrollend_promise;
+        assert_equals(inputscroller.scrollLeft, 10,
+          "text input field is scrolled by the correct amount");
+      }, "scrolled input field should receive scrollend with scrollTo({ behavior: 'instant' }).");
     </script>
   </body>
 </html>

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -126,6 +126,7 @@
 #include "RenderObjectInlines.h"
 #include "RenderSVGModelObject.h"
 #include "RenderStyleSetters.h"
+#include "RenderTextControlSingleLine.h"
 #include "RenderTheme.h"
 #include "RenderTreeUpdater.h"
 #include "RenderView.h"
@@ -1351,7 +1352,15 @@ void Element::scrollTo(const ScrollToOptions& options, ScrollClamping clamping, 
     // If the element does not have any associated CSS layout box, the element has no associated scrolling box,
     // or the element has no overflow, terminate these steps.
     CheckedPtr renderer = renderBox();
-    if (!renderer || !renderer->hasNonVisibleOverflow())
+    if (!renderer)
+        return;
+
+    auto rendererCanScroll = [&] {
+        if (CheckedPtr renderTextControlSingleLine = dynamicDowncast<RenderTextControlSingleLine>(renderer.get()))
+            return renderTextControlSingleLine->innerTextElementHasNonVisibleOverflow();
+        return renderer->hasNonVisibleOverflow();
+    };
+    if (!rendererCanScroll())
         return;
 
     auto scrollToOptions = normalizeNonFiniteCoordinatesOrFallBackTo(options,

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -215,7 +215,7 @@ public:
     virtual int scrollHeight() const;
     virtual void setScrollLeft(int, const ScrollPositionChangeOptions&);
     virtual void setScrollTop(int, const ScrollPositionChangeOptions&);
-    void setScrollPosition(const ScrollPosition&, const ScrollPositionChangeOptions&);
+    virtual void setScrollPosition(const ScrollPosition&, const ScrollPositionChangeOptions&);
 
     const LayoutBoxExtent& marginBox() const { return m_marginBox; }
     LayoutUnit marginTop() const override { return m_marginBox.top(); }

--- a/Source/WebCore/rendering/RenderTextControlSingleLine.cpp
+++ b/Source/WebCore/rendering/RenderTextControlSingleLine.cpp
@@ -362,6 +362,13 @@ LayoutRect RenderTextControlSingleLine::controlClipRect(const LayoutPoint& addit
     return clipRect;
 }
 
+bool RenderTextControlSingleLine::innerTextElementHasNonVisibleOverflow() const
+{
+    if (RefPtr innerTextElement = this->innerTextElement(); innerTextElement && innerTextElement->renderer())
+        return innerTextElement->renderer()->hasNonVisibleOverflow();
+    return false;
+}
+
 float RenderTextControlSingleLine::getAverageCharWidth()
 {
 #if !PLATFORM(IOS_FAMILY)
@@ -471,6 +478,12 @@ void RenderTextControlSingleLine::setScrollTop(int newTop, const ScrollPositionC
 {
     if (innerTextElement())
         innerTextElement()->setScrollTop(newTop);
+}
+
+void RenderTextControlSingleLine::setScrollPosition(const ScrollPosition& position, const ScrollPositionChangeOptions& options)
+{
+    if (RefPtr innerTextElement = this->innerTextElement(); innerTextElement && innerTextElement->renderer())
+        innerTextElement->renderer()->setScrollPosition(position, options);
 }
 
 bool RenderTextControlSingleLine::scroll(ScrollDirection direction, ScrollGranularity granularity, unsigned stepCount, Element** stopElement, RenderBox* startBox, const IntPoint& wheelEventAbsolutePoint)

--- a/Source/WebCore/rendering/RenderTextControlSingleLine.h
+++ b/Source/WebCore/rendering/RenderTextControlSingleLine.h
@@ -37,6 +37,8 @@ public:
 
     RenderTextControlInnerBlock* innerTextRenderer() const;
 
+    bool innerTextElementHasNonVisibleOverflow() const;
+
 protected:
     HTMLElement* containerElement() const;
     HTMLElement* innerBlockElement() const;
@@ -62,6 +64,7 @@ private:
     int scrollHeight() const override;
     void setScrollLeft(int, const ScrollPositionChangeOptions&) override;
     void setScrollTop(int, const ScrollPositionChangeOptions&) override;
+    void setScrollPosition(const ScrollPosition&, const ScrollPositionChangeOptions&) override;
     bool scroll(ScrollDirection, ScrollGranularity, unsigned stepCount = 1, Element** stopElement = nullptr, RenderBox* startBox = nullptr, const IntPoint& wheelEventAbsolutePoint = IntPoint()) final;
     bool logicalScroll(ScrollLogicalDirection, ScrollGranularity, unsigned stepCount = 1, Element** stopElement = nullptr) final;
 


### PR DESCRIPTION
#### 2638b49042d810843a53b4446da335f82512bdad
<pre>
`element.scrollTo` / `element.scrollBy` don&apos;t work on text inputs
<a href="https://bugs.webkit.org/show_bug.cgi?id=299192">https://bugs.webkit.org/show_bug.cgi?id=299192</a>
<a href="https://rdar.apple.com/160963921">rdar://160963921</a>

Reviewed by Simon Fraser.

Forward calls for setScrollPosition to the inner text element, just like we already do on scrollLeft/scrollTop.

Also check hasNonVisibleOverflow() on the inner text element.

* LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-fires-to-text-input-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-fires-to-text-input.html:
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::scrollTo):
* Source/WebCore/rendering/RenderBox.h:
* Source/WebCore/rendering/RenderTextControlSingleLine.cpp:
(WebCore::RenderTextControlSingleLine::innerTextElementHasNonVisibleOverflow const):
(WebCore::RenderTextControlSingleLine::setScrollPosition):
* Source/WebCore/rendering/RenderTextControlSingleLine.h:

Canonical link: <a href="https://commits.webkit.org/300274@main">https://commits.webkit.org/300274@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d42f40a0af85d7d30573fb5d1307467265ad7157

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121930 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41632 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32302 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128483 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74023 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4cc9a666-45c4-4957-952c-ec669bf07b03) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123806 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42347 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50226 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92665 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/61573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0315bf88-45ac-4ec4-b048-5260c489f6ea) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124882 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33773 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109189 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73324 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/547d8527-9e04-47dc-abdb-0c71252037bb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32782 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27356 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71986 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103277 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27546 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131254 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48869 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37161 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101227 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49243 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105404 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101095 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25644 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46475 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24581 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/45570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48726 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54460 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48196 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51546 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49876 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->