### PR TITLE
Non-unified source build fix 2025-09 (part 4)

### DIFF
--- a/Source/WebCore/inspector/FrameInspectorController.cpp
+++ b/Source/WebCore/inspector/FrameInspectorController.cpp
@@ -31,11 +31,13 @@
 #include "FrameInspectorController.h"
 
 #include "CommonVM.h"
+#include "FrameInlines.h"
 #include "InspectorInstrumentation.h"
 #include "InstrumentingAgents.h"
 #include "JSDOMBindingSecurity.h"
 #include "JSDOMWindow.h"
 #include "JSExecState.h"
+#include "Settings.h"
 #include "WebInjectedScriptHost.h"
 #include "WebInjectedScriptManager.h"
 #include <JavaScriptCore/InspectorAgentBase.h>

--- a/Source/WebCore/rendering/style/StyleScrollSnapPoints.cpp
+++ b/Source/WebCore/rendering/style/StyleScrollSnapPoints.cpp
@@ -26,6 +26,9 @@
 #include "config.h"
 #include "StyleScrollSnapPoints.h"
 
+#include <wtf/text/ASCIILiteral.h>
+#include <wtf/text/TextStream.h>
+
 namespace WebCore {
 
 WTF::TextStream& operator<<(WTF::TextStream& ts, ScrollSnapAlign align)

--- a/Source/WebCore/style/values/svg/StyleSVGPaint.cpp
+++ b/Source/WebCore/style/values/svg/StyleSVGPaint.cpp
@@ -27,6 +27,7 @@
 
 #include "AnimationUtilities.h"
 #include "CSSURLValue.h"
+#include "RenderStyle.h"
 #include "StyleBuilderChecking.h"
 #include "StyleForVisitedLink.h"
 

--- a/Source/WebKit/GPUProcess/graphics/RemoteSnapshotRecorder.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteSnapshotRecorder.cpp
@@ -28,6 +28,7 @@
 #if ENABLE(GPU_PROCESS)
 #include "RemoteSnapshotRecorder.h"
 
+#include "Logging.h"
 #include "RemoteGraphicsContextMessages.h"
 #include "RemoteSnapshot.h"
 #include "RemoteSnapshotRecorderMessages.h"

--- a/Source/WebKit/UIProcess/Inspector/Agents/InspectorBrowserAgent.cpp
+++ b/Source/WebKit/UIProcess/Inspector/Agents/InspectorBrowserAgent.cpp
@@ -30,6 +30,7 @@
 #include "WebInspectorUIProxy.h"
 #include "WebPageInspectorController.h"
 #include "WebPageProxy.h"
+#include "WebsiteDataStore.h"
 #include <JavaScriptCore/InspectorProtocolObjects.h>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>

--- a/Source/WebKit/UIProcess/Inspector/WebFrameInspectorTargetProxy.cpp
+++ b/Source/WebKit/UIProcess/Inspector/WebFrameInspectorTargetProxy.cpp
@@ -31,6 +31,7 @@
 #include "ProvisionalFrameProxy.h"
 #include "WebFrameMessages.h"
 #include "WebFrameProxy.h"
+#include "WebProcessProxy.h"
 #include <JavaScriptCore/InspectorTarget.h>
 #include <memory>
 #include <wtf/TZoneMallocInlines.h>

--- a/Source/WebKit/UIProcess/Inspector/WebPageDebuggable.cpp
+++ b/Source/WebKit/UIProcess/Inspector/WebPageDebuggable.cpp
@@ -31,6 +31,7 @@
 #include "WebFrameProxy.h"
 #include "WebPageInspectorController.h"
 #include "WebPageProxy.h"
+#include "WebsiteDataStore.h"
 #include <wtf/MainThread.h>
 #include <wtf/TZoneMallocInlines.h>
 


### PR DESCRIPTION
#### e48b8f5cc10e25614346921a92c5b546d87b7d93
<pre>
Non-unified source build fix 2025-09 (part 4)
<a href="https://bugs.webkit.org/show_bug.cgi?id=298385">https://bugs.webkit.org/show_bug.cgi?id=298385</a>

Unreviewed build fix for non-unified builds.

* Source/WebCore/inspector/FrameInspectorController.cpp:
* Source/WebCore/rendering/style/StyleScrollSnapPoints.cpp:
* Source/WebCore/style/values/svg/StyleSVGPaint.cpp:
* Source/WebKit/GPUProcess/graphics/RemoteSnapshotRecorder.cpp:
* Source/WebKit/UIProcess/Inspector/Agents/InspectorBrowserAgent.cpp:
* Source/WebKit/UIProcess/Inspector/WebFrameInspectorTargetProxy.cpp:
* Source/WebKit/UIProcess/Inspector/WebPageDebuggable.cpp:

Canonical link: <a href="https://commits.webkit.org/300367@main">https://commits.webkit.org/300367@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2db20e000436357b10ccd88d2d0964d9392128f1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122315 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42019 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32701 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128900 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/74409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/124191 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42736 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50613 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/92972 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/74409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125267 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/34090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109523 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/73631 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/33090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/27683 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72390 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/103632 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27890 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/131642 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49255 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/37481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/131642 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/49629 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105743 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/131642 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/24894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/46017 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19337 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49112 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/54854 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/48581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/51931 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50262 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->