### PR TITLE
[visionOS] Entering video fullscreen while animating into element fullscreen results in window without controls

### DIFF
--- a/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm
+++ b/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm
@@ -41,6 +41,7 @@
 #import <QuartzCore/CoreAnimation.h>
 #import <WebCore/Chrome.h>
 #import <WebCore/Color.h>
+#import <WebCore/DocumentFullscreen.h>
 #import <WebCore/DocumentInlines.h>
 #import <WebCore/Event.h>
 #import <WebCore/EventNames.h>
@@ -282,6 +283,12 @@ void VideoPresentationManager::removeClientForContext(WebCore::MediaPlayerClient
 bool VideoPresentationManager::canEnterVideoFullscreen(HTMLVideoElement& videoElement, WebCore::HTMLMediaElementEnums::VideoFullscreenMode mode) const
 {
     ASSERT(mode != HTMLMediaElementEnums::VideoFullscreenModeNone);
+
+#if ENABLE(FULLSCREEN_API)
+    if (videoElement.document().fullscreen().isAnimatingFullscreen())
+        return false;
+#endif
+
 #if PLATFORM(IOS) || PLATFORM(VISION)
     if (m_currentVideoFullscreenMode == mode)
         return videoElement.document().quirks().allowLayeredFullscreenVideos();


### PR DESCRIPTION
#### 871c14262cb54c63c6341b36a6147a7d82381220
<pre>
[visionOS] Entering video fullscreen while animating into element fullscreen results in window without controls
<a href="https://rdar.apple.com/158362342">rdar://158362342</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=299253">https://bugs.webkit.org/show_bug.cgi?id=299253</a>

Reviewed by Eric Carlson.

When the website <a href="https://www.zee5.com">https://www.zee5.com</a> enters fullscreen mode, it also enters video fullscreen mode shortly
afterward. Both APIs consume transient activation, so they shouldn&apos;t be allowed to enter fullscreen simultaneously.
Regardless, protect against the case where somehow both requests succeed.

* Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm:
(WebKit::VideoPresentationManager::canEnterVideoFullscreen const):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/UI/ElementFullscreen.mm:
(-[TestElementFullscreenDelegate waitForWillEnterElementFullscreen]):
(-[TestElementFullscreenDelegate _webViewWillEnterElementFullscreen:_webViewWillEnterFullscreen:]):
(-[TestElementFullscreenDelegate _webViewDidEnterElementFullscreen:_webViewDidEnterFullscreen:]):
(TEST(ElementFullscreen, EnterVideoFullscreenWhileAnimating)):
(-[TestElementFullscreenDelegate _webViewDidEnterElementFullscreen:]): Deleted.

Canonical link: <a href="https://commits.webkit.org/300418@main">https://commits.webkit.org/300418@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/783d47fd0260f7e98e8637096509153ad2341f1f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122226 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42142 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32827 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128803 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74320 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4562b56a-7c5c-4f54-9230-8c2773bfa322) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/124102 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42860 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50746 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92901 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61754 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/40bb5693-e884-4c57-9098-07bb214f75b5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125178 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34185 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109626 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73556 "Found 1 new API test failure: WPE/TestWebKitWebContext:/webkit/WebKitWebContext/no-web-process-leak (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/98f8d9bf-e0b3-430d-b65c-13ee219d8204) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33174 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27783 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72292 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103817 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27994 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131550 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49165 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37587 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101469 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49540 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105847 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101339 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25755 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46707 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24989 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45916 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49022 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54980 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48492 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51842 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50172 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->