### PR TITLE
[GFC] Start computing track sizing functions after item placement.

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/GridLayout.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayout.h
@@ -26,9 +26,14 @@
 #pragma once
 
 #include "GridFormattingContext.h"
+#include "StyleGridTrackBreadth.h"
 
 namespace WebCore {
 class RenderStyle;
+
+namespace Style {
+struct GridTrackSize;
+};
 
 namespace Layout {
 
@@ -42,8 +47,16 @@ public:
 
     void layout(GridFormattingContext::GridLayoutConstraints, const UnplacedGridItems&);
 private:
+    struct TrackSizingFunctions {
+        Style::GridTrackBreadth min { CSS::Keyword::Auto { } };
+        Style::GridTrackBreadth max { CSS::Keyword::Auto { } };
+    };
     using PlacedGridItems = Vector<PlacedGridItem>;
-    static PlacedGridItems placeGridItems(const UnplacedGridItems&, size_t gridTemplateColumnsTracksCount, size_t gridTemplateRowsTracksCount);
+    using TrackSizingFunctionsList = Vector<TrackSizingFunctions>;
+
+    static auto placeGridItems(const UnplacedGridItems&, const Vector<Style::GridTrackSize>& gridTemplateColumnsTrackSizes,
+        const Vector<Style::GridTrackSize>& gridTemplateRowsTrackSizes);
+    static TrackSizingFunctionsList trackSizingFunctions(size_t implicitGridTracksCount, const Vector<Style::GridTrackSize> gridTemplateTrackSizes);
 
     const ElementBox& gridContainer() const;
     const RenderStyle& gridContainerStyle() const;


### PR DESCRIPTION
#### 6697395633a25d708d2050ec34e2ea32fce69222
<pre>
[GFC] Start computing track sizing functions after item placement.
<a href="https://bugs.webkit.org/show_bug.cgi?id=299320">https://bugs.webkit.org/show_bug.cgi?id=299320</a>
<a href="https://rdar.apple.com/problem/161121985">rdar://problem/161121985</a>

Reviewed by Alan Baradlay.

In preparation for the initial implementation of track sizing, we will
need to compute the track sizing functions after item placement has
occurred. This is because the track sizing functions, along with the
placed items, are needed to perform track sizing. To accomplish this, this
patch does two main things:

1.) Return the number of columns and rows in the implicit grid from
placeGridItems(). placeGridItems will resize the ImplicitGrid as item
placement occurs, so this feels like a natural place to return the
dimensions of the grid as well rather than returning the ImplicitGrid
itself.

2.) Provide the initial code that maps each track to its corresponding
track sizing functions as described in:
<a href="https://drafts.csswg.org/css-grid-1/#algo-terms">https://drafts.csswg.org/css-grid-1/#algo-terms</a>

This is a mostly straightforward mapping from spec text to code, but I
decided not to implement the fit-content case for the max track sizing
function just for simplicity.

Canonical link: <a href="https://commits.webkit.org/300417@main">https://commits.webkit.org/300417@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a1e44d4eb3e12c07357ae5df685831d2d1bb330

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122441 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42149 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32834 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/129038 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74540 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/49c1499a-51b5-44a9-aef3-10f6dced3526) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/124317 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42867 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50740 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93068 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/61820 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9a3eaa8e-8400-4ad1-a4f2-39cf491dcb5c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125393 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34192 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109637 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73721 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bba9e733-ed1f-4b77-b372-af6bcdb547b7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33181 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27794 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72526 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103831 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28005 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131769 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49382 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37583 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101612 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49756 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105858 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101481 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25760 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46858 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25000 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/46147 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49240 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54985 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48707 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/52057 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50389 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->