### PR TITLE
WPEPlatform: Add -Werror for DEVELOPER_MODE

### DIFF
--- a/Source/WebKit/UIProcess/API/wpe/qt5/CMakeLists.txt
+++ b/Source/WebKit/UIProcess/API/wpe/qt5/CMakeLists.txt
@@ -21,6 +21,7 @@ set_target_properties(qtwpe PROPERTIES
 target_compile_definitions(qtwpe PUBLIC
     QT_NO_KEYWORDS=1
 )
+target_compile_options(qtwpe PRIVATE ${DEVELOPER_MODE_CXX_FLAGS})
 target_link_libraries(qtwpe PRIVATE
     PkgConfig::Epoxy
     PkgConfig::WPEWebKit

--- a/Source/WebKit/WPEPlatform/CMakeLists.txt
+++ b/Source/WebKit/WPEPlatform/CMakeLists.txt
@@ -188,6 +188,7 @@ if (ENABLE_WPE_PLATFORM_WAYLAND)
 endif ()
 
 add_library(WPEPlatform OBJECT ${WPEPlatform_SOURCES})
+target_compile_options(WPEPlatform PRIVATE ${DEVELOPER_MODE_CXX_FLAGS})
 target_include_directories(WPEPlatform PRIVATE ${WPEPlatform_PRIVATE_INCLUDE_DIRECTORIES})
 target_include_directories(WPEPlatform SYSTEM PRIVATE ${WPEPlatform_SYSTEM_INCLUDE_DIRECTORIES})
 target_link_libraries(WPEPlatform ${WPEPlatform_LIBRARIES})

--- a/Source/WebKit/WPEPlatform/wpe/drm/CMakeLists.txt
+++ b/Source/WebKit/WPEPlatform/wpe/drm/CMakeLists.txt
@@ -50,6 +50,7 @@ set(WPEPlatformDRM_SOURCES_FOR_INTROSPECTION
 
 add_library(WPEPlatformDRM OBJECT ${WPEPlatformDRM_SOURCES})
 add_dependencies(WPEPlatformDRM WPEPlatformGeneratedEnumTypesHeader)
+target_compile_options(WPEPlatformDRM PRIVATE ${DEVELOPER_MODE_CXX_FLAGS})
 target_include_directories(WPEPlatformDRM PRIVATE ${WPEPlatformDRM_PRIVATE_INCLUDE_DIRECTORIES})
 target_include_directories(WPEPlatformDRM SYSTEM PRIVATE ${WPEPlatformDRM_SYSTEM_INCLUDE_DIRECTORIES})
 target_link_libraries(WPEPlatformDRM ${WPEPlatform_LIBRARIES} ${WPEPlatformDRM_LIBRARIES})

--- a/Source/WebKit/WPEPlatform/wpe/headless/CMakeLists.txt
+++ b/Source/WebKit/WPEPlatform/wpe/headless/CMakeLists.txt
@@ -26,6 +26,7 @@ set(WPEPlatformHeadless_SOURCES_FOR_INTROSPECTION
 
 add_library(WPEPlatformHeadless OBJECT ${WPEPlatformHeadless_SOURCES})
 add_dependencies(WPEPlatformHeadless WPEPlatformGeneratedEnumTypesHeader)
+target_compile_options(WPEPlatformHeadless PRIVATE ${DEVELOPER_MODE_CXX_FLAGS})
 target_include_directories(WPEPlatformHeadless PRIVATE ${WPEPlatformHeadless_PRIVATE_INCLUDE_DIRECTORIES})
 target_include_directories(WPEPlatformHeadless SYSTEM PRIVATE ${WPEPlatform_SYSTEM_INCLUDE_DIRECTORIES})
 target_link_libraries(WPEPlatformHeadless ${WPEPlatform_LIBRARIES})

--- a/Source/cmake/WebKitCompilerFlags.cmake
+++ b/Source/cmake/WebKitCompilerFlags.cmake
@@ -123,6 +123,7 @@ endmacro()
 
 
 option(DEVELOPER_MODE_FATAL_WARNINGS "Build with warnings as errors if DEVELOPER_MODE is also enabled" ON)
+set(DEVELOPER_MODE_CXX_FLAGS)
 if (DEVELOPER_MODE AND DEVELOPER_MODE_FATAL_WARNINGS)
     if (MSVC)
         set(FATAL_WARNINGS_FLAG /WX)


### PR DESCRIPTION
#### 1730c143a7d0c00bafa02168915f7df7fe7b1133
<pre>
WPEPlatform: Add -Werror for DEVELOPER_MODE
<a href="https://bugs.webkit.org/show_bug.cgi?id=299263">https://bugs.webkit.org/show_bug.cgi?id=299263</a>

Reviewed by Carlos Garcia Campos.

EWS failed to catch a new compiler warning. For example,
&lt;<a href="https://webkit.org/b/299262">https://webkit.org/b/299262</a>&gt;. Added DEVELOPER_MODE_CXX_FLAGS to
WPEPlatform, WPEPlatformDRM, WPEPlatformHeadless, and qtwpe targets.

* Source/WebKit/UIProcess/API/wpe/qt5/CMakeLists.txt:
* Source/WebKit/WPEPlatform/CMakeLists.txt:
* Source/WebKit/WPEPlatform/wpe/drm/CMakeLists.txt:
* Source/WebKit/WPEPlatform/wpe/headless/CMakeLists.txt:
* Source/cmake/WebKitCompilerFlags.cmake:

Canonical link: <a href="https://commits.webkit.org/300312@main">https://commits.webkit.org/300312@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f7f80a425d35fdb3f0213ea62a0a9f34bc7d1c9d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122092 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41795 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32464 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128659 "Hash f7f80a42 for PR 51091 does not build (failure)") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74186 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42509 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50388 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/128659 "Hash f7f80a42 for PR 51091 does not build (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61683 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125044 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33905 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109330 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/128659 "Hash f7f80a42 for PR 51091 does not build (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32919 "Passed tests") | | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72151 "Hash f7f80a42 for PR 51091 does not build (failure)") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/114240 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103412 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27687 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131416 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/120618 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49031 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37294 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101362 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49405 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105544 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101233 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46601 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24714 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45773 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19319 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48888 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54622 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/150776 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48358 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/38580 "Found 1 new JSC stress test failure: stress/dont-link-virtual-calls-on-compiler-thread.js.no-llint (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51708 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50038 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->