### PR TITLE
[libpas] Introduce stat-counter system for libpas

### DIFF
--- a/Source/bmalloc/CMakeLists.txt
+++ b/Source/bmalloc/CMakeLists.txt
@@ -192,6 +192,7 @@ set(bmalloc_C_SOURCES
     libpas/src/libpas/pas_simple_type.c
     libpas/src/libpas/pas_small_medium_bootstrap_free_heap.c
     libpas/src/libpas/pas_small_medium_bootstrap_heap_page_provider.c
+    libpas/src/libpas/pas_stats.c
     libpas/src/libpas/pas_status_reporter.c
     libpas/src/libpas/pas_stream.c
     libpas/src/libpas/pas_string_stream.c
@@ -662,6 +663,7 @@ set(bmalloc_PUBLIC_HEADERS
     libpas/src/libpas/pas_small_medium_bootstrap_free_heap.h
     libpas/src/libpas/pas_small_medium_bootstrap_heap_page_provider.h
     libpas/src/libpas/pas_snprintf.h
+    libpas/src/libpas/pas_stats.h
     libpas/src/libpas/pas_status_reporter.h
     libpas/src/libpas/pas_stream.h
     libpas/src/libpas/pas_string_stream.h

--- a/Source/bmalloc/bmalloc.xcodeproj/project.pbxproj
+++ b/Source/bmalloc/bmalloc.xcodeproj/project.pbxproj
@@ -26,6 +26,8 @@
 		0100000D37BABA0A0A991999 /* pas_zero_memory.h in Headers */ = {isa = PBXBuildFile; fileRef = 0100000B37BABA0A0A991999 /* pas_zero_memory.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		0100000D37BABA0A0A993999 /* pas_mte_config.h in Headers */ = {isa = PBXBuildFile; fileRef = 0100000B37BABA0A0A993999 /* pas_mte_config.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		0100000D37BABA0A0A999999 /* pas_mte.h in Headers */ = {isa = PBXBuildFile; fileRef = 0100000B37BABA0A0A999999 /* pas_mte.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		0F99999C37AAAA0000999999 /* pas_stats.c in Sources */ = {isa = PBXBuildFile; fileRef = 0F99999A37AAAA0000999999 /* pas_stats.c */; };
+		0F99999D37AAAA0000999999 /* pas_stats.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F99999B37AAAA0000999999 /* pas_stats.h */; settings = {ATTRIBUTES = (Private, ); };};
 		07FB5E3D2EA4B31B00603B46 /* bmalloc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07FB5E3C2EA4B31B00603B46 /* bmalloc.swift */; };
 		0F26A7A5205483130090A141 /* PerProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F26A7A42054830D0090A141 /* PerProcess.cpp */; };
 		0F5167741FAD685C008236A8 /* bmalloc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F5167731FAD6852008236A8 /* bmalloc.cpp */; };
@@ -757,6 +759,8 @@
 		0100000A37BABA0A0A999999 /* pas_mte.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pas_mte.c; path = libpas/src/libpas/pas_mte.c; sourceTree = "<group>"; };
 		0100000B37BABA0A0A991999 /* pas_zero_memory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pas_zero_memory.h; path = libpas/src/libpas/pas_zero_memory.h; sourceTree = "<group>"; };
 		0100000B37BABA0A0A993999 /* pas_mte_config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pas_mte_config.h; path = libpas/src/libpas/pas_mte_config.h; sourceTree = "<group>"; };
+		0F99999A37AAAA0000999999 /* pas_stats.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pas_stats.c; path = libpas/src/libpas/pas_stats.c; sourceTree = "<group>"; };
+		0F99999B37AAAA0000999999 /* pas_stats.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pas_stats.h; path = libpas/src/libpas/pas_stats.h; sourceTree = "<group>"; };
 		0100000B37BABA0A0A999999 /* pas_mte.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pas_mte.h; path = libpas/src/libpas/pas_mte.h; sourceTree = "<group>"; };
 		07FB5E3C2EA4B31B00603B46 /* bmalloc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = bmalloc.swift; sourceTree = "<group>"; };
 		0F18F83C25C3467700721C2A /* pas_segregated_exclusive_view_inlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pas_segregated_exclusive_view_inlines.h; path = libpas/src/libpas/pas_segregated_exclusive_view_inlines.h; sourceTree = "<group>"; };
@@ -2037,6 +2041,8 @@
 				7234F6B52D01112E000B645D /* pas_small_medium_bootstrap_heap_page_provider.c */,
 				7234F6B42D01112E000B645D /* pas_small_medium_bootstrap_heap_page_provider.h */,
 				0FC40AEB2451499300876DA0 /* pas_snprintf.h */,
+				0F99999A37AAAA0000999999 /* pas_stats.c */,
+				0F99999B37AAAA0000999999 /* pas_stats.h */,
 				0FC40A1E2451498400876DA0 /* pas_status_reporter.c */,
 				0FC40A1B2451498400876DA0 /* pas_status_reporter.h */,
 				0FC40A682451498A00876DA0 /* pas_stream.c */,
@@ -2752,6 +2758,7 @@
 				7234F6B72D01112E000B645D /* pas_small_medium_bootstrap_free_heap.h in Headers */,
 				7234F6B62D01112E000B645D /* pas_small_medium_bootstrap_heap_page_provider.h in Headers */,
 				DD4BECCB29CBA49700398E35 /* pas_snprintf.h in Headers */,
+				0F99999D37AAAA0000999999 /* pas_stats.h in Headers */,
 				DD4BEDE429CBA49700398E35 /* pas_status_reporter.h in Headers */,
 				DD4BED7029CBA49700398E35 /* pas_stream.h in Headers */,
 				DD4BED9029CBA49700398E35 /* pas_string_stream.h in Headers */,
@@ -3134,6 +3141,7 @@
 				DD4BEDC529CBA49700398E35 /* pas_simple_type.c in Sources */,
 				7234F6B82D01112E000B645D /* pas_small_medium_bootstrap_free_heap.c in Sources */,
 				7234F6B92D01112E000B645D /* pas_small_medium_bootstrap_heap_page_provider.c in Sources */,
+				0F99999C37AAAA0000999999 /* pas_stats.c in Sources */,
 				DD4BEC7A29CBA49700398E35 /* pas_status_reporter.c in Sources */,
 				DD4BED2329CBA49700398E35 /* pas_stream.c in Sources */,
 				DD4BEE0729CBA49700398E35 /* pas_string_stream.c in Sources */,

--- a/Source/bmalloc/libpas/libpas.xcodeproj/project.pbxproj
+++ b/Source/bmalloc/libpas/libpas.xcodeproj/project.pbxproj
@@ -365,6 +365,8 @@
 		0F99999C26AAAA0000213121 /* pas_mte_config.c in Sources */ = {isa = PBXBuildFile; fileRef = 0F99999A26AAAA0000213121 /* pas_mte_config.c */; };
 		0F99999D26AAAA0000213121 /* pas_mte_config.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F99999B26AAAA0000213121 /* pas_mte_config.h */; };
 		0F99999D26AAAA0000111111 /* pas_mte.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F99999B26AAAA0000111111 /* pas_zero_memory.h */; };
+		0F99999C26AAAA0000999999 /* pas_stats.c in Sources */ = {isa = PBXBuildFile; fileRef = 0F99999A26AAAA0000999999 /* pas_stats.c */; };
+		0F99999D26AAAA0000999999 /* pas_stats.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F99999B26AAAA0000999999 /* pas_stats.h */; };
 		0FC4EC3E234A91E300B710A3 /* pas_compute_summary_object_callbacks.c in Sources */ = {isa = PBXBuildFile; fileRef = 0FC4EC35234A91E300B710A3 /* pas_compute_summary_object_callbacks.c */; };
 		0FC4EC3F234A91E300B710A3 /* pas_fd_stream.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FC4EC36234A91E300B710A3 /* pas_fd_stream.h */; };
 		0FC4EC792351707B00B710A3 /* pas_segregated_page_emptiness_kind.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FC4EC782351707B00B710A3 /* pas_segregated_page_emptiness_kind.h */; };
@@ -1089,6 +1091,8 @@
 		0F99999A26AAAA0000213121 /* pas_mte_config.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pas_mte_config.c; sourceTree = "<group>"; };
 		0F99999B26AAAA0000213121 /* pas_mte_config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pas_mte_config.h; sourceTree = "<group>"; };
 		0F99999B26AAAA0000111111 /* pas_zero_memory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pas_zero_memory.h; sourceTree = "<group>"; };
+		0F99999A26AAAA0000999999 /* pas_stats.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pas_stats.c; sourceTree = "<group>"; };
+		0F99999B26AAAA0000999999 /* pas_stats.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pas_stats.h; sourceTree = "<group>"; };
 		0FC4EC35234A91E300B710A3 /* pas_compute_summary_object_callbacks.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pas_compute_summary_object_callbacks.c; sourceTree = "<group>"; };
 		0FC4EC36234A91E300B710A3 /* pas_fd_stream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pas_fd_stream.h; sourceTree = "<group>"; };
 		0FC4EC782351707B00B710A3 /* pas_segregated_page_emptiness_kind.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pas_segregated_page_emptiness_kind.h; sourceTree = "<group>"; };
@@ -1960,6 +1964,8 @@
 				2BE4B7CA2D2D845E0099B3C5 /* pas_small_medium_bootstrap_heap_page_provider.c */,
 				2BE4B7C92D2D845E0099B3C5 /* pas_small_medium_bootstrap_heap_page_provider.h */,
 				0FC6821721253627003C6A13 /* pas_snprintf.h */,
+				0F99999A26AAAA0000999999 /* pas_stats.c */,
+				0F99999B26AAAA0000999999 /* pas_stats.h */,
 				0FC4EC32234A91E200B710A3 /* pas_status_reporter.c */,
 				0FC4EC34234A91E200B710A3 /* pas_status_reporter.h */,
 				0FC6821621253626003C6A13 /* pas_stream.c */,
@@ -2437,6 +2443,7 @@
 				2BE4B7CB2D2D845E0099B3C5 /* pas_small_medium_bootstrap_free_heap.h in Headers */,
 				2BE4B7CC2D2D845E0099B3C5 /* pas_small_medium_bootstrap_heap_page_provider.h in Headers */,
 				0FE7EE3222960142004F4166 /* pas_snprintf.h in Headers */,
+				0F99999D26AAAA0000999999 /* pas_stats.h in Headers */,
 				0FC4EC3D234A91E300B710A3 /* pas_status_reporter.h in Headers */,
 				0FE7EE3322960142004F4166 /* pas_stream.h in Headers */,
 				0FC4EC3C234A91E300B710A3 /* pas_string_stream.h in Headers */,
@@ -2907,6 +2914,7 @@
 				2C11E88F2728A783002162D0 /* pas_simple_type.c in Sources */,
 				2BE4B7CE2D2D845E0099B3C5 /* pas_small_medium_bootstrap_free_heap.c in Sources */,
 				2BE4B7CD2D2D845E0099B3C5 /* pas_small_medium_bootstrap_heap_page_provider.c in Sources */,
+				0F99999C26AAAA0000999999 /* pas_stats.c in Sources */,
 				0FC4EC3B234A91E300B710A3 /* pas_status_reporter.c in Sources */,
 				0FE7EDD322960142004F4166 /* pas_stream.c in Sources */,
 				0FC4EC37234A91E300B710A3 /* pas_string_stream.c in Sources */,

--- a/Source/bmalloc/libpas/src/libpas/pas_allocation_mode.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_allocation_mode.h
@@ -38,7 +38,7 @@ PAS_BEGIN_EXTERN_C;
 enum pas_allocation_mode {
     /* We are allocating an object from ordinary memory and don't plan on
        compacting its address. */
-    pas_non_compact_allocation_mode,
+    pas_non_compact_allocation_mode = 0,
 
     /* We are allocating an object from ordinary memory and expect to
        be able to compact its address, but don't expect all addresses in
@@ -49,6 +49,7 @@ enum pas_allocation_mode {
        that memory are trivially compactible, like in the immortal heap. */
     pas_always_compact_allocation_mode,
 };
+#define PAS_ALLOCATION_MODE_COUNT (pas_always_compact_allocation_mode + 1)
 
 typedef enum pas_allocation_mode pas_allocation_mode;
 typedef enum pas_allocation_mode __pas_allocation_mode;

--- a/Source/bmalloc/libpas/src/libpas/pas_bitfit_page_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_bitfit_page_inlines.h
@@ -34,6 +34,7 @@
 #include "pas_mte.h"
 #include "pas_page_base_inlines.h"
 #include "pas_page_sharing_pool.h"
+#include "pas_stats.h"
 #include "pas_thread.h"
 
 PAS_BEGIN_EXTERN_C;
@@ -249,6 +250,7 @@ static PAS_ALWAYS_INLINE pas_bitfit_allocation_result pas_bitfit_page_finish_all
 
     PAS_PROFILE(BITFIT_ALLOCATION, &page_config, begin, size, allocation_mode);
     PAS_MTE_HANDLE(BITFIT_ALLOCATION, page_config, begin, size, allocation_mode);
+    PAS_RECORD_STAT_MALLOC(pas_stats_heap_type_bitfit, size);
 
     return pas_bitfit_allocation_result_create_success(begin);
 }

--- a/Source/bmalloc/libpas/src/libpas/pas_config.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_config.h
@@ -72,6 +72,10 @@
 #endif
 #define PAS_ENABLE_TESTING __PAS_ENABLE_TESTING
 
+#ifndef PAS_ENABLE_STATS
+#define PAS_ENABLE_STATS 0
+#endif
+
 #define PAS_ARM64 __PAS_ARM64
 #define PAS_ARM32 __PAS_ARM32
 

--- a/Source/bmalloc/libpas/src/libpas/pas_local_allocator_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_local_allocator_inlines.h
@@ -45,6 +45,7 @@
 #include "pas_segregated_shared_view_inlines.h"
 #include "pas_segregated_size_directory_inlines.h"
 #include "pas_segregated_view_allocator_inlines.h"
+#include "pas_stats.h"
 #include "pas_system_heap.h"
 #include "pas_thread_local_cache.h"
 #include "pas_thread_local_cache_node.h"
@@ -920,6 +921,7 @@ pas_local_allocator_try_allocate_in_primordial_partial_view(
     if (result.did_succeed) {
         PAS_PROFILE(PRIMORDIAL_BUMP_ALLOCATION, &page_config, result.begin, allocator->object_size, allocation_mode);
         PAS_MTE_HANDLE(PRIMORDIAL_BUMP_ALLOCATION, page_config, result.begin, allocator->object_size, allocation_mode);
+        PAS_RECORD_STAT_MALLOC(pas_stats_heap_type_segregated, allocator->object_size);
     }
 
     pas_lock_switch(&held_lock, NULL);
@@ -1520,6 +1522,7 @@ pas_local_allocator_try_allocate_with_free_bits(
 
     PAS_PROFILE(LOCAL_FREEBITS_ALLOCATION, &page_config, result, allocator, allocation_mode);
     PAS_MTE_HANDLE(LOCAL_FREEBITS_ALLOCATION, page_config, result, allocator, allocation_mode);
+    PAS_RECORD_STAT_MALLOC(pas_stats_heap_type_segregated, allocator->object_size);
     
     return pas_allocation_result_create_success(result);
 }
@@ -1566,6 +1569,7 @@ pas_local_allocator_try_allocate_inline_cases(pas_local_allocator* allocator,
 
         PAS_PROFILE(LOCAL_BUMP_ALLOCATION, config, allocator, result, object_size, allocation_mode);
         PAS_MTE_HANDLE(LOCAL_BUMP_ALLOCATION, config, allocator, result, object_size, allocation_mode);
+        PAS_RECORD_STAT_MALLOC(pas_stats_heap_type_segregated, object_size);
 
         return pas_allocation_result_create_success(result);
     }

--- a/Source/bmalloc/libpas/src/libpas/pas_stats.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_stats.c
@@ -1,0 +1,513 @@
+/*
+ * Copyright (c) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "pas_config.h"
+
+#if LIBPAS_ENABLED
+
+#include "pas_stats.h"
+
+#if PAS_ENABLE_STATS
+
+#if !PAS_OS(DARWIN) && !PAS_OS(LINUX)
+#error "Cannot set PAS_ENABLE_STATS on a non-POSIX system"
+#endif
+
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "pas_allocation_mode.h"
+#include "pas_heap_lock.h"
+#include "pas_immortal_heap.h"
+#include "pas_utils.h"
+
+static void pas_stats_default_sink_output(pas_stats_sink* sink, const char* json_output)
+{
+    PAS_UNUSED_PARAM(sink);
+    printf("%s\n", json_output);
+    fflush(stdout);
+}
+
+static void pas_stats_file_sink_output(pas_stats_sink* sink, const char* json_output)
+{
+    FILE* file = (FILE*)sink->context;
+    fprintf(file, "%s\n", json_output);
+    fflush(file);
+}
+
+#define INIT_FIELD(field_name, field_type, field_dumper) \
+    . field_name = { \
+        .base = { \
+            .name = #field_name, \
+            .dumper = field_dumper, \
+            .buffer = { \
+                .ptr = NULL, \
+                .length = 0, \
+            }, \
+            .enabled = true, \
+        } \
+    },
+pas_stats_data g_pas_stats_data = {
+    .log_counter = (PAS_STATS_LOG_INTERVAL - 1),
+    .start_time_ns = 0,
+    .pid = 0,
+    .log_lock = PAS_LOCK_INITIALIZER,
+    .sink = {
+        .output_func = pas_stats_default_sink_output,
+        .context = NULL,
+    },
+    .per_stat_data = {
+        PAS_STATS_FOR_EACH_COUNTER(INIT_FIELD)
+    },
+};
+#undef INIT_FIELD
+
+static uint64_t current_time_ns(void)
+{
+#if PAS_OS(DARWIN) || PAS_OS(LINUX)
+    struct timespec ts;
+    clock_gettime(CLOCK_REALTIME, &ts);
+    return ((uint64_t)ts.tv_sec * 1000000000ULL) + ts.tv_nsec;
+#else
+    return 0;
+#endif // PAS_OS(DARWIN) || PAS_OS(LINUX)
+}
+
+char* pas_stats_ensure_print_buffer(pas_stats_print_buffer* buf, size_t desired_len)
+{
+    // FIXME: find a way to use the utility heap without introducing re-entrancy concerns
+    if (buf->ptr) {
+        if (desired_len <= buf->length)
+            return buf->ptr;
+        free(buf->ptr);
+    }
+    buf->length = desired_len * 2;
+    buf->ptr = calloc(1, buf->length);
+    return buf->ptr;
+}
+
+static void pas_stats_process_stat_enablements(void)
+{
+    pas_lock_assert_held(&g_pas_stats_data.log_lock);
+
+#define DISABLE_STAT(stat_name, type, dumper) g_pas_stats_data.per_stat_data. stat_name .base.enabled = false;
+    PAS_STATS_FOR_EACH_COUNTER(DISABLE_STAT);
+#undef DISABLE_STAT
+
+    const char* env_name = "PAS_STATS_ENABLE";
+    const char* env = getenv(env_name);
+    if (!env || !*env)
+        return;
+
+    // Special case: if the setting is just '1' then enable all stats
+    // This is fine because the stat names have to be valid identifiers,
+    // and thus cannot start with a number.
+    if (env[0] == '1') {
+#define ENABLE_STAT(stat_name, type, dumper) g_pas_stats_data.per_stat_data. stat_name .base.enabled = true;
+        PAS_STATS_FOR_EACH_COUNTER(ENABLE_STAT);
+#undef ENABLE_STAT
+        return;
+    }
+
+    // We don't use strdup+strtok because we don't want to allocate memory if we don't have to,
+    // so instead we non-destructively scan the env-string in-place
+    const char* p = env;
+    for (;;) {
+        // token = [p, comma_or_nul)
+        const char* q = p;
+        while (*q && *q != ',')
+            ++q;
+
+        // trim left/right whitespace without copying
+        const char* s = p;
+        while (s < q && isspace((unsigned char)*s))
+            ++s;
+        const char* e = q;
+        while (e > s && isspace((unsigned char)e[-1]))
+            --e;
+
+        size_t len = (size_t)(e - s);
+
+        // Brute-force match against each known stat name
+        if (len) {
+            int matched = 0;
+            #define TRY_ENABLE(stat_name, type, dumper) \
+                if (!matched) { \
+                    const char* nm = #stat_name; \
+                    if ((nm[len] == '\0') && !memcmp(s, nm, len)) { \
+                        g_pas_stats_data.per_stat_data. stat_name .base.enabled = true; \
+                        matched = 1; \
+                    } \
+                }
+
+            PAS_STATS_FOR_EACH_COUNTER(TRY_ENABLE)
+            #undef TRY_ENABLE
+            if (!matched) {
+                int carat_padding = (strlen(env_name) + 1) + (int)(p - env) + 1;
+                fprintf(stderr, "error: unknown stat name in %s\n%s=%s\n%*c here\n",
+                    env_name, env_name, env, carat_padding, '^');
+            }
+            PAS_ASSERT(matched);
+        }
+
+        // now at comma_or_nul
+        if (*q == ',')
+            p = q + 1;
+        else
+            break;
+    }
+}
+
+static void pas_stats_setup_logging(void)
+{
+    pas_lock_assert_held(&g_pas_stats_data.log_lock);
+
+    // The default sink 'just works'; additional setup is only needed if
+    // the user wants to log stats to a file.
+    const char* env = getenv("PAS_STATS_LOG_FILE");
+    if (!env || !*env)
+        return;
+
+    FILE* file = fopen(env, "w");
+    PAS_ASSERT(file);
+
+    g_pas_stats_data.sink.context = (void*)file;
+    g_pas_stats_data.sink.output_func = pas_stats_file_sink_output;
+    g_pas_stats_data.pid = getpid();
+    g_pas_stats_data.start_time_ns = current_time_ns();
+}
+
+// This setup is only called the first time statistics are actually logged.
+// We use it to handle enablement via a sort of hack: all stats are enabled to
+// begin with, but the first one to accrue a counter will check envvars and
+// disable all the ones which shouldn't actually be enabled. This may lead to
+// some unecessary atomic writes at the beginning, but it avoids placing an
+// extra pthread_once check inline with every statistic, both enabled and
+// disabled.
+static void pas_stats_setup(void)
+{
+    pas_stats_process_stat_enablements();
+    pas_stats_setup_logging();
+}
+
+static void pas_stats_setup_if_necessary(void)
+{
+    static pthread_once_t once_control = PTHREAD_ONCE_INIT;
+    pthread_once(&once_control, pas_stats_setup);
+}
+
+/*
+ * Stats are logged as json; the rough schema is
+ * ```
+ * {
+ *   "pid": <INT>,
+ *   "time_ns": <INT>,
+ *   "per_stat_data": {
+ *     "<STATNAME_1>": {
+ *        ...
+ *     },
+ *     "<STATNAME_2>": {
+ *        ...
+ *     },
+ *     ...
+ *     "<STATNAME_N>": {
+ *        ...
+ *     }
+ *   }
+ * }
+ * ```
+ */
+static void pas_stats_log_all_enabled_stats(void)
+{
+    pas_lock_assert_held(&g_pas_stats_data.log_lock);
+
+    uint64_t log_time = current_time_ns() - g_pas_stats_data.start_time_ns;
+
+#define COUNT_ONE(name, type, dumper_sym) + 1
+    const unsigned pas_stats_count = 0 + PAS_STATS_FOR_EACH_COUNTER(COUNT_ONE);
+#undef COUNT_ONE
+    const char* names[pas_stats_count];
+    char* values[pas_stats_count];
+    size_t value_lens[pas_stats_count];
+    size_t n_used = 0;
+
+    // Collect enabled stats and call their dumpers
+#define COLLECT_ONE(stat_name, type, dumper_sym) \
+    do { \
+        pas_stats_stat_base* base = &g_pas_stats_data.per_stat_data. stat_name .base; \
+        if (base->dumper && base->enabled) { \
+            char* json = base->dumper((void*)&g_pas_stats_data.per_stat_data. stat_name ); \
+            if (json) { \
+                names[n_used] = base->name; \
+                values[n_used] = json; \
+                value_lens[n_used] = strlen(json); \
+                n_used++; \
+            } \
+        } \
+    } while (0);
+
+    PAS_STATS_FOR_EACH_COUNTER(COLLECT_ONE)
+#undef COLLECT_ONE
+
+    static const char* pid_header = "{\"pid\": ";
+    static const char* timing_header = ", \"time_ns\": ";
+    static const char* per_stat_header = ", \"per_stat_data\": {";
+    static const char* footer = "}}\n";
+
+    size_t total_len = 0;
+    total_len += strlen(pid_header);
+    total_len += PAS_STATS_UINT64_MAX_STRING_LEN;
+    total_len += strlen(timing_header);
+    total_len += PAS_STATS_UINT64_MAX_STRING_LEN;
+    total_len += strlen(per_stat_header);
+    total_len += strlen(footer);
+
+    for (size_t i = 0; i < n_used; i++) {
+        const char* name = names[i];
+        size_t name_len = strlen(name);
+        if (!i)
+            total_len += strlen("\"") + name_len + strlen("\": ");
+        else
+            total_len += strlen(", \"") + name_len + strlen("\": ");
+        total_len += value_lens[i];  /* value is a full JSON object string (with its own { }) */
+    }
+
+    char* out = pas_stats_ensure_print_buffer(&g_pas_stats_data.buffer, total_len + 1);
+    PAS_ASSERT(out);
+
+    /* Concatenate into the buffer */
+    char* cursor = out;
+
+    memcpy(cursor, pid_header, strlen(pid_header));
+    cursor += strlen(pid_header);
+    // +1 to account for null terminator, which we subsequently overwrite
+    snprintf(cursor, PAS_STATS_UINT64_MAX_STRING_LEN + 1, "%*llu", PAS_STATS_UINT64_MAX_STRING_LEN, g_pas_stats_data.pid);
+    cursor += PAS_STATS_UINT64_MAX_STRING_LEN;
+
+    memcpy(cursor, timing_header, strlen(timing_header));
+    cursor += strlen(timing_header);
+    // +1 to account for null terminator, which we subsequently overwrite
+    snprintf(cursor, PAS_STATS_UINT64_MAX_STRING_LEN + 1, "%*llu", PAS_STATS_UINT64_MAX_STRING_LEN, log_time);
+    cursor += PAS_STATS_UINT64_MAX_STRING_LEN;
+
+    memcpy(cursor, per_stat_header, strlen(per_stat_header));
+    cursor += strlen(per_stat_header);
+
+    for (size_t i = 0; i < n_used; i++) {
+        const char* name = names[i];
+        size_t name_len = strlen(name);
+
+        const char* prefix = !i ? " \"" : ", \"";
+        size_t prefix_len = strlen(prefix);
+        memcpy(cursor, prefix, prefix_len);
+        cursor += prefix_len;
+
+        memcpy(cursor, name, name_len);
+        cursor += name_len;
+
+        const char* after_name = "\": ";
+        size_t after_name_len = strlen(after_name);
+        memcpy(cursor, after_name, after_name_len);
+        cursor += after_name_len;
+
+        memcpy(cursor, values[i], value_lens[i]);
+        cursor += value_lens[i];
+    }
+
+    memcpy(cursor, footer, strlen(footer));
+    cursor += strlen(footer);
+
+    *cursor = '\0'; /* null-terminate */
+
+    g_pas_stats_data.sink.output_func(&g_pas_stats_data.sink, out);
+}
+
+void pas_stats_do_accounting_before_recording_stat_slow_path(void)
+{
+    pas_lock_lock(&g_pas_stats_data.log_lock);
+
+    pas_stats_setup_if_necessary();
+    // By ensuring that the write of 0 to g_pas_stats_data.log_counter is only visible iff
+    // the writes made by pas_stats_setup are, we ensure that no other code can enter
+    // pas_stats_do_accounting_before_recording_stat_slow_path (except in the unlikely case
+    // of a uint64_t overflow) without being aware of the proper logging configuration.
+    pas_store_store_fence();
+    pas_atomic_store_uint64(&g_pas_stats_data.log_counter, 0);
+
+    // But wait until after resetting the log_counter so that we don't
+    // add further, unnecessary space between log events
+    pas_stats_log_all_enabled_stats();
+
+    pas_lock_unlock(&g_pas_stats_data.log_lock);
+}
+
+static size_t pas_stats_malloc_info_bucket_idx_from_size(size_t size)
+{
+    size_t bucket_base;
+    size_t surplus_size;
+
+    if (size < PAS_STATS_MALLOC_INFO_HIGH_GRANULARITY_MAX_SIZE)
+        return size >> PAS_STATS_MALLOC_INFO_HIGH_GRANULARITY_SHIFT;
+    bucket_base = PAS_STATS_MALLOC_INFO_HIGH_GRANULARITY_BUCKETS;
+
+    if (size < PAS_STATS_MALLOC_INFO_MEDIUM_GRANULARITY_MAX_SIZE) {
+        surplus_size = size - PAS_STATS_MALLOC_INFO_HIGH_GRANULARITY_MAX_SIZE;
+        return bucket_base + (surplus_size >> PAS_STATS_MALLOC_INFO_MEDIUM_GRANULARITY_SHIFT);
+    }
+    bucket_base += PAS_STATS_MALLOC_INFO_MEDIUM_GRANULARITY_BUCKETS;
+
+    if (size < PAS_STATS_MALLOC_INFO_LOW_GRANULARITY_MAX_SIZE) {
+        surplus_size = size - PAS_STATS_MALLOC_INFO_MEDIUM_GRANULARITY_MAX_SIZE;
+        return bucket_base + (surplus_size >> PAS_STATS_MALLOC_INFO_LOW_GRANULARITY_SHIFT);
+    }
+    bucket_base += PAS_STATS_MALLOC_INFO_LOW_GRANULARITY_BUCKETS;
+
+    return bucket_base;
+}
+
+// Returns the minimum size for the bucket
+static size_t pas_stats_malloc_info_size_from_bucket_idx(size_t bucket_idx)
+{
+    const size_t high_granularity_bucket_bound = PAS_STATS_MALLOC_INFO_HIGH_GRANULARITY_BUCKETS;
+    const size_t medium_granularity_bucket_bound = high_granularity_bucket_bound
+        + PAS_STATS_MALLOC_INFO_MEDIUM_GRANULARITY_BUCKETS;
+    const size_t low_granularity_bucket_bound = medium_granularity_bucket_bound
+        + PAS_STATS_MALLOC_INFO_LOW_GRANULARITY_BUCKETS;
+
+    if (bucket_idx < high_granularity_bucket_bound)
+        return bucket_idx * PAS_STATS_MALLOC_INFO_HIGH_GRANULARITY;
+    if (bucket_idx < medium_granularity_bucket_bound)
+        return (bucket_idx - high_granularity_bucket_bound) * PAS_STATS_MALLOC_INFO_MEDIUM_GRANULARITY;
+    if (bucket_idx < low_granularity_bucket_bound)
+        return (bucket_idx - medium_granularity_bucket_bound) * PAS_STATS_MALLOC_INFO_LOW_GRANULARITY;
+    return PAS_STATS_MALLOC_INFO_LOW_GRANULARITY_MAX_SIZE;
+}
+
+void pas_stats_malloc_info_record(pas_stats_malloc_info_data* data, pas_stats_heap_type heap_type, size_t size, size_t count)
+{
+    PAS_TESTING_ASSERT(data);
+    PAS_TESTING_ASSERT(heap_type < pas_stats_heap_type_count);
+
+    size_t size_bucket_idx = pas_stats_malloc_info_bucket_idx_from_size(size);
+
+    pas_atomic_fetch_add_uint64_relaxed(&data->total_count, count);
+    pas_atomic_fetch_add_uint64_relaxed(&data->count_by_heap_type[heap_type], count);
+    pas_atomic_fetch_add_uint64_relaxed(&data->count_by_size[size_bucket_idx], count);
+}
+
+static const char* pas_stats_heap_type_to_string(pas_stats_heap_type heap_type)
+{
+    switch (heap_type) {
+    case pas_stats_heap_type_segregated:
+        return "segregated";
+    case pas_stats_heap_type_bitfit:
+        return "bitfit";
+    case pas_stats_heap_type_large:
+        return "large";
+    default:
+        return "unknown";
+    }
+}
+
+char* pas_stats_malloc_info_dump_to_json(void* stat_v)
+{
+    /*
+     * Rough schema:
+     * ```
+     * {
+     *   "total_count": <NUM>,
+     *   "count_by_heap_type": {
+     *     "segregated": <NUM>,
+     *     "bitfit": <NUM>,
+     *     "large": <NUM>,
+     *   },
+     *   "count_by_size": {
+     *     "0": <NUM>,
+     *     "16": <NUM>,
+     *     "32": <NUM>,
+     *     ...
+     *     "16773120": <NUM>,
+     *     "16777216": <NUM>
+     *   }
+     * }
+     * ```
+     */
+
+    pas_stats_malloc_info_data* stat = (pas_stats_malloc_info_data*)stat_v;
+    
+    // Each "count_by_size" entry looks like
+    // "<NUM>":<NUM>,
+    // ergo 2*sizeof(<NUM>) + strlen("":,)
+    const size_t json_bytes_per_bucket = (2 * PAS_STATS_UINT64_MAX_STRING_LEN) + 4;
+    // 1024 is a conservative overestimate of the rest: total_count, heap_type
+    // If this turns out to be wrong, then we will catch this with PAS_ASSERTs later
+    size_t bufsize = 1024 + (json_bytes_per_bucket * PAS_STATS_MALLOC_INFO_BUCKET_COUNT_PER_STAT);
+    char* buf = pas_stats_ensure_print_buffer(&stat->base.buffer, bufsize);
+
+    char* p = buf;
+    int n = snprintf(p, bufsize,
+        "{ \"name\": \"%s\", \"total_count\": %llu, \"count_by_heap_type\": {",
+        stat->base.name, (unsigned long long)stat->total_count);
+    PAS_ASSERT(n >= 0);
+    p += n;
+    bufsize -= n;
+
+    for (int i = 0; i < pas_stats_heap_type_count; i++) {
+        n = snprintf(p, bufsize, "%s\"%s\":%llu",
+            i ? ", " : "",
+            pas_stats_heap_type_to_string((pas_stats_heap_type)i),
+            (unsigned long long)stat->count_by_heap_type[i]);
+        PAS_ASSERT(n >= 0);
+        p += n;
+        bufsize -= n;
+    }
+
+    n = snprintf(p, bufsize, "}, \"count_by_size\": {");
+    PAS_ASSERT(n >= 0);
+    p += n;
+    bufsize -= n;
+
+    for (size_t i = 0; i < PAS_STATS_MALLOC_INFO_BUCKET_COUNT_PER_STAT; i++) {
+        n = snprintf(p, bufsize, "%s\"%llu\":%llu",
+            i ? "," : "",
+            (unsigned long long)pas_stats_malloc_info_size_from_bucket_idx(i),
+            (unsigned long long)stat->count_by_size[i]);
+        PAS_ASSERT(n >= 0);
+        p += n;
+        bufsize -= n;
+    }
+
+    n = snprintf(p, bufsize, "} }");
+    PAS_ASSERT(n >= 0);
+
+    return buf;
+}
+
+#endif /* PAS_ENABLE_STATS */
+#endif /* LIBPAS_ENABLED */

--- a/Source/bmalloc/libpas/src/libpas/pas_stats.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_stats.h
@@ -1,0 +1,382 @@
+/*
+ * Copyright (c) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+/*
+ * === Overview ===
+ * This is a rudimentary stat-counter collection system, intended primarily for
+ * tracking libpas-internal statistics & performance data.
+ *
+ * By default, it is disabled -- `#define PAS_ENABLE_STATS 1` will enable it at
+ * compile time.
+ * Even when compiled in, each individual metric is by default disabled at runtime.
+ * To enable one at runtime you must pass a comma-separated
+ * list of stat names to the PAS_STATS_ENABLE environment variable
+ * e.g. `PAS_STATS_ENABLE=malloc_info_bytes,malloc_info_allocations`
+ * or, to enable all stat-counters: `PAS_STATS_ENABLE=1`
+ *
+ * === Logging Stats ===
+ * Stats are logged as textual json dumps at periodic intervals,
+ * effectively producing a .jsonl file in the output. See below for a schema.
+ * Only stats which are enabled are logged.
+ *
+ * Rough json schema (prettified):
+ * ```
+ * {
+ *   "pid": <INT>,
+ *   "time_ns": <INT>,
+ *   "per_stat_data": {
+ *     "<STATNAME_1>": {
+ *        ...
+ *     },
+ *     "<STATNAME_2>": {
+ *        ...
+ *     },
+ *     ...
+ *     "<STATNAME_N>": {
+ *        ...
+ *     }
+ *   }
+ * }
+ * ```
+ *
+ * Stats are logged to a 'sink'.
+ * By default, this sink is stdout, but you can set
+ * `PAS_STATS_LOG_FILE=<filename>` to instead log to a file.
+ *
+ * === Adding New Stats ===
+ *
+ * To add a new stat counter, you need to do two things:
+ * 1) Add a new entry in PAS_STATS_FOR_EACH_COUNTER, including
+ *   - the name of the stat (e.g. `mmap_count`)
+ *   - a struct (e.g. `struct mmap_count_data`) which will be used
+ *     to store the stat counter data accumulated at runtime
+ *   - a function to dump that struct to json (e.g. mmap_count_dump_to_json)
+ * 2) Define a new macro PAS_RECORD_STATE_<name> which takes a pointer to the
+ *    data struct registered above, other arguments as necessary, and then
+ *    actually accumulates into that struct.
+ * Then go add PAS_RECORD_STAT(<name>, arg1, ..., argN); wherever in the
+ * codebase to capture into your new stat-counter.
+ *
+ * === Stat Logging Design Notes ===
+ *
+ * Since not all environments in which libpas runs have a clean 'exit' hook
+ * (e.g. Safari tends to call terminate() in order to ensure it exits quickly)
+ * this system instead logs all counters periodically, based on the total number
+ * of stat-count-events which have taken place across all threads:
+ * PAS_STATS_LOG_INTERVAL controls the rate at which this happens.
+ * The reason for not doing this in the scavenger is that the scavenger runs
+ * infrequently enough that relying on it leads to significant under-reporting
+ * of stat counter values.
+ *
+ * It would be relatively easy to add a subsidiary time-based interval check:
+ * just make sure that current_time_ns() is only called inside
+ * pas_stats_do_accounting_before_recording_stat_slow_path(), i.e. underneath
+ * the check for `new_count == PAS_STATS_LOG_INTERVAL`.
+ *
+ * Note that PAS_STATS_LOG_INTERVAL is fixed and does not depend on how many /
+ * which counters are actually enabled. If you add a counter that is not hit
+ * very often, and enable only that counter, you may not see that counterget
+ * logged during runtime. To get around this you can either A) temporarily
+ * change PAS_STATS_LOG_INTERVAL and recompile, or B) enable some other stats
+ * that are accumulated more frequently.
+ *
+ * === Implementation Notes ===
+ *
+ * In order to make the stat-collection-sites inlineable in libpas' C codebase,
+ * we use a C-style macro-for-each to enumerate the stats that are available for
+ * collection.
+ * To register a new stat-counter, you must do three things:
+ *   1. Add a new line to PAS_STATS_FOR_EACH_COUNTER with
+ *     - the name of your stat
+ *     - the struct to be used to carry its data: the first member of this
+ *       struct should be of type `pas_stats_stat_base` and named 'base'.
+ *     - a function which serializes your struct to json: this struct should not
+ *       allocate memory of its own, but instead prefer calling
+ *       `pas_stats_ensure_print_buffer` with whatever size of memory is
+ *       necessary.
+ *   2. Define a new PAS_RECORD_STAT_<statname> macro with the desired arguments
+ *     - this should call the function which actually modifies your stat-struct;
+ *       this function must handle its own synchronization.
+ *   3. Add calls to PAS_RECORD_STAT(<statname>, <args...>) to the relevant
+ *      points inside of libpas.
+ * The fact that we need #2 is somewhat undesirable (in principle we should just
+ * generate that table automatically from PAS_STATS_FOR_EACH_COUNTER) but I
+ * couldn't find a way to do so ergonomically.
+ *
+ * Since this framework is intended for use inside of an allocator, it is
+ * intended to have low overhead (both for enabled and disabled counters) and to
+ * have minimal use of heap-allocated memory -- however, there is room for
+ * improvement on both counts.
+ *   - Re.: heap-allocated memory, on the logging path we currently do rely on
+ *     heap allocations to make it easier for people to add new counters, as
+ *     using a fixed-size static allocation per counter would mean every counter
+ *     would need to pre-compute the theoretical maximum size of its json
+ *     payload.
+ *     Normally the utility heap would be a good fit for this use-case, but to
+ *     avoid reentrancy we do not use libpas to allocate this memory -- even by
+ *     going through the system heap. Instead, we call `malloc` directly. These
+ *     buffers are cached so it shouldn't happen often but it would be better to
+ *     be able to remove that dependency.
+ *   - Re.: performance, the current design is not bad but does introduce a lot
+ *     of atomic traffic and cross-core contention. Ideally, we would instead
+ *     have a per-thread 'local stat counter cache' which we would then
+ *     periodically accumulate into a global stat-counter object. Individual
+ *     stat counters would have to be aware since they need to implement their
+ *     own accumulate functions.
+ *     Even better than thread-local would be if we had something like Linux'
+ *     rseqs, as we could then store this data per-CPU and avoid any migration
+ *     whatsoever.
+ *     In both cases though, we would risk under-counting statistics unless we
+ *     implemented an analog of what pas-TLCs do where they iterate over other
+ *     threads' TLCs and collect data out. Doing so generically across all kinds
+ *     of stat counters seems like a challenge.
+ */
+
+#include "pas_config.h"
+
+#include "pas_allocation_mode.h"
+#include "pas_lock.h"
+#include "pas_internal_config.h"
+#include "pas_utils.h"
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+
+PAS_BEGIN_EXTERN_C;
+
+/**********************************/
+/* General stat-counter machinery */
+/**********************************/
+
+// Each stat-counter must provide a json dumper to serialize the stat counter
+// data to json, which can then be composed with other stats and logged to a
+// log-sink.
+typedef char* (*pas_stats_json_dump_function)(void* stat);
+
+/* Statistics sink for output */
+typedef struct pas_stats_sink pas_stats_sink;
+typedef void (*pas_stats_sink_output_func)(pas_stats_sink* sink, const char* json_output);
+
+// ptr and length are always owned by pas_stats_ensure_print_buffer, and the
+// underlying storage should be considered an implementation detail.
+typedef struct pas_stats_print_buffer {
+    char* ptr;
+    size_t length;
+} pas_stats_print_buffer;
+char* pas_stats_ensure_print_buffer(pas_stats_print_buffer*, size_t desired_len);
+
+// All stat-counter structs must have a field of this type named 'base' as
+// their first member
+typedef struct {
+    const char* name;
+    pas_stats_json_dump_function dumper;
+    pas_stats_print_buffer buffer;
+    bool enabled;
+} pas_stats_stat_base;
+
+/******************************************************************/
+/* Implementations for the individual stat-counter instantiations */
+/******************************************************************/
+
+typedef enum {
+    pas_stats_heap_type_segregated = 0,
+    pas_stats_heap_type_bitfit = 1,
+    pas_stats_heap_type_large = 2,
+
+    pas_stats_heap_type_count
+} pas_stats_heap_type;
+
+/******************************************************/
+/***** Size-bucket logic (used by multiple stats) *****/
+/******************************************************/
+
+/* 
+ * The goal here is to track some stat (# allocs, # bytes) across varying
+ * allocation-sizes. Rather than using a hashmap, we use a fixed number of
+ * buckets: this works well enough since libpas itself only allocates objects
+ * as belonging to a given size-class.
+ * Obviously extending this to 'all possible allocation sizes' would have
+ * diminishing returns, so all objects above
+ * PAS_STATS_MALLOC_INFO_LOW_GRANULARITY_MAX_SIZE just get lumped into a single
+ * bucket.
+ *
+ * Instead of using a constant bucket width for all allocations, we vary
+ * them such that smaller allocations get logged with a higher granularity.
+ * Since the libpas size-category boundaries differ from pas_heap to pas_heap, we
+ * don't attempt to use those -- instead the numbers below are intended to be a
+ * conservative superset, such that we get at least as much granularity as the
+ * actual pas size-class for a given allocation size.
+ *
+ * To justify this scheme: the naive, non-tiered approach would involve
+ * MAX_SIZE / BUCKET_SIZE =
+ * (1 << PAS_VA_BASED_ZERO_MEMORY_SHIFT) / (1 << MIN_ALIGN_SHIFT) =
+ * ((1 << 24) / (1 << 4)) * 8B = 8MiB of storage per malloc_info stat counter,
+ * which memory-wise is perhaps excusable since that price is only paid when
+ * we're building with PAS_ENABLE_STATS, but that takes a copious amount of time
+ * to log which significantly distorts the stat logging functionality.
+ *
+ * The actual sizes are technically arbitrary, but they are chosen to dominate
+ * the typical size-category boundaries used by the bmalloc_heap &c.
+ */
+// Just above the typical maximum small-object size, ~1600KB
+#define PAS_STATS_MALLOC_INFO_HIGH_GRANULARITY_MAX_SIZE   (1ull << 11)
+// 32K -- almost always the small-medium boundary
+#define PAS_STATS_MALLOC_INFO_MEDIUM_GRANULARITY_MAX_SIZE (1ull << 15)
+// Arbitrary maximum size, tuned to where we see allocation-counts drop off
+#define PAS_STATS_MALLOC_INFO_LOW_GRANULARITY_MAX_SIZE    (1ull << (PAS_VA_BASED_ZERO_MEMORY_SHIFT + 2))
+
+#define PAS_STATS_MALLOC_INFO_HIGH_GRANULARITY_SHIFT      PAS_MIN_ALIGN_SHIFT
+#define PAS_STATS_MALLOC_INFO_HIGH_GRANULARITY            (1ull << PAS_STATS_MALLOC_INFO_HIGH_GRANULARITY_SHIFT)
+#define PAS_STATS_MALLOC_INFO_HIGH_GRANULARITY_BUCKETS    (PAS_STATS_MALLOC_INFO_HIGH_GRANULARITY_MAX_SIZE / PAS_STATS_MALLOC_INFO_HIGH_GRANULARITY)
+#define PAS_STATS_MALLOC_INFO_MEDIUM_GRANULARITY_SHIFT    PAS_MIN_MEDIUM_ALIGN_SHIFT
+#define PAS_STATS_MALLOC_INFO_MEDIUM_GRANULARITY          (1ull << PAS_STATS_MALLOC_INFO_MEDIUM_GRANULARITY_SHIFT)
+#define PAS_STATS_MALLOC_INFO_MEDIUM_GRANULARITY_BUCKETS  (PAS_STATS_MALLOC_INFO_MEDIUM_GRANULARITY_MAX_SIZE / PAS_STATS_MALLOC_INFO_MEDIUM_GRANULARITY)
+#define PAS_STATS_MALLOC_INFO_LOW_GRANULARITY_SHIFT       PAS_MIN_MARGE_ALIGN_SHIFT
+#define PAS_STATS_MALLOC_INFO_LOW_GRANULARITY             (1ull << PAS_STATS_MALLOC_INFO_LOW_GRANULARITY_SHIFT)
+#define PAS_STATS_MALLOC_INFO_LOW_GRANULARITY_BUCKETS     (PAS_STATS_MALLOC_INFO_LOW_GRANULARITY_MAX_SIZE / PAS_STATS_MALLOC_INFO_LOW_GRANULARITY)
+// FIXME: handle larger sizes in a sane way -- powers of two?
+#define PAS_STATS_MALLOC_INFO_OVERSIZE_BUCKETS            (1ull)
+
+#define PAS_STATS_MALLOC_INFO_BUCKET_COUNT_PER_STAT (\
+    PAS_STATS_MALLOC_INFO_HIGH_GRANULARITY_BUCKETS + \
+    PAS_STATS_MALLOC_INFO_MEDIUM_GRANULARITY_BUCKETS + \
+    PAS_STATS_MALLOC_INFO_LOW_GRANULARITY_BUCKETS + \
+    PAS_STATS_MALLOC_INFO_OVERSIZE_BUCKETS)
+
+/****************************************/
+/***** malloc-info stat definitions *****/
+/****************************************/
+
+typedef struct {
+    pas_stats_stat_base base;
+    uint64_t total_count;
+    uint64_t count_by_heap_type[pas_stats_heap_type_count];
+    uint64_t count_by_size[PAS_STATS_MALLOC_INFO_BUCKET_COUNT_PER_STAT];
+} pas_stats_malloc_info_data;
+
+#define PAS_STATS_UINT64_MAX_STRING_LEN 20
+
+#if PAS_ENABLE_STATS
+
+PAS_API char* pas_stats_malloc_info_dump_to_json(void* stat_v);
+PAS_API void pas_stats_malloc_info_record(pas_stats_malloc_info_data* data, pas_stats_heap_type heap_type, size_t size, size_t count);
+
+// Arguments:
+//   - stat-name
+//   - struct used to store stat data
+//   - function used to dump that struct to json
+#define PAS_STATS_FOR_EACH_COUNTER(OP) \
+    OP(malloc_info_bytes, pas_stats_malloc_info_data, pas_stats_malloc_info_dump_to_json) \
+    OP(malloc_info_allocations, pas_stats_malloc_info_data, pas_stats_malloc_info_dump_to_json)
+
+// FIXME: in principle it should be possible to automatically generate this via PAS_STATS_FOR_EACH_COUNTER, somehow
+#define PAS_RECORD_STAT_malloc_info_bytes(data, heap_type, size) \
+    pas_stats_malloc_info_record(data, heap_type, size, size)
+#define PAS_RECORD_STAT_malloc_info_allocations(data, heap_type, size) \
+    pas_stats_malloc_info_record(data, heap_type, size, 1)
+
+#endif /* PAS_ENABLE_STATS */
+
+#define PAS_RECORD_STAT_MALLOC(heap_type, size) do { \
+        PAS_RECORD_STAT(malloc_info_bytes, heap_type, size); \
+        PAS_RECORD_STAT_WITHOUT_LOGGING(malloc_info_allocations, heap_type, size); \
+    } while (0)
+
+/*******************************************/
+/* Back to general stat-counter machinery  */
+/*******************************************/
+
+#if PAS_ENABLE_STATS
+PAS_API void pas_stats_do_accounting_before_recording_stat(void);
+
+// It's OK for the .enabled check here to be non-atomic: we know that all
+// .enabled bits will start initialized to true, and will be set to false at most once.
+// If a thread fails to observe that write-to-0, the consequence is that it will
+// make a few unnecessary atomic writes to some stat-counters, but those stat
+// counters will never actually be used since pas_stats_log_all_enabled_stats
+// does use an atomic check for whether .enabled is set.
+#define PAS_RECORD_STAT(name, ...) do { \
+        if (g_pas_stats_data.per_stat_data. name .base.enabled) { \
+            pas_stats_do_accounting_before_recording_stat(); \
+            PAS_RECORD_STAT_ ## name(&(g_pas_stats_data.per_stat_data. name ), __VA_ARGS__); \
+        } \
+    } while (0)
+// This version does not call any setup/logging functions so as to reduce
+// performance overhead in the case that the caller doesn't need them.
+// Since this version does not call any setup/logging functions, it should only
+// be called if you are A) ok with this stat not being logged unless other stats
+// trigger a logging pass on their own, or B) sure that this stat will only be
+// incremented after at least one other stat has called
+// pas_stats_do_accounting_before_recording_stat().
+#define PAS_RECORD_STAT_WITHOUT_LOGGING(name, ...) do { \
+        if (g_pas_stats_data.per_stat_data. name .base.enabled) { \
+            PAS_TESTING_ASSERT(g_pas_stats_data.start_time_ns); \
+            PAS_RECORD_STAT_ ## name(&(g_pas_stats_data.per_stat_data. name ), __VA_ARGS__); \
+        } \
+    } while (0)
+
+#define DECLARE_FIELD(name, type, dumper) type name;
+typedef struct {
+    PAS_STATS_FOR_EACH_COUNTER(DECLARE_FIELD)
+} pas_stats_per_stat_data;
+#undef DECLARE_FIELD
+
+struct pas_stats_sink {
+    pas_stats_sink_output_func output_func;
+    void* context;
+};
+
+typedef struct {
+    uint64_t log_counter;
+    uint64_t start_time_ns;
+    uint64_t pid;
+
+    pas_stats_print_buffer buffer;
+
+    pas_stats_sink sink;
+    pas_lock log_lock; // Guards everything except per_stat_data
+    pas_stats_per_stat_data per_stat_data;
+} pas_stats_data;
+
+PAS_API extern pas_stats_data g_pas_stats_data;
+
+#define PAS_STATS_LOG_INTERVAL (1 << 16)
+
+PAS_API void pas_stats_do_accounting_before_recording_stat_slow_path(void);
+PAS_ALWAYS_INLINE void pas_stats_do_accounting_before_recording_stat(void)
+{
+    uint64_t new_count = pas_atomic_fetch_add_uint64_relaxed(&g_pas_stats_data.log_counter, 1);
+    if (PAS_UNLIKELY(new_count == PAS_STATS_LOG_INTERVAL))
+        pas_stats_do_accounting_before_recording_stat_slow_path();
+}
+
+#else /* !PAS_ENABLE_STATS */
+#define PAS_RECORD_STAT(name, ...) do { PAS_UNUSED_V(__VA_ARGS__); } while (0)
+#define PAS_RECORD_STAT_WITHOUT_LOGGING(name, ...) do { PAS_UNUSED_V(__VA_ARGS__); } while (0)
+#endif /* PAS_ENABLE_STATS */
+
+PAS_END_EXTERN_C;

--- a/Source/bmalloc/libpas/src/libpas/pas_try_allocate_common.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_try_allocate_common.h
@@ -35,6 +35,7 @@
 #include "pas_primitive_heap_ref.h"
 #include "pas_probabilistic_guard_malloc_allocator.h"
 #include "pas_segregated_heap_inlines.h"
+#include "pas_stats.h"
 #include "pas_system_heap.h"
 #include "pas_utils.h"
 
@@ -221,6 +222,9 @@ pas_try_allocate_common_impl_slow(
 
             result = pas_large_heap_try_allocate_user_allocation(&heap->large_heap, size, alignment, allocation_mode, config.config_ptr, &transaction);
             
+            if (result.did_succeed)
+                PAS_RECORD_STAT_MALLOC(pas_stats_heap_type_large, size);
+
             pas_heap_lock_unlock();
         } while (!pas_physical_memory_transaction_end(&transaction));
         


### PR DESCRIPTION
#### 1e34af6e2696cfee789e5dfc6322e10a30718b53
<pre>
[libpas] Introduce stat-counter system for libpas
<a href="https://bugs.webkit.org/show_bug.cgi?id=299311">https://bugs.webkit.org/show_bug.cgi?id=299311</a>
<a href="https://rdar.apple.com/160953463">rdar://160953463</a>

Reviewed by Dan Hecht.

This patch adds a new stat-counter system to libpas, with the intention
of tracking allocator-internal statistics and performance data. A
motivating example is to measure how many allocations are made per
size-class for the purposes of better tuning libpas&apos; configuration
parameters-- we&apos;ve done this in the past, but it&apos;s always been ad-hoc
and thus inefficient / less trustworthy than a built-in and maintained
system would be.

By default, these are compiled out of the build, and even when built in
they include a runtime configuration option (PAS_STATS_ENABLE) which can
be set to turn some/all stat-counters on,
e.g. `PAS_STATS_ENABLE=counter_a,counter_b`, or `PAS_STATS_ENABLE=1` to
turn on all available stat counters.

By default, stats are logged to stdout (as json blobs), but setting
`PAS_STATS_LOG_FILE` will instead log them out to the specified file.
Since not all environments in which libpas runs have a clean &apos;exit&apos; hook
(e.g. Safari tends to call terminate() in order to ensure it exits
quickly) this system instead logs all counters periodically  based on
the total number of stat-count-events which have taken place across all
threads. I tried doing this in the scavenger but that doesn&apos;t work very
well since the scavenger runs infrequently enough that we end up
missing a lot of counter events near the end of a test.

A rough json schema with the current counters:
```
{
  &quot;pid&quot;: &lt;INT&gt;,
  &quot;time_ns&quot;: &lt;INT&gt;,
  &quot;per_stat_data&quot;: {
    &quot;malloc_info_allocations&quot;: {
      &quot;total_count&quot;: &lt;INT&gt;,
      &quot;count_by_heap_type&quot;: [&lt;INT&gt;, &lt;INT&gt;, &lt;INT&gt;],
      &quot;count_by_size&quot;: [&lt;INT&gt;, &lt;INT&gt;, &lt;INT&gt;, &lt;INT&gt;, ..., &lt;INT&gt;],
    },
    &quot;malloc_info_bytes&quot;: {
      &lt;SAME AS FOR malloc_info_allocations&gt;
    }
  }
}
```

This is meant to be extensible and flexible enough to handle different
kinds of stat counters; I would have preferred to do this with
C++, and did look into doing so, but the interface layer ends up being
slower and un-ergonomic so I ultimately went with C to better fit in
with the rest of libpas. This means that we use everyone&apos;s favorite
macro-for-each (PAS_STATS_FOR_EACH_COUNTER) to define new counters.
I wasn&apos;t able to find a clean way to incorporate the definition of the
PAS_RECORD_STAT_&lt;statname&gt; shims, so registering a new counter does
require changes in two places -- but they&apos;re close by so I think it&apos;s
acceptable.

Since this framework is intended for use inside of an allocator, it is
intended to have low overhead (both for enabled and disabled counters) and to
have minimal use of heap-allocated memory -- however, there is room for
improvement on both counts.

Re.: heap-allocated memory:
on the logging path we currently do rely on heap allocations to make it easier
for people to add new counters, as using a fixed-size static allocation per
counter would mean every counter would need to pre-compute the theoretical
maximum size of its json payload.
Normally the utility heap would be a good fit for this use-case, but to avoid
reentrancy we do not use libpas to allocate this memory -- even by going
through the system heap. Instead, we call `malloc` directly. These buffers are
cached so it shouldn&apos;t happen often but it would be better to be able to remove
that dependency.
That exception notwithstanding, pas_stats.h does&apos;t malloc anything anywhere else,
so if we do figure out a way to improve this then we only need to change
`pas_stats_ensure_print_buffer` to match.

Re.: performance:
the current design is not bad but does introduce a lot of atomic traffic and
cross-core contention. Ideally, we would instead have a per-thread &apos;local stat
counter cache&apos; which we would then periodically accumulate into a global
stat-counter object. Individual stat counters would have to be aware since they
need to implement their own accumulate functions.
Even better than thread-local would be if we had something like Linux&apos; rseqs,
as we could then store this data per-CPU and avoid any migration whatsoever.
In both cases though, we would risk under-counting statistics unless we
implemented an analog of what pas-TLCs do where they iterate over other
threads&apos; TLCs and collect data out. Doing so generically across all kinds of
stat counters seems like a challenge.

Canonical link: <a href="https://commits.webkit.org/304490@main">https://commits.webkit.org/304490@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c13979fd666217c431f419311c1aa919fe2c7263

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135744 "13 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8120 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47037 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143458 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/87378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/612d1b11-98cd-4ff0-bdb7-acd1a9fcd6f2) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8777 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7967 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/103737 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/87378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c43389f6-ce4e-458d-b7b8-dfe90b1c4013) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138690 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/6325 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/121675 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84613 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c9975815-815a-49e0-a718-0b72a5c2492f) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/6081 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/3696 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4064 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/127726 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/115308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/39862 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146207 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/134227 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7809 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/40430 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/112099 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7835 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/6553 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112480 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28533 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/5952 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/117975 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/61744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7855 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/36083 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/167048 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/7592 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/43610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7816 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/7689 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->