### PR TITLE
[JSC] Add all B3 opcodes in B3::Value::key switch

### DIFF
--- a/Source/JavaScriptCore/b3/B3Value.cpp
+++ b/Source/JavaScriptCore/b3/B3Value.cpp
@@ -957,7 +957,9 @@ ValueKey Value::key() const
     case Equal:
     case NotEqual:
     case LessThan:
+    case LessEqual:
     case GreaterThan:
+    case GreaterEqual:
     case Above:
     case Below:
     case AboveEqual:
@@ -990,6 +992,8 @@ ValueKey Value::key() const
         return ValueKey(
             SlotBase, type(),
             static_cast<int64_t>(as<SlotBaseValue>()->slot()->index()));
+    case Extract:
+        return ValueKey(kind(), type(), child(0), as<ExtractValue>()->index());
     case VectorNot:
     case VectorSplat:
     case VectorAbs:
@@ -1068,9 +1072,44 @@ ValueKey Value::key() const
         if (numChildren() == 2)
             return ValueKey(kind(), type(), as<SIMDValue>()->simdInfo(), child(0), child(1), nullptr);
         return ValueKey(kind(), type(), as<SIMDValue>()->simdInfo(), child(0), child(1), child(2));
-    default:
+    case Nop:
+    case Set:
+    case Get:
+    case Load:
+    case Load8Z:
+    case Load16Z:
+    case Load8S:
+    case Load16S:
+    case Store:
+    case Store8:
+    case Store16:
+    case AtomicWeakCAS:
+    case AtomicStrongCAS:
+    case AtomicXchgAdd:
+    case AtomicXchgAnd:
+    case AtomicXchgOr:
+    case AtomicXchgSub:
+    case AtomicXchgXor:
+    case AtomicXchg:
+    case WasmAddress:
+    case WasmBoundsCheck:
+    case MemoryCopy:
+    case MemoryFill:
+    case Fence:
+    case CCall:
+    case Patchpoint:
+    case Upsilon:
+    case Phi:
+    case Jump:
+    case Branch:
+    case Switch:
+    case EntrySwitch:
+    case Return:
+    case Oops:
         return ValueKey();
     }
+    RELEASE_ASSERT_NOT_REACHED();
+    return ValueKey();
 }
 
 Value* Value::foldIdentity() const

--- a/Source/JavaScriptCore/b3/B3ValueKey.h
+++ b/Source/JavaScriptCore/b3/B3ValueKey.h
@@ -64,6 +64,8 @@ public:
 
     ValueKey(Kind, Type, Value* a, Value* b, Value* c);
 
+    ValueKey(Kind, Type, Value*, int32_t value);
+
     ValueKey(Kind kind, Type type, int64_t value)
         : m_kind(kind)
         , m_type(type)

--- a/Source/JavaScriptCore/b3/B3ValueKeyInlines.h
+++ b/Source/JavaScriptCore/b3/B3ValueKeyInlines.h
@@ -59,6 +59,15 @@ inline ValueKey::ValueKey(Kind kind, Type type, Value* a, Value* b, Value* c)
     u.indices[2] = c->index();
 }
 
+inline ValueKey::ValueKey(Kind kind, Type type, Value* a, int32_t value)
+    : m_kind(kind)
+    , m_type(type)
+{
+    u.indices[0] = a->index();
+    u.indices[1] = value;
+    u.indices[2] = UINT32_MAX;
+}
+
 inline ValueKey::ValueKey(Kind kind, Type type, SIMDInfo simdInfo, Value* a)
     : m_simdInfo(simdInfo)
     , m_kind(kind)
@@ -107,7 +116,7 @@ inline ValueKey::ValueKey(Kind kind, Type type, SIMDInfo simdInfo, Value* a, Val
 
 inline Value* ValueKey::child(Procedure& proc, unsigned index) const
 {
-    return proc.values()[index];
+    return proc.values()[u.indices[index]];
 }
 
 } } // namespace JSC::B3


### PR DESCRIPTION
#### f2335ec63ebd5451792e93777368f5b8db83de0d
<pre>
[JSC] Add all B3 opcodes in B3::Value::key switch
<a href="https://bugs.webkit.org/show_bug.cgi?id=299354">https://bugs.webkit.org/show_bug.cgi?id=299354</a>
<a href="https://rdar.apple.com/problem/161145916">rdar://problem/161145916</a>

Reviewed by Yijia Huang and Justin Michaud.

List all B3 opcodes in B3::Value::key switch so that we can ensure new
B3 opcodes are always added properly to this list. We also found several
missing handlings for opcodes (GreaterEqual etc.)
Note that this patch fixes B3::ValueKey::materialize. But this does not
matter much in practice since only Constant Value case is used right
now, and Constant values are correctly implemented.

* Source/JavaScriptCore/b3/B3Value.cpp:
(JSC::B3::Value::key const):
* Source/JavaScriptCore/b3/B3ValueKey.cpp:
(JSC::B3::ValueKey::materialize const):
* Source/JavaScriptCore/b3/B3ValueKey.h:
* Source/JavaScriptCore/b3/B3ValueKeyInlines.h:
(JSC::B3::ValueKey::ValueKey):
(JSC::B3::ValueKey::child const):

Canonical link: <a href="https://commits.webkit.org/300393@main">https://commits.webkit.org/300393@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d336de4207fe631884437312cb9a0ffa9002a4b9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122357 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42062 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32749 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128943 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/74456 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d60a677e-0661-49ab-bf5b-eb25c463c6ec) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42782 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50656 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93003 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/74456 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6af75699-c689-4a76-99ae-d3ccb45fab58) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125309 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34123 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109558 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73662 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9c7eb75c-66a8-4efc-81a2-e56a86be4b2b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33112 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27717 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72434 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/114505 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103709 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27925 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131685 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/120883 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49298 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37516 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101552 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49672 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105778 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101423 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46797 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24927 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/46059 "Build was cancelled. Recent messages:Printed configuration") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19349 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49156 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54898 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/151042 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48623 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/38638 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51973 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50305 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->