### PR TITLE
Remove postMessageWithAsyncReply from injectedBundle

### DIFF
--- a/Source/WebKit/UIProcess/API/C/WKPageInjectedBundleClient.h
+++ b/Source/WebKit/UIProcess/API/C/WKPageInjectedBundleClient.h
@@ -32,7 +32,6 @@ typedef void (*WKPageDidReceiveMessageFromInjectedBundleCallback)(WKPageRef page
 typedef void (*WKPageDidReceiveSynchronousMessageFromInjectedBundleCallback)(WKPageRef page, WKStringRef messageName, WKTypeRef messageBody, WKTypeRef* returnData, const void *clientInfo);
 typedef WKTypeRef (*WKPageGetInjectedBundleInitializationUserDataCallback)(WKPageRef page, const void *clientInfo);
 typedef void (*WKPageDidReceiveSynchronousMessageFromInjectedBundleWithListenerCallback)(WKPageRef page, WKStringRef messageName, WKTypeRef messageBody, WKMessageListenerRef listener, const void* clientInfo);
-typedef void (*WKPageDidReceiveAsyncMessageFromInjectedBundleCallback)(WKPageRef page, WKStringRef messageName, WKTypeRef messageBody, WKMessageListenerRef listener, const void* clientInfo);
 
 typedef struct WKPageInjectedBundleClientBase {
     int                                                                 version;
@@ -56,7 +55,6 @@ typedef struct WKPageInjectedBundleClientV1 {
 
     // Version 1.
     WKPageDidReceiveSynchronousMessageFromInjectedBundleWithListenerCallback didReceiveSynchronousMessageFromInjectedBundleWithListener;
-    WKPageDidReceiveAsyncMessageFromInjectedBundleCallback didReceiveAsyncMessageFromInjectedBundle;
 } WKPageInjectedBundleClientV1;
 
 #endif // WKPageInjectedBundleClient_h

--- a/Source/WebKit/UIProcess/WebPageInjectedBundleClient.cpp
+++ b/Source/WebKit/UIProcess/WebPageInjectedBundleClient.cpp
@@ -60,13 +60,4 @@ void WebPageInjectedBundleClient::didReceiveSynchronousMessageFromInjectedBundle
 
     m_client.didReceiveSynchronousMessageFromInjectedBundleWithListener(toAPI(page), toAPI(messageName.impl()), toAPI(messageBody), toAPI(API::MessageListener::create(WTFMove(completionHandler)).ptr()), m_client.base.clientInfo);
 }
-
-void WebPageInjectedBundleClient::didReceiveAsyncMessageFromInjectedBundle(WebPageProxy* page, const String& messageName, API::Object* messageBody, CompletionHandler<void(RefPtr<API::Object>)>&& completionHandler)
-{
-    if (!m_client.didReceiveAsyncMessageFromInjectedBundle)
-        return completionHandler(nullptr);
-
-    m_client.didReceiveAsyncMessageFromInjectedBundle(toAPI(page), toAPI(messageName.impl()), toAPI(messageBody), toAPI(API::MessageListener::create(WTFMove(completionHandler)).ptr()), m_client.base.clientInfo);
-}
-
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebPageInjectedBundleClient.h
+++ b/Source/WebKit/UIProcess/WebPageInjectedBundleClient.h
@@ -47,7 +47,6 @@ class WebPageInjectedBundleClient : public API::Client<WKPageInjectedBundleClien
 public:
     void didReceiveMessageFromInjectedBundle(WebPageProxy*, const String&, API::Object*);
     void didReceiveSynchronousMessageFromInjectedBundle(WebPageProxy*, const String&, API::Object*, CompletionHandler<void(RefPtr<API::Object>)>&&);
-    void didReceiveAsyncMessageFromInjectedBundle(WebPageProxy*, const String&, API::Object*, CompletionHandler<void(RefPtr<API::Object>)>&&);
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -1318,16 +1318,6 @@ void WebPageProxy::handleMessage(IPC::Connection& connection, const String& mess
     m_injectedBundleClient->didReceiveMessageFromInjectedBundle(this, messageName, WebProcessProxy::fromConnection(connection)->transformHandlesToObjects(messageBody.protectedObject().get()).get());
 }
 
-void WebPageProxy::handleMessageWithAsyncReply(const String& messageName, const UserData& messageBody, CompletionHandler<void(UserData&&)>&& completionHandler)
-{
-    if (!m_injectedBundleClient)
-        return completionHandler({ });
-
-    m_injectedBundleClient->didReceiveAsyncMessageFromInjectedBundle(this, messageName, messageBody.protectedObject().get(), [completionHandler = WTFMove(completionHandler)] (RefPtr<API::Object>&& reply) mutable {
-        completionHandler(UserData(WTFMove(reply)));
-    });
-}
-
 void WebPageProxy::handleSynchronousMessage(IPC::Connection& connection, const String& messageName, const UserData& messageBody, CompletionHandler<void(UserData&&)>&& completionHandler)
 {
     if (!m_injectedBundleClient)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -3287,7 +3287,6 @@ private:
     void performSwitchHapticFeedback();
 
     void handleMessage(IPC::Connection&, const String& messageName, const UserData& messageBody);
-    void handleMessageWithAsyncReply(const String& messageName, const UserData& messageBody, CompletionHandler<void(UserData&&)>&&);
     void handleSynchronousMessage(IPC::Connection&, const String& messageName, const UserData& messageBody, CompletionHandler<void(UserData&&)>&&);
 
     void viewIsBecomingVisible();

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -467,7 +467,6 @@ messages -> WebPageProxy {
     DidPerformImmediateActionHitTest(struct WebKit::WebHitTestResultData result, bool contentPreventsDefault, WebKit::UserData userData) CanDispatchOutOfOrder
 #endif
     HandleMessage(String messageName, WebKit::UserData messageBody) AllowedWhenWaitingForSyncReply
-    HandleMessageWithAsyncReply(String messageName, WebKit::UserData messageBody) -> (WebKit::UserData reply)
     HandleSynchronousMessage(String messageName, WebKit::UserData messageBody) -> (WebKit::UserData returnData) Synchronous
 
     HandleAutoFillButtonClick(WebKit::UserData userData)

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
@@ -665,13 +665,6 @@ void WKBundlePagePostMessage(WKBundlePageRef pageRef, WKStringRef messageNameRef
     WebKit::toImpl(pageRef)->postMessage(WebKit::toWTFString(messageNameRef), WebKit::toImpl(messageBodyRef));
 }
 
-void WKBundlePagePostMessageWithAsyncReply(WKBundlePageRef page, WKStringRef messageName, WKTypeRef messageBody, WKBundlePageMessageReplyCallback replyCallback, void* context)
-{
-    WebKit::toImpl(page)->postMessageWithAsyncReply(WebKit::toWTFString(messageName), WebKit::toImpl(messageBody), [replyCallback, context] (API::Object* reply) mutable {
-        replyCallback(WebKit::toAPI(reply), context);
-    });
-}
-
 void WKBundlePagePostMessageIgnoringFullySynchronousMode(WKBundlePageRef pageRef, WKStringRef messageNameRef, WKTypeRef messageBodyRef)
 {
     WebKit::toImpl(pageRef)->postMessageIgnoringFullySynchronousMode(WebKit::toWTFString(messageNameRef), WebKit::toImpl(messageBodyRef));

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.h
@@ -124,9 +124,6 @@ WK_EXPORT void WKBundlePageLayoutIfNeeded(WKBundlePageRef page);
 
 WK_EXPORT void WKBundlePagePostMessage(WKBundlePageRef page, WKStringRef messageName, WKTypeRef messageBody);
 
-typedef void (*WKBundlePageMessageReplyCallback)(WKTypeRef reply, void* context);
-WK_EXPORT void WKBundlePagePostMessageWithAsyncReply(WKBundlePageRef page, WKStringRef messageName, WKTypeRef messageBody, WKBundlePageMessageReplyCallback replyCallback, void* context);
-
 // Switches a connection into a fully synchronous mode, so all messages become synchronous until we get a response.
 WK_EXPORT void WKBundlePagePostSynchronousMessageForTesting(WKBundlePageRef page, WKStringRef messageName, WKTypeRef messageBody, WKTypeRef* returnRetainedData);
 // Same as WKBundlePagePostMessage() but the message cannot become synchronous, even if the connection is in fully synchronous mode.

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -8588,13 +8588,6 @@ void WebPage::postMessage(const String& messageName, API::Object* messageBody)
     send(Messages::WebPageProxy::HandleMessage(messageName, UserData(WebProcess::singleton().transformObjectsToHandles(messageBody))));
 }
 
-void WebPage::postMessageWithAsyncReply(const String& messageName, API::Object* messageBody, CompletionHandler<void(API::Object*)>&& completionHandler)
-{
-    sendWithAsyncReply(Messages::WebPageProxy::HandleMessageWithAsyncReply(messageName, UserData(messageBody)), [completionHandler = WTFMove(completionHandler)] (UserData reply) mutable {
-        completionHandler(reply.protectedObject().get());
-    });
-}
-
 void WebPage::postMessageIgnoringFullySynchronousMode(const String& messageName, API::Object* messageBody)
 {
     send(Messages::WebPageProxy::HandleMessage(messageName, UserData(WebProcess::singleton().transformObjectsToHandles(messageBody))), IPC::SendOption::DispatchMessageEvenWhenWaitingForSyncReply);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1579,7 +1579,6 @@ public:
     bool shouldDispatchFakeMouseMoveEvents() const { return m_shouldDispatchFakeMouseMoveEvents; }
 
     void postMessage(const String& messageName, API::Object* messageBody);
-    void postMessageWithAsyncReply(const String& messageName, API::Object* messageBody, CompletionHandler<void(API::Object*)>&&);
     void postSynchronousMessageForTesting(const String& messageName, API::Object* messageBody, RefPtr<API::Object>& returnData);
     void postMessageIgnoringFullySynchronousMode(const String& messageName, API::Object* messageBody);
 

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/EventSendingController.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/EventSendingController.idl
@@ -31,9 +31,6 @@ interface EventSendingController {
     undefined mouseDown(long buttonNumber, object modifierArray, optional DOMString pointerType);
     undefined mouseUp(long buttonNumber, object modifierArray, optional DOMString pointerType);
     undefined mouseMoveTo(double x, double y, optional DOMString pointerType);
-    Promise<undefined> asyncMouseDown(long buttonNumber, object modifierArray, optional DOMString pointerType);
-    Promise<undefined> asyncMouseUp(long buttonNumber, object modifierArray, optional DOMString pointerType);
-    Promise<undefined> asyncMouseMoveTo(double x, double y, optional DOMString pointerType);
     undefined mouseForceClick();
     undefined startAndCancelMouseForceClick();
     undefined mouseForceDown();

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
@@ -327,11 +327,9 @@ interface TestRunner {
 
     boolean hasAppBoundSession();
     undefined clearAppBoundSession();
-    undefined setAppBoundDomains(object originsArray, object callback);
     boolean didLoadAppInitiatedRequest();
     boolean didLoadNonAppInitiatedRequest();
 
-    undefined setManagedDomains(object originsArray, object callback);
 
     undefined injectUserScript(DOMString string);
     readonly attribute unsigned long userScriptInjectedCount;

--- a/Tools/WebKitTestRunner/InjectedBundle/EventSendingController.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/EventSendingController.cpp
@@ -252,36 +252,6 @@ void EventSendingController::mouseMoveTo(double x, double y, JSStringRef pointer
     postSynchronousPageMessage("EventSender", waitForDidReceiveEventBody);
 }
 
-void EventSendingController::asyncMouseDown(JSContextRef context, int button, JSValueRef modifierArray, JSStringRef pointerType, JSValueRef completionHandler)
-{
-    if (m_isDisabled)
-        return;
-
-    postMessageWithAsyncReply(context, "EventSender", createMouseMessageBody(MouseDown, button, parseModifierArray(context, modifierArray), pointerType), completionHandler);
-}
-
-void EventSendingController::asyncMouseUp(JSContextRef context, int button, JSValueRef modifierArray, JSStringRef pointerType, JSValueRef completionHandler)
-{
-    if (m_isDisabled)
-        return;
-
-    postMessageWithAsyncReply(context, "EventSender", createMouseMessageBody(MouseUp, button, parseModifierArray(context, modifierArray), pointerType), completionHandler);
-}
-
-void EventSendingController::asyncMouseMoveTo(JSContextRef context, double x, double y, JSStringRef pointerType, JSValueRef completionHandler)
-{
-    if (m_isDisabled)
-        return;
-
-    auto body = createEventSenderDictionary("MouseMoveTo");
-    setValue(body, "X", adoptWK(WKDoubleCreate(x)));
-    setValue(body, "Y", adoptWK(WKDoubleCreate(y)));
-    if (pointerType)
-        setValue(body, "PointerType", pointerType);
-    m_position = WKPointMake(x, y);
-    postMessageWithAsyncReply(context, "EventSender", body, completionHandler);
-}
-
 void EventSendingController::mouseForceClick()
 {
     if (m_isDisabled)

--- a/Tools/WebKitTestRunner/InjectedBundle/EventSendingController.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/EventSendingController.h
@@ -52,9 +52,6 @@ public:
     void mouseDown(JSContextRef, int button, JSValueRef modifierArray, JSStringRef pointerType);
     void mouseUp(JSContextRef, int button, JSValueRef modifierArray, JSStringRef pointerType);
     void mouseMoveTo(double x, double y, JSStringRef pointerType);
-    void asyncMouseDown(JSContextRef, int button, JSValueRef modifierArray, JSStringRef pointerType, JSValueRef completionHandler);
-    void asyncMouseUp(JSContextRef, int button, JSValueRef modifierArray, JSStringRef pointerType, JSValueRef completionHandler);
-    void asyncMouseMoveTo(JSContextRef, double x, double y, JSStringRef pointerType, JSValueRef completionHandler);
     void mouseForceClick();
     void startAndCancelMouseForceClick();
     void mouseForceDown();
@@ -67,6 +64,8 @@ public:
     JSValueRef contextClick(JSContextRef);
     void leapForward(int milliseconds);
     void scheduleAsynchronousClick();
+
+    void setMousePosition(double x, double y) { m_position = WKPointMake(x, y); }
 
     void monitorWheelEvents(MonitorWheelEventsOptions*);
     void callAfterScrollingCompletes(JSContextRef, JSValueRef functionCallback);

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.h
@@ -263,8 +263,4 @@ template<typename T> void postSynchronousPageMessage(const char* name, const WKR
         WKBundlePagePostSynchronousMessageForTesting(page, toWK(name).get(), value.get(), nullptr);
     }
 }
-
-void postMessageWithAsyncReply(JSContextRef, const char* messageName, JSValueRef callback);
-void postMessageWithAsyncReply(JSContextRef, const char* messageName, WKRetainPtr<WKTypeRef> value, JSValueRef callback);
-
 } // namespace WTR

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
@@ -1516,54 +1516,6 @@ void TestRunner::clearAppBoundSession()
     postSynchronousMessage("ClearAppBoundSession");
 }
 
-void TestRunner::setAppBoundDomains(JSContextRef context, JSValueRef originArray, JSValueRef completionHandler)
-{
-    if (!JSValueIsArray(context, originArray))
-        return;
-
-    auto origins = JSValueToObject(context, originArray, nullptr);
-    auto originURLs = adoptWK(WKMutableArrayCreate());
-    auto originsLength = arrayLength(context, origins);
-    for (unsigned i = 0; i < originsLength; ++i) {
-        JSValueRef originValue = JSObjectGetPropertyAtIndex(context, origins, i, nullptr);
-        if (!JSValueIsString(context, originValue))
-            continue;
-
-        auto origin = createJSString(context, originValue);
-        size_t originBufferSize = JSStringGetMaximumUTF8CStringSize(origin.get()) + 1;
-        auto originBuffer = makeUniqueArray<char>(originBufferSize);
-        JSStringGetUTF8CString(origin.get(), originBuffer.get(), originBufferSize);
-
-        WKArrayAppendItem(originURLs.get(), adoptWK(WKURLCreateWithUTF8CString(originBuffer.get())).get());
-    }
-
-    postMessageWithAsyncReply(context, "SetAppBoundDomains", originURLs, completionHandler);
-}
-
-void TestRunner::setManagedDomains(JSContextRef context, JSValueRef originArray, JSValueRef completionHandler)
-{
-    if (!JSValueIsArray(context, originArray))
-        return;
-
-    auto origins = JSValueToObject(context, originArray, nullptr);
-    auto originURLs = adoptWK(WKMutableArrayCreate());
-    auto originsLength = arrayLength(context, origins);
-    for (unsigned i = 0; i < originsLength; ++i) {
-        JSValueRef originValue = JSObjectGetPropertyAtIndex(context, origins, i, nullptr);
-        if (!JSValueIsString(context, originValue))
-            continue;
-
-        auto origin = createJSString(context, originValue);
-        size_t originBufferSize = JSStringGetMaximumUTF8CStringSize(origin.get()) + 1;
-        auto originBuffer = makeUniqueArray<char>(originBufferSize);
-        JSStringGetUTF8CString(origin.get(), originBuffer.get(), originBufferSize);
-
-        WKArrayAppendItem(originURLs.get(), adoptWK(WKURLCreateWithUTF8CString(originBuffer.get())).get());
-    }
-
-    postMessageWithAsyncReply(context, "SetManagedDomains", originURLs, completionHandler);
-}
-
 bool TestRunner::didLoadAppInitiatedRequest()
 {
     return postSynchronousPageMessageReturningBoolean("DidLoadAppInitiatedRequest");

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
@@ -432,8 +432,6 @@ public:
 
     bool hasAppBoundSession();
     void clearAppBoundSession();
-    void setAppBoundDomains(JSContextRef, JSValueRef originArray, JSValueRef callback);
-    void setManagedDomains(JSContextRef, JSValueRef originArray, JSValueRef callback);
 
     bool didLoadAppInitiatedRequest();
     bool didLoadNonAppInitiatedRequest();

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -554,8 +554,6 @@ private:
     // WKPageInjectedBundleClient
     static void didReceivePageMessageFromInjectedBundle(WKPageRef, WKStringRef messageName, WKTypeRef messageBody, const void*);
     static void didReceiveSynchronousPageMessageFromInjectedBundleWithListener(WKPageRef, WKStringRef messageName, WKTypeRef messageBody, WKMessageListenerRef, const void*);
-    static void didReceiveAsyncPageMessageFromInjectedBundleWithListener(WKPageRef, WKStringRef, WKTypeRef, WKMessageListenerRef, const void*);
-    void didReceiveAsyncMessageFromInjectedBundle(WKStringRef, WKTypeRef, WKMessageListenerRef);
 
     void didReceiveMessageFromInjectedBundle(WKStringRef messageName, WKTypeRef messageBody);
     void didReceiveSynchronousMessageFromInjectedBundle(WKStringRef messageName, WKTypeRef messageBody, WKMessageListenerRef);


### PR DESCRIPTION
#### 04f3642af67676b2d1696395dd68facc778c4170
<pre>
Remove postMessageWithAsyncReply from injectedBundle
<a href="https://bugs.webkit.org/show_bug.cgi?id=299298">https://bugs.webkit.org/show_bug.cgi?id=299298</a>
<a href="https://rdar.apple.com/161102856">rdar://161102856</a>

Reviewed by Alex Christensen.

Remove the last few uses of postMessageWithAsyncReply and remove postMessageWithAsyncReply from the injectedBundle.

* Source/WebKit/UIProcess/API/C/WKPageInjectedBundleClient.h:
* Source/WebKit/UIProcess/WebPageInjectedBundleClient.cpp:
(WebKit::WebPageInjectedBundleClient::didReceiveSynchronousMessageFromInjectedBundle):
(WebKit::WebPageInjectedBundleClient::didReceiveAsyncMessageFromInjectedBundle): Deleted.
* Source/WebKit/UIProcess/WebPageInjectedBundleClient.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::handleMessageWithAsyncReply): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp:
(WKBundlePagePostMessageWithAsyncReply): Deleted.
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::postMessageWithAsyncReply): Deleted.
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Tools/WebKitTestRunner/InjectedBundle/Bindings/EventSendingController.idl:
* Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl:
* Tools/WebKitTestRunner/InjectedBundle/EventSendingController.cpp:
(WTR::EventSendingController::asyncMouseDown): Deleted.
(WTR::EventSendingController::asyncMouseUp): Deleted.
(WTR::EventSendingController::asyncMouseMoveTo): Deleted.
* Tools/WebKitTestRunner/InjectedBundle/EventSendingController.h:
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp:
(WTR::postSynchronousPageMessage):
(WTR::stringArrayToJS): Deleted.
(WTR::postMessageWithAsyncReply): Deleted.
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.h:
(WTR::postSynchronousPageMessage):
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp:
(WTR::TestRunner::setAppBoundDomains): Deleted.
(WTR::TestRunner::setManagedDomains): Deleted.
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.h:
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::createOtherPlatformWebView):
(WTR::TestController::createWebViewWithOptions):
(WTR::if):
(WTR::CompletionHandler&lt;void):
(WTR::WTF::Function&lt;void): Deleted.
* Tools/WebKitTestRunner/TestController.h:

Canonical link: <a href="https://commits.webkit.org/300839@main">https://commits.webkit.org/300839@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bf6655e543ee010e499898f68118e69ee7b9241d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123901 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43616 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34313 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130688 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76052 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/125778 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44340 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52210 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94325 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62532 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126855 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35324 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110839 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74857 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34278 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29000 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74164 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105052 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29223 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133383 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50854 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38728 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102724 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51228 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107059 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102534 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26107 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47874 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26131 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/47703 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50707 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56471 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50181 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53527 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51855 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->