### PR TITLE
Render MathML unknown elements as mrow.

### DIFF
--- a/Source/WebCore/css/mathml.css
+++ b/Source/WebCore/css/mathml.css
@@ -94,40 +94,22 @@ math[display="inline" i] {
     math-style: compact;
 }
 
-ms, mtext, mi, mn, mo, annotation, mtd {
-    white-space: nowrap !important;
-}
-
-/* Fractions */
-mfrac {
-    padding-inline: 1px;
-}
-
-mfrac > * {
-    math-style: compact;
-}
-
-msub > * + *, msup > * + *, msubsup > * + *, mmultiscripts > * + *, munder > * + *, mover > * + *, munderover > * + * {
-    font-size: 0.71em;
-    math-style: compact;
-}
-
-mroot > *:last-child {
-    font-size: 0.5041em; /* This 0.71^2 since the scriptlevel is incremented by 2 in the index. */
-    math-style: compact;
+/* <mrow>-like elements */
+merror {
+    border: 1px solid red;
+    background-color: lightYellow;
 }
 
 mphantom {
     visibility: hidden;
 }
 
-/* This is a special style for erroneous markup. */
-/* https://w3c.github.io/mathml-core/#error-message-merror */
-merror {
-    border: 1px solid red;
-    background-color: lightYellow;
+/* Token elements */
+ms, mtext, mi, mn, mo, annotation, mtd {
+    white-space: nowrap !important;
 }
 
+/* Tables */
 mtable {
     display: inline-table;
     text-align: center;
@@ -195,7 +177,34 @@ mtable[columnlines="dashed"] > mtr > mtd + mtd {
     border-left: dashed thin;
 }
 
+/* Fractions */
+mfrac {
+    padding-inline: 1px;
+}
+
+mfrac > * {
+    math-style: compact;
+}
+
+mfrac > :nth-child(2) {
+    math-shift: compact;
+}
+
 /* Other rules for scriptlevel, displaystyle and math-shift */
+mroot > *:last-child {
+    font-size: 0.5041em; /* This 0.71^2 since the scriptlevel is incremented by 2 in the index. */
+    math-style: compact;
+}
+
+mroot, msqrt {
+    math-shift: compact;
+}
+
+msub > * + *, msup > * + *, msubsup > * + *, mmultiscripts > * + *, munder > * + *, mover > * + *, munderover > * + * {
+    font-size: 0.71em;
+    math-style: compact;
+}
+
 munder[accentunder="true" i] > :nth-child(2),
 mover[accent="true" i] > :nth-child(2),
 munderover[accentunder="true" i] > :nth-child(2),
@@ -203,9 +212,6 @@ munderover[accent="true" i] > :nth-child(3) {
   font-size: inherit;
 }
 
-mfrac > :nth-child(2),
-mroot,
-msqrt,
 msub > :nth-child(2),
 msubsup > :nth-child(2),
 mmultiscripts > :nth-child(even),

--- a/Source/WebCore/mathml/MathMLElement.cpp
+++ b/Source/WebCore/mathml/MathMLElement.cpp
@@ -228,7 +228,7 @@ void MathMLElement::collectPresentationalHintsForAttribute(const QualifiedName& 
 bool MathMLElement::childShouldCreateRenderer(const Node& child) const
 {
     // In general, only MathML children are allowed. Text nodes are only visible in token MathML elements.
-    return is<MathMLElement>(child);
+    return document().settings().coreMathMLEnabled() || is<MathMLElement>(child);
 }
 
 bool MathMLElement::willRespondToMouseClickEventsWithEditability(Editability editability) const

--- a/Source/WebCore/mathml/MathMLRowElement.cpp
+++ b/Source/WebCore/mathml/MathMLRowElement.cpp
@@ -69,7 +69,6 @@ RenderPtr<RenderElement> MathMLRowElement::createElementRenderer(RenderStyle&& s
     if (hasTagName(mfencedTag))
         return createRenderer<RenderMathMLFenced>(*this, WTFMove(style));
 
-    ASSERT(hasTagName(merrorTag) || hasTagName(mphantomTag) || hasTagName(mrowTag) || hasTagName(mstyleTag));
     return createRenderer<RenderMathMLRow>(RenderObject::Type::MathMLRow, *this, WTFMove(style));
 }
 

--- a/Source/WebCore/mathml/MathMLUnknownElement.cpp
+++ b/Source/WebCore/mathml/MathMLUnknownElement.cpp
@@ -28,11 +28,18 @@
 
 #if ENABLE(MATHML)
 
+#include "ElementInlines.h"
+#include "Settings.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(MathMLUnknownElement);
+
+bool MathMLUnknownElement::rendererIsNeeded(const RenderStyle&)
+{
+    return document().settings().coreMathMLEnabled();
+}
 
 } // namespace WebCore
 

--- a/Source/WebCore/mathml/MathMLUnknownElement.h
+++ b/Source/WebCore/mathml/MathMLUnknownElement.h
@@ -27,11 +27,11 @@
 
 #if ENABLE(MATHML)
 
-#include "MathMLElement.h"
+#include "MathMLRowElement.h"
 
 namespace WebCore {
 
-class MathMLUnknownElement final : public MathMLElement {
+class MathMLUnknownElement final : public MathMLRowElement {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(MathMLUnknownElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(MathMLUnknownElement);
 public:
@@ -42,11 +42,11 @@ public:
 
 private:
     MathMLUnknownElement(const QualifiedName& tagName, Document& document)
-        : MathMLElement(tagName, document, TypeFlag::IsUnknownElement)
+        : MathMLRowElement(tagName, document, TypeFlag::IsUnknownElement)
     {
     }
 
-    bool rendererIsNeeded(const RenderStyle&) final { return false; }
+    bool rendererIsNeeded(const RenderStyle&) final;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 191f0c3ec1c3b6ec945ec88864df6bdf8d04bd83
<pre>
Render MathML unknown elements as mrow.
<a href="https://bugs.webkit.org/show_bug.cgi?id=290625">https://bugs.webkit.org/show_bug.cgi?id=290625</a>

Reviewed by NOBODY (OOPS!).

The MathML Core spec says that unknown elements should be rendered
as an mrow. These changes are gated behind the CoreMathMLEnabled preference.  
Update the user agent stylesheet to align closer with the spec.

No new tests (OOPS!).

* LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/inferred-mrow-stretchy-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/spacing-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/embellished-operator-001-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/inferred-mrow-baseline-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/mrow-preferred-width-expected.txt:
* Source/WebCore/mathml/MathMLRowElement.cpp:
(WebCore::MathMLRowElement::createElementRenderer):
* Source/WebCore/mathml/MathMLUnknownElement.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a4f7d81bb8e45c12dab82b707c0edda2d6b97508

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122385 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42091 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32777 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128972 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/74484 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/124261 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42810 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50684 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93020 "Found 15 new test failures: accessibility/math-foreign-content.html imported/w3c/web-platform-tests/css/css-content/attr-case-sensitivity-003.html imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/inferred-mrow-baseline.html imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/inferred-mrow-stretchy.html imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/mrow-preferred-width.html imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/spacing.html imported/w3c/web-platform-tests/mathml/presentation-markup/operators/embellished-operator-001.html imported/w3c/web-platform-tests/mathml/presentation-markup/tables/table-cell-mrow-layout.html mathml/arbitrary-markup.html mathml/mathml-unknown.xhtml ... (failure)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/74484 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125337 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34138 "Found 4 new test failures: mathml/presentation/foreign-element-in-annotation-xml.html mathml/presentation/semantics-2.html mathml/presentation/semantics-3.html mathml/presentation/semantics-4.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109585 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73679 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27741 "Found 6 new test failures: accessibility/math-foreign-content.html imported/w3c/web-platform-tests/css/css-font-loading/idlharness.https.html mathml/presentation/foreign-element-in-annotation-xml.html mathml/presentation/semantics-2.html mathml/presentation/semantics-3.html mathml/presentation/semantics-4.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72467 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27952 "Found 5 new test failures: accessibility/math-foreign-content.html mathml/presentation/foreign-element-in-annotation-xml.html mathml/presentation/semantics-2.html mathml/presentation/semantics-3.html mathml/presentation/semantics-4.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131713 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49326 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37532 "Found 5 new test failures: accessibility/math-foreign-content.html mathml/presentation/foreign-element-in-annotation-xml.html mathml/presentation/semantics-2.html mathml/presentation/semantics-3.html mathml/presentation/semantics-4.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101569 "Found 15 new test failures: accessibility/math-foreign-content.html imported/w3c/web-platform-tests/css/css-content/attr-case-sensitivity-003.html imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/inferred-mrow-baseline.html imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/inferred-mrow-stretchy.html imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/mrow-preferred-width.html imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/spacing.html imported/w3c/web-platform-tests/mathml/presentation-markup/operators/embellished-operator-001.html imported/w3c/web-platform-tests/mathml/presentation-markup/tables/table-cell-mrow-layout.html mathml/arbitrary-markup.html mathml/mathml-unknown.xhtml ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49700 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105805 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101440 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46812 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24948 "Found 5 new test failures: accessibility/math-foreign-content.html mathml/presentation/foreign-element-in-annotation-xml.html mathml/presentation/semantics-2.html mathml/presentation/semantics-3.html mathml/presentation/semantics-4.html (failure)") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/46088 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49184 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54927 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48651 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/52001 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50333 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->