### PR TITLE
Address safer cpp warnings in CertificateInfoCFNet.cpp & FormDataStreamCFNet.cpp

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
@@ -108,7 +108,6 @@ platform/mediastream/mac/AVVideoCaptureSource.mm
 platform/mediastream/mac/ScreenCaptureKitCaptureSource.mm
 platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.mm
 platform/network/cf/DNSResolveQueueCFNet.cpp
-platform/network/cf/FormDataStreamCFNet.cpp
 platform/network/cocoa/CredentialCocoa.mm
 platform/network/cocoa/NetworkStorageSessionCocoa.mm
 platform/network/cocoa/ProtectionSpaceCocoa.mm

--- a/Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
@@ -71,7 +71,6 @@ platform/libwebrtc/LibWebRTCVPXVideoDecoder.cpp
 platform/mediastream/mac/AVVideoCaptureSource.mm
 platform/mediastream/mac/CoreAudioSharedUnit.mm
 platform/mediastream/mac/RealtimeIncomingVideoSourceCocoa.mm
-platform/network/cf/CertificateInfoCFNet.cpp
 platform/network/mac/NetworkStateNotifierMac.cpp
 platform/network/mac/ResourceHandleMac.mm
 platform/network/mac/UTIUtilities.mm

--- a/Source/WebCore/platform/network/cf/FormDataStreamCFNet.h
+++ b/Source/WebCore/platform/network/cf/FormDataStreamCFNet.h
@@ -44,6 +44,6 @@ RetainPtr<CFReadStreamRef> createHTTPBodyCFReadStream(FormData&);
 
 FormData* httpBodyFromStream(CFReadStreamRef);
 
-CFStringRef formDataStreamLengthPropertyName();
+CFStringRef formDataStreamLengthPropertyNameSingleton();
 
 } // namespace WebCore

--- a/Source/WebCore/platform/network/cocoa/ResourceRequestCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/ResourceRequestCocoa.mm
@@ -361,7 +361,7 @@ void ResourceRequest::doUpdatePlatformHTTPBody()
 
     if (RetainPtr bodyStream = [nsRequest HTTPBodyStream]) {
         // For streams, provide a Content-Length to avoid using chunked encoding, and to get accurate total length in callbacks.
-        RetainPtr<NSString> lengthString = [bodyStream propertyForKey:(__bridge NSString *)formDataStreamLengthPropertyName()];
+        RetainPtr<NSString> lengthString = [bodyStream propertyForKey:bridge_cast(formDataStreamLengthPropertyNameSingleton())];
         if (lengthString) {
             [nsRequest setValue:lengthString.get() forHTTPHeaderField:@"Content-Length"];
             // Since resource request is already marked updated, we need to keep it up to date too.

--- a/Source/WebCore/platform/network/mac/FormDataStreamMac.h
+++ b/Source/WebCore/platform/network/mac/FormDataStreamMac.h
@@ -42,6 +42,6 @@ void setHTTPBody(NSMutableURLRequest *, const RefPtr<FormData>&);
 WEBCORE_EXPORT RetainPtr<NSInputStream> createHTTPBodyNSInputStream(Ref<FormData>&&);
 FormData* httpBodyFromStream(NSInputStream *);
 
-CFStringRef formDataStreamLengthPropertyName();
+CFStringRef formDataStreamLengthPropertyNameSingleton();
 
 } // namespace WebCore


### PR DESCRIPTION
#### dd2a87fa8a8f2ee4cff48c77f054d0c5646f31fe
<pre>
Address safer cpp warnings in CertificateInfoCFNet.cpp &amp; FormDataStreamCFNet.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=299344">https://bugs.webkit.org/show_bug.cgi?id=299344</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations:
* Source/WebCore/platform/network/cf/CertificateInfoCFNet.cpp:
(WebCore::CertificateInfo::containsNonRootSHA1SignedCertificate const):
(WebCore::CertificateInfo::summary const):
* Source/WebCore/platform/network/cf/FormDataStreamCFNet.cpp:
(WebCore::formDataPointerPropertyNameSingleton):
(WebCore::formDataStreamLengthPropertyNameSingleton):
(WebCore::advanceCurrentStream):
(WebCore::formCopyProperty):
(WebCore::formEventCallback):
(WebCore::httpBodyFromStream):
(WebCore::formDataStreamLengthPropertyName): Deleted.
* Source/WebCore/platform/network/cf/FormDataStreamCFNet.h:
* Source/WebCore/platform/network/cocoa/ResourceRequestCocoa.mm:
(WebCore::ResourceRequest::doUpdatePlatformHTTPBody):
* Source/WebCore/platform/network/mac/FormDataStreamMac.h:

Canonical link: <a href="https://commits.webkit.org/300385@main">https://commits.webkit.org/300385@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3bd608c5a514209ae04885eeef15807c26f91a9f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122386 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42092 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32778 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128973 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/74485 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bc17430b-2be4-44ad-bc17-4e0945b546d5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/124262 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42811 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50685 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93022 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/74485 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c88e916a-1cba-4741-8add-fc65a6e1c711) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125338 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34142 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109578 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73681 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/66693aec-e77a-44c5-b2a5-7cd2b49973db) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33128 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27736 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72468 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103741 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27945 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131714 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49327 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37533 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101573 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49701 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105798 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101444 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25725 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46814 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24944 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/46089 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49185 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54928 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48652 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/52002 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50334 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->