### PR TITLE
Format and lint Swift code in WebKit/UIProcess

### DIFF
--- a/Source/WebKit/UIProcess/API/Swift/WebPage.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage.swift
@@ -28,6 +28,8 @@ import Observation
 internal import WebKit_Private
 internal import WebKit_Internal
 
+/// An object that controls and manages the behavior of interactive web content.
+///
 /// A ``WebPage`` is an ``Observable`` type, which you use to access various properties of web content
 /// and track changes to them. Use ``WebPage`` to interact with web content, like evaluating JavaScript
 /// or converting the page to PDF data. The following example shows you how you can combine these
@@ -142,7 +144,7 @@ final public class WebPage {
         /// The page is not currently in fullscreen.
         case notInFullscreen
     }
-    
+
     // This is based on the XGA standard resolution size.
     private static let defaultFrame = CGRect(x: 0, y: 0, width: 1024, height: 768)
 
@@ -404,15 +406,15 @@ final public class WebPage {
     #endif
 
     // MARK: Loading functions
-    
-    @ObservationIgnored
-    private var scopedNavigations: [ObjectIdentifier : AsyncThrowingStream<NavigationEvent, any Error>.Continuation] = [:]
 
     @ObservationIgnored
-    private var scopedStreams: [ObjectIdentifier : AsyncThrowingStream<NavigationEvent, any Error>] = [:]
+    private var scopedNavigations: [ObjectIdentifier: AsyncThrowingStream<NavigationEvent, any Error>.Continuation] = [:]
 
     @ObservationIgnored
-    private var indefiniteNavigations: [UUID : AsyncThrowingStream<NavigationEvent, any Error>.Continuation] = [:]
+    private var scopedStreams: [ObjectIdentifier: AsyncThrowingStream<NavigationEvent, any Error>] = [:]
+
+    @ObservationIgnored
+    private var indefiniteNavigations: [UUID: AsyncThrowingStream<NavigationEvent, any Error>.Continuation] = [:]
 
     /// Loads the web content that the specified URL references and navigates to that content.
     ///
@@ -472,7 +474,7 @@ final public class WebPage {
         guard let convertedEncoding = CFStringConvertEncodingToIANACharSetName(cfEncoding) as? String else {
             preconditionFailure("\(characterEncoding) is not a valid character encoding")
         }
-        
+
         return toNavigationSequence {
             $0.load(data, mimeType: mimeType, characterEncodingName: convertedEncoding, baseURL: baseURL)
         }
@@ -490,6 +492,7 @@ final public class WebPage {
     ///   - baseURL: The base URL to use when the system resolves relative URLs within the HTML string. By default, this is `about:blank`.
     /// - Returns: An async sequence you use to track the loading progress of the navigation. If the `Task` enclosing the sequence is cancelled, the page will stop loading all resources.
     // swift-format-ignore: NeverForceUnwrap
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     @discardableResult
     public func load(
         html: Swift.String,
@@ -508,7 +511,11 @@ final public class WebPage {
     ///   - responseData: The data to use as the contents of the webpage.
     /// - Returns: An async sequence you use to track the loading progress of the navigation. If the `Task` enclosing the sequence is cancelled, the page will stop loading all resources.
     @discardableResult
-    public func load(simulatedRequest request: URLRequest, response: URLResponse, responseData: Data) -> some AsyncSequence<NavigationEvent, any Error> {
+    public func load(
+        simulatedRequest request: URLRequest,
+        response: URLResponse,
+        responseData: Data
+    ) -> some AsyncSequence<NavigationEvent, any Error> {
         toNavigationSequence {
             // `WKWebView` annotates this method as returning non-nil, but it may return nil.
             $0.loadSimulatedRequest(request, response: response, responseData: responseData) as WKNavigation?

--- a/Source/WebKit/UIProcess/Cocoa/WKNavigationDelegateAdapter.swift
+++ b/Source/WebKit/UIProcess/Cocoa/WKNavigationDelegateAdapter.swift
@@ -53,7 +53,7 @@ final class WKNavigationDelegateAdapter: NSObject, WKNavigationDelegate {
             addEvent()
         }
     }
-    
+
     private func failNavigationProgress(kind: some Error, cocoaNavigation: WKNavigation?) {
         owner?.addNavigationEvent(.failure(kind), for: cocoaNavigation)
     }

--- a/Source/WebKit/UIProcess/Cocoa/WebPageWebView.swift
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageWebView.swift
@@ -185,6 +185,8 @@ extension WebPageWebView {
 }
 
 extension WebPageWebView {
+    // SPI for the cross-import overlay.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public func setNeedsScrollGeometryUpdates(_ value: Bool) {
         self._setNeedsScrollGeometryUpdates(value)
     }

--- a/Source/WebKit/UIProcess/WKMouseDeviceObserver.swift
+++ b/Source/WebKit/UIProcess/WKMouseDeviceObserver.swift
@@ -26,11 +26,16 @@
 @_weakLinked internal import GameController
 internal import WebKit_Internal
 
-@objc @implementation extension WKMouseDeviceObserver {
+@objc
+@implementation
+extension WKMouseDeviceObserver {
     private static let shared = WKMouseDeviceObserver()
 
-    @nonobjc private var connectionObservationTask: Task<Void, Never>? = nil
-    @nonobjc private var disconnectionObservationTask: Task<Void, Never>? = nil
+    @nonobjc
+    private var connectionObservationTask: Task<Void, Never>? = nil
+
+    @nonobjc
+    private var disconnectionObservationTask: Task<Void, Never>? = nil
 
     private var startCount = 0
     private var connectedDeviceCount = 0 {
@@ -101,6 +106,7 @@ internal import WebKit_Internal
         disconnectionObservationTask?.cancel()
     }
 
+    // swift-format-ignore: NoLeadingUnderscores
     func _setHasMouseDevice(forTesting hasMouseDevice: Bool) {
         connectedDeviceCount = hasMouseDevice ? 1 : 0
     }


### PR DESCRIPTION
#### e873d186cb5351a491bd793ed3285da36bd311f0
<pre>
Format and lint Swift code in WebKit/UIProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=299221">https://bugs.webkit.org/show_bug.cgi?id=299221</a>
<a href="https://rdar.apple.com/160978972">rdar://160978972</a>

Reviewed by Abrar Rahman Protyasha.

* Source/WebKit/UIProcess/API/Swift/WebPage.swift:
(scopedNavigations):
(scopedStreams):
(indefiniteNavigations):
(load(simulatedRequest:response:responseData:)): Deleted.
* Source/WebKit/UIProcess/Cocoa/WKNavigationDelegateAdapter.swift:
* Source/WebKit/UIProcess/Cocoa/WebPageWebView.swift:
* Source/WebKit/UIProcess/WKMouseDeviceObserver.swift:
(WKMouseDeviceObserver.connectionObservationTask):
(WKMouseDeviceObserver.disconnectionObservationTask):

Canonical link: <a href="https://commits.webkit.org/300286@main">https://commits.webkit.org/300286@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5b5387985e27d77b14495cff7fbf88218a7c6c46

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121956 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41658 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32328 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128514 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74049 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/df7111bd-3fd5-4ea7-b316-b6d28ba5b579) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42373 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50252 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92683 "Failed to checkout and rebase branch from PR 51045") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61581 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d684cabf-9f06-4361-bbce-0d76ff5337d4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124908 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33787 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109212 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73339 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c7b99a1a-051e-4b98-8aa6-a130401ffbf3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32805 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72013 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103298 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27570 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131280 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48895 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37175 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101243 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49269 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105428 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101111 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25652 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46482 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24599 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45596 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48752 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54486 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48222 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51572 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49902 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->