### PR TITLE
Add LayerHostingContextManager

### DIFF
--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
@@ -57,9 +57,9 @@
 #include <WebCore/NotImplemented.h>
 #include <WebCore/ResourceError.h>
 #include <WebCore/SecurityOrigin.h>
-#include <wtf/TZoneMallocInlines.h>
 #include <wtf/MemoryFootprint.h>
-
+#include <wtf/TZoneMallocInlines.h>
+#include <wtf/UniqueRef.h>
 #if ENABLE(ENCRYPTED_MEDIA)
 #include "RemoteCDMFactoryProxy.h"
 #endif
@@ -69,6 +69,7 @@
 #endif
 
 #if PLATFORM(COCOA)
+#include "LayerHostingContextManager.h"
 #include <WebCore/AudioSourceProviderAVFObjC.h>
 #include <WebCore/VideoFrameCV.h>
 #endif
@@ -99,6 +100,9 @@ RemoteMediaPlayerProxy::RemoteMediaPlayerProxy(RemoteMediaPlayerManagerProxy& ma
 #if !RELEASE_LOG_DISABLED
     , m_logger(manager.logger())
 #endif
+#if PLATFORM(COCOA)
+    , m_layerHostingContextManager(makeUniqueRef<LayerHostingContextManager>())
+#endif
 {
     m_typesRequiringHardwareSupport = m_configuration.mediaContentTypesRequiringHardwareSupport;
     m_renderingCanBeAccelerated = m_configuration.renderingCanBeAccelerated;
@@ -118,9 +122,6 @@ RemoteMediaPlayerProxy::~RemoteMediaPlayerProxy()
     if (m_performTaskAtTimeCompletionHandler)
         m_performTaskAtTimeCompletionHandler(std::nullopt);
     setShouldEnableAudioSourceProvider(false);
-
-    for (auto& request : std::exchange(m_layerHostingContextRequests, { }))
-        request({ });
 }
 
 void RemoteMediaPlayerProxy::invalidate()

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
@@ -99,6 +99,7 @@ namespace WebKit {
 
 using LayerHostingContextID = uint32_t;
 class LayerHostingContext;
+class LayerHostingContextManager;
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
 class MediaPlaybackTargetContextSerialized;
 #endif
@@ -371,8 +372,7 @@ private:
     void currentTimeChanged(const MediaTime&);
 
 #if PLATFORM(COCOA)
-    WebCore::FloatSize mediaPlayerVideoLayerSize() const final { return m_configuration.videoLayerSize; }
-    void setVideoLayerSizeIfPossible(const WebCore::FloatSize&);
+    WebCore::FloatSize mediaPlayerVideoLayerSize() const final;
     void nativeImageForCurrentTime(CompletionHandler<void(std::optional<WTF::MachSendRight>&&, WebCore::DestinationColorSpace)>&&);
     void colorSpace(CompletionHandler<void(WebCore::DestinationColorSpace)>&&);
 #endif
@@ -427,11 +427,6 @@ private:
     RefPtr<SandboxExtension> m_sandboxExtension;
     Ref<IPC::Connection> m_webProcessConnection;
     RefPtr<WebCore::MediaPlayer> m_player;
-    Vector<LayerHostingContextCallback> m_layerHostingContextRequests;
-    std::unique_ptr<LayerHostingContext> m_inlineLayerHostingContext;
-#if ENABLE(VIDEO_PRESENTATION_MODE)
-    std::unique_ptr<LayerHostingContext> m_fullscreenLayerHostingContext;
-#endif
     WeakPtr<RemoteMediaPlayerManagerProxy> m_manager;
     WebCore::MediaPlayerEnums::MediaEngineIdentifier m_engineIdentifier;
     Vector<WebCore::ContentType> m_typesRequiringHardwareSupport;
@@ -472,6 +467,9 @@ private:
     SoundStageSize m_soundStageSize { SoundStageSize::Auto };
 #if !RELEASE_LOG_DISABLED
     const Ref<const Logger> m_logger;
+#endif
+#if PLATFORM(COCOA)
+    const UniqueRef<LayerHostingContextManager> m_layerHostingContextManager;
 #endif
 };
 

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxyConfiguration.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxyConfiguration.h
@@ -55,7 +55,6 @@ struct RemoteMediaPlayerProxyConfiguration {
 #endif
     WebCore::SecurityOriginData documentSecurityOrigin;
     WebCore::IntSize presentationSize { };
-    WebCore::FloatSize videoLayerSize { };
     uint64_t logIdentifier { 0 };
     bool shouldUsePersistentCache { false };
     bool isVideo { false };

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxyConfiguration.serialization.in
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxyConfiguration.serialization.in
@@ -40,7 +40,6 @@ struct WebKit::RemoteMediaPlayerProxyConfiguration {
 #endif
     WebCore::SecurityOriginData documentSecurityOrigin;
     WebCore::IntSize presentationSize;
-    WebCore::FloatSize videoLayerSize;
     uint64_t logIdentifier;
     bool shouldUsePersistentCache;
     bool isVideo;

--- a/Source/WebKit/Platform/SourcesCocoa.txt
+++ b/Source/WebKit/Platform/SourcesCocoa.txt
@@ -3,6 +3,7 @@ Platform/cf/ModuleCF.cpp
 Platform/cocoa/CocoaImage.mm
 Platform/cocoa/ImageAnalysisUtilities.mm
 Platform/cocoa/LayerHostingContext.mm
+Platform/cocoa/LayerHostingContextManager.mm
 Platform/cocoa/NetworkIssueReporter.mm
 Platform/cocoa/WKCrashReporter.mm
 Platform/cocoa/XPCUtilities.mm

--- a/Source/WebKit/Platform/cocoa/LayerHostingContextManager.h
+++ b/Source/WebKit/Platform/cocoa/LayerHostingContextManager.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "LayerHostingContext.h"
+#include <WebCore/FloatSize.h>
+#include <WebCore/PlatformLayer.h>
+#include <wtf/CompletionHandler.h>
+#include <wtf/TZoneMalloc.h>
+#include <wtf/Vector.h>
+
+namespace WebKit {
+
+class LayerHostingContext;
+
+class LayerHostingContextManager {
+    WTF_MAKE_TZONE_ALLOCATED(LayerHostingContextManager);
+    WTF_MAKE_NONCOPYABLE(LayerHostingContextManager);
+public:
+    LayerHostingContextManager();
+    LayerHostingContextManager(LayerHostingContextManager&&);
+    LayerHostingContextManager& operator=(LayerHostingContextManager&&);
+    ~LayerHostingContextManager();
+
+    using LayerHostingContextCallback = CompletionHandler<void(WebCore::HostingContext)>;
+
+    void requestHostingContext(LayerHostingContextCallback&&);
+    std::optional<WebCore::HostingContext> createHostingContextIfNeeded(const PlatformLayerContainer&, bool canShowWhileLocked);
+    void setVideoLayerSizeFenced(const WebCore::FloatSize&, WTF::MachSendRightAnnotated&&, NOESCAPE CompletionHandler<void()>&& postCommitAction);
+    WebCore::FloatSize videoLayerSize() const { return m_videoLayerSize; }
+    void setVideoLayerSizeIfPossible();
+
+private:
+    Vector<LayerHostingContextCallback> m_layerHostingContextRequests;
+    std::unique_ptr<LayerHostingContext> m_inlineLayerHostingContext;
+    WebCore::FloatSize m_videoLayerSize;
+};
+
+} // namespace WebKit

--- a/Source/WebKit/Platform/cocoa/LayerHostingContextManager.mm
+++ b/Source/WebKit/Platform/cocoa/LayerHostingContextManager.mm
@@ -1,0 +1,132 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "LayerHostingContextManager.h"
+
+#include <wtf/MachSendRightAnnotated.h>
+
+namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(LayerHostingContextManager);
+
+LayerHostingContextManager::LayerHostingContextManager() = default;
+LayerHostingContextManager::LayerHostingContextManager(LayerHostingContextManager&&) = default;
+LayerHostingContextManager& LayerHostingContextManager::operator=(LayerHostingContextManager&&) = default;
+
+LayerHostingContextManager::~LayerHostingContextManager()
+{
+    for (auto& request : std::exchange(m_layerHostingContextRequests, { }))
+        request({ });
+}
+
+void LayerHostingContextManager::requestHostingContext(LayerHostingContextCallback&& completionHandler)
+{
+    if (m_inlineLayerHostingContext) {
+        completionHandler(m_inlineLayerHostingContext->hostingContext());
+        return;
+    }
+
+    m_layerHostingContextRequests.append(WTFMove(completionHandler));
+}
+
+std::optional<WebCore::HostingContext> LayerHostingContextManager::createHostingContextIfNeeded(const PlatformLayerContainer& layer, bool canShowWhileLocked)
+{
+    bool hadLayer = false;
+    if (layer && !m_inlineLayerHostingContext) {
+        LayerHostingContextOptions contextOptions;
+#if USE(EXTENSIONKIT)
+        contextOptions.useHostable = true;
+#endif
+#if PLATFORM(IOS_FAMILY)
+        contextOptions.canShowWhileLocked = canShowWhileLocked;
+#else
+        UNUSED_PARAM(canShowWhileLocked);
+#endif
+        m_inlineLayerHostingContext = LayerHostingContext::create(contextOptions);
+        if (m_videoLayerSize.isEmpty())
+            m_videoLayerSize = enclosingIntRect(WebCore::FloatRect([layer frame])).size();
+        auto& size = m_videoLayerSize;
+        [layer setFrame:CGRectMake(0, 0, size.width(), size.height())];
+        for (auto& request : std::exchange(m_layerHostingContextRequests, { }))
+            request(m_inlineLayerHostingContext->hostingContext());
+        hadLayer = true;
+    } else if (!layer && m_inlineLayerHostingContext) {
+        m_inlineLayerHostingContext = nullptr;
+        m_videoLayerSize = { };
+        hadLayer = true;
+    }
+
+    if (m_inlineLayerHostingContext)
+        m_inlineLayerHostingContext->setRootLayer(layer.get());
+
+    if (!hadLayer)
+        return std::nullopt;
+    return m_inlineLayerHostingContext ? m_inlineLayerHostingContext->hostingContext() : WebCore::HostingContext { };
+}
+
+void LayerHostingContextManager::setVideoLayerSizeFenced(const WebCore::FloatSize& size, WTF::MachSendRightAnnotated&& sendRightAnnotated, NOESCAPE CompletionHandler<void()>&& postCommitAction)
+{
+#if USE(EXTENSIONKIT)
+    RetainPtr<BELayerHierarchyHostingTransactionCoordinator> hostingUpdateCoordinator;
+#endif
+
+    if (m_inlineLayerHostingContext) {
+#if USE(EXTENSIONKIT)
+#if ENABLE(MACH_PORT_LAYER_HOSTING)
+        auto sendRightAnnotatedCopy = sendRightAnnotated;
+        hostingUpdateCoordinator = LayerHostingContext::createHostingUpdateCoordinator(WTFMove(sendRightAnnotatedCopy));
+#else
+        hostingUpdateCoordinator = LayerHostingContext::createHostingUpdateCoordinator(sendRightAnnotated.sendRight.sendRight());
+#endif // ENABLE(MACH_PORT_LAYER_HOSTING)
+        [hostingUpdateCoordinator addLayerHierarchy:m_inlineLayerHostingContext->hostable().get()];
+#else
+        m_inlineLayerHostingContext->setFencePort(sendRightAnnotated.sendRight.sendRight());
+#endif // USE(EXTENSIONKIT)
+    }
+
+    m_videoLayerSize = size;
+    setVideoLayerSizeIfPossible();
+
+    postCommitAction();
+
+#if USE(EXTENSIONKIT)
+    [hostingUpdateCoordinator commit];
+#endif
+}
+
+void LayerHostingContextManager::setVideoLayerSizeIfPossible()
+{
+    if (!m_inlineLayerHostingContext || !m_inlineLayerHostingContext->rootLayer() || m_videoLayerSize.isEmpty())
+        return;
+
+    // We do not want animations here.
+    [CATransaction begin];
+    [CATransaction setDisableActions:YES];
+    [m_inlineLayerHostingContext->protectedRootLayer() setFrame:CGRectMake(0, 0, m_videoLayerSize.width(), m_videoLayerSize.height())];
+    [CATransaction commit];
+}
+
+}

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1260,6 +1260,7 @@
 		5157AE032B23C34700C0E095 /* CoreIPCContacts.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5157ADFF2B23C33500C0E095 /* CoreIPCContacts.mm */; };
 		5157AE0A2B23E96A00C0E095 /* CoreIPCPassKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 5157AE092B23E96300C0E095 /* CoreIPCPassKit.h */; };
 		5157AE0B2B23E97400C0E095 /* CoreIPCPassKit.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5157AE082B23E96300C0E095 /* CoreIPCPassKit.mm */; };
+		515A0C552E8284CF00D0B56C /* LayerHostingContextManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 515A0C532E8284AC00D0B56C /* LayerHostingContextManager.h */; };
 		515BE1791D53FE8F00DD7C68 /* WebGamepadProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 515BE1741D53FDDC00DD7C68 /* WebGamepadProvider.h */; };
 		515BE1A91D55293400DD7C68 /* UIGamepadProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 515BE1A51D55292800DD7C68 /* UIGamepadProvider.h */; };
 		515BE1AB1D555AA000DD7C68 /* WebGamepad.h in Headers */ = {isa = PBXBuildFile; fileRef = 515BE1A01D550AB000DD7C68 /* WebGamepad.h */; };
@@ -5844,6 +5845,8 @@
 		5157AE002B23C33500C0E095 /* CoreIPCContacts.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CoreIPCContacts.h; sourceTree = "<group>"; };
 		5157AE082B23E96300C0E095 /* CoreIPCPassKit.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CoreIPCPassKit.mm; sourceTree = "<group>"; };
 		5157AE092B23E96300C0E095 /* CoreIPCPassKit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoreIPCPassKit.h; sourceTree = "<group>"; };
+		515A0C532E8284AC00D0B56C /* LayerHostingContextManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LayerHostingContextManager.h; sourceTree = "<group>"; };
+		515A0C542E8284AC00D0B56C /* LayerHostingContextManager.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = LayerHostingContextManager.mm; sourceTree = "<group>"; };
 		515BE1731D53FDDC00DD7C68 /* WebGamepadProvider.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebGamepadProvider.cpp; sourceTree = "<group>"; };
 		515BE1741D53FDDC00DD7C68 /* WebGamepadProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebGamepadProvider.h; sourceTree = "<group>"; };
 		515BE19F1D550AB000DD7C68 /* WebGamepad.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebGamepad.cpp; sourceTree = "<group>"; };
@@ -12995,6 +12998,8 @@
 				F4351B9F25EEC87800D63892 /* ImageAnalysisUtilities.mm */,
 				BCE0937614FB128B001138D9 /* LayerHostingContext.h */,
 				BCE0937514FB128B001138D9 /* LayerHostingContext.mm */,
+				515A0C532E8284AC00D0B56C /* LayerHostingContextManager.h */,
+				515A0C542E8284AC00D0B56C /* LayerHostingContextManager.mm */,
 				A141DF4D2B06ECFB00E80B2D /* MediaCapability.h */,
 				A141DF4E2B06ECFB00E80B2D /* MediaCapability.mm */,
 				516E092C2B953EDC00A8C5B0 /* MediaPlaybackTargetContextSerialized.h */,
@@ -17571,6 +17576,7 @@
 				C1663E5B24AEAA2F00C6A3B2 /* LaunchServicesDatabaseXPCConstants.h in Headers */,
 				51E9049A27BCB9D400929E7E /* LaunchServicesSPI.h in Headers */,
 				BCE0937814FB128C001138D9 /* LayerHostingContext.h in Headers */,
+				515A0C552E8284CF00D0B56C /* LayerHostingContextManager.h in Headers */,
 				1A92DC1112F8BA460017AF65 /* LayerTreeContext.h in Headers */,
 				44E936FD2447C2D8009FA3E3 /* LegacyCustomProtocolID.h in Headers */,
 				5C1427181C23F8B700D41183 /* LegacyCustomProtocolManager.h in Headers */,

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.cpp
@@ -176,7 +176,6 @@ Ref<MediaPlayerPrivateInterface> RemoteMediaPlayerManager::createRemoteMediaPlay
     proxyConfiguration.documentSecurityOrigin = documentSecurityOrigin;
 
     proxyConfiguration.presentationSize = player->presentationSize();
-    proxyConfiguration.videoLayerSize = player->videoLayerSize();
 
     proxyConfiguration.allowedMediaContainerTypes = player->allowedMediaContainerTypes();
     proxyConfiguration.allowedMediaCodecTypes = player->allowedMediaCodecTypes();


### PR DESCRIPTION
#### f23a04c78df7376876bb1166c5f7f4e261f5b627
<pre>
Add LayerHostingContextManager
<a href="https://bugs.webkit.org/show_bug.cgi?id=299365">https://bugs.webkit.org/show_bug.cgi?id=299365</a>
<a href="https://rdar.apple.com/161161377">rdar://161161377</a>

Reviewed by Jer Noble.

We can then re-use the code without duplication.

No change in behaviour. Code just moved around.

* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp:
(WebKit::RemoteMediaPlayerProxy::~RemoteMediaPlayerProxy):
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h: Remove unused members.
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxyConfiguration.h: Remove unused field
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxyConfiguration.serialization.in: Remove unused field
* Source/WebKit/GPUProcess/media/cocoa/RemoteMediaPlayerProxyCocoa.mm:
(WebKit::RemoteMediaPlayerProxy::mediaPlayerFirstVideoFrameAvailable):
(WebKit::RemoteMediaPlayerProxy::mediaPlayerRenderingModeChanged):
(WebKit::RemoteMediaPlayerProxy::requestHostingContext):
(WebKit::RemoteMediaPlayerProxy::setVideoLayerSizeFenced):
(WebKit::RemoteMediaPlayerProxy::setVideoLayerSizeIfPossible): Deleted.
* Source/WebKit/Platform/SourcesCocoa.txt:
* Source/WebKit/Platform/cocoa/LayerHostingContextManager.h: Added.
(WebKit::LayerHostingContextManager::videoLayerSize const):
* Source/WebKit/Platform/cocoa/LayerHostingContextManager.mm: Added.
(WebKit::LayerHostingContextManager::~LayerHostingContextManager):
(WebKit::LayerHostingContextManager::requestHostingContext):
(WebKit::LayerHostingContextManager::createHostingContextIfNeeded):
(WebKit::LayerHostingContextManager::setVideoLayerSizeFenced):
(WebKit::LayerHostingContextManager::setVideoLayerSizeIfPossible):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.cpp:
(WebKit::RemoteMediaPlayerManager::createRemoteMediaPlayer):

Canonical link: <a href="https://commits.webkit.org/300560@main">https://commits.webkit.org/300560@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/80a62a7d78b33efbb71b85ac75ff39626cf4a124

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123087 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42801 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33498 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/129743 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/75197 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5b0f6dd4-7b2d-4252-a9f7-4661b8fd5fbf) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43525 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51396 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/93561 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/75197 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/66d04283-1c5b-4cf4-9249-ac5502efc6f2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126038 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34686 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110159 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/74201 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ca274795-8270-446b-9158-6fb5dc662988) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/33658 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73260 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104397 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28541 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132475 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50037 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38090 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/102063 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50413 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106380 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/101916 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25890 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47285 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25487 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/46810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49892 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/55653 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/49360 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/52712 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/51041 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->