### PR TITLE
[Clang][GTK][WPE] Fix unsafe-buffer-usage-in-libc-call warnings

### DIFF
--- a/Source/JavaScriptCore/inspector/remote/glib/RemoteInspectorServer.cpp
+++ b/Source/JavaScriptCore/inspector/remote/glib/RemoteInspectorServer.cpp
@@ -234,6 +234,7 @@ void RemoteInspectorServer::setTargetList(SocketConnection& remoteInspectorConne
     clientConnection->sendMessage("SetTargetList", g_variant_new("(t@a(tsssb))", addResult.iterator->value, targetList.get()));
 }
 
+IGNORE_CLANG_WARNINGS_BEGIN("unsafe-buffer-usage-in-libc-call")
 GVariant* RemoteInspectorServer::setupInspectorClient(SocketConnection& clientConnection, const char* clientBackendCommandsHash)
 {
     ASSERT(!m_clientConnection);
@@ -252,6 +253,7 @@ GVariant* RemoteInspectorServer::setupInspectorClient(SocketConnection& clientCo
 
     return backendCommands;
 }
+IGNORE_CLANG_WARNINGS_END
 
 void RemoteInspectorServer::setup(SocketConnection& clientConnection, uint64_t connectionID, uint64_t targetID)
 {

--- a/Source/WTF/wtf/glib/ChassisType.cpp
+++ b/Source/WTF/wtf/glib/ChassisType.cpp
@@ -68,7 +68,9 @@ static std::optional<ChassisType> readDMIChassisType()
     GUniqueOutPtr<char> buffer;
     GUniqueOutPtr<GError> error;
     if (g_file_get_contents("/sys/class/dmi/id/chassis_type", &buffer.outPtr(), nullptr, &error.outPtr())) {
+        IGNORE_CLANG_WARNINGS_BEGIN("unsafe-buffer-usage-in-libc-call")
         int type = strtol(buffer.get(), nullptr, 10);
+        IGNORE_CLANG_WARNINGS_END
 
         // See the SMBIOS Specification 3.0 section 7.4.1 for details about the values listed here:
         // https://www.dmtf.org/sites/default/files/standards/documents/DSP0134_3.0.0.pdf
@@ -103,7 +105,9 @@ static std::optional<ChassisType> readACPIChassisType()
     GUniqueOutPtr<char> buffer;
     GUniqueOutPtr<GError> error;
     if (g_file_get_contents("/sys/firmware/acpi/pm_profile", &buffer.outPtr(), nullptr, &error.outPtr())) {
+        IGNORE_CLANG_WARNINGS_BEGIN("unsafe-buffer-usage-in-libc-call")
         int type = strtol(buffer.get(), nullptr, 10);
+        IGNORE_CLANG_WARNINGS_END
 
         // See the ACPI 5.0 Spec Section 5.2.9.1 for details:
         // http://www.acpi.info/DOWNLOADS/ACPIspec50.pdf

--- a/Source/WTF/wtf/glib/GSpanExtras.h
+++ b/Source/WTF/wtf/glib/GSpanExtras.h
@@ -73,7 +73,9 @@ GMallocSpan<char, Malloc> adoptGMallocString(char* str, size_t length)
 template<typename Malloc = GMalloc>
 GMallocSpan<char, Malloc> adoptGMallocString(char* str)
 {
+    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     return adoptGMallocSpan<char, Malloc>(unsafeMakeSpan(str, str ? strlen(str) : 0));
+    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
 WTF_EXPORT_PRIVATE GMallocSpan<char> gFileGetContents(const char* path, GUniqueOutPtr<GError>&);

--- a/Source/WTF/wtf/glib/SocketConnection.cpp
+++ b/Source/WTF/wtf/glib/SocketConnection.cpp
@@ -109,6 +109,7 @@ static inline bool messageIsByteSwapped(MessageFlags flags)
 #endif
 }
 
+IGNORE_CLANG_WARNINGS_BEGIN("unsafe-buffer-usage-in-libc-call")
 bool SocketConnection::readMessage()
 {
     if (m_readBuffer.size() < sizeof(uint32_t))
@@ -203,6 +204,7 @@ void SocketConnection::sendMessage(const char* messageName, GVariant* parameters
 
     write();
 }
+IGNORE_CLANG_WARNINGS_END
 
 void SocketConnection::write()
 {

--- a/Source/WTF/wtf/glib/SysprofAnnotator.h
+++ b/Source/WTF/wtf/glib/SysprofAnnotator.h
@@ -67,11 +67,13 @@ public:
     {
         auto key = std::make_pair(pointer, static_cast<const void*>(name.data()));
 
+        WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         Vector<char> buffer(1024);
         va_list args;
         va_start(args, description);
         vsnprintf(buffer.mutableSpan().data(), buffer.size(), description, args);
         va_end(args);
+        WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
         auto value = std::make_pair(SYSPROF_CAPTURE_CURRENT_TIME, WTFMove(buffer));
 

--- a/Source/WTF/wtf/linux/CurrentProcessMemoryStatus.cpp
+++ b/Source/WTF/wtf/linux/CurrentProcessMemoryStatus.cpp
@@ -33,6 +33,7 @@
 
 namespace WTF {
 
+IGNORE_CLANG_WARNINGS_BEGIN("unsafe-buffer-usage-in-libc-call")
 void currentProcessMemoryStatus(ProcessMemoryStatus& memoryStatus)
 {
     FILE* file = fopen("/proc/self/statm", "r");
@@ -62,5 +63,6 @@ void currentProcessMemoryStatus(ProcessMemoryStatus& memoryStatus)
     intValue = strtoull(end, &end, 10);
     memoryStatus.dt = intValue * pageSize;
 }
+IGNORE_CLANG_WARNINGS_END
 
 } // namespace WTF

--- a/Source/WTF/wtf/linux/MemoryFootprintLinux.cpp
+++ b/Source/WTF/wtf/linux/MemoryFootprintLinux.cpp
@@ -46,6 +46,7 @@ static void forEachLine(FILE* file, Functor functor)
     free(buffer);
 }
 
+IGNORE_CLANG_WARNINGS_BEGIN("unsafe-buffer-usage-in-libc-call")
 static size_t computeMemoryFootprint()
 {
     FILE* file = fopen("/proc/self/smaps", "r");
@@ -85,6 +86,7 @@ static size_t computeMemoryFootprint()
     fclose(file);
     return totalPrivateDirtyInKB * KB;
 }
+IGNORE_CLANG_WARNINGS_END
 
 size_t memoryFootprint()
 {

--- a/Source/WTF/wtf/posix/FileSystemPOSIX.cpp
+++ b/Source/WTF/wtf/posix/FileSystemPOSIX.cpp
@@ -172,11 +172,13 @@ std::pair<String, FileHandle> openTemporaryFile(StringView prefix, StringView su
     // This is OK for now since the code using it is built on macOS only.
     ASSERT_UNUSED(suffix, suffix.isEmpty());
 
+    IGNORE_CLANG_WARNINGS_BEGIN("unsafe-buffer-usage-in-libc-call")
     const char* directory = temporaryFileDirectory();
     CString prefixUTF8 = prefix.utf8();
     size_t length = strlen(directory) + 1 + prefixUTF8.length() + 1 + 6 + 1;
     auto buffer = MallocSpan<char>::malloc(length);
     snprintf(buffer.mutableSpan().data(), length, "%s/%s-XXXXXX", directory, prefixUTF8.data());
+    IGNORE_CLANG_WARNINGS_END
 
     auto handle = FileHandle::adopt(mkostemp(buffer.mutableSpan().data(), O_CLOEXEC));
     if (!handle)

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerDataChannelHandler.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerDataChannelHandler.cpp
@@ -377,6 +377,7 @@ void GStreamerDataChannelHandler::onMessageData(GBytes* bytes)
     });
 }
 
+IGNORE_CLANG_WARNINGS_BEGIN("unsafe-buffer-usage")
 void GStreamerDataChannelHandler::onMessageString(const char* message)
 {
     Locker locker { m_clientLock };
@@ -399,6 +400,7 @@ void GStreamerDataChannelHandler::onMessageString(const char* message)
         client.value()->didReceiveStringData(string);
     });
 }
+IGNORE_CLANG_WARNINGS_END
 
 void GStreamerDataChannelHandler::onError(GError* error)
 {

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
@@ -68,6 +68,8 @@ GST_DEBUG_CATEGORY(webkit_webrtc_endpoint_debug);
 
 namespace WebCore {
 
+IGNORE_CLANG_WARNINGS_BEGIN("unsafe-buffer-usage-in-libc-call")
+
 GStreamerMediaEndpoint::GStreamerMediaEndpoint(GStreamerPeerConnectionBackend& peerConnection)
     : m_peerConnectionBackend(WeakPtr { &peerConnection })
     , m_statsCollector(GStreamerStatsCollector::create())
@@ -2745,6 +2747,8 @@ GUniquePtr<GstSDPMessage> GStreamerMediaEndpoint::completeSDPAnswer(const String
 
     return GUniquePtr<GstSDPMessage>(message.release());
 }
+
+IGNORE_CLANG_WARNINGS_END
 
 } // namespace WebCore
 

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp
@@ -45,6 +45,8 @@ GST_DEBUG_CATEGORY_STATIC(webkit_webrtc_utils_debug);
 
 namespace WebCore {
 
+IGNORE_CLANG_WARNINGS_BEGIN("unsafe-buffer-usage")
+
 static inline RTCIceComponent toRTCIceComponent(int component)
 {
     return component == 1 ? RTCIceComponent::Rtp : RTCIceComponent::Rtcp;
@@ -1175,6 +1177,8 @@ bool validateRTPHeaderExtensions(const GstSDPMessage* previousSDP, const GstSDPM
     }
     return true;
 }
+
+IGNORE_CLANG_WARNINGS_END
 
 #undef GST_CAT_DEFAULT
 

--- a/Source/WebCore/crypto/gcrypt/GCryptUtilities.h
+++ b/Source/WebCore/crypto/gcrypt/GCryptUtilities.h
@@ -60,6 +60,7 @@ static const std::array<uint8_t, 1> s_asn1Version1 { { 0x01 } };
 static const std::array<uint8_t, 1> s_ecUncompressedFormatLeadingByte { { 0x04 } };
 static const std::array<uint8_t, 1> s_x25519UncompressedFormatLeadingByte { { 0x40 } };
 
+IGNORE_CLANG_WARNINGS_BEGIN("unsafe-buffer-usage-in-libc-call")
 template<size_t N>
 static inline bool matches(const void* lhs, size_t size, const std::array<uint8_t, N>& rhs)
 {
@@ -68,6 +69,7 @@ static inline bool matches(const void* lhs, size_t size, const std::array<uint8_
 
     return !std::memcmp(lhs, rhs.data(), rhs.size());
 }
+IGNORE_CLANG_WARNINGS_END
 
 } // namespace CryptoConstants
 

--- a/Source/WebCore/page/linux/ResourceUsageThreadLinux.cpp
+++ b/Source/WebCore/page/linux/ResourceUsageThreadLinux.cpp
@@ -51,6 +51,7 @@
 
 namespace WebCore {
 
+IGNORE_CLANG_WARNINGS_BEGIN("unsafe-buffer-usage")
 static float cpuPeriod()
 {
     FILE* file = fopen("/proc/stat", "r");
@@ -100,6 +101,7 @@ static float cpuPeriod()
     previousTotalTime = totalTime;
     return static_cast<float>(period) / cpuCount;
 }
+IGNORE_CLANG_WARNINGS_END
 
 void ResourceUsageThread::platformSaveStateBeforeStarting()
 {
@@ -133,6 +135,7 @@ static HashMap<pid_t, ThreadInfo>& threadInfoMap()
     return map;
 }
 
+IGNORE_CLANG_WARNINGS_BEGIN("unsafe-buffer-usage-in-libc-call")
 static bool threadCPUUsage(pid_t id, float period, ThreadInfo& info)
 {
     String path = makeString("/proc/self/task/"_s, id, "/stat"_s);
@@ -200,6 +203,7 @@ static bool threadCPUUsage(pid_t id, float period, ThreadInfo& info)
     info.cpuUsage = clampTo<float>(usage, 0, 100);
     return true;
 }
+IGNORE_CLANG_WARNINGS_END
 
 static void collectCPUUsage(float period)
 {

--- a/Source/WebCore/platform/SharedBuffer.h
+++ b/Source/WebCore/platform/SharedBuffer.h
@@ -63,7 +63,9 @@ typedef struct OpaqueCMBlockBuffer* CMBlockBufferRef;
 #endif
 
 #if USE(SKIA)
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <skia/core/SkData.h>
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 #endif
 
 namespace WTF {

--- a/Source/WebCore/platform/audio/gstreamer/FFTFrameGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/FFTFrameGStreamer.cpp
@@ -76,9 +76,11 @@ FFTFrame::FFTFrame(const FFTFrame& frame)
     m_fft.reset(gst_fft_f32_new(fftLength, FALSE));
     m_inverseFft.reset(gst_fft_f32_new(fftLength, TRUE));
 
+    IGNORE_CLANG_WARNINGS_BEGIN("unsafe-buffer-usage-in-libc-call")
     // Copy/setup frame data.
     memcpy(realData().data(), frame.realData().data(), sizeof(float) * realData().size());
     memcpy(imagData().data(), frame.imagData().data(), sizeof(float) * imagData().size());
+    IGNORE_CLANG_WARNINGS_END
 }
 
 void FFTFrame::initialize()

--- a/Source/WebCore/platform/graphics/egl/GLContext.cpp
+++ b/Source/WebCore/platform/graphics/egl/GLContext.cpp
@@ -72,6 +72,7 @@ const char* GLContext::lastErrorString()
     return errorString(eglGetError());
 }
 
+IGNORE_CLANG_WARNINGS_BEGIN("unsafe-buffer-usage-in-libc-call")
 bool GLContext::getEGLConfig(EGLDisplay display, EGLConfig* config, int surfaceType)
 {
     std::array<EGLint, 4> rgbaSize = { 8, 8, 8, 8 };
@@ -127,6 +128,7 @@ bool GLContext::getEGLConfig(EGLDisplay display, EGLConfig* config, int surfaceT
     RELEASE_LOG_INFO(Compositing, "Could not find suitable EGL configuration out of %zu checked.", configs.size());
     return false;
 }
+IGNORE_CLANG_WARNINGS_END
 
 std::unique_ptr<GLContext> GLContext::createWindowContext(GLDisplay& display, Target target, GLNativeWindowType window, EGLContext sharingContext)
 {
@@ -453,6 +455,7 @@ GCGLContext GLContext::platformContext() const
     return m_context;
 }
 
+IGNORE_CLANG_WARNINGS_BEGIN("unsafe-buffer-usage-in-libc-call")
 bool GLContext::isExtensionSupported(const char* extensionList, const char* extension)
 {
     if (!extensionList)
@@ -470,6 +473,7 @@ bool GLContext::isExtensionSupported(const char* extensionList, const char* exte
     }
     return false;
 }
+IGNORE_CLANG_WARNINGS_END
 
 unsigned GLContext::versionFromString(const char* versionStringAsChar)
 {

--- a/Source/WebCore/platform/graphics/filters/FilterImage.h
+++ b/Source/WebCore/platform/graphics/filters/FilterImage.h
@@ -39,8 +39,10 @@ OBJC_CLASS CIImage;
 #endif
 
 #if USE(SKIA)
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <skia/core/SkPicture.h>
 #include <skia/core/SkPictureRecorder.h>
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 #endif
 
 namespace WebCore {

--- a/Source/WebCore/platform/graphics/gbm/MemoryMappedGPUBuffer.cpp
+++ b/Source/WebCore/platform/graphics/gbm/MemoryMappedGPUBuffer.cpp
@@ -292,6 +292,7 @@ void MemoryMappedGPUBuffer::updateContents(AccessScope& scope, const MemoryMappe
     updateContents(scope, srcBuffer.m_mappedData, targetRect, srcBuffer.primaryPlaneDmaBufStride());
 }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 void MemoryMappedGPUBuffer::updateContents(AccessScope& scope, const void* srcData, const IntRect& targetRect, unsigned bytesPerLine)
 {
     ASSERT_UNUSED(scope, &scope.buffer() == this);
@@ -317,13 +318,16 @@ void MemoryMappedGPUBuffer::updateContents(AccessScope& scope, const void* srcDa
     for (int32_t y = 0; y < targetRect.height(); ++y)
         memcpySpan(dstPixelSpan.subspan(y * dstPitch, dstPitch - targetRect.x()), srcPixelSpan.subspan(y * srcPitch, srcPitch));
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 std::span<uint32_t> MemoryMappedGPUBuffer::mappedDataSpan(AccessScope& scope) const
 {
     ASSERT_UNUSED(scope, &scope.buffer() == this);
     ASSERT(isMapped());
     ASSERT(isLinear());
+    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     return { static_cast<uint32_t*>(m_mappedData), primaryPlaneDmaBufStride() / 4 };
+    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
 MemoryMappedGPUBuffer::AccessScope::AccessScope(MemoryMappedGPUBuffer& buffer, AccessScope::Mode mode)

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
@@ -389,7 +389,6 @@ bool ensureGStreamerInitialized()
         argv[0] = g_strdup(FileSystem::currentExecutableName().data());
         for (unsigned i = 0; i < parameters.size(); i++)
             argv[i + 1] = g_strdup(parameters[i].utf8().data());
-        WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
         GUniqueOutPtr<GError> error;
         isGStreamerInitialized = gst_init_check(&argc, &argv, &error.outPtr());
@@ -403,6 +402,7 @@ bool ensureGStreamerInitialized()
             if (!disableFastMalloc || !strcmp(disableFastMalloc, "0"))
                 gst_allocator_set_default(GST_ALLOCATOR(g_object_new(gst_allocator_fast_malloc_get_type(), nullptr)));
         }
+        WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #if USE(GSTREAMER_MPEGTS)
         if (isGStreamerInitialized)
@@ -509,6 +509,7 @@ void registerWebKitGStreamerElements()
         if (auto factory = adoptGRef(gst_element_factory_find("isofmp4mux")))
             gst_plugin_feature_set_rank(GST_PLUGIN_FEATURE_CAST(factory.get()), GST_RANK_PRIMARY + 1);
 
+        WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib port
         // The VAAPI plugin is not much maintained anymore and prone to rendering issues. In the
         // mid-term we will leverage the new stateless VA decoders. Disable the legacy plugin,
         // unless the WEBKIT_GST_ENABLE_LEGACY_VAAPI environment variable is set to 1.
@@ -518,6 +519,7 @@ void registerWebKitGStreamerElements()
             if (auto vaapiPlugin = adoptGRef(gst_registry_find_plugin(registry, "vaapi")))
                 gst_registry_remove_plugin(registry, vaapiPlugin.get());
         }
+        WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
         // Make sure the quirks are created as early as possible.
         [[maybe_unused]] auto& quirksManager = GStreamerQuirksManager::singleton();

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -132,6 +132,8 @@ GST_DEBUG_CATEGORY(webkit_media_player_debug);
 
 namespace WebCore {
 
+IGNORE_CLANG_WARNINGS_BEGIN("unsafe-buffer-usage-in-libc-call")
+
 WTF_MAKE_TZONE_ALLOCATED_IMPL(MediaPlayerPrivateGStreamer);
 
 static const FloatSize s_holePunchDefaultFrameSize(1280, 720);
@@ -4704,6 +4706,8 @@ MediaTelemetryReport::DrmType MediaPlayerPrivateGStreamer::getDrm() const
 #endif // ENABLE(MEDIA_TELEMETRY)
 
 #undef GST_CAT_DEFAULT
+
+IGNORE_CLANG_WARNINGS_END
 
 } // namespace WebCore
 

--- a/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp
@@ -508,6 +508,7 @@ void VideoFrameGStreamer::setMetadataAndContentHint(std::optional<VideoFrameTime
     gst_sample_set_buffer(m_sample.get(), modifiedBuffer.get());
 }
 
+IGNORE_CLANG_WARNINGS_BEGIN("unsafe-buffer-usage")
 static void copyPlane(uint8_t* destination, const uint8_t* source, uint64_t sourceStride, const ComputedPlaneLayout& spanPlaneLayout)
 {
     uint64_t sourceOffset = spanPlaneLayout.sourceTop * sourceStride;
@@ -520,6 +521,7 @@ static void copyPlane(uint8_t* destination, const uint8_t* source, uint64_t sour
         destinationOffset += spanPlaneLayout.destinationStride;
     }
 }
+IGNORE_CLANG_WARNINGS_END
 
 void VideoFrame::copyTo(std::span<uint8_t> destination, VideoPixelFormat pixelFormat, Vector<ComputedPlaneLayout>&& computedPlaneLayout, CompletionHandler<void(std::optional<Vector<PlaneLayout>>&&)>&& callback)
 {

--- a/Source/WebCore/platform/graphics/gstreamer/WebKitAudioSinkGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/WebKitAudioSinkGStreamer.cpp
@@ -56,6 +56,7 @@ WEBKIT_DEFINE_TYPE_WITH_CODE(WebKitAudioSink, webkit_audio_sink, GST_TYPE_BIN,
     GST_DEBUG_CATEGORY_INIT(webkit_audio_sink_debug, "webkitaudiosink", 0, "webkit audio sink element")
 )
 
+IGNORE_CLANG_WARNINGS_BEGIN("unsafe-buffer-usage-in-libc-call")
 static bool webKitAudioSinkConfigure(WebKitAudioSink* sink)
 {
     const char* value = g_getenv("WEBKIT_GST_ENABLE_AUDIO_MIXER");
@@ -105,6 +106,7 @@ static bool webKitAudioSinkConfigure(WebKitAudioSink* sink)
     }
     return false;
 }
+IGNORE_CLANG_WARNINGS_END
 
 static void webKitAudioSinkSetProperty(GObject* object, guint propID, const GValue* value, GParamSpec* pspec)
 {

--- a/Source/WebCore/platform/graphics/skia/FontCacheSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/FontCacheSkia.cpp
@@ -38,6 +38,7 @@
 #include "SystemSettings.h"
 #endif
 
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <skia/ports/SkFontScanner_FreeType.h>
 
 #if OS(ANDROID)
@@ -48,6 +49,7 @@
 #else
 #include <skia/ports/SkFontMgr_fontconfig.h>
 #endif
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 
 namespace WebCore {
 

--- a/Source/WebCore/platform/graphics/skia/FontPlatformDataSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/FontPlatformDataSkia.cpp
@@ -33,10 +33,13 @@
 #include "NotImplemented.h"
 #include "OpenTypeTypes.h"
 #include "SkiaHarfBuzzFont.h"
-#include <skia/core/SkStream.h>
-#include <skia/core/SkTypeface.h>
 #include <wtf/Hasher.h>
 #include <wtf/VectorHash.h>
+
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
+#include <skia/core/SkStream.h>
+#include <skia/core/SkTypeface.h>
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 
 namespace WebCore {
 

--- a/Source/WebCore/platform/graphics/skia/SkiaHarfBuzzFont.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaHarfBuzzFont.cpp
@@ -32,8 +32,11 @@
 #include "FontPlatformData.h"
 #include "NotImplemented.h"
 #include "SkiaHarfBuzzFontCache.h"
-#include <skia/core/SkStream.h>
 #include <wtf/unicode/CharacterNames.h>
+
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
+#include <skia/core/SkStream.h>
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 
 namespace WebCore {
 

--- a/Source/WebCore/platform/graphics/skia/SkiaReplayCanvas.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaReplayCanvas.h
@@ -28,9 +28,12 @@
 #if USE(COORDINATED_GRAPHICS) && USE(SKIA)
 #include "IntSize.h"
 #include "SkiaRecordingResult.h"
-#include <skia/utils/SkNWayCanvas.h>
 #include <wtf/Assertions.h>
 #include <wtf/Function.h>
+
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
+#include <skia/utils/SkNWayCanvas.h>
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 
 class SkImage;
 

--- a/Source/WebCore/platform/graphics/skia/SkiaSystemFallbackFontCache.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaSystemFallbackFontCache.cpp
@@ -43,6 +43,7 @@ static void fontconfigStyle(const SkFontStyle& style, int& weight, int& width, i
         SkScalar newValue;
     };
 
+    IGNORE_CLANG_WARNINGS_BEGIN("unsafe-buffer-usage")
     auto mapRanges = [](SkScalar value, MapRanges const ranges[], int rangesCount) -> SkScalar {
         if (value < ranges[0].oldValue)
             return ranges[0].newValue;
@@ -53,6 +54,7 @@ static void fontconfigStyle(const SkFontStyle& style, int& weight, int& width, i
         }
         return ranges[rangesCount - 1].newValue;
     };
+    IGNORE_CLANG_WARNINGS_END
 
     static constexpr MapRanges weightRanges[] = {
         { SkFontStyle::kThin_Weight,       FC_WEIGHT_THIN },
@@ -218,7 +220,9 @@ private:
             : m_fontSet(fontSet)
         {
             for (int i = 0; i < m_fontSet->nfont; ++i) {
+                IGNORE_CLANG_WARNINGS_BEGIN("unsafe-buffer-usage")
                 FcPattern* pattern = m_fontSet->fonts[i];
+                IGNORE_CLANG_WARNINGS_END
                 if (!pattern)
                     continue;
 

--- a/Source/WebCore/platform/gstreamer/GStreamerCodecUtilities.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerCodecUtilities.cpp
@@ -111,6 +111,7 @@ static std::pair<GRefPtr<GstCaps>, GRefPtr<GstCaps>> h264CapsFromCodecString(con
     return { inputCaps, outputCaps };
 }
 
+IGNORE_CLANG_WARNINGS_BEGIN("unsafe-buffer-usage-in-libc-call")
 const char* GStreamerCodecUtilities::parseHEVCProfile(const String& codec)
 {
     ensureDebugCategoryInitialized();
@@ -144,6 +145,7 @@ const char* GStreamerCodecUtilities::parseHEVCProfile(const String& codec)
 
     return gst_codec_utils_h265_get_profile(profileTierLevel.data(), profileTierLevel.size());
 }
+IGNORE_CLANG_WARNINGS_END
 
 static std::pair<GRefPtr<GstCaps>, GRefPtr<GstCaps>> h265CapsFromCodecString(const String& codecString)
 {

--- a/Source/WebCore/platform/libwpe/PlatformPasteboardLibWPE.cpp
+++ b/Source/WebCore/platform/libwpe/PlatformPasteboardLibWPE.cpp
@@ -91,6 +91,7 @@ void PlatformPasteboard::write(const PasteboardWebContent& content)
     CString textString = content.text.utf8();
     CString markupString = content.markup.utf8();
 
+    IGNORE_CLANG_WARNINGS_BEGIN("unsafe-buffer-usage-in-libc-call")
     std::array<struct wpe_pasteboard_string_pair, 2> pairs = { {
         { { nullptr, 0 }, { nullptr, 0 } },
         { { nullptr, 0 }, { nullptr, 0 } },
@@ -100,6 +101,7 @@ void PlatformPasteboard::write(const PasteboardWebContent& content)
     wpe_pasteboard_string_initialize(&pairs[1].type, htmlText, strlen(htmlText));
     wpe_pasteboard_string_initialize(&pairs[1].string, markupString.data(), markupString.length());
     struct wpe_pasteboard_string_map map = { pairs.data(), pairs.size() };
+    IGNORE_CLANG_WARNINGS_END
 
     wpe_pasteboard_write(m_pasteboard, &map);
     m_changeCount++;

--- a/Source/WebCore/platform/network/glib/DNSResolveQueueGLib.cpp
+++ b/Source/WebCore/platform/network/glib/DNSResolveQueueGLib.cpp
@@ -46,6 +46,7 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(DNSResolveQueueGLib);
 static bool isUsingHttpProxy = true;
 static bool isUsingHttpsProxy = true;
 
+IGNORE_CLANG_WARNINGS_BEGIN("unsafe-buffer-usage-in-libc-call")
 static bool didResolveProxy(char** uris)
 {
     // We have a list of possible proxies to use for the URI. If the first item in the list is
@@ -55,6 +56,7 @@ static bool didResolveProxy(char** uris)
     // to connect, merely to decide whether a proxy "should" be used.
     return uris && *uris && strcmp(*uris, "direct://");
 }
+IGNORE_CLANG_WARNINGS_END
 
 static void didResolveProxy(GProxyResolver* resolver, GAsyncResult* result, bool* isUsingProxyType, bool* isUsingProxy)
 {
@@ -98,6 +100,7 @@ void DNSResolveQueueGLib::platformResolve(const String& hostname)
     }, nullptr);
 }
 
+IGNORE_CLANG_WARNINGS_BEGIN("unsafe-buffer-usage-in-libc-call")
 void DNSResolveQueueGLib::resolve(const String& hostname, uint64_t identifier, DNSCompletionHandler&& completionHandler)
 {
     ASSERT(isMainThread());
@@ -152,6 +155,7 @@ void DNSResolveQueueGLib::resolve(const String& hostname, uint64_t identifier, D
 
     m_requestCancellables.add(identifier, WTFMove(cancellable));
 }
+IGNORE_CLANG_WARNINGS_END
 
 void DNSResolveQueueGLib::stopResolve(uint64_t identifier)
 {

--- a/Source/WebCore/platform/network/soup/NetworkStorageSessionSoup.cpp
+++ b/Source/WebCore/platform/network/soup/NetworkStorageSessionSoup.cpp
@@ -393,6 +393,7 @@ void NetworkStorageSession::setTrackingPreventionEnabled(bool enabled)
     }
 }
 
+IGNORE_CLANG_WARNINGS_BEGIN("unsafe-buffer-usage-in-libc-call")
 static inline bool httpOnlyCookieExists(const GSList* cookies, const gchar* name, const gchar* path)
 {
     for (const GSList* iter = cookies; iter; iter = g_slist_next(iter)) {
@@ -406,6 +407,7 @@ static inline bool httpOnlyCookieExists(const GSList* cookies, const gchar* name
     }
     return false;
 }
+IGNORE_CLANG_WARNINGS_END
 
 void NetworkStorageSession::setCookiesFromDOM(const URL& firstParty, const SameSiteInfo&, const URL& url, std::optional<FrameIdentifier> frameID, std::optional<PageIdentifier> pageID, ApplyTrackingPrevention applyTrackingPrevention, RequiresScriptTrackingPrivacy requiresScriptTrackingPrivacy, const String& value, ShouldRelaxThirdPartyCookieBlocking relaxThirdPartyCookieBlocking, IsKnownCrossSiteTracker isKnownCrossSiteTracker) const
 {

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheDataGLib.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheDataGLib.cpp
@@ -47,7 +47,9 @@ namespace NetworkCache {
 Data::Data(std::span<const uint8_t> data)
 {
     uint8_t* copiedData = static_cast<uint8_t*>(fastMalloc(data.size()));
+    IGNORE_CLANG_WARNINGS_BEGIN("unsafe-buffer-usage-in-libc-call")
     memcpy(copiedData, data.data(), data.size());
+    IGNORE_CLANG_WARNINGS_END
     m_buffer = adoptGRef(g_bytes_new_with_free_func(copiedData, data.size(), fastFree, copiedData));
 }
 
@@ -106,13 +108,13 @@ Data concatenate(const Data& a, const Data& b)
     size_t size = a.size() + b.size();
     WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GTK/WPE port
     uint8_t* data = static_cast<uint8_t*>(fastMalloc(size));
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     gsize aLength;
     const auto* aData = g_bytes_get_data(a.bytes(), &aLength);
     memcpy(data, aData, aLength);
     gsize bLength;
     const auto* bData = g_bytes_get_data(b.bytes(), &bLength);
     memcpy(data + aLength, bData, bLength);
+    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     return { adoptGRef(g_bytes_new_with_free_func(data, size, fastFree, data)) };
 }

--- a/Source/WebKit/NetworkProcess/soup/WebKitDirectoryInputStream.cpp
+++ b/Source/WebKit/NetworkProcess/soup/WebKitDirectoryInputStream.cpp
@@ -43,6 +43,7 @@ struct _WebKitDirectoryInputStreamPrivate {
 
 WEBKIT_DEFINE_TYPE(WebKitDirectoryInputStream, webkit_directory_input_stream, G_TYPE_INPUT_STREAM)
 
+IGNORE_CLANG_WARNINGS_BEGIN("unsafe-buffer-usage-in-libc-call")
 static GBytes* webkitDirectoryInputStreamCreateHeader(WebKitDirectoryInputStream *stream)
 {
     char* header = g_strdup_printf(
@@ -112,6 +113,7 @@ static GBytes* webkitDirectoryInputStreamCreateRow(WebKitDirectoryInputStream *s
         formattedSize ? formattedSize.get() : "", g_date_time_to_unix(modificationTime.get()), formattedTime.get(), formattedDate.get());
     return g_bytes_new_with_free_func(row, strlen(row), g_free, row);
 }
+IGNORE_CLANG_WARNINGS_END
 
 static GBytes* webkitDirectoryInputStreamReadNextFile(WebKitDirectoryInputStream* stream, GCancellable* cancellable, GError** error)
 {

--- a/Source/WebKit/Platform/IPC/glib/ConnectionGLib.cpp
+++ b/Source/WebKit/Platform/IPC/glib/ConnectionGLib.cpp
@@ -198,6 +198,7 @@ std::unique_ptr<Decoder> Connection::createMessageDecoder()
     return Decoder::create(messageBody->mutableSpan().first(messageInfo.bodySize()), WTFMove(attachments));
 }
 
+IGNORE_CLANG_WARNINGS_BEGIN("unsafe-buffer-usage")
 static ssize_t readBytesFromSocket(GSocket* socket, Vector<uint8_t>& buffer, Vector<UnixFileDescriptor>& fileDescriptors, GCancellable* cancellable, GError** error)
 {
     GUniqueOutPtr<GSocketControlMessage*> messages;
@@ -234,6 +235,7 @@ static ssize_t readBytesFromSocket(GSocket* socket, Vector<uint8_t>& buffer, Vec
 
     return bytesRead;
 }
+IGNORE_CLANG_WARNINGS_END
 
 void Connection::readyReadHandler()
 {
@@ -350,6 +352,7 @@ bool Connection::sendOutgoingMessage(UniqueRef<Encoder>&& encoder)
     return sendOutputMessage(WTFMove(outputMessage));
 }
 
+IGNORE_CLANG_WARNINGS_BEGIN("unsafe-buffer-usage")
 bool Connection::sendOutputMessage(UnixMessage&& outputMessage)
 {
 #if OS(ANDROID)
@@ -455,6 +458,7 @@ bool Connection::sendOutputMessage(UnixMessage&& outputMessage)
         RELEASE_LOG_ERROR(IPC, "Error sending IPC message on socket %d in process %d: %s", g_socket_get_fd(m_socket.get()), getpid(), error->message);
     return false;
 }
+IGNORE_CLANG_WARNINGS_END
 
 std::optional<Connection::ConnectionIdentifierPair> Connection::createConnectionIdentifierPair()
 {

--- a/Source/WebKit/Platform/IPC/unix/UnixMessage.h
+++ b/Source/WebKit/Platform/IPC/unix/UnixMessage.h
@@ -106,7 +106,7 @@ public:
 #else
         , m_messageInfo(encoder.span().size(), m_attachments.size())
 #endif
-        , m_body(const_cast<uint8_t*>(encoder.span().data()), encoder.span().size())
+        , m_body(spanConstCast<uint8_t>(encoder.span()))
     {
     }
 

--- a/Source/WebKit/Shared/linux/WebMemorySamplerLinux.cpp
+++ b/Source/WebKit/Shared/linux/WebMemorySamplerLinux.cpp
@@ -84,6 +84,7 @@ do { \
     appendKeyValuePair(stats, key, value); \
 } while (0);
 
+IGNORE_CLANG_WARNINGS_BEGIN("unsafe-buffer-usage-in-libc-call")
 String WebMemorySampler::processName() const
 {
     char processPath[maxProcessPath];
@@ -99,6 +100,7 @@ String WebMemorySampler::processName() const
 
     return processName;
 }
+IGNORE_CLANG_WARNINGS_END
 
 WebMemoryStatistics WebMemorySampler::sampleWebKit() const
 {

--- a/Source/WebKit/Shared/unix/AuxiliaryProcessMain.cpp
+++ b/Source/WebKit/Shared/unix/AuxiliaryProcessMain.cpp
@@ -84,6 +84,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     return true;
 }
 
+IGNORE_CLANG_WARNINGS_BEGIN("unsafe-buffer-usage-in-libc-call")
 void AuxiliaryProcess::platformInitialize(const AuxiliaryProcessInitializationParameters&)
 {
     struct sigaction signalAction;
@@ -92,5 +93,6 @@ void AuxiliaryProcess::platformInitialize(const AuxiliaryProcessInitializationPa
     signalAction.sa_handler = SIG_IGN;
     RELEASE_ASSERT(!sigaction(SIGPIPE, &signalAction, nullptr));
 }
+IGNORE_CLANG_WARNINGS_END
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/API/glib/WebKitInputMethodContext.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitInputMethodContext.cpp
@@ -483,11 +483,13 @@ void webkit_input_method_context_notify_surrounding(WebKitInputMethodContext* co
     g_return_if_fail(WEBKIT_IS_INPUT_METHOD_CONTEXT(context));
     g_return_if_fail(text || !length);
 
+    IGNORE_CLANG_WARNINGS_BEGIN("unsafe-buffer-usage-in-libc-call")
     if (!text)
         text = "";
     if (length < 0)
         length = strlen(text);
     g_return_if_fail(cursorIndex <= static_cast<unsigned>(length));
+    IGNORE_CLANG_WARNINGS_END
 
     auto* imClass = WEBKIT_INPUT_METHOD_CONTEXT_GET_CLASS(context);
     if (imClass->notify_surrounding)

--- a/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp
@@ -343,7 +343,9 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
             webkit_settings_set_draw_compositing_indicators(settings, g_value_get_boolean(value));
         else {
             char* debugVisualsEnvironment = getenv("WEBKIT_SHOW_COMPOSITING_DEBUG_VISUALS");
+            IGNORE_CLANG_WARNINGS_BEGIN("unsafe-buffer-usage-in-libc-call")
             bool showDebugVisuals = debugVisualsEnvironment && !strcmp(debugVisualsEnvironment, "1");
+            IGNORE_CLANG_WARNINGS_END
             webkit_settings_set_draw_compositing_indicators(settings, showDebugVisuals);
         }
         break;

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp
@@ -1428,6 +1428,7 @@ void webkit_web_context_set_sandbox_enabled(WebKitWebContext* context, gboolean 
 }
 #endif
 
+IGNORE_CLANG_WARNINGS_BEGIN("unsafe-buffer-usage-in-libc-call")
 static bool pathExistsAndIsNotHomeDirectory(const char* path)
 {
     std::unique_ptr<char, decltype(free)*> resolvedPath(realpath(path, nullptr), free);
@@ -1450,6 +1451,7 @@ static bool pathExistsAndIsNotHomeDirectory(const char* path)
 
     return strcmp(resolvedPath.get(), resolvedHomeDirectory.get());
 }
+IGNORE_CLANG_WARNINGS_END
 
 static bool pathIsBlocked(const char* path)
 {

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebResource.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebResource.cpp
@@ -427,6 +427,8 @@ guchar* webkit_web_resource_get_data_finish(WebKitWebResource* resource, GAsyncR
         return nullptr;
 
     auto* returnValue = g_malloc(data->webData->size());
+    IGNORE_CLANG_WARNINGS_BEGIN("unsafe-buffer-usage-in-libc-call")
     memcpy(returnValue, bytes.data(), bytes.size());
+    IGNORE_CLANG_WARNINGS_END
     return static_cast<guchar*>(returnValue);
 }

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebViewSessionState.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebViewSessionState.cpp
@@ -325,10 +325,12 @@ static inline void decodeFrameState(GVariant* frameStateVariant, FrameState& fra
     frameState.originalURLString = String::fromUTF8(originalURLString);
     // frameState.referrer must not be an empty string since we never want to
     // send an empty Referer header. Bug #159606.
+    IGNORE_CLANG_WARNINGS_BEGIN("unsafe-buffer-usage-in-libc-call")
     if (strlen(referrer))
         frameState.referrer = String::fromUTF8(referrer);
     if (strlen(target))
         frameState.target = AtomString::fromUTF8(target);
+    IGNORE_CLANG_WARNINGS_END
     if (gsize documentStateLength = g_variant_iter_n_children(documentStateIter.get())) {
         Vector<AtomString> documentState;
         documentState.reserveInitialCapacity(documentStateLength);

--- a/Source/WebKit/UIProcess/API/gtk/DragSourceGtk4.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/DragSourceGtk4.cpp
@@ -72,7 +72,9 @@ void DragSource::begin(SelectionData&& selectionData, OptionSet<DragOperation> o
     if (m_selectionData->hasURL()) {
         CString urlString = m_selectionData->url().string().utf8();
         gchar* url = g_strdup_printf("%s\n%s", urlString.data(), m_selectionData->hasText() ? m_selectionData->text().utf8().data() : urlString.data());
+        IGNORE_CLANG_WARNINGS_BEGIN("unsafe-buffer-usage-in-libc-call")
         GRefPtr<GBytes> bytes = adoptGRef(g_bytes_new_take(url, strlen(url)));
+        IGNORE_CLANG_WARNINGS_END
         providers.append(gdk_content_provider_new_for_bytes("_NETSCAPE_URL", bytes.get()));
     }
 

--- a/Source/WebKit/UIProcess/Automation/libwpe/WebAutomationSessionLibWPE.cpp
+++ b/Source/WebKit/UIProcess/Automation/libwpe/WebAutomationSessionLibWPE.cpp
@@ -360,7 +360,9 @@ void platformSimulateWheelInteractionLibWPE(WebPageProxy& page, const WebCore::I
     // No need to scale the location as the virtual method override already did it for us.
 #if WPE_CHECK_VERSION(1, 5, 0)
     struct wpe_input_axis_2d_event event;
+    IGNORE_CLANG_WARNINGS_BEGIN("unsafe-buffer-usage-in-libc-call")
     memset(&event, 0, sizeof(event));
+    IGNORE_CLANG_WARNINGS_END
     event.base.type = static_cast<wpe_input_axis_event_type>(wpe_input_axis_event_type_mask_2d | wpe_input_axis_event_type_motion_smooth);
     event.base.x = location.x();
     event.base.y = location.y();

--- a/Source/WebKit/UIProcess/Gamepad/wpe/GamepadProviderWPE.cpp
+++ b/Source/WebKit/UIProcess/Gamepad/wpe/GamepadProviderWPE.cpp
@@ -113,8 +113,10 @@ void GamepadProviderWPE::startMonitoringGamepads(GamepadProviderClient& client)
     m_isMonitoringInput = true;
     gsize deviceCount;
     GUniquePtr<WPEGamepad*> gamepads(wpe_gamepad_manager_list_devices(m_manager.get(), &deviceCount));
+    IGNORE_CLANG_WARNINGS_BEGIN("unsafe-buffer-usage")
     for (size_t i = 0; i < deviceCount; ++i)
         gamepadConnected(gamepads.get()[i], IsInitialDevice::Yes);
+    IGNORE_CLANG_WARNINGS_END
 }
 
 void GamepadProviderWPE::stopMonitoringGamepads(GamepadProviderClient& client)

--- a/Source/WebKit/UIProcess/Inspector/glib/RemoteInspectorHTTPServer.cpp
+++ b/Source/WebKit/UIProcess/Inspector/glib/RemoteInspectorHTTPServer.cpp
@@ -94,6 +94,7 @@ const String& RemoteInspectorHTTPServer::inspectorServerAddress() const
 
 unsigned RemoteInspectorHTTPServer::handleRequest(const char* path, SoupMessageHeaders* responseHeaders, SoupMessageBody* responseBody) const
 {
+    IGNORE_CLANG_WARNINGS_BEGIN("unsafe-buffer-usage-in-libc-call")
     if (g_str_equal(path, "/")) {
         auto* html = m_client->buildTargetListPage(RemoteInspectorClient::InspectorType::HTTP);
         soup_message_headers_append(responseHeaders, "Content-Type", "text/html");
@@ -101,6 +102,7 @@ unsigned RemoteInspectorHTTPServer::handleRequest(const char* path, SoupMessageH
         soup_message_body_append(responseBody, SOUP_MEMORY_TAKE, g_string_free(html, FALSE), bodyLength);
         return SOUP_STATUS_OK;
     }
+    IGNORE_CLANG_WARNINGS_END
 
     GUniquePtr<char> resourcePath(g_build_filename("/org/webkit/inspector/UserInterface", path, nullptr));
 

--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRInputSource.cpp
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRInputSource.cpp
@@ -68,6 +68,7 @@ OpenXRInputSource::~OpenXRInputSource()
         xrDestroySpace(m_pointerSpace);
 }
 
+IGNORE_CLANG_WARNINGS_BEGIN("unsafe-buffer-usage-in-libc-call")
 XrResult OpenXRInputSource::initialize(OpenXRSystemProperties&& systemProperties)
 {
     String handednessName = handednessToString(m_handedness);
@@ -201,6 +202,7 @@ std::optional<PlatformXR::FrameData::HandJointsVector> OpenXRInputSource::collec
     }
 #endif
 
+    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     XrHandJointLocationsEXT locations = createOpenXRStruct<XrHandJointLocationsEXT, XR_TYPE_HAND_JOINT_LOCATIONS_EXT>();
     Vector<XrHandJointLocationEXT, XR_HAND_JOINT_COUNT_EXT> jointLocations;
     locations.jointCount = XR_HAND_JOINT_COUNT_EXT;
@@ -222,6 +224,7 @@ std::optional<PlatformXR::FrameData::HandJointsVector> OpenXRInputSource::collec
         } else
             handJoints.append(std::nullopt);
     }
+    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     return handJoints;
 }
 #endif
@@ -337,6 +340,7 @@ XrResult OpenXRInputSource::createAction(XrActionType actionType, const String& 
 
     return xrCreateAction(m_actionSet, &createInfo, &action);
 }
+IGNORE_CLANG_WARNINGS_END
 
 XrResult OpenXRInputSource::createButtonActions(OpenXRButtonType type, const String& prefix, OpenXRButtonActions& actions) const
 {

--- a/Source/WebKit/UIProcess/glib/DRMMainDevice.cpp
+++ b/Source/WebKit/UIProcess/glib/DRMMainDevice.cpp
@@ -71,6 +71,7 @@ static void drmForeachDevice(Function<bool(drmDevice*)>&& functor)
 }
 #endif
 
+IGNORE_CLANG_WARNINGS_BEGIN("unsafe-buffer-usage")
 static std::optional<std::pair<CString, CString>> drmFirstDeviceWithRenderNode()
 {
 #if USE(LIBDRM)
@@ -140,6 +141,7 @@ static CString drmRenderNodeDeviceFromPrimaryNodeDevice(const CString& primaryNo
     return { };
 #endif
 }
+IGNORE_CLANG_WARNINGS_END
 
 static EGLDisplay currentEGLDisplay()
 {

--- a/Source/WebKit/UIProcess/glib/DisplayVBlankMonitor.cpp
+++ b/Source/WebKit/UIProcess/glib/DisplayVBlankMonitor.cpp
@@ -44,6 +44,7 @@ namespace WebKit {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(DisplayVBlankMonitor);
 
+IGNORE_CLANG_WARNINGS_BEGIN("unsafe-buffer-usage-in-libc-call")
 std::unique_ptr<DisplayVBlankMonitor> DisplayVBlankMonitor::create(PlatformDisplayID displayID)
 {
     static const char* forceTimer = getenv("WEBKIT_FORCE_VBLANK_TIMER");
@@ -68,6 +69,7 @@ std::unique_ptr<DisplayVBlankMonitor> DisplayVBlankMonitor::create(PlatformDispl
 
     return DisplayVBlankMonitorTimer::create();
 }
+IGNORE_CLANG_WARNINGS_END
 
 DisplayVBlankMonitor::DisplayVBlankMonitor(unsigned refreshRate)
     : m_refreshRate(refreshRate)

--- a/Source/WebKit/UIProcess/glib/WebProcessPoolGLib.cpp
+++ b/Source/WebKit/UIProcess/glib/WebProcessPoolGLib.cpp
@@ -141,6 +141,7 @@ static void seatDevicesChangedCallback(GdkSeat* seat, GdkDevice*, WebProcessPool
 }
 #endif
 
+IGNORE_CLANG_WARNINGS_BEGIN("unsafe-buffer-usage-in-libc-call")
 void WebProcessPool::platformInitialize(NeedsGlobalStaticInitialization)
 {
     if (const char* forceComplexText = getenv("WEBKIT_FORCE_COMPLEX_TEXT"))
@@ -174,6 +175,7 @@ void WebProcessPool::platformInitialize(NeedsGlobalStaticInitialization)
     }
 #endif
 }
+IGNORE_CLANG_WARNINGS_END
 
 void WebProcessPool::platformInitializeWebProcess(const WebProcessProxy& process, WebProcessCreationParameters& parameters)
 {
@@ -311,10 +313,12 @@ void WebProcessPool::setSandboxEnabled(bool enabled)
     WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 #endif
 
+IGNORE_CLANG_WARNINGS_BEGIN("unsafe-buffer-usage-in-libc-call")
     if (const char* disableSandbox = getenv("WEBKIT_DISABLE_SANDBOX_THIS_IS_DANGEROUS")) {
         if (strcmp(disableSandbox, "0"))
             return;
     }
+IGNORE_CLANG_WARNINGS_END
 
     m_sandboxEnabled = true;
 #if USE(ATSPI)

--- a/Source/WebKit/UIProcess/gtk/HardwareAccelerationManager.cpp
+++ b/Source/WebKit/UIProcess/gtk/HardwareAccelerationManager.cpp
@@ -37,6 +37,7 @@ HardwareAccelerationManager& HardwareAccelerationManager::singleton()
     return manager;
 }
 
+IGNORE_CLANG_WARNINGS_BEGIN("unsafe-buffer-usage-in-libc-call")
 HardwareAccelerationManager::HardwareAccelerationManager()
     : m_canUseHardwareAcceleration(true)
     , m_forceHardwareAcceleration(true)
@@ -53,5 +54,6 @@ HardwareAccelerationManager::HardwareAccelerationManager()
     if (forceCompositing && !strcmp(forceCompositing, "0"))
         m_forceHardwareAcceleration = false;
 }
+IGNORE_CLANG_WARNINGS_END
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/gtk/WebPopupMenuProxyGtk.cpp
+++ b/Source/WebKit/UIProcess/gtk/WebPopupMenuProxyGtk.cpp
@@ -489,8 +489,10 @@ std::optional<unsigned> WebPopupMenuProxyGtk::typeAheadFindIndex(unsigned keyval
         if (!text)
             continue;
 
+IGNORE_CLANG_WARNINGS_BEGIN("unsafe-buffer-usage-in-libc-call")
         if (!strncmp(prefix.get(), text.get(), strlen(prefix.get())))
             return index;
+IGNORE_CLANG_WARNINGS_END
     }
 
     return std::nullopt;

--- a/Source/WebKit/UIProcess/linux/MemoryPressureMonitor.cpp
+++ b/Source/WebKit/UIProcess/linux/MemoryPressureMonitor.cpp
@@ -42,6 +42,8 @@
 
 namespace WebKit {
 
+IGNORE_CLANG_WARNINGS_BEGIN("unsafe-buffer-usage-in-libc-call")
+
 static const size_t notSet = static_cast<size_t>(-1);
 
 static const Seconds s_minPollingInterval { 1_s };
@@ -508,6 +510,8 @@ size_t CGroupMemoryController::getMemoryUsageWithCgroup()
 
     return notSet;
 }
+
+IGNORE_CLANG_WARNINGS_END
 
 } // namespace WebKit
 

--- a/Source/WebKit/UIProcess/wpe/WebPasteboardProxyWPE.cpp
+++ b/Source/WebKit/UIProcess/wpe/WebPasteboardProxyWPE.cpp
@@ -49,10 +49,12 @@ using namespace WebCore;
 static Vector<String> clipboardFormats(WPEClipboard* clipboard)
 {
     Vector<String> types;
+    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     if (const auto* formats = wpe_clipboard_get_formats(clipboard)) {
         for (unsigned i = 0; formats[i]; ++i)
             types.append(String::fromUTF8(formats[i]));
     }
+    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     return types;
 }
 #endif
@@ -164,6 +166,7 @@ void WebPasteboardProxy::typesSafeForDOMToReadAndWrite(IPC::Connection&, const S
                     domTypes.add(type);
             }
 
+            WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
             if (const auto* formats = wpe_clipboard_get_formats(clipboard)) {
                 for (unsigned i = 0; formats[i]; ++i) {
                     String format = String::fromUTF8(formats[i]);
@@ -174,6 +177,7 @@ void WebPasteboardProxy::typesSafeForDOMToReadAndWrite(IPC::Connection&, const S
                         domTypes.add(format);
                 }
             }
+            WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
             completionHandler(copyToVector(domTypes));
             return;
         }

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp
@@ -216,8 +216,10 @@ void DrawingAreaCoordinatedGraphics::updatePreferences(const WebPreferencesStore
 #if ENABLE(DEVELOPER_MODE)
     if (m_supportsAsyncScrolling) {
         auto* disableAsyncScrolling = getenv("WEBKIT_DISABLE_ASYNC_SCROLLING");
+        IGNORE_CLANG_WARNINGS_BEGIN("unsafe-buffer-usage-in-libc-call")
         if (disableAsyncScrolling && strcmp(disableAsyncScrolling, "0"))
             m_supportsAsyncScrolling = false;
+        IGNORE_CLANG_WARNINGS_END
     }
 #endif
 

--- a/Source/WebKit/WebProcess/glib/WebProcessGLib.cpp
+++ b/Source/WebKit/WebProcess/glib/WebProcessGLib.cpp
@@ -146,7 +146,9 @@ void WebProcess::initializePlatformDisplayIfNeeded() const
         bool disabled = false;
 #if PLATFORM(GTK)
         const char* disableGBM = getenv("WEBKIT_DMABUF_RENDERER_DISABLE_GBM");
+        IGNORE_CLANG_WARNINGS_BEGIN("unsafe-buffer-usage-in-libc-call")
         disabled = disableGBM && strcmp(disableGBM, "0");
+        IGNORE_CLANG_WARNINGS_END
 #endif
         if (!disabled) {
             if (auto device = DRMDeviceManager::singleton().mainGBMDevice(DRMDeviceManager::NodeType::Render)) {
@@ -177,8 +179,10 @@ void WebProcess::platformInitializeWebProcess(WebProcessCreationParameters& para
 {
 #if USE(SKIA)
     const char* enableCPURendering = getenv("WEBKIT_SKIA_ENABLE_CPU_RENDERING");
+    IGNORE_CLANG_WARNINGS_BEGIN("unsafe-buffer-usage-in-libc-call")
     if (enableCPURendering && strcmp(enableCPURendering, "0"))
         ProcessCapabilities::setCanUseAcceleratedBuffers(false);
+    IGNORE_CLANG_WARNINGS_END
 #endif
 
 #if ENABLE(MEDIA_STREAM)


### PR DESCRIPTION
#### 067dca7c91cefe66b99712e8f8fb90b645ca8d62
<pre>
[Clang][GTK][WPE] Fix unsafe-buffer-usage-in-libc-call warnings
<a href="https://bugs.webkit.org/show_bug.cgi?id=299357">https://bugs.webkit.org/show_bug.cgi?id=299357</a>

Unreviewed preliminary build fix. Fixing &lt;<a href="https://webkit.org/b/299355">https://webkit.org/b/299355</a>&gt;
discovers a lot of hidden unsafe-buffer-usage-in-libc-call warnings
for GTK and WPE port Clang builds. Suppressed the warnings with
IGNORE_CLANG_WARNINGS_BEGIN and WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
temporarily.

* Source/JavaScriptCore/inspector/remote/glib/RemoteInspectorServer.cpp:
* Source/WTF/wtf/glib/ChassisType.cpp:
(WTF::readDMIChassisType):
(WTF::readACPIChassisType):
* Source/WTF/wtf/glib/GSpanExtras.h:
(WTF::adoptGMallocString):
* Source/WTF/wtf/glib/SocketConnection.cpp:
* Source/WTF/wtf/glib/SysprofAnnotator.h:
* Source/WTF/wtf/linux/CurrentProcessMemoryStatus.cpp:
* Source/WTF/wtf/linux/MemoryFootprintLinux.cpp:
* Source/WTF/wtf/posix/FileSystemPOSIX.cpp:
(WTF::FileSystemImpl::openTemporaryFile):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerDataChannelHandler.cpp:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp:
* Source/WebCore/crypto/gcrypt/GCryptUtilities.h:
* Source/WebCore/page/linux/ResourceUsageThreadLinux.cpp:
* Source/WebCore/platform/SharedBuffer.h:
* Source/WebCore/platform/audio/gstreamer/FFTFrameGStreamer.cpp:
(WebCore::FFTFrame::FFTFrame):
* Source/WebCore/platform/graphics/egl/GLContext.cpp:
* Source/WebCore/platform/graphics/filters/FilterImage.h:
* Source/WebCore/platform/graphics/gbm/MemoryMappedGPUBuffer.cpp:
(WebCore::MemoryMappedGPUBuffer::mappedDataSpan const):
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp:
(WebCore::ensureGStreamerInitialized):
(WebCore::registerWebKitGStreamerElements):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
* Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp:
* Source/WebCore/platform/graphics/gstreamer/WebKitAudioSinkGStreamer.cpp:
* Source/WebCore/platform/graphics/skia/FontCacheSkia.cpp:
* Source/WebCore/platform/graphics/skia/FontPlatformDataSkia.cpp:
* Source/WebCore/platform/graphics/skia/SkiaHarfBuzzFont.cpp:
* Source/WebCore/platform/graphics/skia/SkiaReplayCanvas.h:
* Source/WebCore/platform/graphics/skia/SkiaSystemFallbackFontCache.cpp:
(WebCore::fontconfigStyle):
(WebCore::FontSetCache::FontSet::FontSet):
* Source/WebCore/platform/gstreamer/GStreamerCodecUtilities.cpp:
* Source/WebCore/platform/libwpe/PlatformPasteboardLibWPE.cpp:
(WebCore::PlatformPasteboard::write):
* Source/WebCore/platform/network/glib/DNSResolveQueueGLib.cpp:
* Source/WebCore/platform/network/soup/NetworkStorageSessionSoup.cpp:
* Source/WebKit/NetworkProcess/cache/NetworkCacheDataGLib.cpp:
(WebKit::NetworkCache::Data::Data):
(WebKit::NetworkCache::concatenate):
* Source/WebKit/NetworkProcess/soup/WebKitDirectoryInputStream.cpp:
* Source/WebKit/Platform/IPC/glib/ConnectionGLib.cpp:
* Source/WebKit/Platform/IPC/unix/UnixMessage.h:
(IPC::UnixMessage::m_body):
* Source/WebKit/Shared/linux/WebMemorySamplerLinux.cpp:
* Source/WebKit/Shared/unix/AuxiliaryProcessMain.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitInputMethodContext.cpp:
(webkit_input_method_context_notify_surrounding):
* Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp:
(webKitSettingsSetProperty):
* Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitWebResource.cpp:
(webkit_web_resource_get_data_finish):
* Source/WebKit/UIProcess/API/glib/WebKitWebViewSessionState.cpp:
(decodeFrameState):
* Source/WebKit/UIProcess/API/gtk/DragSourceGtk4.cpp:
(WebKit::DragSource::begin):
* Source/WebKit/UIProcess/Automation/libwpe/WebAutomationSessionLibWPE.cpp:
(WebKit::platformSimulateWheelInteractionLibWPE):
* Source/WebKit/UIProcess/Gamepad/wpe/GamepadProviderWPE.cpp:
(WebKit::GamepadProviderWPE::startMonitoringGamepads):
* Source/WebKit/UIProcess/Inspector/glib/RemoteInspectorHTTPServer.cpp:
* Source/WebKit/UIProcess/XR/openxr/OpenXRInputSource.cpp:
(WebKit::OpenXRInputSource::collectHandTrackingData const):
* Source/WebKit/UIProcess/glib/DRMMainDevice.cpp:
* Source/WebKit/UIProcess/glib/DisplayVBlankMonitor.cpp:
* Source/WebKit/UIProcess/glib/WebProcessPoolGLib.cpp:
(WebKit::WebProcessPool::setSandboxEnabled):
* Source/WebKit/UIProcess/gtk/HardwareAccelerationManager.cpp:
* Source/WebKit/UIProcess/gtk/WebPopupMenuProxyGtk.cpp:
(WebKit::WebPopupMenuProxyGtk::typeAheadFindIndex):
* Source/WebKit/UIProcess/linux/MemoryPressureMonitor.cpp:
* Source/WebKit/UIProcess/wpe/WebPasteboardProxyWPE.cpp:
(WebKit::clipboardFormats):
(WebKit::WebPasteboardProxy::typesSafeForDOMToReadAndWrite):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp:
(WebKit::DrawingAreaCoordinatedGraphics::updatePreferences):
* Source/WebKit/WebProcess/glib/WebProcessGLib.cpp:
(WebKit::WebProcess::initializePlatformDisplayIfNeeded const):
(WebKit::WebProcess::platformInitializeWebProcess):

Canonical link: <a href="https://commits.webkit.org/300380@main">https://commits.webkit.org/300380@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c785cde76f7c326e08e70ee9b452ede8a057437d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122383 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42089 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32775 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128970 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/74482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/124259 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42808 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50682 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93023 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/74482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125335 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34141 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109584 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73682 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33127 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27742 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72465 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/114531 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103739 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27951 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131711 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/120909 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49324 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37535 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/101570 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49698 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105804 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101441 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46815 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24947 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/46086 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19342 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49182 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54925 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/151068 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48649 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/38641 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51999 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50331 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->