### PR TITLE
[Experiment] Check if the bounding rects passed to AcceleratedEffectValues are consistent

### DIFF
--- a/Source/WebCore/platform/animation/AcceleratedEffectValues.cpp
+++ b/Source/WebCore/platform/animation/AcceleratedEffectValues.cpp
@@ -92,7 +92,8 @@ AcceleratedEffectValues AcceleratedEffectValues::clone() const
         WTFMove(clonedOffsetAnchor),
         WTFMove(clonedOffsetRotate),
         WTFMove(clonedFilter),
-        WTFMove(clonedBackdropFilter)
+        WTFMove(clonedBackdropFilter),
+        boundingBox
     };
 }
 
@@ -115,6 +116,10 @@ template<typename T> static RefPtr<TransformOperation> resolveCalculateValuesFor
 
 AcceleratedEffectValues::AcceleratedEffectValues(const RenderStyle& style, const IntRect& borderBoxRect, const RenderLayerModelObject* renderer)
 {
+#if ASSERT_ENABLED
+    this->boundingBox = borderBoxRect;
+#endif
+
     opacity = style.opacity().value.value;
 
     auto borderBoxSize = borderBoxRect.size();
@@ -148,6 +153,12 @@ AcceleratedEffectValues::AcceleratedEffectValues(const RenderStyle& style, const
 
 TransformationMatrix AcceleratedEffectValues::computedTransformationMatrix(const FloatRect& boundingBox) const
 {
+    auto snappedBoundingBox = IntRect(boundingBox);
+    ASSERT(snappedBoundingBox == this->boundingBox);
+    if (snappedBoundingBox != this->boundingBox) {
+        ALWAYS_LOG_WITH_STREAM(stream << "Bounding box passed to AcceleratedEffectValues::computedTransformationMatrix() [" << snappedBoundingBox << "] does not match bounding box AcceleratedEffectValues was initialized with [" << this->boundingBox << "].");
+    }
+
     // https://www.w3.org/TR/css-transforms-2/#ctm
     // The transformation matrix is computed from the transform, transform-origin, translate, rotate, scale, and offset properties as follows:
     // 1. Start with the identity matrix.

--- a/Source/WebCore/platform/animation/AcceleratedEffectValues.h
+++ b/Source/WebCore/platform/animation/AcceleratedEffectValues.h
@@ -28,6 +28,7 @@
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
 
 #include <WebCore/FilterOperations.h>
+#include <WebCore/IntRect.h>
 #include <WebCore/Length.h>
 #include <WebCore/LengthPoint.h>
 #include <WebCore/PathOperation.h>
@@ -41,7 +42,6 @@
 
 namespace WebCore {
 
-class IntRect;
 class Path;
 class RenderLayerModelObject;
 class RenderStyle;
@@ -62,10 +62,11 @@ struct AcceleratedEffectValues {
     Style::OffsetRotate offsetRotate { CSS::Keyword::Auto { } };
     FilterOperations filter { };
     FilterOperations backdropFilter { };
+    IntRect boundingBox { };
 
     AcceleratedEffectValues() = default;
     AcceleratedEffectValues(const RenderStyle&, const IntRect&, const RenderLayerModelObject* = nullptr);
-    AcceleratedEffectValues(float opacity, std::optional<TransformOperationData>&& transformOperationData, LengthPoint&& transformOrigin, TransformBox transformBox, TransformOperations&& transform, RefPtr<TransformOperation>&& translate, RefPtr<TransformOperation>&& scale, RefPtr<TransformOperation>&& rotate, RefPtr<PathOperation>&& offsetPath, Length&& offsetDistance, LengthPoint&& offsetPosition, LengthPoint&& offsetAnchor, Style::OffsetRotate&& offsetRotate, FilterOperations&& filter, FilterOperations&& backdropFilter)
+    AcceleratedEffectValues(float opacity, std::optional<TransformOperationData>&& transformOperationData, LengthPoint&& transformOrigin, TransformBox transformBox, TransformOperations&& transform, RefPtr<TransformOperation>&& translate, RefPtr<TransformOperation>&& scale, RefPtr<TransformOperation>&& rotate, RefPtr<PathOperation>&& offsetPath, Length&& offsetDistance, LengthPoint&& offsetPosition, LengthPoint&& offsetAnchor, Style::OffsetRotate&& offsetRotate, FilterOperations&& filter, FilterOperations&& backdropFilter, IntRect boundingBox)
         : opacity(opacity)
         , transformOperationData(WTFMove(transformOperationData))
         , transformOrigin(WTFMove(transformOrigin))
@@ -81,6 +82,7 @@ struct AcceleratedEffectValues {
         , offsetRotate(WTFMove(offsetRotate))
         , filter(WTFMove(filter))
         , backdropFilter(WTFMove(backdropFilter))
+        , boundingBox(boundingBox)
     {
     }
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6845,6 +6845,7 @@ struct WebCore::AcceleratedEffectValues {
     WebCore::Style::OffsetRotate offsetRotate;
     WebCore::FilterOperations filter;
     WebCore::FilterOperations backdropFilter;
+    WebCore::IntRect boundingBox;
 }
 
 class WebCore::WebAnimationTime {


### PR DESCRIPTION
#### b896bb8f2179c8c75cef6fec5e817171ef45d33c
<pre>
[Experiment] Check if the bounding rects passed to AcceleratedEffectValues are consistent
<a href="https://bugs.webkit.org/show_bug.cgi?id=299244">https://bugs.webkit.org/show_bug.cgi?id=299244</a>

Reviewed by NOBODY (OOPS!).

EXPERIMENT. NOTE FOR REVIEW.

* Source/WebCore/platform/animation/AcceleratedEffectValues.cpp:
* Source/WebCore/platform/animation/AcceleratedEffectValues.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b896bb8f2179c8c75cef6fec5e817171ef45d33c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122021 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41723 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32393 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128584 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74114 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123897 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42438 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50317 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92740 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61621 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124973 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33840 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109272 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73395 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32853 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27437 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72078 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103347 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27629 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131345 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48960 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37233 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101301 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49334 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105486 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101172 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46540 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24656 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45674 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48817 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54551 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48287 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51637 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49967 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->