### PR TITLE
Remove static analyzer suppressions for rdar://160083438

### DIFF
--- a/Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/BarcodeDetectorImplementation.mm
+++ b/Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/BarcodeDetectorImplementation.mm
@@ -152,8 +152,7 @@ static RetainPtr<VNDetectBarcodesRequest> request()
     // configured the same way. This function is intended to make sure both VNDetectBarcodesRequests are
     // configured accordingly.
 
-    // FIXME: This is a safer cpp false positive (rdar://160083438).
-    SUPPRESS_UNRETAINED_ARG auto result = adoptNS([PAL::allocVNDetectBarcodesRequestInstance() init]);
+    RetainPtr result = adoptNS([PAL::allocVNDetectBarcodesRequestInstance() init]);
     configureRequestToUseCPUOrGPU(result.get());
     return result;
 }
@@ -199,8 +198,7 @@ void BarcodeDetectorImpl::detect(Ref<ImageBuffer>&& imageBuffer, CompletionHandl
         request.get().symbologies = requestedSymbologies.allObjects;
     }
 
-    // FIXME: This is a safer cpp false positive (rdar://160083438).
-    SUPPRESS_UNRETAINED_ARG auto imageRequestHandler = adoptNS([PAL::allocVNImageRequestHandlerInstance() initWithCGImage:platformImage.get() options:@{ }]);
+    RetainPtr imageRequestHandler = adoptNS([PAL::allocVNImageRequestHandlerInstance() initWithCGImage:platformImage.get() options:@{ }]);
 
     NSError *error = nil;
     auto result = [imageRequestHandler performRequests:@[request.get()] error:&error];

--- a/Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/FaceDetectorImplementation.mm
+++ b/Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/FaceDetectorImplementation.mm
@@ -87,12 +87,10 @@ void FaceDetectorImpl::detect(Ref<ImageBuffer>&& imageBuffer, CompletionHandler<
         return;
     }
 
-    // FIXME: This is a safer cpp false positive (rdar://160083438).
-    SUPPRESS_UNRETAINED_ARG auto request = adoptNS([PAL::allocVNDetectFaceLandmarksRequestInstance() init]);
+    RetainPtr request = adoptNS([PAL::allocVNDetectFaceLandmarksRequestInstance() init]);
     configureRequestToUseCPUOrGPU(request.get());
 
-    // FIXME: This is a safer cpp false positive (rdar://160083438).
-    SUPPRESS_UNRETAINED_ARG auto imageRequestHandler = adoptNS([PAL::allocVNImageRequestHandlerInstance() initWithCGImage:platformImage.get() options:@{ }]);
+    RetainPtr imageRequestHandler = adoptNS([PAL::allocVNImageRequestHandlerInstance() initWithCGImage:platformImage.get() options:@{ }]);
 
     NSError *error = nil;
     auto result = [imageRequestHandler performRequests:@[request.get()] error:&error];

--- a/Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/TextDetectorImplementation.mm
+++ b/Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/TextDetectorImplementation.mm
@@ -57,12 +57,10 @@ void TextDetectorImpl::detect(Ref<ImageBuffer>&& imageBuffer, CompletionHandler<
         return;
     }
 
-    // FIXME: This is a safer cpp false positive (rdar://160083438).
-    SUPPRESS_UNRETAINED_ARG auto request = adoptNS([PAL::allocVNRecognizeTextRequestInstance() init]);
+    RetainPtr request = adoptNS([PAL::allocVNRecognizeTextRequestInstance() init]);
     configureRequestToUseCPUOrGPU(request.get());
 
-    // FIXME: This is a safer cpp false positive (rdar://160083438).
-    SUPPRESS_UNRETAINED_ARG auto imageRequestHandler = adoptNS([PAL::allocVNImageRequestHandlerInstance() initWithCGImage:platformImage.get() options:@{ }]);
+    RetainPtr imageRequestHandler = adoptNS([PAL::allocVNImageRequestHandlerInstance() initWithCGImage:platformImage.get() options:@{ }]);
 
     NSError *error = nil;
     auto result = [imageRequestHandler performRequests:@[request.get()] error:&error];

--- a/Source/WebCore/Modules/applepay/PaymentInstallmentConfiguration.mm
+++ b/Source/WebCore/Modules/applepay/PaymentInstallmentConfiguration.mm
@@ -185,8 +185,7 @@ static RetainPtr<PKPaymentInstallmentConfiguration> createPlatformConfiguration(
     if (!PAL::getPKPaymentInstallmentConfigurationClassSingleton())
         return nil;
 
-    // FIXME: This is a safer cpp false positive (rdar://160083438).
-    SUPPRESS_UNRETAINED_ARG auto configuration = adoptNS([PAL::allocPKPaymentInstallmentConfigurationInstance() init]);
+    RetainPtr configuration = adoptNS([PAL::allocPKPaymentInstallmentConfigurationInstance() init]);
 
     [configuration setFeature:platformFeatureType(coreConfiguration.featureType)];
 
@@ -195,7 +194,7 @@ static RetainPtr<PKPaymentInstallmentConfiguration> createPlatformConfiguration(
     [configuration setInStorePurchase:coreConfiguration.isInStorePurchase];
     [configuration setOpenToBuyThresholdAmount:toProtectedDecimalNumber(coreConfiguration.openToBuyThresholdAmount).get()];
 
-    auto merchandisingImageData = adoptNS([[NSData alloc] initWithBase64EncodedString:coreConfiguration.merchandisingImageData.createNSString().get() options:0]);
+    RetainPtr merchandisingImageData = adoptNS([[NSData alloc] initWithBase64EncodedString:coreConfiguration.merchandisingImageData.createNSString().get() options:0]);
     [configuration setMerchandisingImageData:merchandisingImageData.get()];
     [configuration setInstallmentMerchantIdentifier:coreConfiguration.merchantIdentifier.createNSString().get()];
     [configuration setReferrerIdentifier:coreConfiguration.referrerIdentifier.createNSString().get()];

--- a/Source/WebCore/Modules/applepay/cocoa/PaymentContactCocoa.mm
+++ b/Source/WebCore/Modules/applepay/cocoa/PaymentContactCocoa.mm
@@ -42,8 +42,7 @@ namespace WebCore {
 
 static RetainPtr<PKContact> convert(unsigned version, const ApplePayPaymentContact& contact)
 {
-    // FIXME: This is a safer cpp false positive (rdar://160083438).
-    SUPPRESS_UNRETAINED_ARG auto result = adoptNS([PAL::allocPKContactInstance() init]);
+    RetainPtr result = adoptNS([PAL::allocPKContactInstance() init]);
 
     RetainPtr<NSString> familyName;
     RetainPtr<NSString> phoneticFamilyName;
@@ -77,14 +76,11 @@ static RetainPtr<PKContact> convert(unsigned version, const ApplePayPaymentConta
     if (!contact.emailAddress.isEmpty())
         [result setEmailAddress:contact.emailAddress.createNSString().get()];
 
-    if (!contact.phoneNumber.isEmpty()) {
-        // FIXME: This is a safer cpp false positive (rdar://160083438).
-        SUPPRESS_UNRETAINED_ARG [result setPhoneNumber:adoptNS([allocCNPhoneNumberInstance() initWithStringValue:contact.phoneNumber.createNSString().get()]).get()];
-    }
+    if (!contact.phoneNumber.isEmpty())
+        [result setPhoneNumber:adoptNS([allocCNPhoneNumberInstance() initWithStringValue:contact.phoneNumber.createNSString().get()]).get()];
 
     if (contact.addressLines && !contact.addressLines->isEmpty()) {
-        // FIXME: This is a safer cpp false positive (rdar://160083438).
-        SUPPRESS_UNRETAINED_ARG auto address = adoptNS([allocCNMutablePostalAddressInstance() init]);
+        RetainPtr address = adoptNS([allocCNMutablePostalAddressInstance() init]);
 
         StringBuilder builder;
         for (unsigned i = 0; i < contact.addressLines->size(); ++i) {

--- a/Source/WebCore/Modules/applepay/cocoa/PaymentMerchantSessionCocoa.mm
+++ b/Source/WebCore/Modules/applepay/cocoa/PaymentMerchantSessionCocoa.mm
@@ -47,8 +47,7 @@ std::optional<PaymentMerchantSession> PaymentMerchantSession::fromJS(JSC::JSGlob
     if (!dictionary || ![dictionary isKindOfClass:[NSDictionary class]])
         return std::nullopt;
 
-    // FIXME: This is a safer cpp false positive (rdar://160083438).
-    SUPPRESS_UNRETAINED_ARG RetainPtr pkPaymentMerchantSession = adoptNS([PAL::allocPKPaymentMerchantSessionInstance() initWithDictionary:dictionary.get()]);
+    RetainPtr pkPaymentMerchantSession = adoptNS([PAL::allocPKPaymentMerchantSessionInstance() initWithDictionary:dictionary.get()]);
 
     return PaymentMerchantSession(WTFMove(pkPaymentMerchantSession));
 }


### PR DESCRIPTION
#### 20a67822b65337b65625a774459f6e6c9d62a024
<pre>
Remove static analyzer suppressions for <a href="https://rdar.apple.com/160083438">rdar://160083438</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=299235">https://bugs.webkit.org/show_bug.cgi?id=299235</a>

Reviewed by Abrar Rahman Protyasha.

Remove the suppressions for <a href="https://rdar.apple.com/160083438">rdar://160083438</a> since the issue seems to have resolved itself.

No new tests since there should be no behavioral change.

* Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/BarcodeDetectorImplementation.mm:
(WebCore::ShapeDetection::request):
(WebCore::ShapeDetection::BarcodeDetectorImpl::detect):
* Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/FaceDetectorImplementation.mm:
(WebCore::ShapeDetection::FaceDetectorImpl::detect):
* Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/TextDetectorImplementation.mm:
(WebCore::ShapeDetection::TextDetectorImpl::detect):
* Source/WebCore/Modules/applepay/PaymentInstallmentConfiguration.mm:
(WebCore::createPlatformConfiguration):
* Source/WebCore/Modules/applepay/cocoa/PaymentContactCocoa.mm:
(WebCore::convert):
* Source/WebCore/Modules/applepay/cocoa/PaymentMerchantSessionCocoa.mm:
(WebCore::PaymentMerchantSession::fromJS):

Canonical link: <a href="https://commits.webkit.org/300285@main">https://commits.webkit.org/300285@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/281a16a26e439e553143804fedb71cb9bcd98881

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122035 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41737 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32407 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128598 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74128 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/93986830-cabf-4518-9d0e-b1555beade58) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123911 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42452 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50331 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92753 "5 flakes 16 failures") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/61634 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a18bdb38-1ef3-453d-bcc6-5dc28af4ecff) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124987 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33851 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109283 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73410 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7e45ef40-7477-4d80-8ee2-a183dc585bfd) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32864 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27449 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72092 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103358 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27640 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131359 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48974 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37243 "Found 1 new test failure: compositing/visible-rect/iframe-and-layers.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101312 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49348 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105497 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101183 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46549 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24667 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45688 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19306 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48831 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54565 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48301 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51651 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49981 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->