### PR TITLE
StyleFilterImage should use an intermediate buffer compatible with the destination context

### DIFF
--- a/LayoutTests/fast/filter-image/filter-image-blur.html
+++ b/LayoutTests/fast/filter-image/filter-image-blur.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta name="fuzzy" content="maxDifference=0-23; totalPixels=0-3538">
+    <meta name="fuzzy" content="maxDifference=0-23; totalPixels=0-20000">
     <style>
         div {
             position: absolute;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/filter-function/filter-function-repeating-conic-gradient.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/filter-function/filter-function-repeating-conic-gradient.html
@@ -4,7 +4,6 @@
 <link rel="help" href="https://drafts.fxtf.org/filter-effects-1/#FilterCSSImageValue">
 <link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
 <link rel="match" href="filter-function-repeating-conic-gradient-ref.html">
-<meta name="fuzzy" content="maxDifference=0-255; totalPixels=0-107939">
 <style>
     div {
         background-image: filter(repeating-conic-gradient(red, red 5%, black 5%, black 10%), invert(1));

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/filter-function/filter-function-repeating-radial-gradient.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/filter-function/filter-function-repeating-radial-gradient.html
@@ -4,7 +4,6 @@
 <link rel="help" href="https://drafts.fxtf.org/filter-effects-1/#FilterCSSImageValue">
 <link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
 <link rel="match" href="filter-function-repeating-radial-gradient-ref.html">
-<meta name="fuzzy" content="maxDifference=0-255; totalPixels=0-56745">
 <style>
     div {
         background-image: filter(repeating-radial-gradient(red, red 10px, black 10px, black 20px), invert(1));

--- a/Source/WebCore/rendering/BackgroundPainter.cpp
+++ b/Source/WebCore/rendering/BackgroundPainter.cpp
@@ -510,7 +510,7 @@ template<typename Layer> void BackgroundPainter::paintFillLayerImpl(const Color&
         geometry.clip(LayoutRect(pixelSnappedRect));
         RefPtr<Image> image;
         bool isFirstLine = inlineBoxIterator && inlineBoxIterator->lineBox()->isFirst();
-        if (!geometry.destinationRect.isEmpty() && (image = bgImage->image(backgroundObject ? backgroundObject : &m_renderer, geometry.tileSize, isFirstLine))) {
+        if (!geometry.destinationRect.isEmpty() && (image = bgImage->image(backgroundObject ? backgroundObject : &m_renderer, geometry.tileSize, context, isFirstLine))) {
             context.setDrawLuminanceMask(layer.layer.maskMode() == MaskMode::Luminance);
 
             ImagePaintingOptions options = {

--- a/Source/WebCore/rendering/NinePieceImagePainter.cpp
+++ b/Source/WebCore/rendering/NinePieceImagePainter.cpp
@@ -239,7 +239,7 @@ static void paintNinePieceImage(const T& ninePieceImage, GraphicsContext& graphi
 
     auto tileScales = computeTileScales(destinationRects, sourceRects, ninePieceImage.repeat().horizontalRule(), ninePieceImage.repeat().verticalRule());
 
-    RefPtr image = styleImage->image(renderer, source);
+    RefPtr image = styleImage->image(renderer, source, graphicsContext);
     if (!image)
         return;
 

--- a/Source/WebCore/rendering/RenderImageResourceStyleImage.cpp
+++ b/Source/WebCore/rendering/RenderImageResourceStyleImage.cpp
@@ -29,6 +29,7 @@
 #include "RenderImageResourceStyleImage.h"
 
 #include "CachedImage.h"
+#include "NullGraphicsContext.h"
 #include "RenderElement.h"
 #include "RenderStyleInlines.h"
 #include "StyleCachedImage.h"
@@ -61,7 +62,7 @@ RefPtr<Image> RenderImageResourceStyleImage::image(const IntSize& size) const
     // Generated content may trigger calls to image() while we're still pending, don't assert but gracefully exit.
     if (m_styleImage->isPending())
         return &Image::nullImage();
-    if (auto image = m_styleImage->image(renderer(), size))
+    if (auto image = m_styleImage->image(renderer(), size, NullGraphicsContext()))
         return image;
     return &Image::nullImage();
 }

--- a/Source/WebCore/rendering/RenderListMarker.cpp
+++ b/Source/WebCore/rendering/RenderListMarker.cpp
@@ -177,7 +177,7 @@ void RenderListMarker::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffse
     GraphicsContext& context = paintInfo.context();
 
     if (isImage()) {
-        if (RefPtr markerImage = m_image->image(this, markerRect.size()))
+        if (RefPtr markerImage = m_image->image(this, markerRect.size(), context))
             context.drawImage(*markerImage, markerRect);
         if (selectionState() != HighlightState::None) {
             LayoutRect selectionRect = localSelectionRect();

--- a/Source/WebCore/rendering/shapes/ShapeOutsideInfo.cpp
+++ b/Source/WebCore/rendering/shapes/ShapeOutsideInfo.cpp
@@ -32,6 +32,7 @@
 
 #include "BoxLayoutShape.h"
 #include "FloatingObjects.h"
+#include "NullGraphicsContext.h"
 #include "RenderBlockFlow.h"
 #include "RenderBoxInlines.h"
 #include "RenderBoxModelObjectInlines.h"
@@ -282,7 +283,7 @@ Ref<const LayoutShape> makeShapeForShapeOutside(const RenderBox& renderer)
             ASSERT(!styleImage->isPending());
             auto physicalImageSize = writingMode.isHorizontal() ? logicalImageSize : logicalImageSize.transposedSize();
 
-            RefPtr image = styleImage->image(const_cast<RenderBox*>(&renderer), physicalImageSize);
+            RefPtr image = styleImage->image(const_cast<RenderBox*>(&renderer), physicalImageSize, NullGraphicsContext());
             return LayoutShape::createRasterShape(image.get(), shapeImageThreshold.value, logicalImageRect, logicalMarginRect, writingMode, logicalMargin);
         },
         [&](const Style::ShapeOutside::ShapeBox&) {

--- a/Source/WebCore/rendering/style/StyleCachedImage.cpp
+++ b/Source/WebCore/rendering/style/StyleCachedImage.cpp
@@ -320,7 +320,7 @@ bool StyleCachedImage::hasImage() const
     return m_cachedImage->hasImage();
 }
 
-RefPtr<Image> StyleCachedImage::image(const RenderElement* renderer, const FloatSize&, bool) const
+RefPtr<Image> StyleCachedImage::image(const RenderElement* renderer, const FloatSize&, const GraphicsContext&, bool) const
 {
     ASSERT(!m_isPending);
 

--- a/Source/WebCore/rendering/style/StyleCachedImage.h
+++ b/Source/WebCore/rendering/style/StyleCachedImage.h
@@ -71,7 +71,7 @@ public:
     void removeClient(RenderElement&) final;
     bool hasClient(RenderElement&) const final;
     bool hasImage() const final;
-    RefPtr<Image> image(const RenderElement*, const FloatSize&, bool isForFirstLine) const final;
+    RefPtr<Image> image(const RenderElement*, const FloatSize&, const GraphicsContext& destinationContext, bool isForFirstLine) const final;
     float imageScaleFactor() const final;
     bool knownToBeOpaque(const RenderElement&) const final;
     bool usesDataProtocol() const final;

--- a/Source/WebCore/rendering/style/StyleCanvasImage.cpp
+++ b/Source/WebCore/rendering/style/StyleCanvasImage.cpp
@@ -72,7 +72,7 @@ void StyleCanvasImage::load(CachedResourceLoader&, const ResourceLoaderOptions&)
 {
 }
 
-RefPtr<Image> StyleCanvasImage::image(const RenderElement* renderer, const FloatSize&, bool) const
+RefPtr<Image> StyleCanvasImage::image(const RenderElement* renderer, const FloatSize&, const GraphicsContext&, bool) const
 {
     if (!renderer)
         return &Image::nullImage();

--- a/Source/WebCore/rendering/style/StyleCanvasImage.h
+++ b/Source/WebCore/rendering/style/StyleCanvasImage.h
@@ -55,7 +55,7 @@ private:
     Ref<CSSValue> computedStyleValue(const RenderStyle&) const final;
     bool isPending() const final;
     void load(CachedResourceLoader&, const ResourceLoaderOptions&) final;
-    RefPtr<Image> image(const RenderElement*, const FloatSize&, bool isForFirstLine) const final;
+    RefPtr<Image> image(const RenderElement*, const FloatSize&, const GraphicsContext& destinationContext, bool isForFirstLine) const final;
     bool knownToBeOpaque(const RenderElement&) const final;
     FloatSize fixedSize(const RenderElement&) const final;
     void didAddClient(RenderElement&) final;

--- a/Source/WebCore/rendering/style/StyleCrossfadeImage.cpp
+++ b/Source/WebCore/rendering/style/StyleCrossfadeImage.cpp
@@ -135,7 +135,7 @@ void StyleCrossfadeImage::load(CachedResourceLoader& loader, const ResourceLoade
     m_inputImagesAreReady = true;
 }
 
-RefPtr<Image> StyleCrossfadeImage::image(const RenderElement* renderer, const FloatSize& size, bool isForFirstLine) const
+RefPtr<Image> StyleCrossfadeImage::image(const RenderElement* renderer, const FloatSize& size, const GraphicsContext& destinationContext, bool isForFirstLine) const
 {
     if (!renderer)
         return &Image::nullImage();
@@ -146,8 +146,8 @@ RefPtr<Image> StyleCrossfadeImage::image(const RenderElement* renderer, const Fl
     if (!m_from || !m_to)
         return &Image::nullImage();
 
-    auto fromImage = m_from->image(renderer, size, isForFirstLine);
-    auto toImage = m_to->image(renderer, size, isForFirstLine);
+    auto fromImage = m_from->image(renderer, size, destinationContext, isForFirstLine);
+    auto toImage = m_to->image(renderer, size, destinationContext, isForFirstLine);
 
     if (!fromImage || !toImage)
         return &Image::nullImage();

--- a/Source/WebCore/rendering/style/StyleCrossfadeImage.h
+++ b/Source/WebCore/rendering/style/StyleCrossfadeImage.h
@@ -58,7 +58,7 @@ private:
     Ref<CSSValue> computedStyleValue(const RenderStyle&) const final;
     bool isPending() const final;
     void load(CachedResourceLoader&, const ResourceLoaderOptions&) final;
-    RefPtr<Image> image(const RenderElement*, const FloatSize&, bool isForFirstLine) const final;
+    RefPtr<Image> image(const RenderElement*, const FloatSize&, const GraphicsContext& destinationContext, bool isForFirstLine) const final;
     bool knownToBeOpaque(const RenderElement&) const final;
     FloatSize fixedSize(const RenderElement&) const final;
     void didAddClient(RenderElement&) final { }

--- a/Source/WebCore/rendering/style/StyleFilterImage.cpp
+++ b/Source/WebCore/rendering/style/StyleFilterImage.cpp
@@ -117,7 +117,7 @@ void StyleFilterImage::load(CachedResourceLoader& cachedResourceLoader, const Re
     m_inputImageIsReady = true;
 }
 
-RefPtr<Image> StyleFilterImage::image(const RenderElement* renderer, const FloatSize& size, bool isForFirstLine) const
+RefPtr<Image> StyleFilterImage::image(const RenderElement* renderer, const FloatSize& size, const GraphicsContext& destinationContext, bool isForFirstLine) const
 {
     if (!renderer)
         return &Image::nullImage();
@@ -129,7 +129,7 @@ RefPtr<Image> StyleFilterImage::image(const RenderElement* renderer, const Float
     if (!styleImage)
         return &Image::nullImage();
 
-    auto image = styleImage->image(renderer, size, isForFirstLine);
+    auto image = styleImage->image(renderer, size, destinationContext, isForFirstLine);
     if (!image || image->isNull())
         return &Image::nullImage();
 
@@ -142,7 +142,7 @@ RefPtr<Image> StyleFilterImage::image(const RenderElement* renderer, const Float
 
     cssFilter->setFilterRegion(sourceImageRect);
 
-    auto sourceImage = ImageBuffer::create(size, cssFilter->renderingMode(), RenderingPurpose::DOM, 1, DestinationColorSpace::SRGB(), PixelFormat::BGRA8, renderer->hostWindow());
+    auto sourceImage = ImageBuffer::create(size, destinationContext.renderingMode(), RenderingPurpose::DOM, 1, DestinationColorSpace::SRGB(), PixelFormat::BGRA8, renderer->hostWindow());
     if (!sourceImage)
         return &Image::nullImage();
 

--- a/Source/WebCore/rendering/style/StyleFilterImage.h
+++ b/Source/WebCore/rendering/style/StyleFilterImage.h
@@ -58,7 +58,7 @@ private:
     Ref<CSSValue> computedStyleValue(const RenderStyle&) const final;
     bool isPending() const final;
     void load(CachedResourceLoader&, const ResourceLoaderOptions&) final;
-    RefPtr<Image> image(const RenderElement*, const FloatSize&, bool isForFirstLine) const final;
+    RefPtr<Image> image(const RenderElement*, const FloatSize&, const GraphicsContext& destinationContext, bool isForFirstLine) const final;
     bool knownToBeOpaque(const RenderElement&) const final;
     FloatSize fixedSize(const RenderElement&) const final;
     void didAddClient(RenderElement&) final { }

--- a/Source/WebCore/rendering/style/StyleGradientImage.cpp
+++ b/Source/WebCore/rendering/style/StyleGradientImage.cpp
@@ -71,7 +71,7 @@ void StyleGradientImage::load(CachedResourceLoader&, const ResourceLoaderOptions
 {
 }
 
-RefPtr<Image> StyleGradientImage::image(const RenderElement* renderer, const FloatSize& size, bool isForFirstLine) const
+RefPtr<Image> StyleGradientImage::image(const RenderElement* renderer, const FloatSize& size, const GraphicsContext&, bool isForFirstLine) const
 {
     if (!renderer)
         return &Image::nullImage();

--- a/Source/WebCore/rendering/style/StyleGradientImage.h
+++ b/Source/WebCore/rendering/style/StyleGradientImage.h
@@ -53,7 +53,7 @@ private:
     Ref<CSSValue> computedStyleValue(const RenderStyle&) const final;
     bool isPending() const final;
     void load(CachedResourceLoader&, const ResourceLoaderOptions&) final;
-    RefPtr<Image> image(const RenderElement*, const FloatSize&, bool isForFirstLine) const final;
+    RefPtr<Image> image(const RenderElement*, const FloatSize&, const GraphicsContext& destinationContext, bool isForFirstLine) const final;
     bool knownToBeOpaque(const RenderElement&) const final;
     FloatSize fixedSize(const RenderElement&) const final;
     void didAddClient(RenderElement&) final { }

--- a/Source/WebCore/rendering/style/StyleImage.h
+++ b/Source/WebCore/rendering/style/StyleImage.h
@@ -80,7 +80,7 @@ public:
     virtual bool imageHasNaturalDimensions() const { return true; }
 
     // Image.
-    virtual RefPtr<Image> image(const RenderElement*, const FloatSize&, bool isForFirstLine = false) const = 0;
+    virtual RefPtr<Image> image(const RenderElement*, const FloatSize&, const GraphicsContext& destinationContext, bool isForFirstLine = false) const = 0;
     virtual StyleImage* selectedImage() { return this; }
     virtual const StyleImage* selectedImage() const { return this; }
     virtual CachedImage* cachedImage() const { return nullptr; }

--- a/Source/WebCore/rendering/style/StyleInvalidImage.cpp
+++ b/Source/WebCore/rendering/style/StyleInvalidImage.cpp
@@ -46,7 +46,7 @@ void StyleInvalidImage::load(CachedResourceLoader&, const ResourceLoaderOptions&
 {
 }
 
-RefPtr<Image> StyleInvalidImage::image(const RenderElement*, const FloatSize&, bool) const
+RefPtr<Image> StyleInvalidImage::image(const RenderElement*, const FloatSize&, const GraphicsContext&, bool) const
 {
     return &Image::nullImage();
 }

--- a/Source/WebCore/rendering/style/StyleInvalidImage.h
+++ b/Source/WebCore/rendering/style/StyleInvalidImage.h
@@ -56,7 +56,7 @@ private:
     void load(CachedResourceLoader&, const ResourceLoaderOptions&) final;
     bool knownToBeOpaque(const RenderElement&) const { return false; }
 
-    RefPtr<Image> image(const RenderElement*, const FloatSize&, bool isForFirstLine) const final;
+    RefPtr<Image> image(const RenderElement*, const FloatSize&, const GraphicsContext& destinationContext, bool isForFirstLine) const final;
     Ref<CSSValue> computedStyleValue(const RenderStyle&) const;
 };
 

--- a/Source/WebCore/rendering/style/StyleMultiImage.cpp
+++ b/Source/WebCore/rendering/style/StyleMultiImage.cpp
@@ -180,11 +180,11 @@ bool StyleMultiImage::hasClient(RenderElement& renderer) const
     return m_selectedImage->hasClient(renderer);
 }
 
-RefPtr<Image> StyleMultiImage::image(const RenderElement* renderer, const FloatSize& size, bool isForFirstLine) const
+RefPtr<Image> StyleMultiImage::image(const RenderElement* renderer, const FloatSize& size, const GraphicsContext& destinationContext, bool isForFirstLine) const
 {
     if (!m_selectedImage)
         return nullptr;
-    return m_selectedImage->image(renderer, size, isForFirstLine);
+    return m_selectedImage->image(renderer, size, destinationContext, isForFirstLine);
 }
 
 float StyleMultiImage::imageScaleFactor() const

--- a/Source/WebCore/rendering/style/StyleMultiImage.h
+++ b/Source/WebCore/rendering/style/StyleMultiImage.h
@@ -73,7 +73,7 @@ private:
     void addClient(RenderElement&) final;
     void removeClient(RenderElement&) final;
     bool hasClient(RenderElement&) const final;
-    RefPtr<Image> image(const RenderElement*, const FloatSize&, bool isForFirstLine) const final;
+    RefPtr<Image> image(const RenderElement*, const FloatSize&, const GraphicsContext& destinationContext, bool isForFirstLine) const final;
     float imageScaleFactor() const final;
     bool knownToBeOpaque(const RenderElement&) const final;
     const StyleImage* selectedImage() const final { return m_selectedImage.get(); }

--- a/Source/WebCore/rendering/style/StyleNamedImage.cpp
+++ b/Source/WebCore/rendering/style/StyleNamedImage.cpp
@@ -65,7 +65,7 @@ void StyleNamedImage::load(CachedResourceLoader&, const ResourceLoaderOptions&)
 {
 }
 
-RefPtr<Image> StyleNamedImage::image(const RenderElement* renderer, const FloatSize& size, bool) const
+RefPtr<Image> StyleNamedImage::image(const RenderElement* renderer, const FloatSize& size, const GraphicsContext&, bool) const
 {
     if (!renderer)
         return &Image::nullImage();

--- a/Source/WebCore/rendering/style/StyleNamedImage.h
+++ b/Source/WebCore/rendering/style/StyleNamedImage.h
@@ -50,7 +50,7 @@ private:
     Ref<CSSValue> computedStyleValue(const RenderStyle&) const final;
     bool isPending() const final;
     void load(CachedResourceLoader&, const ResourceLoaderOptions&) final;
-    RefPtr<Image> image(const RenderElement*, const FloatSize&, bool isForFirstLine) const final;
+    RefPtr<Image> image(const RenderElement*, const FloatSize&, const GraphicsContext& destinationContext, bool isForFirstLine) const final;
     bool knownToBeOpaque(const RenderElement&) const final;
     FloatSize fixedSize(const RenderElement&) const final;
     void didAddClient(RenderElement&) final { }

--- a/Source/WebCore/rendering/style/StylePaintImage.cpp
+++ b/Source/WebCore/rendering/style/StylePaintImage.cpp
@@ -67,7 +67,7 @@ void StylePaintImage::load(CachedResourceLoader&, const ResourceLoaderOptions&)
 {
 }
 
-RefPtr<Image> StylePaintImage::image(const RenderElement* renderer, const FloatSize& size, bool) const
+RefPtr<Image> StylePaintImage::image(const RenderElement* renderer, const FloatSize& size, const GraphicsContext&, bool) const
 {
     if (!renderer)
         return &Image::nullImage();

--- a/Source/WebCore/rendering/style/StylePaintImage.h
+++ b/Source/WebCore/rendering/style/StylePaintImage.h
@@ -51,7 +51,7 @@ private:
     Ref<CSSValue> computedStyleValue(const RenderStyle&) const final;
     bool isPending() const final;
     void load(CachedResourceLoader&, const ResourceLoaderOptions&) final;
-    RefPtr<Image> image(const RenderElement*, const FloatSize&, bool isForFirstLine) const final;
+    RefPtr<Image> image(const RenderElement*, const FloatSize&, const GraphicsContext& destinationContext, bool isForFirstLine) const final;
     bool knownToBeOpaque(const RenderElement&) const final;
     FloatSize fixedSize(const RenderElement&) const final;
     void didAddClient(RenderElement&) final { }


### PR DESCRIPTION
#### 56f1a08d6c4eaf21bcc4692518bf5f007495b49b
<pre>
StyleFilterImage should use an intermediate buffer compatible with the destination context
<a href="https://bugs.webkit.org/show_bug.cgi?id=299228">https://bugs.webkit.org/show_bug.cgi?id=299228</a>
<a href="https://rdar.apple.com/160988326">rdar://160988326</a>

Reviewed by Simon Fraser.

When generating StyleFilterImage, the intermediate buffer should be compatible
with the destination context. Pass the destination context if it is available.
Otherwise pass NullGraphicsContext.

* LayoutTests/fast/filter-image/filter-image-blur.html:

* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/filter-function/filter-function-repeating-conic-gradient.html:
* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/filter-function/filter-function-repeating-radial-gradient.html:
Remove the large pixel tolerance which was added to these tests in 300173@main.

* Source/WebCore/rendering/BackgroundPainter.cpp:
(WebCore::BackgroundPainter::paintFillLayerImpl const):
* Source/WebCore/rendering/NinePieceImagePainter.cpp:
(WebCore::paintNinePieceImage):
* Source/WebCore/rendering/RenderImageResourceStyleImage.cpp:
(WebCore::RenderImageResourceStyleImage::image const):
* Source/WebCore/rendering/RenderListMarker.cpp:
(WebCore::RenderListMarker::paint):
* Source/WebCore/rendering/shapes/ShapeOutsideInfo.cpp:
(WebCore::makeShapeForShapeOutside):
* Source/WebCore/rendering/style/StyleCachedImage.cpp:
(WebCore::StyleCachedImage::image const):
* Source/WebCore/rendering/style/StyleCachedImage.h:
* Source/WebCore/rendering/style/StyleCanvasImage.cpp:
(WebCore::StyleCanvasImage::image const):
* Source/WebCore/rendering/style/StyleCanvasImage.h:
* Source/WebCore/rendering/style/StyleCrossfadeImage.cpp:
(WebCore::StyleCrossfadeImage::image const):
* Source/WebCore/rendering/style/StyleCrossfadeImage.h:
* Source/WebCore/rendering/style/StyleFilterImage.cpp:
(WebCore::StyleFilterImage::image const):
* Source/WebCore/rendering/style/StyleFilterImage.h:
* Source/WebCore/rendering/style/StyleGradientImage.cpp:
(WebCore::StyleGradientImage::image const):
* Source/WebCore/rendering/style/StyleGradientImage.h:
* Source/WebCore/rendering/style/StyleImage.h:
* Source/WebCore/rendering/style/StyleInvalidImage.cpp:
(WebCore::StyleInvalidImage::image const):
* Source/WebCore/rendering/style/StyleInvalidImage.h:
* Source/WebCore/rendering/style/StyleMultiImage.cpp:
(WebCore::StyleMultiImage::image const):
* Source/WebCore/rendering/style/StyleMultiImage.h:
* Source/WebCore/rendering/style/StyleNamedImage.cpp:
(WebCore::StyleNamedImage::image const):
* Source/WebCore/rendering/style/StyleNamedImage.h:
* Source/WebCore/rendering/style/StylePaintImage.cpp:
(WebCore::StylePaintImage::image const):
* Source/WebCore/rendering/style/StylePaintImage.h:

Canonical link: <a href="https://commits.webkit.org/300328@main">https://commits.webkit.org/300328@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/135cbcc0ed2c91512c5fdde1e8c46a3634240357

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122011 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41713 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32383 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128571 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74104 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f49b98be-7ecd-4b38-b6a5-d9b998c71e1e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123887 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42428 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50307 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92730 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61613 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/26051b0d-1a49-403c-a4e3-a442aab5b447) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124963 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33831 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109263 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73384 "Found 1 new API test failure: TestWTF:WTF_Condition.OneProducerOneConsumerOneSlot (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9137b6c2-5365-46fb-b953-fc4d135b772f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32844 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27424 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72068 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103338 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27620 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131335 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48950 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37248 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101289 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49324 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105477 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101160 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25675 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46530 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24647 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45661 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48807 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54541 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48277 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51627 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49957 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->