### PR TITLE
[Length Deprecation] Remove unnecessary use of Length in TableGrid::Column

### DIFF
--- a/Source/WebCore/layout/formattingContexts/table/TableFormattingContext.cpp
+++ b/Source/WebCore/layout/formattingContexts/table/TableFormattingContext.cpp
@@ -330,7 +330,7 @@ IntrinsicWidthConstraints TableFormattingContext::computedPreferredWidthForColum
                 return formattingGeometry.computedColumnWidth(*columnBox);
             }();
         if (fixedWidth)
-            column.setComputedLogicalWidth({ *fixedWidth, LengthType::Fixed });
+            column.setComputedLogicalWidth(Style::Length<CSS::Nonnegative, float> { *fixedWidth });
         }
     };
     collectColsFixedWidth();
@@ -445,7 +445,7 @@ IntrinsicWidthConstraints TableFormattingContext::computedPreferredWidthForColum
         if (hasColumnWithFixedWidth && !hasColumnWithPercentWidth) {
             for (size_t columnIndex = 0; columnIndex < columnList.size(); ++columnIndex) {
                 if (auto fixedWidth = maximumFixedColumnWidths[columnIndex])
-                    columnList[columnIndex].setComputedLogicalWidth({ *fixedWidth, LengthType::Fixed });
+                    columnList[columnIndex].setComputedLogicalWidth(Style::Length<CSS::Nonnegative, float> { *fixedWidth });
             }
             return;
         } 
@@ -461,7 +461,7 @@ IntrinsicWidthConstraints TableFormattingContext::computedPreferredWidthForColum
         for (size_t columnIndex = 0; columnIndex < columnList.size(); ++columnIndex) {
             auto nonPercentColumnWidth = columnIntrinsicWidths[columnIndex].maximum;
             if (auto fixedWidth = maximumFixedColumnWidths[columnIndex]) {
-                columnList[columnIndex].setComputedLogicalWidth({ *fixedWidth, LengthType::Fixed });
+                columnList[columnIndex].setComputedLogicalWidth(Style::Length<CSS::Nonnegative, float> { *fixedWidth });
                 nonPercentColumnWidth = std::max(nonPercentColumnWidth, *fixedWidth);
             }
             if (!maximumPercentColumnWidths[columnIndex]) {
@@ -469,7 +469,7 @@ IntrinsicWidthConstraints TableFormattingContext::computedPreferredWidthForColum
                 continue;
             }
             auto percent = std::min(*maximumPercentColumnWidths[columnIndex], remainingPercent);
-            columnList[columnIndex].setComputedLogicalWidth({ percent, LengthType::Percent });
+            columnList[columnIndex].setComputedLogicalWidth(Style::Percentage<CSS::Nonnegative, float> { percent });
             percentMaximumWidth = std::max(percentMaximumWidth, LayoutUnit { nonPercentColumnWidth * 100.0f / percent });
             remainingPercent -= percent;
         }

--- a/Source/WebCore/layout/formattingContexts/table/TableGrid.cpp
+++ b/Source/WebCore/layout/formattingContexts/table/TableGrid.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2019-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -36,7 +37,8 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(TableGrid);
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(TableGridCell);
 
 TableGrid::Column::Column(const ElementBox* columnBox)
-    : m_layoutBox(columnBox)
+    : m_computedLogicalWidth { CSS::Keyword::Auto { } }
+    , m_layoutBox(columnBox)
 {
 }
 

--- a/Source/WebCore/layout/formattingContexts/table/TableGrid.h
+++ b/Source/WebCore/layout/formattingContexts/table/TableGrid.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2019-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,8 +29,10 @@
 #include "FormattingContext.h"
 #include "LayoutBoxGeometry.h"
 #include "LayoutUnits.h"
+#include "StylePrimitiveNumericTypes.h"
 #include <wtf/HashMap.h>
 #include <wtf/ListHashSet.h>
+#include <wtf/Variant.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -103,6 +106,8 @@ public:
     // Column represents a vertical set of slots in the grid. A column has horizontal position and width.
     class Column {
     public:
+        using ComputedLogicalWidth = Variant<CSS::Keyword::Auto, Style::Length<CSS::Nonnegative, float>, Style::Percentage<CSS::Nonnegative, float>>;
+
         Column(const ElementBox*);
 
         void setUsedLogicalLeft(LayoutUnit);
@@ -111,15 +116,15 @@ public:
         void setUsedLogicalWidth(LayoutUnit);
         LayoutUnit usedLogicalWidth() const;
 
-        void setComputedLogicalWidth(Length&&);
-        const Length& computedLogicalWidth() const { return m_computedLogicalWidth; }
+        void setComputedLogicalWidth(ComputedLogicalWidth&&);
+        const ComputedLogicalWidth& computedLogicalWidth() const { return m_computedLogicalWidth; }
 
         const ElementBox* box() const { return m_layoutBox.get(); }
 
     private:
         LayoutUnit m_usedLogicalWidth;
         LayoutUnit m_usedLogicalLeft;
-        Length m_computedLogicalWidth;
+        ComputedLogicalWidth m_computedLogicalWidth;
         CheckedPtr<const ElementBox> m_layoutBox;
 
 #if ASSERT_ENABLED
@@ -238,9 +243,8 @@ private:
     std::optional<BoxGeometry::Edges> m_collapsedBorder;
 };
 
-inline void TableGrid::Column::setComputedLogicalWidth(Length&& computedLogicalWidth)
+inline void TableGrid::Column::setComputedLogicalWidth(TableGrid::Column::ComputedLogicalWidth&& computedLogicalWidth)
 {
-    ASSERT(computedLogicalWidth.type() == LengthType::Fixed || computedLogicalWidth.type() == LengthType::Percent || computedLogicalWidth.type() == LengthType::Relative);
     m_computedLogicalWidth = WTFMove(computedLogicalWidth);
 }
 


### PR DESCRIPTION
#### 37447ea234d820dc738d4604c4956e475fe5c57a
<pre>
[Length Deprecation] Remove unnecessary use of Length in TableGrid::Column
<a href="https://bugs.webkit.org/show_bug.cgi?id=299240">https://bugs.webkit.org/show_bug.cgi?id=299240</a>

Reviewed by Brent Fulgham.

Replaces a use of platform Length with a variant of strong style types
that more precisely model the state.

* Source/WebCore/layout/formattingContexts/table/TableFormattingContext.cpp:
* Source/WebCore/layout/formattingContexts/table/TableGrid.cpp:
* Source/WebCore/layout/formattingContexts/table/TableGrid.h:
* Source/WebCore/layout/formattingContexts/table/TableLayout.cpp:

Canonical link: <a href="https://commits.webkit.org/300290@main">https://commits.webkit.org/300290@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7e168005a9071058425724ad43aead61bf7ea1ca

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122020 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41722 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32392 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128583 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74113 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123896 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42437 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50316 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92738 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61620 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124972 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33839 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109271 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73392 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32852 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27436 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72077 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103346 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27628 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131344 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48959 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37231 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101296 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49333 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105485 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101167 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25654 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46537 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24655 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45672 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48816 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54550 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48286 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51636 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49966 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->