### PR TITLE
Adopt C++23 size_t literal suffix in WTF

### DIFF
--- a/Source/WTF/wtf/BitSet.h
+++ b/Source/WTF/wtf/BitSet.h
@@ -276,7 +276,7 @@ inline constexpr void BitSet<bitSetSize, WordType>::setAll()
 template<size_t bitSetSize, typename WordType>
 inline constexpr void BitSet<bitSetSize, WordType>::invert()
 {
-    for (size_t i = 0; i < words; ++i)
+    for (auto i = 0uz; i < words; ++i)
         bits[i] = ~bits[i];
     cleanseLastWord();
 }
@@ -298,9 +298,9 @@ inline constexpr int64_t BitSet<bitSetSize, WordType>::findRunOfZeros(size_t run
     if (runLength > bitSetSize)
         return -1;
 
-    for (size_t i = 0; i <= (bitSetSize - runLength) ; i++) {
+    for (auto i = 0uz; i <= (bitSetSize - runLength) ; i++) {
         bool found = true; 
-        for (size_t j = i; j <= (i + runLength - 1) ; j++) { 
+        for (auto j = i; j <= (i + runLength - 1) ; j++) {
             if (get(j)) {
                 found = false; 
                 break;

--- a/Source/WTF/wtf/BitVector.cpp
+++ b/Source/WTF/wtf/BitVector.cpp
@@ -134,7 +134,7 @@ void BitVector::mergeSlow(const BitVector& other)
     
     auto a = outOfLineBits()->wordsSpan();
     auto b = other.outOfLineBits()->wordsSpan();
-    for (size_t i = 0; i < a.size(); ++i)
+    for (auto i = 0uz; i < a.size(); ++i)
         a[i] |= b[i];
 }
 
@@ -157,7 +157,7 @@ void BitVector::filterSlow(const BitVector& other)
     auto a = outOfLineBits()->wordsSpan();
     auto b = other.outOfLineBits()->wordsSpan();
     auto commonSize = std::min(a.size(), b.size());
-    for (size_t i = 0; i < commonSize; ++i)
+    for (auto i = 0uz; i < commonSize; ++i)
         a[i] &= b[i];
     
     if (a.size() > b.size())
@@ -183,7 +183,7 @@ void BitVector::excludeSlow(const BitVector& other)
     auto a = outOfLineBits()->wordsSpan();
     auto b = other.outOfLineBits()->wordsSpan();
     auto commonSize = std::min(a.size(), b.size());
-    for (size_t i = 0; i < commonSize; ++i)
+    for (auto i = 0uz; i < commonSize; ++i)
         a[i] &= ~b[i];
 }
 
@@ -269,7 +269,7 @@ uintptr_t BitVector::hashSlowCase() const
 
 void BitVector::dump(PrintStream& out) const
 {
-    for (size_t i = 0; i < size(); ++i)
+    for (auto i = 0uz; i < size(); ++i)
         out.print(get(i) ? "1" : "-");
 }
 

--- a/Source/WTF/wtf/Deque.h
+++ b/Source/WTF/wtf/Deque.h
@@ -575,7 +575,7 @@ template<typename Func>
 inline size_t Deque<T, inlineCapacity>::removeAllMatching(const Func& func)
 {
     auto oldSize = size();
-    for (size_t i = 0; i < oldSize; ++i) {
+    for (auto i = 0uz; i < oldSize; ++i) {
         auto value = takeFirst();
         if (!func(value))
             append(WTFMove(value));

--- a/Source/WTF/wtf/FastBitVector.h
+++ b/Source/WTF/wtf/FastBitVector.h
@@ -320,7 +320,7 @@ public:
     ALWAYS_INLINE void forEachSetBit(const Func& func) const
     {
         size_t n = arrayLength();
-        for (size_t i = 0; i < n; ++i) {
+        for (auto i = 0uz; i < n; ++i) {
             uint32_t word = m_words.word(i);
             size_t j = i * 32;
             while (word) {
@@ -351,7 +351,7 @@ public:
     // then it will return that index. Returns numBits when we get to the end. For example, you
     // can write a loop to iterate over all set bits like this:
     //
-    // for (size_t i = 0; i < bits.numBits(); i = bits.findBit(i + 1, true))
+    // for (auto i = 0uz; i < bits.numBits(); i = bits.findBit(i + 1, true))
     //     ...
     ALWAYS_INLINE size_t findBit(size_t startIndex, bool value) const
     {
@@ -391,7 +391,7 @@ public:
     
     void dump(PrintStream& out) const
     {
-        for (size_t i = 0; i < numBits(); ++i)
+        for (auto i = 0uz; i < numBits(); ++i)
             out.print((*this)[i] ? "1" : "-");
     }
     

--- a/Source/WTF/wtf/FixedVector.h
+++ b/Source/WTF/wtf/FixedVector.h
@@ -253,7 +253,7 @@ bool FixedVector<T, Malloc>::contains(const auto& value) const
 template<typename T, typename Malloc>
 size_t FixedVector<T, Malloc>::findIf(NOESCAPE const Invocable<bool(const T&)> auto& matches) const
 {
-    for (size_t i = 0; i < size(); ++i) {
+    for (auto i = 0uz; i < size(); ++i) {
         if (matches(at(i)))
             return i;
     }

--- a/Source/WTF/wtf/IntervalSet.h
+++ b/Source/WTF/wtf/IntervalSet.h
@@ -281,11 +281,11 @@ private:
         {
             ASSERT(size + count <= capacity);
             ASSERT(count <= rightSize);
-            for (size_t i = 0; i < count; i++) {
+            for (auto i = 0uz; i < count; i++) {
                 intervals[i + size] = rightNode->intervals[i];
                 payloads[i + size] = rightNode->payloads[i];
             }
-            for (size_t i = 0; i < rightSize - count; i++) {
+            for (auto i = 0uz; i < rightSize - count; i++) {
                 rightNode->intervals[i] = rightNode->intervals[i + count];
                 rightNode->payloads[i] = rightNode->payloads[i + count];
             }
@@ -303,7 +303,7 @@ private:
                 rightNode->intervals[i] = rightNode->intervals[i - count];
                 rightNode->payloads[i] = rightNode->payloads[i - count];
             }
-            for (size_t i = 0; i < count; i++) {
+            for (auto i = 0uz; i < count; i++) {
                 rightNode->intervals[i] = intervals[size - count + i];
                 rightNode->payloads[i] = payloads[size - count + i];
             }
@@ -340,7 +340,7 @@ private:
         size_t firstIntervalEndAfter(size_t size, T point) const
         {
             ASSERT(size <= capacity);
-            for (size_t i = 0; i < size; i++) {
+            for (auto i = 0uz; i < size; i++) {
                 if (point < intervals[i].end())
                     return i;
             }
@@ -434,7 +434,7 @@ private:
         {
             ASSERT(size);
             ASSERT(size <= innerOrder);
-            for (size_t i = 0; i < size - 1; i++) {
+            for (auto i = 0uz; i < size - 1; i++) {
                 if (endPoint <= this->intervals[i + 1].begin())
                     return i;
             }
@@ -884,7 +884,7 @@ private:
                 continue;
             }
             InnerNode* inner = node.asInner();
-            for (size_t i = 0; i < node.size(); ++i)
+            for (auto i = 0uz; i < node.size(); ++i)
                 stack.append({ inner->child(i), distanceToLeaf - 1 });
             freeNode(inner);
         }
@@ -902,7 +902,7 @@ private:
             printIndent();
             out.println("Inner(size=", nodeRef.size(), ", coverage=", inner->coverage(nodeRef.size()), "):");
 
-            for (size_t i = 0; i < nodeRef.size(); ++i) {
+            for (auto i = 0uz; i < nodeRef.size(); ++i) {
                 printIndent();
                 out.println("  [", i, "] ", inner->interval(i));
                 dumpSubtree(out, inner->child(i), distanceToLeaf - 1, indent + 2);
@@ -912,7 +912,7 @@ private:
             LeafNode* leaf = nodeRef.asLeaf();
             printIndent();
             out.print("Leaf(size=", nodeRef.size(), "): ");
-            for (size_t i = 0; i < nodeRef.size(); ++i)
+            for (auto i = 0uz; i < nodeRef.size(); ++i)
                 out.print(comma, leaf->interval(i), "=", leaf->value(i));
             out.println();
         }

--- a/Source/WTF/wtf/PriorityQueue.h
+++ b/Source/WTF/wtf/PriorityQueue.h
@@ -65,7 +65,7 @@ public:
 
     void decreaseKey(NOESCAPE const Invocable<bool(T&)> auto& desiredElement)
     {
-        for (size_t i = 0; i < m_buffer.size(); ++i) {
+        for (auto i = 0uz; i < m_buffer.size(); ++i) {
             if (desiredElement(m_buffer[i])) {
                 siftDown(i);
                 return;
@@ -76,7 +76,7 @@ public:
 
     void increaseKey(NOESCAPE const Invocable<bool(T&)> auto& desiredElement)
     {
-        for (size_t i = 0; i < m_buffer.size(); ++i) {
+        for (auto i = 0uz; i < m_buffer.size(); ++i) {
             if (desiredElement(m_buffer[i])) {
                 siftUp(i);
                 return;
@@ -90,7 +90,7 @@ public:
 
     bool isValidHeap() const
     {
-        for (size_t i = 0; i < m_buffer.size(); ++i) {
+        for (auto i = 0uz; i < m_buffer.size(); ++i) {
             if (leftChildOf(i) < m_buffer.size() && !isHigherPriority(m_buffer[i], m_buffer[leftChildOf(i)]))
                 return false;
             if (rightChildOf(i) < m_buffer.size() && !isHigherPriority(m_buffer[i], m_buffer[rightChildOf(i)]))

--- a/Source/WTF/wtf/PtrTag.h
+++ b/Source/WTF/wtf/PtrTag.h
@@ -125,7 +125,7 @@ template<size_t N>
 constexpr uintptr_t makePtrTagHash(const char (&str)[N])
 {
     uintptr_t result = 134775813;
-    for (size_t i = 0; i < N; ++i)
+    for (auto i = 0uz; i < N; ++i)
         result += ((result * str[i]) ^ (result >> 16));
     return result & 0xffff;
 }

--- a/Source/WTF/wtf/RefCounted.cpp
+++ b/Source/WTF/wtf/RefCounted.cpp
@@ -73,7 +73,7 @@ public:
     static void forEachLIFO(const Callback& callback)
     {
         size_t last = s_end.load(std::memory_order_acquire) - 1;
-        for (size_t i = 0; i < s_size; ++i) {
+        for (auto i = 0uz; i < s_size; ++i) {
             size_t index = (last - i) & s_sizeMask;
             RefLogStackShot* stackShot = s_buffer[index].load(std::memory_order_acquire);
             if (!stackShot)

--- a/Source/WTF/wtf/RefCountedFixedVector.h
+++ b/Source/WTF/wtf/RefCountedFixedVector.h
@@ -137,7 +137,7 @@ inline bool operator==(const RefCountedFixedVectorBase<T, isThreadSafe>& a, cons
 {
     if (a.size() != b.size())
         return false;
-    for (size_t i = 0; i < a.size(); ++i) {
+    for (auto i = 0uz; i < a.size(); ++i) {
         if (a.at(i) != b.at(i))
             return false;
     }

--- a/Source/WTF/wtf/RefVector.h
+++ b/Source/WTF/wtf/RefVector.h
@@ -152,7 +152,7 @@ template<typename T, size_t inlineCapacity>
 template<typename MatchFunction>
 size_t RefVector<T, inlineCapacity>::findIf(NOESCAPE const MatchFunction& matches) const
 {
-    for (size_t i = 0; i < size(); ++i) {
+    for (auto i = 0uz; i < size(); ++i) {
         if (matches(at(i)))
             return i;
     }

--- a/Source/WTF/wtf/ReferenceWrapperVector.h
+++ b/Source/WTF/wtf/ReferenceWrapperVector.h
@@ -161,7 +161,7 @@ template<typename T, size_t inlineCapacity>
 template<typename MatchFunction>
 size_t ReferenceWrapperVector<T, inlineCapacity>::findIf(NOESCAPE const MatchFunction& matches) const
 {
-    for (size_t i = 0; i < size(); ++i) {
+    for (auto i = 0uz; i < size(); ++i) {
         if (matches(at(i)))
             return i;
     }

--- a/Source/WTF/wtf/SegmentedVector.h
+++ b/Source/WTF/wtf/SegmentedVector.h
@@ -228,7 +228,7 @@ namespace WTF {
 
         void destroyAllItems()
         {
-            for (size_t i = 0; i < m_size; ++i)
+            for (auto i = 0uz; i < m_size; ++i)
                 at(i).~T();
         }
 

--- a/Source/WTF/wtf/SequesteredImmortalHeap.cpp
+++ b/Source/WTF/wtf/SequesteredImmortalHeap.cpp
@@ -91,7 +91,7 @@ bool SequesteredImmortalHeap::scavengeImpl(void* /*userdata*/)
         Locker listLocker { m_scavengerLock };
         auto bound = m_nextFreeIndex;
         ASSERT(bound <= m_allocatorSlots.size());
-        for (size_t i = 0; i < bound; i++) {
+        for (auto i = 0uz; i < bound; i++) {
             // FIXME: Refactor the SeqImmortalHeap <-> SeqArenaAllocator
             // relationship so that we don't have to assume data layouts
             // here

--- a/Source/WTF/wtf/TinyLRUCache.h
+++ b/Source/WTF/wtf/TinyLRUCache.h
@@ -68,7 +68,7 @@ public:
 
         // cacheBuffer[0] is the LRU entry, so remove it.
         if (m_size == capacity) {
-            for (size_t i = 0; i < m_size - 1; ++i)
+            for (auto i = 0uz; i < m_size - 1; ++i)
                 cacheBuffer[i] = WTFMove(cacheBuffer[i + 1]);
         } else
             ++m_size;

--- a/Source/WTF/wtf/UniqueRefVector.h
+++ b/Source/WTF/wtf/UniqueRefVector.h
@@ -143,7 +143,7 @@ template<typename T, size_t inlineCapacity>
 template<typename MatchFunction>
 size_t UniqueRefVector<T, inlineCapacity>::findIf(NOESCAPE const MatchFunction& matches) const
 {
-    for (size_t i = 0; i < size(); ++i) {
+    for (auto i = 0uz; i < size(); ++i) {
         if (matches(at(i)))
             return i;
     }

--- a/Source/WTF/wtf/Vector.h
+++ b/Source/WTF/wtf/Vector.h
@@ -235,9 +235,10 @@ struct VectorComparer<false, T>
 {
     static bool compare(const T* a, const T* b, size_t size)
     {
-        for (size_t i = 0; i < size; ++i)
+        for (auto i = 0uz; i < size; ++i) {
             if (!(a[i] == b[i]))
                 return false;
+        }
         return true;
     }
 };
@@ -744,7 +745,7 @@ public:
 
         asanSetInitialBufferSizeTo(size);
 
-        for (size_t i = 0; i < size; ++i)
+        for (auto i = 0uz; i < size; ++i)
             unsafeAppendWithoutCapacityCheck(valueGenerator(i));
     }
 
@@ -756,7 +757,7 @@ public:
 
         asanSetInitialBufferSizeTo(size);
 
-        for (size_t i = 0; i < size; ++i) {
+        for (auto i = 0uz; i < size; ++i) {
             if (auto item = valueGenerator(i))
                 unsafeAppendWithoutCapacityCheck(WTFMove(*item));
             else if (nulloptBehavior == NulloptBehavior::Abort)
@@ -1172,7 +1173,7 @@ bool Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::contains(c
 template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t minCapacity, typename Malloc>
 size_t Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::findIf(NOESCAPE const Invocable<bool(const T&)> auto& matches) const
 {
-    for (size_t i = 0; i < size(); ++i) {
+    for (auto i = 0uz; i < size(); ++i) {
         if (matches(at(i)))
             return i;
     }
@@ -1255,7 +1256,7 @@ template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t min
 void Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::appendUsingFunctor(size_t size, NOESCAPE const Invocable<T(size_t)> auto& valueGenerator)
 {
     reserveCapacity(this->size() + size);
-    for (size_t i = 0; i < size; ++i)
+    for (auto i = 0uz; i < size; ++i)
         unsafeAppendWithoutCapacityCheck(valueGenerator(i));
 }
 
@@ -1804,7 +1805,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t minCapacity, typename Malloc>
 inline void Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::reverse()
 {
-    for (size_t i = 0; i < m_size / 2; ++i)
+    for (auto i = 0uz; i < m_size / 2; ++i)
         std::swap(at(i), at(m_size - 1 - i));
 }
 
@@ -1814,7 +1815,7 @@ inline ResultVector Vector<T, inlineCapacity, OverflowHandler, minCapacity, Mall
 {
     ResultVector result;
     result.reserveInitialCapacity(size());
-    for (size_t i = 0; i < size(); ++i)
+    for (auto i = 0uz; i < size(); ++i)
         result.unsafeAppendWithoutCapacityCheck(mapFunction(at(i)));
     return result;
 }
@@ -1863,7 +1864,7 @@ template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t min
 inline void Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::checkConsistency()
 {
 #if ENABLE(SECURITY_ASSERTIONS)
-    for (size_t i = 0; i < size(); ++i)
+    for (auto i = 0uz; i < size(); ++i)
         ValueCheck<T>::checkConsistency(at(i));
 #endif
 }

--- a/Source/WTF/wtf/WorkQueue.cpp
+++ b/Source/WTF/wtf/WorkQueue.cpp
@@ -163,7 +163,7 @@ void ConcurrentWorkQueue::apply(size_t iterations, WTF::Function<void(size_t ind
         }
     };
 
-    for (size_t i = 0; i < workerCount; ++i)
+    for (auto i = 0uz; i < workerCount; ++i)
         threadPool->dispatch(&applier);
     applier();
 

--- a/Source/WTF/wtf/text/StringCommon.h
+++ b/Source/WTF/wtf/text/StringCommon.h
@@ -341,7 +341,7 @@ ALWAYS_INLINE bool equal(const LChar* a, std::span<const char16_t> b)
         return *a == b.front();
     return true;
 #else
-    for (size_t i = 0; i < b.size(); ++i) {
+    for (auto i = 0uz; i < b.size(); ++i) {
         if (a[i] != b[i])
             return false;
     }
@@ -414,7 +414,7 @@ template<typename CharacterTypeA, typename CharacterTypeB> inline bool equalIgno
 {
     ASSERT(a.size() >= lengthToCheck);
     ASSERT(b.size() >= lengthToCheck);
-    for (size_t i = 0; i < lengthToCheck; ++i) {
+    for (auto i = 0uz; i < lengthToCheck; ++i) {
         if (toASCIILower(a[i]) != toASCIILower(b[i]))
             return false;
     }
@@ -469,7 +469,7 @@ size_t findIgnoringASCIICase(std::span<const SearchCharacterType> source, std::s
     // delta is the number of additional times to test; delta == 0 means test only once.
     size_t delta = startSearchedCharacters.size() - matchCharacters.size();
 
-    for (size_t i = 0; i <= delta; ++i) {
+    for (auto i = 0uz; i <= delta; ++i) {
         if (equalIgnoringASCIICaseWithLength(startSearchedCharacters.subspan(i), matchCharacters, matchCharacters.size()))
             return startOffset + i;
     }
@@ -496,7 +496,7 @@ ALWAYS_INLINE static size_t findInner(std::span<const SearchCharacterType> searc
     unsigned searchHash = 0;
     unsigned matchHash = 0;
 
-    for (size_t i = 0; i < matchCharacters.size(); ++i) {
+    for (auto i = 0uz; i < matchCharacters.size(); ++i) {
         searchHash += searchCharacters[i];
         matchHash += matchCharacters[i];
     }
@@ -749,7 +749,7 @@ ALWAYS_INLINE static size_t reverseFindInner(std::span<const SearchCharacterType
 
     unsigned searchHash = 0;
     unsigned matchHash = 0;
-    for (size_t i = 0; i < matchCharacters.size(); ++i) {
+    for (auto i = 0uz; i < matchCharacters.size(); ++i) {
         searchHash += searchCharacters[delta + i];
         matchHash += matchCharacters[i];
     }
@@ -769,7 +769,7 @@ template<typename CharacterType> inline bool equalLettersIgnoringASCIICaseWithLe
 {
     ASSERT(characters.size() >= length);
     ASSERT(lowercaseLetters.size() >= length);
-    for (size_t i = 0; i < length; ++i) {
+    for (auto i = 0uz; i < length; ++i) {
         if (!isASCIIAlphaCaselessEqual(characters[i], lowercaseLetters[i]))
             return false;
     }

--- a/Source/WTF/wtf/text/StringImpl.cpp
+++ b/Source/WTF/wtf/text/StringImpl.cpp
@@ -734,7 +734,7 @@ template<StringImpl::CaseConvertType type, typename CharacterType>
 ALWAYS_INLINE Ref<StringImpl> StringImpl::convertASCIICase(StringImpl& impl, std::span<const CharacterType> data)
 {
     size_t failingIndex;
-    for (size_t i = 0; i < data.size(); ++i) {
+    for (auto i = 0uz; i < data.size(); ++i) {
         CharacterType character = data[i];
         if constexpr (type == CaseConvertType::Lower) {
             if (isASCIIUpper(character)) [[unlikely]] {
@@ -883,7 +883,7 @@ size_t StringImpl::find(std::span<const LChar> matchString, size_t start)
 
         unsigned searchHash = 0;
         unsigned matchHash = 0;
-        for (size_t i = 0; i < matchString.size(); ++i) {
+        for (auto i = 0uz; i < matchString.size(); ++i) {
             searchHash += searchCharacters[i];
             matchHash += matchString[i];
         }
@@ -903,7 +903,7 @@ size_t StringImpl::find(std::span<const LChar> matchString, size_t start)
 
     unsigned searchHash = 0;
     unsigned matchHash = 0;
-    for (size_t i = 0; i < matchString.size(); ++i) {
+    for (auto i = 0uz; i < matchString.size(); ++i) {
         searchHash += searchCharacters[i];
         matchHash += matchString[i];
     }

--- a/Source/WTF/wtf/text/SuperFastHash.h
+++ b/Source/WTF/wtf/text/SuperFastHash.h
@@ -230,7 +230,7 @@ private:
     static constexpr unsigned computeHashImpl(std::span<const T> characters)
     {
         unsigned result = stringHashingStartValue;
-        for (size_t i = 0; i + 1 < characters.size(); i += 2)
+        for (auto i = 0uz; i + 1 < characters.size(); i += 2)
             result = calculateWithTwoCharacters(result, Converter::convert(characters[i]), Converter::convert(characters[i + 1]));
         if (characters.size() % 2)
             return calculateWithRemainingLastCharacter(result, Converter::convert(characters.back()));

--- a/Source/WTF/wtf/text/TextBreakIterator.h
+++ b/Source/WTF/wtf/text/TextBreakIterator.h
@@ -264,7 +264,7 @@ public:
 
         void update(char16_t last)
         {
-            for (size_t i = 0; i < m_priorContext.size() - 1; ++i)
+            for (auto i = 0uz; i < m_priorContext.size() - 1; ++i)
                 m_priorContext[i] = m_priorContext[i + 1];
             m_priorContext[m_priorContext.size() - 1] = last;
         }


### PR DESCRIPTION
#### 8565e75557734120f76cdd28baeaf3dbac6ee091
<pre>
Adopt C++23 size_t literal suffix in WTF
<a href="https://bugs.webkit.org/show_bug.cgi?id=299334">https://bugs.webkit.org/show_bug.cgi?id=299334</a>
<a href="https://rdar.apple.com/problem/161131698">rdar://problem/161131698</a>

Reviewed by NOBODY (OOPS!).

Use modern C++23 core language features and align with similar literal
suffixes already in use (0u, 0.0f)

C++ standardization proposal: <a href="https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p0330r8.html">https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p0330r8.html</a>

* Source/WTF/wtf/BitSet.h:
(WTF::WordType&gt;::invert):
(WTF::WordType&gt;::findRunOfZeros const):
* Source/WTF/wtf/BitVector.cpp:
(WTF::BitVector::mergeSlow):
(WTF::BitVector::filterSlow):
(WTF::BitVector::excludeSlow):
(WTF::BitVector::dump const):
* Source/WTF/wtf/Deque.h:
(WTF::inlineCapacity&gt;::removeAllMatching):
* Source/WTF/wtf/FastBitVector.h:
(WTF::FastBitVectorImpl::forEachSetBit const):
(WTF::FastBitVectorImpl::dump const):
* Source/WTF/wtf/FixedVector.h:
(WTF::Malloc&gt;::findIf const):
* Source/WTF/wtf/IntervalSet.h:
(WTF::IntervalSet::NodeImpl::shiftLeftFrom):
(WTF::IntervalSet::NodeImpl::shiftRightTo):
(WTF::IntervalSet::NodeImpl::firstIntervalEndAfter const):
(WTF::IntervalSet::InnerNode::subtreeForInsert const):
(WTF::IntervalSet::freeAllNodes):
(WTF::IntervalSet::dumpSubtree const):
* Source/WTF/wtf/PriorityQueue.h:
* Source/WTF/wtf/PtrTag.h:
(WTF::makePtrTagHash):
* Source/WTF/wtf/RefCounted.cpp:
(WTF::RefLogSingleton::forEachLIFO):
* Source/WTF/wtf/RefCountedFixedVector.h:
(WTF::operator==):
* Source/WTF/wtf/RefVector.h:
(WTF::inlineCapacity&gt;::findIf const):
* Source/WTF/wtf/ReferenceWrapperVector.h:
(WTF::inlineCapacity&gt;::findIf const):
* Source/WTF/wtf/SegmentedVector.h:
* Source/WTF/wtf/SequesteredImmortalHeap.cpp:
(WTF::SequesteredImmortalHeap::scavengeImpl):
* Source/WTF/wtf/TinyLRUCache.h:
(WTF::TinyLRUCache::get):
* Source/WTF/wtf/UniqueRefVector.h:
(WTF::inlineCapacity&gt;::findIf const):
* Source/WTF/wtf/Vector.h:
(WTF::Vector::Vector):
(WTF::Malloc&gt;::findIf const):
(WTF::Malloc&gt;::appendUsingFunctor):
(WTF::Malloc&gt;::reverse):
(WTF::Malloc&gt;::map const):
(WTF::Malloc&gt;::checkConsistency):
* Source/WTF/wtf/WorkQueue.cpp:
(WTF::ConcurrentWorkQueue::apply):
* Source/WTF/wtf/text/StringCommon.h:
(WTF::equal):
(WTF::equalIgnoringASCIICaseWithLength):
(WTF::findIgnoringASCIICase):
(WTF::findInner):
(WTF::reverseFindInner):
(WTF::equalLettersIgnoringASCIICaseWithLength):
* Source/WTF/wtf/text/StringImpl.cpp:
(WTF::StringImpl::convertASCIICase):
(WTF::StringImpl::find):
* Source/WTF/wtf/text/SuperFastHash.h:
(WTF::SuperFastHash::computeHashImpl):
* Source/WTF/wtf/text/TextBreakIterator.h:
(WTF::CachedLineBreakIteratorFactory::PriorContext::update):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8565e75557734120f76cdd28baeaf3dbac6ee091

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122288 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41992 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32674 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128868 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74382 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42709 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50586 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92951 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61779 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125240 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34064 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109499 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73608 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33069 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27660 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72356 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/114436 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/103586 "Build was cancelled. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests (failure); re-run-api-tests (failure); Compiled WebKit (cancelled)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27866 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131615 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/120814 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49228 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37454 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101518 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49602 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105719 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101389 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46746 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24873 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/45990 "Build was cancelled. Recent messages:Printed configuration") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49085 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54824 "Failed to build and analyze WebKit") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/150973 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48554 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/38625 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51904 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50235 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->