### PR TITLE
Fix remaining smart pointer errors in webpushd

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
@@ -153,7 +153,4 @@ WebProcess/WebPage/mac/PageBannerMac.mm
 WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm
 WebProcess/WebPage/mac/WebPageMac.mm
 WebProcess/cocoa/WebProcessCocoa.mm
-webpushd/MockPushServiceConnection.mm
-webpushd/WebPushDaemon.mm
-webpushd/WebPushDaemonMain.mm
 webpushd/_WKMockUserNotificationCenter.mm

--- a/Source/WebKit/webpushd/MockPushServiceConnection.mm
+++ b/Source/WebKit/webpushd/MockPushServiceConnection.mm
@@ -52,7 +52,7 @@ void MockPushServiceConnection::subscribe(const String&, const Vector<uint8_t>& 
 {
     auto alwaysRejectedKey = base64URLDecode("BEAxaUMo1s8tjORxJfnSSvWhYb4u51kg1hWT2s_9gpV7Zxar1pF_2BQ8AncuAdS2BoLhN4qaxzBy2CwHE8BBzWg"_s).value();
     if (vapidPublicKey == alwaysRejectedKey) {
-        handler({ }, [NSError errorWithDomain:@"WebPush" code:-1 userInfo:nil]);
+        handler(nil, [NSError errorWithDomain:@"WebPush" code:-1 userInfo:nil]);
         return;
     }
 

--- a/Source/WebKit/webpushd/WebPushDaemon.h
+++ b/Source/WebKit/webpushd/WebPushDaemon.h
@@ -175,7 +175,7 @@ private:
     StdList<PotentialSilentPush> m_potentialSilentPushes;
 
 #if HAVE(FULL_FEATURED_USER_NOTIFICATIONS)
-    Class m_userNotificationCenterClass;
+    RetainPtr<Class> m_userNotificationCenterClass;
 #endif // HAVE(FULL_FEATURED_USER_NOTIFICATIONS)
 
 #if PLATFORM(IOS)

--- a/Source/WebKit/webpushd/WebPushDaemon.mm
+++ b/Source/WebKit/webpushd/WebPushDaemon.mm
@@ -524,7 +524,7 @@ void WebPushDaemon::handleIncomingPush(const PushSubscriptionSetIdentifier& iden
     // FIXME(rdar://134509619): Move APNS topics to appropriate enabled/ignored list so that we
     // don't get push events for web clips without the appropriate permissions.
     RetainPtr notificationCenterBundleIdentifier = platformNotificationCenterBundleIdentifier(identifier.pushPartition);
-    RetainPtr center = adoptNS([[m_userNotificationCenterClass alloc] initWithBundleIdentifier:notificationCenterBundleIdentifier.get()]);
+    RetainPtr center = adoptNS([[m_userNotificationCenterClass.get() alloc] initWithBundleIdentifier:notificationCenterBundleIdentifier.get()]);
     auto blockPtr = makeBlockPtr([identifier = crossThreadCopy(identifier), message = WTFMove(message)](UNNotificationSettings *settings) mutable {
         auto status = settings.authorizationStatus;
         if (status != UNAuthorizationStatusAuthorized) {
@@ -849,7 +849,7 @@ void WebPushDaemon::subscribeToPushService(PushClientConnection& connection, con
 
 #if PLATFORM(IOS) && HAVE(FULL_FEATURED_USER_NOTIFICATIONS)
     RetainPtr notificationCenterBundleIdentifier = platformNotificationCenterBundleIdentifier(identifier.pushPartition);
-    RetainPtr center = adoptNS([[m_userNotificationCenterClass alloc] initWithBundleIdentifier:notificationCenterBundleIdentifier.get()]);
+    RetainPtr center = adoptNS([[m_userNotificationCenterClass.get() alloc] initWithBundleIdentifier:notificationCenterBundleIdentifier.get()]);
     UNNotificationSettings *settings = [center notificationSettings];
     if (settings.authorizationStatus != UNAuthorizationStatusAuthorized) {
         WEBPUSHDAEMON_RELEASE_LOG(Push, "Cannot subscribe because web clip origin %{sensitive}s does not have correct permissions", origin.toString().utf8().data());
@@ -1036,10 +1036,10 @@ ALLOW_NONLITERAL_FORMAT_BEGIN
     content.get().subtitle = adoptNS([[NSString alloc] initWithFormat:WEB_UI_STRING("from %@", "Web Push Notification string to indicate the name of the Web App/Web Site a notification was sent from, such as 'from Wikipedia'").createNSString().get(), notificationSourceForDisplay]).get();
 ALLOW_NONLITERAL_FORMAT_END
 
-    content.get().userInfo = notificationData.dictionaryRepresentation();
+    content.get().userInfo = retainPtr(notificationData.dictionaryRepresentation()).get();
 
     RetainPtr request = [UNNotificationRequest requestWithIdentifier:notificationData.notificationID.toString().createNSString().get() content:content.get() trigger:nil];
-    RetainPtr<UNUserNotificationCenter> center = adoptNS([[m_userNotificationCenterClass alloc] initWithBundleIdentifier:notificationCenterBundleIdentifier.get()]);
+    RetainPtr<UNUserNotificationCenter> center = adoptNS([[m_userNotificationCenterClass.get() alloc] initWithBundleIdentifier:notificationCenterBundleIdentifier.get()]);
     if (!center)
         RELEASE_LOG_ERROR(Push, "Failed to instantiate UNUserNotificationCenter center");
 
@@ -1070,7 +1070,7 @@ void WebPushDaemon::getNotifications(PushClientConnection& connection, const URL
     auto identifier = WTFMove(*maybeIdentifier);
 
     auto placeholderBundleIdentifier = platformNotificationCenterBundleIdentifier(identifier.pushPartition);
-    RetainPtr center = adoptNS([[m_userNotificationCenterClass alloc] initWithBundleIdentifier:placeholderBundleIdentifier.get()]);
+    RetainPtr center = adoptNS([[m_userNotificationCenterClass.get() alloc] initWithBundleIdentifier:placeholderBundleIdentifier.get()]);
 
     auto blockPtr = makeBlockPtr([identifier = crossThreadCopy(identifier), registrationURL = crossThreadCopy(registrationURL), tag = crossThreadCopy(tag), completionHandler = WTFMove(completionHandler)](NSArray<UNNotification *> *notifications) mutable {
         ensureOnMainRunLoop([identifier = crossThreadCopy(identifier), notifications = RetainPtr { notifications }, registrationURL = crossThreadCopy(WTFMove(registrationURL)), tag = crossThreadCopy(WTFMove(tag)), completionHandler = WTFMove(completionHandler)] mutable {
@@ -1105,7 +1105,7 @@ void WebPushDaemon::cancelNotification(PushClientConnection& connection, WebCore
     auto identifier = WTFMove(*maybeIdentifier);
 
     auto placeholderBundleIdentifier = platformNotificationCenterBundleIdentifier(identifier.pushPartition);
-    RetainPtr center = adoptNS([[m_userNotificationCenterClass alloc] initWithBundleIdentifier:placeholderBundleIdentifier.get()]);
+    RetainPtr center = adoptNS([[m_userNotificationCenterClass.get() alloc] initWithBundleIdentifier:placeholderBundleIdentifier.get()]);
 
     RetainPtr identifiers = @[ notificationID.toString().createNSString().get() ];
     [center removePendingNotificationRequestsWithIdentifiers:identifiers.get()];
@@ -1138,7 +1138,7 @@ void WebPushDaemon::getPushPermissionState(PushClientConnection& connection, con
 #endif
 
     RetainPtr notificationCenterBundleIdentifier = platformNotificationCenterBundleIdentifier(identifier.pushPartition);
-    RetainPtr center = adoptNS([[m_userNotificationCenterClass alloc] initWithBundleIdentifier:notificationCenterBundleIdentifier.get()]);
+    RetainPtr center = adoptNS([[m_userNotificationCenterClass.get() alloc] initWithBundleIdentifier:notificationCenterBundleIdentifier.get()]);
 
     auto blockPtr = makeBlockPtr([originString = crossThreadCopy(origin.toString()), replySender = WTFMove(replySender)](UNNotificationSettings *settings) mutable {
         auto permissionState = [](UNAuthorizationStatus status) {
@@ -1185,7 +1185,7 @@ void WebPushDaemon::requestPushPermission(PushClientConnection& connection, cons
 #endif
 
     RetainPtr notificationCenterBundleIdentifier = platformNotificationCenterBundleIdentifier(identifier.pushPartition);
-    RetainPtr center = adoptNS([[m_userNotificationCenterClass alloc] initWithBundleIdentifier:notificationCenterBundleIdentifier.get()]);
+    RetainPtr center = adoptNS([[m_userNotificationCenterClass.get() alloc] initWithBundleIdentifier:notificationCenterBundleIdentifier.get()]);
     UNAuthorizationOptions options = UNAuthorizationOptionBadge | UNAuthorizationOptionAlert | UNAuthorizationOptionSound;
 
     auto blockPtr = makeBlockPtr([originString = crossThreadCopy(origin.toString()), replySender = WTFMove(replySender)](BOOL granted, NSError *error) mutable {
@@ -1233,7 +1233,7 @@ void WebPushDaemon::setAppBadge(PushClientConnection& connection, WebCore::Secur
     state.get().badgeValue = appBadge ? [NSNumber numberWithUnsignedLongLong:*appBadge] : nil;
 #elif PLATFORM(MAC)
     String bundleIdentifier = identifier.pushPartition.isEmpty() ? connection.hostAppCodeSigningIdentifier() : identifier.pushPartition;
-    RetainPtr center = adoptNS([[m_userNotificationCenterClass alloc]  initWithBundleIdentifier:bundleIdentifier.createNSString().get()]);
+    RetainPtr center = adoptNS([[m_userNotificationCenterClass.get() alloc]  initWithBundleIdentifier:bundleIdentifier.createNSString().get()]);
     if (!center)
         return;
 
@@ -1258,7 +1258,7 @@ void WebPushDaemon::getAppBadgeForTesting(PushClientConnection& connection, Comp
     UNUSED_PARAM(connection);
     completionHandler(std::nullopt);
 #else
-    RELEASE_ASSERT(m_userNotificationCenterClass == _WKMockUserNotificationCenter.class);
+    RELEASE_ASSERT(m_userNotificationCenterClass.get() == _WKMockUserNotificationCenter.class);
 
     String bundleIdentifier = connection.pushPartitionIfExists().isEmpty() ? connection.hostAppCodeSigningIdentifier() : connection.pushPartitionIfExists();
     RetainPtr center = adoptNS([[_WKMockUserNotificationCenter alloc] initWithBundleIdentifier:bundleIdentifier.createNSString().get()]);

--- a/Source/WebKit/webpushd/WebPushDaemonMain.mm
+++ b/Source/WebKit/webpushd/WebPushDaemonMain.mm
@@ -120,8 +120,9 @@ static void applySandbox()
 
 static String getWebPushDirectoryPathWithMigrationIfNecessary()
 {
+    RetainPtr paths = NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSUserDomainMask, YES);
+    String libraryPath = paths.get()[0];
 #if PLATFORM(MAC) && !ENABLE(RELOCATABLE_WEBPUSHD)
-    String libraryPath = NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSUserDomainMask, YES)[0];
     String oldPath = FileSystem::pathByAppendingComponents(libraryPath, std::initializer_list<StringView>({ "WebKit"_s, "WebPush"_s }));
 
     RetainPtr containerURL = [[NSFileManager defaultManager] containerURLForSecurityApplicationGroupIdentifier:@"group.com.apple.webkit.webpushd"];
@@ -143,7 +144,6 @@ static String getWebPushDirectoryPathWithMigrationIfNecessary()
 
     return newPath;
 #else
-    String libraryPath = NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSUserDomainMask, YES)[0];
     return FileSystem::pathByAppendingComponents(libraryPath, std::initializer_list<StringView>({ "WebKit"_s, "WebPush"_s }));
 #endif
 }

--- a/Source/WebKit/webpushd/_WKMockUserNotificationCenter.mm
+++ b/Source/WebKit/webpushd/_WKMockUserNotificationCenter.mm
@@ -60,7 +60,7 @@ static _WKMockUserNotificationCenter *centersByBundleIdentifier(NSString *bundle
     if (!self)
         return nil;
 
-    m_queue = adoptOSObject(dispatch_queue_create(nullptr, DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL));
+    m_queue = adoptOSObject(dispatch_queue_create(nullptr, retainPtr(DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL).get()));
     m_bundleIdentifier = bundleIdentifier;
     m_notifications = adoptNS([[NSMutableArray alloc] init]);
 


### PR DESCRIPTION
#### 0157ffa26fb13240224fc8b803e94ca04a315da0
<pre>
Fix remaining smart pointer errors in webpushd
<a href="https://bugs.webkit.org/show_bug.cgi?id=299368">https://bugs.webkit.org/show_bug.cgi?id=299368</a>

Reviewed by Chris Dumez.

Note: The remaining errors for _WKMockUserNotificationCenter.mm is a
false positive due to the checker not recognizing _init*
See <a href="https://github.com/llvm/llvm-project/pull/160569">https://github.com/llvm/llvm-project/pull/160569</a>

* Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations: Update expectations.
* Source/WebKit/webpushd/MockPushServiceConnection.mm:
(WebPushD::MockPushServiceConnection::subscribe): Use nil to turn off false positive warning.
* Source/WebKit/webpushd/WebPushDaemon.h: Make m_userNotificationCenterClass a RetainPtr.
* Source/WebKit/webpushd/WebPushDaemon.mm:
(WebPushD::WebPushDaemon::handleIncomingPush): Ditto.
(WebPushD::WebPushDaemon::subscribeToPushService): Ditto.
(WebPushD::WebPushDaemon::showNotification): Ditto. Also wrap an arg in a RetainPtr.
(WebPushD::WebPushDaemon::getNotifications): Make m_userNotificationCenterClass a RetainPtr.
(WebPushD::WebPushDaemon::cancelNotification): Ditto.
(WebPushD::WebPushDaemon::getPushPermissionState): Ditto.
(WebPushD::WebPushDaemon::requestPushPermission): Ditto.
(WebPushD::WebPushDaemon::setAppBadge): Ditto.
(WebPushD::WebPushDaemon::getAppBadgeForTesting): Ditto.
* Source/WebKit/webpushd/WebPushDaemonMain.mm: Use a RetainPtr for the result of NSSearchPathForDirectoriesInDomains.
(WebKit::getWebPushDirectoryPathWithMigrationIfNecessary):
* Source/WebKit/webpushd/_WKMockUserNotificationCenter.mm:
(+[_WKMockUserNotificationCenter _internalInitWithBundleIdentifier:]):
  Use a retainPtr for a DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL arg, which calls dispatch_queue_attr_make_with_autorelease_frequency.

Canonical link: <a href="https://commits.webkit.org/300566@main">https://commits.webkit.org/300566@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/461d52c40de753abd8ff89f2fbc2bdd31def68a8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123117 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42831 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33528 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/129777 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/75228 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43555 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51426 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/93590 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/75228 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126068 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34711 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110180 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74223 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33678 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73292 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104423 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28562 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132505 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50067 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38117 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/102088 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50443 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106401 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/101941 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25898 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47311 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25504 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/46840 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49922 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/55683 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/49390 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/52742 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/51071 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->