### PR TITLE
[JSC] Suppprt `Promise.any` in async stack trace

### DIFF
--- a/JSTests/stress/async-stack-trace-promise-any-basic.js
+++ b/JSTests/stress/async-stack-trace-promise-any-basic.js
@@ -1,0 +1,148 @@
+//@ requireOptions("--useAsyncStackTrace=1")
+
+const source = "async-stack-trace-promise-any-basic.js";
+
+function nop() {}
+
+function shouldBe(a, b) {
+  if (a !== b)
+    throw new Error(`Expected ${a} to be ${b}`);
+}
+
+function testStack(error, stackFunctions) {
+  const stackTrace = error.stack;
+  if (!stackTrace) {
+    throw new Error("Expected error to have stack trace, but it was undefined");
+  }
+  const stackLines = stackTrace.split('\n').filter(line => line.trim());
+  for (let i = 0; i < stackFunctions.length; i++) {
+    const [expectedFunction, expectedLocation] = stackFunctions[i];
+    const isNativeCode = expectedLocation === "[native code]"
+    const stackLine = stackLines[i];
+
+    let found = false;
+
+    if (isNativeCode) {
+      if (stackLine === `${expectedFunction}@[native code]`)
+        found = true;
+    } else {
+      if (stackLine === `${expectedFunction}@${source}:${expectedLocation}`)
+        found = true;
+      if (stackLine === `${expectedFunction}@${source}`)
+        found = true;
+    }
+
+    if (!found) {
+      throw new Error(
+        `Expected stack trace to contain '${expectedFunction}' at '${expectedLocation}', but got '${stackLine}'` +
+        `\nActual stack trace:\n${stackTrace}\n`
+      );
+    }
+  }
+}
+
+function shouldThrowAsync(run, errorType) {
+  let actual;
+  var hadError = false;
+  run().then(
+    function (value) {
+      actual = value;
+    },
+    function (error) {
+      hadError = true;
+      actual = error;
+    },
+  );
+  drainMicrotasks();
+  if (!hadError) {
+    throw new Error("Expected " + run + "() to throw " + errorType.name + ", but did not throw.");
+  }
+  if (!(actual instanceof errorType)) {
+    throw new Error("Expected " + run + "() to throw " + errorType.name + ", but threw '" + actual + "'");
+  }
+  return actual;
+}
+
+{
+  async function fine() { }
+  async function thrower() { await fine(); throw new Error('error'); }
+  async function run() { await Promise.any([thrower()]); }
+
+  for (let i = 0; i < testLoopCount; i++) {
+    const aggregateError = shouldThrowAsync(
+      async function test() {
+        await run();
+      }, AggregateError
+    );
+    drainMicrotasks();
+    shouldBe(aggregateError.errors.length, 1);
+    testStack(aggregateError.errors[0],
+      [
+        ["thrower", "68:59"],
+        ["async run", "69:43"],
+        ["async test", "74:18"],
+        ["drainMicrotasks", "[native code]"],
+        ["shouldThrowAsync", "56:18"],
+        ["global code", "72:44"]
+      ]
+    );
+  }
+}
+
+{
+  async function task1() {
+    
+    await nop();
+  
+    throw new Error("error from task1");
+  }
+  async function task2() {
+    await nop();
+
+
+
+    throw new Error('task2 error');
+  }
+  async function task3() { await 1; throw new Error("error from task3"); }
+  async function run() { await Promise.any([task1(), task2(), task3()]); }
+
+  for (let i = 0; i < testLoopCount; i++) {
+    const aggregateError = shouldThrowAsync(
+      async function test() {
+        await run();
+      }, AggregateError
+    );
+    drainMicrotasks();
+    shouldBe(aggregateError.errors.length, 3);
+    testStack(aggregateError.errors[0],
+      [
+        ["task1", "97:20"],
+        ["async run", "107:43"],
+        ["async test", "112:18"],
+        ["drainMicrotasks", "[native code]"],
+        ["shouldThrowAsync", "56:18"],
+        ["global code", "110:44"]
+      ]
+    );
+    testStack(aggregateError.errors[1],
+      [
+        ["task2", "104:20"],
+        ["async run", "107:43"],
+        ["async test", "112:18"],
+        ["drainMicrotasks", "[native code]"],
+        ["shouldThrowAsync", "56:18"],
+        ["global code", "110:44"]
+      ]
+    );
+    testStack(aggregateError.errors[2],
+      [
+        ["task3", "106:52"],
+        ["async run", "107:43"],
+        ["async test", "112:18"],
+        ["drainMicrotasks", "[native code]"],
+        ["shouldThrowAsync", "56:18"],
+        ["global code", "110:44"]
+      ]
+    );
+  }
+}

--- a/Source/JavaScriptCore/interpreter/Interpreter.cpp
+++ b/Source/JavaScriptCore/interpreter/Interpreter.cpp
@@ -494,6 +494,15 @@ void Interpreter::getAsyncStackTrace(JSCell* owner, Vector<StackFrame>& results,
                     return generator;
             }
         }
+
+        // handle `Promise.any`
+        if (auto* contextPromise = jsDynamicCast<JSPromise*>(promiseContext)) {
+            if (JSValue parentContext = getContextValueFromPromise(contextPromise)) {
+                if (auto* generator = jsDynamicCast<JSGenerator*>(parentContext))
+                    return generator;
+            }
+        }
+
         return nullptr;
     };
 


### PR DESCRIPTION
#### d9a997b3edaaebbd6b0a8a433272f415ff9f7404
<pre>
[JSC] Suppprt `Promise.any` in async stack trace
<a href="https://bugs.webkit.org/show_bug.cgi?id=299288">https://bugs.webkit.org/show_bug.cgi?id=299288</a>

Reviewed by Yusuke Suzuki.

This patch changes async stack trace to support `Promise.any`.

Test: JSTests/stress/async-stack-trace-promise-any-basic.js

Test: JSTests/stress/async-stack-trace-promise-any-basic.js
* JSTests/stress/async-stack-trace-promise-any-basic.js: Added.
(nop):
(shouldBe):
(testStack):
(async fine):
(async thrower):
(async run):
(i.const.aggregateError.shouldThrowAsync.async test):
(testStack.async task1):
(testStack.async task2):
(testStack.async task3):
(testStack.async run):
* Source/JavaScriptCore/builtins/PromiseConstructor.js:
(any):
* Source/JavaScriptCore/interpreter/Interpreter.cpp:
(JSC::Interpreter::getAsyncStackTrace):

Canonical link: <a href="https://commits.webkit.org/300623@main">https://commits.webkit.org/300623@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b0a5dff71833505cec2967e15039f732a3ac2427

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123271 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42985 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33682 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/129979 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/75384 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43709 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51580 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93701 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/62161 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126224 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34826 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110293 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74329 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33790 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28450 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73497 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/115430 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104540 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28676 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132697 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/121802 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50221 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38214 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102190 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50597 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106515 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102045 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25944 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47398 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25616 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/46995 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50076 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/55837 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/152157 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49547 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/38881 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/52897 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51225 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->