### PR TITLE
Lay some groundwork for LargestContentful Paint support

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2135,6 +2135,7 @@ page/InteractionRegion.cpp
 page/IntersectionObserver.cpp
 page/IntersectionObserverEntry.cpp
 page/LargestContentfulPaint.cpp
+page/LargestContentfulPaintData.cpp
 page/LocalDOMWindow.cpp
 page/LocalDOMWindowProperty.cpp
 page/LocalFrame.cpp

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -168,6 +168,7 @@
 #include "JSViewTransitionUpdateCallback.h"
 #include "KeyboardEvent.h"
 #include "KeyframeEffect.h"
+#include "LargestContentfulPaintData.h"
 #include "LayoutDisallowedScope.h"
 #include "LazyLoadImageObserver.h"
 #include "LegacySchemeRegistry.h"
@@ -8998,6 +8999,30 @@ double Document::monotonicTimestamp() const
     if (!loader)
         return 0.0;
     return (MonotonicTime::now() - loader->timing().startTime()).seconds();
+}
+
+LargestContentfulPaintData& Document::largestContentfulPaintData() const
+{
+    if (!m_largestContentfulPaintData)
+        m_largestContentfulPaintData = makeUnique<LargestContentfulPaintData>();
+
+    return *m_largestContentfulPaintData;
+}
+
+void Document::didPaintImage(Element& element, CachedImage* image, FloatRect localRect) const
+{
+    if (!supportsLargestContentfulPaint())
+        return;
+
+    largestContentfulPaintData().didPaintImage(element, image, localRect);
+}
+
+void Document::didPaintText(const RenderText& renderText, FloatRect localRect) const
+{
+    if (!supportsLargestContentfulPaint())
+        return;
+
+    largestContentfulPaintData().didPaintText(renderText, localRect);
 }
 
 int Document::requestAnimationFrame(Ref<RequestAnimationFrameCallback>&& callback)

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -106,6 +106,7 @@ class CSSFontSelector;
 class CSSStyleProperties;
 class CSSStyleSheet;
 class CachedCSSStyleSheet;
+class CachedImage;
 class CachedFrameBase;
 class CachedResourceLoader;
 class CachedScript;
@@ -185,6 +186,7 @@ class IntPoint;
 class IntersectionObserver;
 class JSNode;
 class JSViewTransitionUpdateCallback;
+class LargestContentfulPaintData;
 class LayoutPoint;
 class LayoutRect;
 class LazyLoadImageObserver;
@@ -219,6 +221,7 @@ class RTCNetworkManager;
 class Range;
 class RealtimeMediaSource;
 class Region;
+class RenderText;
 class RenderTreeBuilder;
 class RenderView;
 class ReportingScope;
@@ -1475,6 +1478,10 @@ public:
     WEBCORE_EXPORT double monotonicTimestamp() const;
     const DocumentEventTiming& eventTiming() const { return m_eventTiming; }
 
+    LargestContentfulPaintData& largestContentfulPaintData() const;
+    void didPaintImage(Element&, CachedImage*, FloatRect localRect) const;
+    void didPaintText(const RenderText&, FloatRect localRect) const;
+
     int requestAnimationFrame(Ref<RequestAnimationFrameCallback>&&);
     void cancelAnimationFrame(int id);
 
@@ -2386,6 +2393,7 @@ private:
     ViewportArguments m_viewportArguments;
 
     DocumentEventTiming m_eventTiming;
+    mutable std::unique_ptr<LargestContentfulPaintData> m_largestContentfulPaintData;
 
     RefPtr<MediaQueryMatcher> m_mediaQueryMatcher;
     

--- a/Source/WebCore/page/LargestContentfulPaintData.cpp
+++ b/Source/WebCore/page/LargestContentfulPaintData.cpp
@@ -1,0 +1,217 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "LargestContentfulPaintData.h"
+
+#include "CachedImage.h"
+#include "Element.h"
+#include "FloatQuad.h"
+#include "LargestContentfulPaint.h"
+#include "LegacyRenderSVGImage.h"
+#include "LocalDOMWindow.h"
+#include "LocalFrameView.h"
+#include "Logging.h"
+#include "Page.h"
+#include "Performance.h"
+#include "RenderBlock.h"
+#include "RenderBox.h"
+#include "RenderElement.h"
+#include "RenderInline.h"
+#include "RenderLineBreak.h"
+#include "RenderReplaced.h"
+#include "RenderSVGImage.h"
+#include "RenderText.h"
+#include "RenderView.h"
+#include "VisibleRectContext.h"
+
+#include <wtf/Ref.h>
+#include <wtf/text/TextStream.h>
+
+namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(LargestContentfulPaintData);
+
+LargestContentfulPaintData::LargestContentfulPaintData() = default;
+LargestContentfulPaintData::~LargestContentfulPaintData() = default;
+
+// https://w3c.github.io/paint-timing/#exposed-for-paint-timing
+bool LargestContentfulPaintData::isExposedForPaintTiming(const Element& element)
+{
+    if (!element.document().isFullyActive())
+        return false;
+
+    if (!element.isInDocumentTree()) // Also checks isConnected().
+        return false;
+
+    return true;
+}
+
+// https://w3c.github.io/largest-contentful-paint/#largest-contentful-paint-candidate
+bool LargestContentfulPaintData::isEligibleForLargestContentfulPaint(const Element& element, float effectiveVisualArea)
+{
+    CheckedPtr renderer = element.renderer();
+    if (!renderer)
+        return false;
+
+    // FIXME: Check isEffectivelyTransparent
+
+    // FIXME: Need to implement the response length vs. image size logic.
+    UNUSED_PARAM(effectiveVisualArea);
+    return true;
+}
+
+// https://w3c.github.io/largest-contentful-paint/#sec-effective-visual-size
+std::optional<float> LargestContentfulPaintData::effectiveVisualArea(const Element& element, CachedImage* image, FloatRect imageLocalRect, FloatRect intersectionRect)
+{
+    RefPtr frameView = element.document().view();
+    if (!frameView)
+        return { };
+
+    auto visualViewportSize = FloatSize { frameView->visualViewportRect().size() };
+    if (intersectionRect.area() >= visualViewportSize.area())
+        return { };
+
+    auto area = intersectionRect.area();
+    if (image) {
+        CheckedPtr renderer = element.renderer();
+        if (!renderer)
+            return { };
+
+        auto absoluteContentRect = renderer->localToAbsoluteQuad(FloatRect(imageLocalRect)).boundingBox();
+
+        auto intersectingContentRect = intersection(absoluteContentRect, intersectionRect);
+        area = intersectingContentRect.area();
+
+        auto naturalSize = image->imageSizeForRenderer(renderer.get(), 1);
+        if (naturalSize.isEmpty())
+            return { };
+
+        auto scaleFactor = absoluteContentRect.area() / FloatSize { naturalSize }.area();
+        if (scaleFactor > 1)
+            area /= scaleFactor;
+
+        return area;
+    }
+
+    return area;
+}
+
+// https://w3c.github.io/largest-contentful-paint/#sec-add-lcp-entry
+void LargestContentfulPaintData::potentiallyAddLargestContentfulPaintEntry(Element&, CachedImage*, FloatRect imageLocalRect, FloatRect intersectionRect, DOMHighResTimeStamp paintTimestamp)
+{
+    UNUSED_PARAM(imageLocalRect);
+    UNUSED_PARAM(intersectionRect);
+    UNUSED_PARAM(paintTimestamp);
+}
+
+RefPtr<LargestContentfulPaint> LargestContentfulPaintData::takePendingEntry(DOMHighResTimeStamp)
+{
+    return nullptr;
+}
+
+// This is a simplified version of IntersectionObserver::computeIntersectionState(). Some code should be shared.
+FloatRect LargestContentfulPaintData::computeViewportIntersectionRect(Element& element, FloatRect localRect)
+{
+    RefPtr frameView = element.document().view();
+    if (!frameView)
+        return { };
+
+    CheckedPtr targetRenderer = element.renderer();
+    if (!targetRenderer)
+        return { };
+
+    if (targetRenderer->isSkippedContent())
+        return { };
+
+    CheckedPtr rootRenderer = frameView->renderView();
+    auto layoutViewport = frameView->layoutViewportRect();
+
+    auto localTargetBounds = LayoutRect { localRect };
+
+    // FIXME: This clips for ancestors, which maybe isn't what we want.
+    auto absoluteRects = targetRenderer->computeVisibleRectsInContainer(
+        { localTargetBounds },
+        &targetRenderer->view(),
+        {
+            .hasPositionFixedDescendant = false,
+            .dirtyRectIsFlipped = false,
+            .options = {
+                VisibleRectContext::Option::UseEdgeInclusiveIntersection,
+                VisibleRectContext::Option::ApplyCompositedClips,
+                VisibleRectContext::Option::ApplyCompositedContainerScrolls
+            },
+        }
+    );
+
+    if (!absoluteRects)
+        return { };
+
+    auto intersectionRect = layoutViewport;
+    intersectionRect.edgeInclusiveIntersect(absoluteRects->clippedOverflowRect);
+    return intersectionRect;
+}
+
+FloatRect LargestContentfulPaintData::computeViewportIntersectionRectForTextContainer(Element& element, const WeakHashSet<Text, WeakPtrImplWithEventTargetData>& textNodes)
+{
+    RefPtr frameView = element.document().view();
+    if (!frameView)
+        return { };
+
+    CheckedPtr rootRenderer = frameView->renderView();
+    auto layoutViewport = frameView->layoutViewportRect();
+
+    IntRect absoluteTextBounds;
+    for (RefPtr node : textNodes) {
+        if (!node)
+            continue;
+
+        CheckedPtr renderer = node->renderer();
+        if (!renderer)
+            continue;
+
+        if (renderer->isSkippedContent())
+            continue;
+
+        static constexpr bool useTransforms = true;
+        auto absoluteBounds = renderer->absoluteBoundingBoxRect(useTransforms);
+        absoluteTextBounds.unite(absoluteBounds);
+    }
+
+    auto intersectionRect = layoutViewport;
+    intersectionRect.edgeInclusiveIntersect(absoluteTextBounds);
+
+    return intersectionRect;
+}
+
+void LargestContentfulPaintData::didPaintImage(Element&, CachedImage*, FloatRect)
+{
+}
+
+void LargestContentfulPaintData::didPaintText(const RenderText&, FloatRect)
+{
+}
+
+} // namespace WebCore

--- a/Source/WebCore/page/LargestContentfulPaintData.h
+++ b/Source/WebCore/page/LargestContentfulPaintData.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "FloatRect.h"
+#include <wtf/FastMalloc.h>
+#include <wtf/WeakHashMap.h>
+#include <wtf/WeakHashSet.h>
+
+namespace WebCore {
+
+class CachedImage;
+class Element;
+class HTMLImageElement;
+class LargestContentfulPaint;
+class Node;
+class RenderText;
+class Text;
+class WeakPtrImplWithEventTargetData;
+
+using DOMHighResTimeStamp = double;
+
+class LargestContentfulPaintData {
+    WTF_MAKE_TZONE_ALLOCATED(LargestContentfulPaintData);
+public:
+    LargestContentfulPaintData();
+    ~LargestContentfulPaintData();
+
+    void didPaintImage(Element&, CachedImage*, FloatRect localRect);
+    void didPaintText(const RenderText&, FloatRect localRect);
+
+    RefPtr<LargestContentfulPaint> takePendingEntry(DOMHighResTimeStamp);
+
+    static bool isExposedForPaintTiming(const Element&);
+
+private:
+
+    static std::optional<float> effectiveVisualArea(const Element&, CachedImage*, FloatRect imageLocalRect, FloatRect intersectionRect);
+
+    static FloatRect computeViewportIntersectionRect(Element&, FloatRect localRect);
+    static FloatRect computeViewportIntersectionRectForTextContainer(Element&, const WeakHashSet<Text, WeakPtrImplWithEventTargetData>&);
+
+    static bool isEligibleForLargestContentfulPaint(const Element&, float effectiveVisualArea);
+
+    void potentiallyAddLargestContentfulPaintEntry(Element&, CachedImage*, FloatRect imageLocalRect, FloatRect intsectionRect, DOMHighResTimeStamp);
+};
+
+} // namespace WebCore

--- a/Source/WebCore/platform/Logging.h
+++ b/Source/WebCore/platform/Logging.h
@@ -123,6 +123,7 @@ namespace WebCore {
     M(IndexedDBOperations) \
     M(Inspector) \
     M(IntersectionObserver) \
+    M(LargestContentfulPaint) \
     M(Layers) \
     M(Layout) \
     M(LazyLoading) \


### PR DESCRIPTION
#### af7f7a28c19550b1b88e9d1e415937b823f42882
<pre>
Lay some groundwork for LargestContentful Paint support
<a href="https://bugs.webkit.org/show_bug.cgi?id=299345">https://bugs.webkit.org/show_bug.cgi?id=299345</a>
<a href="https://rdar.apple.com/161141886">rdar://161141886</a>

Reviewed by Dan Glastonbury.

Add LargestContentfulPaintData, which will keep state related to LCP. Add two entrypoints
on Document, which call into LargestContentfulPaintData after settings checks; these will
be wired up in future commits.

Add a log channel, which will be used in future commits.

Implement some of the basic LCP-related geometry methods for computed rects relative to
the viewport.

This will be tested by largest-contentful-paint WPT.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::largestContentfulPaintData const):
(WebCore::Document::didPaintImage const):
(WebCore::Document::didPaintText const):
* Source/WebCore/dom/Document.h:
* Source/WebCore/page/LargestContentfulPaintData.cpp: Added.
(WebCore::LargestContentfulPaintData::isExposedForPaintTiming):
(WebCore::LargestContentfulPaintData::isEligibleForLargestContentfulPaint):
(WebCore::LargestContentfulPaintData::effectiveVisualArea):
(WebCore::LargestContentfulPaintData::potentiallyAddLargestContentfulPaintEntry):
(WebCore::LargestContentfulPaintData::takePendingEntry):
(WebCore::LargestContentfulPaintData::computeViewportIntersectionRect):
(WebCore::LargestContentfulPaintData::computeViewportIntersectionRectForTextContainer):
(WebCore::LargestContentfulPaintData::didPaintImage):
(WebCore::LargestContentfulPaintData::didPaintText):
* Source/WebCore/page/LargestContentfulPaintData.h: Added.
* Source/WebCore/platform/Logging.h:

Canonical link: <a href="https://commits.webkit.org/300444@main">https://commits.webkit.org/300444@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c501f88d0122a8b6e6e8dd02f0a2d09009581217

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122563 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42271 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32956 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/129172 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/74664 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/16cf5a8e-4d74-46a1-90ae-9a87361f6ab1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/124439 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42989 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50864 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/93168 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/74664 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125515 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/34291 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109743 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/73814 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1ea48159-90ee-4acc-9f5a-aa32362d0cca) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/33274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27900 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72656 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/103954 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28110 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131898 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49504 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37684 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/101702 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49879 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105963 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/101570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25784 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46944 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/25096 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/46274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49362 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/55111 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48830 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/52181 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50511 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->