### PR TITLE
[WTF] Add Thread Sanitizer annotations for custom lock classes

### DIFF
--- a/Source/WTF/wtf/DataMutex.h
+++ b/Source/WTF/wtf/DataMutex.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include <wtf/Lock.h>
+#include <wtf/ThreadSanitizerSupport.h>
 #include <wtf/Threading.h>
 
 namespace WTF {
@@ -124,6 +125,7 @@ private:
     {
         DATA_MUTEX_CHECK(m_dataMutex.m_currentMutexHolder != &Thread::currentSingleton()); // Thread attempted recursive lock on non-recursive lock.
         mutex().lock();
+        TSAN_ANNOTATE_HAPPENS_AFTER(&m_dataMutex.m_mutex);
         m_isLocked = true;
 #if ENABLE_DATA_MUTEX_CHECKS
         m_dataMutex.m_currentMutexHolder = &Thread::currentSingleton();
@@ -138,6 +140,7 @@ private:
         m_dataMutex.m_currentMutexHolder = nullptr;
 #endif
         m_isLocked = false;
+        TSAN_ANNOTATE_HAPPENS_BEFORE(&m_dataMutex.m_mutex);
         mutex().unlock();
     }
 };


### PR DESCRIPTION
#### 319bf3cb9dd8e972697a9d02e30f3512c54ac1bd
<pre>
[WTF] Add Thread Sanitizer annotations for custom lock classes
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=299225">https://bugs.webkit.org/show_bug.cgi?id=299225</a>&gt;
&lt;<a href="https://rdar.apple.com/160982722">rdar://160982722</a>&gt;

Reviewed by Yusuke Suzuki.

* Source/WTF/wtf/CountingLock.h:
* Source/WTF/wtf/DataMutex.h:
* Source/WTF/wtf/Lock.h:
* Source/WTF/wtf/WordLock.h:
- Add TSan annotations for locking and unlocking.

Canonical link: <a href="https://commits.webkit.org/300708@main">https://commits.webkit.org/300708@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5fa1b34ab77be33247682ee7611225d4a567ab64

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121969 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41671 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32341 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128527 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74062 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f8637729-8516-4e2a-a668-8644c725feab) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42386 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50265 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92698 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61590 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/22382e0a-c60f-432c-9dc5-9b55ca5b866d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124921 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33796 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109228 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73354 "Found 1 new API test failure: WPE/TestWebKitWebContext:/webkit/WebKitWebContext/no-web-process-leak (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6a687ad4-18da-4eb3-828c-559ec0a99289) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32808 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27389 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72026 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/114117 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103304 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27585 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131293 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/120495 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48908 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37185 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101255 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49282 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105443 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101126 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46495 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24612 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45609 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19454 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48765 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54499 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/150652 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48235 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/38545 "Found 1 new JSC stress test failure: stress/dont-link-virtual-calls-on-compiler-thread.js.no-llint (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51585 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49915 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->