### PR TITLE
Address safer cpp warnings in platform/network/cocoa

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
@@ -92,8 +92,6 @@ platform/graphics/StringTruncator.cpp
 platform/graphics/ca/PlatformCALayer.h
 platform/graphics/ca/TileController.cpp
 platform/mediastream/libwebrtc/LibWebRTCDav1dDecoder.cpp
-platform/network/cocoa/CredentialCocoa.h
-platform/network/cocoa/ProtectionSpaceCocoa.h
 rendering/AccessibilityRegionContext.h
 rendering/BreakLines.h
 rendering/RenderLayerBacking.cpp

--- a/Source/WebCore/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations
@@ -9,5 +9,3 @@ platform/graphics/cocoa/WebSampleBufferVideoRendering.h
 platform/ios/WebAVPlayerController.h
 platform/ios/WebAVPlayerController.mm
 platform/network/cf/FormDataStreamCFNet.cpp
-platform/network/cocoa/WebCoreNSURLSession.h
-platform/network/cocoa/WebCoreNSURLSession.mm

--- a/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -62,7 +62,6 @@ platform/mediastream/RealtimeVideoCaptureSource.cpp
 platform/mediastream/cocoa/IncomingAudioMediaStreamTrackRendererUnit.cpp
 platform/mediastream/mac/RealtimeIncomingVideoSourceCocoa.mm
 platform/mediastream/mac/RealtimeOutgoingAudioSourceCocoa.cpp
-platform/network/cocoa/NetworkStorageSessionCocoa.mm
 rendering/BackgroundPainter.cpp
 rendering/BorderPainter.cpp
 rendering/RenderBox.cpp

--- a/Source/WebCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
@@ -108,12 +108,6 @@ platform/mediastream/mac/AVVideoCaptureSource.mm
 platform/mediastream/mac/ScreenCaptureKitCaptureSource.mm
 platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.mm
 platform/network/cf/DNSResolveQueueCFNet.cpp
-platform/network/cocoa/CredentialCocoa.mm
-platform/network/cocoa/NetworkStorageSessionCocoa.mm
-platform/network/cocoa/ProtectionSpaceCocoa.mm
-platform/network/cocoa/ResourceRequestCocoa.mm
-platform/network/cocoa/ResourceResponseCocoa.mm
-platform/network/cocoa/WebCoreNSURLSession.mm
 platform/network/mac/AuthenticationMac.mm
 platform/network/mac/CredentialStorageMac.mm
 platform/network/mac/NetworkStateNotifierMac.cpp

--- a/Source/WebCore/platform/Cookie.h
+++ b/Source/WebCore/platform/Cookie.h
@@ -49,8 +49,7 @@ struct Cookie {
 
 #ifdef __OBJC__
     WEBCORE_EXPORT Cookie(NSHTTPCookie *);
-    WEBCORE_EXPORT operator NSHTTPCookie *() const;
-    WEBCORE_EXPORT RetainPtr<NSHTTPCookie> toProtectedNSHTTPCookie() const;
+    WEBCORE_EXPORT RetainPtr<NSHTTPCookie> createNSHTTPCookie() const;
 #elif USE(SOUP)
     explicit Cookie(SoupCookie*);
     SoupCookie* toSoupCookie() const;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -813,7 +813,7 @@ void MediaPlayerPrivateAVFoundationObjC::createAVAssetForURL(const URL& url)
 
         if (cookies.size()) {
             auto nsCookies = createNSArray(cookies, [] (auto& cookie) -> NSHTTPCookie * {
-                return cookie;
+                return cookie.createNSHTTPCookie().autorelease();
             });
 
             [options setObject:nsCookies.get() forKey:AVURLAssetHTTPCookiesKey];

--- a/Source/WebCore/platform/network/cf/ResourceError.h
+++ b/Source/WebCore/platform/network/cf/ResourceError.h
@@ -56,6 +56,7 @@ public:
     WEBCORE_EXPORT NSError *nsError() const;
     WEBCORE_EXPORT NSError *nsError(NSError *) const;
     WEBCORE_EXPORT operator NSError *() const;
+    WEBCORE_EXPORT RetainPtr<NSError> protectedNSError() const;
 
 
     struct IPCData {

--- a/Source/WebCore/platform/network/cf/ResourceRequest.h
+++ b/Source/WebCore/platform/network/cf/ResourceRequest.h
@@ -92,6 +92,7 @@ public:
     
     bool encodingRequiresPlatformData() const { return m_httpBody || m_nsRequest; }
     WEBCORE_EXPORT NSURLRequest *nsURLRequest(HTTPBodyUpdatePolicy) const;
+    WEBCORE_EXPORT RetainPtr<NSURLRequest> protectedNSURLRequest(HTTPBodyUpdatePolicy) const;
 
     WEBCORE_EXPORT static CFStringRef isUserInitiatedKey();
     WEBCORE_EXPORT ResourceRequestPlatformData getResourceRequestPlatformData() const;

--- a/Source/WebCore/platform/network/cf/ResourceResponse.h
+++ b/Source/WebCore/platform/network/cf/ResourceResponse.h
@@ -82,6 +82,7 @@ public:
     }
 
     WEBCORE_EXPORT NSURLResponse *nsURLResponse() const;
+    WEBCORE_EXPORT RetainPtr<NSURLResponse> protectedNSURLResponse() const;
 
 #if USE(QUICK_LOOK)
     bool isQuickLook() const { return m_isQuickLook; }

--- a/Source/WebCore/platform/network/cocoa/CookieCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/CookieCocoa.mm
@@ -126,7 +126,7 @@ Cookie::Cookie(NSHTTPCookie *cookie)
     sameSite = coreSameSitePolicy(cookie.sameSitePolicy);
 }
 
-Cookie::operator NSHTTPCookie * _Nullable () const
+RetainPtr<NSHTTPCookie> Cookie::createNSHTTPCookie() const
 {
     if (isNull())
         return nil;
@@ -189,19 +189,14 @@ bool Cookie::operator==(const Cookie& other) const
     bool otherNull = other.isNull();
     if (thisNull || otherNull)
         return thisNull == otherNull;
-    return [toProtectedNSHTTPCookie() isEqual:other.toProtectedNSHTTPCookie().get()];
+    return [createNSHTTPCookie() isEqual:other.createNSHTTPCookie().get()];
 }
     
 unsigned Cookie::hash() const
 {
     ASSERT(!name.isHashTableDeletedValue());
     ASSERT(!isNull());
-    return toProtectedNSHTTPCookie().get().hash;
-}
-
-RetainPtr<NSHTTPCookie> Cookie::toProtectedNSHTTPCookie() const
-{
-    return static_cast<NSHTTPCookie *>(*this);
+    return createNSHTTPCookie().get().hash;
 }
 
 NS_ASSUME_NONNULL_END

--- a/Source/WebCore/platform/network/cocoa/CredentialCocoa.h
+++ b/Source/WebCore/platform/network/cocoa/CredentialCocoa.h
@@ -51,9 +51,10 @@ public:
 
     WEBCORE_EXPORT bool isEmpty() const;
 
-    bool encodingRequiresPlatformData() const { return m_nsCredential && encodingRequiresPlatformData(RetainPtr { m_nsCredential }.get()); }
+    bool encodingRequiresPlatformData() const;
 
     WEBCORE_EXPORT NSURLCredential *nsCredential() const;
+    WEBCORE_EXPORT RetainPtr<NSURLCredential> protectedNSCredential() const;
 
     static bool platformCompare(const Credential&, const Credential&);
 

--- a/Source/WebCore/platform/network/cocoa/CredentialCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/CredentialCocoa.mm
@@ -96,6 +96,11 @@ NSURLCredential *Credential::nsCredential() const
     return m_nsCredential.get();
 }
 
+RetainPtr<NSURLCredential> Credential::protectedNSCredential() const
+{
+    return nsCredential();
+}
+
 bool Credential::isEmpty() const
 {
     if (m_nsCredential)
@@ -104,12 +109,17 @@ bool Credential::isEmpty() const
     return CredentialBase::isEmpty();
 }
 
+bool Credential::encodingRequiresPlatformData() const
+{
+    return m_nsCredential && encodingRequiresPlatformData(RetainPtr { m_nsCredential }.get());
+}
+
 bool Credential::platformCompare(const Credential& a, const Credential& b)
 {
     if (!a.m_nsCredential && !b.m_nsCredential)
         return true;
 
-    return [a.nsCredential() isEqual:b.nsCredential()];
+    return [a.protectedNSCredential() isEqual:b.protectedNSCredential().get()];
 }
 
 bool Credential::encodingRequiresPlatformData(NSURLCredential *credential)

--- a/Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm
@@ -42,6 +42,7 @@
 #import <wtf/CallbackAggregator.h>
 #import <wtf/ProcessPrivilege.h>
 #import <wtf/URL.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 #import <wtf/cocoa/VectorCocoa.h>
 #import <wtf/darwin/DispatchExtras.h>
 #import <wtf/text/MakeString.h>
@@ -67,7 +68,7 @@ void NetworkStorageSession::setCookie(const Cookie& cookie)
     ASSERT(hasProcessPrivilege(ProcessPrivilege::CanAccessRawCookies) || m_isInMemoryCookieStore);
 
     BEGIN_BLOCK_OBJC_EXCEPTIONS
-    [nsCookieStorage() setCookie:(NSHTTPCookie *)cookie];
+    [nsCookieStorage() setCookie:cookie.createNSHTTPCookie().get()];
     END_BLOCK_OBJC_EXCEPTIONS
 }
 
@@ -81,7 +82,7 @@ void NetworkStorageSession::setCookies(const Vector<Cookie>& cookies, const URL&
     ASSERT(hasProcessPrivilege(ProcessPrivilege::CanAccessRawCookies) || m_isInMemoryCookieStore);
 
     auto nsCookies = createNSArray(cookies, [] (auto& cookie) -> NSHTTPCookie * {
-        return cookie;
+        return cookie.createNSHTTPCookie().autorelease();
     });
 
     BEGIN_BLOCK_OBJC_EXCEPTIONS
@@ -93,7 +94,7 @@ void NetworkStorageSession::deleteCookie(const Cookie& cookie, CompletionHandler
 {
     ASSERT(hasProcessPrivilege(ProcessPrivilege::CanAccessRawCookies) || m_isInMemoryCookieStore);
 
-    auto work = [completionHandler = WTFMove(completionHandler), cookieStorage = RetainPtr { nsCookieStorage() }, cookie = RetainPtr { (NSHTTPCookie *)cookie }] () mutable {
+    auto work = [completionHandler = WTFMove(completionHandler), cookieStorage = RetainPtr { nsCookieStorage() }, cookie = cookie.createNSHTTPCookie()] () mutable {
         [cookieStorage deleteCookie:cookie.get()];
         ensureOnMainThread(WTFMove(completionHandler));
     };
@@ -515,7 +516,7 @@ static RetainPtr<NSHTTPCookie> parseDOMCookie(String cookieString, NSURL* cookie
     // cookiesWithResponseHeaderFields doesn't parse cookies without a value
     cookieString = cookieString.contains('=') ? cookieString : makeString(cookieString, '=');
 
-    return adjustScriptWrittenCookie([NSHTTPCookie _cookieForSetCookieString:cookieString.createNSString().get() forURL:cookieURL partition:nsStringNilIfEmpty(partition)], cappedLifetime);
+    return adjustScriptWrittenCookie([NSHTTPCookie _cookieForSetCookieString:cookieString.createNSString().get() forURL:cookieURL partition:RetainPtr { nsStringNilIfEmpty(partition) }.get()], cappedLifetime);
 }
 
 void NetworkStorageSession::setCookiesFromDOM(const URL& firstParty, const SameSiteInfo& sameSiteInfo, const URL& url, std::optional<FrameIdentifier> frameID, std::optional<PageIdentifier> pageID, ApplyTrackingPrevention applyTrackingPrevention, RequiresScriptTrackingPrivacy requiresScriptTrackingPrivacy, const String& cookieString, ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking, IsKnownCrossSiteTracker isKnownCrossSiteTracker) const
@@ -542,7 +543,7 @@ void NetworkStorageSession::setCookiesFromDOM(const URL& firstParty, const SameS
     if (!cookie)
         return;
 
-    setHTTPCookiesForURL(cookieStorage().get(), @[cookie.get()], cookieURL.get(), firstParty.createNSURL().get(), nsStringNilIfEmpty(partitionKey), sameSiteInfo, thirdPartyCookieBlockingDecision);
+    setHTTPCookiesForURL(cookieStorage().get(), @[cookie.get()], cookieURL.get(), firstParty.createNSURL().get(), RetainPtr { nsStringNilIfEmpty(partitionKey) }.get(), sameSiteInfo, thirdPartyCookieBlockingDecision);
 
     END_BLOCK_OBJC_EXCEPTIONS
 }
@@ -558,7 +559,7 @@ bool NetworkStorageSession::setCookieFromDOM(const URL& firstParty, const SameSi
         return false;
 
     auto expiryCap = clientSideCookieCap(RegistrableDomain { firstParty }, requiresScriptTrackingPrivacy, pageID);
-    RetainPtr nshttpCookie = adjustScriptWrittenCookie((NSHTTPCookie *)cookie, expiryCap);
+    RetainPtr nshttpCookie = adjustScriptWrittenCookie(cookie.createNSHTTPCookie().get(), expiryCap);
     if (!nshttpCookie)
         return false;
 
@@ -602,7 +603,7 @@ bool NetworkStorageSession::getRawCookies(const URL& firstParty, const SameSiteI
     RetainPtr<NSArray> cookies = cookiesForURL(firstParty, sameSiteInfo, url, frameID, pageID, applyTrackingPrevention, shouldRelaxThirdPartyCookieBlocking, IsKnownCrossSiteTracker::No);
     NSUInteger count = [cookies count];
     rawCookies = Vector<Cookie>(count, [cookies](size_t i) {
-        return Cookie { (NSHTTPCookie *)[cookies objectAtIndex:i] };
+        return Cookie { checked_objc_cast<NSHTTPCookie>([cookies objectAtIndex:i]) };
     });
 
     END_BLOCK_OBJC_EXCEPTIONS
@@ -816,12 +817,13 @@ void NetworkStorageSession::registerCookieChangeListenersIfNecessary()
 
     m_didRegisterCookieListeners = true;
 
-    [nsCookieStorage() _setCookiesChangedHandler:makeBlockPtr([this, weakThis = WeakPtr { *this }](NSArray<NSHTTPCookie *> *addedCookies, NSString *domainForChangedCookie) {
-        if (!weakThis)
+    [nsCookieStorage() _setCookiesChangedHandler:makeBlockPtr([weakThis = WeakPtr { *this }](NSArray<NSHTTPCookie *> *addedCookies, NSString *domainForChangedCookie) {
+        CheckedPtr checkedThis = weakThis.get();
+        if (!checkedThis)
             return;
         String host = domainForChangedCookie;
-        auto it = m_cookieChangeObservers.find(host);
-        if (it == m_cookieChangeObservers.end())
+        auto it = checkedThis->m_cookieChangeObservers.find(host);
+        if (it == checkedThis->m_cookieChangeObservers.end())
             return;
         auto cookies = nsCookiesToCookieVector(addedCookies, [](NSHTTPCookie *cookie) { return !cookie.HTTPOnly; });
         if (cookies.isEmpty())
@@ -830,11 +832,12 @@ void NetworkStorageSession::registerCookieChangeListenersIfNecessary()
             observer->cookiesAdded(host, cookies);
     }).get() onQueue:mainDispatchQueueSingleton()];
 
-    [nsCookieStorage() _setCookiesRemovedHandler:makeBlockPtr([this, weakThis = WeakPtr { *this }](NSArray<NSHTTPCookie *> *removedCookies, NSString *domainForRemovedCookies, bool removeAllCookies) {
-        if (!weakThis)
+    [nsCookieStorage() _setCookiesRemovedHandler:makeBlockPtr([weakThis = WeakPtr { *this }](NSArray<NSHTTPCookie *> *removedCookies, NSString *domainForRemovedCookies, bool removeAllCookies) {
+        CheckedPtr checkedThis = weakThis.get();
+        if (!checkedThis)
             return;
         if (removeAllCookies) {
-            for (auto& observers : m_cookieChangeObservers.values()) {
+            for (auto& observers : checkedThis->m_cookieChangeObservers.values()) {
                 for (Ref observer : observers)
                     observer->allCookiesDeleted();
             }
@@ -842,8 +845,8 @@ void NetworkStorageSession::registerCookieChangeListenersIfNecessary()
         }
 
         String host = domainForRemovedCookies;
-        auto it = m_cookieChangeObservers.find(host);
-        if (it == m_cookieChangeObservers.end())
+        auto it = checkedThis->m_cookieChangeObservers.find(host);
+        if (it == checkedThis->m_cookieChangeObservers.end())
             return;
 
         auto cookies = nsCookiesToCookieVector(removedCookies, [](NSHTTPCookie *cookie) { return !cookie.HTTPOnly; });

--- a/Source/WebCore/platform/network/cocoa/ProtectionSpaceCocoa.h
+++ b/Source/WebCore/platform/network/cocoa/ProtectionSpaceCocoa.h
@@ -46,10 +46,11 @@ public:
 
     static bool platformCompare(const ProtectionSpace& a, const ProtectionSpace& b);
 
-    bool encodingRequiresPlatformData() const { return m_nsSpace && encodingRequiresPlatformData(m_nsSpace.get()); }
+    bool encodingRequiresPlatformData() const;
 
     WEBCORE_EXPORT bool receivesCredentialSecurely() const;
     WEBCORE_EXPORT NSURLProtectionSpace *nsSpace() const;
+    WEBCORE_EXPORT RetainPtr<NSURLProtectionSpace> protectedNSSpace() const;
     
     WEBCORE_EXPORT std::optional<PlatformData> getPlatformDataToSerialize() const;
 

--- a/Source/WebCore/platform/network/cocoa/ProtectionSpaceCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/ProtectionSpaceCocoa.mm
@@ -189,17 +189,22 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     return m_nsSpace.get();
 }
 
+RetainPtr<NSURLProtectionSpace> ProtectionSpace::protectedNSSpace() const
+{
+    return nsSpace();
+}
+
 bool ProtectionSpace::platformCompare(const ProtectionSpace& a, const ProtectionSpace& b)
 {
     if (!a.m_nsSpace && !b.m_nsSpace)
         return true;
 
-    return [a.nsSpace() isEqual:b.nsSpace()];
+    return [a.protectedNSSpace() isEqual:b.protectedNSSpace().get()];
 }
 
 bool ProtectionSpace::receivesCredentialSecurely() const
 {
-    return nsSpace().receivesCredentialSecurely;
+    return [protectedNSSpace() receivesCredentialSecurely];
 }
 
 bool ProtectionSpace::encodingRequiresPlatformData(NSURLProtectionSpace *space)
@@ -213,6 +218,11 @@ std::optional<ProtectionSpace::PlatformData> ProtectionSpace::getPlatformDataToS
     if (encodingRequiresPlatformData())
         return PlatformData { nsSpace() };
     return std::nullopt;
+}
+
+bool ProtectionSpace::encodingRequiresPlatformData() const
+{
+    return m_nsSpace && encodingRequiresPlatformData(m_nsSpace.get());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/network/cocoa/ResourceResponseCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/ResourceResponseCocoa.mm
@@ -119,6 +119,11 @@ NSURLResponse *ResourceResponse::nsURLResponse() const
     return m_nsResponse.get();
 }
 
+RetainPtr<NSURLResponse> ResourceResponse::protectedNSURLResponse() const
+{
+    return nsURLResponse();
+}
+
 static void addToHTTPHeaderMap(const void* key, const void* value, void* context)
 {
     HTTPHeaderMap* httpHeaderMap = (HTTPHeaderMap*)context;
@@ -189,7 +194,7 @@ void ResourceResponse::platformLazyInit(InitLevel initLevel)
 
 String ResourceResponse::platformSuggestedFilename() const
 {
-    return [nsURLResponse() suggestedFilename];
+    return [protectedNSURLResponse() suggestedFilename];
 }
 
 bool ResourceResponse::platformCompare(const ResourceResponse& a, const ResourceResponse& b)

--- a/Source/WebCore/platform/network/cocoa/WebCoreNSURLSession.h
+++ b/Source/WebCore/platform/network/cocoa/WebCoreNSURLSession.h
@@ -77,6 +77,7 @@ WEBCORE_EXPORT @interface WebCoreNSURLSession : NSObject {
     WeakObjCPtr<id<NSURLSessionDelegate>> _delegate;
     RetainPtr<NSOperationQueue> _queue;
     RetainPtr<NSString> _sessionDescription;
+    RetainPtr<NSURLSessionConfiguration> _configuration;
     Lock _dataTasksLock;
     HashSet<RetainPtr<WebCoreNSURLSessionDataTask>> _dataTasks WTF_GUARDED_BY_LOCK(_dataTasksLock);
     HashSet<RefPtr<WebCore::SecurityOrigin>> _origins WTF_GUARDED_BY_LOCK(_dataTasksLock);
@@ -87,10 +88,13 @@ WEBCORE_EXPORT @interface WebCoreNSURLSession : NSObject {
     RefPtr<WebCore::RangeResponseGenerator> _rangeResponseGenerator; // Only created/accessed on _targetQueue
 }
 - (id)initWithResourceLoader:(WebCore::PlatformMediaResourceLoader&)loader delegate:(id<NSURLSessionTaskDelegate>)delegate delegateQueue:(NSOperationQueue*)queue;
-@property (readonly, retain) NSOperationQueue *delegateQueue;
+/* FIXME: This is a safer cpp false positive (rdar://161063702). */
+@property (readonly, retain) NSOperationQueue *delegateQueue SUPPRESS_UNRETAINED_MEMBER;
 @property (nullable, readonly) id <NSURLSessionDelegate> delegate;
-@property (readonly, copy) NSURLSessionConfiguration *configuration;
-@property (copy) NSString *sessionDescription;
+/* FIXME: This is a safer cpp false positive (rdar://161063702). */
+@property (readonly, copy) NSURLSessionConfiguration *configuration SUPPRESS_UNRETAINED_MEMBER;
+/* FIXME: This is a safer cpp false positive (rdar://161063702). */
+@property (copy) NSString *sessionDescription SUPPRESS_UNRETAINED_MEMBER;
 @property (readonly) BOOL didPassCORSAccessChecks;
 @property (assign, atomic) WebCoreNSURLSessionCORSAccessCheckResults corsResults;
 @property (assign, atomic) BOOL invalidated;
@@ -150,16 +154,21 @@ WEBCORE_EXPORT @interface WebCoreNSURLSession : NSObject {
 }
 
 @property NSUInteger taskIdentifier;
-@property (nullable, readonly, copy) NSURLRequest *originalRequest;
-@property (nullable, readonly, copy) NSURLRequest *currentRequest;
-@property (nullable, readonly, copy) NSURLResponse *response;
+/* FIXME: This is a safer cpp false positive (rdar://161063702). */
+@property (nullable, readonly, copy) NSURLRequest *originalRequest SUPPRESS_UNRETAINED_MEMBER;
+/* FIXME: This is a safer cpp false positive (rdar://161063702). */
+@property (nullable, readonly, copy) NSURLRequest *currentRequest SUPPRESS_UNRETAINED_MEMBER;
+/* FIXME: This is a safer cpp false positive (rdar://161063702). */
+@property (nullable, readonly, copy) NSURLResponse *response SUPPRESS_UNRETAINED_MEMBER;
 @property (assign, atomic) int64_t countOfBytesReceived;
 @property int64_t countOfBytesSent;
 @property int64_t countOfBytesExpectedToSend;
 @property int64_t countOfBytesExpectedToReceive;
 @property (readonly) NSURLSessionTaskState state;
-@property (nullable, readonly, copy) NSError *error;
-@property (nullable, copy) NSString *taskDescription;
+/* FIXME: This is a safer cpp false positive (rdar://161063702). */
+@property (nullable, readonly, copy) NSError *error SUPPRESS_UNRETAINED_MEMBER;
+/* FIXME: This is a safer cpp false positive (rdar://161063702). */
+@property (nullable, copy) NSString *taskDescription SUPPRESS_UNRETAINED_MEMBER;
 @property float priority;
 - (void)cancel;
 - (void)suspend;

--- a/Source/WebCore/platform/network/mac/ResourceErrorMac.mm
+++ b/Source/WebCore/platform/network/mac/ResourceErrorMac.mm
@@ -267,6 +267,11 @@ NSError *ResourceError::nsError() const
     return m_platformError.get();
 }
 
+RetainPtr<NSError> ResourceError::protectedNSError() const
+{
+    return nsError();
+}
+
 NSError *ResourceError::nsError(NSError *underlyingError) const
 {
     if (isNull()) {

--- a/Source/WebCore/platform/network/mac/ResourceHandleMac.mm
+++ b/Source/WebCore/platform/network/mac/ResourceHandleMac.mm
@@ -164,7 +164,7 @@ void ResourceHandle::createNSURLConnection(id delegate, bool shouldUseCredential
         applyBasicAuthorizationHeader(firstRequest(), d->m_initialCredential);
     }
 
-    auto nsRequest = retainPtr(firstRequest().nsURLRequest(HTTPBodyUpdatePolicy::UpdateHTTPBody));
+    RetainPtr nsRequest = firstRequest().nsURLRequest(HTTPBodyUpdatePolicy::UpdateHTTPBody);
     nsRequest = applySniffingPoliciesIfNeeded(nsRequest.get(), shouldContentSniff, contentEncodingSniffingPolicy);
 
     if (d->m_storageSession)

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -645,7 +645,7 @@ static void updateIgnoreStrictTransportSecuritySetting(RetainPtr<NSURLRequest>& 
 #else
             UNUSED_PARAM(taskIdentifier);
 #endif
-            auto nsRequest = retainPtr(request.nsURLRequest(WebCore::HTTPBodyUpdatePolicy::UpdateHTTPBody));
+            RetainPtr nsRequest = request.nsURLRequest(WebCore::HTTPBodyUpdatePolicy::UpdateHTTPBody);
             updateIgnoreStrictTransportSecuritySetting(nsRequest, shouldIgnoreHSTS);
             completionHandler(nsRequest.get());
         });
@@ -657,7 +657,7 @@ static void updateIgnoreStrictTransportSecuritySetting(RetainPtr<NSURLRequest>& 
 #else
             UNUSED_PARAM(taskIdentifier);
 #endif
-            auto nsRequest = retainPtr(request.nsURLRequest(WebCore::HTTPBodyUpdatePolicy::UpdateHTTPBody));
+            RetainPtr nsRequest = request.nsURLRequest(WebCore::HTTPBodyUpdatePolicy::UpdateHTTPBody);
             completionHandler(nsRequest.get());
         });
     } else {
@@ -698,7 +698,7 @@ static void updateIgnoreStrictTransportSecuritySetting(RetainPtr<NSURLRequest>& 
 #else
             UNUSED_PARAM(taskIdentifier);
 #endif
-            auto nsRequest = retainPtr(request.nsURLRequest(WebCore::HTTPBodyUpdatePolicy::UpdateHTTPBody));
+            RetainPtr nsRequest = request.nsURLRequest(WebCore::HTTPBodyUpdatePolicy::UpdateHTTPBody);
             updateIgnoreStrictTransportSecuritySetting(nsRequest, shouldIgnoreHSTS);
             completionHandler(nsRequest.get());
         });

--- a/Source/WebKit/UIProcess/API/Cocoa/WKHTTPCookieStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKHTTPCookieStore.mm
@@ -42,7 +42,7 @@
 static NSArray<NSHTTPCookie *> *coreCookiesToNSCookies(const Vector<WebCore::Cookie>& coreCookies)
 {
     return createNSArray(coreCookies, [] (auto& cookie) -> NSHTTPCookie * {
-        return cookie;
+        return cookie.createNSHTTPCookie().autorelease();
     }).autorelease();
 }
 


### PR DESCRIPTION
#### 291fe7d7f9356806d930fee91ed5625bb06b655b
<pre>
Address safer cpp warnings in platform/network/cocoa
<a href="https://bugs.webkit.org/show_bug.cgi?id=299358">https://bugs.webkit.org/show_bug.cgi?id=299358</a>

Reviewed by Geoffrey Garen.

* Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations:
* Source/WebCore/platform/Cookie.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::MediaPlayerPrivateAVFoundationObjC::createAVAssetForURL):
* Source/WebCore/platform/network/cf/ResourceError.h:
* Source/WebCore/platform/network/cf/ResourceRequest.h:
* Source/WebCore/platform/network/cf/ResourceResponse.h:
* Source/WebCore/platform/network/cocoa/CookieCocoa.mm:
(WebCore::Cookie::createNSHTTPCookie const):
(WebCore::Cookie::operator== const):
(WebCore::Cookie::hash const):
(WebCore::Cookie::operator NSHTTPCookie * _Nullable  const): Deleted.
(WebCore::Cookie::toProtectedNSHTTPCookie const): Deleted.
* Source/WebCore/platform/network/cocoa/CredentialCocoa.h:
(WebCore::Credential::encodingRequiresPlatformData const): Deleted.
* Source/WebCore/platform/network/cocoa/CredentialCocoa.mm:
(WebCore::Credential::protectedNSCredential const):
(WebCore::Credential::encodingRequiresPlatformData const):
(WebCore::Credential::platformCompare):
* Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm:
(WebCore::NetworkStorageSession::setCookie):
(WebCore::NetworkStorageSession::setCookies):
(WebCore::NetworkStorageSession::deleteCookie):
(WebCore::parseDOMCookie):
(WebCore::NetworkStorageSession::setCookiesFromDOM const):
(WebCore::NetworkStorageSession::setCookieFromDOM const):
(WebCore::NetworkStorageSession::getRawCookies const):
(WebCore::NetworkStorageSession::registerCookieChangeListenersIfNecessary):
* Source/WebCore/platform/network/cocoa/ProtectionSpaceCocoa.h:
(WebCore::ProtectionSpace::encodingRequiresPlatformData const): Deleted.
* Source/WebCore/platform/network/cocoa/ProtectionSpaceCocoa.mm:
(WebCore::ProtectionSpace::protectedNSSpace const):
(WebCore::ProtectionSpace::platformCompare):
(WebCore::ProtectionSpace::receivesCredentialSecurely const):
(WebCore::ProtectionSpace::encodingRequiresPlatformData const):
* Source/WebCore/platform/network/cocoa/ResourceRequestCocoa.mm:
(WebCore::ResourceRequest::protectedNSURLRequest const):
(WebCore::ResourceRequest::getResourceRequestPlatformData const):
(WebCore::ResourceRequest::cfURLRequest const):
(WebCore::ResourceRequest::doUpdatePlatformRequest):
(WebCore::ResourceRequest::doUpdatePlatformHTTPBody):
* Source/WebCore/platform/network/cocoa/ResourceResponseCocoa.mm:
(WebCore::ResourceResponse::protectedNSURLResponse const):
(WebCore::ResourceResponse::platformSuggestedFilename const):
* Source/WebCore/platform/network/cocoa/WebCoreNSURLSession.h:
* Source/WebCore/platform/network/cocoa/WebCoreNSURLSession.mm:
(-[WebCoreNSURLSession configuration]):
(WebCore::WebCoreNSURLSessionDataTaskClient::dataSent):
(WebCore::WebCoreNSURLSessionDataTaskClient::responseReceived):
(WebCore::WebCoreNSURLSessionDataTaskClient::shouldCacheResponse):
(WebCore::WebCoreNSURLSessionDataTaskClient::dataReceived):
(WebCore::WebCoreNSURLSessionDataTaskClient::redirectReceived):
(WebCore::WebCoreNSURLSessionDataTaskClient::accessControlCheckFailed):
(WebCore::WebCoreNSURLSessionDataTaskClient::loadFailed):
(WebCore::WebCoreNSURLSessionDataTaskClient::loadFinished):
(-[WebCoreNSURLSessionDataTask resume]):
(-[WebCoreNSURLSessionDataTask resource:receivedRedirect:request:completionHandler:]):
(-[WebCoreNSURLSessionDataTask resource:accessControlCheckFailedWithError:]):
(-[WebCoreNSURLSessionDataTask resource:loadFailedWithError:]):
* Source/WebCore/platform/network/mac/ResourceErrorMac.mm:
(WebCore::ResourceError::protectedNSError const):
* Source/WebCore/platform/network/mac/ResourceHandleMac.mm:
(WebCore::ResourceHandle::createNSURLConnection):
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
(-[WKNetworkSessionDelegate URLSession:task:willPerformHTTPRedirection:newRequest:completionHandler:]):
(-[WKNetworkSessionDelegate URLSession:task:_schemeUpgraded:completionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/WKHTTPCookieStore.mm:

Canonical link: <a href="https://commits.webkit.org/300445@main">https://commits.webkit.org/300445@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f435473f3378e72cf874347c74c96635f39f149a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122537 "60 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42245 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32930 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/129146 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74638 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/844bc2eb-1eed-4fa9-a3bb-e803f4c26346) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/124413 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42963 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50838 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93147 "15 failures") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/61858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c7a9684a-8ba1-4f4e-922b-a90b837644a5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125489 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34268 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109719 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73794 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c48c1573-fa10-4406-9e95-c8f7c343468f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33251 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27876 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72630 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103924 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28086 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131872 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49478 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37661 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101677 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49853 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105939 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101545 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25785 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46924 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25074 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/46248 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49336 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/55085 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48804 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/52155 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50485 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->