### PR TITLE
Fix run-api-tests Failed to run xcrun simctl spawn on simulators

### DIFF
--- a/Tools/Scripts/webkitpy/api_tests/manager.py
+++ b/Tools/Scripts/webkitpy/api_tests/manager.py
@@ -22,6 +22,7 @@
 
 import json
 import logging
+import os
 import re
 import time
 
@@ -149,11 +150,6 @@ class Manager(object):
             if need_newline:
                 self._stream.writeln('')
 
-    def _initialize_devices(self):
-        if 'simulator' in self._port.port_name:
-            SimulatedDeviceManager.initialize_devices(DeviceRequest(self._port.supported_device_types()[0], allow_incomplete_match=True), self.host, simulator_ui=False)
-        elif 'device' in self._port.port_name:
-            raise RuntimeError('Running api tests on {} is not supported'.format(self._port.port_name))
 
     def _binaries_for_arguments(self, args):
         if self._port.get_option('api_binary'):
@@ -171,6 +167,37 @@ class Manager(object):
                 return self._port.path_to_api_test_binaries().keys()
         return binaries or self._port.path_to_api_test_binaries().keys()
 
+    def _update_worker_count(self):
+        child_processes_option_value = int(self._options.child_processes or 0)
+        specified_child_processes = (
+            child_processes_option_value
+            or self._port.default_child_processes()
+        )
+        self._options.child_processes = specified_child_processes
+
+    def _set_up_run(self, device_type=None):
+        self._stream.write_update("Starting helper ...")
+        if not self._port.start_helper():
+            return False
+
+        self._update_worker_count()
+        self._port.reset_preferences()
+
+        # Set up devices for the test run
+        if 'simulator' in self._port.port_name:
+            if device_type is None:
+                device_type = self._port.supported_device_types()[0]
+            self._port.setup_test_run(device_type=device_type)
+        elif 'device' in self._port.port_name:
+            raise RuntimeError('Running api tests on {} is not supported'.format(self._port.port_name))
+
+        return True
+
+    def _clean_up_run(self):
+        """Clean up the test run."""
+        self._port.stop_helper()
+        self._port.clean_up_test_run()
+
     def run(self, args, json_output=None):
         if json_output:
             json_output = self.host.filesystem.abspath(json_output)
@@ -184,7 +211,8 @@ class Manager(object):
             _log.error('Build check failed')
             return Manager.FAILED_BUILD_CHECK
 
-        self._initialize_devices()
+        if not self._set_up_run():
+            return Manager.FAILED_BUILD_CHECK
 
         self._stream.write_update('Collecting tests ...')
         try:
@@ -215,6 +243,8 @@ class Manager(object):
         except KeyboardInterrupt:
             # If we receive a KeyboardInterrupt, print results.
             self._stream.writeln('')
+        finally:
+            self._clean_up_run()
 
         end_time = time.time()
 


### PR DESCRIPTION
#### 5e7289ab4ca0ceae916fb7a23f91121c9afc4a45
<pre>
Fix run-api-tests Failed to run xcrun simctl spawn on simulators
<a href="https://bugs.webkit.org/show_bug.cgi?id=299329">https://bugs.webkit.org/show_bug.cgi?id=299329</a>
<a href="https://rdar.apple.com/161128346">rdar://161128346</a>

Reviewed by Jonathan Bedard.

When running run-api-tests and child-processes on simulator it will fail to spawn the simulators, changing _initialize_devices to match run-webkit-tests&apos; _set_up_run  fixes this by ensuring the simulators have appropriate time to boot.

* Tools/Scripts/webkitpy/api_tests/manager.py:
(Manager._initialize_devices):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dda1271c3a52b3fd4a39cda2f87d4c53e2e87c86

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122471 "Failed to checkout and rebase branch from PR 51178") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/42179 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/138/builds/32864 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/129069 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/74570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/124347 "Failed to checkout and rebase branch from PR 51178") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42897 "Failed to checkout and rebase branch from PR 51178") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/50772 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/129069 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/74570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125423 "Failed to checkout and rebase branch from PR 51178") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/130/builds/42897 "Failed to checkout and rebase branch from PR 51178") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/138/builds/32864 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/129069 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/121828 "Failed to checkout and rebase branch from PR 51178") | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/130/builds/42897 "Failed to checkout and rebase branch from PR 51178") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/138/builds/32864 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/72558 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/130/builds/42897 "Failed to checkout and rebase branch from PR 51178") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/32864 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/131803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/49412 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/50772 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/131803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/49786 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/138/builds/32864 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/131803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/32864 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/46181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/49270 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/48737 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/52087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/50419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->