### PR TITLE
[JSC] Move OMGOrigin to WasmOrigin and use it in BBQ as well

### DIFF
--- a/Source/JavaScriptCore/b3/B3Origin.h
+++ b/Source/JavaScriptCore/b3/B3Origin.h
@@ -32,7 +32,7 @@
 #include <wtf/ValidatedReinterpretCast.h>
 
 namespace JSC::Wasm {
-class OMGOrigin;
+class WasmOrigin;
 class OpcodeOrigin;
 }
 
@@ -51,12 +51,12 @@ public:
     enum OriginType : uint8_t {
         InvalidTag,
         DFGOriginPtr,
-        OMGOriginPtr,
+        WasmOriginPtr,
         PackedWasmOrigin,
     };
 
-    explicit Origin(const Wasm::OMGOrigin* data)
-        : m_data(data, OMGOriginPtr)
+    explicit Origin(const Wasm::WasmOrigin* data)
+        : m_data(data, WasmOriginPtr)
     {
     }
 
@@ -72,13 +72,13 @@ public:
     explicit operator bool() const { return !!m_data.bits(); }
 
     bool isDFGOrigin() const { return !m_data.bits() || m_data.tag() == DFGOriginPtr; }
-    bool isOMGOrigin() const { return !m_data.bits() || m_data.tag() == OMGOriginPtr; }
+    bool isWasmOrigin() const { return !m_data.bits() || m_data.tag() == WasmOriginPtr; }
     bool isPackedWasmOrigin() const { return !m_data.bits() || m_data.tag() == PackedWasmOrigin; }
 
-    Wasm::OMGOrigin* omgOrigin() const
+    Wasm::WasmOrigin* wasmOrigin() const
     {
-        ASSERT(isOMGOrigin());
-        return VALIDATED_REINTERPRET_CAST("OMGOrigin", Wasm::OMGOrigin, m_data.ptr());
+        ASSERT(isWasmOrigin());
+        return VALIDATED_REINTERPRET_CAST("WasmOrigin", Wasm::WasmOrigin, m_data.ptr());
     }
 
     DFG::Node* dfgOrigin() const
@@ -87,7 +87,7 @@ public:
         return std::bit_cast<DFG::Node*>(m_data.ptr());
     }
 
-    const Wasm::OMGOrigin* maybeOMGOrigin() const { return isOMGOrigin() ? omgOrigin() : nullptr; }
+    const Wasm::WasmOrigin* maybeWasmOrigin() const { return isWasmOrigin() ? wasmOrigin() : nullptr; }
 
     // You should avoid using this. Use OriginDump instead.
     void dump(PrintStream&) const;

--- a/Source/JavaScriptCore/jit/PCToCodeOriginMap.h
+++ b/Source/JavaScriptCore/jit/PCToCodeOriginMap.h
@@ -31,31 +31,23 @@
 #include <JavaScriptCore/CodeOrigin.h>
 #include <JavaScriptCore/MacroAssembler.h>
 #include <JavaScriptCore/VM.h>
+#include <JavaScriptCore/WasmOpcodeOrigin.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/ValidatedReinterpretCast.h>
 #include <wtf/Vector.h>
 
-#if ENABLE(WEBASSEMBLY_OMGJIT)
-#include <JavaScriptCore/WasmOpcodeOrigin.h>
-#endif
-
 namespace JSC {
-
-#if ENABLE(FTL_JIT) || ENABLE(WEBASSEMBLY_OMGJIT)
 namespace B3 {
 class PCToOriginMap;
 }
-#endif
-
-#if ENABLE(WEBASSEMBLY_OMGJIT)
 
 namespace Wasm {
-class OMGOrigin {
+class WasmOrigin {
     MAKE_VALIDATED_REINTERPRET_CAST
 public:
-    friend bool operator==(const OMGOrigin&, const OMGOrigin&) = default;
+    friend bool operator==(const WasmOrigin&, const WasmOrigin&) = default;
 
-    OMGOrigin(CallSiteIndex callSiteIndex, OpcodeOrigin opcodeOrigin)
+    WasmOrigin(CallSiteIndex callSiteIndex, OpcodeOrigin opcodeOrigin)
         : m_callSiteIndex(callSiteIndex)
         , m_opcodeOrigin(opcodeOrigin)
     { }
@@ -64,10 +56,9 @@ public:
     OpcodeOrigin m_opcodeOrigin { };
 };
 
-MAKE_VALIDATED_REINTERPRET_CAST_IMPL("OMGOrigin", OMGOrigin)
+MAKE_VALIDATED_REINTERPRET_CAST_IMPL("WasmOrigin", WasmOrigin)
 
 } // namespace Wasm
-#endif // ENABLE(WEBASSEMBLY_OMGJIT)
 
 class LinkBuffer;
 class PCToCodeOriginMapBuilder;

--- a/Source/JavaScriptCore/wasm/WasmBBQDisassembler.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQDisassembler.h
@@ -43,53 +43,6 @@ namespace Wasm {
 
 class BBQCallee;
 
-struct PrefixedOpcode {
-    OpType prefixOrOpcode;
-    union {
-        Ext1OpType ext1Opcode;
-        ExtAtomicOpType atomicOpcode;
-        ExtSIMDOpType simdOpcode;
-        ExtGCOpType gcOpcode;
-    } prefixed;
-
-    inline explicit PrefixedOpcode(OpType opcode)
-    {
-        switch (opcode) {
-        default:
-            prefixOrOpcode = opcode;
-            break;
-        case OpType::ExtGC:
-        case OpType::Ext1:
-        case OpType::ExtAtomic:
-        case OpType::ExtSIMD:
-            RELEASE_ASSERT_NOT_REACHED();
-        }
-    }
-
-    inline explicit PrefixedOpcode(OpType prefix, uint32_t opcode)
-    {
-        prefixOrOpcode = prefix;
-        switch (prefix) {
-        case OpType::Ext1:
-            prefixed.ext1Opcode = static_cast<Ext1OpType>(opcode);
-            break;
-        case OpType::ExtSIMD:
-            prefixed.simdOpcode = static_cast<ExtSIMDOpType>(opcode);
-            break;
-        case OpType::ExtGC:
-            prefixed.gcOpcode = static_cast<ExtGCOpType>(opcode);
-            break;
-        case OpType::ExtAtomic:
-            prefixed.atomicOpcode = static_cast<ExtAtomicOpType>(opcode);
-            break;
-        default:
-            RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("Expected a valid WASM opcode prefix.");
-        }
-    }
-};
-
-ASCIILiteral makeString(PrefixedOpcode);
-
 class BBQDisassembler {
     WTF_MAKE_TZONE_ALLOCATED(BBQDisassembler);
 public:
@@ -97,9 +50,9 @@ public:
     ~BBQDisassembler();
 
     void setStartOfCode(MacroAssembler::Label label) { m_startOfCode = label; }
-    void setOpcode(MacroAssembler::Label label, PrefixedOpcode opcode, size_t offset)
+    void setOpcode(MacroAssembler::Label label, OpcodeOrigin origin)
     {
-        m_labels.append(std::tuple { label, opcode, offset });
+        m_labels.append(std::tuple { label, origin });
     }
     void setEndOfOpcode(MacroAssembler::Label label) { m_endOfOpcode = label; }
     void setEndOfCode(MacroAssembler::Label label) { m_endOfCode = label; }
@@ -113,13 +66,13 @@ private:
     struct DumpedOp {
         CString disassembly;
     };
-    Vector<DumpedOp> dumpVectorForInstructions(LinkBuffer&, const char* prefix, Vector<std::tuple<MacroAssembler::Label, PrefixedOpcode, size_t>>& labels, MacroAssembler::Label endLabel);
+    Vector<DumpedOp> dumpVectorForInstructions(LinkBuffer&, const char* prefix, Vector<std::tuple<MacroAssembler::Label, OpcodeOrigin>>& labels, MacroAssembler::Label endLabel);
 
-    void dumpForInstructions(PrintStream&, LinkBuffer&, const char* prefix, Vector<std::tuple<MacroAssembler::Label, PrefixedOpcode, size_t>>& labels, MacroAssembler::Label endLabel);
+    void dumpForInstructions(PrintStream&, LinkBuffer&, const char* prefix, Vector<std::tuple<MacroAssembler::Label, OpcodeOrigin>>& labels, MacroAssembler::Label endLabel);
     void dumpDisassembly(PrintStream&, LinkBuffer&, MacroAssembler::Label from, MacroAssembler::Label to);
 
     MacroAssembler::Label m_startOfCode;
-    Vector<std::tuple<MacroAssembler::Label, PrefixedOpcode, size_t>> m_labels;
+    Vector<std::tuple<MacroAssembler::Label, OpcodeOrigin>> m_labels;
     MacroAssembler::Label m_endOfOpcode;
     MacroAssembler::Label m_endOfCode;
     void* m_codeStart { nullptr };

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
@@ -1492,7 +1492,7 @@ void BBQJIT::emitAllocateGCArrayUninitialized(GPRReg resultGPR, uint32_t typeInd
     // if we hit the slow path. But the way Labels work we need to know the exact offset we're returning to when moving to the slow path.
     JIT_COMMENT(m_jit, "Slow path return");
     MacroAssembler::Label done(m_jit);
-    m_slowPaths.append({ WTFMove(slowPath), WTFMove(done), copyBindings(), [typeIndex, size, sizeLocation, resultGPR](BBQJIT& bbq, CCallHelpers& jit) {
+    m_slowPaths.append({ origin(), WTFMove(slowPath), WTFMove(done), copyBindings(), [typeIndex, size, sizeLocation, resultGPR](BBQJIT& bbq, CCallHelpers& jit) {
         jit.prepareWasmCallOperation(GPRInfo::wasmContextInstancePointer);
         if (size.isConst())
             jit.setupArguments<decltype(operationWasmArrayNewEmpty)>(GPRInfo::wasmContextInstancePointer, TrustedImm32(typeIndex), TrustedImm32(size.asI32()));
@@ -2008,7 +2008,7 @@ void BBQJIT::emitAllocateGCStructUninitialized(GPRReg resultGPR, uint32_t typeIn
 
     JIT_COMMENT(m_jit, "Slow path return");
     MacroAssembler::Label done(m_jit);
-    m_slowPaths.append({ WTFMove(slowPath), WTFMove(done), copyBindings(), [typeIndex, resultGPR](BBQJIT& bbq, CCallHelpers& jit) {
+    m_slowPaths.append({ origin(), WTFMove(slowPath), WTFMove(done), copyBindings(), [typeIndex, resultGPR](BBQJIT& bbq, CCallHelpers& jit) {
         jit.prepareWasmCallOperation(GPRInfo::wasmContextInstancePointer);
         jit.setupArguments<decltype(operationWasmStructNewEmpty)>(GPRInfo::wasmContextInstancePointer, TrustedImm32(typeIndex));
         jit.callOperation<OperationPtrTag>(operationWasmStructNewEmpty);

--- a/Source/JavaScriptCore/wasm/WasmCallee.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCallee.cpp
@@ -381,7 +381,7 @@ Box<PCToCodeOriginMap> OptimizingJITCallee::materializePCToOriginMap(B3::PCToOri
     PCToCodeOriginMapBuilder builder(shouldBuildMapping);
     for (const B3::PCToOriginMap::OriginRange& originRange : originMap.ranges()) {
         B3::Origin b3Origin = originRange.origin;
-        if (auto* origin = b3Origin.maybeOMGOrigin()) {
+        if (auto* origin = b3Origin.maybeWasmOrigin()) {
             // We stash the location into a BytecodeIndex.
             builder.appendItem(originRange.label, CodeOrigin(BytecodeIndex(origin->m_callSiteIndex.bits())));
         } else
@@ -395,7 +395,7 @@ Box<PCToCodeOriginMap> OptimizingJITCallee::materializePCToOriginMap(B3::PCToOri
         PCToCodeOriginMapBuilder samplingProfilerBuilder(shouldBuildMapping);
         for (const B3::PCToOriginMap::OriginRange& originRange : originMap.ranges()) {
             B3::Origin b3Origin = originRange.origin;
-            if (auto* origin = b3Origin.maybeOMGOrigin()) {
+            if (auto* origin = b3Origin.maybeWasmOrigin()) {
                 // We stash the location into a BytecodeIndex.
                 samplingProfilerBuilder.appendItem(originRange.label, CodeOrigin(BytecodeIndex(origin->m_opcodeOrigin.location())));
             } else

--- a/Source/JavaScriptCore/wasm/WasmCompilationContext.h
+++ b/Source/JavaScriptCore/wasm/WasmCompilationContext.h
@@ -70,7 +70,7 @@ struct CompilationContext {
     Box<PCToCodeOriginMap> pcToCodeOriginMap;
     Box<PCToCodeOriginMapBuilder> pcToCodeOriginMapBuilder;
     Vector<CCallHelpers::Label> catchEntrypoints;
-    SegmentedVector<OMGOrigin> origins;
+    SegmentedVector<WasmOrigin> origins;
 };
 
 } // namespace Wasm

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -4866,7 +4866,7 @@ auto OMGIRGenerator::addThrow(unsigned exceptionIndex, ArgumentList& args, Stack
         AllowMacroScratchRegisterUsage allowScratch(jit);
         if (handle)
             handle->collectStackMap(this, params);
-        RELEASE_ASSERT(origin.omgOrigin());
+        RELEASE_ASSERT(origin.wasmOrigin());
         emitThrowImpl(jit, exceptionIndex);
     });
     m_currentBlock->append(patch);
@@ -4893,7 +4893,7 @@ auto WARN_UNUSED_RETURN OMGIRGenerator::addThrowRef(TypedExpression exnref, Stac
         AllowMacroScratchRegisterUsage allowScratch(jit);
         if (handle)
             handle->collectStackMap(this, params);
-        RELEASE_ASSERT(origin.omgOrigin());
+        RELEASE_ASSERT(origin.wasmOrigin());
         emitThrowRefImpl(jit);
     });
     m_currentBlock->append(patch);
@@ -4915,7 +4915,7 @@ auto OMGIRGenerator::addRethrow(unsigned, ControlType& data) -> PartialResult
         AllowMacroScratchRegisterUsage allowScratch(jit);
         if (handle)
             handle->collectStackMap(this, params);
-        RELEASE_ASSERT(origin.omgOrigin());
+        RELEASE_ASSERT(origin.wasmOrigin());
         emitThrowRefImpl(jit);
     });
     m_currentBlock->append(patch);
@@ -6278,7 +6278,7 @@ auto OMGIRGenerator::origin() -> Origin
         break;
     }
     ASSERT(isValidOpType(static_cast<uint8_t>(opcodeOrigin.opcode())));
-    OMGOrigin result { CallSiteIndex(callSiteIndex()), opcodeOrigin };
+    WasmOrigin result { CallSiteIndex(callSiteIndex()), opcodeOrigin };
     if (m_context.origins.isEmpty() || m_context.origins.last() != result)
         m_context.origins.append(result);
     return Origin(&m_context.origins.last());
@@ -6312,7 +6312,7 @@ Expected<std::unique_ptr<InternalFunction>, String> parseAndCompileOMG(Compilati
 
     procedure.setNeedsPCToOriginMap();
     procedure.setOriginPrinter([](PrintStream& out, Origin origin) {
-        if (auto* impl = origin.maybeOMGOrigin())
+        if (auto* impl = origin.maybeWasmOrigin())
             out.print("Wasm: ", impl->m_opcodeOrigin, " CallSiteIndex: ", impl->m_callSiteIndex.bits());
     });
 

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp
@@ -4841,7 +4841,7 @@ auto OMGIRGenerator::addThrow(unsigned exceptionIndex, ArgumentList& args, Stack
         AllowMacroScratchRegisterUsage allowScratch(jit);
         if (handle)
             handle->collectStackMap(this, params);
-        RELEASE_ASSERT(origin.omgOrigin());
+        RELEASE_ASSERT(origin.wasmOrigin());
         emitThrowImpl(jit, exceptionIndex);
     });
     m_currentBlock->append(patch);
@@ -4871,7 +4871,7 @@ auto WARN_UNUSED_RETURN OMGIRGenerator::addThrowRef(TypedExpression exnref, Stac
         AllowMacroScratchRegisterUsage allowScratch(jit);
         if (handle)
             handle->collectStackMap(this, params);
-        RELEASE_ASSERT(origin.omgOrigin());
+        RELEASE_ASSERT(origin.wasmOrigin());
         emitThrowRefImpl(jit);
     });
     m_currentBlock->append(patch);
@@ -4896,7 +4896,7 @@ auto OMGIRGenerator::addRethrow(unsigned, ControlType& data) -> PartialResult
         AllowMacroScratchRegisterUsage allowScratch(jit);
         if (handle)
             handle->collectStackMap(this, params);
-        RELEASE_ASSERT(origin.omgOrigin());
+        RELEASE_ASSERT(origin.wasmOrigin());
         emitThrowRefImpl(jit);
     });
     m_currentBlock->append(patch);
@@ -6218,7 +6218,7 @@ auto OMGIRGenerator::origin() -> Origin
         break;
     }
     ASSERT(isValidOpType(static_cast<uint8_t>(opcodeOrigin.opcode())));
-    OMGOrigin result { CallSiteIndex(callSiteIndex()), opcodeOrigin };
+    WasmOrigin result { CallSiteIndex(callSiteIndex()), opcodeOrigin };
     if (m_context.origins.isEmpty() || m_context.origins.last() != result)
         m_context.origins.append(result);
     return Origin(&m_context.origins.last());
@@ -6252,7 +6252,7 @@ Expected<std::unique_ptr<InternalFunction>, String> parseAndCompileOMG(Compilati
 
     procedure.setNeedsPCToOriginMap();
     procedure.setOriginPrinter([](PrintStream& out, Origin origin) {
-        if (auto* impl = origin.maybeOMGOrigin())
+        if (auto* impl = origin.maybeWasmOrigin())
             out.print("Wasm: ", impl->m_opcodeOrigin, " CallSiteIndex: ", impl->m_callSiteIndex.bits());
     });
 

--- a/Source/JavaScriptCore/wasm/WasmOpcodeOrigin.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOpcodeOrigin.cpp
@@ -30,10 +30,12 @@
 
 #include <wtf/text/MakeString.h>
 
-#if ENABLE(WEBASSEMBLY_OMGJIT)
+#if ENABLE(WEBASSEMBLY)
 
 namespace JSC { namespace Wasm {
 
+
+#if ENABLE(WEBASSEMBLY_OMGJIT)
 OpcodeOrigin::OpcodeOrigin(B3::Origin origin)
 {
     ASSERT(origin.isPackedWasmOrigin());
@@ -44,33 +46,36 @@ B3::Origin OpcodeOrigin::asB3Origin()
 {
     return B3::Origin(packedData);
 }
+#endif
 
-void OpcodeOrigin::dump(PrintStream& out) const
+ASCIILiteral OpcodeOrigin::opcodeString() const
 {
     switch (opcode()) {
 #if USE(JSVALUE64)
     case OpType::ExtGC:
-        out.print("{opcode: ", makeString(gcOpcode()), ", location: ", RawHex(location()), "}");
-        break;
+        return makeString(gcOpcode());
     case OpType::Ext1:
-        out.print("{opcode: ", makeString(ext1Opcode()), ", location: ", RawHex(location()), "}");
-        break;
+        return makeString(ext1Opcode());
     case OpType::ExtSIMD:
-        out.print("{opcode: ", makeString(simdOpcode()), ", location: ", RawHex(location()), "}");
-        break;
+        return makeString(simdOpcode());
     case OpType::ExtAtomic:
-        out.print("{opcode: ", makeString(atomicOpcode()), ", location: ", RawHex(location()), "}");
-        break;
+        return makeString(atomicOpcode());
 #endif
     default:
-        out.print("{opcode: ", makeString(opcode()), ", location: ", RawHex(location()), "}");
-        break;
+        return makeString(opcode());
     }
 }
 
+void OpcodeOrigin::dump(PrintStream& out) const
+{
+    out.print("{opcode: ", opcodeString(), ", location: ", RawHex(location()), "}");
+}
+
 static_assert(sizeof(OpcodeOrigin) == sizeof(uint64_t), "this packing doesn't work if this isn't the case");
+#if ENABLE(WEBASSEMBLY_OMGJIT)
 static_assert(sizeof(B3::Origin) == sizeof(uint64_t), "this packing doesn't work if this isn't the case");
+#endif
 
 } } // namespace JSC::Wasm
 
-#endif // ENABLE(WEBASSEMBLY_OMGJIT)
+#endif // ENABLE(WEBASSEMBLY)

--- a/Source/JavaScriptCore/wasm/WasmOpcodeOrigin.h
+++ b/Source/JavaScriptCore/wasm/WasmOpcodeOrigin.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#if ENABLE(WEBASSEMBLY_OMGJIT)
+#if ENABLE(WEBASSEMBLY)
 
 #include <JavaScriptCore/WasmFormat.h>
 
@@ -65,7 +65,9 @@ public:
         packedData = (static_cast<uint64_t>(opcode) << 40) | (static_cast<uint64_t>(prefix) << 32) | offset;
     }
 
+#if ENABLE(WEBASSEMBLY_OMGJIT)
     OpcodeOrigin(B3::Origin);
+#endif
 
     OpType opcode() const
     {
@@ -97,7 +99,11 @@ public:
         return static_cast<uint32_t>(packedData);
     }
 
+    ASCIILiteral opcodeString() const;
+
+#if ENABLE(WEBASSEMBLY_OMGJIT)
     B3::Origin asB3Origin();
+#endif
 
 private:
     uint64_t packedData { 0 };


### PR DESCRIPTION
#### 08524c1b29b51e899d26b5eafa8d8d977f8321e8
<pre>
[JSC] Move OMGOrigin to WasmOrigin and use it in BBQ as well
<a href="https://bugs.webkit.org/show_bug.cgi?id=299257">https://bugs.webkit.org/show_bug.cgi?id=299257</a>
<a href="https://rdar.apple.com/161053703">rdar://161053703</a>

Reviewed by Justin Michaud.

This patch renames OMGOrigin to WasmOrigin, and uses it in BBQ as well.
This simplifies BBQ disassembler&apos;s code, and paves the way to get
CallSiteIndex from PC in BBQ as well as OMG. Also annotating late / slow
code with appropriate origins as well so sampling profiler can find them
correctly for BBQ.

* Source/JavaScriptCore/b3/B3Origin.h:
(JSC::B3::Origin::Origin):
(JSC::B3::Origin::isWasmOrigin const):
(JSC::B3::Origin::wasmOrigin const):
(JSC::B3::Origin::maybeWasmOrigin const):
(JSC::B3::Origin::isOMGOrigin const): Deleted.
(JSC::B3::Origin::omgOrigin const): Deleted.
(JSC::B3::Origin::maybeOMGOrigin const): Deleted.
* Source/JavaScriptCore/jit/PCToCodeOriginMap.h:
(JSC::Wasm::WasmOrigin::WasmOrigin):
(JSC::Wasm::OMGOrigin::OMGOrigin): Deleted.
* Source/JavaScriptCore/wasm/WasmBBQDisassembler.cpp:
(JSC::Wasm::BBQDisassembler::dumpVectorForInstructions):
(JSC::Wasm::BBQDisassembler::dumpForInstructions):
(JSC::Wasm::makeString): Deleted.
* Source/JavaScriptCore/wasm/WasmBBQDisassembler.h:
(JSC::Wasm::BBQDisassembler::setOpcode):
(JSC::Wasm::PrefixedOpcode::PrefixedOpcode): Deleted.
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::BBQJIT):
(JSC::Wasm::BBQJITImpl::BBQJIT::addLatePath):
(JSC::Wasm::BBQJITImpl::BBQJIT::emitEntryTierUpCheck):
(JSC::Wasm::BBQJITImpl::BBQJIT::addTopLevel):
(JSC::Wasm::BBQJITImpl::BBQJIT::emitLoopTierUpCheckAndOSREntryData):
(JSC::Wasm::BBQJITImpl::BBQJIT::endTopLevel):
(JSC::Wasm::BBQJITImpl::BBQJIT::origin):
(JSC::Wasm::BBQJITImpl::BBQJIT::willParseOpcode):
(JSC::Wasm::BBQJITImpl::BBQJIT::willParseExtendedOpcode):
(JSC::Wasm::parseAndCompileBBQ):
* Source/JavaScriptCore/wasm/WasmBBQJIT.h:
* Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::emitAllocateGCArrayUninitialized):
(JSC::Wasm::BBQJITImpl::BBQJIT::emitAllocateGCStructUninitialized):
* Source/JavaScriptCore/wasm/WasmCallee.cpp:
(JSC::Wasm::OptimizingJITCallee::materializePCToOriginMap):
* Source/JavaScriptCore/wasm/WasmCompilationContext.h:
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::OMGIRGenerator::addThrow):
(JSC::Wasm::OMGIRGenerator::addThrowRef):
(JSC::Wasm::OMGIRGenerator::addRethrow):
(JSC::Wasm::OMGIRGenerator::origin):
(JSC::Wasm::parseAndCompileOMG):
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp:
(JSC::Wasm::OMGIRGenerator::addThrow):
(JSC::Wasm::OMGIRGenerator::addThrowRef):
(JSC::Wasm::OMGIRGenerator::addRethrow):
(JSC::Wasm::OMGIRGenerator::origin):
(JSC::Wasm::parseAndCompileOMG):
* Source/JavaScriptCore/wasm/WasmOpcodeOrigin.cpp:
(JSC::Wasm::OpcodeOrigin::opcodeString const):
(JSC::Wasm::OpcodeOrigin::dump const):
* Source/JavaScriptCore/wasm/WasmOpcodeOrigin.h:

Canonical link: <a href="https://commits.webkit.org/300303@main">https://commits.webkit.org/300303@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/407643568389849cf404b698af69d8ba8510c87c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122072 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41775 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32444 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128636 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74166 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5f296179-6889-4942-b792-63514a08ff76) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42489 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50368 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92785 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61668 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d7cc7928-2f6d-4b85-8559-abdd280b8d68) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125024 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33885 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109317 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73441 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/35ed67e6-269f-4bd9-9c52-8e145c2b9204) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32898 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27483 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72130 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/114220 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103392 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27674 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131396 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/120598 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49011 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37277 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101347 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49385 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105531 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101218 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46582 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24701 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45748 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19312 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48868 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54602 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/150756 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48338 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/38576 "Found 1 new JSC stress test failure: stress/dont-link-virtual-calls-on-compiler-thread.js.no-llint (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51688 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50018 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->