### PR TITLE
REGRESSION (299884@main): [macOS] Safari AutoFill filling unit tests are hanging

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -854,17 +854,6 @@ void WebProcessPool::registerNotificationObservers()
         textCheckerStateChanged();
     }];
 
-    // FIXME: This isn't that ideal since it listens to every user default change and not just the smart lists default.
-    m_smartListsNotificationObserver = [[NSNotificationCenter defaultCenter] addObserverForName:NSUserDefaultsDidChangeNotification object:nil queue:[NSOperationQueue currentQueue] usingBlock:^(NSNotification *notification) {
-        TextChecker::didChangeSmartListsEnabled();
-
-        auto newValue = TextChecker::state().contains(TextCheckerState::SmartListsEnabled);
-        if (std::exchange(m_smartListsEnabled, newValue) == newValue)
-            return;
-
-        textCheckerStateChanged();
-    }];
-
     m_accessibilityDisplayOptionsNotificationObserver = [[NSWorkspace.sharedWorkspace notificationCenter] addObserverForName:NSWorkspaceAccessibilityDisplayOptionsDidChangeNotification object:nil queue:[NSOperationQueue currentQueue] usingBlock:^(NSNotification *notification) {
         screenPropertiesChanged();
     }];
@@ -1023,7 +1012,6 @@ void WebProcessPool::unregisterNotificationObservers()
     [[NSNotificationCenter defaultCenter] removeObserver:m_automaticSpellingCorrectionNotificationObserver.get()];
     [[NSNotificationCenter defaultCenter] removeObserver:m_automaticQuoteSubstitutionNotificationObserver.get()];
     [[NSNotificationCenter defaultCenter] removeObserver:m_automaticDashSubstitutionNotificationObserver.get()];
-    [[NSNotificationCenter defaultCenter] removeObserver:m_smartListsNotificationObserver.get()];
     [[NSWorkspace.sharedWorkspace notificationCenter] removeObserver:m_accessibilityDisplayOptionsNotificationObserver.get()];
     [[NSNotificationCenter defaultCenter] removeObserver:m_scrollerStyleNotificationObserver.get()];
     [[NSNotificationCenter defaultCenter] removeObserver:m_deactivationObserver.get()];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SmartLists.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SmartLists.mm
@@ -126,6 +126,8 @@ static void runTest(NSString *input, NSString *expectedHTML, NSString *expectedS
 
 TEST(SmartLists, EnablementIsLogicallyConsistentWhenInterfacedThroughResponder)
 {
+    resetUserDefaults();
+
     RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
     [webView synchronouslyLoadHTMLString:@"<div>hi</div>"];
@@ -134,7 +136,6 @@ TEST(SmartLists, EnablementIsLogicallyConsistentWhenInterfacedThroughResponder)
     // Case 1: user default => nil, preference => false
 
     setSmartListsPreference(configuration.get(), NO);
-    resetUserDefaults();
 
     EXPECT_FALSE([webView _isSmartListsEnabled]);
     EXPECT_NULL(userDefaultsValue());
@@ -143,22 +144,9 @@ TEST(SmartLists, EnablementIsLogicallyConsistentWhenInterfacedThroughResponder)
     EXPECT_FALSE([webView _isSmartListsEnabled]);
     EXPECT_NULL(userDefaultsValue());
 
-    // Case 2: user default => true, preference => false
-
-    setSmartListsPreference(configuration.get(), NO);
-    setUserDefaultsValue(YES);
-
-    EXPECT_FALSE([webView _isSmartListsEnabled]);
-    EXPECT_TRUE([userDefaultsValue() boolValue]);
-
-    [webView _setSmartListsEnabled:YES];
-    EXPECT_FALSE([webView _isSmartListsEnabled]);
-    EXPECT_TRUE([userDefaultsValue() boolValue]);
-
-    // Case 3: user default => nil, preference => true
+    // Case 2: user default => nil, preference => true
 
     setSmartListsPreference(configuration.get(), YES);
-    resetUserDefaults();
 
     EXPECT_TRUE([webView _isSmartListsEnabled]);
     EXPECT_NULL(userDefaultsValue());
@@ -169,6 +157,18 @@ TEST(SmartLists, EnablementIsLogicallyConsistentWhenInterfacedThroughResponder)
 
     [webView _toggleSmartLists:nil];
     EXPECT_TRUE([webView _isSmartListsEnabled]);
+    EXPECT_TRUE([userDefaultsValue() boolValue]);
+
+    // Case 3: user default => true, preference => false
+
+    setSmartListsPreference(configuration.get(), NO);
+    setUserDefaultsValue(YES);
+
+    EXPECT_FALSE([webView _isSmartListsEnabled]);
+    EXPECT_TRUE([userDefaultsValue() boolValue]);
+
+    [webView _setSmartListsEnabled:YES];
+    EXPECT_FALSE([webView _isSmartListsEnabled]);
     EXPECT_TRUE([userDefaultsValue() boolValue]);
 
     // Case 4: user default => true, preference => true


### PR DESCRIPTION
#### 1a86d2229137761f806d0068a8e38dced3a318c1
<pre>
REGRESSION (299884@main): [macOS] Safari AutoFill filling unit tests are hanging
<a href="https://bugs.webkit.org/show_bug.cgi?id=299379">https://bugs.webkit.org/show_bug.cgi?id=299379</a>
<a href="https://rdar.apple.com/160980482">rdar://160980482</a>

Reviewed by Richard Robinson and Abrar Rahman Protyasha.

Partially revert logic introduced in 299884@main, which observes changes to all user defaults in
order to update smart lists enablement. This was only necessary for the scenario where the user
default is modified by the user or app, through the command line or `NSUserDefaults` API.
Importantly, these user defaults still persist across app launches, and also update correctly as
the user uses the context menu or other UI that&apos;s integrated with `-[WKWebView _toggleSmartLists:]`.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/SmartLists.mm

* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(WebKit::WebProcessPool::registerNotificationObservers):
(WebKit::WebProcessPool::unregisterNotificationObservers):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SmartLists.mm:
(TEST(SmartLists, EnablementIsLogicallyConsistentWhenInterfacedThroughResponder)):

Adjust an API test by moving the `user default =&gt; nil, preference =&gt; true` test case up to the
start, when the user default is (initially) set to `nil`.

Canonical link: <a href="https://commits.webkit.org/300414@main">https://commits.webkit.org/300414@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e3e1a8fc3847f0e9c40e330e93db4f8a18be66aa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122460 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42168 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32853 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/129058 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/74559 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/da48463a-2164-4128-a5ed-9aa52846a3c4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/124336 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42886 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50761 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93083 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/74559 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9dce13fa-af15-4c6e-a295-4ea3153be860) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125412 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34202 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109651 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73735 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/10bfee03-acfe-43fc-814e-a47b7d809d6f) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/33191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27807 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72545 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103844 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28018 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/131788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49401 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37598 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/131788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49775 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105871 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/131788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25753 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/46870 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25012 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/46169 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49259 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/55007 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/48726 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/52076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50408 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->