### PR TITLE
Throttle foreground timers that have exceeded the maximum nesting level

### DIFF
--- a/LayoutTests/fast/dom/repeating-timer-visible-element-clamped-expected.txt
+++ b/LayoutTests/fast/dom/repeating-timer-visible-element-clamped-expected.txt
@@ -1,0 +1,24 @@
+Tests that a repeating timer with an interval < 4ms will be clamped to 4ms after 5 iterations.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+The timer should not be initially throttled or clamped.
+PASS internals.isTimerThrottled(timeoutId) is false
+PASS internals.isTimerClamped(timeoutId) is false
+5th iteration should not have clamped the timer.
+PASS wasClamped is false
+6th iteration should be clamped
+PASS internals.isTimerClamped(timeoutId) is true
+Iteration 7, timer should be clamped.
+PASS internals.isTimerClamped(timeoutId) is true
+Iteration 8, timer should be clamped.
+PASS internals.isTimerClamped(timeoutId) is true
+Iteration 9, timer should be clamped.
+PASS internals.isTimerClamped(timeoutId) is true
+Iteration 10, timer should be clamped.
+PASS internals.isTimerClamped(timeoutId) is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Test

--- a/LayoutTests/fast/dom/repeating-timer-visible-element-clamped.html
+++ b/LayoutTests/fast/dom/repeating-timer-visible-element-clamped.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../resources/js-test.js"></script>
+<div id="testElement">Test</div>
+<script>
+description("Tests that a repeating timer with an interval < 4ms will be clamped to 4ms after 5 iterations.");
+jsTestIsAsync = true;
+
+var iterationCount = 0;
+var timeoutId;
+var testElement = document.getElementById("testElement");
+var wasClamped = false;
+
+function timerCallback()
+{
+    ++iterationCount;
+    // Interact with the style of the element.
+    testElement.style["left"] = `${iterationCount}px`;
+
+    if (iterationCount == 5) {
+        wasClamped = internals.isTimerClamped(timeoutId);
+    } else if (iterationCount == 6) {
+        debug("5th iteration should not have clamped the timer.");
+        shouldBeFalse("wasClamped");
+        debug("6th iteration should be clamped");
+        shouldBeTrue("internals.isTimerClamped(timeoutId)");
+    } else if (iterationCount > 6) {
+        debug(`Iteration ${iterationCount}, timer should be clamped.`);
+        shouldBeTrue("internals.isTimerClamped(timeoutId)");
+    }
+
+    if (iterationCount == 10) {
+        clearInterval(timeoutId);
+        finishJSTest();
+    }
+}
+
+timeoutId = setInterval(timerCallback, 1);
+debug("The timer should not be initially throttled or clamped.");
+shouldBeFalse("internals.isTimerThrottled(timeoutId)");
+shouldBeFalse("internals.isTimerClamped(timeoutId)");
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/dom/repeating-timer-visible-element-throttling-expected.txt
+++ b/LayoutTests/fast/dom/repeating-timer-visible-element-throttling-expected.txt
@@ -9,6 +9,14 @@ PASS internals.isTimerThrottled(timeoutId) is false
 PASS wasThrottled is false
 6th iteration, timer should still be unthrottled.
 PASS internals.isTimerThrottled(timeoutId) is false
+Iteration 7, timer should not be throttled (but it should be clamped to minimum).
+PASS internals.isTimerThrottled(timeoutId) is false
+Iteration 8, timer should not be throttled (but it should be clamped to minimum).
+PASS internals.isTimerThrottled(timeoutId) is false
+Iteration 9, timer should not be throttled (but it should be clamped to minimum).
+PASS internals.isTimerThrottled(timeoutId) is false
+10th iteration, timer should be throttled.
+PASS internals.isTimerThrottled(timeoutId) is true
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/dom/repeating-timer-visible-element-throttling.html
+++ b/LayoutTests/fast/dom/repeating-timer-visible-element-throttling.html
@@ -27,6 +27,13 @@ function timerCallback()
     shouldBeFalse("wasThrottled");
     debug("6th iteration, timer should still be unthrottled.");
     shouldBeFalse("internals.isTimerThrottled(timeoutId)");
+  } else if (iterationCount > 6 && iterationCount < 10) {
+    debug(`Iteration ${iterationCount}, timer should not be throttled.`);
+    shouldBeFalse("internals.isTimerThrottled(timeoutId)");
+  } else if (iterationCount == 10) {
+    // Maximally nested timers should be unconditionally throttled.
+    debug("10th iteration, timer should be throttled.");
+    shouldBeTrue("internals.isTimerThrottled(timeoutId)");
     clearInterval(timeoutId);
     finishJSTest();
   }

--- a/LayoutTests/fast/dom/timer-throttling-aggressiveThermalMitigation-expected.txt
+++ b/LayoutTests/fast/dom/timer-throttling-aggressiveThermalMitigation-expected.txt
@@ -27,7 +27,7 @@ PASS internals.isTimerThrottled(timerHandle) is false
 * Nesting: 9
 PASS internals.isTimerThrottled(timerHandle) is false
 * Nesting: 10
-PASS internals.isTimerThrottled(timerHandle) is false
+PASS internals.isTimerThrottled(timerHandle) is true
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/dom/timer-throttling-aggressiveThermalMitigation.html
+++ b/LayoutTests/fast/dom/timer-throttling-aggressiveThermalMitigation.html
@@ -8,6 +8,7 @@ jsTestIsAsync = true;
 
 let i = 0;
 const maxNestingLevel = 5;
+const unconditionalThrottlingLevel = 10;
 
 let enabled = true;
 debug("Enabling aggressive thermal mitigation");
@@ -16,7 +17,7 @@ evalAndLog("internals.setAggressiveThermalMitigationEnabled(true)");
 const timerHandle = setInterval(function() {
     i++;
     debug("* Nesting: " + i);
-    if (i >= maxNestingLevel && enabled)
+    if (i >= maxNestingLevel && enabled || i == unconditionalThrottlingLevel)
         shouldBeTrue("internals.isTimerThrottled(timerHandle)");
     else
         shouldBeFalse("internals.isTimerThrottled(timerHandle)");
@@ -28,7 +29,7 @@ const timerHandle = setInterval(function() {
         evalAndLog("internals.setAggressiveThermalMitigationEnabled(false)");
     }
 
-    if (i == 10) {
+    if (i == unconditionalThrottlingLevel) {
         clearInterval(timerHandle);
         finishJSTest();
     }

--- a/LayoutTests/fast/dom/timer-throttling-lowPowerMode-expected.txt
+++ b/LayoutTests/fast/dom/timer-throttling-lowPowerMode-expected.txt
@@ -27,7 +27,7 @@ PASS internals.isTimerThrottled(timerHandle) is false
 * Nesting: 9
 PASS internals.isTimerThrottled(timerHandle) is false
 * Nesting: 10
-PASS internals.isTimerThrottled(timerHandle) is false
+PASS internals.isTimerThrottled(timerHandle) is true
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/dom/timer-throttling-lowPowerMode.html
+++ b/LayoutTests/fast/dom/timer-throttling-lowPowerMode.html
@@ -8,6 +8,7 @@ jsTestIsAsync = true;
 
 let i = 0;
 const maxNestingLevel = 5;
+const unconditionalThrottlingLevel = 10;
 
 let lowPowerModeEnabled = true;
 debug("Enabling low power mode");
@@ -16,7 +17,7 @@ evalAndLog("internals.setLowPowerModeEnabled(true)");
 const timerHandle = setInterval(function() {
     i++;
     debug("* Nesting: " + i);
-    if (i >= maxNestingLevel && lowPowerModeEnabled)
+    if (i >= maxNestingLevel && lowPowerModeEnabled || i == unconditionalThrottlingLevel)
         shouldBeTrue("internals.isTimerThrottled(timerHandle)");
     else
         shouldBeFalse("internals.isTimerThrottled(timerHandle)");
@@ -28,7 +29,7 @@ const timerHandle = setInterval(function() {
         evalAndLog("internals.setLowPowerModeEnabled(false)");
     }
 
-    if (i == 10) {
+    if (i == unconditionalThrottlingLevel) {
         clearInterval(timerHandle);
         finishJSTest();
     }

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2378,6 +2378,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/ThreadSafeDataBuffer.h
     platform/ThreadTimers.h
     platform/Timer.h
+    platform/TimerNestingState.h
     platform/TouchAction.h
     platform/TrackInfo.h
     platform/UserActivity.h

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -1703,6 +1703,7 @@
 		44FA8DA42B0B787B007C99D8 /* LegacyRenderSVGResourceRadialGradient.h in Headers */ = {isa = PBXBuildFile; fileRef = 44FA8D9A2B0B787A007C99D8 /* LegacyRenderSVGResourceRadialGradient.h */; };
 		44FA8DA52B0B787B007C99D8 /* LegacyRenderSVGResourceRadialGradientInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 44FA8D9B2B0B787A007C99D8 /* LegacyRenderSVGResourceRadialGradientInlines.h */; };
 		4512502315DCE37D002F84E2 /* SpinButtonElement.h in Headers */ = {isa = PBXBuildFile; fileRef = 4512502115DCE37D002F84E2 /* SpinButtonElement.h */; };
+		45213B562E7F6B6A00F6A18D /* TimerNestingState.h in Headers */ = {isa = PBXBuildFile; fileRef = 45213B552E7F6A9800F6A18D /* TimerNestingState.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		453EB637159C570400001BB7 /* DateTimeFormat.h in Headers */ = {isa = PBXBuildFile; fileRef = 453EB635159C570400001BB7 /* DateTimeFormat.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		45830D4E1679B4F800ACF8C3 /* AutoscrollController.h in Headers */ = {isa = PBXBuildFile; fileRef = 45830D4C1679B4F800ACF8C3 /* AutoscrollController.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		458FE40A1589DF0B005609E6 /* RenderSearchField.h in Headers */ = {isa = PBXBuildFile; fileRef = 458FE4081589DF0B005609E6 /* RenderSearchField.h */; };
@@ -11147,6 +11148,7 @@
 		4512502115DCE37D002F84E2 /* SpinButtonElement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SpinButtonElement.h; sourceTree = "<group>"; };
 		45160A892A09FA22009E39A2 /* JSMediaSessionCustom.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = JSMediaSessionCustom.cpp; sourceTree = "<group>"; };
 		451A49F8F8726BE071518BE2 /* ISOProtectionSystemSpecificHeaderBox.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ISOProtectionSystemSpecificHeaderBox.cpp; sourceTree = "<group>"; };
+		45213B552E7F6A9800F6A18D /* TimerNestingState.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TimerNestingState.h; sourceTree = "<group>"; };
 		45245AF12C322ADE0003D1FF /* JSReportingObserverCustom.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = JSReportingObserverCustom.cpp; sourceTree = "<group>"; };
 		453EB635159C570400001BB7 /* DateTimeFormat.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DateTimeFormat.h; sourceTree = "<group>"; };
 		454F512629A9E57D00CDBA10 /* StyleInvalidImage.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = StyleInvalidImage.cpp; sourceTree = "<group>"; };
@@ -37244,6 +37246,7 @@
 				185BCF270F3279CE000EA262 /* ThreadTimers.h */,
 				93309EA1099EB78C0056E581 /* Timer.cpp */,
 				9305B24C098F1B6B00C28855 /* Timer.h */,
+				45213B552E7F6A9800F6A18D /* TimerNestingState.h */,
 				71AEE4EB21B5A49C00DDB036 /* TouchAction.h */,
 				513C7B6F2E7C312E00079881 /* TrackInfo.cpp */,
 				513C7B6B2E7C2A0E00079881 /* TrackInfo.h */,
@@ -46601,6 +46604,7 @@
 				9305B24D098F1B6B00C28855 /* Timer.h in Headers */,
 				E44613B00CD6331000FADA75 /* TimeRanges.h in Headers */,
 				2D7ED0AB1BAE99170043B3E5 /* TimerEventBasedMock.h in Headers */,
+				45213B562E7F6B6A00F6A18D /* TimerNestingState.h in Headers */,
 				5CC7900E266AFA89006924FE /* TimingAllowOrigin.h in Headers */,
 				49E912AE0EFAC906009D0CAF /* TimingFunction.h in Headers */,
 				72BB9E8A2952582000842DBB /* ToggleButtonMac.h in Headers */,

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -4498,10 +4498,10 @@ void Document::setVisibilityHiddenDueToDismissal(bool hiddenDueToDismissal)
     dispatchEvent(Event::create(eventNames().visibilitychangeEvent, Event::CanBubble::Yes, Event::IsCancelable::No));
 }
 
-Seconds Document::domTimerAlignmentInterval(bool hasReachedMaxNestingLevel) const
+Seconds Document::domTimerAlignmentInterval(TimerNestingState nestingState) const
 {
-    auto alignmentInterval = ScriptExecutionContext::domTimerAlignmentInterval(hasReachedMaxNestingLevel);
-    if (!hasReachedMaxNestingLevel)
+    auto alignmentInterval = ScriptExecutionContext::domTimerAlignmentInterval(nestingState);
+    if (nestingState == TimerNestingState::Low)
         return alignmentInterval;
 
     // Apply Document-level DOMTimer throttling only if timers have reached their maximum nesting level as the Page may still be visible.
@@ -4513,6 +4513,9 @@ Seconds Document::domTimerAlignmentInterval(bool hasReachedMaxNestingLevel) cons
 
     if (!topOrigin().isSameOriginDomain(securityOrigin()) && !hasHadUserInteraction())
         alignmentInterval = std::max(alignmentInterval, DOMTimer::nonInteractedCrossOriginFrameAlignmentInterval());
+
+    if (nestingState == TimerNestingState::Maximum)
+        alignmentInterval = std::max(alignmentInterval, DOMTimer::maximallyNestedTimerAlignmentInterval());
 
     return alignmentInterval;
 }

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -2081,7 +2081,7 @@ private:
 
     Seconds minimumDOMTimerInterval() const final;
 
-    Seconds domTimerAlignmentInterval(bool hasReachedMaxNestingLevel) const final;
+    Seconds domTimerAlignmentInterval(TimerNestingState) const final;
 
     void updateTitleFromTitleElement();
     void updateTitle(const StringWithDirection&);

--- a/Source/WebCore/dom/EventLoop.cpp
+++ b/Source/WebCore/dom/EventLoop.cpp
@@ -199,12 +199,12 @@ void EventLoop::queueTask(std::unique_ptr<EventLoopTask>&& task)
     m_tasks.append(WTFMove(task));
 }
 
-EventLoopTimerHandle EventLoop::scheduleTask(Seconds timeout, TimerAlignment* alignment, HasReachedMaxNestingLevel hasReachedMaxNestingLevel, std::unique_ptr<EventLoopTask>&& action)
+EventLoopTimerHandle EventLoop::scheduleTask(Seconds timeout, TimerAlignment* alignment, TimerNestingState nestingState, std::unique_ptr<EventLoopTask>&& action)
 {
     auto timer = EventLoopTimer::create(EventLoopTimer::Type::OneShot, WTFMove(action));
     if (alignment)
         timer->setTimerAlignment(*alignment);
-    timer->setHasReachedMaxNestingLevel(hasReachedMaxNestingLevel == HasReachedMaxNestingLevel::Yes);
+    timer->setTimerNestingState(nestingState);
     timer->startOneShot(timeout);
     if (timer->group()->isSuspended())
         timer->suspend();
@@ -225,12 +225,12 @@ void EventLoop::removeScheduledTimer(EventLoopTimer& timer)
     invalidateNextTimerFireTimeCache();
 }
 
-EventLoopTimerHandle EventLoop::scheduleRepeatingTask(Seconds nextTimeout, Seconds interval, TimerAlignment* alignment, HasReachedMaxNestingLevel hasReachedMaxNestingLevel, std::unique_ptr<EventLoopTask>&& action)
+EventLoopTimerHandle EventLoop::scheduleRepeatingTask(Seconds nextTimeout, Seconds interval, TimerAlignment* alignment, TimerNestingState nestingState, std::unique_ptr<EventLoopTask>&& action)
 {
     auto timer = EventLoopTimer::create(EventLoopTimer::Type::Repeating, WTFMove(action));
     if (alignment)
         timer->setTimerAlignment(*alignment);
-    timer->setHasReachedMaxNestingLevel(hasReachedMaxNestingLevel == HasReachedMaxNestingLevel::Yes);
+    timer->setTimerNestingState(nestingState);
     timer->startRepeating(nextTimeout, interval);
     if (timer->group()->isSuspended())
         timer->suspend();
@@ -589,14 +589,14 @@ EventLoopTimerHandle EventLoopTaskGroup::scheduleTask(Seconds timeout, TaskSourc
 {
     if (m_state == State::Stopped || !m_eventLoop)
         return { };
-    return protectedEventLoop()->scheduleTask(timeout, nullptr, HasReachedMaxNestingLevel::No, makeUnique<EventLoopFunctionDispatchTask>(source, *this, WTFMove(function)));
+    return protectedEventLoop()->scheduleTask(timeout, nullptr, TimerNestingState::Low, makeUnique<EventLoopFunctionDispatchTask>(source, *this, WTFMove(function)));
 }
 
-EventLoopTimerHandle EventLoopTaskGroup::scheduleTask(Seconds timeout, TimerAlignment& alignment, HasReachedMaxNestingLevel hasReachedMaxNestingLevel, TaskSource source, EventLoop::TaskFunction&& function)
+EventLoopTimerHandle EventLoopTaskGroup::scheduleTask(Seconds timeout, TimerAlignment& alignment, TimerNestingState nestingState, TaskSource source, EventLoop::TaskFunction&& function)
 {
     if (m_state == State::Stopped || !m_eventLoop)
         return { };
-    return protectedEventLoop()->scheduleTask(timeout, &alignment, hasReachedMaxNestingLevel, makeUnique<EventLoopFunctionDispatchTask>(source, *this, WTFMove(function)));
+    return protectedEventLoop()->scheduleTask(timeout, &alignment, nestingState, makeUnique<EventLoopFunctionDispatchTask>(source, *this, WTFMove(function)));
 }
 
 void EventLoopTaskGroup::removeScheduledTimer(EventLoopTimer& timer)
@@ -611,14 +611,14 @@ EventLoopTimerHandle EventLoopTaskGroup::scheduleRepeatingTask(Seconds nextTimeo
 {
     if (m_state == State::Stopped || !m_eventLoop)
         return { };
-    return protectedEventLoop()->scheduleRepeatingTask(nextTimeout, interval, nullptr, HasReachedMaxNestingLevel::No, makeUnique<EventLoopFunctionDispatchTask>(source, *this, WTFMove(function)));
+    return protectedEventLoop()->scheduleRepeatingTask(nextTimeout, interval, nullptr, TimerNestingState::Low, makeUnique<EventLoopFunctionDispatchTask>(source, *this, WTFMove(function)));
 }
 
-EventLoopTimerHandle EventLoopTaskGroup::scheduleRepeatingTask(Seconds nextTimeout, Seconds interval, TimerAlignment& alignment, HasReachedMaxNestingLevel hasReachedMaxNestingLevel, TaskSource source, EventLoop::TaskFunction&& function)
+EventLoopTimerHandle EventLoopTaskGroup::scheduleRepeatingTask(Seconds nextTimeout, Seconds interval, TimerAlignment& alignment, TimerNestingState nestingState, TaskSource source, EventLoop::TaskFunction&& function)
 {
     if (m_state == State::Stopped || !m_eventLoop)
         return { };
-    return protectedEventLoop()->scheduleRepeatingTask(nextTimeout, interval, &alignment, hasReachedMaxNestingLevel, makeUnique<EventLoopFunctionDispatchTask>(source, *this, WTFMove(function)));
+    return protectedEventLoop()->scheduleRepeatingTask(nextTimeout, interval, &alignment, nestingState, makeUnique<EventLoopFunctionDispatchTask>(source, *this, WTFMove(function)));
 }
 
 void EventLoopTaskGroup::removeRepeatingTimer(EventLoopTimer& timer)
@@ -639,12 +639,12 @@ void EventLoopTaskGroup::didChangeTimerAlignmentInterval(EventLoopTimerHandle ha
         eventLoop->invalidateNextTimerFireTimeCache();
 }
 
-void EventLoopTaskGroup::setTimerHasReachedMaxNestingLevel(EventLoopTimerHandle handle, bool value)
+void EventLoopTaskGroup::setTimerNestingState(EventLoopTimerHandle handle, TimerNestingState nestingState)
 {
     if (!handle.m_timer)
         return;
     ASSERT(m_timers.contains(*handle.m_timer));
-    handle.m_timer->setHasReachedMaxNestingLevel(value);
+    handle.m_timer->setTimerNestingState(nestingState);
     if (RefPtr eventLoop = m_eventLoop.get())
         eventLoop->invalidateNextTimerFireTimeCache();
 }

--- a/Source/WebCore/dom/EventLoop.h
+++ b/Source/WebCore/dom/EventLoop.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <WebCore/TaskSource.h>
+#include <WebCore/TimerNestingState.h>
 #include <optional>
 #include <wtf/ApproximateTime.h>
 #include <wtf/CheckedRef.h>
@@ -98,8 +99,6 @@ private:
     RefPtr<EventLoopTimer> m_timer;
 };
 
-enum class HasReachedMaxNestingLevel : bool { No, Yes };
-
 // https://html.spec.whatwg.org/multipage/webappapis.html#event-loop
 class EventLoop : public RefCountedAndCanMakeWeakPtr<EventLoop> {
 public:
@@ -110,10 +109,10 @@ public:
     typedef Function<void ()> TaskFunction;
     void queueTask(std::unique_ptr<EventLoopTask>&&);
 
-    EventLoopTimerHandle scheduleTask(Seconds timeout, TimerAlignment*, HasReachedMaxNestingLevel, std::unique_ptr<EventLoopTask>&&);
+    EventLoopTimerHandle scheduleTask(Seconds timeout, TimerAlignment*, TimerNestingState, std::unique_ptr<EventLoopTask>&&);
     void removeScheduledTimer(EventLoopTimer&);
 
-    EventLoopTimerHandle scheduleRepeatingTask(Seconds nextTimeout, Seconds interval, TimerAlignment*, HasReachedMaxNestingLevel, std::unique_ptr<EventLoopTask>&&);
+    EventLoopTimerHandle scheduleRepeatingTask(Seconds nextTimeout, Seconds interval, TimerAlignment*, TimerNestingState, std::unique_ptr<EventLoopTask>&&);
     void removeRepeatingTimer(EventLoopTimer&);
 
     // https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-microtask
@@ -215,16 +214,16 @@ public:
     void runAtEndOfMicrotaskCheckpoint(EventLoop::TaskFunction&&);
 
     EventLoopTimerHandle scheduleTask(Seconds timeout, TaskSource, EventLoop::TaskFunction&&);
-    EventLoopTimerHandle scheduleTask(Seconds timeout, TimerAlignment&, HasReachedMaxNestingLevel, TaskSource, EventLoop::TaskFunction&&);
+    EventLoopTimerHandle scheduleTask(Seconds timeout, TimerAlignment&, TimerNestingState, TaskSource, EventLoop::TaskFunction&&);
     void didExecuteScheduledTask(EventLoopTimer&);
     void removeScheduledTimer(EventLoopTimer&);
 
     EventLoopTimerHandle scheduleRepeatingTask(Seconds nextTimeout, Seconds interval, TaskSource, EventLoop::TaskFunction&&);
-    EventLoopTimerHandle scheduleRepeatingTask(Seconds nextTimeout, Seconds interval, TimerAlignment&, HasReachedMaxNestingLevel, TaskSource, EventLoop::TaskFunction&&);
+    EventLoopTimerHandle scheduleRepeatingTask(Seconds nextTimeout, Seconds interval, TimerAlignment&, TimerNestingState, TaskSource, EventLoop::TaskFunction&&);
     void removeRepeatingTimer(EventLoopTimer&);
 
     void didChangeTimerAlignmentInterval(EventLoopTimerHandle);
-    void setTimerHasReachedMaxNestingLevel(EventLoopTimerHandle, bool);
+    void setTimerNestingState(EventLoopTimerHandle, TimerNestingState);
     void adjustTimerNextFireTime(EventLoopTimerHandle, Seconds delta);
     void adjustTimerRepeatInterval(EventLoopTimerHandle, Seconds delta);
 

--- a/Source/WebCore/dom/ScriptExecutionContext.cpp
+++ b/Source/WebCore/dom/ScriptExecutionContext.cpp
@@ -621,7 +621,7 @@ void ScriptExecutionContext::didChangeTimerAlignmentInterval()
         eventLoop->didChangeTimerAlignmentInterval(timer->timer());
 }
 
-Seconds ScriptExecutionContext::domTimerAlignmentInterval(bool) const
+Seconds ScriptExecutionContext::domTimerAlignmentInterval(TimerNestingState) const
 {
     return DOMTimer::defaultAlignmentInterval();
 }

--- a/Source/WebCore/dom/ScriptExecutionContext.h
+++ b/Source/WebCore/dom/ScriptExecutionContext.h
@@ -296,10 +296,10 @@ public:
     virtual Seconds minimumDOMTimerInterval() const;
 
     void didChangeTimerAlignmentInterval();
-    virtual Seconds domTimerAlignmentInterval(bool hasReachedMaxNestingLevel) const;
+    virtual Seconds domTimerAlignmentInterval(TimerNestingState) const;
 
     // TimerAlignment
-    WEBCORE_EXPORT std::optional<MonotonicTime> alignedFireTime(bool hasReachedMaxNestingLevel, MonotonicTime fireTime) const final;
+    WEBCORE_EXPORT std::optional<MonotonicTime> alignedFireTime(TimerNestingState, MonotonicTime fireTime) const final;
 
     virtual EventTarget* errorEventTarget() = 0;
 

--- a/Source/WebCore/page/DOMTimer.cpp
+++ b/Source/WebCore/page/DOMTimer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008, 2014 Apple Inc. All rights reserved.
+ * Copyright (C) 2008, 2014, 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -54,9 +54,12 @@ namespace WebCore {
 static constexpr Seconds minIntervalForNonUserObservableChangeTimers { 1_s }; // Empirically determined to maximize battery life.
 static constexpr Seconds minIntervalForOneShotTimers { 0_ms };
 static constexpr Seconds minIntervalForRepeatingTimers { 1_ms };
-static constexpr int maxTimerNestingLevel = 10;
-static constexpr int maxTimerNestingLevelForOneShotTimers = 10;
+// The HTML spec says that for nesting level > 5 we clamp intervals to 4ms. We deviate from the spec for
+// nested one-shot timers by keeping them unclamped up to our unconditional throttling nesting level.
+static constexpr int maxTimerNestingLevelForUnconditionalThrottling = 10;
+static constexpr int maxTimerNestingLevelForOneShotTimers = maxTimerNestingLevelForUnconditionalThrottling;
 static constexpr int maxTimerNestingLevelForRepeatingTimers = 5;
+
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(DOMTimer);
 
@@ -175,14 +178,14 @@ DOMTimer::DOMTimer(ScriptExecutionContext& context, Function<void(ScriptExecutio
     , m_userGestureTokenToForward(UserGestureIndicator::currentUserGesture())
 {
     CheckedRef eventLoop = context.eventLoop();
-    m_hasReachedMaxNestingLevel = m_nestingLevel >= (m_oneShot ? maxTimerNestingLevelForOneShotTimers : maxTimerNestingLevelForRepeatingTimers);
+    auto nestingState = nestingStateForCurrentNestingLevel();
     if (m_oneShot) {
-        m_timer = eventLoop->scheduleTask(m_currentTimerInterval, context, m_hasReachedMaxNestingLevel ? HasReachedMaxNestingLevel::Yes : HasReachedMaxNestingLevel::No, TaskSource::Timer, [weakThis = WeakPtr { *this }] {
+        m_timer = eventLoop->scheduleTask(m_currentTimerInterval, context, nestingState, TaskSource::Timer, [weakThis = WeakPtr { *this }] {
             if (RefPtr protectedThis = weakThis.get())
                 protectedThis->fired();
         });
     } else {
-        m_timer = eventLoop->scheduleRepeatingTask(m_originalInterval, m_currentTimerInterval, context, m_hasReachedMaxNestingLevel ? HasReachedMaxNestingLevel::Yes : HasReachedMaxNestingLevel::No, TaskSource::Timer, [weakThis = WeakPtr { *this }] {
+        m_timer = eventLoop->scheduleRepeatingTask(m_originalInterval, m_currentTimerInterval, context, nestingState, TaskSource::Timer, [weakThis = WeakPtr { *this }] {
             if (RefPtr protectedThis = weakThis.get())
                 protectedThis->fired();
         });
@@ -322,7 +325,7 @@ void DOMTimer::fired()
     }
 #endif
 
-    DOMTimerFireState fireState(context, std::min(m_nestingLevel + 1, maxTimerNestingLevel));
+    DOMTimerFireState fireState(context, std::min(m_nestingLevel + 1, maxTimerNestingLevelForUnconditionalThrottling));
 
     if (m_userGestureTokenToForward && m_userGestureTokenToForward->hasExpired(UserGestureToken::maximumIntervalForUserGestureForwarding))
         m_userGestureTokenToForward = nullptr;
@@ -336,10 +339,12 @@ void DOMTimer::fired()
 
     // Simple case for non-one-shot timers.
     if (!m_oneShot) {
-        if (m_nestingLevel < maxTimerNestingLevel) {
+        if (m_nestingLevel < maxTimerNestingLevelForUnconditionalThrottling) {
+            auto previousNestingState = nestingStateForCurrentNestingLevel();
             m_nestingLevel++;
-            m_hasReachedMaxNestingLevel = m_nestingLevel >= maxTimerNestingLevelForRepeatingTimers;
-            context->checkedEventLoop()->setTimerHasReachedMaxNestingLevel(m_timer, m_hasReachedMaxNestingLevel);
+            auto currentNestingState = nestingStateForCurrentNestingLevel();
+            if (previousNestingState != currentNestingState)
+                context->checkedEventLoop()->setTimerNestingState(m_timer, currentNestingState);
             updateTimerIntervalIfNecessary();
         }
 
@@ -393,7 +398,7 @@ void DOMTimer::stop()
 
 void DOMTimer::updateTimerIntervalIfNecessary()
 {
-    ASSERT(m_nestingLevel <= maxTimerNestingLevel);
+    ASSERT(m_nestingLevel <= maxTimerNestingLevelForUnconditionalThrottling);
 
     if (!scriptExecutionContext())
         return;
@@ -416,12 +421,12 @@ void DOMTimer::updateTimerIntervalIfNecessary()
 Seconds DOMTimer::intervalClampedToMinimum() const
 {
     ASSERT(scriptExecutionContext());
-    ASSERT(m_nestingLevel <= maxTimerNestingLevel);
+    ASSERT(m_nestingLevel <= maxTimerNestingLevelForUnconditionalThrottling);
 
     Seconds interval = std::max(m_oneShot ? minIntervalForOneShotTimers : minIntervalForRepeatingTimers, m_originalInterval);
 
     // Only apply throttling to repeating timers.
-    if (m_nestingLevel < (m_oneShot ? maxTimerNestingLevelForOneShotTimers : maxTimerNestingLevelForRepeatingTimers))
+    if (m_nestingLevel <= (m_oneShot ? maxTimerNestingLevelForOneShotTimers : maxTimerNestingLevelForRepeatingTimers))
         return interval;
 
     // Apply two throttles - the global (per Page) minimum, and also a per-timer throttle.
@@ -431,9 +436,9 @@ Seconds DOMTimer::intervalClampedToMinimum() const
     return interval;
 }
 
-std::optional<MonotonicTime> ScriptExecutionContext::alignedFireTime(bool hasReachedMaxNestingLevel, MonotonicTime fireTime) const
+std::optional<MonotonicTime> ScriptExecutionContext::alignedFireTime(TimerNestingState nestingState, MonotonicTime fireTime) const
 {
-    Seconds alignmentInterval = domTimerAlignmentInterval(hasReachedMaxNestingLevel);
+    Seconds alignmentInterval = domTimerAlignmentInterval(nestingState);
     if (!alignmentInterval)
         return std::nullopt;
     
@@ -465,6 +470,15 @@ void DOMTimer::makeImminentlyScheduledWorkScopeIfPossible(ScriptExecutionContext
 void DOMTimer::clearImminentlyScheduledWorkScope()
 {
     m_imminentlyScheduledWorkScope = nullptr;
+}
+
+TimerNestingState DOMTimer::nestingStateForCurrentNestingLevel() const
+{
+    if (m_nestingLevel < (m_oneShot ? maxTimerNestingLevelForOneShotTimers : maxTimerNestingLevelForRepeatingTimers))
+        return TimerNestingState::Low;
+    if (m_nestingLevel < maxTimerNestingLevelForUnconditionalThrottling)
+        return TimerNestingState::SpecClamped;
+    return TimerNestingState::Maximum;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/DOMTimer.h
+++ b/Source/WebCore/page/DOMTimer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008, 2014 Apple Inc. All rights reserved.
+ * Copyright (C) 2008, 2014, 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -56,6 +56,7 @@ public:
     static Seconds defaultAlignmentInterval() { return 0_s; }
     static Seconds defaultAlignmentIntervalInLowPowerOrThermallyMitigatedMode() { return 30_ms; }
     static Seconds nonInteractedCrossOriginFrameAlignmentInterval() { return 30_ms; }
+    static Seconds maximallyNestedTimerAlignmentInterval() { return 30_ms; }
     static Seconds hiddenPageAlignmentInterval() { return 1_s; }
 
     enum class Type : bool { SingleShot, Repeating };
@@ -70,7 +71,6 @@ public:
     static void scriptDidInteractWithPlugin();
 
     EventLoopTimerHandle timer() const { return m_timer; }
-    bool hasReachedMaxNestingLevel() const { return m_hasReachedMaxNestingLevel; }
 
 private:
     DOMTimer(ScriptExecutionContext&, Function<void(ScriptExecutionContext&)>&&, Seconds interval, Type);
@@ -80,6 +80,7 @@ private:
 
     bool isDOMTimersThrottlingEnabled(const Document&) const;
     void updateThrottlingStateIfNecessary(const DOMTimerFireState&);
+    WEBCORE_EXPORT TimerNestingState nestingStateForCurrentNestingLevel() const;
 
     void fired();
 
@@ -102,7 +103,6 @@ private:
     Seconds m_originalInterval;
     TimerThrottleState m_throttleState;
     bool m_oneShot;
-    bool m_hasReachedMaxNestingLevel;
     Seconds m_currentTimerInterval;
     RefPtr<UserGestureToken> m_userGestureTokenToForward;
     RefPtr<ImminentlyScheduledWorkScope> m_imminentlyScheduledWorkScope;

--- a/Source/WebCore/platform/Timer.cpp
+++ b/Source/WebCore/platform/Timer.cpp
@@ -529,7 +529,7 @@ void TimerBase::setNextFireTime(MonotonicTime newTime)
     MonotonicTime oldTime = nextFireTime();
     // Don't realign zero-delay timers.
     if (auto* alignment = m_alignment.get(); newTime && alignment) {
-        if (auto newAlignedTime = alignment->alignedFireTime(hasReachedMaxNestingLevel(), newTime))
+        if (auto newAlignedTime = alignment->alignedFireTime(timerNestingState(), newTime))
             newTime = newAlignedTime.value();
     }
 

--- a/Source/WebCore/platform/Timer.h
+++ b/Source/WebCore/platform/Timer.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <WebCore/ThreadTimers.h>
+#include <WebCore/TimerNestingState.h>
 #include <functional>
 #include <wtf/CheckedRef.h>
 #include <wtf/CompactRefPtrTuple.h>
@@ -59,7 +60,7 @@ namespace WebCore {
 class TimerAlignment : public CanMakeWeakPtr<TimerAlignment> {
 public:
     virtual ~TimerAlignment() = default;
-    virtual std::optional<MonotonicTime> alignedFireTime(bool hasReachedMaxNestingLevel, MonotonicTime) const = 0;
+    virtual std::optional<MonotonicTime> alignedFireTime(TimerNestingState, MonotonicTime) const = 0;
 };
 
 class TimerBase {
@@ -89,8 +90,8 @@ public:
     void setTimerAlignment(TimerAlignment& alignment) { m_alignment = alignment; }
     TimerAlignment* timerAlignment() { return m_alignment.get(); }
 
-    bool hasReachedMaxNestingLevel() const { return bitfields().hasReachedMaxNestingLevel; }
-    void setHasReachedMaxNestingLevel(bool);
+    TimerNestingState timerNestingState() const { return bitfields().nestingState; }
+    void setTimerNestingState(TimerNestingState);
 
     void augmentFireInterval(Seconds delta) { setNextFireTime(m_heapItemWithBitfields.pointer()->time + delta); }
     void augmentRepeatInterval(Seconds delta) { augmentFireInterval(delta); m_repeatInterval += delta; }
@@ -101,7 +102,7 @@ public:
 
 protected:
     struct TimerBitfields {
-        uint8_t hasReachedMaxNestingLevel : 1 { false };
+        TimerNestingState nestingState : 2 { TimerNestingState::Low };
         uint8_t shouldRestartWhenTimerFires : 1 { false }; // DeferrableOneShotTimer
     };
 
@@ -228,10 +229,10 @@ inline bool TimerBase::isActive() const
     return static_cast<bool>(nextFireTime());
 }
 
-inline void TimerBase::setHasReachedMaxNestingLevel(bool value)
+inline void TimerBase::setTimerNestingState(TimerNestingState nestingState)
 {
     auto values = bitfields();
-    values.hasReachedMaxNestingLevel = value;
+    values.nestingState = nestingState;
     setBitfields(values);
 }
 

--- a/Source/WebCore/platform/TimerNestingState.h
+++ b/Source/WebCore/platform/TimerNestingState.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#pragma once
+
+namespace WebCore {
+// https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#timers:timer-nesting-level
+// We deviate from the spec and have a third state "Maximum" where we will unconditionally throttle.
+enum class TimerNestingState : uint8_t {
+    Low,
+    SpecClamped,
+    Maximum
+};
+}

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -1575,7 +1575,16 @@ ExceptionOr<bool> Internals::isTimerThrottled(int timeoutId)
     if (timer->intervalClampedToMinimum() > timer->m_originalInterval)
         return true;
 
-    return !!scriptExecutionContext()->alignedFireTime(timer->hasReachedMaxNestingLevel(), MonotonicTime { });
+    return !!scriptExecutionContext()->alignedFireTime(timer->nestingStateForCurrentNestingLevel(), MonotonicTime { });
+}
+
+ExceptionOr<bool> Internals::isTimerClamped(int timeoutId)
+{
+    auto* timer = scriptExecutionContext()->findTimeout(timeoutId);
+    if (!timer)
+        return Exception { ExceptionCode::NotFoundError };
+
+    return timer->intervalClampedToMinimum() > timer->m_originalInterval;
 }
 
 String Internals::requestAnimationFrameThrottlingReasons() const

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -295,6 +295,7 @@ public:
 
     // DOMTimers throttling testing.
     ExceptionOr<bool> isTimerThrottled(int timeoutId);
+    ExceptionOr<bool> isTimerClamped(int timeoutId);
     String requestAnimationFrameThrottlingReasons() const;
     double requestAnimationFrameInterval() const;
     bool scriptedAnimationsAreSuspended() const;

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -914,6 +914,7 @@ enum ContentsFormat {
 
     // Query if a timer is currently throttled, to debug timer throttling.
     boolean isTimerThrottled(long timerHandle);
+    boolean isTimerClamped(long timerHandle);
 
     DOMString requestAnimationFrameThrottlingReasons();
     boolean areTimersThrottled();


### PR DESCRIPTION
#### 4c2908b0d72ab7a5da8b2323dad1df5455636996
<pre>
Throttle foreground timers that have exceeded the maximum nesting level
<a href="https://bugs.webkit.org/show_bug.cgi?id=299229">https://bugs.webkit.org/show_bug.cgi?id=299229</a>
<a href="https://rdar.apple.com/160531755">rdar://160531755</a>

Reviewed by NOBODY (OOPS!).

WIP draft. Right now I&apos;m throttling timers to 30ms alignments once they&apos;ve exceeded the spec max nesting level of 5.

Probably need to think more carefully about how to move from a clamped to heavily throttled state. The intent is to
use less power and be resilient to abandoned timers.

Explanation of why this fixes the bug (OOPS!).

Test: fast/dom/repeating-timer-visible-element-clamped.html

Test: fast/dom/repeating-timer-visible-element-clamped.html
* LayoutTests/fast/dom/repeating-timer-visible-element-clamped-expected.txt: Added.
* LayoutTests/fast/dom/repeating-timer-visible-element-clamped.html: Added.
* LayoutTests/fast/dom/repeating-timer-visible-element-throttling-expected.txt:
* LayoutTests/fast/dom/repeating-timer-visible-element-throttling.html:
* LayoutTests/fast/dom/timer-throttling-aggressiveThermalMitigation-expected.txt:
* LayoutTests/fast/dom/timer-throttling-aggressiveThermalMitigation.html:
* LayoutTests/fast/dom/timer-throttling-lowPowerMode-expected.txt:
* LayoutTests/fast/dom/timer-throttling-lowPowerMode.html:
* Source/WebCore/Headers.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::domTimerAlignmentInterval const):
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/EventLoop.cpp:
(WebCore::EventLoop::scheduleTask):
(WebCore::EventLoop::scheduleRepeatingTask):
(WebCore::EventLoopTaskGroup::scheduleTask):
(WebCore::EventLoopTaskGroup::scheduleRepeatingTask):
(WebCore::EventLoopTaskGroup::setTimerNestingState):
(WebCore::EventLoopTaskGroup::setTimerHasReachedMaxNestingLevel): Deleted.
* Source/WebCore/dom/EventLoop.h:
* Source/WebCore/dom/ScriptExecutionContext.cpp:
(WebCore::ScriptExecutionContext::domTimerAlignmentInterval const):
* Source/WebCore/dom/ScriptExecutionContext.h:
* Source/WebCore/page/DOMTimer.cpp:
(WebCore::DOMTimer::DOMTimer):
(WebCore::DOMTimer::fired):
(WebCore::DOMTimer::updateTimerIntervalIfNecessary):
(WebCore::DOMTimer::intervalClampedToMinimum const):
(WebCore::ScriptExecutionContext::alignedFireTime const):
(WebCore::DOMTimer::nestingStateForCurrentNestingLevel const):
* Source/WebCore/page/DOMTimer.h:
* Source/WebCore/platform/Timer.cpp:
(WebCore::TimerBase::setNextFireTime):
* Source/WebCore/platform/Timer.h:
(WebCore::TimerBase::timerNestingState const):
(WebCore::TimerBase::setTimerNestingState):
(WebCore::TimerBase::hasReachedMaxNestingLevel const): Deleted.
(WebCore::TimerBase::setHasReachedMaxNestingLevel): Deleted.
* Source/WebCore/platform/TimerNestingState.h: Added.
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::isTimerThrottled):
(WebCore::Internals::isTimerClamped):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4c2908b0d72ab7a5da8b2323dad1df5455636996

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122096 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41799 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32468 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128663 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74190 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a8958382-0ef8-4d5f-9575-196d91fcd412) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123972 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42513 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50392 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92804 "Found 4 new test failures: fast/dom/repeating-timer-visible-element-throttling.html fast/dom/timer-increase-min-interval.html fast/events/dispatch-message-string-data.html webgl/2.0.y/conformance2/query/occlusion-query-scissor.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61687 "Found 2 new test failures: fast/dom/repeating-timer-visible-element-throttling.html fast/dom/timer-increase-min-interval.html (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7304a20c-089c-4de8-80b2-729e03c8e5c1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125048 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33908 "Found 2 new test failures: fast/dom/repeating-timer-visible-element-throttling.html fast/images/page-wide-animation-toggle.html (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109337 "Found 1 new API test failure: TestWebKitAPI.WebKit.WebAudioAndGetUserMedia (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73459 "Found 2 new API test failures: TestWTF:WTF_Condition.OneProducerOneConsumerOneSlotTimeout, TestWTF:WTF_Condition.OneProducerOneConsumerOneSlot (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/af47740e-7ce0-499e-a60c-b25cfe7dac5b) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32922 "Exiting early after 10 failures. 38 tests run. 1 failures") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27503 "Found 3 new test failures: fast/dom/repeating-timer-visible-element-throttling.html fast/dom/timer-increase-min-interval.html imported/w3c/web-platform-tests/uievents/mouse/mouse_boundary_events_after_reappending_last_over_target.tentative.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72155 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103415 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27694 "Found 3 new test failures: fast/dom/repeating-timer-visible-element-throttling.html fast/dom/timer-increase-min-interval.html fast/images/mac/play-pause-individual-animation-context-menu-items.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131420 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49035 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37299 "Found 2 new test failures: fast/dom/repeating-timer-visible-element-throttling.html fast/dom/timer-increase-min-interval.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101369 "Found 4 new test failures: fast/dom/repeating-timer-visible-element-throttling.html fast/dom/timer-increase-min-interval.html fast/events/dispatch-message-string-data.html webgl/2.0.y/conformance2/query/occlusion-query-scissor.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49409 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105551 "Exiting early after 10 failures. 48 tests run. 1 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101239 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46606 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24721 "Found 3 new test failures: fast/dom/repeating-timer-visible-element-throttling.html fast/dom/timer-increase-min-interval.html imported/w3c/web-platform-tests/uievents/mouse/mouse_boundary_events_after_reappending_last_over_target.tentative.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45777 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48892 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54626 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48362 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51712 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50042 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->