### PR TITLE
Inline error message in the Sources tab is cut on the right side.

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/SourceCodeTextEditor.css
+++ b/Source/WebInspectorUI/UserInterface/Views/SourceCodeTextEditor.css
@@ -27,6 +27,14 @@
     color: var(--text-color-active);
     overflow: initial;
     z-index: 3; /* overlap line content */
+    display: flex;
+    justify-content: end;
+    container-type: inline-size;
+}
+
+.source-code.text-editor .CodeMirror-linewidget:has(.line-indicator-widget.inline) {
+    position: absolute;
+    top: 0;
 }
 
 .source-code.text-editor > .CodeMirror .warning {
@@ -42,29 +50,27 @@
 }
 
 .source-code.text-editor > .CodeMirror .line-indicator-widget {
-    float: right;
-    padding: 0 5px 1px 5px;
-    border-bottom-left-radius: 5px;
+    padding: 0 5px 0px 5px;
     cursor: default;
+    min-height: 13px;
+    display: flex;
+    align-items: baseline;
+    gap: 3px;
+
 }
 
 .source-code.text-editor > .CodeMirror .line-indicator-widget.inline {
-    position: relative;
-    top: -13px;
-    height: 13px;
     padding: 0 5px 0 8px;
-    border-bottom-left-radius: 0;
     clip-path: polygon(0% 50%, 8px 100%, 100% 100%, 100% 0, 8px 0);
 }
 
 .source-code.text-editor > .CodeMirror .line-indicator-widget > .icon {
+    flex: none;
     height: 9px;
     width: 9px;
-    padding-right: 12px;
 
     background-size: 9px 9px;
     background-repeat: no-repeat;
-    background-position-y: 1px;
 }
 
 .source-code.text-editor > .CodeMirror .line-indicator-widget > .text {
@@ -72,11 +78,10 @@
 }
 
 .source-code.text-editor > .CodeMirror .line-indicator-widget.inline > .text {
-    display: inline-block;
-    max-width: 300px;
-    vertical-align: baseline;
+    max-width: min(300px, 30cqi); /* Keep part of the overlapped line content always visible */
     text-overflow: ellipsis;
     white-space: nowrap;
+    overflow: hidden;
 }
 
 .source-code.text-editor > .CodeMirror .issue-widget > .icon.icon-warning {


### PR DESCRIPTION
#### 3f60d204d75306116a0e79c932c80051a14bad35
<pre>
Inline error message in the Sources tab is cut on the right side.
<a href="https://bugs.webkit.org/show_bug.cgi?id=299277">https://bugs.webkit.org/show_bug.cgi?id=299277</a>
<a href="https://rdar.apple.com/161078966">rdar://161078966</a>

Reviewed by NOBODY (OOPS!).

Errors with long text in inline widgets should be trimmed with ellipses.
On click, these trimmed errors are fully revealed and display on their own line.

This patch adds the missing `overflow: hidden` CSS property to achieve ellipsis trimming.
It also modernizes the float layout to use Flexbox. It now accounts for the container dimensions
in order to size the inline error widget such that part of the overlapped line content
is always visible, even at narrow sizes.

No new tests (OOPS!).
* Source/WebInspectorUI/UserInterface/Views/SourceCodeTextEditor.css:
(.source-code.text-editor .CodeMirror-linewidget):
(.source-code.text-editor .CodeMirror-linewidget:has(.line-indicator-widget.inline)):
(.source-code.text-editor &gt; .CodeMirror .line-indicator-widget):
(.source-code.text-editor &gt; .CodeMirror .line-indicator-widget.inline):
(.source-code.text-editor &gt; .CodeMirror .line-indicator-widget &gt; .icon):
(.source-code.text-editor &gt; .CodeMirror .line-indicator-widget.inline &gt; .text):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3f60d204d75306116a0e79c932c80051a14bad35

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122141 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41844 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32513 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128713 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74235 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fe128e84-3023-44f4-9aef-ce76077664cf) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42558 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50437 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92836 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61717 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/84104762-cce1-4dca-a088-b7f61362b240) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125093 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33947 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109377 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73491 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/16786cad-d220-4e8f-bf8f-7331bb441495) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32960 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27542 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72202 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103455 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27733 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131465 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49080 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37337 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101402 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49454 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105590 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101271 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46646 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24758 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45831 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48937 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54671 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48407 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51757 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50087 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->