### PR TITLE
[Style] Convert the 'text-box-edge' and 'line-fit-edge` properties to strong style types

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -3145,7 +3145,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     rendering/style/StyleScrollSnapPoints.h
     rendering/style/StyleSelfAlignmentData.h
     rendering/style/StyleSurroundData.h
-    rendering/style/StyleTextEdge.h
     rendering/style/StyleTransformData.h
     rendering/style/StyleVisitedLinkColorData.h
     rendering/style/WillChangeData.h
@@ -3280,6 +3279,9 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     style/values/images/StyleObjectPosition.h
 
     style/values/inline/StyleLineBoxContain.h
+    style/values/inline/StyleLineFitEdge.h
+    style/values/inline/StyleTextBoxEdge.h
+    style/values/inline/StyleTextEdge.h
     style/values/inline/StyleVerticalAlign.h
     style/values/inline/StyleWebKitInitialLetter.h
 

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2993,7 +2993,6 @@ rendering/style/StyleRareNonInheritedData.cpp
 rendering/style/StyleScrollSnapPoints.cpp
 rendering/style/StyleSelfAlignmentData.cpp
 rendering/style/StyleSurroundData.cpp
-rendering/style/StyleTextEdge.cpp
 rendering/style/StyleTransformData.cpp
 rendering/style/StyleVisitedLinkColorData.cpp
 rendering/style/WillChangeData.cpp

--- a/Source/WebCore/css/CSSPrimitiveValueMappings.h
+++ b/Source/WebCore/css/CSSPrimitiveValueMappings.h
@@ -2307,56 +2307,6 @@ DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
 #undef TYPE
 #undef FOR_EACH
 
-constexpr CSSValueID toCSSValueID(TextEdgeType textEdgeType)
-{
-    switch (textEdgeType) {
-    case TextEdgeType::Auto:
-        return CSSValueAuto;
-    case TextEdgeType::Leading:
-        return CSSValueLeading;
-    case TextEdgeType::Text:
-        return CSSValueText;
-    case TextEdgeType::CapHeight:
-        return CSSValueCap;
-    case TextEdgeType::ExHeight:
-        return CSSValueEx;
-    case TextEdgeType::Alphabetic:
-        return CSSValueAlphabetic;
-    case TextEdgeType::CJKIdeographic:
-        return CSSValueIdeographic;
-    case TextEdgeType::CJKIdeographicInk:
-        return CSSValueIdeographicInk;
-    }
-    ASSERT_NOT_REACHED_UNDER_CONSTEXPR_CONTEXT();
-    return CSSValueInvalid;
-}
-
-template<> constexpr TextEdgeType fromCSSValueID(CSSValueID valueID)
-{
-    switch (valueID) {
-    case CSSValueAuto:
-        return TextEdgeType::Auto;
-    case CSSValueLeading:
-        return TextEdgeType::Leading;
-    case CSSValueText:
-        return TextEdgeType::Text;
-    case CSSValueCap:
-        return TextEdgeType::CapHeight;
-    case CSSValueEx:
-        return TextEdgeType::ExHeight;
-    case CSSValueAlphabetic:
-        return TextEdgeType::Alphabetic;
-    case CSSValueIdeographic:
-        return TextEdgeType::CJKIdeographic;
-    case CSSValueIdeographicInk:
-        return TextEdgeType::CJKIdeographicInk;
-    default:
-        break;
-    }
-    ASSERT_NOT_REACHED_UNDER_CONSTEXPR_CONTEXT();
-    return TextEdgeType::Auto;
-}
-
 #if ENABLE(APPLE_PAY)
 
 #define TYPE ApplePayButtonStyle
@@ -2632,6 +2582,18 @@ DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
 
 #define TYPE TransitionBehavior
 #define FOR_EACH(CASE) CASE(Normal) CASE(AllowDiscrete)
+DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
+#undef TYPE
+#undef FOR_EACH
+
+#define TYPE TextEdgeOver
+#define FOR_EACH(CASE) CASE(Text) CASE(Ideographic) CASE(IdeographicInk) CASE(Cap) CASE(Ex)
+DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
+#undef TYPE
+#undef FOR_EACH
+
+#define TYPE TextEdgeUnder
+#define FOR_EACH(CASE) CASE(Text) CASE(Ideographic) CASE(IdeographicInk) CASE(Alphabetic)
 DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
 #undef TYPE
 #undef FOR_EACH

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -819,8 +819,7 @@
             ],
             "codegen-properties": {
                 "settings-flag": "cssTextBoxTrimEnabled",
-                "style-builder-converter": "TextEdge",
-                "style-extractor-converter": "TextBoxEdge",
+                "style-converter": "StyleType<TextBoxEdge>",
                 "parser-function": "consumeTextBoxEdge",
                 "parser-grammar-unused": "auto | [ [ text | cap | ex | ideographic | ideographic-ink ] [ text | alphabetic | ideographic | ideographic-ink ]? ]",
                 "parser-grammar-unused-reason": "Needs support for transforming parsed input to minimal form."
@@ -4982,15 +4981,14 @@
             ],
             "codegen-properties": {
                 "settings-flag": "cssLineFitEdgeEnabled",
-                "style-builder-converter": "TextEdge",
-                "style-extractor-converter": "LineFitEdge",
+                "style-converter": "StyleType<LineFitEdge>",
                 "parser-function": "consumeLineFitEdge",
                 "parser-grammar-unused": "leading | [ [ text | cap | ex | ideographic | ideographic-ink ] [ text | alphabetic | ideographic | ideographic-ink ]? ]",
                 "parser-grammar-unused-reason": "Needs support for transforming parsed input to minimal form."
             },
             "specification": {
                 "category": "css-inline",
-                "url": "https://www.w3.org/TR/css-inline-3/#text-edges"
+                "url": "https://drafts.csswg.org/css-inline-3/#propdef-line-fit-edge"
             },
             "status": "experimental"
         },

--- a/Source/WebCore/layout/formattingContexts/block/BlockLayoutState.h
+++ b/Source/WebCore/layout/formattingContexts/block/BlockLayoutState.h
@@ -27,7 +27,7 @@
 
 #include <WebCore/Font.h>
 #include <WebCore/PlacedFloats.h>
-#include <WebCore/StyleTextEdge.h>
+#include <WebCore/StyleTextBoxEdge.h>
 #include <algorithm>
 
 namespace WebCore {
@@ -60,14 +60,14 @@ public:
         LayoutUnit pageLogicalTop;
     };
 
-    BlockLayoutState(PlacedFloats&, std::optional<LineClamp> = { }, TextBoxTrim = { }, TextEdge = { }, std::optional<LayoutUnit> intrusiveInitialLetterLogicalBottom = { }, std::optional<LineGrid> lineGrid = { });
+    BlockLayoutState(PlacedFloats&, std::optional<LineClamp> = { }, TextBoxTrim = { }, Style::TextBoxEdge = CSS::Keyword::Auto { }, std::optional<LayoutUnit> intrusiveInitialLetterLogicalBottom = { }, std::optional<LineGrid> lineGrid = { });
 
     PlacedFloats& placedFloats() { return m_placedFloats; }
     const PlacedFloats& placedFloats() const { return m_placedFloats; }
 
     std::optional<LineClamp> lineClamp() const { return m_lineClamp; }
     TextBoxTrim textBoxTrim() const { return m_textBoxTrim; }
-    TextEdge textBoxEdge() const { return m_textBoxEdge; }
+    Style::TextBoxEdge textBoxEdge() const { return m_textBoxEdge; }
 
     std::optional<LayoutUnit> intrusiveInitialLetterLogicalBottom() const { return m_intrusiveInitialLetterLogicalBottom; }
     const std::optional<LineGrid>& lineGrid() const { return m_lineGrid; }
@@ -76,12 +76,12 @@ private:
     PlacedFloats& m_placedFloats;
     std::optional<LineClamp> m_lineClamp;
     TextBoxTrim m_textBoxTrim;
-    TextEdge m_textBoxEdge;
+    Style::TextBoxEdge m_textBoxEdge;
     std::optional<LayoutUnit> m_intrusiveInitialLetterLogicalBottom;
     std::optional<LineGrid> m_lineGrid;
 };
 
-inline BlockLayoutState::BlockLayoutState(PlacedFloats& placedFloats, std::optional<LineClamp> lineClamp, TextBoxTrim textBoxTrim, TextEdge textBoxEdge, std::optional<LayoutUnit> intrusiveInitialLetterLogicalBottom, std::optional<LineGrid> lineGrid)
+inline BlockLayoutState::BlockLayoutState(PlacedFloats& placedFloats, std::optional<LineClamp> lineClamp, TextBoxTrim textBoxTrim, Style::TextBoxEdge textBoxEdge, std::optional<LayoutUnit> intrusiveInitialLetterLogicalBottom, std::optional<LineGrid> lineGrid)
     : m_placedFloats(placedFloats)
     , m_lineClamp(lineClamp)
     , m_textBoxTrim(textBoxTrim)

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLevelBox.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLevelBox.h
@@ -31,7 +31,8 @@
 #include <WebCore/LayoutBox.h>
 #include <WebCore/LayoutUnits.h>
 #include <WebCore/LengthFunctions.h>
-#include <WebCore/StyleTextEdge.h>
+#include <WebCore/StyleLineFitEdge.h>
+#include <WebCore/StyleTextBoxEdge.h>
 #include <wtf/OptionSet.h>
 
 namespace WebCore {
@@ -81,8 +82,8 @@ public:
     InlineLayoutUnit fontSize() const { return m_style.primaryFontSize; }
 
     TextBoxTrim textBoxTrim() const { return m_style.textBoxTrim; }
-    TextEdge textBoxEdge() const { return m_style.textBoxEdge; }
-    TextEdge lineFitEdge() const { return m_style.lineFitEdge; }
+    Style::TextBoxEdge textBoxEdge() const { return m_style.textBoxEdge; }
+    Style::LineFitEdge lineFitEdge() const { return m_style.lineFitEdge; }
     InlineLayoutUnit inlineBoxContentOffsetForTextBoxTrim() const { return m_inlineBoxContentOffsetForTextBoxTrim; }
 
     bool hasTextEmphasis() const { return (hasContent() || isAtomicInlineBox()) && m_textEmphasis.has_value(); };
@@ -165,8 +166,8 @@ private:
         const FontMetrics& primaryFontMetrics;
         const Length& lineHeight;
         TextBoxTrim textBoxTrim;
-        TextEdge textBoxEdge;
-        TextEdge lineFitEdge;
+        WebCore::Style::TextBoxEdge textBoxEdge;
+        WebCore::Style::LineFitEdge lineFitEdge;
         OptionSet<WebCore::Style::LineBoxContain> lineBoxContain;
         InlineLayoutUnit primaryFontSize { 0 };
         VerticalAlignment verticalAlignment { };

--- a/Source/WebCore/rendering/RenderLayoutState.h
+++ b/Source/WebCore/rendering/RenderLayoutState.h
@@ -27,7 +27,6 @@
 
 #include <WebCore/LayoutRect.h>
 #include <WebCore/LocalFrameViewLayoutContext.h>
-#include <WebCore/StyleTextEdge.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -56,7 +56,6 @@
 #include "StyleResolver.h"
 #include "StyleScrollSnapPoints.h"
 #include "StyleSelfAlignmentData.h"
-#include "StyleTextEdge.h"
 #include "StyleTreeResolver.h"
 #include "TransformOperationData.h"
 #include <algorithm>
@@ -3472,36 +3471,6 @@ bool RenderStyle::hasSnapPosition() const
 {
     const ScrollSnapAlign& alignment = this->scrollSnapAlign();
     return alignment.blockAlign != ScrollSnapAxisAlignType::None || alignment.inlineAlign != ScrollSnapAxisAlignType::None;
-}
-
-TextEdge RenderStyle::textBoxEdge() const
-{
-    return m_rareInheritedData->textBoxEdge;
-}
-
-void RenderStyle::setTextBoxEdge(TextEdge value)
-{
-    SET_VAR(m_rareInheritedData, textBoxEdge, value);
-}
-
-TextEdge RenderStyle::initialTextBoxEdge()
-{
-    return { TextEdgeType::Auto, TextEdgeType::Auto };
-}
-
-TextEdge RenderStyle::lineFitEdge() const
-{
-    return m_rareInheritedData->lineFitEdge;
-}
-
-void RenderStyle::setLineFitEdge(TextEdge value)
-{
-    SET_VAR(m_rareInheritedData, lineFitEdge, value);
-}
-
-TextEdge RenderStyle::initialLineFitEdge()
-{
-    return { TextEdgeType::Leading, TextEdgeType::Leading };
 }
 
 Style::LineWidth RenderStyle::outlineWidth() const

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -223,7 +223,6 @@ struct NameScope;
 struct ScrollSnapAlign;
 struct ScrollSnapType;
 struct TabSize;
-struct TextEdge;
 struct TransformOperationData;
 
 template<typename> class FontTaggedSettings;
@@ -281,6 +280,7 @@ struct HyphenateLimitLines;
 struct ImageOrNone;
 struct InsetEdge;
 struct LineWidth;
+struct LineFitEdge;
 struct ListStyleType;
 struct MarginEdge;
 struct MaskBorder;
@@ -333,6 +333,7 @@ struct ShapeMargin;
 struct ShapeOutside;
 struct StrokeMiterlimit;
 struct StrokeWidth;
+struct TextBoxEdge;
 struct TextDecorationThickness;
 struct TextEmphasisStyle;
 struct TextIndent;
@@ -734,8 +735,8 @@ public:
     inline TextJustify textJustify() const;
 
     inline TextBoxTrim textBoxTrim() const;
-    TextEdge textBoxEdge() const;
-    TextEdge lineFitEdge() const;
+    inline Style::TextBoxEdge textBoxEdge() const;
+    inline Style::LineFitEdge lineFitEdge() const;
 
     inline OptionSet<MarginTrimType> marginTrim() const;
 
@@ -1374,8 +1375,8 @@ public:
     inline void setTextJustify(TextJustify);
 
     inline void setTextBoxTrim(TextBoxTrim);
-    void setTextBoxEdge(TextEdge);
-    void setLineFitEdge(TextEdge);
+    inline void setTextBoxEdge(Style::TextBoxEdge);
+    inline void setLineFitEdge(Style::LineFitEdge);
 
     inline void setMarginTrim(OptionSet<MarginTrimType>);
 
@@ -1981,8 +1982,8 @@ public:
     static inline Style::PageSize initialPageSize();
     static inline Style::TextIndent initialTextIndent();
     static constexpr TextBoxTrim initialTextBoxTrim();
-    static TextEdge initialTextBoxEdge();
-    static TextEdge initialLineFitEdge();
+    static constexpr Style::TextBoxEdge initialTextBoxEdge();
+    static constexpr Style::LineFitEdge initialLineFitEdge();
     static constexpr LengthType zeroLength();
     static constexpr Style::Widows initialWidows();
     static constexpr Style::Orphans initialOrphans();

--- a/Source/WebCore/rendering/style/RenderStyleConstants.cpp
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.cpp
@@ -1363,17 +1363,25 @@ TextStream& operator<<(TextStream& ts, TextBoxTrim textBoxTrim)
     return ts;
 }
 
-TextStream& operator<<(TextStream& ts, TextEdgeType textEdgeType)
+TextStream& operator<<(TextStream& ts, TextEdgeOver textEdgeOver)
 {
-    switch (textEdgeType) {
-    case TextEdgeType::Auto: ts << "auto"_s; break;
-    case TextEdgeType::Leading: ts << "half-leading"_s; break;
-    case TextEdgeType::Text: ts << "text-over/under baseline"_s; break;
-    case TextEdgeType::CapHeight: ts << "cap-height baseline"_s; break;
-    case TextEdgeType::ExHeight: ts << "x-height baseline"_s; break;
-    case TextEdgeType::Alphabetic: ts << "alphabetic baseline"_s; break;
-    case TextEdgeType::CJKIdeographic: ts << "ideographic-over baseline"_s; break;
-    case TextEdgeType::CJKIdeographicInk: ts << "ideographic-ink-over/ink-under baseline"_s; break;
+    switch (textEdgeOver) {
+    case TextEdgeOver::Text: ts << "text"_s; break;
+    case TextEdgeOver::Ideographic: ts << "ideographic"_s; break;
+    case TextEdgeOver::IdeographicInk: ts << "ideographic-ink"_s; break;
+    case TextEdgeOver::Cap: ts << "cap"_s; break;
+    case TextEdgeOver::Ex: ts << "ex"_s; break;
+    }
+    return ts;
+}
+
+TextStream& operator<<(TextStream& ts, TextEdgeUnder textEdgeUnder)
+{
+    switch (textEdgeUnder) {
+    case TextEdgeUnder::Text: ts << "text"_s; break;
+    case TextEdgeUnder::Ideographic: ts << "ideographic"_s; break;
+    case TextEdgeUnder::IdeographicInk: ts << "ideographic-ink"_s; break;
+    case TextEdgeUnder::Alphabetic: ts << "alphabetic"_s; break;
     }
     return ts;
 }

--- a/Source/WebCore/rendering/style/RenderStyleConstants.h
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.h
@@ -723,17 +723,19 @@ enum class MarginTrimType : uint8_t {
     InlineEnd = 1 << 3
 };
 
-enum class TextEdgeType : uint8_t {
-    // Note that TextEdgeType is shared between text-box-edge and line-fit-edge,
-    // where text-box-edge's default value is auto, and line-fit-edge has leading.
-    Auto,
-    Leading,
+enum class TextEdgeOver : uint8_t {
     Text,
-    CapHeight,
-    ExHeight,
+    Ideographic,
+    IdeographicInk,
+    Cap,
+    Ex
+};
+
+enum class TextEdgeUnder : uint8_t {
+    Text,
+    Ideographic,
+    IdeographicInk,
     Alphabetic,
-    CJKIdeographic,
-    CJKIdeographicInk
 };
 
 enum class TextZoom : bool {
@@ -1375,7 +1377,8 @@ WTF::TextStream& operator<<(WTF::TextStream&, TextUnderlinePosition);
 WTF::TextStream& operator<<(WTF::TextStream&, TextWrapMode);
 WTF::TextStream& operator<<(WTF::TextStream&, TextWrapStyle);
 WTF::TextStream& operator<<(WTF::TextStream&, TextBoxTrim);
-WTF::TextStream& operator<<(WTF::TextStream&, TextEdgeType);
+WTF::TextStream& operator<<(WTF::TextStream&, TextEdgeOver);
+WTF::TextStream& operator<<(WTF::TextStream&, TextEdgeUnder);
 WTF::TextStream& operator<<(WTF::TextStream&, TextZoom);
 WTF::TextStream& operator<<(WTF::TextStream&, TransformBox);
 WTF::TextStream& operator<<(WTF::TextStream&, TransformStyle3D);

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -508,6 +508,8 @@ constexpr TableLayoutType RenderStyle::initialTableLayout() { return TableLayout
 constexpr TextAlignMode RenderStyle::initialTextAlign() { return TextAlignMode::Start; }
 constexpr TextAlignLast RenderStyle::initialTextAlignLast() { return TextAlignLast::Auto; }
 constexpr TextBoxTrim RenderStyle::initialTextBoxTrim() { return TextBoxTrim::None; }
+constexpr Style::TextBoxEdge RenderStyle::initialTextBoxEdge() { return CSS::Keyword::Auto { }; }
+constexpr Style::LineFitEdge RenderStyle::initialLineFitEdge() { return CSS::Keyword::Leading { }; }
 constexpr TextCombine RenderStyle::initialTextCombine() { return TextCombine::None; }
 inline Style::Color RenderStyle::initialTextDecorationColor() { return Style::Color::currentColor(); }
 inline Style::TextDecorationLine RenderStyle::initialTextDecorationLine() { return CSS::Keyword::None { }; }
@@ -744,6 +746,8 @@ inline const TabSize& RenderStyle::tabSize() const { return m_rareInheritedData-
 inline TableLayoutType RenderStyle::tableLayout() const { return static_cast<TableLayoutType>(m_nonInheritedData->miscData->tableLayout); }
 inline TextAlignLast RenderStyle::textAlignLast() const { return static_cast<TextAlignLast>(m_rareInheritedData->textAlignLast); }
 inline TextBoxTrim RenderStyle::textBoxTrim() const { return static_cast<TextBoxTrim>(m_nonInheritedData->rareData->textBoxTrim); }
+inline Style::TextBoxEdge RenderStyle::textBoxEdge() const { return m_rareInheritedData->textBoxEdge; }
+inline Style::LineFitEdge RenderStyle::lineFitEdge() const { return m_rareInheritedData->lineFitEdge; }
 inline TextCombine RenderStyle::textCombine() const { return static_cast<TextCombine>(m_rareInheritedData->textCombine); }
 inline const Style::Color& RenderStyle::textDecorationColor() const { return m_nonInheritedData->rareData->textDecorationColor; }
 inline Style::TextDecorationLine RenderStyle::textDecorationLine() const { return m_nonInheritedFlags.textDecorationLine; }

--- a/Source/WebCore/rendering/style/RenderStyleSetters.h
+++ b/Source/WebCore/rendering/style/RenderStyleSetters.h
@@ -290,6 +290,8 @@ inline void RenderStyle::setStrokeWidth(Style::StrokeWidth&& width) { SET(m_rare
 inline void RenderStyle::setTabSize(const TabSize& size) { SET(m_rareInheritedData, tabSize, size); }
 inline void RenderStyle::setTextAlignLast(TextAlignLast value) { SET(m_rareInheritedData, textAlignLast, static_cast<unsigned>(value)); }
 inline void RenderStyle::setTextBoxTrim(TextBoxTrim value) { SET_NESTED(m_nonInheritedData, rareData, textBoxTrim, static_cast<unsigned>(value)); }
+inline void RenderStyle::setTextBoxEdge(Style::TextBoxEdge value) { SET(m_rareInheritedData, textBoxEdge, value); }
+inline void RenderStyle::setLineFitEdge(Style::LineFitEdge value) { SET(m_rareInheritedData, lineFitEdge, value); }
 inline void RenderStyle::setTextCombine(TextCombine value) { SET(m_rareInheritedData, textCombine, static_cast<unsigned>(value)); }
 inline void RenderStyle::setTextDecorationColor(Style::Color&& color) { SET_NESTED(m_nonInheritedData, rareData, textDecorationColor, WTFMove(color)); }
 inline void RenderStyle::setTextDecorationLine(Style::TextDecorationLine&& value) { m_nonInheritedFlags.textDecorationLine = value.toRaw(); }

--- a/Source/WebCore/rendering/style/StyleRareInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleRareInheritedData.cpp
@@ -47,7 +47,8 @@ struct GreaterThanOrSameSizeAsStyleRareInheritedData : public RefCounted<Greater
     Style::TextEmphasisStyle textEmphasisStyle;
     Style::TextIndent textIndent;
     Style::TextUnderlineOffset offset;
-    TextEdge textEdges[2];
+    Style::TextBoxEdge textBoxEdge;
+    Style::LineFitEdge lineFitEdge;
     Length length;
     void* customPropertyDataRefs[1];
     unsigned bitfields[7];

--- a/Source/WebCore/rendering/style/StyleRareInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleRareInheritedData.h
@@ -37,13 +37,14 @@
 #include <WebCore/StyleHyphenateLimitLines.h>
 #include <WebCore/StyleImageOrNone.h>
 #include <WebCore/StyleLineBoxContain.h>
+#include <WebCore/StyleLineFitEdge.h>
 #include <WebCore/StyleListStyleType.h>
 #include <WebCore/StyleOrphans.h>
 #include <WebCore/StyleQuotes.h>
 #include <WebCore/StyleScrollbarColor.h>
 #include <WebCore/StyleStrokeMiterlimit.h>
 #include <WebCore/StyleStrokeWidth.h>
-#include <WebCore/StyleTextEdge.h>
+#include <WebCore/StyleTextBoxEdge.h>
 #include <WebCore/StyleTextEmphasisStyle.h>
 #include <WebCore/StyleTextIndent.h>
 #include <WebCore/StyleTextShadow.h>
@@ -134,9 +135,9 @@ public:
     Style::TextIndent textIndent;
     Style::TextUnderlineOffset textUnderlineOffset;
 
-    TextEdge textBoxEdge;
-    TextEdge lineFitEdge;
-    
+    Style::TextBoxEdge textBoxEdge;
+    Style::LineFitEdge lineFitEdge;
+
     Length wordSpacing;
     Style::StrokeMiterlimit miterLimit;
 

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp
@@ -31,7 +31,6 @@
 #include "StyleImage.h"
 #include "StylePrimitiveNumericTypes+Logging.h"
 #include "StyleResolver.h"
-#include "StyleTextEdge.h"
 #include <wtf/PointerComparison.h>
 #include <wtf/RefPtr.h>
 #include <wtf/text/TextStream.h>

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
@@ -68,7 +68,6 @@
 #include <WebCore/StyleShapeMargin.h>
 #include <WebCore/StyleShapeOutside.h>
 #include <WebCore/StyleTextDecorationThickness.h>
-#include <WebCore/StyleTextEdge.h>
 #include <WebCore/StyleTranslate.h>
 #include <WebCore/StyleViewTimelineInsets.h>
 #include <WebCore/StyleViewTimelines.h>

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -98,7 +98,7 @@
 #include "StyleScrollMargin.h"
 #include "StyleScrollPadding.h"
 #include "StyleScrollSnapPoints.h"
-#include "StyleTextEdge.h"
+#include "StyleTextEdge+CSSValueConversion.h"
 #include "StyleTranslate.h"
 #include "StyleURL.h"
 #include "StyleValueTypes+CSSValueConversion.h"
@@ -132,7 +132,6 @@ public:
     static TextAlignLast convertTextAlignLast(BuilderState&, const CSSValue&);
     static Resize convertResize(BuilderState&, const CSSValue&);
     static OptionSet<TextUnderlinePosition> convertTextUnderlinePosition(BuilderState&, const CSSValue&);
-    static TextEdge convertTextEdge(BuilderState&, const CSSValue&);
     static OptionSet<LineBoxContain> convertLineBoxContain(BuilderState&, const CSSValue&);
     static ScrollSnapType convertScrollSnapType(BuilderState&, const CSSValue&);
     static ScrollSnapAlign convertScrollSnapAlign(BuilderState&, const CSSValue&);
@@ -396,70 +395,6 @@ inline OptionSet<TextUnderlinePosition> BuilderConverter::convertTextUnderlinePo
     auto position = valueToUnderlinePosition(pair->first);
     position.add(valueToUnderlinePosition(pair->second));
     return position;
-}
-
-inline TextEdge BuilderConverter::convertTextEdge(BuilderState& builderState, const CSSValue& value)
-{
-    auto overValue = [&](CSSValueID valueID) {
-        switch (valueID) {
-        case CSSValueText:
-            return TextEdgeType::Text;
-        case CSSValueCap:
-            return TextEdgeType::CapHeight;
-        case CSSValueEx:
-            return TextEdgeType::ExHeight;
-        case CSSValueIdeographic:
-            return TextEdgeType::CJKIdeographic;
-        case CSSValueIdeographicInk:
-            return TextEdgeType::CJKIdeographicInk;
-        default:
-            ASSERT_NOT_REACHED();
-            return TextEdgeType::Auto;
-        }
-    };
-
-    auto underValue = [&](CSSValueID valueID) {
-        switch (valueID) {
-        case CSSValueText:
-            return TextEdgeType::Text;
-        case CSSValueAlphabetic:
-            return TextEdgeType::Alphabetic;
-        case CSSValueIdeographic:
-            return TextEdgeType::CJKIdeographic;
-        case CSSValueIdeographicInk:
-            return TextEdgeType::CJKIdeographicInk;
-        default:
-            ASSERT_NOT_REACHED();
-            return TextEdgeType::Auto;
-        }
-    };
-
-    // One value was given.
-    if (is<CSSPrimitiveValue>(value)) {
-        switch (value.valueID()) {
-        case CSSValueAuto:
-            return { TextEdgeType::Auto, TextEdgeType::Auto };
-        case CSSValueLeading:
-            return { TextEdgeType::Leading, TextEdgeType::Leading };
-        // https://www.w3.org/TR/css-inline-3/#text-edges
-        // "If only one value is specified, both edges are assigned that same keyword if possible; else text is assumed as the missing value."
-        case CSSValueCap:
-        case CSSValueEx:
-            return { overValue(value.valueID()), TextEdgeType::Text };
-        default:
-            return { overValue(value.valueID()), underValue(value.valueID()) };
-        }
-    }
-
-    // Two values were given.
-    auto pair = requiredPairDowncast<CSSPrimitiveValue>(builderState, value);
-    if (!pair)
-        return { };
-
-    return {
-        overValue(pair->first->valueID()),
-        underValue(pair->second->valueID())
-    };
 }
 
 inline OptionSet<LineBoxContain> BuilderConverter::convertLineBoxContain(BuilderState& builderState, const CSSValue& value)

--- a/Source/WebCore/style/StyleExtractorConverter.h
+++ b/Source/WebCore/style/StyleExtractorConverter.h
@@ -152,8 +152,6 @@ public:
     static Ref<CSSValue> convertContain(ExtractorState&, OptionSet<Containment>);
     static Ref<CSSValue> convertTextSpacingTrim(ExtractorState&, TextSpacingTrim);
     static Ref<CSSValue> convertTextAutospace(ExtractorState&, TextAutospace);
-    static Ref<CSSValue> convertLineFitEdge(ExtractorState&, const TextEdge&);
-    static Ref<CSSValue> convertTextBoxEdge(ExtractorState&, const TextEdge&);
     static Ref<CSSValue> convertPositionTryFallbacks(ExtractorState&, const FixedVector<PositionTryFallback>&);
     static Ref<CSSValue> convertWillChange(ExtractorState&, const WillChangeData*);
     static Ref<CSSValue> convertTabSize(ExtractorState&, const TabSize&);
@@ -452,43 +450,6 @@ inline Ref<CSSValue> ExtractorConverter::convertTextAutospace(ExtractorState&, T
     return CSSValueList::createSpaceSeparated(WTFMove(list));
 }
 
-inline Ref<CSSValue> ExtractorConverter::convertLineFitEdge(ExtractorState& state, const TextEdge& textEdge)
-{
-    if (textEdge.over == TextEdgeType::Leading && textEdge.under == TextEdgeType::Leading)
-        return convert(state, textEdge.over);
-
-    // https://www.w3.org/TR/css-inline-3/#text-edges
-    // "If only one value is specified, both edges are assigned that same keyword if possible; else text is assumed as the missing value."
-    auto shouldSerializeUnderEdge = [&] {
-        if (textEdge.over == TextEdgeType::CapHeight || textEdge.over == TextEdgeType::ExHeight)
-            return textEdge.under != TextEdgeType::Text;
-        return textEdge.over != textEdge.under;
-    }();
-
-    if (!shouldSerializeUnderEdge)
-        return convert(state, textEdge.over);
-
-    return CSSValuePair::create(convert(state, textEdge.over), convert(state, textEdge.under));
-}
-
-inline Ref<CSSValue> ExtractorConverter::convertTextBoxEdge(ExtractorState& state, const TextEdge& textEdge)
-{
-    if (textEdge.over == TextEdgeType::Auto && textEdge.under == TextEdgeType::Auto)
-        return convert(state, textEdge.over);
-
-    // https://www.w3.org/TR/css-inline-3/#text-edges
-    // "If only one value is specified, both edges are assigned that same keyword if possible; else text is assumed as the missing value."
-    auto shouldSerializeUnderEdge = [&] {
-        if (textEdge.over == TextEdgeType::CapHeight || textEdge.over == TextEdgeType::ExHeight)
-            return textEdge.under != TextEdgeType::Text;
-        return textEdge.over != textEdge.under;
-    }();
-
-    if (!shouldSerializeUnderEdge)
-        return convert(state, textEdge.over);
-
-    return CSSValuePair::create(convert(state, textEdge.over), convert(state, textEdge.under));
-}
 
 inline Ref<CSSValue> ExtractorConverter::convertPositionTryFallbacks(ExtractorState& state, const FixedVector<PositionTryFallback>& fallbacks)
 {

--- a/Source/WebCore/style/StyleExtractorCustom.h
+++ b/Source/WebCore/style/StyleExtractorCustom.h
@@ -2887,18 +2887,18 @@ inline RefPtr<CSSValue> ExtractorCustom::extractTextBoxShorthand(ExtractorState&
 {
     auto textBoxTrim = state.style.textBoxTrim();
     auto textBoxEdge = state.style.textBoxEdge();
-    auto textBoxEdgeIsAuto = textBoxEdge == TextEdge { TextEdgeType::Auto, TextEdgeType::Auto };
+    auto textBoxEdgeIsAuto = textBoxEdge.isAuto();
 
     if (textBoxTrim == TextBoxTrim::None && textBoxEdgeIsAuto)
-        return CSSPrimitiveValue::create(CSSValueNormal);
+        return createCSSValue(state.pool, state.style, CSS::Keyword::Normal { });
     if (textBoxEdgeIsAuto)
-        return ExtractorConverter::convert(state, textBoxTrim);
+        return createCSSValue(state.pool, state.style, textBoxTrim);
     if (textBoxTrim == TextBoxTrim::TrimBoth)
-        return ExtractorConverter::convertTextBoxEdge(state, textBoxEdge);
+        return createCSSValue(state.pool, state.style, textBoxEdge);
 
     return CSSValuePair::create(
-        ExtractorConverter::convert(state, textBoxTrim),
-        ExtractorConverter::convertTextBoxEdge(state, textBoxEdge)
+        createCSSValue(state.pool, state.style, textBoxTrim),
+        createCSSValue(state.pool, state.style, textBoxEdge)
     );
 }
 
@@ -2906,24 +2906,24 @@ inline void ExtractorCustom::extractTextBoxShorthandSerialization(ExtractorState
 {
     auto textBoxTrim = state.style.textBoxTrim();
     auto textBoxEdge = state.style.textBoxEdge();
-    auto textBoxEdgeIsAuto = textBoxEdge == TextEdge { TextEdgeType::Auto, TextEdgeType::Auto };
+    auto textBoxEdgeIsAuto = textBoxEdge.isAuto();
 
     if (textBoxTrim == TextBoxTrim::None && textBoxEdgeIsAuto) {
-        CSS::serializationForCSS(builder, context, CSS::Keyword::Normal { });
+        serializationForCSS(builder, context, state.style, CSS::Keyword::Normal { });
         return;
     }
     if (textBoxEdgeIsAuto) {
-        ExtractorSerializer::serialize(state, builder, context, textBoxTrim);
+        serializationForCSS(builder, context, state.style, textBoxTrim);
         return;
     }
     if (textBoxTrim == TextBoxTrim::TrimBoth) {
-        ExtractorSerializer::serializeTextBoxEdge(state, builder, context, textBoxEdge);
+        serializationForCSS(builder, context, state.style, textBoxEdge);
         return;
     }
 
-    ExtractorSerializer::serialize(state, builder, context, textBoxTrim);
+    serializationForCSS(builder, context, state.style, textBoxTrim);
     builder.append(' ');
-    ExtractorSerializer::serializeTextBoxEdge(state, builder, context, textBoxEdge);
+    serializationForCSS(builder, context, state.style, textBoxEdge);
 }
 
 inline RefPtr<CSSValue> ExtractorCustom::extractTextDecorationShorthand(ExtractorState& state)

--- a/Source/WebCore/style/StyleExtractorSerializer.h
+++ b/Source/WebCore/style/StyleExtractorSerializer.h
@@ -84,8 +84,6 @@ public:
     static void serializeSmoothScrolling(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, bool);
     static void serializeTextSpacingTrim(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, TextSpacingTrim);
     static void serializeTextAutospace(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, TextAutospace);
-    static void serializeLineFitEdge(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const TextEdge&);
-    static void serializeTextBoxEdge(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const TextEdge&);
     static void serializePositionTryFallbacks(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const FixedVector<PositionTryFallback>&);
     static void serializeWillChange(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const WillChangeData*);
     static void serializeTabSize(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const TabSize&);
@@ -482,56 +480,6 @@ inline void ExtractorSerializer::serializeTextAutospace(ExtractorState& state, S
         serializationForCSS(builder, context, state.style, CSS::Keyword::IdeographNumeric { });
         return;
     }
-}
-
-inline void ExtractorSerializer::serializeLineFitEdge(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, const TextEdge& textEdge)
-{
-    if (textEdge.over == TextEdgeType::Leading && textEdge.under == TextEdgeType::Leading) {
-        serialize(state, builder, context, textEdge.over);
-        return;
-    }
-
-    // https://www.w3.org/TR/css-inline-3/#text-edges
-    // "If only one value is specified, both edges are assigned that same keyword if possible; else text is assumed as the missing value."
-    auto shouldSerializeUnderEdge = [&] {
-        if (textEdge.over == TextEdgeType::CapHeight || textEdge.over == TextEdgeType::ExHeight)
-            return textEdge.under != TextEdgeType::Text;
-        return textEdge.over != textEdge.under;
-    }();
-
-    if (!shouldSerializeUnderEdge) {
-        serialize(state, builder, context, textEdge.over);
-        return;
-    }
-
-    serialize(state, builder, context, textEdge.over);
-    builder.append(' ');
-    serialize(state, builder, context, textEdge.under);
-}
-
-inline void ExtractorSerializer::serializeTextBoxEdge(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, const TextEdge& textEdge)
-{
-    if (textEdge.over == TextEdgeType::Auto && textEdge.under == TextEdgeType::Auto) {
-        serialize(state, builder, context, textEdge.over);
-        return;
-    }
-
-    // https://www.w3.org/TR/css-inline-3/#text-edges
-    // "If only one value is specified, both edges are assigned that same keyword if possible; else text is assumed as the missing value."
-    auto shouldSerializeUnderEdge = [&] {
-        if (textEdge.over == TextEdgeType::CapHeight || textEdge.over == TextEdgeType::ExHeight)
-            return textEdge.under != TextEdgeType::Text;
-        return textEdge.over != textEdge.under;
-    }();
-
-    if (!shouldSerializeUnderEdge) {
-        serialize(state, builder, context, textEdge.over);
-        return;
-    }
-
-    serialize(state, builder, context, textEdge.over);
-    builder.append(' ');
-    serialize(state, builder, context, textEdge.under);
 }
 
 inline void ExtractorSerializer::serializePositionTryFallbacks(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, const FixedVector<PositionTryFallback>& fallbacks)

--- a/Source/WebCore/style/StyleInterpolationFunctions.h
+++ b/Source/WebCore/style/StyleInterpolationFunctions.h
@@ -58,7 +58,6 @@
 #include "StyleLengthWrapper+Blending.h"
 #include "StylePrimitiveNumericTypes+Blending.h"
 #include "StyleResolver.h"
-#include "StyleTextEdge.h"
 #include <algorithm>
 #include <wtf/MathExtras.h>
 #include <wtf/PointerComparison.h>

--- a/Source/WebCore/style/values/inline/StyleLineFitEdge.h
+++ b/Source/WebCore/style/values/inline/StyleLineFitEdge.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/StyleTextEdge.h>
+
+namespace WebCore {
+namespace Style {
+
+// <'line-fit-edge'> = leading | <text-edge>
+// https://drafts.csswg.org/css-inline-3/#propdef-line-fit-edge
+struct LineFitEdge : TextEdge<CSS::Keyword::Leading> {
+    using Base::Base;
+
+    constexpr bool isLeading() const { return isKeyword(); }
+};
+
+} // namespace Style
+} // namespace WebCore
+
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::LineFitEdge)

--- a/Source/WebCore/style/values/inline/StyleTextBoxEdge.h
+++ b/Source/WebCore/style/values/inline/StyleTextBoxEdge.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/StyleTextEdge.h>
+
+namespace WebCore {
+namespace Style {
+
+// <'text-box-edge'> = auto | <text-edge>
+// https://drafts.csswg.org/css-inline-3/#propdef-text-box-edge
+struct TextBoxEdge : TextEdge<CSS::Keyword::Auto> {
+    using Base::Base;
+
+    constexpr bool isAuto() const { return isKeyword(); }
+};
+
+} // namespace Style
+} // namespace WebCore
+
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::TextBoxEdge)

--- a/Source/WebCore/style/values/inline/StyleTextEdge+CSSValueConversion.h
+++ b/Source/WebCore/style/values/inline/StyleTextEdge+CSSValueConversion.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "StyleBuilderChecking.h"
+#include "StylePrimitiveKeyword+CSSValueConversion.h"
+#include "StyleTextEdge.h"
+
+namespace WebCore {
+namespace Style {
+
+template<TextEdgeDerived T> struct CSSValueConversion<T> {
+    auto operator()(BuilderState& state, const CSSValue& value) -> T
+    {
+        using Keyword = typename T::Keyword;
+
+        if (is<CSSPrimitiveValue>(value)) {
+            switch (value.valueID()) {
+            case Keyword::value:
+                return Keyword { };
+            case CSSValueText:
+                return { TextEdgeOver::Text, TextEdgeUnder::Text };
+            case CSSValueIdeographic:
+                return { TextEdgeOver::Ideographic, TextEdgeUnder::Ideographic };
+            case CSSValueIdeographicInk:
+                return { TextEdgeOver::IdeographicInk, TextEdgeUnder::IdeographicInk };
+            case CSSValueCap:
+                return { TextEdgeOver::Cap, TextEdgeUnder::Text };
+            case CSSValueEx:
+                return { TextEdgeOver::Ex, TextEdgeUnder::Text };
+            default:
+                break;
+            }
+
+            state.setCurrentPropertyInvalidAtComputedValueTime();
+            return Keyword { };
+        }
+
+        auto pair = requiredPairDowncast<CSSPrimitiveValue>(state, value);
+        if (!pair)
+            return Keyword { };
+
+        return {
+            toStyleFromCSSValue<TextEdgeOver>(state, pair->first),
+            toStyleFromCSSValue<TextEdgeUnder>(state, pair->second),
+        };
+    }
+};
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/inline/StyleTextEdge.h
+++ b/Source/WebCore/style/values/inline/StyleTextEdge.h
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/RenderStyleConstants.h>
+#include <WebCore/StyleValueTypes.h>
+
+namespace WebCore {
+namespace Style {
+
+// <text-edge> = [ text | cap | ex | ideographic | ideographic-ink ]
+//               [ text | alphabetic | ideographic | ideographic-ink ]?
+// https://drafts.csswg.org/css-inline-3/#typedef-text-edge
+
+struct TextEdgePair {
+    TextEdgeOver over;
+    TextEdgeUnder under;
+
+    template<typename... F> constexpr  decltype(auto) switchOn(F&&... f) const
+    {
+        auto visitor = WTF::makeVisitor(std::forward<F>(f)...);
+
+        switch (over) {
+        case TextEdgeOver::Text:
+        case TextEdgeOver::Cap:
+        case TextEdgeOver::Ex:
+            if (under == TextEdgeUnder::Text)
+                return visitor(over);
+            break;
+        case TextEdgeOver::Ideographic:
+            if (under == TextEdgeUnder::Ideographic)
+                return visitor(over);
+            break;
+        case TextEdgeOver::IdeographicInk:
+            if (under == TextEdgeUnder::IdeographicInk)
+                return visitor(over);
+            break;
+        }
+
+        return visitor(SpaceSeparatedTuple { over, under });
+    }
+
+    constexpr bool operator==(const TextEdgePair&) const = default;
+};
+
+template<typename K> struct TextEdge {
+    using Keyword = K;
+    using Base = TextEdge<Keyword>;
+
+    constexpr TextEdge(Keyword keyword) : m_value { keyword } { }
+    constexpr TextEdge(TextEdgeOver over, TextEdgeUnder under) : m_value { TextEdgePair { over, under } } { }
+
+    constexpr bool isKeyword() const { return holdsAlternative<Keyword>(); }
+    constexpr bool isTextEdgePair() const { return holdsAlternative<TextEdgePair>(); }
+    constexpr std::optional<TextEdgePair> tryTextEdgePair() const { return isTextEdgePair() ? std::make_optional(std::get<TextEdgePair>(m_value)) : std::nullopt; }
+
+    template<typename U> constexpr bool holdsAlternative() const
+    {
+        return WTF::holdsAlternative<U>(m_value);
+    }
+
+    template<typename... F> constexpr decltype(auto) switchOn(F&&... f) const
+    {
+        return WTF::switchOn(m_value, std::forward<F>(f)...);
+    }
+
+    constexpr bool operator==(const TextEdge<Keyword>&) const = default;
+
+protected:
+    Variant<Keyword, TextEdgePair> m_value;
+};
+
+// MARK: - Concepts
+
+template<typename T> concept TextEdgeDerived = WTF::IsBaseOfTemplate<TextEdge, T>::value && VariantLike<T>;
+
+} // namespace Style
+} // namespace WebCore
+
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::TextEdgePair)


### PR DESCRIPTION
#### 51b2f4778959ce0469ad7e4ac1fbb6c09e2e6b60
<pre>
[Style] Convert the &apos;text-box-edge&apos; and &apos;line-fit-edge` properties to strong style types
<a href="https://bugs.webkit.org/show_bug.cgi?id=299297">https://bugs.webkit.org/show_bug.cgi?id=299297</a>

Reviewed by Darin Adler.

Converts the &apos;text-box-edge&apos; and &apos;line-fit-edge` properties to
use strong style types.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/CSSPrimitiveValueMappings.h:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/layout/formattingContexts/block/BlockLayoutState.h:
* Source/WebCore/layout/formattingContexts/inline/InlineLevelBox.h:
* Source/WebCore/layout/formattingContexts/inline/InlineLineBoxBuilder.cpp:
* Source/WebCore/rendering/RenderLayoutState.h:
* Source/WebCore/rendering/style/RenderStyle.cpp:
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleConstants.cpp:
* Source/WebCore/rendering/style/RenderStyleConstants.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
* Source/WebCore/rendering/style/RenderStyleSetters.h:
* Source/WebCore/rendering/style/StyleRareInheritedData.cpp:
* Source/WebCore/rendering/style/StyleRareInheritedData.h:
* Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp:
* Source/WebCore/rendering/style/StyleRareNonInheritedData.h:
* Source/WebCore/style/StyleBuilderConverter.h:
* Source/WebCore/style/StyleExtractorConverter.h:
* Source/WebCore/style/StyleExtractorCustom.h:
* Source/WebCore/style/StyleExtractorSerializer.h:
* Source/WebCore/style/StyleInterpolationFunctions.h:
* Source/WebCore/style/values/inline/StyleLineFitEdge.h: Added.
* Source/WebCore/style/values/inline/StyleTextBoxEdge.h: Added.
* Source/WebCore/style/values/inline/StyleTextEdge+CSSValueConversion.h: Added.
* Source/WebCore/style/values/inline/StyleTextEdge.h: Added.

Canonical link: <a href="https://commits.webkit.org/300341@main">https://commits.webkit.org/300341@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/94e08cad68510f6231f0a5254fe85b6a87463f27

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122187 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41890 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32559 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128768 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74281 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/124063 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42604 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50483 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92879 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61739 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125139 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33986 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109416 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73534 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32996 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27579 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72254 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103494 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27772 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131511 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49126 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37376 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101438 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49500 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105627 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101307 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25688 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46680 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24795 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45877 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48983 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54717 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48453 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51803 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50133 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->