### PR TITLE
Make scrollend test assertions more explicit

### DIFF
--- a/LayoutTests/fast/scrolling/mac/scrollend-event-on-select-element-expected.txt
+++ b/LayoutTests/fast/scrolling/mac/scrollend-event-on-select-element-expected.txt
@@ -1,7 +1,7 @@
 
 Test scroll over content
-PASS overflowScrollendEventCount == 1 is true
-PASS windowScrollendEventCount == 0 is true
+PASS overflowScrollendEventCount is 1
+PASS windowScrollendEventCount is 0
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/scrolling/mac/scrollend-event-on-select-element.html
+++ b/LayoutTests/fast/scrolling/mac/scrollend-event-on-select-element.html
@@ -83,8 +83,8 @@
             await UIHelper.mouseWheelSequence(wheelEventSquence);
             await UIHelper.renderingUpdate();
 
-            shouldBe('overflowScrollendEventCount == 1', 'true');
-            shouldBe('windowScrollendEventCount == 0', 'true');
+            shouldBe('overflowScrollendEventCount', '1');
+            shouldBe('windowScrollendEventCount', '0');
         }
 
         async function scrollTest()

--- a/LayoutTests/fast/scrolling/mac/scrollend-event-user-scroll-basic-expected.txt
+++ b/LayoutTests/fast/scrolling/mac/scrollend-event-user-scroll-basic-expected.txt
@@ -1,11 +1,11 @@
 
 Test scroll over content
-PASS overflowScrollendEventCount == 1 is true
-PASS windowScrollendEventCount == 0 is true
+PASS overflowScrollendEventCount is 1
+PASS windowScrollendEventCount is 0
 
 Test scroll over document
-PASS overflowScrollendEventCount == 0 is true
-PASS windowScrollendEventCount == 1 is true
+PASS overflowScrollendEventCount is 0
+PASS windowScrollendEventCount is 1
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/scrolling/mac/scrollend-event-user-scroll-basic.html
+++ b/LayoutTests/fast/scrolling/mac/scrollend-event-user-scroll-basic.html
@@ -84,8 +84,8 @@
             await UIHelper.mouseWheelSequence(wheelEventSquence);
             await UIHelper.renderingUpdate();
 
-            shouldBe('overflowScrollendEventCount == 1', 'true');
-            shouldBe('windowScrollendEventCount == 0', 'true');
+            shouldBe('overflowScrollendEventCount', '1');
+            shouldBe('windowScrollendEventCount', '0');
         }
 
         async function testScrollOverDocument()
@@ -133,8 +133,8 @@
             await UIHelper.mouseWheelSequence(wheelEventSquence);
             await UIHelper.renderingUpdate();
 
-            shouldBe('overflowScrollendEventCount == 0', 'true');
-            shouldBe('windowScrollendEventCount == 1', 'true');
+            shouldBe('overflowScrollendEventCount', '0');
+            shouldBe('windowScrollendEventCount', '1');
         }
 
 

--- a/LayoutTests/fast/scrolling/mac/stateless-user-scroll-scrollend-expected.txt
+++ b/LayoutTests/fast/scrolling/mac/stateless-user-scroll-scrollend-expected.txt
@@ -1,4 +1,4 @@
-PASS windowScrollendEventCount == 1 is true
+PASS windowScrollendEventCount is 1
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/scrolling/mac/stateless-user-scroll-scrollend.html
+++ b/LayoutTests/fast/scrolling/mac/stateless-user-scroll-scrollend.html
@@ -42,7 +42,7 @@ addEventListener("load", async () => {
     await UIHelper.statelessMouseWheelScrollAt(200, 200, 0, -1);
     await UIHelper.ensurePresentationUpdate();
     setTimeout(function() {
-        shouldBe('windowScrollendEventCount == 1', 'true');
+        shouldBe('windowScrollendEventCount', '1');
         finishJSTest();
     }, 100);
 });


### PR DESCRIPTION
#### 7e26a0b0c6958e46af25f497f7f1bf6498f39244
<pre>
Make scrollend test assertions more explicit
<a href="https://bugs.webkit.org/show_bug.cgi?id=299342">https://bugs.webkit.org/show_bug.cgi?id=299342</a>
<a href="https://rdar.apple.com/161139933">rdar://161139933</a>

Reviewed by Simon Fraser.

Make it easier to see what&apos;s the incorrect number when test fails.

* LayoutTests/fast/scrolling/mac/scrollend-event-on-select-element-expected.txt:
* LayoutTests/fast/scrolling/mac/scrollend-event-on-select-element.html:
* LayoutTests/fast/scrolling/mac/scrollend-event-user-scroll-basic-expected.txt:
* LayoutTests/fast/scrolling/mac/scrollend-event-user-scroll-basic.html:
* LayoutTests/fast/scrolling/mac/stateless-user-scroll-scrollend-expected.txt:
* LayoutTests/fast/scrolling/mac/stateless-user-scroll-scrollend.html:

Canonical link: <a href="https://commits.webkit.org/300366@main">https://commits.webkit.org/300366@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ec087f8cd53bb7e4379e9db7b5a33bb5814d219f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122309 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42013 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32695 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128893 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/74403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a283cdd4-8104-41ab-821a-501238d02278) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42730 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50607 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/92967 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/74403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/06835cf6-c3fe-4764-8440-8b40e0c922da) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125261 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34081 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109521 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73625 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4b951dcf-2bb3-4976-85e3-b625b6084ec8) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/33084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/27681 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72383 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/103615 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27888 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/131636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49249 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/37476 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/131636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49623 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105741 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/131636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25709 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/46761 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/24892 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/46011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49106 "Built successfully") | | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/48575 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/51925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50256 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->