### PR TITLE
FTL's NewButterflyWithSize passes the wrong size to the slow path

### DIFF
--- a/JSTests/stress/array-constant-size-allocation-large.js
+++ b/JSTests/stress/array-constant-size-allocation-large.js
@@ -1,0 +1,9 @@
+function f0() {
+    const v56 = new Array(1600);
+    let data = v56.fill(null)
+    for (const v66 of data) {}
+}
+noInline(f0);
+
+for (let i = 0; i < testLoopCount; ++i)
+    f0();

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -20761,10 +20761,10 @@ IGNORE_CLANG_WARNINGS_END
                     pointerType()),
                 m_out.constIntPtr(3));
 
-        LValue butterflySize = m_out.add(
+        LValue allocationSizeInBytes = m_out.add(
             payloadSizeInBytes, m_out.constIntPtr(sizeof(IndexingHeader)));
 
-        LValue allocator = allocatorForSize(vm().auxiliarySpace(), butterflySize, slowBlock);
+        LValue allocator = allocatorForSize(vm().auxiliarySpace(), allocationSizeInBytes, slowBlock);
         LValue base = allocateHeapCell(allocator, slowBlock);
         ValueFromBlock fastBase = m_out.anchor(base);
         m_out.jump(continuation);
@@ -20777,7 +20777,7 @@ IGNORE_CLANG_WARNINGS_END
                     operationAllocateUnitializedAuxiliaryBase, locations[0].directGPR(), CCallHelpers::TrustedImmPtr(&vm),
                     locations[1].directGPR());
             },
-            payloadSizeInBytes);
+            allocationSizeInBytes);
         ValueFromBlock slowBase = m_out.anchor(slowButterflyBase);
         m_out.jump(continuation);
 


### PR DESCRIPTION
#### d9d88254ab5e7727f7c48d9bb274da5f8381a887
<pre>
FTL&apos;s NewButterflyWithSize passes the wrong size to the slow path
<a href="https://bugs.webkit.org/show_bug.cgi?id=299308">https://bugs.webkit.org/show_bug.cgi?id=299308</a>
<a href="https://rdar.apple.com/160976464">rdar://160976464</a>

Reviewed by Yijia Huang.

My original patch 300129@main passed the indexed payload size rather than allocation size, which the
slow path expected. This meant the butterfly was allocated 8 bytes too small. This patch fixes the
lowering code to pass the correct value.

Canonical link: <a href="https://commits.webkit.org/300386@main">https://commits.webkit.org/300386@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/932b0e71bdc0cee2bc0a82a8d79d611afaabc708

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122212 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41915 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32584 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128788 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74306 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cb8aa9a4-c4ac-4981-9d2e-2c4094c9eae7) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42629 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50508 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92891 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61749 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125164 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34001 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109436 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73545 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/29fca112-7f2d-46d2-9455-c2104e1d659d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33011 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27598 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72276 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/114360 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103509 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27792 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131536 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/120738 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49151 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37399 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101457 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49526 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105647 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101327 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46697 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24813 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45902 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19345 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49008 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54743 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/150897 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48478 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/38610 "Passed tests") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51828 "Hash 932b0e71 for PR 51132 does not build (failure)") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50158 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->