### PR TITLE
[visionOS] WebViews need to request the "Two Handed Interaction Processor" behavior

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/QuartzCoreSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/QuartzCoreSPI.h
@@ -56,6 +56,10 @@ DECLARE_SYSTEM_HEADER
 #import <QuartzCore/CADisplayLinkPrivate.h>
 #endif
 
+#if PLATFORM(VISION)
+#import <QuartzCore/CARemoteEffectPrivate.h>
+#endif
+
 #if ENABLE(ARKIT_INLINE_PREVIEW)
 #import <QuartzCore/CAFenceHandle.h>
 #endif
@@ -233,6 +237,11 @@ typedef enum {
 @interface CARemoteEffect: NSObject <NSCopying, NSSecureCoding>
 @end
 
+#if PLATFORM(VISION)
+@interface CARemoteExternalEffect: CARemoteEffect
+@end
+#endif
+
 @interface CARemoteEffectGroup : CARemoteEffect
 + (instancetype)groupWithEffects:(NSArray<CARemoteEffect *> *)effects;
 @property (copy) NSString *groupName;
@@ -360,4 +369,11 @@ extern NSString * const kCASnapshotOriginX;
 extern NSString * const kCASnapshotOriginY;
 extern NSString * const kCASnapshotTransform;
 extern NSString * const kCASnapshotTimeOffset;
+#endif
+
+#if PLATFORM(VISION)
+// FIXME:rdar://160881286 - clean-up once in SDK.
+@interface CARemoteExternalEffect (Radar_160881286)
++ (instancetype)rcp_requiresTwoHandedInteractionProcessorEffect;
+@end
 #endif

--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -639,6 +639,9 @@ extern NSString * const UIPresentationControllerDismissalTransitionDidEndComplet
 @interface UIActivityViewController ()
 @property (nonatomic) BOOL allowsCustomPresentationStyle;
 @end
+@interface UIView ()
+- (void)_requestRemoteEffects:(NSArray *)effects forKey:(NSString *)key;
+@end
 #endif // PLATFORM(VISION)
 
 @interface UIView ()

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -224,6 +224,11 @@ static WebCore::IntDegrees deviceOrientationForUIInterfaceOrientation(UIInterfac
     [_contentView setFrame:bounds];
     [_scrollView addSubview:_contentView.get()];
     [_scrollView addSubview:[_contentView unscaledView]];
+
+#if PLATFORM(VISION)
+    if ([[CARemoteExternalEffect class] respondsToSelector:@selector(rcp_requiresTwoHandedInteractionProcessorEffect)])
+        [_scrollView _requestRemoteEffects:@[[CARemoteExternalEffect rcp_requiresTwoHandedInteractionProcessorEffect]] forKey:@"input"];
+#endif
 }
 
 - (void)_setObscuredInsetsInternal:(UIEdgeInsets)obscuredInsets


### PR DESCRIPTION
#### a4e70b2a81fd7d3d9dde89786f41bdc1406a44a2
<pre>
[visionOS] WebViews need to request the &quot;Two Handed Interaction Processor&quot; behavior
<a href="https://bugs.webkit.org/show_bug.cgi?id=299118">https://bugs.webkit.org/show_bug.cgi?id=299118</a>
&lt;<a href="https://rdar.apple.com/160683670">rdar://160683670</a>&gt;

Reviewed by Abrar Rahman Protyasha.

When available, add the RemoteEffect that lets us opt-into the correct
behavior for two handed gestures on the top level scroll view.

* Source/WebCore/PAL/pal/spi/cocoa/QuartzCoreSPI.h:
Forward-declaration.
* Source/WebKit/Platform/spi/ios/UIKitSPI.h:
Add missing public SDK stub.
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _setupScrollAndContentViews]):
Add the effect when available.

Canonical link: <a href="https://commits.webkit.org/300326@main">https://commits.webkit.org/300326@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e9c1d0b381a373bbfa02e14fccf389280edfdf4d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122158 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41861 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32530 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128731 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74252 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1bbf0867-de22-45b7-b966-9b3e67adfbcc) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/124034 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42575 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50454 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92849 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61724 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1bd11274-63c5-45fb-b5b5-ebd948b751a8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125110 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33956 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109389 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73503 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3e861820-02db-4bfc-8b6a-113babe62907) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32969 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27554 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72219 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103464 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27745 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131482 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49097 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37348 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101417 "Found 1 new test failure: inspector/dom-debugger/event-animation-frame-breakpoints.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49471 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105600 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101286 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25674 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46657 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/24770 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45848 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48954 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54688 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48424 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51774 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50104 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->