### PR TITLE
[GFC] Track auto positioned and row positioned grid items.

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp
@@ -69,14 +69,39 @@ UnplacedGridItems GridFormattingContext::constructUnplacedGridItems() const
         auto gridItemRowStart = gridItemStyle->gridItemRowStart();
         auto gridItemRowEnd = gridItemStyle->gridItemRowEnd();
 
-        if (!gridItemColumnStart.isExplicit() || !gridItemColumnEnd.isExplicit()
-            || !gridItemRowStart.isExplicit() || !gridItemRowEnd.isExplicit()) {
-            ASSERT_NOT_IMPLEMENTED_YET();
-            return { };
-        }
+        // Check if this item is fully explicitly positioned
+        bool fullyExplicitlyPositionedItem = gridItemColumnStart.isExplicit()
+            && gridItemColumnEnd.isExplicit()
+            && gridItemRowStart.isExplicit()
+            && gridItemRowEnd.isExplicit();
 
-        unplacedGridItems.nonAutoPositionedItems.constructAndAppend(gridItem.layoutBox, gridItemStyle->gridItemColumnStart(), gridItemStyle->gridItemColumnEnd(),
-    gridItemStyle->gridItemRowStart(), gridItemStyle->gridItemRowEnd());
+        bool definiteRowPositioned = gridItemRowStart.isExplicit() || gridItemRowEnd.isExplicit();
+
+        if (fullyExplicitlyPositionedItem) {
+            unplacedGridItems.nonAutoPositionedItems.constructAndAppend(
+                gridItem.layoutBox,
+                gridItemColumnStart,
+                gridItemColumnEnd,
+                gridItemRowStart,
+                gridItemRowEnd
+            );
+        } else if (definiteRowPositioned) {
+            unplacedGridItems.definiteRowPositionedItems.constructAndAppend(
+                gridItem.layoutBox,
+                gridItemColumnStart,
+                gridItemColumnEnd,
+                gridItemRowStart,
+                gridItemRowEnd
+            );
+        } else {
+            unplacedGridItems.autoPositionedItems.constructAndAppend(
+                gridItem.layoutBox,
+                gridItemColumnStart,
+                gridItemColumnEnd,
+                gridItemRowStart,
+                gridItemRowEnd
+            );
+        }
     }
     return unplacedGridItems;
 }

--- a/Source/WebCore/layout/formattingContexts/grid/UnplacedGridItem.h
+++ b/Source/WebCore/layout/formattingContexts/grid/UnplacedGridItem.h
@@ -64,8 +64,14 @@ private:
     friend void add(Hasher&, const WebCore::Layout::UnplacedGridItem&);
 };
 
+// https://drafts.csswg.org/css-grid-1/#auto-placement-algo
 struct UnplacedGridItems {
+    // 1. Position anything that’s not auto-positioned.
     Vector<UnplacedGridItem> nonAutoPositionedItems;
+    // 2. Process the items locked to a given row.
+    Vector<UnplacedGridItem> definiteRowPositionedItems;
+    // 4. Position the remaining grid items.
+    Vector<UnplacedGridItem> autoPositionedItems;
 };
 
 }


### PR DESCRIPTION
#### 222b79b8b859755d83a4bbd71a163cb896c1ca73
<pre>
[GFC] Track auto positioned and row positioned grid items.
<a href="https://bugs.webkit.org/show_bug.cgi?id=299128">https://bugs.webkit.org/show_bug.cgi?id=299128</a>
&lt;<a href="https://rdar.apple.com/160888594">rdar://160888594</a>&gt;

Reviewed by Sammy Gill.

This PR updates the UnplacedGridItems struct to track items with definite
row positions and items that are fully auto positioned items in addition
to fully explicitly (non-auto) positioned items. Note that this PR does not
place any of these items.

* Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp:
(WebCore::Layout::GridFormattingContext::constructUnplacedGridItems const):
* Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp:
(WebCore::Layout::GridLayout::placeGridItems):
* Source/WebCore/layout/formattingContexts/grid/ImplicitGrid.cpp:
(WebCore::Layout::ImplicitGrid::ImplicitGrid):
(WebCore::Layout::ImplicitGrid::insertUnplacedGridItem):
(WebCore::Layout::ImplicitGrid::placedGridItems const):
* Source/WebCore/layout/formattingContexts/grid/ImplicitGrid.h:
* Source/WebCore/layout/formattingContexts/grid/UnplacedGridItem.h:

Canonical link: <a href="https://commits.webkit.org/300448@main">https://commits.webkit.org/300448@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/96082dcbe5aca71b571d2e7b69fa9b9b61c3a0d8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122558 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42266 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32951 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/129167 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74659 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f79a779b-6a06-4f4b-b921-87baeeda646a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/124434 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42984 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50859 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93163 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/61868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/74f7b886-25bf-4b6a-8ad5-60d5b3325b58) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125510 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34287 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109740 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73809 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/60bc7b8b-643c-4570-a1b1-d05a2492399c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33270 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27897 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72651 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103950 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28107 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131893 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49499 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37678 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101695 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49874 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105960 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101563 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25787 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46945 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25093 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/46269 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49357 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/55106 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48825 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/52176 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50506 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->