### PR TITLE
[Style] Add standalone strong style type for SVG marker-* properties

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -3393,6 +3393,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     style/values/svg/StyleSVGBaselineShift.h
     style/values/svg/StyleSVGCenterCoordinateComponent.h
     style/values/svg/StyleSVGCoordinateComponent.h
+    style/values/svg/StyleSVGMarkerResource.h
     style/values/svg/StyleSVGPaint.h
     style/values/svg/StyleSVGPathData.h
     style/values/svg/StyleSVGRadius.h

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -5462,8 +5462,7 @@
                 "none"
             ],
             "codegen-properties": {
-                "render-style-name-for-methods": "MarkerEndResource",
-                "style-converter": "SVGURIReference",
+                "style-converter": "StyleType<SVGMarkerResource>",
                 "svg": true,
                 "parser-grammar": "none | <marker-ref>"
             },
@@ -5480,8 +5479,7 @@
                 "none"
             ],
             "codegen-properties": {
-                "render-style-name-for-methods": "MarkerMidResource",
-                "style-converter": "SVGURIReference",
+                "style-converter": "StyleType<SVGMarkerResource>",
                 "svg": true,
                 "parser-grammar": "none | <marker-ref>"
             },
@@ -5498,8 +5496,7 @@
                 "none"
             ],
             "codegen-properties": {
-                "render-style-name-for-methods": "MarkerStartResource",
-                "style-converter": "SVGURIReference",
+                "style-converter": "StyleType<SVGMarkerResource>",
                 "svg": true,
                 "parser-grammar": "none | <marker-ref>"
             },

--- a/Source/WebCore/rendering/ReferencedSVGResources.cpp
+++ b/Source/WebCore/rendering/ReferencedSVGResources.cpp
@@ -141,11 +141,8 @@ ReferencedSVGResources::SVGElementIdentifierAndTagPairs ReferencedSVGResources::
 
     if (style.hasPositionedMask()) {
         // FIXME: We should support all the values in the CSS mask property, but for now just use the first mask-image if it's a reference.
-        RefPtr maskImage = style.maskLayers().first().image().tryStyleImage();
-        auto maskImageURL = maskImage ? maskImage->url() : Style::URL::none();
-
-        if (!maskImageURL.isNone()) {
-            auto resourceID = SVGURIReference::fragmentIdentifierFromIRIString(maskImageURL, document);
+        if (RefPtr maskImage = style.maskLayers().first().image().tryStyleImage()) {
+            auto resourceID = SVGURIReference::fragmentIdentifierFromIRIString(maskImage->url(), document);
             if (!resourceID.isEmpty())
                 referencedResources.append({ resourceID, { SVGNames::maskTag } });
         }
@@ -153,19 +150,19 @@ ReferencedSVGResources::SVGElementIdentifierAndTagPairs ReferencedSVGResources::
 
     const auto& svgStyle = style.svgStyle();
     if (svgStyle.hasMarkers()) {
-        if (auto markerStartResource = svgStyle.markerStartResource(); !markerStartResource.isNone()) {
+        if (auto markerStartResource = svgStyle.markerStart(); !markerStartResource.isNone()) {
             auto resourceID = SVGURIReference::fragmentIdentifierFromIRIString(markerStartResource, document);
             if (!resourceID.isEmpty())
                 referencedResources.append({ resourceID, { SVGNames::markerTag } });
         }
 
-        if (auto markerMidResource = svgStyle.markerMidResource(); !markerMidResource.isNone()) {
+        if (auto markerMidResource = svgStyle.markerMid(); !markerMidResource.isNone()) {
             auto resourceID = SVGURIReference::fragmentIdentifierFromIRIString(markerMidResource, document);
             if (!resourceID.isEmpty())
                 referencedResources.append({ resourceID, { SVGNames::markerTag } });
         }
 
-        if (auto markerEndResource = svgStyle.markerEndResource(); !markerEndResource.isNone()) {
+        if (auto markerEndResource = svgStyle.markerEnd(); !markerEndResource.isNone()) {
             auto resourceID = SVGURIReference::fragmentIdentifierFromIRIString(markerEndResource, document);
             if (!resourceID.isEmpty())
                 referencedResources.append({ resourceID, { SVGNames::markerTag } });

--- a/Source/WebCore/rendering/RenderLayerModelObject.h
+++ b/Source/WebCore/rendering/RenderLayerModelObject.h
@@ -40,7 +40,7 @@ class RenderSVGResourcePaintServer;
 class SVGGraphicsElement;
 
 namespace Style {
-struct URL;
+struct SVGMarkerResource;
 }
 
 class RenderLayerModelObject : public RenderElement {
@@ -138,7 +138,7 @@ protected:
     virtual void updateFromStyle() { }
 
 private:
-    RenderSVGResourceMarker* svgMarkerResourceFromStyle(const Style::URL& markerResource) const;
+    RenderSVGResourceMarker* svgMarkerResourceFromStyle(const Style::SVGMarkerResource&) const;
 
     std::unique_ptr<RenderLayer> m_layer;
 

--- a/Source/WebCore/rendering/style/SVGRenderStyle.h
+++ b/Source/WebCore/rendering/style/SVGRenderStyle.h
@@ -90,9 +90,9 @@ public:
     static constexpr Style::Opacity initialFloodOpacity();
     static Style::Color initialFloodColor() { return Color::black; }
     static Style::Color initialLightingColor() { return Color::white; }
-    static Style::URL initialMarkerStartResource() { return Style::URL::none(); }
-    static Style::URL initialMarkerMidResource() { return Style::URL::none(); }
-    static Style::URL initialMarkerEndResource() { return Style::URL::none(); }
+    static Style::SVGMarkerResource initialMarkerStart() { return CSS::Keyword::None { }; }
+    static Style::SVGMarkerResource initialMarkerMid() { return CSS::Keyword::None { }; }
+    static Style::SVGMarkerResource initialMarkerEnd() { return CSS::Keyword::None { }; }
     static MaskType initialMaskType() { return MaskType::Luminance; }
     static Style::SVGBaselineShift initialBaselineShift() { return CSS::Keyword::Baseline { }; }
 
@@ -135,9 +135,9 @@ public:
     void setBaselineShift(Style::SVGBaselineShift&&);
 
     // Setters for inherited resources
-    void setMarkerStartResource(Style::URL&&);
-    void setMarkerMidResource(Style::URL&&);
-    void setMarkerEndResource(Style::URL&&);
+    void setMarkerStart(Style::SVGMarkerResource&&);
+    void setMarkerMid(Style::SVGMarkerResource&&);
+    void setMarkerEnd(Style::SVGMarkerResource&&);
 
     // Read accessors for all the properties
     AlignmentBaseline alignmentBaseline() const { return static_cast<AlignmentBaseline>(m_nonInheritedFlags.flagBits.alignmentBaseline); }
@@ -172,15 +172,15 @@ public:
     const Style::SVGCoordinateComponent& x() const { return m_layoutData->x; }
     const Style::SVGCoordinateComponent& y() const { return m_layoutData->y; }
     const Style::SVGPathData& d() const { return m_layoutData->d; }
-    const Style::URL& markerStartResource() const { return m_inheritedResourceData->markerStart; }
-    const Style::URL& markerMidResource() const { return m_inheritedResourceData->markerMid; }
-    const Style::URL& markerEndResource() const { return m_inheritedResourceData->markerEnd; }
+    const Style::SVGMarkerResource& markerStart() const { return m_inheritedResourceData->markerStart; }
+    const Style::SVGMarkerResource& markerMid() const { return m_inheritedResourceData->markerMid; }
+    const Style::SVGMarkerResource& markerEnd() const { return m_inheritedResourceData->markerEnd; }
     MaskType maskType() const { return static_cast<MaskType>(m_nonInheritedFlags.flagBits.maskType); }
     const Style::SVGPaint& visitedLinkFill() const { return m_fillData->visitedLinkPaint; }
     const Style::SVGPaint& visitedLinkStroke() const { return m_strokeData->visitedLinkPaint; }
 
     // convenience
-    bool hasMarkers() const { return !markerStartResource().isNone() || !markerMidResource().isNone() || !markerEndResource().isNone(); }
+    bool hasMarkers() const { return !markerStart().isNone() || !markerMid().isNone() || !markerEnd().isNone(); }
     bool hasStroke() const { return !stroke().isNone(); }
     bool hasFill() const { return !fill().isNone(); }
 
@@ -450,19 +450,19 @@ inline void SVGRenderStyle::setBaselineShift(Style::SVGBaselineShift&& baselineS
         m_miscData.access().baselineShift = WTFMove(baselineShift);
 }
 
-inline void SVGRenderStyle::setMarkerStartResource(Style::URL&& resource)
+inline void SVGRenderStyle::setMarkerStart(Style::SVGMarkerResource&& resource)
 {
     if (!(m_inheritedResourceData->markerStart == resource))
         m_inheritedResourceData.access().markerStart = WTFMove(resource);
 }
 
-inline void SVGRenderStyle::setMarkerMidResource(Style::URL&& resource)
+inline void SVGRenderStyle::setMarkerMid(Style::SVGMarkerResource&& resource)
 {
     if (!(m_inheritedResourceData->markerMid == resource))
         m_inheritedResourceData.access().markerMid = WTFMove(resource);
 }
 
-inline void SVGRenderStyle::setMarkerEndResource(Style::URL&& resource)
+inline void SVGRenderStyle::setMarkerEnd(Style::SVGMarkerResource&& resource)
 {
     if (!(m_inheritedResourceData->markerEnd == resource))
         m_inheritedResourceData.access().markerEnd = WTFMove(resource);

--- a/Source/WebCore/rendering/style/SVGRenderStyleDefs.cpp
+++ b/Source/WebCore/rendering/style/SVGRenderStyleDefs.cpp
@@ -231,9 +231,9 @@ void StyleShadowSVGData::dumpDifferences(TextStream& ts, const StyleShadowSVGDat
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleInheritedResourceData);
 
 StyleInheritedResourceData::StyleInheritedResourceData()
-    : markerStart(SVGRenderStyle::initialMarkerStartResource())
-    , markerMid(SVGRenderStyle::initialMarkerMidResource())
-    , markerEnd(SVGRenderStyle::initialMarkerEndResource())
+    : markerStart(SVGRenderStyle::initialMarkerStart())
+    , markerMid(SVGRenderStyle::initialMarkerMid())
+    , markerEnd(SVGRenderStyle::initialMarkerEnd())
 {
 }
 

--- a/Source/WebCore/rendering/style/SVGRenderStyleDefs.h
+++ b/Source/WebCore/rendering/style/SVGRenderStyleDefs.h
@@ -37,13 +37,13 @@
 #include <WebCore/StyleSVGBaselineShift.h>
 #include <WebCore/StyleSVGCenterCoordinateComponent.h>
 #include <WebCore/StyleSVGCoordinateComponent.h>
+#include <WebCore/StyleSVGMarkerResource.h>
 #include <WebCore/StyleSVGPaint.h>
 #include <WebCore/StyleSVGPathData.h>
 #include <WebCore/StyleSVGRadius.h>
 #include <WebCore/StyleSVGRadiusComponent.h>
 #include <WebCore/StyleSVGStrokeDasharray.h>
 #include <WebCore/StyleSVGStrokeDashoffset.h>
-#include <WebCore/StyleURL.h>
 #include <wtf/FixedVector.h>
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
@@ -262,9 +262,9 @@ public:
     void dumpDifferences(TextStream&, const StyleInheritedResourceData&) const;
 #endif
 
-    Style::URL markerStart;
-    Style::URL markerMid;
-    Style::URL markerEnd;
+    Style::SVGMarkerResource markerStart;
+    Style::SVGMarkerResource markerMid;
+    Style::SVGMarkerResource markerEnd;
 
 private:
     StyleInheritedResourceData();

--- a/Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp
@@ -259,7 +259,7 @@ void writeSVGPaintingFeatures(TextStream& ts, const RenderElement& renderer, Opt
         writeIfNotDefault(ts, "clip rule"_s, svgStyle->clipRule(), WindRule::NonZero);
     }
 
-    auto writeMarker = [&](ASCIILiteral name, const Style::URL& value) {
+    auto writeMarker = [&](ASCIILiteral name, const Style::SVGMarkerResource& value) {
         auto* element = renderer.element();
         if (!element)
             return;
@@ -268,9 +268,9 @@ void writeSVGPaintingFeatures(TextStream& ts, const RenderElement& renderer, Opt
         writeIfNotEmpty(ts, name, fragment);
     };
 
-    writeMarker("start marker"_s, svgStyle->markerStartResource());
-    writeMarker("middle marker"_s, svgStyle->markerMidResource());
-    writeMarker("end marker"_s, svgStyle->markerEndResource());
+    writeMarker("start marker"_s, svgStyle->markerStart());
+    writeMarker("middle marker"_s, svgStyle->markerMid());
+    writeMarker("end marker"_s, svgStyle->markerEnd());
 }
 
 static TextStream& writePositionAndStyle(TextStream& ts, const RenderElement& renderer, OptionSet<RenderAsTextFlag> behavior = { })
@@ -584,12 +584,9 @@ void writeResources(TextStream& ts, const RenderObject& renderer, OptionSet<Rend
     // FIXME: We want to use SVGResourcesCache to determine which resources are present, instead of quering the resource <-> id cache.
     // For now leave the DRT output as is, but later on we should change this so cycles are properly ignored in the DRT output.
     if (style.hasPositionedMask()) {
-        RefPtr maskImage = style.maskLayers().first().image().tryStyleImage();
-        auto maskImageURL = maskImage ? maskImage->url() : Style::URL::none();
-
-        if (!maskImageURL.isNone()) {
+        if (RefPtr maskImage = style.maskLayers().first().image().tryStyleImage()) {
             Ref document = renderer.document();
-            auto resourceID = SVGURIReference::fragmentIdentifierFromIRIString(maskImageURL, document);
+            auto resourceID = SVGURIReference::fragmentIdentifierFromIRIString(maskImage->url(), document);
             if (auto* masker = getRenderSVGResourceById<LegacyRenderSVGResourceMasker>(renderer.treeScopeForSVGReferences(), resourceID)) {
                 ts << indent << ' ';
                 writeNameAndQuotedValue(ts, "masker"_s, resourceID);

--- a/Source/WebCore/rendering/svg/legacy/SVGResources.cpp
+++ b/Source/WebCore/rendering/svg/legacy/SVGResources.cpp
@@ -258,11 +258,8 @@ std::unique_ptr<SVGResources> SVGResources::buildCachedResources(const RenderEle
 
         if (style.hasPositionedMask()) {
             // FIXME: We should support all the values in the CSS mask property, but for now just use the first mask-image if it's a reference.
-            RefPtr maskImage = style.maskLayers().first().image().tryStyleImage();
-            auto maskImageURL = maskImage ? maskImage->url() : Style::URL::none();
-
-            if (!maskImageURL.isNone()) {
-                auto resourceID = SVGURIReference::fragmentIdentifierFromIRIString(maskImageURL, document);
+            if (RefPtr maskImage = style.maskLayers().first().image().tryStyleImage()) {
+                auto resourceID = SVGURIReference::fragmentIdentifierFromIRIString(maskImage->url(), document);
                 if (auto* masker = getRenderSVGResourceById<LegacyRenderSVGResourceMasker>(treeScope, resourceID))
                     ensureResources(foundResources).setMasker(masker);
                 else
@@ -272,16 +269,16 @@ std::unique_ptr<SVGResources> SVGResources::buildCachedResources(const RenderEle
     }
 
     if (markerTags().contains(tagName) && svgStyle.hasMarkers()) {
-        auto buildCachedMarkerResource = [&](const Style::URL& markerResource, bool (SVGResources::*setMarker)(LegacyRenderSVGResourceMarker*)) {
+        auto buildCachedMarkerResource = [&](const Style::SVGMarkerResource& markerResource, bool (SVGResources::*setMarker)(LegacyRenderSVGResourceMarker*)) {
             auto markerId = SVGURIReference::fragmentIdentifierFromIRIString(markerResource, document);
             if (auto* marker = getRenderSVGResourceById<LegacyRenderSVGResourceMarker>(treeScope, markerId))
                 (ensureResources(foundResources).*setMarker)(marker);
             else
                 treeScope->addPendingSVGResource(markerId, element);
         };
-        buildCachedMarkerResource(svgStyle.markerStartResource(), &SVGResources::setMarkerStart);
-        buildCachedMarkerResource(svgStyle.markerMidResource(), &SVGResources::setMarkerMid);
-        buildCachedMarkerResource(svgStyle.markerEndResource(), &SVGResources::setMarkerEnd);
+        buildCachedMarkerResource(svgStyle.markerStart(), &SVGResources::setMarkerStart);
+        buildCachedMarkerResource(svgStyle.markerMid(), &SVGResources::setMarkerMid);
+        buildCachedMarkerResource(svgStyle.markerEnd(), &SVGResources::setMarkerEnd);
     }
 
     if (fillAndStrokeTags().contains(tagName)) {

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -147,7 +147,6 @@ public:
     static FontFeatureSettings convertFontFeatureSettings(BuilderState&, const CSSValue&);
     static FontVariationSettings convertFontVariationSettings(BuilderState&, const CSSValue&);
     static PaintOrder convertPaintOrder(BuilderState&, const CSSValue&);
-    static URL convertSVGURIReference(BuilderState&, const CSSValue&);
     static StyleSelfAlignmentData convertSelfOrDefaultAlignmentData(BuilderState&, const CSSValue&);
     static StyleContentAlignmentData convertContentAlignmentData(BuilderState&, const CSSValue&);
     static GlyphOrientation convertGlyphOrientation(BuilderState&, const CSSValue&);
@@ -655,19 +654,6 @@ inline PaintOrder BuilderConverter::convertPaintOrder(BuilderState& builderState
         ASSERT_NOT_REACHED();
         return PaintOrder::Normal;
     }
-}
-
-inline URL BuilderConverter::convertSVGURIReference(BuilderState& builderState, const CSSValue& value)
-{
-    if (auto url = dynamicDowncast<CSSURLValue>(value))
-        return toStyle(url->url(), builderState);
-
-    auto* primitiveValue = requiredDowncast<CSSPrimitiveValue>(builderState, value);
-    if (!primitiveValue)
-        return URL::none();
-
-    ASSERT(primitiveValue->valueID() == CSSValueNone);
-    return URL::none();
 }
 
 // Get the "opposite" ItemPosition to the provided ItemPosition.

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -129,6 +129,7 @@ inline PositionY forwardInheritedValue(const PositionY& value) { auto copy = val
 inline SVGBaselineShift forwardInheritedValue(const SVGBaselineShift& value) { auto copy = value; return copy; }
 inline SVGCenterCoordinateComponent forwardInheritedValue(const SVGCenterCoordinateComponent& value) { auto copy = value; return copy; }
 inline SVGCoordinateComponent forwardInheritedValue(const SVGCoordinateComponent& value) { auto copy = value; return copy; }
+inline SVGMarkerResource forwardInheritedValue(const SVGMarkerResource& value) { auto copy = value; return copy; }
 inline SVGPathData forwardInheritedValue(const SVGPathData& value) { auto copy = value; return copy; }
 inline SVGPaint forwardInheritedValue(const SVGPaint& value) { auto copy = value; return copy; }
 inline SVGRadius forwardInheritedValue(const SVGRadius& value) { auto copy = value; return copy; }

--- a/Source/WebCore/style/StyleExtractorConverter.h
+++ b/Source/WebCore/style/StyleExtractorConverter.h
@@ -133,10 +133,6 @@ public:
 
     template<CSSValueID> static Ref<CSSPrimitiveValue> convertCustomIdentAtomOrKeyword(ExtractorState&, const AtomString&);
 
-    // MARK: SVG conversions
-
-    static Ref<CSSValue> convertSVGURIReference(ExtractorState&, const URL&);
-
     // MARK: Transform conversions
 
     static Ref<CSSValue> convertTransformationMatrix(ExtractorState&, const TransformationMatrix&);
@@ -275,15 +271,6 @@ template<CSSValueID keyword> Ref<CSSPrimitiveValue> ExtractorConverter::convertC
     if (string.isNull())
         return CSSPrimitiveValue::create(keyword);
     return CSSPrimitiveValue::createCustomIdent(string);
-}
-
-// MARK: - SVG conversions
-
-inline Ref<CSSValue> ExtractorConverter::convertSVGURIReference(ExtractorState& state, const URL& marker)
-{
-    if (marker.isNone())
-        return CSSPrimitiveValue::create(CSSValueNone);
-    return CSSURLValue::create(toCSS(marker, state.style));
 }
 
 // MARK: - Transform conversions

--- a/Source/WebCore/style/StyleExtractorSerializer.h
+++ b/Source/WebCore/style/StyleExtractorSerializer.h
@@ -64,10 +64,6 @@ public:
 
     template<CSSValueID> static void serializeCustomIdentAtomOrKeyword(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const AtomString&);
 
-    // MARK: SVG serializations
-
-    static void serializeSVGURIReference(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const URL&);
-
     // MARK: Transform serializations
 
     static void serializeTransformationMatrix(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const TransformationMatrix&);
@@ -254,18 +250,6 @@ template<CSSValueID keyword> void ExtractorSerializer::serializeCustomIdentAtomO
     }
 
     serializationForCSS(builder, context, state.style, CustomIdentifier { string });
-}
-
-// MARK: - SVG serializations
-
-inline void ExtractorSerializer::serializeSVGURIReference(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, const URL& marker)
-{
-    if (marker.isNone()) {
-        serializationForCSS(builder, context, state.style, CSS::Keyword::None { });
-        return;
-    }
-
-    serializationForCSS(builder, context, state.style, marker);
 }
 
 // MARK: - Transform serializations

--- a/Source/WebCore/style/values/primitives/StyleURL.cpp
+++ b/Source/WebCore/style/values/primitives/StyleURL.cpp
@@ -85,6 +85,13 @@ Ref<CSSValue> CSSValueCreation<URL>::operator()(CSSValuePool&, const RenderStyle
     return CSSURLValue::create(toCSS(value, style));
 }
 
+auto CSSValueConversion<URL>::operator()(BuilderState& state, const CSSValue& value) -> URL
+{
+    if (auto url = requiredDowncast<CSSURLValue>(state, value))
+        return toStyle(url->url(), state);
+    return { .resolved = WTF::URL { emptyString() }, .modifiers = { } };
+}
+
 // MARK: - Serialization
 
 void Serialize<URL>::operator()(StringBuilder& builder, const CSS::SerializationContext& context, const RenderStyle& style, const URL& value)

--- a/Source/WebCore/style/values/primitives/StyleURL.h
+++ b/Source/WebCore/style/values/primitives/StyleURL.h
@@ -37,9 +37,6 @@ struct URL {
     WTF::URL resolved;
     CSS::URLModifiers modifiers;
 
-    static URL none() { return { .resolved = { }, .modifiers = { } }; }
-    bool isNone() const { return resolved.isNull(); }
-
     bool operator==(const URL&) const = default;
 };
 
@@ -61,6 +58,7 @@ template<> struct ToStyle<CSS::URL> { auto operator()(const CSS::URL&, const Bui
 
 // `URL` is special-cased to return a `CSSURLValue`.
 template<> struct CSSValueCreation<URL> { Ref<CSSValue> operator()(CSSValuePool&, const RenderStyle&, const URL&); };
+template<> struct CSSValueConversion<URL> { auto operator()(BuilderState&, const CSSValue&) -> URL; };
 
 // MARK: Serialization
 
@@ -72,5 +70,15 @@ TextStream& operator<<(TextStream&, const URL&);
 
 } // namespace Style
 } // namespace WebCore
+
+namespace WTF {
+
+template<>
+struct MarkableTraits<WebCore::Style::URL> {
+    static bool isEmptyValue(const WebCore::Style::URL& value) { return value.resolved.isNull(); }
+    static WebCore::Style::URL emptyValue() { return { .resolved = { }, .modifiers = { } }; }
+};
+
+} // namespace WTF
 
 DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::Style::URL, 2)

--- a/Source/WebCore/style/values/svg/StyleSVGMarkerResource.h
+++ b/Source/WebCore/style/values/svg/StyleSVGMarkerResource.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/StyleURL.h>
+
+namespace WebCore {
+namespace Style {
+
+// <paint> = none | <url>
+// NOTE: `context-fill` and `context-stroke` are not implemented.
+// https://svgwg.org/svg2-draft/painting.html#SpecifyingPaint
+struct SVGMarkerResource : ValueOrKeyword<URL, CSS::Keyword::None> {
+    using Base::Base;
+
+    bool isNone() const { return isKeyword(); }
+    bool isURL() const { return isValue(); }
+    std::optional<URL> tryURL() const { return tryValue(); }
+};
+
+} // namespace Style
+} // namespace WebCore
+
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::SVGMarkerResource)

--- a/Source/WebCore/svg/SVGURIReference.cpp
+++ b/Source/WebCore/svg/SVGURIReference.cpp
@@ -27,6 +27,7 @@
 #include "SVGElement.h"
 #include "SVGElementTypeHelpers.h"
 #include "SVGUseElement.h"
+#include "StyleSVGMarkerResource.h"
 #include "XLinkNames.h"
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/URL.h>
@@ -85,6 +86,13 @@ AtomString SVGURIReference::fragmentIdentifierFromIRIString(const String& url, c
 AtomString SVGURIReference::fragmentIdentifierFromIRIString(const Style::URL& url, const Document& document)
 {
     return fragmentIdentifierFromIRIString(url.resolved.string(), document);
+}
+
+AtomString SVGURIReference::fragmentIdentifierFromIRIString(const Style::SVGMarkerResource& markerResource, const Document& document)
+{
+    if (auto url = markerResource.tryURL())
+        return fragmentIdentifierFromIRIString(*url, document);
+    return emptyAtom();
 }
 
 auto SVGURIReference::targetElementFromIRIString(const String& iri, const TreeScope& treeScope, RefPtr<Document> externalDocument) -> TargetElementResult

--- a/Source/WebCore/svg/SVGURIReference.h
+++ b/Source/WebCore/svg/SVGURIReference.h
@@ -29,6 +29,7 @@
 namespace WebCore {
 
 namespace Style {
+struct SVGMarkerResource;
 struct URL;
 }
 
@@ -44,6 +45,7 @@ public:
 
     static AtomString fragmentIdentifierFromIRIString(const String&, const Document&);
     static AtomString fragmentIdentifierFromIRIString(const Style::URL&, const Document&);
+    static AtomString fragmentIdentifierFromIRIString(const Style::SVGMarkerResource&, const Document&);
 
     struct TargetElementResult {
         RefPtr<Element> element;


### PR DESCRIPTION
#### fb28dedd22f117ba3aa9f738e8f9a1fa2fd5159f
<pre>
[Style] Add standalone strong style type for SVG marker-* properties
<a href="https://bugs.webkit.org/show_bug.cgi?id=299323">https://bugs.webkit.org/show_bug.cgi?id=299323</a>

Reviewed by Darin Adler.

Removes the need for all Style::URL values to have an implicit `none` value
by adding a type just for the SVG `marker-*` types which where the types that
needed it.

* Source/WebCore/Headers.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/rendering/ReferencedSVGResources.cpp:
* Source/WebCore/rendering/RenderLayerModelObject.cpp:
* Source/WebCore/rendering/RenderLayerModelObject.h:
* Source/WebCore/rendering/style/SVGRenderStyle.h:
* Source/WebCore/rendering/style/SVGRenderStyleDefs.cpp:
* Source/WebCore/rendering/style/SVGRenderStyleDefs.h:
* Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp:
* Source/WebCore/rendering/svg/legacy/SVGResources.cpp:
* Source/WebCore/style/StyleBuilderConverter.h:
* Source/WebCore/style/StyleBuilderCustom.h:
* Source/WebCore/style/StyleExtractorConverter.h:
* Source/WebCore/style/StyleExtractorSerializer.h:
* Source/WebCore/style/values/primitives/StyleURL.cpp:
* Source/WebCore/style/values/primitives/StyleURL.h:
* Source/WebCore/style/values/svg/StyleSVGMarkerResource.h: Added.
* Source/WebCore/svg/SVGURIReference.cpp:
* Source/WebCore/svg/SVGURIReference.h:

Canonical link: <a href="https://commits.webkit.org/300401@main">https://commits.webkit.org/300401@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df7c5d743af75f0f921ca95e66254f4669d59b61

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122257 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41960 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32629 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128840 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74351 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/124133 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42674 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50553 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92936 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61768 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125209 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34038 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109471 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73590 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33047 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27634 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72323 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103546 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27827 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131581 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49196 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37432 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101495 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49571 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105682 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101365 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25737 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46728 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24847 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/45959 "Build was cancelled. Recent messages:Printed configuration") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49053 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54788 "Failed to build and analyze WebKit") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48523 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51873 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50203 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->