### PR TITLE
Make select-multiple-scrolling.optional.html less chaotic

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-multiple-scrolling.optional-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-multiple-scrolling.optional-expected.txt
@@ -3,6 +3,6 @@
 PASS select[multiple][style="writing-mode: horizontal-tb"] scrolls correctly
 PASS select[multiple][style="writing-mode: vertical-lr"] scrolls correctly
 PASS select[multiple][style="writing-mode: vertical-rl"] scrolls correctly
-FAIL select[multiple][style="writing-mode: sideways-lr"] scrolls correctly assert_equals: scrolling is initially at block start for writing-mode: sideways-lr expected 0 but got 98
-FAIL select[multiple][style="writing-mode: sideways-rl"] scrolls correctly assert_equals: scrolling is initially at block start for writing-mode: sideways-rl expected 0 but got -98
+PASS select[multiple][style="writing-mode: sideways-lr"] scrolls correctly
+PASS select[multiple][style="writing-mode: sideways-rl"] scrolls correctly
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-multiple-scrolling.optional.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-multiple-scrolling.optional.html
@@ -39,12 +39,14 @@ for (const writingMode of ["horizontal-tb", "vertical-lr", "vertical-rl", "sidew
     const scrollBlock = isHorizontal ? "scrollHeight" : "scrollWidth";
     const scrollInline = isHorizontal ? "scrollWidth" : "scrollHeight";
 
-    test(t => {
-        select.scrollTop = select.scrollLeft = 0;
+    promise_test(async t => {
         select.style.writingMode = writingMode;
+        select.scrollTop = select.scrollLeft = 0;
+
         t.add_cleanup(() => {
             select.removeAttribute("style");
             select.scrollTop = select.scrollLeft = 0;
+            return new Promise(resolve => requestAnimationFrame(resolve));
         });
 
         assert_true(

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-multiple-scrolling.optional-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-multiple-scrolling.optional-expected.txt
@@ -1,8 +1,0 @@
-
-
-PASS select[multiple][style="writing-mode: horizontal-tb"] scrolls correctly
-PASS select[multiple][style="writing-mode: vertical-lr"] scrolls correctly
-PASS select[multiple][style="writing-mode: vertical-rl"] scrolls correctly
-FAIL select[multiple][style="writing-mode: sideways-lr"] scrolls correctly assert_equals: scrolling is initially at block start for writing-mode: sideways-lr expected 0 but got 90
-FAIL select[multiple][style="writing-mode: sideways-rl"] scrolls correctly assert_equals: scrolling is initially at block start for writing-mode: sideways-rl expected 0 but got -90
-


### PR DESCRIPTION
#### cd482cffc640ee9072b5d41cdcc89254458e1ad8
<pre>
Make select-multiple-scrolling.optional.html less chaotic
<a href="https://bugs.webkit.org/show_bug.cgi?id=299243">https://bugs.webkit.org/show_bug.cgi?id=299243</a>
<a href="https://rdar.apple.com/161009941">rdar://161009941</a>

Reviewed by Alan Baradlay.

The current failure is caused by a race between a lot of scrollTop/scrollLeft changes and setting the writing mode.

Wait for at least a frame to render when cleaning up previous subtest.

* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-multiple-scrolling.optional-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-multiple-scrolling.optional.html:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-multiple-scrolling.optional-expected.txt: Removed.

Canonical link: <a href="https://commits.webkit.org/300284@main">https://commits.webkit.org/300284@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a7a92ed6b1abc71d26ec478142fb34baf301638

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122032 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41734 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32404 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128595 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74125 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e56f5735-6ba0-48ee-8c3a-722cda3eafcc) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42449 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50328 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92750 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61628 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d4d93175-ad9d-4f22-abb8-c0b600713f12) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124984 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33849 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109282 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73406 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a1aba6ed-b70f-4f80-84db-af5ea4e2127b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32862 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27448 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72089 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103356 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27639 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131356 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48971 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37239 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101307 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49345 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105496 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101178 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25651 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46546 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24666 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45685 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48828 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48298 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51648 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49978 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->