### PR TITLE
Remove static analyzer suppressions for rdar://160322553

### DIFF
--- a/Source/WebCore/Modules/mediasource/MediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSource.cpp
@@ -1652,10 +1652,10 @@ void MediaSource::addTextTrackToElement(Ref<TextTrack>&& track)
 
 void MediaSource::addVideoTrackToElement(Ref<VideoTrack>&& track)
 {
-    ensureWeakOnHTMLMediaElementContext([track = WTFMove(track)](auto& mediaElement) mutable {
+    ensureWeakOnHTMLMediaElementContext([track = WTFMove(track)](HTMLMediaElement& mediaElement) mutable {
         // Select the first video track being added and unselect the next ones, since only one
         // video track can be selected at once.
-        auto videoTracks = mediaElement.videoTracks();
+        RefPtr videoTracks = mediaElement.videoTracks();
         track->setSelected(!(videoTracks && videoTracks->length()));
         mediaElement.addVideoTrack(WTFMove(track));
     });
@@ -1663,9 +1663,8 @@ void MediaSource::addVideoTrackToElement(Ref<VideoTrack>&& track)
 
 void MediaSource::addAudioTrackMirrorToElement(Ref<AudioTrackPrivate>&& track, bool enabled)
 {
-    ensureWeakOnHTMLMediaElementContext([track = WTFMove(track), enabled](auto& mediaElement) mutable {
-        // FIXME: This is a safer cpp false positive (rdar://160322553).
-        SUPPRESS_UNCOUNTED_ARG auto audioTrack = AudioTrack::create(mediaElement.protectedScriptExecutionContext().get(), track);
+    ensureWeakOnHTMLMediaElementContext([track = WTFMove(track), enabled](HTMLMediaElement& mediaElement) mutable {
+        Ref audioTrack = AudioTrack::create(mediaElement.protectedScriptExecutionContext().get(), track);
         audioTrack->setEnabled(enabled);
         mediaElement.addAudioTrack(WTFMove(audioTrack));
     });
@@ -1673,19 +1672,17 @@ void MediaSource::addAudioTrackMirrorToElement(Ref<AudioTrackPrivate>&& track, b
 
 void MediaSource::addTextTrackMirrorToElement(Ref<InbandTextTrackPrivate>&& track)
 {
-    ensureWeakOnHTMLMediaElementContext([track = WTFMove(track)](auto& mediaElement) mutable {
+    ensureWeakOnHTMLMediaElementContext([track = WTFMove(track)](HTMLMediaElement& mediaElement) mutable {
         if (!mediaElement.scriptExecutionContext())
             return;
-        // FIXME: This is a safer cpp false positive (rdar://160322553).
-        SUPPRESS_UNCOUNTED_ARG mediaElement.addTextTrack(InbandTextTrack::create(*mediaElement.protectedScriptExecutionContext(), track));
+        mediaElement.addTextTrack(InbandTextTrack::create(*mediaElement.protectedScriptExecutionContext(), track));
     });
 }
 
 void MediaSource::addVideoTrackMirrorToElement(Ref<VideoTrackPrivate>&& track, bool selected)
 {
-    ensureWeakOnHTMLMediaElementContext([track = WTFMove(track), selected](auto& mediaElement) mutable {
-        // FIXME: This is a safer cpp false positive (rdar://160322553).
-        SUPPRESS_UNCOUNTED_ARG auto videoTrack = VideoTrack::create(mediaElement.protectedScriptExecutionContext().get(), track);
+    ensureWeakOnHTMLMediaElementContext([track = WTFMove(track), selected](HTMLMediaElement& mediaElement) mutable {
+        auto videoTrack = VideoTrack::create(mediaElement.protectedScriptExecutionContext().get(), track);
         videoTrack->setSelected(selected);
         mediaElement.addVideoTrack(WTFMove(videoTrack));
     });

--- a/Source/WebCore/workers/service/ServiceWorkerContainer.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerContainer.cpp
@@ -143,12 +143,11 @@ auto ServiceWorkerContainer::ready() -> ReadyPromise&
 
         Ref context = *scriptExecutionContext();
         ensureSWClientConnection().whenRegistrationReady(context->topOrigin().data(), context->url(), [this, protectedThis = Ref { *this }](ServiceWorkerRegistrationData&& registrationData) mutable {
-            queueTaskKeepingObjectAlive(*this, TaskSource::DOMManipulation, [registrationData = WTFMove(registrationData)](auto& container) mutable {
+            queueTaskKeepingObjectAlive(*this, TaskSource::DOMManipulation, [registrationData = WTFMove(registrationData)](ServiceWorkerContainer& container) mutable {
                 RefPtr context = container.scriptExecutionContext();
                 if (!context || !container.m_readyPromise)
                     return;
-                // FIXME: This is a safer cpp false positive (rdar://160322553).
-                SUPPRESS_UNCOUNTED_ARG Ref registration = ServiceWorkerRegistration::getOrCreate(*context, container, WTFMove(registrationData));
+                Ref registration = ServiceWorkerRegistration::getOrCreate(*context, container, WTFMove(registrationData));
                 container.m_readyPromise->resolve(WTFMove(registration));
             });
         });
@@ -332,13 +331,12 @@ void ServiceWorkerContainer::getRegistration(const String& clientURL, Ref<Deferr
     }
 
     ensureSWClientConnection().matchRegistration(SecurityOriginData { context->topOrigin().data() }, parsedURL, [this, protectedThis = Ref { *this }, promise = WTFMove(promise)](std::optional<ServiceWorkerRegistrationData>&& result) mutable {
-        queueTaskKeepingObjectAlive(*this, TaskSource::DOMManipulation, [promise = WTFMove(promise), result = WTFMove(result)](auto& container) mutable {
+        queueTaskKeepingObjectAlive(*this, TaskSource::DOMManipulation, [promise = WTFMove(promise), result = WTFMove(result)](ServiceWorkerContainer& container) mutable {
             if (!result) {
                 promise->resolve();
                 return;
             }
-            // FIXME: This is a safer cpp false positive (rdar://160322553).
-            SUPPRESS_UNCOUNTED_ARG promise->resolve<IDLInterface<ServiceWorkerRegistration>>(ServiceWorkerRegistration::getOrCreate(*container.protectedScriptExecutionContext(), container, WTFMove(result.value())));
+            promise->resolve<IDLInterface<ServiceWorkerRegistration>>(ServiceWorkerRegistration::getOrCreate(*container.protectedScriptExecutionContext(), container, WTFMove(result.value())));
         });
     });
 }
@@ -348,12 +346,10 @@ void ServiceWorkerContainer::updateRegistrationState(ServiceWorkerRegistrationId
     if (m_isStopped)
         return;
 
-    queueTaskKeepingObjectAlive(*this, TaskSource::DOMManipulation, [identifier, state, serviceWorkerData = std::optional<ServiceWorkerData> { serviceWorkerData }](auto& container) mutable {
+    queueTaskKeepingObjectAlive(*this, TaskSource::DOMManipulation, [identifier, state, serviceWorkerData = std::optional<ServiceWorkerData> { serviceWorkerData }](ServiceWorkerContainer& container) mutable {
         RefPtr<ServiceWorker> serviceWorker;
-        if (serviceWorkerData) {
-            // FIXME: This is a safer cpp false positive (rdar://160322553).
-            SUPPRESS_UNCOUNTED_ARG serviceWorker = ServiceWorker::getOrCreate(*container.protectedScriptExecutionContext(), WTFMove(*serviceWorkerData));
-        }
+        if (serviceWorkerData)
+            serviceWorker = ServiceWorker::getOrCreate(*container.protectedScriptExecutionContext(), WTFMove(*serviceWorkerData));
 
         if (RefPtr registration = container.m_registrations.get(identifier))
             registration->updateStateFromServer(state, WTFMove(serviceWorker));
@@ -380,10 +376,9 @@ void ServiceWorkerContainer::getRegistrations(Ref<DeferredPromise>&& promise)
 
     Ref context = *scriptExecutionContext();
     ensureSWClientConnection().getRegistrations(SecurityOriginData { context->topOrigin().data() }, context->url(), [this, protectedThis = Ref { *this }, promise = WTFMove(promise)] (Vector<ServiceWorkerRegistrationData>&& registrationDatas) mutable {
-        queueTaskKeepingObjectAlive(*this, TaskSource::DOMManipulation, [promise = WTFMove(promise), registrationDatas = WTFMove(registrationDatas)](auto& container) mutable {
+        queueTaskKeepingObjectAlive(*this, TaskSource::DOMManipulation, [promise = WTFMove(promise), registrationDatas = WTFMove(registrationDatas)](ServiceWorkerContainer& container) mutable {
             auto registrations = WTF::map(WTFMove(registrationDatas), [&](auto&& registrationData) {
-                // FIXME: This is a safer cpp false positive (rdar://160322553).
-                SUPPRESS_UNCOUNTED_ARG return ServiceWorkerRegistration::getOrCreate(*container.protectedScriptExecutionContext(), container, WTFMove(registrationData));
+                return ServiceWorkerRegistration::getOrCreate(*container.protectedScriptExecutionContext(), container, WTFMove(registrationData));
             });
             promise->resolve<IDLSequence<IDLInterface<ServiceWorkerRegistration>>>(WTFMove(registrations));
         });
@@ -466,11 +461,10 @@ void ServiceWorkerContainer::jobResolvedWithRegistration(ServiceWorkerJob& job, 
     if (!promise)
         return;
 
-    queueTaskKeepingObjectAlive(*this, TaskSource::DOMManipulation, [promise = WTFMove(promise), jobIdentifier = job.identifier(), data = WTFMove(data), shouldNotifyWhenResolved, notifyIfExitEarly = WTFMove(notifyIfExitEarly)](auto& container) mutable {
+    queueTaskKeepingObjectAlive(*this, TaskSource::DOMManipulation, [promise = WTFMove(promise), jobIdentifier = job.identifier(), data = WTFMove(data), shouldNotifyWhenResolved, notifyIfExitEarly = WTFMove(notifyIfExitEarly)](ServiceWorkerContainer& container) mutable {
         notifyIfExitEarly.release();
 
-        // FIXME: This is a safer cpp false positive (rdar://160322553).
-        SUPPRESS_UNCOUNTED_ARG Ref registration = ServiceWorkerRegistration::getOrCreate(*container.protectedScriptExecutionContext(), container, WTFMove(data));
+        Ref registration = ServiceWorkerRegistration::getOrCreate(*container.protectedScriptExecutionContext(), container, WTFMove(data));
 
         CONTAINER_RELEASE_LOG_WITH_THIS(&container, "jobResolvedWithRegistration: Resolving promise for job %" PRIu64 ". registrationID=%" PRIu64, jobIdentifier.toUInt64(), registration->identifier().toUInt64());
 


### PR DESCRIPTION
#### 3776143db910e5b5646bf7c931adb1fd042bcc3c
<pre>
Remove static analyzer suppressions for <a href="https://rdar.apple.com/160322553">rdar://160322553</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=299234">https://bugs.webkit.org/show_bug.cgi?id=299234</a>

Reviewed by Chris Dumez.

These false positives were caused by the use of `auto` in lambda arguments.
Removed the suppression by explicitly declaring the type in each lambda.

No new tests since there should be no behavioral change.

* Source/WebCore/Modules/mediasource/MediaSource.cpp:
(WebCore::MediaSource::addVideoTrackToElement):
(WebCore::MediaSource::addAudioTrackMirrorToElement):
(WebCore::MediaSource::addTextTrackMirrorToElement):
(WebCore::MediaSource::addVideoTrackMirrorToElement):
* Source/WebCore/workers/service/ServiceWorkerContainer.cpp:
(WebCore::ServiceWorkerContainer::ready):
(WebCore::ServiceWorkerContainer::getRegistration):
(WebCore::ServiceWorkerContainer::updateRegistrationState):
(WebCore::ServiceWorkerContainer::getRegistrations):
(WebCore::ServiceWorkerContainer::jobResolvedWithRegistration):

Canonical link: <a href="https://commits.webkit.org/300287@main">https://commits.webkit.org/300287@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/28e5c66d4be547fe140a937a18cc596442d003f5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122034 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41736 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32406 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128597 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74127 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/381e5937-a608-40fc-b8b2-793e698af597) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123910 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42451 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50330 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92752 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61632 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/37580472-39bb-4287-a3d0-cadbf288adb4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124986 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33850 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109281 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73409 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d35278e2-3146-4fdd-8f67-40428a9e301f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32863 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27447 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72091 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103357 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27638 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131358 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48973 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37242 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101311 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49347 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105495 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101182 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46550 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24665 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45687 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19307 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48830 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54564 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48300 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51650 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49980 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->