### PR TITLE
Add more enforcement of zoom evaluation for Style::Length<>

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -3363,7 +3363,10 @@ void Document::pageSizeAndMarginsInPixels(int pageIndex, IntSize& pageSize, int&
             return pageSize;
         },
         [&](const Style::PageSize::Lengths& lengths) -> IntSize {
-            return { static_cast<int>(lengths.width().value), static_cast<int>(lengths.height().value) };
+            return {
+                static_cast<int>(lengths.width().evaluate(1.0f /* FIXME FIND ZOOM */)),
+                static_cast<int>(lengths.height().evaluate(1.0f /* FIXME FIND ZOOM */)),
+            };
         }
     );
 

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -4625,8 +4625,8 @@ FontAttributes Editor::fontAttributesAtSelectionStart()
         [&](const auto& shadows) {
             return FontShadow {
                 style->colorWithColorFilter(shadows[0].color),
-                { shadows[0].location.x().value, shadows[0].location.y().value },
-                shadows[0].blur.value
+                { shadows[0].location.x().evaluate(1.0f /* FIXME FIND ZOOM */), shadows[0].location.y().evaluate(1.0f /* FIXME FIND ZOOM */) },
+                shadows[0].blur.evaluate(1.0f /* FIXME FIND ZOOM */)
             };
         }
     );

--- a/Source/WebCore/html/NumberInputType.cpp
+++ b/Source/WebCore/html/NumberInputType.cpp
@@ -310,7 +310,7 @@ float NumberInputType::decorationWidth(float inputWidth) const
 
         // FIXME <https://webkit.org/b/294858>: This is incorrect for anything other than fixed widths.
         if (auto fixedLogicalWidth = spinButton->computedStyle()->logicalWidth().tryFixed())
-            width += fixedLogicalWidth->value;
+            width += fixedLogicalWidth->evaluate(1.0f /* FIXME FIND ZOOM */);
         else if (auto percentageLogicalWidth = spinButton->computedStyle()->logicalWidth().tryPercentage()) {
             auto percentageLogicalWidthValue = percentageLogicalWidth->value;
             if (percentageLogicalWidthValue != 100.f)

--- a/Source/WebCore/html/SearchInputType.cpp
+++ b/Source/WebCore/html/SearchInputType.cpp
@@ -199,12 +199,12 @@ float SearchInputType::decorationWidth(float) const
     if (RefPtr resultsButton = m_resultsButton; resultsButton && resultsButton->renderStyle()) {
         // FIXME: Document what invariant holds to allow only using fixed logical widths?
         if (auto fixedLogicalWidth = resultsButton->renderStyle()->logicalWidth().tryFixed())
-            width += fixedLogicalWidth->value;
+            width += fixedLogicalWidth->evaluate(1.0f /* FIXME FIND ZOOM */);
     }
     if (RefPtr cancelButton = m_cancelButton; cancelButton && cancelButton->renderStyle()) {
         // FIXME: Document what invariant holds to allow only using fixed logical widths?
         if (auto fixedLogicalWidth = cancelButton->renderStyle()->logicalWidth().tryFixed())
-            width += fixedLogicalWidth->value;
+            width += fixedLogicalWidth->evaluate(1.0f /* FIXME FIND ZOOM */);
     }
     return width;
 }

--- a/Source/WebCore/layout/formattingContexts/FormattingGeometry.cpp
+++ b/Source/WebCore/layout/formattingContexts/FormattingGeometry.cpp
@@ -87,7 +87,7 @@ template<FormattingGeometry::HeightType heightType> std::optional<LayoutUnit> Fo
             return { };
     }
     if (auto fixedHeight = height.tryFixed())
-        return LayoutUnit { fixedHeight->value };
+        return LayoutUnit { fixedHeight->evaluate(1.0f /* FIXME FIND ZOOM */) };
 
     if (!containingBlockHeight) {
         if (layoutState().inQuirksMode()) {

--- a/Source/WebCore/layout/formattingContexts/FormattingGeometry.h
+++ b/Source/WebCore/layout/formattingContexts/FormattingGeometry.h
@@ -136,7 +136,7 @@ std::optional<LayoutUnit> FormattingGeometry::computedValue(const auto& geometry
 std::optional<LayoutUnit> FormattingGeometry::fixedValue(const auto& geometryProperty) const
 {
     if (auto fixed = geometryProperty.tryFixed())
-        return LayoutUnit { fixed->value };
+        return LayoutUnit { fixed->evaluate(1.0f /* FIXME FIND ZOOM */) };
     return { };
 }
 

--- a/Source/WebCore/layout/formattingContexts/block/BlockFormattingQuirks.cpp
+++ b/Source/WebCore/layout/formattingContexts/block/BlockFormattingQuirks.cpp
@@ -139,7 +139,7 @@ LayoutUnit BlockFormattingQuirks::heightValueOfNearestContainingBlockWithFixedHe
     for (auto& containingBlock : containingBlockChain(layoutBox)) {
         auto containingBlockHeight = containingBlock.style().logicalHeight();
         if (auto fixedContainingBlockHeight = containingBlockHeight.tryFixed())
-            return LayoutUnit(fixedContainingBlockHeight->value - bodyAndDocumentVerticalMarginPaddingAndBorder);
+            return LayoutUnit(fixedContainingBlockHeight->evaluate(1.0f /* FIXME FIND ZOOM */) - bodyAndDocumentVerticalMarginPaddingAndBorder);
 
         // If the only fixed value box we find is the ICB, then ignore the body and the document (vertical) margin, padding and border. So much quirkiness.
         // -and it's totally insane because now we freely travel across formatting context boundaries and computed margins are nonexistent.

--- a/Source/WebCore/layout/formattingContexts/flex/FlexFormattingContext.cpp
+++ b/Source/WebCore/layout/formattingContexts/flex/FlexFormattingContext.cpp
@@ -91,7 +91,7 @@ FlexLayout::LogicalFlexItems FlexFormattingContext::convertFlexItemsToLogicalSpa
 
             auto propertyValueForLength = [&](auto& propertyValue, auto availableSize) -> std::optional<LayoutUnit> {
                 if (auto fixedPropertyValue = propertyValue.tryFixed())
-                    return LayoutUnit { fixedPropertyValue->value };
+                    return LayoutUnit { fixedPropertyValue->evaluate(1.0f /* FIXME FIND ZOOM */) };
                 if (propertyValue.isSpecified() && availableSize)
                     return Style::evaluate(propertyValue, *availableSize, 1.0f /* FIXME FIND ZOOM */);
                 return { };

--- a/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
@@ -81,7 +81,7 @@ TrackSizingAlgorithm::UnsizedTracks TrackSizingAlgorithm::initializeTrackSizes(c
             if (minTrackSizingFunction.isLength()) {
                 auto& trackBreadthLength = minTrackSizingFunction.length();
                 if (auto fixedValue = trackBreadthLength.tryFixed())
-                    return LayoutUnit { fixedValue->value };
+                    return LayoutUnit { fixedValue->evaluate(1.0f /* FIXME FIND ZOOM */) };
 
                 if (auto percentValue = trackBreadthLength.tryPercentage()) {
                     ASSERT_NOT_IMPLEMENTED_YET();
@@ -108,7 +108,7 @@ TrackSizingAlgorithm::UnsizedTracks TrackSizingAlgorithm::initializeTrackSizes(c
             if (maxTrackSizingFunction.isLength()) {
                 auto trackBreadthLength = maxTrackSizingFunction.length();
                 if (auto fixedValue = trackBreadthLength.tryFixed())
-                    return LayoutUnit { fixedValue->value };
+                    return LayoutUnit { fixedValue->evaluate(1.0f /* FIXME FIND ZOOM */) };
             }
 
             // An intrinsic sizing function

--- a/Source/WebCore/layout/formattingContexts/inline/InlineFormattingContext.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineFormattingContext.cpp
@@ -215,7 +215,7 @@ std::pair<LayoutUnit, LayoutUnit> InlineFormattingContext::minimumMaximumContent
     if (*minimumContentSize > *maximumContentSize) {
         auto hasNegativeImplicitMargin = [](auto& style) {
             auto textIndentFixedLength = style.textIndent().length.tryFixed();
-            return (textIndentFixedLength && textIndentFixedLength->value < 0) || style.wordSpacing() < 0 || style.letterSpacing() < 0;
+            return (textIndentFixedLength && textIndentFixedLength->isNegative()) || style.wordSpacing() < 0 || style.letterSpacing() < 0;
         };
         auto contentHasNegativeImplicitMargin = hasNegativeImplicitMargin(root().style());
         if (!contentHasNegativeImplicitMargin) {

--- a/Source/WebCore/layout/formattingContexts/table/TableFormattingContext.cpp
+++ b/Source/WebCore/layout/formattingContexts/table/TableFormattingContext.cpp
@@ -363,7 +363,7 @@ IntrinsicWidthConstraints TableFormattingContext::computedPreferredWidthForColum
             auto columnIndex = cellPosition.column;
             WTF::switchOn(cellStyle.logicalWidth(),
                 [&](const Style::PreferredSize::Fixed& fixed) {
-                    auto fixedWidth = LayoutUnit { fixed.value } + horizontalBorderAndPaddingWidth;
+                    auto fixedWidth = LayoutUnit { fixed.evaluate(1.0f /* FIXME FIND ZOOM */) } + horizontalBorderAndPaddingWidth;
                     maximumFixedColumnWidths[columnIndex] = std::max(maximumFixedColumnWidths[columnIndex].value_or(0_lu), fixedWidth);
                     hasColumnWithFixedWidth = true;
                 },

--- a/Source/WebCore/layout/formattingContexts/table/TableFormattingQuirks.cpp
+++ b/Source/WebCore/layout/formattingContexts/table/TableFormattingQuirks.cpp
@@ -63,7 +63,7 @@ LayoutUnit TableFormattingQuirks::heightValueOfNearestContainingBlockWithFixedHe
     // e.g <div style="height: 100px"><table><tr><td style="height: 100%"></td></tr></table></div> is resolved to 0px.
     for (auto& ancestor : containingBlockChainWithinFormattingContext(layoutBox, formattingContext().root())) {
         if (auto fixedHeight = ancestor.style().logicalHeight().tryFixed())
-            return LayoutUnit { fixedHeight->value };
+            return LayoutUnit { fixedHeight->evaluate(1.0f /* FIXME FIND ZOOM */) };
     }
     return { };
 }

--- a/Source/WebCore/layout/formattingContexts/table/TableLayout.cpp
+++ b/Source/WebCore/layout/formattingContexts/table/TableLayout.cpp
@@ -339,7 +339,7 @@ TableFormattingContext::TableLayout::DistributedSpaces TableFormattingContext::T
                 return { std::nullopt, GridSpace::Type::Auto };
             },
             [&](const Style::Length<CSS::Nonnegative, float>& fixed) -> std::pair<std::optional<float>, GridSpace::Type> {
-                return { fixed.value, GridSpace::Type::Fixed };
+                return { fixed.evaluate(1.0f /* FIXME FIND ZOOM */), GridSpace::Type::Fixed };
             },
             [&](const Style::Percentage<CSS::Nonnegative, float>& percentage) -> std::pair<std::optional<float>, GridSpace::Type> {
                 return { Style::evaluate(percentage, availableHorizontalSpace), GridSpace::Type::Percent };

--- a/Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.cpp
@@ -74,7 +74,7 @@ namespace LayoutIntegration {
 static LayoutUnit usedValueOrZero(const Style::MarginEdge& marginEdge, std::optional<LayoutUnit> availableWidth)
 {
     if (auto fixed = marginEdge.tryFixed())
-        return LayoutUnit { fixed->value };
+        return LayoutUnit { fixed->evaluate(1.0f /* FIXME FIND ZOOM */) };
 
     if (marginEdge.isAuto() || !availableWidth)
         return { };
@@ -85,7 +85,7 @@ static LayoutUnit usedValueOrZero(const Style::MarginEdge& marginEdge, std::opti
 static LayoutUnit usedValueOrZero(const Style::PaddingEdge& paddingEdge, std::optional<LayoutUnit> availableWidth)
 {
     if (auto fixed = paddingEdge.tryFixed())
-        return LayoutUnit { fixed->value };
+        return LayoutUnit { fixed->evaluate(1.0f /* FIXME FIND ZOOM */) };
 
     if (!availableWidth)
         return { };

--- a/Source/WebCore/layout/integration/flex/LayoutIntegrationFlexLayout.cpp
+++ b/Source/WebCore/layout/integration/flex/LayoutIntegrationFlexLayout.cpp
@@ -73,7 +73,7 @@ static inline Layout::ConstraintsForFlexContent constraintsForFlexContent(const 
 
     auto widthValue = [&](auto& computedValue) -> std::optional<LayoutUnit> {
         if (auto fixedWidth = computedValue.tryFixed())
-            return LayoutUnit { boxSizingIsContentBox ? fixedWidth->value : fixedWidth->value - horizontalMarginBorderAndPadding };
+            return LayoutUnit { boxSizingIsContentBox ? fixedWidth->evaluate(1.0f /* FIXME FIND ZOOM */) : fixedWidth->evaluate(1.0f /* FIXME FIND ZOOM */) - horizontalMarginBorderAndPadding };
 
         if (auto percentageWidth = computedValue.tryPercentage()) {
             auto value = Style::evaluate(*percentageWidth, flexContainerRenderer.containingBlock()->logicalWidth());
@@ -84,14 +84,14 @@ static inline Layout::ConstraintsForFlexContent constraintsForFlexContent(const 
 
     auto heightValue = [&](auto& computedValue, bool callRendererForPercentValue = false) -> std::optional<LayoutUnit> {
         if (auto fixedHeight = computedValue.tryFixed())
-            return LayoutUnit { boxSizingIsContentBox ? fixedHeight->value : fixedHeight->value - verticalMarginBorderAndPadding };
+            return LayoutUnit { boxSizingIsContentBox ? fixedHeight->evaluate(1.0f /* FIXME FIND ZOOM */) : fixedHeight->evaluate(1.0f /* FIXME FIND ZOOM */) - verticalMarginBorderAndPadding };
 
         if (auto percentageHeight = computedValue.tryPercentage()) {
             if (callRendererForPercentValue)
                 return flexContainerRenderer.computePercentageLogicalHeight(*percentageHeight, RenderBox::UpdatePercentageHeightDescendants::No);
 
             if (auto fixedContainingBlockHeight = flexContainerRenderer.containingBlock()->style().height().tryFixed()) {
-                auto value = Style::evaluate(*percentageHeight, fixedContainingBlockHeight->value, 1.0f);
+                auto value = Style::evaluate(*percentageHeight, fixedContainingBlockHeight->evaluate(1.0f /* FIXME FIND ZOOM */));
                 return LayoutUnit { boxSizingIsContentBox ? value : value - verticalMarginBorderAndPadding };
             }
         }

--- a/Source/WebCore/layout/layouttree/LayoutElementBox.cpp
+++ b/Source/WebCore/layout/layouttree/LayoutElementBox.cpp
@@ -208,7 +208,7 @@ LayoutUnit ElementBox::intrinsicWidth() const
         return m_replacedData->intrinsicSize->width();
 
     // FIXME: Document what invariant holds to allow not checking if the logicalWidth() is fixed.
-    return LayoutUnit { style().logicalWidth().tryFixed()->value };
+    return LayoutUnit { style().logicalWidth().tryFixed()->evaluate(1.0f /* FIXME FIND ZOOM */) };
 }
 
 LayoutUnit ElementBox::intrinsicHeight() const
@@ -218,7 +218,7 @@ LayoutUnit ElementBox::intrinsicHeight() const
         return m_replacedData->intrinsicSize->height();
 
     // FIXME: Document what invariant holds to allow not checking if the logicalHeight() is fixed.
-    return LayoutUnit { style().logicalHeight().tryFixed()->value };;
+    return LayoutUnit { style().logicalHeight().tryFixed()->evaluate(1.0f /* FIXME FIND ZOOM */) };;
 }
 
 LayoutUnit ElementBox::intrinsicRatio() const

--- a/Source/WebCore/page/IntersectionObserver.cpp
+++ b/Source/WebCore/page/IntersectionObserver.cpp
@@ -216,7 +216,7 @@ static String marginBoxToString(const IntersectionObserverMarginBox& marginBox)
         if (auto percentage = edge.tryPercentage())
             stringBuilder.append(static_cast<int>(percentage->value), "%"_s, side != BoxSide::Left ? " "_s : ""_s);
         else
-            stringBuilder.append(static_cast<int>(edge.tryFixed()->value), "px"_s, side != BoxSide::Left ? " "_s : ""_s);
+            stringBuilder.append(static_cast<int>(edge.tryFixed()->evaluate(1.0f /* FIXME FIND ZOOM */)), "px"_s, side != BoxSide::Left ? " "_s : ""_s);
     }
     return stringBuilder.toString();
 }
@@ -333,8 +333,8 @@ static void expandRootBoundsWithRootMargin(FloatRect& rootBounds, const Intersec
 {
     auto zoomAdjustedLength = [](const IntersectionObserverMarginEdge& edge, float maximumValue, float zoomFactor) {
         if (auto percentage = edge.tryPercentage())
-            return Style::evaluate(*percentage, maximumValue, 1.0f /* FIXME FIND ZOOM */);
-        return edge.tryFixed()->value * zoomFactor;
+            return Style::evaluate(*percentage, maximumValue);
+        return edge.tryFixed()->evaluate(zoomFactor);
     };
 
     auto rootMarginEdges = FloatBoxExtent {

--- a/Source/WebCore/page/PrintContext.cpp
+++ b/Source/WebCore/page/PrintContext.cpp
@@ -109,10 +109,10 @@ FloatBoxExtent PrintContext::computedPageMargin(FloatBoxExtent printMargin)
     auto marginLeft = style->marginLeft().tryFixed();
 
     return {
-        marginTop ? marginTop->value * pixelToPointScaleFactor : printMargin.top(),
-        marginRight ? marginRight->value * pixelToPointScaleFactor : printMargin.right(),
-        marginBottom ? marginBottom->value * pixelToPointScaleFactor : printMargin.bottom(),
-        marginLeft ? marginLeft->value * pixelToPointScaleFactor : printMargin.left(),
+        marginTop ? marginTop->evaluate(1.0f /* FIXME FIND ZOOM */) * pixelToPointScaleFactor : printMargin.top(),
+        marginRight ? marginRight->evaluate(1.0f /* FIXME FIND ZOOM */) * pixelToPointScaleFactor : printMargin.right(),
+        marginBottom ? marginBottom->evaluate(1.0f /* FIXME FIND ZOOM */) * pixelToPointScaleFactor : printMargin.bottom(),
+        marginLeft ? marginLeft->evaluate(1.0f /* FIXME FIND ZOOM */) * pixelToPointScaleFactor : printMargin.left(),
     };
 }
 
@@ -389,7 +389,7 @@ String PrintContext::pageProperty(LocalFrame* frame, const String& propertyName,
     // Implement formatters for properties we care about.
     if (propertyName == "margin-left"_s) {
         if (auto marginLeft = style->marginLeft().tryFixed())
-            return String::number(marginLeft->value);
+            return String::number(marginLeft->evaluate(1.0f /* FIXME FIND ZOOM */));
         return autoAtom();
     }
     if (propertyName == "line-height"_s)
@@ -410,7 +410,7 @@ String PrintContext::pageProperty(LocalFrame* frame, const String& propertyName,
                 return "portrait"_s;
             },
             [&](const Style::PageSize::Lengths& lengths) {
-                return makeString(lengths.width().value, ' ', lengths.height().value);
+                return makeString(lengths.width().evaluate(1.0f /* FIXME FIND ZOOM */), ' ', lengths.height().evaluate(1.0f /* FIXME FIND ZOOM */));
             }
         );
     }

--- a/Source/WebCore/page/ios/ContentChangeObserver.cpp
+++ b/Source/WebCore/page/ios/ContentChangeObserver.cpp
@@ -105,23 +105,23 @@ bool ContentChangeObserver::isVisuallyHidden(const Node& node)
 
     auto fixedWidth = style.logicalWidth().tryFixed();
     auto fixedHeight = style.logicalHeight().tryFixed();
-    if ((fixedWidth && !fixedWidth->value) || (fixedHeight && !fixedHeight->value))
+    if ((fixedWidth && fixedWidth->isZero()) || (fixedHeight && fixedHeight->isZero()))
         return true;
 
     auto fixedTop = style.logicalTop().tryFixed();
     auto fixedLeft = style.logicalLeft().tryFixed();
     // FIXME: This is trying to check if the element is outside of the viewport. This is incorrect for many reasons.
-    if (fixedLeft && fixedWidth && -fixedLeft->value >= fixedWidth->value)
+    if (fixedLeft && fixedWidth && -fixedLeft->evaluate(1.0f /* FIXME FIND ZOOM */) >= fixedWidth->evaluate(1.0f /* FIXME FIND ZOOM */))
         return true;
-    if (fixedTop && fixedHeight && -fixedTop->value >= fixedHeight->value)
+    if (fixedTop && fixedHeight && -fixedTop->evaluate(1.0f /* FIXME FIND ZOOM */) >= fixedHeight->evaluate(1.0f /* FIXME FIND ZOOM */))
         return true;
 
     // It's a common technique used to position content offscreen.
-    if (style.hasOutOfFlowPosition() && fixedLeft && fixedLeft->value <= -999)
+    if (style.hasOutOfFlowPosition() && fixedLeft && fixedLeft->evaluate(1.0f /* FIXME FIND ZOOM */) <= -999)
         return true;
 
     // FIXME: Check for other cases like zero height with overflow hidden.
-    if (auto fixedMaxHeight = style.maxHeight().tryFixed(); fixedMaxHeight && !fixedMaxHeight->value)
+    if (auto fixedMaxHeight = style.maxHeight().tryFixed(); fixedMaxHeight && fixedMaxHeight->isZero())
         return true;
 
     // Special case opacity, because a descendant with non-zero opacity should still be considered hidden when one of its ancetors has opacity: 0;
@@ -148,9 +148,9 @@ bool ContentChangeObserver::isConsideredVisible(const Node& node)
     // 1px width or height content is not considered visible.
     auto& style = *node.renderStyle();
 
-    if (auto fixedWidth = style.logicalWidth().tryFixed(); fixedWidth && fixedWidth->value <= 1)
+    if (auto fixedWidth = style.logicalWidth().tryFixed(); fixedWidth && fixedWidth->evaluate(1.0f /* FIXME FIND ZOOM */) <= 1)
         return false;
-    if (auto fixedHeight = style.logicalHeight().tryFixed(); fixedHeight && fixedHeight->value <= 1)
+    if (auto fixedHeight = style.logicalHeight().tryFixed(); fixedHeight && fixedHeight->evaluate(1.0f /* FIXME FIND ZOOM */) <= 1)
         return false;
     return true;
 }

--- a/Source/WebCore/rendering/AutoTableLayout.cpp
+++ b/Source/WebCore/rendering/AutoTableLayout.cpp
@@ -93,20 +93,20 @@ void AutoTableLayout::recalcColumn(unsigned effCol)
                     const float cCellMaxWidth = 32760;
                     auto cellLogicalWidth = cell->styleOrColLogicalWidth();
                     if (auto fixedCellLogicalWidth = cellLogicalWidth.tryFixed()) {
-                        if (fixedCellLogicalWidth->value > cCellMaxWidth)
+                        if (fixedCellLogicalWidth->evaluate(1.0f /* FIXME FIND ZOOM */) > cCellMaxWidth)
                             cellLogicalWidth = Style::PreferredSize::Fixed { cCellMaxWidth };
-                        if (fixedCellLogicalWidth->value < 0)
+                        if (fixedCellLogicalWidth->isNegative())
                             cellLogicalWidth = 0_css_px;
                     }
                     WTF::switchOn(cellLogicalWidth,
                         [&](const Style::PreferredSize::Fixed& fixedCellLogicalWidth) {
                             // ignore width=0
-                            if (fixedCellLogicalWidth.value > 0 && !columnLayout.logicalWidth.isPercentOrCalculated()) {
+                            if (fixedCellLogicalWidth.isPositive() && !columnLayout.logicalWidth.isPercentOrCalculated()) {
                                 float logicalWidth = cell->adjustBorderBoxLogicalWidthForBoxSizing(fixedCellLogicalWidth);
                                 if (auto fixedColumnLayoutLogicalWidth = columnLayout.logicalWidth.tryFixed()) {
                                     // Nav/IE weirdness
-                                    if ((logicalWidth > fixedColumnLayoutLogicalWidth->value)
-                                        || ((fixedColumnLayoutLogicalWidth->value == logicalWidth) && (maxContributor == cell))) {
+                                    if ((logicalWidth > fixedColumnLayoutLogicalWidth->evaluate(1.0f /* FIXME FIND ZOOM */))
+                                        || ((fixedColumnLayoutLogicalWidth->evaluate(1.0f /* FIXME FIND ZOOM */) == logicalWidth) && (maxContributor == cell))) {
                                         columnLayout.logicalWidth = Style::PreferredSize::Fixed { logicalWidth };
                                         fixedContributor = cell;
                                     }
@@ -139,7 +139,7 @@ void AutoTableLayout::recalcColumn(unsigned effCol)
 
     // Nav/IE weirdness
     if (auto fixedColumnLayoutLogicalWidth = columnLayout.logicalWidth.tryFixed()) {
-        if (m_table->document().inQuirksMode() && columnLayout.maxLogicalWidth > fixedColumnLayoutLogicalWidth->value && fixedContributor != maxContributor) {
+        if (m_table->document().inQuirksMode() && columnLayout.maxLogicalWidth > fixedColumnLayoutLogicalWidth->evaluate(1.0f /* FIXME FIND ZOOM */) && fixedContributor != maxContributor) {
             columnLayout.logicalWidth = CSS::Keyword::Auto { };
             fixedContributor = nullptr;
         }
@@ -174,8 +174,8 @@ void AutoTableLayout::fullRecalc()
             unsigned span = column->span();
             if (!colLogicalWidth.isAuto() && span == 1 && effCol < nEffCols && m_table->spanOfEffCol(effCol) == 1) {
                 m_layoutStruct[effCol].logicalWidth = colLogicalWidth;
-                if (auto fixedColLogicalWidth = colLogicalWidth.tryFixed(); fixedColLogicalWidth && m_layoutStruct[effCol].maxLogicalWidth < fixedColLogicalWidth->value)
-                    m_layoutStruct[effCol].maxLogicalWidth = fixedColLogicalWidth->value;
+                if (auto fixedColLogicalWidth = colLogicalWidth.tryFixed(); fixedColLogicalWidth && m_layoutStruct[effCol].maxLogicalWidth < fixedColLogicalWidth->evaluate(1.0f /* FIXME FIND ZOOM */))
+                    m_layoutStruct[effCol].maxLogicalWidth = fixedColLogicalWidth->evaluate(1.0f /* FIXME FIND ZOOM */);
             }
             currentColumn += span;
         }
@@ -267,8 +267,8 @@ void AutoTableLayout::computeIntrinsicLogicalWidths(LayoutUnit& minWidth, Layout
 
 void AutoTableLayout::applyPreferredLogicalWidthQuirks(LayoutUnit& minWidth, LayoutUnit& maxWidth) const
 {
-    if (auto fixedTableLogicalWidth = m_table->style().logicalWidth().tryFixed(); fixedTableLogicalWidth && fixedTableLogicalWidth->value > 0) {
-        minWidth = std::max(minWidth, m_table->overridingBorderBoxLogicalWidth().value_or(LayoutUnit { fixedTableLogicalWidth->value }));
+    if (auto fixedTableLogicalWidth = m_table->style().logicalWidth().tryFixed(); fixedTableLogicalWidth && fixedTableLogicalWidth->isPositive()) {
+        minWidth = std::max(minWidth, m_table->overridingBorderBoxLogicalWidth().value_or(LayoutUnit { fixedTableLogicalWidth->evaluate(1.0f /* FIXME FIND ZOOM */) }));
         maxWidth = minWidth;
     }
 }
@@ -341,8 +341,8 @@ float AutoTableLayout::calcEffectiveLogicalWidth()
                     allColsAreFixed = false;
                 },
                 [&](const Style::PreferredSize::Fixed& fixed) {
-                    if (fixed.value > 0) {
-                        fixedWidth += fixed.value;
+                    if (fixed.isPositive()) {
+                        fixedWidth += fixed.evaluate(1.0f /* FIXME FIND ZOOM */);
                         allColsArePercent = false;
                         // IE resets effWidth to Auto here, but this breaks the konqueror about page and seems to be some bad
                         // legacy behavior anyway. mozilla doesn't do this so I decided we don't neither.
@@ -408,7 +408,7 @@ float AutoTableLayout::calcEffectiveLogicalWidth()
                 for (unsigned pos = effCol; fixedWidth > 0 && pos < lastCol; ++pos) {
                     // NOTE: The unchecked use of tryFixed() here is allowed because `allColsAreFixed` is true.
                     // FIXME: Find a more type safe way to enforce this invariant.
-                    auto fixedLogicalWidth = m_layoutStruct[pos].logicalWidth.tryFixed()->value;
+                    auto fixedLogicalWidth = m_layoutStruct[pos].logicalWidth.tryFixed()->evaluate(1.0f /* FIXME FIND ZOOM */);
 
                     float cellLogicalWidth = std::max(m_layoutStruct[pos].effectiveMinLogicalWidth, cellMinLogicalWidth * fixedLogicalWidth / fixedWidth);
                     fixedWidth -= fixedLogicalWidth;
@@ -448,8 +448,8 @@ float AutoTableLayout::calcEffectiveLogicalWidth()
                 // Give min to variable first, to fixed second, and to others third.
                 for (unsigned pos = effCol; remainingMaxLogicalWidth >= 0 && pos < lastCol; ++pos) {
                     if (auto fixedLogicalWidth = m_layoutStruct[pos].logicalWidth.tryFixed(); fixedLogicalWidth && haveAuto && fixedWidth <= cellMinLogicalWidth) {
-                        float colMinLogicalWidth = std::max(m_layoutStruct[pos].effectiveMinLogicalWidth, fixedLogicalWidth->value);
-                        fixedWidth -= fixedLogicalWidth->value;
+                        float colMinLogicalWidth = std::max(m_layoutStruct[pos].effectiveMinLogicalWidth, fixedLogicalWidth->evaluate(1.0f /* FIXME FIND ZOOM */));
+                        fixedWidth -= fixedLogicalWidth->evaluate(1.0f /* FIXME FIND ZOOM */);
                         remainingMinLogicalWidth -= m_layoutStruct[pos].effectiveMinLogicalWidth;
                         remainingMaxLogicalWidth -= m_layoutStruct[pos].effectiveMaxLogicalWidth;
                         cellMinLogicalWidth -= colMinLogicalWidth;
@@ -605,9 +605,9 @@ void AutoTableLayout::layout()
     if (available > 0) {
         for (size_t i = 0; i < nEffCols; ++i) {
             auto& logicalWidth = m_layoutStruct[i].effectiveLogicalWidth;
-            if (auto fixedLogicalWidth = logicalWidth.tryFixed(); fixedLogicalWidth && fixedLogicalWidth->value > m_layoutStruct[i].computedLogicalWidth) {
-                available += m_layoutStruct[i].computedLogicalWidth - fixedLogicalWidth->value;
-                m_layoutStruct[i].computedLogicalWidth = fixedLogicalWidth->value;
+            if (auto fixedLogicalWidth = logicalWidth.tryFixed(); fixedLogicalWidth && fixedLogicalWidth->evaluate(1.0f /* FIXME FIND ZOOM */) > m_layoutStruct[i].computedLogicalWidth) {
+                available += m_layoutStruct[i].computedLogicalWidth - fixedLogicalWidth->evaluate(1.0f /* FIXME FIND ZOOM */);
+                m_layoutStruct[i].computedLogicalWidth = fixedLogicalWidth->evaluate(1.0f /* FIXME FIND ZOOM */);
             }
         }
     }

--- a/Source/WebCore/rendering/BackgroundPainter.cpp
+++ b/Source/WebCore/rendering/BackgroundPainter.cpp
@@ -179,8 +179,8 @@ static void applyBoxShadowForBackground(GraphicsContext& context, const RenderSt
         if (shadow.inset)
             continue;
 
-        FloatSize shadowOffset(shadow.location.x().value, shadow.location.y().value);
-        context.setDropShadow({ shadowOffset, shadow.blur.value, style.colorWithColorFilter(shadow.color), shadow.isWebkitBoxShadow ? ShadowRadiusMode::Legacy : ShadowRadiusMode::Default });
+        FloatSize shadowOffset(shadow.location.x().evaluate(1.0f /* FIXME FIND ZOOM */), shadow.location.y().evaluate(1.0f /* FIXME FIND ZOOM */));
+        context.setDropShadow({ shadowOffset, shadow.blur.evaluate(1.0f /* FIXME FIND ZOOM */), style.colorWithColorFilter(shadow.color), shadow.isWebkitBoxShadow ? ShadowRadiusMode::Legacy : ShadowRadiusMode::Default });
         break;
     }
 }
@@ -799,7 +799,7 @@ template<typename Layer> LayoutSize BackgroundPainter::calculateFillTileSize(con
             auto layerHeight = size.height();
 
             if (auto fixed = layerWidth.tryFixed())
-                tileSize.setWidth(fixed->value);
+                tileSize.setWidth(fixed->evaluate(1.0f /* FIXME FIND ZOOM */));
             else if (layerWidth.isPercentOrCalculated()) {
                 auto resolvedWidth = Style::evaluate(layerWidth, positioningAreaSize.width(), 1.0f /* FIXME FIND ZOOM */);
                 // Non-zero resolved value should always produce some content.
@@ -807,7 +807,7 @@ template<typename Layer> LayoutSize BackgroundPainter::calculateFillTileSize(con
             }
 
             if (auto fixed = layerHeight.tryFixed())
-                tileSize.setHeight(fixed->value);
+                tileSize.setHeight(fixed->evaluate(1.0f /* FIXME FIND ZOOM */));
             else if (layerHeight.isPercentOrCalculated()) {
                 auto resolvedHeight = Style::evaluate(layerHeight, positioningAreaSize.height(), 1.0f /* FIXME FIND ZOOM */);
                 // Non-zero resolved value should always produce some content.
@@ -851,10 +851,10 @@ void BackgroundPainter::paintBoxShadow(const LayoutRect& paintRect, const Render
         if (Style::shadowStyle(shadow) != shadowStyle)
             continue;
 
-        LayoutSize shadowOffset(shadow.location.x().value, shadow.location.y().value);
+        LayoutSize shadowOffset(shadow.location.x().evaluate(1.0f /* FIXME FIND ZOOM */), shadow.location.y().evaluate(1.0f /* FIXME FIND ZOOM */));
         LayoutUnit shadowPaintingExtent = Style::paintingExtent(shadow);
-        LayoutUnit shadowSpread = LayoutUnit(shadow.spread.value);
-        auto shadowRadius = shadow.blur.value;
+        LayoutUnit shadowSpread = LayoutUnit(shadow.spread.evaluate(1.0f /* FIXME FIND ZOOM */));
+        auto shadowRadius = shadow.blur.evaluate(1.0f /* FIXME FIND ZOOM */);
 
         if (shadowOffset.isZero() && !shadowRadius && !shadowSpread)
             continue;

--- a/Source/WebCore/rendering/EllipsisBoxPainter.cpp
+++ b/Source/WebCore/rendering/EllipsisBoxPainter.cpp
@@ -69,7 +69,7 @@ void EllipsisBoxPainter::paint()
             return false;
         },
         [&](const auto& shadows) {
-            context.setDropShadow({ LayoutSize(shadows[0].location.x().value, shadows[0].location.y().value), shadows[0].blur.value, style.colorWithColorFilter(shadows[0].color), ShadowRadiusMode::Default });
+            context.setDropShadow({ LayoutSize(shadows[0].location.x().evaluate(1.0f /* FIXME FIND ZOOM */), shadows[0].location.y().evaluate(1.0f /* FIXME FIND ZOOM */)), shadows[0].blur.evaluate(1.0f /* FIXME FIND ZOOM */), style.colorWithColorFilter(shadows[0].color), ShadowRadiusMode::Default });
             return true;
         }
     );

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
@@ -1108,7 +1108,7 @@ LayoutUnit GridTrackSizingAlgorithmStrategy::minContentContributionForGridItem(R
             auto gridItemLogicalMinWidth = gridItem.style().logicalMinWidth();
 
             if (auto fixedFridItemLogicalMinWidth = gridItemLogicalMinWidth.tryFixed())
-                return LayoutUnit { fixedFridItemLogicalMinWidth->value };
+                return LayoutUnit { fixedFridItemLogicalMinWidth->evaluate(1.0f /* FIXME FIND ZOOM */) };
             if (gridItemLogicalMinWidth.isMaxContent())
                 return gridItem.maxPreferredLogicalWidth();
 

--- a/Source/WebCore/rendering/NinePieceImagePainter.cpp
+++ b/Source/WebCore/rendering/NinePieceImagePainter.cpp
@@ -105,10 +105,10 @@ template<typename SliceValues>
 static LayoutBoxExtent computeSlices(const LayoutSize& size, const SliceValues& slices, int scaleFactor)
 {
     return {
-        std::min(size.height(),  Style::evaluate(slices.values.top(),    size.height(), 1.0f /* FIXME ZOOM EFFECTED? */)) * scaleFactor,
-        std::min(size.width(),   Style::evaluate(slices.values.right(),  size.width(), 1.0f /* FIXME ZOOM EFFECTED? */))  * scaleFactor,
-        std::min(size.height(),  Style::evaluate(slices.values.bottom(), size.height(), 1.0f /* FIXME ZOOM EFFECTED? */)) * scaleFactor,
-        std::min(size.width(),   Style::evaluate(slices.values.left(),   size.width(), 1.0f /* FIXME ZOOM EFFECTED? */))  * scaleFactor,
+        std::min(size.height(),  Style::evaluate(slices.values.top(),    size.height())) * scaleFactor,
+        std::min(size.width(),   Style::evaluate(slices.values.right(),  size.width()))  * scaleFactor,
+        std::min(size.height(),  Style::evaluate(slices.values.bottom(), size.height())) * scaleFactor,
+        std::min(size.width(),   Style::evaluate(slices.values.left(),   size.width()))  * scaleFactor,
     };
 }
 

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -771,9 +771,9 @@ LayoutUnit RenderBlock::marginIntrinsicLogicalWidthForChild(RenderBox& child) co
     auto& marginRight = child.style().marginEnd(writingMode());
     LayoutUnit margin;
     if (auto fixedMarginLeft = marginLeft.tryFixed(); fixedMarginLeft && !shouldTrimChildMargin(MarginTrimType::InlineStart, child))
-        margin += fixedMarginLeft->value;
+        margin += fixedMarginLeft->evaluate(1.0f /* FIXME FIND ZOOM */);
     if (auto fixedMarginRight = marginRight.tryFixed(); fixedMarginRight && !shouldTrimChildMargin(MarginTrimType::InlineEnd, child))
-        margin += fixedMarginRight->value;
+        margin += fixedMarginRight->evaluate(1.0f /* FIXME FIND ZOOM */);
     return margin;
 }
 
@@ -2225,7 +2225,7 @@ void RenderBlock::computePreferredLogicalWidths()
 
     auto& styleToUse = style();
     auto logicalWidth = overridingLogicalWidthForFlexBasisComputation().value_or(styleToUse.logicalWidth());
-    if (auto fixedLogicalWidth = logicalWidth.tryFixed(); !isRenderTableCell() && fixedLogicalWidth && fixedLogicalWidth->value >= 0 && !(isDeprecatedFlexItem() && !static_cast<int>(fixedLogicalWidth->value))) {
+    if (auto fixedLogicalWidth = logicalWidth.tryFixed(); !isRenderTableCell() && fixedLogicalWidth && fixedLogicalWidth->isPositiveOrZero() && !(isDeprecatedFlexItem() && !static_cast<int>(fixedLogicalWidth->evaluate(1.0f /* FIXME FIND ZOOM */)))) {
         m_minPreferredLogicalWidth = adjustContentBoxLogicalWidthForBoxSizing(*fixedLogicalWidth);
         m_maxPreferredLogicalWidth = m_minPreferredLogicalWidth;
     } else if (logicalWidth.isMaxContent()) {
@@ -2291,9 +2291,9 @@ void RenderBlock::computeBlockPreferredLogicalWidths(LayoutUnit& minLogicalWidth
         LayoutUnit marginStart;
         LayoutUnit marginEnd;
         if (auto fixedMarginStart = childStyle.marginStart(writingMode()).tryFixed())
-            marginStart += fixedMarginStart->value;
+            marginStart += fixedMarginStart->evaluate(1.0f /* FIXME FIND ZOOM */);
         if (auto fixedMarginEnd = childStyle.marginEnd(writingMode()).tryFixed())
-            marginEnd += fixedMarginEnd->value;
+            marginEnd += fixedMarginEnd->evaluate(1.0f /* FIXME FIND ZOOM */);
         auto margin = marginStart + marginEnd;
 
         LayoutUnit childMinPreferredLogicalWidth;
@@ -2367,7 +2367,7 @@ void RenderBlock::computeChildPreferredLogicalWidths(RenderBox& childBox, Layout
                 childBox.verticalBorderAndPaddingExtent(),
                 LayoutUnit { childBoxStyle.logicalAspectRatio() },
                 childBoxStyle.boxSizingForAspectRatio(),
-                LayoutUnit { fixedChildBoxStyleLogicalWidth->value },
+                LayoutUnit { fixedChildBoxStyleLogicalWidth->evaluate(1.0f /* FIXME FIND ZOOM */) },
                 style().aspectRatio(),
                 isRenderReplaced()
             );
@@ -3051,7 +3051,7 @@ std::optional<LayoutUnit> RenderBlock::availableLogicalHeightForPercentageComput
 
         auto& style = this->style();
         if (auto fixedLogicalHeight = style.logicalHeight().tryFixed()) {
-            auto contentBoxHeight = adjustContentBoxLogicalHeightForBoxSizing(LayoutUnit { fixedLogicalHeight->value });
+            auto contentBoxHeight = adjustContentBoxLogicalHeightForBoxSizing(LayoutUnit { fixedLogicalHeight->evaluate(1.0f /* FIXME FIND ZOOM */) });
             return std::max(0_lu, constrainContentBoxLogicalHeightByMinMax(contentBoxHeight - scrollbarLogicalHeight(), { }));
         }
 
@@ -3324,9 +3324,9 @@ bool RenderBlock::computePreferredWidthsForExcludedChildren(LayoutUnit& minWidth
     LayoutUnit marginStart;
     LayoutUnit marginEnd;
     if (auto fixedMarginStart = childStyle.marginStart(writingMode()).tryFixed())
-        marginStart += fixedMarginStart->value;
+        marginStart += fixedMarginStart->evaluate(1.0f /* FIXME FIND ZOOM */);
     if (auto fixedMarginEnd = childStyle.marginEnd(writingMode()).tryFixed())
-        marginEnd += fixedMarginEnd->value;
+        marginEnd += fixedMarginEnd->evaluate(1.0f /* FIXME FIND ZOOM */);
 
     auto margin = marginStart + marginEnd;
 

--- a/Source/WebCore/rendering/RenderBoxModelObject.cpp
+++ b/Source/WebCore/rendering/RenderBoxModelObject.cpp
@@ -380,7 +380,7 @@ LayoutSize RenderBoxModelObject::relativePositionOffset() const
     auto topFixed = top.tryFixed();
     auto leftFixed = left.tryFixed();
     if (topFixed && leftFixed && bottom.isAuto() && right.isAuto() && containingBlock->writingMode().isAnyLeftToRight()) {
-        offset.expand(leftFixed->value, topFixed->value);
+        offset.expand(leftFixed->evaluate(1.0f /* FIXME FIND ZOOM */), topFixed->evaluate(1.0f /* FIXME FIND ZOOM */));
         return offset;
     }
 

--- a/Source/WebCore/rendering/RenderDeprecatedFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderDeprecatedFlexibleBox.cpp
@@ -146,9 +146,9 @@ static LayoutUnit marginWidthForChild(RenderBox* child)
     // Fixed margins can be added in as is.
     LayoutUnit margin;
     if (auto fixedMarginLeft = child->style().marginLeft().tryFixed())
-        margin += fixedMarginLeft->value;
+        margin += fixedMarginLeft->evaluate(1.0f /* FIXME FIND ZOOM */);
     if (auto fixedMarginRight = child->style().marginRight().tryFixed())
-        margin += fixedMarginRight->value;
+        margin += fixedMarginRight->evaluate(1.0f /* FIXME FIND ZOOM */);
     return margin;
 }
 
@@ -246,7 +246,7 @@ void RenderDeprecatedFlexibleBox::computePreferredLogicalWidths()
     ASSERT(needsPreferredLogicalWidthsUpdate());
 
     m_minPreferredLogicalWidth = m_maxPreferredLogicalWidth = 0;
-    if (auto fixedWidth = style().width().tryFixed(); fixedWidth && fixedWidth->value > 0)
+    if (auto fixedWidth = style().width().tryFixed(); fixedWidth && fixedWidth->isPositive())
         m_minPreferredLogicalWidth = m_maxPreferredLogicalWidth = adjustContentBoxLogicalWidthForBoxSizing(*fixedWidth);
     else
         computeIntrinsicLogicalWidths(m_minPreferredLogicalWidth, m_maxPreferredLogicalWidth);
@@ -1152,7 +1152,7 @@ LayoutUnit RenderDeprecatedFlexibleBox::allowedChildFlex(RenderBox* child, bool 
             LayoutUnit maxWidth = LayoutUnit::max();
             LayoutUnit width = contentWidthForChild(child);
             if (auto fixedMaxWidth = child->style().maxWidth().tryFixed())
-                maxWidth = fixedMaxWidth->value;
+                maxWidth = fixedMaxWidth->evaluate(1.0f /* FIXME FIND ZOOM */);
             else if (child->style().maxWidth().isIntrinsicKeyword())
                 maxWidth = child->maxPreferredLogicalWidth();
             else if (child->style().maxWidth().isMinIntrinsic())
@@ -1165,7 +1165,7 @@ LayoutUnit RenderDeprecatedFlexibleBox::allowedChildFlex(RenderBox* child, bool 
             LayoutUnit maxHeight = LayoutUnit::max();
             LayoutUnit height = contentHeightForChild(child);
             if (auto fixedMaxHeight = child->style().maxHeight().tryFixed())
-                maxHeight = fixedMaxHeight->value;
+                maxHeight = fixedMaxHeight->evaluate(1.0f /* FIXME FIND ZOOM */);
             if (maxHeight == LayoutUnit::max())
                 return maxHeight;
             return std::max<LayoutUnit>(0, maxHeight - height);
@@ -1177,7 +1177,7 @@ LayoutUnit RenderDeprecatedFlexibleBox::allowedChildFlex(RenderBox* child, bool 
         LayoutUnit minWidth = child->minPreferredLogicalWidth();
         LayoutUnit width = contentWidthForChild(child);
         if (auto fixedMinWidth = child->style().minWidth().tryFixed())
-            minWidth = fixedMinWidth->value;
+            minWidth = fixedMinWidth->evaluate(1.0f /* FIXME FIND ZOOM */);
         else if (child->style().minWidth().isIntrinsicKeyword())
             minWidth = child->maxPreferredLogicalWidth();
         else if (child->style().minWidth().isMinIntrinsic())
@@ -1190,7 +1190,7 @@ LayoutUnit RenderDeprecatedFlexibleBox::allowedChildFlex(RenderBox* child, bool 
     } else {
         auto& minHeight = child->style().minHeight();
         if (auto fixedMinHeight = minHeight.tryFixed()) {
-            LayoutUnit minHeight { fixedMinHeight->value };
+            LayoutUnit minHeight { fixedMinHeight->evaluate(1.0f /* FIXME FIND ZOOM */) };
             LayoutUnit height = contentHeightForChild(child);
             LayoutUnit allowedShrinkage = std::min<LayoutUnit>(0, minHeight - height);
             return allowedShrinkage;

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -1503,7 +1503,7 @@ bool RenderElement::repaintAfterLayoutIfNeeded(SingleThreadWeakPtr<const RenderL
 
         auto insetExtent = [&] {
             // Inset "content" is inside the border box (e.g. border, negative outline and box shadow).
-            auto borderRightExtent = [&]() -> LayoutUnit {
+            auto borderRightExtent = [&] -> LayoutUnit {
                 auto* renderBox = dynamicDowncast<RenderBox>(*this);
                 if (!renderBox)
                     return { };
@@ -2519,7 +2519,7 @@ static RenderObject::BlockContentHeightType includeNonFixedHeight(const RenderOb
         if (CheckedPtr block = dynamicDowncast<RenderBlock>(renderer)) {
             // For fixed height styles, if the overflow size of the element spills out of the specified
             // height, assume we can apply text auto-sizing.
-            if (block->effectiveOverflowY() == Overflow::Visible && fixedHeight->value < block->layoutOverflowRect().maxY())
+            if (block->effectiveOverflowY() == Overflow::Visible && fixedHeight->evaluate(1.0f /* FIXME FIND ZOOM */) < block->layoutOverflowRect().maxY())
                 return RenderObject::OverflowHeight;
         }
         return RenderObject::FixedHeight;

--- a/Source/WebCore/rendering/RenderFileUploadControl.cpp
+++ b/Source/WebCore/rendering/RenderFileUploadControl.cpp
@@ -308,7 +308,7 @@ void RenderFileUploadControl::computePreferredLogicalWidths()
     m_minPreferredLogicalWidth = 0;
     m_maxPreferredLogicalWidth = 0;
 
-    if (auto fixedLogicalWidth = style().logicalWidth().tryFixed(); fixedLogicalWidth && fixedLogicalWidth->value > 0)
+    if (auto fixedLogicalWidth = style().logicalWidth().tryFixed(); fixedLogicalWidth && fixedLogicalWidth->isPositive())
         m_minPreferredLogicalWidth = m_maxPreferredLogicalWidth = adjustContentBoxLogicalWidthForBoxSizing(*fixedLogicalWidth);
     else
         computeIntrinsicLogicalWidths(m_minPreferredLogicalWidth, m_maxPreferredLogicalWidth);

--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -1109,17 +1109,17 @@ template<typename SizeType> LayoutUnit RenderFlexibleBox::computeMainSizeFromAsp
 
     auto crossSizeOptional = WTF::switchOn(crossSizeLength,
         [&](const SizeType::Fixed& fixedCrossSizeLength) -> std::optional<LayoutUnit> {
-            return LayoutUnit(fixedCrossSizeLength.value);
+            return LayoutUnit(fixedCrossSizeLength.evaluate(1.0f /* FIXME FIND ZOOM */));
         },
         [&](const SizeType::Percentage& percentageCrossSizeLength) -> std::optional<LayoutUnit> {
             return mainAxisIsFlexItemInlineAxis(flexItem)
                 ? flexItem.computePercentageLogicalHeight(percentageCrossSizeLength)
-                : adjustBorderBoxLogicalWidthForBoxSizing(Style::evaluate(percentageCrossSizeLength, contentBoxWidth(), 1.0f /* FIXME FIND ZOOM */));
+                : adjustBorderBoxLogicalWidthForBoxSizing(Style::evaluate(percentageCrossSizeLength, contentBoxWidth()));
         },
         [&](const SizeType::Calc& calcCrossSizeLength) -> std::optional<LayoutUnit> {
             return mainAxisIsFlexItemInlineAxis(flexItem)
                 ? flexItem.computePercentageLogicalHeight(calcCrossSizeLength)
-                : adjustBorderBoxLogicalWidthForBoxSizing(Style::evaluate(calcCrossSizeLength, contentBoxWidth(), 1.0f /* FIXME FIND ZOOM */));
+                : adjustBorderBoxLogicalWidthForBoxSizing(Style::evaluate(calcCrossSizeLength, contentBoxWidth()));
         },
         [&](const CSS::Keyword::Auto&) -> std::optional<LayoutUnit> {
             ASSERT(flexItemCrossSizeShouldUseContainerCrossSize(flexItem));
@@ -2114,17 +2114,17 @@ LayoutUnit RenderFlexibleBox::computeCrossSizeForFlexItemUsingContainerCrossSize
         ASSERT(size.isFixed() || (size.isPercent() && availableLogicalHeightForPercentageComputation()));
         LayoutUnit definiteValue;
         if (auto fixedSize = size.tryFixed())
-            definiteValue = LayoutUnit { fixedSize->value };
+            definiteValue = LayoutUnit { fixedSize->evaluate(1.0f /* FIXME FIND ZOOM */) };
         else if (size.isPercent())
             definiteValue = availableLogicalHeightForPercentageComputation().value_or(0_lu);
 
         auto maximumSize = isHorizontal ? style().maxHeight() : style().maxWidth();
         if (auto fixedMaximumSize = maximumSize.tryFixed())
-            definiteValue = std::min(definiteValue, LayoutUnit { fixedMaximumSize->value });
+            definiteValue = std::min(definiteValue, LayoutUnit { fixedMaximumSize->evaluate(1.0f /* FIXME FIND ZOOM */) });
 
         auto minimumSize = isHorizontal ? style().minHeight() : style().minWidth();
         if (auto fixedMinimumSize = minimumSize.tryFixed())
-            definiteValue = std::max(definiteValue, LayoutUnit { fixedMinimumSize->value });
+            definiteValue = std::max(definiteValue, LayoutUnit { fixedMinimumSize->evaluate(1.0f /* FIXME FIND ZOOM */) });
 
         return definiteValue;
     };

--- a/Source/WebCore/rendering/RenderFragmentContainer.cpp
+++ b/Source/WebCore/rendering/RenderFragmentContainer.cpp
@@ -398,7 +398,7 @@ void RenderFragmentContainer::computePreferredLogicalWidths()
     m_minPreferredLogicalWidth = m_maxPreferredLogicalWidth = 0;
 
     auto& styleToUse = style();
-    if (auto fixedLogicalWidth = styleToUse.logicalWidth().tryFixed(); fixedLogicalWidth && fixedLogicalWidth->value > 0)
+    if (auto fixedLogicalWidth = styleToUse.logicalWidth().tryFixed(); fixedLogicalWidth && fixedLogicalWidth->isPositive())
         m_minPreferredLogicalWidth = m_maxPreferredLogicalWidth = adjustContentBoxLogicalWidthForBoxSizing(*fixedLogicalWidth);
     else
         computeIntrinsicLogicalWidths(m_minPreferredLogicalWidth, m_maxPreferredLogicalWidth);

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -893,19 +893,19 @@ unsigned RenderGrid::computeAutoRepeatTracksCount(Style::GridTrackSizingDirectio
         auto& maxSize = isRowAxis ? style().logicalMaxWidth() : style().logicalMaxHeight();
         auto availableMaxSize = WTF::switchOn(maxSize,
             [&](const Style::MaximumSize::Fixed& fixedMaxSize) -> std::optional<LayoutUnit> {
-                auto maxSizeValue = LayoutUnit { fixedMaxSize.value };
+                auto maxSizeValue = LayoutUnit { fixedMaxSize.evaluate(1.0f /* FIXME FIND ZOOM */) };
                 return isRowAxis
                     ? adjustContentBoxLogicalWidthForBoxSizing(maxSizeValue)
                     : adjustContentBoxLogicalHeightForBoxSizing(maxSizeValue);
             },
             [&](const Style::MaximumSize::Percentage& percentageMaxSize) -> std::optional<LayoutUnit> {
-                auto maxSizeValue = Style::evaluate(percentageMaxSize, containingBlockAvailableSize(), 1.0f /* FIXME FIND ZOOM */);
+                auto maxSizeValue = Style::evaluate(percentageMaxSize, containingBlockAvailableSize());
                 return isRowAxis
                     ? adjustContentBoxLogicalWidthForBoxSizing(maxSizeValue)
                     : adjustContentBoxLogicalHeightForBoxSizing(maxSizeValue);
             },
             [&](const Style::MaximumSize::Calc& calcMaxSize) -> std::optional<LayoutUnit> {
-                auto maxSizeValue = Style::evaluate(calcMaxSize, containingBlockAvailableSize(), 1.0f /* FIXME FIND ZOOM */);
+                auto maxSizeValue = Style::evaluate(calcMaxSize, containingBlockAvailableSize());
                 return isRowAxis
                     ? adjustContentBoxLogicalWidthForBoxSizing(maxSizeValue)
                     : adjustContentBoxLogicalHeightForBoxSizing(maxSizeValue);
@@ -925,19 +925,19 @@ unsigned RenderGrid::computeAutoRepeatTracksCount(Style::GridTrackSizingDirectio
 
         auto availableMinSize = WTF::switchOn(minSize,
             [&](const Style::MinimumSize::Fixed& fixedMinSize) -> std::optional<LayoutUnit> {
-                auto minSizeValue = LayoutUnit { fixedMinSize.value };
+                auto minSizeValue = LayoutUnit { fixedMinSize.evaluate(1.0f /* FIXME FIND ZOOM */) };
                 return isRowAxis
                     ? adjustContentBoxLogicalWidthForBoxSizing(minSizeValue)
                     : adjustContentBoxLogicalHeightForBoxSizing(minSizeValue);
             },
             [&](const Style::MinimumSize::Percentage& percentageMinSize) -> std::optional<LayoutUnit> {
-                auto minSizeValue = Style::evaluate(percentageMinSize, containingBlockAvailableSize(), 1.0f /* FIXME FIND ZOOM */);
+                auto minSizeValue = Style::evaluate(percentageMinSize, containingBlockAvailableSize());
                 return isRowAxis
                     ? adjustContentBoxLogicalWidthForBoxSizing(minSizeValue)
                     : adjustContentBoxLogicalHeightForBoxSizing(minSizeValue);
             },
             [&](const Style::MinimumSize::Calc& calcMinSize) -> std::optional<LayoutUnit> {
-                auto minSizeValue = Style::evaluate(calcMinSize, containingBlockAvailableSize(), 1.0f /* FIXME FIND ZOOM */);
+                auto minSizeValue = Style::evaluate(calcMinSize, containingBlockAvailableSize());
                 return isRowAxis
                     ? adjustContentBoxLogicalWidthForBoxSizing(minSizeValue)
                     : adjustContentBoxLogicalHeightForBoxSizing(minSizeValue);

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -1016,8 +1016,8 @@ static bool hasNonZeroTransformOrigin(const RenderLayerModelObject& renderer)
     auto& style = renderer.style();
     auto fixedTransformOriginX = style.transformOriginX().tryFixed();
     auto fixedTransformOriginY = style.transformOriginY().tryFixed();
-    return (fixedTransformOriginX && fixedTransformOriginX->value)
-        || (fixedTransformOriginY && fixedTransformOriginY->value);
+    return (fixedTransformOriginX && !fixedTransformOriginX->isZero())
+        || (fixedTransformOriginY && !fixedTransformOriginY->isZero());
 }
 
 bool RenderLayerBacking::updateCompositedBounds()

--- a/Source/WebCore/rendering/RenderListBox.cpp
+++ b/Source/WebCore/rendering/RenderListBox.cpp
@@ -248,7 +248,7 @@ void RenderListBox::computePreferredLogicalWidths()
     m_minPreferredLogicalWidth = 0;
     m_maxPreferredLogicalWidth = 0;
 
-    if (auto fixedLogicalWidth = style().logicalWidth().tryFixed(); fixedLogicalWidth && fixedLogicalWidth->value > 0)
+    if (auto fixedLogicalWidth = style().logicalWidth().tryFixed(); fixedLogicalWidth && fixedLogicalWidth->isPositive())
         m_minPreferredLogicalWidth = m_maxPreferredLogicalWidth = adjustContentBoxLogicalWidthForBoxSizing(*fixedLogicalWidth);
     else
         computeIntrinsicLogicalWidths(m_minPreferredLogicalWidth, m_maxPreferredLogicalWidth);

--- a/Source/WebCore/rendering/RenderListMarker.cpp
+++ b/Source/WebCore/rendering/RenderListMarker.cpp
@@ -268,9 +268,9 @@ void RenderListMarker::layout()
     setMarginEnd(0);
 
     if (auto fixedStartMargin = style().marginStart().tryFixed())
-        setMarginStart(LayoutUnit(fixedStartMargin->value));
+        setMarginStart(LayoutUnit(fixedStartMargin->evaluate(1.0f /* FIXME FIND ZOOM */)));
     if (auto fixedEndMargin = style().marginEnd().tryFixed())
-        setMarginEnd(LayoutUnit(fixedEndMargin->value));
+        setMarginEnd(LayoutUnit(fixedEndMargin->evaluate(1.0f /* FIXME FIND ZOOM */)));
 
     clearNeedsLayout();
 }

--- a/Source/WebCore/rendering/RenderMenuList.cpp
+++ b/Source/WebCore/rendering/RenderMenuList.cpp
@@ -365,7 +365,7 @@ void RenderMenuList::computePreferredLogicalWidths()
     m_minPreferredLogicalWidth = 0;
     m_maxPreferredLogicalWidth = 0;
     
-    if (auto fixedLogicalWidth = style().logicalWidth().tryFixed(); fixedLogicalWidth && fixedLogicalWidth->value > 0)
+    if (auto fixedLogicalWidth = style().logicalWidth().tryFixed(); fixedLogicalWidth && fixedLogicalWidth->isPositive())
         m_minPreferredLogicalWidth = m_maxPreferredLogicalWidth = adjustContentBoxLogicalWidthForBoxSizing(*fixedLogicalWidth);
     else
         computeIntrinsicLogicalWidths(m_minPreferredLogicalWidth, m_maxPreferredLogicalWidth);

--- a/Source/WebCore/rendering/RenderReplaced.cpp
+++ b/Source/WebCore/rendering/RenderReplaced.cpp
@@ -631,13 +631,13 @@ void RenderReplaced::computeAspectRatioAdjustedIntrinsicLogicalWidths(LayoutUnit
     auto computedIntrinsicLogicalWidth = minLogicalWidth;
 
     if (auto fixedLogicalHeight = style.logicalHeight().tryFixed())
-        computedIntrinsicLogicalWidth = fixedLogicalHeight->value * computedAspectRatio;
+        computedIntrinsicLogicalWidth = fixedLogicalHeight->evaluate(1.0f /* FIXME FIND ZOOM */) * computedAspectRatio;
 
     if (auto fixedLogicalMaxHeight = style.logicalMaxHeight().tryFixed())
-        computedIntrinsicLogicalWidth = std::min(computedIntrinsicLogicalWidth, LayoutUnit { fixedLogicalMaxHeight->value * computedAspectRatio });
+        computedIntrinsicLogicalWidth = std::min(computedIntrinsicLogicalWidth, LayoutUnit { fixedLogicalMaxHeight->evaluate(1.0f /* FIXME FIND ZOOM */) * computedAspectRatio });
 
     if (auto fixedLogicalMinHeight = style.logicalMinHeight().tryFixed())
-        computedIntrinsicLogicalWidth = std::max(computedIntrinsicLogicalWidth, LayoutUnit { fixedLogicalMinHeight->value * computedAspectRatio });
+        computedIntrinsicLogicalWidth = std::max(computedIntrinsicLogicalWidth, LayoutUnit { fixedLogicalMinHeight->evaluate(1.0f /* FIXME FIND ZOOM */) * computedAspectRatio });
 
     minLogicalWidth = computedIntrinsicLogicalWidth;
     maxLogicalWidth = minLogicalWidth;
@@ -809,7 +809,7 @@ void RenderReplaced::computePreferredLogicalWidths()
     if (styleToUse.logicalWidth().isPercentOrCalculated() || styleToUse.logicalMaxWidth().isPercentOrCalculated())
         m_minPreferredLogicalWidth = 0;
 
-    if (auto fixedLogicalMinWidth = styleToUse.logicalMinWidth().tryFixed(); !ignoreMinMaxSizes && fixedLogicalMinWidth && fixedLogicalMinWidth->value > 0) {
+    if (auto fixedLogicalMinWidth = styleToUse.logicalMinWidth().tryFixed(); !ignoreMinMaxSizes && fixedLogicalMinWidth && fixedLogicalMinWidth->isPositive()) {
         m_maxPreferredLogicalWidth = std::max(m_maxPreferredLogicalWidth, adjustContentBoxLogicalWidthForBoxSizing(*fixedLogicalMinWidth));
         m_minPreferredLogicalWidth = std::max(m_minPreferredLogicalWidth, adjustContentBoxLogicalWidthForBoxSizing(*fixedLogicalMinWidth));
     }

--- a/Source/WebCore/rendering/RenderTable.cpp
+++ b/Source/WebCore/rendering/RenderTable.cpp
@@ -393,7 +393,7 @@ template<typename SizeType> LayoutUnit RenderTable::convertStyleLogicalHeightToC
         if (is<HTMLTableElement>(element()) || style().boxSizing() == BoxSizing::BorderBox) {
             borders = borderAndPadding;
         }
-        return LayoutUnit(fixedStyleLogicalHeight->value - borders);
+        return LayoutUnit(fixedStyleLogicalHeight->evaluate(1.0f /* FIXME FIND ZOOM */) - borders);
     } else if (styleLogicalHeight.isPercentOrCalculated())
         return computePercentageLogicalHeight(styleLogicalHeight).value_or(0);
     else if (styleLogicalHeight.isIntrinsic())
@@ -962,7 +962,7 @@ void RenderTable::computePreferredLogicalWidths()
 
     auto& styleToUse = style();
     // FIXME: This should probably be checking for isSpecified since you should be able to use percentage or calc values for min-width.
-    if (auto fixedLogicalMinWidth = styleToUse.logicalMinWidth().tryFixed(); fixedLogicalMinWidth && fixedLogicalMinWidth->value > 0) {
+    if (auto fixedLogicalMinWidth = styleToUse.logicalMinWidth().tryFixed(); fixedLogicalMinWidth && fixedLogicalMinWidth->isPositive()) {
         m_maxPreferredLogicalWidth = std::max(m_maxPreferredLogicalWidth, adjustContentBoxLogicalWidthForBoxSizing(*fixedLogicalMinWidth));
         m_minPreferredLogicalWidth = std::max(m_minPreferredLogicalWidth, adjustContentBoxLogicalWidthForBoxSizing(*fixedLogicalMinWidth));
     }

--- a/Source/WebCore/rendering/RenderTableCell.cpp
+++ b/Source/WebCore/rendering/RenderTableCell.cpp
@@ -196,7 +196,7 @@ Style::PreferredSize RenderTableCell::logicalWidthFromColumns(RenderTableCol* fi
             return colWidth;
         }
 
-        colWidthSum += fixedColWidth->value;
+        colWidthSum += fixedColWidth->evaluate(1.0f /* FIXME FIND ZOOM */);
         tableCol = tableCol->nextColumn();
         // If no next <col> tag found for the span we just return what we have for now.
         if (!tableCol)
@@ -237,7 +237,7 @@ void RenderTableCell::computePreferredLogicalWidths()
         // to make the minwidth of the cell into the fixed width. They do this
         // even in strict mode, so do not make this a quirk. Affected the top
         // of hiptop.com.
-        m_minPreferredLogicalWidth = std::max(LayoutUnit(fixedLogicalWidth->value), m_minPreferredLogicalWidth);
+        m_minPreferredLogicalWidth = std::max(LayoutUnit(fixedLogicalWidth->evaluate(1.0f /* FIXME FIND ZOOM */)), m_minPreferredLogicalWidth);
     }
 }
 

--- a/Source/WebCore/rendering/RenderTableSection.cpp
+++ b/Source/WebCore/rendering/RenderTableSection.cpp
@@ -81,7 +81,7 @@ static inline void updateLogicalHeightForCell(RenderTableSection::RowStruct& row
             if (auto percentageRowLogicalHeight = row.logicalHeight.tryPercentage(); !percentageRowLogicalHeight || percentageRowLogicalHeight->value < percentageLogicalHeight->value)
                 row.logicalHeight = logicalHeight;
         } else if (auto fixedLogicalHeight = logicalHeight.tryFixed()) {
-            if (auto fixedRowLogicalHeight = row.logicalHeight.tryFixed(); row.logicalHeight.isAuto() || (fixedRowLogicalHeight && fixedRowLogicalHeight->value < fixedLogicalHeight->value))
+            if (auto fixedRowLogicalHeight = row.logicalHeight.tryFixed(); row.logicalHeight.isAuto() || (fixedRowLogicalHeight && fixedRowLogicalHeight->evaluate(1.0f /* FIXME FIND ZOOM */) < fixedLogicalHeight->evaluate(1.0f /* FIXME FIND ZOOM */)))
                 row.logicalHeight = logicalHeight;
         }
     }
@@ -219,7 +219,7 @@ void RenderTableSection::addCell(RenderTableCell* cell, RenderTableRow* row)
 static LayoutUnit resolveLogicalHeightForRow(const Style::PreferredSize& rowLogicalHeight)
 {
     if (auto fixedRowLogicalHeight = rowLogicalHeight.tryFixed())
-        return LayoutUnit(fixedRowLogicalHeight->value);
+        return LayoutUnit(fixedRowLogicalHeight->evaluate(1.0f /* FIXME FIND ZOOM */));
     if (rowLogicalHeight.isCalculated())
         return LayoutUnit(Style::evaluate(rowLogicalHeight, 0, 1.0f /* FIXME FIND ZOOM */));
     return 0;

--- a/Source/WebCore/rendering/RenderTextControl.cpp
+++ b/Source/WebCore/rendering/RenderTextControl.cpp
@@ -211,7 +211,7 @@ void RenderTextControl::computePreferredLogicalWidths()
     m_minPreferredLogicalWidth = 0;
     m_maxPreferredLogicalWidth = 0;
 
-    if (auto fixedLogicalWidth = style().logicalWidth().tryFixed(); fixedLogicalWidth && fixedLogicalWidth->value >= 0)
+    if (auto fixedLogicalWidth = style().logicalWidth().tryFixed(); fixedLogicalWidth && fixedLogicalWidth->isPositiveOrZero())
         m_minPreferredLogicalWidth = m_maxPreferredLogicalWidth = adjustContentBoxLogicalWidthForBoxSizing(*fixedLogicalWidth);
     else
         computeIntrinsicLogicalWidths(m_minPreferredLogicalWidth, m_maxPreferredLogicalWidth);

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -551,8 +551,8 @@ static void updateSliderTrackPartForRenderer(SliderTrackPart& sliderTrackPart, c
 
         auto fixedWidth = thumbStyle.width().tryFixed();
         auto fixedHeight = thumbStyle.height().tryFixed();
-        auto thumbWidth = fixedWidth ? static_cast<int>(fixedWidth->value) : 0;
-        auto thumbHeight = fixedHeight ? static_cast<int>(fixedHeight->value) : 0;
+        auto thumbWidth = fixedWidth ? static_cast<int>(fixedWidth->evaluate(1.0f /* FIXME FIND ZOOM */)) : 0;
+        auto thumbHeight = fixedHeight ? static_cast<int>(fixedHeight->evaluate(1.0f /* FIXME FIND ZOOM */)) : 0;
 
         thumbSize = { thumbWidth, thumbHeight };
     }
@@ -1449,47 +1449,47 @@ void RenderTheme::adjustButtonOrCheckboxOrColorWellOrInnerSpinButtonOrRadioStyle
 
     if (auto fixedOverrideMinWidth = minimumControlSize.width().tryFixed()) {
         if (auto fixedOriginalMinWidth = style.minWidth().tryFixed()) {
-            if (fixedOverrideMinWidth->value > fixedOriginalMinWidth->value)
+            if (fixedOverrideMinWidth->evaluate(1.0f /* FIXME FIND ZOOM */) > fixedOriginalMinWidth->evaluate(1.0f /* FIXME FIND ZOOM */))
                 style.setMinWidth(Style::MinimumSize(minimumControlSize.width()));
         } else if (auto percentageOriginalMinWidth = style.minWidth().tryPercentage()) {
             // FIXME: This really makes no sense but matches existing behavior. Should use a `calc(max(override, original))` here instead.
-            if (fixedOverrideMinWidth->value > percentageOriginalMinWidth->value)
+            if (fixedOverrideMinWidth->evaluate(1.0f /* FIXME FIND ZOOM */) > percentageOriginalMinWidth->value)
                 style.setMinWidth(Style::MinimumSize(minimumControlSize.width()));
-        } else if (fixedOverrideMinWidth->value > 0) {
+        } else if (fixedOverrideMinWidth->isPositive()) {
             style.setMinWidth(Style::MinimumSize(minimumControlSize.width()));
         }
     } else if (auto percentageOverrideMinWidth = minimumControlSize.width().tryPercentage()) {
         if (auto fixedOriginalMinWidth = style.minWidth().tryFixed()) {
             // FIXME: This really makes no sense but matches existing behavior. Should use a `calc(max(override, original))` here instead.
-            if (percentageOverrideMinWidth->value > fixedOriginalMinWidth->value)
+            if (percentageOverrideMinWidth->value > fixedOriginalMinWidth->evaluate(1.0f /* FIXME FIND ZOOM */))
                 style.setMinWidth(Style::MinimumSize(minimumControlSize.width()));
         } else if (auto percentageOriginalMinWidth = style.minWidth().tryPercentage()) {
             if (percentageOverrideMinWidth->value > percentageOriginalMinWidth->value)
                 style.setMinWidth(Style::MinimumSize(minimumControlSize.width()));
-        } else if (percentageOverrideMinWidth->value > 0) {
+        } else if (percentageOverrideMinWidth->isPositive()) {
             style.setMinWidth(Style::MinimumSize(minimumControlSize.width()));
         }
     }
     if (auto fixedOverrideMinHeight = minimumControlSize.height().tryFixed()) {
         if (auto fixedOriginalMinHeight = style.minHeight().tryFixed()) {
-            if (fixedOverrideMinHeight->value > fixedOriginalMinHeight->value)
+            if (fixedOverrideMinHeight->evaluate(1.0f /* FIXME FIND ZOOM */) > fixedOriginalMinHeight->evaluate(1.0f /* FIXME FIND ZOOM */))
                 style.setMinHeight(Style::MinimumSize(minimumControlSize.height()));
         } else if (auto percentageOriginalMinHeight = style.minHeight().tryPercentage()) {
             // FIXME: This really makes no sense but matches existing behavior. Should use a `calc(max(override, original))` here instead.
-            if (fixedOverrideMinHeight->value > percentageOriginalMinHeight->value)
+            if (fixedOverrideMinHeight->evaluate(1.0f /* FIXME FIND ZOOM */) > percentageOriginalMinHeight->value)
                 style.setMinHeight(Style::MinimumSize(minimumControlSize.height()));
-        } else if (fixedOverrideMinHeight->value > 0) {
+        } else if (fixedOverrideMinHeight->isPositive()) {
             style.setMinHeight(Style::MinimumSize(minimumControlSize.height()));
         }
     } else if (auto percentageOverrideMinHeight = minimumControlSize.height().tryPercentage()) {
         if (auto fixedOriginalMinHeight = style.minHeight().tryFixed()) {
             // FIXME: This really makes no sense but matches existing behavior. Should use a `calc(max(override, original))` here instead.
-            if (percentageOverrideMinHeight->value > fixedOriginalMinHeight->value)
+            if (percentageOverrideMinHeight->value > fixedOriginalMinHeight->evaluate(1.0f /* FIXME FIND ZOOM */))
                 style.setMinHeight(Style::MinimumSize(minimumControlSize.height()));
         } else if (auto percentageOriginalMinHeight = style.minHeight().tryPercentage()) {
             if (percentageOverrideMinHeight->value > percentageOriginalMinHeight->value)
                 style.setMinHeight(Style::MinimumSize(minimumControlSize.height()));
-        } else if (percentageOverrideMinHeight->value > 0) {
+        } else if (percentageOverrideMinHeight->isPositive()) {
             style.setMinHeight(Style::MinimumSize(minimumControlSize.height()));
         }
     }
@@ -1582,11 +1582,11 @@ void RenderTheme::paintSliderTicks(const RenderElement& renderer, const PaintInf
 
         int thumbWidth = 0;
         if (auto fixedWidth = thumbStyle.width().tryFixed())
-            thumbWidth = static_cast<int>(fixedWidth->value);
+            thumbWidth = static_cast<int>(fixedWidth->evaluate(1.0f /* FIXME FIND ZOOM */));
 
         int thumbHeight = 0;
         if (auto fixedHeight = thumbStyle.height().tryFixed())
-            thumbHeight = static_cast<int>(fixedHeight->value);
+            thumbHeight = static_cast<int>(fixedHeight->evaluate(1.0f /* FIXME FIND ZOOM */));
 
         thumbSize.setWidth(isHorizontal ? thumbWidth : thumbHeight);
         thumbSize.setHeight(isHorizontal ? thumbHeight : thumbWidth);

--- a/Source/WebCore/rendering/TextBoxPainter.h
+++ b/Source/WebCore/rendering/TextBoxPainter.h
@@ -118,10 +118,24 @@ protected:
 
 inline FloatSize TextBoxPainter::rotateShadowOffset(const SpaceSeparatedPoint<Style::Length<>>& offset, WritingMode writingMode)
 {
-    if (writingMode.isHorizontal())
-        return { offset.x().value, offset.y().value };
-    if (writingMode.isLineOverLeft()) // sideways-lr
-        return { -offset.y().value, offset.x().value };
-    return { offset.y().value, -offset.x().value };
+    if (writingMode.isHorizontal()) {
+        return {
+            offset.x().evaluate(1.0f /* FIXME FIND ZOOM */),
+            offset.y().evaluate(1.0f /* FIXME FIND ZOOM */),
+        };
+    }
+
+    if (writingMode.isLineOverLeft()) { // sideways-lr
+        return {
+            -offset.y().evaluate(1.0f /* FIXME FIND ZOOM */),
+             offset.x().evaluate(1.0f /* FIXME FIND ZOOM */),
+        };
+    }
+
+    return {
+         offset.y().evaluate(1.0f /* FIXME FIND ZOOM */),
+        -offset.x().evaluate(1.0f /* FIXME FIND ZOOM */),
+    };
 }
-}
+
+} // namespace WebCore

--- a/Source/WebCore/rendering/TextDecorationPainter.cpp
+++ b/Source/WebCore/rendering/TextDecorationPainter.cpp
@@ -281,7 +281,7 @@ void TextDecorationPainter::paintBackgroundDecorations(const RenderStyle& style,
 
             auto shadowOffset = TextBoxPainter::rotateShadowOffset(shadow.location, m_writingMode);
             shadowOffset.expand(0, -extraOffset);
-            m_context.setDropShadow({ shadowOffset, shadow.blur.value, shadowColor, ShadowRadiusMode::Default });
+            m_context.setDropShadow({ shadowOffset, shadow.blur.evaluate(1.0f /* FIXME FIND ZOOM */), shadowColor, ShadowRadiusMode::Default });
 
             draw(&shadow);
         }

--- a/Source/WebCore/rendering/TextPainter.cpp
+++ b/Source/WebCore/rendering/TextPainter.cpp
@@ -55,7 +55,7 @@ ShadowApplier::ShadowApplier(const RenderStyle& style, GraphicsContext& context,
     }
 
     auto shadowOffset = TextBoxPainter::rotateShadowOffset(shadow->location, ignoreWritingMode ? WritingMode() : style.writingMode());
-    auto shadowRadius = shadow->blur.value;
+    auto shadowRadius = shadow->blur.evaluate(1.0f /* FIXME FIND ZOOM */);
     auto shadowColor = style.colorResolvingCurrentColor(shadow->color);
 
     colorFilter.transformColor(shadowColor);

--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
@@ -2302,7 +2302,7 @@ static void adjustInputElementButtonStyleForVectorBasedControls(RenderStyle& sty
     applyCommonButtonPaddingToStyleForVectorBasedControls(style, inputElement);
 
     // Don't adjust the style if the width is specified.
-    if (auto fixedLogicalWidth = style.logicalWidth().tryFixed(); fixedLogicalWidth && fixedLogicalWidth->value > 0)
+    if (auto fixedLogicalWidth = style.logicalWidth().tryFixed(); fixedLogicalWidth && fixedLogicalWidth->isPositive())
         return;
 
     // Don't adjust for unsupported date input types.
@@ -2440,7 +2440,7 @@ bool RenderThemeCocoa::adjustButtonStyleForVectorBasedControls(RenderStyle& styl
     if (style.logicalWidth().isIntrinsicOrLegacyIntrinsicOrAuto() || style.logicalHeight().isAuto()) {
         auto minimumHeight = controlBaseHeight / controlBaseFontSize * style.fontDescription().computedSize();
         if (auto fixedValue = style.logicalMinHeight().tryFixed())
-            minimumHeight = std::max(minimumHeight, fixedValue->value);
+            minimumHeight = std::max(minimumHeight, fixedValue->evaluate(1.0f /* FIXME FIND ZOOM */));
         // FIXME: This may need to be a layout time adjustment to support various
         // values like fit-content etc.
         style.setLogicalMinHeight(Style::MinimumSize::Fixed { minimumHeight });
@@ -2574,18 +2574,18 @@ bool RenderThemeCocoa::paintMenuListButtonDecorationsForVectorBasedControls(cons
 
     auto glyphPaddingEnd = logicalRect.width();
     if (auto fixedPaddingEnd = box.style().paddingEnd().tryFixed())
-        glyphPaddingEnd = fixedPaddingEnd->value;
+        glyphPaddingEnd = fixedPaddingEnd->evaluate(1.0f /* FIXME FIND ZOOM */);
 
     // Add RenderMenuList inner start padding for symmetry.
     if (CheckedPtr menulist = dynamicDowncast<RenderMenuList>(box); menulist && menulist->innerRenderer()) {
         if (auto innerPaddingStart = menulist->innerRenderer()->style().paddingStart().tryFixed())
-            glyphPaddingEnd += innerPaddingStart->value;
+            glyphPaddingEnd += innerPaddingStart->evaluate(1.0f /* FIXME FIND ZOOM */);
     }
 
     if (!style->writingMode().isInlineFlipped())
-        glyphOrigin.setX(logicalRect.maxX() - glyphSize.width() - Style::evaluate(box.style().borderEndWidth(), 1.0f /* FIXME ZOOM EFFECTED? */) - glyphPaddingEnd);
+        glyphOrigin.setX(logicalRect.maxX() - glyphSize.width() - Style::evaluate(box.style().borderEndWidth(), 1.0f /* FIXME FIND ZOOM */) - glyphPaddingEnd);
     else
-        glyphOrigin.setX(logicalRect.x() + Style::evaluate(box.style().borderEndWidth(), 1.0f /* FIXME ZOOM EFFECTED? */) + glyphPaddingEnd);
+        glyphOrigin.setX(logicalRect.x() + Style::evaluate(box.style().borderEndWidth(), 1.0f /* FIXME FIND ZOOM */) + glyphPaddingEnd);
 
     if (!isHorizontalWritingMode)
         glyphOrigin = glyphOrigin.transposedPoint();
@@ -3891,7 +3891,7 @@ float RenderThemeCocoa::adjustedMaximumLogicalWidthForControl(const RenderStyle&
 
         if (auto paddingEdgeInlineStartFixed = paddingEdgeInlineStart.tryFixed()) {
             if (auto paddingEdgeInlineEndFixed = paddingEdgeInlineEnd.tryFixed())
-                maximumLogicalWidth += paddingEdgeInlineStartFixed->value - paddingEdgeInlineEndFixed->value;
+                maximumLogicalWidth += paddingEdgeInlineStartFixed->evaluate(1.0f /* FIXME FIND ZOOM */) - paddingEdgeInlineEndFixed->evaluate(1.0f /* FIXME FIND ZOOM */);
         }
     }
 #else

--- a/Source/WebCore/rendering/ios/RenderThemeIOS.mm
+++ b/Source/WebCore/rendering/ios/RenderThemeIOS.mm
@@ -175,47 +175,47 @@ void RenderThemeIOS::adjustMinimumIntrinsicSizeForAppearance(StyleAppearance app
 
     if (auto fixedOverrideMinWidth = minimumControlSize.width().tryFixed()) {
         if (auto fixedOriginalMinWidth = style.minWidth().tryFixed()) {
-            if (fixedOverrideMinWidth->value > fixedOriginalMinWidth->value)
+            if (fixedOverrideMinWidth->evaluate(1.0f /* FIXME FIND ZOOM */) > fixedOriginalMinWidth->evaluate(1.0f /* FIXME FIND ZOOM */))
                 style.setMinWidth(Style::MinimumSize(minimumControlSize.width()));
         } else if (auto percentageOriginalMinWidth = style.minWidth().tryPercentage()) {
             // FIXME: This really makes no sense but matches existing behavior. Should use a `calc(max(override, original))` here instead.
-            if (fixedOverrideMinWidth->value > percentageOriginalMinWidth->value)
+            if (fixedOverrideMinWidth->evaluate(1.0f /* FIXME FIND ZOOM */) > percentageOriginalMinWidth->value)
                 style.setMinWidth(Style::MinimumSize(minimumControlSize.width()));
-        } else if (fixedOverrideMinWidth->value > 0) {
+        } else if (fixedOverrideMinWidth->isPositive()) {
             style.setMinWidth(Style::MinimumSize(minimumControlSize.width()));
         }
     } else if (auto percentageOverrideMinWidth = minimumControlSize.width().tryPercentage()) {
         if (auto fixedOriginalMinWidth = style.minWidth().tryFixed()) {
             // FIXME: This really makes no sense but matches existing behavior. Should use a `calc(max(override, original))` here instead.
-            if (percentageOverrideMinWidth->value > fixedOriginalMinWidth->value)
+            if (percentageOverrideMinWidth->value > fixedOriginalMinWidth->evaluate(1.0f /* FIXME FIND ZOOM */))
                 style.setMinWidth(Style::MinimumSize(minimumControlSize.width()));
         } else if (auto percentageOriginalMinWidth = style.minWidth().tryPercentage()) {
             if (percentageOverrideMinWidth->value > percentageOriginalMinWidth->value)
                 style.setMinWidth(Style::MinimumSize(minimumControlSize.width()));
-        } else if (percentageOverrideMinWidth->value > 0) {
+        } else if (percentageOverrideMinWidth->isPositive()) {
             style.setMinWidth(Style::MinimumSize(minimumControlSize.width()));
         }
     }
     if (auto fixedOverrideMinHeight = minimumControlSize.height().tryFixed()) {
         if (auto fixedOriginalMinHeight = style.minHeight().tryFixed()) {
-            if (fixedOverrideMinHeight->value > fixedOriginalMinHeight->value)
+            if (fixedOverrideMinHeight->evaluate(1.0f /* FIXME FIND ZOOM */) > fixedOriginalMinHeight->evaluate(1.0f /* FIXME FIND ZOOM */))
                 style.setMinHeight(Style::MinimumSize(minimumControlSize.height()));
         } else if (auto percentageOriginalMinHeight = style.minHeight().tryPercentage()) {
             // FIXME: This really makes no sense but matches existing behavior. Should use a `calc(max(override, original))` here instead.
-            if (fixedOverrideMinHeight->value > percentageOriginalMinHeight->value)
+            if (fixedOverrideMinHeight->evaluate(1.0f /* FIXME FIND ZOOM */) > percentageOriginalMinHeight->value)
                 style.setMinHeight(Style::MinimumSize(minimumControlSize.height()));
-        } else if (fixedOverrideMinHeight->value > 0) {
+        } else if (fixedOverrideMinHeight->isPositive()) {
             style.setMinHeight(Style::MinimumSize(minimumControlSize.height()));
         }
     } else if (auto percentageOverrideMinHeight = minimumControlSize.height().tryPercentage()) {
         if (auto fixedOriginalMinHeight = style.minHeight().tryFixed()) {
             // FIXME: This really makes no sense but matches existing behavior. Should use a `calc(max(override, original))` here instead.
-            if (percentageOverrideMinHeight->value > fixedOriginalMinHeight->value)
+            if (percentageOverrideMinHeight->value > fixedOriginalMinHeight->evaluate(1.0f /* FIXME FIND ZOOM */))
                 style.setMinHeight(Style::MinimumSize(minimumControlSize.height()));
         } else if (auto percentageOriginalMinHeight = style.minHeight().tryPercentage()) {
             if (percentageOverrideMinHeight->value > percentageOriginalMinHeight->value)
                 style.setMinHeight(Style::MinimumSize(minimumControlSize.height()));
-        } else if (percentageOverrideMinHeight->value > 0) {
+        } else if (percentageOverrideMinHeight->isPositive()) {
             style.setMinHeight(Style::MinimumSize(minimumControlSize.height()));
         }
     }
@@ -480,7 +480,7 @@ static void adjustInputElementButtonStyle(RenderStyle& style, const HTMLInputEle
     applyCommonNonCapsuleBorderRadiusToStyle(style);
 
     // Don't adjust the style if the width is specified.
-    if (auto fixedLogicalWidth = style.logicalWidth().tryFixed(); fixedLogicalWidth && fixedLogicalWidth->value > 0)
+    if (auto fixedLogicalWidth = style.logicalWidth().tryFixed(); fixedLogicalWidth && fixedLogicalWidth->isPositive())
         return;
 
     // Don't adjust for unsupported date input types.
@@ -942,7 +942,7 @@ void RenderThemeIOS::adjustButtonStyle(RenderStyle& style, const Element* elemen
     if (style.logicalWidth().isIntrinsicOrLegacyIntrinsicOrAuto() || style.logicalHeight().isAuto()) {
         auto minimumHeight = ControlBaseHeight / ControlBaseFontSize * style.fontDescription().computedSize();
         if (auto fixedLogicalMinHeight = style.logicalMinHeight().tryFixed())
-            minimumHeight = std::max(minimumHeight, fixedLogicalMinHeight->value);
+            minimumHeight = std::max(minimumHeight, fixedLogicalMinHeight->evaluate(1.0f /* FIXME FIND ZOOM */));
         // FIXME: This may need to be a layout time adjustment to support various values like fit-content etc.
         style.setLogicalMinHeight(Style::MinimumSize::Fixed { minimumHeight });
     }

--- a/Source/WebCore/rendering/mathml/RenderMathMLBlock.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLBlock.cpp
@@ -280,12 +280,12 @@ RenderMathMLBlock::SizeAppliedToMathContent RenderMathMLBlock::sizeAppliedToMath
     // FIXME: Resolve percentages.
     // https://github.com/w3c/mathml-core/issues/76
     if (auto fixedLogicalWidth = style().logicalWidth().tryFixed())
-        sizes.logicalWidth = fixedLogicalWidth->value;
+        sizes.logicalWidth = fixedLogicalWidth->evaluate(1.0f /* FIXME FIND ZOOM */);
 
     // FIXME: Resolve percentages.
     // https://github.com/w3c/mathml-core/issues/77
     if (auto fixedLogicalHeight = style().logicalHeight().tryFixed(); phase == LayoutPhase::Layout && fixedLogicalHeight)
-        sizes.logicalHeight = fixedLogicalHeight->value;
+        sizes.logicalHeight = fixedLogicalHeight->evaluate(1.0f /* FIXME FIND ZOOM */);
 
     return sizes;
 }

--- a/Source/WebCore/rendering/style/AutosizeStatus.cpp
+++ b/Source/WebCore/rendering/style/AutosizeStatus.cpp
@@ -42,9 +42,9 @@ bool AutosizeStatus::probablyContainsASmallFixedNumberOfLines(const RenderStyle&
     auto& maxHeight = style.maxHeight();
     std::optional<float> heightOrMaxHeightAsLength;
     if (auto fixedMaxHeight = maxHeight.tryFixed())
-        heightOrMaxHeightAsLength = fixedMaxHeight->value;
+        heightOrMaxHeightAsLength = fixedMaxHeight->evaluate(1.0f /* FIXME FIND ZOOM */);
     else if (auto fixedHeight = style.height().tryFixed(); fixedHeight && (!maxHeight.isSpecified() || maxHeight.isNone()))
-        heightOrMaxHeightAsLength = fixedHeight->value;
+        heightOrMaxHeightAsLength = fixedHeight->evaluate(1.0f /* FIXME FIND ZOOM */);
 
     if (!heightOrMaxHeightAsLength)
         return false;

--- a/Source/WebCore/rendering/style/BorderData.h
+++ b/Source/WebCore/rendering/style/BorderData.h
@@ -68,7 +68,7 @@ public:
             return 0_css_px;
         if (m_image.overridesBorderWidths()) {
             if (auto fixedBorderWidthValue = m_image.width().values[side].tryFixed())
-                return Style::LineWidth { fixedBorderWidthValue->value };
+                return Style::LineWidth { *fixedBorderWidthValue };
         }
         return m_edges[side].width();
     }

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -614,7 +614,7 @@ bool RenderStyle::isIdempotentTextAutosizingCandidate(AutosizeStatus status) con
                     return false;
                 if (auto fixedHeight = height().tryFixed(); fixedHeight && specifiedLineHeight().isFixed()) {
                     float specifiedSize = specifiedFontSize();
-                    if (fixedHeight->value == specifiedSize && specifiedLineHeight().value() == specifiedSize)
+                    if (fixedHeight->evaluate(1.0f /* FIXME FIND ZOOM */) == specifiedSize && specifiedLineHeight().value() == specifiedSize)
                         return false;
                 }
                 return true;
@@ -623,7 +623,7 @@ bool RenderStyle::isIdempotentTextAutosizingCandidate(AutosizeStatus status) con
                 if (auto fixedHeight = height().tryFixed(); specifiedLineHeight().isFixed() && fixedHeight) {
                     float specifiedSize = specifiedFontSize();
                     if (specifiedLineHeight().value() - specifiedSize > smallMinimumDifferenceThresholdBetweenLineHeightAndSpecifiedFontSizeForBoostingText
-                        && fixedHeight->value - specifiedSize > smallMinimumDifferenceThresholdBetweenLineHeightAndSpecifiedFontSizeForBoostingText) {
+                        && fixedHeight->evaluate(1.0f /* FIXME FIND ZOOM */) - specifiedSize > smallMinimumDifferenceThresholdBetweenLineHeightAndSpecifiedFontSizeForBoostingText) {
                         return true;
                     }
                 }
@@ -2293,7 +2293,7 @@ FloatPoint3D RenderStyle::computeTransformOrigin(const FloatRect& boundingBox) c
 {
     FloatPoint3D originTranslate;
     originTranslate.setXY(boundingBox.location() + floatPointForLengthPoint(Style::toPlatform(transformOrigin().xy()), boundingBox.size(), 1.0f /* FIXME FIND ZOOM */));
-    originTranslate.setZ(transformOriginZ().value);
+    originTranslate.setZ(transformOriginZ().evaluate(1.0f /* FIXME FIND ZOOM */));
     return originTranslate;
 }
 
@@ -3107,7 +3107,7 @@ static LayoutUnit computeOutset(const OutsetValue& outsetValue, LayoutUnit borde
             return LayoutUnit(number.value * borderWidth);
         },
         [&](const typename OutsetValue::Length& length) {
-            return LayoutUnit(length.value);
+            return LayoutUnit(length.evaluate(1.0f /* FIXME FIND ZOOM */));
         }
     );
 }
@@ -3489,7 +3489,7 @@ float RenderStyle::computedStrokeWidth(const IntSize& viewportSize) const
 
     return WTF::switchOn(strokeWidth(),
         [&](const Style::StrokeWidth::Fixed& fixedStrokeWidth) -> float {
-            return fixedStrokeWidth.value;
+            return fixedStrokeWidth.evaluate(1.0f /* FIXME FIND ZOOM */);
         },
         [&](const Style::StrokeWidth::Percentage& percentageStrokeWidth) -> float {
             // According to the spec, https://drafts.fxtf.org/paint/#stroke-width, the percentage is relative to the scaled viewport size.
@@ -3498,7 +3498,7 @@ float RenderStyle::computedStrokeWidth(const IntSize& viewportSize) const
         },
         [&](const Style::StrokeWidth::Calc& calcStrokeWidth) -> float {
             // FIXME: It is almost certainly wrong that calc and percentage are being handled differently - https://bugs.webkit.org/show_bug.cgi?id=296482
-            return Style::evaluate(calcStrokeWidth, viewportSize.width(), 1.0f /* FIXME ZOOM EFFECTED? */);
+            return Style::evaluate(calcStrokeWidth, viewportSize.width());
         }
     );
 }

--- a/Source/WebCore/rendering/updating/RenderTreeBuilder.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilder.cpp
@@ -1107,7 +1107,7 @@ void RenderTreeBuilder::reportVisuallyNonEmptyContent(const RenderElement& paren
             auto fixedHeight = style.height().tryFixed();
             if (!fixedWidth || !fixedHeight)
                 return { };
-            return std::make_optional(IntSize { static_cast<int>(fixedWidth->value), static_cast<int>(fixedHeight->value) });
+            return std::make_optional(IntSize { static_cast<int>(fixedWidth->evaluate(1.0f /* FIXME FIND ZOOM */)), static_cast<int>(fixedHeight->evaluate(1.0f /* FIXME FIND ZOOM */)) });
         };
         // SVG content tends to have a fixed size construct. However this is known to be inaccurate in certain cases (box-sizing: border-box) or especially when the parent box is oversized.
         auto candidateSize = IntSize { };

--- a/Source/WebCore/style/StyleExtractorCustom.h
+++ b/Source/WebCore/style/StyleExtractorCustom.h
@@ -3050,12 +3050,12 @@ inline RefPtr<CSSValue> ExtractorCustom::extractTransformOriginShorthand(Extract
         auto box = state.renderer->transformReferenceBoxRect(state.style);
         list.append(ExtractorConverter::convertNumberAsPixels(state, Style::evaluate(state.style.transformOriginX(), box.width(), 1.0f /* FIXME FIND ZOOM */)));
         list.append(ExtractorConverter::convertNumberAsPixels(state, Style::evaluate(state.style.transformOriginY(), box.height(), 1.0f /* FIXME FIND ZOOM */)));
-        if (auto transformOriginZ = state.style.transformOriginZ(); transformOriginZ.value)
+        if (auto transformOriginZ = state.style.transformOriginZ(); !transformOriginZ.isZero())
             list.append(ExtractorConverter::convertStyleType(state, transformOriginZ));
     } else {
         list.append(ExtractorConverter::convertStyleType(state, state.style.transformOriginX()));
         list.append(ExtractorConverter::convertStyleType(state, state.style.transformOriginY()));
-        if (auto transformOriginZ = state.style.transformOriginZ(); transformOriginZ.value)
+        if (auto transformOriginZ = state.style.transformOriginZ(); !transformOriginZ.isZero())
             list.append(ExtractorConverter::convertStyleType(state, transformOriginZ));
     }
     return CSSValueList::createSpaceSeparated(WTFMove(list));
@@ -3068,7 +3068,7 @@ inline void ExtractorCustom::extractTransformOriginShorthandSerialization(Extrac
         ExtractorSerializer::serializeNumberAsPixels(state, builder, context, Style::evaluate(state.style.transformOriginX(), box.width(), 1.0f /* FIXME FIND ZOOM */));
         builder.append(' ');
         ExtractorSerializer::serializeNumberAsPixels(state, builder, context, Style::evaluate(state.style.transformOriginY(), box.height(), 1.0f /* FIXME FIND ZOOM */));
-        if (auto transformOriginZ = state.style.transformOriginZ(); transformOriginZ.value) {
+        if (auto transformOriginZ = state.style.transformOriginZ(); !transformOriginZ.isZero()) {
             builder.append(' ');
             ExtractorSerializer::serializeStyleType(state, builder, context, transformOriginZ);
         }
@@ -3076,7 +3076,7 @@ inline void ExtractorCustom::extractTransformOriginShorthandSerialization(Extrac
         ExtractorSerializer::serializeStyleType(state, builder, context, state.style.transformOriginX());
         builder.append(' ');
         ExtractorSerializer::serializeStyleType(state, builder, context, state.style.transformOriginY());
-        if (auto transformOriginZ = state.style.transformOriginZ(); transformOriginZ.value) {
+        if (auto transformOriginZ = state.style.transformOriginZ(); !transformOriginZ.isZero()) {
             builder.append(' ');
             ExtractorSerializer::serializeStyleType(state, builder, context, transformOriginZ);
         }

--- a/Source/WebCore/style/StyleResolveForFont.cpp
+++ b/Source/WebCore/style/StyleResolveForFont.cpp
@@ -331,7 +331,7 @@ static ResolvedFontSize fontSizeFromUnresolvedFontSize(const CSSPropertyParserHe
                     return CSS::switchOnUnitType(lengthPercentage.unit,
                         [&](CSS::PercentageUnit) -> ResolvedFontSize {
                             return {
-                                .size = Style::evaluate(Style::Percentage<> { narrowPrecisionToFloat(lengthPercentage.value) }, parentSize, 1.0f /* FIXME FIND ZOOM */),
+                                .size = Style::evaluate(Style::Percentage<> { narrowPrecisionToFloat(lengthPercentage.value) }, parentSize),
                                 .keyword = CSSValueInvalid
                             };
                         },

--- a/Source/WebCore/style/values/StyleValueTypes.h
+++ b/Source/WebCore/style/values/StyleValueTypes.h
@@ -685,12 +685,12 @@ template<CSSValueID Name, typename StyleType> struct Serialize<FunctionNotation<
 
 template<typename> struct Evaluation;
 
-template<typename StyleType, typename Reference> concept HasTwoParameterEvaluate = requires {
-    Evaluation<StyleType> { }(std::declval<const StyleType&>(), std::declval<Reference>());
+template<typename StyleType, typename T1> concept HasTwoParameterEvaluate = requires {
+    Evaluation<StyleType> { }(std::declval<const StyleType&>(), std::declval<T1>());
 };
 
-template<typename StyleType, typename Reference, typename Zoom> concept HasThreeParameterEvaluate = requires {
-    Evaluation<StyleType> { }(std::declval<const StyleType&>(), std::declval<Reference>(), std::declval<Zoom>());
+template<typename StyleType, typename T1, typename T2> concept HasThreeParameterEvaluate = requires {
+    Evaluation<StyleType> { }(std::declval<const StyleType&>(), std::declval<T1>(), std::declval<T2>());
 };
 
 // `Evaluation` Invokers
@@ -699,20 +699,16 @@ template<typename StyleType> decltype(auto) evaluate(const StyleType& value)
     return Evaluation<StyleType> { }(value);
 }
 
-template<typename StyleType, typename Reference> decltype(auto) evaluate(const StyleType& value, Reference&& reference)
+template<typename StyleType, typename T1> decltype(auto) evaluate(const StyleType& value, T1&& t1)
 {
-    if constexpr (HasTwoParameterEvaluate<StyleType, Reference>)
-        return Evaluation<StyleType> { }(value, std::forward<Reference>(reference));
-    else
-        return evaluate(value);
+    if constexpr (HasTwoParameterEvaluate<StyleType, T1>)
+        return Evaluation<StyleType> { }(value, std::forward<T1>(t1));
 }
 
-template<typename StyleType, typename Reference, typename Zoom> decltype(auto) evaluate(const StyleType& value, Reference&& reference, Zoom&& zoom)
+template<typename StyleType, typename T1, typename T2> decltype(auto) evaluate(const StyleType& value, T1&& t1, T2&& t2)
 {
-    if constexpr (HasThreeParameterEvaluate<StyleType, Reference, Zoom>)
-        return Evaluation<StyleType> { }(value, std::forward<Reference>(reference), std::forward<Zoom>(zoom));
-    else
-        return evaluate(value, std::forward<Reference>(reference));
+    if constexpr (HasThreeParameterEvaluate<StyleType, T1, T2>)
+        return Evaluation<StyleType> { }(value, std::forward<T1>(t1), std::forward<T2>(t2));
 }
 
 // Constrained for `TreatAsVariantLike`.

--- a/Source/WebCore/style/values/animations/StyleSingleAnimationRange.cpp
+++ b/Source/WebCore/style/values/animations/StyleSingleAnimationRange.cpp
@@ -51,7 +51,7 @@ static RefPtr<CSSNumericValue> toCSSNumericValue(const SingleAnimationRangeLengt
     // FIXME: This will fail for calc().
     return offset.isPercentOrCalculated()
         ? CSSNumericFactory::percent(offset.tryPercentage()->value)
-        : CSSNumericFactory::px(offset.tryFixed()->value);
+        : CSSNumericFactory::px(offset.tryFixed()->evaluate(1.0f /* FIXME FIND ZOOM */));
 }
 
 TimelineRangeValue SingleAnimationRangeStart::toTimelineRangeValue() const

--- a/Source/WebCore/style/values/backgrounds/StyleBorderImageSlice.h
+++ b/Source/WebCore/style/values/backgrounds/StyleBorderImageSlice.h
@@ -40,12 +40,10 @@ struct BorderImageSliceValue {
     {
     }
 
-
     BorderImageSliceValue(Percentage percentage)
         : m_value { percentage }
     {
     }
-
 
     bool isNumber() const { return WTF::holdsAlternative<Number>(m_value); }
     bool isPercentage() const { return WTF::holdsAlternative<Percentage>(m_value); }

--- a/Source/WebCore/style/values/backgrounds/StyleLineWidth.h
+++ b/Source/WebCore/style/values/backgrounds/StyleLineWidth.h
@@ -50,7 +50,7 @@ struct LineWidth {
     constexpr bool isZero() const { return value.isZero(); }
     constexpr bool isPositive() const { return value.isPositive(); }
 
-    constexpr explicit operator bool() const { return !!value.value; }
+    constexpr explicit operator bool() const { return !isZero(); }
 
     constexpr bool operator==(const LineWidth&) const = default;
     constexpr auto operator<=>(const LineWidth&) const = default;
@@ -66,9 +66,9 @@ template<> struct CSSValueConversion<LineWidth> { auto operator()(BuilderState&,
 // MARK: - Evaluate
 
 template<> struct Evaluation<LineWidth> {
-    constexpr auto operator()(const LineWidth& value) -> float
+    constexpr auto operator()(const LineWidth& value, float zoom) -> float
     {
-        return value.value.evaluate(1.0f /* FIXME FIND ZOOM */);
+        return value.value.evaluate(zoom);
     }
 };
 

--- a/Source/WebCore/style/values/borders/StyleBoxShadow.h
+++ b/Source/WebCore/style/values/borders/StyleBoxShadow.h
@@ -104,7 +104,7 @@ inline bool isInset(const BoxShadow& shadow)
 
 inline LayoutUnit paintingSpread(const BoxShadow& shadow)
 {
-    return LayoutUnit { shadow.spread.value };
+    return LayoutUnit { shadow.spread.evaluate(1.0f /* FIXME FIND ZOOM */) };
 }
 
 } // namespace Style

--- a/Source/WebCore/style/values/borders/StyleShadow.h
+++ b/Source/WebCore/style/values/borders/StyleShadow.h
@@ -49,7 +49,7 @@ LayoutUnit paintingExtent(Shadow auto const& shadow)
     // extends to infinity. In 8-bit contexts, however, rounding causes the effect to become
     // undetectable at around 1.4x the radius.
     constexpr const float radiusExtentMultiplier = 1.4;
-    return LayoutUnit { ceilf(shadow.blur.value * radiusExtentMultiplier) };
+    return LayoutUnit { ceilf(shadow.blur.evaluate(1.0f /* FIXME FIND ZOOM */) * radiusExtentMultiplier) };
 }
 
 LayoutUnit paintingExtentAndSpread(Shadow auto const& shadow)
@@ -70,10 +70,10 @@ template<Shadow ShadowType> auto shadowOutsetExtent(const Shadows<ShadowType>& s
 
         auto extentAndSpread = paintingExtentAndSpread(shadow);
 
-        left = std::min<LayoutUnit>(left, LayoutUnit(shadow.location.x().value) - extentAndSpread);
-        right = std::max<LayoutUnit>(right, LayoutUnit(shadow.location.x().value) + extentAndSpread);
-        top = std::min<LayoutUnit>(top, LayoutUnit(shadow.location.y().value) - extentAndSpread);
-        bottom = std::max<LayoutUnit>(bottom, LayoutUnit(shadow.location.y().value) + extentAndSpread);
+        left = std::min<LayoutUnit>(left, LayoutUnit(shadow.location.x().evaluate(1.0f /* FIXME FIND ZOOM */)) - extentAndSpread);
+        right = std::max<LayoutUnit>(right, LayoutUnit(shadow.location.x().evaluate(1.0f /* FIXME FIND ZOOM */)) + extentAndSpread);
+        top = std::min<LayoutUnit>(top, LayoutUnit(shadow.location.y().evaluate(1.0f /* FIXME FIND ZOOM */)) - extentAndSpread);
+        bottom = std::max<LayoutUnit>(bottom, LayoutUnit(shadow.location.y().evaluate(1.0f /* FIXME FIND ZOOM */)) + extentAndSpread);
     }
 
     return { top, right, bottom, left };
@@ -92,10 +92,10 @@ template<Shadow ShadowType> auto shadowInsetExtent(const Shadows<ShadowType>& sh
 
         auto extentAndSpread = paintingExtentAndSpread(shadow);
 
-        top = std::max<LayoutUnit>(top, LayoutUnit(shadow.location.y().value) + extentAndSpread);
-        right = std::min<LayoutUnit>(right, LayoutUnit(shadow.location.x().value) - extentAndSpread);
-        bottom = std::min<LayoutUnit>(bottom, LayoutUnit(shadow.location.y().value) - extentAndSpread);
-        left = std::max<LayoutUnit>(left, LayoutUnit(shadow.location.x().value) + extentAndSpread);
+        top = std::max<LayoutUnit>(top, LayoutUnit(shadow.location.y().evaluate(1.0f /* FIXME FIND ZOOM */)) + extentAndSpread);
+        right = std::min<LayoutUnit>(right, LayoutUnit(shadow.location.x().evaluate(1.0f /* FIXME FIND ZOOM */)) - extentAndSpread);
+        bottom = std::min<LayoutUnit>(bottom, LayoutUnit(shadow.location.y().evaluate(1.0f /* FIXME FIND ZOOM */)) - extentAndSpread);
+        left = std::max<LayoutUnit>(left, LayoutUnit(shadow.location.x().evaluate(1.0f /* FIXME FIND ZOOM */)) + extentAndSpread);
     }
 
     return { top, right, bottom, left };
@@ -112,8 +112,8 @@ template<Shadow ShadowType> auto shadowHorizontalExtent(const Shadows<ShadowType
 
         auto extentAndSpread = paintingExtentAndSpread(shadow);
 
-        left = std::min<LayoutUnit>(left, LayoutUnit(shadow.location.x().value) - extentAndSpread);
-        right = std::max<LayoutUnit>(right, LayoutUnit(shadow.location.x().value) + extentAndSpread);
+        left = std::min<LayoutUnit>(left, LayoutUnit(shadow.location.x().evaluate(1.0f /* FIXME FIND ZOOM */)) - extentAndSpread);
+        right = std::max<LayoutUnit>(right, LayoutUnit(shadow.location.x().evaluate(1.0f /* FIXME FIND ZOOM */)) + extentAndSpread);
     }
 
     return { left, right };
@@ -131,8 +131,8 @@ template<Shadow ShadowType> auto shadowVerticalExtent(const Shadows<ShadowType>&
         auto extentAndSpread = paintingExtentAndSpread(shadow);
 
         // FIXME: Why does this do a static cast to `int` but all of the other "extent" functions in this file do not?
-        top = std::min<LayoutUnit>(top, LayoutUnit(static_cast<int>(shadow.location.y().value)) - extentAndSpread);
-        bottom = std::max<LayoutUnit>(bottom, LayoutUnit(static_cast<int>(shadow.location.y().value)) + extentAndSpread);
+        top = std::min<LayoutUnit>(top, LayoutUnit(static_cast<int>(shadow.location.y().evaluate(1.0f /* FIXME FIND ZOOM */))) - extentAndSpread);
+        bottom = std::max<LayoutUnit>(bottom, LayoutUnit(static_cast<int>(shadow.location.y().evaluate(1.0f /* FIXME FIND ZOOM */))) + extentAndSpread);
     }
 
     return { top, bottom };

--- a/Source/WebCore/style/values/filter-effects/StyleBlurFunction.cpp
+++ b/Source/WebCore/style/values/filter-effects/StyleBlurFunction.cpp
@@ -42,7 +42,7 @@ Ref<FilterOperation> createFilterOperation(const CSS::Blur& filter, const Builde
 {
     float stdDeviation = 0;
     if (auto parameter = filter.value)
-        stdDeviation = toStyle(*parameter, state).value;
+        stdDeviation = toStyle(*parameter, state).evaluate(1.0f /* FIXME FIND ZOOM */);
     else
         stdDeviation = filterFunctionDefaultValue<CSS::BlurFunction::name>().value;
 

--- a/Source/WebCore/style/values/filter-effects/StyleDropShadowFunction.cpp
+++ b/Source/WebCore/style/values/filter-effects/StyleDropShadowFunction.cpp
@@ -51,9 +51,9 @@ CSS::DropShadow toCSSDropShadow(Ref<DropShadowFilterOperationWithStyleColor> ope
 
 Ref<FilterOperation> createFilterOperation(const CSS::DropShadow& filter, const BuilderState& state)
 {
-    int x = roundForImpreciseConversion<int>(toStyle(filter.location.x(), state).value);
-    int y = roundForImpreciseConversion<int>(toStyle(filter.location.y(), state).value);
-    int stdDeviation = filter.stdDeviation ? roundForImpreciseConversion<int>(toStyle(*filter.stdDeviation, state).value) : 0;
+    int x = roundForImpreciseConversion<int>(toStyle(filter.location.x(), state).evaluate(1.0f /* FIXME FIND ZOOM */));
+    int y = roundForImpreciseConversion<int>(toStyle(filter.location.y(), state).evaluate(1.0f /* FIXME FIND ZOOM */));
+    int stdDeviation = filter.stdDeviation ? roundForImpreciseConversion<int>(toStyle(*filter.stdDeviation, state).evaluate(1.0f /* FIXME FIND ZOOM */)) : 0;
     auto color = filter.color ? toStyleColor(*filter.color, state, ForVisitedLink::No) : Style::Color { CurrentColor { } };
 
     return DropShadowFilterOperationWithStyleColor::create(

--- a/Source/WebCore/style/values/images/StyleGradient.cpp
+++ b/Source/WebCore/style/values/images/StyleGradient.cpp
@@ -129,7 +129,7 @@ static std::optional<float> resolveColorStopPosition(const GradientLinearColorSt
         [&](const typename LengthPercentage<>::Dimension& length) -> std::optional<float> {
             if (gradientLength <= 0)
                 return 0;
-            return length.value / gradientLength;
+            return length.evaluate(1.0f /* FIXME FIND ZOOM */) / gradientLength;
         },
         [&](const typename LengthPercentage<>::Percentage& percentage) -> std::optional<float> {
             return percentage.value / 100.0;
@@ -943,7 +943,7 @@ template<CSSValueID Name> static Ref<WebCore::Gradient> createPlatformGradient(c
     auto computeCircleRadius = [&](const Variant<RadialGradient::Circle::Length, RadialGradient::Extent>& circleLengthOrExtent, FloatPoint centerPoint) -> std::pair<float, float> {
         return WTF::switchOn(circleLengthOrExtent,
             [&](const RadialGradient::Circle::Length& circleLength) -> std::pair<float, float> {
-                return { circleLength.value, 1 };
+                return { circleLength.evaluate(1.0f /* FIXME FIND ZOOM */), 1 };
             },
             [&](const RadialGradient::Extent& extent) -> std::pair<float, float> {
                 return WTF::switchOn(extent,

--- a/Source/WebCore/style/values/non-standard/StyleWebKitTextStrokeWidth.h
+++ b/Source/WebCore/style/values/non-standard/StyleWebKitTextStrokeWidth.h
@@ -55,7 +55,7 @@ template<> struct CSSValueConversion<WebkitTextStrokeWidth> { auto operator()(Bu
 
 template<> struct Evaluation<WebkitTextStrokeWidth> {
     constexpr auto operator()(const WebkitTextStrokeWidth& value, float zoom) -> float {
-        return value.value.value * zoom;
+        return value.value.evaluate(zoom);
     }
 };
 

--- a/Source/WebCore/style/values/primitives/StyleLengthWrapper.h
+++ b/Source/WebCore/style/values/primitives/StyleLengthWrapper.h
@@ -69,8 +69,8 @@ template<typename Numeric, CSS::PrimitiveKeyword... Ks> struct LengthWrapperBase
 
     LengthWrapperBase(CSS::ValidKeywordForList<Keywords> auto keyword) : m_value(Keywords::offsetForKeyword(keyword)) { }
 
-    LengthWrapperBase(Fixed fixed) : m_value(indexForFixed, fixed.value) { }
-    LengthWrapperBase(Fixed fixed, bool hasQuirk) : m_value(indexForFixed, fixed.value, hasQuirk) { }
+    LengthWrapperBase(Fixed fixed) : m_value(indexForFixed, fixed.unevaluatedValue()) { }
+    LengthWrapperBase(Fixed fixed, bool hasQuirk) : m_value(indexForFixed, fixed.unevaluatedValue(), hasQuirk) { }
     LengthWrapperBase(Percentage percent) : m_value(indexForPercentage, percent.value) { }
     LengthWrapperBase(Calc&& calc) : m_value(indexForCalc, calc.protectedCalculation()) { }
     LengthWrapperBase(Specified&& specified) : m_value(toData(specified)) { }
@@ -155,7 +155,7 @@ private:
     {
         return WTF::switchOn(specified,
             [](const Fixed& fixed) {
-                return LengthWrapperData { indexForFixed, fixed.value };
+                return LengthWrapperData { indexForFixed, fixed.unevaluatedValue() };
             },
             [](const Percentage& percentage) {
                 return LengthWrapperData { indexForPercentage, percentage.value };

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Calculation.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Calculation.h
@@ -53,6 +53,11 @@ template<auto R, typename V> Calculation::Child copyCalculation(const Percentage
     return Calculation::percentage(value.value);
 }
 
+template<auto R, typename V> Calculation::Child copyCalculation(const Length<R, V>& value)
+{
+    return Calculation::dimension(value.unevaluatedValue());
+}
+
 inline Calculation::Child copyCalculation(Numeric auto const& value)
 {
     return Calculation::dimension(value.value);

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.h
@@ -239,7 +239,7 @@ float adjustForZoom(float, const RenderStyle&);
 template<auto R, typename V> struct ToCSS<Length<R, V>> {
     auto operator()(const Length<R, V>& value, const RenderStyle& style) -> CSS::Length<R, V>
     {
-        return CSS::LengthRaw<R, V> { value.unit, adjustForZoom(value.value, style) };
+        return CSS::LengthRaw<R, V> { value.unit, adjustForZoom(value.unevaluatedValue(), style) };
     }
 };
 
@@ -280,7 +280,7 @@ template<auto R, typename V> struct ToCSS<LengthPercentage<R, V>> {
     {
         return WTF::switchOn(value,
             [&](const typename LengthPercentage<R, V>::Dimension& length) -> CSS::LengthPercentage<R, V> {
-                return typename CSS::LengthPercentage<R, V>::Raw { length.unit, adjustForZoom(length.value, style) };
+                return typename CSS::LengthPercentage<R, V>::Raw { length.unit, adjustForZoom(length.unevaluatedValue(), style) };
             },
             [&](const typename LengthPercentage<R, V>::Percentage& percentage) -> CSS::LengthPercentage<R, V> {
                 return typename CSS::LengthPercentage<R, V>::Raw { percentage.unit, percentage.value };

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Logging.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Logging.h
@@ -38,6 +38,11 @@ WTF::TextStream& operator<<(WTF::TextStream& ts, Calc auto const& value)
     return ts << value.protectedCalculation().get();
 }
 
+template<auto R, typename V> WTF::TextStream& operator<<(WTF::TextStream& ts, const Length<R, V>& value)
+{
+    return ts << CSS::serializationForCSS(CSS::defaultSerializationContext(), CSS::SerializableNumber { static_cast<double>(value.unevaluatedValue()), CSS::unitString(value.unit) });
+}
+
 WTF::TextStream& operator<<(WTF::TextStream& ts, Numeric auto const& value)
 {
     return ts << CSS::serializationForCSS(CSS::defaultSerializationContext(), CSS::SerializableNumber { static_cast<double>(value.value), CSS::unitString(value.unit) });

--- a/Source/WebCore/style/values/scroll-snap/StyleScrollMargin.cpp
+++ b/Source/WebCore/style/values/scroll-snap/StyleScrollMargin.cpp
@@ -35,12 +35,12 @@ namespace Style {
 
 LayoutUnit Evaluation<ScrollMarginEdge>::operator()(const ScrollMarginEdge& edge, LayoutUnit, float zoom)
 {
-    return LayoutUnit(edge.m_value.value * zoom);
+    return LayoutUnit(edge.m_value.evaluate(zoom));
 }
 
 float Evaluation<ScrollMarginEdge>::operator()(const ScrollMarginEdge& edge, float, float zoom)
 {
-    return edge.m_value.value * zoom;
+    return edge.m_value.evaluate(zoom);
 }
 
 auto CSSValueConversion<ScrollMarginEdge>::operator()(BuilderState& state, const CSSValue& value) -> ScrollMarginEdge

--- a/Source/WebCore/style/values/scroll-snap/StyleScrollPadding.cpp
+++ b/Source/WebCore/style/values/scroll-snap/StyleScrollPadding.cpp
@@ -35,13 +35,13 @@ LayoutUnit Evaluation<ScrollPaddingEdge>::operator()(const ScrollPaddingEdge& ed
 {
     return WTF::switchOn(edge,
         [&](const ScrollPaddingEdge::Fixed& fixed) {
-            return LayoutUnit(fixed.value);
+            return LayoutUnit(fixed.evaluate(zoom));
         },
         [&](const ScrollPaddingEdge::Percentage& percentage) {
-            return Style::evaluate(percentage, referenceLength, zoom /* FIXME ZOOM EFFECTED? */);
+            return Style::evaluate(percentage, referenceLength);
         },
         [&](const ScrollPaddingEdge::Calc& calculated) {
-            return Style::evaluate(calculated, referenceLength, zoom /* FIXME FIND ZOOM */);
+            return Style::evaluate(calculated, referenceLength);
         },
         [&](const CSS::Keyword::Auto&) {
             return 0_lu;
@@ -53,13 +53,13 @@ float Evaluation<ScrollPaddingEdge>::operator()(const ScrollPaddingEdge& edge, f
 {
     return WTF::switchOn(edge,
         [&](const ScrollPaddingEdge::Fixed& fixed) {
-            return fixed.value;
+            return fixed.evaluate(zoom);
         },
         [&](const ScrollPaddingEdge::Percentage& percentage) {
-            return Style::evaluate(percentage, referenceLength, zoom /* FIXME ZOOM EFFECTED? */);
+            return Style::evaluate(percentage, referenceLength);
         },
         [&](const ScrollPaddingEdge::Calc& calculated) {
-            return Style::evaluate(calculated, referenceLength, zoom /* FIXME ZOOM EFFECTED? */);
+            return Style::evaluate(calculated, referenceLength);
         },
         [&](const CSS::Keyword::Auto&) {
             return 0.0f;

--- a/Source/WebCore/style/values/transforms/StylePerspective.h
+++ b/Source/WebCore/style/values/transforms/StylePerspective.h
@@ -35,7 +35,7 @@ struct Perspective : ValueOrKeyword<Length<CSS::Nonnegative, float>, CSS::Keywor
     using Base::Base;
     using Length = typename Base::Value;
 
-    float usedPerspective() const { return std::max(1.0f, tryValue().value_or(1.0f).value); }
+    float usedPerspective() const { return std::max(1.0f, tryValue().value_or(1.0f).evaluate(1.0f /* FIXME FIND ZOOM */)); }
 
     bool isNone() const { return isKeyword(); }
     bool isLength() const { return isValue(); }

--- a/Source/WebCore/svg/SVGLengthContext.cpp
+++ b/Source/WebCore/svg/SVGLengthContext.cpp
@@ -114,7 +114,7 @@ template<typename SizeType> float SVGLengthContext::valueForSizeType(const SizeT
 {
     return WTF::switchOn(size,
         [&](const typename SizeType::Fixed& fixed) -> float {
-            return fixed.value;
+            return fixed.evaluate(1.0f /* FIXME FIND ZOOM */);
         },
         [&](const typename SizeType::Percentage& percentage) -> float {
             auto result = convertValueFromPercentageToUserUnits(percentage.value / 100, lengthMode);
@@ -124,7 +124,7 @@ template<typename SizeType> float SVGLengthContext::valueForSizeType(const SizeT
         },
         [&](const typename SizeType::Calc& calc) -> float {
             auto viewportSize = this->viewportSize().value_or(FloatSize { });
-            return Style::evaluate(calc, dimensionForLengthMode(lengthMode, viewportSize), 1.0f /* FIXME FIND ZOOM */);
+            return Style::evaluate(calc, dimensionForLengthMode(lengthMode, viewportSize));
         },
         [&](const auto&) -> float {
             return 0;

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -3168,11 +3168,11 @@ header: <WebCore/StylePrimitiveNumericTypes.h>
 };
 
 [CustomHeader, Nested] struct WebCore::Style::LengthNonnegative {
-    float value;
+    float unevaluatedValue();
 };
 using WebCore::Style::LengthAll = WebCore::Style::Length<WebCore::CSS::All>;
 [CustomHeader, Nested] struct WebCore::Style::Length<WebCore::CSS::All> {
-    float value;
+    float unevaluatedValue();
 };
 
 [CustomHeader, Nested] struct WebCore::Style::Percentage<WebCore::CSS::Nonnegative> {


### PR DESCRIPTION
#### ab4abdb7a3cf6a6060921739812f7a73263bb2a6
<pre>
Add more enforcement of zoom evaluation for Style::Length&lt;&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=299346">https://bugs.webkit.org/show_bug.cgi?id=299346</a>

Reviewed by Antti Koivisto.

The initial change to add evaluation time zoom application didn&apos;t fully
enforce the need to call evaluate. This change makes a stronger guarantee
by specializing Style::PrimitiveNumeric for lengths and making the value
private, requiring callers to use the evaluate(zoom) function.

With this new guarantee in place, a number of additional &quot;FIXME FIND ZOOM&quot;s
were added, giving a clearer picture of what work is needed.

This change also makes it so that calling Style::evaluate() with something
that isn&apos;t a length (or something that contains a length) doesn&apos;t allow
passing a zoom parameter, allowing the removal of a number of &quot;FIXME FIND ZOOM&quot;s.

* Source/WebCore/dom/Document.cpp:
* Source/WebCore/editing/Editor.cpp:
* Source/WebCore/html/NumberInputType.cpp:
* Source/WebCore/html/SearchInputType.cpp:
* Source/WebCore/layout/formattingContexts/FormattingGeometry.cpp:
* Source/WebCore/layout/formattingContexts/FormattingGeometry.h:
* Source/WebCore/layout/formattingContexts/block/BlockFormattingQuirks.cpp:
* Source/WebCore/layout/formattingContexts/flex/FlexFormattingContext.cpp:
* Source/WebCore/layout/formattingContexts/inline/InlineFormattingContext.cpp:
* Source/WebCore/layout/formattingContexts/table/TableFormattingContext.cpp:
* Source/WebCore/layout/formattingContexts/table/TableFormattingQuirks.cpp:
* Source/WebCore/layout/formattingContexts/table/TableLayout.cpp:
* Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.cpp:
* Source/WebCore/layout/integration/flex/LayoutIntegrationFlexLayout.cpp:
* Source/WebCore/layout/layouttree/LayoutElementBox.cpp:
* Source/WebCore/page/IntersectionObserver.cpp:
* Source/WebCore/page/PrintContext.cpp:
* Source/WebCore/rendering/AutoTableLayout.cpp:
* Source/WebCore/rendering/BackgroundPainter.cpp:
* Source/WebCore/rendering/EllipsisBoxPainter.cpp:
* Source/WebCore/rendering/FixedTableLayout.cpp:
* Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp:
* Source/WebCore/rendering/NinePieceImagePainter.cpp:
* Source/WebCore/rendering/RenderBlock.cpp:
* Source/WebCore/rendering/RenderBlockFlow.cpp:
* Source/WebCore/rendering/RenderBox.cpp:
* Source/WebCore/rendering/RenderBoxModelObject.cpp:
* Source/WebCore/rendering/RenderDeprecatedFlexibleBox.cpp:
* Source/WebCore/rendering/RenderElement.cpp:
* Source/WebCore/rendering/RenderFileUploadControl.cpp:
* Source/WebCore/rendering/RenderFlexibleBox.cpp:
* Source/WebCore/rendering/RenderFragmentContainer.cpp:
* Source/WebCore/rendering/RenderGrid.cpp:
* Source/WebCore/rendering/RenderLayerBacking.cpp:
* Source/WebCore/rendering/RenderListBox.cpp:
* Source/WebCore/rendering/RenderListMarker.cpp:
* Source/WebCore/rendering/RenderMenuList.cpp:
* Source/WebCore/rendering/RenderReplaced.cpp:
* Source/WebCore/rendering/RenderTable.cpp:
* Source/WebCore/rendering/RenderTableCell.cpp:
* Source/WebCore/rendering/RenderTableSection.cpp:
* Source/WebCore/rendering/RenderTextControl.cpp:
* Source/WebCore/rendering/RenderTheme.cpp:
* Source/WebCore/rendering/TextBoxPainter.h:
* Source/WebCore/rendering/TextDecorationPainter.cpp:
* Source/WebCore/rendering/TextPainter.cpp:
* Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm:
* Source/WebCore/rendering/mathml/RenderMathMLBlock.cpp:
* Source/WebCore/rendering/style/AutosizeStatus.cpp:
* Source/WebCore/rendering/style/BorderData.h:
* Source/WebCore/rendering/style/RenderStyle.cpp:
* Source/WebCore/rendering/updating/RenderTreeBuilder.cpp:
* Source/WebCore/style/StyleExtractorCustom.h:
* Source/WebCore/style/StyleResolveForFont.cpp:
* Source/WebCore/style/values/StyleValueTypes.h:
* Source/WebCore/style/values/animations/StyleSingleAnimationRange.cpp:
* Source/WebCore/style/values/backgrounds/StyleBorderImageSlice.h:
* Source/WebCore/style/values/backgrounds/StyleLineWidth.h:
* Source/WebCore/style/values/borders/StyleBoxShadow.h:
* Source/WebCore/style/values/borders/StyleShadow.h:
* Source/WebCore/style/values/filter-effects/StyleBlurFunction.cpp:
* Source/WebCore/style/values/filter-effects/StyleDropShadowFunction.cpp:
* Source/WebCore/style/values/images/StyleGradient.cpp:
* Source/WebCore/style/values/non-standard/StyleWebKitTextStrokeWidth.h:
* Source/WebCore/style/values/primitives/StyleLengthWrapper.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumeric.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Blending.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Calculation.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Evaluation.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Logging.h:
* Source/WebCore/style/values/scroll-snap/StyleScrollMargin.cpp:
* Source/WebCore/style/values/scroll-snap/StyleScrollPadding.cpp:
* Source/WebCore/style/values/transforms/StylePerspective.h:
* Source/WebCore/svg/SVGLengthContext.cpp:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/300470@main">https://commits.webkit.org/300470@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a3700b1e46e3c1121b8ef7a2b5171c35f11666d5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122702 "13 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42414 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33104 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/129323 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/74806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/124578 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43133 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51007 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/93254 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/74806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125654 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34387 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/109851 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/73895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33374 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/28006 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72810 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104086 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28217 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132051 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49647 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/37789 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/101780 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50024 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106064 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/101646 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25810 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/47026 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/25199 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/46417 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49504 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/55257 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/48971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/52323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50654 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->