### PR TITLE
`window.load` event is not dispatched when same-document navigation is pending before finish parsing.

### DIFF
--- a/LayoutTests/http/wpt/dom/window-load-location-change-same-document-expected.txt
+++ b/LayoutTests/http/wpt/dom/window-load-location-change-same-document-expected.txt
@@ -1,0 +1,3 @@
+
+PASS window.load event should be fired with pending same-document navigation
+

--- a/LayoutTests/http/wpt/dom/window-load-location-change-same-document.html
+++ b/LayoutTests/http/wpt/dom/window-load-location-change-same-document.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+async_test(t => {
+  assert_equals(document.readyState, "loading");
+
+  history.pushState(1, "", "#1");
+  history.back();
+
+  window.onpopstate = t.step_func_done(() => {
+    assert_equals(document.readyState, "complete");
+  });
+}, "window.load event should be fired with pending same-document navigation");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-when-inactive-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-when-inactive-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
 PASS A non-active entry in navigation.entries() should not be modified when a different entry is modified
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/key-id-back-same-document-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/key-id-back-same-document-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
 PASS NavigationHistoryEntry's key and id on same-document back navigation
 


### PR DESCRIPTION
#### 988937f5384f41891af3c6e9b3c01dd845847016
<pre>
`window.load` event is not dispatched when same-document navigation is pending before finish parsing.
<a href="https://bugs.webkit.org/show_bug.cgi?id=299317">https://bugs.webkit.org/show_bug.cgi?id=299317</a>
<a href="https://rdar.apple.com/161101550">rdar://161101550</a>

Reviewed by Alex Christensen.

Document::implicitClose() won&apos;t call dispatchWindowLoadEvent() if location change is pending. If the
navigation is same-document, this behavior is wrong. Additonal check is required in NavigationScheduler::
locationChangePending() to ensure the pending navigation is not same-document navigation.

NavigationScheduler::locationChangePending() is also used from HTMLDocumentParser::pumpTokenizerLoop()
and this change works well with this method that same-document navigation should not stop parsing.

Test: http/wpt/dom/window-load-location-change-same-document.html

Test: http/wpt/dom/window-load-location-change-same-document.html
* LayoutTests/http/wpt/dom/window-load-location-change-same-document-expected.txt: Added.
* LayoutTests/http/wpt/dom/window-load-location-change-same-document.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-when-inactive-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/key-id-back-same-document-expected.txt:
* Source/WebCore/loader/NavigationScheduler.cpp:
(WebCore::ScheduledNavigation::isSameDocumentNavigation const):
(WebCore::ScheduledHistoryNavigationByKey::findBackForwardItemByKey const): Added const.
(WebCore::NavigationScheduler::locationChangePending):
(WebCore::ScheduledHistoryNavigationByKey::findBackForwardItemByKey): Deleted.

Canonical link: <a href="https://commits.webkit.org/300583@main">https://commits.webkit.org/300583@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ff645e2f0bff822041437f4d45689aa50a6c9688

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122730 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42442 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33132 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/129351 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74834 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/945acb05-2bcc-4904-9d4c-957f2faf0a61) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/124606 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43161 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51035 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93272 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61927 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0abca4d2-1554-454a-88a1-925ff0f5e6fb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125682 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34411 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109869 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73913 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33399 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28024 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72838 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104111 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28237 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132079 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49675 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37811 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101795 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50052 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106084 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101663 "Found 1 new API test failure: TestWTF:CompletionHandlerDeathTest.ConstructionThreadHandlerOnThreadAssertsDeathTest (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25919 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47043 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25217 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/46445 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49532 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/55285 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48999 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/52351 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50682 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->