### PR TITLE
[World Leaks] Investigate leaks in LayoutTests/imported/w3c/web-platform-tests/webvtt/

### DIFF
--- a/LayoutTests/media/track/track-cue-css.html
+++ b/LayoutTests/media/track/track-cue-css.html
@@ -12,21 +12,24 @@
             setTimeout(endTest, 100);
         }
         
-        function loaded()
-        {
-            consoleWrite("Test that CSS in VTT file is applied correctly.");
-            findMediaElement();
-            video.src = findMediaFile('video', '../content/test');
-            waitForEvent('seeked', seeked);
-            waitForEvent('canplaythrough', function() { video.currentTime = 0; });
-        }
-
         setCaptionDisplayMode('Automatic');
         </script>
     </head>
-    <body onload="loaded()">
-        <video controls >
-            <track src="captions-webvtt/css-styling.vtt" kind="captions" default>
+    <body>
+        <video controls>
+            <track id="testTrack" src="captions-webvtt/css-styling.vtt" kind="captions" default>
         </video>
+        <script>
+            function onTrackLoad() {
+                consoleWrite("Test that CSS in VTT file is applied correctly.");
+                parent.postMessage("webvttParsed");
+                findMediaElement();
+                video.src = findMediaFile('video', '../content/test');
+                waitForEvent('seeked', seeked);
+                waitForEvent('canplaythrough', function() { video.currentTime = 0; });
+            }
+
+            document.getElementById('testTrack').addEventListener('load', onTrackLoad);
+        </script>
     </body>
 </html>

--- a/LayoutTests/media/track/webvtt-parser-does-not-leak-expected.txt
+++ b/LayoutTests/media/track/webvtt-parser-does-not-leak-expected.txt
@@ -1,0 +1,10 @@
+Tests that WebVTT parsing does not leak the document object when parsing WebVTT files
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS The iframe document didn't leak.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/media/track/webvtt-parser-does-not-leak.html
+++ b/LayoutTests/media/track/webvtt-parser-does-not-leak.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+</head>
+<body>
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/document-leak-test.js"></script>
+<script>
+    description("Tests that WebVTT parsing does not leak the document object when parsing WebVTT files");
+    onload = () => runDocumentLeakTest({ frameURL: "track-cue-css.html", framesToCreate: 20 });
+</script>
+</body>
+</html>

--- a/Source/WebCore/html/track/WebVTTParser.cpp
+++ b/Source/WebCore/html/track/WebVTTParser.cpp
@@ -332,7 +332,7 @@ bool WebVTTParser::checkAndCreateRegion(StringView line)
     // zero or more U+0020 SPACE characters or U+0009 CHARACTER TABULATION
     // (tab) characters expected other than these characters it is invalid.
     if (line.startsWith("REGION"_s) && line.substring(regionIdentifierLength).containsOnly<isASCIIWhitespace>()) {
-        m_currentRegion = VTTRegion::create(m_document.get());
+        m_currentRegion = VTTRegion::create(protectedDocument().get());
         return true;
     }
     return false;
@@ -419,6 +419,11 @@ bool WebVTTParser::checkAndStoreStyleSheet(StringView line)
         m_styleSheets.append(sanitizedStyleSheetBuilder.toString());
 
     return true;
+}
+
+Ref<Document> WebVTTParser::protectedDocument() const
+{
+    return m_document.get();
 }
 
 WebVTTParser::ParseState WebVTTParser::collectCueId(const String& line)

--- a/Source/WebCore/html/track/WebVTTParser.h
+++ b/Source/WebCore/html/track/WebVTTParser.h
@@ -169,7 +169,9 @@ private:
 
     static bool collectTimeStamp(VTTScanner& input, MediaTime& timeStamp);
 
-    const Ref<Document> m_document;
+    Ref<Document> protectedDocument() const;
+
+    const WeakRef<Document, WeakPtrImplWithEventTargetData> m_document;
     ParseState m_state { Initial };
 
     BufferedLineReader m_lineReader;


### PR DESCRIPTION
#### 417f208ec5d85416e089fa61541f47a387b8c61b
<pre>
[World Leaks] Investigate leaks in LayoutTests/imported/w3c/web-platform-tests/webvtt/
<a href="https://bugs.webkit.org/show_bug.cgi?id=299220">https://bugs.webkit.org/show_bug.cgi?id=299220</a>
<a href="https://rdar.apple.com/160965639">rdar://160965639</a>

Reviewed by Jer Noble.

WebVTTParser holds a strong const Ref&lt;Document&gt;. Changing this to a WeakRef
fixes approximately 300 leaky tests.

Test: media/track/webvtt-parser-does-not-leak.html

Test: media/track/webvtt-parser-does-not-leak.html
* LayoutTests/media/track/track-cue-css.html:
* LayoutTests/media/track/webvtt-parser-does-not-leak-expected.txt: Added.
* LayoutTests/media/track/webvtt-parser-does-not-leak.html: Added.
* Source/WebCore/html/track/WebVTTParser.cpp:
(WebCore::WebVTTParser::checkAndCreateRegion):
* Source/WebCore/html/track/WebVTTParser.h:

Canonical link: <a href="https://commits.webkit.org/300881@main">https://commits.webkit.org/300881@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d4e84008a8c6ff56f40d939628bb392a5bab603c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121999 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41701 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32371 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128558 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74092 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123875 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42416 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50295 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92718 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61600 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124951 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33818 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109251 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73372 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32831 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27412 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72056 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103326 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27608 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131323 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48938 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37211 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101277 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49312 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105465 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101148 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26140 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46518 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24635 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/45639 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48795 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54529 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48265 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51615 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49945 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->