### PR TITLE
[Style] Remove unused style interpolation wrappers and functions

### DIFF
--- a/Source/WebCore/style/StyleInterpolationFunctions.h
+++ b/Source/WebCore/style/StyleInterpolationFunctions.h
@@ -104,11 +104,6 @@ inline TabSize blendFunc(const TabSize& from, const TabSize& to, const Context& 
     return { blendedValue < 0 ? 0 : blendedValue, from.isSpaces() ? SpaceValueType : LengthValueType };
 }
 
-inline FilterOperations blendFunc(const FilterOperations& from, const FilterOperations& to, const Context& context)
-{
-    return from.blend(to, context);
-}
-
 inline ContentVisibility blendFunc(ContentVisibility from, ContentVisibility to, const Context& context)
 {
     // https://drafts.csswg.org/css-contain-3/#content-visibility-animation
@@ -156,19 +151,6 @@ inline DisplayType blendFunc(DisplayType from, DisplayType to, const Context& co
     if (context.progress >= 1)
         return to;
     return from == DisplayType::None ? to : from;
-}
-
-inline RefPtr<StyleImage> blendFunc(StyleImage* from, StyleImage* to, const Context& context)
-{
-    if (!context.progress)
-        return from;
-
-    if (context.progress == 1.0)
-        return to;
-
-    ASSERT(from);
-    ASSERT(to);
-    return blend(ImageWrapper { *from }, ImageWrapper { *to }, context).value.ptr();
 }
 
 #if ENABLE(VARIATION_FONTS)


### PR DESCRIPTION
#### 93d3de050525026eea10afe7a83f3003a7e44ed1
<pre>
[Style] Remove unused style interpolation wrappers and functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=299255">https://bugs.webkit.org/show_bug.cgi?id=299255</a>

Reviewed by Darin Adler.

Removes a few now unused style interpolation wrappers and functions
and rearranges the wrappers to be a bit more organized.

* Source/WebCore/style/StyleInterpolationFunctions.h:
* Source/WebCore/style/StyleInterpolationWrappers.h:

Canonical link: <a href="https://commits.webkit.org/300301@main">https://commits.webkit.org/300301@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8a57a45aa5628b87060f59d1b0a43e0481c8cfbd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122065 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41767 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32437 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128629 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74159 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123941 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42482 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50361 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92780 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61662 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125017 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33880 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109311 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73436 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32893 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27477 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72122 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103387 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27668 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131389 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49004 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37271 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101342 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49378 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105525 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101213 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25661 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46578 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24695 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45741 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48861 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54595 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48331 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51681 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50011 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->