### PR TITLE
[Skia] Implement Font::platformBoundsForGlyphs

### DIFF
--- a/Source/WebCore/platform/graphics/ComplexTextController.cpp
+++ b/Source/WebCore/platform/graphics/ComplexTextController.cpp
@@ -168,7 +168,7 @@ std::pair<float, float> ComplexTextController::enclosingGlyphBoundsForTextRun(co
         auto glyphs = complexTextRun.glyphs();
         ASSERT(glyphs.size() == complexTextRun.glyphCount());
 
-#if USE(CORE_TEXT)
+#if USE(CORE_TEXT) || USE(SKIA)
         auto glyphBounds = font.boundsForGlyphs(glyphs);
         for (auto& bounds : glyphBounds) {
 #else
@@ -712,7 +712,7 @@ void ComplexTextController::adjustGlyphsAndAdvances()
         unsigned previousCharacterIndex = m_run->ltr() ? std::numeric_limits<unsigned>::min() : std::numeric_limits<unsigned>::max();
         bool isMonotonic = true;
 
-#if USE(CORE_TEXT)
+#if USE(CORE_TEXT) || USE(SKIA)
         auto boundsForGlyphs = font.boundsForGlyphs(glyphs);
 #endif
 
@@ -736,20 +736,20 @@ void ComplexTextController::adjustGlyphsAndAdvances()
                 // Like simple text path in WidthIterator::applyCSSVisibilityRules,
                 // make tabCharacter glyph invisible after advancing.
                 glyph = deletedGlyph;
-#if USE(CORE_TEXT)
+#if USE(CORE_TEXT) || USE(SKIA)
                 boundsForGlyphs[glyphIndex] = font.boundsForGlyph(glyph);
 #endif
             } else if (character == zeroWidthNonJoiner) {
                 // zeroWidthNonJoiner is rendered as deletedGlyph for compatibility with other engines: https://bugs.webkit.org/show_bug.cgi?id=285959
                 advance.setWidth(0);
                 glyph = deletedGlyph;
-#if USE(CORE_TEXT)
+#if USE(CORE_TEXT) || USE(SKIA)
                 boundsForGlyphs[glyphIndex] = font.boundsForGlyph(glyph);
 #endif
             } else if (!treatAsSpace && FontCascade::treatAsZeroWidthSpace(character)) {
                 advance.setWidth(0);
                 glyph = font.spaceGlyph();
-#if USE(CORE_TEXT)
+#if USE(CORE_TEXT) || USE(SKIA)
                 boundsForGlyphs[glyphIndex] = font.boundsForGlyph(glyph);
 #endif
             }
@@ -760,7 +760,7 @@ void ComplexTextController::adjustGlyphsAndAdvances()
             if (character != newlineCharacter && character != carriageReturn && character != noBreakSpace && character != tabCharacter && character != nullCharacter && isControlCharacter(character)) {
                 // Let's assume that .notdef is visible.
                 glyph = 0;
-#if USE(CORE_TEXT)
+#if USE(CORE_TEXT) || USE(SKIA)
                 boundsForGlyphs[glyphIndex] = font.boundsForGlyph(glyph);
 #endif
                 advance.setWidth(font.widthForGlyph(glyph));
@@ -855,7 +855,7 @@ void ComplexTextController::adjustGlyphsAndAdvances()
                 // FIXME: Combining marks should receive a text emphasis mark if they are combine with a space.
                 if (!FontCascade::canReceiveTextEmphasis(ch32) || (U_GET_GC_MASK(character) & U_GC_M_MASK)) {
                     glyph = deletedGlyph;
-#if USE(CORE_TEXT)
+#if USE(CORE_TEXT) || USE(SKIA)
                     boundsForGlyphs[glyphIndex] = font.boundsForGlyph(glyph);
 #endif
                 }
@@ -870,7 +870,7 @@ void ComplexTextController::adjustGlyphsAndAdvances()
             }
             m_adjustedGlyphs.append(glyph);
 
-#if USE(CORE_TEXT)
+#if USE(CORE_TEXT) || USE(SKIA)
             auto& glyphBounds = boundsForGlyphs[glyphIndex];
 #else
             auto glyphBounds = font.boundsForGlyph(glyph);

--- a/Source/WebCore/platform/graphics/Font.h
+++ b/Source/WebCore/platform/graphics/Font.h
@@ -171,7 +171,7 @@ public:
     void setAvgCharWidth(float avgCharWidth) { m_avgCharWidth = avgCharWidth; }
 
     FloatRect boundsForGlyph(Glyph) const;
-#if USE(CORE_TEXT)
+#if USE(CORE_TEXT) || USE(SKIA)
     static constexpr size_t inlineGlyphRunCapacity = 128;
     Vector<FloatRect, inlineGlyphRunCapacity> boundsForGlyphs(std::span<const Glyph>) const;
 #endif
@@ -282,7 +282,7 @@ private:
     DerivedFonts& ensureDerivedFontData() const;
 
     FloatRect platformBoundsForGlyph(Glyph) const;
-#if USE(CORE_TEXT)
+#if USE(CORE_TEXT) || USE(SKIA)
     Vector<FloatRect, inlineGlyphRunCapacity> platformBoundsForGlyphs(const Vector<Glyph, inlineGlyphRunCapacity>&) const;
 #endif
     float platformWidthForGlyph(Glyph) const;
@@ -439,7 +439,7 @@ ALWAYS_INLINE FloatRect Font::boundsForGlyph(Glyph glyph) const
     return bounds;
 }
 
-#if USE(CORE_TEXT)
+#if USE(CORE_TEXT) || USE(SKIA)
 ALWAYS_INLINE Vector<FloatRect, Font::inlineGlyphRunCapacity> Font::boundsForGlyphs(std::span<const Glyph> glyphs) const
 {
     const auto glyphCount = glyphs.size();

--- a/Source/WebCore/platform/graphics/skia/FontSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/FontSkia.cpp
@@ -58,6 +58,28 @@ FloatRect Font::platformBoundsForGlyph(Glyph glyph) const
     return bounds;
 }
 
+Vector<FloatRect, Font::inlineGlyphRunCapacity> Font::platformBoundsForGlyphs(const Vector<Glyph, inlineGlyphRunCapacity>& glyphs) const
+{
+    if (!m_platformData.size())
+        return { };
+
+    static_assert(sizeof(Glyph) == sizeof(SkGlyphID));
+
+    Vector<SkRect, inlineGlyphRunCapacity> bounds(glyphs.size());
+    const auto& font = m_platformData.skFont();
+    font.getBounds(glyphs.span(), bounds.mutableSpan(), nullptr);
+    return bounds.map<Vector<FloatRect, inlineGlyphRunCapacity>>([&](const auto& boundsRect) -> auto {
+        if (font.isSubpixel())
+            return boundsRect;
+
+        SkRect returnValue = boundsRect;
+        SkIRect rect;
+        returnValue.roundOut(&rect);
+        returnValue.set(rect);
+        return returnValue;
+    });
+}
+
 float Font::platformWidthForGlyph(Glyph glyph) const
 {
     if (!m_platformData.size())


### PR DESCRIPTION
#### 753877fbd9243704ae4f7d09be13c484e01fb723
<pre>
[Skia] Implement Font::platformBoundsForGlyphs
<a href="https://bugs.webkit.org/show_bug.cgi?id=299280">https://bugs.webkit.org/show_bug.cgi?id=299280</a>

Reviewed by Adrian Perez de Castro.

Canonical link: <a href="https://commits.webkit.org/300369@main">https://commits.webkit.org/300369@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/558ebf2eb145feb073048e8e6ead64ff703f2f13

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122136 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41839 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32508 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128708 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74230 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/124012 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42553 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50432 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92833 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61714 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125088 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33941 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109371 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73488 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32954 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27537 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72197 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103449 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27728 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131460 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49075 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37333 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101400 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49449 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105585 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101269 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46639 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24753 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45825 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19339 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48932 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54666 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48402 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51752 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50082 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->