### PR TITLE
First pointerdown event lost after context menu is triggered

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1277,10 +1277,6 @@ imported/w3c/web-platform-tests/resource-timing/TAO-match.html [ Pass Failure ]
 imported/w3c/web-platform-tests/resource-timing/iframe-failed-commit.html [ Pass Failure ]
 imported/w3c/web-platform-tests/resource-timing/fetch-cross-origin-redirect.https.html [ Pass Failure ]
 
-# Timing out (missing auxclick automation?):
-webkit.org/b/214677 imported/w3c/web-platform-tests/event-timing/interactionid-aux-pointerdown-and-pointerdown.html [ Skip ]
-webkit.org/b/214677 imported/w3c/web-platform-tests/event-timing/interactionid-aux-pointerdown.html [ Skip ]
-
 # No browser passes, test is likely outdated:
 webkit.org/b/214677 imported/w3c/web-platform-tests/event-timing/modal-dialog-interrupt-paint.html [ Skip ]
 webkit.org/b/214677 imported/w3c/web-platform-tests/event-timing/TapToStopFling.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/event-timing/interactionid-aux-pointerdown-and-pointerdown-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/event-timing/interactionid-aux-pointerdown-and-pointerdown-expected.txt
@@ -1,4 +1,4 @@
 Right click me to bring up OS level contextmenu popup.
 
-FAIL Event Timing: verify pointerdown reporting for mouse aux pointerdown only triggered contextmenu followed immediately by another pointerdown event. assert_implements: Event Timing is not supported. undefined
+PASS Event Timing: verify pointerdown reporting for mouse aux pointerdown only triggered contextmenu followed immediately by another pointerdown event.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/event-timing/interactionid-aux-pointerdown-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/event-timing/interactionid-aux-pointerdown-expected.txt
@@ -1,4 +1,4 @@
 Right click me to bring up OS level contextmenu popup.
 
-FAIL Event Timing: verify pointerdown reporting for mouse aux pointerdown only triggered contextmenu. assert_implements: Event Timing is not supported. undefined
+PASS Event Timing: verify pointerdown reporting for mouse aux pointerdown only triggered contextmenu.
 

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -68,6 +68,8 @@ webkit.org/b/285993 imported/w3c/web-platform-tests/html/canvas/offscreen/manual
 
 # Times out, possibly missing automation:
 webkit.org/b/214677 imported/w3c/web-platform-tests/event-timing/interactionid-auxclick.html [ Skip ]
+webkit.org/b/214677 imported/w3c/web-platform-tests/event-timing/interactionid-aux-pointerdown-and-pointerdown.html [ Skip ]
+webkit.org/b/214677 imported/w3c/web-platform-tests/event-timing/interactionid-aux-pointerdown.html [ Skip ]
 
 # Media controls
 accessibility/gtk/media-controls-panel-title.html [ Failure ]

--- a/LayoutTests/platform/win/TestExpectations
+++ b/LayoutTests/platform/win/TestExpectations
@@ -1979,6 +1979,8 @@ imported/w3c/web-platform-tests/event-timing/interactionid-orphan-pointerup.html
 # Fail with AccessDeniedAccess
 imported/w3c/web-platform-tests/event-timing/contextmenu.html [ Skip ]
 imported/w3c/web-platform-tests/event-timing/interactionid-auxclick.html [ Skip ]
+imported/w3c/web-platform-tests/event-timing/interactionid-aux-pointerdown-and-pointerdown.html [ Skip ]
+imported/w3c/web-platform-tests/event-timing/interactionid-aux-pointerdown.html [ Skip ]
 imported/w3c/web-platform-tests/event-timing/first-input-interactionid-key.html [ Skip ]
 
 compositing/video [ Skip ]

--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -533,6 +533,8 @@ webkit.org/b/244186 imported/w3c/web-platform-tests/event-timing/duration-with-t
 webkit.org/b/244186 imported/w3c/web-platform-tests/event-timing/event-retarget.html [ Skip ]
 webkit.org/b/244186 imported/w3c/web-platform-tests/event-timing/first-input-shadow-dom.html [ Skip ]
 webkit.org/b/244186 imported/w3c/web-platform-tests/event-timing/interactionid-auxclick.html [ Skip ]
+webkit.org/b/244186 imported/w3c/web-platform-tests/event-timing/interactionid-aux-pointerdown-and-pointerdown.html [ Skip ]
+webkit.org/b/244186 imported/w3c/web-platform-tests/event-timing/interactionid-aux-pointerdown.html [ Skip ]
 webkit.org/b/244186 imported/w3c/web-platform-tests/event-timing/interactionid-orphan-pointerup.html [ Skip ]
 webkit.org/b/244186 imported/w3c/web-platform-tests/event-timing/keydown.html [ Skip ]
 webkit.org/b/244186 imported/w3c/web-platform-tests/event-timing/large-duration-threshold.html [ Skip ]

--- a/Source/WebCore/page/PointerCaptureController.cpp
+++ b/Source/WebCore/page/PointerCaptureController.cpp
@@ -379,6 +379,12 @@ void PointerCaptureController::dispatchEventForTouchAtIndex(EventTarget& target,
 }
 #endif // ENABLE(TOUCH_EVENTS) && (PLATFORM(IOS_FAMILY) || PLATFORM(WPE))
 
+void PointerCaptureController::clearUnmatchedMouseDown(PointerID pointerID)
+{
+    if (RefPtr capturingData = m_activePointerIdsToCapturingData.get(pointerID))
+        capturingData->pointerIsPressed = false;
+}
+
 RefPtr<PointerEvent> PointerCaptureController::pointerEventForMouseEvent(const MouseEvent& mouseEvent, PointerID pointerId, const String& pointerType)
 {
     // If we already have known touches then we cannot dispatch a mouse event,

--- a/Source/WebCore/page/PointerCaptureController.h
+++ b/Source/WebCore/page/PointerCaptureController.h
@@ -73,6 +73,9 @@ public:
     void dispatchEvent(PointerEvent&, EventTarget*);
     WEBCORE_EXPORT void cancelPointer(PointerID, const IntPoint&, PointerEvent* existingCancelEvent = nullptr);
     void processPendingPointerCapture(PointerID);
+    // Used for mouse presses that trigger contextmenu, causing
+    // the matching release to be suppressed.
+    WEBCORE_EXPORT void clearUnmatchedMouseDown(PointerID);
 
 private:
     struct CapturingData : public RefCounted<CapturingData> {

--- a/Source/WebKit/WebProcess/WebPage/WebContextMenu.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebContextMenu.cpp
@@ -38,6 +38,7 @@
 #include <WebCore/LocalFrameInlines.h>
 #include <WebCore/LocalFrameView.h>
 #include <WebCore/Page.h>
+#include <WebCore/PointerCaptureController.h>
 
 namespace WebKit {
 using namespace WebCore;
@@ -51,19 +52,19 @@ WebContextMenu::~WebContextMenu()
 {
 }
 
-void WebContextMenu::show()
+bool WebContextMenu::show()
 {
     Ref page = *m_page;
     auto& controller = page->corePage()->contextMenuController();
     RefPtr frame = controller.hitTestResult().innerNodeFrame();
     if (!frame)
-        return;
+        return false;
     RefPtr webFrame = WebFrame::fromCoreFrame(*frame);
     if (!webFrame)
-        return;
+        return false;
     RefPtr view = frame->view();
     if (!view)
-        return;
+        return false;
 
     Vector<WebContextMenuItemData> menuItems;
     RefPtr<API::Object> userData;
@@ -74,6 +75,7 @@ void WebContextMenu::show()
     ContextMenuContextData contextMenuContextData(menuLocation, menuItems, controller.context());
 
     page->showContextMenuFromFrame(webFrame->info(), contextMenuContextData, UserData(WebProcess::singleton().transformObjectsToHandles(userData.get()).get()));
+    return true;
 }
 
 void WebContextMenu::itemSelected(const WebContextMenuItemData& item)

--- a/Source/WebKit/WebProcess/WebPage/WebContextMenu.h
+++ b/Source/WebKit/WebProcess/WebPage/WebContextMenu.h
@@ -45,7 +45,7 @@ public:
     
     ~WebContextMenu();
 
-    void show();
+    bool show();
     void itemSelected(const WebContextMenuItemData&);
     Vector<WebContextMenuItemData> items() const;
 

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -94,6 +94,7 @@
 #include <WebCore/OriginAccessPatterns.h>
 #include <WebCore/Page.h>
 #include <WebCore/PluginDocument.h>
+#include <WebCore/PointerCaptureController.h>
 #include <WebCore/ReferrerPolicy.h>
 #include <WebCore/RemoteDOMWindow.h>
 #include <WebCore/RemoteFrame.h>
@@ -1379,8 +1380,9 @@ bool WebFrame::handleContextMenuEvent(const PlatformMouseEvent& platformMouseEve
 
     bool handled = frame->eventHandler().sendContextMenuEvent(platformMouseEvent);
 #if ENABLE(CONTEXT_MENUS)
-    if (handled)
-        protectedPage()->protectedContextMenu()->show();
+    if (handled && protectedPage()->protectedContextMenu()->show())
+        protectedPage()->corePage()->pointerCaptureController().clearUnmatchedMouseDown(platformMouseEvent.pointerId());
+
 #endif
     return handled;
 }


### PR DESCRIPTION
#### a19b08297f53de5702b7aa7878843c40bfc08e9e
<pre>
First pointerdown event lost after context menu is triggered
<a href="https://bugs.webkit.org/show_bug.cgi?id=232123">https://bugs.webkit.org/show_bug.cgi?id=232123</a>
<a href="https://rdar.apple.com/84787733">rdar://84787733</a>

Reviewed by Lily Spiniolas and Abrar Rahman Protyasha.

We now explicitly do some cleanup on PointerCaptureController when
showing a contextmenu due right-click. This is required because the
events are not processed while the contextmenu is open, causing the
mousedown that opens the contextmenu to not have a matching mouseup.

The lack of a matching mouseup used to result in one later mousedown
being interpreted as part of a mouse button chord, causing
PointerCaptureController::pointerEventForMouseEvent() to produce a
pointermove instead of a pointerdown.

Canonical link: <a href="https://commits.webkit.org/300696@main">https://commits.webkit.org/300696@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d1db1d5a9c9d7a1cfd19be42db71772affe6e67

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123234 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42948 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33645 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/129942 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/75347 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/125111 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43672 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51543 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93678 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62148 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126187 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34796 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110278 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74305 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33764 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28434 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73457 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104510 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28660 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132659 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50184 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38196 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102168 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50560 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106499 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102024 "Found 1 new API test failure: WebKitGTK/TestInspector:/webkit/WebKitWebInspector/manual-attach-detach (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25991 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47381 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25601 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/46958 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50039 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/55800 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49509 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/52860 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51188 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->