### PR TITLE
[JSC] Improve the Performance of `Math.sumPrecise` and Refactor Code

### DIFF
--- a/Source/WTF/wtf/Compiler.h
+++ b/Source/WTF/wtf/Compiler.h
@@ -213,6 +213,12 @@
 #define ALWAYS_INLINE_LAMBDA
 #endif
 
+/* COLD */
+
+#if !defined(COLD)
+#define COLD __attribute((__cold__))
+#endif
+
 /* WTF_EXTERN_C_{BEGIN, END} */
 
 #ifdef __cplusplus

--- a/Source/WTF/wtf/PreciseSum.h
+++ b/Source/WTF/wtf/PreciseSum.h
@@ -47,7 +47,7 @@ struct SmallAccumulator final {
     bool hasPosNumber; // check if added values have at least one positive number
 
     int carryPropagate();
-    void addInfNan(int64_t ivalue);
+    COLD void addInfNan(int64_t ivalue);
     inline void add1NoCarry(double value);
     ALWAYS_INLINE void incrementWhenValueAdded(double value);
 };
@@ -63,7 +63,7 @@ struct LargeAccumulator final {
     ~LargeAccumulator() = default;
 
     void addLchunkToSmall(int_fast16_t ix);
-    void largeAddValueInfNan(int_fast16_t ix, uint64_t uintv);
+    COLD void largeAddValueInfNan(int_fast16_t ix, uint64_t uintv);
     void transferToSmall();
 };
 


### PR DESCRIPTION
#### 60229405733763e1d7668d76cc878724f0506c0f
<pre>
[JSC] Improve the Performance of `Math.sumPrecise` and Refactor Code
<a href="https://bugs.webkit.org/show_bug.cgi?id=299274">https://bugs.webkit.org/show_bug.cgi?id=299274</a>

Reviewed by Yusuke Suzuki.

This patch improves the performance of `Math.sumPrecise`
by adding `COLD` attributes.
Additionally, this patch refactors the code.

                                  TipOfTree                   Patched                              Ratio
math-sumPrecise-10           2.6638+-0.0572            2.6412+-0.0249
math-sumPrecise-100         18.0470+-0.1080           17.8394+-0.1166          might be 1.0116x faster
math-sumPrecise-1000       153.7020+-0.2018     ^    138.7791+-0.5696        ^ definitely 1.1075x faster
math-sumPrecise-10000     1504.9830+-4.6367     ^   1354.8530+-3.8322        ^ definitely 1.1108x faster

* Source/WTF/wtf/Compiler.h:
* Source/WTF/wtf/PreciseSum.cpp:
(WTF::Xsum::SmallAccumulator::addInfNan):
(WTF::Xsum::SmallAccumulator::carryPropagate):
(WTF::Xsum::SmallAccumulator::add1NoCarry):
(WTF::Xsum::LargeAccumulator::addLchunkToSmall):
(WTF::Xsum::LargeAccumulator::largeAddValueInfNan):
(WTF::Xsum::XsumSmall::addList):
(WTF::Xsum::XsumSmall::compute):
(WTF::Xsum::XsumLarge::add):
* Source/WTF/wtf/PreciseSum.h:

Canonical link: <a href="https://commits.webkit.org/300406@main">https://commits.webkit.org/300406@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9cbd7c5f0982b190875fea2ae2909dbc8577b7e5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122120 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41823 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32492 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128690 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74214 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42537 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50416 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92822 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61705 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125072 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33925 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109357 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73472 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32939 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27523 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72179 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/114268 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103432 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27714 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131444 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/120646 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49059 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37319 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101389 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49433 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105571 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101259 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25742 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46626 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24741 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/45809 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48916 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54650 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/150806 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48386 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/38590 "Found 1 new JSC stress test failure: stress/dont-link-virtual-calls-on-compiler-thread.js.no-llint (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51736 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50066 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->