### PR TITLE
[css-anchor-position-1] Resolve position-try-fallback names as tree-scoped references

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-tree-scoped-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-tree-scoped-expected.txt
@@ -2,11 +2,11 @@
 PASS Document position-try-fallbacks matches @position-try in document scope
 PASS Document position-try-fallbacks does not match @position-try in #outer_host scope
 PASS Document position-try-fallbacks does not match @position-try in #inner_host scope
-FAIL Outer position-try-fallbacks matches @position-try in document scope assert_equals: expected 100 but got 999999
+PASS Outer position-try-fallbacks matches @position-try in document scope
 PASS Outer position-try-fallbacks matches @position-try in #outer_host scope
 PASS Outer position-try-fallbacks does not match @position-try in #inner_host scope
-FAIL Inner position-try-fallbacks matches @position-try in document scope assert_equals: expected 100 but got 999999
-FAIL Inner position-try-fallbacks matches @position-try in #outer_host scope assert_equals: expected 200 but got 999999
+PASS Inner position-try-fallbacks matches @position-try in document scope
+PASS Inner position-try-fallbacks matches @position-try in #outer_host scope
 PASS Inner position-try-fallbacks matches @position-try in #inner_host scope
 PASS @position-try from same scope as :host rule
 PASS @position-try from same scope as ::slotted() rule

--- a/Source/WebCore/style/StyleScope.cpp
+++ b/Source/WebCore/style/StyleScope.cpp
@@ -1105,6 +1105,13 @@ Element* hostForScopeOrdinal(const Element& element, ScopeOrdinal scopeOrdinal)
     return host;
 }
 
+CheckedPtr<const Scope> Scope::hostScope() const
+{
+    if (!m_shadowRoot || !m_shadowRoot->host())
+        return nullptr;
+    return &forNode(*m_shadowRoot->host());
+}
+
 void Scope::updateAnchorPositioningStateAfterStyleResolution()
 {
     if (CheckedPtr renderView = m_document->renderView())


### PR DESCRIPTION
#### c27f12a8d6a47aa09c52499a2d756218f0c0ab44
<pre>
[css-anchor-position-1] Resolve position-try-fallback names as tree-scoped references
<a href="https://bugs.webkit.org/show_bug.cgi?id=299279">https://bugs.webkit.org/show_bug.cgi?id=299279</a>
<a href="https://rdar.apple.com/161081231">rdar://161081231</a>

Reviewed by Alan Baradlay.

&quot;If an at-rule or property defines a name that other CSS constructs can refer to it by, ... it must be defined as a tree-scoped name.&quot;
<a href="https://drafts.csswg.org/css-scoping-1/#shadow-names">https://drafts.csswg.org/css-scoping-1/#shadow-names</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-tree-scoped-expected.txt:

* Source/WebCore/style/StyleScope.cpp:
(WebCore::Style::Scope::hostScope const):
* Source/WebCore/style/StyleScope.h:
(WebCore::Style::Scope::resolveTreeScopedReference):

Add a generic helper for resolving tree-scoped references.

* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::generatePositionOption):

Search all the relevant scopes.

Canonical link: <a href="https://commits.webkit.org/300333@main">https://commits.webkit.org/300333@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dcb99c0f45886785945de1df469cc6b89a335e32

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122175 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41878 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32547 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128748 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/74269 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9a4d4ba3-a68c-43e2-9a8e-9389dcb2167b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/124051 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42592 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50471 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92862 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/74269 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ae7290c2-c7bb-476b-8d56-d9ae821c7b01) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125127 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33971 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109402 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73518 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1464b19e-4176-4268-be58-8d846a303fd4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32983 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27567 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72236 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103479 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27758 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131499 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49114 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37367 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101430 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49488 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105613 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101299 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25678 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46672 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24783 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/45865 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48971 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54705 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48441 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/51791 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50121 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->