### PR TITLE
[Length Deprecation] Replace use of LengthPoint in Style::OffsetPosition and Style::OffsetAnchor

### DIFF
--- a/Source/WebCore/style/values/motion/StyleOffsetPosition.h
+++ b/Source/WebCore/style/values/motion/StyleOffsetPosition.h
@@ -29,27 +29,22 @@
 #include <WebCore/StyleValueTypes.h>
 
 namespace WebCore {
-
-class CSSValue;
-class RenderStyle;
-
 namespace Style {
-
-class BuilderState;
 
 // <'offset-position'> = auto | normal | <position>
 // https://drafts.fxtf.org/motion/#propdef-offset-position
 struct OffsetPosition {
-    OffsetPosition(CSS::Keyword::Auto) : value { WebCore::LengthType::Auto, WebCore::LengthType::Auto } { }
-    OffsetPosition(CSS::Keyword::Normal) : value { WebCore::LengthType::Normal, WebCore::LengthType::Normal } { }
-    OffsetPosition(Position&& position) : value { toPlatform(position) } { }
-    OffsetPosition(const Position& position) : value { toPlatform(position) } { }
-    explicit OffsetPosition(WebCore::LengthPoint&& point) : value { WTFMove(point) } { RELEASE_ASSERT(isValid(value)); }
-    explicit OffsetPosition(const WebCore::LengthPoint& point) : value { point } { RELEASE_ASSERT(isValid(value)); }
+    OffsetPosition(CSS::Keyword::Auto keyword) : m_value { keyword} { }
+    OffsetPosition(CSS::Keyword::Normal keyword) : m_value { keyword} { }
+    OffsetPosition(Position&& position) : m_value { WTFMove(position) } { }
+    OffsetPosition(const Position& position) : m_value { position } { }
+    explicit OffsetPosition(WebCore::LengthPoint&& point) : m_value { convert(point) } { }
+    explicit OffsetPosition(const WebCore::LengthPoint& point) : m_value { convert(point) } { }
 
-    ALWAYS_INLINE bool isAuto() const { return value.x.isAuto(); }
-    ALWAYS_INLINE bool isNormal() const { return value.x.isNormal(); }
-    ALWAYS_INLINE bool isPosition() const { return value.x.isSpecified(); }
+    ALWAYS_INLINE bool isAuto() const { return holdsAlternative<CSS::Keyword::Auto>(); }
+    ALWAYS_INLINE bool isNormal() const { return holdsAlternative<CSS::Keyword::Auto>(); }
+    ALWAYS_INLINE bool isPosition() const { return holdsAlternative<Position>(); }
+    std::optional<Position> tryPosition() const { return isPosition() ? std::make_optional(std::get<Position>(m_value)) : std::nullopt; }
 
     template<typename> bool holdsAlternative() const;
     template<typename... F> decltype(auto) switchOn(F&&...) const;
@@ -57,35 +52,31 @@ struct OffsetPosition {
     bool operator==(const OffsetPosition&) const = default;
 
 private:
-    friend struct Blending<OffsetPosition>;
-    friend struct ToPlatform<OffsetPosition>;
-
-    static bool isValid(const WebCore::LengthPoint& point)
+    static auto convert(const WebCore::LengthPoint& point) -> Variant<CSS::Keyword::Auto, CSS::Keyword::Normal, Position>
     {
-        return (point.x.isAuto() && point.y.isAuto())
-            || (point.x.isNormal() && point.y.isNormal())
-            || (point.x.isSpecified() && point.y.isSpecified());
+        if (point.x.isAuto() && point.y.isAuto())
+            return CSS::Keyword::Auto { };
+
+        if (point.x.isNormal() && point.y.isNormal())
+            return CSS::Keyword::Auto { };
+
+        if (point.x.isSpecified() && point.y.isSpecified())
+            return Position { point };
+
+        RELEASE_ASSERT_NOT_REACHED();
     }
 
-    WebCore::LengthPoint value;
+    Variant<CSS::Keyword::Auto, CSS::Keyword::Normal, Position> m_value;
 };
 
 template<typename T> bool OffsetPosition::holdsAlternative() const
 {
-         if constexpr (std::same_as<T, CSS::Keyword::Auto>)     return isAuto();
-    else if constexpr (std::same_as<T, CSS::Keyword::Normal>)   return isNormal();
-    else if constexpr (std::same_as<T, Position>)               return isPosition();
+    return std::holds_alternative<T>(m_value);
 }
 
 template<typename... F> decltype(auto) OffsetPosition::switchOn(F&&... f) const
 {
-    auto visitor = WTF::makeVisitor(std::forward<F>(f)...);
-
-    if (isAuto())
-        return visitor(CSS::Keyword::Auto { });
-    if (isNormal())
-        return visitor(CSS::Keyword::Normal { });
-    return visitor(Position { value });
+    return WTF::switchOn(m_value, std::forward<F>(f)...);
 }
 
 // MARK: - Conversion


### PR DESCRIPTION
#### ee9bc0962d87c15c4fe374de20a2e3ad5e71d22a
<pre>
[Length Deprecation] Replace use of LengthPoint in Style::OffsetPosition and Style::OffsetAnchor
<a href="https://bugs.webkit.org/show_bug.cgi?id=299241">https://bugs.webkit.org/show_bug.cgi?id=299241</a>

Reviewed by Darin Adler.

Replaces use of LengthPoint in Style::OffsetPosition and Style::OffsetAnchor
with variants that model the state directly.

* Source/WebCore/style/values/motion/StyleOffsetAnchor.cpp:
* Source/WebCore/style/values/motion/StyleOffsetAnchor.h:
* Source/WebCore/style/values/motion/StyleOffsetPosition.cpp:
* Source/WebCore/style/values/motion/StyleOffsetPosition.h:

Canonical link: <a href="https://commits.webkit.org/300294@main">https://commits.webkit.org/300294@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0e47bba6ac6c8d77d67c103eede4f219f00c2240

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122046 "14 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41748 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32418 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128609 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74139 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123922 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42463 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50342 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92764 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61645 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124998 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33863 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109295 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73419 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32876 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27461 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72103 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103370 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27652 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131370 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48985 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37256 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101323 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49359 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105509 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101194 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25656 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46563 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24679 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45705 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48842 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54576 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48312 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51662 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49992 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->