### PR TITLE
Implement EventCounts as maplike

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1295,6 +1295,9 @@ imported/w3c/web-platform-tests/resource-timing/TAO-match.html [ Pass Failure ]
 imported/w3c/web-platform-tests/resource-timing/iframe-failed-commit.html [ Pass Failure ]
 imported/w3c/web-platform-tests/resource-timing/fetch-cross-origin-redirect.https.html [ Pass Failure ]
 
+# Partially implemented:
+webkit.org/b/214677 imported/w3c/web-platform-tests/event-timing/event-counts-maplike-iterators-always-updated.html [ Pass Failure ]
+
 # No browser passes, test is likely outdated:
 webkit.org/b/214677 imported/w3c/web-platform-tests/event-timing/modal-dialog-interrupt-paint.html [ Skip ]
 webkit.org/b/214677 imported/w3c/web-platform-tests/event-timing/TapToStopFling.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/event-timing/event-counts-maplike-iterators-always-updated-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/event-timing/event-counts-maplike-iterators-always-updated-expected.txt
@@ -1,0 +1,5 @@
+Outside target!
+Click me
+
+FAIL Event Timing eventCount iterators always updated. assert_equals: Iterators must be always up-to-date expected 2 but got 1
+

--- a/LayoutTests/imported/w3c/web-platform-tests/event-timing/event-counts-maplike-iterators-always-updated.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/event-timing/event-counts-maplike-iterators-always-updated.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+<meta charset=utf-8 />
+<title>Event Timing eventCount iterators always updated.</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=/resources/testdriver.js></script>
+<script src=/resources/testdriver-actions.js></script>
+<script src=/resources/testdriver-vendor.js></script>
+<script src=resources/event-timing-test-utils.js></script>
+<div>Outside target!</div>
+<div id='target'>Click me</div>
+<script>
+  promise_test(async t => {
+    let entriesIterator1 = performance.eventCounts.entries()
+    const nClicksStart = performance.eventCounts.get('click')
+
+    await clickAndBlockMain('target');
+    await afterNextPaint();
+    let entriesIterator2 = performance.eventCounts.entries()
+    let entriesIterator3 = performance.eventCounts.entries()
+    let clickFound = false
+    entriesIterator1.forEach( pair => {
+      let [key1, value1] = [...pair]
+      let [key2,value2] = [...entriesIterator2.next().value]
+      assert_equals(key1, key2, "Iterators created at different moments must match")
+      assert_equals(value1, value2, "Iterators created at different moments must match")
+      if (key1 == 'click') {
+        assert_equals(value1, nClicksStart + 1)
+        clickFound = true
+      }
+    })
+    assert_true(clickFound, 'click entry should exist')
+
+    await clickAndBlockMain('target')
+    await afterNextPaint()
+    clickFound = false
+    entriesIterator3.forEach( pair => {
+      let [key, value] = [...pair]
+      if (key == 'click') {
+        assert_equals(value, nClicksStart + 2, "Iterators must be always up-to-date")
+        clickFound = true
+      }
+    })
+    assert_true(clickFound, 'click entry should exist')
+  })
+
+</script>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/event-timing/event-counts-maplike-validate-iterators-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/event-timing/event-counts-maplike-validate-iterators-expected.txt
@@ -1,0 +1,3 @@
+
+PASS EventCounts iterators constent with .get() and .size
+

--- a/LayoutTests/imported/w3c/web-platform-tests/event-timing/event-counts-maplike-validate-iterators.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/event-timing/event-counts-maplike-validate-iterators.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<meta charset=utf-8 />
+<title>Event Timing eventCount validate iterators.</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=/resources/testdriver.js></script>
+<script src=/resources/testdriver-actions.js></script>
+<script src=/resources/testdriver-vendor.js></script>
+<script src=resources/event-timing-test-utils.js></script>
+<script>
+  test( () => {
+    keysIterator = performance.eventCounts.keys();
+    valuesIterator = performance.eventCounts.values();
+    entriesIterator = performance.eventCounts.entries();
+    nEntries = 0;
+    performance.eventCounts.forEach( (value, key) => {
+      nEntries++;
+      keyFromIterator = keysIterator.next().value;
+      valueFromIterator = valuesIterator.next().value;
+      entryFromIterator = entriesIterator.next().value;
+      assert_equals(keyFromIterator, key, ".keys() should match .forEach()");
+      assert_equals(valueFromIterator, value, ".values() should match .forEach()");
+      assert_equals(entryFromIterator[0], key, ".entries() should match .forEach()");
+      assert_equals(entryFromIterator[1], value, ".entries() should match .forEach()");
+      assert_equals(performance.eventCounts.get(key), value, "iterators should match .get()");
+    })
+    assert_equals(nEntries, performance.eventCounts.size, "Number of entries in .forEach() should match .size");
+    assert_true(keysIterator.next().done, "Number of entries in .keys() should match .size");
+    assert_true(valuesIterator.next().done, "Number of entries in .values() should match .size");
+    assert_true(entriesIterator.next().done, "Number of entries in .entries() should match .size");
+  }, "EventCounts iterators constent with .get() and .size")
+</script>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/event-timing/idlharness.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/event-timing/idlharness.any-expected.txt
@@ -25,7 +25,7 @@ PASS EventCounts interface object name
 PASS EventCounts interface: existence and properties of interface prototype object
 PASS EventCounts interface: existence and properties of interface prototype object's "constructor" property
 PASS EventCounts interface: existence and properties of interface prototype object's @@unscopables property
-FAIL EventCounts interface: maplike<DOMString, unsigned long long> undefined is not an object (evaluating 'desc.value')
+PASS EventCounts interface: maplike<DOMString, unsigned long long>
 PASS Performance interface: attribute eventCounts
 PASS Performance interface: attribute interactionCount
 PASS Performance interface: performance must inherit property "eventCounts" with the proper type

--- a/LayoutTests/imported/w3c/web-platform-tests/event-timing/idlharness.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/event-timing/idlharness.window-expected.txt
@@ -25,7 +25,7 @@ PASS EventCounts interface object name
 PASS EventCounts interface: existence and properties of interface prototype object
 PASS EventCounts interface: existence and properties of interface prototype object's "constructor" property
 PASS EventCounts interface: existence and properties of interface prototype object's @@unscopables property
-FAIL EventCounts interface: maplike<DOMString, unsigned long long> undefined is not an object (evaluating 'desc.value')
+PASS EventCounts interface: maplike<DOMString, unsigned long long>
 PASS EventCounts must be primary interface of performance.eventCounts
 PASS Stringification of performance.eventCounts
 PASS Performance interface: attribute eventCounts

--- a/Source/WebCore/page/EventCounts.cpp
+++ b/Source/WebCore/page/EventCounts.cpp
@@ -43,13 +43,6 @@ void EventCounts::add(EventType type)
     ++m_counts[index];
 }
 
-unsigned EventCounts::get(const String& type) const
-{
-    auto typeInfo = eventNames().typeInfoForEvent(AtomString(type));
-    size_t index = std::ranges::lower_bound(EventNames::timedEvents, typeInfo.type()) - EventNames::timedEvents.begin();
-    return m_counts[index];
-}
-
 void EventCounts::initializeMapLike(DOMMapAdapter& map)
 {
     auto& eventNamesObject = eventNames();

--- a/Source/WebCore/page/EventCounts.h
+++ b/Source/WebCore/page/EventCounts.h
@@ -42,11 +42,10 @@ public:
     void deref() { m_performance->deref(); }
 
     void initializeMapLike(DOMMapAdapter&);
-    void add(EventType);
+    // Trait that causes the wrapper's backing map to be initialized again before every access:
+    using shouldAlwaysInitializeMapLikeMarker = void;
 
-    // FIXME: get() and size() should be provided by the maplike interface
-    unsigned get(const String& type) const;
-    unsigned size() const { return m_counts.size(); };
+    void add(EventType);
 
 private:
     WeakRef<Performance, Performance::WeakPtrImplType> m_performance;

--- a/Source/WebCore/page/EventCounts.idl
+++ b/Source/WebCore/page/EventCounts.idl
@@ -29,9 +29,5 @@
     Exposed=Window,
     EnabledBySetting=EventTimingEnabled
 ] interface EventCounts {
-    // FIXME: EventCounts' methods and operations should
-    // be provided by maplike instead:
-    // readonly maplike<DOMString, unsigned long long>;
-    unsigned long long get(DOMString type);
-    readonly attribute unsigned long long size;
+    readonly maplike<DOMString, unsigned long long>;
 };


### PR DESCRIPTION
#### f044942fbcb02a01fefab9f52e102d45f7986944
<pre>
Implement EventCounts as maplike
<a href="https://bugs.webkit.org/show_bug.cgi?id=299211">https://bugs.webkit.org/show_bug.cgi?id=299211</a>
<a href="https://rdar.apple.com/160968888">rdar://160968888</a>

Reviewed by Youenn Fablet.

Implements the EventCounts interface as a maplike, which
provides methods such as .forEach(), keys(), etc.

EventCounts cannot use the previous maplike implementation
because it would get out of sync after the backing map is
initialized. To solve this, we use the trait
shouldAlwaysInitializeMapLike to decide if the backing map
should be reloaded on every access through the wrapper. The trait
simply checks for the presence of a marker
(shouldAlwaysInitializeMapLikeMarker).

This implementation isn&apos;t perfect: although the backing map
will be kept up-to-date when accessed through the wrapper,
it won&apos;t be updated if accessed through an iterator generated
from that map. This is documented by the failing test
event-timing/event-counts-maplike-iterators-always-updated.html.

Canonical link: <a href="https://commits.webkit.org/300830@main">https://commits.webkit.org/300830@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/98f431c183e0cfe2190e1cb2728ae5dceaf4985d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123776 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43491 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34188 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130555 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/75926 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/125653 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44215 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52085 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94132 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62469 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126729 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35225 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110728 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74735 "Found 1 new API test failure: TestWTF:WTF_Condition.OneProducerOneConsumerOneSlot (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34183 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28887 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74036 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104949 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29111 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133247 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50728 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38630 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102610 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51103 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106947 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102439 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26101 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47780 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26032 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/47578 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50582 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56346 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50056 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53402 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51730 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->