### PR TITLE
[macOS] Context menu images should be more consistent with other system applications

### DIFF
--- a/Source/WebCore/PAL/pal/spi/mac/NSMenuSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/NSMenuSPI.h
@@ -63,6 +63,11 @@ enum {
 + (QLPreviewMenuItem *)standardQuickLookMenuItem;
 + (NSMenuItem *)standardShareMenuItemForItems:(NSArray *)items;
 + (NSMenuItem *)standardWritingToolsMenuItem;
+
+#if ENABLE(CONTEXT_MENU_IMAGES_ON_MAC)
+@property (strong, setter=_setActionImage:) NSImage *_actionImage;
+@property (setter=_setHasActionImage:) BOOL _hasActionImage;
+#endif
 @end
 
 #endif
@@ -70,16 +75,6 @@ enum {
 @interface NSMenu (Staging_81123724)
 - (BOOL)_containsItemMatchingEvent:(NSEvent *)event includingDisabledItems:(BOOL)includingDisabledItems;
 @end
-
-#if ENABLE(CONTEXT_MENU_IMAGES_ON_MAC)
-@interface NSMenuItem (Staging_138651669)
-
-+ (NSString *)_systemImageNameForAction:(SEL)action;
-@property (strong, setter=_setActionImage:) NSImage *_actionImage;
-@property (setter=_setHasActionImage:) BOOL _hasActionImage;
-
-@end
-#endif
 
 typedef NSUInteger NSPopUpMenuFlags;
 

--- a/Source/WebKit/Platform/mac/MenuUtilities.mm
+++ b/Source/WebKit/Platform/mac/MenuUtilities.mm
@@ -193,9 +193,6 @@ static std::optional<SymbolNameWithType> symbolForTransformationItem(String symb
 
 static std::optional<SymbolNameWithType> symbolNameWithTypeForAction(const WebCore::ContextMenuAction action, bool useAlternateImage)
 {
-    if (![NSMenuItem respondsToSelector:@selector(_systemImageNameForAction:)])
-        return { };
-
     switch (action) {
     case WebCore::ContextMenuItemBaseApplicationTag:
     case WebCore::ContextMenuItemBaseCustomTag:
@@ -207,32 +204,27 @@ static std::optional<SymbolNameWithType> symbolNameWithTypeForAction(const WebCo
     case WebCore::ContextMenuItemPDFTwoPages:
     case WebCore::ContextMenuItemPDFTwoPagesContinuous:
     case WebCore::ContextMenuItemTagCheckGrammarWithSpelling:
+    case WebCore::ContextMenuItemTagCheckSpelling:
     case WebCore::ContextMenuItemTagCheckSpellingWhileTyping:
     case WebCore::ContextMenuItemTagCopyLinkWithHighlight:
     case WebCore::ContextMenuItemTagCopySubject:
     case WebCore::ContextMenuItemTagCorrectSpellingAutomatically:
     case WebCore::ContextMenuItemTagDictationAlternative:
-    case WebCore::ContextMenuItemTagFontMenu:
     case WebCore::ContextMenuItemTagNoAction:
     case WebCore::ContextMenuItemTagNoGuessesFound:
     case WebCore::ContextMenuItemTagOther:
-    case WebCore::ContextMenuItemTagOutline:
     case WebCore::ContextMenuItemTagPDFFacingPagesScrolling:
     case WebCore::ContextMenuItemTagPDFSinglePageScrolling:
+    case WebCore::ContextMenuItemTagShowSpellingPanel:
+    case WebCore::ContextMenuItemTagShowSubstitutions:
     case WebCore::ContextMenuItemTagSmartCopyPaste:
     case WebCore::ContextMenuItemTagSmartDashes:
     case WebCore::ContextMenuItemTagSmartLinks:
     case WebCore::ContextMenuItemTagSmartLists:
     case WebCore::ContextMenuItemTagSmartQuotes:
-    case WebCore::ContextMenuItemTagSpeechMenu:
     case WebCore::ContextMenuItemTagSpellingGuess:
-    case WebCore::ContextMenuItemTagSpellingMenu:
-    case WebCore::ContextMenuItemTagStyles:
-    case WebCore::ContextMenuItemTagSubstitutionsMenu:
     case WebCore::ContextMenuItemTagTextDirectionMenu:
     case WebCore::ContextMenuItemTagTextReplacement:
-    case WebCore::ContextMenuItemTagTransformationsMenu:
-    case WebCore::ContextMenuItemTagWritingDirectionMenu:
         return { };
     case WebCore::ContextMenuItemTagWritingTools:
         return { { SymbolType::Public, "apple.writing.tools"_s } };
@@ -243,9 +235,9 @@ static std::optional<SymbolNameWithType> symbolNameWithTypeForAction(const WebCo
     case WebCore::ContextMenuItemTagSummarize:
         return { { SymbolType::Private, "text.line.3.summary"_s } };
     case WebCore::ContextMenuItemPDFAutoSize:
-        return { { SymbolType::Public, "sparkle.magnifyingglass"_s } };
+        return { { SymbolType::Public, "arrow.up.left.and.down.right.magnifyingglass"_s } };
     case WebCore::ContextMenuItemPDFActualSize:
-        return { { SymbolType::Public, "text.magnifyingglass"_s } };
+        return { { SymbolType::Public, "1.magnifyingglass"_s } };
     case WebCore::ContextMenuItemPDFNextPage:
         return { { SymbolType::Public, "chevron.down"_s } };
     case WebCore::ContextMenuItemPDFPreviousPage:
@@ -260,20 +252,20 @@ static std::optional<SymbolNameWithType> symbolNameWithTypeForAction(const WebCo
     case WebCore::ContextMenuItemTagBold:
         return { { SymbolType::Public, "bold"_s } };
     case WebCore::ContextMenuItemTagCapitalize:
+    case WebCore::ContextMenuItemTagTransformationsMenu:
         return symbolForTransformationItem("textformat.characters"_s);
     case WebCore::ContextMenuItemTagChangeBack:
         return { { SymbolType::Public, "arrow.uturn.backward.circle"_s } };
-    case WebCore::ContextMenuItemTagCheckSpelling:
-        return { { SymbolType::Public, "text.page.badge.magnifyingglass"_s } };
     case WebCore::ContextMenuItemTagCopy:
     case WebCore::ContextMenuItemTagCopyImageToClipboard:
     case WebCore::ContextMenuItemTagCopyLinkToClipboard:
     case WebCore::ContextMenuItemTagCopyMediaLinkToClipboard:
-        return { { SymbolType::Public, [NSMenuItem _systemImageNameForAction:@selector(copy:)] } };
+        return { { SymbolType::Public, "document.on.document"_s } };
     case WebCore::ContextMenuItemTagCut:
-        return { { SymbolType::Public, [NSMenuItem _systemImageNameForAction:@selector(cut:)] } };
+        return { { SymbolType::Public, "scissors"_s } };
     case WebCore::ContextMenuItemTagDefaultDirection:
     case WebCore::ContextMenuItemTagTextDirectionDefault:
+    case WebCore::ContextMenuItemTagWritingDirectionMenu:
         return { { SymbolType::Public, "arrow.left.arrow.right"_s } };
     case WebCore::ContextMenuItemTagDownloadImageToDisk:
     case WebCore::ContextMenuItemTagDownloadLinkToDisk:
@@ -320,14 +312,16 @@ static std::optional<SymbolNameWithType> symbolNameWithTypeForAction(const WebCo
         return { { SymbolType::Public, "safari"_s } };
     case WebCore::ContextMenuItemTagOpenWithDefaultApplication:
         return { { SymbolType::Public, "arrow.up.forward.app"_s } };
+    case WebCore::ContextMenuItemTagOutline:
+        return { { SymbolType::Public, "circle.circle"_s } };
     case WebCore::ContextMenuItemTagPaste:
-        return { { SymbolType::Public, [NSMenuItem _systemImageNameForAction:@selector(paste:)] } };
+        return { { SymbolType::Public, "document.on.clipboard"_s } };
     case WebCore::ContextMenuItemTagPauseAllAnimations:
         return { { SymbolType::Public, "rectangle.stack.badge.minus"_s } };
     case WebCore::ContextMenuItemTagPauseAnimation:
         return { { SymbolType::Public, "pause.rectangle"_s } };
     case WebCore::ContextMenuItemTagPlayAllAnimations:
-        return { { SymbolType::Public, "rectangle.stack.badge.play.fill"_s } };
+        return { { SymbolType::Public, "rectangle.stack.badge.play"_s } };
     case WebCore::ContextMenuItemTagPlayAnimation:
         return { { SymbolType::Public, "play.rectangle"_s } };
     case WebCore::ContextMenuItemTagReload:
@@ -342,19 +336,23 @@ static std::optional<SymbolNameWithType> symbolNameWithTypeForAction(const WebCo
     case WebCore::ContextMenuItemTagShowColors:
         return { { SymbolType::Public, "paintpalette"_s } };
     case WebCore::ContextMenuItemTagShowFonts:
-        return { { SymbolType::Public, "text.and.command.macwindow"_s } };
+    case WebCore::ContextMenuItemTagFontMenu:
+        return { { SymbolType::Public, "textformat"_s } };
     case WebCore::ContextMenuItemTagShowMediaStats:
         return { { SymbolType::Public, "info.circle"_s } };
-    case WebCore::ContextMenuItemTagShowSpellingPanel:
-    case WebCore::ContextMenuItemTagShowSubstitutions: {
-        const auto symbolName = useAlternateImage ? "eye.slash"_s : "text.and.command.macwindow"_s;
-        return { { SymbolType::Public, symbolName } };
-    }
+    case WebCore::ContextMenuItemTagSpeechMenu:
+        return { { SymbolType::Public, "text.bubble"_s } };
+    case WebCore::ContextMenuItemTagSpellingMenu:
+        return { { SymbolType::Public, "textformat.characters.dottedunderline"_s } };
     case WebCore::ContextMenuItemTagStartSpeaking:
-        return { { SymbolType::Public, "play.fill"_s } };
+        return { { SymbolType::Public, "play"_s } };
     case WebCore::ContextMenuItemTagStop:
     case WebCore::ContextMenuItemTagStopSpeaking:
-        return { { SymbolType::Public, "stop.fill"_s } };
+        return { { SymbolType::Public, "stop"_s } };
+    case WebCore::ContextMenuItemTagStyles:
+        return { { SymbolType::Public, "paragraphsign"_s } };
+    case WebCore::ContextMenuItemTagSubstitutionsMenu:
+        return { { SymbolType::Public, "arrow.trianglehead.2.clockwise"_s } };
     case WebCore::ContextMenuItemTagToggleMediaControls: {
         const auto symbolName = useAlternateImage ? "eye"_s : "eye.slash"_s;
         return { { SymbolType::Public, symbolName } };
@@ -376,7 +374,7 @@ static std::optional<SymbolNameWithType> symbolNameWithTypeForAction(const WebCo
     case WebCore::ContextMenuItemTagTranslate:
         return { { SymbolType::Public, "translate"_s } };
     case WebCore::ContextMenuItemTagUnderline:
-        return { { SymbolType::Public, [NSMenuItem _systemImageNameForAction:@selector(underline:)] } };
+        return { { SymbolType::Public, "underline"_s } };
     }
 
     return { };

--- a/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
@@ -422,41 +422,38 @@ void WebContextMenuProxyMac::removeBackgroundFromControlledImage()
 }
 
 #if ENABLE(CONTEXT_MENU_IMAGES_ON_MAC)
-static void updateMenuItemImage(NSMenuItem *menuItem, const WebContextMenuItemData& webMenuItem)
+static void updateMenuItemImage(NSMenuItem *menuItem, const WebCore::ContextMenuAction& action, const String& title)
 {
-    if (![menuItem respondsToSelector:@selector(_setActionImage:)])
-        return;
+    bool useAlternateImage = false;
 
-    bool useAlternateImage;
-
-    switch (webMenuItem.action()) {
+    switch (action) {
     case ContextMenuItemTagMediaPlayPause:
-        useAlternateImage = webMenuItem.title() == contextMenuItemTagMediaPause();
+        useAlternateImage = title == contextMenuItemTagMediaPause();
         break;
     case ContextMenuItemTagShowSpellingPanel:
-        useAlternateImage = webMenuItem.title() == contextMenuItemTagShowSpellingPanel(false);
+        useAlternateImage = title == contextMenuItemTagShowSpellingPanel(false);
         break;
     case ContextMenuItemTagShowSubstitutions:
-        useAlternateImage = webMenuItem.title() == contextMenuItemTagShowSubstitutions(false);
+        useAlternateImage = title == contextMenuItemTagShowSubstitutions(false);
         break;
     case ContextMenuItemTagToggleMediaControls:
-        useAlternateImage = webMenuItem.title() == contextMenuItemTagShowMediaControls();
+        useAlternateImage = title == contextMenuItemTagShowMediaControls();
         break;
     case ContextMenuItemTagToggleVideoEnhancedFullscreen:
-        useAlternateImage = webMenuItem.title() == contextMenuItemTagExitVideoEnhancedFullscreen();
+        useAlternateImage = title == contextMenuItemTagExitVideoEnhancedFullscreen();
         break;
     case ContextMenuItemTagToggleVideoFullscreen:
-        useAlternateImage = webMenuItem.title() == contextMenuItemTagExitVideoFullscreen();
+        useAlternateImage = title == contextMenuItemTagExitVideoFullscreen();
         break;
     case ContextMenuItemTagToggleVideoViewer:
-        useAlternateImage = webMenuItem.title() == contextMenuItemTagExitVideoViewer();
+        useAlternateImage = title == contextMenuItemTagExitVideoViewer();
         break;
     default:
         useAlternateImage = false;
         break;
     }
 
-    addImageToMenuItem(menuItem, webMenuItem.action(), useAlternateImage);
+    addImageToMenuItem(menuItem, action, useAlternateImage);
 }
 #endif
 
@@ -920,7 +917,7 @@ void WebContextMenuProxyMac::getContextMenuItem(const WebContextMenuItemData& it
     case WebCore::ContextMenuItemType::CheckableAction: {
         RetainPtr menuItem = createMenuActionItem(item);
 #if ENABLE(CONTEXT_MENU_IMAGES_ON_MAC)
-        updateMenuItemImage(menuItem.get(), item);
+        updateMenuItemImage(menuItem.get(), item.action(), item.title());
 #endif
         completionHandler(menuItem.get());
         return;
@@ -937,6 +934,9 @@ void WebContextMenuProxyMac::getContextMenuItem(const WebContextMenuItemData& it
             [menuItem setIndentationLevel:indentationLevel];
             [menuItem setSubmenu:menu];
             [menuItem setIdentifier:menuItemIdentifier(action)];
+#if ENABLE(CONTEXT_MENU_IMAGES_ON_MAC)
+            updateMenuItemImage(menuItem.get(), action, title);
+#endif
             completionHandler(menuItem.get());
         });
         return;


### PR DESCRIPTION
#### 4bd5142a65321002fd193ed8791206506b71a913
<pre>
[macOS] Context menu images should be more consistent with other system applications
<a href="https://bugs.webkit.org/show_bug.cgi?id=299250">https://bugs.webkit.org/show_bug.cgi?id=299250</a>
<a href="https://rdar.apple.com/161026018">rdar://161026018</a>

Reviewed by Wenson Hsieh and Abrar Rahman Protyasha.

Updated context menu images to be more consistent with other system applications and
to improve clarity.

* Source/WebCore/PAL/pal/spi/mac/NSMenuSPI.h:
* Source/WebKit/Platform/mac/MenuUtilities.mm:
(WebKit::symbolNameWithTypeForAction):
* Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm:
(WebKit::updateMenuItemImage):
(WebKit::WebContextMenuProxyMac::getContextMenuItem):

Canonical link: <a href="https://commits.webkit.org/300331@main">https://commits.webkit.org/300331@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/feafad768086d6a237cbde4aed3441e4533df100

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122051 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41753 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32423 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128614 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74144 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d1dfd6a0-1e44-4d82-8215-dce4d5724db7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123927 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42468 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50347 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92768 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61649 "Found 2 new test failures: imported/w3c/web-platform-tests/event-timing/duration-with-target-low.html webgl/2.0.y/conformance2/query/occlusion-query.html (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/47d18c3e-045f-40e2-b912-3119320d6cd8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125003 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33867 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109299 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73423 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1b9bccc2-a0b2-4dd4-bcbb-bdb41cd81eab) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32880 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27465 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72108 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103374 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27656 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131375 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48990 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37260 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101328 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49364 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105513 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101199 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25679 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46566 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24683 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45712 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48847 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54581 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48317 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51667 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49997 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->