### PR TITLE
Address some safer CPP warnings in platform/mediastream

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
@@ -92,7 +92,6 @@ platform/graphics/StringTruncator.cpp
 platform/graphics/ca/PlatformCALayer.h
 platform/graphics/ca/TileController.cpp
 platform/mediastream/libwebrtc/LibWebRTCDav1dDecoder.cpp
-platform/mediastream/mac/CoreAudioSharedUnit.h
 platform/network/cocoa/CredentialCocoa.h
 platform/network/cocoa/ProtectionSpaceCocoa.h
 rendering/AccessibilityRegionContext.h

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -723,7 +723,6 @@ platform/mac/WebPlaybackControlsManager.mm
 platform/mediarecorder/MediaRecorderPrivate.h
 platform/mediarecorder/MediaRecorderPrivateAVFImpl.cpp
 platform/mediarecorder/MediaRecorderPrivateMock.cpp
-platform/mediastream/RealtimeMediaSourceCenter.cpp
 platform/mediastream/RealtimeOutgoingAudioSource.cpp
 platform/mediastream/RealtimeOutgoingVideoSource.cpp
 platform/mediastream/cocoa/AudioMediaStreamTrackRendererCocoa.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -59,8 +59,6 @@ platform/graphics/cocoa/VideoMediaSampleRenderer.mm
 platform/graphics/filters/FilterOperation.cpp
 platform/mac/VideoPresentationInterfaceMac.mm
 platform/mediarecorder/MediaRecorderPrivateEncoder.cpp
-platform/mediastream/RealtimeMediaSource.cpp
-platform/mediastream/RealtimeMediaSourceCenter.cpp
 platform/mediastream/RealtimeVideoCaptureSource.cpp
 platform/mediastream/cocoa/IncomingAudioMediaStreamTrackRendererUnit.cpp
 platform/mediastream/mac/RealtimeIncomingVideoSourceCocoa.mm

--- a/Source/WebCore/platform/mediastream/MediaConstraints.cpp
+++ b/Source/WebCore/platform/mediastream/MediaConstraints.cpp
@@ -119,7 +119,7 @@ void StringConstraint::merge(const StringConstraint& other)
     }
 }
 
-void MediaTrackConstraintSetMap::forEach(Function<void(MediaConstraintType, const MediaConstraint&)>&& callback) const
+void MediaTrackConstraintSetMap::forEach(NOESCAPE Function<void(MediaConstraintType, const MediaConstraint&)>&& callback) const
 {
     filter([callback = WTFMove(callback)] (auto type, auto& constraint) mutable {
         callback(type, constraint);

--- a/Source/WebCore/platform/mediastream/MediaConstraints.h
+++ b/Source/WebCore/platform/mediastream/MediaConstraints.h
@@ -613,7 +613,7 @@ public:
     {
     }
 
-    WEBCORE_EXPORT void forEach(Function<void(MediaConstraintType, const MediaConstraint&)>&&) const;
+    WEBCORE_EXPORT void forEach(NOESCAPE Function<void(MediaConstraintType, const MediaConstraint&)>&&) const;
     void filter(NOESCAPE const Function<bool(MediaConstraintType, const MediaConstraint&)>&) const;
     bool isEmpty() const;
     WEBCORE_EXPORT bool isValid() const;

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
@@ -256,7 +256,7 @@ void RealtimeMediaSource::notifySettingsDidChangeObservers(OptionSet<RealtimeMed
 
     ALWAYS_LOG_IF(m_logger, LOGIDENTIFIER, flags);
 
-    scheduleDeferredTask([this] {
+    scheduleDeferredTask([this, protectedThis = Ref { *this }] {
         m_pendingSettingsDidChangeNotification = false;
         forEachObserver([](auto& observer) {
             observer.sourceSettingsChanged();
@@ -1351,7 +1351,7 @@ void RealtimeMediaSource::setIntrinsicSize(const IntSize& intrinsicSize, bool no
 
     m_intrinsicSize = intrinsicSize;
     if (notifyObservers) {
-        scheduleDeferredTask([this] {
+        scheduleDeferredTask([this, protectedThis = Ref { *this }] {
             notifySettingsDidChangeObservers({ RealtimeMediaSourceSettings::Flag::Width, RealtimeMediaSourceSettings::Flag::Height });
         });
     }
@@ -1501,7 +1501,7 @@ void RealtimeMediaSource::setType(Type type)
 
     m_type = type;
 
-    scheduleDeferredTask([this] {
+    scheduleDeferredTask([this, protectedThis = Ref { *this }] {
         forEachObserver([](auto& observer) {
             observer.sourceSettingsChanged();
         });

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.cpp
@@ -117,7 +117,7 @@ void RealtimeMediaSourceCenter::createMediaStream(Ref<const Logger>&& logger, Ne
 void RealtimeMediaSourceCenter::getMediaStreamDevices(CompletionHandler<void(Vector<CaptureDevice>&&)>&& completion)
 {
     auto shouldEnumerateDisplay = displayCaptureFactory().displayCaptureDeviceManager().requiresCaptureDevicesEnumeration();
-    enumerateDevices(true, shouldEnumerateDisplay, true, true, [this, completion = WTFMove(completion)]() mutable {
+    enumerateDevices(true, shouldEnumerateDisplay, true, true, [this, protectedThis = Ref { *this }, completion = WTFMove(completion)]() mutable {
         Vector<CaptureDevice> results;
 
         results.appendVector(audioCaptureFactory().audioCaptureDeviceManager().captureDevices());
@@ -229,7 +229,7 @@ void RealtimeMediaSourceCenter::getDisplayMediaDevices(const MediaStreamRequest&
         if (!sourceOrError)
             continue;
 
-        if (auto invalidConstraint = sourceOrError.captureSource->hasAnyInvalidConstraint(request.videoConstraints)) {
+        if (auto invalidConstraint = RefPtr { sourceOrError.captureSource }->hasAnyInvalidConstraint(request.videoConstraints)) {
             if (firstInvalidConstraint == MediaConstraintType::Unknown)
                 firstInvalidConstraint = *invalidConstraint;
             continue;
@@ -252,7 +252,7 @@ void RealtimeMediaSourceCenter::getUserMediaDevices(const MediaStreamRequest& re
             if (!sourceOrError)
                 continue;
 
-            if (auto invalidConstraint = sourceOrError.captureSource->hasAnyInvalidConstraint(request.audioConstraints)) {
+            if (auto invalidConstraint = RefPtr { sourceOrError.captureSource }->hasAnyInvalidConstraint(request.audioConstraints)) {
                 if (firstInvalidConstraint == MediaConstraintType::Unknown)
                     firstInvalidConstraint = *invalidConstraint;
                 continue;
@@ -282,7 +282,7 @@ void RealtimeMediaSourceCenter::getUserMediaDevices(const MediaStreamRequest& re
             if (!sourceOrError)
                 continue;
 
-            if (auto invalidConstraint = sourceOrError.captureSource->hasAnyInvalidConstraint(request.videoConstraints)) {
+            if (auto invalidConstraint = RefPtr { sourceOrError.captureSource }->hasAnyInvalidConstraint(request.videoConstraints)) {
                 if (firstInvalidConstraint == MediaConstraintType::Unknown)
                     firstInvalidConstraint = *invalidConstraint;
                 continue;
@@ -312,7 +312,7 @@ void RealtimeMediaSourceCenter::validateRequestConstraints(ValidateHandler&& val
     bool shouldEnumerateDisplay = displayCaptureFactory().displayCaptureDeviceManager().requiresCaptureDevicesEnumeration();
     bool shouldEnumerateMicrophone = request.audioConstraints.isValid;
     bool shouldEnumerateSpeakers = false;
-    enumerateDevices(shouldEnumerateCamera, shouldEnumerateDisplay, shouldEnumerateMicrophone, shouldEnumerateSpeakers, [this, validateHandler = WTFMove(validateHandler), request, deviceIdentifierHashSalts = WTFMove(deviceIdentifierHashSalts)]() mutable {
+    enumerateDevices(shouldEnumerateCamera, shouldEnumerateDisplay, shouldEnumerateMicrophone, shouldEnumerateSpeakers, [this, protectedThis = Ref { *this }, validateHandler = WTFMove(validateHandler), request, deviceIdentifierHashSalts = WTFMove(deviceIdentifierHashSalts)]() mutable {
         validateHandler(validateRequestConstraintsAfterEnumeration(request, deviceIdentifierHashSalts));
     });
 }

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.h
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.h
@@ -31,6 +31,7 @@
 #include <WebCore/AudioSampleDataSource.h>
 #include <WebCore/BaseAudioSharedUnit.h>
 #include <WebCore/CAAudioStreamDescription.h>
+#include <WebCore/CoreAudioCaptureSource.h>
 #include <WebCore/Timer.h>
 
 OBJC_CLASS WebCoreAudioInputMuteChangeListener;


### PR DESCRIPTION
#### 1032ae34d9797e2c75b323f6af55da5ff7ccca0f
<pre>
Address some safer CPP warnings in platform/mediastream
<a href="https://bugs.webkit.org/show_bug.cgi?id=299276">https://bugs.webkit.org/show_bug.cgi?id=299276</a>

Reviewed by Geoffrey Garen.

* Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations:
* Source/WebCore/platform/mediastream/MediaConstraints.cpp:
(WebCore::MediaTrackConstraintSetMap::forEach const):
* Source/WebCore/platform/mediastream/MediaConstraints.h:
* Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp:
(WebCore::RealtimeMediaSource::notifySettingsDidChangeObservers):
(WebCore::RealtimeMediaSource::setIntrinsicSize):
(WebCore::RealtimeMediaSource::setType):
* Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.cpp:
(WebCore::RealtimeMediaSourceCenter::getMediaStreamDevices):
(WebCore::RealtimeMediaSourceCenter::getDisplayMediaDevices):
(WebCore::RealtimeMediaSourceCenter::getUserMediaDevices):
(WebCore::RealtimeMediaSourceCenter::validateRequestConstraints):
* Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.h:

Canonical link: <a href="https://commits.webkit.org/300355@main">https://commits.webkit.org/300355@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d5a81e4c24f366092ff30fe3f117f260d7cc327

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122119 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41822 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32491 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128689 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74213 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4f942536-d70f-4905-93aa-63a004d095ef) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123995 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42536 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50415 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92818 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61701 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f37fab37-efa3-4690-9926-5e9a88f488df) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125071 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33926 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109355 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73473 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3730b055-4e14-40a5-8b30-d157c0ba0a8f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32940 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27521 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72178 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103433 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27712 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131443 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49058 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37318 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101384 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49432 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105569 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101254 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25701 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46623 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24739 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45808 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48915 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54649 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48385 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51735 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50065 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->