### PR TITLE
Repaint renderer before teardown

### DIFF
--- a/LayoutTests/fast/rendering/render-linebreak-crash-expected.txt
+++ b/LayoutTests/fast/rendering/render-linebreak-crash-expected.txt
@@ -1,0 +1,2 @@
+
+PASS if no crash

--- a/LayoutTests/fast/rendering/render-linebreak-crash.html
+++ b/LayoutTests/fast/rendering/render-linebreak-crash.html
@@ -1,0 +1,26 @@
+<script>
+    function load() {
+        canvas.toBlob(callback);
+        p1.style.setProperty("text-combine-upright", "initial");
+        span.parentNode.removeChild(span);
+    }
+
+    function callback() {
+        div.parentNode.removeChild(div);
+        document.caretRangeFromPoint();
+    }
+
+    if (window.testRunner)
+      testRunner.dumpAsText();
+</script>
+
+<body onload=load()>
+    <div id="div" style="display: contents;">
+        <br/>
+        <span id="span">
+            <p id="p1"></p>
+        </span>
+    </div>
+    <canvas id="canvas"></canvas>
+    <p>PASS if no crash</p>
+</body>


### PR DESCRIPTION
#### 415fff658cddc2b3a4bd81a5ce1eeab7a75a76fa
<pre>
Repaint renderer before teardown
<a href="https://bugs.webkit.org/show_bug.cgi?id=299258">https://bugs.webkit.org/show_bug.cgi?id=299258</a>
<a href="https://rdar.apple.com/159753148">rdar://159753148</a>

Reviewed by Antti Koivisto.

Ensure repaint and layout is performed on descendants if necessary.

Test: fast/rendering/render-linebreak-crash.html
* LayoutTests/fast/rendering/render-linebreak-crash-expected.txt: Added.
* LayoutTests/fast/rendering/render-linebreak-crash.html: Added.
* Source/WebCore/rendering/updating/RenderTreeUpdater.cpp:
(WebCore::performRepaintAndLayout):
(WebCore::RenderTreeUpdater::tearDownRenderers):
(WebCore::RenderTreeUpdater::tearDownTextRenderer):

Canonical link: <a href="https://commits.webkit.org/300534@main">https://commits.webkit.org/300534@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2aa2bce8e0e951456fcf98c269c7c912210870cd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122916 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42631 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33318 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/129556 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/75025 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4702cabd-84a6-4f0f-a3f5-57b8ded6c941) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/124792 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43347 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51225 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93439 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/62019 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fe31e4ef-2df8-4c32-be49-ab01a68b8ad9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125868 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34563 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110027 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74053 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/29b2c57e-6b55-4bb4-824a-cf01e755d1f1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33543 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28182 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73048 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104269 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28393 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132288 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49866 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37965 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101949 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50243 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106232 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101820 "Found 2 new API test failures: TestWTF:CompletionHandlerDeathTest.MainThreadHandlerOnThreadAssertsDeathTest, WebKitGTK/TestWebKitNetworkSession:/webkit/WebKitNetworkSession/proxy (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25869 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47176 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25364 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/46640 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49722 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/55482 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49189 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/52541 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50871 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->