### PR TITLE
Separate defer and module script execution into individual tasks

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -6821,6 +6821,20 @@ SelectionHonorsOverflowScrolling:
     WebCore:
       default: false
 
+SeparateDeferModuleScriptTasksEnabled:
+  type: bool
+  status: testable
+  category: dom
+  humanReadableName: "Separate Defer Module Script Tasks"
+  humanReadableDescription: "Execute defer and module scripts in separate tasks for better responsiveness"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 SerifFontFamily:
   type: String
   status: embedder

--- a/Source/WebCore/html/parser/HTMLScriptRunner.cpp
+++ b/Source/WebCore/html/parser/HTMLScriptRunner.cpp
@@ -44,6 +44,7 @@
 #include "NestingLevelIncrementer.h"
 #include "ScriptElement.h"
 #include "ScriptSourceCode.h"
+#include "TaskSource.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -57,6 +58,7 @@ HTMLScriptRunner::HTMLScriptRunner(Document& document, HTMLScriptRunnerHost& hos
     , m_host(host)
     , m_scriptNestingLevel(0)
     , m_hasScriptsWaitingForStylesheets(false)
+    , m_executingScriptsAsync(false)
 {
 }
 
@@ -193,6 +195,82 @@ void HTMLScriptRunner::executeScriptsWaitingForStylesheets()
 
 bool HTMLScriptRunner::executeScriptsWaitingForParsing()
 {
+    // If the feature is enabled, execute scripts one at a time with event loop
+    // yields between them to prevent long tasks and improve responsiveness.
+    if (m_document && m_document->settings().separateDeferModuleScriptTasksEnabled()) {
+        WTFLogAlways("SeparateDeferModuleScriptTasks: Feature is ENABLED, using async execution");
+
+        // Check if all scripts have been executed
+        if (m_scriptsToExecuteAfterParsing.isEmpty()) {
+            // All scripts completed, clear the flag and allow parsing to complete.
+            m_executingScriptsAsync = false;
+            WTFLogAlways("SeparateDeferModuleScriptTasks: All scripts completed");
+            return true;
+        }
+
+        ASSERT(!isExecutingScript());
+        ASSERT(!hasParserBlockingScript());
+        ASSERT(m_scriptsToExecuteAfterParsing.first()->needsLoading());
+
+        // Check if the first script is ready
+        if (!m_scriptsToExecuteAfterParsing.first()->isLoaded()) {
+            watchForLoad(m_scriptsToExecuteAfterParsing.first());
+            return false;
+        }
+
+        // If we're already in async mode, execute one script now
+        if (m_executingScriptsAsync) {
+            WTFLogAlways("SeparateDeferModuleScriptTasks: Executing script %zu of %zu",
+                m_scriptsToExecuteAfterParsing.size(), m_scriptsToExecuteAfterParsing.size());
+
+            // Execute the script element given by the first script in the list
+            executePendingScriptAndDispatchEvent(m_scriptsToExecuteAfterParsing.takeFirst().get());
+
+            // FIXME: What is this m_document check for?
+            if (!m_document)
+                return false;
+
+            // If there are more scripts, queue the next one
+            if (!m_scriptsToExecuteAfterParsing.isEmpty()) {
+                // Use a RefPtr to the document since HTMLScriptRunner is owned by
+                // HTMLDocumentParser which is owned by the document
+                RefPtr<Document> protectedDocument = m_document.get();
+                m_document->eventLoop().queueTask(TaskSource::DOMManipulation, [this, protectedDocument]() {
+                    if (!protectedDocument || !m_document || !protectedDocument->frame())
+                        return;
+                    WTFLogAlways("SeparateDeferModuleScriptTasks: Task executing, continuing script execution");
+                    // Directly call executeScriptsWaitingForParsing recursively
+                    executeScriptsWaitingForParsing();
+                });
+                // Return false to keep the parser paused until all scripts complete
+                return false;
+            }
+
+            // Last script executed, allow parsing to continue
+            m_executingScriptsAsync = false;
+            return true;
+        }
+
+        // First call - start async execution by queuing the first script
+        m_executingScriptsAsync = true;
+        WTFLogAlways("SeparateDeferModuleScriptTasks: Starting async execution with %zu scripts",
+            m_scriptsToExecuteAfterParsing.size());
+
+        // Queue a task to execute the first script on the next event loop iteration.
+        // This ensures even the first script runs asynchronously.
+        RefPtr<Document> protectedDocument = m_document.get();
+        m_document->eventLoop().queueTask(TaskSource::DOMManipulation, [this, protectedDocument]() {
+            if (!protectedDocument || !m_document || !protectedDocument->frame())
+                return;
+            WTFLogAlways("SeparateDeferModuleScriptTasks: First task executing, continuing script execution");
+            // Directly call executeScriptsWaitingForParsing recursively
+            executeScriptsWaitingForParsing();
+        });
+        // Return false to keep the parser paused until all scripts complete
+        return false;
+    }
+
+    // Original synchronous execution code follows...
     while (!m_scriptsToExecuteAfterParsing.isEmpty()) {
         ASSERT(!isExecutingScript());
         ASSERT(!hasParserBlockingScript());
@@ -272,5 +350,6 @@ void HTMLScriptRunner::runScript(ScriptElement& scriptElement, const TextPositio
     } else
         requestParsingBlockingScript(scriptElement);
 }
+
 
 }

--- a/Source/WebCore/html/parser/HTMLScriptRunner.h
+++ b/Source/WebCore/html/parser/HTMLScriptRunner.h
@@ -85,6 +85,10 @@ private:
     // cause nested script execution when parsing <style> tags since </style>
     // tags can cause Document to call executeScriptsWaitingForStylesheets.
     bool m_hasScriptsWaitingForStylesheets;
+
+    // When SeparateDeferModuleScriptTasksEnabled is true, this tracks whether
+    // we're executing scripts asynchronously with task separation.
+    bool m_executingScriptsAsync;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/parser/HTMLScriptRunnerHost.h
+++ b/Source/WebCore/html/parser/HTMLScriptRunnerHost.h
@@ -42,7 +42,7 @@ public:
     virtual HTMLInputStream& inputStream() = 0;
 
     virtual bool hasPreloadScanner() const = 0;
-    virtual void appendCurrentInputStreamToPreloadScannerAndScan() = 0;    
+    virtual void appendCurrentInputStreamToPreloadScannerAndScan() = 0;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
Port of Chromium [CL](http://crrev.com/c/6931651) to WebKit. This change improves main thread responsiveness by allowing other tasks (RAF, Promises) to run between defer/module script executions.

## Summary
When the experimental feature `SeparateDeferModuleScriptTasksEnabled` is enabled, defer and module scripts are executed as separate tasks with event loop yields between them. This allows requestAnimationFrame callbacks and other tasks to run between script executions, preventing long blocking tasks and improving page interactivity.

## Key Changes
- Added `SeparateDeferModuleScriptTasksEnabled` preference in UnifiedWebPreferences.yaml 
- Modified HTMLScriptRunner to queue defer/module scripts as separate tasks when feature is enabled

## Testing
Tested with MiniBrowser:
- Feature OFF: Scripts run synchronously, RAF callbacks blocked until all scripts complete
- Feature ON: RAF callbacks execute between module scripts, improving responsiveness

## References
- Original Chromium CL: [6931651](http://crrev.com/c/6931651)
- Improves main thread responsiveness during script loading phase<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3f3d35e53cc4cad6ba51d0004dfdae77614f4d6d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122129 "6 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41832 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32501 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128701 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74223 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/124005 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42546 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50425 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92826 "Found 354 new test failures: dom/html/level2/html/HTMLScriptElement01.html dom/html/level2/html/HTMLScriptElement02.html dom/html/level2/html/HTMLScriptElement03.html dom/html/level2/html/HTMLScriptElement04.html dom/html/level2/html/HTMLScriptElement05.html dom/html/level2/html/HTMLScriptElement06.html dom/html/level2/html/HTMLScriptElement07.html fast/dom/Document/document-current-script.html fast/dom/Document/readystate.html fast/dom/HTMLScriptElement/defer-script-invalid-url.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61708 "Found 60 new test failures: dom/html/level2/html/HTMLScriptElement01.html dom/html/level2/html/HTMLScriptElement02.html dom/html/level2/html/HTMLScriptElement03.html dom/html/level2/html/HTMLScriptElement04.html dom/html/level2/html/HTMLScriptElement05.html dom/html/level2/html/HTMLScriptElement06.html dom/html/level2/html/HTMLScriptElement07.html fast/dom/Document/document-current-script.html fast/dom/Document/readystate.html fast/dom/HTMLScriptElement/defer-inline-script.html ... (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125081 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33936 "Found 39 new test failures: dom/html/level2/html/HTMLScriptElement01.html dom/html/level2/html/HTMLScriptElement02.html dom/html/level2/html/HTMLScriptElement03.html dom/html/level2/html/HTMLScriptElement04.html dom/html/level2/html/HTMLScriptElement05.html dom/html/level2/html/HTMLScriptElement06.html dom/html/level2/html/HTMLScriptElement07.html fast/dom/Document/document-current-script.html fast/dom/Document/readystate.html fast/dom/HTMLScriptElement/defer-inline-script.html ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109363 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73480 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32949 "Found 60 new test failures: imported/w3c/web-platform-tests/WebIDL/ecmascript-binding/allow-resizable.html imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-strict_dynamic_parser_inserted_correct_nonce.html imported/w3c/web-platform-tests/credential-management/otpcredential-get-basics.https.html imported/w3c/web-platform-tests/credential-management/otpcredential-iframe.https.html imported/w3c/web-platform-tests/credential-management/otpcredential-store.https.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-dynamic-001.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-dynamic-002.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-dynamic-003.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-dynamic-004.html imported/w3c/web-platform-tests/css/css-grid/abspos/orthogonal-positioned-grid-descendants-001.html ... (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27529 "Found 60 new test failures: dom/html/level2/html/HTMLScriptElement01.html dom/html/level2/html/HTMLScriptElement02.html dom/html/level2/html/HTMLScriptElement03.html dom/html/level2/html/HTMLScriptElement04.html dom/html/level2/html/HTMLScriptElement05.html dom/html/level2/html/HTMLScriptElement06.html dom/html/level2/html/HTMLScriptElement07.html fast/dom/Document/document-current-script.html fast/dom/Document/readystate.html fast/dom/HTMLScriptElement/defer-inline-script.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72191 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/114277 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103443 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27720 "Found 60 new test failures: compositing/filters/invert-transparent.html compositing/transforms/perspective-with-clipping.html dom/html/level2/html/HTMLScriptElement01.html dom/html/level2/html/HTMLScriptElement02.html dom/html/level2/html/HTMLScriptElement03.html dom/html/level2/html/HTMLScriptElement04.html dom/html/level2/html/HTMLScriptElement05.html dom/html/level2/html/HTMLScriptElement06.html dom/html/level2/html/HTMLScriptElement07.html fast/css/aspect-ratio-min-height-replaced.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131453 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/120655 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49068 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37328 "Found 60 new test failures: dom/html/level2/html/HTMLScriptElement01.html dom/html/level2/html/HTMLScriptElement02.html dom/html/level2/html/HTMLScriptElement03.html dom/html/level2/html/HTMLScriptElement04.html dom/html/level2/html/HTMLScriptElement05.html dom/html/level2/html/HTMLScriptElement06.html dom/html/level2/html/HTMLScriptElement07.html fast/dom/Document/document-current-script.html fast/dom/Document/readystate.html fast/dom/HTMLScriptElement/defer-inline-script.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101396 "Found 364 new test failures: dom/html/level2/html/HTMLScriptElement01.html dom/html/level2/html/HTMLScriptElement02.html dom/html/level2/html/HTMLScriptElement03.html dom/html/level2/html/HTMLScriptElement04.html dom/html/level2/html/HTMLScriptElement05.html dom/html/level2/html/HTMLScriptElement06.html dom/html/level2/html/HTMLScriptElement07.html fast/dom/Document/document-current-script.html fast/dom/Document/readystate.html fast/dom/HTMLScriptElement/defer-inline-script.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49442 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105577 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101265 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46633 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/45818 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48925 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54659 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/150814 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48395 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/38589 "Found 1 new JSC stress test failure: stress/dont-link-virtual-calls-on-compiler-thread.js.no-llint (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51745 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50075 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->