### PR TITLE
[Style] Cleanup Style builder/extractor converters

### DIFF
--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -1327,8 +1327,8 @@
                 "auto"
             ],
             "codegen-properties": {
-                "style-converter": "CustomIdentAtomOrKeyword<CSSValueAuto>",
-                "style-converter-comment": "FIXME: This should probably be using StringAtomOrKeyword<CSSValueAuto>",
+                "style-converter": "CustomIdentAtomOrAuto",
+                "style-converter-comment": "FIXME: This should probably be using StringAtomOrAuto",
                 "font-description-name-for-methods": "SpecifiedLocale",
                 "font-property": true,
                 "high-priority": true,

--- a/Source/WebCore/dom/ViewTransition.cpp
+++ b/Source/WebCore/dom/ViewTransition.cpp
@@ -964,7 +964,7 @@ void ViewTransition::copyElementBaseProperties(RenderLayerModelObject& renderer,
         transform.translate(output.size.width() / 2, output.size.height() / 2);
         transform.translateRight(-output.size.width() / 2, -output.size.height() / 2);
 
-        Ref transformListValue = CSSTransformListValue::create(Style::ExtractorConverter::convertTransformationMatrix(documentElementRenderer->style(), transform));
+        Ref transformListValue = CSSTransformListValue::create(Style::ExtractorConverter::convertTransformationMatrix(CSSValuePool::singleton(), documentElementRenderer->style(), transform));
         RefPtr { output.properties }->setProperty(CSSPropertyTransform, WTFMove(transformListValue));
     }
 

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -120,90 +120,58 @@ class BuilderConverter {
 public:
     template<typename T, typename... Rest> static T convertStyleType(BuilderState&, const CSSValue&, Rest&&...);
 
-    static WebCore::Length convertLength(BuilderState&, const CSSValue&);
-    static WebCore::Length convertLengthOrAuto(BuilderState&, const CSSValue&);
-    static WebCore::Length convertLengthAllowingNumber(BuilderState&, const CSSValue&); // Assumes unit is 'px' if input is a number.
-    static WebCore::Length convertTextLengthOrNormal(BuilderState&, const CSSValue&); // Converts length by text zoom factor, normal to zero
-    static TabSize convertTabSize(BuilderState&, const CSSValue&);
-    template<typename T> static T convertComputedLength(BuilderState&, const CSSValue&);
-    template<typename T> static T convertLineWidth(BuilderState&, const CSSValue&);
-    static OptionSet<TextTransform> convertTextTransform(BuilderState&, const CSSValue&);
-    template<typename T> static T convertNumber(BuilderState&, const CSSValue&);
-    static ImageOrientation convertImageOrientation(BuilderState&, const CSSValue&);
-    template<CSSValueID> static AtomString convertCustomIdentAtomOrKeyword(BuilderState&, const CSSValue&);
+    static NameScope convertNameScope(BuilderState&, const CSSValue&);
+    static AtomString convertCustomIdentAtomOrAuto(BuilderState&, const CSSValue&);
 
+    static WebCore::Length convertLengthUsingDoubleNoClamping(BuilderState&, const CSSValue&);
+    static WebCore::Length convertTextLengthOrNormal(BuilderState&, const CSSValue&); // Converts length by text zoom factor, normal to zero
+    static WebCore::Length convertLineHeight(BuilderState&, const CSSValue&, float multiplier = 1.f);
+
+    static OptionSet<TextTransform> convertTextTransform(BuilderState&, const CSSValue&);
     static OptionSet<TextEmphasisPosition> convertTextEmphasisPosition(BuilderState&, const CSSValue&);
+    static OptionSet<TextUnderlinePosition> convertTextUnderlinePosition(BuilderState&, const CSSValue&);
+    static OptionSet<LineBoxContain> convertLineBoxContain(BuilderState&, const CSSValue&);
+    static OptionSet<TouchAction> convertTouchAction(BuilderState&, const CSSValue&);
+    static OptionSet<HangingPunctuation> convertHangingPunctuation(BuilderState&, const CSSValue&);
+    static OptionSet<SpeakAs> convertSpeakAs(BuilderState&, const CSSValue&);
+    static OptionSet<Containment> convertContain(BuilderState&, const CSSValue&);
+    static OptionSet<MarginTrimType> convertMarginTrim(BuilderState&, const CSSValue&);
+    static OptionSet<PositionVisibility> convertPositionVisibility(BuilderState&, const CSSValue&);
+
+    static ImageOrientation convertImageOrientation(BuilderState&, const CSSValue&);
     static TextAlignMode convertTextAlign(BuilderState&, const CSSValue&);
     static TextAlignLast convertTextAlignLast(BuilderState&, const CSSValue&);
     static Resize convertResize(BuilderState&, const CSSValue&);
-    static OptionSet<TextUnderlinePosition> convertTextUnderlinePosition(BuilderState&, const CSSValue&);
+    static ScrollbarWidth convertScrollbarWidth(BuilderState&, const CSSValue&); // scrollbar-width converter is only needed for quirking.
+    static GlyphOrientation convertGlyphOrientation(BuilderState&, const CSSValue&);
+    static GlyphOrientation convertGlyphOrientationOrAuto(BuilderState&, const CSSValue&);
+    static MaskMode convertFillLayerMaskMode(BuilderState&, const CSSValue&);
     static TextEdge convertTextEdge(BuilderState&, const CSSValue&);
-    static OptionSet<LineBoxContain> convertLineBoxContain(BuilderState&, const CSSValue&);
     static ScrollSnapType convertScrollSnapType(BuilderState&, const CSSValue&);
     static ScrollSnapAlign convertScrollSnapAlign(BuilderState&, const CSSValue&);
-    // scrollbar-width converter is only needed for quirking.
-    static ScrollbarWidth convertScrollbarWidth(BuilderState&, const CSSValue&);
     static GridAutoFlow convertGridAutoFlow(BuilderState&, const CSSValue&);
-#if PLATFORM(IOS_FAMILY)
-    static bool convertTouchCallout(BuilderState&, const CSSValue&);
-#endif
-#if ENABLE(TOUCH_EVENTS)
-    static Color convertTapHighlightColor(BuilderState&, const CSSValue&);
-#endif
-    static OptionSet<TouchAction> convertTouchAction(BuilderState&, const CSSValue&);
-#if ENABLE(WEBKIT_OVERFLOW_SCROLLING_CSS_PROPERTY)
-    static bool convertOverflowScrolling(BuilderState&, const CSSValue&);
-#endif
-
-    static FontSizeAdjust convertFontSizeAdjust(BuilderState&, const CSSValue&);
-    static std::optional<FontSelectionValue> convertFontStyleFromValue(BuilderState&, const CSSValue&);
-    static FontSelectionValue convertFontWeight(BuilderState&, const CSSValue&);
-    static FontSelectionValue convertFontWidth(BuilderState&, const CSSValue&);
-    static FontSelectionValue convertFontStyle(BuilderState&, const CSSValue&);
-    static FontFeatureSettings convertFontFeatureSettings(BuilderState&, const CSSValue&);
-    static FontVariationSettings convertFontVariationSettings(BuilderState&, const CSSValue&);
     static PaintOrder convertPaintOrder(BuilderState&, const CSSValue&);
     static URL convertSVGURIReference(BuilderState&, const CSSValue&);
     static StyleSelfAlignmentData convertSelfOrDefaultAlignmentData(BuilderState&, const CSSValue&);
     static StyleContentAlignmentData convertContentAlignmentData(BuilderState&, const CSSValue&);
-    static GlyphOrientation convertGlyphOrientation(BuilderState&, const CSSValue&);
-    static GlyphOrientation convertGlyphOrientationOrAuto(BuilderState&, const CSSValue&);
-    static WebCore::Length convertLineHeight(BuilderState&, const CSSValue&, float multiplier = 1.f);
-    static FontPalette convertFontPalette(BuilderState&, const CSSValue&);
-    
-    static BreakBetween convertPageBreakBetween(BuilderState&, const CSSValue&);
-    static BreakInside convertPageBreakInside(BuilderState&, const CSSValue&);
-    static BreakBetween convertColumnBreakBetween(BuilderState&, const CSSValue&);
-    static BreakInside convertColumnBreakInside(BuilderState&, const CSSValue&);
-
-    static OptionSet<HangingPunctuation> convertHangingPunctuation(BuilderState&, const CSSValue&);
-
-    static OptionSet<SpeakAs> convertSpeakAs(BuilderState&, const CSSValue&);
-
-    static OptionSet<Containment> convertContain(BuilderState&, const CSSValue&);
-
-    static OptionSet<MarginTrimType> convertMarginTrim(BuilderState&, const CSSValue&);
-
-    static TextSpacingTrim convertTextSpacingTrim(BuilderState&, const CSSValue&);
-    static TextAutospace convertTextAutospace(BuilderState&, const CSSValue&);
-
     static RefPtr<WillChangeData> convertWillChange(BuilderState&, const CSSValue&);
-
     static std::optional<ScopedName> convertPositionAnchor(BuilderState&, const CSSValue&);
     static std::optional<PositionArea> convertPositionArea(BuilderState&, const CSSValue&);
-    static OptionSet<PositionVisibility> convertPositionVisibility(BuilderState&, const CSSValue&);
-
-    static NameScope convertNameScope(BuilderState&, const CSSValue&);
-
     static FixedVector<PositionTryFallback> convertPositionTryFallbacks(BuilderState&, const CSSValue&);
 
-    static MaskMode convertFillLayerMaskMode(BuilderState&, const CSSValue&);
+    // Font Properties
+    static FontSizeAdjust convertFontSizeAdjust(BuilderState&, const CSSValue&);
+    static std::optional<FontSelectionValue> convertFontStyleFromValue(BuilderState&, const CSSValue&);
+    static FontSelectionValue convertFontWeight(BuilderState&, const CSSValue&);
+    static FontSelectionValue convertFontWidth(BuilderState&, const CSSValue&);
+    static FontFeatureSettings convertFontFeatureSettings(BuilderState&, const CSSValue&);
+    static FontVariationSettings convertFontVariationSettings(BuilderState&, const CSSValue&);
+    static FontPalette convertFontPalette(BuilderState&, const CSSValue&);
+    static TextSpacingTrim convertTextSpacingTrim(BuilderState&, const CSSValue&);
+    static TextAutospace convertTextAutospace(BuilderState&, const CSSValue&);
+    static TabSize convertTabSize(BuilderState&, const CSSValue&);
 
 private:
-    friend class BuilderCustom;
-
-    static WebCore::Length parseSnapCoordinate(BuilderState&, const CSSValue&);
-
     static CSSToLengthConversionData cssToLengthConversionDataWithTextZoomFactor(BuilderState&);
 };
 
@@ -212,9 +180,11 @@ template<typename T, typename... Rest> inline T BuilderConverter::convertStyleTy
     return toStyleFromCSSValue<T>(builderState, value, std::forward<Rest>(rest)...);
 }
 
-inline WebCore::Length BuilderConverter::convertLength(BuilderState& builderState, const CSSValue& value)
+inline WebCore::Length BuilderConverter::convertLengthUsingDoubleNoClamping(BuilderState& builderState, const CSSValue& value)
 {
-    auto* primitiveValue = requiredDowncast<CSSPrimitiveValue>(builderState, value);
+    // FIXME: Callers of this should be using toStyleFromCSSValue<LengthPercentage<>>()`, but doing so breaks transforms/hittest-translated-content-off-to-infinity-and-back.html, due to it clamping between minValueForCssLength and maxValueForCssLength.
+
+    RefPtr primitiveValue = requiredDowncast<CSSPrimitiveValue>(builderState, value);
     if (!primitiveValue)
         return { };
 
@@ -222,42 +192,15 @@ inline WebCore::Length BuilderConverter::convertLength(BuilderState& builderStat
         builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f)
         : builderState.cssToLengthConversionData();
 
-    if (primitiveValue->isLength()) {
-        auto length = primitiveValue->resolveAsLength<WebCore::Length>(conversionData);
-        length.setHasQuirk(primitiveValue->primitiveType() == CSSUnitType::CSS_QUIRKY_EM);
-        return length;
-    }
-
+    if (primitiveValue->isLength())
+        return WebCore::Length(primitiveValue->resolveAsLength<double>(conversionData), LengthType::Fixed);
     if (primitiveValue->isPercentage())
-        return WebCore::Length(primitiveValue->resolveAsPercentage(conversionData), LengthType::Percent);
-
+        return WebCore::Length(primitiveValue->resolveAsPercentage<double>(conversionData), LengthType::Percent);
     if (primitiveValue->isCalculatedPercentageWithLength())
         return WebCore::Length(primitiveValue->cssCalcValue()->createCalculationValue(conversionData, CSSCalcSymbolTable { }));
 
     ASSERT_NOT_REACHED();
     return WebCore::Length(0, LengthType::Fixed);
-}
-
-inline WebCore::Length BuilderConverter::convertLengthAllowingNumber(BuilderState& builderState, const CSSValue& value)
-{
-    CSSToLengthConversionData conversionData = builderState.useSVGZoomRulesForLength() ?
-        builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f)
-        : builderState.cssToLengthConversionData();
-
-    auto* primitiveValue = requiredDowncast<CSSPrimitiveValue>(builderState, value);
-    if (!primitiveValue)
-        return { };
-
-    if (primitiveValue->isNumberOrInteger())
-        return WebCore::Length(primitiveValue->resolveAsNumber(conversionData), LengthType::Fixed);
-    return convertLength(builderState, value);
-}
-
-inline WebCore::Length BuilderConverter::convertLengthOrAuto(BuilderState& builderState, const CSSValue& value)
-{
-    if (value.valueID() == CSSValueAuto)
-        return WebCore::Length(LengthType::Auto);
-    return convertLength(builderState, value);
 }
 
 inline TabSize BuilderConverter::convertTabSize(BuilderState& builderState, const CSSValue& value)
@@ -270,49 +213,6 @@ inline TabSize BuilderConverter::convertTabSize(BuilderState& builderState, cons
     return TabSize(primitiveValue->resolveAsLength<float>(builderState.cssToLengthConversionData()), LengthValueType);
 }
 
-template<typename T>
-inline T BuilderConverter::convertComputedLength(BuilderState& builderState, const CSSValue& value)
-{
-    auto* primitiveValue = requiredDowncast<CSSPrimitiveValue>(builderState, value);
-    if (!primitiveValue)
-        return { };
-    return primitiveValue->resolveAsLength<T>(builderState.cssToLengthConversionData());
-}
-
-template<typename T>
-inline T BuilderConverter::convertLineWidth(BuilderState& builderState, const CSSValue& value)
-{
-    auto* primitiveValue = requiredDowncast<CSSPrimitiveValue>(builderState, value);
-    if (!primitiveValue)
-        return { };
-    switch (primitiveValue->valueID()) {
-    case CSSValueThin:
-        return 1;
-    case CSSValueMedium:
-        return 3;
-    case CSSValueThick:
-        return 5;
-    case CSSValueInvalid: {
-        // Any original result that was >= 1 should not be allowed to fall below 1.
-        // This keeps border lines from vanishing.
-        T result = convertComputedLength<T>(builderState, value);
-        if (builderState.style().usedZoom() < 1.0f && result < 1.0) {
-            T originalLength = primitiveValue->resolveAsLength<T>(builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0));
-            if (originalLength >= 1.0)
-                return 1;
-        }
-        float minimumLineWidth = 1 / builderState.document().deviceScaleFactor();
-        if (result > 0 && result < minimumLineWidth)
-            return minimumLineWidth;
-        return floorToDevicePixel(result, builderState.document().deviceScaleFactor());
-    }
-    default:
-        ASSERT_NOT_REACHED();
-        return 0;
-    }
-}
-
-
 inline OptionSet<TextTransform> BuilderConverter::convertTextTransform(BuilderState&, const CSSValue& value)
 {
     auto result = RenderStyle::initialTextTransform();
@@ -321,15 +221,6 @@ inline OptionSet<TextTransform> BuilderConverter::convertTextTransform(BuilderSt
             result.add(fromCSSValue<TextTransform>(currentValue));
     }
     return result;
-}
-
-template<typename T>
-inline T BuilderConverter::convertNumber(BuilderState& builderState, const CSSValue& value)
-{
-    auto* primitiveValue = requiredDowncast<CSSPrimitiveValue>(builderState, value);
-    if (!primitiveValue)
-        return { };
-    return primitiveValue->resolveAsNumber<T>(builderState.cssToLengthConversionData());
 }
 
 inline ImageOrientation BuilderConverter::convertImageOrientation(BuilderState& builderState, const CSSValue& value)
@@ -342,13 +233,13 @@ inline ImageOrientation BuilderConverter::convertImageOrientation(BuilderState& 
     return ImageOrientation::Orientation::None;
 }
 
-template<CSSValueID keyword> inline AtomString BuilderConverter::convertCustomIdentAtomOrKeyword(BuilderState& builderState, const CSSValue& value)
+inline AtomString BuilderConverter::convertCustomIdentAtomOrAuto(BuilderState& builderState, const CSSValue& value)
 {
     RefPtr primitiveValue = requiredDowncast<CSSPrimitiveValue>(builderState, value);
     if (!primitiveValue)
         return nullAtom();
 
-    if (primitiveValue->valueID() == keyword)
+    if (primitiveValue->valueID() == CSSValueAuto)
         return nullAtom();
     return AtomString { primitiveValue->stringValue() };
 }
@@ -775,23 +666,6 @@ inline FontSizeAdjust BuilderConverter::convertFontSizeAdjust(BuilderState& buil
     return fontSizeAdjustFromCSSValue(builderState, value);
 }
 
-#if PLATFORM(IOS_FAMILY)
-inline bool BuilderConverter::convertTouchCallout(BuilderState& builderState, const CSSValue& value)
-{
-    auto* primitiveValue = requiredDowncast<CSSPrimitiveValue>(builderState, value);
-    if (!primitiveValue)
-        return { };
-    return !equalLettersIgnoringASCIICase(primitiveValue->stringValue(), "none"_s);
-}
-#endif
-
-#if ENABLE(TOUCH_EVENTS)
-inline Color BuilderConverter::convertTapHighlightColor(BuilderState& builderState, const CSSValue& value)
-{
-    return convertStyleType<Color>(builderState, value, ForVisitedLink::No);
-}
-#endif
-
 inline OptionSet<TouchAction> BuilderConverter::convertTouchAction(BuilderState&, const CSSValue& value)
 {
     if (is<CSSPrimitiveValue>(value))
@@ -810,13 +684,6 @@ inline OptionSet<TouchAction> BuilderConverter::convertTouchAction(BuilderState&
 
     return RenderStyle::initialTouchActions();
 }
-
-#if ENABLE(WEBKIT_OVERFLOW_SCROLLING_CSS_PROPERTY)
-inline bool BuilderConverter::convertOverflowScrolling(BuilderState&, const CSSValue& value)
-{
-    return value.valueID() == CSSValueTouch;
-}
-#endif
 
 inline PaintOrder BuilderConverter::convertPaintOrder(BuilderState& builderState, const CSSValue& value)
 {

--- a/Source/WebCore/style/StyleExtractorConverter.h
+++ b/Source/WebCore/style/StyleExtractorConverter.h
@@ -124,19 +124,12 @@ public:
     static Ref<CSSPrimitiveValue> convert(ExtractorState&, int);
     static Ref<CSSPrimitiveValue> convert(ExtractorState&, unsigned short);
     static Ref<CSSPrimitiveValue> convert(ExtractorState&, short);
-    static Ref<CSSPrimitiveValue> convert(ExtractorState&, const ScopedName&);
 
     static Ref<CSSPrimitiveValue> convertLength(ExtractorState&, const WebCore::Length&);
-    static Ref<CSSPrimitiveValue> convertLength(const RenderStyle&, const WebCore::Length&);
-    static Ref<CSSPrimitiveValue> convertLengthAllowingNumber(ExtractorState&, const WebCore::Length&);
-    static Ref<CSSPrimitiveValue> convertLengthOrAuto(ExtractorState&, const WebCore::Length&);
-
-    template<typename T> static Ref<CSSPrimitiveValue> convertNumber(ExtractorState&, T);
+    static Ref<CSSPrimitiveValue> convertLength(CSSValuePool&, const RenderStyle&, const WebCore::Length&);
     template<typename T> static Ref<CSSPrimitiveValue> convertNumberAsPixels(ExtractorState&, T);
-    template<typename T> static Ref<CSSPrimitiveValue> convertComputedLength(ExtractorState&, T);
-    template<typename T> static Ref<CSSPrimitiveValue> convertLineWidth(ExtractorState&, T lineWidth);
 
-    template<CSSValueID> static Ref<CSSPrimitiveValue> convertCustomIdentAtomOrKeyword(ExtractorState&, const AtomString&);
+    static Ref<CSSValue> convertCustomIdentAtomOrAuto(ExtractorState&, const AtomString&);
 
     // MARK: SVG conversions
 
@@ -145,14 +138,13 @@ public:
     // MARK: Transform conversions
 
     static Ref<CSSValue> convertTransformationMatrix(ExtractorState&, const TransformationMatrix&);
-    static Ref<CSSValue> convertTransformationMatrix(const RenderStyle&, const TransformationMatrix&);
+    static Ref<CSSValue> convertTransformationMatrix(CSSValuePool&, const RenderStyle&, const TransformationMatrix&);
 
     // MARK: Shared conversions
 
     static Ref<CSSValue> convertGlyphOrientation(ExtractorState&, GlyphOrientation);
     static Ref<CSSValue> convertGlyphOrientationOrAuto(ExtractorState&, GlyphOrientation);
     static Ref<CSSValue> convertMarginTrim(ExtractorState&, OptionSet<MarginTrimType>);
-    static Ref<CSSValue> convertStrokeDashArray(ExtractorState&, const FixedVector<WebCore::Length>&);
     static Ref<CSSValue> convertWebkitTextCombine(ExtractorState&, TextCombine);
     static Ref<CSSValue> convertImageOrientation(ExtractorState&, ImageOrientation);
     static Ref<CSSValue> convertContain(ExtractorState&, OptionSet<Containment>);
@@ -167,7 +159,6 @@ public:
     static Ref<CSSValue> convertScrollSnapAlign(ExtractorState&, const ScrollSnapAlign&);
     static Ref<CSSValue> convertLineBoxContain(ExtractorState&, OptionSet<Style::LineBoxContain>);
     static Ref<CSSValue> convertWebkitRubyPosition(ExtractorState&, RubyPosition);
-    static Ref<CSSValue> convertPosition(ExtractorState&, const LengthPoint&);
     static Ref<CSSValue> convertTouchAction(ExtractorState&, OptionSet<TouchAction>);
     static Ref<CSSValue> convertTextTransform(ExtractorState&, OptionSet<TextTransform>);
     static Ref<CSSValue> convertTextUnderlinePosition(ExtractorState&, OptionSet<TextUnderlinePosition>);
@@ -236,58 +227,34 @@ inline Ref<CSSPrimitiveValue> ExtractorConverter::convert(ExtractorState&, float
 
 inline Ref<CSSPrimitiveValue> ExtractorConverter::convert(ExtractorState&, unsigned value)
 {
-    return CSSPrimitiveValue::createInteger(value);
+    return CSSPrimitiveValue::create(value);
 }
 
 inline Ref<CSSPrimitiveValue> ExtractorConverter::convert(ExtractorState&, int value)
 {
-    return CSSPrimitiveValue::createInteger(value);
+    return CSSPrimitiveValue::create(value);
 }
 
 inline Ref<CSSPrimitiveValue> ExtractorConverter::convert(ExtractorState&, unsigned short value)
 {
-    return CSSPrimitiveValue::createInteger(value);
+    return CSSPrimitiveValue::create(value);
 }
 
 inline Ref<CSSPrimitiveValue> ExtractorConverter::convert(ExtractorState&, short value)
 {
-    return CSSPrimitiveValue::createInteger(value);
-}
-
-inline Ref<CSSPrimitiveValue> ExtractorConverter::convert(ExtractorState&, const ScopedName& scopedName)
-{
-    if (scopedName.isIdentifier)
-        return CSSPrimitiveValue::createCustomIdent(scopedName.name);
-    return CSSPrimitiveValue::create(scopedName.name);
+    return CSSPrimitiveValue::create(value);
 }
 
 inline Ref<CSSPrimitiveValue> ExtractorConverter::convertLength(ExtractorState& state, const WebCore::Length& length)
 {
-    return convertLength(state.style, length);
+    return convertLength(state.pool, state.style, length);
 }
 
-inline Ref<CSSPrimitiveValue> ExtractorConverter::convertLength(const RenderStyle& style, const WebCore::Length& length)
+inline Ref<CSSPrimitiveValue> ExtractorConverter::convertLength(CSSValuePool&, const RenderStyle& style, const WebCore::Length& length)
 {
     if (length.isFixed())
         return CSSPrimitiveValue::create(adjustFloatForAbsoluteZoom(length.value(), style), CSSUnitType::CSS_PX);
     return CSSPrimitiveValue::create(length, style);
-}
-
-inline Ref<CSSPrimitiveValue> ExtractorConverter::convertLengthAllowingNumber(ExtractorState& state, const WebCore::Length& length)
-{
-    return convertLength(state, length);
-}
-
-inline Ref<CSSPrimitiveValue> ExtractorConverter::convertLengthOrAuto(ExtractorState& state, const WebCore::Length& length)
-{
-    if (length.isAuto())
-        return CSSPrimitiveValue::create(CSSValueAuto);
-    return convertLength(state, length);
-}
-
-template<typename T> Ref<CSSPrimitiveValue> ExtractorConverter::convertNumber(ExtractorState& state, T number)
-{
-    return convert(state, number);
 }
 
 template<typename T> Ref<CSSPrimitiveValue> ExtractorConverter::convertNumberAsPixels(ExtractorState& state, T number)
@@ -295,21 +262,11 @@ template<typename T> Ref<CSSPrimitiveValue> ExtractorConverter::convertNumberAsP
     return CSSPrimitiveValue::create(adjustFloatForAbsoluteZoom(number, state.style), CSSUnitType::CSS_PX);
 }
 
-template<typename T> Ref<CSSPrimitiveValue> ExtractorConverter::convertComputedLength(ExtractorState& state, T number)
-{
-    return convertNumberAsPixels(state, number);
-}
-
-template<typename T> Ref<CSSPrimitiveValue> ExtractorConverter::convertLineWidth(ExtractorState& state, T lineWidth)
-{
-    return convertNumberAsPixels(state, lineWidth);
-}
-
-template<CSSValueID keyword> Ref<CSSPrimitiveValue> ExtractorConverter::convertCustomIdentAtomOrKeyword(ExtractorState&, const AtomString& string)
+inline Ref<CSSValue> ExtractorConverter::convertCustomIdentAtomOrAuto(ExtractorState& state, const AtomString& string)
 {
     if (string.isNull())
-        return CSSPrimitiveValue::create(keyword);
-    return CSSPrimitiveValue::createCustomIdent(string);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::Auto { });
+    return createCSSValue(state.pool, state.style, CustomIdentifier { string });
 }
 
 // MARK: - SVG conversions
@@ -317,7 +274,7 @@ template<CSSValueID keyword> Ref<CSSPrimitiveValue> ExtractorConverter::convertC
 inline Ref<CSSValue> ExtractorConverter::convertSVGURIReference(ExtractorState& state, const URL& marker)
 {
     if (marker.isNone())
-        return CSSPrimitiveValue::create(CSSValueNone);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::None { });
     return CSSURLValue::create(toCSS(marker, state.style));
 }
 
@@ -325,17 +282,17 @@ inline Ref<CSSValue> ExtractorConverter::convertSVGURIReference(ExtractorState& 
 
 inline Ref<CSSValue> ExtractorConverter::convertTransformationMatrix(ExtractorState& state, const TransformationMatrix& transform)
 {
-    return convertTransformationMatrix(state.style, transform);
+    return convertTransformationMatrix(state.pool, state.style, transform);
 }
 
-inline Ref<CSSValue> ExtractorConverter::convertTransformationMatrix(const RenderStyle& style, const TransformationMatrix& transform)
+inline Ref<CSSValue> ExtractorConverter::convertTransformationMatrix(CSSValuePool& pool, const RenderStyle& style, const TransformationMatrix& transform)
 {
     auto zoom = style.usedZoom();
     if (transform.isAffine()) {
         double values[] = { transform.a(), transform.b(), transform.c(), transform.d(), transform.e() / zoom, transform.f() / zoom };
         CSSValueListBuilder arguments;
         for (auto value : values)
-            arguments.append(CSSPrimitiveValue::create(value));
+            arguments.append(createCSSValue(pool, style, Number<> { value }));
         return CSSFunctionValue::create(CSSValueMatrix, WTFMove(arguments));
     }
 
@@ -347,150 +304,140 @@ inline Ref<CSSValue> ExtractorConverter::convertTransformationMatrix(const Rende
     };
     CSSValueListBuilder arguments;
     for (auto value : values)
-        arguments.append(CSSPrimitiveValue::create(value));
+        arguments.append(createCSSValue(pool, style, Number<> { value }));
     return CSSFunctionValue::create(CSSValueMatrix3d, WTFMove(arguments));
 }
 
 // MARK: - Shared conversions
 
-inline Ref<CSSValue> ExtractorConverter::convertGlyphOrientation(ExtractorState&, GlyphOrientation orientation)
+inline Ref<CSSValue> ExtractorConverter::convertGlyphOrientation(ExtractorState& state, GlyphOrientation orientation)
 {
     switch (orientation) {
     case GlyphOrientation::Degrees0:
-        return CSSPrimitiveValue::create(0.0f, CSSUnitType::CSS_DEG);
+        return createCSSValue(state.pool, state.style, Angle<> { 0.0 });
     case GlyphOrientation::Degrees90:
-        return CSSPrimitiveValue::create(90.0f, CSSUnitType::CSS_DEG);
+        return createCSSValue(state.pool, state.style, Angle<> { 90.0 });
     case GlyphOrientation::Degrees180:
-        return CSSPrimitiveValue::create(180.0f, CSSUnitType::CSS_DEG);
+        return createCSSValue(state.pool, state.style, Angle<> { 180.0 });
     case GlyphOrientation::Degrees270:
-        return CSSPrimitiveValue::create(270.0f, CSSUnitType::CSS_DEG);
+        return createCSSValue(state.pool, state.style, Angle<> { 270.0 });
     case GlyphOrientation::Auto:
         ASSERT_NOT_REACHED();
-        return CSSPrimitiveValue::create(0.0f, CSSUnitType::CSS_DEG);
+        return createCSSValue(state.pool, state.style, Angle<> { 0.0 });
     }
 
     RELEASE_ASSERT_NOT_REACHED();
 }
 
-inline Ref<CSSValue> ExtractorConverter::convertGlyphOrientationOrAuto(ExtractorState&, GlyphOrientation orientation)
+inline Ref<CSSValue> ExtractorConverter::convertGlyphOrientationOrAuto(ExtractorState& state, GlyphOrientation orientation)
 {
     switch (orientation) {
     case GlyphOrientation::Degrees0:
-        return CSSPrimitiveValue::create(0.0f, CSSUnitType::CSS_DEG);
+        return createCSSValue(state.pool, state.style, Angle<> { 0.0 });
     case GlyphOrientation::Degrees90:
-        return CSSPrimitiveValue::create(90.0f, CSSUnitType::CSS_DEG);
+        return createCSSValue(state.pool, state.style, Angle<> { 90.0 });
     case GlyphOrientation::Degrees180:
-        return CSSPrimitiveValue::create(180.0f, CSSUnitType::CSS_DEG);
+        return createCSSValue(state.pool, state.style, Angle<> { 180.0 });
     case GlyphOrientation::Degrees270:
-        return CSSPrimitiveValue::create(270.0f, CSSUnitType::CSS_DEG);
+        return createCSSValue(state.pool, state.style, Angle<> { 270.0 });
     case GlyphOrientation::Auto:
-        return CSSPrimitiveValue::create(CSSValueAuto);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::Auto { });
     }
 
     RELEASE_ASSERT_NOT_REACHED();
 }
 
-inline Ref<CSSValue> ExtractorConverter::convertMarginTrim(ExtractorState&, OptionSet<MarginTrimType> marginTrim)
+inline Ref<CSSValue> ExtractorConverter::convertMarginTrim(ExtractorState& state, OptionSet<MarginTrimType> marginTrim)
 {
     if (marginTrim.isEmpty())
-        return CSSPrimitiveValue::create(CSSValueNone);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::None { });
 
     // Try to serialize into one of the "block" or "inline" shorthands
     if (marginTrim.containsAll({ MarginTrimType::BlockStart, MarginTrimType::BlockEnd }) && !marginTrim.containsAny({ MarginTrimType::InlineStart, MarginTrimType::InlineEnd }))
-        return CSSPrimitiveValue::create(CSSValueBlock);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::Block { });
     if (marginTrim.containsAll({ MarginTrimType::InlineStart, MarginTrimType::InlineEnd }) && !marginTrim.containsAny({ MarginTrimType::BlockStart, MarginTrimType::BlockEnd }))
-        return CSSPrimitiveValue::create(CSSValueInline);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::Inline { });
     if (marginTrim.containsAll({ MarginTrimType::BlockStart, MarginTrimType::BlockEnd, MarginTrimType::InlineStart, MarginTrimType::InlineEnd }))
-        return CSSValueList::createSpaceSeparated(CSSPrimitiveValue::create(CSSValueBlock), CSSPrimitiveValue::create(CSSValueInline));
+        return CSSValueList::createSpaceSeparated(createCSSValue(state.pool, state.style, CSS::Keyword::Block { }), createCSSValue(state.pool, state.style, CSS::Keyword::Inline { }));
 
     CSSValueListBuilder list;
     if (marginTrim.contains(MarginTrimType::BlockStart))
-        list.append(CSSPrimitiveValue::create(CSSValueBlockStart));
+        list.append(createCSSValue(state.pool, state.style, CSS::Keyword::BlockStart { }));
     if (marginTrim.contains(MarginTrimType::InlineStart))
-        list.append(CSSPrimitiveValue::create(CSSValueInlineStart));
+        list.append(createCSSValue(state.pool, state.style, CSS::Keyword::InlineStart { }));
     if (marginTrim.contains(MarginTrimType::BlockEnd))
-        list.append(CSSPrimitiveValue::create(CSSValueBlockEnd));
+        list.append(createCSSValue(state.pool, state.style, CSS::Keyword::BlockEnd { }));
     if (marginTrim.contains(MarginTrimType::InlineEnd))
-        list.append(CSSPrimitiveValue::create(CSSValueInlineEnd));
+        list.append(createCSSValue(state.pool, state.style, CSS::Keyword::InlineEnd { }));
     return CSSValueList::createSpaceSeparated(WTFMove(list));
-}
-
-inline Ref<CSSValue> ExtractorConverter::convertStrokeDashArray(ExtractorState& state, const FixedVector<WebCore::Length>& dashes)
-{
-    if (dashes.isEmpty())
-        return CSSPrimitiveValue::create(CSSValueNone);
-    CSSValueListBuilder list;
-    for (auto& dash : dashes)
-        list.append(convertLength(state, dash));
-    return CSSValueList::createCommaSeparated(WTFMove(list));
 }
 
 inline Ref<CSSValue> ExtractorConverter::convertWebkitTextCombine(ExtractorState& state, TextCombine textCombine)
 {
     if (textCombine == TextCombine::All)
-        return CSSPrimitiveValue::create(CSSValueHorizontal);
-    return convert(state, textCombine);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::Horizontal { });
+    return createCSSValue(state.pool, state.style, textCombine);
 }
 
-inline Ref<CSSValue> ExtractorConverter::convertImageOrientation(ExtractorState&, ImageOrientation imageOrientation)
+inline Ref<CSSValue> ExtractorConverter::convertImageOrientation(ExtractorState& state, ImageOrientation imageOrientation)
 {
     if (imageOrientation == ImageOrientation::Orientation::FromImage)
-        return CSSPrimitiveValue::create(CSSValueFromImage);
-    return CSSPrimitiveValue::create(CSSValueNone);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::FromImage { });
+    return createCSSValue(state.pool, state.style, CSS::Keyword::None { });
 }
 
-inline Ref<CSSValue> ExtractorConverter::convertContain(ExtractorState&, OptionSet<Containment> containment)
+inline Ref<CSSValue> ExtractorConverter::convertContain(ExtractorState& state, OptionSet<Containment> containment)
 {
     if (!containment)
-        return CSSPrimitiveValue::create(CSSValueNone);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::None { });
     if (containment == RenderStyle::strictContainment())
-        return CSSPrimitiveValue::create(CSSValueStrict);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::Strict { });
     if (containment == RenderStyle::contentContainment())
-        return CSSPrimitiveValue::create(CSSValueContent);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::Content { });
     CSSValueListBuilder list;
     if (containment & Containment::Size)
-        list.append(CSSPrimitiveValue::create(CSSValueSize));
+        list.append(createCSSValue(state.pool, state.style, CSS::Keyword::Size { }));
     if (containment & Containment::InlineSize)
-        list.append(CSSPrimitiveValue::create(CSSValueInlineSize));
+        list.append(createCSSValue(state.pool, state.style, CSS::Keyword::InlineSize { }));
     if (containment & Containment::Layout)
-        list.append(CSSPrimitiveValue::create(CSSValueLayout));
+        list.append(createCSSValue(state.pool, state.style, CSS::Keyword::Layout { }));
     if (containment & Containment::Style)
-        list.append(CSSPrimitiveValue::create(CSSValueStyle));
+        list.append(createCSSValue(state.pool, state.style, CSS::Keyword::Style { }));
     if (containment & Containment::Paint)
-        list.append(CSSPrimitiveValue::create(CSSValuePaint));
+        list.append(createCSSValue(state.pool, state.style, CSS::Keyword::Paint { }));
     return CSSValueList::createSpaceSeparated(WTFMove(list));
 }
 
-inline Ref<CSSValue> ExtractorConverter::convertTextSpacingTrim(ExtractorState&, TextSpacingTrim textSpacingTrim)
+inline Ref<CSSValue> ExtractorConverter::convertTextSpacingTrim(ExtractorState& state, TextSpacingTrim textSpacingTrim)
 {
     switch (textSpacingTrim.type()) {
     case TextSpacingTrim::TrimType::SpaceAll:
-        return CSSPrimitiveValue::create(CSSValueSpaceAll);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::SpaceAll { });
     case TextSpacingTrim::TrimType::Auto:
-        return CSSPrimitiveValue::create(CSSValueAuto);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::Auto { });
     case TextSpacingTrim::TrimType::TrimAll:
-        return CSSPrimitiveValue::create(CSSValueTrimAll);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::TrimAll { });
     default:
         ASSERT_NOT_REACHED();
         break;
     }
-    return CSSPrimitiveValue::create(CSSValueSpaceAll);
+    return createCSSValue(state.pool, state.style, CSS::Keyword::SpaceAll { });
 }
 
-inline Ref<CSSValue> ExtractorConverter::convertTextAutospace(ExtractorState&, TextAutospace textAutospace)
+inline Ref<CSSValue> ExtractorConverter::convertTextAutospace(ExtractorState& state, TextAutospace textAutospace)
 {
     if (textAutospace.isAuto())
-        return CSSPrimitiveValue::create(CSSValueAuto);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::Auto { });
     if (textAutospace.isNoAutospace())
-        return CSSPrimitiveValue::create(CSSValueNoAutospace);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::NoAutospace { });
     if (textAutospace.isNormal())
-        return CSSPrimitiveValue::create(CSSValueNormal);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::Normal { });
 
     CSSValueListBuilder list;
     if (textAutospace.hasIdeographAlpha())
-        list.append(CSSPrimitiveValue::create(CSSValueIdeographAlpha));
+        list.append(createCSSValue(state.pool, state.style, CSS::Keyword::IdeographAlpha { }));
     if (textAutospace.hasIdeographNumeric())
-        list.append(CSSPrimitiveValue::create(CSSValueIdeographNumeric));
+        list.append(createCSSValue(state.pool, state.style, CSS::Keyword::IdeographNumeric { }));
 
     return CSSValueList::createSpaceSeparated(WTFMove(list));
 }
@@ -498,7 +445,7 @@ inline Ref<CSSValue> ExtractorConverter::convertTextAutospace(ExtractorState&, T
 inline Ref<CSSValue> ExtractorConverter::convertLineFitEdge(ExtractorState& state, const TextEdge& textEdge)
 {
     if (textEdge.over == TextEdgeType::Leading && textEdge.under == TextEdgeType::Leading)
-        return convert(state, textEdge.over);
+        return createCSSValue(state.pool, state.style, textEdge.over);
 
     // https://www.w3.org/TR/css-inline-3/#text-edges
     // "If only one value is specified, both edges are assigned that same keyword if possible; else text is assumed as the missing value."
@@ -509,15 +456,15 @@ inline Ref<CSSValue> ExtractorConverter::convertLineFitEdge(ExtractorState& stat
     }();
 
     if (!shouldSerializeUnderEdge)
-        return convert(state, textEdge.over);
+        return createCSSValue(state.pool, state.style, textEdge.over);
 
-    return CSSValuePair::create(convert(state, textEdge.over), convert(state, textEdge.under));
+    return CSSValuePair::create(createCSSValue(state.pool, state.style, textEdge.over), createCSSValue(state.pool, state.style, textEdge.under));
 }
 
 inline Ref<CSSValue> ExtractorConverter::convertTextBoxEdge(ExtractorState& state, const TextEdge& textEdge)
 {
     if (textEdge.over == TextEdgeType::Auto && textEdge.under == TextEdgeType::Auto)
-        return convert(state, textEdge.over);
+        return createCSSValue(state.pool, state.style, textEdge.over);
 
     // https://www.w3.org/TR/css-inline-3/#text-edges
     // "If only one value is specified, both edges are assigned that same keyword if possible; else text is assumed as the missing value."
@@ -528,15 +475,15 @@ inline Ref<CSSValue> ExtractorConverter::convertTextBoxEdge(ExtractorState& stat
     }();
 
     if (!shouldSerializeUnderEdge)
-        return convert(state, textEdge.over);
+        return createCSSValue(state.pool, state.style, textEdge.over);
 
-    return CSSValuePair::create(convert(state, textEdge.over), convert(state, textEdge.under));
+    return CSSValuePair::create(createCSSValue(state.pool, state.style, textEdge.over), createCSSValue(state.pool, state.style, textEdge.under));
 }
 
 inline Ref<CSSValue> ExtractorConverter::convertPositionTryFallbacks(ExtractorState& state, const FixedVector<PositionTryFallback>& fallbacks)
 {
     if (fallbacks.isEmpty())
-        return CSSPrimitiveValue::create(CSSValueNone);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::None { });
 
     CSSValueListBuilder list;
     for (auto& fallback : fallbacks) {
@@ -549,29 +496,29 @@ inline Ref<CSSValue> ExtractorConverter::convertPositionTryFallbacks(ExtractorSt
 
         CSSValueListBuilder singleFallbackList;
         if (fallback.positionTryRuleName)
-            singleFallbackList.append(convert(state, *fallback.positionTryRuleName));
+            singleFallbackList.append(createCSSValue(state.pool, state.style, *fallback.positionTryRuleName));
         for (auto& tactic : fallback.tactics)
-            singleFallbackList.append(convert(state, tactic));
+            singleFallbackList.append(createCSSValue(state.pool, state.style, tactic));
         list.append(CSSValueList::createSpaceSeparated(singleFallbackList));
     }
 
     return CSSValueList::createCommaSeparated(WTFMove(list));
 }
 
-inline Ref<CSSValue> ExtractorConverter::convertWillChange(ExtractorState&, const WillChangeData* willChangeData)
+inline Ref<CSSValue> ExtractorConverter::convertWillChange(ExtractorState& state, const WillChangeData* willChangeData)
 {
     if (!willChangeData || !willChangeData->numFeatures())
-        return CSSPrimitiveValue::create(CSSValueAuto);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::Auto { });
 
     CSSValueListBuilder list;
     for (size_t i = 0; i < willChangeData->numFeatures(); ++i) {
         auto feature = willChangeData->featureAt(i);
         switch (feature.first) {
         case WillChangeData::Feature::ScrollPosition:
-            list.append(CSSPrimitiveValue::create(CSSValueScrollPosition));
+            list.append(createCSSValue(state.pool, state.style, CSS::Keyword::ScrollPosition { }));
             break;
         case WillChangeData::Feature::Contents:
-            list.append(CSSPrimitiveValue::create(CSSValueContents));
+            list.append(createCSSValue(state.pool, state.style, CSS::Keyword::Contents { }));
             break;
         case WillChangeData::Feature::Property:
             list.append(CSSPrimitiveValue::create(feature.second));
@@ -584,124 +531,118 @@ inline Ref<CSSValue> ExtractorConverter::convertWillChange(ExtractorState&, cons
     return CSSValueList::createCommaSeparated(WTFMove(list));
 }
 
-inline Ref<CSSValue> ExtractorConverter::convertTabSize(ExtractorState&, const TabSize& tabSize)
+inline Ref<CSSValue> ExtractorConverter::convertTabSize(ExtractorState& state, const TabSize& tabSize)
 {
-    return CSSPrimitiveValue::create(tabSize.widthInPixels(1.0), tabSize.isSpaces() ? CSSUnitType::CSS_NUMBER : CSSUnitType::CSS_PX);
+    auto value = tabSize.widthInPixels(1.0);
+    if (tabSize.isSpaces())
+        return createCSSValue(state.pool, state.style, Number<> { value });
+    else
+        return createCSSValue(state.pool, state.style, Length<> { value });
 }
 
 inline Ref<CSSValue> ExtractorConverter::convertScrollSnapType(ExtractorState& state, const ScrollSnapType& type)
 {
     if (type.strictness == ScrollSnapStrictness::None)
-        return CSSValueList::createSpaceSeparated(CSSPrimitiveValue::create(CSSValueNone));
+        return CSSValueList::createSpaceSeparated(createCSSValue(state.pool, state.style, CSS::Keyword::None { }));
     if (type.strictness == ScrollSnapStrictness::Proximity)
-        return CSSValueList::createSpaceSeparated(convert(state, type.axis));
-    return CSSValueList::createSpaceSeparated(convert(state, type.axis), convert(state, type.strictness));
+        return CSSValueList::createSpaceSeparated(createCSSValue(state.pool, state.style, type.axis));
+    return CSSValueList::createSpaceSeparated(createCSSValue(state.pool, state.style, type.axis), createCSSValue(state.pool, state.style, type.strictness));
 }
 
 inline Ref<CSSValue> ExtractorConverter::convertScrollSnapAlign(ExtractorState& state, const ScrollSnapAlign& alignment)
 {
     return CSSValuePair::create(
-        convert(state, alignment.blockAlign),
-        convert(state, alignment.inlineAlign)
+        createCSSValue(state.pool, state.style, alignment.blockAlign),
+        createCSSValue(state.pool, state.style, alignment.inlineAlign)
     );
 }
 
-inline Ref<CSSValue> ExtractorConverter::convertLineBoxContain(ExtractorState&, OptionSet<Style::LineBoxContain> lineBoxContain)
+inline Ref<CSSValue> ExtractorConverter::convertLineBoxContain(ExtractorState& state, OptionSet<Style::LineBoxContain> lineBoxContain)
 {
     if (!lineBoxContain)
-        return CSSPrimitiveValue::create(CSSValueNone);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::None { });
 
     CSSValueListBuilder list;
     if (lineBoxContain.contains(LineBoxContain::Block))
-        list.append(CSSPrimitiveValue::create(CSSValueBlock));
+        list.append(createCSSValue(state.pool, state.style, CSS::Keyword::Block { }));
     if (lineBoxContain.contains(LineBoxContain::Inline))
-        list.append(CSSPrimitiveValue::create(CSSValueInline));
+        list.append(createCSSValue(state.pool, state.style, CSS::Keyword::Inline { }));
     if (lineBoxContain.contains(LineBoxContain::Font))
-        list.append(CSSPrimitiveValue::create(CSSValueFont));
+        list.append(createCSSValue(state.pool, state.style, CSS::Keyword::Font { }));
     if (lineBoxContain.contains(LineBoxContain::Glyphs))
-        list.append(CSSPrimitiveValue::create(CSSValueGlyphs));
+        list.append(createCSSValue(state.pool, state.style, CSS::Keyword::Glyphs { }));
     if (lineBoxContain.contains(LineBoxContain::Replaced))
-        list.append(CSSPrimitiveValue::create(CSSValueReplaced));
+        list.append(createCSSValue(state.pool, state.style, CSS::Keyword::Replaced { }));
     if (lineBoxContain.contains(LineBoxContain::InlineBox))
-        list.append(CSSPrimitiveValue::create(CSSValueInlineBox));
+        list.append(createCSSValue(state.pool, state.style, CSS::Keyword::InlineBox { }));
     if (lineBoxContain.contains(LineBoxContain::InitialLetter))
-        list.append(CSSPrimitiveValue::create(CSSValueInitialLetter));
+        list.append(createCSSValue(state.pool, state.style, CSS::Keyword::InitialLetter { }));
     return CSSValueList::createSpaceSeparated(WTFMove(list));
 }
 
-inline Ref<CSSValue> ExtractorConverter::convertWebkitRubyPosition(ExtractorState&, RubyPosition position)
+inline Ref<CSSValue> ExtractorConverter::convertWebkitRubyPosition(ExtractorState& state, RubyPosition position)
 {
-    return CSSPrimitiveValue::create([&] {
-        switch (position) {
-        case RubyPosition::Over:
-            return CSSValueBefore;
-        case RubyPosition::Under:
-            return CSSValueAfter;
-        case RubyPosition::InterCharacter:
-        case RubyPosition::LegacyInterCharacter:
-            return CSSValueInterCharacter;
-        }
-        return CSSValueBefore;
-    }());
+    switch (position) {
+    case RubyPosition::Over:
+        return createCSSValue(state.pool, state.style, CSS::Keyword::Before { });
+    case RubyPosition::Under:
+        return createCSSValue(state.pool, state.style, CSS::Keyword::After { });
+    case RubyPosition::InterCharacter:
+    case RubyPosition::LegacyInterCharacter:
+        return createCSSValue(state.pool, state.style, CSS::Keyword::InterCharacter { });
+    }
+    RELEASE_ASSERT_NOT_REACHED();
 }
 
-inline Ref<CSSValue> ExtractorConverter::convertPosition(ExtractorState& state, const LengthPoint& position)
-{
-    return CSSValueList::createSpaceSeparated(
-        convertLength(state, position.x),
-        convertLength(state, position.y)
-    );
-}
-
-inline Ref<CSSValue> ExtractorConverter::convertTouchAction(ExtractorState&, OptionSet<TouchAction> touchActions)
+inline Ref<CSSValue> ExtractorConverter::convertTouchAction(ExtractorState& state, OptionSet<TouchAction> touchActions)
 {
     if (touchActions & TouchAction::Auto)
-        return CSSPrimitiveValue::create(CSSValueAuto);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::Auto { });
     if (touchActions & TouchAction::None)
-        return CSSPrimitiveValue::create(CSSValueNone);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::None { });
     if (touchActions & TouchAction::Manipulation)
-        return CSSPrimitiveValue::create(CSSValueManipulation);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::Manipulation { });
 
     CSSValueListBuilder list;
     if (touchActions & TouchAction::PanX)
-        list.append(CSSPrimitiveValue::create(CSSValuePanX));
+        list.append(createCSSValue(state.pool, state.style, CSS::Keyword::PanX { }));
     if (touchActions & TouchAction::PanY)
-        list.append(CSSPrimitiveValue::create(CSSValuePanY));
+        list.append(createCSSValue(state.pool, state.style, CSS::Keyword::PanY { }));
     if (touchActions & TouchAction::PinchZoom)
-        list.append(CSSPrimitiveValue::create(CSSValuePinchZoom));
+        list.append(createCSSValue(state.pool, state.style, CSS::Keyword::PinchZoom { }));
     if (list.isEmpty())
-        return CSSPrimitiveValue::create(CSSValueAuto);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::Auto { });
     return CSSValueList::createSpaceSeparated(WTFMove(list));
 }
 
-inline Ref<CSSValue> ExtractorConverter::convertTextTransform(ExtractorState&, OptionSet<TextTransform> textTransform)
+inline Ref<CSSValue> ExtractorConverter::convertTextTransform(ExtractorState& state, OptionSet<TextTransform> textTransform)
 {
     CSSValueListBuilder list;
     if (textTransform.contains(TextTransform::Capitalize))
-        list.append(CSSPrimitiveValue::create(CSSValueCapitalize));
+        list.append(createCSSValue(state.pool, state.style, CSS::Keyword::Capitalize { }));
     else if (textTransform.contains(TextTransform::Uppercase))
-        list.append(CSSPrimitiveValue::create(CSSValueUppercase));
+        list.append(createCSSValue(state.pool, state.style, CSS::Keyword::Uppercase { }));
     else if (textTransform.contains(TextTransform::Lowercase))
-        list.append(CSSPrimitiveValue::create(CSSValueLowercase));
+        list.append(createCSSValue(state.pool, state.style, CSS::Keyword::Lowercase { }));
 
     if (textTransform.contains(TextTransform::FullWidth))
-        list.append(CSSPrimitiveValue::create(CSSValueFullWidth));
+        list.append(createCSSValue(state.pool, state.style, CSS::Keyword::FullWidth { }));
 
     if (textTransform.contains(TextTransform::FullSizeKana))
-        list.append(CSSPrimitiveValue::create(CSSValueFullSizeKana));
+        list.append(createCSSValue(state.pool, state.style, CSS::Keyword::FullSizeKana { }));
 
     if (list.isEmpty())
-        return CSSPrimitiveValue::create(CSSValueNone);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::None { });
     return CSSValueList::createSpaceSeparated(WTFMove(list));
 }
 
-inline Ref<CSSValue> ExtractorConverter::convertTextUnderlinePosition(ExtractorState&, OptionSet<TextUnderlinePosition> textUnderlinePosition)
+inline Ref<CSSValue> ExtractorConverter::convertTextUnderlinePosition(ExtractorState& state, OptionSet<TextUnderlinePosition> textUnderlinePosition)
 {
     ASSERT(!((textUnderlinePosition & TextUnderlinePosition::FromFont) && (textUnderlinePosition & TextUnderlinePosition::Under)));
     ASSERT(!((textUnderlinePosition & TextUnderlinePosition::Left) && (textUnderlinePosition & TextUnderlinePosition::Right)));
 
     if (textUnderlinePosition.isEmpty())
-        return CSSPrimitiveValue::create(CSSValueAuto);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::Auto { });
     bool isFromFont = textUnderlinePosition.contains(TextUnderlinePosition::FromFont);
     bool isUnder = textUnderlinePosition.contains(TextUnderlinePosition::Under);
     bool isLeft = textUnderlinePosition.contains(TextUnderlinePosition::Left);
@@ -716,7 +657,7 @@ inline Ref<CSSValue> ExtractorConverter::convertTextUnderlinePosition(ExtractorS
     return CSSValuePair::create(CSSPrimitiveValue::create(metric), CSSPrimitiveValue::create(side));
 }
 
-inline Ref<CSSValue> ExtractorConverter::convertTextEmphasisPosition(ExtractorState&, OptionSet<TextEmphasisPosition> textEmphasisPosition)
+inline Ref<CSSValue> ExtractorConverter::convertTextEmphasisPosition(ExtractorState& state, OptionSet<TextEmphasisPosition> textEmphasisPosition)
 {
     ASSERT(!((textEmphasisPosition & TextEmphasisPosition::Over) && (textEmphasisPosition & TextEmphasisPosition::Under)));
     ASSERT(!((textEmphasisPosition & TextEmphasisPosition::Left) && (textEmphasisPosition & TextEmphasisPosition::Right)));
@@ -724,96 +665,96 @@ inline Ref<CSSValue> ExtractorConverter::convertTextEmphasisPosition(ExtractorSt
 
     CSSValueListBuilder list;
     if (textEmphasisPosition & TextEmphasisPosition::Over)
-        list.append(CSSPrimitiveValue::create(CSSValueOver));
+        list.append(createCSSValue(state.pool, state.style, CSS::Keyword::Over { }));
     if (textEmphasisPosition & TextEmphasisPosition::Under)
-        list.append(CSSPrimitiveValue::create(CSSValueUnder));
+        list.append(createCSSValue(state.pool, state.style, CSS::Keyword::Under { }));
     if (textEmphasisPosition & TextEmphasisPosition::Left)
-        list.append(CSSPrimitiveValue::create(CSSValueLeft));
+        list.append(createCSSValue(state.pool, state.style, CSS::Keyword::Left { }));
     return CSSValueList::createSpaceSeparated(WTFMove(list));
 }
 
-inline Ref<CSSValue> ExtractorConverter::convertSpeakAs(ExtractorState&, OptionSet<SpeakAs> speakAs)
+inline Ref<CSSValue> ExtractorConverter::convertSpeakAs(ExtractorState& state, OptionSet<SpeakAs> speakAs)
 {
     CSSValueListBuilder list;
     if (speakAs & SpeakAs::SpellOut)
-        list.append(CSSPrimitiveValue::create(CSSValueSpellOut));
+        list.append(createCSSValue(state.pool, state.style, CSS::Keyword::SpellOut { }));
     if (speakAs & SpeakAs::Digits)
-        list.append(CSSPrimitiveValue::create(CSSValueDigits));
+        list.append(createCSSValue(state.pool, state.style, CSS::Keyword::Digits { }));
     if (speakAs & SpeakAs::LiteralPunctuation)
-        list.append(CSSPrimitiveValue::create(CSSValueLiteralPunctuation));
+        list.append(createCSSValue(state.pool, state.style, CSS::Keyword::LiteralPunctuation { }));
     if (speakAs & SpeakAs::NoPunctuation)
-        list.append(CSSPrimitiveValue::create(CSSValueNoPunctuation));
+        list.append(createCSSValue(state.pool, state.style, CSS::Keyword::NoPunctuation { }));
     if (list.isEmpty())
-        return CSSPrimitiveValue::create(CSSValueNormal);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::Normal { });
     return CSSValueList::createSpaceSeparated(WTFMove(list));
 }
 
-inline Ref<CSSValue> ExtractorConverter::convertHangingPunctuation(ExtractorState&, OptionSet<HangingPunctuation> hangingPunctuation)
+inline Ref<CSSValue> ExtractorConverter::convertHangingPunctuation(ExtractorState& state, OptionSet<HangingPunctuation> hangingPunctuation)
 {
     CSSValueListBuilder list;
     if (hangingPunctuation & HangingPunctuation::First)
-        list.append(CSSPrimitiveValue::create(CSSValueFirst));
+        list.append(createCSSValue(state.pool, state.style, CSS::Keyword::First { }));
     if (hangingPunctuation & HangingPunctuation::AllowEnd)
-        list.append(CSSPrimitiveValue::create(CSSValueAllowEnd));
+        list.append(createCSSValue(state.pool, state.style, CSS::Keyword::AllowEnd { }));
     if (hangingPunctuation & HangingPunctuation::ForceEnd)
-        list.append(CSSPrimitiveValue::create(CSSValueForceEnd));
+        list.append(createCSSValue(state.pool, state.style, CSS::Keyword::ForceEnd { }));
     if (hangingPunctuation & HangingPunctuation::Last)
-        list.append(CSSPrimitiveValue::create(CSSValueLast));
+        list.append(createCSSValue(state.pool, state.style, CSS::Keyword::Last { }));
     if (list.isEmpty())
-        return CSSPrimitiveValue::create(CSSValueNone);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::None { });
     return CSSValueList::createSpaceSeparated(WTFMove(list));
 }
 
-inline Ref<CSSValue> ExtractorConverter::convertPageBreak(ExtractorState&, BreakBetween value)
+inline Ref<CSSValue> ExtractorConverter::convertPageBreak(ExtractorState& state, BreakBetween value)
 {
     if (value == BreakBetween::Page || value == BreakBetween::LeftPage || value == BreakBetween::RightPage
         || value == BreakBetween::RectoPage || value == BreakBetween::VersoPage)
-        return CSSPrimitiveValue::create(CSSValueAlways); // CSS 2.1 allows us to map these to always.
+        return createCSSValue(state.pool, state.style, CSS::Keyword::Always { }); // CSS 2.1 allows us to map these to always.
     if (value == BreakBetween::Avoid || value == BreakBetween::AvoidPage)
-        return CSSPrimitiveValue::create(CSSValueAvoid);
-    return CSSPrimitiveValue::create(CSSValueAuto);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::Avoid { });
+    return createCSSValue(state.pool, state.style, CSS::Keyword::Auto { });
 }
 
-inline Ref<CSSValue> ExtractorConverter::convertPageBreak(ExtractorState&, BreakInside value)
+inline Ref<CSSValue> ExtractorConverter::convertPageBreak(ExtractorState& state, BreakInside value)
 {
     if (value == BreakInside::Avoid || value == BreakInside::AvoidPage)
-        return CSSPrimitiveValue::create(CSSValueAvoid);
-    return CSSPrimitiveValue::create(CSSValueAuto);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::Avoid { });
+    return createCSSValue(state.pool, state.style, CSS::Keyword::Auto { });
 }
 
-inline Ref<CSSValue> ExtractorConverter::convertWebkitColumnBreak(ExtractorState&, BreakBetween value)
+inline Ref<CSSValue> ExtractorConverter::convertWebkitColumnBreak(ExtractorState& state, BreakBetween value)
 {
     if (value == BreakBetween::Column)
-        return CSSPrimitiveValue::create(CSSValueAlways);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::Always { });
     if (value == BreakBetween::Avoid || value == BreakBetween::AvoidColumn)
-        return CSSPrimitiveValue::create(CSSValueAvoid);
-    return CSSPrimitiveValue::create(CSSValueAuto);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::Avoid { });
+    return createCSSValue(state.pool, state.style, CSS::Keyword::Auto { });
 }
 
-inline Ref<CSSValue> ExtractorConverter::convertWebkitColumnBreak(ExtractorState&, BreakInside value)
+inline Ref<CSSValue> ExtractorConverter::convertWebkitColumnBreak(ExtractorState& state, BreakInside value)
 {
     if (value == BreakInside::Avoid || value == BreakInside::AvoidColumn)
-        return CSSPrimitiveValue::create(CSSValueAvoid);
-    return CSSPrimitiveValue::create(CSSValueAuto);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::Avoid { });
+    return createCSSValue(state.pool, state.style, CSS::Keyword::Auto { });
 }
 
 inline Ref<CSSValue> ExtractorConverter::convertSelfOrDefaultAlignmentData(ExtractorState& state, const StyleSelfAlignmentData& data)
 {
     CSSValueListBuilder list;
     if (data.positionType() == ItemPositionType::Legacy)
-        list.append(CSSPrimitiveValue::create(CSSValueLegacy));
+        list.append(createCSSValue(state.pool, state.style, CSS::Keyword::Legacy { }));
     if (data.position() == ItemPosition::Baseline)
-        list.append(CSSPrimitiveValue::create(CSSValueBaseline));
+        list.append(createCSSValue(state.pool, state.style, CSS::Keyword::Baseline { }));
     else if (data.position() == ItemPosition::LastBaseline) {
-        list.append(CSSPrimitiveValue::create(CSSValueLast));
-        list.append(CSSPrimitiveValue::create(CSSValueBaseline));
+        list.append(createCSSValue(state.pool, state.style, CSS::Keyword::Last { }));
+        list.append(createCSSValue(state.pool, state.style, CSS::Keyword::Baseline { }));
     } else {
         if (data.position() >= ItemPosition::Center && data.overflow() != OverflowAlignment::Default)
-            list.append(convert(state, data.overflow()));
+            list.append(createCSSValue(state.pool, state.style, data.overflow()));
         if (data.position() == ItemPosition::Legacy)
-            list.append(CSSPrimitiveValue::create(CSSValueNormal));
+            list.append(createCSSValue(state.pool, state.style, CSS::Keyword::Normal { }));
         else
-            list.append(convert(state, data.position()));
+            list.append(createCSSValue(state.pool, state.style, data.position()));
     }
     return CSSValueList::createSpaceSeparated(WTFMove(list));
 }
@@ -824,24 +765,24 @@ inline Ref<CSSValue> ExtractorConverter::convertContentAlignmentData(ExtractorSt
 
     // Handle content-distribution values
     if (data.distribution() != ContentDistribution::Default)
-        list.append(convert(state, data.distribution()));
+        list.append(createCSSValue(state.pool, state.style, data.distribution()));
 
     // Handle content-position values (either as fallback or actual value)
     switch (data.position()) {
     case ContentPosition::Normal:
         // Handle 'normal' value, not valid as content-distribution fallback.
         if (data.distribution() == ContentDistribution::Default)
-            list.append(CSSPrimitiveValue::create(CSSValueNormal));
+            list.append(createCSSValue(state.pool, state.style, CSS::Keyword::Normal { }));
         break;
     case ContentPosition::LastBaseline:
-        list.append(CSSPrimitiveValue::create(CSSValueLast));
-        list.append(CSSPrimitiveValue::create(CSSValueBaseline));
+        list.append(createCSSValue(state.pool, state.style, CSS::Keyword::Last { }));
+        list.append(createCSSValue(state.pool, state.style, CSS::Keyword::Baseline { }));
         break;
     default:
         // Handle overflow-alignment (only allowed for content-position values)
         if ((data.position() >= ContentPosition::Center || data.distribution() != ContentDistribution::Default) && data.overflow() != OverflowAlignment::Default)
-            list.append(convert(state, data.overflow()));
-        list.append(convert(state, data.position()));
+            list.append(createCSSValue(state.pool, state.style, data.overflow()));
+        list.append(createCSSValue(state.pool, state.style, data.position()));
     }
 
     ASSERT(list.size() > 0);
@@ -849,10 +790,10 @@ inline Ref<CSSValue> ExtractorConverter::convertContentAlignmentData(ExtractorSt
     return CSSValueList::createSpaceSeparated(WTFMove(list));
 }
 
-inline Ref<CSSValue> ExtractorConverter::convertPaintOrder(ExtractorState&, PaintOrder paintOrder)
+inline Ref<CSSValue> ExtractorConverter::convertPaintOrder(ExtractorState& state, PaintOrder paintOrder)
 {
     if (paintOrder == PaintOrder::Normal)
-        return CSSPrimitiveValue::create(CSSValueNormal);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::Normal { });
 
     CSSValueListBuilder paintOrderList;
     switch (paintOrder) {
@@ -860,25 +801,25 @@ inline Ref<CSSValue> ExtractorConverter::convertPaintOrder(ExtractorState&, Pain
         ASSERT_NOT_REACHED();
         break;
     case PaintOrder::Fill:
-        paintOrderList.append(CSSPrimitiveValue::create(CSSValueFill));
+        paintOrderList.append(createCSSValue(state.pool, state.style, CSS::Keyword::Fill { }));
         break;
     case PaintOrder::FillMarkers:
-        paintOrderList.append(CSSPrimitiveValue::create(CSSValueFill));
-        paintOrderList.append(CSSPrimitiveValue::create(CSSValueMarkers));
+        paintOrderList.append(createCSSValue(state.pool, state.style, CSS::Keyword::Fill { }));
+        paintOrderList.append(createCSSValue(state.pool, state.style, CSS::Keyword::Markers { }));
         break;
     case PaintOrder::Stroke:
-        paintOrderList.append(CSSPrimitiveValue::create(CSSValueStroke));
+        paintOrderList.append(createCSSValue(state.pool, state.style, CSS::Keyword::Stroke { }));
         break;
     case PaintOrder::StrokeMarkers:
-        paintOrderList.append(CSSPrimitiveValue::create(CSSValueStroke));
-        paintOrderList.append(CSSPrimitiveValue::create(CSSValueMarkers));
+        paintOrderList.append(createCSSValue(state.pool, state.style, CSS::Keyword::Stroke { }));
+        paintOrderList.append(createCSSValue(state.pool, state.style, CSS::Keyword::Markers { }));
         break;
     case PaintOrder::Markers:
-        paintOrderList.append(CSSPrimitiveValue::create(CSSValueMarkers));
+        paintOrderList.append(createCSSValue(state.pool, state.style, CSS::Keyword::Markers { }));
         break;
     case PaintOrder::MarkersStroke:
-        paintOrderList.append(CSSPrimitiveValue::create(CSSValueMarkers));
-        paintOrderList.append(CSSPrimitiveValue::create(CSSValueStroke));
+        paintOrderList.append(createCSSValue(state.pool, state.style, CSS::Keyword::Markers { }));
+        paintOrderList.append(createCSSValue(state.pool, state.style, CSS::Keyword::Stroke { }));
         break;
     }
     return CSSValueList::createSpaceSeparated(WTFMove(paintOrderList));
@@ -887,8 +828,8 @@ inline Ref<CSSValue> ExtractorConverter::convertPaintOrder(ExtractorState&, Pain
 inline Ref<CSSValue> ExtractorConverter::convertPositionAnchor(ExtractorState& state, const std::optional<ScopedName>& positionAnchor)
 {
     if (!positionAnchor)
-        return CSSPrimitiveValue::create(CSSValueAuto);
-    return convert(state, *positionAnchor);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::Auto { });
+    return createCSSValue(state.pool, state.style, *positionAnchor);
 }
 
 inline Ref<CSSValue> ExtractorConverter::convertPositionArea(ExtractorState&, const PositionArea& positionArea)
@@ -1029,48 +970,48 @@ inline Ref<CSSValue> ExtractorConverter::convertPositionArea(ExtractorState&, co
 inline Ref<CSSValue> ExtractorConverter::convertPositionArea(ExtractorState& state, const std::optional<PositionArea>& positionArea)
 {
     if (!positionArea)
-        return CSSPrimitiveValue::create(CSSValueNone);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::None { });
     return convertPositionArea(state, *positionArea);
 }
 
-inline Ref<CSSValue> ExtractorConverter::convertNameScope(ExtractorState&, const NameScope& scope)
+inline Ref<CSSValue> ExtractorConverter::convertNameScope(ExtractorState& state, const NameScope& scope)
 {
     switch (scope.type) {
     case NameScope::Type::None:
-        return CSSPrimitiveValue::create(CSSValueNone);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::None { });
 
     case NameScope::Type::All:
-        return CSSPrimitiveValue::create(CSSValueAll);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::All { });
 
     case NameScope::Type::Ident:
         if (scope.names.isEmpty())
-            return CSSPrimitiveValue::create(CSSValueNone);
+            return createCSSValue(state.pool, state.style, CSS::Keyword::None { });
 
         CSSValueListBuilder list;
         for (auto& name : scope.names) {
             ASSERT(!name.isNull());
-            list.append(CSSPrimitiveValue::createCustomIdent(name));
+            list.append(createCSSValue(state.pool, state.style, CustomIdentifier { name }));
         }
 
         return CSSValueList::createCommaSeparated(WTFMove(list));
     }
 
     ASSERT_NOT_REACHED();
-    return CSSPrimitiveValue::create(CSSValueNone);
+    return createCSSValue(state.pool, state.style, CSS::Keyword::None { });
 }
 
-inline Ref<CSSValue> ExtractorConverter::convertPositionVisibility(ExtractorState&, OptionSet<PositionVisibility> positionVisibility)
+inline Ref<CSSValue> ExtractorConverter::convertPositionVisibility(ExtractorState& state, OptionSet<PositionVisibility> positionVisibility)
 {
     CSSValueListBuilder list;
     if (positionVisibility & PositionVisibility::AnchorsValid)
-        list.append(CSSPrimitiveValue::create(CSSValueAnchorsValid));
+        list.append(createCSSValue(state.pool, state.style, CSS::Keyword::AnchorsValid { }));
     if (positionVisibility & PositionVisibility::AnchorsVisible)
-        list.append(CSSPrimitiveValue::create(CSSValueAnchorsVisible));
+        list.append(createCSSValue(state.pool, state.style, CSS::Keyword::AnchorsVisible { }));
     if (positionVisibility & PositionVisibility::NoOverflow)
-        list.append(CSSPrimitiveValue::create(CSSValueNoOverflow));
+        list.append(createCSSValue(state.pool, state.style, CSS::Keyword::NoOverflow { }));
 
     if (list.isEmpty())
-        return CSSPrimitiveValue::create(CSSValueAlways);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::Always { });
 
     return CSSValueList::createSpaceSeparated(WTFMove(list));
 }
@@ -1087,109 +1028,104 @@ inline Ref<CSSValue> ExtractorConverter::convertFillLayerWebkitMaskComposite(Ext
     return CSSPrimitiveValue::create(toCSSValueID(composite, CSSPropertyWebkitMaskComposite));
 }
 
-inline Ref<CSSValue> ExtractorConverter::convertFillLayerMaskMode(ExtractorState&, MaskMode maskMode)
+inline Ref<CSSValue> ExtractorConverter::convertFillLayerMaskMode(ExtractorState& state, MaskMode maskMode)
 {
     switch (maskMode) {
     case MaskMode::Alpha:
-        return CSSPrimitiveValue::create(CSSValueAlpha);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::Alpha { });
     case MaskMode::Luminance:
-        return CSSPrimitiveValue::create(CSSValueLuminance);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::Luminance { });
     case MaskMode::MatchSource:
-        return CSSPrimitiveValue::create(CSSValueMatchSource);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::MatchSource { });
     }
     ASSERT_NOT_REACHED();
-    return CSSPrimitiveValue::create(CSSValueMatchSource);
+    return createCSSValue(state.pool, state.style, CSS::Keyword::MatchSource { });
 }
 
-inline Ref<CSSValue> ExtractorConverter::convertFillLayerWebkitMaskSourceType(ExtractorState&, MaskMode maskMode)
+inline Ref<CSSValue> ExtractorConverter::convertFillLayerWebkitMaskSourceType(ExtractorState& state, MaskMode maskMode)
 {
     switch (maskMode) {
     case MaskMode::Alpha:
-        return CSSPrimitiveValue::create(CSSValueAlpha);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::Alpha { });
     case MaskMode::Luminance:
-        return CSSPrimitiveValue::create(CSSValueLuminance);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::Luminance { });
     case MaskMode::MatchSource:
         // MatchSource is only available in the mask-mode property.
-        return CSSPrimitiveValue::create(CSSValueAlpha);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::Alpha { });
     }
     ASSERT_NOT_REACHED();
-    return CSSPrimitiveValue::create(CSSValueAlpha);
+    return createCSSValue(state.pool, state.style, CSS::Keyword::Alpha { });
 }
 
 // MARK: - Font conversions
 
 inline Ref<CSSValue> ExtractorConverter::convertFontFamily(ExtractorState& state, const AtomString& family)
 {
-    auto identifierForFamily = [](const auto& family) {
-        if (family == cursiveFamily)
-            return CSSValueCursive;
-        if (family == fantasyFamily)
-            return CSSValueFantasy;
-        if (family == monospaceFamily)
-            return CSSValueMonospace;
-        if (family == mathFamily)
-            return CSSValueMath;
-        if (family == pictographFamily)
-            return CSSValueWebkitPictograph;
-        if (family == sansSerifFamily)
-            return CSSValueSansSerif;
-        if (family == serifFamily)
-            return CSSValueSerif;
-        if (family == systemUiFamily)
-            return CSSValueSystemUi;
-        return CSSValueInvalid;
-    };
+    if (family == cursiveFamily)
+        return createCSSValue(state.pool, state.style, CSS::Keyword::Cursive { });
+    if (family == fantasyFamily)
+        return createCSSValue(state.pool, state.style, CSS::Keyword::Fantasy { });
+    if (family == monospaceFamily)
+        return createCSSValue(state.pool, state.style, CSS::Keyword::Monospace { });
+    if (family == mathFamily)
+        return createCSSValue(state.pool, state.style, CSS::Keyword::Math { });
+    if (family == pictographFamily)
+        return createCSSValue(state.pool, state.style, CSS::Keyword::WebkitPictograph { });
+    if (family == sansSerifFamily)
+        return createCSSValue(state.pool, state.style, CSS::Keyword::SansSerif { });
+    if (family == serifFamily)
+        return createCSSValue(state.pool, state.style, CSS::Keyword::Serif { });
+    if (family == systemUiFamily)
+        return createCSSValue(state.pool, state.style, CSS::Keyword::SystemUi { });
 
-    if (auto familyIdentifier = identifierForFamily(family))
-        return CSSPrimitiveValue::create(familyIdentifier);
     return state.pool.createFontFamilyValue(family);
 }
 
 inline Ref<CSSValue> ExtractorConverter::convertFontSizeAdjust(ExtractorState& state, const FontSizeAdjust& fontSizeAdjust)
 {
     if (fontSizeAdjust.isNone())
-        return CSSPrimitiveValue::create(CSSValueNone);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::None { });
 
     auto metric = fontSizeAdjust.metric;
     auto value = fontSizeAdjust.shouldResolveFromFont() ? fontSizeAdjust.resolve(state.style.computedFontSize(), state.style.metricsOfPrimaryFont()) : fontSizeAdjust.value.asOptional();
     if (!value)
-        return CSSPrimitiveValue::create(CSSValueNone);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::None { });
 
     if (metric == FontSizeAdjust::Metric::ExHeight)
-        return CSSPrimitiveValue::create(*value);
+        return createCSSValue(state.pool, state.style, Number<> { *value });
 
-    return CSSValuePair::create(convert(state, metric), CSSPrimitiveValue::create(*value));
+    return CSSValuePair::create(createCSSValue(state.pool, state.style, metric), createCSSValue(state.pool, state.style, Number<> { *value }));
 }
 
-inline Ref<CSSValue> ExtractorConverter::convertFontPalette(ExtractorState&, const FontPalette& fontPalette)
+inline Ref<CSSValue> ExtractorConverter::convertFontPalette(ExtractorState& state, const FontPalette& fontPalette)
 {
     switch (fontPalette.type) {
     case FontPalette::Type::Normal:
-        return CSSPrimitiveValue::create(CSSValueNormal);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::Normal { });
     case FontPalette::Type::Light:
-        return CSSPrimitiveValue::create(CSSValueLight);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::Light { });
     case FontPalette::Type::Dark:
-        return CSSPrimitiveValue::create(CSSValueDark);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::Dark { });
     case FontPalette::Type::Custom:
-        return CSSPrimitiveValue::createCustomIdent(fontPalette.identifier);
+        return createCSSValue(state.pool, state.style, CustomIdentifier { fontPalette.identifier });
     }
     RELEASE_ASSERT_NOT_REACHED();
 }
 
-inline Ref<CSSValue> ExtractorConverter::convertFontWeight(ExtractorState&, FontSelectionValue fontWeight)
+inline Ref<CSSValue> ExtractorConverter::convertFontWeight(ExtractorState& state, FontSelectionValue fontWeight)
 {
-    return CSSPrimitiveValue::create(static_cast<float>(fontWeight));
+    return createCSSValue(state.pool, state.style, Number<> { static_cast<float>(fontWeight) });
 }
 
-inline Ref<CSSValue> ExtractorConverter::convertFontWidth(ExtractorState&, FontSelectionValue fontWidth)
+inline Ref<CSSValue> ExtractorConverter::convertFontWidth(ExtractorState& state, FontSelectionValue fontWidth)
 {
-    return CSSPrimitiveValue::create(static_cast<float>(fontWidth), CSSUnitType::CSS_PERCENTAGE);
+    return createCSSValue(state.pool, state.style, Percentage<> { static_cast<float>(fontWidth) });
 }
 
 inline Ref<CSSValue> ExtractorConverter::convertFontFeatureSettings(ExtractorState& state, const FontFeatureSettings& fontFeatureSettings)
 {
     if (!fontFeatureSettings.size())
-        return CSSPrimitiveValue::create(CSSValueNormal);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::Normal { });
     CSSValueListBuilder list;
     for (auto& feature : fontFeatureSettings)
         list.append(CSSFontFeatureValue::create(FontTag(feature.tag()), convert(state, feature.value())));
@@ -1199,7 +1135,7 @@ inline Ref<CSSValue> ExtractorConverter::convertFontFeatureSettings(ExtractorSta
 inline Ref<CSSValue> ExtractorConverter::convertFontVariationSettings(ExtractorState& state, const FontVariationSettings& fontVariationSettings)
 {
     if (fontVariationSettings.isEmpty())
-        return CSSPrimitiveValue::create(CSSValueNormal);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::Normal { });
     CSSValueListBuilder list;
     for (auto& feature : fontVariationSettings)
         list.append(CSSFontVariationValue::create(feature.tag(), convert(state, feature.value())));
@@ -1208,18 +1144,18 @@ inline Ref<CSSValue> ExtractorConverter::convertFontVariationSettings(ExtractorS
 
 // MARK: - Grid conversions
 
-inline Ref<CSSValue> ExtractorConverter::convertGridAutoFlow(ExtractorState&, GridAutoFlow gridAutoFlow)
+inline Ref<CSSValue> ExtractorConverter::convertGridAutoFlow(ExtractorState& state, GridAutoFlow gridAutoFlow)
 {
     ASSERT(gridAutoFlow & static_cast<GridAutoFlow>(InternalAutoFlowDirectionRow) || gridAutoFlow & static_cast<GridAutoFlow>(InternalAutoFlowDirectionColumn));
 
     CSSValueListBuilder list;
     if (gridAutoFlow & static_cast<GridAutoFlow>(InternalAutoFlowDirectionColumn))
-        list.append(CSSPrimitiveValue::create(CSSValueColumn));
+        list.append(createCSSValue(state.pool, state.style, CSS::Keyword::Column { }));
     else if (!(gridAutoFlow & static_cast<GridAutoFlow>(InternalAutoFlowAlgorithmDense)))
-        list.append(CSSPrimitiveValue::create(CSSValueRow));
+        list.append(createCSSValue(state.pool, state.style, CSS::Keyword::Row { }));
 
     if (gridAutoFlow & static_cast<GridAutoFlow>(InternalAutoFlowAlgorithmDense))
-        list.append(CSSPrimitiveValue::create(CSSValueDense));
+        list.append(createCSSValue(state.pool, state.style, CSS::Keyword::Dense { }));
 
     return CSSValueList::createSpaceSeparated(WTFMove(list));
 }

--- a/Source/WebCore/style/StyleExtractorCustom.h
+++ b/Source/WebCore/style/StyleExtractorCustom.h
@@ -233,6 +233,33 @@ public:
 
 template<CSSPropertyID> struct PropertyExtractorAdaptor;
 
+template<> struct PropertyExtractorAdaptor<CSSPropertyDirection> {
+    template<typename F> decltype(auto) computedValue(ExtractorState& state, F&& functor) const
+    {
+        if (state.element.ptr() == state.element->document().documentElement() && !state.style.hasExplicitlySetDirection())
+            return functor(RenderStyle::initialDirection());
+        return functor(state.style.writingMode().computedTextDirection());
+    }
+};
+
+template<> struct PropertyExtractorAdaptor<CSSPropertyWritingMode> {
+    template<typename F> decltype(auto) computedValue(ExtractorState& state, F&& functor) const
+    {
+        if (state.element.ptr() == state.element->document().documentElement() && !state.style.hasExplicitlySetWritingMode())
+            return functor(RenderStyle::initialWritingMode());
+        return functor(state.style.writingMode().computedWritingMode());
+    }
+};
+
+template<> struct PropertyExtractorAdaptor<CSSPropertyFloat> {
+    template<typename F> decltype(auto) computedValue(ExtractorState& state, F&& functor) const
+    {
+        if (state.style.hasOutOfFlowPosition())
+            return functor(CSS::Keyword::None { });
+        return functor(state.style.floating());
+    }
+};
+
 template<> struct PropertyExtractorAdaptor<CSSPropertyContent> {
     template<typename F> decltype(auto) computedValue(ExtractorState& state, F&& functor) const
     {
@@ -450,7 +477,7 @@ template<CSSPropertyID propertyID, typename InsetEdgeApplier, typename NumberAsP
 template<CSSPropertyID propertyID> Ref<CSSValue> extractZoomAdjustedInsetValue(ExtractorState& state)
 {
     return extractZoomAdjustedInset<propertyID>(state,
-        [&](const auto& edge)   -> Ref<CSSValue> { return ExtractorConverter::convertStyleType(state, edge); },
+        [&](const auto& edge)   -> Ref<CSSValue> { return createCSSValue(state.pool, state.style, edge); },
         [&](const auto& number) -> Ref<CSSValue> { return ExtractorConverter::convertNumberAsPixels(state, number); },
         [&](const auto& value)  -> Ref<CSSValue> { return CSSPrimitiveValue::create(value); }
     );
@@ -459,7 +486,7 @@ template<CSSPropertyID propertyID> Ref<CSSValue> extractZoomAdjustedInsetValue(E
 template<CSSPropertyID propertyID> void extractZoomAdjustedInsetSerialization(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context)
 {
     extractZoomAdjustedInset<propertyID>(state,
-        [&](const auto& edge)   { ExtractorSerializer::serializeStyleType(state, builder, context, edge); },
+        [&](const auto& edge)   { serializationForCSS(builder, context, state.style, edge); },
         [&](const auto& number) { ExtractorSerializer::serializeNumberAsPixels(state, builder, context, number); },
         [&](const auto& value)  { builder.append(nameLiteralForSerialization(value)); }
     );
@@ -520,7 +547,7 @@ template<auto styleGetter, auto computedCSSValueGetter> Ref<CSSValue> extractZoo
 {
     auto* renderBox = dynamicDowncast<RenderBox>(state.renderer);
     if (!renderBox)
-        return ExtractorConverter::convertStyleType(state, (state.style.*styleGetter)());
+        return createCSSValue(state.pool, state.style, (state.style.*styleGetter)());
     return ExtractorConverter::convertNumberAsPixels(state, (renderBox->*computedCSSValueGetter)());
 }
 
@@ -528,7 +555,7 @@ template<auto styleGetter, auto computedCSSValueGetter> void extractZoomAdjusted
 {
     auto* renderBox = dynamicDowncast<RenderBox>(state.renderer);
     if (!renderBox) {
-        ExtractorSerializer::serializeStyleType(state, builder, context, (state.style.*styleGetter)());
+        serializationForCSS(builder, context, state.style, (state.style.*styleGetter)());
         return;
     }
 
@@ -540,7 +567,7 @@ template<auto styleGetter, auto computedCSSValueGetter> Ref<CSSValue> extractZoo
     auto& paddingEdge  = (state.style.*styleGetter)();
     auto* renderBox = dynamicDowncast<RenderBox>(state.renderer);
     if (!renderBox || paddingEdge.isFixed())
-        return ExtractorConverter::convertStyleType(state, paddingEdge);
+        return createCSSValue(state.pool, state.style, paddingEdge);
     return ExtractorConverter::convertNumberAsPixels(state, (renderBox->*computedCSSValueGetter)());
 }
 
@@ -549,7 +576,7 @@ template<auto styleGetter, auto computedCSSValueGetter> void extractZoomAdjusted
     auto paddingEdge = (state.style.*styleGetter)();
     auto* renderBox = dynamicDowncast<RenderBox>(state.renderer);
     if (!renderBox || paddingEdge.isFixed()) {
-        ExtractorSerializer::serializeStyleType(state, builder, context, paddingEdge);
+        serializationForCSS(builder, context, state.style, paddingEdge);
         return;
     }
     ExtractorSerializer::serializeNumberAsPixels(state, builder, context, (renderBox->*computedCSSValueGetter)());
@@ -574,7 +601,7 @@ template<auto styleGetter, auto boxGetter> Ref<CSSValue> extractZoomAdjustedPref
         if (!isNonReplacedInline(*state.renderer))
             return ExtractorConverter::convertNumberAsPixels(state, (sizingBox(*state.renderer).*boxGetter)());
     }
-    return ExtractorConverter::convertStyleType(state, (state.style.*styleGetter)());
+    return createCSSValue(state.pool, state.style, (state.style.*styleGetter)());
 }
 
 template<auto styleGetter, auto boxGetter> void extractZoomAdjustedPreferredSizeSerialization(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context)
@@ -599,26 +626,26 @@ template<auto styleGetter, auto boxGetter> void extractZoomAdjustedPreferredSize
         }
     }
 
-    ExtractorSerializer::serializeStyleType(state, builder, context, (state.style.*styleGetter)());
+    serializationForCSS(builder, context, state.style, (state.style.*styleGetter)());
 }
 
 template<auto styleGetter> Ref<CSSValue> extractZoomAdjustedMaxSizeValue(ExtractorState& state)
 {
     auto unzoomedLength = (state.style.*styleGetter)();
     if (unzoomedLength.isNone())
-        return CSSPrimitiveValue::create(CSSValueNone);
-    return ExtractorConverter::convertStyleType(state, unzoomedLength);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::None { });
+    return createCSSValue(state.pool, state.style, unzoomedLength);
 }
 
 template<auto styleGetter> void extractZoomAdjustedMaxSizeSerialization(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context)
 {
     auto unzoomedLength = (state.style.*styleGetter)();
     if (unzoomedLength.isNone()) {
-        CSS::serializationForCSS(builder, context, CSS::Keyword::None { });
+        serializationForCSS(builder, context, state.style, CSS::Keyword::None { });
         return;
     }
 
-    ExtractorSerializer::serializeStyleType(state, builder, context, unzoomedLength);
+    serializationForCSS(builder, context, state.style, unzoomedLength);
 }
 
 template<auto styleGetter> Ref<CSSValue> extractZoomAdjustedMinSizeValue(ExtractorState& state)
@@ -631,10 +658,10 @@ template<auto styleGetter> Ref<CSSValue> extractZoomAdjustedMinSizeValue(Extract
     auto unzoomedLength = (state.style.*styleGetter)();
     if (unzoomedLength.isAuto()) {
         if (isFlexOrGridItem(state.renderer))
-            return CSSPrimitiveValue::create(CSSValueAuto);
+            return createCSSValue(state.pool, state.style, CSS::Keyword::Auto { });
         return ExtractorConverter::convertNumberAsPixels(state, 0);
     }
-    return ExtractorConverter::convertStyleType(state, unzoomedLength);
+    return createCSSValue(state.pool, state.style, unzoomedLength);
 }
 
 template<auto styleGetter> void extractZoomAdjustedMinSizeSerialization(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context)
@@ -647,7 +674,7 @@ template<auto styleGetter> void extractZoomAdjustedMinSizeSerialization(Extracto
     auto unzoomedLength = (state.style.*styleGetter)();
     if (unzoomedLength.isAuto()) {
         if (isFlexOrGridItem(state.renderer)) {
-            CSS::serializationForCSS(builder, context, CSS::Keyword::Auto { });
+            serializationForCSS(builder, context, state.style, CSS::Keyword::Auto { });
             return;
         }
 
@@ -655,14 +682,14 @@ template<auto styleGetter> void extractZoomAdjustedMinSizeSerialization(Extracto
         return;
     }
 
-    ExtractorSerializer::serializeStyleType(state, builder, context, unzoomedLength);
+    serializationForCSS(builder, context, state.style, unzoomedLength);
 }
 
 template<CSSPropertyID propertyID> Ref<CSSValue> extractCounterValue(ExtractorState& state)
 {
     auto& map = state.style.counterDirectives().map;
     if (map.isEmpty())
-        return CSSPrimitiveValue::create(CSSValueNone);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::None { });
 
     CSSValueListBuilder list;
     for (auto& keyValue : map) {
@@ -681,14 +708,14 @@ template<CSSPropertyID propertyID> Ref<CSSValue> extractCounterValue(ExtractorSt
     }
     if (!list.isEmpty())
         return CSSValueList::createSpaceSeparated(WTFMove(list));
-    return CSSPrimitiveValue::create(CSSValueNone);
+    return createCSSValue(state.pool, state.style, CSS::Keyword::None { });
 }
 
 template<CSSPropertyID propertyID> void extractCounterSerialization(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context)
 {
     auto& map = state.style.counterDirectives().map;
     if (map.isEmpty()) {
-        CSS::serializationForCSS(builder, context, CSS::Keyword::None { });
+        serializationForCSS(builder, context, state.style, CSS::Keyword::None { });
         return;
     }
 
@@ -707,16 +734,16 @@ template<CSSPropertyID propertyID> void extractCounterSerialization(ExtractorSta
             if (!listEmpty)
                 builder.append(' ');
 
-            CSS::serializationForCSS(builder, context, CustomIdentifier { keyValue.key });
+            serializationForCSS(builder, context, state.style, CustomIdentifier { keyValue.key });
             builder.append(' ');
-            CSS::serializationForCSS(builder, context, CSS::IntegerRaw<> { *number });
+            serializationForCSS(builder, context, state.style, Integer<> { *number });
 
             listEmpty = false;
         }
     }
 
     if (listEmpty)
-        CSS::serializationForCSS(builder, context, CSS::Keyword::None { });
+        serializationForCSS(builder, context, state.style, CSS::Keyword::None { });
 }
 
 template<GridTrackSizingDirection direction> Ref<CSSValue> extractGridTemplateValue(ExtractorState& state)
@@ -734,7 +761,7 @@ template<GridTrackSizingDirection direction> Ref<CSSValue> extractGridTemplateVa
     auto& tracks = state.style.gridTemplateList(direction);
 
     if (tracks.masonry)
-        return CSSPrimitiveValue::create(CSSValueMasonry);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::Masonry { });
 
     auto* renderGrid = dynamicDowncast<RenderGrid>(state.renderer);
 
@@ -753,7 +780,7 @@ template<GridTrackSizingDirection direction> Ref<CSSValue> extractGridTemplateVa
     bool isSubgrid = tracks.subgrid;
 
     if (trackListIsEmpty && !isSubgrid)
-        return CSSPrimitiveValue::create(CSSValueNone);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::None { });
 
     CSSValueListBuilder list;
 
@@ -763,7 +790,7 @@ template<GridTrackSizingDirection direction> Ref<CSSValue> extractGridTemplateVa
     // an appropriate grid parent), then we fall back to using the specified value.
     if (renderGrid && (!isSubgrid || renderGrid->isSubgrid(direction))) {
         if (isSubgrid) {
-            list.append(CSSPrimitiveValue::create(CSSValueSubgrid));
+            list.append(createCSSValue(state.pool, state.style, CSS::Keyword::Subgrid { }));
 
             OrderedNamedLinesCollectorInSubgridLayout collector(state, tracks, renderGrid->numTracks(direction));
             for (int i = 0; i < collector.namedGridLineCount(); i++)
@@ -801,13 +828,13 @@ template<GridTrackSizingDirection direction> Ref<CSSValue> extractGridTemplateVa
                 return;
             list.append(CSSGridLineNamesValue::create(names));
         } else
-            list.append(ExtractorConverter::convertStyleType(state, std::get<GridTrackSize>(entry)));
+            list.append(createCSSValue(state.pool, state.style, std::get<GridTrackSize>(entry)));
     };
 
     for (auto& entry : computedTracks) {
         WTF::switchOn(entry,
             [&](const GridTrackSize& size) {
-                list.append(ExtractorConverter::convertStyleType(state, size));
+                list.append(createCSSValue(state.pool, state.style, size));
             },
             [&](const Vector<String>& names) {
                 // Subgrids don't have track sizes specified, so empty line names sets
@@ -829,10 +856,10 @@ template<GridTrackSizingDirection direction> Ref<CSSValue> extractGridTemplateVa
                 list.append(CSSGridAutoRepeatValue::create(repeat.type == AutoRepeatType::Fill ? CSSValueAutoFill : CSSValueAutoFit, WTFMove(repeatedValues)));
             },
             [&](const GridTrackEntrySubgrid&) {
-                list.append(CSSPrimitiveValue::create(CSSValueSubgrid));
+                list.append(createCSSValue(state.pool, state.style, CSS::Keyword::Subgrid { }));
             },
             [&](const GridTrackEntryMasonry&) {
-                list.append(CSSPrimitiveValue::create(CSSValueMasonry));
+                list.append(createCSSValue(state.pool, state.style, CSS::Keyword::Masonry { }));
             }
         );
     }
@@ -1062,8 +1089,8 @@ inline Ref<CSSValue> extractBorderRadiusShorthand(ExtractorState& state, CSSProp
     };
 
     auto extractBorderRadiusCornerValues = [&](auto& state, const auto& radius) {
-        auto x = ExtractorConverter::convertStyleType(state, radius.width());
-        auto y = radius.width() == radius.height() ? x.copyRef() : ExtractorConverter::convertStyleType(state, radius.height());
+        auto x = createCSSValue(state.pool, state.style, radius.width());
+        auto y = radius.width() == radius.height() ? x.copyRef() : createCSSValue(state.pool, state.style, radius.height());
         return std::pair<Ref<CSSValue>, Ref<CSSValue>> { WTFMove(x), WTFMove(y) };
     };
 
@@ -1153,7 +1180,7 @@ template<CSSPropertyID property> inline Ref<CSSValue> extractFillLayerPropertySh
     }();
     if (!layerCount) {
         ASSERT(property == CSSPropertyMask);
-        return CSSPrimitiveValue::create(CSSValueNone);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::None { });
     }
 
     auto lastValue = lastLayerProperty != CSSPropertyInvalid ? ExtractorGenerated::extractValue(state, lastLayerProperty) : nullptr;
@@ -1193,55 +1220,34 @@ template<CSSPropertyID property> inline void extractFillLayerPropertyShorthandSe
 
 // MARK: - Custom Extractors
 
-inline CSSValueID extractDirectionValueID(ExtractorState& state)
-{
-    if (state.element.ptr() == state.element->document().documentElement() && !state.style.hasExplicitlySetDirection())
-        return toCSSValueID(RenderStyle::initialDirection());
-    return toCSSValueID(state.style.writingMode().computedTextDirection());
-}
-
 inline Ref<CSSValue> ExtractorCustom::extractDirection(ExtractorState& state)
 {
-    return CSSPrimitiveValue::create(extractDirectionValueID(state));
+    return extractCSSValue<CSSPropertyDirection>(state);
 }
 
-inline void ExtractorCustom::extractDirectionSerialization(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext&)
+inline void ExtractorCustom::extractDirectionSerialization(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context)
 {
-    builder.append(nameLiteralForSerialization(extractDirectionValueID(state)));
-}
-
-inline CSSValueID extractWritingModeValueID(ExtractorState& state)
-{
-    if (state.element.ptr() == state.element->document().documentElement() && !state.style.hasExplicitlySetWritingMode())
-        return toCSSValueID(RenderStyle::initialWritingMode());
-    return toCSSValueID(state.style.writingMode().computedWritingMode());
+    extractSerialization<CSSPropertyDirection>(state, builder, context);
 }
 
 inline Ref<CSSValue> ExtractorCustom::extractWritingMode(ExtractorState& state)
 {
-    return CSSPrimitiveValue::create(extractWritingModeValueID(state));
+    return extractCSSValue<CSSPropertyWritingMode>(state);
 }
 
-inline void ExtractorCustom::extractWritingModeSerialization(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext&)
+inline void ExtractorCustom::extractWritingModeSerialization(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context)
 {
-    builder.append(nameLiteralForSerialization(extractWritingModeValueID(state)));
+    extractSerialization<CSSPropertyWritingMode>(state, builder, context);
 }
 
 inline Ref<CSSValue> ExtractorCustom::extractFloat(ExtractorState& state)
 {
-    if (state.style.hasOutOfFlowPosition())
-        return CSSPrimitiveValue::create(CSSValueNone);
-    return ExtractorConverter::convert(state, state.style.floating());
+    return extractCSSValue<CSSPropertyFloat>(state);
 }
 
 inline void ExtractorCustom::extractFloatSerialization(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context)
 {
-    if (state.style.hasOutOfFlowPosition()) {
-        CSS::serializationForCSS(builder, context, CSS::Keyword::None { });
-        return;
-    }
-
-    ExtractorSerializer::serialize(state, builder, context, state.style.floating());
+    extractSerialization<CSSPropertyFloat>(state, builder, context);
 }
 
 inline Ref<CSSValue> ExtractorCustom::extractContent(ExtractorState& state)
@@ -1258,7 +1264,7 @@ inline Ref<CSSValue> ExtractorCustom::extractLetterSpacing(ExtractorState& state
 {
     auto& spacing = state.style.computedLetterSpacing();
     if (spacing.isFixed() && spacing.isZero())
-        return CSSPrimitiveValue::create(CSSValueNormal);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::Normal { });
     return ExtractorConverter::convertLength(state, spacing);
 }
 
@@ -1266,7 +1272,7 @@ inline void ExtractorCustom::extractLetterSpacingSerialization(ExtractorState& s
 {
     auto& spacing = state.style.computedLetterSpacing();
     if (spacing.isFixed() && spacing.isZero()) {
-        CSS::serializationForCSS(builder, context, CSS::Keyword::Normal { });
+        serializationForCSS(builder, context, state.style, CSS::Keyword::Normal { });
         return;
     }
     ExtractorSerializer::serializeLength(state, builder, context, spacing);
@@ -1286,7 +1292,7 @@ inline Ref<CSSValue> ExtractorCustom::extractLineHeight(ExtractorState& state)
 {
     auto& length = state.style.lineHeight();
     if (length.isNormal())
-        return CSSPrimitiveValue::create(CSSValueNormal);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::Normal { });
     if (length.isPercent()) {
         // BuilderConverter::convertLineHeight() will convert a percentage value to a fixed value,
         // and a number value to a percentage value. To be able to roundtrip a number value, we thus
@@ -1307,7 +1313,7 @@ inline void ExtractorCustom::extractLineHeightSerialization(ExtractorState& stat
 {
     auto& length = state.style.lineHeight();
     if (length.isNormal()) {
-        CSS::serializationForCSS(builder, context, CSS::Keyword::Normal { });
+        serializationForCSS(builder, context, state.style, CSS::Keyword::Normal { });
         return;
     }
     if (length.isPercent()) {
@@ -1315,7 +1321,7 @@ inline void ExtractorCustom::extractLineHeightSerialization(ExtractorState& stat
         // and a number value to a percentage value. To be able to roundtrip a number value, we thus
         // look for a percent value and convert it back to a number.
         if (state.valueType == ExtractorState::PropertyValueType::Computed) {
-            ExtractorSerializer::serializeNumber(state, builder, context, length.value() / 100);
+            serializationForCSS(builder, context, state.style, Number<> { length.value() / 100 });
             return;
         }
 
@@ -1376,13 +1382,13 @@ inline void ExtractorCustom::extractFontStyleSerialization(ExtractorState& state
 
     float angle = *italic;
     if (!angle) {
-        CSS::serializationForCSS(builder, context, CSS::Keyword::Normal { });
+        serializationForCSS(builder, context, state.style, CSS::Keyword::Normal { });
         return;
     }
 
-    CSS::serializationForCSS(builder, context, CSS::Keyword::Oblique { });
+    serializationForCSS(builder, context, state.style, CSS::Keyword::Oblique { });
     builder.append(' ');
-    CSS::serializationForCSS(builder, context, CSS::AngleRaw<> { CSS::AngleUnit::Deg, angle });
+    serializationForCSS(builder, context, state.style, Angle<> { angle });
 }
 
 inline Ref<CSSValue> ExtractorCustom::extractFontVariantLigatures(ExtractorState& state)
@@ -1393,9 +1399,9 @@ inline Ref<CSSValue> ExtractorCustom::extractFontVariantLigatures(ExtractorState
     auto contextualAlternates = state.style.fontDescription().variantContextualAlternates();
 
     if (common == FontVariantLigatures::No && discretionary == FontVariantLigatures::No && historical == FontVariantLigatures::No && contextualAlternates == FontVariantLigatures::No)
-        return CSSPrimitiveValue::create(CSSValueNone);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::None { });
     if (common == FontVariantLigatures::Normal && discretionary == FontVariantLigatures::Normal && historical == FontVariantLigatures::Normal && contextualAlternates == FontVariantLigatures::Normal)
-        return CSSPrimitiveValue::create(CSSValueNormal);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::Normal { });
 
     auto appendLigaturesValue = [](auto& list, auto value, auto yesValue, auto noValue) {
         switch (value) {
@@ -1434,17 +1440,17 @@ inline Ref<CSSValue> ExtractorCustom::extractFontVariantNumeric(ExtractorState& 
     auto slashedZero = state.style.fontDescription().variantNumericSlashedZero();
 
     if (figure == FontVariantNumericFigure::Normal && spacing == FontVariantNumericSpacing::Normal && fraction == FontVariantNumericFraction::Normal && ordinal == FontVariantNumericOrdinal::Normal && slashedZero == FontVariantNumericSlashedZero::Normal)
-        return CSSPrimitiveValue::create(CSSValueNormal);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::Normal { });
 
     CSSValueListBuilder valueList;
     switch (figure) {
     case FontVariantNumericFigure::Normal:
         break;
     case FontVariantNumericFigure::LiningNumbers:
-        valueList.append(CSSPrimitiveValue::create(CSSValueLiningNums));
+        valueList.append(createCSSValue(state.pool, state.style, CSS::Keyword::LiningNums { }));
         break;
     case FontVariantNumericFigure::OldStyleNumbers:
-        valueList.append(CSSPrimitiveValue::create(CSSValueOldstyleNums));
+        valueList.append(createCSSValue(state.pool, state.style, CSS::Keyword::OldstyleNums { }));
         break;
     }
 
@@ -1452,10 +1458,10 @@ inline Ref<CSSValue> ExtractorCustom::extractFontVariantNumeric(ExtractorState& 
     case FontVariantNumericSpacing::Normal:
         break;
     case FontVariantNumericSpacing::ProportionalNumbers:
-        valueList.append(CSSPrimitiveValue::create(CSSValueProportionalNums));
+        valueList.append(createCSSValue(state.pool, state.style, CSS::Keyword::ProportionalNums { }));
         break;
     case FontVariantNumericSpacing::TabularNumbers:
-        valueList.append(CSSPrimitiveValue::create(CSSValueTabularNums));
+        valueList.append(createCSSValue(state.pool, state.style, CSS::Keyword::TabularNums { }));
         break;
     }
 
@@ -1463,17 +1469,17 @@ inline Ref<CSSValue> ExtractorCustom::extractFontVariantNumeric(ExtractorState& 
     case FontVariantNumericFraction::Normal:
         break;
     case FontVariantNumericFraction::DiagonalFractions:
-        valueList.append(CSSPrimitiveValue::create(CSSValueDiagonalFractions));
+        valueList.append(createCSSValue(state.pool, state.style, CSS::Keyword::DiagonalFractions { }));
         break;
     case FontVariantNumericFraction::StackedFractions:
-        valueList.append(CSSPrimitiveValue::create(CSSValueStackedFractions));
+        valueList.append(createCSSValue(state.pool, state.style, CSS::Keyword::StackedFractions { }));
         break;
     }
 
     if (ordinal == FontVariantNumericOrdinal::Yes)
-        valueList.append(CSSPrimitiveValue::create(CSSValueOrdinal));
+        valueList.append(createCSSValue(state.pool, state.style, CSS::Keyword::Ordinal { }));
     if (slashedZero == FontVariantNumericSlashedZero::Yes)
-        valueList.append(CSSPrimitiveValue::create(CSSValueSlashedZero));
+        valueList.append(createCSSValue(state.pool, state.style, CSS::Keyword::SlashedZero { }));
 
     return CSSValueList::createSpaceSeparated(WTFMove(valueList));
 }
@@ -1488,7 +1494,7 @@ inline Ref<CSSValue> ExtractorCustom::extractFontVariantAlternates(ExtractorStat
 {
     auto alternates = state.style.fontDescription().variantAlternates();
     if (alternates.isNormal())
-        return CSSPrimitiveValue::create(CSSValueNormal);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::Normal { });
 
     CSSValueListBuilder valueList;
 
@@ -1496,7 +1502,7 @@ inline Ref<CSSValue> ExtractorCustom::extractFontVariantAlternates(ExtractorStat
         valueList.append(CSSFunctionValue::create(CSSValueStylistic, CSSPrimitiveValue::createCustomIdent(alternates.values().stylistic)));
 
     if (alternates.values().historicalForms)
-        valueList.append(CSSPrimitiveValue::create(CSSValueHistoricalForms));
+        valueList.append(createCSSValue(state.pool, state.style, CSS::Keyword::HistoricalForms { }));
 
     if (!alternates.values().styleset.isEmpty()) {
         CSSValueListBuilder stylesetArguments;
@@ -1539,29 +1545,29 @@ inline Ref<CSSValue> ExtractorCustom::extractFontVariantEastAsian(ExtractorState
     auto width = state.style.fontDescription().variantEastAsianWidth();
     auto ruby = state.style.fontDescription().variantEastAsianRuby();
     if (variant == FontVariantEastAsianVariant::Normal && width == FontVariantEastAsianWidth::Normal && ruby == FontVariantEastAsianRuby::Normal)
-        return CSSPrimitiveValue::create(CSSValueNormal);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::Normal { });
 
     CSSValueListBuilder valueList;
     switch (variant) {
     case FontVariantEastAsianVariant::Normal:
         break;
     case FontVariantEastAsianVariant::Jis78:
-        valueList.append(CSSPrimitiveValue::create(CSSValueJis78));
+        valueList.append(createCSSValue(state.pool, state.style, CSS::Keyword::Jis78 { }));
         break;
     case FontVariantEastAsianVariant::Jis83:
-        valueList.append(CSSPrimitiveValue::create(CSSValueJis83));
+        valueList.append(createCSSValue(state.pool, state.style, CSS::Keyword::Jis83 { }));
         break;
     case FontVariantEastAsianVariant::Jis90:
-        valueList.append(CSSPrimitiveValue::create(CSSValueJis90));
+        valueList.append(createCSSValue(state.pool, state.style, CSS::Keyword::Jis90 { }));
         break;
     case FontVariantEastAsianVariant::Jis04:
-        valueList.append(CSSPrimitiveValue::create(CSSValueJis04));
+        valueList.append(createCSSValue(state.pool, state.style, CSS::Keyword::Jis04 { }));
         break;
     case FontVariantEastAsianVariant::Simplified:
-        valueList.append(CSSPrimitiveValue::create(CSSValueSimplified));
+        valueList.append(createCSSValue(state.pool, state.style, CSS::Keyword::Simplified { }));
         break;
     case FontVariantEastAsianVariant::Traditional:
-        valueList.append(CSSPrimitiveValue::create(CSSValueTraditional));
+        valueList.append(createCSSValue(state.pool, state.style, CSS::Keyword::Traditional { }));
         break;
     }
 
@@ -1569,15 +1575,15 @@ inline Ref<CSSValue> ExtractorCustom::extractFontVariantEastAsian(ExtractorState
     case FontVariantEastAsianWidth::Normal:
         break;
     case FontVariantEastAsianWidth::Full:
-        valueList.append(CSSPrimitiveValue::create(CSSValueFullWidth));
+        valueList.append(createCSSValue(state.pool, state.style, CSS::Keyword::FullWidth { }));
         break;
     case FontVariantEastAsianWidth::Proportional:
-        valueList.append(CSSPrimitiveValue::create(CSSValueProportionalWidth));
+        valueList.append(createCSSValue(state.pool, state.style, CSS::Keyword::ProportionalWidth { }));
         break;
     }
 
     if (ruby == FontVariantEastAsianRuby::Yes)
-        valueList.append(CSSPrimitiveValue::create(CSSValueRuby));
+        valueList.append(createCSSValue(state.pool, state.style, CSS::Keyword::Ruby { }));
 
     return CSSValueList::createSpaceSeparated(WTFMove(valueList));
 }
@@ -1655,7 +1661,7 @@ inline Ref<CSSValue> ExtractorCustom::extractMarginRight(ExtractorState& state)
 
     auto& marginRight = state.style.marginRight();
     if (marginRight.isFixed() || !box)
-        return ExtractorConverter::convertStyleType(state, marginRight);
+        return createCSSValue(state.pool, state.style, marginRight);
 
     float value;
     if (marginRight.isPercentOrCalculated()) {
@@ -1678,7 +1684,7 @@ inline void ExtractorCustom::extractMarginRightSerialization(ExtractorState& sta
 
     auto& marginRight = state.style.marginRight();
     if (marginRight.isFixed() || !box) {
-        ExtractorSerializer::serializeStyleType(state, builder, context, marginRight);
+        serializationForCSS(builder, context, state.style, marginRight);
         return;
     }
 
@@ -1957,12 +1963,12 @@ inline Ref<CSSValue> ExtractorCustom::extractGridAutoFlow(ExtractorState& state)
     CSSValueListBuilder list;
     ASSERT(state.style.isGridAutoFlowDirectionRow() || state.style.isGridAutoFlowDirectionColumn());
     if (state.style.isGridAutoFlowDirectionColumn())
-        list.append(CSSPrimitiveValue::create(CSSValueColumn));
+        list.append(createCSSValue(state.pool, state.style, CSS::Keyword::Column { }));
     else if (!state.style.isGridAutoFlowAlgorithmDense())
-        list.append(CSSPrimitiveValue::create(CSSValueRow));
+        list.append(createCSSValue(state.pool, state.style, CSS::Keyword::Row { }));
 
     if (state.style.isGridAutoFlowAlgorithmDense())
-        list.append(CSSPrimitiveValue::create(CSSValueDense));
+        list.append(createCSSValue(state.pool, state.style, CSS::Keyword::Dense { }));
 
     return CSSValueList::createSpaceSeparated(WTFMove(list));
 }
@@ -1973,17 +1979,17 @@ inline void ExtractorCustom::extractGridAutoFlowSerialization(ExtractorState& st
 
     bool listEmpty = true;
     if (state.style.isGridAutoFlowDirectionColumn()) {
-        CSS::serializationForCSS(builder, context, CSS::Keyword::Column { });
+        serializationForCSS(builder, context, state.style, CSS::Keyword::Column { });
         listEmpty = false;
     } else if (!state.style.isGridAutoFlowAlgorithmDense()) {
-        CSS::serializationForCSS(builder, context, CSS::Keyword::Row { });
+        serializationForCSS(builder, context, state.style, CSS::Keyword::Row { });
         listEmpty = false;
     }
 
     if (state.style.isGridAutoFlowAlgorithmDense()) {
         if (!listEmpty)
             builder.append(' ');
-        CSS::serializationForCSS(builder, context, CSS::Keyword::Dense { });
+        serializationForCSS(builder, context, state.style, CSS::Keyword::Dense { });
     }
 }
 
@@ -2160,7 +2166,7 @@ inline Ref<CSSValue> convertSingleAnimation(ExtractorState& state, const Animati
     if (animation.compositeOperation() != Animation::initialCompositeOperation())
         list.append(createCSSValue(state.pool, state.style, animation.compositeOperation()));
     if (list.isEmpty())
-        return CSSPrimitiveValue::create(CSSValueNone);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::None { });
     return CSSValueList::createSpaceSeparated(WTFMove(list));
 }
 
@@ -2295,7 +2301,7 @@ inline void ExtractorCustom::extractBackgroundShorthandSerialization(ExtractorSt
 inline RefPtr<CSSValue> ExtractorCustom::extractBackgroundPositionShorthand(ExtractorState& state)
 {
     auto mapper = [](auto& state, auto& layer) -> Ref<CSSValue> {
-        return ExtractorConverter::convertStyleType(state, layer.position());
+        return createCSSValue(state.pool, state.style, layer.position());
     };
     return extractFillLayerValue(state, state.style.backgroundLayers(), mapper);
 }
@@ -2305,7 +2311,7 @@ inline void ExtractorCustom::extractBackgroundPositionShorthandSerialization(Ext
     auto mapper = [](auto& state, auto& builder, const auto& context, bool includeComma, auto& layer) {
         if (includeComma)
             builder.append(", "_s);
-        ExtractorSerializer::serializeStyleType(state, builder, context, layer.position());
+        serializationForCSS(builder, context, state.style, layer.position());
     };
     extractFillLayerValueSerialization(state, builder, context, state.style.backgroundLayers(), mapper);
 }
@@ -2314,21 +2320,21 @@ inline RefPtr<CSSValue> ExtractorCustom::extractBlockStepShorthand(ExtractorStat
 {
     CSSValueListBuilder list;
     if (auto blockStepSize = state.style.blockStepSize(); blockStepSize != RenderStyle::initialBlockStepSize())
-        list.append(ExtractorConverter::convertStyleType(state, blockStepSize));
+        list.append(createCSSValue(state.pool, state.style, blockStepSize));
 
     if (auto blockStepInsert = state.style.blockStepInsert(); blockStepInsert != RenderStyle::initialBlockStepInsert())
-        list.append(ExtractorConverter::convert(state, blockStepInsert));
+        list.append(createCSSValue(state.pool, state.style, blockStepInsert));
 
     if (auto blockStepAlign = state.style.blockStepAlign(); blockStepAlign != RenderStyle::initialBlockStepAlign())
-        list.append(ExtractorConverter::convert(state, blockStepAlign));
+        list.append(createCSSValue(state.pool, state.style, blockStepAlign));
 
     if (auto blockStepRound = state.style.blockStepRound(); blockStepRound != RenderStyle::initialBlockStepRound())
-        list.append(ExtractorConverter::convert(state, blockStepRound));
+        list.append(createCSSValue(state.pool, state.style, blockStepRound));
 
     if (!list.isEmpty())
         return CSSValueList::createSpaceSeparated(list);
 
-    return CSSPrimitiveValue::create(CSSValueNone);
+    return createCSSValue(state.pool, state.style, CSS::Keyword::None { });
 }
 
 inline void ExtractorCustom::extractBlockStepShorthandSerialization(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context)
@@ -2338,33 +2344,33 @@ inline void ExtractorCustom::extractBlockStepShorthandSerialization(ExtractorSta
     if (auto blockStepSize = state.style.blockStepSize(); blockStepSize != RenderStyle::initialBlockStepSize()) {
         if (!listEmpty)
             builder.append(' ');
-        ExtractorSerializer::serializeStyleType(state, builder, context, blockStepSize);
+        serializationForCSS(builder, context, state.style, blockStepSize);
         listEmpty = false;
     }
 
     if (auto blockStepInsert = state.style.blockStepInsert(); blockStepInsert != RenderStyle::initialBlockStepInsert()) {
         if (!listEmpty)
             builder.append(' ');
-        ExtractorSerializer::serialize(state, builder, context, blockStepInsert);
+        serializationForCSS(builder, context, state.style, blockStepInsert);
         listEmpty = false;
     }
 
     if (auto blockStepAlign = state.style.blockStepAlign(); blockStepAlign != RenderStyle::initialBlockStepAlign()) {
         if (!listEmpty)
             builder.append(' ');
-        ExtractorSerializer::serialize(state, builder, context, blockStepAlign);
+        serializationForCSS(builder, context, state.style, blockStepAlign);
         listEmpty = false;
     }
 
     if (auto blockStepRound = state.style.blockStepRound(); blockStepRound != RenderStyle::initialBlockStepRound()) {
         if (!listEmpty)
             builder.append(' ');
-        ExtractorSerializer::serialize(state, builder, context, blockStepRound);
+        serializationForCSS(builder, context, state.style, blockStepRound);
         listEmpty = false;
     }
 
     if (listEmpty)
-        CSS::serializationForCSS(builder, context, CSS::Keyword::None { });
+        serializationForCSS(builder, context, state.style, CSS::Keyword::None { });
 }
 
 inline RefPtr<CSSValue> ExtractorCustom::extractBorderShorthand(ExtractorState& state)
@@ -2395,7 +2401,7 @@ inline RefPtr<CSSValue> ExtractorCustom::extractBorderImageShorthand(ExtractorSt
 {
     auto& borderImage = state.style.borderImage();
     if (borderImage.source().isNone())
-        return CSSPrimitiveValue::create(CSSValueNone);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::None { });
     if (borderImage.overridesBorderWidths())
         return nullptr;
     return createCSSValue(state.pool, state.style, borderImage);
@@ -2405,7 +2411,7 @@ inline void ExtractorCustom::extractBorderImageShorthandSerialization(ExtractorS
 {
     auto& borderImage = state.style.borderImage();
     if (borderImage.source().isNone()) {
-        CSS::serializationForCSS(builder, context, CSS::Keyword::None { });
+        serializationForCSS(builder, context, state.style, CSS::Keyword::None { });
         return;
     }
     if (borderImage.overridesBorderWidths())
@@ -2462,7 +2468,7 @@ inline RefPtr<CSSValue> ExtractorCustom::extractContainerShorthand(ExtractorStat
 {
     auto name = [&]() -> Ref<CSSValue> {
         if (state.style.containerNames().isNone())
-            return CSSPrimitiveValue::create(CSSValueNone);
+            return createCSSValue(state.pool, state.style, CSS::Keyword::None { });
         return ExtractorGenerated::extractValue(state, CSSPropertyContainerName).releaseNonNull();
     }();
 
@@ -2478,7 +2484,7 @@ inline RefPtr<CSSValue> ExtractorCustom::extractContainerShorthand(ExtractorStat
 inline void ExtractorCustom::extractContainerShorthandSerialization(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context)
 {
     if (state.style.containerNames().isNone())
-        CSS::serializationForCSS(builder, context, CSS::Keyword::None { });
+        serializationForCSS(builder, context, state.style, CSS::Keyword::None { });
     else
         ExtractorGenerated::extractValueSerialization(state, builder, context, CSSPropertyContainerName);
 
@@ -2492,20 +2498,20 @@ inline void ExtractorCustom::extractContainerShorthandSerialization(ExtractorSta
 inline RefPtr<CSSValue> ExtractorCustom::extractFlexFlowShorthand(ExtractorState& state)
 {
     if (state.style.flexWrap() == RenderStyle::initialFlexWrap())
-        return ExtractorConverter::convert(state, state.style.flexDirection());
+        return createCSSValue(state.pool, state.style, state.style.flexDirection());
     if (state.style.flexDirection() == RenderStyle::initialFlexDirection())
-        return ExtractorConverter::convert(state, state.style.flexWrap());
+        return createCSSValue(state.pool, state.style, state.style.flexWrap());
     return extractStandardSpaceSeparatedShorthand(state, flexFlowShorthand());
 }
 
 inline void ExtractorCustom::extractFlexFlowShorthandSerialization(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context)
 {
     if (state.style.flexWrap() == RenderStyle::initialFlexWrap()) {
-        ExtractorSerializer::serialize(state, builder, context, state.style.flexDirection());
+        serializationForCSS(builder, context, state.style, state.style.flexDirection());
         return;
     }
     if (state.style.flexDirection() == RenderStyle::initialFlexDirection()) {
-        ExtractorSerializer::serialize(state, builder, context, state.style.flexWrap());
+        serializationForCSS(builder, context, state.style, state.style.flexWrap());
         return;
     }
     extractStandardSpaceSeparatedShorthandSerialization(state, builder, context, flexFlowShorthand());
@@ -2574,13 +2580,13 @@ inline RefPtr<CSSValue> ExtractorCustom::extractFontSynthesisShorthand(Extractor
 
     CSSValueListBuilder list;
     if (description.hasAutoFontSynthesisWeight())
-        list.append(CSSPrimitiveValue::create(CSSValueWeight));
+        list.append(createCSSValue(state.pool, state.style, CSS::Keyword::Weight { }));
     if (description.hasAutoFontSynthesisStyle())
-        list.append(CSSPrimitiveValue::create(CSSValueStyle));
+        list.append(createCSSValue(state.pool, state.style, CSS::Keyword::Style { }));
     if (description.hasAutoFontSynthesisSmallCaps())
-        list.append(CSSPrimitiveValue::create(CSSValueSmallCaps));
+        list.append(createCSSValue(state.pool, state.style, CSS::Keyword::SmallCaps { }));
     if (list.isEmpty())
-        return CSSPrimitiveValue::create(CSSValueNone);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::None { });
     return CSSValueList::createSpaceSeparated(WTFMove(list));
 }
 
@@ -2602,7 +2608,7 @@ inline void ExtractorCustom::extractFontSynthesisShorthandSerialization(Extracto
     appendOption(description.hasAutoFontSynthesisSmallCaps(), CSSValueSmallCaps);
 
     if (listEmpty)
-        CSS::serializationForCSS(builder, context, CSS::Keyword::None { });
+        serializationForCSS(builder, context, state.style, CSS::Keyword::None { });
 }
 
 inline RefPtr<CSSValue> ExtractorCustom::extractFontVariantShorthand(ExtractorState& state)
@@ -2616,7 +2622,7 @@ inline RefPtr<CSSValue> ExtractorCustom::extractFontVariantShorthand(ExtractorSt
         list.append(value.releaseNonNull());
     }
     if (list.isEmpty())
-        return CSSPrimitiveValue::create(CSSValueNormal);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::Normal { });
     return CSSValueList::createSpaceSeparated(WTFMove(list));
 }
 
@@ -2630,7 +2636,7 @@ inline RefPtr<CSSValue> ExtractorCustom::extractLineClampShorthand(ExtractorStat
 {
     auto maxLines = state.style.maxLines().tryValue();
     if (!maxLines)
-        return CSSPrimitiveValue::create(CSSValueNone);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::None { });
 
     return CSSValuePair::create(
         createCSSValue(state.pool, state.style, *maxLines),
@@ -2642,7 +2648,7 @@ inline void ExtractorCustom::extractLineClampShorthandSerialization(ExtractorSta
 {
     auto maxLines = state.style.maxLines().tryValue();
     if (!maxLines) {
-        CSS::serializationForCSS(builder, context, CSS::Keyword::None { });
+        serializationForCSS(builder, context, state.style, CSS::Keyword::None { });
         return;
     }
 
@@ -2692,7 +2698,7 @@ inline void ExtractorCustom::extractMaskBorderShorthandSerialization(ExtractorSt
 inline RefPtr<CSSValue> ExtractorCustom::extractMaskPositionShorthand(ExtractorState& state)
 {
     auto mapper = [](auto& state, auto& layer) -> Ref<CSSValue> {
-        return ExtractorConverter::convertStyleType(state, layer.position());
+        return createCSSValue(state.pool, state.style, layer.position());
     };
     return extractFillLayerValue(state, state.style.maskLayers(), mapper);
 }
@@ -2702,7 +2708,7 @@ inline void ExtractorCustom::extractMaskPositionShorthandSerialization(Extractor
     auto mapper = [](auto& state, auto& builder, const auto& context, bool includeComma, auto& layer) {
         if (includeComma)
             builder.append(", "_s);
-        ExtractorSerializer::serializeStyleType(state, builder, context, layer.position());
+        serializationForCSS(builder, context, state.style, layer.position());
     };
     extractFillLayerValueSerialization(state, builder, context, state.style.maskLayers(), mapper);
 }
@@ -2720,7 +2726,7 @@ inline RefPtr<CSSValue> ExtractorCustom::extractOffsetShorthand(ExtractorState& 
         [&](const CSS::Keyword::Auto&) { },
         [&](const CSS::Keyword::Normal&) { },
         [&](const Position& position) {
-            innerList.append(ExtractorConverter::convertStyleType(state, position));
+            innerList.append(createCSSValue(state.pool, state.style, position));
         }
     );
 
@@ -2728,15 +2734,15 @@ inline RefPtr<CSSValue> ExtractorCustom::extractOffsetShorthand(ExtractorState& 
     bool nonInitialRotate = state.style.offsetRotate() != state.style.initialOffsetRotate();
 
     if (state.style.hasOffsetPath() || nonInitialDistance || nonInitialRotate)
-        innerList.append(ExtractorConverter::convertStyleType(state, state.style.offsetPath()));
+        innerList.append(createCSSValue(state.pool, state.style, state.style.offsetPath()));
 
     if (nonInitialDistance)
-        innerList.append(ExtractorConverter::convertStyleType(state, state.style.offsetDistance()));
+        innerList.append(createCSSValue(state.pool, state.style, state.style.offsetDistance()));
     if (nonInitialRotate)
-        innerList.append(ExtractorConverter::convertStyleType(state, state.style.offsetRotate()));
+        innerList.append(createCSSValue(state.pool, state.style, state.style.offsetRotate()));
 
     auto inner = innerList.isEmpty()
-        ? Ref<CSSValue> { CSSPrimitiveValue::create(CSSValueAuto) }
+        ? Ref<CSSValue> { createCSSValue(state.pool, state.style, CSS::Keyword::Auto { }) }
         : Ref<CSSValue> { CSSValueList::createSpaceSeparated(WTFMove(innerList)) };
 
     return WTF::switchOn(state.style.offsetAnchor(),
@@ -2746,7 +2752,7 @@ inline RefPtr<CSSValue> ExtractorCustom::extractOffsetShorthand(ExtractorState& 
         [&](const Position& position) -> Ref<CSSValue> {
             return CSSValueList::createSlashSeparated(
                 WTFMove(inner),
-                ExtractorConverter::convertStyleType(state, position)
+                createCSSValue(state.pool, state.style, position)
             );
         }
     );
@@ -2760,12 +2766,12 @@ inline void ExtractorCustom::extractOffsetShorthandSerialization(ExtractorState&
 
 inline RefPtr<CSSValue> ExtractorCustom::extractOverscrollBehaviorShorthand(ExtractorState& state)
 {
-    return ExtractorConverter::convert(state, std::max(state.style.overscrollBehaviorX(), state.style.overscrollBehaviorY()));
+    return createCSSValue(state.pool, state.style, std::max(state.style.overscrollBehaviorX(), state.style.overscrollBehaviorY()));
 }
 
 inline void ExtractorCustom::extractOverscrollBehaviorShorthandSerialization(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context)
 {
-    ExtractorSerializer::serialize(state, builder, context, std::max(state.style.overscrollBehaviorX(), state.style.overscrollBehaviorY()));
+    serializationForCSS(builder, context, state.style, std::max(state.style.overscrollBehaviorX(), state.style.overscrollBehaviorY()));
 }
 
 inline RefPtr<CSSValue> ExtractorCustom::extractPageBreakAfterShorthand(ExtractorState& state)
@@ -2806,8 +2812,8 @@ inline RefPtr<CSSValue> ExtractorCustom::extractPerspectiveOriginShorthand(Extra
         list.append(ExtractorConverter::convertNumberAsPixels(state, Style::evaluate(state.style.perspectiveOriginX(), box.width(), 1.0f /* FIXME FIND ZOOM */)));
         list.append(ExtractorConverter::convertNumberAsPixels(state, Style::evaluate(state.style.perspectiveOriginY(), box.height(), 1.0f /* FIXME FIND ZOOM */)));
     } else {
-        list.append(ExtractorConverter::convertStyleType(state, state.style.perspectiveOriginX()));
-        list.append(ExtractorConverter::convertStyleType(state, state.style.perspectiveOriginY()));
+        list.append(createCSSValue(state.pool, state.style, state.style.perspectiveOriginX()));
+        list.append(createCSSValue(state.pool, state.style, state.style.perspectiveOriginY()));
     }
     return CSSValueList::createSpaceSeparated(WTFMove(list));
 }
@@ -2820,9 +2826,9 @@ inline void ExtractorCustom::extractPerspectiveOriginShorthandSerialization(Extr
         builder.append(' ');
         ExtractorSerializer::serializeNumberAsPixels(state, builder, context, Style::evaluate(state.style.perspectiveOriginY(), box.height(), 1.0f /* FIXME FIND ZOOM */));
     } else {
-        ExtractorSerializer::serializeStyleType(state, builder, context, state.style.perspectiveOriginX());
+        serializationForCSS(builder, context, state.style, state.style.perspectiveOriginX());
         builder.append(' ');
-        ExtractorSerializer::serializeStyleType(state, builder, context, state.style.perspectiveOriginY());
+        serializationForCSS(builder, context, state.style, state.style.perspectiveOriginY());
     }
 }
 
@@ -2846,7 +2852,7 @@ inline RefPtr<CSSValue> ExtractorCustom::extractScrollTimelineShorthand(Extracto
 {
     auto& timelines = state.style.scrollTimelines();
     if (timelines.isEmpty())
-        return CSSPrimitiveValue::create(CSSValueNone);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::None { });
 
     CSSValueListBuilder list;
     for (auto& timeline : timelines) {
@@ -2854,12 +2860,12 @@ inline RefPtr<CSSValue> ExtractorCustom::extractScrollTimelineShorthand(Extracto
         auto axis = timeline->axis();
 
         ASSERT(!name.isNull());
-        auto nameCSSValue = CSSPrimitiveValue::createCustomIdent(name);
+        auto nameCSSValue = createCSSValue(state.pool, state.style, CustomIdentifier { name });
 
         if (axis == ScrollAxis::Block)
             list.append(WTFMove(nameCSSValue));
         else
-            list.append(CSSValuePair::createNoncoalescing(nameCSSValue, ExtractorConverter::convert(state, axis)));
+            list.append(CSSValuePair::createNoncoalescing(nameCSSValue, createCSSValue(state.pool, state.style, axis)));
     }
     return CSSValueList::createCommaSeparated(WTFMove(list));
 }
@@ -2868,17 +2874,17 @@ inline void ExtractorCustom::extractScrollTimelineShorthandSerialization(Extract
 {
     auto& timelines = state.style.scrollTimelines();
     if (timelines.isEmpty()) {
-        CSS::serializationForCSS(builder, context, CSS::Keyword::None { });
+        serializationForCSS(builder, context, state.style, CSS::Keyword::None { });
         return;
     }
 
     builder.append(interleave(timelines, [&](auto& builder, auto& timeline) {
         ASSERT(!timeline->name().isNull());
 
-        CSS::serializationForCSS(builder, context, CustomIdentifier { timeline->name() });
+        serializationForCSS(builder, context, state.style, CustomIdentifier { timeline->name() });
         if (auto axis = timeline->axis(); axis != ScrollAxis::Block) {
             builder.append(' ');
-            ExtractorSerializer::serialize(state, builder, context, axis);
+            serializationForCSS(builder, context, state.style, axis);
         }
     }, ", "_s));
 }
@@ -2890,14 +2896,14 @@ inline RefPtr<CSSValue> ExtractorCustom::extractTextBoxShorthand(ExtractorState&
     auto textBoxEdgeIsAuto = textBoxEdge == TextEdge { TextEdgeType::Auto, TextEdgeType::Auto };
 
     if (textBoxTrim == TextBoxTrim::None && textBoxEdgeIsAuto)
-        return CSSPrimitiveValue::create(CSSValueNormal);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::Normal { });
     if (textBoxEdgeIsAuto)
-        return ExtractorConverter::convert(state, textBoxTrim);
+        return createCSSValue(state.pool, state.style, textBoxTrim);
     if (textBoxTrim == TextBoxTrim::TrimBoth)
         return ExtractorConverter::convertTextBoxEdge(state, textBoxEdge);
 
     return CSSValuePair::create(
-        ExtractorConverter::convert(state, textBoxTrim),
+        createCSSValue(state.pool, state.style, textBoxTrim),
         ExtractorConverter::convertTextBoxEdge(state, textBoxEdge)
     );
 }
@@ -2909,11 +2915,11 @@ inline void ExtractorCustom::extractTextBoxShorthandSerialization(ExtractorState
     auto textBoxEdgeIsAuto = textBoxEdge == TextEdge { TextEdgeType::Auto, TextEdgeType::Auto };
 
     if (textBoxTrim == TextBoxTrim::None && textBoxEdgeIsAuto) {
-        CSS::serializationForCSS(builder, context, CSS::Keyword::Normal { });
+        serializationForCSS(builder, context, state.style, CSS::Keyword::Normal { });
         return;
     }
     if (textBoxEdgeIsAuto) {
-        ExtractorSerializer::serialize(state, builder, context, textBoxTrim);
+        serializationForCSS(builder, context, state.style, textBoxTrim);
         return;
     }
     if (textBoxTrim == TextBoxTrim::TrimBoth) {
@@ -2921,7 +2927,7 @@ inline void ExtractorCustom::extractTextBoxShorthandSerialization(ExtractorState
         return;
     }
 
-    ExtractorSerializer::serialize(state, builder, context, textBoxTrim);
+    serializationForCSS(builder, context, state.style, textBoxTrim);
     builder.append(' ');
     ExtractorSerializer::serializeTextBoxEdge(state, builder, context, textBoxEdge);
 }
@@ -2934,7 +2940,7 @@ inline RefPtr<CSSValue> ExtractorCustom::extractTextDecorationShorthand(Extracto
     bool hasDefaultTextDecorationColor = state.style.textDecorationColor().isCurrentColor();
 
     if (hasDefaultTextDecorationLine && hasDefaultTextDecorationStyle && hasDefaultTextDecorationColor && hasDefaultTextDecorationThickness)
-        return CSSPrimitiveValue::create(CSSValueNone);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::None { });
 
     CSSValueListBuilder list;
     if (!hasDefaultTextDecorationLine)
@@ -2942,7 +2948,7 @@ inline RefPtr<CSSValue> ExtractorCustom::extractTextDecorationShorthand(Extracto
     if (!hasDefaultTextDecorationThickness)
         list.append(ExtractorConverter::convertStyleType<TextDecorationThickness>(state, state.style.textDecorationThickness()));
     if (!hasDefaultTextDecorationStyle)
-        list.append(ExtractorConverter::convert(state, state.style.textDecorationStyle()));
+        list.append(createCSSValue(state.pool, state.style, state.style.textDecorationStyle()));
     if (!hasDefaultTextDecorationColor)
         list.append(ExtractorConverter::convertStyleType<Color>(state, state.style.textDecorationColor()));
 
@@ -2957,26 +2963,26 @@ inline void ExtractorCustom::extractTextDecorationShorthandSerialization(Extract
     bool hasDefaultTextDecorationColor = state.style.textDecorationColor().isCurrentColor();
 
     if (hasDefaultTextDecorationLine && hasDefaultTextDecorationStyle && hasDefaultTextDecorationColor && hasDefaultTextDecorationThickness) {
-        CSS::serializationForCSS(builder, context, CSS::Keyword::None { });
+        serializationForCSS(builder, context, state.style, CSS::Keyword::None { });
         return;
     }
 
     if (!hasDefaultTextDecorationLine)
-        ExtractorSerializer::serialize(state, builder, context, state.style.textDecorationLine());
+        serializationForCSS(builder, context, state.style, state.style.textDecorationLine());
     if (!hasDefaultTextDecorationThickness) {
         if (!builder.isEmpty())
             builder.append(' ');
-        ExtractorSerializer::serialize(state, builder, context, state.style.textDecorationThickness());
+        serializationForCSS(builder, context, state.style, state.style.textDecorationThickness());
     }
     if (!hasDefaultTextDecorationStyle) {
         if (!builder.isEmpty())
             builder.append(' ');
-        ExtractorSerializer::serialize(state, builder, context, state.style.textDecorationStyle());
+        serializationForCSS(builder, context, state.style, state.style.textDecorationStyle());
     }
     if (!hasDefaultTextDecorationColor) {
         if (!builder.isEmpty())
             builder.append(' ');
-        ExtractorSerializer::serialize(state, builder, context, state.style.textDecorationColor());
+        serializationForCSS(builder, context, state.style, state.style.textDecorationColor());
     }
 }
 
@@ -2984,9 +2990,9 @@ inline RefPtr<CSSValue> ExtractorCustom::extractTextDecorationSkipShorthand(Extr
 {
     switch (state.style.textDecorationSkipInk()) {
     case TextDecorationSkipInk::None:
-        return CSSPrimitiveValue::create(CSSValueNone);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::None { });
     case TextDecorationSkipInk::Auto:
-        return CSSPrimitiveValue::create(CSSValueAuto);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::Auto { });
     case TextDecorationSkipInk::All:
         return nullptr;
     }
@@ -2997,10 +3003,10 @@ inline void ExtractorCustom::extractTextDecorationSkipShorthandSerialization(Ext
 {
     switch (state.style.textDecorationSkipInk()) {
     case TextDecorationSkipInk::None:
-        CSS::serializationForCSS(builder, context, CSS::Keyword::None { });
+        serializationForCSS(builder, context, state.style, CSS::Keyword::None { });
         return;
     case TextDecorationSkipInk::Auto:
-        CSS::serializationForCSS(builder, context, CSS::Keyword::Auto { });
+        serializationForCSS(builder, context, state.style, CSS::Keyword::Auto { });
         return;
     case TextDecorationSkipInk::All:
         return;
@@ -3014,13 +3020,13 @@ inline RefPtr<CSSValue> ExtractorCustom::extractTextWrapShorthand(ExtractorState
     auto textWrapStyle = state.style.textWrapStyle();
 
     if (textWrapStyle == TextWrapStyle::Auto)
-        return ExtractorConverter::convert(state, textWrapMode);
+        return createCSSValue(state.pool, state.style, textWrapMode);
     if (textWrapMode == TextWrapMode::Wrap)
-        return ExtractorConverter::convert(state, textWrapStyle);
+        return createCSSValue(state.pool, state.style, textWrapStyle);
 
     return CSSValuePair::create(
-        ExtractorConverter::convert(state, textWrapMode),
-        ExtractorConverter::convert(state, textWrapStyle)
+        createCSSValue(state.pool, state.style, textWrapMode),
+        createCSSValue(state.pool, state.style, textWrapStyle)
     );
 }
 
@@ -3030,17 +3036,17 @@ inline void ExtractorCustom::extractTextWrapShorthandSerialization(ExtractorStat
     auto textWrapStyle = state.style.textWrapStyle();
 
     if (textWrapStyle == TextWrapStyle::Auto) {
-        ExtractorSerializer::serialize(state, builder, context, textWrapMode);
+        serializationForCSS(builder, context, state.style, textWrapMode);
         return;
     }
     if (textWrapMode == TextWrapMode::Wrap) {
-        ExtractorSerializer::serialize(state, builder, context, textWrapStyle);
+        serializationForCSS(builder, context, state.style, textWrapStyle);
         return;
     }
 
-    ExtractorSerializer::serialize(state, builder, context, textWrapMode);
+    serializationForCSS(builder, context, state.style, textWrapMode);
     builder.append(' ');
-    ExtractorSerializer::serialize(state, builder, context, textWrapStyle);
+    serializationForCSS(builder, context, state.style, textWrapStyle);
 }
 
 inline RefPtr<CSSValue> ExtractorCustom::extractTransformOriginShorthand(ExtractorState& state)
@@ -3051,12 +3057,12 @@ inline RefPtr<CSSValue> ExtractorCustom::extractTransformOriginShorthand(Extract
         list.append(ExtractorConverter::convertNumberAsPixels(state, Style::evaluate(state.style.transformOriginX(), box.width(), 1.0f /* FIXME FIND ZOOM */)));
         list.append(ExtractorConverter::convertNumberAsPixels(state, Style::evaluate(state.style.transformOriginY(), box.height(), 1.0f /* FIXME FIND ZOOM */)));
         if (auto transformOriginZ = state.style.transformOriginZ(); transformOriginZ.value)
-            list.append(ExtractorConverter::convertStyleType(state, transformOriginZ));
+            list.append(createCSSValue(state.pool, state.style, transformOriginZ));
     } else {
-        list.append(ExtractorConverter::convertStyleType(state, state.style.transformOriginX()));
-        list.append(ExtractorConverter::convertStyleType(state, state.style.transformOriginY()));
+        list.append(createCSSValue(state.pool, state.style, state.style.transformOriginX()));
+        list.append(createCSSValue(state.pool, state.style, state.style.transformOriginY()));
         if (auto transformOriginZ = state.style.transformOriginZ(); transformOriginZ.value)
-            list.append(ExtractorConverter::convertStyleType(state, transformOriginZ));
+            list.append(createCSSValue(state.pool, state.style, transformOriginZ));
     }
     return CSSValueList::createSpaceSeparated(WTFMove(list));
 }
@@ -3070,15 +3076,15 @@ inline void ExtractorCustom::extractTransformOriginShorthandSerialization(Extrac
         ExtractorSerializer::serializeNumberAsPixels(state, builder, context, Style::evaluate(state.style.transformOriginY(), box.height(), 1.0f /* FIXME FIND ZOOM */));
         if (auto transformOriginZ = state.style.transformOriginZ(); transformOriginZ.value) {
             builder.append(' ');
-            ExtractorSerializer::serializeStyleType(state, builder, context, transformOriginZ);
+            serializationForCSS(builder, context, state.style, transformOriginZ);
         }
     } else {
-        ExtractorSerializer::serializeStyleType(state, builder, context, state.style.transformOriginX());
+        serializationForCSS(builder, context, state.style, state.style.transformOriginX());
         builder.append(' ');
-        ExtractorSerializer::serializeStyleType(state, builder, context, state.style.transformOriginY());
+        serializationForCSS(builder, context, state.style, state.style.transformOriginY());
         if (auto transformOriginZ = state.style.transformOriginZ(); transformOriginZ.value) {
             builder.append(' ');
-            ExtractorSerializer::serializeStyleType(state, builder, context, transformOriginZ);
+            serializationForCSS(builder, context, state.style, transformOriginZ);
         }
     }
 }
@@ -3105,7 +3111,7 @@ inline Ref<CSSValue> convertSingleTransition(ExtractorState& state, const Transi
     if (transition.behavior() != Transition::initialBehavior())
         list.append(createCSSValue(state.pool, state.style, transition.behavior()));
     if (list.isEmpty())
-        return CSSPrimitiveValue::create(CSSValueAll);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::All { });
     return CSSValueList::createSpaceSeparated(WTFMove(list));
 }
 
@@ -3140,7 +3146,7 @@ inline RefPtr<CSSValue> ExtractorCustom::extractViewTimelineShorthand(ExtractorS
 {
     auto& timelines = state.style.viewTimelines();
     if (timelines.isEmpty())
-        return CSSPrimitiveValue::create(CSSValueNone);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::None { });
 
     CSSValueListBuilder list;
     for (auto& timeline : timelines) {
@@ -3159,11 +3165,11 @@ inline RefPtr<CSSValue> ExtractorCustom::extractViewTimelineShorthand(ExtractorS
         else if (hasDefaultAxis)
             list.append(CSSValuePair::createNoncoalescing(nameCSSValue, createCSSValue(state.pool, state.style, insets)));
         else if (hasDefaultInsets)
-            list.append(CSSValuePair::createNoncoalescing(nameCSSValue, ExtractorConverter::convert(state, axis)));
+            list.append(CSSValuePair::createNoncoalescing(nameCSSValue, createCSSValue(state.pool, state.style, axis)));
         else {
             list.append(CSSValueList::createSpaceSeparated(
                 WTFMove(nameCSSValue),
-                ExtractorConverter::convert(state, axis),
+                createCSSValue(state.pool, state.style, axis),
                 createCSSValue(state.pool, state.style, insets)
             ));
         }
@@ -3184,23 +3190,23 @@ inline RefPtr<CSSValue> ExtractorCustom::extractWhiteSpaceShorthand(ExtractorSta
 
     // Convert to backwards-compatible keywords if possible.
     if (whiteSpaceCollapse == WhiteSpaceCollapse::Collapse && textWrapMode == TextWrapMode::Wrap)
-        return CSSPrimitiveValue::create(CSSValueNormal);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::Normal { });
     if (whiteSpaceCollapse == WhiteSpaceCollapse::Preserve && textWrapMode == TextWrapMode::NoWrap)
-        return CSSPrimitiveValue::create(CSSValuePre);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::Pre { });
     if (whiteSpaceCollapse == WhiteSpaceCollapse::Preserve && textWrapMode == TextWrapMode::Wrap)
-        return CSSPrimitiveValue::create(CSSValuePreWrap);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::PreWrap { });
     if (whiteSpaceCollapse == WhiteSpaceCollapse::PreserveBreaks && textWrapMode == TextWrapMode::Wrap)
-        return CSSPrimitiveValue::create(CSSValuePreLine);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::PreLine { });
 
     // Omit default longhand values.
     if (whiteSpaceCollapse == WhiteSpaceCollapse::Collapse)
-        return ExtractorConverter::convert(state, textWrapMode);
+        return createCSSValue(state.pool, state.style, textWrapMode);
     if (textWrapMode == TextWrapMode::Wrap)
-        return ExtractorConverter::convert(state, whiteSpaceCollapse);
+        return createCSSValue(state.pool, state.style, whiteSpaceCollapse);
 
     return CSSValuePair::create(
-        ExtractorConverter::convert(state, whiteSpaceCollapse),
-        ExtractorConverter::convert(state, textWrapMode)
+        createCSSValue(state.pool, state.style, whiteSpaceCollapse),
+        createCSSValue(state.pool, state.style, textWrapMode)
     );
 }
 
@@ -3211,42 +3217,42 @@ inline void ExtractorCustom::extractWhiteSpaceShorthandSerialization(ExtractorSt
 
     // Convert to backwards-compatible keywords if possible.
     if (whiteSpaceCollapse == WhiteSpaceCollapse::Collapse && textWrapMode == TextWrapMode::Wrap) {
-        CSS::serializationForCSS(builder, context, CSS::Keyword::Normal { });
+        serializationForCSS(builder, context, state.style, CSS::Keyword::Normal { });
         return;
     }
     if (whiteSpaceCollapse == WhiteSpaceCollapse::Preserve && textWrapMode == TextWrapMode::NoWrap) {
-        CSS::serializationForCSS(builder, context, CSS::Keyword::Pre { });
+        serializationForCSS(builder, context, state.style, CSS::Keyword::Pre { });
         return;
     }
     if (whiteSpaceCollapse == WhiteSpaceCollapse::Preserve && textWrapMode == TextWrapMode::Wrap) {
-        CSS::serializationForCSS(builder, context, CSS::Keyword::PreWrap { });
+        serializationForCSS(builder, context, state.style, CSS::Keyword::PreWrap { });
         return;
     }
     if (whiteSpaceCollapse == WhiteSpaceCollapse::PreserveBreaks && textWrapMode == TextWrapMode::Wrap) {
-        CSS::serializationForCSS(builder, context, CSS::Keyword::PreLine { });
+        serializationForCSS(builder, context, state.style, CSS::Keyword::PreLine { });
         return;
     }
 
     // Omit default longhand values.
     if (whiteSpaceCollapse == WhiteSpaceCollapse::Collapse) {
-        ExtractorSerializer::serialize(state, builder, context, textWrapMode);
+        serializationForCSS(builder, context, state.style, textWrapMode);
         return;
     }
     if (textWrapMode == TextWrapMode::Wrap) {
-        ExtractorSerializer::serialize(state, builder, context, whiteSpaceCollapse);
+        serializationForCSS(builder, context, state.style, whiteSpaceCollapse);
         return;
     }
 
-    ExtractorSerializer::serialize(state, builder, context, whiteSpaceCollapse);
+    serializationForCSS(builder, context, state.style, whiteSpaceCollapse);
     builder.append(' ');
-    ExtractorSerializer::serialize(state, builder, context, textWrapMode);
+    serializationForCSS(builder, context, state.style, textWrapMode);
 }
 
 inline RefPtr<CSSValue> ExtractorCustom::extractWebkitBorderImageShorthand(ExtractorState& state)
 {
     auto& borderImage = state.style.borderImage();
     if (borderImage.source().isNone())
-        return CSSPrimitiveValue::create(CSSValueNone);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::None { });
     // -webkit-border-image has a legacy behavior that makes fixed border slices also set the border widths.
     bool overridesBorderWidths = borderImage.width().values.anyOf([](const auto& side) { return side.isFixed(); });
     if (overridesBorderWidths != borderImage.overridesBorderWidths())
@@ -3258,7 +3264,7 @@ inline void ExtractorCustom::extractWebkitBorderImageShorthandSerialization(Extr
 {
     auto& borderImage = state.style.borderImage();
     if (borderImage.source().isNone()) {
-        CSS::serializationForCSS(builder, context, CSS::Keyword::None { });
+        serializationForCSS(builder, context, state.style, CSS::Keyword::None { });
         return;
     }
     // -webkit-border-image has a legacy behavior that makes fixed border slices also set the border widths.

--- a/Source/WebCore/style/StyleExtractorSerializer.h
+++ b/Source/WebCore/style/StyleExtractorSerializer.h
@@ -24,12 +24,8 @@
 
 #pragma once
 
-#include "CSSDynamicRangeLimitMix.h"
 #include "CSSMarkup.h"
 #include "CSSPrimitiveNumericTypes+Serialization.h"
-#include "CSSPrimitiveNumericTypes.h"
-#include "CSSValueTypes.h"
-#include "ColorSerialization.h"
 #include "StyleExtractorConverter.h"
 #include "StylePrimitiveKeyword+Serialization.h"
 #include "StylePrimitiveNumericTypes+Serialization.h"
@@ -54,19 +50,12 @@ public:
     static void serialize(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, int);
     static void serialize(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, unsigned short);
     static void serialize(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, short);
-    static void serialize(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const ScopedName&);
 
     static void serializeLength(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const WebCore::Length&);
     static void serializeLength(const RenderStyle&, StringBuilder&, const CSS::SerializationContext&, const WebCore::Length&);
-    static void serializeLengthAllowingNumber(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const WebCore::Length&);
-    static void serializeLengthOrAuto(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const WebCore::Length&);
-
-    template<typename T> static void serializeNumber(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, T);
     template<typename T> static void serializeNumberAsPixels(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, T);
-    template<typename T> static void serializeComputedLength(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, T);
-    template<typename T> static void serializeLineWidth(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, T lineWidth);
 
-    template<CSSValueID> static void serializeCustomIdentAtomOrKeyword(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const AtomString&);
+    static void serializeCustomIdentAtomOrAuto(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const AtomString&);
 
     // MARK: SVG serializations
 
@@ -76,19 +65,15 @@ public:
 
     static void serializeTransformationMatrix(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const TransformationMatrix&);
     static void serializeTransformationMatrix(const RenderStyle&, StringBuilder&, const CSS::SerializationContext&, const TransformationMatrix&);
-    static void serializeTransformOperation(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const TransformOperation&);
-    static void serializeTransformOperation(const RenderStyle&, StringBuilder&, const CSS::SerializationContext&, const TransformOperation&);
 
     // MARK: Shared serializations
 
     static void serializeGlyphOrientation(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, GlyphOrientation);
     static void serializeGlyphOrientationOrAuto(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, GlyphOrientation);
     static void serializeMarginTrim(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, OptionSet<MarginTrimType>);
-    static void serializeStrokeDashArray(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const FixedVector<WebCore::Length>&);
     static void serializeWebkitTextCombine(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, TextCombine);
     static void serializeImageOrientation(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, ImageOrientation);
     static void serializeContain(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, OptionSet<Containment>);
-    static void serializeSmoothScrolling(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, bool);
     static void serializeTextSpacingTrim(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, TextSpacingTrim);
     static void serializeTextAutospace(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, TextAutospace);
     static void serializeLineFitEdge(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const TextEdge&);
@@ -100,7 +85,6 @@ public:
     static void serializeScrollSnapAlign(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const ScrollSnapAlign&);
     static void serializeLineBoxContain(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, OptionSet<Style::LineBoxContain>);
     static void serializeWebkitRubyPosition(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, RubyPosition);
-    static void serializePosition(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const LengthPoint&);
     static void serializeTouchAction(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, OptionSet<TouchAction>);
     static void serializeTextTransform(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, OptionSet<TextTransform>);
     static void serializeTextUnderlinePosition(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, OptionSet<TextUnderlinePosition>);
@@ -156,42 +140,34 @@ void ExtractorSerializer::serialize(ExtractorState& state, StringBuilder& builde
     serializationForCSS(builder, context, state.style, value);
 }
 
-inline void ExtractorSerializer::serialize(ExtractorState&, StringBuilder& builder, const CSS::SerializationContext& context, double value)
+inline void ExtractorSerializer::serialize(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, double value)
 {
-    CSS::serializationForCSS(builder, context, CSS::NumberRaw<> { value });
+    serializationForCSS(builder, context, state.style, Number<> { value });
 }
 
-inline void ExtractorSerializer::serialize(ExtractorState&, StringBuilder& builder, const CSS::SerializationContext& context, float value)
+inline void ExtractorSerializer::serialize(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, float value)
 {
-    CSS::serializationForCSS(builder, context, CSS::NumberRaw<> { value });
+    serializationForCSS(builder, context, state.style, Number<> { value });
 }
 
-inline void ExtractorSerializer::serialize(ExtractorState&, StringBuilder& builder, const CSS::SerializationContext& context, unsigned value)
+inline void ExtractorSerializer::serialize(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, unsigned value)
 {
-    CSS::serializationForCSS(builder, context, CSS::IntegerRaw<CSS::All, unsigned> { value });
+    serializationForCSS(builder, context, state.style, Integer<CSS::All, unsigned> { value });
 }
 
-inline void ExtractorSerializer::serialize(ExtractorState&, StringBuilder& builder, const CSS::SerializationContext& context, int value)
+inline void ExtractorSerializer::serialize(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, int value)
 {
-    CSS::serializationForCSS(builder, context, CSS::IntegerRaw<CSS::All, int> { value });
+    serializationForCSS(builder, context, state.style, Integer<CSS::All, int> { value });
 }
 
-inline void ExtractorSerializer::serialize(ExtractorState&, StringBuilder& builder, const CSS::SerializationContext& context, unsigned short value)
+inline void ExtractorSerializer::serialize(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, unsigned short value)
 {
-    CSS::serializationForCSS(builder, context, CSS::IntegerRaw<CSS::All, unsigned short> { value });
+    serializationForCSS(builder, context, state.style, Integer<CSS::All, unsigned short> { value });
 }
 
-inline void ExtractorSerializer::serialize(ExtractorState&, StringBuilder& builder, const CSS::SerializationContext& context, short value)
+inline void ExtractorSerializer::serialize(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, short value)
 {
-    CSS::serializationForCSS(builder, context, CSS::IntegerRaw<CSS::All, short> { value });
-}
-
-inline void ExtractorSerializer::serialize(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, const ScopedName& scopedName)
-{
-    if (scopedName.isIdentifier)
-        serializationForCSS(builder, context, state.style, CustomIdentifier { scopedName.name });
-    else
-        serializationForCSS(builder, context, state.style, scopedName.name);
+    serializationForCSS(builder, context, state.style, Integer<CSS::All, short> { value });
 }
 
 inline void ExtractorSerializer::serializeLength(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, const WebCore::Length& length)
@@ -230,10 +206,10 @@ inline void ExtractorSerializer::serializeLength(const RenderStyle& style, Strin
         serializationForCSS(builder, context, style, CSS::Keyword::Normal { });
         return;
     case LengthType::Fixed:
-        CSS::serializationForCSS(builder, context, CSS::LengthRaw<> { CSS::LengthUnit::Px, adjustFloatForAbsoluteZoom(length.value(), style) });
+        serializationForCSS(builder, context, style, Length<> { length.value() });
         return;
     case LengthType::Percent:
-        CSS::serializationForCSS(builder, context, CSS::PercentageRaw<> { length.value() });
+        serializationForCSS(builder, context, style, Percentage<> { length.value() });
         return;
     case LengthType::Calculated:
         builder.append(CSSCalcValue::create(length.protectedCalculationValue(), style)->customCSSText(context));
@@ -245,40 +221,15 @@ inline void ExtractorSerializer::serializeLength(const RenderStyle& style, Strin
     RELEASE_ASSERT_NOT_REACHED();
 }
 
-inline void ExtractorSerializer::serializeLengthAllowingNumber(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, const WebCore::Length& length)
-{
-    serializeLength(state, builder, context, length);
-}
-
-inline void ExtractorSerializer::serializeLengthOrAuto(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, const WebCore::Length& length)
-{
-    serializeLength(state, builder, context, length);
-}
-
-template<typename T> void ExtractorSerializer::serializeNumber(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, T number)
-{
-    serialize(state, builder, context, number);
-}
-
 template<typename T> void ExtractorSerializer::serializeNumberAsPixels(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, T number)
 {
-    CSS::serializationForCSS(builder, context, CSS::LengthRaw<> { CSS::LengthUnit::Px, adjustFloatForAbsoluteZoom(number, state.style) });
+    serializationForCSS(builder, context, state.style, Length<CSS::All, T> { number });
 }
 
-template<typename T> void ExtractorSerializer::serializeComputedLength(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, T number)
-{
-    serializeNumberAsPixels(state, builder, context, number);
-}
-
-template<typename T> void ExtractorSerializer::serializeLineWidth(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, T lineWidth)
-{
-    serializeNumberAsPixels(state, builder, context, lineWidth);
-}
-
-template<CSSValueID keyword> void ExtractorSerializer::serializeCustomIdentAtomOrKeyword(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, const AtomString& string)
+inline void ExtractorSerializer::serializeCustomIdentAtomOrAuto(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, const AtomString& string)
 {
     if (string.isNull()) {
-        serializationForCSS(builder, context, state.style, Constant<keyword> { });
+        serializationForCSS(builder, context, state.style, CSS::Keyword::Auto { });
         return;
     }
 
@@ -310,7 +261,7 @@ inline void ExtractorSerializer::serializeTransformationMatrix(const RenderStyle
     if (transform.isAffine()) {
         std::array values { transform.a(), transform.b(), transform.c(), transform.d(), transform.e() / zoom, transform.f() / zoom };
         builder.append(nameLiteral(CSSValueMatrix), '(', interleave(values, [&](auto& builder, auto& value) {
-            CSS::serializationForCSS(builder, context, CSS::NumberRaw<> { value });
+            serializationForCSS(builder, context, style, Number<> { value });
         }, ", "_s), ')');
         return;
     }
@@ -322,30 +273,30 @@ inline void ExtractorSerializer::serializeTransformationMatrix(const RenderStyle
         transform.m41() / zoom, transform.m42() / zoom, transform.m43() / zoom, transform.m44()
     };
     builder.append(nameLiteral(CSSValueMatrix3d), '(', interleave(values, [&](auto& builder, auto& value) {
-        CSS::serializationForCSS(builder, context, CSS::NumberRaw<> { value });
+        serializationForCSS(builder, context, style, Number<> { value });
     }, ", "_s), ')');
 }
 
 // MARK: - Shared serializations
 
-inline void ExtractorSerializer::serializeGlyphOrientation(ExtractorState&, StringBuilder& builder, const CSS::SerializationContext& context, GlyphOrientation orientation)
+inline void ExtractorSerializer::serializeGlyphOrientation(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, GlyphOrientation orientation)
 {
     switch (orientation) {
     case GlyphOrientation::Degrees0:
-        CSS::serializationForCSS(builder, context, CSS::AngleRaw<> { 0_css_deg });
+        serializationForCSS(builder, context, state.style, Angle<> { 0_css_deg });
         return;
     case GlyphOrientation::Degrees90:
-        CSS::serializationForCSS(builder, context, CSS::AngleRaw<> { 90_css_deg });
+        serializationForCSS(builder, context, state.style, Angle<> { 90_css_deg });
         return;
     case GlyphOrientation::Degrees180:
-        CSS::serializationForCSS(builder, context, CSS::AngleRaw<> { 180_css_deg });
+        serializationForCSS(builder, context, state.style, Angle<> { 180_css_deg });
         return;
     case GlyphOrientation::Degrees270:
-        CSS::serializationForCSS(builder, context, CSS::AngleRaw<> { 270_css_deg });
+        serializationForCSS(builder, context, state.style, Angle<> { 270_css_deg });
         return;
     case GlyphOrientation::Auto:
         ASSERT_NOT_REACHED();
-        CSS::serializationForCSS(builder, context, CSS::AngleRaw<> { 0_css_deg });
+        serializationForCSS(builder, context, state.style, Angle<> { 0_css_deg });
         return;
     }
 
@@ -356,16 +307,16 @@ inline void ExtractorSerializer::serializeGlyphOrientationOrAuto(ExtractorState&
 {
     switch (orientation) {
     case GlyphOrientation::Degrees0:
-        CSS::serializationForCSS(builder, context, CSS::AngleRaw<> { 0_css_deg });
+        serializationForCSS(builder, context, state.style, Angle<> { 0_css_deg });
         return;
     case GlyphOrientation::Degrees90:
-        CSS::serializationForCSS(builder, context, CSS::AngleRaw<> { 90_css_deg });
+        serializationForCSS(builder, context, state.style, Angle<> { 90_css_deg });
         return;
     case GlyphOrientation::Degrees180:
-        CSS::serializationForCSS(builder, context, CSS::AngleRaw<> { 180_css_deg });
+        serializationForCSS(builder, context, state.style, Angle<> { 180_css_deg });
         return;
     case GlyphOrientation::Degrees270:
-        CSS::serializationForCSS(builder, context, CSS::AngleRaw<> { 270_css_deg });
+        serializationForCSS(builder, context, state.style, Angle<> { 270_css_deg });
         return;
     case GlyphOrientation::Auto:
         serializationForCSS(builder, context, state.style, CSS::Keyword::Auto { });
@@ -414,25 +365,13 @@ inline void ExtractorSerializer::serializeMarginTrim(ExtractorState& state, Stri
 }
 
 
-inline void ExtractorSerializer::serializeStrokeDashArray(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, const FixedVector<WebCore::Length>& dashes)
-{
-    if (dashes.isEmpty()) {
-        serializationForCSS(builder, context, state.style, CSS::Keyword::None { });
-        return;
-    }
-
-    builder.append(interleave(dashes, [&](auto& builder, auto& dash) {
-        serializeLength(state, builder, context, dash);
-    }, ", "_s));
-}
-
 inline void ExtractorSerializer::serializeWebkitTextCombine(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, TextCombine textCombine)
 {
     if (textCombine == TextCombine::All) {
         serializationForCSS(builder, context, state.style, CSS::Keyword::Horizontal { });
         return;
     }
-    serialize(state, builder, context, textCombine);
+    serializationForCSS(builder, context, state.style, textCombine);
 }
 
 inline void ExtractorSerializer::serializeImageOrientation(ExtractorState&, StringBuilder& builder, const CSS::SerializationContext&, ImageOrientation imageOrientation)
@@ -526,7 +465,7 @@ inline void ExtractorSerializer::serializeTextAutospace(ExtractorState& state, S
 inline void ExtractorSerializer::serializeLineFitEdge(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, const TextEdge& textEdge)
 {
     if (textEdge.over == TextEdgeType::Leading && textEdge.under == TextEdgeType::Leading) {
-        serialize(state, builder, context, textEdge.over);
+        serializationForCSS(builder, context, state.style, textEdge.over);
         return;
     }
 
@@ -539,19 +478,19 @@ inline void ExtractorSerializer::serializeLineFitEdge(ExtractorState& state, Str
     }();
 
     if (!shouldSerializeUnderEdge) {
-        serialize(state, builder, context, textEdge.over);
+        serializationForCSS(builder, context, state.style, textEdge.over);
         return;
     }
 
-    serialize(state, builder, context, textEdge.over);
+    serializationForCSS(builder, context, state.style, textEdge.over);
     builder.append(' ');
-    serialize(state, builder, context, textEdge.under);
+    serializationForCSS(builder, context, state.style, textEdge.under);
 }
 
 inline void ExtractorSerializer::serializeTextBoxEdge(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, const TextEdge& textEdge)
 {
     if (textEdge.over == TextEdgeType::Auto && textEdge.under == TextEdgeType::Auto) {
-        serialize(state, builder, context, textEdge.over);
+        serializationForCSS(builder, context, state.style, textEdge.over);
         return;
     }
 
@@ -564,13 +503,13 @@ inline void ExtractorSerializer::serializeTextBoxEdge(ExtractorState& state, Str
     }();
 
     if (!shouldSerializeUnderEdge) {
-        serialize(state, builder, context, textEdge.over);
+        serializationForCSS(builder, context, state.style, textEdge.over);
         return;
     }
 
-    serialize(state, builder, context, textEdge.over);
+    serializationForCSS(builder, context, state.style, textEdge.over);
     builder.append(' ');
-    serialize(state, builder, context, textEdge.under);
+    serializationForCSS(builder, context, state.style, textEdge.under);
 }
 
 inline void ExtractorSerializer::serializePositionTryFallbacks(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, const FixedVector<PositionTryFallback>& fallbacks)
@@ -580,24 +519,36 @@ inline void ExtractorSerializer::serializePositionTryFallbacks(ExtractorState& s
         return;
     }
 
-    CSSValueListBuilder list;
+    bool needsComma = false;
     for (auto& fallback : fallbacks) {
+        if (needsComma) {
+            builder.append(", "_s);
+            needsComma = false;
+        }
+
         if (fallback.positionAreaProperties) {
-            auto areaValue = fallback.positionAreaProperties->getPropertyCSSValue(CSSPropertyPositionArea);
-            if (areaValue)
-                list.append(*areaValue);
+            RefPtr areaValue = fallback.positionAreaProperties->getPropertyCSSValue(CSSPropertyPositionArea);
+            if (areaValue) {
+                builder.append(areaValue->cssText(context));
+                needsComma = true;
+            }
             continue;
         }
 
-        CSSValueListBuilder singleFallbackList;
-        if (fallback.positionTryRuleName)
-            singleFallbackList.append(ExtractorConverter::convert(state, *fallback.positionTryRuleName));
-        for (auto& tactic : fallback.tactics)
-            singleFallbackList.append(ExtractorConverter::convert(state, tactic));
-        list.append(CSSValueList::createSpaceSeparated(singleFallbackList));
-    }
+        bool needsSpace = false;
+        if (fallback.positionTryRuleName) {
+            serializationForCSS(builder, context, state.style, *fallback.positionTryRuleName);
+            needsSpace = true;
+        }
+        for (auto tactic : fallback.tactics) {
+            if (needsSpace)
+                builder.append(' ');
+            serializationForCSS(builder, context, state.style, tactic);
+            needsSpace = true;
+        }
 
-    builder.append(CSSValueList::createCommaSeparated(WTFMove(list))->cssText(context));
+        needsComma = true;
+    }
 }
 
 inline void ExtractorSerializer::serializeWillChange(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, const WillChangeData* willChangeData)
@@ -628,13 +579,13 @@ inline void ExtractorSerializer::serializeWillChange(ExtractorState& state, Stri
     builder.append(CSSValueList::createCommaSeparated(WTFMove(list))->cssText(context));
 }
 
-inline void ExtractorSerializer::serializeTabSize(ExtractorState&, StringBuilder& builder, const CSS::SerializationContext& context, const TabSize& tabSize)
+inline void ExtractorSerializer::serializeTabSize(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, const TabSize& tabSize)
 {
     auto value = tabSize.widthInPixels(1.0);
     if (tabSize.isSpaces())
-        CSS::serializationForCSS(builder, context, CSS::NumberRaw<> { value });
+        serializationForCSS(builder, context, state.style, Number<> { value });
     else
-        CSS::serializationForCSS(builder, context, CSS::LengthRaw<> { CSS::LengthUnit::Px, value });
+        serializationForCSS(builder, context, state.style, Length<> { value });
 }
 
 inline void ExtractorSerializer::serializeScrollSnapType(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, const ScrollSnapType& type)
@@ -645,25 +596,25 @@ inline void ExtractorSerializer::serializeScrollSnapType(ExtractorState& state, 
     }
 
     if (type.strictness == ScrollSnapStrictness::Proximity) {
-        serialize(state, builder, context, type.axis);
+        serializationForCSS(builder, context, state.style, type.axis);
         return;
     }
 
-    serialize(state, builder, context, type.axis);
+    serializationForCSS(builder, context, state.style, type.axis);
     builder.append(' ');
-    serialize(state, builder, context, type.strictness);
+    serializationForCSS(builder, context, state.style, type.strictness);
 }
 
 inline void ExtractorSerializer::serializeScrollSnapAlign(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, const ScrollSnapAlign& alignment)
 {
     if (alignment.blockAlign == alignment.inlineAlign) {
-        serialize(state, builder, context, alignment.blockAlign);
+        serializationForCSS(builder, context, state.style, alignment.blockAlign);
         return;
     }
 
-    serialize(state, builder, context, alignment.blockAlign);
+    serializationForCSS(builder, context, state.style, alignment.blockAlign);
     builder.append(' ');
-    serialize(state, builder, context, alignment.inlineAlign);
+    serializationForCSS(builder, context, state.style, alignment.inlineAlign);
 }
 
 inline void ExtractorSerializer::serializeLineBoxContain(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, OptionSet<Style::LineBoxContain> lineBoxContain)
@@ -707,13 +658,6 @@ inline void ExtractorSerializer::serializeWebkitRubyPosition(ExtractorState& sta
     }
 
     RELEASE_ASSERT_NOT_REACHED();
-}
-
-inline void ExtractorSerializer::serializePosition(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, const LengthPoint& position)
-{
-    serializeLength(state, builder, context, position.x);
-    builder.append(' ');
-    serializeLength(state, builder, context, position.y);
 }
 
 inline void ExtractorSerializer::serializeTouchAction(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, OptionSet<TouchAction> touchActions)
@@ -924,11 +868,11 @@ inline void ExtractorSerializer::serializeSelfOrDefaultAlignmentData(ExtractorSt
         list.append(CSSPrimitiveValue::create(CSSValueBaseline));
     } else {
         if (data.position() >= ItemPosition::Center && data.overflow() != OverflowAlignment::Default)
-            list.append(ExtractorConverter::convert(state, data.overflow()));
+            list.append(ExtractorConverter::convertStyleType(state, data.overflow()));
         if (data.position() == ItemPosition::Legacy)
             list.append(CSSPrimitiveValue::create(CSSValueNormal));
         else
-            list.append(ExtractorConverter::convert(state, data.position()));
+            list.append(ExtractorConverter::convertStyleType(state, data.position()));
     }
     builder.append(CSSValueList::createSpaceSeparated(WTFMove(list))->cssText(context));
 }
@@ -939,7 +883,7 @@ inline void ExtractorSerializer::serializeContentAlignmentData(ExtractorState& s
 
     // Handle content-distribution values
     if (data.distribution() != ContentDistribution::Default)
-        list.append(ExtractorConverter::convert(state, data.distribution()));
+        list.append(ExtractorConverter::convertStyleType(state, data.distribution()));
 
     // Handle content-position values (either as fallback or actual value)
     switch (data.position()) {
@@ -955,8 +899,8 @@ inline void ExtractorSerializer::serializeContentAlignmentData(ExtractorState& s
     default:
         // Handle overflow-alignment (only allowed for content-position values)
         if ((data.position() >= ContentPosition::Center || data.distribution() != ContentDistribution::Default) && data.overflow() != OverflowAlignment::Default)
-            list.append(ExtractorConverter::convert(state, data.overflow()));
-        list.append(ExtractorConverter::convert(state, data.position()));
+            list.append(ExtractorConverter::convertStyleType(state, data.overflow()));
+        list.append(ExtractorConverter::convertStyleType(state, data.position()));
     }
 
     ASSERT(list.size() > 0);
@@ -1013,7 +957,7 @@ inline void ExtractorSerializer::serializePositionAnchor(ExtractorState& state, 
         return;
     }
 
-    serialize(state, builder, context, *positionAnchor);
+    serializationForCSS(builder, context, state.style, *positionAnchor);
 }
 
 inline void ExtractorSerializer::serializePositionArea(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, const std::optional<PositionArea>& positionArea)
@@ -1161,13 +1105,13 @@ inline void ExtractorSerializer::serializeFontSizeAdjust(ExtractorState& state, 
     }
 
     if (metric == FontSizeAdjust::Metric::ExHeight) {
-        CSS::serializationForCSS(builder, context, CSS::NumberRaw<> { *value });
+        serializationForCSS(builder, context, state.style, Number<> { *value });
         return;
     }
 
-    serialize(state, builder, context, metric);
+    serializationForCSS(builder, context, state.style, metric);
     builder.append(' ');
-    CSS::serializationForCSS(builder, context, CSS::NumberRaw<> { *value });
+    serializationForCSS(builder, context, state.style, Number<> { *value });
 }
 
 inline void ExtractorSerializer::serializeFontPalette(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, const FontPalette& fontPalette)
@@ -1189,14 +1133,14 @@ inline void ExtractorSerializer::serializeFontPalette(ExtractorState& state, Str
     RELEASE_ASSERT_NOT_REACHED();
 }
 
-inline void ExtractorSerializer::serializeFontWeight(ExtractorState&, StringBuilder& builder, const CSS::SerializationContext& context, FontSelectionValue fontWeight)
+inline void ExtractorSerializer::serializeFontWeight(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, FontSelectionValue fontWeight)
 {
-    CSS::serializationForCSS(builder, context, CSS::NumberRaw<> { static_cast<float>(fontWeight) });
+    serializationForCSS(builder, context, state.style, Number<> { static_cast<float>(fontWeight) });
 }
 
-inline void ExtractorSerializer::serializeFontWidth(ExtractorState&, StringBuilder& builder, const CSS::SerializationContext& context, FontSelectionValue fontWidth)
+inline void ExtractorSerializer::serializeFontWidth(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, FontSelectionValue fontWidth)
 {
-    CSS::serializationForCSS(builder, context, CSS::PercentageRaw<> { static_cast<float>(fontWidth) });
+    serializationForCSS(builder, context, state.style, Percentage<> { static_cast<float>(fontWidth) });
 }
 
 inline void ExtractorSerializer::serializeFontFeatureSettings(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, const FontFeatureSettings& fontFeatureSettings)

--- a/Source/WebCore/style/values/transforms/StyleTransformFunction.cpp
+++ b/Source/WebCore/style/values/transforms/StyleTransformFunction.cpp
@@ -45,6 +45,7 @@
 #include "ScaleTransformOperation.h"
 #include "SkewTransformOperation.h"
 #include "StyleBuilderChecking.h"
+#include "StyleBuilderConverter.h"
 #include "StyleExtractorConverter.h"
 #include "StyleExtractorSerializer.h"
 #include "StyleInterpolationContext.h"
@@ -55,33 +56,18 @@
 namespace WebCore {
 namespace Style {
 
-static WebCore::Length resolveAsFloatPercentOrCalculatedLength(const CSSPrimitiveValue& primitiveValue, BuilderState& builderState)
-{
-    // FIXME: This should use `BuilderConverter::convertLength`, but doing so breaks transforms/hittest-translated-content-off-to-infinity-and-back.html, due to it using `resolveAsLength<WebCore::Length>` rather than `resolveAsLength<double>`, the difference being the former clamps between minValueForCssLength/maxValueForCssLength.
-
-    auto& conversionData = builderState.cssToLengthConversionData();
-    if (primitiveValue.isLength())
-        return WebCore::Length(primitiveValue.resolveAsLength<double>(conversionData), LengthType::Fixed);
-    if (primitiveValue.isPercentage())
-        return WebCore::Length(primitiveValue.resolveAsPercentage<double>(conversionData), LengthType::Percent);
-    if (primitiveValue.isCalculated())
-        return WebCore::Length(primitiveValue.protectedCssCalcValue()->createCalculationValue(conversionData, CSSCalcSymbolTable { }));
-    builderState.setCurrentPropertyInvalidAtComputedValueTime();
-    return WebCore::Length(0, LengthType::Fixed);
-}
-
 // MARK: Matrix
 
-static RefPtr<TransformOperation> createMatrixTransformOperation(const CSSFunctionValue& value, BuilderState& builderState)
+static RefPtr<TransformOperation> createMatrixTransformOperation(BuilderState& state, const CSSFunctionValue& value)
 {
     // https://drafts.csswg.org/css-transforms-1/#funcdef-transform-matrix
     // matrix() = matrix( <number>#{6} )
 
-    auto function = requiredFunctionDowncast<CSSValueMatrix, CSSPrimitiveValue, 6>(builderState, value);
+    auto function = requiredFunctionDowncast<CSSValueMatrix, CSSPrimitiveValue, 6>(state, value);
     if (!function)
         return { };
 
-    auto& conversionData = builderState.cssToLengthConversionData();
+    auto& conversionData = state.cssToLengthConversionData();
 
     auto zoom = conversionData.zoom();
     return MatrixTransformOperation::create(
@@ -94,16 +80,16 @@ static RefPtr<TransformOperation> createMatrixTransformOperation(const CSSFuncti
     );
 }
 
-static RefPtr<TransformOperation> createMatrix3dTransformOperation(const CSSFunctionValue& value, BuilderState& builderState)
+static RefPtr<TransformOperation> createMatrix3dTransformOperation(BuilderState& state, const CSSFunctionValue& value)
 {
     // https://drafts.csswg.org/css-transforms-2/#funcdef-matrix3d
     // matrix3d() = matrix3d( <number>#{16} )
 
-    auto function = requiredFunctionDowncast<CSSValueMatrix3d, CSSPrimitiveValue, 16>(builderState, value);
+    auto function = requiredFunctionDowncast<CSSValueMatrix3d, CSSPrimitiveValue, 16>(state, value);
     if (!function)
         return { };
 
-    auto& conversionData = builderState.cssToLengthConversionData();
+    auto& conversionData = state.cssToLengthConversionData();
 
     TransformationMatrix matrix(
         function->item(0).resolveAsNumber(conversionData),
@@ -130,16 +116,16 @@ static RefPtr<TransformOperation> createMatrix3dTransformOperation(const CSSFunc
 
 // MARK: Rotate
 
-static RefPtr<TransformOperation> createRotateTransformOperation(const CSSFunctionValue& value, BuilderState& builderState)
+static RefPtr<TransformOperation> createRotateTransformOperation(BuilderState& state, const CSSFunctionValue& value)
 {
     // https://drafts.csswg.org/css-transforms-1/#funcdef-transform-rotate
     // rotate() = rotate( [ <angle> | <zero> ] )
 
-    auto function = requiredFunctionDowncast<CSSValueRotate, CSSPrimitiveValue, 1>(builderState, value);
+    auto function = requiredFunctionDowncast<CSSValueRotate, CSSPrimitiveValue, 1>(state, value);
     if (!function)
         return { };
 
-    auto& conversionData = builderState.cssToLengthConversionData();
+    auto& conversionData = state.cssToLengthConversionData();
 
     double x = 0;
     double y = 0;
@@ -149,16 +135,16 @@ static RefPtr<TransformOperation> createRotateTransformOperation(const CSSFuncti
     return RotateTransformOperation::create(x, y, z, angle, TransformOperation::Type::Rotate);
 }
 
-static RefPtr<TransformOperation> createRotate3dTransformOperation(const CSSFunctionValue& value, BuilderState& builderState)
+static RefPtr<TransformOperation> createRotate3dTransformOperation(BuilderState& state, const CSSFunctionValue& value)
 {
     // https://drafts.csswg.org/css-transforms-2/#funcdef-rotate3d
     // rotate3d() = rotate3d( <number> , <number> , <number> , [ <angle> | <zero> ] )
 
-    auto function = requiredFunctionDowncast<CSSValueRotate3d, CSSPrimitiveValue, 4>(builderState, value);
+    auto function = requiredFunctionDowncast<CSSValueRotate3d, CSSPrimitiveValue, 4>(state, value);
     if (!function)
         return { };
 
-    auto& conversionData = builderState.cssToLengthConversionData();
+    auto& conversionData = state.cssToLengthConversionData();
 
     double x = function->item(0).resolveAsNumber(conversionData);
     double y = function->item(1).resolveAsNumber(conversionData);
@@ -168,16 +154,16 @@ static RefPtr<TransformOperation> createRotate3dTransformOperation(const CSSFunc
     return RotateTransformOperation::create(x, y, z, angle, TransformOperation::Type::Rotate3D);
 }
 
-static RefPtr<TransformOperation> createRotateXTransformOperation(const CSSFunctionValue& value, BuilderState& builderState)
+static RefPtr<TransformOperation> createRotateXTransformOperation(BuilderState& state, const CSSFunctionValue& value)
 {
     // https://drafts.csswg.org/css-transforms-2/#funcdef-rotatex
     // rotateX() = rotateX( [ <angle> | <zero> ] )
 
-    auto function = requiredFunctionDowncast<CSSValueRotateX, CSSPrimitiveValue, 1>(builderState, value);
+    auto function = requiredFunctionDowncast<CSSValueRotateX, CSSPrimitiveValue, 1>(state, value);
     if (!function)
         return { };
 
-    auto& conversionData = builderState.cssToLengthConversionData();
+    auto& conversionData = state.cssToLengthConversionData();
 
     double x = 1;
     double y = 0;
@@ -187,16 +173,16 @@ static RefPtr<TransformOperation> createRotateXTransformOperation(const CSSFunct
     return RotateTransformOperation::create(x, y, z, angle, TransformOperation::Type::RotateX);
 }
 
-static RefPtr<TransformOperation> createRotateYTransformOperation(const CSSFunctionValue& value, BuilderState& builderState)
+static RefPtr<TransformOperation> createRotateYTransformOperation(BuilderState& state, const CSSFunctionValue& value)
 {
     // https://drafts.csswg.org/css-transforms-2/#funcdef-rotatey
     // rotateY() = rotateY( [ <angle> | <zero> ] )
 
-    auto function = requiredFunctionDowncast<CSSValueRotateY, CSSPrimitiveValue, 1>(builderState, value);
+    auto function = requiredFunctionDowncast<CSSValueRotateY, CSSPrimitiveValue, 1>(state, value);
     if (!function)
         return { };
 
-    auto& conversionData = builderState.cssToLengthConversionData();
+    auto& conversionData = state.cssToLengthConversionData();
 
     double x = 0;
     double y = 1;
@@ -206,16 +192,16 @@ static RefPtr<TransformOperation> createRotateYTransformOperation(const CSSFunct
     return RotateTransformOperation::create(x, y, z, angle, TransformOperation::Type::RotateY);
 }
 
-static RefPtr<TransformOperation> createRotateZTransformOperation(const CSSFunctionValue& value, BuilderState& builderState)
+static RefPtr<TransformOperation> createRotateZTransformOperation(BuilderState& state, const CSSFunctionValue& value)
 {
     // https://drafts.csswg.org/css-transforms-2/#funcdef-rotatez
     // rotateZ() = rotateZ( [ <angle> | <zero> ] )
 
-    auto function = requiredFunctionDowncast<CSSValueRotateZ, CSSPrimitiveValue, 1>(builderState, value);
+    auto function = requiredFunctionDowncast<CSSValueRotateZ, CSSPrimitiveValue, 1>(state, value);
     if (!function)
         return { };
 
-    auto& conversionData = builderState.cssToLengthConversionData();
+    auto& conversionData = state.cssToLengthConversionData();
 
     double x = 0;
     double y = 0;
@@ -227,16 +213,16 @@ static RefPtr<TransformOperation> createRotateZTransformOperation(const CSSFunct
 
 // MARK: Skew
 
-static RefPtr<TransformOperation> createSkewTransformOperation(const CSSFunctionValue& value, BuilderState& builderState)
+static RefPtr<TransformOperation> createSkewTransformOperation(BuilderState& state, const CSSFunctionValue& value)
 {
     // https://drafts.csswg.org/css-transforms-1/#funcdef-transform-skew
     // skew() = skew( [ <angle> | <zero> ] , [ <angle> | <zero> ]? )
 
-    auto function = requiredFunctionDowncast<CSSValueSkew, CSSPrimitiveValue, 1>(builderState, value);
+    auto function = requiredFunctionDowncast<CSSValueSkew, CSSPrimitiveValue, 1>(state, value);
     if (!function)
         return { };
 
-    auto& conversionData = builderState.cssToLengthConversionData();
+    auto& conversionData = state.cssToLengthConversionData();
 
     double angleX = function->item(0).resolveAsAngle(conversionData);
     double angleY = function->size() > 1 ? function->item(1).resolveAsAngle(conversionData) : 0;
@@ -244,16 +230,16 @@ static RefPtr<TransformOperation> createSkewTransformOperation(const CSSFunction
     return SkewTransformOperation::create(angleX, angleY, TransformOperation::Type::Skew);
 }
 
-static RefPtr<TransformOperation> createSkewXTransformOperation(const CSSFunctionValue& value, BuilderState& builderState)
+static RefPtr<TransformOperation> createSkewXTransformOperation(BuilderState& state, const CSSFunctionValue& value)
 {
     // https://drafts.csswg.org/css-transforms-1/#funcdef-transform-skewx
     // skewX() = skewX( [ <angle> | <zero> ] )
 
-    auto function = requiredFunctionDowncast<CSSValueSkewX, CSSPrimitiveValue, 1>(builderState, value);
+    auto function = requiredFunctionDowncast<CSSValueSkewX, CSSPrimitiveValue, 1>(state, value);
     if (!function)
         return { };
 
-    auto& conversionData = builderState.cssToLengthConversionData();
+    auto& conversionData = state.cssToLengthConversionData();
 
     double angleX = function->item(0).resolveAsAngle(conversionData);
     double angleY = 0;
@@ -261,16 +247,16 @@ static RefPtr<TransformOperation> createSkewXTransformOperation(const CSSFunctio
     return SkewTransformOperation::create(angleX, angleY, TransformOperation::Type::SkewX);
 }
 
-static RefPtr<TransformOperation> createSkewYTransformOperation(const CSSFunctionValue& value, BuilderState& builderState)
+static RefPtr<TransformOperation> createSkewYTransformOperation(BuilderState& state, const CSSFunctionValue& value)
 {
     // https://drafts.csswg.org/css-transforms-1/#funcdef-transform-skewy
     // skewY() = skewY( [ <angle> | <zero> ] )
 
-    auto function = requiredFunctionDowncast<CSSValueSkewY, CSSPrimitiveValue, 1>(builderState, value);
+    auto function = requiredFunctionDowncast<CSSValueSkewY, CSSPrimitiveValue, 1>(state, value);
     if (!function)
         return { };
 
-    auto& conversionData = builderState.cssToLengthConversionData();
+    auto& conversionData = state.cssToLengthConversionData();
 
     double angleX = 0;
     double angleY = function->item(0).resolveAsAngle(conversionData);
@@ -280,16 +266,16 @@ static RefPtr<TransformOperation> createSkewYTransformOperation(const CSSFunctio
 
 // MARK: Scale
 
-static RefPtr<TransformOperation> createScaleTransformOperation(const CSSFunctionValue& value, BuilderState& builderState)
+static RefPtr<TransformOperation> createScaleTransformOperation(BuilderState& state, const CSSFunctionValue& value)
 {
     // https://drafts.csswg.org/css-transforms-2/#funcdef-scale
     // scale() = scale( [ <number> | <percentage> ]#{1,2} )
 
-    auto function = requiredFunctionDowncast<CSSValueScale, CSSPrimitiveValue, 1>(builderState, value);
+    auto function = requiredFunctionDowncast<CSSValueScale, CSSPrimitiveValue, 1>(state, value);
     if (!function)
         return { };
 
-    auto& conversionData = builderState.cssToLengthConversionData();
+    auto& conversionData = state.cssToLengthConversionData();
 
     double sx = function->item(0).valueDividingBy100IfPercentage<double>(conversionData);
     double sy = function->size() > 1 ? function->item(1).valueDividingBy100IfPercentage<double>(conversionData) : sx;
@@ -298,16 +284,16 @@ static RefPtr<TransformOperation> createScaleTransformOperation(const CSSFunctio
     return ScaleTransformOperation::create(sx, sy, sz, TransformOperation::Type::Scale);
 }
 
-static RefPtr<TransformOperation> createScale3dTransformOperation(const CSSFunctionValue& value, BuilderState& builderState)
+static RefPtr<TransformOperation> createScale3dTransformOperation(BuilderState& state, const CSSFunctionValue& value)
 {
     // https://drafts.csswg.org/css-transforms-2/#funcdef-scale3d
     // scale3d() = scale3d( [ <number> | <percentage> ]#{3} )
 
-    auto function = requiredFunctionDowncast<CSSValueScale3d, CSSPrimitiveValue, 3>(builderState, value);
+    auto function = requiredFunctionDowncast<CSSValueScale3d, CSSPrimitiveValue, 3>(state, value);
     if (!function)
         return { };
 
-    auto& conversionData = builderState.cssToLengthConversionData();
+    auto& conversionData = state.cssToLengthConversionData();
 
     double sx = function->item(0).valueDividingBy100IfPercentage<double>(conversionData);
     double sy = function->item(1).valueDividingBy100IfPercentage<double>(conversionData);
@@ -316,16 +302,16 @@ static RefPtr<TransformOperation> createScale3dTransformOperation(const CSSFunct
     return ScaleTransformOperation::create(sx, sy, sz, TransformOperation::Type::Scale3D);
 }
 
-static RefPtr<TransformOperation> createScaleXTransformOperation(const CSSFunctionValue& value, BuilderState& builderState)
+static RefPtr<TransformOperation> createScaleXTransformOperation(BuilderState& state, const CSSFunctionValue& value)
 {
     // https://drafts.csswg.org/css-transforms-2/#funcdef-scalex
     // scaleX() = scaleX( [ <number> | <percentage> ] )
 
-    auto function = requiredFunctionDowncast<CSSValueScaleX, CSSPrimitiveValue, 1>(builderState, value);
+    auto function = requiredFunctionDowncast<CSSValueScaleX, CSSPrimitiveValue, 1>(state, value);
     if (!function)
         return { };
 
-    auto& conversionData = builderState.cssToLengthConversionData();
+    auto& conversionData = state.cssToLengthConversionData();
 
     double sx = function->item(0).valueDividingBy100IfPercentage<double>(conversionData);
     double sy = 1;
@@ -334,16 +320,16 @@ static RefPtr<TransformOperation> createScaleXTransformOperation(const CSSFuncti
     return ScaleTransformOperation::create(sx, sy, sz, TransformOperation::Type::ScaleX);
 }
 
-static RefPtr<TransformOperation> createScaleYTransformOperation(const CSSFunctionValue& value, BuilderState& builderState)
+static RefPtr<TransformOperation> createScaleYTransformOperation(BuilderState& state, const CSSFunctionValue& value)
 {
     // https://drafts.csswg.org/css-transforms-2/#funcdef-scaley
     // scaleY() = scaleY( [ <number> | <percentage> ] )
 
-    auto function = requiredFunctionDowncast<CSSValueScaleY, CSSPrimitiveValue, 1>(builderState, value);
+    auto function = requiredFunctionDowncast<CSSValueScaleY, CSSPrimitiveValue, 1>(state, value);
     if (!function)
         return { };
 
-    auto& conversionData = builderState.cssToLengthConversionData();
+    auto& conversionData = state.cssToLengthConversionData();
 
     double sx = 1;
     double sy = function->item(0).valueDividingBy100IfPercentage<double>(conversionData);
@@ -352,16 +338,16 @@ static RefPtr<TransformOperation> createScaleYTransformOperation(const CSSFuncti
     return ScaleTransformOperation::create(sx, sy, sz, TransformOperation::Type::ScaleY);
 }
 
-static RefPtr<TransformOperation> createScaleZTransformOperation(const CSSFunctionValue& value, BuilderState& builderState)
+static RefPtr<TransformOperation> createScaleZTransformOperation(BuilderState& state, const CSSFunctionValue& value)
 {
     // https://drafts.csswg.org/css-transforms-2/#funcdef-scalez
     // scaleZ() = scaleZ( [ <number> | <percentage> ] )
 
-    auto function = requiredFunctionDowncast<CSSValueScaleZ, CSSPrimitiveValue, 1>(builderState, value);
+    auto function = requiredFunctionDowncast<CSSValueScaleZ, CSSPrimitiveValue, 1>(state, value);
     if (!function)
         return { };
 
-    auto& conversionData = builderState.cssToLengthConversionData();
+    auto& conversionData = state.cssToLengthConversionData();
 
     double sx = 1.0;
     double sy = 1.0;
@@ -372,94 +358,94 @@ static RefPtr<TransformOperation> createScaleZTransformOperation(const CSSFuncti
 
 // MARK: Translate
 
-static RefPtr<TransformOperation> createTranslateTransformOperation(const CSSFunctionValue& value, BuilderState& builderState)
+static RefPtr<TransformOperation> createTranslateTransformOperation(BuilderState& state, const CSSFunctionValue& value)
 {
     // https://drafts.csswg.org/css-transforms-1/#funcdef-transform-translate
     // translate() = translate( <length-percentage> , <length-percentage>? )
 
-    auto function = requiredFunctionDowncast<CSSValueTranslate, CSSPrimitiveValue, 1>(builderState, value);
+    auto function = requiredFunctionDowncast<CSSValueTranslate, CSSPrimitiveValue, 1>(state, value);
     if (!function)
         return { };
 
-    auto tx = resolveAsFloatPercentOrCalculatedLength(function->item(0), builderState);
-    auto ty = function->size() > 1 ? resolveAsFloatPercentOrCalculatedLength(function->item(1), builderState) : WebCore::Length(0, LengthType::Fixed);
+    auto tx = BuilderConverter::convertLengthUsingDoubleNoClamping(state, function->item(0));
+    auto ty = function->size() > 1 ? BuilderConverter::convertLengthUsingDoubleNoClamping(state, function->item(1)) : WebCore::Length(0, LengthType::Fixed);
     auto tz = WebCore::Length(0, LengthType::Fixed);
 
     return TranslateTransformOperation::create(WTFMove(tx), WTFMove(ty), WTFMove(tz), TransformOperation::Type::Translate);
 }
 
-static RefPtr<TransformOperation> createTranslate3dTransformOperation(const CSSFunctionValue& value, BuilderState& builderState)
+static RefPtr<TransformOperation> createTranslate3dTransformOperation(BuilderState& state, const CSSFunctionValue& value)
 {
     // https://drafts.csswg.org/css-transforms-2/#funcdef-translate3d
     // translate3d() = translate3d( <length-percentage> , <length-percentage> , <length> )
 
-    auto function = requiredFunctionDowncast<CSSValueTranslate3d, CSSPrimitiveValue, 3>(builderState, value);
+    auto function = requiredFunctionDowncast<CSSValueTranslate3d, CSSPrimitiveValue, 3>(state, value);
     if (!function)
         return { };
 
-    auto tx = resolveAsFloatPercentOrCalculatedLength(function->item(0), builderState);
-    auto ty = resolveAsFloatPercentOrCalculatedLength(function->item(1), builderState);
-    auto tz = resolveAsFloatPercentOrCalculatedLength(function->item(2), builderState);
+    auto tx = BuilderConverter::convertLengthUsingDoubleNoClamping(state, function->item(0));
+    auto ty = BuilderConverter::convertLengthUsingDoubleNoClamping(state, function->item(1));
+    auto tz = BuilderConverter::convertLengthUsingDoubleNoClamping(state, function->item(2));
 
     return TranslateTransformOperation::create(WTFMove(tx), WTFMove(ty), WTFMove(tz), TransformOperation::Type::Translate3D);
 }
 
-static RefPtr<TransformOperation> createTranslateXTransformOperation(const CSSFunctionValue& value, BuilderState& builderState)
+static RefPtr<TransformOperation> createTranslateXTransformOperation(BuilderState& state, const CSSFunctionValue& value)
 {
     // https://drafts.csswg.org/css-transforms-1/#funcdef-transform-translatex
     // translateX() = translateX( <length-percentage> )
 
-    auto function = requiredFunctionDowncast<CSSValueTranslateX, CSSPrimitiveValue, 1>(builderState, value);
+    auto function = requiredFunctionDowncast<CSSValueTranslateX, CSSPrimitiveValue, 1>(state, value);
     if (!function)
         return { };
 
-    auto tx = resolveAsFloatPercentOrCalculatedLength(function->item(0), builderState);
+    auto tx = BuilderConverter::convertLengthUsingDoubleNoClamping(state, function->item(0));
     auto ty = WebCore::Length(0, LengthType::Fixed);
     auto tz = WebCore::Length(0, LengthType::Fixed);
 
     return TranslateTransformOperation::create(WTFMove(tx), WTFMove(ty), WTFMove(tz), TransformOperation::Type::TranslateX);
 }
 
-static RefPtr<TransformOperation> createTranslateYTransformOperation(const CSSFunctionValue& value, BuilderState& builderState)
+static RefPtr<TransformOperation> createTranslateYTransformOperation(BuilderState& state, const CSSFunctionValue& value)
 {
     // https://drafts.csswg.org/css-transforms-1/#funcdef-transform-translatey
     // translateY() = translateY( <length-percentage> )
 
-    auto function = requiredFunctionDowncast<CSSValueTranslateY, CSSPrimitiveValue, 1>(builderState, value);
+    auto function = requiredFunctionDowncast<CSSValueTranslateY, CSSPrimitiveValue, 1>(state, value);
     if (!function)
         return { };
 
     auto tx = WebCore::Length(0, LengthType::Fixed);
-    auto ty = resolveAsFloatPercentOrCalculatedLength(function->item(0), builderState);
+    auto ty = BuilderConverter::convertLengthUsingDoubleNoClamping(state, function->item(0));
     auto tz = WebCore::Length(0, LengthType::Fixed);
 
     return TranslateTransformOperation::create(WTFMove(tx), WTFMove(ty), WTFMove(tz), TransformOperation::Type::TranslateY);
 }
 
-static RefPtr<TransformOperation> createTranslateZTransformOperation(const CSSFunctionValue& value, BuilderState& builderState)
+static RefPtr<TransformOperation> createTranslateZTransformOperation(BuilderState& state, const CSSFunctionValue& value)
 {
     // https://drafts.csswg.org/css-transforms-2/#funcdef-translatez
     // translateZ() = translateZ( <length> )
 
-    auto function = requiredFunctionDowncast<CSSValueTranslateZ, CSSPrimitiveValue, 1>(builderState, value);
+    auto function = requiredFunctionDowncast<CSSValueTranslateZ, CSSPrimitiveValue, 1>(state, value);
     if (!function)
         return { };
 
     auto tx = WebCore::Length(0, LengthType::Fixed);
     auto ty = WebCore::Length(0, LengthType::Fixed);
-    auto tz = resolveAsFloatPercentOrCalculatedLength(function->item(0), builderState);
+    auto tz = BuilderConverter::convertLengthUsingDoubleNoClamping(state, function->item(0));
 
     return TranslateTransformOperation::create(WTFMove(tx), WTFMove(ty), WTFMove(tz), TransformOperation::Type::TranslateZ);
 }
 
 // MARK: Perspective
 
-static RefPtr<TransformOperation> createPerspectiveTransformOperation(const CSSFunctionValue& value, BuilderState& builderState)
+static RefPtr<TransformOperation> createPerspectiveTransformOperation(BuilderState& state, const CSSFunctionValue& value)
 {
     // https://drafts.csswg.org/css-transforms-2/#funcdef-perspective
     // perspective() = perspective( [ <length [0,∞]> | none ] )
 
-    auto function = requiredFunctionDowncast<CSSValuePerspective, CSSPrimitiveValue, 1>(builderState, value);
+    auto function = requiredFunctionDowncast<CSSValuePerspective, CSSPrimitiveValue, 1>(state, value);
     if (!function)
         return { };
 
@@ -470,17 +456,17 @@ static RefPtr<TransformOperation> createPerspectiveTransformOperation(const CSSF
     }
 
     if (parameter.isLength())
-        return PerspectiveTransformOperation::create(parameter.resolveAsLength<float>(builderState.cssToLengthConversionData()));
+        return PerspectiveTransformOperation::create(parameter.resolveAsLength<float>(state.cssToLengthConversionData()));
 
     // FIXME: Support for <number> parameters for `perspective` is a quirk that should go away when 3d transforms are finalized.
-    return PerspectiveTransformOperation::create(clampToPositiveInteger(parameter.resolveAsNumber<double>(builderState.cssToLengthConversionData())));
+    return PerspectiveTransformOperation::create(clampToPositiveInteger(parameter.resolveAsNumber<double>(state.cssToLengthConversionData())));
 }
 
 // MARK: - Conversion
 
-auto CSSValueConversion<TransformFunction>::operator()(BuilderState& builderState, const CSSValue& value) -> TransformFunction
+auto CSSValueConversion<TransformFunction>::operator()(BuilderState& state, const CSSValue& value) -> TransformFunction
 {
-    auto transform = requiredDowncast<CSSFunctionValue>(builderState, value);
+    auto transform = requiredDowncast<CSSFunctionValue>(state, value);
     if (!transform)
         return TransformFunction { MatrixTransformOperation::createIdentity() };
 
@@ -492,47 +478,47 @@ auto CSSValueConversion<TransformFunction>::operator()(BuilderState& builderStat
 
     switch (transform->name()) {
     case CSSValueMatrix:
-        return makeFunction(createMatrixTransformOperation(*transform, builderState));
+        return makeFunction(createMatrixTransformOperation(state, *transform));
     case CSSValueMatrix3d:
-        return makeFunction(createMatrix3dTransformOperation(*transform, builderState));
+        return makeFunction(createMatrix3dTransformOperation(state, *transform));
     case CSSValueRotate:
-        return makeFunction(createRotateTransformOperation(*transform, builderState));
+        return makeFunction(createRotateTransformOperation(state, *transform));
     case CSSValueRotate3d:
-        return makeFunction(createRotate3dTransformOperation(*transform, builderState));
+        return makeFunction(createRotate3dTransformOperation(state, *transform));
     case CSSValueRotateX:
-        return makeFunction(createRotateXTransformOperation(*transform, builderState));
+        return makeFunction(createRotateXTransformOperation(state, *transform));
     case CSSValueRotateY:
-        return makeFunction(createRotateYTransformOperation(*transform, builderState));
+        return makeFunction(createRotateYTransformOperation(state, *transform));
     case CSSValueRotateZ:
-        return makeFunction(createRotateZTransformOperation(*transform, builderState));
+        return makeFunction(createRotateZTransformOperation(state, *transform));
     case CSSValueSkew:
-        return makeFunction(createSkewTransformOperation(*transform, builderState));
+        return makeFunction(createSkewTransformOperation(state, *transform));
     case CSSValueSkewX:
-        return makeFunction(createSkewXTransformOperation(*transform, builderState));
+        return makeFunction(createSkewXTransformOperation(state, *transform));
     case CSSValueSkewY:
-        return makeFunction(createSkewYTransformOperation(*transform, builderState));
+        return makeFunction(createSkewYTransformOperation(state, *transform));
     case CSSValueScale:
-        return makeFunction(createScaleTransformOperation(*transform, builderState));
+        return makeFunction(createScaleTransformOperation(state, *transform));
     case CSSValueScale3d:
-        return makeFunction(createScale3dTransformOperation(*transform, builderState));
+        return makeFunction(createScale3dTransformOperation(state, *transform));
     case CSSValueScaleX:
-        return makeFunction(createScaleXTransformOperation(*transform, builderState));
+        return makeFunction(createScaleXTransformOperation(state, *transform));
     case CSSValueScaleY:
-        return makeFunction(createScaleYTransformOperation(*transform, builderState));
+        return makeFunction(createScaleYTransformOperation(state, *transform));
     case CSSValueScaleZ:
-        return makeFunction(createScaleZTransformOperation(*transform, builderState));
+        return makeFunction(createScaleZTransformOperation(state, *transform));
     case CSSValueTranslate:
-        return makeFunction(createTranslateTransformOperation(*transform, builderState));
+        return makeFunction(createTranslateTransformOperation(state, *transform));
     case CSSValueTranslate3d:
-        return makeFunction(createTranslate3dTransformOperation(*transform, builderState));
+        return makeFunction(createTranslate3dTransformOperation(state, *transform));
     case CSSValueTranslateX:
-        return makeFunction(createTranslateXTransformOperation(*transform, builderState));
+        return makeFunction(createTranslateXTransformOperation(state, *transform));
     case CSSValueTranslateY:
-        return makeFunction(createTranslateYTransformOperation(*transform, builderState));
+        return makeFunction(createTranslateYTransformOperation(state, *transform));
     case CSSValueTranslateZ:
-        return makeFunction(createTranslateZTransformOperation(*transform, builderState));
+        return makeFunction(createTranslateZTransformOperation(state, *transform));
     case CSSValuePerspective:
-        return makeFunction(createPerspectiveTransformOperation(*transform, builderState));
+        return makeFunction(createPerspectiveTransformOperation(state, *transform));
     default:
         break;
     }
@@ -542,10 +528,10 @@ auto CSSValueConversion<TransformFunction>::operator()(BuilderState& builderStat
 
 auto CSSValueCreation<TransformFunction>::operator()(CSSValuePool& pool, const RenderStyle& style, const TransformFunction& value) -> Ref<CSSValue>
 {
-    auto translateLength = [&](const auto& length) -> Ref<CSSPrimitiveValue> {
+    auto translateLength = [&](const auto& length) -> Ref<CSSValue> {
         if (length.isZero())
             return CSSPrimitiveValue::create(0, CSSUnitType::CSS_PX);
-        return ExtractorConverter::convertLength(style, length);
+        return ExtractorConverter::convertLength(pool, style, length);
     };
 
     auto includeLength = [](const auto& length) -> bool {
@@ -625,7 +611,7 @@ auto CSSValueCreation<TransformFunction>::operator()(CSSValuePool& pool, const R
     case TransformOperation::Type::Matrix3D: {
         TransformationMatrix transform;
         operation.apply(transform, { });
-        return ExtractorConverter::convertTransformationMatrix(style, transform);
+        return ExtractorConverter::convertTransformationMatrix(pool, style, transform);
     }
     case TransformOperation::Type::Identity:
     case TransformOperation::Type::None:

--- a/Source/WebCore/style/values/transforms/StyleTranslate.cpp
+++ b/Source/WebCore/style/values/transforms/StyleTranslate.cpp
@@ -56,9 +56,9 @@ auto CSSValueConversion<Translate>::operator()(BuilderState& state, const CSSVal
         return CSS::Keyword::None { };
 
     auto type = list->size() > 2 ? TransformOperation::Type::Translate3D : TransformOperation::Type::Translate;
-    auto tx = BuilderConverter::convertLength(state, list->item(0));
-    auto ty = list->size() > 1 ? BuilderConverter::convertLength(state, list->item(1)) : WebCore::Length(0, LengthType::Fixed);
-    auto tz = list->size() > 2 ? BuilderConverter::convertLength(state, list->item(2)) : WebCore::Length(0, LengthType::Fixed);
+    auto tx = BuilderConverter::convertLengthUsingDoubleNoClamping(state, list->item(0));
+    auto ty = list->size() > 1 ? BuilderConverter::convertLengthUsingDoubleNoClamping(state, list->item(1)) : WebCore::Length(0, LengthType::Fixed);
+    auto tz = list->size() > 2 ? BuilderConverter::convertLengthUsingDoubleNoClamping(state, list->item(2)) : WebCore::Length(0, LengthType::Fixed);
 
     return Translate { TranslateTransformOperation::create(WTFMove(tx), WTFMove(ty), WTFMove(tz), type) };
 }


### PR DESCRIPTION
#### ac0dd6910ed9162811acce16813e68a69dff4cec
<pre>
[Style] Cleanup Style builder/extractor converters
<a href="https://bugs.webkit.org/show_bug.cgi?id=299256">https://bugs.webkit.org/show_bug.cgi?id=299256</a>

Reviewed by NOBODY (OOPS!).

Performs various cleanups of Style::BuilderConverter, Style::ExtractorConverter,
Style::ExtractorSerializer and Style::ExtractorCustom.

- Removes unused functions.
- Switches to using standard createCSSValue/serializationForCSS where possible.
- De-duplicate where possible.

These will help as we move the remaining properties to use strong style types.

* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/dom/ViewTransition.cpp:
* Source/WebCore/style/StyleBuilderConverter.h:
* Source/WebCore/style/StyleExtractorConverter.h:
* Source/WebCore/style/StyleExtractorCustom.h:
* Source/WebCore/style/StyleExtractorSerializer.h:
* Source/WebCore/style/values/transforms/StyleTransformFunction.cpp:
* Source/WebCore/style/values/transforms/StyleTranslate.cpp:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ac0dd6910ed9162811acce16813e68a69dff4cec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122064 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41766 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32436 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128627 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74158 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123940 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42481 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50360 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92779 "Found 8 new test failures: imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer.html imported/w3c/web-platform-tests/css/css-fonts/discrete-no-interpolation.html imported/w3c/web-platform-tests/css/css-fonts/font-feature-settings-serialization-001.html imported/w3c/web-platform-tests/css/css-fonts/inheritance.html imported/w3c/web-platform-tests/css/css-pseudo/first-line-allowed-properties.html imported/w3c/web-platform-tests/css/css-pseudo/parsing/marker-supported-properties-in-animation.html imported/w3c/web-platform-tests/css/css-pseudo/parsing/marker-supported-properties.html imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-001.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61663 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125016 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33881 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109310 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73435 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32894 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27476 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72121 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103388 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27667 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131388 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49003 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37272 "Found 18 new test failures: css3/font-feature-settings-parsing.html fast/css/inherited-properties-rare-text.html imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer.html imported/w3c/web-platform-tests/css/css-fonts/discrete-no-interpolation.html imported/w3c/web-platform-tests/css/css-fonts/font-feature-settings-serialization-001.html imported/w3c/web-platform-tests/css/css-fonts/inheritance.html imported/w3c/web-platform-tests/css/css-fonts/parsing/font-feature-settings-computed.html imported/w3c/web-platform-tests/css/css-pseudo/first-letter-allowed-properties.html imported/w3c/web-platform-tests/css/css-pseudo/first-line-allowed-properties.html imported/w3c/web-platform-tests/css/css-pseudo/parsing/marker-supported-properties-in-animation.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101341 "Found 17 new test failures: css3/font-feature-settings-parsing.html fast/css/inherited-properties-rare-text.html imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer.html imported/w3c/web-platform-tests/css/css-fonts/discrete-no-interpolation.html imported/w3c/web-platform-tests/css/css-fonts/font-feature-settings-serialization-001.html imported/w3c/web-platform-tests/css/css-fonts/inheritance.html imported/w3c/web-platform-tests/css/css-fonts/parsing/font-feature-settings-computed.html imported/w3c/web-platform-tests/css/css-pseudo/first-letter-allowed-properties.html imported/w3c/web-platform-tests/css/css-pseudo/first-line-allowed-properties.html imported/w3c/web-platform-tests/css/css-pseudo/parsing/marker-supported-properties-in-animation.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49377 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105524 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101212 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46579 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24694 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45738 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48860 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54594 "Found 2 new failures in style/StyleExtractorSerializer.h") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48330 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51680 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50010 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->