### PR TITLE
[Style] Convert the 'line-height' property to strong style types

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -3328,6 +3328,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
 
     style/values/inline/StyleLineBoxContain.h
     style/values/inline/StyleLineFitEdge.h
+    style/values/inline/StyleLineHeight.h
     style/values/inline/StyleTextBoxEdge.h
     style/values/inline/StyleTextEdge.h
     style/values/inline/StyleVerticalAlign.h

--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -697,7 +697,6 @@ style/PseudoClassChangeInvalidation.cpp
 style/RuleSetBuilder.cpp
 style/StyleAdjuster.cpp
 style/StyleBuilder.cpp
-style/StyleBuilderConverter.h
 style/StyleBuilderCustom.h
 style/StyleBuilderState.cpp
 style/StyleBuilderStateInlines.h
@@ -722,6 +721,7 @@ style/values/color/StyleKeywordColor.cpp
 style/values/content/StyleContent.cpp
 style/values/fonts/StyleFontWeight.cpp
 style/values/grid/StyleGridPositionsResolver.cpp
+style/values/inline/StyleLineHeight.cpp
 style/values/primitives/StyleLengthResolution.cpp
 svg/SVGAElement.cpp
 svg/SVGClipPathElement.cpp

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -3244,6 +3244,7 @@ style/values/grid/StyleGridTrackSizes.cpp
 style/values/images/StyleGradient.cpp
 style/values/images/StyleImageOrNone.cpp
 style/values/images/StyleImageWrapper.cpp
+style/values/inline/StyleLineHeight.cpp
 style/values/inline/StyleVerticalAlign.cpp
 style/values/inline/StyleWebKitInitialLetter.cpp
 style/values/lists/StyleListStyleType.cpp

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -4902,7 +4902,7 @@
             "codegen-properties": {
                 "accepts-quirky-length": true,
                 "animation-wrapper": "StyleTypeWrapper",
-                "animation-wrapper-requires-computed-getter": true,
+                "animation-wrapper-requires-getter": "computedLetterSpacing",
                 "animation-wrapper-requires-render-style": true,
                 "style-builder-custom": "All",
                 "style-builder-converter": "StyleType<LetterSpacing>",
@@ -4965,8 +4965,8 @@
             ],
             "codegen-properties": [
                 {
-                    "animation-wrapper": "LineHeightWrapper",
-                    "animation-wrapper-requires-override-parameters": [],
+                    "animation-wrapper": "StyleTypeWrapper",
+                    "animation-wrapper-requires-getter": "specifiedLineHeight",
                     "style-builder-custom": "All",
                     "style-extractor-custom": true,
                     "enable-if": "ENABLE_TEXT_AUTOSIZING",
@@ -4974,10 +4974,9 @@
                     "parser-exported": true
                 },
                 {
-                    "animation-wrapper": "LineHeightWrapper",
-                    "animation-wrapper-requires-override-parameters": [],
+                    "animation-wrapper": "StyleTypeWrapper",
                     "render-style-getter": "specifiedLineHeight",
-                    "style-builder-converter": "LineHeight",
+                    "style-builder-converter": "StyleType<LineHeight>",
                     "style-extractor-custom": true,
                     "enable-if": "!ENABLE_TEXT_AUTOSIZING",
                     "parser-grammar": "normal | <number [0,inf]> | <length-percentage [0,inf]>",
@@ -8409,7 +8408,7 @@
             "codegen-properties": {
                 "accepts-quirky-length": true,
                 "animation-wrapper": "StyleTypeWrapper",
-                "animation-wrapper-requires-computed-getter": true,
+                "animation-wrapper-requires-getter": "computedWordSpacing",
                 "animation-wrapper-requires-render-style": true,
                 "style-builder-custom": "All",
                 "style-builder-converter": "StyleType<WordSpacing>",

--- a/Source/WebCore/css/scripts/process-css-properties.py
+++ b/Source/WebCore/css/scripts/process-css-properties.py
@@ -463,10 +463,11 @@ class StylePropertyCodeGenProperties:
         Schema.Entry("animation-wrapper", allowed_types=[str]),
         Schema.Entry("animation-wrapper-acceleration", allowed_types=[str]),
         Schema.Entry("animation-wrapper-requires-additional-parameters", allowed_types=[list], default_value=[]),
-        Schema.Entry("animation-wrapper-requires-computed-getter", allowed_types=[bool], default_value=False),
+        Schema.Entry("animation-wrapper-requires-getter", allowed_types=[str]),
         Schema.Entry("animation-wrapper-requires-non-additive-or-cumulative-interpolation", allowed_types=[bool], default_value=False),
         Schema.Entry("animation-wrapper-requires-non-normalized-discrete-interpolation", allowed_types=[bool], default_value=False),
         Schema.Entry("animation-wrapper-requires-override-parameters", allowed_types=[list]),
+        Schema.Entry("animation-wrapper-requires-setter", allowed_types=[str]),
         Schema.Entry("animation-wrapper-requires-render-style", allowed_types=[bool], default_value=False),
         Schema.Entry("cascade-alias", allowed_types=[str]),
         Schema.Entry("color-property", allowed_types=[bool], default_value=False),
@@ -5269,13 +5270,16 @@ class GenerateStyleInterpolationWrapperMap:
                 property_wrapper_type = "FillLayersWrapper"
             else:
                 # Add getter
-                if property.codegen_properties.animation_wrapper_requires_computed_getter:
-                    property_wrapper_parameters += [f"&{style_type}::computed{name_for_methods}"]
+                if property.codegen_properties.animation_wrapper_requires_getter is not None:
+                    property_wrapper_parameters += [f"&{style_type}::{property.codegen_properties.animation_wrapper_requires_getter}"]
                 else:
                     property_wrapper_parameters += [f"&{style_type}::{getter}"]
 
                 # Add setter
-                property_wrapper_parameters += [f"&{style_type}::{setter}"]
+                if property.codegen_properties.animation_wrapper_requires_setter is not None:
+                    property_wrapper_parameters += [f"&{style_type}::{property.codegen_properties.animation_wrapper_requires_setter}"]
+                else:
+                    property_wrapper_parameters += [f"&{style_type}::{setter}"]
 
                 # Add property type specific parameters
                 if property.codegen_properties.visited_link_color_support:

--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
@@ -2276,7 +2276,7 @@ static void adjustSelectListButtonStyleForVectorBasedControls(RenderStyle& style
     applyCommonButtonPaddingToStyleForVectorBasedControls(style, element);
 
     // Enforce "line-height: normal".
-    style.setLineHeight(Length(LengthType::Normal));
+    style.setLineHeight(CSS::Keyword::Normal { });
 }
 
 // FIXME: This is a copy of RenderThemeMeasureTextClient from RenderThemeIOS. Refactor to remove duplicate code.

--- a/Source/WebCore/rendering/ios/RenderThemeIOS.mm
+++ b/Source/WebCore/rendering/ios/RenderThemeIOS.mm
@@ -452,7 +452,7 @@ static void adjustSelectListButtonStyle(RenderStyle& style, const Element& eleme
     applyCommonButtonPaddingToStyle(style, element);
 
     // Enforce "line-height: normal".
-    style.setLineHeight(Length(LengthType::Normal));
+    style.setLineHeight(CSS::Keyword::Normal { });
 }
 
 class RenderThemeMeasureTextClient : public MeasureTextClient {

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -287,6 +287,7 @@ struct HyphenateLimitLines;
 struct ImageOrNone;
 struct InsetEdge;
 struct LetterSpacing;
+struct LineHeight;
 struct LineWidth;
 struct LineFitEdge;
 struct ListStyleType;
@@ -770,10 +771,10 @@ public:
 
     inline TextZoom textZoom() const;
 
-    const Length& specifiedLineHeight() const;
-    WEBCORE_EXPORT const Length& lineHeight() const;
+    const Style::LineHeight& specifiedLineHeight() const;
+    WEBCORE_EXPORT const Style::LineHeight& lineHeight() const;
     WEBCORE_EXPORT float computedLineHeight() const;
-    float computeLineHeight(const Length&) const;
+    float computeLineHeight(const Style::LineHeight&) const;
 
     inline bool autoWrap() const;
     static constexpr bool preserveNewline(WhiteSpaceCollapse);
@@ -1387,7 +1388,6 @@ public:
     inline void setTextUnderlinePosition(OptionSet<TextUnderlinePosition>);
     inline void setTextUnderlineOffset(Style::TextUnderlineOffset&&);
     inline void setTextTransform(OptionSet<TextTransform>);
-    void setLineHeight(Length&&);
     bool setZoom(float);
     inline bool setUsedZoom(float);
     inline void setTextZoom(TextZoom);
@@ -1400,8 +1400,9 @@ public:
 
     inline void setMarginTrim(OptionSet<MarginTrimType>);
 
+    void setLineHeight(Style::LineHeight&&);
 #if ENABLE(TEXT_AUTOSIZING)
-    void setSpecifiedLineHeight(Length&&);
+    void setSpecifiedLineHeight(Style::LineHeight&&);
 #endif
 
     inline void setImageOrientation(ImageOrientation);
@@ -2033,8 +2034,7 @@ public:
     static constexpr Style::LineFitEdge initialLineFitEdge();
     static constexpr Style::Widows initialWidows();
     static constexpr Style::Orphans initialOrphans();
-    // Returning -100% percent here means the line-height is not set.
-    static inline Length initialLineHeight();
+    static inline Style::LineHeight initialLineHeight();
     static constexpr TextAlignMode initialTextAlign();
     static constexpr TextAlignLast initialTextAlignLast();
     static constexpr TextGroupAlign initialTextGroupAlign();
@@ -2167,7 +2167,7 @@ public:
 #endif
 
 #if ENABLE(TEXT_AUTOSIZING)
-    static inline Length initialSpecifiedLineHeight();
+    static inline Style::LineHeight initialSpecifiedLineHeight();
     static constexpr Style::TextSizeAdjust initialTextSizeAdjust();
 #endif
 

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -434,6 +434,7 @@ constexpr OptionSet<Style::LineBoxContain> RenderStyle::initialLineBoxContain() 
 constexpr LineBreak RenderStyle::initialLineBreak() { return LineBreak::Auto; }
 constexpr Style::WebkitLineClamp RenderStyle::initialLineClamp() { return CSS::Keyword::None { }; }
 inline Style::WebkitLineGrid RenderStyle::initialLineGrid() { return CSS::Keyword::None { }; }
+inline Style::LineHeight RenderStyle::initialLineHeight() { return CSS::Keyword::Normal { }; }
 constexpr LineSnap RenderStyle::initialLineSnap() { return LineSnap::None; }
 inline Style::ImageOrNone RenderStyle::initialListStyleImage() { return CSS::Keyword::None { }; }
 constexpr ListStylePosition RenderStyle::initialListStylePosition() { return ListStylePosition::Outside; }
@@ -902,7 +903,7 @@ constexpr Style::WebkitTouchCallout RenderStyle::initialTouchCallout() { return 
 #endif
 
 #if ENABLE(TEXT_AUTOSIZING)
-inline Length RenderStyle::initialSpecifiedLineHeight() { return LengthType::Normal; }
+inline Style::LineHeight RenderStyle::initialSpecifiedLineHeight() { return CSS::Keyword::Normal { }; }
 constexpr Style::TextSizeAdjust RenderStyle::initialTextSizeAdjust() { return CSS::Keyword::Auto { }; }
 inline Style::TextSizeAdjust RenderStyle::textSizeAdjust() const { return m_rareInheritedData->textSizeAdjust; }
 #endif
@@ -1034,11 +1035,6 @@ inline bool RenderStyle::hasInlineColumnAxis() const
 {
     auto axis = columnAxis();
     return axis == ColumnAxis::Auto || writingMode().isHorizontal() == (axis == ColumnAxis::Horizontal);
-}
-
-inline Length RenderStyle::initialLineHeight()
-{
-    return LengthType::Normal;
 }
 
 inline bool RenderStyle::isCollapsibleWhiteSpace(char16_t character) const

--- a/Source/WebCore/rendering/style/StyleInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleInheritedData.h
@@ -28,6 +28,7 @@
 #include <WebCore/Length.h>
 #include <WebCore/StyleColor.h>
 #include <WebCore/StyleFontData.h>
+#include <WebCore/StyleLineHeight.h>
 #include <WebCore/StyleWebKitBorderSpacing.h>
 #include <wtf/DataRef.h>
 
@@ -57,9 +58,9 @@ public:
     Style::WebkitBorderSpacing borderHorizontalSpacing;
     Style::WebkitBorderSpacing borderVerticalSpacing;
 
-    Length lineHeight;
+    Style::LineHeight lineHeight;
 #if ENABLE(TEXT_AUTOSIZING)
-    Length specifiedLineHeight;
+    Style::LineHeight specifiedLineHeight;
 #endif
 
     DataRef<StyleFontData> fontData;

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -1188,7 +1188,7 @@ auto Adjuster::adjustmentForTextAutosizing(const RenderStyle& style, const Eleme
 
         constexpr static float boostFactor = 1.25;
         auto minimumLineHeight = boostFactor * computedFontSize;
-        if (!lineHeight.isFixed() || lineHeight.value() >= minimumLineHeight)
+        if (auto fixedLineHeight = lineHeight.tryFixed(); !fixedLineHeight || fixedLineHeight->resolveZoom(ZoomNeeded { }) >= minimumLineHeight)
             return;
 
         if (AutosizeStatus::probablyContainsASmallFixedNumberOfLines(style))
@@ -1231,7 +1231,7 @@ bool Adjuster::adjustForTextAutosizing(RenderStyle& style, AdjustmentForTextAuto
         style.setFontDescription(WTFMove(fontDescription));
     }
     if (auto newLineHeight = adjustment.newLineHeight)
-        style.setLineHeight({ *newLineHeight, LengthType::Fixed });
+        style.setLineHeight(LineHeight::Fixed { *newLineHeight });
     if (auto newStatus = adjustment.newStatus)
         style.setAutosizeStatus(*newStatus);
     return adjustment.newFontSize || adjustment.newLineHeight;

--- a/Source/WebCore/style/StyleInterpolationWrappers.h
+++ b/Source/WebCore/style/StyleInterpolationWrappers.h
@@ -536,33 +536,6 @@ public:
 
 #endif
 
-class LineHeightWrapper final : public LengthWrapper {
-    WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(LineHeightWrapper, Animation);
-public:
-    LineHeightWrapper()
-        : LengthWrapper(CSSPropertyLineHeight, &RenderStyle::specifiedLineHeight, &RenderStyle::setLineHeight)
-    {
-    }
-
-    bool canInterpolate(const RenderStyle& from, const RenderStyle& to, CompositeOperation compositeOperation) const final
-    {
-        // We must account for how BuilderConverter::convertLineHeight() deals with line-height values:
-        // - "normal" is converted to LengthType::Percent with a -100 value
-        // - <number> values are converted to LengthType::Percent
-        // - <length-percentage> values are converted to LengthType::Fixed
-        // This means that animating between "normal" and a "<number>" would work with LengthWrapper::canInterpolate()
-        // since it would see two LengthType::Percent values. So if either value is "normal" we cannot interpolate since those
-        // values are either equal or of incompatible types.
-        auto normalLineHeight = RenderStyle::initialLineHeight();
-        if (value(from) == normalLineHeight || value(to) == normalLineHeight)
-            return false;
-
-        // The default logic will now apply since <number> and <length-percentage> values
-        // are converted to different LengthType values.
-        return LengthWrapper::canInterpolate(from, to, compositeOperation);
-    }
-};
-
 // MARK: - Color Property Wrappers
 
 class ColorWrapper final : public WrapperWithGetter<const WebCore::Color&> {

--- a/Source/WebCore/style/values/inline/StyleLineHeight.cpp
+++ b/Source/WebCore/style/values/inline/StyleLineHeight.cpp
@@ -1,0 +1,142 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "StyleLineHeight.h"
+
+#include "AnimationUtilities.h"
+#include "StyleBuilderChecking.h"
+#include "StyleBuilderConverter.h"
+#include "StyleLengthWrapper+Blending.h"
+#include "StyleLengthWrapper+CSSValueConversion.h"
+#include "StylePrimitiveNumericTypes+CSSValueConversion.h"
+
+namespace WebCore {
+namespace Style {
+
+auto CSSValueConversion<LineHeight>::operator()(BuilderState& state, const CSSValue& value, float multiplier) -> LineHeight
+{
+    RefPtr primitiveValue = requiredDowncast<CSSPrimitiveValue>(state, value);
+    if (!primitiveValue)
+        return CSS::Keyword::Normal { };
+
+    return operator()(state, *primitiveValue, multiplier);
+}
+
+auto CSSValueConversion<LineHeight>::operator()(BuilderState& state, const CSSPrimitiveValue& primitiveValue, float multiplier) -> LineHeight
+{
+    auto valueID = primitiveValue.valueID();
+    if (valueID == CSSValueNormal || CSSPropertyParserHelpers::isSystemFontShorthand(valueID))
+        return CSS::Keyword::Normal { };
+
+    auto conversionData = state
+        .cssToLengthConversionData()
+        .copyForLineHeight(zoomWithTextZoomFactor(state));
+
+    if (primitiveValue.isLength() || primitiveValue.isCalculatedPercentageWithLength()) {
+        double fixedValue = 0;
+        if (primitiveValue.isLength())
+            fixedValue = primitiveValue.resolveAsLength(conversionData);
+        else
+            fixedValue = primitiveValue.protectedCssCalcValue()->createCalculationValue(conversionData, CSSCalcSymbolTable { })->evaluate(state.style().computedFontSize());
+
+        if (multiplier != 1.0f)
+            fixedValue *= multiplier;
+
+        return LineHeight::Fixed {
+            CSS::clampToRange<LineHeight::Fixed::range, float>(fixedValue, minValueForCssLength, maxValueForCssLength)
+        };
+    }
+
+    // Line-height percentages need to inherit as if they were Fixed pixel values. In the example:
+    // <div style="font-size: 10px; line-height: 150%;"><div style="font-size: 100px;"></div></div>
+    // the inner element should have line-height of 15px. However, in this example:
+    // <div style="font-size: 10px; line-height: 1.5;"><div style="font-size: 100px;"></div></div>
+    // the inner element should have a line-height of 150px. Therefore, we map percentages to Fixed
+    // values and raw numbers to percentages.
+    if (primitiveValue.isPercentage()) {
+        // FIXME: percentage should not be restricted to an integer here.
+        return LineHeight::Fixed {
+            CSS::clampToRange<LineHeight::Fixed::range, float>((state.style().computedFontSize() * primitiveValue.resolveAsPercentage<int>(conversionData)) / 100.0, minValueForCssLength, maxValueForCssLength)
+        };
+    }
+
+    if (primitiveValue.isNumber()) {
+        return LineHeight::Percentage {
+            CSS::clampToRange<LineHeight::Percentage::range, float>(primitiveValue.resolveAsNumber(conversionData) * 100.0)
+        };
+    }
+
+    state.setCurrentPropertyInvalidAtComputedValueTime();
+    return CSS::Keyword::Normal { };
+}
+
+// MARK: - Blending
+
+auto Blending<LineHeight>::canBlend(const LineHeight& a, const LineHeight& b) -> bool
+{
+    return a.hasSameType(b) || (a.isCalculated() && b.isSpecified()) || (b.isCalculated() && a.isSpecified());
+}
+
+auto Blending<LineHeight>::requiresInterpolationForAccumulativeIteration(const LineHeight& a, const LineHeight& b) -> bool
+{
+    return !a.hasSameType(b) || a.isCalculated() || b.isCalculated();
+}
+
+auto Blending<LineHeight>::blend(const LineHeight& a, const LineHeight& b, const BlendingContext& context) -> LineHeight
+{
+    if (!a.isSpecified() || !b.isSpecified())
+        return context.progress < 0.5 ? a : b;
+
+    if (a.isCalculated() || b.isCalculated() || !a.hasSameType(b))
+        return LengthWrapperBlendingSupport<LineHeight>::blendMixedSpecifiedTypes(a, b, context);
+
+    if (!context.progress && context.isReplace())
+        return a;
+
+    if (context.progress == 1 && context.isReplace())
+        return b;
+
+    auto resultType = b.m_value.type();
+
+    ASSERT(resultType == LineHeight::indexForPercentage || resultType == LineHeight::indexForFixed);
+
+    if (resultType == LineHeight::indexForPercentage) {
+        return Style::blend(
+            LineHeight::Percentage { a.m_value.value() },
+            LineHeight::Percentage { b.m_value.value() },
+            context
+        );
+    } else {
+        return Style::blend(
+            LineHeight::Fixed { a.m_value.value() },
+            LineHeight::Fixed { b.m_value.value() },
+            context
+        );
+    }
+}
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/inline/StyleLineHeight.h
+++ b/Source/WebCore/style/values/inline/StyleLineHeight.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/StyleLengthWrapper.h>
+#include <wtf/Hasher.h>
+
+namespace WebCore {
+namespace Style {
+
+// <'line-height'> = normal | <number [0,∞]> | <length-percentage [0,∞]>
+// NOTE: <number [0,∞]> gets converted to <length-percentage [0,∞]>.
+// https://drafts.csswg.org/css-inline/#propdef-line-height
+struct LineHeight : LengthWrapperBase<LengthPercentage<CSS::Nonnegative>, CSS::Keyword::Normal> {
+    using Base::Base;
+
+    bool isNormal() const { return holdsAlternative<CSS::Keyword::Normal>(); }
+
+    unsigned valueForHash() const
+    {
+        return switchOn(
+            [&](const CSS::Keyword::Normal&) -> unsigned { return computeHash(0); },
+            [&](const Fixed& fixed) -> unsigned { return computeHash(1, fixed.unresolvedValue()); },
+            [&](const Percentage& percentage) -> unsigned { return computeHash(2, percentage.value); },
+            [&](const Calc&) -> unsigned { return computeHash(3); }
+        );
+    }
+};
+
+// MARK: - Conversion
+
+template<> struct CSSValueConversion<LineHeight> {
+    auto operator()(BuilderState&, const CSSValue&, float multiplier = 1.0f) -> LineHeight;
+    auto operator()(BuilderState&, const CSSPrimitiveValue&, float multiplier = 1.0f) -> LineHeight;
+};
+
+// MARK: - Blending
+
+template<> struct Blending<LineHeight> {
+    auto canBlend(const LineHeight&, const LineHeight&) -> bool;
+    auto requiresInterpolationForAccumulativeIteration(const LineHeight&, const LineHeight&) -> bool;
+    auto blend(const LineHeight&, const LineHeight&, const BlendingContext&) -> LineHeight;
+};
+
+} // namespace Style
+} // namespace WebCore
+
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::LineHeight)

--- a/Source/WebCore/style/values/non-standard/StyleWebKitLineClamp.h
+++ b/Source/WebCore/style/values/non-standard/StyleWebKitLineClamp.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <WebCore/StylePrimitiveNumericTypes.h>
+#include <wtf/Hasher.h>
 
 namespace WebCore {
 namespace Style {
@@ -68,11 +69,11 @@ struct WebkitLineClamp {
         return WTF::switchOn(m_value, std::forward<F>(f)...);
     }
 
-    unsigned valueForTextAutosizingHash() const
+    unsigned valueForHash() const
     {
         return WTF::switchOn(m_value,
-            [](const CSS::Keyword::None&) { return std::numeric_limits<unsigned>::max(); },
-            [](const auto& numeric) { return static_cast<unsigned>(numeric.value); }
+            [&](const CSS::Keyword::None&) { return computeHash(m_value.index()); },
+            [&](const auto& numeric) { return computeHash(m_value.index(), numeric.value); }
         );
     }
 

--- a/Source/WebCore/style/values/primitives/StyleLengthWrapper.h
+++ b/Source/WebCore/style/values/primitives/StyleLengthWrapper.h
@@ -160,6 +160,7 @@ private:
     template<typename, typename> friend struct Evaluation;
     template<typename, typename> friend struct MinimumEvaluation;
     template<typename> friend struct Blending;
+    template<typename> friend struct LengthWrapperBlendingSupport;
 
     static LengthWrapperData toData(const Specified& specified)
     {

--- a/Tools/Scripts/webkitpy/style/checkers/jsonchecker.py
+++ b/Tools/Scripts/webkitpy/style/checkers/jsonchecker.py
@@ -386,7 +386,7 @@ class JSONCSSPropertiesChecker(JSONChecker):
             'animation-wrapper-acceleration': self.validate_string,
             'animation-wrapper-comment': self.validate_comment,
             'animation-wrapper-requires-additional-parameters': self.validate_array,
-            'animation-wrapper-requires-computed-getter': self.validate_boolean,
+            'animation-wrapper-requires-getter': self.validate_string,
             'animation-wrapper-requires-non-additive-or-cumulative-interpolation': self.validate_boolean,
             'animation-wrapper-requires-non-normalized-discrete-interpolation': self.validate_boolean,
             'animation-wrapper-requires-override-parameters': self.validate_array,


### PR DESCRIPTION
#### beeb06e098ecc29cdd2736a7eb80c8ed7055e6ce
<pre>
[Style] Convert the &apos;line-height&apos; property to strong style types
<a href="https://bugs.webkit.org/show_bug.cgi?id=299337">https://bugs.webkit.org/show_bug.cgi?id=299337</a>

Reviewed by Darin Adler.

Converts the &apos;line-height&apos; property to use strong style types.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/layout/formattingContexts/inline/InlineLevelBox.h:
* Source/WebCore/page/PrintContext.cpp:
* Source/WebCore/rendering/TextAutoSizing.cpp:
* Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm:
* Source/WebCore/rendering/ios/RenderThemeIOS.mm:
* Source/WebCore/rendering/style/AutosizeStatus.cpp:
* Source/WebCore/rendering/style/RenderStyle.cpp:
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
* Source/WebCore/rendering/style/StyleInheritedData.h:
* Source/WebCore/style/StyleAdjuster.cpp:
* Source/WebCore/style/StyleBuilderConverter.h:
* Source/WebCore/style/StyleBuilderCustom.h:
* Source/WebCore/style/StyleExtractorCustom.h:
* Source/WebCore/style/StyleInterpolationWrappers.h:
* Source/WebCore/style/values/inline/StyleLineHeight.cpp: Added.
* Source/WebCore/style/values/inline/StyleLineHeight.h: Added.

Canonical link: <a href="https://commits.webkit.org/301039@main">https://commits.webkit.org/301039@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/03cb94aeadfa5ee89bd0db040e344992354ce112

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124768 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44440 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35175 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131613 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76683 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/126645 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45143 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53010 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94928 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62978 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127722 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36007 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111579 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75496 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/124124 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34939 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29733 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75094 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105764 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29964 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134279 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51614 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39418 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103405 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52028 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107799 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103177 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26266 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48540 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26821 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48618 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51488 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57287 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50881 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54236 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52575 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->