### PR TITLE
[Grid Formatting Context] Pass RenderGrid's available width/height into GFC.

### DIFF
--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -139,6 +139,7 @@ set(WebCore_PRIVATE_INCLUDE_DIRECTORIES
     "${WEBCORE_DIR}/layout/formattingContexts/block"
     "${WEBCORE_DIR}/layout/formattingContexts/block/tablewrapper"
     "${WEBCORE_DIR}/layout/formattingContexts/flex"
+    "${WEBCORE_DIR}/layout/formattingContexts/grid"
     "${WEBCORE_DIR}/layout/floats"
     "${WEBCORE_DIR}/layout/formattingContexts/inline"
     "${WEBCORE_DIR}/layout/formattingContexts/inline/display"

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1785,6 +1785,8 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     layout/formattingContexts/flex/FlexRect.h
     layout/formattingContexts/flex/LogicalFlexItem.h
 
+    layout/formattingContexts/grid/GridFormattingContext.h
+
     layout/formattingContexts/inline/AbstractLineBuilder.h
     layout/formattingContexts/inline/AvailableLineWidthOverride.h
     layout/formattingContexts/inline/InlineContentAligner.h

--- a/Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.cpp
+++ b/Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.cpp
@@ -27,6 +27,7 @@
 #include "LayoutIntegrationGridLayout.h"
 
 #include "FormattingContextBoxIterator.h"
+#include "GridFormattingContext.h"
 #include "LayoutIntegrationBoxTreeUpdater.h"
 #include "RenderGrid.h"
 #include "RenderView.h"
@@ -44,9 +45,26 @@ GridLayout::GridLayout(RenderGrid& renderGrid)
 {
 }
 
+static inline Layout::GridFormattingContext::GridLayoutConstraints constraintsForGridContent(const Layout::ElementBox& gridContainer)
+{
+    CheckedRef gridContainerRenderer = downcast<RenderGrid>(*gridContainer.rendererForIntegration());
+
+    auto availableInlineSpace = [&]() -> LayoutUnit {
+        if (auto overridingWidth = gridContainerRenderer->overridingBorderBoxLogicalWidth())
+            return gridContainerRenderer->contentBoxLogicalWidth(*overridingWidth);
+        return gridContainerRenderer->contentBoxLogicalWidth();
+    }();
+    auto availableBlockSpace = gridContainerRenderer->availableLogicalHeightForContentBox();
+
+    return {
+        .inlineAxisAvailableSpace = availableInlineSpace,
+        .blockAxisAvailableSpace = availableBlockSpace
+    };
+}
+
 void GridLayout::layout()
 {
-    // FIXME: implement this.
+    Layout::GridFormattingContext { gridBox(), layoutState() }.layout(constraintsForGridContent(gridBox()));
 }
 
 TextStream& operator<<(TextStream& stream, const GridLayout& layout)

--- a/Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.h
+++ b/Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.h
@@ -57,6 +57,7 @@ private:
     const RenderGrid& gridBoxRenderer() const { return downcast<RenderGrid>(*m_gridBox->rendererForIntegration()); }
     RenderGrid& gridBoxRenderer() { return downcast<RenderGrid>(*m_gridBox->rendererForIntegration()); }
 
+    Layout::LayoutState& layoutState() { return m_layoutState; }
     const Layout::LayoutState& layoutState() const { return m_layoutState; }
 
     const CheckedPtr<Layout::ElementBox> m_gridBox;

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -419,8 +419,6 @@ const std::optional<LayoutUnit> RenderGrid::availableLogicalHeightForContentBox(
 
 void RenderGrid::layoutGrid(RelayoutChildren relayoutChildren)
 {
-    if (layoutUsingGridFormattingContext())
-        return;
 
     LayoutRepainter repainter(*this);
     {
@@ -442,6 +440,9 @@ void RenderGrid::layoutGrid(RelayoutChildren relayoutChildren)
         resetLogicalHeightBeforeLayoutIfNeeded();
 
         updateLogicalWidth();
+
+        if (layoutUsingGridFormattingContext())
+            return;
 
         // Fieldsets need to find their legend and position it inside the border of the object.
         // The legend then gets skipped during normal layout. The same is true for ruby text.


### PR DESCRIPTION
#### 6623480628d5b2ee9ba4f248e69fd8264ec462ca
<pre>
[Grid Formatting Context] Pass RenderGrid&apos;s available width/height into GFC.
<a href="https://bugs.webkit.org/show_bug.cgi?id=299209">https://bugs.webkit.org/show_bug.cgi?id=299209</a>
&lt;<a href="https://rdar.apple.com/160965760">rdar://160965760</a>&gt;

Reviewed by Sammy Gill.

This PR passes RenderGrid&apos;s height and width constraints into GFC.

This PR also fixes some incorrect xcode project ettings for LayoutIntegrationGridLayout.

Combined changes:

* Source/WebCore/Headers.cmake:
* Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.cpp:
(WebCore::LayoutIntegration::constraintsForGridContent):
(WebCore::LayoutIntegration::GridLayout::layout):
* Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.h:
(WebCore::LayoutIntegration::GridLayout::layoutState):
* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::layoutUsingGridFormattingContext):

Canonical link: <a href="https://commits.webkit.org/300446@main">https://commits.webkit.org/300446@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/16220b3be98e617c0eaf117931139c2f694664c8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122553 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42261 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32946 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/129162 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74654 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/82b3ce0f-0d46-4021-a967-21768ae4ef6e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/124429 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42979 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50854 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93159 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/61866 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/17b2b1fa-72e9-4a30-bfb8-4b4c3d9738ed) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125505 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34286 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109729 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73805 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33269 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27886 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72646 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103947 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28096 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131888 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49494 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37673 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101688 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49869 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105949 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101556 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25786 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46933 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25084 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/46264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49352 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/55101 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48820 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/52171 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50501 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->