### PR TITLE
[Xcode] Ability to add OTHER_CLFAGS and OTHER_LDFLAGS using Makefile.shared

### DIFF
--- a/Makefile.shared
+++ b/Makefile.shared
@@ -60,7 +60,7 @@ ifeq (, $(findstring WK_USE_CCACHE, $(ARGS)))
 endif
 
 ifneq (,$(EXPORT_COMPILE_COMMANDS))
-		XCODE_OPTIONS += OTHER_CFLAGS='$$(inherited) -gen-cdb-fragment-path $$(BUILT_PRODUCTS_DIR)/compile_commands'
+		EXTRA_CFLAGS += -gen-cdb-fragment-path $$(BUILT_PRODUCTS_DIR)/compile_commands
 		XCODE_OPTIONS += GCC_PRECOMPILE_PREFIX_HEADER=NO
 		XCODE_OPTIONS += CLANG_ENABLE_MODULE_DEBUGGING=NO
 		XCODE_OPTIONS += COMPILER_INDEX_STORE_ENABLE=NO
@@ -112,6 +112,14 @@ else
 ifeq ($(LIBFUZZER),NO)
 CONFIG_OPTIONS += --no-libfuzzer
 endif
+endif
+
+ifneq (,$(OTHER_CFLAGS)$(EXTRA_CFLAGS))
+XCODE_OPTIONS += OTHER_CFLAGS='$$(inherited) $(EXTRA_CFLAGS) $(OTHER_CFLAGS)'
+endif
+
+ifneq (,$(OTHER_LDFLAGS))
+XCODE_OPTIONS += OTHER_LDFLAGS='$$(inherited) $(OTHER_LDFLAGS)'
 endif
 
 ifneq ($(WK_SANITIZER_COVERAGE),)


### PR DESCRIPTION
#### 98a41938bf5e07f4de7718c63aa273870cc6ce66
<pre>
[Xcode] Ability to add OTHER_CLFAGS and OTHER_LDFLAGS using Makefile.shared
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=299216">https://bugs.webkit.org/show_bug.cgi?id=299216</a>&gt;
&lt;<a href="https://rdar.apple.com/160974662">rdar://160974662</a>&gt;

Reviewed by Elliott Williams and Jonathan Bedard.

* Makefile.shared:
- Add support for specifying OTHER_CFLAGS and OTHER_LDFLAGS on the
  `make` command-line.  Create `EXTRA_CFLAGS` internal variable to
  track switches added for other settings.

Canonical link: <a href="https://commits.webkit.org/300613@main">https://commits.webkit.org/300613@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9f0a7d98320d6e2ccff12cfc199e81540677a10c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121944 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41646 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32316 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128501 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74037 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8b21f7d9-3f0e-49e6-b217-9f72c169a43f) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42361 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50240 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92672 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61583 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9edd67a0-b46b-4ee8-84a2-d511c17e5bbf) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124896 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33776 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109201 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73330 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/093748a5-507e-48b0-83b4-fcdaf26ebf1c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32786 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72000 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/114092 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103281 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27559 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131268 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/120470 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48883 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37169 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101234 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49257 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105417 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101102 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46472 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24591 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45584 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19416 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48740 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/150627 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48210 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/38536 "Found 1 new JSC stress test failure: stress/dont-link-virtual-calls-on-compiler-thread.js.no-llint (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51560 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49890 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->