### PR TITLE
Modernize `<select>` fallback style

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
@@ -60,7 +60,6 @@ platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
 platform/graphics/cocoa/VideoMediaSampleRenderer.mm
 platform/graphics/mac/controls/ControlMac.mm
 platform/graphics/mac/controls/ImageControlsButtonMac.mm
-platform/graphics/mac/controls/MenuListButtonMac.mm
 platform/graphics/mac/controls/ProgressBarMac.mm
 platform/graphics/mac/controls/SliderTrackMac.mm
 platform/graphics/mac/controls/SwitchMacUtilities.mm

--- a/Source/WebCore/platform/graphics/mac/controls/MenuListButtonMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/MenuListButtonMac.mm
@@ -45,117 +45,6 @@ MenuListButtonMac::MenuListButtonMac(MenuListButtonPart& owningPart, ControlFact
 
 MenuListButtonMac::~MenuListButtonMac() = default;
 
-static void interpolateGradient(const CGFloat* rawInData, CGFloat* rawOutData, std::span<const float, 4> dark, std::span<const float, 4> light)
-{
-    auto inData = unsafeMakeSpan(rawInData, 1);
-    auto outData = unsafeMakeSpan(rawOutData, 4);
-
-    float a = inData[0];
-    for (size_t i = 0; i < 4; ++i)
-        outData[i] = (1.0f - a) * dark[i] + a * light[i];
-}
-
-static void topGradientInterpolate(void*, const CGFloat* inData, CGFloat* outData)
-{
-    static constexpr std::array dark { 1.0f, 1.0f, 1.0f, 0.4f };
-    static constexpr std::array light { 1.0f, 1.0f, 1.0f, 0.15f };
-    interpolateGradient(inData, outData, dark, light);
-}
-
-static void bottomGradientInterpolate(void*, const CGFloat* inData, CGFloat* outData)
-{
-    static constexpr std::array dark { 1.0f, 1.0f, 1.0f, 0.0f };
-    static constexpr std::array light { 1.0f, 1.0f, 1.0f, 0.3f };
-    interpolateGradient(inData, outData, dark, light);
-}
-
-static void mainGradientInterpolate(void*, const CGFloat* inData, CGFloat* outData)
-{
-    static constexpr std::array dark { 0.0f, 0.0f, 0.0f, 0.15f };
-    static constexpr std::array light { 0.0f, 0.0f, 0.0f, 0.0f };
-    interpolateGradient(inData, outData, dark, light);
-}
-
-static void darkTopGradientInterpolate(void*, const CGFloat* inData, CGFloat* outData)
-{
-    static constexpr std::array dark { 0.0f, 0.0f, 0.0f, 0.4f };
-    static constexpr std::array light { 0.0f, 0.0f, 0.0f, 0.15f };
-    interpolateGradient(inData, outData, dark, light);
-}
-
-static void darkBottomGradientInterpolate(void*, const CGFloat* inData, CGFloat* outData)
-{
-    static constexpr std::array dark { 0.0f, 0.0f, 0.0f, 0.0f };
-    static constexpr std::array light { 0.0f, 0.0f, 0.0f, 0.3f };
-    interpolateGradient(inData, outData, dark, light);
-}
-
-static void darkMainGradientInterpolate(void*, const CGFloat* inData, CGFloat* outData)
-{
-    static constexpr std::array dark { 1.0f, 1.0f, 1.0f, 0.15f };
-    static constexpr std::array light { 1.0f, 1.0f, 1.0f, 0.0f };
-    interpolateGradient(inData, outData, dark, light);
-}
-
-static void drawMenuListBackground(GraphicsContext& context, const FloatRect& rect, const FloatRoundedRect& borderRect, const ControlStyle& style)
-{
-    CGContextRef cgContext = context.platformContext();
-
-    const auto& radii = borderRect.radii();
-    int radius = radii.topLeft().width();
-
-    bool useDarkAppearance = style.states.contains(ControlStyle::State::DarkAppearance);
-
-    CGColorSpaceRef cspace = sRGBColorSpaceSingleton();
-
-    FloatRect topGradient(rect.x(), rect.y(), rect.width(), rect.height() / 2.0f);
-    struct CGFunctionCallbacks topCallbacks = { 0, useDarkAppearance ? darkTopGradientInterpolate : topGradientInterpolate, NULL };
-    RetainPtr<CGFunctionRef> topFunction = adoptCF(CGFunctionCreate(NULL, 1, NULL, 4, NULL, &topCallbacks));
-    RetainPtr<CGShadingRef> topShading = adoptCF(CGShadingCreateAxial(cspace, CGPointMake(topGradient.x(), topGradient.y()), CGPointMake(topGradient.x(), topGradient.maxY()), topFunction.get(), false, false));
-
-    FloatRect bottomGradient(rect.x() + radius, rect.y() + rect.height() / 2.0f, rect.width() - 2.0f * radius, rect.height() / 2.0f);
-    struct CGFunctionCallbacks bottomCallbacks = { 0, useDarkAppearance ? darkBottomGradientInterpolate : bottomGradientInterpolate, NULL };
-    RetainPtr<CGFunctionRef> bottomFunction = adoptCF(CGFunctionCreate(NULL, 1, NULL, 4, NULL, &bottomCallbacks));
-    RetainPtr<CGShadingRef> bottomShading = adoptCF(CGShadingCreateAxial(cspace, CGPointMake(bottomGradient.x(),  bottomGradient.y()), CGPointMake(bottomGradient.x(), bottomGradient.maxY()), bottomFunction.get(), false, false));
-
-    struct CGFunctionCallbacks mainCallbacks = { 0, useDarkAppearance ? darkMainGradientInterpolate : mainGradientInterpolate, NULL };
-    RetainPtr<CGFunctionRef> mainFunction = adoptCF(CGFunctionCreate(NULL, 1, NULL, 4, NULL, &mainCallbacks));
-    RetainPtr<CGShadingRef> mainShading = adoptCF(CGShadingCreateAxial(cspace, CGPointMake(rect.x(),  rect.y()), CGPointMake(rect.x(), rect.maxY()), mainFunction.get(), false, false));
-
-    RetainPtr<CGShadingRef> leftShading = adoptCF(CGShadingCreateAxial(cspace, CGPointMake(rect.x(),  rect.y()), CGPointMake(rect.x() + radius, rect.y()), mainFunction.get(), false, false));
-
-    RetainPtr<CGShadingRef> rightShading = adoptCF(CGShadingCreateAxial(cspace, CGPointMake(rect.maxX(),  rect.y()), CGPointMake(rect.maxX() - radius, rect.y()), mainFunction.get(), false, false));
-
-    {
-        GraphicsContextStateSaver stateSaver(context);
-        CGContextClipToRect(cgContext, rect);
-        context.clipRoundedRect(borderRect);
-        CGContextDrawShading(cgContext, mainShading.get());
-    }
-
-    {
-        GraphicsContextStateSaver stateSaver(context);
-        CGContextClipToRect(cgContext, topGradient);
-        context.clipRoundedRect(FloatRoundedRect(enclosingIntRect(topGradient), radii.topLeft(), radii.topRight(), { }, { }));
-        CGContextDrawShading(cgContext, topShading.get());
-    }
-
-    if (!bottomGradient.isEmpty()) {
-        GraphicsContextStateSaver stateSaver(context);
-        CGContextClipToRect(cgContext, bottomGradient);
-        context.clipRoundedRect(FloatRoundedRect(enclosingIntRect(bottomGradient), { }, { }, radii.bottomLeft(), radii.bottomRight()));
-        CGContextDrawShading(cgContext, bottomShading.get());
-    }
-
-    {
-        GraphicsContextStateSaver stateSaver(context);
-        CGContextClipToRect(cgContext, rect);
-        context.clipRoundedRect(borderRect);
-        CGContextDrawShading(cgContext, leftShading.get());
-        CGContextDrawShading(cgContext, rightShading.get());
-    }
-}
-
 void MenuListButtonMac::draw(GraphicsContext& context, const FloatRoundedRect& borderRect, float, const ControlStyle& style)
 {
     auto bounds = borderRect.rect();
@@ -164,66 +53,66 @@ void MenuListButtonMac::draw(GraphicsContext& context, const FloatRoundedRect& b
     if (bounds.isEmpty())
         return;
 
-    // Draw the gradients to give the styled popup menu a button appearance
-    drawMenuListBackground(context, bounds, borderRect, style);
+    // SF symbols 6: chevron.up.chevron.down / semibold / 20pt.
+    // FIXME: This is duplicated with RenderThemeCocoa.mm.
+    Path glyphPath;
+    glyphPath.moveTo({ 7.05356f, 0.0f });
+    glyphPath.addBezierCurveTo({ 6.6506f, 0.0f }, { 6.31419f, 0.159764f }, { 5.98845f, 0.476187f });
+    glyphPath.addLineTo({ 0.449547f, 5.79359f });
+    glyphPath.addBezierCurveTo({ 0.188162f, 6.04876f }, { 0.0f, 6.37185f }, { 0.0f, 6.75753f });
+    glyphPath.addBezierCurveTo({ 0.0f, 7.5262f }, { 0.619975f, 8.0783f }, { 1.31101f, 8.0783f });
+    glyphPath.addBezierCurveTo({ 1.64075f, 8.0783f }, { 1.99003f, 7.97934f }, { 2.27895f, 7.69662f });
+    glyphPath.addLineTo({ 7.05356f, 3.02633f });
+    glyphPath.addLineTo({ 11.8215f, 7.69662f });
+    glyphPath.addBezierCurveTo({ 12.1171f, 7.97268f }, { 12.4597f, 8.0783f }, { 12.7895f, 8.0783f });
+    glyphPath.addBezierCurveTo({ 13.4805f, 8.0783f }, { 14.1005f, 7.5262f }, { 14.1005f, 6.75753f });
+    glyphPath.addBezierCurveTo({ 14.1005f, 6.37185f }, { 13.9159f, 6.04876f }, { 13.6509f, 5.79359f });
+    glyphPath.addLineTo({ 8.11201f, 0.476187f });
+    glyphPath.addBezierCurveTo({ 7.78627f, 0.159764f }, { 7.44987f, 0.0f }, { 7.05356f, 0.0f });
+    glyphPath.moveTo({ 7.05356f, 20.1625f });
+    glyphPath.addBezierCurveTo({ 7.44987f, 20.1625f }, { 7.78627f, 19.9961f }, { 8.11201f, 19.6833f });
+    glyphPath.addLineTo({ 13.6509f, 14.3659f });
+    glyphPath.addBezierCurveTo({ 13.9159f, 14.1071f }, { 14.1005f, 13.7907f }, { 14.1005f, 13.3984f });
+    glyphPath.addBezierCurveTo({ 14.1005f, 12.6297f }, { 13.4805f, 12.0811f }, { 12.7895f, 12.0811f });
+    glyphPath.addBezierCurveTo({ 12.4597f, 12.0811f }, { 12.1171f, 12.1899f }, { 11.8215f, 12.4659f });
+    glyphPath.addLineTo({ 7.05356f, 17.1362f });
+    glyphPath.addLineTo({ 2.27895f, 12.4659f });
+    glyphPath.addBezierCurveTo({ 1.99003f, 12.1801f }, { 1.64075f, 12.0811f }, { 1.31101f, 12.0811f });
+    glyphPath.addBezierCurveTo({ 0.619975f, 12.0811f }, { 0.0f, 12.6297f }, { 0.0f, 13.3984f });
+    glyphPath.addBezierCurveTo({ 0.0f, 13.7907f }, { 0.188162f, 14.1071f }, { 0.449547f, 14.3659f });
+    glyphPath.addLineTo({ 5.98845f, 19.6833f });
+    glyphPath.addBezierCurveTo({ 6.31419f, 19.9961f }, { 6.6506f, 20.1625f }, { 7.05356f, 20.1625f });
 
-    static constexpr float baseFontSize = 11.0f;
-    static constexpr float baseArrowHeight = 4.0f;
-    static constexpr float baseArrowWidth = 5.0f;
-    static constexpr float baseSpaceBetweenArrows = 2.0f;
-    static constexpr int arrowPaddingBefore = 6;
-    static constexpr int arrowPaddingAfter = 6;
+    constexpr float baseGlyphWidth = 14.4618f;
+    constexpr float baseGlyphHeight = 20.1723f;
+    const auto glyphScale = 0.55f * style.fontSize / baseGlyphWidth;
+    FloatSize glyphSize { baseGlyphWidth * glyphScale, baseGlyphHeight * glyphScale };
 
     bool isVerticalWritingMode = style.states.contains(ControlStyle::State::VerticalWritingMode);
     auto logicalBounds = isVerticalWritingMode ? bounds.transposedRect() : bounds;
 
-    // Since we actually know the size of the control here, we restrict the font scale to make sure the arrows will fit vertically in the bounds
-    float fontScale = std::min(style.fontSize / baseFontSize, bounds.height() / (baseArrowHeight * 2 + baseSpaceBetweenArrows));
-    float centerY = logicalBounds.y() + logicalBounds.height() / 2.0f;
-    float arrowHeight = baseArrowHeight * fontScale;
-    float arrowWidth = baseArrowWidth * fontScale;
-    float spaceBetweenArrows = baseSpaceBetweenArrows * fontScale;
-
-    if (bounds.width() < arrowWidth + arrowPaddingBefore * style.zoomFactor)
-        return;
-
     bool isInlineFlipped = style.states.contains(ControlStyle::State::InlineFlippedWritingMode);
+    float endEdge = [&] {
+        static constexpr int arrowPaddingAfter = 6;
+        if (isInlineFlipped)
+            return logicalBounds.x() + arrowPaddingAfter * style.zoomFactor;
+        return logicalBounds.maxX() - arrowPaddingAfter * style.zoomFactor - glyphSize.width();
+    }();
 
-    float leftEdge;
-    if (isInlineFlipped)
-        leftEdge = logicalBounds.x() + arrowPaddingAfter * style.zoomFactor;
-    else
-        leftEdge = logicalBounds.maxX() - arrowPaddingAfter * style.zoomFactor - arrowWidth;
+    FloatPoint glyphOrigin { endEdge, logicalBounds.y() + (logicalBounds.height() - glyphSize.height()) / 2 };
+
+    if (isVerticalWritingMode)
+        glyphOrigin = glyphOrigin.transposedPoint();
+
+    AffineTransform transform;
+    transform.translate(glyphOrigin);
+    transform.scale(glyphScale);
+    glyphPath.transform(transform);
 
     GraphicsContextStateSaver stateSaver(context);
-
     context.setFillColor(style.textColor);
     context.setStrokeStyle(StrokeStyle::NoStroke);
-
-    Vector<FloatPoint> topArrow = {
-        { leftEdge, centerY - spaceBetweenArrows / 2.0f },
-        { leftEdge + arrowWidth, centerY - spaceBetweenArrows / 2.0f },
-        { leftEdge + arrowWidth / 2.0f, centerY - spaceBetweenArrows / 2.0f - arrowHeight }
-    };
-
-    Vector<FloatPoint> bottomArrow = {
-        { leftEdge, centerY + spaceBetweenArrows / 2.0f },
-        { leftEdge + arrowWidth, centerY + spaceBetweenArrows / 2.0f },
-        { leftEdge + arrowWidth / 2.0f, centerY + spaceBetweenArrows / 2.0f + arrowHeight }
-    };
-
-    // Rotate the arrows for vertical writing mode since the popup appears to the side of the control instead of under it.
-    if (isVerticalWritingMode) {
-        auto transposePoint = [](const FloatPoint& point) {
-            return point.transposedPoint();
-        };
-
-        topArrow = topArrow.map(transposePoint);
-        bottomArrow = bottomArrow.map(transposePoint);
-    }
-
-    context.fillPath(Path(topArrow));
-    context.fillPath(Path(bottomArrow));
+    context.fillPath(glyphPath);
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### 626e6fe843336ebd192a1e5b7f17120ae19118c2
<pre>
Modernize `&lt;select&gt;` fallback style
<a href="https://bugs.webkit.org/show_bug.cgi?id=299251">https://bugs.webkit.org/show_bug.cgi?id=299251</a>
<a href="https://rdar.apple.com/161032297">rdar://161032297</a>

Reviewed by Lily Spiniolas.

Remove outdated aqua background and update the arrow to match the one in RenderThemeCocoa.mm.

* Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations:
* Source/WebCore/platform/graphics/mac/controls/MenuListButtonMac.mm:
(WebCore::MenuListButtonMac::draw):
(WebCore::interpolateGradient): Deleted.
(WebCore::topGradientInterpolate): Deleted.
(WebCore::bottomGradientInterpolate): Deleted.
(WebCore::mainGradientInterpolate): Deleted.
(WebCore::darkTopGradientInterpolate): Deleted.
(WebCore::darkBottomGradientInterpolate): Deleted.
(WebCore::darkMainGradientInterpolate): Deleted.
(WebCore::drawMenuListBackground): Deleted.

Canonical link: <a href="https://commits.webkit.org/300324@main">https://commits.webkit.org/300324@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/97f7b9f3d4ea5cfc03280660b7277008deb442e3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122057 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41759 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32429 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128620 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74151 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ad4789af-407c-405f-8b42-40d57f396ef4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123933 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42474 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50353 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92772 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61654 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/816ddc33-72cf-4e87-8712-ba39637041ff) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125009 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33873 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109302 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73428 "Found 1 new API test failure: TestWTF:WTF_Condition.OneProducerOneConsumerOneSlotTimeout (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/056b52ec-a328-4cfc-a344-3adabe59bfb6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32886 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27468 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72114 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103380 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27659 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131381 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48996 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37264 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101334 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49370 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105516 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101205 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25673 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46572 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24686 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45719 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48853 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54587 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48323 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51673 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50003 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->