### PR TITLE
[JSC] Add B3::Mutability and Immutable loads

### DIFF
--- a/Source/JavaScriptCore/b3/B3Effects.cpp
+++ b/Source/JavaScriptCore/b3/B3Effects.cpp
@@ -94,6 +94,8 @@ void Effects::dump(PrintStream& out) const
         out.print(comma, "ExitsSideways"_s);
     if (controlDependent)
         out.print(comma, "ControlDependent"_s);
+    if (readsMutability == Mutability::Immutable)
+        out.print(comma, "ReadsImmutable"_s);
     if (writesLocalState)
         out.print(comma, "WritesLocalState"_s);
     if (readsLocalState)

--- a/Source/JavaScriptCore/b3/B3MemoryValue.h
+++ b/Source/JavaScriptCore/b3/B3MemoryValue.h
@@ -71,6 +71,12 @@ public:
     const HeapRange& fenceRange() const { return m_fenceRange; }
     void setFenceRange(const HeapRange& range) { m_fenceRange = range; }
 
+    Mutability readsMutability() const { return m_readsMutability; }
+    void setReadsMutability(Mutability value) { m_readsMutability = value; }
+
+    bool controlDependent() const { return m_controlDependent; }
+    void setControlDependent(bool value) { m_controlDependent = value; }
+
     bool isStore() const { return B3::isStore(opcode()); }
     bool isLoad() const { return B3::isLoad(opcode()); }
 
@@ -152,6 +158,8 @@ private:
     OffsetType m_offset { 0 };
     HeapRange m_range { HeapRange::top() };
     HeapRange m_fenceRange { HeapRange() };
+    Mutability m_readsMutability : 1 { Mutability::Mutable };
+    bool m_controlDependent : 1 { true };
 };
 
 } } // namespace JSC::B3

--- a/Source/JavaScriptCore/b3/B3Value.cpp
+++ b/Source/JavaScriptCore/b3/B3Value.cpp
@@ -798,7 +798,8 @@ Effects Value::effects() const
             result.writes = memory->fenceRange();
             result.fence = true;
         }
-        result.controlDependent = true;
+        result.controlDependent = memory->controlDependent();
+        result.readsMutability = memory->readsMutability();
         break;
     }
     case Store8:
@@ -810,7 +811,7 @@ Effects Value::effects() const
             result.reads = memory->fenceRange();
             result.fence = true;
         }
-        result.controlDependent = true;
+        result.controlDependent = memory->controlDependent();
         break;
     }
     case MemoryCopy: {

--- a/Source/JavaScriptCore/b3/testb3.h
+++ b/Source/JavaScriptCore/b3/testb3.h
@@ -1400,4 +1400,6 @@ void testMemoryCopyConstant();
 void testMemoryFill();
 void testMemoryFillConstant();
 
+void testLoadImmutable();
+
 #endif // ENABLE(B3_JIT)

--- a/Source/JavaScriptCore/b3/testb3_1.cpp
+++ b/Source/JavaScriptCore/b3/testb3_1.cpp
@@ -894,6 +894,8 @@ void run(const TestConfig* config)
     RUN(testConstDoubleMove());
     RUN(testConstFloatMove());
 
+    RUN(testLoadImmutable());
+
     RUN_UNARY(testSShrCompare32, int32OperandsMore());
     RUN_UNARY(testSShrCompare64, int64OperandsMore());
 

--- a/Source/JavaScriptCore/ftl/FTLAbstractHeap.cpp
+++ b/Source/JavaScriptCore/ftl/FTLAbstractHeap.cpp
@@ -42,8 +42,9 @@ namespace JSC { namespace FTL {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(AbstractHeap);
 
-AbstractHeap::AbstractHeap(AbstractHeap* parent, const char* heapName, ptrdiff_t offset)
+AbstractHeap::AbstractHeap(AbstractHeap* parent, const char* heapName, ptrdiff_t offset, B3::Mutability mutability)
     : m_offset(offset)
+    , m_mutability(mutability)
     , m_heapName(heapName)
 {
     changeParent(parent);
@@ -97,6 +98,8 @@ void AbstractHeap::shallowDump(PrintStream& out) const
     out.print(heapName(), "(", m_offset, ")");
     if (m_range)
         out.print("<", m_range, ">");
+    if (m_mutability == B3::Mutability::Immutable)
+        out.print("[immutable]");
 }
 
 void AbstractHeap::dump(PrintStream& out) const

--- a/Source/JavaScriptCore/ftl/FTLAbstractHeap.h
+++ b/Source/JavaScriptCore/ftl/FTLAbstractHeap.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(FTL_JIT)
 
+#include "B3Effects.h"
 #include "B3HeapRange.h"
 #include "FTLAbbreviatedTypes.h"
 #include "JSCJSValue.h"
@@ -51,15 +52,16 @@ public:
     {
     }
     
-    AbstractHeap(AbstractHeap* parent, const char* heapName, ptrdiff_t offset = 0);
+    AbstractHeap(AbstractHeap* parent, const char* heapName, ptrdiff_t offset = 0, B3::Mutability = B3::Mutability::Mutable);
 
     bool isInitialized() const { return !!m_heapName; }
     
-    void initialize(AbstractHeap* parent, const char* heapName, ptrdiff_t offset = 0)
+    void initialize(AbstractHeap* parent, const char* heapName, ptrdiff_t offset = 0, B3::Mutability mutability = B3::Mutability::Mutable)
     {
         changeParent(parent);
         m_heapName = heapName;
         m_offset = offset;
+        m_mutability = mutability;
     }
     
     void changeParent(AbstractHeap* parent);
@@ -88,6 +90,12 @@ public:
         return m_range;
     }
 
+    B3::Mutability mutability() const
+    {
+        ASSERT(isInitialized());
+        return m_mutability;
+    }
+
     // WARNING: Not all abstract heaps have a meaningful offset.
     ptrdiff_t offset() const
     {
@@ -114,6 +122,7 @@ private:
     AbstractHeap* m_parent { nullptr };
     Vector<AbstractHeap*> m_children;
     intptr_t m_offset { 0 };
+    B3::Mutability m_mutability { B3::Mutability::Mutable };
     B3::HeapRange m_range;
     const char* m_heapName { nullptr };
 };

--- a/Source/JavaScriptCore/ftl/FTLAbstractHeapRepository.h
+++ b/Source/JavaScriptCore/ftl/FTLAbstractHeapRepository.h
@@ -47,149 +47,150 @@ namespace JSC { namespace FTL {
     macro(JSCellHeaderAndNamedProperties) \
     macro(OrderedHashTableData) \
 
+// macro(name, offset, mutability)
 #define FOR_EACH_ABSTRACT_FIELD(macro) \
-    macro(ArrayBuffer_data, ArrayBuffer::offsetOfData()) \
-    macro(ArrayStorage_numValuesInVector, ArrayStorage::numValuesInVectorOffset()) \
-    macro(Butterfly_arrayBuffer, Butterfly::offsetOfArrayBuffer()) \
-    macro(Butterfly_publicLength, Butterfly::offsetOfPublicLength()) \
-    macro(Butterfly_vectorLength, Butterfly::offsetOfVectorLength()) \
-    macro(CallFrame_callerFrame, CallFrame::callerFrameOffset()) \
-    macro(ClassInfo_parentClass, ClassInfo::offsetOfParentClass()) \
-    macro(ClonedArguments_callee, ClonedArguments::offsetOfCallee()) \
-    macro(ConcatKeyAtomStringCache_quickCache0_key, ConcatKeyAtomStringCache::offsetOfQuickCache0() + ConcatKeyAtomStringCache::CacheEntry::offsetOfKey()) \
-    macro(ConcatKeyAtomStringCache_quickCache0_value, ConcatKeyAtomStringCache::offsetOfQuickCache0() + ConcatKeyAtomStringCache::CacheEntry::offsetOfValue()) \
-    macro(ConcatKeyAtomStringCache_quickCache1_key, ConcatKeyAtomStringCache::offsetOfQuickCache1() + ConcatKeyAtomStringCache::CacheEntry::offsetOfKey()) \
-    macro(ConcatKeyAtomStringCache_quickCache1_value, ConcatKeyAtomStringCache::offsetOfQuickCache1() + ConcatKeyAtomStringCache::CacheEntry::offsetOfValue()) \
-    macro(DateInstance_internalNumber, DateInstance::offsetOfInternalNumber()) \
-    macro(DateInstance_data, DateInstance::offsetOfData()) \
-    macro(DateInstanceData_gregorianDateTimeCachedForMS, DateInstanceData::offsetOfGregorianDateTimeCachedForMS()) \
-    macro(DateInstanceData_gregorianDateTimeUTCCachedForMS, DateInstanceData::offsetOfGregorianDateTimeUTCCachedForMS()) \
-    macro(DateInstanceData_cachedGregorianDateTime_year, DateInstanceData::offsetOfCachedGregorianDateTime() + GregorianDateTime::offsetOfYear()) \
-    macro(DateInstanceData_cachedGregorianDateTimeUTC_year, DateInstanceData::offsetOfCachedGregorianDateTimeUTC() + GregorianDateTime::offsetOfYear()) \
-    macro(DateInstanceData_cachedGregorianDateTime_month, DateInstanceData::offsetOfCachedGregorianDateTime() + GregorianDateTime::offsetOfMonth()) \
-    macro(DateInstanceData_cachedGregorianDateTimeUTC_month, DateInstanceData::offsetOfCachedGregorianDateTimeUTC() + GregorianDateTime::offsetOfMonth()) \
-    macro(DateInstanceData_cachedGregorianDateTime_monthDay, DateInstanceData::offsetOfCachedGregorianDateTime() + GregorianDateTime::offsetOfMonthDay()) \
-    macro(DateInstanceData_cachedGregorianDateTimeUTC_monthDay, DateInstanceData::offsetOfCachedGregorianDateTimeUTC() + GregorianDateTime::offsetOfMonthDay()) \
-    macro(DateInstanceData_cachedGregorianDateTime_weekDay, DateInstanceData::offsetOfCachedGregorianDateTime() + GregorianDateTime::offsetOfWeekDay()) \
-    macro(DateInstanceData_cachedGregorianDateTimeUTC_weekDay, DateInstanceData::offsetOfCachedGregorianDateTimeUTC() + GregorianDateTime::offsetOfWeekDay()) \
-    macro(DateInstanceData_cachedGregorianDateTime_hour, DateInstanceData::offsetOfCachedGregorianDateTime() + GregorianDateTime::offsetOfHour()) \
-    macro(DateInstanceData_cachedGregorianDateTimeUTC_hour, DateInstanceData::offsetOfCachedGregorianDateTimeUTC() + GregorianDateTime::offsetOfHour()) \
-    macro(DateInstanceData_cachedGregorianDateTime_minute, DateInstanceData::offsetOfCachedGregorianDateTime() + GregorianDateTime::offsetOfMinute()) \
-    macro(DateInstanceData_cachedGregorianDateTimeUTC_minute, DateInstanceData::offsetOfCachedGregorianDateTimeUTC() + GregorianDateTime::offsetOfMinute()) \
-    macro(DateInstanceData_cachedGregorianDateTime_second, DateInstanceData::offsetOfCachedGregorianDateTime() + GregorianDateTime::offsetOfSecond()) \
-    macro(DateInstanceData_cachedGregorianDateTimeUTC_second, DateInstanceData::offsetOfCachedGregorianDateTimeUTC() + GregorianDateTime::offsetOfSecond()) \
-    macro(DateInstanceData_cachedGregorianDateTime_utcOffsetInMinute, DateInstanceData::offsetOfCachedGregorianDateTime() + GregorianDateTime::offsetOfUTCOffsetInMinute()) \
-    macro(DateInstanceData_cachedGregorianDateTimeUTC_utcOffsetInMinute, DateInstanceData::offsetOfCachedGregorianDateTimeUTC() + GregorianDateTime::offsetOfUTCOffsetInMinute()) \
-    macro(DirectArguments_callee, DirectArguments::offsetOfCallee()) \
-    macro(DirectArguments_length, DirectArguments::offsetOfLength()) \
-    macro(DirectArguments_minCapacity, DirectArguments::offsetOfMinCapacity()) \
-    macro(DirectArguments_mappedArguments, DirectArguments::offsetOfMappedArguments()) \
-    macro(DirectArguments_modifiedArgumentsDescriptor, DirectArguments::offsetOfModifiedArgumentsDescriptor()) \
-    macro(FunctionExecutable_rareData, FunctionExecutable::offsetOfRareData()) \
-    macro(FunctionExecutableRareData_asString, FunctionExecutable::RareData::offsetOfAsString()) \
-    macro(FunctionRareData_allocator, FunctionRareData::offsetOfObjectAllocationProfile() + ObjectAllocationProfileWithPrototype::offsetOfAllocator()) \
-    macro(FunctionRareData_structure, FunctionRareData::offsetOfObjectAllocationProfile() + ObjectAllocationProfileWithPrototype::offsetOfStructure()) \
-    macro(FunctionRareData_prototype, FunctionRareData::offsetOfObjectAllocationProfile() + ObjectAllocationProfileWithPrototype::offsetOfPrototype()) \
-    macro(FunctionRareData_allocationProfileWatchpointSet, FunctionRareData::offsetOfAllocationProfileWatchpointSet()) \
-    macro(FunctionRareData_executable, FunctionRareData::offsetOfExecutable()) \
-    macro(FunctionRareData_internalFunctionAllocationProfile_structureID, FunctionRareData::offsetOfInternalFunctionAllocationProfile() + InternalFunctionAllocationProfile::offsetOfStructureID()) \
-    macro(GetterSetter_getter, GetterSetter::offsetOfGetter()) \
-    macro(GetterSetter_setter, GetterSetter::offsetOfSetter()) \
-    macro(JSArrayBufferView_byteOffset, JSArrayBufferView::offsetOfByteOffset()) \
-    macro(JSArrayBufferView_length, JSArrayBufferView::offsetOfLength()) \
-    macro(JSArrayBufferView_mode, JSArrayBufferView::offsetOfMode()) \
-    macro(JSArrayBufferView_vector, JSArrayBufferView::offsetOfVector()) \
-    macro(JSBigInt_length, JSBigInt::offsetOfLength()) \
-    macro(JSBoundFunction_targetFunction, JSBoundFunction::offsetOfTargetFunction()) \
-    macro(JSBoundFunction_boundThis, JSBoundFunction::offsetOfBoundThis()) \
-    macro(JSBoundFunction_boundArg0, JSBoundFunction::offsetOfBoundArgs() + sizeof(WriteBarrier<Unknown>) * 0) \
-    macro(JSBoundFunction_boundArg1, JSBoundFunction::offsetOfBoundArgs() + sizeof(WriteBarrier<Unknown>) * 1) \
-    macro(JSBoundFunction_boundArg2, JSBoundFunction::offsetOfBoundArgs() + sizeof(WriteBarrier<Unknown>) * 2) \
-    macro(JSBoundFunction_nameMayBeNull, JSBoundFunction::offsetOfNameMayBeNull()) \
-    macro(JSBoundFunction_length, JSBoundFunction::offsetOfLength()) \
-    macro(JSBoundFunction_boundArgsLength, JSBoundFunction::offsetOfBoundArgsLength()) \
-    macro(JSBoundFunction_canConstruct, JSBoundFunction::offsetOfCanConstruct()) \
-    macro(JSCallee_scope, JSCallee::offsetOfScopeChain()) \
-    macro(JSCell_cellState, JSCell::cellStateOffset()) \
-    macro(JSCell_header, 0) \
-    macro(JSCell_indexingTypeAndMisc, JSCell::indexingTypeAndMiscOffset()) \
-    macro(JSCell_structureID, JSCell::structureIDOffset()) \
-    macro(JSCell_typeInfoFlags, JSCell::typeInfoFlagsOffset()) \
-    macro(JSCell_typeInfoType, JSCell::typeInfoTypeOffset()) \
-    macro(JSCell_usefulBytes, JSCell::indexingTypeAndMiscOffset()) \
-    macro(JSFunction_executableOrRareData, JSFunction::offsetOfExecutableOrRareData()) \
-    macro(JSGlobalObject_regExpGlobalData_cachedResult_lastRegExp, JSGlobalObject::regExpGlobalDataOffset() + RegExpGlobalData::offsetOfCachedResult() + RegExpCachedResult::offsetOfLastRegExp()) \
-    macro(JSGlobalObject_regExpGlobalData_cachedResult_lastInput, JSGlobalObject::regExpGlobalDataOffset() + RegExpGlobalData::offsetOfCachedResult() + RegExpCachedResult::offsetOfLastInput()) \
-    macro(JSGlobalObject_regExpGlobalData_cachedResult_result_start, JSGlobalObject::regExpGlobalDataOffset() + RegExpGlobalData::offsetOfCachedResult() + RegExpCachedResult::offsetOfResult() + OBJECT_OFFSETOF(MatchResult, start)) \
-    macro(JSGlobalObject_regExpGlobalData_cachedResult_result_end, JSGlobalObject::regExpGlobalDataOffset() + RegExpGlobalData::offsetOfCachedResult() + RegExpCachedResult::offsetOfResult() + OBJECT_OFFSETOF(MatchResult, end)) \
-    macro(JSGlobalObject_regExpGlobalData_cachedResult_reified, JSGlobalObject::regExpGlobalDataOffset() + RegExpGlobalData::offsetOfCachedResult() + RegExpCachedResult::offsetOfReified()) \
-    macro(JSGlobalObject_regExpGlobalData_cachedResult_oneCharacterMatch, JSGlobalObject::regExpGlobalDataOffset() + RegExpGlobalData::offsetOfCachedResult() + RegExpCachedResult::offsetOfOneCharacterMatch()) \
-    macro(JSGlobalProxy_target, JSGlobalProxy::targetOffset()) \
-    macro(JSObject_butterfly, JSObject::butterflyOffset()) \
-    macro(JSPropertyNameEnumerator_cachedInlineCapacity, JSPropertyNameEnumerator::cachedInlineCapacityOffset()) \
-    macro(JSPropertyNameEnumerator_cachedPropertyNamesVector, JSPropertyNameEnumerator::cachedPropertyNamesVectorOffset()) \
-    macro(JSPropertyNameEnumerator_cachedStructureID, JSPropertyNameEnumerator::cachedStructureIDOffset()) \
-    macro(JSPropertyNameEnumerator_endGenericPropertyIndex, JSPropertyNameEnumerator::endGenericPropertyIndexOffset()) \
-    macro(JSPropertyNameEnumerator_endStructurePropertyIndex, JSPropertyNameEnumerator::endStructurePropertyIndexOffset()) \
-    macro(JSPropertyNameEnumerator_indexLength, JSPropertyNameEnumerator::indexedLengthOffset()) \
-    macro(JSPropertyNameEnumerator_flags, JSPropertyNameEnumerator::flagsOffset()) \
-    macro(JSRopeString_flags, JSRopeString::offsetOfFlags()) \
-    macro(JSRopeString_length, JSRopeString::offsetOfLength()) \
-    macro(JSRopeString_fiber0, JSRopeString::offsetOfFiber0()) \
-    macro(JSRopeString_fiber1, JSRopeString::offsetOfFiber1()) \
-    macro(JSRopeString_fiber2, JSRopeString::offsetOfFiber2()) \
-    macro(JSScope_next, JSScope::offsetOfNext()) \
-    macro(JSSymbolTableObject_symbolTable, JSSymbolTableObject::offsetOfSymbolTable()) \
-    macro(JSWebAssemblyInstance_moduleRecord, JSWebAssemblyInstance::offsetOfModuleRecord()) \
-    macro(NativeExecutable_asString, NativeExecutable::offsetOfAsString()) \
-    macro(RegExpObject_regExpAndFlags, RegExpObject::offsetOfRegExpAndFlags()) \
-    macro(RegExpObject_lastIndex, RegExpObject::offsetOfLastIndex()) \
-    macro(ShadowChicken_Packet_callee, OBJECT_OFFSETOF(ShadowChicken::Packet, callee)) \
-    macro(ShadowChicken_Packet_frame, OBJECT_OFFSETOF(ShadowChicken::Packet, frame)) \
-    macro(ShadowChicken_Packet_callerFrame, OBJECT_OFFSETOF(ShadowChicken::Packet, callerFrame)) \
-    macro(ShadowChicken_Packet_thisValue, OBJECT_OFFSETOF(ShadowChicken::Packet, thisValue)) \
-    macro(ShadowChicken_Packet_scope, OBJECT_OFFSETOF(ShadowChicken::Packet, scope)) \
-    macro(ShadowChicken_Packet_codeBlock, OBJECT_OFFSETOF(ShadowChicken::Packet, codeBlock)) \
-    macro(ShadowChicken_Packet_callSiteIndex, OBJECT_OFFSETOF(ShadowChicken::Packet, callSiteIndex)) \
-    macro(ScopedArguments_overrodeThings, ScopedArguments::offsetOfOverrodeThings()) \
-    macro(ScopedArguments_scope, ScopedArguments::offsetOfScope()) \
-    macro(ScopedArguments_storage, ScopedArguments::offsetOfStorage()) \
-    macro(ScopedArguments_table, ScopedArguments::offsetOfTable()) \
-    macro(ScopedArguments_totalLength, ScopedArguments::offsetOfTotalLength()) \
-    macro(ScopedArgumentsTable_arguments, ScopedArgumentsTable::offsetOfArguments()) \
-    macro(ScopedArgumentsTable_length, ScopedArgumentsTable::offsetOfLength()) \
-    macro(StringImpl_data, StringImpl::dataOffset()) \
-    macro(StringImpl_hashAndFlags, StringImpl::flagsOffset()) \
-    macro(StringImpl_length, StringImpl::lengthMemoryOffset()) \
-    macro(Structure_bitField, Structure::bitFieldOffset()) \
-    macro(Structure_classInfo, Structure::classInfoOffset()) \
-    macro(Structure_globalObject, Structure::globalObjectOffset()) \
-    macro(Structure_indexingModeIncludingHistory, Structure::indexingModeIncludingHistoryOffset()) \
-    macro(Structure_inlineCapacity, Structure::inlineCapacityOffset()) \
-    macro(Structure_outOfLineTypeFlags, Structure::outOfLineTypeFlagsOffset()) \
-    macro(Structure_previousOrRareData, Structure::previousOrRareDataOffset()) \
-    macro(Structure_propertyHash, Structure::propertyHashOffset()) \
-    macro(Structure_prototype, Structure::prototypeOffset()) \
-    macro(Structure_seenProperties, Structure::seenPropertiesOffset()) \
-    macro(StructureRareData_cachedEnumerableStrings, StructureRareData::offsetOfCachedPropertyNames(CachedPropertyNamesKind::EnumerableStrings)) \
-    macro(StructureRareData_cachedStrings, StructureRareData::offsetOfCachedPropertyNames(CachedPropertyNamesKind::Strings)) \
-    macro(StructureRareData_cachedSymbols, StructureRareData::offsetOfCachedPropertyNames(CachedPropertyNamesKind::Symbols)) \
-    macro(StructureRareData_cachedStringsAndSymbols, StructureRareData::offsetOfCachedPropertyNames(CachedPropertyNamesKind::StringsAndSymbols)) \
-    macro(StructureRareData_cachedPropertyNameEnumeratorAndFlag, StructureRareData::offsetOfCachedPropertyNameEnumeratorAndFlag()) \
-    macro(StructureRareData_specialPropertyCache, StructureRareData::offsetOfSpecialPropertyCache()) \
-    macro(SpecialPropertyCache_cachedToStringTagValue, SpecialPropertyCache::offsetOfCache(CachedSpecialPropertyKey::ToStringTag) + SpecialPropertyCacheEntry::offsetOfValue()) \
-    macro(JSMap_storage, (JSMap::offsetOfStorage())) \
-    macro(JSSet_storage, (JSSet::offsetOfStorage())) \
-    macro(VM_heap_barrierThreshold, VM::offsetOfHeapBarrierThreshold()) \
-    macro(VM_heap_mutatorShouldBeFenced, VM::offsetOfHeapMutatorShouldBeFenced()) \
-    macro(VM_exception, VM::exceptionOffset()) \
-    macro(WatchpointSet_state, WatchpointSet::offsetOfState()) \
-    macro(WeakMapImpl_capacity, WeakMapImpl<WeakMapBucket<WeakMapBucketDataKey>>::offsetOfCapacity()) \
-    macro(WeakMapImpl_buffer,  WeakMapImpl<WeakMapBucket<WeakMapBucketDataKey>>::offsetOfBuffer()) \
-    macro(WeakMapBucket_value, WeakMapBucket<WeakMapBucketDataKeyValue>::offsetOfValue()) \
-    macro(WeakMapBucket_key, WeakMapBucket<WeakMapBucketDataKeyValue>::offsetOfKey()) \
-    macro(WebAssemblyModuleRecord_exportsObject, WebAssemblyModuleRecord::offsetOfExportsObject()) \
-    macro(Symbol_symbolImpl, Symbol::offsetOfSymbolImpl()) \
+    macro(ArrayBuffer_data, ArrayBuffer::offsetOfData(), B3::Mutability::Mutable) \
+    macro(ArrayStorage_numValuesInVector, ArrayStorage::numValuesInVectorOffset(), B3::Mutability::Mutable) \
+    macro(Butterfly_arrayBuffer, Butterfly::offsetOfArrayBuffer(), B3::Mutability::Mutable) \
+    macro(Butterfly_publicLength, Butterfly::offsetOfPublicLength(), B3::Mutability::Mutable) \
+    macro(Butterfly_vectorLength, Butterfly::offsetOfVectorLength(), B3::Mutability::Mutable) \
+    macro(CallFrame_callerFrame, CallFrame::callerFrameOffset(), B3::Mutability::Mutable) \
+    macro(ClassInfo_parentClass, ClassInfo::offsetOfParentClass(), B3::Mutability::Immutable) \
+    macro(ClonedArguments_callee, ClonedArguments::offsetOfCallee(), B3::Mutability::Mutable) \
+    macro(ConcatKeyAtomStringCache_quickCache0_key, ConcatKeyAtomStringCache::offsetOfQuickCache0() + ConcatKeyAtomStringCache::CacheEntry::offsetOfKey(), B3::Mutability::Mutable) \
+    macro(ConcatKeyAtomStringCache_quickCache0_value, ConcatKeyAtomStringCache::offsetOfQuickCache0() + ConcatKeyAtomStringCache::CacheEntry::offsetOfValue(), B3::Mutability::Mutable) \
+    macro(ConcatKeyAtomStringCache_quickCache1_key, ConcatKeyAtomStringCache::offsetOfQuickCache1() + ConcatKeyAtomStringCache::CacheEntry::offsetOfKey(), B3::Mutability::Mutable) \
+    macro(ConcatKeyAtomStringCache_quickCache1_value, ConcatKeyAtomStringCache::offsetOfQuickCache1() + ConcatKeyAtomStringCache::CacheEntry::offsetOfValue(), B3::Mutability::Mutable) \
+    macro(DateInstance_internalNumber, DateInstance::offsetOfInternalNumber(), B3::Mutability::Mutable) \
+    macro(DateInstance_data, DateInstance::offsetOfData(), B3::Mutability::Mutable) \
+    macro(DateInstanceData_gregorianDateTimeCachedForMS, DateInstanceData::offsetOfGregorianDateTimeCachedForMS(), B3::Mutability::Mutable) \
+    macro(DateInstanceData_gregorianDateTimeUTCCachedForMS, DateInstanceData::offsetOfGregorianDateTimeUTCCachedForMS(), B3::Mutability::Mutable) \
+    macro(DateInstanceData_cachedGregorianDateTime_year, DateInstanceData::offsetOfCachedGregorianDateTime() + GregorianDateTime::offsetOfYear(), B3::Mutability::Mutable) \
+    macro(DateInstanceData_cachedGregorianDateTimeUTC_year, DateInstanceData::offsetOfCachedGregorianDateTimeUTC() + GregorianDateTime::offsetOfYear(), B3::Mutability::Mutable) \
+    macro(DateInstanceData_cachedGregorianDateTime_month, DateInstanceData::offsetOfCachedGregorianDateTime() + GregorianDateTime::offsetOfMonth(), B3::Mutability::Mutable) \
+    macro(DateInstanceData_cachedGregorianDateTimeUTC_month, DateInstanceData::offsetOfCachedGregorianDateTimeUTC() + GregorianDateTime::offsetOfMonth(), B3::Mutability::Mutable) \
+    macro(DateInstanceData_cachedGregorianDateTime_monthDay, DateInstanceData::offsetOfCachedGregorianDateTime() + GregorianDateTime::offsetOfMonthDay(), B3::Mutability::Mutable) \
+    macro(DateInstanceData_cachedGregorianDateTimeUTC_monthDay, DateInstanceData::offsetOfCachedGregorianDateTimeUTC() + GregorianDateTime::offsetOfMonthDay(), B3::Mutability::Mutable) \
+    macro(DateInstanceData_cachedGregorianDateTime_weekDay, DateInstanceData::offsetOfCachedGregorianDateTime() + GregorianDateTime::offsetOfWeekDay(), B3::Mutability::Mutable) \
+    macro(DateInstanceData_cachedGregorianDateTimeUTC_weekDay, DateInstanceData::offsetOfCachedGregorianDateTimeUTC() + GregorianDateTime::offsetOfWeekDay(), B3::Mutability::Mutable) \
+    macro(DateInstanceData_cachedGregorianDateTime_hour, DateInstanceData::offsetOfCachedGregorianDateTime() + GregorianDateTime::offsetOfHour(), B3::Mutability::Mutable) \
+    macro(DateInstanceData_cachedGregorianDateTimeUTC_hour, DateInstanceData::offsetOfCachedGregorianDateTimeUTC() + GregorianDateTime::offsetOfHour(), B3::Mutability::Mutable) \
+    macro(DateInstanceData_cachedGregorianDateTime_minute, DateInstanceData::offsetOfCachedGregorianDateTime() + GregorianDateTime::offsetOfMinute(), B3::Mutability::Mutable) \
+    macro(DateInstanceData_cachedGregorianDateTimeUTC_minute, DateInstanceData::offsetOfCachedGregorianDateTimeUTC() + GregorianDateTime::offsetOfMinute(), B3::Mutability::Mutable) \
+    macro(DateInstanceData_cachedGregorianDateTime_second, DateInstanceData::offsetOfCachedGregorianDateTime() + GregorianDateTime::offsetOfSecond(), B3::Mutability::Mutable) \
+    macro(DateInstanceData_cachedGregorianDateTimeUTC_second, DateInstanceData::offsetOfCachedGregorianDateTimeUTC() + GregorianDateTime::offsetOfSecond(), B3::Mutability::Mutable) \
+    macro(DateInstanceData_cachedGregorianDateTime_utcOffsetInMinute, DateInstanceData::offsetOfCachedGregorianDateTime() + GregorianDateTime::offsetOfUTCOffsetInMinute(), B3::Mutability::Mutable) \
+    macro(DateInstanceData_cachedGregorianDateTimeUTC_utcOffsetInMinute, DateInstanceData::offsetOfCachedGregorianDateTimeUTC() + GregorianDateTime::offsetOfUTCOffsetInMinute(), B3::Mutability::Mutable) \
+    macro(DirectArguments_callee, DirectArguments::offsetOfCallee(), B3::Mutability::Mutable) \
+    macro(DirectArguments_length, DirectArguments::offsetOfLength(), B3::Mutability::Mutable) \
+    macro(DirectArguments_minCapacity, DirectArguments::offsetOfMinCapacity(), B3::Mutability::Mutable) \
+    macro(DirectArguments_mappedArguments, DirectArguments::offsetOfMappedArguments(), B3::Mutability::Mutable) \
+    macro(DirectArguments_modifiedArgumentsDescriptor, DirectArguments::offsetOfModifiedArgumentsDescriptor(), B3::Mutability::Mutable) \
+    macro(FunctionExecutable_rareData, FunctionExecutable::offsetOfRareData(), B3::Mutability::Mutable) \
+    macro(FunctionExecutableRareData_asString, FunctionExecutable::RareData::offsetOfAsString(), B3::Mutability::Mutable) \
+    macro(FunctionRareData_allocator, FunctionRareData::offsetOfObjectAllocationProfile() + ObjectAllocationProfileWithPrototype::offsetOfAllocator(), B3::Mutability::Mutable) \
+    macro(FunctionRareData_structure, FunctionRareData::offsetOfObjectAllocationProfile() + ObjectAllocationProfileWithPrototype::offsetOfStructure(), B3::Mutability::Mutable) \
+    macro(FunctionRareData_prototype, FunctionRareData::offsetOfObjectAllocationProfile() + ObjectAllocationProfileWithPrototype::offsetOfPrototype(), B3::Mutability::Mutable) \
+    macro(FunctionRareData_allocationProfileWatchpointSet, FunctionRareData::offsetOfAllocationProfileWatchpointSet(), B3::Mutability::Mutable) \
+    macro(FunctionRareData_executable, FunctionRareData::offsetOfExecutable(), B3::Mutability::Mutable) \
+    macro(FunctionRareData_internalFunctionAllocationProfile_structureID, FunctionRareData::offsetOfInternalFunctionAllocationProfile() + InternalFunctionAllocationProfile::offsetOfStructureID(), B3::Mutability::Mutable) \
+    macro(GetterSetter_getter, GetterSetter::offsetOfGetter(), B3::Mutability::Mutable) \
+    macro(GetterSetter_setter, GetterSetter::offsetOfSetter(), B3::Mutability::Mutable) \
+    macro(JSArrayBufferView_byteOffset, JSArrayBufferView::offsetOfByteOffset(), B3::Mutability::Mutable) \
+    macro(JSArrayBufferView_length, JSArrayBufferView::offsetOfLength(), B3::Mutability::Mutable) \
+    macro(JSArrayBufferView_mode, JSArrayBufferView::offsetOfMode(), B3::Mutability::Mutable) \
+    macro(JSArrayBufferView_vector, JSArrayBufferView::offsetOfVector(), B3::Mutability::Mutable) \
+    macro(JSBigInt_length, JSBigInt::offsetOfLength(), B3::Mutability::Immutable) \
+    macro(JSBoundFunction_targetFunction, JSBoundFunction::offsetOfTargetFunction(), B3::Mutability::Mutable) \
+    macro(JSBoundFunction_boundThis, JSBoundFunction::offsetOfBoundThis(), B3::Mutability::Mutable) \
+    macro(JSBoundFunction_boundArg0, JSBoundFunction::offsetOfBoundArgs() + sizeof(WriteBarrier<Unknown>) * 0, B3::Mutability::Mutable) \
+    macro(JSBoundFunction_boundArg1, JSBoundFunction::offsetOfBoundArgs() + sizeof(WriteBarrier<Unknown>) * 1, B3::Mutability::Mutable) \
+    macro(JSBoundFunction_boundArg2, JSBoundFunction::offsetOfBoundArgs() + sizeof(WriteBarrier<Unknown>) * 2, B3::Mutability::Mutable) \
+    macro(JSBoundFunction_nameMayBeNull, JSBoundFunction::offsetOfNameMayBeNull(), B3::Mutability::Mutable) \
+    macro(JSBoundFunction_length, JSBoundFunction::offsetOfLength(), B3::Mutability::Mutable) \
+    macro(JSBoundFunction_boundArgsLength, JSBoundFunction::offsetOfBoundArgsLength(), B3::Mutability::Mutable) \
+    macro(JSBoundFunction_canConstruct, JSBoundFunction::offsetOfCanConstruct(), B3::Mutability::Mutable) \
+    macro(JSCallee_scope, JSCallee::offsetOfScopeChain(), B3::Mutability::Mutable) \
+    macro(JSCell_cellState, JSCell::cellStateOffset(), B3::Mutability::Mutable) \
+    macro(JSCell_header, 0, B3::Mutability::Mutable) \
+    macro(JSCell_indexingTypeAndMisc, JSCell::indexingTypeAndMiscOffset(), B3::Mutability::Mutable) \
+    macro(JSCell_structureID, JSCell::structureIDOffset(), B3::Mutability::Mutable) \
+    macro(JSCell_typeInfoFlags, JSCell::typeInfoFlagsOffset(), B3::Mutability::Mutable) \
+    macro(JSCell_typeInfoType, JSCell::typeInfoTypeOffset(), B3::Mutability::Immutable) \
+    macro(JSCell_usefulBytes, JSCell::indexingTypeAndMiscOffset(), B3::Mutability::Mutable) \
+    macro(JSFunction_executableOrRareData, JSFunction::offsetOfExecutableOrRareData(), B3::Mutability::Mutable) \
+    macro(JSGlobalObject_regExpGlobalData_cachedResult_lastRegExp, JSGlobalObject::regExpGlobalDataOffset() + RegExpGlobalData::offsetOfCachedResult() + RegExpCachedResult::offsetOfLastRegExp(), B3::Mutability::Mutable) \
+    macro(JSGlobalObject_regExpGlobalData_cachedResult_lastInput, JSGlobalObject::regExpGlobalDataOffset() + RegExpGlobalData::offsetOfCachedResult() + RegExpCachedResult::offsetOfLastInput(), B3::Mutability::Mutable) \
+    macro(JSGlobalObject_regExpGlobalData_cachedResult_result_start, JSGlobalObject::regExpGlobalDataOffset() + RegExpGlobalData::offsetOfCachedResult() + RegExpCachedResult::offsetOfResult() + OBJECT_OFFSETOF(MatchResult, start), B3::Mutability::Mutable) \
+    macro(JSGlobalObject_regExpGlobalData_cachedResult_result_end, JSGlobalObject::regExpGlobalDataOffset() + RegExpGlobalData::offsetOfCachedResult() + RegExpCachedResult::offsetOfResult() + OBJECT_OFFSETOF(MatchResult, end), B3::Mutability::Mutable) \
+    macro(JSGlobalObject_regExpGlobalData_cachedResult_reified, JSGlobalObject::regExpGlobalDataOffset() + RegExpGlobalData::offsetOfCachedResult() + RegExpCachedResult::offsetOfReified(), B3::Mutability::Mutable) \
+    macro(JSGlobalObject_regExpGlobalData_cachedResult_oneCharacterMatch, JSGlobalObject::regExpGlobalDataOffset() + RegExpGlobalData::offsetOfCachedResult() + RegExpCachedResult::offsetOfOneCharacterMatch(), B3::Mutability::Mutable) \
+    macro(JSGlobalProxy_target, JSGlobalProxy::targetOffset(), B3::Mutability::Mutable) \
+    macro(JSObject_butterfly, JSObject::butterflyOffset(), B3::Mutability::Mutable) \
+    macro(JSPropertyNameEnumerator_cachedInlineCapacity, JSPropertyNameEnumerator::cachedInlineCapacityOffset(), B3::Mutability::Mutable) \
+    macro(JSPropertyNameEnumerator_cachedPropertyNamesVector, JSPropertyNameEnumerator::cachedPropertyNamesVectorOffset(), B3::Mutability::Mutable) \
+    macro(JSPropertyNameEnumerator_cachedStructureID, JSPropertyNameEnumerator::cachedStructureIDOffset(), B3::Mutability::Mutable) \
+    macro(JSPropertyNameEnumerator_endGenericPropertyIndex, JSPropertyNameEnumerator::endGenericPropertyIndexOffset(), B3::Mutability::Mutable) \
+    macro(JSPropertyNameEnumerator_endStructurePropertyIndex, JSPropertyNameEnumerator::endStructurePropertyIndexOffset(), B3::Mutability::Mutable) \
+    macro(JSPropertyNameEnumerator_indexLength, JSPropertyNameEnumerator::indexedLengthOffset(), B3::Mutability::Mutable) \
+    macro(JSPropertyNameEnumerator_flags, JSPropertyNameEnumerator::flagsOffset(), B3::Mutability::Mutable) \
+    macro(JSRopeString_flags, JSRopeString::offsetOfFlags(), B3::Mutability::Mutable) \
+    macro(JSRopeString_length, JSRopeString::offsetOfLength(), B3::Mutability::Immutable) \
+    macro(JSRopeString_fiber0, JSRopeString::offsetOfFiber0(), B3::Mutability::Mutable) \
+    macro(JSRopeString_fiber1, JSRopeString::offsetOfFiber1(), B3::Mutability::Mutable) \
+    macro(JSRopeString_fiber2, JSRopeString::offsetOfFiber2(), B3::Mutability::Mutable) \
+    macro(JSScope_next, JSScope::offsetOfNext(), B3::Mutability::Immutable) \
+    macro(JSSymbolTableObject_symbolTable, JSSymbolTableObject::offsetOfSymbolTable(), B3::Mutability::Mutable) \
+    macro(JSWebAssemblyInstance_moduleRecord, JSWebAssemblyInstance::offsetOfModuleRecord(), B3::Mutability::Mutable) \
+    macro(NativeExecutable_asString, NativeExecutable::offsetOfAsString(), B3::Mutability::Mutable) \
+    macro(RegExpObject_regExpAndFlags, RegExpObject::offsetOfRegExpAndFlags(), B3::Mutability::Mutable) \
+    macro(RegExpObject_lastIndex, RegExpObject::offsetOfLastIndex(), B3::Mutability::Mutable) \
+    macro(ShadowChicken_Packet_callee, OBJECT_OFFSETOF(ShadowChicken::Packet, callee), B3::Mutability::Mutable) \
+    macro(ShadowChicken_Packet_frame, OBJECT_OFFSETOF(ShadowChicken::Packet, frame), B3::Mutability::Mutable) \
+    macro(ShadowChicken_Packet_callerFrame, OBJECT_OFFSETOF(ShadowChicken::Packet, callerFrame), B3::Mutability::Mutable) \
+    macro(ShadowChicken_Packet_thisValue, OBJECT_OFFSETOF(ShadowChicken::Packet, thisValue), B3::Mutability::Mutable) \
+    macro(ShadowChicken_Packet_scope, OBJECT_OFFSETOF(ShadowChicken::Packet, scope), B3::Mutability::Mutable) \
+    macro(ShadowChicken_Packet_codeBlock, OBJECT_OFFSETOF(ShadowChicken::Packet, codeBlock), B3::Mutability::Mutable) \
+    macro(ShadowChicken_Packet_callSiteIndex, OBJECT_OFFSETOF(ShadowChicken::Packet, callSiteIndex), B3::Mutability::Mutable) \
+    macro(ScopedArguments_overrodeThings, ScopedArguments::offsetOfOverrodeThings(), B3::Mutability::Mutable) \
+    macro(ScopedArguments_scope, ScopedArguments::offsetOfScope(), B3::Mutability::Mutable) \
+    macro(ScopedArguments_storage, ScopedArguments::offsetOfStorage(), B3::Mutability::Mutable) \
+    macro(ScopedArguments_table, ScopedArguments::offsetOfTable(), B3::Mutability::Mutable) \
+    macro(ScopedArguments_totalLength, ScopedArguments::offsetOfTotalLength(), B3::Mutability::Mutable) \
+    macro(ScopedArgumentsTable_arguments, ScopedArgumentsTable::offsetOfArguments(), B3::Mutability::Mutable) \
+    macro(ScopedArgumentsTable_length, ScopedArgumentsTable::offsetOfLength(), B3::Mutability::Mutable) \
+    macro(StringImpl_data, StringImpl::dataOffset(), B3::Mutability::Immutable) \
+    macro(StringImpl_hashAndFlags, StringImpl::flagsOffset(), B3::Mutability::Mutable) \
+    macro(StringImpl_length, StringImpl::lengthMemoryOffset(), B3::Mutability::Immutable) \
+    macro(Structure_bitField, Structure::bitFieldOffset(), B3::Mutability::Mutable) \
+    macro(Structure_classInfo, Structure::classInfoOffset(), B3::Mutability::Immutable) \
+    macro(Structure_globalObject, Structure::globalObjectOffset(), B3::Mutability::Immutable) \
+    macro(Structure_indexingModeIncludingHistory, Structure::indexingModeIncludingHistoryOffset(), B3::Mutability::Immutable) \
+    macro(Structure_inlineCapacity, Structure::inlineCapacityOffset(), B3::Mutability::Immutable) \
+    macro(Structure_outOfLineTypeFlags, Structure::outOfLineTypeFlagsOffset(), B3::Mutability::Immutable) \
+    macro(Structure_previousOrRareData, Structure::previousOrRareDataOffset(), B3::Mutability::Mutable) \
+    macro(Structure_propertyHash, Structure::propertyHashOffset(), B3::Mutability::Mutable) \
+    macro(Structure_prototype, Structure::prototypeOffset(), B3::Mutability::Immutable) \
+    macro(Structure_seenProperties, Structure::seenPropertiesOffset(), B3::Mutability::Mutable) \
+    macro(StructureRareData_cachedEnumerableStrings, StructureRareData::offsetOfCachedPropertyNames(CachedPropertyNamesKind::EnumerableStrings), B3::Mutability::Mutable) \
+    macro(StructureRareData_cachedStrings, StructureRareData::offsetOfCachedPropertyNames(CachedPropertyNamesKind::Strings), B3::Mutability::Mutable) \
+    macro(StructureRareData_cachedSymbols, StructureRareData::offsetOfCachedPropertyNames(CachedPropertyNamesKind::Symbols), B3::Mutability::Mutable) \
+    macro(StructureRareData_cachedStringsAndSymbols, StructureRareData::offsetOfCachedPropertyNames(CachedPropertyNamesKind::StringsAndSymbols), B3::Mutability::Mutable) \
+    macro(StructureRareData_cachedPropertyNameEnumeratorAndFlag, StructureRareData::offsetOfCachedPropertyNameEnumeratorAndFlag(), B3::Mutability::Mutable) \
+    macro(StructureRareData_specialPropertyCache, StructureRareData::offsetOfSpecialPropertyCache(), B3::Mutability::Mutable) \
+    macro(SpecialPropertyCache_cachedToStringTagValue, SpecialPropertyCache::offsetOfCache(CachedSpecialPropertyKey::ToStringTag) + SpecialPropertyCacheEntry::offsetOfValue(), B3::Mutability::Mutable) \
+    macro(JSMap_storage, (JSMap::offsetOfStorage()), B3::Mutability::Mutable) \
+    macro(JSSet_storage, (JSSet::offsetOfStorage()), B3::Mutability::Mutable) \
+    macro(VM_heap_barrierThreshold, VM::offsetOfHeapBarrierThreshold(), B3::Mutability::Mutable) \
+    macro(VM_heap_mutatorShouldBeFenced, VM::offsetOfHeapMutatorShouldBeFenced(), B3::Mutability::Mutable) \
+    macro(VM_exception, VM::exceptionOffset(), B3::Mutability::Mutable) \
+    macro(WatchpointSet_state, WatchpointSet::offsetOfState(), B3::Mutability::Mutable) \
+    macro(WeakMapImpl_capacity, WeakMapImpl<WeakMapBucket<WeakMapBucketDataKey>>::offsetOfCapacity(), B3::Mutability::Mutable) \
+    macro(WeakMapImpl_buffer,  WeakMapImpl<WeakMapBucket<WeakMapBucketDataKey>>::offsetOfBuffer(), B3::Mutability::Mutable) \
+    macro(WeakMapBucket_value, WeakMapBucket<WeakMapBucketDataKeyValue>::offsetOfValue(), B3::Mutability::Mutable) \
+    macro(WeakMapBucket_key, WeakMapBucket<WeakMapBucketDataKeyValue>::offsetOfKey(), B3::Mutability::Mutable) \
+    macro(WebAssemblyModuleRecord_exportsObject, WebAssemblyModuleRecord::offsetOfExportsObject(), B3::Mutability::Mutable) \
+    macro(Symbol_symbolImpl, Symbol::offsetOfSymbolImpl(), B3::Mutability::Immutable) \
 
 #define FOR_EACH_INDEXED_ABSTRACT_HEAP(macro) \
     macro(ArrayStorage_vector, ArrayStorage::vectorOffset(), sizeof(WriteBarrier<Unknown>)) \
@@ -230,7 +231,7 @@ public:
     FOR_EACH_ABSTRACT_HEAP(ABSTRACT_HEAP_DECLARATION)
 #undef ABSTRACT_HEAP_DECLARATION
 
-#define ABSTRACT_FIELD_DECLARATION(name, offset) AbstractHeap name;
+#define ABSTRACT_FIELD_DECLARATION(name, offset, mutability) AbstractHeap name;
     FOR_EACH_ABSTRACT_FIELD(ABSTRACT_FIELD_DECLARATION)
 #undef ABSTRACT_FIELD_DECLARATION
     


### PR DESCRIPTION
#### 570a3530f9490b5a09863d56d3726e7a1c384971
<pre>
[JSC] Add B3::Mutability and Immutable loads
<a href="https://bugs.webkit.org/show_bug.cgi?id=299223">https://bugs.webkit.org/show_bug.cgi?id=299223</a>
<a href="https://rdar.apple.com/problem/160980434">rdar://problem/160980434</a>

Reviewed by Yijia Huang.

This patch adds B3::Mutability and Immutable loads concept.
Unlike super simple C program, JS and Wasm can offer much more
semantics. One of the important thing is &quot;immutable&quot; loads which the
runtime can ensure this load is producing an immutable value, and all
the following execution with the same Load will generate the same value.
This is still control dependent, but this immutable information can
allow B3 to do CSE. Let&apos;s say,

    @0: Load(@x, immutable)
    @1: CCall(...) # potentially clobber everything
    @2: Load(@x, immutable)

Without this strong guarantee, @1 can potentially clobber all heap, and
@2 can produce the different value from @0. But JS / Wasm loads are not
just a memory load, and the runtime can offer much stronger guarantee.
For example, JSC knows StringImpl::m_length never changes. Thus, we can
replace @2 with @1 when @1 says it is an &quot;immutable&quot; load.

Actual implementation is teaching B3 CSE to handle immutable load
correctly. When clobbering happens, B3 CSE will prune all potential CSE
memory values. But we keep immutable ones. So the subsequent B3 values
dominated this value can still find this, and replace itself with this.

We start annotating FTL abstract heap with this Immutable information.
And many wasm&apos;s Immutable fields start getting this information (for
example, immutable wasm global value should get this annotation).

We also attach controlDependent: false flag to loads which does not rely
on the other checks.

Tests: Source/JavaScriptCore/b3/testb3_1.cpp
       Source/JavaScriptCore/b3/testb3_8.cpp
* Source/JavaScriptCore/b3/B3Effects.cpp:
(JSC::B3::Effects::dump const):
* Source/JavaScriptCore/b3/B3Effects.h:
* Source/JavaScriptCore/b3/B3EliminateCommonSubexpressions.cpp:
* Source/JavaScriptCore/b3/B3MemoryValue.h:
* Source/JavaScriptCore/b3/B3Value.cpp:
(JSC::B3::Value::effects const):
* Source/JavaScriptCore/b3/testb3.h:
* Source/JavaScriptCore/b3/testb3_1.cpp:
(run):
* Source/JavaScriptCore/b3/testb3_8.cpp:
(testLoadImmutable):
* Source/JavaScriptCore/ftl/FTLAbstractHeap.cpp:
(JSC::FTL::AbstractHeap::AbstractHeap):
(JSC::FTL::AbstractHeap::shallowDump const):
* Source/JavaScriptCore/ftl/FTLAbstractHeap.h:
(JSC::FTL::AbstractHeap::initialize):
(JSC::FTL::AbstractHeap::mutability const):
* Source/JavaScriptCore/ftl/FTLAbstractHeapRepository.cpp:
(JSC::FTL::AbstractHeapRepository::AbstractHeapRepository):
(JSC::FTL::AbstractHeapRepository::computeRangesAndDecorateInstructions):
* Source/JavaScriptCore/ftl/FTLAbstractHeapRepository.h:
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::OMGIRGenerator::getGlobal):
(JSC::Wasm::OMGIRGenerator::setGlobal):
(JSC::Wasm::OMGIRGenerator::emitWriteBarrier):
(JSC::Wasm::OMGIRGenerator::emitStructSet):
(JSC::Wasm::OMGIRGenerator::addArrayGet):
(JSC::Wasm::OMGIRGenerator::emitArraySetUncheckedWithoutWriteBarrier):
(JSC::Wasm::OMGIRGenerator::addArraySet):
(JSC::Wasm::OMGIRGenerator::addArrayLen):
(JSC::Wasm::OMGIRGenerator::addStructGet):
(JSC::Wasm::OMGIRGenerator::emitRefTestOrCast):
(JSC::Wasm::OMGIRGenerator::allocatorForWasmGCHeapCellSize):
(JSC::Wasm::OMGIRGenerator::allocateWasmGCArrayUninitialized):
(JSC::Wasm::OMGIRGenerator::allocateWasmGCStructUninitialized):
(JSC::Wasm::OMGIRGenerator::mutatorFence):
(JSC::Wasm::OMGIRGenerator::emitLoadRTTFromObject):
(JSC::Wasm::OMGIRGenerator::addCallIndirect):
(JSC::Wasm::OMGIRGenerator::emitNotRTTKind): Deleted.

Canonical link: <a href="https://commits.webkit.org/300327@main">https://commits.webkit.org/300327@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ad01faee9773edd6b69da7eacd1294c67b20201e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122184 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41887 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32556 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128757 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/74278 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4fa0a143-4820-4e18-ba72-3f1333ed6c6f) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42601 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50480 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/92866 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/74278 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/99427a17-9f05-4a16-aab4-9e0103872ccd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125136 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33979 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/109414 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/73522 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fb879f4b-1246-4c13-8a61-e06d09ea4af3) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/32989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/27577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72245 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/114332 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/103487 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/27770 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131508 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/120710 "Built successfully and passed tests") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/49123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/37372 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/101434 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/49497 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/105625 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101303 "Passed tests") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/24793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/45874 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19323 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/48980 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/54714 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/150869 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/48450 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/38603 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/51800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50130 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->