### PR TITLE
[WebXR] Inline sessions do not correctly update the visibilitystate

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webxr/xrSession_visibilityState_inline.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webxr/xrSession_visibilityState_inline.https-expected.txt
@@ -1,0 +1,5 @@
+
+PASS setup
+PASS Ensures that the XRSession's visibilityState is correctly reported and that the associated visibilitychange event fires for non-immersive sessions. - webgl
+PASS Ensures that the XRSession's visibilityState is correctly reported and that the associated visibilitychange event fires for non-immersive sessions. - webgl2
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webxr/xrSession_visibilityState_inline.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webxr/xrSession_visibilityState_inline.https.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html>
+<title>View transitions: Transition in a hidden page</title>
+<link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
+<meta name="timeout" content="long">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="resources/webxr_util.js"></script>
+<script src="resources/webxr_test_constants.js"></script>
+<script src="../page-visibility/resources/window_state_context.js"></script>
+<script>
+let watcherDone = new Event("watcherdone");
+
+let fakeDeviceInitParams = TRACKED_IMMERSIVE_DEVICE;
+let testName = "Ensures that the XRSession's visibilityState is correctly "
+  + "reported and that the associated visibilitychange event fires for "
+  + "non-immersive sessions.";
+
+promise_test(
+  async (setup) => {
+    xr_session_promise_test(
+      testName,
+      (session, fakeDeviceController, t) => {
+        let wsc = null;
+        let eventWatcher = new EventWatcher(
+          t, session, ["visibilitychange", "watcherdone"]);
+        let eventPromise = eventWatcher.wait_for(
+          ["visibilitychange", "visibilitychange", "watcherdone"]);
+
+        async function showDocument() {
+          await wsc.restore();
+        }
+
+        async function hideDocument() {
+          wsc = window_state_context(t);
+          await wsc.minimize();
+        }
+
+        function onSessionVisibilityChangeVisible(event) {
+          t.step( () => {
+            assert_equals(session.visibilityState, "visible");
+          });
+          t.step_timeout(()=>{
+            session.dispatchEvent(watcherDone);
+          }, 300);
+        }
+
+        function onSessionVisibilityChangeHidden(event) {
+          t.step( () => {
+            assert_equals(session.visibilityState, "hidden");
+          });
+          session.removeEventListener("visibilitychange", onSessionVisibilityChangeHidden, false);
+          session.addEventListener("visibilitychange", onSessionVisibilityChangeVisible, false);
+          showDocument();
+        }
+
+        assert_equals(session.visibilityState, "visible");
+
+        session.addEventListener("visibilitychange", onSessionVisibilityChangeHidden, false);
+        hideDocument();
+
+        return eventPromise;
+      },
+      fakeDeviceInitParams, 'inline'
+    );
+  },
+  "setup"
+);
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -246,6 +246,10 @@ imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-overridesexpir
 imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-overridesexpires.html?timeout_set_to_expiring_value_after_load_fires [ Skip ]
 imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-overridesexpires.html?timeout_set_to_non-expiring_value_after_timeout_fires [ Skip ]
 
+# WebXR
+
+webkit.org/b/299366 imported/w3c/web-platform-tests/webxr/xrSession_visibilityState_inline.https.html [ Skip ] # Timeout
+
 #//////////////////////////////////////////////////////////////////////////////////////////
 # End of Triaged Expectations
 # Legacy Expectations sections below

--- a/Source/WebCore/Modules/webxr/WebXRSession.h
+++ b/Source/WebCore/Modules/webxr/WebXRSession.h
@@ -32,6 +32,7 @@
 #include "EventTarget.h"
 #include "EventTargetInterfaces.h"
 #include "JSDOMPromiseDeferredForward.h"
+#include "VisibilityChangeClient.h"
 #include "WebXRFrame.h"
 #include "WebXRInputSourceArray.h"
 #include "WebXRRenderState.h"
@@ -57,7 +58,7 @@ class WebXRViewerSpace;
 struct XRCanvasConfiguration;
 struct XRRenderStateInit;
 
-class WebXRSession final : public RefCounted<WebXRSession>, public EventTarget, public ActiveDOMObject, public PlatformXR::TrackingAndRenderingClient {
+class WebXRSession final : public RefCounted<WebXRSession>, public EventTarget, public ActiveDOMObject, public PlatformXR::TrackingAndRenderingClient, VisibilityChangeClient {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(WebXRSession);
 public:
     void ref() const final { RefCounted::ref(); }
@@ -132,6 +133,9 @@ private:
     void sessionDidInitializeInputSources(Vector<PlatformXR::FrameData::InputSource>&&) final;
     void sessionDidEnd() final;
     void updateSessionVisibilityState(PlatformXR::VisibilityState) final;
+
+    // VisibilityChangeClient
+    void visibilityStateChanged() final;
 
     enum class InitiatedBySystem : bool { No, Yes };
     void shutdown(InitiatedBySystem);


### PR DESCRIPTION
#### 056f4d4a7024092eb5d6c8756c0c5010ae8b8789
<pre>
[WebXR] Inline sessions do not correctly update the visibilitystate
<a href="https://bugs.webkit.org/show_bug.cgi?id=299302">https://bugs.webkit.org/show_bug.cgi?id=299302</a>

Reviewed by Dan Glastonbury.

Each XRSession has a visibility state value. For inline sessions the
visibility state MUST mirror the Document’s visibilityState. Modified
the WebXR session so it listens to Document&apos;s changes in visibility
and updates its state accordingly.

Test: imported/w3c/web-platform-tests/webxr/xrSession_visibilityState_inline.https.html

Test: imported/w3c/web-platform-tests/webxr/xrSession_visibilityState_inline.https.html
* LayoutTests/imported/w3c/web-platform-tests/webxr/xrSession_visibilityState_inline.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webxr/xrSession_visibilityState_inline.https.html: Added.
* LayoutTests/platform/wpe/TestExpectations:
* Source/WebCore/Modules/webxr/WebXRSession.cpp:
(WebCore::WebXRSession::WebXRSession):
(WebCore::WebXRSession::~WebXRSession):
(WebCore::WebXRSession::visibilityStateChanged):
* Source/WebCore/Modules/webxr/WebXRSession.h:

Canonical link: <a href="https://commits.webkit.org/300383@main">https://commits.webkit.org/300383@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e7955b93675c9169af02170ba4375da40fa4b650

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122396 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42102 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32788 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128985 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/74495 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/124272 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42821 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50695 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/93029 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/74495 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125348 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34152 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109594 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/73688 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33139 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/27751 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72482 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103756 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/27961 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131724 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49337 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37546 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/101579 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49711 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105814 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101449 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25723 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46824 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24957 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/46100 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49195 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54938 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/48662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/52012 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50344 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->