### PR TITLE
Address safer cpp warnings in MediaPlaybackTargetPickerMock.cpp & MockRealtimeMediaSourceCenter.cpp

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -732,7 +732,6 @@ platform/mediastream/mac/MediaStreamTrackAudioSourceProviderCocoa.cpp
 platform/mediastream/mac/RealtimeOutgoingAudioSourceCocoa.cpp
 platform/mediastream/mac/WebAudioSourceProviderCocoa.mm
 platform/mock/GeolocationClientMock.cpp
-platform/mock/MockRealtimeMediaSourceCenter.cpp
 platform/mock/MockRealtimeVideoSource.cpp
 platform/mock/RTCNotifiersMock.cpp
 platform/mock/mediasource/MockMediaSourcePrivate.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -63,7 +63,6 @@ platform/mediastream/RealtimeVideoCaptureSource.cpp
 platform/mediastream/cocoa/IncomingAudioMediaStreamTrackRendererUnit.cpp
 platform/mediastream/mac/RealtimeIncomingVideoSourceCocoa.mm
 platform/mediastream/mac/RealtimeOutgoingAudioSourceCocoa.cpp
-platform/mock/MediaPlaybackTargetPickerMock.cpp
 platform/network/cocoa/NetworkStorageSessionCocoa.mm
 platform/sql/SQLiteDatabase.cpp
 rendering/BackgroundPainter.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -369,7 +369,6 @@ platform/graphics/mac/controls/ProgressBarMac.mm
 platform/graphics/mac/controls/SliderTrackMac.mm
 platform/graphics/transforms/RotateTransformOperation.cpp
 platform/mediastream/mac/RealtimeIncomingVideoSourceCocoa.mm
-platform/mock/MockRealtimeMediaSourceCenter.cpp
 platform/mock/MockRealtimeVideoSource.cpp
 platform/text/BidiContext.cpp
 platform/text/BidiResolver.h

--- a/Source/WebCore/platform/mock/MediaPlaybackTargetPickerMock.cpp
+++ b/Source/WebCore/platform/mock/MediaPlaybackTargetPickerMock.cpp
@@ -77,12 +77,13 @@ void MediaPlaybackTargetPickerMock::showPlaybackTargetPicker(CocoaView*, const F
     LOG(Media, "MediaPlaybackTargetPickerMock::showPlaybackTargetPicker - checkActiveRoute = %i, useDarkAppearance = %i", (int)checkActiveRoute, (int)useDarkAppearance);
 
     m_showingMenu = true;
-    callOnMainThread([this, weakThis = WeakPtr { *this }] {
-        if (!weakThis)
+    callOnMainThread([weakThis = WeakPtr { *this }] {
+        CheckedPtr checkedThis = weakThis.get();
+        if (!checkedThis)
             return;
 
-        m_showingMenu = false;
-        currentDeviceDidChange();
+        checkedThis->m_showingMenu = false;
+        checkedThis->currentDeviceDidChange();
     });
 }
 
@@ -90,15 +91,16 @@ void MediaPlaybackTargetPickerMock::startingMonitoringPlaybackTargets()
 {
     LOG(Media, "MediaPlaybackTargetPickerMock::startingMonitoringPlaybackTargets");
 
-    callOnMainThread([this, weakThis = WeakPtr { *this }] {
-        if (!weakThis)
+    callOnMainThread([weakThis = WeakPtr { *this }] {
+        CheckedPtr checkedThis = weakThis.get();
+        if (!checkedThis)
             return;
 
-        if (m_state == MediaPlaybackTargetContext::MockState::OutputDeviceAvailable)
-            availableDevicesDidChange();
+        if (checkedThis->m_state == MediaPlaybackTargetContext::MockState::OutputDeviceAvailable)
+            checkedThis->availableDevicesDidChange();
 
-        if (!m_deviceName.isEmpty() && m_state != MediaPlaybackTargetContext::MockState::Unknown)
-            currentDeviceDidChange();
+        if (!checkedThis->m_deviceName.isEmpty() && checkedThis->m_state != MediaPlaybackTargetContext::MockState::Unknown)
+            checkedThis->currentDeviceDidChange();
     });
 }
 
@@ -117,18 +119,19 @@ void MediaPlaybackTargetPickerMock::setState(const String& deviceName, MediaPlay
 {
     LOG(Media, "MediaPlaybackTargetPickerMock::setState - name = %s, state = 0x%x", deviceName.utf8().data(), (unsigned)state);
 
-    callOnMainThread([this, weakThis = WeakPtr { *this }, state, deviceName] {
-        if (!weakThis)
+    callOnMainThread([weakThis = WeakPtr { *this }, state, deviceName] {
+        CheckedPtr checkedThis = weakThis.get();
+        if (!checkedThis)
             return;
 
-        if (deviceName != m_deviceName && state != MediaPlaybackTargetContext::MockState::Unknown) {
-            m_deviceName = deviceName;
-            currentDeviceDidChange();
+        if (deviceName != checkedThis->m_deviceName && state != MediaPlaybackTargetContext::MockState::Unknown) {
+            checkedThis->m_deviceName = deviceName;
+            checkedThis->currentDeviceDidChange();
         }
 
-        if (m_state != state) {
-            m_state = state;
-            availableDevicesDidChange();
+        if (checkedThis->m_state != state) {
+            checkedThis->m_state = state;
+            checkedThis->availableDevicesDidChange();
         }
     });
 }


### PR DESCRIPTION
#### a1518bfe6638e4f4518cb649184e516d5c9f9e72
<pre>
Address safer cpp warnings in MediaPlaybackTargetPickerMock.cpp &amp; MockRealtimeMediaSourceCenter.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=299339">https://bugs.webkit.org/show_bug.cgi?id=299339</a>

Reviewed by Darin Adler and Ryosuke Niwa.

* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebCore/platform/mock/MediaPlaybackTargetPickerMock.cpp:
(WebCore::MediaPlaybackTargetPickerMock::showPlaybackTargetPicker):
(WebCore::MediaPlaybackTargetPickerMock::startingMonitoringPlaybackTargets):
(WebCore::MediaPlaybackTargetPickerMock::setState):
* Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp:
(WebCore::MockDisplayCapturer::start):
(WebCore::MockDisplayCapturer::stop):
(WebCore::MockDisplayCapturer::generateFrame):
(WebCore::MockDisplayCapturer::triggerMockCaptureConfigurationChange):

Canonical link: <a href="https://commits.webkit.org/300375@main">https://commits.webkit.org/300375@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a7ea0783cde6f74e2d46e8e6e555d07c5dab9add

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122303 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42007 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32689 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128887 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74397 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/56d86781-ec68-4228-a349-4392b5cc3390) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/124179 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42724 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50601 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92963 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/61785 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0759fcf4-60e8-4b41-ad55-f053770d333a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125255 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34078 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109515 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73620 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5d4eab02-0150-47ff-b6c1-b0a85012e9c2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33081 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27675 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72377 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/103732 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27882 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131630 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49243 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37467 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101525 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49617 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105735 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101396 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25721 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46758 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24887 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/46005 "Build was cancelled. Recent messages:Printed configuration") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49100 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54839 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48569 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51919 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50250 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->