### PR TITLE
REGRESSION:(300243@main) [ Debug] 3x TestWebKitAPI.ContentRuleList(api-tests) are constant timeouts

### DIFF
--- a/Source/WebCore/contentextensions/ContentExtension.cpp
+++ b/Source/WebCore/contentextensions/ContentExtension.cpp
@@ -30,6 +30,7 @@
 #include "CompiledContentExtension.h"
 #include "ContentExtensionParser.h"
 #include "ContentExtensionsBackend.h"
+#include "ProcessWarming.h"
 #include "StyleSheetContents.h"
 #include <wtf/text/StringBuilder.h>
 
@@ -74,6 +75,8 @@ StyleSheetContents* ContentExtension::globalDisplayNoneStyleSheet()
 
 void ContentExtension::compileGlobalDisplayNoneStyleSheet()
 {
+    ProcessWarming::initializeNames();
+
     uint32_t firstIgnoreRule = findFirstIgnoreRule();
 
     auto serializedActions = m_compiledExtension->serializedActions();


### PR DESCRIPTION
#### ab7628f87106c69a31b42da885f0996378c6e278
<pre>
REGRESSION:(300243@main) [ Debug] 3x TestWebKitAPI.ContentRuleList(api-tests) are constant timeouts
<a href="https://bugs.webkit.org/show_bug.cgi?id=299309">https://bugs.webkit.org/show_bug.cgi?id=299309</a>
<a href="https://rdar.apple.com/161116923">rdar://161116923</a>

Reviewed by Alexey Proskuryakov.

We were missing a call to ProcessWarming::initializeNames in ContentExtension::compileGlobalDisplayNoneStyleSheet
before using the CSS parser.  This now happens sometimes before the first LocalFrame constructor in a process.

Covered by 3 existing tests.

* Source/WebCore/contentextensions/ContentExtension.cpp:
(WebCore::ContentExtensions::ContentExtension::compileGlobalDisplayNoneStyleSheet):

Canonical link: <a href="https://commits.webkit.org/300344@main">https://commits.webkit.org/300344@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c751b874f6068330bec69b9c88008dcaebdee7a3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122229 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41932 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32601 "Hash c751b874 for PR 51135 does not build (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128806 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/74323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/89839321-85b6-436c-a05b-0fff079dd968) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/124105 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42646 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50525 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92906 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/74323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6ea7bb9c-5f82-4e09-a6ff-192a71c5cf57) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125181 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34018 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/138/builds/32601 "Hash c751b874 for PR 51135 does not build (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73560 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fd8dce71-666a-4422-99af-d12b402db3a8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33028 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/138/builds/32601 "Hash c751b874 for PR 51135 does not build (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72295 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103526 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/138/builds/32601 "Hash c751b874 for PR 51135 does not build (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131553 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49168 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37409 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101472 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49543 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/138/builds/32601 "Hash c751b874 for PR 51135 does not build (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101342 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46709 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/138/builds/32601 "Hash c751b874 for PR 51135 does not build (failure)") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/45919 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19327 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49025 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54760 "Failed to build and analyze WebKit") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/48495 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51845 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50175 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->