### PR TITLE
Remove static analyzer suppressions for rdar://160265318

### DIFF
--- a/Source/WebCore/Modules/reporting/ReportingObserver.cpp
+++ b/Source/WebCore/Modules/reporting/ReportingObserver.cpp
@@ -138,7 +138,7 @@ void ReportingObserver::appendQueuedReportIfCorrectType(const Ref<Report>& repor
     ASSERT(m_reportingScope && scriptExecutionContext() == m_reportingScope->scriptExecutionContext());
 
     // Step 4.3.4: Queue a task to § 4.4
-    queueTaskKeepingObjectAlive(*this, TaskSource::Reporting, [protectedCallback = Ref { m_callback }](auto& observer) {
+    queueTaskKeepingObjectAlive(*this, TaskSource::Reporting, [protectedCallback = Ref { m_callback }](ReportingObserver& observer) {
         RefPtr context = observer.scriptExecutionContext();
         ASSERT(context);
         if (!context)
@@ -147,13 +147,11 @@ void ReportingObserver::appendQueuedReportIfCorrectType(const Ref<Report>& repor
         // Step 4.4: Invoke reporting observers with notify list with a copy of global’s registered reporting observer list.
         auto reports = observer.takeRecords();
 
-        // FIXME: This is a safer cpp false positive (rdar://160265318).
-        SUPPRESS_UNCOUNTED_ARG InspectorInstrumentation::willFireObserverCallback(*context, "ReportingObserver"_s);
+        InspectorInstrumentation::willFireObserverCallback(*context, "ReportingObserver"_s);
 
         protectedCallback->invoke(reports, observer);
 
-        // FIXME: This is a safer cpp false positive (rdar://160265318).
-        SUPPRESS_UNCOUNTED_ARG InspectorInstrumentation::didFireObserverCallback(*context);
+        InspectorInstrumentation::didFireObserverCallback(*context);
     });
 }
 


### PR DESCRIPTION
#### afe441837c2e1228438bda847dfc6ba93850c68a
<pre>
Remove static analyzer suppressions for <a href="https://rdar.apple.com/160265318">rdar://160265318</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=299236">https://bugs.webkit.org/show_bug.cgi?id=299236</a>

Reviewed by Wenson Hsieh.

Remove the static analyzer suppressions for <a href="https://rdar.apple.com/160265318">rdar://160265318</a>
by explicitly declaring the argument type of the lambda.

No new tests since there should be no behavioral change.

* Source/WebCore/Modules/reporting/ReportingObserver.cpp:
(WebCore::ReportingObserver::appendQueuedReportIfCorrectType):

Canonical link: <a href="https://commits.webkit.org/300288@main">https://commits.webkit.org/300288@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9f6cc071aeafeb40e70c98eb95178263a45dda33

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122001 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41703 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32373 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128561 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74094 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/52abceff-9b51-4365-91da-1679ba5ef03b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123877 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42418 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50297 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92720 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61602 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f00a51bf-aec2-41fa-8f81-6558e8d281aa) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124953 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33821 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109254 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73374 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f4935bc9-000f-4e59-83a7-81cda6c18f44) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32833 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27415 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72058 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103328 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27611 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131325 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48940 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37213 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101278 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49314 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105468 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101149 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46520 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24638 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45641 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19308 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48797 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54531 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48267 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51617 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49947 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->