### PR TITLE
[JSC] Simplify BBQJIT::addF32Copysign

### DIFF
--- a/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
@@ -1286,6 +1286,18 @@ public:
             m_assembler.andnpd_rr(src, dst);
     }
 
+    void absFloat(FPRegisterID src, FPRegisterID dst)
+    {
+        if (supportsAVX()) {
+            m_assembler.vpslld_i8rr(1, src, dst);
+            m_assembler.vpsrld_i8rr(1, dst, dst);
+        } else {
+            moveDouble(src, dst);
+            m_assembler.pslld_i8r(1, dst);
+            m_assembler.psrld_i8r(1, dst);
+        }
+    }
+
     void negateDouble(FPRegisterID src, FPRegisterID dst)
     {
         ASSERT(src != dst);
@@ -1295,6 +1307,17 @@ public:
             m_assembler.vxorpd_rrr(src, dst, dst);
         else
             m_assembler.xorpd_rr(src, dst);
+    }
+
+    void negateFloat(FPRegisterID src, FPRegisterID dst)
+    {
+        ASSERT(src != dst);
+        static constexpr float negativeZeroConstant = -0.0f;
+        loadFloat(TrustedImmPtr(&negativeZeroConstant), dst);
+        if (supportsAVX())
+            m_assembler.vxorps_rrr(src, dst, dst);
+        else
+            m_assembler.xorps_rr(src, dst);
     }
 
     void ceilDouble(FPRegisterID src, FPRegisterID dst)

--- a/Source/JavaScriptCore/assembler/X86Assembler.h
+++ b/Source/JavaScriptCore/assembler/X86Assembler.h
@@ -3776,6 +3776,13 @@ public:
         m_formatter.immediate8(whichWord);
     }
 
+    void pslld_i8r(uint8_t imm8, XMMRegisterID dst)
+    {
+        m_formatter.prefix(PRE_SSE_66);
+        m_formatter.twoByteOp8(OP2_PSLLD_UdqIb, GROUP14_OP_PSLLD, (RegisterID)dst);
+        m_formatter.immediate8(imm8);
+    }
+
     void psllq_i8r(int imm, XMMRegisterID dst)
     {
         m_formatter.prefix(PRE_SSE_66);


### PR DESCRIPTION
#### e0651af57025a59af5f46f37ec2cf377878ca18d
<pre>
[JSC] Simplify BBQJIT::addF32Copysign
<a href="https://bugs.webkit.org/show_bug.cgi?id=299383">https://bugs.webkit.org/show_bug.cgi?id=299383</a>

Reviewed by Yusuke Suzuki.

This PR simplifies the BBQJIT::addF32Copysign implementation by using fp
instructions on all platforms.

In some cases, we were converting the fps to scalar to perform part or all of the
copy sign operation, especially on x86_64, where a couple of float operations
were missing. These are now also implemented.

* Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h:
(JSC::MacroAssemblerX86_64::absFloat):
(JSC::MacroAssemblerX86_64::negateFloat):
* Source/JavaScriptCore/assembler/X86Assembler.h:
(JSC::X86Assembler::pslld_i8r):
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::addF32Copysign):

Canonical link: <a href="https://commits.webkit.org/300704@main">https://commits.webkit.org/300704@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cdf7ccb9f14b23bd2bcf7fe5f4216006f3c9f009

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122947 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42661 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33358 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/129600 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/75055 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43384 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51255 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93468 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62034 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125898 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34589 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110052 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74108 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33569 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28206 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73099 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/115106 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104297 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28417 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132329 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/121478 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49896 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37990 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101970 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50273 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106258 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101840 "Found 3 new API test failures: TestWTF:CompletionHandlerDeathTest.MainThreadHandlerOnThreadAssertsDeathTest, WebKitGTK/TestInspector:/webkit/WebKitWebInspector/manual-attach-detach, TestWTF:CompletionHandlerDeathTest.ConstructionThreadHandlerOnThreadAssertsDeathTest (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25997 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47192 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25387 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/46670 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49752 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/55512 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/151743 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49219 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/38804 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/52571 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50901 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->