### PR TITLE
Deploy smart pointer in GtkVersioning

### DIFF
--- a/Source/WebCore/platform/gtk/GtkVersioning.h
+++ b/Source/WebCore/platform/gtk/GtkVersioning.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include <gtk/gtk.h>
+#include <wtf/glib/GRefPtr.h>
 
 #if USE(GTK4)
 
@@ -210,17 +211,16 @@ static inline int
 gtk_native_dialog_run(GtkNativeDialog* dialog)
 {
     struct RunDialogContext {
-        GMainLoop *loop;
+        GRefPtr<GMainLoop> loop;
         int response;
-    } context = { g_main_loop_new(nullptr, FALSE), 0 };
+    } context = { adoptGRef(g_main_loop_new(nullptr, FALSE)), 0 };
 
     gtk_native_dialog_show(dialog);
     g_signal_connect(dialog, "response", G_CALLBACK(+[](GtkNativeDialog*, int response, RunDialogContext* context) {
         context->response = response;
-        g_main_loop_quit(context->loop);
+        g_main_loop_quit(context->loop.get());
     }), &context);
-    g_main_loop_run(context.loop);
-    g_main_loop_unref(context.loop);
+    g_main_loop_run(context.loop.get());
 
     return context.response;
 }
@@ -229,17 +229,16 @@ static inline int
 gtk_dialog_run(GtkDialog* dialog)
 {
     struct RunDialogContext {
-        GMainLoop *loop;
+        GRefPtr<GMainLoop> loop;
         int response;
-    } context = { g_main_loop_new(nullptr, FALSE), 0 };
+    } context = { adoptGRef(g_main_loop_new(nullptr, FALSE)), 0 };
 
     gtk_widget_show(GTK_WIDGET(dialog));
     g_signal_connect(dialog, "response", G_CALLBACK(+[](GtkDialog*, int response, RunDialogContext* context) {
         context->response = response;
-        g_main_loop_quit(context->loop);
+        g_main_loop_quit(context->loop.get());
     }), &context);
-    g_main_loop_run(context.loop);
-    g_main_loop_unref(context.loop);
+    g_main_loop_run(context.loop.get());
 
     return context.response;
 }


### PR DESCRIPTION
#### 0229055c0bd24e6243ba051e807cfbd0bdecdcf9
<pre>
Deploy smart pointer in GtkVersioning
<a href="https://bugs.webkit.org/show_bug.cgi?id=299349">https://bugs.webkit.org/show_bug.cgi?id=299349</a>

Reviewed by Michael Catanzaro.

Use smart pointers instead of raw pointers in GtkVersioning

* Source/WebCore/platform/gtk/GtkVersioning.h:
(gtk_native_dialog_run):
(gtk_dialog_run):

Canonical link: <a href="https://commits.webkit.org/300919@main">https://commits.webkit.org/300919@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3d19b5774e4de71ca304f83e99f9a3b378f065ee

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124328 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44010 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34738 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131167 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/76382 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/126205 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44755 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52608 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/94574 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/76382 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127282 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35667 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111204 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75161 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/34608 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29364 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74644 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105412 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29587 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133833 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51229 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39066 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/103053 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51626 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107423 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/102849 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26169 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48212 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/26463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/48165 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51095 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56880 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/50529 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/53885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/52204 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->