### PR TITLE
[JSC] Assertion message for unknown private name should be more readble

### DIFF
--- a/Source/JavaScriptCore/parser/Lexer.cpp
+++ b/Source/JavaScriptCore/parser/Lexer.cpp
@@ -990,10 +990,15 @@ template <bool shouldCreateIdentifier> ALWAYS_INLINE JSTokenType Lexer<Latin1Cha
     if (shouldCreateIdentifier || m_parsingBuiltinFunction) {
         std::span identifierSpan { identifierStart, static_cast<size_t>(currentSourcePtr() - identifierStart) };
         if (m_parsingBuiltinFunction && isBuiltinName) {
-            if (isWellKnownSymbol)
-                ident = &m_arena->makeIdentifier(m_vm, m_vm.propertyNames->builtinNames().lookUpWellKnownSymbol(identifierSpan));
-            else
-                ident = &m_arena->makeIdentifier(m_vm, m_vm.propertyNames->builtinNames().lookUpPrivateName(identifierSpan));
+            if (isWellKnownSymbol) {
+                SUPPRESS_UNCOUNTED_LOCAL auto* symbol = m_vm.propertyNames->builtinNames().lookUpWellKnownSymbol(identifierSpan);
+                ASSERT_WITH_MESSAGE(symbol, "Private well-known symbol @@%s not found", StringView(identifierSpan).utf8().data());
+                ident = &m_arena->makeIdentifier(m_vm, symbol);
+            } else {
+                SUPPRESS_UNCOUNTED_LOCAL auto* symbol = m_vm.propertyNames->builtinNames().lookUpPrivateName(identifierSpan);
+                ASSERT_WITH_MESSAGE(symbol, "Private name @%s not found", StringView(identifierSpan).utf8().data());
+                ident = &m_arena->makeIdentifier(m_vm, symbol);
+            }
             if (!ident)
                 return INVALID_PRIVATE_NAME_ERRORTOK;
         } else {


### PR DESCRIPTION
#### 75d0bf64415055f5210e238b51b4bd7e5d01814b
<pre>
[JSC] Assertion message for unknown private name should be more readble
<a href="https://bugs.webkit.org/show_bug.cgi?id=299292">https://bugs.webkit.org/show_bug.cgi?id=299292</a>

Reviewed by NOBODY (OOPS!).

If unknown a private name is used in builtins JS code, an assertion error occurs.
This patch changes to make it more readable.

Before:
    ASSERTION FAILED: symbol

After:
    ASSERTION FAILED: Private name @foo not found
    or
    ASSERTION FAILED: Private well-known symbol @@foo not found

* Source/JavaScriptCore/parser/Lexer.cpp:
(JSC::Lexer&lt;Latin1Character&gt;::parseIdentifier):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/75d0bf64415055f5210e238b51b4bd7e5d01814b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128244 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/529 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39076 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135640 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79732 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/458 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/399 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97620 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65528 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131192 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/297 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114886 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78206 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/287 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32994 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78927 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/120275 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108665 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33478 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138092 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/126705 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/379 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/353 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106157 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/411 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111228 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105952 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/296 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29782 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52666 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/424 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/63299 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/159731 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/332 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39892 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/402 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/389 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->