### PR TITLE
wpe_view_render_buffer: assertion 'WPE_IS_BUFFER(buffer)' failed

### DIFF
--- a/Source/WebKit/UIProcess/wpe/AcceleratedBackingStore.cpp
+++ b/Source/WebKit/UIProcess/wpe/AcceleratedBackingStore.cpp
@@ -52,7 +52,10 @@ Ref<AcceleratedBackingStore> AcceleratedBackingStore::create(WebPageProxy& webPa
 AcceleratedBackingStore::AcceleratedBackingStore(WebPageProxy& webPage, WPEView* view)
     : m_webPage(webPage)
     , m_wpeView(view)
-    , m_fenceMonitor([this] { renderPendingBuffer(); })
+    , m_fenceMonitor([this] {
+        if (m_webPage && m_pendingBuffer)
+            renderPendingBuffer();
+    })
     , m_legacyMainFrameProcess(webPage.legacyMainFrameProcess())
 {
     g_signal_connect(m_wpeView.get(), "buffer-rendered", G_CALLBACK(+[](WPEView*, WPEBuffer*, gpointer userData) {


### PR DESCRIPTION
#### 2b754f0fec286bb0c6d4de60ac6f238031f49b81
<pre>
wpe_view_render_buffer: assertion &apos;WPE_IS_BUFFER(buffer)&apos; failed
<a href="https://bugs.webkit.org/show_bug.cgi?id=298599">https://bugs.webkit.org/show_bug.cgi?id=298599</a>

Reviewed by Carlos Garcia Campos.

An assertion failed in wpe_view_render_buffer() if the active web
process was switched before the previous rendering request wasn&apos;t
finished.

&gt; ** (MiniBrowser:190744): CRITICAL **: 23:35:59.702: gboolean wpe_view_render_buffer(WPEView*, WPEBuffer*, const WPERectangle*, guint, GError**): assertion &apos;WPE_IS_BUFFER(buffer)&apos; failed

In AcceleratedBackingStore class, if updateSurfaceID() is called
before renderPendingBuffer() is called, m_pendingBuffer is null in
renderPendingBuffer(). Check if m_pendingBuffer is null in the fence
monitor callback.

* Source/WebKit/UIProcess/wpe/AcceleratedBackingStore.cpp:
(WebKit::AcceleratedBackingStore::AcceleratedBackingStore):

Canonical link: <a href="https://commits.webkit.org/300316@main">https://commits.webkit.org/300316@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b11b1713cbfe7bff9d0b8bf2a946fe90c19b6355

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122123 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41826 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32495 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128695 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74217 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42540 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50419 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92821 "3 flakes 17 failures") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61703 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125075 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33929 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109356 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73476 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32943 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72183 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103436 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27713 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131447 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49062 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/37322 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101386 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49436 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105570 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101256 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46625 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24740 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45812 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19321 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48919 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54653 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48389 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51739 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50069 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->