### PR TITLE
REGRESSION(300214@main): [macOS Debug] compositing/visible-rect/flipped-preserve-3d.html is a flaky crash

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2422,5 +2422,3 @@ webkit.org/b/298903 webrtc/video-rotation-black.html [ Pass Failure ]
 webkit.org/b/298416 [ Debug ] http/tests/websocket/construct-in-detached-frame.html [ Skip ]
 
 webkit.org/b/299110 webrtc/calling-peerconnection-once-closed.html [ Pass Failure ]
-
-webkit.org/b/299195 [ Debug ] compositing/visible-rect/flipped-preserve-3d.html [ Pass Crash ]

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.h
@@ -93,7 +93,7 @@ public:
 // IPC call.
 // FIXME: It would be nice if this could actually be a subclass of ImageBufferSet, but
 // probably can't while it uses batching for prepare and volatility.
-class RemoteImageBufferSetProxy : public IPC::WorkQueueMessageReceiver<WTF::DestructionThread::Any>, public Identified<RemoteImageBufferSetIdentifier> {
+class RemoteImageBufferSetProxy : public IPC::WorkQueueMessageReceiver<WTF::DestructionThread::MainRunLoop>, public Identified<RemoteImageBufferSetIdentifier> {
 public:
     static Ref<RemoteImageBufferSetProxy> create(RemoteRenderingBackendProxy&, ImageBufferSetClient&);
     ~RemoteImageBufferSetProxy();


### PR DESCRIPTION
#### afa0df42cd3aeeed356fda03d627934ce1226a34
<pre>
REGRESSION(300214@main): [macOS Debug] compositing/visible-rect/flipped-preserve-3d.html is a flaky crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=299195">https://bugs.webkit.org/show_bug.cgi?id=299195</a>
<a href="https://rdar.apple.com/160953686">rdar://160953686</a>

Reviewed by Geoffrey Garen.

When RemoteImageBufferSetProxy gets destroyed, it destroys the RemoteGraphicsContextProxy,
which destroys the DisplayList::Recorder and ends up destroying DrawGlyphsRecorder
which holds a SingleThreadWeakPtr to a Font.

However, we currently let the RemoteImageBufferSetProxy get destroyed off the main thread,
which triggers an assertion in the SingleThreadWeakPtr. We could make the Font support
thread-safe WeakPtr instead but I suspect using SingleThreadWeakPtr was done for performance
reasons. Therefore, I am opting to have the RemoteImageBufferSetProxy get destroyed on the
main thread instead.

* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.h:

Canonical link: <a href="https://commits.webkit.org/300289@main">https://commits.webkit.org/300289@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e0ce2927590468f191527eed57f9c8a9a6268e6c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121962 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41664 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32334 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128520 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74055 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4b0acabd-2160-4023-8be6-026824478c8f) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42379 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50258 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92689 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61584 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/22331f22-9b53-4832-916f-654426b7392a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124914 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33789 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109219 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73345 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/acad7edc-6bde-451d-ab07-187a125ddae4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32799 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27382 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72019 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103296 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27577 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131286 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48901 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37178 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101249 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49275 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105435 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101118 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25653 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46486 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24605 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45602 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48758 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54492 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48228 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51578 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49908 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->