### PR TITLE
PlatformPasteboardiOS operations should serialize AttributedString using the WebCore type as opposed to sending opaque data

### DIFF
--- a/Source/WebCore/editing/cocoa/EditorCocoa.mm
+++ b/Source/WebCore/editing/cocoa/EditorCocoa.mm
@@ -78,14 +78,6 @@
 
 namespace WebCore {
 
-static RefPtr<SharedBuffer> archivedDataForAttributedString(NSAttributedString *attributedString)
-{
-    if (!attributedString.length)
-        return nullptr;
-
-    return SharedBuffer::create([NSKeyedArchiver archivedDataWithRootObject:attributedString requiringSecureCoding:YES error:nullptr]);
-}
-
 String Editor::selectionInHTMLFormat()
 {
     if (ImageOverlay::isInsideOverlay(document().selection().selection()))
@@ -171,7 +163,7 @@ void populateRichTextDataIfNeeded(PasteboardContent& content, const Document& do
     auto string = selectionAsAttributedString(document);
     content.dataInRTFDFormat = [string containsAttachments] ? Editor::dataInRTFDFormat(string.get()) : nullptr;
     content.dataInRTFFormat = Editor::dataInRTFFormat(string.get());
-    content.dataInAttributedStringFormat = archivedDataForAttributedString(string.get());
+    content.dataInAttributedStringFormat = AttributedString::fromNSAttributedString(string.get());
 }
 
 void Editor::writeSelectionToPasteboard(Pasteboard& pasteboard)

--- a/Source/WebCore/platform/Pasteboard.h
+++ b/Source/WebCore/platform/Pasteboard.h
@@ -44,6 +44,7 @@ OBJC_CLASS NSString;
 #endif
 
 #if PLATFORM(COCOA)
+#include <WebCore/AttributedString.h>
 OBJC_CLASS NSArray;
 #endif
 
@@ -88,7 +89,7 @@ struct PasteboardWebContent {
     RefPtr<SharedBuffer> dataInWebArchiveFormat;
     RefPtr<SharedBuffer> dataInRTFDFormat;
     RefPtr<SharedBuffer> dataInRTFFormat;
-    RefPtr<SharedBuffer> dataInAttributedStringFormat;
+    std::optional<WebCore::AttributedString> dataInAttributedStringFormat;
     String dataInHTMLFormat;
     String dataInStringFormat;
     Vector<std::pair<String, RefPtr<WebCore::SharedBuffer>>> clientTypesAndData;

--- a/Source/WebCore/platform/PasteboardWriterData.h
+++ b/Source/WebCore/platform/PasteboardWriterData.h
@@ -29,6 +29,10 @@
 #include <wtf/URL.h>
 #include <wtf/text/WTFString.h>
 
+#if PLATFORM(COCOA)
+#include <WebCore/AttributedString.h>
+#endif
+
 namespace WebCore {
 
 class SharedBuffer;
@@ -55,7 +59,7 @@ public:
         RefPtr<SharedBuffer> dataInWebArchiveFormat;
         RefPtr<SharedBuffer> dataInRTFDFormat;
         RefPtr<SharedBuffer> dataInRTFFormat;
-        RefPtr<SharedBuffer> dataInAttributedStringFormat;
+        std::optional<WebCore::AttributedString> dataInAttributedStringFormat;
         String dataInHTMLFormat;
         String dataInStringFormat;
         Vector<std::pair<String, RefPtr<WebCore::SharedBuffer>>> clientTypesAndData;

--- a/Source/WebCore/platform/ios/PlatformPasteboardIOS.mm
+++ b/Source/WebCore/platform/ios/PlatformPasteboardIOS.mm
@@ -41,6 +41,7 @@
 #import <UIKit/UIImage.h>
 #import <UIKit/UIPasteboard.h>
 #import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
+#import <WebCore/AttributedString.h>
 #import <pal/spi/ios/UIKitSPI.h>
 #import <wtf/ListHashSet.h>
 #import <wtf/URL.h>
@@ -488,8 +489,7 @@ void PlatformPasteboard::write(const PasteboardWebContent& content)
     }
 
     if (content.dataInAttributedStringFormat) {
-        if (NSAttributedString *attributedString = [NSKeyedUnarchiver unarchivedObjectOfClasses:[NSSet setWithObject:NSAttributedString.class] fromData:content.dataInAttributedStringFormat->makeContiguous()->createNSData().get() error:nullptr])
-            [representationsToRegister addRepresentingObject:attributedString];
+        [representationsToRegister addRepresentingObject:content.dataInAttributedStringFormat.value().nsAttributedString().get()];
     }
 
     if (content.dataInRTFDFormat)

--- a/Source/WebKit/Shared/Pasteboard.serialization.in
+++ b/Source/WebKit/Shared/Pasteboard.serialization.in
@@ -49,7 +49,7 @@ header: <WebCore/Pasteboard.h>
     RefPtr<WebCore::SharedBuffer> dataInWebArchiveFormat;
     RefPtr<WebCore::SharedBuffer> dataInRTFDFormat;
     RefPtr<WebCore::SharedBuffer> dataInRTFFormat;
-    RefPtr<WebCore::SharedBuffer> dataInAttributedStringFormat;
+    std::optional<WebCore::AttributedString> dataInAttributedStringFormat;
     String dataInHTMLFormat;
     String dataInStringFormat;
     Vector<std::pair<String, RefPtr<WebCore::SharedBuffer>>> clientTypesAndData;


### PR DESCRIPTION
#### bd475b0178847796018e91181164be4db2966547
<pre>
PlatformPasteboardiOS operations should serialize AttributedString using the WebCore type as opposed to sending opaque data
<a href="https://bugs.webkit.org/show_bug.cgi?id=299291">https://bugs.webkit.org/show_bug.cgi?id=299291</a>
<a href="https://rdar.apple.com/152512505">rdar://152512505</a>

Reviewed by Ryosuke Niwa.

Instead of serializing NSAttributedString as opaque data, we should instead
use the existing WebCore AttributedString type.

* Source/WebCore/editing/cocoa/EditorCocoa.mm:
(WebCore::populateRichTextDataIfNeeded):
(WebCore::archivedDataForAttributedString): Deleted.
* Source/WebCore/platform/Pasteboard.h:
* Source/WebCore/platform/PasteboardWriterData.h:
* Source/WebCore/platform/ios/PlatformPasteboardIOS.mm:
(WebCore::PlatformPasteboard::write):
* Source/WebKit/Shared/Pasteboard.serialization.in:

Canonical link: <a href="https://commits.webkit.org/300339@main">https://commits.webkit.org/300339@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/55299428507a31ccb2bf41506fa5262743765357

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122180 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41883 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32552 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128753 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74274 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a63d0ed9-b9d0-44f4-82b3-2741c7ca44a0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/124056 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42597 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50476 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92865 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61736 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b906cfdc-8500-4fb9-9352-3ecef1dd6864) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125132 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33982 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109418 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73521 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3e66541c-ec73-4bc4-9726-2140be41f411) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32992 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27581 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72241 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103490 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27774 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131504 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49119 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37370 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101435 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49493 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105629 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101304 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25686 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46676 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24797 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45870 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48976 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54710 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48446 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51796 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50126 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->