### PR TITLE
[ARMv7][EWS] Revert "Make ARMv7 EWS use Gold" 298522@main

### DIFF
--- a/Tools/CISupport/build-webkit-org/config.json
+++ b/Tools/CISupport/build-webkit-org/config.json
@@ -588,7 +588,7 @@
                     "workernames": ["jsconly-linux-igalia-bot-2"]
                   },
                   {
-                    "name": "JSCOnly-Linux-ARMv7-Thumb2-Release", "factory": "BuildAndJSCTests32Factory",
+                    "name": "JSCOnly-Linux-ARMv7-Thumb2-Release", "factory": "BuildAndJSCTestsFactory",
                     "platform": "jsc-only", "configuration": "release", "architectures": ["armv7"],
                     "workernames": ["jsconly-linux-igalia-bot-3"]
                   },

--- a/Tools/CISupport/build-webkit-org/factories_unittest.py
+++ b/Tools/CISupport/build-webkit-org/factories_unittest.py
@@ -1405,7 +1405,7 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'show-identifier',
             'delete-WebKitBuild-directory',
             'delete-stale-build-files',
-            'compile-jsc-32bit',
+            'compile-jsc',
             'jscore-test'
         ],
         'WPE-Linux-64-bit-Release-Build': [

--- a/Tools/CISupport/build-webkit-org/steps.py
+++ b/Tools/CISupport/build-webkit-org/steps.py
@@ -499,9 +499,9 @@ class CompileLLINTCLoop(CompileWebKit):
     build_command = ["perl", "Tools/Scripts/build-jsc", "--cloop"]
 
 
-class CompileJSCOnly32(CompileWebKit):
+class Compile32bitJSC(CompileWebKit):
     name = 'compile-jsc-32bit'
-    build_command = ["linux32", "perl", "Tools/Scripts/build-jsc", "--32-bit", "--cmakeargs", "-DUSE_LIBBACKTRACE=OFF -DDEVELOPER_MODE=ON -DENABLE_OFFLINE_ASM_ALT_ENTRY=1 -DCMAKE_CXX_FLAGS='-fuse-ld=gold -Wl,--no-map-whole-files -Wl,--no-keep-memory -Wl,--no-keep-files-mapped -Wl,--no-mmap-output-file -fno-omit-frame-pointer' -DCMAKE_C_FLAGS='-fuse-ld=gold -Wl,--no-map-whole-files -Wl,--no-keep-memory -Wl,--no-keep-files-mapped -Wl,--no-mmap-output-file -fno-omit-frame-pointer' -DUSE_LD_LLD=OFF"]
+    build_command = ["perl", "Tools/Scripts/build-jsc", "--32-bit"]
 
 
 class CompileJSCOnly(CompileWebKit):

--- a/Tools/CISupport/ews-build/factories.py
+++ b/Tools/CISupport/ews-build/factories.py
@@ -193,7 +193,7 @@ class JSCBuildFactory(Factory):
         Factory.__init__(self, platform=platform, configuration=configuration, architectures=architectures, buildOnly=False, triggers=triggers, remotes=remotes, additionalArguments=additionalArguments, checkRelevance=True)
         self.addStep(KillOldProcesses())
         self.addStep(ValidateChange(addURLs=False))
-        self.addStep(CompileJSC32() if architectures and 'armv7' in architectures else CompileJSC())
+        self.addStep(CompileJSC())
 
 
 class JSCBuildAndTestsFactory(Factory):
@@ -201,9 +201,9 @@ class JSCBuildAndTestsFactory(Factory):
         Factory.__init__(self, platform=platform, configuration=configuration, architectures=architectures, buildOnly=False, remotes=remotes, additionalArguments=additionalArguments, checkRelevance=True)
         self.addStep(KillOldProcesses())
         self.addStep(ValidateChange(addURLs=False))
-        self.addStep(CompileJSC32(skipUpload=True) if architectures and 'armv7' in architectures else CompileJSC(skipUpload=True))
+        self.addStep(CompileJSC(skipUpload=True))
         if runTests.lower() == 'true':
-            self.addStep(RunJavaScriptCoreTests32() if architectures and 'armv7' in architectures else RunJavaScriptCoreTests())
+            self.addStep(RunJavaScriptCoreTests())
 
 
 class JSCTestsFactory(Factory):
@@ -212,7 +212,7 @@ class JSCTestsFactory(Factory):
         self.addStep(KillOldProcesses())
         self.addStep(DownloadBuiltProduct())
         self.addStep(ExtractBuiltProduct())
-        self.addStep(RunJavaScriptCoreTests32() if architectures and 'armv7' in architectures else RunJavaScriptCoreTests())
+        self.addStep(RunJavaScriptCoreTests())
 
 
 class APITestsFactory(TestFactory):

--- a/Tools/CISupport/ews-build/factories_unittest.py
+++ b/Tools/CISupport/ews-build/factories_unittest.py
@@ -630,7 +630,7 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'checkout-pull-request',
             'kill-old-processes',
             'validate-change',
-            'compile-jsc-32bit'
+            'compile-jsc'
         ],
         'JSC-ARMv7-32bits-Tests-EWS': [
             'configure-build',
@@ -648,7 +648,7 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'kill-old-processes',
             'download-built-product',
             'extract-built-product',
-            'jscore-test-32bit'
+            'jscore-test'
         ],
         'Bindings-Tests-EWS': [
             'configure-build',

--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -3675,32 +3675,8 @@ class CompileJSC(CompileWebKit):
         return shell.CompileNewStyle.getResultSummary(self)
 
 
-class CompileJSC32(CompileWebKit):
-    name = 'compile-jsc-32bit'
-    descriptionDone = ['Compiled JSC']
-    build_command = ["linux32", "perl", "Tools/Scripts/build-jsc", "--32-bit", "--cmakeargs", "-DUSE_LIBBACKTRACE=OFF -DDEVELOPER_MODE=ON -DENABLE_OFFLINE_ASM_ALT_ENTRY=1 -DCMAKE_CXX_FLAGS='-fuse-ld=gold -Wl,--no-map-whole-files -Wl,--no-keep-memory -Wl,--no-keep-files-mapped -Wl,--no-mmap-output-file -fno-omit-frame-pointer' -DCMAKE_C_FLAGS='-fuse-ld=gold -Wl,--no-map-whole-files -Wl,--no-keep-memory -Wl,--no-keep-files-mapped -Wl,--no-mmap-output-file -fno-omit-frame-pointer' -DUSE_LD_LLD=OFF"]
-
-    @defer.inlineCallbacks
-    def run(self):
-        self.setProperty('group', 'jsc')
-        rc = yield super().run()
-        defer.returnValue(rc)
-
-    def getResultSummary(self):
-        if self.results == FAILURE:
-            return {'step': 'Failed to compile JSC'}
-        return shell.CompileNewStyle.getResultSummary(self)
-
-
 class CompileJSCWithoutChange(CompileJSC):
     name = 'compile-jsc-without-change'
-
-    def evaluateCommand(self, cmd):
-        return shell.CompileNewStyle.evaluateCommand(self, cmd)
-
-
-class CompileJSCWithoutChange32(CompileJSC32):
-    name = 'compile-jsc-32bit-without-change'
 
     def evaluateCommand(self, cmd):
         return shell.CompileNewStyle.evaluateCommand(self, cmd)
@@ -3833,7 +3809,7 @@ class RunJavaScriptCoreTests(shell.TestNewStyle, AddToLogMixin, ShellMixin):
                 RevertAppliedChanges(),
                 CleanWorkingDirectory(),
                 ValidateChange(verifyBugClosed=False, addURLs=False),
-                CompileJSCWithoutChange() if self.bits() == 64 else CompileJSCWithoutChange32(),
+                CompileJSCWithoutChange(),
                 ValidateChange(verifyBugClosed=False, addURLs=False),
                 KillOldProcesses(),
                 RunJSCTestsWithoutChange(),
@@ -3923,16 +3899,6 @@ class RunJavaScriptCoreTests(shell.TestNewStyle, AddToLogMixin, ShellMixin):
             count += int(match.group(1))
 
         return count
-
-    def bits(self):
-        return 64
-
-
-class RunJavaScriptCoreTests32(RunJavaScriptCoreTests):
-    name = 'jscore-test-32bit'
-
-    def bits(self):
-        return 32
 
 
 class RunJSCTestsWithoutChange(RunJavaScriptCoreTests):


### PR DESCRIPTION
#### 0b64e8e53211cb6663fb7b513007c60b63071f20
<pre>
[ARMv7][EWS] Revert &quot;Make ARMv7 EWS use Gold&quot; 298522@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=299212">https://bugs.webkit.org/show_bug.cgi?id=299212</a>

Reviewed by Aakash Jain.

This was fixed in build-webkit, so it is not needed anymore. Furthermore
it is breaking compile-jsc-32bit-without-change, which is blocking
the EWS queue with endless repeats.

Canonical link: <a href="https://commits.webkit.org/300395@main">https://commits.webkit.org/300395@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d447970b387d6681c566c4b5dd931cd7b307164

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122191 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41894 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32563 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128764 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74285 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/124067 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42608 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50487 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92871 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61741 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125143 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33990 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109421 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73527 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32999 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27584 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72255 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103497 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27777 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131515 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49130 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37381 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101439 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/121612 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49504 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105632 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101308 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25730 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46681 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24800 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45881 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48987 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48457 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51807 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50137 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->