### PR TITLE
[CSS ZOOM] Apply zoom factor to border spacing and border width

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7552,7 +7552,6 @@ fast/canvas/image-buffer-resource-limits.html [ Slow ]
 
 # Standardized CSS zoom tests.
 imported/w3c/web-platform-tests/css/css-viewport/width.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-viewport/zoom/border-spacing.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-viewport/zoom/iframe-zoom-nested.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-viewport/zoom/iframe-zoom.sub.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-viewport/zoom/letter-spacing.html [ ImageOnlyFailure ]

--- a/LayoutTests/fast/backgrounds/size/contain-and-cover-zoomed-expected.txt
+++ b/LayoutTests/fast/backgrounds/size/contain-and-cover-zoomed-expected.txt
@@ -1,13 +1,13 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x265
-  RenderBlock {HTML} at (0,0) size 800x266
+layer at (0,0) size 800x260
+  RenderBlock {HTML} at (0,0) size 800x261
     RenderBody {BODY} at (0,0) size 800x0
-      RenderBlock (floating) {DIV} at (1,1) size 232x88 [bgcolor=#ADD8E6] [border: (3px solid #000000)]
-      RenderBlock (floating) {DIV} at (235,1) size 232x88 [bgcolor=#ADD8E6] [border: (3px solid #000000)]
-      RenderBlock (floating) {DIV} at (469,1) size 232x88 [bgcolor=#ADD8E6] [border: (3px solid #000000)]
-      RenderBlock (floating) {DIV} at (1,90) size 232x88 [bgcolor=#ADD8E6] [border: (3px solid #000000)]
-      RenderBlock (floating) {DIV} at (235,90) size 117x175 [bgcolor=#ADD8E6] [border: (3px solid #000000)]
-      RenderBlock (floating) {DIV} at (353,90) size 117x175 [bgcolor=#ADD8E6] [border: (3px solid #000000)]
-      RenderBlock (floating) {DIV} at (471,90) size 117x175 [bgcolor=#ADD8E6] [border: (3px solid #000000)]
-      RenderBlock (floating) {DIV} at (589,90) size 117x175 [bgcolor=#ADD8E6] [border: (3px solid #000000)]
+      RenderBlock (floating) {DIV} at (1,1) size 230x85 [bgcolor=#ADD8E6] [border: (1.73px solid #000000)]
+      RenderBlock (floating) {DIV} at (232,1) size 230x85 [bgcolor=#ADD8E6] [border: (1.73px solid #000000)]
+      RenderBlock (floating) {DIV} at (464,1) size 230x85 [bgcolor=#ADD8E6] [border: (1.73px solid #000000)]
+      RenderBlock (floating) {DIV} at (1,87) size 230x86 [bgcolor=#ADD8E6] [border: (1.73px solid #000000)]
+      RenderBlock (floating) {DIV} at (232,87) size 115x173 [bgcolor=#ADD8E6] [border: (1.73px solid #000000)]
+      RenderBlock (floating) {DIV} at (348,87) size 114x173 [bgcolor=#ADD8E6] [border: (1.73px solid #000000)]
+      RenderBlock (floating) {DIV} at (464,87) size 114x173 [bgcolor=#ADD8E6] [border: (1.73px solid #000000)]
+      RenderBlock (floating) {DIV} at (579,87) size 115x173 [bgcolor=#ADD8E6] [border: (1.73px solid #000000)]

--- a/LayoutTests/fast/canvas/canvas-zoom-expected.html
+++ b/LayoutTests/fast/canvas/canvas-zoom-expected.html
@@ -1,5 +1,5 @@
 <style>
-    canvas { border: solid green; }
+    canvas { border: 6px solid green; }
 </style>
 <p>
     These should be four green hollow boxes with dimensions 600x300, 100x300, 600x100, 100x100.

--- a/LayoutTests/fast/sub-pixel/zoomed-em-border.html
+++ b/LayoutTests/fast/sub-pixel/zoomed-em-border.html
@@ -1,6 +1,12 @@
 <!DOCTYPE html>
 <html>
     <head>
+        <meta name="fuzzy" content="maxDifference=0-255; totalPixels=208" />
+        <script>
+            if (window.internals) {
+                internals.setEvaluationTimeZoom(false);
+            }
+        </script>
         <style>
             html {
                 padding: 1em;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/border-width-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/border-width-expected.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<title>CSS zoom applies to border-width when specified and inherited</title>
+<link rel="help" href="https://drafts.csswg.org/css-viewport/">
+
+<style>
+body {
+  --scale: 1;
+}
+.box {
+  width: calc(60px * var(--scale));
+  height: calc(60px * var(--scale));
+  border: calc(8px * var(--scale)) solid red;
+  margin: calc(10px * var(--scale));
+  display: inline-block;
+  font-size: calc(16px * var(--scale));
+}
+.box-rem {
+  width: calc(60px * var(--scale));
+  height: calc(60px * var(--scale));
+  border: calc(0.5rem * var(--scale)) solid blue;
+  margin: calc(10px * var(--scale));
+  display: inline-block;
+  font-size: calc(1rem * var(--scale));
+}
+.zoom {
+  --scale: 2;
+}
+</style>
+
+<div class="box">unzoomed px</div>
+<div class="box-rem">unzoomed rem</div>
+
+<div class="zoom">
+  <div class="box">zoomed px</div>
+</div>
+
+<div class="zoom box">zoomed inherited px</div>
+<div class="zoom box-rem">zoomed inherited rem</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/border-width.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/border-width.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<title>CSS zoom applies to border-width when specified and inherited</title>
+<link rel="help" href="https://drafts.csswg.org/css-viewport/">
+
+<style>
+.box {
+  width: 60px;
+  height: 60px;
+  border: 8px solid red;
+  margin: 10px;
+  display: inline-block;
+}
+.box-rem {
+  width: 60px;
+  height: 60px;
+  border: 0.5rem solid blue;
+  margin: 10px;
+  display: inline-block;
+}
+.zoom {
+  zoom: 2;
+}
+</style>
+
+<div class="box">unzoomed px</div>
+<div class="box-rem">unzoomed rem</div>
+
+<div class="zoom">
+  <div class="box">zoomed px</div>
+</div>
+
+<div class="zoom box">zoomed inherited px</div>
+<div class="zoom box-rem">zoomed inherited rem</div>

--- a/LayoutTests/platform/gtk/fast/multicol/span/anonymous-style-inheritance-expected.txt
+++ b/LayoutTests/platform/gtk/fast/multicol/span/anonymous-style-inheritance-expected.txt
@@ -1,0 +1,55 @@
+layer at (0,0) size 844x585
+  RenderView at (0,0) size 800x585
+layer at (0,0) size 800x499
+  RenderBlock {HTML} at (0,0) size 800x499
+    RenderBody {BODY} at (8,17) size 784x465
+layer at (8,18) size 836x464
+  RenderBlock {DIV} at (0,0) size 836x464 [border: (5.50px solid #800000)]
+    RenderBlock {H2} at (5,27) size 826x32 [bgcolor=#EEEEEE]
+      RenderText {#text} at (0,0) size 740x30
+        text run at (0,0) width 740: "This is a spanning element at the beginning of the columns block."
+    RenderMultiColumnSet at (5,80) size 826x379
+layer at (14,23) size 403x756 backgroundClip at (0,0) size 844x585 clip at (0,0) size 844x585
+  RenderMultiColumnFlowThread at (5,5) size 405x757
+    RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
+    RenderBlock (anonymous) at (0,0) size 404x756
+      RenderText {#text} at (0,0) size 403x755
+        text run at (0,0) width 374: "Lorem ipsum dolor sit amet, consectetuer adipiscing"
+        text run at (0,21) width 399: "elit. Nulla varius enim ac mi. Curabitur sollicitudin felis"
+        text run at (0,42) width 403: "quis lectus. Quisque adipiscing rhoncus sem. Proin nulla"
+        text run at (0,63) width 366: "purus, vulputate vel, varius ut, euismod et, nisi. Sed"
+        text run at (0,84) width 355: "vitae felis vel orci sagittis aliquam. Cras convallis"
+        text run at (0,105) width 329: "adipiscing sem. Nam nonummy enim. Nullam"
+        text run at (0,126) width 397: "bibendum lobortis neque. Vestibulum velit orci, tempus"
+        text run at (0,147) width 391: "euismod, pretium quis, interdum vitae, nulla. Phasellus"
+        text run at (0,168) width 316: "eget ante et tortor condimentum vestibulum."
+        text run at (0,189) width 393: "Suspendisse hendrerit quam nec felis. Sed varius turpis"
+        text run at (0,210) width 377: "vitae pede. Lorem ipsum dolor sit amet, consectetuer"
+        text run at (0,231) width 109: "adipiscing elit. "
+        text run at (109,231) width 202: "Lorem ipsum dolor sit amet,"
+        text run at (0,252) width 378: "consectetuer adipiscing elit. Nulla varius enim ac mi."
+        text run at (0,273) width 337: "Curabitur sollicitudin felis quis lectus. Quisque"
+        text run at (0,294) width 374: "adipiscing rhoncus sem. Proin nulla purus, vulputate"
+        text run at (0,315) width 379: "vel, varius ut, euismod et, nisi. Sed vitae felis vel orci"
+        text run at (0,336) width 377: "sagittis aliquam. Cras convallis adipiscing sem. Nam"
+        text run at (0,357) width 361: "nonummy enim. Nullam bibendum lobortis neque."
+        text run at (0,378) width 378: "Vestibulum velit orci, tempus euismod, pretium quis,"
+        text run at (0,399) width 353: "interdum vitae, nulla. Phasellus eget ante et tortor"
+        text run at (0,420) width 392: "condimentum vestibulum. Suspendisse hendrerit quam"
+        text run at (0,441) width 369: "nec felis. Sed varius turpis vitae pede. Lorem ipsum"
+        text run at (0,462) width 309: "dolor sit amet, consectetuer adipiscing elit. "
+        text run at (309,462) width 48: "Lorem"
+        text run at (0,483) width 397: "ipsum dolor sit amet, consectetuer adipiscing elit. Nulla"
+        text run at (0,504) width 358: "varius enim ac mi. Curabitur sollicitudin felis quis"
+        text run at (0,525) width 369: "lectus. Quisque adipiscing rhoncus sem. Proin nulla"
+        text run at (0,546) width 366: "purus, vulputate vel, varius ut, euismod et, nisi. Sed"
+        text run at (0,567) width 355: "vitae felis vel orci sagittis aliquam. Cras convallis"
+        text run at (0,588) width 329: "adipiscing sem. Nam nonummy enim. Nullam"
+        text run at (0,609) width 397: "bibendum lobortis neque. Vestibulum velit orci, tempus"
+        text run at (0,630) width 391: "euismod, pretium quis, interdum vitae, nulla. Phasellus"
+        text run at (0,651) width 316: "eget ante et tortor condimentum vestibulum."
+        text run at (0,672) width 393: "Suspendisse hendrerit quam nec felis. Sed varius turpis"
+        text run at (0,693) width 377: "vitae pede. Lorem ipsum dolor sit amet, consectetuer"
+        text run at (0,714) width 109: "adipiscing elit. "
+        text run at (109,714) width 202: "Lorem ipsum dolor sit amet,"
+        text run at (0,735) width 378: "consectetuer adipiscing elit. Nulla varius enim ac mi."

--- a/LayoutTests/platform/gtk/fast/repaint/repaint-during-scroll-with-zoom-expected.txt
+++ b/LayoutTests/platform/gtk/fast/repaint/repaint-during-scroll-with-zoom-expected.txt
@@ -1,0 +1,14 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x0
+  RenderBlock {HTML} at (0,0) size 800x0
+    RenderBody {BODY} at (0,0) size 800x0 [bgcolor=#C0C0C0]
+layer at (0,63) size 255x255
+  RenderIFrame {IFRAME} at (0,62) size 255x256 [border: (2.50px inset #000000)]
+    layer at (0,0) size 2008x2016
+      RenderView at (0,0) size 235x235
+    layer at (0,0) size 235x2016
+      RenderBlock {HTML} at (0,0) size 235x2016
+        RenderBody {BODY} at (8,8) size 2000x2000 [bgcolor=#FFFFFF]
+          RenderText {#text} at (0,0) size 57x17
+            text run at (0,0) width 57: "scroll me"

--- a/LayoutTests/platform/gtk/media/video-zoom-expected.txt
+++ b/LayoutTests/platform/gtk/media/video-zoom-expected.txt
@@ -1,0 +1,23 @@
+layer at (0,0) size 785x846
+  RenderView at (0,0) size 785x600
+layer at (0,0) size 785x846
+  RenderBlock {HTML} at (0,0) size 785x846
+    RenderBody {BODY} at (8,8) size 769x830
+      RenderBlock {P} at (0,0) size 769x18
+        RenderText {#text} at (0,0) size 283x17
+          text run at (0,0) width 283: "150% zoom, with width and height attributes"
+      RenderBlock (anonymous) at (0,34) size 769x373
+        RenderText {#text} at (0,355) size 4x17
+          text run at (0,355) width 4: " "
+        RenderBR {BR} at (493,355) size 0x17
+      RenderBlock {P} at (0,423) size 769x18
+        RenderText {#text} at (0,0) size 303x17
+          text run at (0,0) width 303: "150% zoom, without width and height attributes"
+      RenderBlock (anonymous) at (0,457) size 769x373
+        RenderText {#text} at (0,355) size 4x17
+          text run at (0,355) width 4: " "
+        RenderBR {BR} at (493,355) size 0x17
+layer at (12,42) size 489x369
+  RenderVideo {VIDEO} at (4,0) size 489x369 [border: (4.50px solid #FF0000)]
+layer at (12,465) size 489x369
+  RenderVideo {VIDEO} at (4,0) size 489x369 [border: (4.50px solid #FF0000)]

--- a/LayoutTests/platform/gtk/svg/zoom/page/zoom-background-images-expected.txt
+++ b/LayoutTests/platform/gtk/svg/zoom/page/zoom-background-images-expected.txt
@@ -1,0 +1,19 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x164
+  RenderBlock {HTML} at (0,0) size 800x164
+    RenderBody {BODY} at (4,4) size 792x156
+      RenderBlock {DIV} at (11,11) size 131x131 [border: (1.16px solid #000000)]
+      RenderText {#text} at (152,144) size 3x11
+        text run at (152,144) width 3: " "
+      RenderBlock {DIV} at (166,11) size 130x131 [border: (1.16px solid #000000)]
+      RenderText {#text} at (307,144) size 3x11
+        text run at (307,144) width 3: " "
+      RenderBlock {DIV} at (321,11) size 130x131 [border: (1.16px solid #000000)]
+      RenderText {#text} at (462,144) size 3x11
+        text run at (462,144) width 3: " "
+      RenderImage {IMG} at (475,11) size 131x131 [border: (1.16px solid #000000)]
+      RenderText {#text} at (0,0) size 0x0
+      RenderText {#text} at (0,0) size 0x0
+      RenderText {#text} at (0,0) size 0x0
+      RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/gtk/svg/zoom/page/zoom-img-preserveAspectRatio-support-1-expected.txt
+++ b/LayoutTests/platform/gtk/svg/zoom/page/zoom-img-preserveAspectRatio-support-1-expected.txt
@@ -1,0 +1,156 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x345
+  RenderBlock {HTML} at (0,0) size 800x346
+    RenderBody {BODY} at (5,5) size 790x335
+      RenderTable {TABLE} at (0,0) size 464x335
+        RenderTableSection {TBODY} at (0,0) size 464x335
+          RenderTableRow {TR} at (0,1) size 464x14
+            RenderTableCell {TH} at (1,1) size 65x14 [bgcolor=#DDDD99] [r=0 c=0 rs=1 cs=1]
+              RenderText {#text} at (6,0) size 53x13
+                text run at (6,0) width 53: "viewBox?"
+            RenderTableCell {TH} at (67,1) size 112x14 [bgcolor=#DDDD99] [r=0 c=1 rs=1 cs=1]
+              RenderText {#text} at (0,0) size 111x13
+                text run at (0,0) width 111: "preserve\x{AD}Aspect\x{AD}Ratio"
+            RenderTableCell {TH} at (179,1) size 142x14 [bgcolor=#DDDD99] [r=0 c=2 rs=1 cs=1]
+              RenderText {#text} at (54,0) size 33x13
+                text run at (54,0) width 33: "<img>"
+            RenderTableCell {TH} at (321,1) size 141x14 [bgcolor=#DDDD99] [r=0 c=3 rs=1 cs=1]
+              RenderText {#text} at (47,0) size 46x13
+                text run at (47,0) width 46: "<object>"
+          RenderTableRow {TR} at (0,16) size 464x39
+            RenderTableCell {TH} at (1,88) size 65x14 [bgcolor=#DDDD99] [r=1 c=0 rs=4 cs=1]
+              RenderText {#text} at (0,72) size 64x13
+                text run at (0,0) width 64: "No viewBox"
+            RenderTableCell {TH} at (67,34) size 112x2 [bgcolor=#DDDD99] [r=1 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (179,16) size 142x39 [r=1 c=2 rs=1 cs=1]
+              RenderImage {IMG} at (0,0) size 140x36 [border: (1.38px dashed #800000)]
+              RenderText {#text} at (0,0) size 0x0
+            RenderTableCell {TD} at (321,16) size 141x39 [r=1 c=3 rs=1 cs=1]
+              RenderEmbeddedObject {OBJECT} at (0,0) size 140x36 [border: (1px dashed #008000)]
+                layer at (0,0) size 133x29
+                  RenderView at (0,0) size 133x29
+                layer at (0,0) size 133x29
+                  RenderSVGRoot {svg} at (0,0) size 133x29
+                    RenderSVGEllipse {circle} at (0,0) size 133x29 [stroke={[type=SOLID] [color=#000000]}] [fill={[type=SOLID] [color=#D9BB7A] [fill rule=EVEN-ODD]}] [cx=110.00] [cy=110.00] [r=110.00]
+              RenderText {#text} at (0,0) size 0x0
+          RenderTableRow {TR} at (0,55) size 464x40
+            RenderTableCell {TH} at (67,68) size 112x14 [bgcolor=#DDDD99] [r=2 c=1 rs=1 cs=1]
+              RenderText {#text} at (42,13) size 28x13
+                text run at (42,1) width 28: "none"
+            RenderTableCell {TD} at (179,55) size 142x40 [r=2 c=2 rs=1 cs=1]
+              RenderImage {IMG} at (0,0) size 140x36 [border: (1.38px dashed #800000)]
+              RenderText {#text} at (0,0) size 0x0
+            RenderTableCell {TD} at (321,55) size 141x40 [r=2 c=3 rs=1 cs=1]
+              RenderEmbeddedObject {OBJECT} at (0,0) size 140x36 [border: (1px dashed #008000)]
+                layer at (0,0) size 133x29
+                  RenderView at (0,0) size 133x29
+                layer at (0,0) size 133x29
+                  RenderSVGRoot {svg} at (0,0) size 133x29
+                    RenderSVGHiddenContainer {defs} at (0,0) size 0x0
+                    RenderSVGContainer {g} at (0,0) size 133x29 [transform={m=((1.00,0.00)(0.00,1.00)) t=(-162.36,-403.29)}]
+                      RenderSVGPath {path} at (0,0) size 133x29 [stroke={[type=SOLID] [color=#000000]}] [fill={[type=SOLID] [color=#D9BB7A] [fill rule=EVEN-ODD]}] [data="M 525.714 585.219 C 525.714 685.419 444.486 766.648 344.286 766.648 C 244.085 766.648 162.857 685.419 162.857 585.219 C 162.857 485.019 244.085 403.791 344.286 403.791 C 444.486 403.791 525.714 485.019 525.714 585.219 Z"]
+              RenderText {#text} at (0,0) size 0x0
+          RenderTableRow {TR} at (0,95) size 464x39
+            RenderTableCell {TH} at (67,108) size 112x14 [bgcolor=#DDDD99] [r=3 c=1 rs=1 cs=1]
+              RenderText {#text} at (42,13) size 27x13
+                text run at (42,1) width 27: "meet"
+            RenderTableCell {TD} at (179,95) size 142x39 [r=3 c=2 rs=1 cs=1]
+              RenderImage {IMG} at (0,0) size 140x36 [border: (1.38px dashed #800000)]
+              RenderText {#text} at (0,0) size 0x0
+            RenderTableCell {TD} at (321,95) size 141x39 [r=3 c=3 rs=1 cs=1]
+              RenderEmbeddedObject {OBJECT} at (0,0) size 140x36 [border: (1px dashed #008000)]
+                layer at (0,0) size 133x29
+                  RenderView at (0,0) size 133x29
+                layer at (0,0) size 133x29
+                  RenderSVGRoot {svg} at (0,0) size 133x29
+                    RenderSVGHiddenContainer {defs} at (0,0) size 0x0
+                    RenderSVGContainer {g} at (0,0) size 133x29 [transform={m=((1.00,0.00)(0.00,1.00)) t=(-162.36,-403.29)}]
+                      RenderSVGPath {path} at (0,0) size 133x29 [stroke={[type=SOLID] [color=#000000]}] [fill={[type=SOLID] [color=#D9BB7A] [fill rule=EVEN-ODD]}] [data="M 525.714 585.219 C 525.714 685.419 444.486 766.648 344.286 766.648 C 244.085 766.648 162.857 685.419 162.857 585.219 C 162.857 485.019 244.085 403.791 344.286 403.791 C 444.486 403.791 525.714 485.019 525.714 585.219 Z"]
+              RenderText {#text} at (0,0) size 0x0
+          RenderTableRow {TR} at (0,135) size 464x39
+            RenderTableCell {TH} at (67,147) size 112x15 [bgcolor=#DDDD99] [r=4 c=1 rs=1 cs=1]
+              RenderText {#text} at (43,13) size 25x13
+                text run at (43,1) width 25: "slice"
+            RenderTableCell {TD} at (179,135) size 142x39 [r=4 c=2 rs=1 cs=1]
+              RenderImage {IMG} at (0,0) size 140x36 [border: (1.38px dashed #800000)]
+              RenderText {#text} at (0,0) size 0x0
+            RenderTableCell {TD} at (321,135) size 141x39 [r=4 c=3 rs=1 cs=1]
+              RenderEmbeddedObject {OBJECT} at (0,0) size 140x36 [border: (1px dashed #008000)]
+                layer at (0,0) size 133x29
+                  RenderView at (0,0) size 133x29
+                layer at (0,0) size 133x29
+                  RenderSVGRoot {svg} at (0,0) size 133x29
+                    RenderSVGHiddenContainer {defs} at (0,0) size 0x0
+                    RenderSVGContainer {g} at (0,0) size 133x29 [transform={m=((1.00,0.00)(0.00,1.00)) t=(-162.36,-403.29)}]
+                      RenderSVGPath {path} at (0,0) size 133x29 [stroke={[type=SOLID] [color=#000000]}] [fill={[type=SOLID] [color=#D9BB7A] [fill rule=EVEN-ODD]}] [data="M 525.714 585.219 C 525.714 685.419 444.486 766.648 344.286 766.648 C 244.085 766.648 162.857 685.419 162.857 585.219 C 162.857 485.019 244.085 403.791 344.286 403.791 C 444.486 403.791 525.714 485.019 525.714 585.219 Z"]
+              RenderText {#text} at (0,0) size 0x0
+          RenderTableRow {TR} at (0,175) size 464x39
+            RenderTableCell {TH} at (1,247) size 65x14 [bgcolor=#DDDD99] [r=5 c=0 rs=4 cs=1]
+              RenderText {#text} at (9,72) size 46x13
+                text run at (9,0) width 46: "viewBox"
+            RenderTableCell {TH} at (67,193) size 112x2 [bgcolor=#DDDD99] [r=5 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (179,175) size 142x39 [r=5 c=2 rs=1 cs=1]
+              RenderImage {IMG} at (0,0) size 140x36 [border: (1.38px dashed #800000)]
+              RenderText {#text} at (0,0) size 0x0
+            RenderTableCell {TD} at (321,175) size 141x39 [r=5 c=3 rs=1 cs=1]
+              RenderEmbeddedObject {OBJECT} at (0,0) size 140x36 [border: (1px dashed #008000)]
+                layer at (0,0) size 133x29
+                  RenderView at (0,0) size 133x29
+                layer at (0,0) size 133x29
+                  RenderSVGRoot {svg} at (52,0) size 22x22
+                    RenderSVGHiddenContainer {defs} at (0,0) size 0x0
+                    RenderSVGContainer {g} at (52,0) size 22x22 [transform={m=((1.00,0.00)(0.00,1.00)) t=(-162.36,-403.29)}]
+                      RenderSVGPath {path} at (52,0) size 22x22 [stroke={[type=SOLID] [color=#000000]}] [fill={[type=SOLID] [color=#D9BB7A] [fill rule=EVEN-ODD]}] [data="M 525.714 585.219 C 525.714 685.419 444.486 766.648 344.286 766.648 C 244.085 766.648 162.857 685.419 162.857 585.219 C 162.857 485.019 244.085 403.791 344.286 403.791 C 444.486 403.791 525.714 485.019 525.714 585.219 Z"]
+              RenderText {#text} at (0,0) size 0x0
+          RenderTableRow {TR} at (0,214) size 464x40
+            RenderTableCell {TH} at (67,227) size 112x14 [bgcolor=#DDDD99] [r=6 c=1 rs=1 cs=1]
+              RenderText {#text} at (42,13) size 28x13
+                text run at (42,1) width 28: "none"
+            RenderTableCell {TD} at (179,214) size 142x40 [r=6 c=2 rs=1 cs=1]
+              RenderImage {IMG} at (0,0) size 140x36 [border: (1.38px dashed #800000)]
+              RenderText {#text} at (0,0) size 0x0
+            RenderTableCell {TD} at (321,214) size 141x40 [r=6 c=3 rs=1 cs=1]
+              RenderEmbeddedObject {OBJECT} at (0,0) size 140x36 [border: (1px dashed #008000)]
+                layer at (0,0) size 133x29
+                  RenderView at (0,0) size 133x29
+                layer at (0,0) size 133x29
+                  RenderSVGRoot {svg} at (0,0) size 97x22
+                    RenderSVGHiddenContainer {defs} at (0,0) size 0x0
+                    RenderSVGContainer {g} at (0,0) size 97x22 [transform={m=((1.00,0.00)(0.00,1.00)) t=(-162.36,-403.29)}]
+                      RenderSVGPath {path} at (0,0) size 97x22 [stroke={[type=SOLID] [color=#000000]}] [fill={[type=SOLID] [color=#D9BB7A] [fill rule=EVEN-ODD]}] [data="M 525.714 585.219 C 525.714 685.419 444.486 766.648 344.286 766.648 C 244.085 766.648 162.857 685.419 162.857 585.219 C 162.857 485.019 244.085 403.791 344.286 403.791 C 444.486 403.791 525.714 485.019 525.714 585.219 Z"]
+              RenderText {#text} at (0,0) size 0x0
+          RenderTableRow {TR} at (0,254) size 464x39
+            RenderTableCell {TH} at (67,267) size 112x14 [bgcolor=#DDDD99] [r=7 c=1 rs=1 cs=1]
+              RenderText {#text} at (42,13) size 27x13
+                text run at (42,1) width 27: "meet"
+            RenderTableCell {TD} at (179,254) size 142x39 [r=7 c=2 rs=1 cs=1]
+              RenderImage {IMG} at (0,0) size 140x36 [border: (1.38px dashed #800000)]
+              RenderText {#text} at (0,0) size 0x0
+            RenderTableCell {TD} at (321,254) size 141x39 [r=7 c=3 rs=1 cs=1]
+              RenderEmbeddedObject {OBJECT} at (0,0) size 140x36 [border: (1px dashed #008000)]
+                layer at (0,0) size 133x29
+                  RenderView at (0,0) size 133x29
+                layer at (0,0) size 133x29
+                  RenderSVGRoot {svg} at (52,0) size 22x22
+                    RenderSVGHiddenContainer {defs} at (0,0) size 0x0
+                    RenderSVGContainer {g} at (52,0) size 22x22 [transform={m=((1.00,0.00)(0.00,1.00)) t=(-162.36,-403.29)}]
+                      RenderSVGPath {path} at (52,0) size 22x22 [stroke={[type=SOLID] [color=#000000]}] [fill={[type=SOLID] [color=#D9BB7A] [fill rule=EVEN-ODD]}] [data="M 525.714 585.219 C 525.714 685.419 444.486 766.648 344.286 766.648 C 244.085 766.648 162.857 685.419 162.857 585.219 C 162.857 485.019 244.085 403.791 344.286 403.791 C 444.486 403.791 525.714 485.019 525.714 585.219 Z"]
+              RenderText {#text} at (0,0) size 0x0
+          RenderTableRow {TR} at (0,294) size 464x39
+            RenderTableCell {TH} at (67,306) size 112x15 [bgcolor=#DDDD99] [r=8 c=1 rs=1 cs=1]
+              RenderText {#text} at (43,13) size 25x13
+                text run at (43,1) width 25: "slice"
+            RenderTableCell {TD} at (179,294) size 142x39 [r=8 c=2 rs=1 cs=1]
+              RenderImage {IMG} at (0,0) size 140x36 [border: (1.38px dashed #800000)]
+              RenderText {#text} at (0,0) size 0x0
+            RenderTableCell {TD} at (321,294) size 141x39 [r=8 c=3 rs=1 cs=1]
+              RenderEmbeddedObject {OBJECT} at (0,0) size 140x36 [border: (1px dashed #008000)]
+                layer at (0,0) size 133x29
+                  RenderView at (0,0) size 133x29
+                layer at (0,0) size 133x29
+                  RenderSVGRoot {svg} at (0,0) size 97x29
+                    RenderSVGHiddenContainer {defs} at (0,0) size 0x0
+                    RenderSVGContainer {g} at (0,0) size 97x29 [transform={m=((1.00,0.00)(0.00,1.00)) t=(-162.36,-403.29)}]
+                      RenderSVGPath {path} at (0,0) size 97x29 [stroke={[type=SOLID] [color=#000000]}] [fill={[type=SOLID] [color=#D9BB7A] [fill rule=EVEN-ODD]}] [data="M 525.714 585.219 C 525.714 685.419 444.486 766.648 344.286 766.648 C 244.085 766.648 162.857 685.419 162.857 585.219 C 162.857 485.019 244.085 403.791 344.286 403.791 C 444.486 403.791 525.714 485.019 525.714 585.219 Z"]
+              RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/gtk/svg/zoom/page/zoom-replaced-intrinsic-ratio-001-expected.txt
+++ b/LayoutTests/platform/gtk/svg/zoom/page/zoom-replaced-intrinsic-ratio-001-expected.txt
@@ -1,0 +1,62 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x456
+  RenderBlock {HTML} at (0,0) size 800x457
+    RenderBody {BODY} at (4,4) size 142x445 [border: (1px dashed #C0C0C0)]
+      RenderBlock {P} at (1,10) size 139x28
+        RenderText {#text} at (0,-1) size 137x28
+          text run at (0,-1) width 135: "The following six blue boxes must"
+          text run at (0,8) width 137: "be of the same width. There must be"
+          text run at (0,17) width 26: "no red."
+      RenderBlock {P} at (10,46) size 121x21 [bgcolor=#008000] [border: (5.20px solid #0000FF)]
+        RenderText {#text} at (5,4) size 3x11
+          text run at (5,4) width 3: " "
+      RenderBlock {P} at (1,121) size 139x10
+        RenderText {#text} at (0,-1) size 12x10
+          text run at (0,-1) width 12: "      "
+        RenderText {#text} at (0,0) size 0x0
+        RenderEmbeddedObject {OBJECT} at (9,-1) size 121x39 [bgcolor=#FF0000] [border: (5.20px solid #0000FF)]
+          layer at (0,0) size 110x27
+            RenderView at (0,0) size 110x27
+          layer at (0,0) size 110x27
+            RenderSVGRoot {svg} at (0,0) size 109x27
+              RenderSVGRect {rect} at (0,0) size 109x27 [stroke={[type=SOLID] [color=#008000] [stroke width=12.00]}] [fill={[type=SOLID] [color=#00FF00]}] [x=0.00] [y=0.00] [width=1000.00] [height=250.00]
+              RenderSVGPath {path} at (16,5) size 76x17 [fill={[type=SOLID] [color=#008000]}] [data="M 500 50 L 150 200 L 850 200 Z"]
+      RenderBlock {P} at (1,186) size 139x10
+        RenderEmbeddedObject {OBJECT} at (9,0) size 121x38 [bgcolor=#FF0000] [border: (5.20px solid #0000FF)]
+          layer at (0,0) size 110x27
+            RenderView at (0,0) size 110x27
+          layer at (0,0) size 110x27
+            RenderSVGRoot {svg} at (0,0) size 109x27
+              RenderSVGRect {rect} at (0,0) size 109x27 [stroke={[type=SOLID] [color=#008000] [stroke width=12.00]}] [fill={[type=SOLID] [color=#00FF00]}] [x=0.00] [y=0.00] [width=1000.00] [height=250.00]
+              RenderSVGPath {path} at (16,5) size 76x17 [fill={[type=SOLID] [color=#008000]}] [data="M 500 50 L 150 200 L 850 200 Z"]
+      RenderTable at (1,251) size 139x41
+        RenderTableSection (anonymous) at (0,0) size 139x40
+          RenderTableRow (anonymous) at (0,0) size 139x40
+            RenderTableCell {P} at (0,0) size 139x40 [r=0 c=0 rs=1 cs=1]
+              RenderEmbeddedObject {OBJECT} at (9,0) size 121x38 [bgcolor=#FF0000] [border: (5.20px solid #0000FF)]
+                layer at (0,0) size 110x27
+                  RenderView at (0,0) size 110x27
+                layer at (0,0) size 110x27
+                  RenderSVGRoot {svg} at (0,0) size 109x27
+                    RenderSVGRect {rect} at (0,0) size 109x27 [stroke={[type=SOLID] [color=#008000] [stroke width=12.00]}] [fill={[type=SOLID] [color=#00FF00]}] [x=0.00] [y=0.00] [width=1000.00] [height=250.00]
+                    RenderSVGPath {path} at (16,5) size 76x17 [fill={[type=SOLID] [color=#008000]}] [data="M 500 50 L 150 200 L 850 200 Z"]
+      RenderTable {TABLE} at (1,346) size 139x41
+        RenderTableSection {TBODY} at (0,0) size 139x40
+          RenderTableRow {TR} at (0,0) size 139x40
+            RenderTableCell {TD} at (0,0) size 139x40 [r=0 c=0 rs=1 cs=1]
+              RenderEmbeddedObject {OBJECT} at (9,0) size 121x38 [bgcolor=#FF0000] [border: (5.20px solid #0000FF)]
+                layer at (0,0) size 110x27
+                  RenderView at (0,0) size 110x27
+                layer at (0,0) size 110x27
+                  RenderSVGRoot {svg} at (0,0) size 109x27
+                    RenderSVGRect {rect} at (0,0) size 109x27 [stroke={[type=SOLID] [color=#008000] [stroke width=12.00]}] [fill={[type=SOLID] [color=#00FF00]}] [x=0.00] [y=0.00] [width=1000.00] [height=250.00]
+                    RenderSVGPath {path} at (16,5) size 76x17 [fill={[type=SOLID] [color=#008000]}] [data="M 500 50 L 150 200 L 850 200 Z"]
+      RenderBlock (floating) {P} at (1,442) size 139x10
+        RenderEmbeddedObject {OBJECT} at (9,0) size 121x38 [bgcolor=#FF0000] [border: (5.20px solid #0000FF)]
+          layer at (0,0) size 110x27
+            RenderView at (0,0) size 110x27
+          layer at (0,0) size 110x27
+            RenderSVGRoot {svg} at (0,0) size 109x27
+              RenderSVGRect {rect} at (0,0) size 109x27 [stroke={[type=SOLID] [color=#008000] [stroke width=12.00]}] [fill={[type=SOLID] [color=#00FF00]}] [x=0.00] [y=0.00] [width=1000.00] [height=250.00]
+              RenderSVGPath {path} at (16,5) size 76x17 [fill={[type=SOLID] [color=#008000]}] [data="M 500 50 L 150 200 L 850 200 Z"]

--- a/LayoutTests/platform/gtk/svg/zoom/page/zoom-svg-through-object-with-auto-size-expected.txt
+++ b/LayoutTests/platform/gtk/svg/zoom/page/zoom-svg-through-object-with-auto-size-expected.txt
@@ -1,0 +1,24 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x173
+  RenderBlock {HTML} at (0,0) size 800x174
+    RenderBody {BODY} at (5,5) size 790x163
+      RenderEmbeddedObject {OBJECT} at (0,0) size 160x160 [border: (1.38px dashed #800000)]
+        layer at (0,0) size 153x153
+          RenderView at (0,0) size 153x153
+        layer at (0,0) size 153x153
+          RenderSVGRoot {svg} at (0,0) size 153x153
+            RenderSVGEllipse {circle} at (0,0) size 153x153 [stroke={[type=SOLID] [color=#000000]}] [fill={[type=SOLID] [color=#D9BB7A] [fill rule=EVEN-ODD]}] [cx=110.00] [cy=110.00] [r=110.00]
+      RenderText {#text} at (159,150) size 4x12
+        text run at (159,150) width 4: " "
+      RenderEmbeddedObject {OBJECT} at (162,0) size 161x160 [border: (1.38px dashed #800000)]
+        layer at (0,0) size 153x153
+          RenderView at (0,0) size 153x153
+        layer at (0,0) size 153x153
+          RenderSVGRoot {svg} at (0,0) size 153x153
+            RenderSVGEllipse {circle} at (0,0) size 153x153 [stroke={[type=SOLID] [color=#000000]}] [fill={[type=SOLID] [color=#D9BB7A] [fill rule=EVEN-ODD]}] [cx=110.00] [cy=110.00] [r=110.00]
+      RenderText {#text} at (0,0) size 0x0
+      RenderText {#text} at (0,0) size 0x0
+      RenderText {#text} at (0,0) size 0x0
+      RenderText {#text} at (0,0) size 0x0
+      RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/ios/fast/backgrounds/background-position-parsing-expected.txt
+++ b/LayoutTests/platform/ios/fast/backgrounds/background-position-parsing-expected.txt
@@ -1,158 +1,158 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x407
-  RenderBlock {HTML} at (0,0) size 800x407
+layer at (0,0) size 800x389
+  RenderBlock {HTML} at (0,0) size 800x389
     RenderBody {BODY} at (8,16) size 784x20
       RenderBlock {P} at (0,0) size 784x20
         RenderText {#text} at (0,0) size 509x19
           text run at (0,0) width 509: "In all the following boxes, the fuchsia diamond should be surrounded by a ring."
-      RenderBlock (floating) {DIV} at (1,37) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (1,37) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (86,37) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (83,37) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (170,37) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (164,37) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (255,37) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (246,37) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (340,37) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (328,37) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (424,37) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (409,37) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (509,37) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (491,37) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (593,37) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (572,37) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (678,37) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (654,37) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (1,96) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (1,93) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (86,96) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (83,93) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (170,96) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (164,93) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (255,96) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (246,93) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (340,96) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (328,93) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (424,96) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (409,93) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (509,96) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (491,93) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (593,96) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (572,93) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (678,96) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (654,93) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (1,155) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (1,149) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (86,155) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (83,149) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (170,155) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (164,149) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (255,155) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (246,149) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (340,155) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (328,149) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (424,155) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (409,149) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (509,155) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (491,149) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (593,155) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (572,149) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (678,155) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (654,149) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (1,214) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (1,205) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (86,214) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (83,205) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (170,214) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (164,205) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (255,214) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (246,205) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (340,214) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (328,205) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (424,214) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (409,205) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (509,214) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (491,205) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (593,214) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (572,205) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (678,214) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (654,205) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (1,273) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (1,261) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (86,273) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (83,261) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (170,273) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (164,261) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (255,273) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (246,261) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (340,273) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (328,261) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (424,273) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (409,261) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (509,273) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (491,261) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (593,273) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (572,261) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (678,273) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (654,261) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (1,332) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (1,317) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (86,332) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (83,317) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (170,332) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (164,317) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (255,332) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (246,317) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (340,332) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (328,317) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34

--- a/LayoutTests/platform/mac/fast/backgrounds/background-position-parsing-expected.txt
+++ b/LayoutTests/platform/mac/fast/backgrounds/background-position-parsing-expected.txt
@@ -1,158 +1,158 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x405
-  RenderBlock {HTML} at (0,0) size 800x405
+layer at (0,0) size 800x387
+  RenderBlock {HTML} at (0,0) size 800x387
     RenderBody {BODY} at (8,16) size 784x18
       RenderBlock {P} at (0,0) size 784x18
         RenderText {#text} at (0,0) size 509x18
           text run at (0,0) width 509: "In all the following boxes, the fuchsia diamond should be surrounded by a ring."
-      RenderBlock (floating) {DIV} at (1,35) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (1,35) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (86,35) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (83,35) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (170,35) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (164,35) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (255,35) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (246,35) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (340,35) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (328,35) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (424,35) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (409,35) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (509,35) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (491,35) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (593,35) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (572,35) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (678,35) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (654,35) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (1,94) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (1,91) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (86,94) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (83,91) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (170,94) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (164,91) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (255,94) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (246,91) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (340,94) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (328,91) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (424,94) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (409,91) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (509,94) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (491,91) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (593,94) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (572,91) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (678,94) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (654,91) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (1,153) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (1,147) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (86,153) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (83,147) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (170,153) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (164,147) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (255,153) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (246,147) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (340,153) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (328,147) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (424,153) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (409,147) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (509,153) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (491,147) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (593,153) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (572,147) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (678,153) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (654,147) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (1,212) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (1,203) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (86,212) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (83,203) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (170,212) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (164,203) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (255,212) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (246,203) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (340,212) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (328,203) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (424,212) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (409,203) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (509,212) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (491,203) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (593,212) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (572,203) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (678,212) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (654,203) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (1,271) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (1,259) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (86,271) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (83,259) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (170,271) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (164,259) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (255,271) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (246,259) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (340,271) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (328,259) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (424,271) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (409,259) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (509,271) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (491,259) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (593,271) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (572,259) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (678,271) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (654,259) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (1,330) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (1,315) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (86,330) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (83,315) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (170,330) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (164,315) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (255,330) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (246,315) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (340,330) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (328,315) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34

--- a/LayoutTests/platform/mac/fast/multicol/span/anonymous-style-inheritance-expected.txt
+++ b/LayoutTests/platform/mac/fast/multicol/span/anonymous-style-inheritance-expected.txt
@@ -1,16 +1,16 @@
-layer at (0,0) size 843x585
+layer at (0,0) size 844x585
   RenderView at (0,0) size 800x585
-layer at (0,0) size 800x480
-  RenderBlock {HTML} at (0,0) size 800x480
-    RenderBody {BODY} at (8,17) size 784x446
-layer at (8,18) size 835x445
-  RenderBlock {DIV} at (0,0) size 835x445 [border: (5px solid #800000)]
-    RenderBlock {H2} at (5,26) size 825x32 [bgcolor=#EEEEEE]
+layer at (0,0) size 800x481
+  RenderBlock {HTML} at (0,0) size 800x481
+    RenderBody {BODY} at (8,17) size 784x447
+layer at (8,18) size 836x446
+  RenderBlock {DIV} at (0,0) size 836x446 [border: (5.50px solid #800000)]
+    RenderBlock {H2} at (5,27) size 826x32 [bgcolor=#EEEEEE]
       RenderText {#text} at (0,0) size 732x31
         text run at (0,0) width 732: "This is a spanning element at the beginning of the columns block."
-    RenderMultiColumnSet at (5,79) size 825x361
-layer at (13,23) size 404x700 backgroundClip at (0,0) size 843x585 clip at (0,0) size 843x585
-  RenderMultiColumnFlowThread at (5,5) size 404x700
+    RenderMultiColumnSet at (5,80) size 826x361
+layer at (14,23) size 403x700 backgroundClip at (0,0) size 844x585 clip at (0,0) size 844x585
+  RenderMultiColumnFlowThread at (5,5) size 405x701
     RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
     RenderBlock (anonymous) at (0,0) size 404x700
       RenderText {#text} at (0,0) size 403x700

--- a/LayoutTests/platform/mac/fast/repaint/repaint-during-scroll-with-zoom-expected.txt
+++ b/LayoutTests/platform/mac/fast/repaint/repaint-during-scroll-with-zoom-expected.txt
@@ -3,8 +3,8 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x0
   RenderBlock {HTML} at (0,0) size 800x0
     RenderBody {BODY} at (0,0) size 800x0 [bgcolor=#C0C0C0]
-layer at (0,63) size 254x254
-  RenderIFrame {IFRAME} at (0,62) size 254x255 [border: (2px inset #000000)]
+layer at (0,63) size 255x255
+  RenderIFrame {IFRAME} at (0,62) size 255x256 [border: (2.50px inset #000000)]
     layer at (0,0) size 2008x2016
       RenderView at (0,0) size 235x235
     layer at (0,0) size 235x2016

--- a/LayoutTests/platform/mac/svg/zoom/page/zoom-background-images-expected.txt
+++ b/LayoutTests/platform/mac/svg/zoom/page/zoom-background-images-expected.txt
@@ -3,16 +3,16 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x164
   RenderBlock {HTML} at (0,0) size 800x164
     RenderBody {BODY} at (4,4) size 792x156
-      RenderBlock {DIV} at (11,11) size 130x130 [border: (1px solid #000000)]
-      RenderText {#text} at (152,144) size 3x11
-        text run at (152,144) width 3: " "
-      RenderBlock {DIV} at (166,11) size 130x130 [border: (1px solid #000000)]
-      RenderText {#text} at (307,144) size 3x11
-        text run at (307,144) width 3: " "
-      RenderBlock {DIV} at (321,11) size 130x130 [border: (1px solid #000000)]
-      RenderText {#text} at (461,144) size 4x11
-        text run at (461,144) width 4: " "
-      RenderImage {IMG} at (475,11) size 131x130 [border: (1px solid #000000)]
+      RenderBlock {DIV} at (11,11) size 131x131 [border: (1.16px solid #000000)]
+      RenderText {#text} at (152,144) size 4x11
+        text run at (152,144) width 4: " "
+      RenderBlock {DIV} at (166,11) size 131x131 [border: (1.16px solid #000000)]
+      RenderText {#text} at (307,144) size 4x11
+        text run at (307,144) width 4: " "
+      RenderBlock {DIV} at (321,11) size 131x131 [border: (1.16px solid #000000)]
+      RenderText {#text} at (462,144) size 4x11
+        text run at (462,144) width 4: " "
+      RenderImage {IMG} at (476,11) size 131x131 [border: (1.16px solid #000000)]
       RenderText {#text} at (0,0) size 0x0
       RenderText {#text} at (0,0) size 0x0
       RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/mac/svg/zoom/page/zoom-img-preserveAspectRatio-support-1-expected.txt
+++ b/LayoutTests/platform/mac/svg/zoom/page/zoom-img-preserveAspectRatio-support-1-expected.txt
@@ -24,7 +24,7 @@ layer at (0,0) size 800x355
                 text run at (0,0) width 64: "No viewBox"
             RenderTableCell {TH} at (67,37) size 113x2 [bgcolor=#DDDD99] [r=1 c=1 rs=1 cs=1]
             RenderTableCell {TD} at (181,18) size 141x40 [r=1 c=2 rs=1 cs=1]
-              RenderImage {IMG} at (0,0) size 140x36 [border: (1px dashed #800000)]
+              RenderImage {IMG} at (0,0) size 140x36 [border: (1.38px dashed #800000)]
               RenderText {#text} at (0,0) size 0x0
             RenderTableCell {TD} at (322,18) size 141x40 [r=1 c=3 rs=1 cs=1]
               RenderEmbeddedObject {OBJECT} at (0,0) size 140x36 [border: (1px dashed #008000)]
@@ -39,7 +39,7 @@ layer at (0,0) size 800x355
               RenderText {#text} at (43,12) size 27x15
                 text run at (43,0) width 27: "none"
             RenderTableCell {TD} at (181,58) size 141x41 [r=2 c=2 rs=1 cs=1]
-              RenderImage {IMG} at (0,0) size 140x36 [border: (1px dashed #800000)]
+              RenderImage {IMG} at (0,0) size 140x36 [border: (1.38px dashed #800000)]
               RenderText {#text} at (0,0) size 0x0
             RenderTableCell {TD} at (322,58) size 141x41 [r=2 c=3 rs=1 cs=1]
               RenderEmbeddedObject {OBJECT} at (0,0) size 140x36 [border: (1px dashed #008000)]
@@ -56,7 +56,7 @@ layer at (0,0) size 800x355
               RenderText {#text} at (43,12) size 27x15
                 text run at (43,0) width 27: "meet"
             RenderTableCell {TD} at (181,99) size 141x40 [r=3 c=2 rs=1 cs=1]
-              RenderImage {IMG} at (0,0) size 140x36 [border: (1px dashed #800000)]
+              RenderImage {IMG} at (0,0) size 140x36 [border: (1.38px dashed #800000)]
               RenderText {#text} at (0,0) size 0x0
             RenderTableCell {TD} at (322,99) size 141x40 [r=3 c=3 rs=1 cs=1]
               RenderEmbeddedObject {OBJECT} at (0,0) size 140x36 [border: (1px dashed #008000)]
@@ -73,7 +73,7 @@ layer at (0,0) size 800x355
               RenderText {#text} at (43,12) size 26x15
                 text run at (43,0) width 26: "slice"
             RenderTableCell {TD} at (181,140) size 141x40 [r=4 c=2 rs=1 cs=1]
-              RenderImage {IMG} at (0,0) size 140x36 [border: (1px dashed #800000)]
+              RenderImage {IMG} at (0,0) size 140x36 [border: (1.38px dashed #800000)]
               RenderText {#text} at (0,0) size 0x0
             RenderTableCell {TD} at (322,140) size 141x40 [r=4 c=3 rs=1 cs=1]
               RenderEmbeddedObject {OBJECT} at (0,0) size 140x36 [border: (1px dashed #008000)]
@@ -91,7 +91,7 @@ layer at (0,0) size 800x355
                 text run at (9,0) width 46: "viewBox"
             RenderTableCell {TH} at (67,200) size 113x2 [bgcolor=#DDDD99] [r=5 c=1 rs=1 cs=1]
             RenderTableCell {TD} at (181,181) size 141x40 [r=5 c=2 rs=1 cs=1]
-              RenderImage {IMG} at (0,0) size 140x36 [border: (1px dashed #800000)]
+              RenderImage {IMG} at (0,0) size 140x36 [border: (1.38px dashed #800000)]
               RenderText {#text} at (0,0) size 0x0
             RenderTableCell {TD} at (322,181) size 141x40 [r=5 c=3 rs=1 cs=1]
               RenderEmbeddedObject {OBJECT} at (0,0) size 140x36 [border: (1px dashed #008000)]
@@ -108,7 +108,7 @@ layer at (0,0) size 800x355
               RenderText {#text} at (43,12) size 27x15
                 text run at (43,0) width 27: "none"
             RenderTableCell {TD} at (181,221) size 141x41 [r=6 c=2 rs=1 cs=1]
-              RenderImage {IMG} at (0,0) size 140x36 [border: (1px dashed #800000)]
+              RenderImage {IMG} at (0,0) size 140x36 [border: (1.38px dashed #800000)]
               RenderText {#text} at (0,0) size 0x0
             RenderTableCell {TD} at (322,221) size 141x41 [r=6 c=3 rs=1 cs=1]
               RenderEmbeddedObject {OBJECT} at (0,0) size 140x36 [border: (1px dashed #008000)]
@@ -125,7 +125,7 @@ layer at (0,0) size 800x355
               RenderText {#text} at (43,12) size 27x15
                 text run at (43,0) width 27: "meet"
             RenderTableCell {TD} at (181,262) size 141x40 [r=7 c=2 rs=1 cs=1]
-              RenderImage {IMG} at (0,0) size 140x36 [border: (1px dashed #800000)]
+              RenderImage {IMG} at (0,0) size 140x36 [border: (1.38px dashed #800000)]
               RenderText {#text} at (0,0) size 0x0
             RenderTableCell {TD} at (322,262) size 141x40 [r=7 c=3 rs=1 cs=1]
               RenderEmbeddedObject {OBJECT} at (0,0) size 140x36 [border: (1px dashed #008000)]
@@ -142,7 +142,7 @@ layer at (0,0) size 800x355
               RenderText {#text} at (43,12) size 26x15
                 text run at (43,0) width 26: "slice"
             RenderTableCell {TD} at (181,303) size 141x40 [r=8 c=2 rs=1 cs=1]
-              RenderImage {IMG} at (0,0) size 140x36 [border: (1px dashed #800000)]
+              RenderImage {IMG} at (0,0) size 140x36 [border: (1.38px dashed #800000)]
               RenderText {#text} at (0,0) size 0x0
             RenderTableCell {TD} at (322,303) size 141x40 [r=8 c=3 rs=1 cs=1]
               RenderEmbeddedObject {OBJECT} at (0,0) size 140x36 [border: (1px dashed #008000)]

--- a/LayoutTests/platform/mac/svg/zoom/page/zoom-replaced-intrinsic-ratio-001-expected.txt
+++ b/LayoutTests/platform/mac/svg/zoom/page/zoom-replaced-intrinsic-ratio-001-expected.txt
@@ -1,62 +1,62 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x476
-  RenderBlock {HTML} at (0,0) size 800x476
-    RenderBody {BODY} at (4,4) size 142x464 [border: (1px dashed #C0C0C0)]
+layer at (0,0) size 800x456
+  RenderBlock {HTML} at (0,0) size 800x457
+    RenderBody {BODY} at (4,4) size 142x445 [border: (1px dashed #C0C0C0)]
       RenderBlock {P} at (1,10) size 139x28
         RenderText {#text} at (0,-1) size 135x28
           text run at (0,-1) width 129: "The following six blue boxes must"
           text run at (0,8) width 135: "be of the same width. There must be"
           text run at (0,17) width 26: "no red."
-      RenderBlock {P} at (10,46) size 121x28 [bgcolor=#008000] [border: (9px solid #0000FF)]
-        RenderText {#text} at (9,8) size 3x10
-          text run at (9,8) width 3: " "
-      RenderBlock {P} at (1,129) size 139x10
+      RenderBlock {P} at (10,46) size 121x21 [bgcolor=#008000] [border: (5.20px solid #0000FF)]
+        RenderText {#text} at (5,4) size 3x11
+          text run at (5,4) width 3: " "
+      RenderBlock {P} at (1,121) size 139x10
         RenderText {#text} at (0,-1) size 14x10
           text run at (0,-1) width 14: "      "
         RenderText {#text} at (0,0) size 0x0
-        RenderEmbeddedObject {OBJECT} at (9,-1) size 121x45 [bgcolor=#FF0000] [border: (9px solid #0000FF)]
-          layer at (0,0) size 102x26
-            RenderView at (0,0) size 102x26
-          layer at (0,0) size 102x26
-            RenderSVGRoot {svg} at (0,0) size 102x26
-              RenderSVGRect {rect} at (0,0) size 102x26 [stroke={[type=SOLID] [color=#008000] [stroke width=12.00]}] [fill={[type=SOLID] [color=#00FF00]}] [x=0.00] [y=0.00] [width=1000.00] [height=250.00]
-              RenderSVGPath {path} at (15,5) size 72x16 [fill={[type=SOLID] [color=#008000]}] [data="M 500 50 L 150 200 L 850 200 Z"]
-      RenderBlock {P} at (1,194) size 139x10
-        RenderEmbeddedObject {OBJECT} at (9,0) size 121x44 [bgcolor=#FF0000] [border: (9px solid #0000FF)]
-          layer at (0,0) size 102x26
-            RenderView at (0,0) size 102x26
-          layer at (0,0) size 102x26
-            RenderSVGRoot {svg} at (0,0) size 102x26
-              RenderSVGRect {rect} at (0,0) size 102x26 [stroke={[type=SOLID] [color=#008000] [stroke width=12.00]}] [fill={[type=SOLID] [color=#00FF00]}] [x=0.00] [y=0.00] [width=1000.00] [height=250.00]
-              RenderSVGPath {path} at (15,5) size 72x16 [fill={[type=SOLID] [color=#008000]}] [data="M 500 50 L 150 200 L 850 200 Z"]
-      RenderTable at (1,258) size 139x47
-        RenderTableSection (anonymous) at (0,0) size 139x46
-          RenderTableRow (anonymous) at (0,0) size 139x46
-            RenderTableCell {P} at (0,0) size 139x46 [r=0 c=0 rs=1 cs=1]
-              RenderEmbeddedObject {OBJECT} at (9,0) size 121x44 [bgcolor=#FF0000] [border: (9px solid #0000FF)]
-                layer at (0,0) size 102x26
-                  RenderView at (0,0) size 102x26
-                layer at (0,0) size 102x26
-                  RenderSVGRoot {svg} at (0,0) size 102x26
-                    RenderSVGRect {rect} at (0,0) size 102x26 [stroke={[type=SOLID] [color=#008000] [stroke width=12.00]}] [fill={[type=SOLID] [color=#00FF00]}] [x=0.00] [y=0.00] [width=1000.00] [height=250.00]
-                    RenderSVGPath {path} at (15,5) size 72x16 [fill={[type=SOLID] [color=#008000]}] [data="M 500 50 L 150 200 L 850 200 Z"]
-      RenderTable {TABLE} at (1,360) size 139x47
-        RenderTableSection {TBODY} at (0,0) size 139x46
-          RenderTableRow {TR} at (0,0) size 139x46
-            RenderTableCell {TD} at (0,0) size 139x46 [r=0 c=0 rs=1 cs=1]
-              RenderEmbeddedObject {OBJECT} at (9,0) size 121x44 [bgcolor=#FF0000] [border: (9px solid #0000FF)]
-                layer at (0,0) size 102x26
-                  RenderView at (0,0) size 102x26
-                layer at (0,0) size 102x26
-                  RenderSVGRoot {svg} at (0,0) size 102x26
-                    RenderSVGRect {rect} at (0,0) size 102x26 [stroke={[type=SOLID] [color=#008000] [stroke width=12.00]}] [fill={[type=SOLID] [color=#00FF00]}] [x=0.00] [y=0.00] [width=1000.00] [height=250.00]
-                    RenderSVGPath {path} at (15,5) size 72x16 [fill={[type=SOLID] [color=#008000]}] [data="M 500 50 L 150 200 L 850 200 Z"]
-      RenderBlock (floating) {P} at (1,461) size 139x11
-        RenderEmbeddedObject {OBJECT} at (9,0) size 121x44 [bgcolor=#FF0000] [border: (9px solid #0000FF)]
-          layer at (0,0) size 102x26
-            RenderView at (0,0) size 102x26
-          layer at (0,0) size 102x26
-            RenderSVGRoot {svg} at (0,0) size 102x26
-              RenderSVGRect {rect} at (0,0) size 102x26 [stroke={[type=SOLID] [color=#008000] [stroke width=12.00]}] [fill={[type=SOLID] [color=#00FF00]}] [x=0.00] [y=0.00] [width=1000.00] [height=250.00]
-              RenderSVGPath {path} at (15,5) size 72x16 [fill={[type=SOLID] [color=#008000]}] [data="M 500 50 L 150 200 L 850 200 Z"]
+        RenderEmbeddedObject {OBJECT} at (9,-1) size 121x39 [bgcolor=#FF0000] [border: (5.20px solid #0000FF)]
+          layer at (0,0) size 110x27
+            RenderView at (0,0) size 110x27
+          layer at (0,0) size 110x27
+            RenderSVGRoot {svg} at (0,0) size 109x27
+              RenderSVGRect {rect} at (0,0) size 109x27 [stroke={[type=SOLID] [color=#008000] [stroke width=12.00]}] [fill={[type=SOLID] [color=#00FF00]}] [x=0.00] [y=0.00] [width=1000.00] [height=250.00]
+              RenderSVGPath {path} at (16,5) size 76x17 [fill={[type=SOLID] [color=#008000]}] [data="M 500 50 L 150 200 L 850 200 Z"]
+      RenderBlock {P} at (1,186) size 139x10
+        RenderEmbeddedObject {OBJECT} at (9,0) size 121x38 [bgcolor=#FF0000] [border: (5.20px solid #0000FF)]
+          layer at (0,0) size 110x27
+            RenderView at (0,0) size 110x27
+          layer at (0,0) size 110x27
+            RenderSVGRoot {svg} at (0,0) size 109x27
+              RenderSVGRect {rect} at (0,0) size 109x27 [stroke={[type=SOLID] [color=#008000] [stroke width=12.00]}] [fill={[type=SOLID] [color=#00FF00]}] [x=0.00] [y=0.00] [width=1000.00] [height=250.00]
+              RenderSVGPath {path} at (16,5) size 76x17 [fill={[type=SOLID] [color=#008000]}] [data="M 500 50 L 150 200 L 850 200 Z"]
+      RenderTable at (1,251) size 139x41
+        RenderTableSection (anonymous) at (0,0) size 139x40
+          RenderTableRow (anonymous) at (0,0) size 139x40
+            RenderTableCell {P} at (0,0) size 139x40 [r=0 c=0 rs=1 cs=1]
+              RenderEmbeddedObject {OBJECT} at (9,0) size 121x38 [bgcolor=#FF0000] [border: (5.20px solid #0000FF)]
+                layer at (0,0) size 110x27
+                  RenderView at (0,0) size 110x27
+                layer at (0,0) size 110x27
+                  RenderSVGRoot {svg} at (0,0) size 109x27
+                    RenderSVGRect {rect} at (0,0) size 109x27 [stroke={[type=SOLID] [color=#008000] [stroke width=12.00]}] [fill={[type=SOLID] [color=#00FF00]}] [x=0.00] [y=0.00] [width=1000.00] [height=250.00]
+                    RenderSVGPath {path} at (16,5) size 76x17 [fill={[type=SOLID] [color=#008000]}] [data="M 500 50 L 150 200 L 850 200 Z"]
+      RenderTable {TABLE} at (1,346) size 139x41
+        RenderTableSection {TBODY} at (0,0) size 139x40
+          RenderTableRow {TR} at (0,0) size 139x40
+            RenderTableCell {TD} at (0,0) size 139x40 [r=0 c=0 rs=1 cs=1]
+              RenderEmbeddedObject {OBJECT} at (9,0) size 121x38 [bgcolor=#FF0000] [border: (5.20px solid #0000FF)]
+                layer at (0,0) size 110x27
+                  RenderView at (0,0) size 110x27
+                layer at (0,0) size 110x27
+                  RenderSVGRoot {svg} at (0,0) size 109x27
+                    RenderSVGRect {rect} at (0,0) size 109x27 [stroke={[type=SOLID] [color=#008000] [stroke width=12.00]}] [fill={[type=SOLID] [color=#00FF00]}] [x=0.00] [y=0.00] [width=1000.00] [height=250.00]
+                    RenderSVGPath {path} at (16,5) size 76x17 [fill={[type=SOLID] [color=#008000]}] [data="M 500 50 L 150 200 L 850 200 Z"]
+      RenderBlock (floating) {P} at (1,442) size 139x10
+        RenderEmbeddedObject {OBJECT} at (9,0) size 121x38 [bgcolor=#FF0000] [border: (5.20px solid #0000FF)]
+          layer at (0,0) size 110x27
+            RenderView at (0,0) size 110x27
+          layer at (0,0) size 110x27
+            RenderSVGRoot {svg} at (0,0) size 109x27
+              RenderSVGRect {rect} at (0,0) size 109x27 [stroke={[type=SOLID] [color=#008000] [stroke width=12.00]}] [fill={[type=SOLID] [color=#00FF00]}] [x=0.00] [y=0.00] [width=1000.00] [height=250.00]
+              RenderSVGPath {path} at (16,5) size 76x17 [fill={[type=SOLID] [color=#008000]}] [data="M 500 50 L 150 200 L 850 200 Z"]

--- a/LayoutTests/platform/mac/svg/zoom/page/zoom-svg-float-border-padding-expected.txt
+++ b/LayoutTests/platform/mac/svg/zoom/page/zoom-svg-float-border-padding-expected.txt
@@ -1,8 +1,8 @@
-layer at (0,0) size 785x767
+layer at (0,0) size 785x769
   RenderView at (0,0) size 785x600
-layer at (0,0) size 785x767
-  RenderBlock {html} at (0,0) size 785x767
-    RenderBody {body} at (11,11) size 763x733
+layer at (0,0) size 785x769
+  RenderBlock {html} at (0,0) size 785x770
+    RenderBody {body} at (11,11) size 763x736
       RenderBlock (anonymous) at (0,0) size 762x52
         RenderText {#text} at (0,0) size 749x52
           text run at (0,0) width 353: "The two blocks should look identical. "
@@ -11,18 +11,18 @@ layer at (0,0) size 785x767
       RenderBlock {p} at (0,75) size 762x27
         RenderText {#text} at (0,0) size 518x26
           text run at (0,0) width 518: "There should be a red, white and blue pattern below this"
-      RenderSVGRoot {svg} at (25,149) size 202x202
-        RenderSVGRect {rect} at (25,149) size 202x202 [fill={[type=SOLID] [color=#0000FF]}] [x=0.00] [y=0.00] [width=100.00] [height=100.00]
-      RenderBlock {p} at (0,353) size 762x27
+      RenderSVGRoot {svg} at (25,149) size 203x203
+        RenderSVGRect {rect} at (25,149) size 203x203 [fill={[type=SOLID] [color=#0000FF]}] [x=0.00] [y=0.00] [width=100.00] [height=100.00]
+      RenderBlock {p} at (0,354) size 762x27
         RenderText {#text} at (0,0) size 517x26
           text run at (0,0) width 517: "There should be a red, white and blue pattern above this"
-      RenderBlock {p} at (0,427) size 762x27
+      RenderBlock {p} at (0,429) size 762x27
         RenderText {#text} at (0,0) size 518x26
           text run at (0,0) width 518: "There should be a red, white and blue pattern below this"
-      RenderBlock (floating) {div} at (14,491) size 202x201 [border: (14px solid #FF0000)]
+      RenderBlock (floating) {div} at (14,492) size 202x203 [border: (14.39px solid #FF0000)]
         RenderBlock {div} at (28,28) size 145x145 [bgcolor=#0000FF]
-      RenderBlock {p} at (0,706) size 762x27
+      RenderBlock {p} at (0,708) size 762x27
         RenderText {#text} at (0,0) size 517x26
           text run at (0,0) width 517: "There should be a red, white and blue pattern above this"
-layer at (12,414) size 762x2 backgroundClip at (12,414) size 761x2 clip at (0,0) size 0x0
-  RenderBlock {hr} at (0,402) size 762x3 [color=#808080] [border: (1px inset #808080)]
+layer at (12,415) size 762x3 backgroundClip at (12,415) size 761x3 clip at (0,0) size 0x0
+  RenderBlock {hr} at (0,403) size 762x4 [color=#808080] [border: (1.44px inset #808080)]

--- a/LayoutTests/platform/mac/svg/zoom/page/zoom-svg-through-object-with-auto-size-expected.txt
+++ b/LayoutTests/platform/mac/svg/zoom/page/zoom-svg-through-object-with-auto-size-expected.txt
@@ -1,17 +1,17 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x173
-  RenderBlock {HTML} at (0,0) size 800x174
-    RenderBody {BODY} at (5,5) size 790x163
-      RenderEmbeddedObject {OBJECT} at (0,0) size 159x159 [border: (1px dashed #800000)]
+layer at (0,0) size 800x174
+  RenderBlock {HTML} at (0,0) size 800x175
+    RenderBody {BODY} at (5,5) size 790x164
+      RenderEmbeddedObject {OBJECT} at (0,0) size 160x160 [border: (1.38px dashed #800000)]
         layer at (0,0) size 153x153
           RenderView at (0,0) size 153x153
         layer at (0,0) size 153x153
           RenderSVGRoot {svg} at (0,0) size 153x153
             RenderSVGEllipse {circle} at (0,0) size 153x153 [stroke={[type=SOLID] [color=#000000]}] [fill={[type=SOLID] [color=#D9BB7A] [fill rule=EVEN-ODD]}] [cx=110.00] [cy=110.00] [r=110.00]
-      RenderText {#text} at (158,149) size 4x13
-        text run at (158,149) width 4: " "
-      RenderEmbeddedObject {OBJECT} at (161,0) size 160x159 [border: (1px dashed #800000)]
+      RenderText {#text} at (159,150) size 4x13
+        text run at (159,150) width 4: " "
+      RenderEmbeddedObject {OBJECT} at (162,0) size 161x160 [border: (1.38px dashed #800000)]
         layer at (0,0) size 153x153
           RenderView at (0,0) size 153x153
         layer at (0,0) size 153x153

--- a/LayoutTests/platform/wpe/fast/backgrounds/background-position-parsing-expected.txt
+++ b/LayoutTests/platform/wpe/fast/backgrounds/background-position-parsing-expected.txt
@@ -1,158 +1,158 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x405
-  RenderBlock {HTML} at (0,0) size 800x405
+layer at (0,0) size 800x387
+  RenderBlock {HTML} at (0,0) size 800x387
     RenderBody {BODY} at (8,16) size 784x18
       RenderBlock {P} at (0,0) size 784x18
         RenderText {#text} at (0,0) size 500x17
           text run at (0,0) width 500: "In all the following boxes, the fuchsia diamond should be surrounded by a ring."
-      RenderBlock (floating) {DIV} at (1,35) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (1,35) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (86,35) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (83,35) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (170,35) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (164,35) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (255,35) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (246,35) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (340,35) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (328,35) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (424,35) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (409,35) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (509,35) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (491,35) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (593,35) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (572,35) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (678,35) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (654,35) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (1,94) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (1,91) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (86,94) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (83,91) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (170,94) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (164,91) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (255,94) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (246,91) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (340,94) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (328,91) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (424,94) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (409,91) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (509,94) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (491,91) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (593,94) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (572,91) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (678,94) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (654,91) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (1,153) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (1,147) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (86,153) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (83,147) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (170,153) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (164,147) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (255,153) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (246,147) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (340,153) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (328,147) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (424,153) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (409,147) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (509,153) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (491,147) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (593,153) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (572,147) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (678,153) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (654,147) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (1,212) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (1,203) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (86,212) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (83,203) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (170,212) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (164,203) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (255,212) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (246,203) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (340,212) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (328,203) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (424,212) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (409,203) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (509,212) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (491,203) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (593,212) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (572,203) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (678,212) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (654,203) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (1,271) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (1,259) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (86,271) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (83,259) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (170,271) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (164,259) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (255,271) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (246,259) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (340,271) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (328,259) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (424,271) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (409,259) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (509,271) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (491,259) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (593,271) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (572,259) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (678,271) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (654,259) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (1,330) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (1,315) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (86,330) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (83,315) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (170,330) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (164,315) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (255,330) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (246,315) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (340,330) size 82x57 [border: (3px solid #000000)]
-        RenderBlock {DIV} at (3,3) size 75x50 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (328,315) size 79x54 [border: (1.50px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34

--- a/LayoutTests/platform/wpe/fast/multicol/span/anonymous-style-inheritance-expected.txt
+++ b/LayoutTests/platform/wpe/fast/multicol/span/anonymous-style-inheritance-expected.txt
@@ -1,0 +1,55 @@
+layer at (0,0) size 844x585
+  RenderView at (0,0) size 800x585
+layer at (0,0) size 800x499
+  RenderBlock {HTML} at (0,0) size 800x499
+    RenderBody {BODY} at (8,17) size 784x465
+layer at (8,18) size 836x464
+  RenderBlock {DIV} at (0,0) size 836x464 [border: (5.50px solid #800000)]
+    RenderBlock {H2} at (5,27) size 826x32 [bgcolor=#EEEEEE]
+      RenderText {#text} at (0,0) size 740x30
+        text run at (0,0) width 740: "This is a spanning element at the beginning of the columns block."
+    RenderMultiColumnSet at (5,80) size 826x379
+layer at (14,23) size 403x756 backgroundClip at (0,0) size 844x585 clip at (0,0) size 844x585
+  RenderMultiColumnFlowThread at (5,5) size 405x757
+    RenderMultiColumnSpannerPlaceholder at (0,0) size 0x0
+    RenderBlock (anonymous) at (0,0) size 404x756
+      RenderText {#text} at (0,0) size 403x755
+        text run at (0,0) width 374: "Lorem ipsum dolor sit amet, consectetuer adipiscing"
+        text run at (0,21) width 399: "elit. Nulla varius enim ac mi. Curabitur sollicitudin felis"
+        text run at (0,42) width 403: "quis lectus. Quisque adipiscing rhoncus sem. Proin nulla"
+        text run at (0,63) width 366: "purus, vulputate vel, varius ut, euismod et, nisi. Sed"
+        text run at (0,84) width 355: "vitae felis vel orci sagittis aliquam. Cras convallis"
+        text run at (0,105) width 329: "adipiscing sem. Nam nonummy enim. Nullam"
+        text run at (0,126) width 397: "bibendum lobortis neque. Vestibulum velit orci, tempus"
+        text run at (0,147) width 391: "euismod, pretium quis, interdum vitae, nulla. Phasellus"
+        text run at (0,168) width 316: "eget ante et tortor condimentum vestibulum."
+        text run at (0,189) width 393: "Suspendisse hendrerit quam nec felis. Sed varius turpis"
+        text run at (0,210) width 377: "vitae pede. Lorem ipsum dolor sit amet, consectetuer"
+        text run at (0,231) width 109: "adipiscing elit. "
+        text run at (109,231) width 202: "Lorem ipsum dolor sit amet,"
+        text run at (0,252) width 378: "consectetuer adipiscing elit. Nulla varius enim ac mi."
+        text run at (0,273) width 337: "Curabitur sollicitudin felis quis lectus. Quisque"
+        text run at (0,294) width 374: "adipiscing rhoncus sem. Proin nulla purus, vulputate"
+        text run at (0,315) width 379: "vel, varius ut, euismod et, nisi. Sed vitae felis vel orci"
+        text run at (0,336) width 377: "sagittis aliquam. Cras convallis adipiscing sem. Nam"
+        text run at (0,357) width 361: "nonummy enim. Nullam bibendum lobortis neque."
+        text run at (0,378) width 378: "Vestibulum velit orci, tempus euismod, pretium quis,"
+        text run at (0,399) width 353: "interdum vitae, nulla. Phasellus eget ante et tortor"
+        text run at (0,420) width 392: "condimentum vestibulum. Suspendisse hendrerit quam"
+        text run at (0,441) width 369: "nec felis. Sed varius turpis vitae pede. Lorem ipsum"
+        text run at (0,462) width 309: "dolor sit amet, consectetuer adipiscing elit. "
+        text run at (309,462) width 48: "Lorem"
+        text run at (0,483) width 397: "ipsum dolor sit amet, consectetuer adipiscing elit. Nulla"
+        text run at (0,504) width 358: "varius enim ac mi. Curabitur sollicitudin felis quis"
+        text run at (0,525) width 369: "lectus. Quisque adipiscing rhoncus sem. Proin nulla"
+        text run at (0,546) width 366: "purus, vulputate vel, varius ut, euismod et, nisi. Sed"
+        text run at (0,567) width 355: "vitae felis vel orci sagittis aliquam. Cras convallis"
+        text run at (0,588) width 329: "adipiscing sem. Nam nonummy enim. Nullam"
+        text run at (0,609) width 397: "bibendum lobortis neque. Vestibulum velit orci, tempus"
+        text run at (0,630) width 391: "euismod, pretium quis, interdum vitae, nulla. Phasellus"
+        text run at (0,651) width 316: "eget ante et tortor condimentum vestibulum."
+        text run at (0,672) width 393: "Suspendisse hendrerit quam nec felis. Sed varius turpis"
+        text run at (0,693) width 377: "vitae pede. Lorem ipsum dolor sit amet, consectetuer"
+        text run at (0,714) width 109: "adipiscing elit. "
+        text run at (109,714) width 202: "Lorem ipsum dolor sit amet,"
+        text run at (0,735) width 378: "consectetuer adipiscing elit. Nulla varius enim ac mi."

--- a/LayoutTests/platform/wpe/fast/repaint/repaint-during-scroll-with-zoom-expected.txt
+++ b/LayoutTests/platform/wpe/fast/repaint/repaint-during-scroll-with-zoom-expected.txt
@@ -1,0 +1,14 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x0
+  RenderBlock {HTML} at (0,0) size 800x0
+    RenderBody {BODY} at (0,0) size 800x0 [bgcolor=#C0C0C0]
+layer at (0,63) size 255x255
+  RenderIFrame {IFRAME} at (0,62) size 255x256 [border: (2.50px inset #000000)]
+    layer at (0,0) size 2008x2016
+      RenderView at (0,0) size 235x235
+    layer at (0,0) size 235x2016
+      RenderBlock {HTML} at (0,0) size 235x2016
+        RenderBody {BODY} at (8,8) size 2000x2000 [bgcolor=#FFFFFF]
+          RenderText {#text} at (0,0) size 57x17
+            text run at (0,0) width 57: "scroll me"

--- a/LayoutTests/platform/wpe/media/video-zoom-expected.txt
+++ b/LayoutTests/platform/wpe/media/video-zoom-expected.txt
@@ -1,0 +1,23 @@
+layer at (0,0) size 785x846
+  RenderView at (0,0) size 785x600
+layer at (0,0) size 785x846
+  RenderBlock {HTML} at (0,0) size 785x846
+    RenderBody {BODY} at (8,8) size 769x830
+      RenderBlock {P} at (0,0) size 769x18
+        RenderText {#text} at (0,0) size 283x17
+          text run at (0,0) width 283: "150% zoom, with width and height attributes"
+      RenderBlock (anonymous) at (0,34) size 769x373
+        RenderText {#text} at (0,355) size 4x17
+          text run at (0,355) width 4: " "
+        RenderBR {BR} at (493,355) size 0x17
+      RenderBlock {P} at (0,423) size 769x18
+        RenderText {#text} at (0,0) size 303x17
+          text run at (0,0) width 303: "150% zoom, without width and height attributes"
+      RenderBlock (anonymous) at (0,457) size 769x373
+        RenderText {#text} at (0,355) size 4x17
+          text run at (0,355) width 4: " "
+        RenderBR {BR} at (493,355) size 0x17
+layer at (12,42) size 489x369
+  RenderVideo {VIDEO} at (4,0) size 489x369 [border: (4.50px solid #FF0000)]
+layer at (12,465) size 489x369
+  RenderVideo {VIDEO} at (4,0) size 489x369 [border: (4.50px solid #FF0000)]

--- a/LayoutTests/platform/wpe/svg/zoom/page/zoom-background-images-expected.txt
+++ b/LayoutTests/platform/wpe/svg/zoom/page/zoom-background-images-expected.txt
@@ -1,0 +1,19 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x164
+  RenderBlock {HTML} at (0,0) size 800x164
+    RenderBody {BODY} at (4,4) size 792x156
+      RenderBlock {DIV} at (11,11) size 131x131 [border: (1.16px solid #000000)]
+      RenderText {#text} at (152,144) size 3x11
+        text run at (152,144) width 3: " "
+      RenderBlock {DIV} at (166,11) size 130x131 [border: (1.16px solid #000000)]
+      RenderText {#text} at (307,144) size 3x11
+        text run at (307,144) width 3: " "
+      RenderBlock {DIV} at (321,11) size 130x131 [border: (1.16px solid #000000)]
+      RenderText {#text} at (462,144) size 3x11
+        text run at (462,144) width 3: " "
+      RenderImage {IMG} at (475,11) size 131x131 [border: (1.16px solid #000000)]
+      RenderText {#text} at (0,0) size 0x0
+      RenderText {#text} at (0,0) size 0x0
+      RenderText {#text} at (0,0) size 0x0
+      RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/wpe/svg/zoom/page/zoom-img-preserveAspectRatio-support-1-expected.txt
+++ b/LayoutTests/platform/wpe/svg/zoom/page/zoom-img-preserveAspectRatio-support-1-expected.txt
@@ -1,0 +1,156 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x345
+  RenderBlock {HTML} at (0,0) size 800x346
+    RenderBody {BODY} at (5,5) size 790x335
+      RenderTable {TABLE} at (0,0) size 464x335
+        RenderTableSection {TBODY} at (0,0) size 464x335
+          RenderTableRow {TR} at (0,1) size 464x14
+            RenderTableCell {TH} at (1,1) size 65x14 [bgcolor=#DDDD99] [r=0 c=0 rs=1 cs=1]
+              RenderText {#text} at (6,0) size 53x13
+                text run at (6,0) width 53: "viewBox?"
+            RenderTableCell {TH} at (67,1) size 112x14 [bgcolor=#DDDD99] [r=0 c=1 rs=1 cs=1]
+              RenderText {#text} at (0,0) size 111x13
+                text run at (0,0) width 111: "preserve\x{AD}Aspect\x{AD}Ratio"
+            RenderTableCell {TH} at (179,1) size 142x14 [bgcolor=#DDDD99] [r=0 c=2 rs=1 cs=1]
+              RenderText {#text} at (54,0) size 33x13
+                text run at (54,0) width 33: "<img>"
+            RenderTableCell {TH} at (321,1) size 141x14 [bgcolor=#DDDD99] [r=0 c=3 rs=1 cs=1]
+              RenderText {#text} at (47,0) size 46x13
+                text run at (47,0) width 46: "<object>"
+          RenderTableRow {TR} at (0,16) size 464x39
+            RenderTableCell {TH} at (1,88) size 65x14 [bgcolor=#DDDD99] [r=1 c=0 rs=4 cs=1]
+              RenderText {#text} at (0,72) size 64x13
+                text run at (0,0) width 64: "No viewBox"
+            RenderTableCell {TH} at (67,34) size 112x2 [bgcolor=#DDDD99] [r=1 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (179,16) size 142x39 [r=1 c=2 rs=1 cs=1]
+              RenderImage {IMG} at (0,0) size 140x36 [border: (1.38px dashed #800000)]
+              RenderText {#text} at (0,0) size 0x0
+            RenderTableCell {TD} at (321,16) size 141x39 [r=1 c=3 rs=1 cs=1]
+              RenderEmbeddedObject {OBJECT} at (0,0) size 140x36 [border: (1px dashed #008000)]
+                layer at (0,0) size 133x29
+                  RenderView at (0,0) size 133x29
+                layer at (0,0) size 133x29
+                  RenderSVGRoot {svg} at (0,0) size 133x29
+                    RenderSVGEllipse {circle} at (0,0) size 133x29 [stroke={[type=SOLID] [color=#000000]}] [fill={[type=SOLID] [color=#D9BB7A] [fill rule=EVEN-ODD]}] [cx=110.00] [cy=110.00] [r=110.00]
+              RenderText {#text} at (0,0) size 0x0
+          RenderTableRow {TR} at (0,55) size 464x40
+            RenderTableCell {TH} at (67,68) size 112x14 [bgcolor=#DDDD99] [r=2 c=1 rs=1 cs=1]
+              RenderText {#text} at (42,13) size 28x13
+                text run at (42,1) width 28: "none"
+            RenderTableCell {TD} at (179,55) size 142x40 [r=2 c=2 rs=1 cs=1]
+              RenderImage {IMG} at (0,0) size 140x36 [border: (1.38px dashed #800000)]
+              RenderText {#text} at (0,0) size 0x0
+            RenderTableCell {TD} at (321,55) size 141x40 [r=2 c=3 rs=1 cs=1]
+              RenderEmbeddedObject {OBJECT} at (0,0) size 140x36 [border: (1px dashed #008000)]
+                layer at (0,0) size 133x29
+                  RenderView at (0,0) size 133x29
+                layer at (0,0) size 133x29
+                  RenderSVGRoot {svg} at (0,0) size 133x29
+                    RenderSVGHiddenContainer {defs} at (0,0) size 0x0
+                    RenderSVGContainer {g} at (0,0) size 133x29 [transform={m=((1.00,0.00)(0.00,1.00)) t=(-162.36,-403.29)}]
+                      RenderSVGPath {path} at (0,0) size 133x29 [stroke={[type=SOLID] [color=#000000]}] [fill={[type=SOLID] [color=#D9BB7A] [fill rule=EVEN-ODD]}] [data="M 525.714 585.219 C 525.714 685.419 444.486 766.648 344.286 766.648 C 244.085 766.648 162.857 685.419 162.857 585.219 C 162.857 485.019 244.085 403.791 344.286 403.791 C 444.486 403.791 525.714 485.019 525.714 585.219 Z"]
+              RenderText {#text} at (0,0) size 0x0
+          RenderTableRow {TR} at (0,95) size 464x39
+            RenderTableCell {TH} at (67,108) size 112x14 [bgcolor=#DDDD99] [r=3 c=1 rs=1 cs=1]
+              RenderText {#text} at (42,13) size 27x13
+                text run at (42,1) width 27: "meet"
+            RenderTableCell {TD} at (179,95) size 142x39 [r=3 c=2 rs=1 cs=1]
+              RenderImage {IMG} at (0,0) size 140x36 [border: (1.38px dashed #800000)]
+              RenderText {#text} at (0,0) size 0x0
+            RenderTableCell {TD} at (321,95) size 141x39 [r=3 c=3 rs=1 cs=1]
+              RenderEmbeddedObject {OBJECT} at (0,0) size 140x36 [border: (1px dashed #008000)]
+                layer at (0,0) size 133x29
+                  RenderView at (0,0) size 133x29
+                layer at (0,0) size 133x29
+                  RenderSVGRoot {svg} at (0,0) size 133x29
+                    RenderSVGHiddenContainer {defs} at (0,0) size 0x0
+                    RenderSVGContainer {g} at (0,0) size 133x29 [transform={m=((1.00,0.00)(0.00,1.00)) t=(-162.36,-403.29)}]
+                      RenderSVGPath {path} at (0,0) size 133x29 [stroke={[type=SOLID] [color=#000000]}] [fill={[type=SOLID] [color=#D9BB7A] [fill rule=EVEN-ODD]}] [data="M 525.714 585.219 C 525.714 685.419 444.486 766.648 344.286 766.648 C 244.085 766.648 162.857 685.419 162.857 585.219 C 162.857 485.019 244.085 403.791 344.286 403.791 C 444.486 403.791 525.714 485.019 525.714 585.219 Z"]
+              RenderText {#text} at (0,0) size 0x0
+          RenderTableRow {TR} at (0,135) size 464x39
+            RenderTableCell {TH} at (67,147) size 112x15 [bgcolor=#DDDD99] [r=4 c=1 rs=1 cs=1]
+              RenderText {#text} at (43,13) size 25x13
+                text run at (43,1) width 25: "slice"
+            RenderTableCell {TD} at (179,135) size 142x39 [r=4 c=2 rs=1 cs=1]
+              RenderImage {IMG} at (0,0) size 140x36 [border: (1.38px dashed #800000)]
+              RenderText {#text} at (0,0) size 0x0
+            RenderTableCell {TD} at (321,135) size 141x39 [r=4 c=3 rs=1 cs=1]
+              RenderEmbeddedObject {OBJECT} at (0,0) size 140x36 [border: (1px dashed #008000)]
+                layer at (0,0) size 133x29
+                  RenderView at (0,0) size 133x29
+                layer at (0,0) size 133x29
+                  RenderSVGRoot {svg} at (0,0) size 133x29
+                    RenderSVGHiddenContainer {defs} at (0,0) size 0x0
+                    RenderSVGContainer {g} at (0,0) size 133x29 [transform={m=((1.00,0.00)(0.00,1.00)) t=(-162.36,-403.29)}]
+                      RenderSVGPath {path} at (0,0) size 133x29 [stroke={[type=SOLID] [color=#000000]}] [fill={[type=SOLID] [color=#D9BB7A] [fill rule=EVEN-ODD]}] [data="M 525.714 585.219 C 525.714 685.419 444.486 766.648 344.286 766.648 C 244.085 766.648 162.857 685.419 162.857 585.219 C 162.857 485.019 244.085 403.791 344.286 403.791 C 444.486 403.791 525.714 485.019 525.714 585.219 Z"]
+              RenderText {#text} at (0,0) size 0x0
+          RenderTableRow {TR} at (0,175) size 464x39
+            RenderTableCell {TH} at (1,247) size 65x14 [bgcolor=#DDDD99] [r=5 c=0 rs=4 cs=1]
+              RenderText {#text} at (9,72) size 46x13
+                text run at (9,0) width 46: "viewBox"
+            RenderTableCell {TH} at (67,193) size 112x2 [bgcolor=#DDDD99] [r=5 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (179,175) size 142x39 [r=5 c=2 rs=1 cs=1]
+              RenderImage {IMG} at (0,0) size 140x36 [border: (1.38px dashed #800000)]
+              RenderText {#text} at (0,0) size 0x0
+            RenderTableCell {TD} at (321,175) size 141x39 [r=5 c=3 rs=1 cs=1]
+              RenderEmbeddedObject {OBJECT} at (0,0) size 140x36 [border: (1px dashed #008000)]
+                layer at (0,0) size 133x29
+                  RenderView at (0,0) size 133x29
+                layer at (0,0) size 133x29
+                  RenderSVGRoot {svg} at (52,0) size 22x22
+                    RenderSVGHiddenContainer {defs} at (0,0) size 0x0
+                    RenderSVGContainer {g} at (52,0) size 22x22 [transform={m=((1.00,0.00)(0.00,1.00)) t=(-162.36,-403.29)}]
+                      RenderSVGPath {path} at (52,0) size 22x22 [stroke={[type=SOLID] [color=#000000]}] [fill={[type=SOLID] [color=#D9BB7A] [fill rule=EVEN-ODD]}] [data="M 525.714 585.219 C 525.714 685.419 444.486 766.648 344.286 766.648 C 244.085 766.648 162.857 685.419 162.857 585.219 C 162.857 485.019 244.085 403.791 344.286 403.791 C 444.486 403.791 525.714 485.019 525.714 585.219 Z"]
+              RenderText {#text} at (0,0) size 0x0
+          RenderTableRow {TR} at (0,214) size 464x40
+            RenderTableCell {TH} at (67,227) size 112x14 [bgcolor=#DDDD99] [r=6 c=1 rs=1 cs=1]
+              RenderText {#text} at (42,13) size 28x13
+                text run at (42,1) width 28: "none"
+            RenderTableCell {TD} at (179,214) size 142x40 [r=6 c=2 rs=1 cs=1]
+              RenderImage {IMG} at (0,0) size 140x36 [border: (1.38px dashed #800000)]
+              RenderText {#text} at (0,0) size 0x0
+            RenderTableCell {TD} at (321,214) size 141x40 [r=6 c=3 rs=1 cs=1]
+              RenderEmbeddedObject {OBJECT} at (0,0) size 140x36 [border: (1px dashed #008000)]
+                layer at (0,0) size 133x29
+                  RenderView at (0,0) size 133x29
+                layer at (0,0) size 133x29
+                  RenderSVGRoot {svg} at (0,0) size 97x22
+                    RenderSVGHiddenContainer {defs} at (0,0) size 0x0
+                    RenderSVGContainer {g} at (0,0) size 97x22 [transform={m=((1.00,0.00)(0.00,1.00)) t=(-162.36,-403.29)}]
+                      RenderSVGPath {path} at (0,0) size 97x22 [stroke={[type=SOLID] [color=#000000]}] [fill={[type=SOLID] [color=#D9BB7A] [fill rule=EVEN-ODD]}] [data="M 525.714 585.219 C 525.714 685.419 444.486 766.648 344.286 766.648 C 244.085 766.648 162.857 685.419 162.857 585.219 C 162.857 485.019 244.085 403.791 344.286 403.791 C 444.486 403.791 525.714 485.019 525.714 585.219 Z"]
+              RenderText {#text} at (0,0) size 0x0
+          RenderTableRow {TR} at (0,254) size 464x39
+            RenderTableCell {TH} at (67,267) size 112x14 [bgcolor=#DDDD99] [r=7 c=1 rs=1 cs=1]
+              RenderText {#text} at (42,13) size 27x13
+                text run at (42,1) width 27: "meet"
+            RenderTableCell {TD} at (179,254) size 142x39 [r=7 c=2 rs=1 cs=1]
+              RenderImage {IMG} at (0,0) size 140x36 [border: (1.38px dashed #800000)]
+              RenderText {#text} at (0,0) size 0x0
+            RenderTableCell {TD} at (321,254) size 141x39 [r=7 c=3 rs=1 cs=1]
+              RenderEmbeddedObject {OBJECT} at (0,0) size 140x36 [border: (1px dashed #008000)]
+                layer at (0,0) size 133x29
+                  RenderView at (0,0) size 133x29
+                layer at (0,0) size 133x29
+                  RenderSVGRoot {svg} at (52,0) size 22x22
+                    RenderSVGHiddenContainer {defs} at (0,0) size 0x0
+                    RenderSVGContainer {g} at (52,0) size 22x22 [transform={m=((1.00,0.00)(0.00,1.00)) t=(-162.36,-403.29)}]
+                      RenderSVGPath {path} at (52,0) size 22x22 [stroke={[type=SOLID] [color=#000000]}] [fill={[type=SOLID] [color=#D9BB7A] [fill rule=EVEN-ODD]}] [data="M 525.714 585.219 C 525.714 685.419 444.486 766.648 344.286 766.648 C 244.085 766.648 162.857 685.419 162.857 585.219 C 162.857 485.019 244.085 403.791 344.286 403.791 C 444.486 403.791 525.714 485.019 525.714 585.219 Z"]
+              RenderText {#text} at (0,0) size 0x0
+          RenderTableRow {TR} at (0,294) size 464x39
+            RenderTableCell {TH} at (67,306) size 112x15 [bgcolor=#DDDD99] [r=8 c=1 rs=1 cs=1]
+              RenderText {#text} at (43,13) size 25x13
+                text run at (43,1) width 25: "slice"
+            RenderTableCell {TD} at (179,294) size 142x39 [r=8 c=2 rs=1 cs=1]
+              RenderImage {IMG} at (0,0) size 140x36 [border: (1.38px dashed #800000)]
+              RenderText {#text} at (0,0) size 0x0
+            RenderTableCell {TD} at (321,294) size 141x39 [r=8 c=3 rs=1 cs=1]
+              RenderEmbeddedObject {OBJECT} at (0,0) size 140x36 [border: (1px dashed #008000)]
+                layer at (0,0) size 133x29
+                  RenderView at (0,0) size 133x29
+                layer at (0,0) size 133x29
+                  RenderSVGRoot {svg} at (0,0) size 97x29
+                    RenderSVGHiddenContainer {defs} at (0,0) size 0x0
+                    RenderSVGContainer {g} at (0,0) size 97x29 [transform={m=((1.00,0.00)(0.00,1.00)) t=(-162.36,-403.29)}]
+                      RenderSVGPath {path} at (0,0) size 97x29 [stroke={[type=SOLID] [color=#000000]}] [fill={[type=SOLID] [color=#D9BB7A] [fill rule=EVEN-ODD]}] [data="M 525.714 585.219 C 525.714 685.419 444.486 766.648 344.286 766.648 C 244.085 766.648 162.857 685.419 162.857 585.219 C 162.857 485.019 244.085 403.791 344.286 403.791 C 444.486 403.791 525.714 485.019 525.714 585.219 Z"]
+              RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/wpe/svg/zoom/page/zoom-replaced-intrinsic-ratio-001-expected.txt
+++ b/LayoutTests/platform/wpe/svg/zoom/page/zoom-replaced-intrinsic-ratio-001-expected.txt
@@ -1,0 +1,62 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x456
+  RenderBlock {HTML} at (0,0) size 800x457
+    RenderBody {BODY} at (4,4) size 142x445 [border: (1px dashed #C0C0C0)]
+      RenderBlock {P} at (1,10) size 139x28
+        RenderText {#text} at (0,-1) size 137x28
+          text run at (0,-1) width 135: "The following six blue boxes must"
+          text run at (0,8) width 137: "be of the same width. There must be"
+          text run at (0,17) width 26: "no red."
+      RenderBlock {P} at (10,46) size 121x21 [bgcolor=#008000] [border: (5.20px solid #0000FF)]
+        RenderText {#text} at (5,4) size 3x11
+          text run at (5,4) width 3: " "
+      RenderBlock {P} at (1,121) size 139x10
+        RenderText {#text} at (0,-1) size 12x10
+          text run at (0,-1) width 12: "      "
+        RenderText {#text} at (0,0) size 0x0
+        RenderEmbeddedObject {OBJECT} at (9,-1) size 121x39 [bgcolor=#FF0000] [border: (5.20px solid #0000FF)]
+          layer at (0,0) size 110x27
+            RenderView at (0,0) size 110x27
+          layer at (0,0) size 110x27
+            RenderSVGRoot {svg} at (0,0) size 109x27
+              RenderSVGRect {rect} at (0,0) size 109x27 [stroke={[type=SOLID] [color=#008000] [stroke width=12.00]}] [fill={[type=SOLID] [color=#00FF00]}] [x=0.00] [y=0.00] [width=1000.00] [height=250.00]
+              RenderSVGPath {path} at (16,5) size 76x17 [fill={[type=SOLID] [color=#008000]}] [data="M 500 50 L 150 200 L 850 200 Z"]
+      RenderBlock {P} at (1,186) size 139x10
+        RenderEmbeddedObject {OBJECT} at (9,0) size 121x38 [bgcolor=#FF0000] [border: (5.20px solid #0000FF)]
+          layer at (0,0) size 110x27
+            RenderView at (0,0) size 110x27
+          layer at (0,0) size 110x27
+            RenderSVGRoot {svg} at (0,0) size 109x27
+              RenderSVGRect {rect} at (0,0) size 109x27 [stroke={[type=SOLID] [color=#008000] [stroke width=12.00]}] [fill={[type=SOLID] [color=#00FF00]}] [x=0.00] [y=0.00] [width=1000.00] [height=250.00]
+              RenderSVGPath {path} at (16,5) size 76x17 [fill={[type=SOLID] [color=#008000]}] [data="M 500 50 L 150 200 L 850 200 Z"]
+      RenderTable at (1,251) size 139x41
+        RenderTableSection (anonymous) at (0,0) size 139x40
+          RenderTableRow (anonymous) at (0,0) size 139x40
+            RenderTableCell {P} at (0,0) size 139x40 [r=0 c=0 rs=1 cs=1]
+              RenderEmbeddedObject {OBJECT} at (9,0) size 121x38 [bgcolor=#FF0000] [border: (5.20px solid #0000FF)]
+                layer at (0,0) size 110x27
+                  RenderView at (0,0) size 110x27
+                layer at (0,0) size 110x27
+                  RenderSVGRoot {svg} at (0,0) size 109x27
+                    RenderSVGRect {rect} at (0,0) size 109x27 [stroke={[type=SOLID] [color=#008000] [stroke width=12.00]}] [fill={[type=SOLID] [color=#00FF00]}] [x=0.00] [y=0.00] [width=1000.00] [height=250.00]
+                    RenderSVGPath {path} at (16,5) size 76x17 [fill={[type=SOLID] [color=#008000]}] [data="M 500 50 L 150 200 L 850 200 Z"]
+      RenderTable {TABLE} at (1,346) size 139x41
+        RenderTableSection {TBODY} at (0,0) size 139x40
+          RenderTableRow {TR} at (0,0) size 139x40
+            RenderTableCell {TD} at (0,0) size 139x40 [r=0 c=0 rs=1 cs=1]
+              RenderEmbeddedObject {OBJECT} at (9,0) size 121x38 [bgcolor=#FF0000] [border: (5.20px solid #0000FF)]
+                layer at (0,0) size 110x27
+                  RenderView at (0,0) size 110x27
+                layer at (0,0) size 110x27
+                  RenderSVGRoot {svg} at (0,0) size 109x27
+                    RenderSVGRect {rect} at (0,0) size 109x27 [stroke={[type=SOLID] [color=#008000] [stroke width=12.00]}] [fill={[type=SOLID] [color=#00FF00]}] [x=0.00] [y=0.00] [width=1000.00] [height=250.00]
+                    RenderSVGPath {path} at (16,5) size 76x17 [fill={[type=SOLID] [color=#008000]}] [data="M 500 50 L 150 200 L 850 200 Z"]
+      RenderBlock (floating) {P} at (1,442) size 139x10
+        RenderEmbeddedObject {OBJECT} at (9,0) size 121x38 [bgcolor=#FF0000] [border: (5.20px solid #0000FF)]
+          layer at (0,0) size 110x27
+            RenderView at (0,0) size 110x27
+          layer at (0,0) size 110x27
+            RenderSVGRoot {svg} at (0,0) size 109x27
+              RenderSVGRect {rect} at (0,0) size 109x27 [stroke={[type=SOLID] [color=#008000] [stroke width=12.00]}] [fill={[type=SOLID] [color=#00FF00]}] [x=0.00] [y=0.00] [width=1000.00] [height=250.00]
+              RenderSVGPath {path} at (16,5) size 76x17 [fill={[type=SOLID] [color=#008000]}] [data="M 500 50 L 150 200 L 850 200 Z"]

--- a/LayoutTests/platform/wpe/svg/zoom/page/zoom-svg-float-border-padding-expected.txt
+++ b/LayoutTests/platform/wpe/svg/zoom/page/zoom-svg-float-border-padding-expected.txt
@@ -1,8 +1,8 @@
-layer at (0,0) size 785x773
+layer at (0,0) size 785x775
   RenderView at (0,0) size 785x600
-layer at (0,0) size 785x773
-  RenderBlock {html} at (0,0) size 785x773
-    RenderBody {body} at (11,11) size 763x739
+layer at (0,0) size 785x775
+  RenderBlock {html} at (0,0) size 785x776
+    RenderBody {body} at (11,11) size 763x742
       RenderBlock (anonymous) at (0,0) size 762x54
         RenderText {#text} at (0,0) size 758x53
           text run at (0,0) width 357: "The two blocks should look identical. "
@@ -11,18 +11,18 @@ layer at (0,0) size 785x773
       RenderBlock {p} at (0,77) size 762x28
         RenderText {#text} at (0,0) size 524x26
           text run at (0,0) width 524: "There should be a red, white and blue pattern below this"
-      RenderSVGRoot {svg} at (25,152) size 202x202
-        RenderSVGRect {rect} at (25,152) size 202x202 [fill={[type=SOLID] [color=#0000FF]}] [x=0.00] [y=0.00] [width=100.00] [height=100.00]
-      RenderBlock {p} at (0,356) size 762x28
+      RenderSVGRoot {svg} at (25,152) size 203x203
+        RenderSVGRect {rect} at (25,152) size 203x203 [fill={[type=SOLID] [color=#0000FF]}] [x=0.00] [y=0.00] [width=100.00] [height=100.00]
+      RenderBlock {p} at (0,357) size 762x28
         RenderText {#text} at (0,0) size 523x26
           text run at (0,0) width 523: "There should be a red, white and blue pattern above this"
-      RenderBlock {p} at (0,431) size 762x28
+      RenderBlock {p} at (0,433) size 762x28
         RenderText {#text} at (0,0) size 524x26
           text run at (0,0) width 524: "There should be a red, white and blue pattern below this"
-      RenderBlock (floating) {div} at (14,496) size 202x201 [border: (14px solid #FF0000)]
+      RenderBlock (floating) {div} at (14,497) size 202x203 [border: (14.39px solid #FF0000)]
         RenderBlock {div} at (28,28) size 145x145 [bgcolor=#0000FF]
-      RenderBlock {p} at (0,711) size 762x28
+      RenderBlock {p} at (0,713) size 762x28
         RenderText {#text} at (0,0) size 523x26
           text run at (0,0) width 523: "There should be a red, white and blue pattern above this"
-layer at (12,418) size 762x2 backgroundClip at (12,418) size 761x2 clip at (0,0) size 0x0
-  RenderBlock {hr} at (0,406) size 762x3 [color=#808080] [border: (1px inset #808080)]
+layer at (12,419) size 762x3 backgroundClip at (12,419) size 761x3 clip at (0,0) size 0x0
+  RenderBlock {hr} at (0,407) size 762x4 [color=#808080] [border: (1.44px inset #808080)]

--- a/LayoutTests/platform/wpe/svg/zoom/page/zoom-svg-through-object-with-auto-size-expected.txt
+++ b/LayoutTests/platform/wpe/svg/zoom/page/zoom-svg-through-object-with-auto-size-expected.txt
@@ -1,0 +1,24 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x173
+  RenderBlock {HTML} at (0,0) size 800x174
+    RenderBody {BODY} at (5,5) size 790x163
+      RenderEmbeddedObject {OBJECT} at (0,0) size 160x160 [border: (1.38px dashed #800000)]
+        layer at (0,0) size 153x153
+          RenderView at (0,0) size 153x153
+        layer at (0,0) size 153x153
+          RenderSVGRoot {svg} at (0,0) size 153x153
+            RenderSVGEllipse {circle} at (0,0) size 153x153 [stroke={[type=SOLID] [color=#000000]}] [fill={[type=SOLID] [color=#D9BB7A] [fill rule=EVEN-ODD]}] [cx=110.00] [cy=110.00] [r=110.00]
+      RenderText {#text} at (159,150) size 4x12
+        text run at (159,150) width 4: " "
+      RenderEmbeddedObject {OBJECT} at (162,0) size 161x160 [border: (1.38px dashed #800000)]
+        layer at (0,0) size 153x153
+          RenderView at (0,0) size 153x153
+        layer at (0,0) size 153x153
+          RenderSVGRoot {svg} at (0,0) size 153x153
+            RenderSVGEllipse {circle} at (0,0) size 153x153 [stroke={[type=SOLID] [color=#000000]}] [fill={[type=SOLID] [color=#D9BB7A] [fill rule=EVEN-ODD]}] [cx=110.00] [cy=110.00] [r=110.00]
+      RenderText {#text} at (0,0) size 0x0
+      RenderText {#text} at (0,0) size 0x0
+      RenderText {#text} at (0,0) size 0x0
+      RenderText {#text} at (0,0) size 0x0
+      RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/svg/zoom/page/zoom-background-image-tiled-expected.txt
+++ b/LayoutTests/svg/zoom/page/zoom-background-image-tiled-expected.txt
@@ -2,5 +2,5 @@ layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
 layer at (0,0) size 800x245
   RenderBlock {HTML} at (0,0) size 800x245
-    RenderBody {BODY} at (16,16) size 768x212
-      RenderBlock {DIV} at (0,0) size 771x212 [border: (2px solid #CCCCCC)]
+    RenderBody {BODY} at (16,16) size 768x213
+      RenderBlock {DIV} at (0,0) size 771x212 [border: (2.06px solid #CCCCCC)]

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -2691,6 +2691,20 @@ EnumeratingVisibleNetworkInterfacesEnabled:
     WebKit:
       default: true
 
+EvaluationTimeZoomEnabled:
+  category: css
+  type: bool
+  status: testable
+  humanReadableName: "Evaluation time zoom enabled"
+  humanReadableDescription: "Enables used zoom value to be applied during layout and avoid applying at style-build time"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 EventHandlerDrivenSmoothKeyboardScrollingEnabled:
   type: bool
   status: internal

--- a/Source/WebCore/accessibility/AXTableHelpers.cpp
+++ b/Source/WebCore/accessibility/AXTableHelpers.cpp
@@ -196,8 +196,8 @@ bool isDataTableWithTraversal(HTMLTableElement& tableElement, AXObjectCache& cac
     CheckedPtr<const RenderStyle> tableStyle = safeStyleFrom(tableElement);
     // Store the background color of the table to check against cell's background colors.
     Color tableBackgroundColor = tableStyle ? tableStyle->visitedDependentColor(CSSPropertyBackgroundColor) : Color::white;
-    unsigned tableHorizontalBorderSpacing = tableStyle ? tableStyle->borderHorizontalSpacing().resolveZoom(Style::ZoomNeeded { }) : 0;
-    unsigned tableVerticalBorderSpacing = tableStyle ? tableStyle->borderVerticalSpacing().resolveZoom(Style::ZoomNeeded { }) : 0;
+    unsigned tableHorizontalBorderSpacing = tableStyle ? tableStyle->borderHorizontalSpacing().resolveZoom(tableStyle->usedZoomForLength()) : 0;
+    unsigned tableVerticalBorderSpacing = tableStyle ? tableStyle->borderVerticalSpacing().resolveZoom(tableStyle->usedZoomForLength()) : 0;
 
     unsigned cellCount = 0;
     unsigned borderedCellCount = 0;

--- a/Source/WebCore/layout/formattingContexts/FormattingGeometry.cpp
+++ b/Source/WebCore/layout/formattingContexts/FormattingGeometry.cpp
@@ -1085,12 +1085,12 @@ BoxGeometry::Edges FormattingGeometry::computedBorder(const Box& layoutBox) cons
     LOG_WITH_STREAM(FormattingContextLayout, stream << "[Border] -> layoutBox: " << &layoutBox);
     return {
         {
-            Style::evaluate<LayoutUnit>(style.borderLeftWidth(), Style::ZoomNeeded { }),
-            Style::evaluate<LayoutUnit>(style.borderRightWidth(), Style::ZoomNeeded { })
+            Style::evaluate<LayoutUnit>(style.borderLeftWidth(), style.usedZoomForLength()),
+            Style::evaluate<LayoutUnit>(style.borderRightWidth(), style.usedZoomForLength())
         },
         {
-            Style::evaluate<LayoutUnit>(style.borderTopWidth(), Style::ZoomNeeded { }),
-            Style::evaluate<LayoutUnit>(style.borderBottomWidth(), Style::ZoomNeeded { })
+            Style::evaluate<LayoutUnit>(style.borderTopWidth(), style.usedZoomForLength()),
+            Style::evaluate<LayoutUnit>(style.borderBottomWidth(), style.usedZoomForLength())
         },
     };
 }

--- a/Source/WebCore/layout/formattingContexts/block/BlockFormattingGeometry.cpp
+++ b/Source/WebCore/layout/formattingContexts/block/BlockFormattingGeometry.cpp
@@ -327,10 +327,10 @@ IntrinsicWidthConstraints BlockFormattingGeometry::intrinsicWidthConstraints(con
     auto fixedMarginBorderAndPadding = [&](auto& layoutBox) {
         auto& style = layoutBox.style();
         return fixedValue(style.marginStart()).value_or(0)
-            + Style::evaluate<LayoutUnit>(style.borderLeftWidth(), Style::ZoomNeeded { })
+            + Style::evaluate<LayoutUnit>(style.borderLeftWidth(), style.usedZoomForLength())
             + fixedValue(style.paddingLeft()).value_or(0)
             + fixedValue(style.paddingRight()).value_or(0)
-            + Style::evaluate<LayoutUnit>(style.borderRightWidth(), Style::ZoomNeeded { })
+            + Style::evaluate<LayoutUnit>(style.borderRightWidth(), style.usedZoomForLength())
             + fixedValue(style.marginEnd()).value_or(0);
     };
 

--- a/Source/WebCore/layout/formattingContexts/table/TableFormattingState.cpp
+++ b/Source/WebCore/layout/formattingContexts/table/TableFormattingState.cpp
@@ -42,8 +42,8 @@ static UniqueRef<TableGrid> ensureTableGrid(const ElementBox& tableBox)
     auto tableGrid = makeUniqueRef<TableGrid>();
     auto& tableStyle = tableBox.style();
     auto shouldApplyBorderSpacing = tableStyle.borderCollapse() == BorderCollapse::Separate;
-    tableGrid->setHorizontalSpacing(LayoutUnit { shouldApplyBorderSpacing ? tableStyle.borderHorizontalSpacing().resolveZoom(Style::ZoomNeeded { }) : 0 });
-    tableGrid->setVerticalSpacing(LayoutUnit { shouldApplyBorderSpacing ? tableStyle.borderVerticalSpacing().resolveZoom(Style::ZoomNeeded { }) : 0 });
+    tableGrid->setHorizontalSpacing(LayoutUnit { shouldApplyBorderSpacing ? tableStyle.borderHorizontalSpacing().resolveZoom(tableStyle.usedZoomForLength()) : 0 });
+    tableGrid->setVerticalSpacing(LayoutUnit { shouldApplyBorderSpacing ? tableStyle.borderVerticalSpacing().resolveZoom(tableStyle.usedZoomForLength()) : 0 });
 
     auto* firstChild = tableBox.firstChild();
     if (!firstChild) {

--- a/Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.cpp
@@ -240,8 +240,8 @@ Layout::BoxGeometry::Edges BoxGeometryUpdater::logicalBorder(const RenderBoxMode
 {
     auto& style = renderer.style();
 
-    auto borderWidths = RectEdges<LayoutUnit>::map(style.borderWidth(), [](auto width) {
-        return Style::evaluate<LayoutUnit>(width, Style::ZoomNeeded { });
+    auto borderWidths = RectEdges<LayoutUnit>::map(style.borderWidth(), [&](auto width) {
+        return Style::evaluate<LayoutUnit>(width, style.usedZoomForLength());
     });
 
     if (!isIntrinsicWidthMode)

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -2464,7 +2464,7 @@ std::pair<FixedContainerEdges, WeakElementEdges> LocalFrameView::fixedContainerE
         if (!border->isVisible())
             return samplingRect;
 
-        auto borderWidth = Style::evaluate<float>(border->width(), Style::ZoomNeeded { });
+        auto borderWidth = Style::evaluate<float>(border->width(), style->usedZoomForLength());
         if (borderWidth > thinBorderWidth)
             return samplingRect;
 

--- a/Source/WebCore/page/SpatialNavigation.cpp
+++ b/Source/WebCore/page/SpatialNavigation.cpp
@@ -523,9 +523,9 @@ LayoutRect nodeRectInAbsoluteCoordinates(const ContainerNode& containerNode, boo
         // the rect of the focused element.
         if (ignoreBorder) {
             auto& style = renderer->style();
-            rect.move(Style::evaluate<LayoutUnit>(style.borderLeftWidth(), Style::ZoomNeeded { }), Style::evaluate<LayoutUnit>(style.borderTopWidth(), Style::ZoomNeeded { }));
-            rect.setWidth(rect.width() - Style::evaluate<LayoutUnit>(style.borderLeftWidth(), Style::ZoomNeeded { }) - Style::evaluate<LayoutUnit>(style.borderRightWidth(), Style::ZoomNeeded { }));
-            rect.setHeight(rect.height() - Style::evaluate<LayoutUnit>(style.borderTopWidth(), Style::ZoomNeeded { }) - Style::evaluate<LayoutUnit>(style.borderBottomWidth(), Style::ZoomNeeded { }));
+            rect.move(Style::evaluate<LayoutUnit>(style.borderLeftWidth(), style.usedZoomForLength()), Style::evaluate<LayoutUnit>(style.borderTopWidth(), style.usedZoomForLength()));
+            rect.setWidth(rect.width() - Style::evaluate<LayoutUnit>(style.borderLeftWidth(), style.usedZoomForLength()) - Style::evaluate<LayoutUnit>(style.borderRightWidth(), style.usedZoomForLength()));
+            rect.setHeight(rect.height() - Style::evaluate<LayoutUnit>(style.borderTopWidth(), style.usedZoomForLength()) - Style::evaluate<LayoutUnit>(style.borderBottomWidth(), style.usedZoomForLength()));
         }
         return rect;
     }

--- a/Source/WebCore/rendering/BorderEdge.cpp
+++ b/Source/WebCore/rendering/BorderEdge.cpp
@@ -51,7 +51,7 @@ BorderEdges borderEdges(const RenderStyle& style, float deviceScaleFactor, RectE
 {
     auto constructBorderEdge = [&](const RenderStyle& style, Style::LineWidth width, float inflation, CSSPropertyID borderColorProperty, BorderStyle borderStyle, bool isTransparent, bool isPresent) {
         auto color = setColorsToBlack ? Color::black : style.visitedDependentColorWithColorFilter(borderColorProperty);
-        auto evaluatedWidth = Style::evaluate<float>(width, Style::ZoomNeeded { });
+        auto evaluatedWidth = Style::evaluate<float>(width, style.usedZoomForLength());
         auto inflatedWidth = evaluatedWidth ? evaluatedWidth + inflation : evaluatedWidth;
         return BorderEdge(inflatedWidth, color, borderStyle, !setColorsToBlack && isTransparent, isPresent, deviceScaleFactor);
     };
@@ -68,7 +68,7 @@ BorderEdges borderEdgesForOutline(const RenderStyle& style, BorderStyle borderSt
 {
     auto color = style.visitedDependentColorWithColorFilter(CSSPropertyOutlineColor);
     auto isTransparent = color.isValid() && !color.isVisible();
-    auto size = Style::evaluate<float>(style.outlineWidth(), Style::ZoomNeeded { });
+    auto size = Style::evaluate<float>(style.outlineWidth(), style.usedZoomForLength());
     return {
         BorderEdge { size, color, borderStyle, isTransparent, true, deviceScaleFactor },
         BorderEdge { size, color, borderStyle, isTransparent, true, deviceScaleFactor },

--- a/Source/WebCore/rendering/BorderPainter.cpp
+++ b/Source/WebCore/rendering/BorderPainter.cpp
@@ -309,7 +309,7 @@ void BorderPainter::paintOutline(const LayoutRect& paintRect) const
     if (!borderStyle || *borderStyle == BorderStyle::None)
         return;
 
-    auto outlineWidth = Style::evaluate<LayoutUnit>(styleToUse.outlineWidth(), Style::ZoomNeeded { });
+    auto outlineWidth = Style::evaluate<LayoutUnit>(styleToUse.outlineWidth(), styleToUse.usedZoomForLength());
     auto outlineOffset = Style::evaluate<LayoutUnit>(styleToUse.outlineOffset(), Style::ZoomNeeded { });
 
     auto outerRect = paintRect;
@@ -352,7 +352,7 @@ void BorderPainter::paintOutline(const LayoutPoint& paintOffset, const Vector<La
 
     auto& styleToUse = m_renderer->style();
     auto outlineOffset = Style::evaluate<float>(styleToUse.outlineOffset(), Style::ZoomNeeded { });
-    auto outlineWidth = Style::evaluate<float>(styleToUse.outlineWidth(), Style::ZoomNeeded { });
+    auto outlineWidth = Style::evaluate<float>(styleToUse.outlineWidth(), styleToUse.usedZoomForLength());
     auto deviceScaleFactor = document().deviceScaleFactor();
 
     Vector<FloatRect> pixelSnappedRects;

--- a/Source/WebCore/rendering/BorderShape.cpp
+++ b/Source/WebCore/rendering/BorderShape.cpp
@@ -42,8 +42,8 @@ namespace WebCore {
 
 BorderShape BorderShape::shapeForBorderRect(const RenderStyle& style, const LayoutRect& borderRect, RectEdges<bool> closedEdges)
 {
-    auto borderWidths = RectEdges<LayoutUnit>::map(style.borderWidth(), [](auto width) {
-        return Style::evaluate<LayoutUnit>(width, Style::ZoomNeeded { });
+    auto borderWidths = RectEdges<LayoutUnit>::map(style.borderWidth(), [&](auto width) {
+        return Style::evaluate<LayoutUnit>(width, style.usedZoomForLength());
     });
     return shapeForBorderRect(style, borderRect, borderWidths, closedEdges);
 }

--- a/Source/WebCore/rendering/NinePieceImagePainter.cpp
+++ b/Source/WebCore/rendering/NinePieceImagePainter.cpp
@@ -79,7 +79,7 @@ static LayoutUnit computeSlice(const WidthValue& length, LayoutUnit width, Layou
 {
     return WTF::switchOn(length,
         [&](const typename WidthValue::LengthPercentage& value) {
-            return Style::evaluate<LayoutUnit>(value, extent, Style::ZoomNeeded { });
+            return Style::evaluate<LayoutUnit>(value, extent, Style::ZoomFactor(1.0f) /* FIXME FIND ZOOM */);
         },
         [&](const typename WidthValue::Number& value) {
             return LayoutUnit { value.value * width };
@@ -230,7 +230,7 @@ static void paintNinePieceImage(const T& ninePieceImage, GraphicsContext& graphi
     ASSERT(styleImage->isLoaded(renderer));
 
     auto sourceSlices      = computeSlices(source, ninePieceImage.slice(), styleImage->imageScaleFactor());
-    auto destinationSlices = computeSlices(destination.size(), ninePieceImage.width(), Style::evaluate<LayoutBoxExtent>(style.borderWidth(), Style::ZoomNeeded { }), sourceSlices);
+    auto destinationSlices = computeSlices(destination.size(), ninePieceImage.width(), Style::evaluate<LayoutBoxExtent>(style.borderWidth(), style.usedZoomForLength()), sourceSlices);
 
     scaleSlicesIfNeeded(destination.size(), destinationSlices, deviceScaleFactor);
 

--- a/Source/WebCore/rendering/RenderBoxModelObjectInlines.h
+++ b/Source/WebCore/rendering/RenderBoxModelObjectInlines.h
@@ -25,7 +25,7 @@
 
 namespace WebCore {
 
-inline LayoutUnit RenderBoxModelObject::borderAfter() const { return Style::evaluate<LayoutUnit>(style().borderAfterWidth(), Style::ZoomNeeded { }); }
+inline LayoutUnit RenderBoxModelObject::borderAfter() const { return Style::evaluate<LayoutUnit>(style().borderAfterWidth(), style().usedZoomForLength()); }
 inline LayoutUnit RenderBoxModelObject::borderAndPaddingAfter() const { return borderAfter() + paddingAfter(); }
 inline LayoutUnit RenderBoxModelObject::borderAndPaddingBefore() const { return borderBefore() + paddingBefore(); }
 inline LayoutUnit RenderBoxModelObject::borderAndPaddingLogicalHeight() const { return borderAndPaddingBefore() + borderAndPaddingAfter(); }
@@ -34,17 +34,17 @@ inline LayoutUnit RenderBoxModelObject::borderAndPaddingLogicalLeft() const { re
 inline LayoutUnit RenderBoxModelObject::borderAndPaddingLogicalRight() const { return writingMode().isHorizontal() ? borderRight() + paddingRight() : borderBottom() + paddingBottom(); }
 inline LayoutUnit RenderBoxModelObject::borderAndPaddingStart() const { return borderStart() + paddingStart(); }
 inline LayoutUnit RenderBoxModelObject::borderAndPaddingEnd() const { return borderEnd() + paddingEnd(); }
-inline LayoutUnit RenderBoxModelObject::borderBefore() const { return Style::evaluate<LayoutUnit>(style().borderBeforeWidth(), Style::ZoomNeeded { }); }
-inline LayoutUnit RenderBoxModelObject::borderBottom() const { return Style::evaluate<LayoutUnit>(style().borderBottomWidth(), Style::ZoomNeeded { }); }
-inline LayoutUnit RenderBoxModelObject::borderEnd() const { return Style::evaluate<LayoutUnit>(style().borderEndWidth(), Style::ZoomNeeded { }); }
-inline LayoutUnit RenderBoxModelObject::borderLeft() const { return Style::evaluate<LayoutUnit>(style().borderLeftWidth(), Style::ZoomNeeded { }); }
+inline LayoutUnit RenderBoxModelObject::borderBefore() const { return Style::evaluate<LayoutUnit>(style().borderBeforeWidth(), style().usedZoomForLength()); }
+inline LayoutUnit RenderBoxModelObject::borderBottom() const { return Style::evaluate<LayoutUnit>(style().borderBottomWidth(), style().usedZoomForLength()); }
+inline LayoutUnit RenderBoxModelObject::borderEnd() const { return Style::evaluate<LayoutUnit>(style().borderEndWidth(), style().usedZoomForLength()); }
+inline LayoutUnit RenderBoxModelObject::borderLeft() const { return Style::evaluate<LayoutUnit>(style().borderLeftWidth(), style().usedZoomForLength()); }
 inline LayoutUnit RenderBoxModelObject::borderLogicalHeight() const { return borderBefore() + borderAfter(); }
 inline LayoutUnit RenderBoxModelObject::borderLogicalLeft() const { return writingMode().isHorizontal() ? borderLeft() : borderTop(); }
 inline LayoutUnit RenderBoxModelObject::borderLogicalRight() const { return writingMode().isHorizontal() ? borderRight() : borderBottom(); }
 inline LayoutUnit RenderBoxModelObject::borderLogicalWidth() const { return borderStart() + borderEnd(); }
-inline LayoutUnit RenderBoxModelObject::borderRight() const { return Style::evaluate<LayoutUnit>(style().borderRightWidth(), Style::ZoomNeeded { }); }
-inline LayoutUnit RenderBoxModelObject::borderStart() const { return Style::evaluate<LayoutUnit>(style().borderStartWidth(), Style::ZoomNeeded { }); }
-inline LayoutUnit RenderBoxModelObject::borderTop() const { return Style::evaluate<LayoutUnit>(style().borderTopWidth(), Style::ZoomNeeded { }); }
+inline LayoutUnit RenderBoxModelObject::borderRight() const { return Style::evaluate<LayoutUnit>(style().borderRightWidth(), style().usedZoomForLength()); }
+inline LayoutUnit RenderBoxModelObject::borderStart() const { return Style::evaluate<LayoutUnit>(style().borderStartWidth(), style().usedZoomForLength()); }
+inline LayoutUnit RenderBoxModelObject::borderTop() const { return Style::evaluate<LayoutUnit>(style().borderTopWidth(), style().usedZoomForLength()); }
 inline LayoutUnit RenderBoxModelObject::computedCSSPaddingAfter() const { return resolveLengthPercentageUsingContainerLogicalWidth(style().paddingAfter()); }
 inline LayoutUnit RenderBoxModelObject::computedCSSPaddingBefore() const { return resolveLengthPercentageUsingContainerLogicalWidth(style().paddingBefore()); }
 inline LayoutUnit RenderBoxModelObject::computedCSSPaddingBottom() const { return resolveLengthPercentageUsingContainerLogicalWidth(style().paddingBottom()); }
@@ -81,7 +81,7 @@ inline LayoutUnit RenderBoxModelObject::verticalBorderExtent() const { return bo
 inline RectEdges<LayoutUnit> RenderBoxModelObject::borderWidths() const
 {
     return RectEdges<LayoutUnit>::map(style().borderWidth(), [&](auto width) {
-        return Style::evaluate<LayoutUnit>(width, Style::ZoomNeeded { });
+        return Style::evaluate<LayoutUnit>(width, style().usedZoomForLength());
     });
 }
 

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -2120,15 +2120,15 @@ static bool useShrinkWrappedFocusRingForOutlineStyleAuto()
 
 static void drawFocusRing(GraphicsContext& context, const Path& path, const RenderStyle& style, const Color& color)
 {
-    context.drawFocusRing(path, Style::evaluate<float>(style.outlineWidth(), Style::ZoomNeeded { }), color);
+    context.drawFocusRing(path, Style::evaluate<float>(style.outlineWidth(), style.usedZoomForLength()), color);
 }
 
 static void drawFocusRing(GraphicsContext& context, Vector<FloatRect> rects, const RenderStyle& style, const Color& color)
 {
 #if PLATFORM(MAC)
-    context.drawFocusRing(rects, 0, Style::evaluate<float>(style.outlineWidth(), Style::ZoomNeeded { }), color);
+    context.drawFocusRing(rects, 0, Style::evaluate<float>(style.outlineWidth(), style.usedZoomForLength()), color);
 #else
-    context.drawFocusRing(rects, Style::evaluate<float>(style.outlineOffset(), Style::ZoomNeeded { }), Style::evaluate<float>(style.outlineWidth(), Style::ZoomNeeded { }), color);
+    context.drawFocusRing(rects, Style::evaluate<float>(style.outlineOffset(), Style::ZoomNeeded { }), Style::evaluate<float>(style.outlineWidth(), style.usedZoomForLength()), color);
 #endif
 }
 

--- a/Source/WebCore/rendering/RenderImage.cpp
+++ b/Source/WebCore/rendering/RenderImage.cpp
@@ -701,7 +701,7 @@ void RenderImage::paintAreaElementFocusRing(PaintInfo& paintInfo, const LayoutPo
     if (!areaElementStyle)
         return;
 
-    auto outlineWidth = Style::evaluate<float>(areaElementStyle->outlineWidth(), Style::ZoomNeeded { });
+    auto outlineWidth = Style::evaluate<float>(areaElementStyle->outlineWidth(), style().usedZoomForLength());
     if (!outlineWidth)
         return;
 

--- a/Source/WebCore/rendering/RenderMultiColumnSet.cpp
+++ b/Source/WebCore/rendering/RenderMultiColumnSet.cpp
@@ -632,7 +632,7 @@ void RenderMultiColumnSet::paintColumnRules(PaintInfo& paintInfo, const LayoutPo
     const Color& ruleColor = blockStyle.visitedDependentColorWithColorFilter(CSSPropertyColumnRuleColor);
     bool ruleTransparent = blockStyle.columnRuleIsTransparent();
     auto ruleStyle = collapsedBorderStyle(blockStyle.columnRuleStyle());
-    auto ruleThickness = Style::evaluate<LayoutUnit>(blockStyle.columnRuleWidth(), Style::ZoomNeeded { });
+    auto ruleThickness = Style::evaluate<LayoutUnit>(blockStyle.columnRuleWidth(), blockStyle.usedZoomForLength());
     auto colGap = columnGap();
     bool renderRule = ruleStyle > BorderStyle::Hidden && !ruleTransparent;
     if (!renderRule)

--- a/Source/WebCore/rendering/RenderTable.cpp
+++ b/Source/WebCore/rendering/RenderTable.cpp
@@ -157,8 +157,8 @@ void RenderTable::styleDidChange(StyleDifference diff, const RenderStyle* oldSty
     bool oldFixedTableLayout = oldStyle ? oldStyle->isFixedTableLayout() : false;
 
     // In the collapsed border model, there is no cell spacing.
-    m_hSpacing = collapseBorders() ? 0 : style().borderHorizontalSpacing().resolveZoom(Style::ZoomNeeded { });
-    m_vSpacing = collapseBorders() ? 0 : style().borderVerticalSpacing().resolveZoom(Style::ZoomNeeded { });
+    m_hSpacing = collapseBorders() ? 0 : style().borderHorizontalSpacing().resolveZoom(style().usedZoomForLength());
+    m_vSpacing = collapseBorders() ? 0 : style().borderVerticalSpacing().resolveZoom(style().usedZoomForLength());
     ASSERT(m_hSpacing >= 0);
     ASSERT(m_vSpacing >= 0);
 
@@ -1287,7 +1287,7 @@ LayoutUnit RenderTable::calcBorderStart() const
                 borderWidth = std::max(borderWidth, firstRowAdjoiningBorder.width());
         }
     }
-    return CollapsedBorderValue::adjustedCollapsedBorderWidth(Style::evaluate<float>(borderWidth, Style::ZoomNeeded { }), document().deviceScaleFactor(), writingMode().isInlineFlipped());
+    return CollapsedBorderValue::adjustedCollapsedBorderWidth(Style::evaluate<float>(borderWidth, style().usedZoomForLength()), document().deviceScaleFactor(), writingMode().isInlineFlipped());
 }
 
 LayoutUnit RenderTable::calcBorderEnd() const
@@ -1342,7 +1342,7 @@ LayoutUnit RenderTable::calcBorderEnd() const
                 borderWidth = std::max(borderWidth, firstRowAdjoiningBorder.width());
         }
     }
-    return CollapsedBorderValue::adjustedCollapsedBorderWidth(Style::evaluate<float>(borderWidth, Style::ZoomNeeded { }), document().deviceScaleFactor(), !writingMode().isInlineFlipped());
+    return CollapsedBorderValue::adjustedCollapsedBorderWidth(Style::evaluate<float>(borderWidth, style().usedZoomForLength()), document().deviceScaleFactor(), !writingMode().isInlineFlipped());
 }
 
 void RenderTable::recalcBordersInRowDirection()
@@ -1384,7 +1384,7 @@ LayoutUnit RenderTable::outerBorderBefore() const
     if (tb.style() == BorderStyle::Hidden)
         return 0;
     if (tb.style() > BorderStyle::Hidden) {
-        LayoutUnit collapsedBorderWidth = std::max(borderWidth, LayoutUnit(Style::evaluate<float>(tb.width(), Style::ZoomNeeded { }) / 2));
+        LayoutUnit collapsedBorderWidth = std::max(borderWidth, LayoutUnit(Style::evaluate<float>(tb.width(), style().usedZoomForLength()) / 2));
         borderWidth = floorToDevicePixel(collapsedBorderWidth, document().deviceScaleFactor());
     }
     return borderWidth;
@@ -1406,7 +1406,7 @@ LayoutUnit RenderTable::outerBorderAfter() const
         return 0;
     if (tb.style() > BorderStyle::Hidden) {
         float deviceScaleFactor = document().deviceScaleFactor();
-        LayoutUnit collapsedBorderWidth = std::max(borderWidth, LayoutUnit((Style::evaluate<float>(tb.width(), Style::ZoomNeeded { }) + (1 / deviceScaleFactor)) / 2));
+        LayoutUnit collapsedBorderWidth = std::max(borderWidth, LayoutUnit((Style::evaluate<float>(tb.width(), style().usedZoomForLength()) + (1 / deviceScaleFactor)) / 2));
         borderWidth = floorToDevicePixel(collapsedBorderWidth, deviceScaleFactor);
     }
     return borderWidth;
@@ -1423,7 +1423,7 @@ LayoutUnit RenderTable::outerBorderStart() const
     if (tb.style() == BorderStyle::Hidden)
         return 0;
     if (tb.style() > BorderStyle::Hidden)
-        return CollapsedBorderValue::adjustedCollapsedBorderWidth(Style::evaluate<float>(tb.width(), Style::ZoomNeeded { }), document().deviceScaleFactor(), writingMode().isInlineFlipped());
+        return CollapsedBorderValue::adjustedCollapsedBorderWidth(Style::evaluate<float>(tb.width(), style().usedZoomForLength()), document().deviceScaleFactor(), writingMode().isInlineFlipped());
 
     bool allHidden = true;
     for (RenderTableSection* section = topSection(); section; section = sectionBelow(section)) {
@@ -1450,7 +1450,7 @@ LayoutUnit RenderTable::outerBorderEnd() const
     if (tb.style() == BorderStyle::Hidden)
         return 0;
     if (tb.style() > BorderStyle::Hidden)
-        return CollapsedBorderValue::adjustedCollapsedBorderWidth(Style::evaluate<float>(tb.width(), Style::ZoomNeeded { }), document().deviceScaleFactor(), !writingMode().isInlineFlipped());
+        return CollapsedBorderValue::adjustedCollapsedBorderWidth(Style::evaluate<float>(tb.width(), style().usedZoomForLength()), document().deviceScaleFactor(), !writingMode().isInlineFlipped());
 
     bool allHidden = true;
     for (RenderTableSection* section = topSection(); section; section = sectionBelow(section)) {

--- a/Source/WebCore/rendering/RenderTableSection.cpp
+++ b/Source/WebCore/rendering/RenderTableSection.cpp
@@ -788,7 +788,7 @@ LayoutUnit RenderTableSection::calcBlockDirectionOuterBorder(BlockBorderSide sid
 
     if (allHidden)
         return -1;
-    return CollapsedBorderValue::adjustedCollapsedBorderWidth(Style::evaluate<float>(borderWidth, Style::ZoomNeeded { }), document().deviceScaleFactor(), (side == BlockBorderSide::BorderAfter));
+    return CollapsedBorderValue::adjustedCollapsedBorderWidth(Style::evaluate<float>(borderWidth, style().usedZoomForLength()), document().deviceScaleFactor(), (side == BlockBorderSide::BorderAfter));
 }
 
 LayoutUnit RenderTableSection::calcInlineDirectionOuterBorder(InlineBorderSide side) const
@@ -842,7 +842,7 @@ LayoutUnit RenderTableSection::calcInlineDirectionOuterBorder(InlineBorderSide s
 
     if (allHidden)
         return -1;
-    return CollapsedBorderValue::adjustedCollapsedBorderWidth(Style::evaluate<float>(borderWidth, Style::ZoomNeeded { }), document().deviceScaleFactor(), (side == InlineBorderSide::BorderStart) ? writingMode.isInlineFlipped() : !writingMode.isInlineFlipped());
+    return CollapsedBorderValue::adjustedCollapsedBorderWidth(Style::evaluate<float>(borderWidth, style().usedZoomForLength()), document().deviceScaleFactor(), (side == InlineBorderSide::BorderStart) ? writingMode.isInlineFlipped() : !writingMode.isInlineFlipped());
 }
 
 void RenderTableSection::recalcOuterBorder()
@@ -1151,7 +1151,7 @@ void RenderTableSection::paintRowGroupBorderIfRequired(const PaintInfo& paintInf
                 paintOffset.x() + offsetLeftForRowGroupBorder(cell, rowGroupRect, row),
                 rowGroupRect.y(),
                 horizontalRowGroupBorderWidth(cell, rowGroupRect, row, column),
-                LayoutUnit { Style::evaluate<float>(style.borderTop().width(), Style::ZoomNeeded { }) },
+                LayoutUnit { Style::evaluate<float>(style.borderTop().width(), style.usedZoomForLength()) },
             },
             BoxSide::Top,
             CSSPropertyBorderTopColor,
@@ -1167,7 +1167,7 @@ void RenderTableSection::paintRowGroupBorderIfRequired(const PaintInfo& paintInf
                 paintOffset.x() + offsetLeftForRowGroupBorder(cell, rowGroupRect, row),
                 rowGroupRect.y() + rowGroupRect.height(),
                 horizontalRowGroupBorderWidth(cell, rowGroupRect, row, column),
-                LayoutUnit { Style::evaluate<float>(style.borderBottom().width(), Style::ZoomNeeded { }) },
+                LayoutUnit { Style::evaluate<float>(style.borderBottom().width(), style.usedZoomForLength()) },
             },
             BoxSide::Bottom,
             CSSPropertyBorderBottomColor,
@@ -1182,7 +1182,7 @@ void RenderTableSection::paintRowGroupBorderIfRequired(const PaintInfo& paintInf
             LayoutRect {
                 rowGroupRect.x(),
                 rowGroupRect.y() + offsetTopForRowGroupBorder(cell, borderSide, row),
-                LayoutUnit { Style::evaluate<float>(style.borderLeft().width(), Style::ZoomNeeded { }) },
+                LayoutUnit { Style::evaluate<float>(style.borderLeft().width(), style.usedZoomForLength()) },
                 verticalRowGroupBorderHeight(cell, rowGroupRect, row),
             },
             BoxSide::Left,
@@ -1198,7 +1198,7 @@ void RenderTableSection::paintRowGroupBorderIfRequired(const PaintInfo& paintInf
             LayoutRect {
                 rowGroupRect.x() + rowGroupRect.width(),
                 rowGroupRect.y() + offsetTopForRowGroupBorder(cell, borderSide, row),
-                LayoutUnit { Style::evaluate<float>(style.borderRight().width(), Style::ZoomNeeded { }) },
+                LayoutUnit { Style::evaluate<float>(style.borderRight().width(), style.usedZoomForLength()) },
                 verticalRowGroupBorderHeight(cell, rowGroupRect, row),
             },
             BoxSide::Right,

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -838,7 +838,7 @@ ControlStyle RenderTheme::extractControlStyleForRenderer(const RenderElement& re
         style->usedZoom(),
         style->usedAccentColor(renderObject.styleColorOptions()),
         style->visitedDependentColorWithColorFilter(CSSPropertyColor),
-        Style::evaluate<FloatBoxExtent>(style->borderWidth(), Style::ZoomNeeded { })
+        Style::evaluate<FloatBoxExtent>(style->borderWidth(), style->usedZoomForLength())
     };
 }
 
@@ -1395,27 +1395,26 @@ void RenderTheme::adjustButtonOrCheckboxOrColorWellOrInnerSpinButtonOrRadioStyle
     if (!style.writingMode().isHorizontal() && supportsVerticalWritingMode(appearance))
         borderBox = Style::LineWidthBox { borderBox.left(), borderBox.top(), borderBox.right(), borderBox.bottom() };
 
-    /* FIXME: FIND ZOOM */
-    if (Style::evaluate<float>(borderBox.top(), Style::ZoomNeeded { }) != Style::evaluate<int>(style.borderTopWidth(), Style::ZoomNeeded { })) {
+    if (Style::evaluate<float>(borderBox.top(), style.usedZoomForLength()) != Style::evaluate<int>(style.borderTopWidth(), style.usedZoomForLength())) {
         if (!borderBox.top().isZero())
             style.setBorderTopWidth(borderBox.top());
         else
             style.resetBorderTop();
     }
-    if (Style::evaluate<float>(borderBox.right(), Style::ZoomNeeded { }) != Style::evaluate<int>(style.borderRightWidth(), Style::ZoomNeeded { })) {
+    if (Style::evaluate<float>(borderBox.right(), style.usedZoomForLength()) != Style::evaluate<int>(style.borderRightWidth(), style.usedZoomForLength())) {
         if (!borderBox.right().isZero())
             style.setBorderRightWidth(borderBox.right());
         else
             style.resetBorderRight();
     }
-    if (Style::evaluate<float>(borderBox.bottom(), Style::ZoomNeeded { }) != Style::evaluate<int>(style.borderBottomWidth(), Style::ZoomNeeded { })) {
+    if (Style::evaluate<float>(borderBox.bottom(), style.usedZoomForLength()) != Style::evaluate<int>(style.borderBottomWidth(), style.usedZoomForLength())) {
         style.setBorderBottomWidth(borderBox.bottom());
         if (!borderBox.bottom().isZero())
             style.setBorderBottomWidth(borderBox.bottom());
         else
             style.resetBorderBottom();
     }
-    if (Style::evaluate<float>(borderBox.left(), Style::ZoomNeeded { }) != Style::evaluate<int>(style.borderLeftWidth(), Style::ZoomNeeded { })) {
+    if (Style::evaluate<float>(borderBox.left(), style.usedZoomForLength()) != Style::evaluate<int>(style.borderLeftWidth(), style.usedZoomForLength())) {
         style.setBorderLeftWidth(borderBox.left());
         if (!borderBox.left().isZero())
             style.setBorderLeftWidth(borderBox.left());

--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
@@ -2583,9 +2583,9 @@ bool RenderThemeCocoa::paintMenuListButtonDecorationsForVectorBasedControls(cons
     }
 
     if (!style->writingMode().isInlineFlipped())
-        glyphOrigin.setX(logicalRect.maxX() - glyphSize.width() - Style::evaluate<float>(box.style().borderEndWidth(), Style::ZoomNeeded { }) - glyphPaddingEnd);
+        glyphOrigin.setX(logicalRect.maxX() - glyphSize.width() - Style::evaluate<float>(box.style().borderEndWidth(), style->usedZoomForLength()) - glyphPaddingEnd);
     else
-        glyphOrigin.setX(logicalRect.x() + Style::evaluate<float>(box.style().borderEndWidth(), Style::ZoomNeeded { }) + glyphPaddingEnd);
+        glyphOrigin.setX(logicalRect.x() + Style::evaluate<float>(box.style().borderEndWidth(), style->usedZoomForLength()) + glyphPaddingEnd);
 
     if (!isHorizontalWritingMode)
         glyphOrigin = glyphOrigin.transposedPoint();

--- a/Source/WebCore/rendering/ios/RenderThemeIOS.mm
+++ b/Source/WebCore/rendering/ios/RenderThemeIOS.mm
@@ -383,7 +383,7 @@ Style::PaddingBox RenderThemeIOS::popupInternalPaddingBox(const RenderStyle& sty
     auto padding = emSize->resolveAsLength<float>({ style, nullptr, nullptr, nullptr });
 
     if (style.usedAppearance() == StyleAppearance::MenulistButton) {
-        auto value = toTruncatedPaddingEdge(padding + Style::evaluate<float>(style.borderTopWidth(), Style::ZoomNeeded { }));
+        auto value = toTruncatedPaddingEdge(padding + Style::evaluate<float>(style.borderTopWidth(), style.usedZoomForLength()));
         if (style.writingMode().isBidiRTL())
             return { 0_css_px, 0_css_px, 0_css_px, value };
         return { 0_css_px, value, 0_css_px, 0_css_px };
@@ -610,9 +610,9 @@ void RenderThemeIOS::paintMenuListButtonDecorations(const RenderBox& box, const 
     FloatPoint glyphOrigin;
     glyphOrigin.setY(logicalRect.center().y() - glyphSize.height() / 2.0f);
     if (!style.writingMode().isInlineFlipped())
-        glyphOrigin.setX(logicalRect.maxX() - glyphSize.width() - Style::evaluate<float>(box.style().borderEndWidth(), Style::ZoomNeeded { }) - Style::evaluate<float>(box.style().paddingEnd(), logicalRect.width(), Style::ZoomNeeded { }));
+        glyphOrigin.setX(logicalRect.maxX() - glyphSize.width() - Style::evaluate<float>(box.style().borderEndWidth(), style.usedZoomForLength()) - Style::evaluate<float>(box.style().paddingEnd(), logicalRect.width(), Style::ZoomNeeded { }));
     else
-        glyphOrigin.setX(logicalRect.x() + Style::evaluate<float>(box.style().borderEndWidth(), Style::ZoomNeeded { }) + Style::evaluate<float>(box.style().paddingEnd(), logicalRect.width(), Style::ZoomNeeded { }));
+        glyphOrigin.setX(logicalRect.x() + Style::evaluate<float>(box.style().borderEndWidth(), style.usedZoomForLength()) + Style::evaluate<float>(box.style().paddingEnd(), logicalRect.width(), Style::ZoomNeeded { }));
 
     if (!isHorizontalWritingMode)
         glyphOrigin = glyphOrigin.transposedPoint();

--- a/Source/WebCore/rendering/style/CollapsedBorderValue.h
+++ b/Source/WebCore/rendering/style/CollapsedBorderValue.h
@@ -39,7 +39,7 @@ public:
     }
 
     CollapsedBorderValue(const BorderValue& border, const Color& color, BorderPrecedence precedence)
-        : m_width(border.nonZero() ? Style::evaluate<LayoutUnit>(border.width(), Style::ZoomNeeded { }) : 0_lu)
+        : m_width(border.nonZero() ? Style::evaluate<LayoutUnit>(border.width(), Style::ZoomFactor(1.0f)) : 0_lu)
         , m_color(color)
         , m_style(static_cast<unsigned>(border.style()))
         , m_precedence(static_cast<unsigned>(precedence))

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -418,6 +418,11 @@ void RenderStyle::copyContentFrom(const RenderStyle& other)
     m_nonInheritedData.access().miscData.access().content = other.m_nonInheritedData->miscData->content;
 }
 
+void RenderStyle::setEnableEvaluationTimeZoom(bool value)
+{
+    SET_VAR(m_rareInheritedData, enableEvaluationTimeZoom, value);
+}
+
 void RenderStyle::copyPseudoElementsFrom(const RenderStyle& other)
 {
     if (!other.m_cachedPseudoStyles)
@@ -3078,20 +3083,20 @@ static LayoutUnit computeOutset(const OutsetValue& outsetValue, LayoutUnit borde
 LayoutBoxExtent RenderStyle::imageOutsets(const Style::BorderImage& image) const
 {
     return {
-        computeOutset(image.outset().values.top(), Style::evaluate<LayoutUnit>(borderTopWidth(), Style::ZoomNeeded { })),
-        computeOutset(image.outset().values.right(), Style::evaluate<LayoutUnit>(borderRightWidth(), Style::ZoomNeeded { })),
-        computeOutset(image.outset().values.bottom(), Style::evaluate<LayoutUnit>(borderBottomWidth(), Style::ZoomNeeded { })),
-        computeOutset(image.outset().values.left(), Style::evaluate<LayoutUnit>(borderLeftWidth(), Style::ZoomNeeded { })),
+        computeOutset(image.outset().values.top(), Style::evaluate<LayoutUnit>(borderTopWidth(), usedZoomForLength())),
+        computeOutset(image.outset().values.right(), Style::evaluate<LayoutUnit>(borderRightWidth(), usedZoomForLength())),
+        computeOutset(image.outset().values.bottom(), Style::evaluate<LayoutUnit>(borderBottomWidth(), usedZoomForLength())),
+        computeOutset(image.outset().values.left(), Style::evaluate<LayoutUnit>(borderLeftWidth(), usedZoomForLength())),
     };
 }
 
 LayoutBoxExtent RenderStyle::imageOutsets(const Style::MaskBorder& image) const
 {
     return {
-        computeOutset(image.outset().values.top(), Style::evaluate<LayoutUnit>(borderTopWidth(), Style::ZoomNeeded { })),
-        computeOutset(image.outset().values.right(), Style::evaluate<LayoutUnit>(borderRightWidth(), Style::ZoomNeeded { })),
-        computeOutset(image.outset().values.bottom(), Style::evaluate<LayoutUnit>(borderBottomWidth(), Style::ZoomNeeded { })),
-        computeOutset(image.outset().values.left(), Style::evaluate<LayoutUnit>(borderLeftWidth(), Style::ZoomNeeded { })),
+        computeOutset(image.outset().values.top(), Style::evaluate<LayoutUnit>(borderTopWidth(), usedZoomForLength())),
+        computeOutset(image.outset().values.right(), Style::evaluate<LayoutUnit>(borderRightWidth(), usedZoomForLength())),
+        computeOutset(image.outset().values.bottom(), Style::evaluate<LayoutUnit>(borderBottomWidth(), usedZoomForLength())),
+        computeOutset(image.outset().values.left(), Style::evaluate<LayoutUnit>(borderLeftWidth(), usedZoomForLength())),
     };
 }
 
@@ -3388,7 +3393,7 @@ Style::LineWidth RenderStyle::outlineWidth() const
     if (outline.style() == OutlineStyle::None)
         return 0_css_px;
     if (outlineStyle() == OutlineStyle::Auto)
-        return Style::LineWidth { std::max(Style::evaluate<float>(outline.width(), Style::ZoomNeeded { }), RenderTheme::platformFocusRingWidth()) };
+        return Style::LineWidth { std::max(Style::evaluate<float>(outline.width(), usedZoomForLength()), RenderTheme::platformFocusRingWidth()) };
     return outline.width();
 }
 
@@ -3396,13 +3401,13 @@ Style::Length<> RenderStyle::outlineOffset() const
 {
     auto& outline = m_nonInheritedData->backgroundData->outline;
     if (outlineStyle() == OutlineStyle::Auto)
-        return Style::Length<> { Style::evaluate<float>(outline.offset(), Style::ZoomNeeded { }) + RenderTheme::platformFocusRingOffset(Style::evaluate<float>(outline.width(), Style::ZoomNeeded { })) };
+        return Style::Length<> { Style::evaluate<float>(outline.offset(), Style::ZoomNeeded { }) + RenderTheme::platformFocusRingOffset(Style::evaluate<float>(outline.width(), usedZoomForLength())) };
     return outline.offset();
 }
 
 float RenderStyle::outlineSize() const
 {
-    return std::max(0.0f, Style::evaluate<float>(outlineWidth(), Style::ZoomNeeded { }) + Style::evaluate<float>(outlineOffset(), Style::ZoomNeeded { }));
+    return std::max(0.0f, Style::evaluate<float>(outlineWidth(), usedZoomForLength()) + Style::evaluate<float>(outlineOffset(), Style::ZoomNeeded { }));
 }
 
 CheckedRef<const FontCascade> RenderStyle::checkedFontCascade() const

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -30,6 +30,7 @@
 #include <WebCore/PseudoElementIdentifier.h>
 #include <WebCore/StylePrimitiveNumeric+Forward.h>
 #include <WebCore/StyleTextDecorationLine.h>
+#include <WebCore/StyleWebKitBorderSpacing.h>
 #include <WebCore/WritingMode.h>
 #include <unicode/utypes.h>
 #include <wtf/CheckedRef.h>
@@ -408,7 +409,6 @@ using TransformOriginXY = Position;
 using TransformOriginY = PositionY;
 using TransformOriginZ = Length<>;
 using Transitions = CoordinatedValueList<Transition>;
-using WebkitBorderSpacing = Length<CSS::Nonnegative>;
 using WebkitBoxFlex = Number<CSS::All, float>;
 using WebkitBoxFlexGroup = Integer<CSS::Nonnegative>;
 using WebkitBoxOrdinalGroup = Integer<CSS::Positive>;
@@ -766,7 +766,8 @@ public:
 
     inline float zoom() const;
     inline float usedZoom() const;
-    
+    inline Style::ZoomFactor usedZoomForLength() const;
+
     inline TextZoom textZoom() const;
 
     const Length& specifiedLineHeight() const;
@@ -1766,6 +1767,9 @@ public:
     inline void setFill(Style::SVGPaint&&);
     inline void setVisitedLinkFill(Style::SVGPaint&&);
     static inline Style::SVGPaint initialFill();
+
+    inline bool enableEvaluationTimeZoom() const;
+    void setEnableEvaluationTimeZoom(bool);
 
     inline Style::Opacity fillOpacity() const;
     inline void setFillOpacity(Style::Opacity);

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -1364,4 +1364,17 @@ inline bool RenderStyle::fontCascadeEqual(const RenderStyle& other) const
         || m_inheritedData->fontData->fontCascade == other.m_inheritedData->fontData->fontCascade;
 }
 
+inline bool RenderStyle::enableEvaluationTimeZoom() const
+{
+    return m_rareInheritedData->enableEvaluationTimeZoom;
+}
+
+inline Style::ZoomFactor RenderStyle::usedZoomForLength() const
+{
+    if (enableEvaluationTimeZoom())
+        return Style::ZoomFactor(usedZoom());
+
+    return Style::ZoomFactor(1.0f);
+}
+
 } // namespace WebCore

--- a/Source/WebCore/rendering/style/StyleRareInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleRareInheritedData.cpp
@@ -173,6 +173,7 @@ StyleRareInheritedData::StyleRareInheritedData()
 #endif
     , listStyleType(RenderStyle::initialListStyleType())
     , blockEllipsis(RenderStyle::initialBlockEllipsis())
+    , enableEvaluationTimeZoom(false)
 {
 }
 
@@ -279,6 +280,7 @@ inline StyleRareInheritedData::StyleRareInheritedData(const StyleRareInheritedDa
 #endif
     , listStyleType(o.listStyleType)
     , blockEllipsis(o.blockEllipsis)
+    , enableEvaluationTimeZoom(o.enableEvaluationTimeZoom)
 {
     ASSERT(o == *this, "StyleRareInheritedData should be properly copied.");
 }
@@ -392,7 +394,8 @@ bool StyleRareInheritedData::operator==(const StyleRareInheritedData& o) const
         && customProperties == o.customProperties
         && listStyleImage == o.listStyleImage
         && listStyleType == o.listStyleType
-        && blockEllipsis == o.blockEllipsis;
+        && blockEllipsis == o.blockEllipsis
+        && enableEvaluationTimeZoom == o.enableEvaluationTimeZoom;
 }
 
 bool StyleRareInheritedData::hasColorFilters() const
@@ -549,6 +552,8 @@ void StyleRareInheritedData::dumpDifferences(TextStream& ts, const StyleRareInhe
 
     LOG_IF_DIFFERENT(listStyleType);
     LOG_IF_DIFFERENT(blockEllipsis);
+
+    LOG_IF_DIFFERENT(enableEvaluationTimeZoom);
 }
 #endif
 

--- a/Source/WebCore/rendering/style/StyleRareInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleRareInheritedData.h
@@ -230,7 +230,7 @@ public:
 #endif
     Style::ListStyleType listStyleType;
     Style::BlockEllipsis blockEllipsis;
-
+    PREFERRED_TYPE(bool) unsigned enableEvaluationTimeZoom : 1;
 private:
     StyleRareInheritedData();
     StyleRareInheritedData(const StyleRareInheritedData&);

--- a/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
@@ -86,7 +86,7 @@ std::optional<FloatRect> SVGRenderSupport::computeFloatVisibleRectInContainer(co
         return FloatRect();
 
     FloatRect adjustedRect = rect;
-    adjustedRect.inflate(Style::evaluate<float>(renderer.style().outlineWidth(), Style::ZoomNeeded { }));
+    adjustedRect.inflate(Style::evaluate<float>(renderer.style().outlineWidth(), renderer.style().usedZoomForLength()));
 
     // Translate to coords in our parent renderer, and then call computeFloatVisibleRectInContainer() on our parent.
     adjustedRect = renderer.localToParentTransform().mapRect(adjustedRect);

--- a/Source/WebCore/style/StyleResolveForDocument.cpp
+++ b/Source/WebCore/style/StyleResolveForDocument.cpp
@@ -108,6 +108,8 @@ RenderStyle resolveForDocument(const Document& document)
     fontCascade.update(WTFMove(fontSelector));
     documentStyle.setFontCascade(WTFMove(fontCascade));
 
+    documentStyle.setEnableEvaluationTimeZoom(document.settings().evaluationTimeZoomEnabled());
+
     return documentStyle;
 }
 

--- a/Source/WebCore/style/values/backgrounds/StyleBorderImageWidth.h
+++ b/Source/WebCore/style/values/backgrounds/StyleBorderImageWidth.h
@@ -30,7 +30,7 @@
 namespace WebCore {
 namespace Style {
 
-struct BorderImageWidthValueLength : LengthWrapperBase<LengthPercentage<CSS::Nonnegative>> {
+struct BorderImageWidthValueLength : LengthWrapperBase<LengthPercentage<CSS::NonnegativeUnzoomed>> {
     using Base::Base;
 };
 

--- a/Source/WebCore/style/values/backgrounds/StyleLineWidth.h
+++ b/Source/WebCore/style/values/backgrounds/StyleLineWidth.h
@@ -39,7 +39,7 @@ namespace Style {
 // <line-width> = <length [0,∞]> | thin | medium | thick
 // https://drafts.csswg.org/css-backgrounds/#typedef-line-width
 struct LineWidth {
-    using Length = Style::Length<CSS::Nonnegative>;
+    using Length = Style::Length<CSS::NonnegativeUnzoomed>;
 
     Length value;
 
@@ -69,17 +69,23 @@ template<> struct CSSValueConversion<LineWidth> { auto operator()(BuilderState&,
 // MARK: - Evaluate
 
 template<typename Result> struct Evaluation<LineWidth, Result> {
-    constexpr auto operator()(const LineWidth& value, ZoomNeeded token) -> Result
+    constexpr auto operator()(const LineWidth& value, ZoomFactor zoom) -> Result
     {
-        return Result(value.value.resolveZoom(token));
+        auto result = value.value.resolveZoom(zoom);
+
+        // Any original result that was >= 1 should not be allowed to fall below 1. This keeps border lines from vanishing.
+        if (zoom < 1.0f && result < 1.0f && value.value.unresolvedValue() >= 1.0f)
+            return Result(1.0f); // CSS::Keyword::Thin equivalent
+
+        return Result(result);
     }
 };
 
 template<> struct Evaluation<LineWidthBox, FloatBoxExtent> {
-    auto operator()(const LineWidthBox&, ZoomNeeded) -> FloatBoxExtent;
+    auto operator()(const LineWidthBox&, ZoomFactor) -> FloatBoxExtent;
 };
 template<> struct Evaluation<LineWidthBox, LayoutBoxExtent> {
-    auto operator()(const LineWidthBox&, ZoomNeeded) -> LayoutBoxExtent;
+    auto operator()(const LineWidthBox&, ZoomFactor) -> LayoutBoxExtent;
 };
 
 } // namespace Style

--- a/Source/WebCore/style/values/masking/StyleMaskBorderWidth.h
+++ b/Source/WebCore/style/values/masking/StyleMaskBorderWidth.h
@@ -30,7 +30,7 @@
 namespace WebCore {
 namespace Style {
 
-struct MaskBorderWidthValueLength : LengthWrapperBase<LengthPercentage<CSS::Nonnegative>> {
+struct MaskBorderWidthValueLength : LengthWrapperBase<LengthPercentage<CSS::NonnegativeUnzoomed>> {
     using Base::Base;
 };
 

--- a/Source/WebCore/style/values/non-standard/StyleWebKitBorderSpacing.h
+++ b/Source/WebCore/style/values/non-standard/StyleWebKitBorderSpacing.h
@@ -32,7 +32,7 @@ namespace Style {
 
 // <'-webkit-border-horizontal-spacing'/'-webkit-border-vertical-spacing'> = <length [0,∞]>
 // NOTE: There is no standard associated with this property.
-using WebkitBorderSpacing = Length<CSS::Nonnegative>;
+using WebkitBorderSpacing = Length<CSS::NonnegativeUnzoomed>;
 
 } // namespace Style
 } // namespace WebCore

--- a/Source/WebCore/style/values/primitives/StyleLengthWrapper.h
+++ b/Source/WebCore/style/values/primitives/StyleLengthWrapper.h
@@ -293,12 +293,12 @@ template<LengthWrapperBaseDerived T, typename Result> struct Evaluation<T, Resul
         return value.m_value.template valueForLengthWrapperDataWithLazyMaximum<Result, Result>(value.evaluationKind(), [&] ALWAYS_INLINE_LAMBDA { return maximumValue; }, token);
     }
 
-    auto operator()(const T& value, NOESCAPE const Invocable<Result()> auto& lazyMaximumValueFunctor, float zoom) -> Result
+    auto operator()(const T& value, NOESCAPE const Invocable<Result()> auto& lazyMaximumValueFunctor, ZoomFactor zoom) -> Result
         requires (T::Fixed::range.zoomOptions == CSS::RangeZoomOptions::Unzoomed)
     {
         return value.m_value.template valueForLengthWrapperDataWithLazyMaximum<Result, Result>(value.evaluationKind(), lazyMaximumValueFunctor, zoom);
     }
-    auto operator()(const T& value, Result maximumValue, float zoom) -> Result
+    auto operator()(const T& value, Result maximumValue, ZoomFactor zoom) -> Result
         requires (T::Fixed::range.zoomOptions == CSS::RangeZoomOptions::Unzoomed)
     {
         return value.m_value.template valueForLengthWrapperDataWithLazyMaximum<Result, Result>(value.evaluationKind(), [&] ALWAYS_INLINE_LAMBDA { return maximumValue; }, zoom);
@@ -325,12 +325,12 @@ template<LengthWrapperBaseDerived T, typename Result> struct MinimumEvaluation<T
         return value.m_value.template minimumValueForLengthWrapperDataWithLazyMaximum<LayoutUnit, LayoutUnit>(value.evaluationKind(), [&] ALWAYS_INLINE_LAMBDA { return LayoutUnit(maximumValue); }, token);
     }
 
-    auto operator()(const T& value, NOESCAPE const Invocable<Result()> auto& lazyMaximumValueFunctor, float zoom) -> Result
+    auto operator()(const T& value, NOESCAPE const Invocable<Result()> auto& lazyMaximumValueFunctor, ZoomFactor zoom) -> Result
         requires (T::Fixed::range.zoomOptions == CSS::RangeZoomOptions::Unzoomed)
     {
         return value.m_value.template minimumValueForLengthWrapperDataWithLazyMaximum<LayoutUnit, LayoutUnit>(value.evaluationKind(), lazyMaximumValueFunctor, zoom);
     }
-    auto operator()(const T& value, Result maximumValue, float zoom) -> Result
+    auto operator()(const T& value, Result maximumValue, ZoomFactor zoom) -> Result
         requires (T::Fixed::range.zoomOptions == CSS::RangeZoomOptions::Unzoomed)
     {
         return value.m_value.template minimumValueForLengthWrapperDataWithLazyMaximum<LayoutUnit, LayoutUnit>(value.evaluationKind(), [&] ALWAYS_INLINE_LAMBDA { return LayoutUnit(maximumValue); }, zoom);

--- a/Source/WebCore/style/values/primitives/StyleLengthWrapperData.h
+++ b/Source/WebCore/style/values/primitives/StyleLengthWrapperData.h
@@ -88,12 +88,12 @@ struct LengthWrapperData {
     template<typename ReturnType, typename MaximumType>
     ReturnType minimumValueForLengthWrapperDataWithLazyMaximum(LengthWrapperDataEvaluationKind, NOESCAPE const Invocable<MaximumType()> auto& lazyMaximumValueFunctor, ZoomNeeded) const;
     template<typename ReturnType, typename MaximumType>
-    ReturnType minimumValueForLengthWrapperDataWithLazyMaximum(LengthWrapperDataEvaluationKind, NOESCAPE const Invocable<MaximumType()> auto& lazyMaximumValueFunctor, float zoom) const;
+    ReturnType minimumValueForLengthWrapperDataWithLazyMaximum(LengthWrapperDataEvaluationKind, NOESCAPE const Invocable<MaximumType()> auto& lazyMaximumValueFunctor, ZoomFactor) const;
 
     template<typename ReturnType, typename MaximumType>
     ReturnType valueForLengthWrapperDataWithLazyMaximum(LengthWrapperDataEvaluationKind, NOESCAPE const Invocable<MaximumType()> auto& lazyMaximumValueFunctor, ZoomNeeded) const;
     template<typename ReturnType, typename MaximumType>
-    ReturnType valueForLengthWrapperDataWithLazyMaximum(LengthWrapperDataEvaluationKind, NOESCAPE const Invocable<MaximumType()> auto& lazyMaximumValueFunctor, float zoom) const;
+    ReturnType valueForLengthWrapperDataWithLazyMaximum(LengthWrapperDataEvaluationKind, NOESCAPE const Invocable<MaximumType()> auto& lazyMaximumValueFunctor, ZoomFactor) const;
 
 private:
     WEBCORE_EXPORT float nonNanCalculatedValue(float maxValue) const;
@@ -273,12 +273,12 @@ ReturnType LengthWrapperData::minimumValueForLengthWrapperDataWithLazyMaximum(Le
 }
 
 template<typename ReturnType, typename MaximumType>
-ReturnType LengthWrapperData::minimumValueForLengthWrapperDataWithLazyMaximum(LengthWrapperDataEvaluationKind evaluationKind, NOESCAPE const Invocable<MaximumType()> auto& lazyMaximumValueFunctor, float zoom) const
+ReturnType LengthWrapperData::minimumValueForLengthWrapperDataWithLazyMaximum(LengthWrapperDataEvaluationKind evaluationKind, NOESCAPE const Invocable<MaximumType()> auto& lazyMaximumValueFunctor, ZoomFactor zoom) const
 {
     switch (evaluationKind) {
     case LengthWrapperDataEvaluationKind::Fixed:
         ASSERT(m_kind == LengthWrapperDataKind::Default);
-        return ReturnType(m_floatValue * zoom);
+        return ReturnType(m_floatValue * zoom.value);
     case LengthWrapperDataEvaluationKind::Percentage:
         ASSERT(m_kind == LengthWrapperDataKind::Default);
         return ReturnType(static_cast<float>(lazyMaximumValueFunctor() * m_floatValue / 100.0f));
@@ -315,12 +315,12 @@ ReturnType LengthWrapperData::valueForLengthWrapperDataWithLazyMaximum(LengthWra
 }
 
 template<typename ReturnType, typename MaximumType>
-ReturnType LengthWrapperData::valueForLengthWrapperDataWithLazyMaximum(LengthWrapperDataEvaluationKind evaluationKind, NOESCAPE const Invocable<MaximumType()> auto& lazyMaximumValueFunctor, float zoom) const
+ReturnType LengthWrapperData::valueForLengthWrapperDataWithLazyMaximum(LengthWrapperDataEvaluationKind evaluationKind, NOESCAPE const Invocable<MaximumType()> auto& lazyMaximumValueFunctor, ZoomFactor zoom) const
 {
     switch (evaluationKind) {
     case LengthWrapperDataEvaluationKind::Fixed:
         ASSERT(m_kind == LengthWrapperDataKind::Default);
-        return ReturnType(m_floatValue * zoom);
+        return ReturnType(m_floatValue * zoom.value);
     case LengthWrapperDataEvaluationKind::Percentage:
         ASSERT(m_kind == LengthWrapperDataKind::Default);
         return ReturnType(static_cast<float>(lazyMaximumValueFunctor() * m_floatValue / 100.0f));

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumeric.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumeric.h
@@ -139,10 +139,10 @@ template<CSS::Range R, typename V> struct PrimitiveNumeric<CSS::Length<R, V>> {
         return value;
     }
 
-    constexpr auto resolveZoom(float zoom) const
+    constexpr auto resolveZoom(ZoomFactor zoom) const
         requires (range.zoomOptions == WebCore::CSS::RangeZoomOptions::Unzoomed)
     {
-        return value * zoom;
+        return value * zoom.value;
     }
 
     constexpr auto unresolvedValue() const { return value; }

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+CSSValueConversion.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+CSSValueConversion.h
@@ -26,6 +26,7 @@
 
 #include "CSSPrimitiveNumericUnits.h"
 #include "CSSPrimitiveValue.h"
+#include "Settings.h"
 #include "StyleBuilderChecking.h"
 #include "StylePrimitiveNumericTypes.h"
 #include "StyleValueTypes.h"
@@ -103,7 +104,12 @@ template<auto R, typename V> struct CSSValueConversion<Length<R, V>> {
                 ? builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f)
                 : builderState.cssToLengthConversionData();
         } else if constexpr (R.zoomOptions == CSS::RangeZoomOptions::Unzoomed) {
-            return builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f);
+            if (builderState.document().settings().evaluationTimeZoomEnabled())
+                return builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f);
+
+            return builderState.useSVGZoomRulesForLength()
+                ? builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f)
+                : builderState.cssToLengthConversionData();
         }
     }
     auto operator()(BuilderState& builderState, const CSSPrimitiveValue& value) -> Length<R, V>
@@ -181,7 +187,12 @@ template<auto R, typename V> struct CSSValueConversion<LengthPercentage<R, V>> {
                 ? builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f)
                 : builderState.cssToLengthConversionData();
         } else if constexpr (LengthPercentage<R, V>::Dimension::range.zoomOptions == CSS::RangeZoomOptions::Unzoomed) {
-            return builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f);
+            if (builderState.document().settings().evaluationTimeZoomEnabled())
+                return builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f);
+
+            return builderState.useSVGZoomRulesForLength()
+                ? builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f)
+                : builderState.cssToLengthConversionData();
         }
     }
     auto operator()(BuilderState& builderState, const CSSPrimitiveValue& value) -> LengthPercentage<R, V>

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.cpp
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.cpp
@@ -65,5 +65,10 @@ float adjustForZoom(float value, const RenderStyle& style)
     return adjustFloatForAbsoluteZoom(value, style);
 }
 
+bool shouldUseEvaluationTimeZoom(const RenderStyle& style)
+{
+    return style.enableEvaluationTimeZoom();
+}
+
 } // namespace Style
 } // namespace WebCore

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.h
@@ -31,6 +31,7 @@
 #include "CSSToLengthConversionData.h"
 #include "CalculationValue.h"
 #include "FloatConversion.h"
+#include "Settings.h"
 #include "StyleBuilderState.h"
 #include "StylePrimitiveNumericTypes.h"
 
@@ -54,7 +55,13 @@ template<auto R, typename V> struct ConversionDataSpecializer<CSS::LengthRaw<R, 
                 ? state.cssToLengthConversionData().copyWithAdjustedZoom(1.0f)
                 : state.cssToLengthConversionData();
         } else if constexpr (R.zoomOptions == CSS::RangeZoomOptions::Unzoomed) {
-            return state.cssToLengthConversionData().copyWithAdjustedZoom(1.0f);
+            if (state.document().settings().evaluationTimeZoomEnabled())
+                return state.cssToLengthConversionData().copyWithAdjustedZoom(1.0f);
+
+            return state.useSVGZoomRulesForLength()
+                ? state.cssToLengthConversionData().copyWithAdjustedZoom(1.0f)
+                : state.cssToLengthConversionData();
+
         }
     }
 };
@@ -238,6 +245,7 @@ template<auto R, typename V, typename... Rest> LengthPercentage<R, V> canonicali
 
 // Out of line to avoid inclusion of RenderStyleInlines.h
 float adjustForZoom(float, const RenderStyle&);
+bool shouldUseEvaluationTimeZoom(const RenderStyle&);
 
 // Length requires a specialized implementation due to zoom adjustment.
 template<auto R, typename V> struct ToCSS<Length<R, V>> {
@@ -246,7 +254,10 @@ template<auto R, typename V> struct ToCSS<Length<R, V>> {
         if constexpr (R.zoomOptions == CSS::RangeZoomOptions::Default) {
             return CSS::LengthRaw<R, V> { value.unit, adjustForZoom(value.unresolvedValue(), style) };
         } else if constexpr (R.zoomOptions == CSS::RangeZoomOptions::Unzoomed) {
-            return CSS::LengthRaw<R, V> { value.unit, value.unresolvedValue() };
+            if (shouldUseEvaluationTimeZoom(style))
+                return CSS::LengthRaw<R, V> { value.unit, value.unresolvedValue() };
+
+            return CSS::LengthRaw<R, V> { value.unit, adjustForZoom(value.unresolvedValue(), style) };
         }
     }
 };

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Evaluation.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Evaluation.h
@@ -47,7 +47,7 @@ template<auto R, typename V, typename Result> struct Evaluation<Length<R, V>, Re
     {
         return Result(value.resolveZoom(token));
     }
-    constexpr auto operator()(const Length<R, V>& value, float zoom) -> Result
+    constexpr auto operator()(const Length<R, V>& value, ZoomFactor zoom) -> Result
         requires (R.zoomOptions == CSS::RangeZoomOptions::Unzoomed)
     {
         return Result(value.resolveZoom(zoom));
@@ -58,7 +58,7 @@ template<auto R, typename V, typename Result> struct Evaluation<Length<R, V>, Re
     {
         return Result(value.resolveZoom(token));
     }
-    constexpr auto operator()(const Length<R, V>& value, Result, float zoom) -> Result
+    constexpr auto operator()(const Length<R, V>& value, Result, ZoomFactor zoom) -> Result
         requires (R.zoomOptions == CSS::RangeZoomOptions::Unzoomed)
     {
         return Result(value.resolveZoom(zoom));
@@ -125,7 +125,7 @@ template<auto R, typename V, typename Result> struct Evaluation<LengthPercentage
             }
         );
     }
-    constexpr auto operator()(const LengthPercentage<R, V>& lengthPercentage, Result referenceLength, float zoom) -> Result
+    constexpr auto operator()(const LengthPercentage<R, V>& lengthPercentage, Result referenceLength, ZoomFactor zoom) -> Result
         requires (R.zoomOptions == CSS::RangeZoomOptions::Unzoomed)
     {
         return WTF::switchOn(lengthPercentage,
@@ -161,8 +161,8 @@ template<typename T> struct Evaluation<SpaceSeparatedPoint<T>, FloatPoint> {
             evaluate<float>(value.y(), referenceBox.height(), token)
         };
     }
-    auto operator()(const SpaceSeparatedPoint<T>& value, FloatSize referenceBox, float zoom) -> FloatPoint
-        requires HasThreeParameterEvaluate<T, float, float, float>
+    auto operator()(const SpaceSeparatedPoint<T>& value, FloatSize referenceBox, ZoomFactor zoom) -> FloatPoint
+        requires HasThreeParameterEvaluate<T, float, float, ZoomFactor>
     {
         return {
             evaluate<float>(value.x(), referenceBox.width(), zoom),
@@ -187,8 +187,8 @@ template<typename T> struct Evaluation<SpaceSeparatedPoint<T>, LayoutPoint> {
             evaluate<LayoutUnit>(value.y(), referenceBox.height(), token)
         };
     }
-    auto operator()(const SpaceSeparatedPoint<T>& value, LayoutSize referenceBox, float zoom) -> LayoutPoint
-        requires HasThreeParameterEvaluate<T, LayoutUnit, LayoutUnit, float>
+    auto operator()(const SpaceSeparatedPoint<T>& value, LayoutSize referenceBox, ZoomFactor zoom) -> LayoutPoint
+        requires HasThreeParameterEvaluate<T, LayoutUnit, LayoutUnit, ZoomFactor>
     {
         return {
             evaluate<LayoutUnit>(value.x(), referenceBox.width(), zoom),
@@ -216,7 +216,7 @@ template<typename T> struct Evaluation<SpaceSeparatedSize<T>, FloatSize> {
             evaluate<float>(value.height(), referenceBox.height(), token)
         };
     }
-    auto operator()(const SpaceSeparatedSize<T>& value, FloatSize referenceBox, float zoom) -> FloatSize
+    auto operator()(const SpaceSeparatedSize<T>& value, FloatSize referenceBox, ZoomFactor zoom) -> FloatSize
         requires HasThreeParameterEvaluate<T, float, float, float>
     {
         return {
@@ -242,7 +242,7 @@ template<typename T> struct Evaluation<SpaceSeparatedSize<T>, LayoutSize> {
             evaluate<LayoutUnit>(value.height(), referenceBox.height(), token)
         };
     }
-    auto operator()(const SpaceSeparatedSize<T>& value, LayoutSize referenceBox, float zoom) -> LayoutSize
+    auto operator()(const SpaceSeparatedSize<T>& value, LayoutSize referenceBox, ZoomFactor zoom) -> LayoutSize
         requires HasThreeParameterEvaluate<T, LayoutUnit, LayoutUnit, float>
     {
         return {
@@ -271,8 +271,8 @@ template<typename T> struct Evaluation<MinimallySerializingSpaceSeparatedSize<T>
             evaluate<float>(value.height(), referenceBox.height(), token)
         };
     }
-    auto operator()(const MinimallySerializingSpaceSeparatedSize<T>& value, FloatSize referenceBox, float zoom) -> FloatSize
-        requires HasThreeParameterEvaluate<T, float, float, float>
+    auto operator()(const MinimallySerializingSpaceSeparatedSize<T>& value, FloatSize referenceBox, ZoomFactor zoom) -> FloatSize
+        requires HasThreeParameterEvaluate<T, float, float, ZoomFactor>
     {
         return {
             evaluate<float>(value.width(), referenceBox.width(), zoom),
@@ -297,8 +297,8 @@ template<typename T> struct Evaluation<MinimallySerializingSpaceSeparatedSize<T>
             evaluate<LayoutUnit>(value.height(), referenceBox.height(), token)
         };
     }
-    auto operator()(const MinimallySerializingSpaceSeparatedSize<T>& value, LayoutSize referenceBox, float zoom) -> LayoutSize
-        requires HasThreeParameterEvaluate<T, LayoutUnit, LayoutUnit, float>
+    auto operator()(const MinimallySerializingSpaceSeparatedSize<T>& value, LayoutSize referenceBox, ZoomFactor zoom) -> LayoutSize
+        requires HasThreeParameterEvaluate<T, LayoutUnit, LayoutUnit, ZoomFactor>
     {
         return {
             evaluate<LayoutUnit>(value.width(), referenceBox.width(), zoom),

--- a/Source/WebCore/style/values/primitives/StyleZoomNeededToken.h
+++ b/Source/WebCore/style/values/primitives/StyleZoomNeededToken.h
@@ -30,5 +30,14 @@ namespace Style {
 // Token passed around to indicate that the evaluation will need zoom passed in the future.
 struct ZoomNeeded { };
 
+struct ZoomFactor {
+    float value;
+
+    constexpr ZoomFactor() : value(1.0f) { }
+    constexpr explicit ZoomFactor(float v) : value(v) { }
+
+    constexpr operator float() const { return value; }
+};
+
 } // namespace Style
 } // namespace WebCore

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -8064,4 +8064,13 @@ bool Internals::isModelElementIntersectingViewport(HTMLModelElement& element)
 }
 #endif
 
+void Internals::setEvaluationTimeZoom(bool value)
+{
+    auto* document = contextDocument();
+    if (!document || !document->view())
+        return;
+
+    document->protectedPage()->settings().setEvaluationTimeZoomEnabled(value);
+}
+
 } // namespace WebCore

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -1629,6 +1629,7 @@ public:
     bool isModelElementIntersectingViewport(HTMLModelElement&);
 #endif
 
+    void setEvaluationTimeZoom(bool value);
 private:
     explicit Internals(Document&);
 

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -1471,4 +1471,5 @@ enum ContentsFormat {
     [Conditional=MODEL_ELEMENT] undefined disableModelLoadDelaysForTesting();
     [Conditional=MODEL_ELEMENT] DOMString modelElementState(HTMLModelElement element);
     [Conditional=MODEL_ELEMENT] boolean isModelElementIntersectingViewport(HTMLModelElement element);
+    undefined setEvaluationTimeZoom(boolean value);
 };

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -2076,9 +2076,9 @@ IntRect WebPage::absoluteInteractionBounds(const Node& node)
     auto& style = renderer->style();
     FloatRect boundingBox = renderer->absoluteBoundingBoxRect(true /* use transforms*/);
     // This is wrong. It's subtracting borders after converting to absolute coords on something that probably doesn't represent a rectangular element.
-    boundingBox.move(WebCore::Style::evaluate<float>(style.borderLeftWidth(), WebCore::Style::ZoomNeeded { }), WebCore::Style::evaluate<float>(style.borderTopWidth(), WebCore::Style::ZoomNeeded { }));
-    boundingBox.setWidth(boundingBox.width() - WebCore::Style::evaluate<float>(style.borderLeftWidth(), WebCore::Style::ZoomNeeded { }) - WebCore::Style::evaluate<float>(style.borderRightWidth(), WebCore::Style::ZoomNeeded { }));
-    boundingBox.setHeight(boundingBox.height() - WebCore::Style::evaluate<float>(style.borderBottomWidth(), WebCore::Style::ZoomNeeded { }) - WebCore::Style::evaluate<float>(style.borderTopWidth(), WebCore::Style::ZoomNeeded { }));
+    boundingBox.move(WebCore::Style::evaluate<float>(style.borderLeftWidth(), style.usedZoomForLength()), WebCore::Style::evaluate<float>(style.borderTopWidth(), style.usedZoomForLength()));
+    boundingBox.setWidth(boundingBox.width() - WebCore::Style::evaluate<float>(style.borderLeftWidth(), style.usedZoomForLength()) - WebCore::Style::evaluate<float>(style.borderRightWidth(), style.usedZoomForLength()));
+    boundingBox.setHeight(boundingBox.height() - WebCore::Style::evaluate<float>(style.borderBottomWidth(), style.usedZoomForLength()) - WebCore::Style::evaluate<float>(style.borderTopWidth(), style.usedZoomForLength()));
     return enclosingIntRect(boundingBox);
 }
 

--- a/Source/WebKitLegacy/mac/DOM/DOM.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOM.mm
@@ -448,9 +448,9 @@ id <DOMEventTarget> kit(EventTarget* target)
     auto& style = renderer->style();
     IntRect boundingBox = renderer->absoluteBoundingBoxRect(true /* use transforms*/);
 
-    boundingBox.move(WebCore::Style::evaluate<float>(style.borderLeftWidth(), WebCore::Style::ZoomNeeded { }), WebCore::Style::evaluate<float>(style.borderTopWidth(), WebCore::Style::ZoomNeeded { }));
-    boundingBox.setWidth(boundingBox.width() - WebCore::Style::evaluate<float>(style.borderLeftWidth(), WebCore::Style::ZoomNeeded { }) - WebCore::Style::evaluate<float>(style.borderRightWidth(), WebCore::Style::ZoomNeeded { }));
-    boundingBox.setHeight(boundingBox.height() - WebCore::Style::evaluate<float>(style.borderBottomWidth(), WebCore::Style::ZoomNeeded { }) - WebCore::Style::evaluate<float>(style.borderTopWidth(), WebCore::Style::ZoomNeeded { }));
+    boundingBox.move(WebCore::Style::evaluate<float>(style.borderLeftWidth(), style.usedZoomForLength()), WebCore::Style::evaluate<float>(style.borderTopWidth(), style.usedZoomForLength()));
+    boundingBox.setWidth(boundingBox.width() - WebCore::Style::evaluate<float>(style.borderLeftWidth(), style.usedZoomForLength()) - WebCore::Style::evaluate<float>(style.borderRightWidth(), style.usedZoomForLength()));
+    boundingBox.setHeight(boundingBox.height() - WebCore::Style::evaluate<float>(style.borderBottomWidth(), style.usedZoomForLength()) - WebCore::Style::evaluate<float>(style.borderTopWidth(), style.usedZoomForLength()));
 
     // FIXME: This function advertises returning a quad, but it actually returns a bounding box (so there is no rotation, for instance).
     return wkQuadFromFloatQuad(FloatQuad(boundingBox));


### PR DESCRIPTION
#### 2ac6832444d1bbe2be30c4f0e0a0ab605c726058
<pre>
[CSS ZOOM] Apply zoom factor to border spacing and border width
<a href="https://bugs.webkit.org/show_bug.cgi?id=299238">https://bugs.webkit.org/show_bug.cgi?id=299238</a>
<a href="https://rdar.apple.com/161008191">rdar://161008191</a>

Reviewed by Antti Koivisto.

We allow evaluation-time zoom for LineWidth and WebKitBorderSpacing,
which applies the zoom factor to the border-width and border-spacing properties.

We also added a feature flag in this PR to enable evaluation-time zoom.

Test: imported/w3c/web-platform-tests/css/css-viewport/zoom/border-width.html
* LayoutTests/TestExpectations:
* LayoutTests/platform/gtk/fast/multicol/span/anonymous-style-inheritance-expected.txt: Added.
* LayoutTests/platform/gtk/fast/repaint/repaint-during-scroll-with-zoom-expected.txt: Added.
* LayoutTests/platform/gtk/media/video-zoom-expected.txt: Added.
* LayoutTests/platform/gtk/svg/zoom/page/zoom-background-images-expected.txt: Added.
* LayoutTests/platform/gtk/svg/zoom/page/zoom-img-preserveAspectRatio-support-1-expected.txt: Added.
* LayoutTests/platform/gtk/svg/zoom/page/zoom-replaced-intrinsic-ratio-001-expected.txt: Added.
* LayoutTests/platform/gtk/svg/zoom/page/zoom-svg-through-object-with-auto-size-expected.txt: Added.
* LayoutTests/platform/ios/fast/backgrounds/background-position-parsing-expected.txt:
* LayoutTests/platform/wpe/media/video-zoom-expected.txt: Added.
* LayoutTests/fast/backgrounds/size/contain-and-cover-zoomed-expected.txt:
* LayoutTests/fast/canvas/canvas-zoom-expected.html:
* LayoutTests/fast/sub-pixel/zoomed-em-border.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/border-width-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/border-width.html: Added.
* LayoutTests/platform/ios/fast/backgrounds/background-position-parsing-expected.txt:
* LayoutTests/platform/mac/fast/backgrounds/background-position-parsing-expected.txt:
* LayoutTests/platform/mac/fast/multicol/span/anonymous-style-inheritance-expected.txt:
* LayoutTests/platform/mac/fast/repaint/repaint-during-scroll-with-zoom-expected.txt:
* LayoutTests/platform/mac/svg/zoom/page/zoom-background-images-expected.txt:
* LayoutTests/platform/mac/svg/zoom/page/zoom-img-preserveAspectRatio-support-1-expected.txt:
* LayoutTests/platform/mac/svg/zoom/page/zoom-replaced-intrinsic-ratio-001-expected.txt:
* LayoutTests/platform/mac/svg/zoom/page/zoom-svg-float-border-padding-expected.txt:
* LayoutTests/platform/mac/svg/zoom/page/zoom-svg-through-object-with-auto-size-expected.txt:
* LayoutTests/platform/wpe/fast/backgrounds/background-position-parsing-expected.txt:
* LayoutTests/platform/wpe/fast/multicol/span/anonymous-style-inheritance-expected.txt: Added.
* LayoutTests/platform/wpe/fast/repaint/repaint-during-scroll-with-zoom-expected.txt: Copied from LayoutTests/platform/mac/fast/repaint/repaint-during-scroll-with-zoom-expected.txt.
* LayoutTests/platform/wpe/svg/zoom/page/zoom-background-images-expected.txt: Copied from LayoutTests/platform/mac/svg/zoom/page/zoom-background-images-expected.txt.
* LayoutTests/platform/wpe/svg/zoom/page/zoom-img-preserveAspectRatio-support-1-expected.txt: Copied from LayoutTests/platform/mac/svg/zoom/page/zoom-img-preserveAspectRatio-support-1-expected.txt.
* LayoutTests/platform/wpe/svg/zoom/page/zoom-replaced-intrinsic-ratio-001-expected.txt: Added.
* LayoutTests/platform/wpe/svg/zoom/page/zoom-svg-float-border-padding-expected.txt:
* LayoutTests/platform/wpe/svg/zoom/page/zoom-svg-through-object-with-auto-size-expected.txt: Copied from LayoutTests/platform/mac/svg/zoom/page/zoom-svg-through-object-with-auto-size-expected.txt.
* LayoutTests/svg/zoom/page/zoom-background-image-tiled-expected.txt:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/accessibility/AXTableHelpers.cpp:
(WebCore::AXTableHelpers::isDataTableWithTraversal):
* Source/WebCore/layout/formattingContexts/FormattingGeometry.cpp:
(WebCore::Layout::FormattingGeometry::computedBorder const):
* Source/WebCore/layout/formattingContexts/block/BlockFormattingGeometry.cpp:
(WebCore::Layout::BlockFormattingGeometry::intrinsicWidthConstraints const):
* Source/WebCore/layout/formattingContexts/table/TableFormattingState.cpp:
(WebCore::Layout::ensureTableGrid):
* Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.cpp:
(WebCore::LayoutIntegration::BoxGeometryUpdater::logicalBorder):
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::fixedContainerEdges const):
* Source/WebCore/page/SpatialNavigation.cpp:
(WebCore::nodeRectInAbsoluteCoordinates):
* Source/WebCore/rendering/BorderEdge.cpp:
(WebCore::borderEdges):
(WebCore::borderEdgesForOutline):
* Source/WebCore/rendering/BorderPainter.cpp:
(WebCore::BorderPainter::paintOutline const):
* Source/WebCore/rendering/BorderShape.cpp:
(WebCore::BorderShape::shapeForBorderRect):
* Source/WebCore/rendering/NinePieceImagePainter.cpp:
(WebCore::computeSlice):
(WebCore::paintNinePieceImage):
* Source/WebCore/rendering/RenderBoxModelObjectInlines.h:
(WebCore::RenderBoxModelObject::borderAfter const):
(WebCore::RenderBoxModelObject::borderBefore const):
(WebCore::RenderBoxModelObject::borderBottom const):
(WebCore::RenderBoxModelObject::borderEnd const):
(WebCore::RenderBoxModelObject::borderLeft const):
(WebCore::RenderBoxModelObject::borderRight const):
(WebCore::RenderBoxModelObject::borderStart const):
(WebCore::RenderBoxModelObject::borderTop const):
(WebCore::RenderBoxModelObject::borderWidths const):
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::drawFocusRing):
* Source/WebCore/rendering/RenderImage.cpp:
(WebCore::RenderImage::paintAreaElementFocusRing):
* Source/WebCore/rendering/RenderMultiColumnSet.cpp:
(WebCore::RenderMultiColumnSet::paintColumnRules):
* Source/WebCore/rendering/RenderTable.cpp:
(WebCore::RenderTable::styleDidChange):
(WebCore::RenderTable::calcBorderStart const):
(WebCore::RenderTable::calcBorderEnd const):
(WebCore::RenderTable::outerBorderBefore const):
(WebCore::RenderTable::outerBorderAfter const):
(WebCore::RenderTable::outerBorderStart const):
(WebCore::RenderTable::outerBorderEnd const):
* Source/WebCore/rendering/RenderTableSection.cpp:
(WebCore::RenderTableSection::calcBlockDirectionOuterBorder const):
(WebCore::RenderTableSection::calcInlineDirectionOuterBorder const):
(WebCore::RenderTableSection::paintRowGroupBorderIfRequired):
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::extractControlStyleForRenderer const):
(WebCore::RenderTheme::adjustButtonOrCheckboxOrColorWellOrInnerSpinButtonOrRadioStyle const):
* Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm:
(WebCore::RenderThemeCocoa::paintMenuListButtonDecorationsForVectorBasedControls):
* Source/WebCore/rendering/ios/RenderThemeIOS.mm:
(WebCore::RenderThemeIOS::popupInternalPaddingBox const):
(WebCore::RenderThemeIOS::paintMenuListButtonDecorations):
* Source/WebCore/rendering/style/CollapsedBorderValue.h:
(WebCore::CollapsedBorderValue::CollapsedBorderValue):
(WebCore::CollapsedBorderValue::m_transparent): Deleted.
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::setEnableEvaluationTimeZoom):
(WebCore::RenderStyle::imageOutsets const):
(WebCore::RenderStyle::outlineWidth const):
(WebCore::RenderStyle::outlineOffset const):
(WebCore::RenderStyle::outlineSize const):
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
(WebCore::RenderStyle::enableEvaluationTimeZoom const):
(WebCore::RenderStyle::usedZoomForLength const):
* Source/WebCore/rendering/style/StyleRareInheritedData.cpp:
(WebCore::StyleRareInheritedData::StyleRareInheritedData):
(WebCore::StyleRareInheritedData::operator== const):
(WebCore::StyleRareInheritedData::dumpDifferences const):
* Source/WebCore/rendering/style/StyleRareInheritedData.h:
* Source/WebCore/rendering/svg/SVGRenderSupport.cpp:
(WebCore::SVGRenderSupport::computeFloatVisibleRectInContainer):
* Source/WebCore/style/StyleResolveForDocument.cpp:
(WebCore::Style::resolveForDocument):
* Source/WebCore/style/values/backgrounds/StyleBorderImageWidth.h:
* Source/WebCore/style/values/backgrounds/StyleLineWidth.cpp:
(WebCore::Style::CSSValueConversion&lt;LineWidth&gt;::operator):
(WebCore::Style::FloatBoxExtent&gt;::operator):
(WebCore::Style::LayoutBoxExtent&gt;::operator):
* Source/WebCore/style/values/backgrounds/StyleLineWidth.h:
* Source/WebCore/style/values/masking/StyleMaskBorderWidth.h:
* Source/WebCore/style/values/non-standard/StyleWebKitBorderSpacing.h:
* Source/WebCore/style/values/primitives/StyleLengthWrapper.h:
* Source/WebCore/style/values/primitives/StyleLengthWrapperData.h:
(WebCore::Style::LengthWrapperData::minimumValueForLengthWrapperDataWithLazyMaximum const):
(WebCore::Style::LengthWrapperData::valueForLengthWrapperDataWithLazyMaximum const):
* Source/WebCore/style/values/primitives/StylePrimitiveNumeric.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+CSSValueConversion.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Evaluation.h:
* Source/WebCore/style/values/primitives/StyleZoomNeededToken.h:
(WebCore::Style::ZoomFactor::ZoomFactor):
(WebCore::Style::ZoomFactor::operator float const):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::setEvaluationTimeZoom):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::absoluteInteractionBounds):
* Source/WebKitLegacy/mac/DOM/DOM.mm:
(-[DOMNode innerFrameQuad]):

Canonical link: <a href="https://commits.webkit.org/300756@main">https://commits.webkit.org/300756@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5cd02b3971ce31adba416288e76cf48561d49ce9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123759 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43474 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34171 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130537 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/75908 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d2c2a109-0343-4e91-a234-295e8c008b3b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/125636 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44198 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52068 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94122 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/62461 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c6fc40d6-fd8d-49e1-b08d-21516ec0ee3e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126712 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35214 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110717 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74725 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/88a578be-e008-4091-9430-66fdf019b81c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34174 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28876 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74017 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/115918 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104938 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29100 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133227 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/122291 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50711 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38620 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102598 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51086 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106936 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102427 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26039 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47769 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26022 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/47555 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50565 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56329 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/153383 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50039 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/38992 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53385 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51713 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->