### PR TITLE
[Style] Hide more details about the implementation of Style::SVGPaint

### DIFF
--- a/Source/WebCore/page/InteractionRegion.cpp
+++ b/Source/WebCore/page/InteractionRegion.cpp
@@ -289,20 +289,8 @@ static bool colorIsChallengingToHighlight(const Color& color)
 
 static bool styleIsChallengingToHighlight(const RenderStyle& style)
 {
-    auto fillPaintType = style.fill().type;
-
-    if (fillPaintType == Style::SVGPaintType::None) {
-        auto strokePaintType = style.stroke().type;
-        if (strokePaintType != Style::SVGPaintType::RGBColor && strokePaintType != Style::SVGPaintType::CurrentColor)
-            return false;
-
-        return colorIsChallengingToHighlight(style.colorResolvingCurrentColor(style.stroke().color));
-    }
-
-    if (fillPaintType != Style::SVGPaintType::RGBColor && fillPaintType != Style::SVGPaintType::CurrentColor)
-        return false;
-
-    return colorIsChallengingToHighlight(style.colorResolvingCurrentColor(style.fill().color));
+    auto color = (style.fill().isNone() ? style.stroke() : style.fill()).tryColor();
+    return color && colorIsChallengingToHighlight(style.colorResolvingCurrentColor(*color));
 }
 
 static bool isGuardContainer(const Element& element)

--- a/Source/WebCore/rendering/ReferencedSVGResources.cpp
+++ b/Source/WebCore/rendering/ReferencedSVGResources.cpp
@@ -172,14 +172,14 @@ ReferencedSVGResources::SVGElementIdentifierAndTagPairs ReferencedSVGResources::
         }
     }
 
-    if (svgStyle.fill().type >= Style::SVGPaintType::URINone) {
-        auto resourceID = SVGURIReference::fragmentIdentifierFromIRIString(svgStyle.fill().url, document);
+    if (auto fillURL = svgStyle.fill().tryAnyURL()) {
+        auto resourceID = SVGURIReference::fragmentIdentifierFromIRIString(*fillURL, document);
         if (!resourceID.isEmpty())
             referencedResources.append({ resourceID, { SVGNames::linearGradientTag, SVGNames::radialGradientTag, SVGNames::patternTag } });
     }
 
-    if (svgStyle.stroke().type >= Style::SVGPaintType::URINone) {
-        auto resourceID = SVGURIReference::fragmentIdentifierFromIRIString(svgStyle.stroke().url, document);
+    if (auto strokeURL = svgStyle.stroke().tryAnyURL()) {
+        auto resourceID = SVGURIReference::fragmentIdentifierFromIRIString(*strokeURL, document);
         if (!resourceID.isEmpty())
             referencedResources.append({ resourceID, { SVGNames::linearGradientTag, SVGNames::radialGradientTag, SVGNames::patternTag } });
     }

--- a/Source/WebCore/rendering/RenderLayerModelObject.cpp
+++ b/Source/WebCore/rendering/RenderLayerModelObject.cpp
@@ -562,17 +562,17 @@ RenderSVGResourcePaintServer* RenderLayerModelObject::svgFillPaintServerResource
     if (!document().settings().layerBasedSVGEngineEnabled())
         return nullptr;
 
-    const auto& svgStyle = style.svgStyle();
-    if (svgStyle.fill().type < Style::SVGPaintType::URINone)
+    auto fillURL = style.svgStyle().fill().tryAnyURL();
+    if (!fillURL)
         return nullptr;
 
-    if (RefPtr referencedElement = ReferencedSVGResources::referencedPaintServerElement(treeScopeForSVGReferences(), svgStyle.fill().url)) {
+    if (RefPtr referencedElement = ReferencedSVGResources::referencedPaintServerElement(treeScopeForSVGReferences(), *fillURL)) {
         if (auto* referencedPaintServerRenderer = dynamicDowncast<RenderSVGResourcePaintServer>(referencedElement->renderer()))
             return referencedPaintServerRenderer;
     }
 
     if (auto* element = this->element())
-        document().addPendingSVGResource(AtomString(svgStyle.fill().url.resolved.string()), downcast<SVGElement>(*element));
+        document().addPendingSVGResource(AtomString(fillURL->resolved.string()), downcast<SVGElement>(*element));
 
     return nullptr;
 }
@@ -582,17 +582,17 @@ RenderSVGResourcePaintServer* RenderLayerModelObject::svgStrokePaintServerResour
     if (!document().settings().layerBasedSVGEngineEnabled())
         return nullptr;
 
-    const auto& svgStyle = style.svgStyle();
-    if (svgStyle.stroke().type < Style::SVGPaintType::URINone)
+    auto strokeURL = style.svgStyle().stroke().tryAnyURL();
+    if (!strokeURL)
         return nullptr;
 
-    if (RefPtr referencedElement = ReferencedSVGResources::referencedPaintServerElement(treeScopeForSVGReferences(), svgStyle.stroke().url)) {
+    if (RefPtr referencedElement = ReferencedSVGResources::referencedPaintServerElement(treeScopeForSVGReferences(), *strokeURL)) {
         if (auto* referencedPaintServerRenderer = dynamicDowncast<RenderSVGResourcePaintServer>(referencedElement->renderer()))
             return referencedPaintServerRenderer;
     }
 
     if (auto* element = this->element())
-        document().addPendingSVGResource(AtomString(svgStyle.stroke().url.resolved.string()), downcast<SVGElement>(*element));
+        document().addPendingSVGResource(AtomString(strokeURL->resolved.string()), downcast<SVGElement>(*element));
 
     return nullptr;
 }

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -2719,7 +2719,7 @@ const Style::Color& RenderStyle::unresolvedColorForProperty(CSSPropertyID colorP
     case CSSPropertyBorderTopColor:
         return visitedLink ? visitedLinkBorderTopColor() : borderTopColor();
     case CSSPropertyFill:
-        return fill().color;
+        return fill().colorDisregardingType();
     case CSSPropertyFloodColor:
         return floodColor();
     case CSSPropertyLightingColor:
@@ -2729,7 +2729,7 @@ const Style::Color& RenderStyle::unresolvedColorForProperty(CSSPropertyID colorP
     case CSSPropertyStopColor:
         return stopColor();
     case CSSPropertyStroke:
-        return stroke().color;
+        return stroke().colorDisregardingType();
     case CSSPropertyStrokeColor:
         return visitedLink ? visitedLinkStrokeColor() : strokeColor();
     case CSSPropertyBorderBlockEndColor:

--- a/Source/WebCore/rendering/style/SVGRenderStyle.cpp
+++ b/Source/WebCore/rendering/style/SVGRenderStyle.cpp
@@ -170,12 +170,12 @@ bool SVGRenderStyle::changeRequiresLayout(const SVGRenderStyle& other) const
         return true; 
 
     // Some stroke properties, requires relayouts, as the cached stroke boundaries need to be recalculated.
-    if (m_strokeData->paint.type != other.m_strokeData->paint.type
-        || m_strokeData->paint.url != other.m_strokeData->paint.url
+    if (!m_strokeData->paint.hasSameType(other.m_strokeData->paint)
+        || m_strokeData->paint.urlDisregardingType() != other.m_strokeData->paint.urlDisregardingType()
         || m_strokeData->dashArray != other.m_strokeData->dashArray
         || m_strokeData->dashOffset != other.m_strokeData->dashOffset
-        || m_strokeData->visitedLinkPaint.type != other.m_strokeData->visitedLinkPaint.type
-        || m_strokeData->visitedLinkPaint.url != other.m_strokeData->visitedLinkPaint.url)
+        || !m_strokeData->visitedLinkPaint.hasSameType(other.m_strokeData->visitedLinkPaint)
+        || m_strokeData->visitedLinkPaint.urlDisregardingType() != other.m_strokeData->visitedLinkPaint.urlDisregardingType())
         return true;
 
     // vector-effect changes require a re-layout.
@@ -189,16 +189,16 @@ bool SVGRenderStyle::changeRequiresRepaint(const SVGRenderStyle& other, bool cur
 {
     if (this == &other) {
         ASSERT(currentColorDiffers);
-        return containsCurrentColor(m_strokeData->paint.color)
-            || containsCurrentColor(m_strokeData->visitedLinkPaint.color)
+        return containsCurrentColor(m_strokeData->paint)
+            || containsCurrentColor(m_strokeData->visitedLinkPaint)
             || containsCurrentColor(m_miscData->floodColor)
             || containsCurrentColor(m_miscData->lightingColor)
-            || containsCurrentColor(m_fillData->paint.color); // FIXME: Should this be checking m_fillData->visitedLinkPaint.color as well?
+            || containsCurrentColor(m_fillData->paint); // FIXME: Should this be checking m_fillData->visitedLinkPaint.color as well?
     }
 
     if (m_strokeData->opacity != other.m_strokeData->opacity
-        || colorChangeRequiresRepaint(m_strokeData->paint.color, other.m_strokeData->paint.color, currentColorDiffers)
-        || colorChangeRequiresRepaint(m_strokeData->visitedLinkPaint.color, other.m_strokeData->visitedLinkPaint.color, currentColorDiffers))
+        || colorChangeRequiresRepaint(m_strokeData->paint.colorDisregardingType(), other.m_strokeData->paint.colorDisregardingType(), currentColorDiffers)
+        || colorChangeRequiresRepaint(m_strokeData->visitedLinkPaint.colorDisregardingType(), other.m_strokeData->visitedLinkPaint.colorDisregardingType(), currentColorDiffers))
         return true;
 
     // Painting related properties only need repaints. 
@@ -208,9 +208,9 @@ bool SVGRenderStyle::changeRequiresRepaint(const SVGRenderStyle& other, bool cur
         return true;
 
     // If fill data changes, we just need to repaint. Fill boundaries are not influenced by this, only by the Path, that RenderSVGPath contains.
-    if (m_fillData->paint.type != other.m_fillData->paint.type
-        || colorChangeRequiresRepaint(m_fillData->paint.color, other.m_fillData->paint.color, currentColorDiffers)
-        || m_fillData->paint.url != other.m_fillData->paint.url
+    if (!m_fillData->paint.hasSameType(other.m_fillData->paint)
+        || colorChangeRequiresRepaint(m_fillData->paint.colorDisregardingType(), other.m_fillData->paint.colorDisregardingType(), currentColorDiffers)
+        || m_fillData->paint.urlDisregardingType() != other.m_fillData->paint.urlDisregardingType()
         || m_fillData->opacity != other.m_fillData->opacity)
         return true;
 

--- a/Source/WebCore/rendering/style/SVGRenderStyle.h
+++ b/Source/WebCore/rendering/style/SVGRenderStyle.h
@@ -78,9 +78,11 @@ public:
     static GlyphOrientation initialGlyphOrientationHorizontal() { return GlyphOrientation::Degrees0; }
     static GlyphOrientation initialGlyphOrientationVertical() { return GlyphOrientation::Auto; }
     static constexpr Style::Opacity initialFillOpacity();
-    static Style::SVGPaint initialFill() { return Style::SVGPaint { Style::SVGPaintType::RGBColor, Style::URL::none(), Color::black }; }
+    static Style::Color initialFillColor() { return Color::black; }
+    static Style::SVGPaint initialFill() { return initialFillColor(); }
     static constexpr Style::Opacity initialStrokeOpacity();
-    static Style::SVGPaint initialStroke() { return Style::SVGPaint { Style::SVGPaintType::None, Style::URL::none(), Color { } }; }
+    static Style::Color initialStrokeColor() { return Color { }; }
+    static Style::SVGPaint initialStroke() { return CSS::Keyword::None { }; }
     static inline Style::SVGStrokeDasharray initialStrokeDashArray();
     static inline Style::SVGStrokeDashoffset initialStrokeDashOffset();
     static constexpr Style::Opacity initialStopOpacity();
@@ -179,8 +181,8 @@ public:
 
     // convenience
     bool hasMarkers() const { return !markerStartResource().isNone() || !markerMidResource().isNone() || !markerEndResource().isNone(); }
-    bool hasStroke() const { return stroke().type != Style::SVGPaintType::None; }
-    bool hasFill() const { return fill().type != Style::SVGPaintType::None; }
+    bool hasStroke() const { return !stroke().isNone(); }
+    bool hasFill() const { return !fill().isNone(); }
 
     void conservativelyCollectChangedAnimatableProperties(const SVGRenderStyle&, CSSPropertiesBitSet&) const;
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResource.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResource.cpp
@@ -59,44 +59,35 @@ static inline LegacyRenderSVGResource* requestPaintingResource(RenderSVGResource
         
         // But always use the initial fill paint server.
         LegacyRenderSVGResourceSolidColor* colorResource = LegacyRenderSVGResource::sharedSolidPaintingResource();
-        colorResource->setColor(SVGRenderStyle::initialFill().color.resolvedColor());
+        colorResource->setColor(SVGRenderStyle::initialFillColor().resolvedColor());
         return colorResource;
     }
 
     const auto& svgStyle = style.svgStyle();
-    auto paintType = applyToFill ? svgStyle.fill().type : svgStyle.stroke().type;
+    const auto& paint = applyToFill ? svgStyle.fill() : svgStyle.stroke();
 
     // If we have no fill/stroke, return nullptr.
-    if (paintType == Style::SVGPaintType::None)
+    if (paint.isNone())
         return nullptr;
 
     Color color;
-    switch (paintType) {
-    case Style::SVGPaintType::CurrentColor:
-    case Style::SVGPaintType::RGBColor:
-    case Style::SVGPaintType::URICurrentColor:
-    case Style::SVGPaintType::URIRGBColor:
-        color = style.colorResolvingCurrentColor(applyToFill ? svgStyle.fill().color : svgStyle.stroke().color);
-        break;
-    default:
-        break;
-    }
+    if (auto paintColor = paint.tryAnyColor())
+        color = style.colorResolvingCurrentColor(*paintColor);
 
     if (style.insideLink() == InsideLink::InsideVisited) {
         // FIXME: This code doesn't support the uri component of the visited link paint, https://bugs.webkit.org/show_bug.cgi?id=70006
-        auto visitedPaintType = applyToFill ? svgStyle.visitedLinkFill().type : svgStyle.visitedLinkStroke().type;
+        auto& visitedPaint = applyToFill ? svgStyle.visitedLinkFill() : svgStyle.visitedLinkStroke();
 
-        // For Style::SVGPaintType::CurrentColor, 'color' already contains the 'visitedColor'.
-        if (visitedPaintType < Style::SVGPaintType::URINone && visitedPaintType != Style::SVGPaintType::CurrentColor) {
-            const Color& visitedColor = style.colorResolvingCurrentColor(applyToFill ? svgStyle.visitedLinkFill().color : svgStyle.visitedLinkStroke().color);
-            if (visitedColor.isValid())
+        // For `currentcolor`, 'color' already contains the 'visitedColor'.
+        if (auto visitedPaintColor = visitedPaint.tryColor(); visitedPaintColor && !visitedPaintColor->isCurrentColor()) {
+            if (auto visitedColor = style.colorResolvingCurrentColor(*visitedPaintColor); visitedColor.isValid())
                 color = visitedColor.colorWithAlpha(color.alphaAsFloat());
         }
     }
 
     // If the primary resource is just a color, return immediately.
     auto* colorResource = LegacyRenderSVGResource::sharedSolidPaintingResource();
-    if (paintType < Style::SVGPaintType::URINone) {
+    if (paint.isColor()) {
         colorResource->setColor(color);
         return colorResource;
     }
@@ -113,7 +104,7 @@ static inline LegacyRenderSVGResource* requestPaintingResource(RenderSVGResource
     // If the requested resource is not available, return the color resource or 'none'.
     if (!uriResource) {
         // The fallback is 'none'. (SVG2 say 'none' is implied when no fallback is specified.)
-        if (paintType == Style::SVGPaintType::URINone)
+        if (paint.isURLNone())
             return nullptr;
 
         colorResource->setColor(color);

--- a/Source/WebCore/rendering/svg/legacy/SVGResources.cpp
+++ b/Source/WebCore/rendering/svg/legacy/SVGResources.cpp
@@ -186,26 +186,13 @@ static inline bool isChainableResource(const SVGElement& element, const SVGEleme
     return false;
 }
 
-static inline bool svgPaintTypeHasURL(const Style::SVGPaintType& paintType)
-{
-    switch (paintType) {
-    case Style::SVGPaintType::URI:
-    case Style::SVGPaintType::URINone:
-    case Style::SVGPaintType::URICurrentColor:
-    case Style::SVGPaintType::URIRGBColor:
-        return true;
-    default:
-        break;
-    }
-    return false;
-}
-
 static inline LegacyRenderSVGResourceContainer* paintingResourceFromSVGPaint(TreeScope& treeScope, const Style::SVGPaint& paint, AtomString& id, bool& hasPendingResource)
 {
-    if (!svgPaintTypeHasURL(paint.type))
+    auto paintURL = paint.tryAnyURL();
+    if (!paintURL)
         return nullptr;
 
-    id = SVGURIReference::fragmentIdentifierFromIRIString(paint.url, treeScope.protectedDocumentScope());
+    id = SVGURIReference::fragmentIdentifierFromIRIString(*paintURL, treeScope.protectedDocumentScope());
     CheckedPtr container = getRenderSVGResourceContainerById(treeScope, id);
     if (!container) {
         hasPendingResource = true;

--- a/Source/WebCore/rendering/svg/legacy/SVGResourcesCache.cpp
+++ b/Source/WebCore/rendering/svg/legacy/SVGResourcesCache.cpp
@@ -185,10 +185,10 @@ void SVGResourcesCache::clientStyleChanged(RenderElement& renderer, StyleDiffere
         Ref oldSVGStyle = oldStyle->svgStyle();
         Ref newSVGStyle = newStyle.svgStyle();
 
-        if (oldSVGStyle->fill().url != newSVGStyle->fill().url)
+        if (oldSVGStyle->fill().urlDisregardingType() != newSVGStyle->fill().urlDisregardingType())
             return true;
 
-        if (oldSVGStyle->stroke().url != newSVGStyle->stroke().url)
+        if (oldSVGStyle->stroke().urlDisregardingType() != newSVGStyle->stroke().urlDisregardingType())
             return true;
 
         return false;

--- a/Source/WebCore/style/values/svg/StyleSVGPaint.h
+++ b/Source/WebCore/style/values/svg/StyleSVGPaint.h
@@ -32,47 +32,123 @@ namespace Style {
 
 enum class ForVisitedLink : bool;
 
-enum class SVGPaintType : uint8_t {
-    RGBColor,
-    None,
-    CurrentColor,
-    URINone,
-    URICurrentColor,
-    URIRGBColor,
-    URI
-};
-
 // <paint> = none | <color> | <url> [none | <color>]? | context-fill | context-stroke
 // NOTE: `context-fill` and `context-stroke` are not implemented.
 // https://svgwg.org/svg2-draft/painting.html#SpecifyingPaint
 struct SVGPaint {
-    // Models Variant<CSS::Keyword::None, Color, URL, SpaceSeparatedTuple<URL, CSS::Keyword::None>, SpaceSeparatedTuple<URL, Color>>;
+    struct URLNone {
+        URL url;
+        CSS::Keyword::None none;
 
-    SVGPaintType type;
-    URL url { URL::none() };
-    Color color { Color::currentColor() };
+        bool operator==(const URLNone&) const = default;
+    };
+    struct URLColor {
+        URL url;
+        Color color;
 
-    template<typename F> decltype(auto) switchOn(F&& functor) const
+        bool operator==(const URLColor&) const = default;
+    };
+
+    SVGPaint(CSS::Keyword::None)
+        : m_type { Type::None }
     {
-        switch (type) {
-        case SVGPaintType::None:
-            return functor(CSS::Keyword::None { });
-        case SVGPaintType::RGBColor:
-        case SVGPaintType::CurrentColor:
-            return functor(color);
-        case SVGPaintType::URINone:
-            return functor(SpaceSeparatedTuple { url, CSS::Keyword::None { } });
-        case SVGPaintType::URICurrentColor:
-        case SVGPaintType::URIRGBColor:
-            return functor(SpaceSeparatedTuple { url, color });
-        case SVGPaintType::URI:
-            return functor(url);
+    }
+    SVGPaint(Style::Color&& value)
+        : m_type { Type::Color }
+        , m_color { WTFMove(value) }
+    {
+    }
+    SVGPaint(Style::URL&& value)
+        : m_type { Type::URL }
+        , m_url { WTFMove(value) }
+    {
+    }
+    SVGPaint(URLNone&& value)
+        : m_type { Type::URLNone }
+        , m_url { WTFMove(value.url) }
+    {
+    }
+    SVGPaint(URLColor&& value)
+        : m_type { Type::URLColor }
+        , m_url { WTFMove(value.url) }
+        , m_color { WTFMove(value.color) }
+    {
+    }
+
+    bool isNone() const { return m_type == Type::None; }
+    bool isColor() const { return m_type == Type::Color; }
+    bool isURL() const { return m_type == Type::URL; }
+    bool isURLNone() const { return m_type == Type::URLNone; }
+    bool isURLColor() const { return m_type == Type::URLColor; }
+
+    bool hasColor() const { return isColor() || isURLColor(); }
+    bool hasURL() const { return isURL() || isURLNone() || isURLColor(); }
+
+    std::optional<Color> tryColor() const { return isColor() ? std::make_optional(m_color) : std::nullopt; }
+    std::optional<URL> tryURL() const { return isURL() ? std::make_optional(m_url) : std::nullopt; }
+    std::optional<URLNone> tryURLNone() const { return isURLNone() ? std::make_optional(URLNone { m_url, CSS::Keyword::None { } }) : std::nullopt; }
+    std::optional<URLColor> tryURLColor() const { return isURLColor() ? std::make_optional(URLColor { m_url, m_color }) : std::nullopt; }
+
+    std::optional<Color> tryAnyColor() const { return hasColor() ? std::make_optional(m_color) : std::nullopt; }
+    std::optional<URL> tryAnyURL() const { return hasURL() ? std::make_optional(m_url) : std::nullopt; }
+
+    const Color& colorDisregardingType() const { return m_color; }
+    const URL& urlDisregardingType() const { return m_url; }
+
+    template<typename... F> decltype(auto) switchOn(F&&... f) const
+    {
+        auto visitor = WTF::makeVisitor(std::forward<F>(f)...);
+
+        switch (m_type) {
+        case Type::None:
+            return visitor(CSS::Keyword::None { });
+        case Type::Color:
+            return visitor(m_color);
+        case Type::URL:
+            return visitor(m_url);
+        case Type::URLNone:
+            return visitor(URLNone { m_url, CSS::Keyword::None { } });
+        case Type::URLColor:
+            return visitor(URLColor { m_url, m_color });
         }
         RELEASE_ASSERT_NOT_REACHED();
     }
 
     bool operator==(const SVGPaint&) const = default;
+
+    bool hasSameType(const SVGPaint& other) const { return m_type == other.m_type; }
+
+private:
+    enum class Type : uint8_t {
+        None,
+        Color,
+        URL,
+        URLNone,
+        URLColor
+    };
+
+    Type m_type;
+    URL m_url { .resolved = { }, .modifiers = { } };
+    Color m_color { WebCore::Color { } };
 };
+
+template<size_t I> const auto& get(const SVGPaint::URLNone& value)
+{
+    if constexpr (!I)
+        return value.url;
+    else if constexpr (I == 1)
+        return value.none;
+}
+
+template<size_t I> const auto& get(const SVGPaint::URLColor& value)
+{
+    if constexpr (!I)
+        return value.url;
+    else if constexpr (I == 1)
+        return value.color;
+}
+
+bool containsCurrentColor(const Style::SVGPaint&);
 
 // MARK: - Conversion
 
@@ -86,11 +162,9 @@ template<> struct Blending<SVGPaint> {
     auto blend(const SVGPaint&, const SVGPaint&, const RenderStyle&, const RenderStyle&, const BlendingContext&) -> SVGPaint;
 };
 
-// MARK: - Logging
-
-WTF::TextStream& operator<<(WTF::TextStream&, SVGPaintType);
-
 } // namespace Style
 } // namespace WebCore
 
+DEFINE_SPACE_SEPARATED_TUPLE_LIKE_CONFORMANCE(WebCore::Style::SVGPaint::URLNone, 2)
+DEFINE_SPACE_SEPARATED_TUPLE_LIKE_CONFORMANCE(WebCore::Style::SVGPaint::URLColor, 2)
 DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::SVGPaint)


### PR DESCRIPTION
#### e4fae8bfe7a9e0ce3f655131120391a701775eff
<pre>
[Style] Hide more details about the implementation of Style::SVGPaint
<a href="https://bugs.webkit.org/show_bug.cgi?id=299247">https://bugs.webkit.org/show_bug.cgi?id=299247</a>

Reviewed by Darin Adler.

Stop exposing the SVGPaintType enumeration and hide the details of
Style::SVGPaint behind its strong style type.

* Source/WebCore/page/InteractionRegion.cpp:
* Source/WebCore/rendering/ReferencedSVGResources.cpp:
* Source/WebCore/rendering/RenderLayerModelObject.cpp:
* Source/WebCore/rendering/style/RenderStyle.cpp:
* Source/WebCore/rendering/style/SVGRenderStyle.cpp:
* Source/WebCore/rendering/style/SVGRenderStyle.h:
* Source/WebCore/rendering/svg/SVGPaintServerHandling.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResource.cpp:
* Source/WebCore/rendering/svg/legacy/SVGResources.cpp:
* Source/WebCore/rendering/svg/legacy/SVGResourcesCache.cpp:
* Source/WebCore/style/values/svg/StyleSVGPaint.cpp:
* Source/WebCore/style/values/svg/StyleSVGPaint.h:

Canonical link: <a href="https://commits.webkit.org/300300@main">https://commits.webkit.org/300300@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0455956af35add8c86945d506b5143f9906cef7e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122061 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41763 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32433 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128624 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74155 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123937 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42478 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50357 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92776 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61659 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125013 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33877 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109307 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73432 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32890 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27473 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72118 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103384 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27664 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131385 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49000 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37268 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101338 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49374 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105521 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101209 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25660 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46576 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24691 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45730 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48857 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54591 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48327 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51677 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50007 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->