### PR TITLE
[css-anchor-position-1] Acceptable anchor algorithm should consider inline containing block

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-inline-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-inline-001-expected.txt
@@ -1,11 +1,7 @@
 12 123
 
-FAIL .target 1 assert_equals:
-<span class="target" data-expected-width="30"></span>
-width expected 30 but got 20
-FAIL .target 2 assert_equals:
-<span class="target" data-expected-width="30"></span>
-width expected 30 but got 20
+PASS .target 1
+PASS .target 2
 PASS .target 3
 PASS .target 4
 PASS .target 5

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-004-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-004-expected.txt
@@ -3,6 +3,6 @@ before anchor after target
 before anchor after target
 
 PASS Initial position of the targets
-FAIL #target1 should scroll with #anchor1 assert_equals: expected 120 but got 140
+PASS #target1 should scroll with #anchor1
 PASS #target2 should scroll with #anchor2
 

--- a/Source/WebCore/style/AnchorPositionEvaluator.cpp
+++ b/Source/WebCore/style/AnchorPositionEvaluator.cpp
@@ -979,7 +979,7 @@ std::optional<double> AnchorPositionEvaluator::evaluateSize(BuilderState& builde
 static const RenderElement* penultimateContainingBlockChainElement(const RenderElement& descendant, const RenderElement* ancestor)
 {
     auto* currentElement = &descendant;
-    for (auto* nextElement = currentElement->containingBlock(); nextElement; nextElement = nextElement->containingBlock()) {
+    for (auto* nextElement = currentElement->container(); nextElement; nextElement = nextElement->container()) {
         if (nextElement == ancestor)
             return currentElement;
         currentElement = nextElement;
@@ -987,7 +987,7 @@ static const RenderElement* penultimateContainingBlockChainElement(const RenderE
     return nullptr;
 }
 
-static bool firstChildPrecedesSecondChild(const RenderObject* firstChild, const RenderObject* secondChild, const RenderBlock* containingBlock)
+static bool firstChildPrecedesSecondChild(const RenderObject* firstChild, const RenderObject* secondChild, const RenderObject* containingBlock)
 {
     HashSet<CheckedRef<const RenderObject>> firstAncestorChain;
 
@@ -1105,7 +1105,7 @@ static bool isAcceptableAnchorElement(const RenderBoxModelObject& anchorRenderer
             return false;
     }
 
-    CheckedPtr containingBlock = anchorPositionedRenderer->containingBlock();
+    CheckedPtr containingBlock = anchorPositionedRenderer->container();
     ASSERT(containingBlock);
 
     // "possible anchor is laid out strictly before positioned el, aka one of the following is true:"


### PR DESCRIPTION
#### 39cf916c9b474368030570d2e1118b5720523208
<pre>
[css-anchor-position-1] Acceptable anchor algorithm should consider inline containing block
<a href="https://rdar.apple.com/160917762">rdar://160917762</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=299157">https://bugs.webkit.org/show_bug.cgi?id=299157</a>

Reviewed by Elika Etemad.

THe acceptable anchor code uses RenderObject::containingBlock() to get
the containing block, but the name is a bit deceptive: it returns the
container that is a _block element_. For determining acceptable anchor,
the containing block could be an inline element. Switch to using
RenderObject::container(), which does return an inline element
as containing block.

Test: LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-004.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-inline-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-004-expected.txt:
* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::Style::penultimateContainingBlockChainElement):
(WebCore::Style::firstChildPrecedesSecondChild):

Canonical link: <a href="https://commits.webkit.org/300614@main">https://commits.webkit.org/300614@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/953acf1219bc847ba01e226db40fe1fa11984ffa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123202 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42916 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33613 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/129909 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/75314 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/eb1e0e13-3259-49f3-a090-04ef65edd98f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/125079 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43640 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51511 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93655 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/62137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/42cb7eed-4b71-46b0-adf7-eebafb4a4461) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126155 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34783 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110261 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74285 "Found 1 new API test failure: TestWTF:WTF_Condition.OneProducerOneConsumerOneSlotTimeout (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6397147d-3cd0-4b8a-9e04-618b5a2d749a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33751 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28418 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73425 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104495 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28643 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132624 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50152 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38176 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102146 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50528 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106482 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102004 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25939 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47368 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25585 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/46926 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50007 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/55768 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49477 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/52828 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51156 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->