### PR TITLE
[appearance: base] Parse internal at-rule for base appearance style

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -917,6 +917,7 @@ css/CSSImageSetOptionValue.cpp
 css/CSSImageSetValue.cpp
 css/CSSImageValue.cpp
 css/CSSImportRule.cpp
+css/CSSInternalBaseAppearanceRule.cpp
 css/CSSKeyframeRule.cpp
 css/CSSKeyframesRule.cpp
 css/CSSLayerBlockRule.cpp

--- a/Source/WebCore/bindings/js/JSCSSRuleCustom.cpp
+++ b/Source/WebCore/bindings/js/JSCSSRuleCustom.cpp
@@ -142,6 +142,7 @@ JSValue toJSNewlyCreated(JSGlobalObject*, JSDOMGlobalObject* globalObject, Ref<C
     case StyleRuleType::Charset:
     case StyleRuleType::Margin:
     case StyleRuleType::FontFeatureValuesBlock:
+    case StyleRuleType::InternalBaseAppearance:
         return createWrapper<CSSRule>(globalObject, WTFMove(rule));
     }
     RELEASE_ASSERT_NOT_REACHED();

--- a/Source/WebCore/css/CSSInternalBaseAppearanceRule.cpp
+++ b/Source/WebCore/css/CSSInternalBaseAppearanceRule.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CSSInternalBaseAppearanceRule.h"
+
+#include "StyleRule.h"
+
+namespace WebCore {
+
+CSSInternalBaseAppearanceRule::CSSInternalBaseAppearanceRule(StyleRuleInternalBaseAppearance& rule, CSSStyleSheet* parent)
+    : CSSGroupingRule(rule, parent)
+{
+}
+
+String CSSInternalBaseAppearanceRule::cssText() const
+{
+    StringBuilder builder;
+    builder.append("@-internal-base-appearance"_s);
+    appendCSSTextForItems(builder);
+    return builder.toString();
+}
+
+}

--- a/Source/WebCore/css/CSSInternalBaseAppearanceRule.h
+++ b/Source/WebCore/css/CSSInternalBaseAppearanceRule.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CSSGroupingRule.h"
+
+namespace WebCore {
+
+class StyleRuleInternalBaseAppearance;
+
+class CSSInternalBaseAppearanceRule final : public CSSGroupingRule {
+public:
+    static Ref<CSSInternalBaseAppearanceRule> create(StyleRuleInternalBaseAppearance& rule, CSSStyleSheet* parent)
+    {
+        return adoptRef(*new CSSInternalBaseAppearanceRule(rule, parent));
+    }
+
+    String cssText() const final;
+
+private:
+    CSSInternalBaseAppearanceRule(StyleRuleInternalBaseAppearance&, CSSStyleSheet*);
+
+    StyleRuleType styleRuleType() const final { return StyleRuleType::InternalBaseAppearance; }
+};
+
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_CSS_RULE(CSSInternalBaseAppearanceRule, StyleRuleType::InternalBaseAppearance)

--- a/Source/WebCore/css/StyleRule.cpp
+++ b/Source/WebCore/css/StyleRule.cpp
@@ -31,6 +31,7 @@
 #include "CSSFunctionRule.h"
 #include "CSSGroupingRule.h"
 #include "CSSImportRule.h"
+#include "CSSInternalBaseAppearanceRule.h"
 #include "CSSKeyframeRule.h"
 #include "CSSKeyframesRule.h"
 #include "CSSLayerBlockRule.h"
@@ -142,6 +143,8 @@ template<typename Visitor> constexpr decltype(auto) StyleRuleBase::visitDerived(
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<StyleRuleFunction>(*this));
     case StyleRuleType::FunctionDeclarations:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<StyleRuleFunctionDeclarations>(*this));
+    case StyleRuleType::InternalBaseAppearance:
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<StyleRuleInternalBaseAppearance>(*this));
     case StyleRuleType::Margin:
         break;
     }
@@ -247,6 +250,9 @@ Ref<CSSRule> StyleRuleBase::createCSSOMWrapper(CSSStyleSheet* parentSheet, CSSRu
         },
         [&](StyleRuleFunctionDeclarations& rule) -> Ref<CSSRule> {
             return CSSFunctionDeclarations::create(rule, parentSheet);
+        },
+        [&](StyleRuleInternalBaseAppearance& rule) -> Ref<CSSRule> {
+            return CSSInternalBaseAppearanceRule::create(rule, parentSheet);
         },
         [](StyleRuleCharset&) -> Ref<CSSRule> {
             RELEASE_ASSERT_NOT_REACHED();
@@ -517,6 +523,16 @@ StyleRuleFontPaletteValues::StyleRuleFontPaletteValues(const AtomString& name, V
     , m_name(name)
     , m_fontFamilies(WTFMove(fontFamilies))
     , m_fontPaletteValues(basePalette, WTFMove(overrideColors))
+{
+}
+
+Ref<StyleRuleInternalBaseAppearance> StyleRuleInternalBaseAppearance::create(Vector<Ref<StyleRuleBase>>&& rules)
+{
+    return adoptRef(*new StyleRuleInternalBaseAppearance(WTFMove(rules)));
+}
+
+StyleRuleInternalBaseAppearance::StyleRuleInternalBaseAppearance(Vector<Ref<StyleRuleBase>>&& rules)
+    : StyleRuleGroup(StyleRuleType::InternalBaseAppearance, WTFMove(rules))
 {
 }
 

--- a/Source/WebCore/css/StyleRule.h
+++ b/Source/WebCore/css/StyleRule.h
@@ -71,7 +71,7 @@ public:
     bool isStyleRule() const { return type() == StyleRuleType::Style || type() == StyleRuleType::StyleWithNesting || type() == StyleRuleType::NestedDeclarations; }
     bool isStyleRuleWithNesting() const { return type() == StyleRuleType::StyleWithNesting; }
     bool isNestedDeclarationsRule() const { return type() == StyleRuleType::NestedDeclarations; }
-    bool isGroupRule() const { return type() == StyleRuleType::Media || type() == StyleRuleType::Supports || type() == StyleRuleType::LayerBlock || type() == StyleRuleType::Container || type() == StyleRuleType::Scope || type() == StyleRuleType::StartingStyle || type() == StyleRuleType::Function; }
+    bool isGroupRule() const { return type() == StyleRuleType::Media || type() == StyleRuleType::Supports || type() == StyleRuleType::LayerBlock || type() == StyleRuleType::Container || type() == StyleRuleType::Scope || type() == StyleRuleType::StartingStyle || type() == StyleRuleType::Function || type() == StyleRuleType::InternalBaseAppearance; }
     bool isSupportsRule() const { return type() == StyleRuleType::Supports; }
     bool isImportRule() const { return type() == StyleRuleType::Import; }
     bool isLayerRule() const { return type() == StyleRuleType::LayerBlock || type() == StyleRuleType::LayerStatement; }
@@ -81,6 +81,7 @@ public:
     bool isStartingStyleRule() const { return type() == StyleRuleType::StartingStyle; }
     bool isViewTransitionRule() const { return type() == StyleRuleType::ViewTransition; }
     bool isPositionTryRule() const { return type() == StyleRuleType::PositionTry; }
+    bool isInternalBaseAppearanceRule() const { return type() == StyleRuleType::InternalBaseAppearance; }
 
     Ref<StyleRuleBase> copy() const;
 
@@ -465,6 +466,16 @@ private:
     StyleRuleCharset(const StyleRuleCharset&) = default;
 };
 
+class StyleRuleInternalBaseAppearance final : public StyleRuleGroup {
+public:
+    static Ref<StyleRuleInternalBaseAppearance> create(Vector<Ref<StyleRuleBase>>&&);
+    Ref<StyleRuleInternalBaseAppearance> copy() const { return adoptRef(*new StyleRuleInternalBaseAppearance(*this)); }
+
+private:
+    StyleRuleInternalBaseAppearance(Vector<Ref<StyleRuleBase>>&&);
+    StyleRuleInternalBaseAppearance(const StyleRuleInternalBaseAppearance&) = default;
+};
+
 class StyleRuleNamespace final : public StyleRuleBase {
 public:
     static Ref<StyleRuleNamespace> create(const AtomString& prefix, const AtomString& uri);
@@ -597,4 +608,8 @@ SPECIALIZE_TYPE_TRAITS_END()
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::StyleRuleStartingStyle)
     static bool isType(const WebCore::StyleRuleBase& rule) { return rule.isStartingStyleRule(); }
+SPECIALIZE_TYPE_TRAITS_END()
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::StyleRuleInternalBaseAppearance)
+    static bool isType(const WebCore::StyleRuleBase& rule) { return rule.isInternalBaseAppearanceRule(); }
 SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/css/StyleRuleType.h
+++ b/Source/WebCore/css/StyleRuleType.h
@@ -58,6 +58,7 @@ enum class StyleRuleType : uint8_t {
     PositionTry,
     Function,
     FunctionDeclarations,
+    InternalBaseAppearance, // For UA stylesheets only.
 };
 
 static constexpr auto firstUnexposedStyleRuleType = StyleRuleType::ViewTransition;

--- a/Source/WebCore/css/StyleSheetContents.cpp
+++ b/Source/WebCore/css/StyleSheetContents.cpp
@@ -590,6 +590,7 @@ bool StyleSheetContents::traverseSubresources(NOESCAPE const Function<bool(const
         case StyleRuleType::PositionTry:
         case StyleRuleType::Function:
         case StyleRuleType::FunctionDeclarations:
+        case StyleRuleType::InternalBaseAppearance:
             return false;
         };
         ASSERT_NOT_REACHED();
@@ -669,6 +670,7 @@ bool StyleSheetContents::mayDependOnBaseURL() const
         case StyleRuleType::PositionTry:
         case StyleRuleType::Function:
         case StyleRuleType::FunctionDeclarations:
+        case StyleRuleType::InternalBaseAppearance:
             return false;
         };
         ASSERT_NOT_REACHED();

--- a/Source/WebCore/css/parser/CSSAtRuleID.cpp
+++ b/Source/WebCore/css/parser/CSSAtRuleID.cpp
@@ -37,6 +37,7 @@ namespace WebCore {
 CSSAtRuleID cssAtRuleID(StringView name)
 {
     static constexpr std::pair<ComparableLettersLiteral, CSSAtRuleID> mappings[] = {
+        { "-internal-base-appearance"_s, CSSAtRuleInternalBaseAppearance },
         { "-webkit-keyframes"_s,     CSSAtRuleWebkitKeyframes },
         { "annotation"_s,            CSSAtRuleAnnotation },
         { "character-variant"_s,     CSSAtRuleCharacterVariant },

--- a/Source/WebCore/css/parser/CSSAtRuleID.h
+++ b/Source/WebCore/css/parser/CSSAtRuleID.h
@@ -47,6 +47,7 @@ enum CSSAtRuleID : uint8_t {
     CSSAtRuleSupports,
     CSSAtRuleViewTransition,
 
+    CSSAtRuleInternalBaseAppearance,
     CSSAtRuleWebkitKeyframes,
     CSSAtRuleCounterStyle,
     CSSAtRuleLayer,

--- a/Source/WebCore/css/parser/CSSParser.cpp
+++ b/Source/WebCore/css/parser/CSSParser.cpp
@@ -491,6 +491,8 @@ RefPtr<StyleRuleBase> CSSParser::consumeAtRule(CSSParserTokenRange& range, Allow
         return consumePositionTryRule(prelude, block);
     case CSSAtRuleFunction:
         return consumeFunctionRule(prelude, block);
+    case CSSAtRuleInternalBaseAppearance:
+        return consumeInternalBaseAppearanceRule(prelude, block);
     default:
         return nullptr; // Parse error, unrecognised at-rule with block
     }
@@ -1285,6 +1287,28 @@ RefPtr<StyleRuleStartingStyle> CSSParser::consumeStartingStyleRule(CSSParserToke
         observerWrapper->observer().endRuleBody(observerWrapper->endOffset(block));
 
     return StyleRuleStartingStyle::create(WTFMove(rules));
+}
+
+RefPtr<StyleRuleInternalBaseAppearance> CSSParser::consumeInternalBaseAppearanceRule(CSSParserTokenRange prelude, CSSParserTokenRange block)
+{
+    if (m_context.mode != UASheetMode)
+        return nullptr;
+
+    if (!prelude.atEnd())
+        return nullptr;
+
+    if (RefPtr observerWrapper = m_observerWrapper.get()) {
+        observerWrapper->observer().startRuleHeader(StyleRuleType::InternalBaseAppearance, observerWrapper->startOffset(prelude));
+        observerWrapper->observer().endRuleHeader(observerWrapper->endOffset(prelude));
+        observerWrapper->observer().startRuleBody(observerWrapper->previousTokenStartOffset(block));
+    }
+
+    auto rules = consumeNestedGroupRules(block);
+
+    if (RefPtr observerWrapper = m_observerWrapper.get())
+        observerWrapper->observer().endRuleBody(observerWrapper->endOffset(block));
+
+    return StyleRuleInternalBaseAppearance::create(WTFMove(rules));
 }
 
 RefPtr<StyleRuleLayer> CSSParser::consumeLayerRule(CSSParserTokenRange prelude, std::optional<CSSParserTokenRange> block)

--- a/Source/WebCore/css/parser/CSSParser.h
+++ b/Source/WebCore/css/parser/CSSParser.h
@@ -175,6 +175,7 @@ private:
     RefPtr<StyleRuleViewTransition> consumeViewTransitionRule(CSSParserTokenRange prelude, CSSParserTokenRange block);
     RefPtr<StyleRulePositionTry> consumePositionTryRule(CSSParserTokenRange prelude, CSSParserTokenRange block);
     RefPtr<StyleRuleFunction> consumeFunctionRule(CSSParserTokenRange prelude, CSSParserTokenRange block);
+    RefPtr<StyleRuleInternalBaseAppearance> consumeInternalBaseAppearanceRule(CSSParserTokenRange prelude, CSSParserTokenRange block);
 
     RefPtr<StyleRuleKeyframe> consumeKeyframeStyleRule(CSSParserTokenRange prelude, CSSParserTokenRange block);
     RefPtr<StyleRuleBase> consumeStyleRule(CSSParserTokenRange prelude, CSSParserTokenRange block);

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -114,6 +114,9 @@ static bool consumePositionTryDescriptor(CSSParserTokenRange&, const CSSParserCo
 // @function descriptors.
 static bool consumeFunctionDescriptor(CSSParserTokenRange&, const CSSParserContext&, CSSPropertyID, CSS::PropertyParserResult&);
 
+// @-internal-base-appearance descriptors.
+static bool consumeInternalBaseAppearanceDescriptor(CSSParserTokenRange&, const CSSParserContext&, CSSPropertyID, IsImportant, CSS::PropertyParserResult&);
+
 // MARK: - CSSPropertyID parsing
 
 template<typename CharacterType> static CSSPropertyID cssPropertyID(std::span<const CharacterType> characters)
@@ -263,6 +266,9 @@ bool CSSPropertyParser::parseValue(CSSPropertyID property, IsImportant important
         break;
     case StyleRuleType::Function:
         parseSuccess = consumeFunctionDescriptor(range, context, property, result);
+        break;
+    case StyleRuleType::InternalBaseAppearance:
+        parseSuccess = consumeInternalBaseAppearanceDescriptor(range, context, property, important, result);
         break;
     default:
         parseSuccess = consumeStyleProperty(range, context, property, important, ruleType, result);
@@ -825,6 +831,16 @@ bool consumeFunctionDescriptor(CSSParserTokenRange& range, const CSSParserContex
 
     result.addProperty(state, property, CSSPropertyInvalid, WTFMove(parsedValue), IsImportant::No);
     return true;
+}
+
+bool consumeInternalBaseAppearanceDescriptor(CSSParserTokenRange& range, const CSSParserContext& context, CSSPropertyID property, IsImportant important, CSS::PropertyParserResult& result)
+{
+    ASSERT(context.mode == UASheetMode);
+
+    if (property == CSSPropertyAppearance)
+        return false;
+
+    return consumeStyleProperty(range, context, property, important, StyleRuleType::InternalBaseAppearance, result);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/inspector/InspectorStyleSheet.cpp
+++ b/Source/WebCore/inspector/InspectorStyleSheet.cpp
@@ -99,6 +99,7 @@ static RuleFlatteningStrategy flatteningStrategyForStyleRuleType(StyleRuleType s
     case StyleRuleType::Container:
     case StyleRuleType::Scope:
     case StyleRuleType::StartingStyle:
+    case StyleRuleType::InternalBaseAppearance:
         // These rules MUST be handled by the following methods in order to provide functionality in
         // and avoid mismatched lists of source data and CSSOM wrappers:
         // - `isValidRuleHeaderText`

--- a/Source/WebCore/style/ElementRuleCollector.cpp
+++ b/Source/WebCore/style/ElementRuleCollector.cpp
@@ -297,7 +297,7 @@ void ElementRuleCollector::transferMatchedRules(DeclarationOrigin declarationOri
             matchedRule.styleScopeOrdinal,
             FromStyleAttribute::No,
             matchedRule.cascadeLayerPriority,
-            matchedRule.ruleData->isStartingStyle()
+            matchedRule.ruleData->usedRuleTypes()
         }, declarationOrigin);
     }
 }
@@ -914,8 +914,11 @@ void ElementRuleCollector::addMatchedProperties(MatchedProperties&& matchedPrope
         // It might also be beneficial to overwrite the previous declaration (insteading of appending) if it affects the same exact properties.
         return;
     }
-    if (matchedProperties.isStartingStyle == IsStartingStyle::Yes)
-        m_result->hasStartingStyle = true;
+    if (matchedProperties.usedRuleTypes.contains(UsedRuleType::StartingStyle))
+        m_result->usedRuleTypes.add(UsedRuleType::StartingStyle);
+
+    if (matchedProperties.usedRuleTypes.contains(UsedRuleType::BaseAppearance))
+        m_result->usedRuleTypes.add(UsedRuleType::BaseAppearance);
 
     if (matchedProperties.isCacheable == IsCacheable::Partially && !m_result->isCompletelyNonCacheable) {
         for (auto property : matchedProperties.properties.get())

--- a/Source/WebCore/style/MatchResult.h
+++ b/Source/WebCore/style/MatchResult.h
@@ -43,7 +43,7 @@ struct MatchedProperties {
     ScopeOrdinal styleScopeOrdinal { ScopeOrdinal::Element };
     FromStyleAttribute fromStyleAttribute { FromStyleAttribute::No };
     CascadeLayerPriority cascadeLayerPriority { RuleSet::cascadeLayerPriorityForUnlayered };
-    IsStartingStyle isStartingStyle { IsStartingStyle::No };
+    OptionSet<UsedRuleType> usedRuleTypes { };
     IsCacheable isCacheable { IsCacheable::Yes };
 };
 
@@ -52,7 +52,7 @@ struct MatchResult : RefCounted<MatchResult> {
 
     bool isForLink { false };
     bool isCompletelyNonCacheable { false };
-    bool hasStartingStyle { false };
+    OptionSet<UsedRuleType> usedRuleTypes { };
     Vector<MatchedProperties> userAgentDeclarations;
     Vector<MatchedProperties> userDeclarations;
     Vector<MatchedProperties> authorDeclarations;
@@ -78,13 +78,13 @@ inline bool operator==(const MatchedProperties& a, const MatchedProperties& b)
         && a.styleScopeOrdinal == b.styleScopeOrdinal
         && a.fromStyleAttribute == b.fromStyleAttribute
         && a.cascadeLayerPriority == b.cascadeLayerPriority
-        && a.isStartingStyle == b.isStartingStyle
+        && a.usedRuleTypes == b.usedRuleTypes
         && a.isCacheable == b.isCacheable;
 }
 
 inline bool MatchResult::cacheablePropertiesEqual(const MatchResult& other) const
 {
-    if (isForLink != other.isForLink || hasStartingStyle != other.hasStartingStyle)
+    if (isForLink != other.isForLink || usedRuleTypes != other.usedRuleTypes)
         return false;
 
     // Only author style can be non-cacheable.
@@ -126,7 +126,7 @@ inline void add(Hasher& hasher, const MatchedProperties& matchedProperties)
         matchedProperties.styleScopeOrdinal,
         matchedProperties.fromStyleAttribute,
         matchedProperties.cascadeLayerPriority,
-        matchedProperties.isStartingStyle
+        matchedProperties.usedRuleTypes
     );
 }
 

--- a/Source/WebCore/style/PropertyCascade.cpp
+++ b/Source/WebCore/style/PropertyCascade.cpp
@@ -226,7 +226,10 @@ bool PropertyCascade::addMatch(const MatchedProperties& matchedProperties, Origi
     if (m_maximumCascadeLayerPriorityForRollback && !includePropertiesForRollback())
         return false;
 
-    if (matchedProperties.isStartingStyle == IsStartingStyle::Yes && !m_includedProperties.types.contains(PropertyType::StartingStyle))
+    if ((matchedProperties.usedRuleTypes & UsedRuleType::StartingStyle) && !m_includedProperties.types.contains(PropertyType::StartingStyle))
+        return false;
+
+    if ((matchedProperties.usedRuleTypes & UsedRuleType::BaseAppearance) && !m_includedProperties.types.contains(PropertyType::BaseAppearanceStyle))
         return false;
 
     auto propertyAllowlist = matchedProperties.allowlistType;

--- a/Source/WebCore/style/PropertyCascade.h
+++ b/Source/WebCore/style/PropertyCascade.h
@@ -48,7 +48,8 @@ public:
         AfterAnimation = 1 << 3,
         AfterTransition = 1 << 4,
         StartingStyle = 1 << 5,
-        NonCacheable = 1 << 6,
+        BaseAppearanceStyle = 1 << 6,
+        NonCacheable = 1 << 7,
     };
 
     enum class Origin : uint8_t {
@@ -107,6 +108,8 @@ public:
     const PropertyBitSet& propertyIsPresent() const { return m_propertyIsPresent; }
 
     bool applyLowPriorityOnly() const { return !m_includedProperties.ids.isEmpty(); }
+
+    void addBaseAppearanceStyles();
 
 private:
     void buildCascade();

--- a/Source/WebCore/style/RuleData.cpp
+++ b/Source/WebCore/style/RuleData.cpp
@@ -114,15 +114,15 @@ static inline PropertyAllowlist determinePropertyAllowlist(const CSSSelector* se
     return PropertyAllowlist::None;
 }
 
-RuleData::RuleData(const StyleRule& styleRule, unsigned selectorIndex, unsigned selectorListIndex, unsigned position, IsStartingStyle isStartingStyle)
+RuleData::RuleData(const StyleRule& styleRule, unsigned selectorIndex, unsigned selectorListIndex, unsigned position, OptionSet<UsedRuleType> usedRuleTypes)
     : m_styleRuleWithSelectorIndex(&styleRule, static_cast<uint16_t>(selectorIndex))
     , m_selectorListIndex(selectorListIndex)
-    , m_position(position)
     , m_matchBasedOnRuleHash(enumToUnderlyingType(computeMatchBasedOnRuleHash(*selector())))
     , m_canMatchPseudoElement(complexSelectorCanMatchPseudoElement(*selector()))
     , m_propertyAllowlist(enumToUnderlyingType(determinePropertyAllowlist(selector())))
-    , m_isStartingStyle(enumToUnderlyingType(isStartingStyle))
+    , m_usedRuleTypes(usedRuleTypes.toRaw())
     , m_isEnabled(true)
+    , m_position(position)
     , m_descendantSelectorIdentifierHashes(SelectorFilter::collectHashes(*selector()))
 {
     ASSERT(m_position == position);

--- a/Source/WebCore/style/RuleData.h
+++ b/Source/WebCore/style/RuleData.h
@@ -37,13 +37,16 @@ enum class MatchBasedOnRuleHash : unsigned {
     ClassC
 };
 
-enum class IsStartingStyle : bool { No, Yes };
+enum class UsedRuleType : uint8_t {
+    StartingStyle = 1 << 0,
+    BaseAppearance = 1 << 1
+};
 
 class RuleData {
 public:
     static const unsigned maximumSelectorComponentCount = 8192;
 
-    RuleData(const StyleRule&, unsigned selectorIndex, unsigned selectorListIndex, unsigned position, IsStartingStyle);
+    RuleData(const StyleRule&, unsigned selectorIndex, unsigned selectorListIndex, unsigned position, OptionSet<UsedRuleType>);
 
     unsigned position() const { return m_position; }
 
@@ -66,7 +69,7 @@ public:
     unsigned linkMatchType() const { return m_linkMatchType; }
     void setLinkMatchType(unsigned value) { m_linkMatchType = value; }
     PropertyAllowlist propertyAllowlist() const { return static_cast<PropertyAllowlist>(m_propertyAllowlist); }
-    IsStartingStyle isStartingStyle() const { return static_cast<IsStartingStyle>(m_isStartingStyle); }
+    OptionSet<UsedRuleType> usedRuleTypes() const { return OptionSet<UsedRuleType>::fromRaw(m_usedRuleTypes); }
     bool isEnabled() const { return m_isEnabled; }
     void setEnabled(bool value) { m_isEnabled = value; }
 
@@ -78,14 +81,14 @@ private:
     // Keep in sync with RuleFeature's selectorIndex and selectorListIndex size.
     CompactRefPtrTuple<const StyleRule, uint16_t> m_styleRuleWithSelectorIndex;
     unsigned m_selectorListIndex : 16;
-    // If we have more rules than 2^bitcount here we'll get confused about rule order.
-    unsigned m_position : 21;
     unsigned m_matchBasedOnRuleHash : 3;
     unsigned m_canMatchPseudoElement : 1;
     unsigned m_linkMatchType : 2; //  SelectorChecker::LinkMatchMask
     unsigned m_propertyAllowlist : 2;
-    unsigned m_isStartingStyle : 1;
+    unsigned m_usedRuleTypes : 2;
     unsigned m_isEnabled : 1;
+    // If we have more rules than 2^bitcount here we'll get confused about rule order.
+    unsigned m_position : 21;
     SelectorFilter::Hashes m_descendantSelectorIdentifierHashes;
 };
 

--- a/Source/WebCore/style/RuleFeature.cpp
+++ b/Source/WebCore/style/RuleFeature.cpp
@@ -441,7 +441,7 @@ void RuleFeatureSet::collectFeatures(const RuleData& ruleData, const Vector<Ref<
         collectSelectorList(scopeRule->scopeEnd());
     }
 
-    if (ruleData.isStartingStyle() == IsStartingStyle::Yes)
+    if (ruleData.usedRuleTypes().contains(UsedRuleType::StartingStyle))
         hasStartingStyleRules = true;
 
     auto addToMap = [&]<typename HostAffectingNames>(auto& map, auto& entries, HostAffectingNames hostAffectingNames) {

--- a/Source/WebCore/style/RuleSet.cpp
+++ b/Source/WebCore/style/RuleSet.cpp
@@ -136,7 +136,7 @@ static bool shouldHaveBucketForAttributeName(const CSSSelector& attributeSelecto
 
 void RuleSet::addRule(const StyleRule& rule, unsigned selectorIndex, unsigned selectorListIndex)
 {
-    RuleData ruleData(rule, selectorIndex, selectorListIndex, m_ruleCount, IsStartingStyle::No);
+    RuleData ruleData(rule, selectorIndex, selectorListIndex, m_ruleCount, { });
     addRule(WTFMove(ruleData), 0, 0, 0);
 }
 

--- a/Source/WebCore/style/RuleSetBuilder.cpp
+++ b/Source/WebCore/style/RuleSetBuilder.cpp
@@ -205,9 +205,16 @@ void RuleSetBuilder::addChildRule(Ref<StyleRuleBase> rule)
     }
 
     case StyleRuleType::StartingStyle: {
-        SetForScope startingStyleScope { m_isStartingStyle, IsStartingStyle::Yes };
+        SetForScope startingStyleScope { m_usedRuleTypes, m_usedRuleTypes | UsedRuleType::StartingStyle };
         auto startingStyleRule = uncheckedDowncast<StyleRuleStartingStyle>(WTFMove(rule));
         addChildRules(startingStyleRule->childRules());
+        return;
+    }
+
+    case StyleRuleType::InternalBaseAppearance: {
+        SetForScope scope { m_usedRuleTypes, m_usedRuleTypes | UsedRuleType::BaseAppearance };
+        auto internalBaseAppearanceRule = uncheckedDowncast<StyleRuleInternalBaseAppearance>(WTFMove(rule));
+        addChildRules(internalBaseAppearanceRule->childRules());
         return;
     }
 
@@ -296,7 +303,7 @@ void RuleSetBuilder::addStyleRuleWithSelectorList(const CSSSelectorList& selecto
     ASSERT(!selectorList.isEmpty());
     unsigned selectorListIndex = 0;
     for (size_t selectorIndex = 0; selectorIndex != notFound; selectorIndex = selectorList.indexOfNextSelectorAfter(selectorIndex)) {
-        RuleData ruleData(rule, selectorIndex, selectorListIndex, m_ruleSet->ruleCount(), m_isStartingStyle);
+        RuleData ruleData(rule, selectorIndex, selectorListIndex, m_ruleSet->ruleCount(), m_usedRuleTypes);
         m_mediaQueryCollector.addRuleIfNeeded(ruleData);
         m_ruleSet->addRule(WTFMove(ruleData), m_currentCascadeLayerIdentifier, m_currentContainerQueryIdentifier, m_currentScopeIdentifier);
         ++selectorListIndex;

--- a/Source/WebCore/style/RuleSetBuilder.h
+++ b/Source/WebCore/style/RuleSetBuilder.h
@@ -92,7 +92,7 @@ private:
     RuleSet::ContainerQueryIdentifier m_currentContainerQueryIdentifier { 0 };
     RuleSet::ScopeRuleIdentifier m_currentScopeIdentifier { 0 };
 
-    IsStartingStyle m_isStartingStyle { IsStartingStyle::No };
+    OptionSet<UsedRuleType> m_usedRuleTypes { };
 
     Vector<RuleSet::ResolverMutatingRule> m_collectedResolverMutatingRules;
     bool requiresStaticMediaQueryEvaluation { false };

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -874,7 +874,7 @@ ElementUpdate TreeResolver::createAnimatedElementUpdate(ResolvedStyle&& resolved
 
 std::unique_ptr<RenderStyle> TreeResolver::resolveStartingStyle(const ResolvedStyle& resolvedStyle, const Styleable& styleable, const ResolutionContext& resolutionContext)
 {
-    if (!resolvedStyle.matchResult || !resolvedStyle.matchResult->hasStartingStyle)
+    if (!resolvedStyle.matchResult || !resolvedStyle.matchResult->usedRuleTypes.contains(UsedRuleType::StartingStyle))
         return nullptr;
 
     // "Starting style inherits from the parent’s after-change style just like after-change style does."


### PR DESCRIPTION
#### e7b6d1770468838d8e981f2df47f3b65002e93d8
<pre>
[appearance: base] Parse internal at-rule for base appearance style
<a href="https://bugs.webkit.org/show_bug.cgi?id=299305">https://bugs.webkit.org/show_bug.cgi?id=299305</a>
<a href="https://rdar.apple.com/161108451">rdar://161108451</a>

Reviewed by Antti Koivisto.

This adds a `@-internal-base-appearance` at-rule that can only be used in UA stylesheets.

Rules contained inside that at-rule will only be applied when `appearance: base` is set (see `html.css`).

Style building support will be added in an upcoming commit.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/JSCSSRuleCustom.cpp:
(WebCore::toJSNewlyCreated):
* Source/WebCore/css/CSSInternalBaseAppearanceRule.cpp: Added.
(WebCore::CSSInternalBaseAppearanceRule::CSSInternalBaseAppearanceRule):
(WebCore::CSSInternalBaseAppearanceRule::cssText const):
* Source/WebCore/css/CSSInternalBaseAppearanceRule.h: Added.
* Source/WebCore/css/StyleRule.cpp:
(WebCore::StyleRuleBase::visitDerived):
(WebCore::StyleRuleBase::createCSSOMWrapper const):
(WebCore::StyleRuleInternalBaseAppearance::create):
(WebCore::StyleRuleInternalBaseAppearance::StyleRuleInternalBaseAppearance):
* Source/WebCore/css/StyleRule.h:
(WebCore::StyleRuleBase::isGroupRule const):
(WebCore::StyleRuleBase::isInternalBaseAppearanceRule const):
(isType):
* Source/WebCore/css/StyleRuleType.h:
* Source/WebCore/css/StyleSheetContents.cpp:
(WebCore::StyleSheetContents::traverseSubresources const):
(WebCore::StyleSheetContents::mayDependOnBaseURL const):
* Source/WebCore/css/parser/CSSAtRuleID.cpp:
(WebCore::cssAtRuleID):
* Source/WebCore/css/parser/CSSAtRuleID.h:
* Source/WebCore/css/parser/CSSParser.cpp:
(WebCore::CSSParser::consumeAtRule):
(WebCore::CSSParser::consumeInternalBaseAppearanceRule):
* Source/WebCore/css/parser/CSSParser.h:
* Source/WebCore/css/parser/CSSPropertyParser.cpp:
(WebCore::CSSPropertyParser::parseValue):
(WebCore::consumeInternalBaseAppearanceDescriptor):
* Source/WebCore/inspector/InspectorStyleSheet.cpp:
(WebCore::flatteningStrategyForStyleRuleType):
* Source/WebCore/style/ElementRuleCollector.cpp:
(WebCore::Style::ElementRuleCollector::transferMatchedRules):
(WebCore::Style::ElementRuleCollector::addMatchedProperties):
* Source/WebCore/style/MatchResult.h:
(WebCore::Style::operator==):
(WebCore::Style::MatchResult::cacheablePropertiesEqual const):
(WebCore::Style::add):
* Source/WebCore/style/PropertyCascade.cpp:
(WebCore::Style::PropertyCascade::addMatch):
* Source/WebCore/style/PropertyCascade.h:
* Source/WebCore/style/RuleData.cpp:
(WebCore::Style::RuleData::RuleData):
* Source/WebCore/style/RuleData.h:
(WebCore::Style::RuleData::usedRuleTypes const):
(WebCore::Style::RuleData::isStartingStyle const): Deleted.
* Source/WebCore/style/RuleFeature.cpp:
(WebCore::Style::RuleFeatureSet::collectFeatures):
* Source/WebCore/style/RuleSet.cpp:
(WebCore::Style::RuleSet::addRule):
* Source/WebCore/style/RuleSetBuilder.cpp:
(WebCore::Style::RuleSetBuilder::addChildRule):
(WebCore::Style::RuleSetBuilder::addStyleRuleWithSelectorList):
* Source/WebCore/style/RuleSetBuilder.h:
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::resolveStartingStyle):

Canonical link: <a href="https://commits.webkit.org/300371@main">https://commits.webkit.org/300371@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/70f6da139ca1a83e9af92746677d8cf1f3270462

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122208 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41911 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32580 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128782 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74302 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/27a654b1-77bc-4229-b123-fed0127a2386) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/124084 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42625 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50504 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92886 "6 flakes 17 failures") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61750 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d174fe2e-4bfa-4680-bbc0-02dd252880c0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125160 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34003 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109439 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73540 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/71c196f9-917d-40d7-b577-1b6a789c30cf) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33013 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27601 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72272 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103511 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27795 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131532 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49147 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37392 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101461 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49522 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105650 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101331 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25713 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46699 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24815 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45898 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49004 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54739 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48474 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51824 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50154 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->