### PR TITLE
[GFC] Inserting items within the grid which fit should not resize the grid.

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
@@ -62,6 +62,8 @@ GridLayout::PlacedGridItems GridLayout::placeGridItems(const UnplacedGridItems& 
     auto& nonAutoPositionedGridItems = unplacedGridItems.nonAutoPositionedItems;
     for (auto& nonAutoPositionedItem : nonAutoPositionedGridItems)
         implicitGrid.insertUnplacedGridItem(nonAutoPositionedItem);
+    ASSERT(implicitGrid.columnsCount() == gridTemplateColumnsTracksCount && implicitGrid.rowsCount()== gridTemplateRowsTracksCount,
+        "Since we currently only support placing items which are explicitly placed and fit within the explicit grid, the size of the implicit grid should match the passed in sizes.");
     return implicitGrid.placedGridItems();
 }
 

--- a/Source/WebCore/layout/formattingContexts/grid/ImplicitGrid.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/ImplicitGrid.cpp
@@ -38,7 +38,7 @@ namespace Layout {
 // implicit grid as exactly the explicit grid and allow placement to add implicit
 // tracks and grow the grid.
 ImplicitGrid::ImplicitGrid(size_t gridTemplateColumnsCount, size_t gridTemplateRowsCount)
-    : m_gridMatrix(Vector(gridTemplateRowsCount, Vector<std::optional<const UnplacedGridItem>>(gridTemplateColumnsCount)))
+    : m_gridMatrix(Vector(gridTemplateRowsCount, Vector<std::optional<UnplacedGridItem>>(gridTemplateColumnsCount)))
 {
 }
 
@@ -95,7 +95,7 @@ void ImplicitGrid::insertUnplacedGridItem(const UnplacedGridItem& unplacedGridIt
     auto rowsRange = WTF::Range(explicitRowStart, explicitRowEnd);
     for (auto rowIndex = rowsRange.begin(); rowIndex < rowsRange.end(); ++rowIndex) {
         for (auto columnIndex = columnsRange.begin(); columnIndex < columnsRange.end(); ++columnIndex)
-            m_gridMatrix[rowIndex].insert(columnIndex, unplacedGridItem);
+            m_gridMatrix[rowIndex][columnIndex] = unplacedGridItem;
     }
 
 }

--- a/Source/WebCore/layout/formattingContexts/grid/ImplicitGrid.h
+++ b/Source/WebCore/layout/formattingContexts/grid/ImplicitGrid.h
@@ -49,7 +49,7 @@ public:
     PlacedGridItems placedGridItems() const;
 
 private:
-    using GridMatrix = Vector<Vector<std::optional<const UnplacedGridItem>>>;
+    using GridMatrix = Vector<Vector<std::optional<UnplacedGridItem>>>;
     GridMatrix m_gridMatrix;
 };
 


### PR DESCRIPTION
#### 63f8ee0d10fdc5595b592f7ce77c301fe4ca3d59
<pre>
[GFC] Inserting items within the grid which fit should not resize the grid.
<a href="https://bugs.webkit.org/show_bug.cgi?id=299245">https://bugs.webkit.org/show_bug.cgi?id=299245</a>
<a href="https://rdar.apple.com/161011615">rdar://161011615</a>

Reviewed by Alan Baradlay.

Currently, if we try to insert an item which already fits within the
explicit grid, we end up accidentally adding new columns in the grid when
there is no reason to. This is because using Vector::insert will add the
item at the desired index and shuffle the rest of the content over,
increasing the size. The desired outcome is instead to replace the
contents of that cell with the unplaced item we are positioning.

Canonical link: <a href="https://commits.webkit.org/300322@main">https://commits.webkit.org/300322@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/113f7d3e3808e91011e449e8ce7a877f4910a706

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122025 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41727 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32397 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128588 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74118 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fde331dc-54c3-433b-8113-e4635a79a3e2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123901 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42442 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50321 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92743 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61624 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/849d20aa-24d2-411f-9d63-92daa54b8c8f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124977 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33842 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109273 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73399 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5a33b69e-3f05-44bd-b1cf-011c7829646b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32855 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27438 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72082 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103349 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27630 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131349 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48964 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37234 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101304 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49338 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105487 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101175 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25671 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46541 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24657 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45678 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48821 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54555 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48291 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51641 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49971 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->