### PR TITLE
[World Leaks] Investigate leaks in LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioworklet-interface/

### DIFF
--- a/LayoutTests/webaudio/audioworklet-does-not-leak-expected.txt
+++ b/LayoutTests/webaudio/audioworklet-does-not-leak-expected.txt
@@ -1,0 +1,10 @@
+Tests that AudioWorklet functionality does not leak the document object
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS The iframe document didn't leak.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/webaudio/audioworklet-does-not-leak.html
+++ b/LayoutTests/webaudio/audioworklet-does-not-leak.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../resources/js-test.js"></script>
+<script src="../resources/document-leak-test.js"></script>
+<script>
+description("Tests that AudioWorklet functionality does not leak the document object");
+onload = () => runDocumentLeakTest({ frameURL: "resources/audioworklet-leak-test-frame.html", framesToCreate: 20 });
+</script>
+</body>
+</html>

--- a/LayoutTests/webaudio/resources/audioworklet-leak-test-frame.html
+++ b/LayoutTests/webaudio/resources/audioworklet-leak-test-frame.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+const context = new OfflineAudioContext(1, 1, 44100);
+context.audioWorklet.addModule('../bad-array-type-processor.js?' + Math.random()).then(() => {
+    const node = new AudioWorkletNode(context, 'bad-array-type-processor');
+    let d = document;
+    let p = d.createElement("p");
+    p.innerText = "AudioWorklet leak test completed";
+    d.body.appendChild(p);
+});
+
+onload = () => {
+    parent.postMessage("frameLoaded");
+};
+</script>
+</body>
+</html>

--- a/Source/WebCore/Modules/webaudio/AudioWorkletMessagingProxy.h
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletMessagingProxy.h
@@ -73,7 +73,7 @@ private:
     bool isAudioWorkletMessagingProxy() const final { return true; }
 
     WeakPtr<AudioWorklet> m_worklet;
-    const Ref<Document> m_document;
+    const ScriptExecutionContextIdentifier m_documentIdentifier;
     const Ref<AudioWorkletThread> m_workletThread;
 };
 

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -1626,8 +1626,7 @@ void NetworkConnectionToWebProcess::entangleLocalPortInThisProcessToRemote(const
 
 void NetworkConnectionToWebProcess::messagePortDisentangled(const MessagePortIdentifier& port)
 {
-    auto result = m_processEntangledPorts.remove(port);
-    ASSERT_UNUSED(result, result);
+    m_processEntangledPorts.remove(port);
 
     m_networkProcess->checkedMessagePortChannelRegistry()->didDisentangleMessagePort(port);
 }


### PR DESCRIPTION
#### eadd64122b83781dc378218c5a073f9935bec2b9
<pre>
[World Leaks] Investigate leaks in LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioworklet-interface/
<a href="https://bugs.webkit.org/show_bug.cgi?id=299312">https://bugs.webkit.org/show_bug.cgi?id=299312</a>
<a href="https://rdar.apple.com/161118548">rdar://161118548</a>

Reviewed by Chris Dumez.

AudioWorkletMessagingProxy holds a strong const Ref&lt;Document&gt;. Removing this reference and
using a ScriptExecutionContextIdentifier to post tasks when necessary fixes approximately
30 leaky tests.

Test: webaudio/audioworklet-does-not-leak.html

* LayoutTests/webaudio/audioworklet-does-not-leak-expected.txt: Added.
* LayoutTests/webaudio/audioworklet-does-not-leak.html: Added.
* LayoutTests/webaudio/resources/audioworklet-leak-test-frame.html: Added.
* Source/WebCore/Modules/webaudio/AudioWorkletMessagingProxy.cpp:
(WebCore::AudioWorkletMessagingProxy::AudioWorkletMessagingProxy):
(WebCore::AudioWorkletMessagingProxy::createRTCDataChannelRemoteHandlerConnection):
(WebCore::AudioWorkletMessagingProxy::loaderContextIdentifier const):
(WebCore::AudioWorkletMessagingProxy::postTaskToLoader):
(WebCore::AudioWorkletMessagingProxy::postTaskToAudioWorklet):
* Source/WebCore/Modules/webaudio/AudioWorkletMessagingProxy.h:
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::messagePortDisentangled):

Canonical link: <a href="https://commits.webkit.org/301328@main">https://commits.webkit.org/301328@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c2c4ccbaff5f73064c3d0b2337242dd0f4036917

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125603 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45265 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36012 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132465 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/77531 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127474 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45952 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53825 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95682 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/63798 "Unable to confirm if test failures are introduced by change, retrying build") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128551 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36726 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112312 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76179 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35635 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30494 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75938 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106512 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30712 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135137 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52403 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40153 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104153 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52844 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108528 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103885 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26458 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49241 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27544 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/49614 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52293 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58090 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51645 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54997 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53340 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->