### PR TITLE
[JSC] OMG exception throwing thunk should be called instead of jumped

### DIFF
--- a/Source/JavaScriptCore/b3/B3CheckSpecial.cpp
+++ b/Source/JavaScriptCore/b3/B3CheckSpecial.cpp
@@ -181,7 +181,8 @@ CCallHelpers::Jump CheckSpecial::generate(Inst& inst, CCallHelpers& jit, Generat
     for (unsigned i = 0; i < m_numCheckArgs; ++i)
         args.append(inst.args[1 + i]);
 
-    context.latePaths.append(
+    context.latePaths.append(std::tuple {
+        inst.origin->origin(),
         createSharedTask<GenerationContext::LatePathFunction>(
             [=, this] (auto& jit, GenerationContext& context) {
                 fail.link(&jit);
@@ -279,7 +280,8 @@ CCallHelpers::Jump CheckSpecial::generate(Inst& inst, CCallHelpers& jit, Generat
                     break;
                 }
                 value->m_generator->run(jit, StackmapGenerationParams(value, reps, context));
-            }));
+            })
+        });
     return CCallHelpers::Jump(); // As far as Air thinks, we are not a terminal.
 }
 

--- a/Source/JavaScriptCore/b3/B3StackmapGenerationParams.cpp
+++ b/Source/JavaScriptCore/b3/B3StackmapGenerationParams.cpp
@@ -99,6 +99,11 @@ StackmapGenerationParams::StackmapGenerationParams(
 {
 }
 
+Origin StackmapGenerationParams::origin() const
+{
+    return m_value->origin();
+}
+
 } } // namespace JSC::B3
 
 #endif // ENABLE(B3_JIT)

--- a/Source/JavaScriptCore/b3/B3StackmapGenerationParams.h
+++ b/Source/JavaScriptCore/b3/B3StackmapGenerationParams.h
@@ -107,14 +107,18 @@ public:
     // The Air::GenerationContext gives you even more power.
     Air::GenerationContext& context() const { return m_context; };
 
+    JS_EXPORT_PRIVATE Origin origin() const;
+
     template<typename Functor>
     void addLatePath(const Functor& functor) const
     {
-        context().latePaths.append(
+        context().latePaths.append(std::tuple {
+            origin(),
             createSharedTask<Air::GenerationContext::LatePathFunction>(
                 [=] (CCallHelpers& jit, Air::GenerationContext&) {
                     functor(jit);
-                }));
+                })
+            });
     }
 
 private:

--- a/Source/JavaScriptCore/b3/air/AirAllocateRegistersAndStackAndGenerateCode.cpp
+++ b/Source/JavaScriptCore/b3/air/AirAllocateRegistersAndStackAndGenerateCode.cpp
@@ -1043,9 +1043,11 @@ void GenerateAndAllocateRegisters::generate(CCallHelpers& jit)
     if (disassembler)
         disassembler->startLatePath(*m_jit);
 
-    // FIXME: Make late paths have Origins: https://bugs.webkit.org/show_bug.cgi?id=153689
-    for (auto& latePath : context.latePaths)
+    for (auto& [origin, latePath] : context.latePaths) {
+        if (m_code.shouldPreserveB3Origins())
+            pcToOriginMap.appendItem(m_jit->labelIgnoringWatchpoints(), origin);
         latePath->run(*m_jit, context);
+    }
 
     if (disassembler)
         disassembler->endLatePath(*m_jit);

--- a/Source/JavaScriptCore/b3/air/AirGenerate.cpp
+++ b/Source/JavaScriptCore/b3/air/AirGenerate.cpp
@@ -340,8 +340,11 @@ static void generateWithAlreadyAllocatedRegisters(Code& code, CCallHelpers& jit)
     if (disassembler)
         disassembler->startLatePath(jit);
 
-    for (auto& latePath : context.latePaths)
+    for (auto& [origin, latePath] : context.latePaths) {
+        if (code.shouldPreserveB3Origins())
+            pcToOriginMap.appendItem(jit.labelIgnoringWatchpoints(), origin);
         latePath->run(jit, context);
+    }
 
     if (disassembler)
         disassembler->endLatePath(jit);

--- a/Source/JavaScriptCore/b3/air/AirGenerationContext.h
+++ b/Source/JavaScriptCore/b3/air/AirGenerationContext.h
@@ -47,7 +47,7 @@ public:
     typedef void LatePathFunction(CCallHelpers&, GenerationContext&);
     typedef SharedTask<LatePathFunction> LatePath;
 
-    Vector<RefPtr<LatePath>> latePaths;
+    Vector<std::tuple<Origin, Ref<LatePath>>> latePaths;
     IndexMap<BasicBlock*, Box<MacroAssembler::Label>> blockLabels;
     BasicBlock* currentBlock { nullptr };
     unsigned indexInBlock { UINT_MAX };

--- a/Source/JavaScriptCore/interpreter/StackVisitor.cpp
+++ b/Source/JavaScriptCore/interpreter/StackVisitor.cpp
@@ -228,7 +228,8 @@ void StackVisitor::readInlinableNativeCalleeFrame(CallFrame* callFrame)
         // Because PC is just after the call instruction, to query to the origin for the call instruction, we decrease it by 1.
         // While it can be pointing at the broken offset (e.g. all ARM64 instructions are 4-byte aligned), it is still fine since map is controlling pc with range.
         auto callSiteIndexFromPC = omgCallee.tryGetCallSiteIndex(std::bit_cast<void*>(std::bit_cast<uintptr_t>(removeCodePtrTag<void*>(m_frame.m_returnPC)) - 1));
-        CallSiteIndex callSiteIndex = callSiteIndexFromPC.value_or(callFrame->callSiteIndex());
+        RELEASE_ASSERT(callSiteIndexFromPC);
+        CallSiteIndex callSiteIndex = callSiteIndexFromPC.value();
         m_frame.m_wasmCallSiteIndexBits = callSiteIndex.bits();
 
         auto codeOrigin = omgCallee.getCodeOrigin(callSiteIndex.bits(), depth, isInlined);

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -1265,8 +1265,18 @@ OMGIRGenerator::OMGIRGenerator(CompilationContext& context, Module& module, Call
                 GPRReg fp = params[1].gpr();
                 if (m_compilationMode == CompilationMode::OMGForOSREntryMode)
                     jit.checkWasmStackOverflow(contextInstance, CCallHelpers::TrustedImm32(checkSize), fp).linkThunk(CodeLocationLabel<JITThunkPtrTag>(Thunks::singleton().stub(crashDueToOMGStackOverflowGenerator).code()), &jit);
-                else
-                    jit.checkWasmStackOverflow(contextInstance, CCallHelpers::TrustedImm32(checkSize), fp).linkThunk(CodeLocationLabel<JITThunkPtrTag>(Thunks::singleton().stub(throwStackOverflowFromWasmThunkGenerator).code()), &jit);
+                else {
+                    auto failure = jit.checkWasmStackOverflow(contextInstance, CCallHelpers::TrustedImm32(checkSize), fp);
+                    params.addLatePath(
+                        [=](CCallHelpers& jit) {
+                            failure.link(jit);
+                            int32_t stackSpace = WTF::roundUpToMultipleOf<stackAlignmentBytes()>(RegisterSetBuilder::calleeSaveRegisters().numberOfSetRegisters() * sizeof(Register));
+                            ASSERT(static_cast<unsigned>(stackSpace) < Options::softReservedZoneSize());
+                            jit.addPtr(CCallHelpers::TrustedImm32(-stackSpace), GPRInfo::callFrameRegister, MacroAssembler::stackPointerRegister);
+                            jit.move(CCallHelpers::TrustedImm32(static_cast<uint32_t>(ExceptionType::StackOverflow)), GPRInfo::argumentGPR1);
+                            jit.nearCallThunk(CodeLocationLabel<JITThunkPtrTag>(Thunks::singleton().stub(throwExceptionFromOMGThunkGenerator).code()));
+                        });
+                }
             }
         });
     }
@@ -1334,16 +1344,10 @@ void OMGIRGenerator::reloadMemoryRegistersFromInstance(const MemoryInformation& 
     }
 }
 
-void OMGIRGenerator::emitExceptionCheck(CCallHelpers& jit, Origin origin, ExceptionType type)
+void OMGIRGenerator::emitExceptionCheck(CCallHelpers& jit, Origin, ExceptionType type)
 {
     jit.move(CCallHelpers::TrustedImm32(static_cast<uint32_t>(type)), GPRInfo::argumentGPR1);
-    // Unfortunately, we still need to have this since we are throwing an error from non OMGCallee code.
-    // In that case, we will fall back to stack's CallSiteIndex. We should make the following a call instead of jump.
-    if (auto* omgOrigin = origin.omgOrigin()) {
-        jit.move(CCallHelpers::TrustedImm32(omgOrigin->m_callSiteIndex.bits()), GPRInfo::argumentGPR2);
-        jit.store32(GPRInfo::argumentGPR2, CCallHelpers::tagFor(CallFrameSlot::argumentCountIncludingThis));
-    }
-    jit.jumpThunk(CodeLocationLabel<JITThunkPtrTag>(Thunks::singleton().stub(throwExceptionFromWasmThunkGenerator).code()));
+    jit.nearCallThunk(CodeLocationLabel<JITThunkPtrTag>(Thunks::singleton().stub(throwExceptionFromOMGThunkGenerator).code()));
 }
 
 Value* OMGIRGenerator::constant(B3::Type type, uint64_t bits, std::optional<Origin> maybeOrigin)

--- a/Source/JavaScriptCore/wasm/WasmOperations.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOperations.cpp
@@ -1694,6 +1694,16 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmToJSException, void*, (JSWebAssem
     return throwWasmToJSException(callFrame, type, instance);
 }
 
+JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationThrowExceptionFromOMG, void*, (JSWebAssemblyInstance* instance, Wasm::ExceptionType type, void* returnAddress))
+{
+    CallFrame* callFrame = DECLARE_WASM_CALL_FRAME(instance);
+    assertCalleeIsReferenced(callFrame, instance);
+    VM& vm = instance->vm();
+    // This operation is called from a thunk. Thus we need a return address from OMG callee.
+    WasmOperationPrologueCallFrameTracer tracer(vm, callFrame, removeCodePtrTag(returnAddress));
+    return throwWasmToJSException(callFrame, type, instance);
+}
+
 JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationCrashDueToBBQStackOverflow, void, ())
 {
     // We have crashed because of a mismatch between the stack check in the wasm slow path loop_osr and the BBQ JIT LoopOSREntrypoint.

--- a/Source/JavaScriptCore/wasm/WasmOperations.h
+++ b/Source/JavaScriptCore/wasm/WasmOperations.h
@@ -116,6 +116,7 @@ JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationWasmThrow, void*, (JSWebAssemblyInst
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationWasmRethrow, void*, (JSWebAssemblyInstance*, EncodedJSValue thrownValue));
 
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationWasmToJSException, void*, (JSWebAssemblyInstance*, Wasm::ExceptionType));
+JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationThrowExceptionFromOMG, void*, (JSWebAssemblyInstance*, Wasm::ExceptionType, void* returnAddress));
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationCrashDueToBBQStackOverflow, void, ());
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationCrashDueToOMGStackOverflow, void, ());
 

--- a/Source/JavaScriptCore/wasm/WasmThunks.h
+++ b/Source/JavaScriptCore/wasm/WasmThunks.h
@@ -37,6 +37,8 @@ typedef MacroAssemblerCodeRef<JITThunkPtrTag> (*ThunkGenerator)(const AbstractLo
 
 MacroAssemblerCodeRef<JITThunkPtrTag> throwExceptionFromWasmThunkGenerator(const AbstractLocker&);
 MacroAssemblerCodeRef<JITThunkPtrTag> throwStackOverflowFromWasmThunkGenerator(const AbstractLocker&);
+MacroAssemblerCodeRef<JITThunkPtrTag> throwExceptionFromOMGThunkGenerator(const AbstractLocker&);
+
 MacroAssemblerCodeRef<JITThunkPtrTag> catchInWasmThunkGenerator(const AbstractLocker&);
 MacroAssemblerCodeRef<JITThunkPtrTag> crashDueToBBQStackOverflowGenerator(const AbstractLocker&);
 MacroAssemblerCodeRef<JITThunkPtrTag> crashDueToOMGStackOverflowGenerator(const AbstractLocker&);


### PR DESCRIPTION
#### 276a1470de2093bdfdc48b7575e2d349db856b27
<pre>
[JSC] OMG exception throwing thunk should be called instead of jumped
<a href="https://bugs.webkit.org/show_bug.cgi?id=299248">https://bugs.webkit.org/show_bug.cgi?id=299248</a>
<a href="https://rdar.apple.com/161021356">rdar://161021356</a>

Reviewed by Justin Michaud.

This patch removes the last remaining reliance to CallSiteIndex on the
stack on OMG. Previously we jump to the thunk and thunk calls an
operation which throws exceptions. But this had a problem that PC
becomes thunk&apos;s address and StackVisitor cannot get the CallSiteIndex of
OMG since this thunk&apos;s PC is not OMG&apos;s code region. Previously, we were
still placing CallSiteIndex just for this pattern.

Let&apos;s make this thunk called instead of jumped. And extracting PC of OMG
and set it to operation. So StackVisitor can get CallSiteIndex for OMG
by using this PC.

* Source/JavaScriptCore/b3/B3CheckSpecial.cpp:
(JSC::B3::CheckSpecial::generate):
* Source/JavaScriptCore/b3/B3StackmapGenerationParams.cpp:
(JSC::B3::StackmapGenerationParams::origin const):
* Source/JavaScriptCore/b3/B3StackmapGenerationParams.h:
(JSC::B3::StackmapGenerationParams::addLatePath const):
* Source/JavaScriptCore/b3/air/AirAllocateRegistersAndStackAndGenerateCode.cpp:
(JSC::B3::Air::GenerateAndAllocateRegisters::generate):
* Source/JavaScriptCore/b3/air/AirCustom.cpp:
(JSC::B3::Air::WasmBoundsCheckCustom::generate):
* Source/JavaScriptCore/b3/air/AirGenerate.cpp:
(JSC::B3::Air::generateWithAlreadyAllocatedRegisters):
* Source/JavaScriptCore/b3/air/AirGenerationContext.h:
* Source/JavaScriptCore/interpreter/StackVisitor.cpp:
(JSC::StackVisitor::readInlinableNativeCalleeFrame):
* Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp:
(JSC::IPInt::slow_path_wasm_throw_exception):
(JSC::IPInt::slow_path_wasm_unwind_exception):
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::OMGIRGenerator::OMGIRGenerator):
(JSC::Wasm::OMGIRGenerator::emitExceptionCheck):
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp:
(JSC::Wasm::OMGIRGenerator::OMGIRGenerator):
(JSC::Wasm::OMGIRGenerator::emitExceptionCheck):
* Source/JavaScriptCore/wasm/WasmOperations.cpp:
(JSC::Wasm::JSC_DEFINE_NOEXCEPT_JIT_OPERATION):
* Source/JavaScriptCore/wasm/WasmOperations.h:
* Source/JavaScriptCore/wasm/WasmThunks.cpp:
(JSC::Wasm::throwExceptionFromOMGThunkGenerator):
* Source/JavaScriptCore/wasm/WasmThunks.h:

Canonical link: <a href="https://commits.webkit.org/300298@main">https://commits.webkit.org/300298@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/69e2434164280ac1b5c6a912c116eda041e2bf39

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122041 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41743 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32413 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128604 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74134 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/49b7fab1-e5e0-4037-bff1-806003b33036) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42458 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50337 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92759 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61639 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7d4d1efc-f9fd-4de3-91b9-f9dad9d87e2e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124993 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33857 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109289 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73416 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/48fed0f9-dbf5-4c9a-91f3-5559356f5698) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32870 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27455 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72098 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/114189 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103364 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27646 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131365 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/120567 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48980 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37250 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101318 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49354 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105503 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101189 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46556 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24673 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45696 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19310 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48837 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54571 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/150725 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48307 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/38566 "Found 1 new JSC stress test failure: stress/dont-link-virtual-calls-on-compiler-thread.js.no-llint (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51657 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49987 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->