### PR TITLE
Encode whether zoom should be applied at style building or use time in the CSS::Range

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -3350,6 +3350,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     style/values/primitives/StyleRatio.h
     style/values/primitives/StyleURL.h
     style/values/primitives/StyleUnevaluatedCalculation.h
+    style/values/primitives/StyleZoomNeededToken.h
 
     style/values/rhythm/StyleBlockStepSize.h
 

--- a/Source/WebCore/accessibility/AXTableHelpers.cpp
+++ b/Source/WebCore/accessibility/AXTableHelpers.cpp
@@ -196,8 +196,8 @@ bool isDataTableWithTraversal(HTMLTableElement& tableElement, AXObjectCache& cac
     CheckedPtr<const RenderStyle> tableStyle = safeStyleFrom(tableElement);
     // Store the background color of the table to check against cell's background colors.
     Color tableBackgroundColor = tableStyle ? tableStyle->visitedDependentColor(CSSPropertyBackgroundColor) : Color::white;
-    unsigned tableHorizontalBorderSpacing = tableStyle ? Style::evaluate(tableStyle->borderHorizontalSpacing(), 1.0f /* FIXME ZOOM EFFECTED? */) : 0;
-    unsigned tableVerticalBorderSpacing = tableStyle ? Style::evaluate(tableStyle->borderVerticalSpacing(), 1.0f /* FIXME ZOOM EFFECTED? */) : 0;
+    unsigned tableHorizontalBorderSpacing = tableStyle ? tableStyle->borderHorizontalSpacing().resolveZoom(Style::ZoomNeeded { }) : 0;
+    unsigned tableVerticalBorderSpacing = tableStyle ? tableStyle->borderVerticalSpacing().resolveZoom(Style::ZoomNeeded { }) : 0;
 
     unsigned cellCount = 0;
     unsigned borderedCellCount = 0;

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -949,7 +949,7 @@ Path AccessibilityRenderObject::elementPath() const
         if (!needsPath)
             return { };
 
-        float outlineOffset = Style::evaluate(style.outlineOffset(), 1.0f /* FIXME ZOOM EFFECTED? */);
+        float outlineOffset = Style::evaluate(style.outlineOffset(), Style::ZoomNeeded { });
         float deviceScaleFactor = renderText->document().deviceScaleFactor();
         Vector<FloatRect> pixelSnappedRects;
         for (auto rect : rects) {

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp
@@ -793,7 +793,7 @@ AccessibilityObjectAtspi::TextAttributes AccessibilityObjectAtspi::textAttribute
         addAttributeIfNeeded("invisible"_s, style.visibility() == Visibility::Hidden ? "true"_s : "false"_s);
         addAttributeIfNeeded("editable"_s, m_coreObject->canSetValueAttribute() ? "true"_s : "false"_s);
         addAttributeIfNeeded("direction"_s, style.writingMode().isBidiLTR() ? "ltr"_s : "rtl"_s);
-        addAttributeIfNeeded("indent"_s, makeString(Style::evaluate(style.textIndent().length, m_coreObject->size().width(), 1.0f /* FIXME FIND ZOOM */)));
+        addAttributeIfNeeded("indent"_s, makeString(Style::evaluate(style.textIndent().length, m_coreObject->size().width(), Style::ZoomNeeded { })));
 
         switch (style.textAlign()) {
         case TextAlignMode::Start:

--- a/Source/WebCore/animation/ScrollTimeline.cpp
+++ b/Source/WebCore/animation/ScrollTimeline.cpp
@@ -318,13 +318,6 @@ ScrollableArea* ScrollTimeline::scrollableAreaForSourceRenderer(const RenderElem
     return renderBox->hasLayer() ? renderBox->layer()->scrollableArea() : nullptr;
 }
 
-float ScrollTimeline::floatValueForOffset(const Length& offset, float maxValue)
-{
-    if (offset.isNormal() || offset.isAuto())
-        return 0.f;
-    return floatValueForLength(offset, maxValue, 1.0f /* FIXME FIND ZOOM */);
-}
-
 Style::SingleAnimationRange ScrollTimeline::defaultRange() const
 {
     return Style::SingleAnimationRange::defaultForScrollTimeline();
@@ -352,7 +345,7 @@ std::pair<WebAnimationTime, WebAnimationTime> ScrollTimeline::intervalForAttachm
     auto computedPercentageIfNecessary = [&](const auto& rangeOffset) {
         if (auto percentage = rangeOffset.tryPercentage())
             return percentage->value;
-        return Style::evaluate(rangeOffset, maxScrollOffset, 1.0f /* FIXME FIND ZOOM */) / maxScrollOffset * 100;
+        return Style::evaluate(rangeOffset, maxScrollOffset, Style::ZoomNeeded { }) / maxScrollOffset * 100;
     };
 
     return {

--- a/Source/WebCore/animation/ScrollTimeline.h
+++ b/Source/WebCore/animation/ScrollTimeline.h
@@ -92,7 +92,6 @@ protected:
         float rangeStart { 0 };
         float rangeEnd { 0 };
     };
-    static float floatValueForOffset(const Length&, float);
     virtual Data computeTimelineData() const;
 
     static ScrollableArea* scrollableAreaForSourceRenderer(const RenderElement*, Document&);

--- a/Source/WebCore/animation/ViewTimeline.cpp
+++ b/Source/WebCore/animation/ViewTimeline.cpp
@@ -376,14 +376,14 @@ void ViewTimeline::cacheCurrentTime()
         float insetEnd = 0;
 
         if (m_insets.start().isAuto())
-            insetStart = Style::evaluate(scrollPadding(PaddingEdge::Start), scrollContainerSize, 1.0f /* FIXME FIND ZOOM */);
+            insetStart = Style::evaluate(scrollPadding(PaddingEdge::Start), scrollContainerSize, Style::ZoomNeeded { });
         else
-            insetStart = Style::evaluate(m_insets.start(), scrollContainerSize, 1.0f /* FIXME FIND ZOOM */);
+            insetStart = Style::evaluate(m_insets.start(), scrollContainerSize, Style::ZoomNeeded { });
 
         if (m_insets.end().isAuto())
-            insetEnd = Style::evaluate(scrollPadding(PaddingEdge::End), scrollContainerSize, 1.0f /* FIXME FIND ZOOM */);
+            insetEnd = Style::evaluate(scrollPadding(PaddingEdge::End), scrollContainerSize, Style::ZoomNeeded { });
         else
-            insetEnd = Style::evaluate(m_insets.end(), scrollContainerSize, 1.0f /* FIXME FIND ZOOM */);
+            insetEnd = Style::evaluate(m_insets.end(), scrollContainerSize, Style::ZoomNeeded { });
 
         StickinessAdjustmentData stickyData;
         if (auto stickyContainer = dynamicDowncast<RenderBoxModelObject>(this->stickyContainer())) {
@@ -583,7 +583,7 @@ std::pair<double, double> ViewTimeline::offsetIntervalForAttachmentRange(const S
     auto offsetForSingleTimelineRange = [&](const auto& rangeToConvert) {
         auto [conversionRangeStart, conversionRangeEnd] = intervalForTimelineRangeName(data, rangeToConvert.name());
         auto conversionRange = conversionRangeEnd - conversionRangeStart;
-        auto convertedValue = Style::evaluate(rangeToConvert.offset(), conversionRange, 1.0f /* FIXME FIND ZOOM */);
+        auto convertedValue = Style::evaluate(rangeToConvert.offset(), conversionRange, Style::ZoomNeeded { });
         auto position = conversionRangeStart + convertedValue;
         return (position - data.rangeStart) / timelineRange;
     };
@@ -604,7 +604,7 @@ std::pair<WebAnimationTime, WebAnimationTime> ViewTimeline::intervalForAttachmen
 
     auto computeTime = [&](const auto& rangeToConvert) {
         auto mappedOffset = mapOffsetToTimelineRange(data, rangeToConvert.name(), [&](const float& subjectRange) {
-            return Style::evaluate(rangeToConvert.offset(), subjectRange, 1.0f /* FIXME FIND ZOOM */);
+            return Style::evaluate(rangeToConvert.offset(), subjectRange, Style::ZoomNeeded { });
         });
         return WebAnimationTime::fromPercentage(mappedOffset * 100);
     };

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+IntegerDefinitions.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+IntegerDefinitions.h
@@ -53,7 +53,7 @@ template<typename Primitive, typename Validator> struct NumberConsumerForInteger
 
         auto rawValue = typename Primitive::Raw { CSS::IntegerUnit::Integer, range.peek().numericValue() };
 
-        if constexpr (rawValue.range.options != CSS::RangeOptions::Default)
+        if constexpr (rawValue.range.clampOptions != CSS::RangeClampOptions::Default)
             rawValue = performParseTimeClamp(rawValue);
 
         if (!Validator::isValid(rawValue, options))

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+MetaConsumerDefinitions.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+MetaConsumerDefinitions.h
@@ -123,13 +123,13 @@ template<typename Raw> bool isValidCanonicalValue(Raw raw)
 // Shared clamping utility.
 template<typename Raw> Raw performParseTimeClamp(Raw raw)
 {
-    static_assert(raw.range.options != CSS::RangeOptions::Default);
+    static_assert(raw.range.clampOptions != CSS::RangeClampOptions::Default);
 
-    if constexpr (raw.range.options == CSS::RangeOptions::ClampLower)
+    if constexpr (raw.range.clampOptions == CSS::RangeClampOptions::ClampLower)
         return { std::max<typename Raw::ResolvedValueType>(raw.value, raw.range.min) };
-    else if constexpr (raw.range.options == CSS::RangeOptions::ClampUpper)
+    else if constexpr (raw.range.clampOptions == CSS::RangeClampOptions::ClampUpper)
         return { std::min<typename Raw::ResolvedValueType>(raw.value, raw.range.max) };
-    else if constexpr (raw.range.options == CSS::RangeOptions::ClampBoth)
+    else if constexpr (raw.range.clampOptions == CSS::RangeClampOptions::ClampBoth)
         return { std::clamp<typename Raw::ResolvedValueType>(raw.value, raw.range.min, raw.range.max) };
 }
 
@@ -149,7 +149,7 @@ template<typename Primitive, typename Validator> struct DimensionConsumer {
 
         auto rawValue = typename Primitive::Raw { *validatedUnit, token.numericValue() };
 
-        if constexpr (rawValue.range.options != CSS::RangeOptions::Default)
+        if constexpr (rawValue.range.clampOptions != CSS::RangeClampOptions::Default)
             rawValue = performParseTimeClamp(rawValue);
 
         if (!Validator::isValid(rawValue, options))
@@ -170,7 +170,7 @@ template<typename Primitive, typename Validator> struct PercentageConsumer {
 
         auto rawValue = typename Primitive::Raw { CSS::PercentageUnit::Percentage, range.peek().numericValue() };
 
-        if constexpr (rawValue.range.options != CSS::RangeOptions::Default)
+        if constexpr (rawValue.range.clampOptions != CSS::RangeClampOptions::Default)
             rawValue = performParseTimeClamp(rawValue);
 
         if (!Validator::isValid(rawValue, options))
@@ -191,7 +191,7 @@ template<typename Primitive, typename Validator> struct NumberConsumer {
 
         auto rawValue = typename Primitive::Raw { CSS::NumberUnit::Number, range.peek().numericValue() };
 
-        if constexpr (rawValue.range.options != CSS::RangeOptions::Default)
+        if constexpr (rawValue.range.clampOptions != CSS::RangeClampOptions::Default)
             rawValue = performParseTimeClamp(rawValue);
 
         if (!Validator::isValid(rawValue, options))
@@ -216,7 +216,7 @@ template<typename Primitive, typename Validator, auto unit> struct NumberConsume
 
         auto rawValue = typename Primitive::Raw { unit, numericValue };
 
-        if constexpr (rawValue.range.options != CSS::RangeOptions::Default)
+        if constexpr (rawValue.range.clampOptions != CSS::RangeClampOptions::Default)
             rawValue = performParseTimeClamp(rawValue);
 
         if (!Validator::isValid(rawValue, options))

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -3364,18 +3364,18 @@ void Document::pageSizeAndMarginsInPixels(int pageIndex, IntSize& pageSize, int&
         },
         [&](const Style::PageSize::Lengths& lengths) -> IntSize {
             return {
-                static_cast<int>(lengths.width().evaluate(1.0f /* FIXME FIND ZOOM */)),
-                static_cast<int>(lengths.height().evaluate(1.0f /* FIXME FIND ZOOM */)),
+                static_cast<int>(lengths.width().resolveZoom(Style::ZoomNeeded { })),
+                static_cast<int>(lengths.height().resolveZoom(Style::ZoomNeeded { })),
             };
         }
     );
 
     // The percentage is calculated with respect to the width even for margin top and bottom.
     // http://www.w3.org/TR/CSS2/box.html#margin-properties
-    marginTop = style->marginTop().isAuto() ? marginTop : Style::evaluate(style->marginTop(), pageSize.width(), 1.0f /* FIXME FIND ZOOM */);
-    marginRight = style->marginRight().isAuto() ? marginRight : Style::evaluate(style->marginRight(), pageSize.width(), 1.0f /* FIXME FIND ZOOM */);
-    marginBottom = style->marginBottom().isAuto() ? marginBottom : Style::evaluate(style->marginBottom(), pageSize.width(), 1.0f /* FIXME FIND ZOOM */);
-    marginLeft = style->marginLeft().isAuto() ? marginLeft : Style::evaluate(style->marginLeft(), pageSize.width(), 1.0f /* FIXME FIND ZOOM */);
+    marginTop = style->marginTop().isAuto() ? marginTop : Style::evaluate(style->marginTop(), pageSize.width(), Style::ZoomNeeded { });
+    marginRight = style->marginRight().isAuto() ? marginRight : Style::evaluate(style->marginRight(), pageSize.width(), Style::ZoomNeeded { });
+    marginBottom = style->marginBottom().isAuto() ? marginBottom : Style::evaluate(style->marginBottom(), pageSize.width(), Style::ZoomNeeded { });
+    marginLeft = style->marginLeft().isAuto() ? marginLeft : Style::evaluate(style->marginLeft(), pageSize.width(), Style::ZoomNeeded { });
 }
 
 void Document::fontsNeedUpdate(FontSelector&)

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -4625,8 +4625,8 @@ FontAttributes Editor::fontAttributesAtSelectionStart()
         [&](const auto& shadows) {
             return FontShadow {
                 style->colorWithColorFilter(shadows[0].color),
-                { shadows[0].location.x().evaluate(1.0f /* FIXME FIND ZOOM */), shadows[0].location.y().evaluate(1.0f /* FIXME FIND ZOOM */) },
-                shadows[0].blur.evaluate(1.0f /* FIXME FIND ZOOM */)
+                { shadows[0].location.x().resolveZoom(Style::ZoomNeeded { }), shadows[0].location.y().resolveZoom(Style::ZoomNeeded { }) },
+                shadows[0].blur.resolveZoom(Style::ZoomNeeded { })
             };
         }
     );

--- a/Source/WebCore/html/NumberInputType.cpp
+++ b/Source/WebCore/html/NumberInputType.cpp
@@ -310,7 +310,7 @@ float NumberInputType::decorationWidth(float inputWidth) const
 
         // FIXME <https://webkit.org/b/294858>: This is incorrect for anything other than fixed widths.
         if (auto fixedLogicalWidth = spinButton->computedStyle()->logicalWidth().tryFixed())
-            width += fixedLogicalWidth->evaluate(1.0f /* FIXME FIND ZOOM */);
+            width += fixedLogicalWidth->resolveZoom(Style::ZoomNeeded { });
         else if (auto percentageLogicalWidth = spinButton->computedStyle()->logicalWidth().tryPercentage()) {
             auto percentageLogicalWidthValue = percentageLogicalWidth->value;
             if (percentageLogicalWidthValue != 100.f)

--- a/Source/WebCore/html/SearchInputType.cpp
+++ b/Source/WebCore/html/SearchInputType.cpp
@@ -199,12 +199,12 @@ float SearchInputType::decorationWidth(float) const
     if (RefPtr resultsButton = m_resultsButton; resultsButton && resultsButton->renderStyle()) {
         // FIXME: Document what invariant holds to allow only using fixed logical widths?
         if (auto fixedLogicalWidth = resultsButton->renderStyle()->logicalWidth().tryFixed())
-            width += fixedLogicalWidth->evaluate(1.0f /* FIXME FIND ZOOM */);
+            width += fixedLogicalWidth->resolveZoom(Style::ZoomNeeded { });
     }
     if (RefPtr cancelButton = m_cancelButton; cancelButton && cancelButton->renderStyle()) {
         // FIXME: Document what invariant holds to allow only using fixed logical widths?
         if (auto fixedLogicalWidth = cancelButton->renderStyle()->logicalWidth().tryFixed())
-            width += fixedLogicalWidth->evaluate(1.0f /* FIXME FIND ZOOM */);
+            width += fixedLogicalWidth->resolveZoom(Style::ZoomNeeded { });
     }
     return width;
 }

--- a/Source/WebCore/layout/Verification.cpp
+++ b/Source/WebCore/layout/Verification.cpp
@@ -190,12 +190,12 @@ static bool outputMismatchingBlockBoxInformationIfNeeded(TextStream& stream, con
         auto marginStart = LayoutUnit { };
         auto& marginStartStyle = layoutBox.style().marginStart();
         if (marginStartStyle.isFixed() || marginStartStyle.isPercent() || marginStartStyle.isCalculated())
-            marginStart = Style::evaluate(marginStartStyle, containingBlockWidth, 1.0f /* FIXME FIND ZOOM */);
+            marginStart = Style::evaluate(marginStartStyle, containingBlockWidth, Style::ZoomNeeded { });
 
         auto marginEnd = LayoutUnit { };
         auto& marginEndStyle = layoutBox.style().marginEnd();
         if (marginEndStyle.isFixed() || marginEndStyle.isPercent() || marginEndStyle.isCalculated())
-            marginEnd = Style::evaluate(marginEndStyle, containingBlockWidth, 1.0f /* FIXME FIND ZOOM */);
+            marginEnd = Style::evaluate(marginEndStyle, containingBlockWidth, Style::ZoomNeeded { });
 
         auto marginBefore = boxGeometry.marginBefore();
         auto marginAfter = boxGeometry.marginAfter();

--- a/Source/WebCore/layout/formattingContexts/FormattingGeometry.cpp
+++ b/Source/WebCore/layout/formattingContexts/FormattingGeometry.cpp
@@ -87,7 +87,7 @@ template<FormattingGeometry::HeightType heightType> std::optional<LayoutUnit> Fo
             return { };
     }
     if (auto fixedHeight = height.tryFixed())
-        return LayoutUnit { fixedHeight->evaluate(1.0f /* FIXME FIND ZOOM */) };
+        return LayoutUnit { fixedHeight->resolveZoom(Style::ZoomNeeded { }) };
 
     if (!containingBlockHeight) {
         if (layoutState().inQuirksMode()) {
@@ -113,7 +113,7 @@ template<FormattingGeometry::HeightType heightType> std::optional<LayoutUnit> Fo
     if (!containingBlockHeight)
         return { };
 
-    return Style::evaluate(height, *containingBlockHeight, 1.0f /* FIXME FIND ZOOM */);
+    return Style::evaluate(height, *containingBlockHeight, Style::ZoomNeeded { });
 }
 
 std::optional<LayoutUnit> FormattingGeometry::computedHeight(const Box& layoutBox, std::optional<LayoutUnit> containingBlockHeight) const
@@ -1084,8 +1084,8 @@ BoxGeometry::Edges FormattingGeometry::computedBorder(const Box& layoutBox) cons
     auto& style = layoutBox.style();
     LOG_WITH_STREAM(FormattingContextLayout, stream << "[Border] -> layoutBox: " << &layoutBox);
     return {
-        { LayoutUnit(Style::evaluate(style.borderLeftWidth(), 1.0f /* FIXME FIND ZOOM */)), LayoutUnit(Style::evaluate(style.borderRightWidth(), 1.0f /* FIXME FIND ZOOM */)) },
-        { LayoutUnit(Style::evaluate(style.borderTopWidth(), 1.0f /* FIXME FIND ZOOM */)), LayoutUnit(Style::evaluate(style.borderBottomWidth(), 1.0f /* FIXME FIND ZOOM */)) },
+        { LayoutUnit(Style::evaluate(style.borderLeftWidth(), Style::ZoomNeeded { })), LayoutUnit(Style::evaluate(style.borderRightWidth(), Style::ZoomNeeded { })) },
+        { LayoutUnit(Style::evaluate(style.borderTopWidth(), Style::ZoomNeeded { })), LayoutUnit(Style::evaluate(style.borderBottomWidth(), Style::ZoomNeeded { })) },
     };
 }
 
@@ -1097,8 +1097,8 @@ BoxGeometry::Edges FormattingGeometry::computedPadding(const Box& layoutBox, con
     auto& style = layoutBox.style();
     LOG_WITH_STREAM(FormattingContextLayout, stream << "[Padding] -> layoutBox: " << &layoutBox);
     return {
-        { Style::evaluate(style.paddingStart(), containingBlockWidth, 1.0f /* FIXME FIND ZOOM */), Style::evaluate(style.paddingEnd(), containingBlockWidth, 1.0f /* FIXME FIND ZOOM */) },
-        { Style::evaluate(style.paddingBefore(), containingBlockWidth, 1.0f /* FIXME FIND ZOOM */), Style::evaluate(style.paddingAfter(), containingBlockWidth, 1.0f /* FIXME FIND ZOOM */) }
+        { Style::evaluate(style.paddingStart(), containingBlockWidth, Style::ZoomNeeded { }), Style::evaluate(style.paddingEnd(), containingBlockWidth, Style::ZoomNeeded { }) },
+        { Style::evaluate(style.paddingBefore(), containingBlockWidth, Style::ZoomNeeded { }), Style::evaluate(style.paddingAfter(), containingBlockWidth, Style::ZoomNeeded { }) }
     };
 }
 

--- a/Source/WebCore/layout/formattingContexts/FormattingGeometry.h
+++ b/Source/WebCore/layout/formattingContexts/FormattingGeometry.h
@@ -27,6 +27,7 @@
 
 #include "FormattingContext.h"
 #include <WebCore/LayoutBoxGeometry.h>
+#include <WebCore/StyleZoomNeededToken.h>
 
 namespace WebCore {
 
@@ -129,14 +130,14 @@ std::optional<LayoutUnit> FormattingGeometry::computedValue(const auto& geometry
 {
     // In general, the computed value resolves the specified value as far as possible without laying out the content.
     if (geometryProperty.isSpecified())
-        return Style::evaluate(geometryProperty, containingBlockWidth, 1.0f /* FIXME FIND ZOOM */);
+        return Style::evaluate(geometryProperty, containingBlockWidth, Style::ZoomNeeded { });
     return { };
 }
 
 std::optional<LayoutUnit> FormattingGeometry::fixedValue(const auto& geometryProperty) const
 {
     if (auto fixed = geometryProperty.tryFixed())
-        return LayoutUnit { fixed->evaluate(1.0f /* FIXME FIND ZOOM */) };
+        return LayoutUnit { fixed->resolveZoom(Style::ZoomNeeded { }) };
     return { };
 }
 

--- a/Source/WebCore/layout/formattingContexts/block/BlockFormattingGeometry.cpp
+++ b/Source/WebCore/layout/formattingContexts/block/BlockFormattingGeometry.cpp
@@ -327,10 +327,10 @@ IntrinsicWidthConstraints BlockFormattingGeometry::intrinsicWidthConstraints(con
     auto fixedMarginBorderAndPadding = [&](auto& layoutBox) {
         auto& style = layoutBox.style();
         return fixedValue(style.marginStart()).value_or(0)
-            + LayoutUnit { Style::evaluate(style.borderLeftWidth(), 1.0f /* FIXME FIND ZOOM */) }
+            + LayoutUnit { Style::evaluate(style.borderLeftWidth(), Style::ZoomNeeded { }) }
             + fixedValue(style.paddingLeft()).value_or(0)
             + fixedValue(style.paddingRight()).value_or(0)
-            + LayoutUnit { Style::evaluate(style.borderRightWidth(), 1.0f /* FIXME FIND ZOOM */) }
+            + LayoutUnit { Style::evaluate(style.borderRightWidth(), Style::ZoomNeeded { }) }
             + fixedValue(style.marginEnd()).value_or(0);
     };
 

--- a/Source/WebCore/layout/formattingContexts/block/BlockFormattingQuirks.cpp
+++ b/Source/WebCore/layout/formattingContexts/block/BlockFormattingQuirks.cpp
@@ -139,7 +139,7 @@ LayoutUnit BlockFormattingQuirks::heightValueOfNearestContainingBlockWithFixedHe
     for (auto& containingBlock : containingBlockChain(layoutBox)) {
         auto containingBlockHeight = containingBlock.style().logicalHeight();
         if (auto fixedContainingBlockHeight = containingBlockHeight.tryFixed())
-            return LayoutUnit(fixedContainingBlockHeight->evaluate(1.0f /* FIXME FIND ZOOM */) - bodyAndDocumentVerticalMarginPaddingAndBorder);
+            return LayoutUnit(fixedContainingBlockHeight->resolveZoom(Style::ZoomNeeded { }) - bodyAndDocumentVerticalMarginPaddingAndBorder);
 
         // If the only fixed value box we find is the ICB, then ignore the body and the document (vertical) margin, padding and border. So much quirkiness.
         // -and it's totally insane because now we freely travel across formatting context boundaries and computed margins are nonexistent.

--- a/Source/WebCore/layout/formattingContexts/flex/FlexFormattingContext.cpp
+++ b/Source/WebCore/layout/formattingContexts/flex/FlexFormattingContext.cpp
@@ -91,9 +91,9 @@ FlexLayout::LogicalFlexItems FlexFormattingContext::convertFlexItemsToLogicalSpa
 
             auto propertyValueForLength = [&](auto& propertyValue, auto availableSize) -> std::optional<LayoutUnit> {
                 if (auto fixedPropertyValue = propertyValue.tryFixed())
-                    return LayoutUnit { fixedPropertyValue->evaluate(1.0f /* FIXME FIND ZOOM */) };
+                    return LayoutUnit { fixedPropertyValue->resolveZoom(Style::ZoomNeeded { }) };
                 if (propertyValue.isSpecified() && availableSize)
-                    return Style::evaluate(propertyValue, *availableSize, 1.0f /* FIXME FIND ZOOM */);
+                    return Style::evaluate(propertyValue, *availableSize, Style::ZoomNeeded { });
                 return { };
             };
 

--- a/Source/WebCore/layout/formattingContexts/flex/FlexFormattingUtils.cpp
+++ b/Source/WebCore/layout/formattingContexts/flex/FlexFormattingUtils.cpp
@@ -93,7 +93,7 @@ LayoutUnit FlexFormattingUtils::mainAxisGapValue(const ElementBox& flexContainer
     auto flexDirection = flexContainer.style().flexDirection();
     auto isMainAxisInlineAxis = flexDirection == FlexDirection::Row || flexDirection == FlexDirection::RowReverse;
     auto& gap = isMainAxisInlineAxis ? flexContainer.style().columnGap() : flexContainer.style().rowGap();
-    return Style::evaluateMinimum(gap, flexContainerContentBoxWidth, 1.0f /* FIXME FIND ZOOM */);
+    return Style::evaluateMinimum(gap, flexContainerContentBoxWidth, Style::ZoomNeeded { });
 }
 
 LayoutUnit FlexFormattingUtils::crossAxisGapValue(const ElementBox& flexContainer, LayoutUnit flexContainerContentBoxHeight)
@@ -102,7 +102,7 @@ LayoutUnit FlexFormattingUtils::crossAxisGapValue(const ElementBox& flexContaine
     auto flexDirection = flexContainer.style().flexDirection();
     auto isMainAxisInlineAxis = flexDirection == FlexDirection::Row || flexDirection == FlexDirection::RowReverse;
     auto& gap = isMainAxisInlineAxis ? flexContainer.style().rowGap() : flexContainer.style().columnGap();
-    return Style::evaluateMinimum(gap, flexContainerContentBoxHeight, 1.0f /* FIXME FIND ZOOM */);
+    return Style::evaluateMinimum(gap, flexContainerContentBoxHeight, Style::ZoomNeeded { });
 }
 
 // flex container  direction  flex item    main axis size

--- a/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
@@ -81,7 +81,7 @@ TrackSizingAlgorithm::UnsizedTracks TrackSizingAlgorithm::initializeTrackSizes(c
             if (minTrackSizingFunction.isLength()) {
                 auto& trackBreadthLength = minTrackSizingFunction.length();
                 if (auto fixedValue = trackBreadthLength.tryFixed())
-                    return LayoutUnit { fixedValue->evaluate(1.0f /* FIXME FIND ZOOM */) };
+                    return LayoutUnit { fixedValue->resolveZoom(Style::ZoomNeeded { }) };
 
                 if (auto percentValue = trackBreadthLength.tryPercentage()) {
                     ASSERT_NOT_IMPLEMENTED_YET();
@@ -108,7 +108,7 @@ TrackSizingAlgorithm::UnsizedTracks TrackSizingAlgorithm::initializeTrackSizes(c
             if (maxTrackSizingFunction.isLength()) {
                 auto trackBreadthLength = maxTrackSizingFunction.length();
                 if (auto fixedValue = trackBreadthLength.tryFixed())
-                    return LayoutUnit { fixedValue->evaluate(1.0f /* FIXME FIND ZOOM */) };
+                    return LayoutUnit { fixedValue->resolveZoom(Style::ZoomNeeded { }) };
             }
 
             // An intrinsic sizing function

--- a/Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.cpp
@@ -179,7 +179,7 @@ InlineLayoutUnit InlineFormattingUtils::computedTextIndent(IsIntrinsicWidthMode 
         // https://drafts.csswg.org/css-text/#text-indent-property
         return { };
     }
-    return Style::evaluate(textIndentLength, availableWidth, 1.0f /* FIXME ZOOM EFFECTED? */);
+    return Style::evaluate(textIndentLength, availableWidth, Style::ZoomNeeded { });
 }
 
 InlineLayoutUnit InlineFormattingUtils::initialLineHeight(bool isFirstLine) const

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLevelBoxInlines.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLevelBoxInlines.h
@@ -40,7 +40,7 @@ template<typename PreferredLineHeightFunctor> InlineLevelBox::VerticalAlignment 
             return keyword;
         },
         [&](const Style::VerticalAlign::Length& length) -> InlineLevelBox::VerticalAlignment {
-            return InlineLayoutUnit { Style::evaluate(length, std::forward<PreferredLineHeightFunctor>(preferredLineHeightFunctor), 1.0f /* FIXME FIND ZOOM */) };
+            return InlineLayoutUnit { Style::evaluate(length, std::forward<PreferredLineHeightFunctor>(preferredLineHeightFunctor), Style::ZoomNeeded { }) };
         }
     );
 }

--- a/Source/WebCore/layout/formattingContexts/table/TableFormattingContext.cpp
+++ b/Source/WebCore/layout/formattingContexts/table/TableFormattingContext.cpp
@@ -363,7 +363,7 @@ IntrinsicWidthConstraints TableFormattingContext::computedPreferredWidthForColum
             auto columnIndex = cellPosition.column;
             WTF::switchOn(cellStyle.logicalWidth(),
                 [&](const Style::PreferredSize::Fixed& fixed) {
-                    auto fixedWidth = LayoutUnit { fixed.evaluate(1.0f /* FIXME FIND ZOOM */) } + horizontalBorderAndPaddingWidth;
+                    auto fixedWidth = LayoutUnit { fixed.resolveZoom(Style::ZoomNeeded { }) } + horizontalBorderAndPaddingWidth;
                     maximumFixedColumnWidths[columnIndex] = std::max(maximumFixedColumnWidths[columnIndex].value_or(0_lu), fixedWidth);
                     hasColumnWithFixedWidth = true;
                 },

--- a/Source/WebCore/layout/formattingContexts/table/TableFormattingQuirks.cpp
+++ b/Source/WebCore/layout/formattingContexts/table/TableFormattingQuirks.cpp
@@ -63,7 +63,7 @@ LayoutUnit TableFormattingQuirks::heightValueOfNearestContainingBlockWithFixedHe
     // e.g <div style="height: 100px"><table><tr><td style="height: 100%"></td></tr></table></div> is resolved to 0px.
     for (auto& ancestor : containingBlockChainWithinFormattingContext(layoutBox, formattingContext().root())) {
         if (auto fixedHeight = ancestor.style().logicalHeight().tryFixed())
-            return LayoutUnit { fixedHeight->evaluate(1.0f /* FIXME FIND ZOOM */) };
+            return LayoutUnit { fixedHeight->resolveZoom(Style::ZoomNeeded { }) };
     }
     return { };
 }

--- a/Source/WebCore/layout/formattingContexts/table/TableFormattingState.cpp
+++ b/Source/WebCore/layout/formattingContexts/table/TableFormattingState.cpp
@@ -42,8 +42,8 @@ static UniqueRef<TableGrid> ensureTableGrid(const ElementBox& tableBox)
     auto tableGrid = makeUniqueRef<TableGrid>();
     auto& tableStyle = tableBox.style();
     auto shouldApplyBorderSpacing = tableStyle.borderCollapse() == BorderCollapse::Separate;
-    tableGrid->setHorizontalSpacing(LayoutUnit { shouldApplyBorderSpacing ? Style::evaluate(tableStyle.borderHorizontalSpacing(), 1.0f /* FIXME FIND ZOOM */) : 0 });
-    tableGrid->setVerticalSpacing(LayoutUnit { shouldApplyBorderSpacing ? Style::evaluate(tableStyle.borderVerticalSpacing(), 1.0f /* FIXME FIND ZOOM */) : 0 });
+    tableGrid->setHorizontalSpacing(LayoutUnit { shouldApplyBorderSpacing ? tableStyle.borderHorizontalSpacing().resolveZoom(Style::ZoomNeeded { }) : 0 });
+    tableGrid->setVerticalSpacing(LayoutUnit { shouldApplyBorderSpacing ? tableStyle.borderVerticalSpacing().resolveZoom(Style::ZoomNeeded { }) : 0 });
 
     auto* firstChild = tableBox.firstChild();
     if (!firstChild) {

--- a/Source/WebCore/layout/formattingContexts/table/TableLayout.cpp
+++ b/Source/WebCore/layout/formattingContexts/table/TableLayout.cpp
@@ -339,7 +339,7 @@ TableFormattingContext::TableLayout::DistributedSpaces TableFormattingContext::T
                 return { std::nullopt, GridSpace::Type::Auto };
             },
             [&](const Style::Length<CSS::Nonnegative, float>& fixed) -> std::pair<std::optional<float>, GridSpace::Type> {
-                return { fixed.evaluate(1.0f /* FIXME FIND ZOOM */), GridSpace::Type::Fixed };
+                return { fixed.resolveZoom(Style::ZoomNeeded { }), GridSpace::Type::Fixed };
             },
             [&](const Style::Percentage<CSS::Nonnegative, float>& percentage) -> std::pair<std::optional<float>, GridSpace::Type> {
                 return { Style::evaluate(percentage, availableHorizontalSpace), GridSpace::Type::Percent };

--- a/Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.cpp
@@ -74,23 +74,23 @@ namespace LayoutIntegration {
 static LayoutUnit usedValueOrZero(const Style::MarginEdge& marginEdge, std::optional<LayoutUnit> availableWidth)
 {
     if (auto fixed = marginEdge.tryFixed())
-        return LayoutUnit { fixed->evaluate(1.0f /* FIXME FIND ZOOM */) };
+        return LayoutUnit { fixed->resolveZoom(Style::ZoomNeeded { }) };
 
     if (marginEdge.isAuto() || !availableWidth)
         return { };
 
-    return Style::evaluateMinimum(marginEdge, *availableWidth, 1.0f /* FIXME FIND ZOOM */);
+    return Style::evaluateMinimum(marginEdge, *availableWidth, Style::ZoomNeeded { });
 }
 
 static LayoutUnit usedValueOrZero(const Style::PaddingEdge& paddingEdge, std::optional<LayoutUnit> availableWidth)
 {
     if (auto fixed = paddingEdge.tryFixed())
-        return LayoutUnit { fixed->evaluate(1.0f /* FIXME FIND ZOOM */) };
+        return LayoutUnit { fixed->resolveZoom(Style::ZoomNeeded { }) };
 
     if (!availableWidth)
         return { };
 
-    return Style::evaluateMinimum(paddingEdge, *availableWidth, 1.0f /* FIXME FIND ZOOM */);
+    return Style::evaluateMinimum(paddingEdge, *availableWidth, Style::ZoomNeeded { });
 }
 
 static inline void adjustBorderForTableAndFieldset(const RenderBoxModelObject& renderer, RectEdges<LayoutUnit>& borderWidths)
@@ -241,7 +241,7 @@ Layout::BoxGeometry::Edges BoxGeometryUpdater::logicalBorder(const RenderBoxMode
     auto& style = renderer.style();
 
     auto borderWidths = RectEdges<LayoutUnit>::map(style.borderWidth(), [](auto width) {
-        return LayoutUnit { Style::evaluate(width, 1.0f /* FIXME ZOOM EFFECTED? */) };
+        return LayoutUnit { Style::evaluate(width, Style::ZoomNeeded { }) };
     });
 
     if (!isIntrinsicWidthMode)

--- a/Source/WebCore/layout/integration/flex/LayoutIntegrationFlexLayout.cpp
+++ b/Source/WebCore/layout/integration/flex/LayoutIntegrationFlexLayout.cpp
@@ -73,7 +73,7 @@ static inline Layout::ConstraintsForFlexContent constraintsForFlexContent(const 
 
     auto widthValue = [&](auto& computedValue) -> std::optional<LayoutUnit> {
         if (auto fixedWidth = computedValue.tryFixed())
-            return LayoutUnit { boxSizingIsContentBox ? fixedWidth->evaluate(1.0f /* FIXME FIND ZOOM */) : fixedWidth->evaluate(1.0f /* FIXME FIND ZOOM */) - horizontalMarginBorderAndPadding };
+            return LayoutUnit { boxSizingIsContentBox ? fixedWidth->resolveZoom(Style::ZoomNeeded { }) : fixedWidth->resolveZoom(Style::ZoomNeeded { }) - horizontalMarginBorderAndPadding };
 
         if (auto percentageWidth = computedValue.tryPercentage()) {
             auto value = Style::evaluate(*percentageWidth, flexContainerRenderer.containingBlock()->logicalWidth());
@@ -84,14 +84,14 @@ static inline Layout::ConstraintsForFlexContent constraintsForFlexContent(const 
 
     auto heightValue = [&](auto& computedValue, bool callRendererForPercentValue = false) -> std::optional<LayoutUnit> {
         if (auto fixedHeight = computedValue.tryFixed())
-            return LayoutUnit { boxSizingIsContentBox ? fixedHeight->evaluate(1.0f /* FIXME FIND ZOOM */) : fixedHeight->evaluate(1.0f /* FIXME FIND ZOOM */) - verticalMarginBorderAndPadding };
+            return LayoutUnit { boxSizingIsContentBox ? fixedHeight->resolveZoom(Style::ZoomNeeded { }) : fixedHeight->resolveZoom(Style::ZoomNeeded { }) - verticalMarginBorderAndPadding };
 
         if (auto percentageHeight = computedValue.tryPercentage()) {
             if (callRendererForPercentValue)
                 return flexContainerRenderer.computePercentageLogicalHeight(*percentageHeight, RenderBox::UpdatePercentageHeightDescendants::No);
 
             if (auto fixedContainingBlockHeight = flexContainerRenderer.containingBlock()->style().height().tryFixed()) {
-                auto value = Style::evaluate(*percentageHeight, fixedContainingBlockHeight->evaluate(1.0f /* FIXME FIND ZOOM */));
+                auto value = Style::evaluate(*percentageHeight, fixedContainingBlockHeight->resolveZoom(Style::ZoomNeeded { }));
                 return LayoutUnit { boxSizingIsContentBox ? value : value - verticalMarginBorderAndPadding };
             }
         }

--- a/Source/WebCore/layout/layouttree/LayoutElementBox.cpp
+++ b/Source/WebCore/layout/layouttree/LayoutElementBox.cpp
@@ -208,7 +208,7 @@ LayoutUnit ElementBox::intrinsicWidth() const
         return m_replacedData->intrinsicSize->width();
 
     // FIXME: Document what invariant holds to allow not checking if the logicalWidth() is fixed.
-    return LayoutUnit { style().logicalWidth().tryFixed()->evaluate(1.0f /* FIXME FIND ZOOM */) };
+    return LayoutUnit { style().logicalWidth().tryFixed()->resolveZoom(Style::ZoomNeeded { }) };
 }
 
 LayoutUnit ElementBox::intrinsicHeight() const
@@ -218,7 +218,7 @@ LayoutUnit ElementBox::intrinsicHeight() const
         return m_replacedData->intrinsicSize->height();
 
     // FIXME: Document what invariant holds to allow not checking if the logicalHeight() is fixed.
-    return LayoutUnit { style().logicalHeight().tryFixed()->evaluate(1.0f /* FIXME FIND ZOOM */) };;
+    return LayoutUnit { style().logicalHeight().tryFixed()->resolveZoom(Style::ZoomNeeded { }) };;
 }
 
 LayoutUnit ElementBox::intrinsicRatio() const

--- a/Source/WebCore/page/IntersectionObserver.cpp
+++ b/Source/WebCore/page/IntersectionObserver.cpp
@@ -216,7 +216,7 @@ static String marginBoxToString(const IntersectionObserverMarginBox& marginBox)
         if (auto percentage = edge.tryPercentage())
             stringBuilder.append(static_cast<int>(percentage->value), "%"_s, side != BoxSide::Left ? " "_s : ""_s);
         else
-            stringBuilder.append(static_cast<int>(edge.tryFixed()->evaluate(1.0f /* FIXME FIND ZOOM */)), "px"_s, side != BoxSide::Left ? " "_s : ""_s);
+            stringBuilder.append(static_cast<int>(edge.tryFixed()->resolveZoom(Style::ZoomNeeded { })), "px"_s, side != BoxSide::Left ? " "_s : ""_s);
     }
     return stringBuilder.toString();
 }
@@ -334,7 +334,7 @@ static void expandRootBoundsWithRootMargin(FloatRect& rootBounds, const Intersec
     auto zoomAdjustedLength = [](const IntersectionObserverMarginEdge& edge, float maximumValue, float zoomFactor) {
         if (auto percentage = edge.tryPercentage())
             return Style::evaluate(*percentage, maximumValue);
-        return edge.tryFixed()->evaluate(zoomFactor);
+        return edge.tryFixed()->resolveZoom(Style::ZoomNeeded { }) * zoomFactor;
     };
 
     auto rootMarginEdges = FloatBoxExtent {
@@ -372,12 +372,11 @@ static std::optional<LayoutRect> computeClippedRectInRootContentsSpace(const Lay
         return absoluteClippedRect;
 
     auto frameRect = renderer->view().frameView().layoutViewportRect();
-    float zoom = 1.0f; /* FIXME FIND ZOOM */
     auto scrollMarginEdges = LayoutBoxExtent {
-        LayoutUnit(static_cast<int>(Style::evaluate(scrollMargin.top(), frameRect.height(), zoom))),
-        LayoutUnit(static_cast<int>(Style::evaluate(scrollMargin.right(), frameRect.width(), zoom))),
-        LayoutUnit(static_cast<int>(Style::evaluate(scrollMargin.bottom(), frameRect.height(), zoom))),
-        LayoutUnit(static_cast<int>(Style::evaluate(scrollMargin.left(), frameRect.width(), zoom)))
+        LayoutUnit(static_cast<int>(Style::evaluate(scrollMargin.top(), frameRect.height(), Style::ZoomNeeded { }))),
+        LayoutUnit(static_cast<int>(Style::evaluate(scrollMargin.right(), frameRect.width(), Style::ZoomNeeded { }))),
+        LayoutUnit(static_cast<int>(Style::evaluate(scrollMargin.bottom(), frameRect.height(), Style::ZoomNeeded { }))),
+        LayoutUnit(static_cast<int>(Style::evaluate(scrollMargin.left(), frameRect.width(), Style::ZoomNeeded { })))
     };
     frameRect.expand(scrollMarginEdges);
 

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -681,7 +681,7 @@ void LocalFrameView::applyPaginationToViewport()
         if (!columnGap.isNormal()) {
             auto* renderBox = dynamicDowncast<RenderBox>(documentOrBodyRenderer);
             if (auto* containerForPaginationGap = renderBox ? renderBox : documentOrBodyRenderer->containingBlock())
-                pagination.gap = Style::evaluate(columnGap, containerForPaginationGap->contentBoxLogicalWidth(), 1.0f /* FIXME FIND ZOOM */).toUnsigned();
+                pagination.gap = Style::evaluate(columnGap, containerForPaginationGap->contentBoxLogicalWidth(), Style::ZoomNeeded { }).toUnsigned();
         }
     }
     setPagination(pagination);
@@ -2464,7 +2464,7 @@ std::pair<FixedContainerEdges, WeakElementEdges> LocalFrameView::fixedContainerE
         if (!border->isVisible())
             return samplingRect;
 
-        auto borderWidth = Style::evaluate(border->width(), 1.0f /* FIXME FIND ZOOM */);
+        auto borderWidth = Style::evaluate(border->width(), Style::ZoomNeeded { });
         if (borderWidth > thinBorderWidth)
             return samplingRect;
 

--- a/Source/WebCore/page/PrintContext.cpp
+++ b/Source/WebCore/page/PrintContext.cpp
@@ -109,10 +109,10 @@ FloatBoxExtent PrintContext::computedPageMargin(FloatBoxExtent printMargin)
     auto marginLeft = style->marginLeft().tryFixed();
 
     return {
-        marginTop ? marginTop->evaluate(1.0f /* FIXME FIND ZOOM */) * pixelToPointScaleFactor : printMargin.top(),
-        marginRight ? marginRight->evaluate(1.0f /* FIXME FIND ZOOM */) * pixelToPointScaleFactor : printMargin.right(),
-        marginBottom ? marginBottom->evaluate(1.0f /* FIXME FIND ZOOM */) * pixelToPointScaleFactor : printMargin.bottom(),
-        marginLeft ? marginLeft->evaluate(1.0f /* FIXME FIND ZOOM */) * pixelToPointScaleFactor : printMargin.left(),
+        marginTop ? marginTop->resolveZoom(Style::ZoomNeeded { }) * pixelToPointScaleFactor : printMargin.top(),
+        marginRight ? marginRight->resolveZoom(Style::ZoomNeeded { }) * pixelToPointScaleFactor : printMargin.right(),
+        marginBottom ? marginBottom->resolveZoom(Style::ZoomNeeded { }) * pixelToPointScaleFactor : printMargin.bottom(),
+        marginLeft ? marginLeft->resolveZoom(Style::ZoomNeeded { }) * pixelToPointScaleFactor : printMargin.left(),
     };
 }
 
@@ -389,7 +389,7 @@ String PrintContext::pageProperty(LocalFrame* frame, const String& propertyName,
     // Implement formatters for properties we care about.
     if (propertyName == "margin-left"_s) {
         if (auto marginLeft = style->marginLeft().tryFixed())
-            return String::number(marginLeft->evaluate(1.0f /* FIXME FIND ZOOM */));
+            return String::number(marginLeft->resolveZoom(Style::ZoomNeeded { }));
         return autoAtom();
     }
     if (propertyName == "line-height"_s)
@@ -410,7 +410,7 @@ String PrintContext::pageProperty(LocalFrame* frame, const String& propertyName,
                 return "portrait"_s;
             },
             [&](const Style::PageSize::Lengths& lengths) {
-                return makeString(lengths.width().evaluate(1.0f /* FIXME FIND ZOOM */), ' ', lengths.height().evaluate(1.0f /* FIXME FIND ZOOM */));
+                return makeString(lengths.width().resolveZoom(Style::ZoomNeeded { }), ' ', lengths.height().resolveZoom(Style::ZoomNeeded { }));
             }
         );
     }

--- a/Source/WebCore/page/SpatialNavigation.cpp
+++ b/Source/WebCore/page/SpatialNavigation.cpp
@@ -523,9 +523,9 @@ LayoutRect nodeRectInAbsoluteCoordinates(const ContainerNode& containerNode, boo
         // the rect of the focused element.
         if (ignoreBorder) {
             auto& style = renderer->style();
-            rect.move(Style::evaluate(style.borderLeftWidth(), 1.0f /* FIXME FIND ZOOM */), Style::evaluate(style.borderTopWidth(), 1.0f /* FIXME FIND ZOOM */));
-            rect.setWidth(rect.width() - Style::evaluate(style.borderLeftWidth(), 1.0f /* FIXME FIND ZOOM */) - Style::evaluate(style.borderRightWidth(), 1.0f /* FIXME FIND ZOOM */));
-            rect.setHeight(rect.height() - Style::evaluate(style.borderTopWidth(), 1.0f /* FIXME FIND ZOOM */) - Style::evaluate(style.borderBottomWidth(), 1.0f /* FIXME FIND ZOOM */));
+            rect.move(Style::evaluate(style.borderLeftWidth(), Style::ZoomNeeded { }), Style::evaluate(style.borderTopWidth(), Style::ZoomNeeded { }));
+            rect.setWidth(rect.width() - Style::evaluate(style.borderLeftWidth(), Style::ZoomNeeded { }) - Style::evaluate(style.borderRightWidth(), Style::ZoomNeeded { }));
+            rect.setHeight(rect.height() - Style::evaluate(style.borderTopWidth(), Style::ZoomNeeded { }) - Style::evaluate(style.borderBottomWidth(), Style::ZoomNeeded { }));
         }
         return rect;
     }

--- a/Source/WebCore/page/ios/ContentChangeObserver.cpp
+++ b/Source/WebCore/page/ios/ContentChangeObserver.cpp
@@ -111,13 +111,13 @@ bool ContentChangeObserver::isVisuallyHidden(const Node& node)
     auto fixedTop = style.logicalTop().tryFixed();
     auto fixedLeft = style.logicalLeft().tryFixed();
     // FIXME: This is trying to check if the element is outside of the viewport. This is incorrect for many reasons.
-    if (fixedLeft && fixedWidth && -fixedLeft->evaluate(1.0f /* FIXME FIND ZOOM */) >= fixedWidth->evaluate(1.0f /* FIXME FIND ZOOM */))
+    if (fixedLeft && fixedWidth && -fixedLeft->resolveZoom(Style::ZoomNeeded { }) >= fixedWidth->resolveZoom(Style::ZoomNeeded { }))
         return true;
-    if (fixedTop && fixedHeight && -fixedTop->evaluate(1.0f /* FIXME FIND ZOOM */) >= fixedHeight->evaluate(1.0f /* FIXME FIND ZOOM */))
+    if (fixedTop && fixedHeight && -fixedTop->resolveZoom(Style::ZoomNeeded { }) >= fixedHeight->resolveZoom(Style::ZoomNeeded { }))
         return true;
 
     // It's a common technique used to position content offscreen.
-    if (style.hasOutOfFlowPosition() && fixedLeft && fixedLeft->evaluate(1.0f /* FIXME FIND ZOOM */) <= -999)
+    if (style.hasOutOfFlowPosition() && fixedLeft && fixedLeft->resolveZoom(Style::ZoomNeeded { }) <= -999)
         return true;
 
     // FIXME: Check for other cases like zero height with overflow hidden.
@@ -148,9 +148,9 @@ bool ContentChangeObserver::isConsideredVisible(const Node& node)
     // 1px width or height content is not considered visible.
     auto& style = *node.renderStyle();
 
-    if (auto fixedWidth = style.logicalWidth().tryFixed(); fixedWidth && fixedWidth->evaluate(1.0f /* FIXME FIND ZOOM */) <= 1)
+    if (auto fixedWidth = style.logicalWidth().tryFixed(); fixedWidth && fixedWidth->resolveZoom(Style::ZoomNeeded { }) <= 1)
         return false;
-    if (auto fixedHeight = style.logicalHeight().tryFixed(); fixedHeight && fixedHeight->evaluate(1.0f /* FIXME FIND ZOOM */) <= 1)
+    if (auto fixedHeight = style.logicalHeight().tryFixed(); fixedHeight && fixedHeight->resolveZoom(Style::ZoomNeeded { }) <= 1)
         return false;
     return true;
 }

--- a/Source/WebCore/page/scrolling/ScrollSnapOffsetsInfo.cpp
+++ b/Source/WebCore/page/scrolling/ScrollSnapOffsetsInfo.cpp
@@ -254,7 +254,7 @@ static std::pair<LayoutType, std::optional<unsigned>> closestSnapOffsetWithInfoA
 static LayoutRect computeScrollSnapPortRect(const Style::ScrollPaddingBox& padding, const LayoutRect& rect)
 {
     auto result = rect;
-    result.contract(Style::extentForRect(padding, rect, 1.0f /* FIXME ZOOM EFFECTED? */));
+    result.contract(Style::extentForRect(padding, rect, Style::ZoomNeeded { }));
     return result;
 }
 

--- a/Source/WebCore/platform/graphics/PathUtilities.cpp
+++ b/Source/WebCore/platform/graphics/PathUtilities.cpp
@@ -506,7 +506,7 @@ Path PathUtilities::pathWithShrinkWrappedRectsForOutline(const Vector<FloatRect>
     float outlineOffset, WritingMode writingMode, float deviceScaleFactor)
 {
     auto roundedRect = [radii, outlineOffset, deviceScaleFactor](const FloatRect& rect) {
-        auto adjustedRadii = adjustedRadiiForHuggingCurve(Style::evaluate(radii, rect.size(), 1.0f /* FIXME FIND ZOOM */), outlineOffset);
+        auto adjustedRadii = adjustedRadiiForHuggingCurve(Style::evaluate(radii, rect.size(), Style::ZoomNeeded { }), outlineOffset);
         adjustedRadii.scale(calcBorderRadiiConstraintScaleFor(rect, adjustedRadii));
 
         LayoutRoundedRect roundedRect(
@@ -543,8 +543,8 @@ Path PathUtilities::pathWithShrinkWrappedRectsForOutline(const Vector<FloatRect>
     auto firstLineRect = isLeftToRight ? rects.at(0) : rects.at(rects.size() - 1);
     auto lastLineRect = isLeftToRight ? rects.at(rects.size() - 1) : rects.at(0);
     // Adjust radius so that it matches the box border.
-    auto firstLineRadii = Style::evaluate(radii, firstLineRect.size(), 1.0f /* FIXME FIND ZOOM */);
-    auto lastLineRadii = Style::evaluate(radii, lastLineRect.size(), 1.0f /* FIXME FIND ZOOM */);
+    auto firstLineRadii = Style::evaluate(radii, firstLineRect.size(), Style::ZoomNeeded { });
+    auto lastLineRadii = Style::evaluate(radii, lastLineRect.size(), Style::ZoomNeeded { });
     firstLineRadii.scale(calcBorderRadiiConstraintScaleFor(firstLineRect, firstLineRadii));
     lastLineRadii.scale(calcBorderRadiiConstraintScaleFor(lastLineRect, lastLineRadii));
 

--- a/Source/WebCore/rendering/BackgroundPainter.cpp
+++ b/Source/WebCore/rendering/BackgroundPainter.cpp
@@ -179,8 +179,8 @@ static void applyBoxShadowForBackground(GraphicsContext& context, const RenderSt
         if (shadow.inset)
             continue;
 
-        FloatSize shadowOffset(shadow.location.x().evaluate(1.0f /* FIXME FIND ZOOM */), shadow.location.y().evaluate(1.0f /* FIXME FIND ZOOM */));
-        context.setDropShadow({ shadowOffset, shadow.blur.evaluate(1.0f /* FIXME FIND ZOOM */), style.colorWithColorFilter(shadow.color), shadow.isWebkitBoxShadow ? ShadowRadiusMode::Legacy : ShadowRadiusMode::Default });
+        FloatSize shadowOffset(shadow.location.x().resolveZoom(Style::ZoomNeeded { }), shadow.location.y().resolveZoom(Style::ZoomNeeded { }));
+        context.setDropShadow({ shadowOffset, shadow.blur.resolveZoom(Style::ZoomNeeded { }), style.colorWithColorFilter(shadow.color), shadow.isWebkitBoxShadow ? ShadowRadiusMode::Legacy : ShadowRadiusMode::Default });
         break;
     }
 }
@@ -679,7 +679,7 @@ template<typename Layer> BackgroundImageGeometry BackgroundPainter::calculateFil
 
     LayoutSize spaceSize;
     LayoutSize phase;
-    auto computedXPosition = Style::evaluate(fillLayer.xPosition(), availableWidth, 1.0f /* FIXME FIND ZOOM */);
+    auto computedXPosition = Style::evaluate(fillLayer.xPosition(), availableWidth, Style::ZoomNeeded { });
     if (backgroundRepeatX == FillRepeat::Round && positioningAreaSize.width() > 0 && tileSize.width() > 0) {
         int numTiles = std::max(1, roundToInt(positioningAreaSize.width() / tileSize.width()));
         if (!fillLayer.size().specifiedHeight() && backgroundRepeatY != FillRepeat::Round)
@@ -689,7 +689,7 @@ template<typename Layer> BackgroundImageGeometry BackgroundPainter::calculateFil
         phase.setWidth(tileSize.width() ? tileSize.width() - fmodf((computedXPosition + left), tileSize.width()) : 0);
     }
 
-    auto computedYPosition = Style::evaluate(fillLayer.yPosition(), availableHeight, 1.0f /* FIXME FIND ZOOM */);
+    auto computedYPosition = Style::evaluate(fillLayer.yPosition(), availableHeight, Style::ZoomNeeded { });
     if (backgroundRepeatY == FillRepeat::Round && positioningAreaSize.height() > 0 && tileSize.height() > 0) {
         int numTiles = std::max(1, roundToInt(positioningAreaSize.height() / tileSize.height()));
         if (!fillLayer.size().specifiedWidth() && backgroundRepeatX != FillRepeat::Round)
@@ -799,17 +799,17 @@ template<typename Layer> LayoutSize BackgroundPainter::calculateFillTileSize(con
             auto layerHeight = size.height();
 
             if (auto fixed = layerWidth.tryFixed())
-                tileSize.setWidth(fixed->evaluate(1.0f /* FIXME FIND ZOOM */));
+                tileSize.setWidth(fixed->resolveZoom(Style::ZoomNeeded { }));
             else if (layerWidth.isPercentOrCalculated()) {
-                auto resolvedWidth = Style::evaluate(layerWidth, positioningAreaSize.width(), 1.0f /* FIXME FIND ZOOM */);
+                auto resolvedWidth = Style::evaluate(layerWidth, positioningAreaSize.width(), Style::ZoomNeeded { });
                 // Non-zero resolved value should always produce some content.
                 tileSize.setWidth(!resolvedWidth ? resolvedWidth : std::max(devicePixelSize, resolvedWidth));
             }
 
             if (auto fixed = layerHeight.tryFixed())
-                tileSize.setHeight(fixed->evaluate(1.0f /* FIXME FIND ZOOM */));
+                tileSize.setHeight(fixed->resolveZoom(Style::ZoomNeeded { }));
             else if (layerHeight.isPercentOrCalculated()) {
-                auto resolvedHeight = Style::evaluate(layerHeight, positioningAreaSize.height(), 1.0f /* FIXME FIND ZOOM */);
+                auto resolvedHeight = Style::evaluate(layerHeight, positioningAreaSize.height(), Style::ZoomNeeded { });
                 // Non-zero resolved value should always produce some content.
                 tileSize.setHeight(!resolvedHeight ? resolvedHeight : std::max(devicePixelSize, resolvedHeight));
             }
@@ -851,10 +851,10 @@ void BackgroundPainter::paintBoxShadow(const LayoutRect& paintRect, const Render
         if (Style::shadowStyle(shadow) != shadowStyle)
             continue;
 
-        LayoutSize shadowOffset(shadow.location.x().evaluate(1.0f /* FIXME FIND ZOOM */), shadow.location.y().evaluate(1.0f /* FIXME FIND ZOOM */));
+        LayoutSize shadowOffset(shadow.location.x().resolveZoom(Style::ZoomNeeded { }), shadow.location.y().resolveZoom(Style::ZoomNeeded { }));
         LayoutUnit shadowPaintingExtent = Style::paintingExtent(shadow);
-        LayoutUnit shadowSpread = LayoutUnit(shadow.spread.evaluate(1.0f /* FIXME FIND ZOOM */));
-        auto shadowRadius = shadow.blur.evaluate(1.0f /* FIXME FIND ZOOM */);
+        LayoutUnit shadowSpread = LayoutUnit(shadow.spread.resolveZoom(Style::ZoomNeeded { }));
+        auto shadowRadius = shadow.blur.resolveZoom(Style::ZoomNeeded { });
 
         if (shadowOffset.isZero() && !shadowRadius && !shadowSpread)
             continue;

--- a/Source/WebCore/rendering/BorderEdge.cpp
+++ b/Source/WebCore/rendering/BorderEdge.cpp
@@ -49,18 +49,18 @@ BorderEdge::BorderEdge(float edgeWidth, Color edgeColor, BorderStyle edgeStyle, 
 
 BorderEdges borderEdges(const RenderStyle& style, float deviceScaleFactor, RectEdges<bool> closedEdges, LayoutSize inflation, bool setColorsToBlack)
 {
-    auto constructBorderEdge = [&](Style::LineWidth width, float inflation, CSSPropertyID borderColorProperty, BorderStyle borderStyle, bool isTransparent, bool isPresent) {
+    auto constructBorderEdge = [&](const RenderStyle& style, Style::LineWidth width, float inflation, CSSPropertyID borderColorProperty, BorderStyle borderStyle, bool isTransparent, bool isPresent) {
         auto color = setColorsToBlack ? Color::black : style.visitedDependentColorWithColorFilter(borderColorProperty);
-        auto evaluatedWidth = Style::evaluate(width, 1.0f /* FIXME FIND ZOOM */);
+        auto evaluatedWidth = Style::evaluate(width, Style::ZoomNeeded { });
         auto inflatedWidth = evaluatedWidth ? evaluatedWidth + inflation : evaluatedWidth;
         return BorderEdge(inflatedWidth, color, borderStyle, !setColorsToBlack && isTransparent, isPresent, deviceScaleFactor);
     };
 
     return {
-        constructBorderEdge(style.borderTopWidth(), inflation.height().toFloat(), CSSPropertyBorderTopColor, style.borderTopStyle(), style.borderTopIsTransparent(), closedEdges.top()),
-        constructBorderEdge(style.borderRightWidth(), inflation.width().toFloat(), CSSPropertyBorderRightColor, style.borderRightStyle(), style.borderRightIsTransparent(), closedEdges.right()),
-        constructBorderEdge(style.borderBottomWidth(), inflation.height().toFloat(), CSSPropertyBorderBottomColor, style.borderBottomStyle(), style.borderBottomIsTransparent(), closedEdges.bottom()),
-        constructBorderEdge(style.borderLeftWidth(), inflation.width().toFloat(), CSSPropertyBorderLeftColor, style.borderLeftStyle(), style.borderLeftIsTransparent(), closedEdges.left())
+        constructBorderEdge(style, style.borderTopWidth(), inflation.height().toFloat(), CSSPropertyBorderTopColor, style.borderTopStyle(), style.borderTopIsTransparent(), closedEdges.top()),
+        constructBorderEdge(style, style.borderRightWidth(), inflation.width().toFloat(), CSSPropertyBorderRightColor, style.borderRightStyle(), style.borderRightIsTransparent(), closedEdges.right()),
+        constructBorderEdge(style, style.borderBottomWidth(), inflation.height().toFloat(), CSSPropertyBorderBottomColor, style.borderBottomStyle(), style.borderBottomIsTransparent(), closedEdges.bottom()),
+        constructBorderEdge(style, style.borderLeftWidth(), inflation.width().toFloat(), CSSPropertyBorderLeftColor, style.borderLeftStyle(), style.borderLeftIsTransparent(), closedEdges.left())
     };
 }
 
@@ -68,7 +68,7 @@ BorderEdges borderEdgesForOutline(const RenderStyle& style, BorderStyle borderSt
 {
     auto color = style.visitedDependentColorWithColorFilter(CSSPropertyOutlineColor);
     auto isTransparent = color.isValid() && !color.isVisible();
-    auto size = Style::evaluate(style.outlineWidth(), 1.0f /* FIXME FIND ZOOM */);
+    auto size = Style::evaluate(style.outlineWidth(), Style::ZoomNeeded { });
     return {
         BorderEdge { size, color, borderStyle, isTransparent, true, deviceScaleFactor },
         BorderEdge { size, color, borderStyle, isTransparent, true, deviceScaleFactor },

--- a/Source/WebCore/rendering/BorderPainter.cpp
+++ b/Source/WebCore/rendering/BorderPainter.cpp
@@ -309,8 +309,8 @@ void BorderPainter::paintOutline(const LayoutRect& paintRect) const
     if (!borderStyle || *borderStyle == BorderStyle::None)
         return;
 
-    auto outlineWidth = LayoutUnit { Style::evaluate(styleToUse.outlineWidth(), 1.0f /* FIXME ZOOM EFFECTED? */) };
-    auto outlineOffset = LayoutUnit { Style::evaluate(styleToUse.outlineOffset(), 1.0f /* FIXME ZOOM EFFECTED? */) };
+    auto outlineWidth = LayoutUnit { Style::evaluate(styleToUse.outlineWidth(), Style::ZoomNeeded { }) };
+    auto outlineOffset = LayoutUnit { Style::evaluate(styleToUse.outlineOffset(), Style::ZoomNeeded { }) };
 
     auto outerRect = paintRect;
     outerRect.inflate(outlineOffset + outlineWidth);
@@ -351,8 +351,8 @@ void BorderPainter::paintOutline(const LayoutPoint& paintOffset, const Vector<La
     }
 
     auto& styleToUse = m_renderer->style();
-    auto outlineOffset = Style::evaluate(styleToUse.outlineOffset(), 1.0f /* FIXME ZOOM EFFECTED? */);
-    auto outlineWidth = Style::evaluate(styleToUse.outlineWidth(), 1.0f /* FIXME ZOOM EFFECTED? */);
+    auto outlineOffset = Style::evaluate(styleToUse.outlineOffset(), Style::ZoomNeeded { });
+    auto outlineWidth = Style::evaluate(styleToUse.outlineWidth(), Style::ZoomNeeded { });
     auto deviceScaleFactor = document().deviceScaleFactor();
 
     Vector<FloatRect> pixelSnappedRects;

--- a/Source/WebCore/rendering/BorderShape.cpp
+++ b/Source/WebCore/rendering/BorderShape.cpp
@@ -43,7 +43,7 @@ namespace WebCore {
 BorderShape BorderShape::shapeForBorderRect(const RenderStyle& style, const LayoutRect& borderRect, RectEdges<bool> closedEdges)
 {
     auto borderWidths = RectEdges<LayoutUnit>::map(style.borderWidth(), [](auto width) {
-        return LayoutUnit { Style::evaluate(width, 1.0f /* FIXME ZOOM EFFECTED? */) };
+        return LayoutUnit { Style::evaluate(width, Style::ZoomNeeded { }) };
     });
     return shapeForBorderRect(style, borderRect, borderWidths, closedEdges);
 }
@@ -59,7 +59,7 @@ BorderShape BorderShape::shapeForBorderRect(const RenderStyle& style, const Layo
     };
 
     if (style.hasBorderRadius()) {
-        auto radii = Style::evaluate(style.borderRadii(), borderRect.size(), 1.0f/* FIXME ZOOM EFFECTED? */);
+        auto radii = Style::evaluate(style.borderRadii(), borderRect.size(), Style::ZoomNeeded { });
         radii.scale(calcBorderRadiiConstraintScaleFor(borderRect, radii));
 
         if (!closedEdges.top()) {
@@ -99,7 +99,7 @@ BorderShape BorderShape::shapeForOutsetRect(const RenderStyle& style, const Layo
     };
 
     if (style.hasBorderRadius()) {
-        auto radii = Style::evaluate(style.borderRadii(), borderRect.size(), 1.0f /* FIXME ZOOM EFFECTED? */);
+        auto radii = Style::evaluate(style.borderRadii(), borderRect.size(), Style::ZoomNeeded { });
 
         auto leftOutset = std::max(borderRect.x() - outlineBoxRect.x(), 0_lu);
         auto topOutset = std::max(borderRect.y() - outlineBoxRect.y(), 0_lu);
@@ -138,7 +138,7 @@ BorderShape BorderShape::shapeForOutsetRect(const RenderStyle& style, const Layo
 BorderShape BorderShape::shapeForInsetRect(const RenderStyle& style, const LayoutRect& borderRect, const LayoutRect& insetRect)
 {
     if (style.hasBorderRadius()) {
-        auto radii = Style::evaluate(style.borderRadii(), borderRect.size(), 1.0f /* FIXME ZOOM EFFECTED? */);
+        auto radii = Style::evaluate(style.borderRadii(), borderRect.size(), Style::ZoomNeeded { });
 
         auto leftInset = std::max(insetRect.x() - borderRect.x(), 0_lu);
         auto topInset = std::max(insetRect.y()- borderRect.y(), 0_lu);

--- a/Source/WebCore/rendering/EllipsisBoxPainter.cpp
+++ b/Source/WebCore/rendering/EllipsisBoxPainter.cpp
@@ -69,7 +69,7 @@ void EllipsisBoxPainter::paint()
             return false;
         },
         [&](const auto& shadows) {
-            context.setDropShadow({ LayoutSize(shadows[0].location.x().evaluate(1.0f /* FIXME FIND ZOOM */), shadows[0].location.y().evaluate(1.0f /* FIXME FIND ZOOM */)), shadows[0].blur.evaluate(1.0f /* FIXME FIND ZOOM */), style.colorWithColorFilter(shadows[0].color), ShadowRadiusMode::Default });
+            context.setDropShadow({ LayoutSize(shadows[0].location.x().resolveZoom(Style::ZoomNeeded { }), shadows[0].location.y().resolveZoom(Style::ZoomNeeded { })), shadows[0].blur.resolveZoom(Style::ZoomNeeded { }), style.colorWithColorFilter(shadows[0].color), ShadowRadiusMode::Default });
             return true;
         }
     );

--- a/Source/WebCore/rendering/FixedTableLayout.cpp
+++ b/Source/WebCore/rendering/FixedTableLayout.cpp
@@ -101,7 +101,7 @@ float FixedTableLayout::calcWidthArray()
         auto colStyleLogicalWidth = col->style().logicalWidth();
         float effectiveColWidth = 0;
         if (auto fixedColStyleLogicalWidth = colStyleLogicalWidth.tryFixed(); fixedColStyleLogicalWidth && fixedColStyleLogicalWidth->isPositive())
-            effectiveColWidth = fixedColStyleLogicalWidth->evaluate(1.0f /* FIXME FIND ZOOM */);
+            effectiveColWidth = fixedColStyleLogicalWidth->resolveZoom(Style::ZoomNeeded { });
         else if (colStyleLogicalWidth.isCalculated())
             colStyleLogicalWidth = CSS::Keyword::Auto { };
 
@@ -122,7 +122,7 @@ float FixedTableLayout::calcWidthArray()
                 spanInCurrentEffectiveColumn = m_table->spanOfEffCol(currentEffectiveColumn);
             }
             if (auto fixedColStyleLogicalWidth = colStyleLogicalWidth.tryFixed(); fixedColStyleLogicalWidth && fixedColStyleLogicalWidth->isPositive()) {
-                m_width[currentEffectiveColumn] = Style::PreferredSize::Fixed { fixedColStyleLogicalWidth->evaluate(1.0f /* FIXME FIND ZOOM */) * spanInCurrentEffectiveColumn };
+                m_width[currentEffectiveColumn] = Style::PreferredSize::Fixed { fixedColStyleLogicalWidth->resolveZoom(Style::ZoomNeeded { }) * spanInCurrentEffectiveColumn };
                 usedWidth += effectiveColWidth * spanInCurrentEffectiveColumn;
             } else if (auto percentageColStyleLogicalWidth = colStyleLogicalWidth.tryPercentage(); percentageColStyleLogicalWidth && percentageColStyleLogicalWidth->value > 0) {
                 m_width[currentEffectiveColumn] = Style::PreferredSize::Percentage { percentageColStyleLogicalWidth->value * spanInCurrentEffectiveColumn };
@@ -159,7 +159,7 @@ float FixedTableLayout::calcWidthArray()
             // Only set if no col element has already set it.
             if (m_width[currentColumn].isAuto() && !logicalWidth.isAuto()) {
                 if (auto fixedLogicalWidth = logicalWidth.tryFixed())
-                    m_width[currentColumn] = Style::PreferredSize::Fixed { fixedLogicalWidth->evaluate(1.0f /* FIXME FIND ZOOM */) * eSpan / span };
+                    m_width[currentColumn] = Style::PreferredSize::Fixed { fixedLogicalWidth->resolveZoom(Style::ZoomNeeded { }) * eSpan / span };
                 else if (auto percentageLogicalWidth = logicalWidth.tryPercentage())
                     m_width[currentColumn] = Style::PreferredSize::Percentage { percentageLogicalWidth->value * eSpan / span };
                 usedWidth += fixedBorderBoxLogicalWidth * eSpan / span;
@@ -187,7 +187,7 @@ void FixedTableLayout::applyPreferredLogicalWidthQuirks(LayoutUnit& minWidth, La
 {
     auto& tableLogicalWidth = m_table->style().logicalWidth();
     if (auto fixedTableLogicalWidth = tableLogicalWidth.tryFixed(); fixedTableLogicalWidth && fixedTableLogicalWidth->isPositive())
-        minWidth = maxWidth = std::max(minWidth, LayoutUnit(fixedTableLogicalWidth->evaluate(1.0f /* FIXME FIND ZOOM */)) - m_table->bordersPaddingAndSpacingInRowDirection());
+        minWidth = maxWidth = std::max(minWidth, LayoutUnit(fixedTableLogicalWidth->resolveZoom(Style::ZoomNeeded { })) - m_table->bordersPaddingAndSpacingInRowDirection());
 
     /*
         <table style="width:100%; background-color:red"><tr><td>
@@ -232,7 +232,7 @@ void FixedTableLayout::layout()
     // to 10px here, and will scale up to 20px in the final (80px, 20px).
     for (unsigned i = 0; i < nEffCols; i++) {
         if (auto fixedWidth = m_width[i].tryFixed()) {
-            calcWidth[i] = fixedWidth->evaluate(1.0f /* FIXME FIND ZOOM */);
+            calcWidth[i] = fixedWidth->resolveZoom(Style::ZoomNeeded { });
             totalFixedWidth += calcWidth[i];
         } else if (auto percentageWidth = m_width[i].tryPercentage()) {
             calcWidth[i] = Style::evaluate(*percentageWidth, tableLogicalWidth);

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
@@ -263,7 +263,7 @@ LayoutUnit GridTrackSizingAlgorithm::initialBaseSize(const Style::GridTrackSize&
 
     auto& trackLength = gridLength.length();
     if (trackLength.isSpecified())
-        return Style::evaluate(trackLength, std::max<LayoutUnit>(availableSpace().value_or(0), 0), 1.0f /* FIXME ZOOM EFFECTED? */);
+        return Style::evaluate(trackLength, std::max<LayoutUnit>(availableSpace().value_or(0), 0), Style::ZoomNeeded { });
 
     ASSERT(trackLength.isMinContent() || trackLength.isAuto() || trackLength.isMaxContent());
     return 0;
@@ -277,7 +277,7 @@ LayoutUnit GridTrackSizingAlgorithm::initialGrowthLimit(const Style::GridTrackSi
 
     auto& trackLength = gridLength.length();
     if (trackLength.isSpecified())
-        return Style::evaluate(trackLength, std::max<LayoutUnit>(availableSpace().value_or(0), 0), 1.0f /* FIXME ZOOM EFFECTED? */);
+        return Style::evaluate(trackLength, std::max<LayoutUnit>(availableSpace().value_or(0), 0), Style::ZoomNeeded { });
 
     ASSERT(trackLength.isMinContent() || trackLength.isAuto() || trackLength.isMaxContent());
     return infinity;
@@ -300,7 +300,7 @@ void GridTrackSizingAlgorithm::sizeTrackToFitSingleSpanMasonryGroup(const GridSp
     else if (trackSize.hasMaxContentOrAutoMaxTrackBreadth()) {
         auto growthLimit = masonryIndefiniteItems.maxContentSize;
         if (trackSize.isFitContent())
-            growthLimit = std::min(growthLimit, Style::evaluate(trackSize.fitContentTrackLength(), availableSpace().value_or(0), 1.0f /* FIXME ZOOM EFFECTED? */));
+            growthLimit = std::min(growthLimit, Style::evaluate(trackSize.fitContentTrackLength(), availableSpace().value_or(0), Style::ZoomNeeded { }));
         track.setGrowthLimit(std::max(track.growthLimit(), growthLimit));
     }
 }
@@ -323,7 +323,7 @@ void GridTrackSizingAlgorithm::sizeTrackToFitNonSpanningItem(const GridSpan& spa
     } else if (trackSize.hasMaxContentOrAutoMaxTrackBreadth()) {
         LayoutUnit growthLimit = m_strategy->maxContentContributionForGridItem(gridItem, gridLayoutState);
         if (trackSize.isFitContent())
-            growthLimit = std::min(growthLimit, Style::evaluate(trackSize.fitContentTrackLength(), availableSpace().value_or(0), 1.0f /* FIXME ZOOM EFFECTED? */));
+            growthLimit = std::min(growthLimit, Style::evaluate(trackSize.fitContentTrackLength(), availableSpace().value_or(0), Style::ZoomNeeded { }));
         track.setGrowthLimit(std::max(track.growthLimit(), growthLimit));
     }
 }
@@ -828,7 +828,7 @@ std::optional<LayoutUnit> GridTrackSizingAlgorithm::estimatedGridAreaBreadthForG
         if (maxTrackSize.isContentSized() || maxTrackSize.isFlex() || GridLayoutFunctions::isRelativeGridTrackBreadthAsAuto(maxTrackSize, availableSpace(direction)))
             gridAreaIsIndefinite = true;
         else
-            gridAreaSize += Style::evaluate(maxTrackSize.length(), availableSize.value_or(0_lu), 1.0f /* FIXME ZOOM EFFECTED? */);
+            gridAreaSize += Style::evaluate(maxTrackSize.length(), availableSize.value_or(0_lu), Style::ZoomNeeded { });
     }
 
     gridAreaSize += m_renderGrid->guttersSize(direction, span.startLine(), span.integerSpan(), availableSize);
@@ -1108,7 +1108,7 @@ LayoutUnit GridTrackSizingAlgorithmStrategy::minContentContributionForGridItem(R
             auto gridItemLogicalMinWidth = gridItem.style().logicalMinWidth();
 
             if (auto fixedFridItemLogicalMinWidth = gridItemLogicalMinWidth.tryFixed())
-                return LayoutUnit { fixedFridItemLogicalMinWidth->evaluate(1.0f /* FIXME FIND ZOOM */) };
+                return LayoutUnit { fixedFridItemLogicalMinWidth->resolveZoom(Style::ZoomNeeded { }) };
             if (gridItemLogicalMinWidth.isMaxContent())
                 return gridItem.maxPreferredLogicalWidth();
 
@@ -1193,7 +1193,7 @@ LayoutUnit GridTrackSizingAlgorithmStrategy::minContributionForGridItem(RenderBo
             if (!trackSize.hasFixedMaxTrackBreadth())
                 allFixed = false;
             else if (allFixed)
-                maxBreadth += Style::evaluate(trackSize.maxTrackBreadth().length(), availableSpace().value_or(0_lu), 1.0f /* FIXME ZOOM EFFECTED? */);
+                maxBreadth += Style::evaluate(trackSize.maxTrackBreadth().length(), availableSpace().value_or(0_lu), Style::ZoomNeeded { });
         }
         if (!allFixed)
             return minSize;
@@ -1647,7 +1647,7 @@ void GridTrackSizingAlgorithm::initializeTrackSizes()
         track.setInfinitelyGrowable(false);
 
         if (trackSize.isFitContent())
-            track.setGrowthLimitCap(Style::evaluate(trackSize.fitContentTrackLength(), maxSize, 1.0f /* FIXME ZOOM EFFECTED? */));
+            track.setGrowthLimitCap(Style::evaluate(trackSize.fitContentTrackLength(), maxSize, Style::ZoomNeeded { }));
         if (trackSize.isContentSized())
             m_contentSizedTracksIndex.append(i);
         if (trackSize.maxTrackBreadth().isFlex())
@@ -2041,7 +2041,7 @@ void GridTrackSizingAlgorithm::setup(Style::GridTrackSizingDirection direction, 
             const auto subgridSpan = m_renderGrid->gridSpanForGridItem(subgrid, Style::GridTrackSizingDirection::Columns);
             auto& subgridRowStartMargin = subgrid.style().marginBefore(m_renderGrid->writingMode());
             if (!subgridRowStartMargin.isAuto())
-                m_renderGrid->setMarginBeforeForChild(subgrid, Style::evaluateMinimum(subgridRowStartMargin, computeGridSpanSize(tracks(Style::GridTrackSizingDirection::Columns), subgridSpan, std::make_optional(m_renderGrid->gridItemOffset(direction)), m_renderGrid->guttersSize(Style::GridTrackSizingDirection::Columns, subgridSpan.startLine(), subgridSpan.integerSpan(), this->availableSpace(Style::GridTrackSizingDirection::Columns))), 1.0f /* FIXME ZOOM EFFECTED? */));
+                m_renderGrid->setMarginBeforeForChild(subgrid, Style::evaluateMinimum(subgridRowStartMargin, computeGridSpanSize(tracks(Style::GridTrackSizingDirection::Columns), subgridSpan, std::make_optional(m_renderGrid->gridItemOffset(direction)), m_renderGrid->guttersSize(Style::GridTrackSizingDirection::Columns, subgridSpan.startLine(), subgridSpan.integerSpan(), this->availableSpace(Style::GridTrackSizingDirection::Columns))), Style::ZoomNeeded { }));
         }
     };
     if (m_direction == Style::GridTrackSizingDirection::Rows && (m_sizingState == SizingState::RowSizingFirstIteration || m_sizingState == SizingState::RowSizingSecondIteration))

--- a/Source/WebCore/rendering/MotionPath.cpp
+++ b/Source/WebCore/rendering/MotionPath.cpp
@@ -102,7 +102,7 @@ std::optional<MotionPathData> MotionPath::motionPathDataForRenderer(const Render
                 return offsetFromContainer(renderer, container, referenceRect);
             },
             [&](const Style::Position& position) -> FloatPoint {
-                return Style::evaluate(position, referenceRect.size(), 1.0f /* FIXME ZOOM EFFECTED? */);
+                return Style::evaluate(position, referenceRect.size(), Style::ZoomNeeded { });
             }
         );
     };
@@ -124,7 +124,7 @@ std::optional<MotionPathData> MotionPath::motionPathDataForRenderer(const Render
         [&](const Style::RayPath& offsetPath) {
             auto startingPosition = offsetPath.ray()->position;
             data.usedStartingPosition = startingPosition
-                ? Style::evaluate(*startingPosition, data.containingBlockBoundingRect.rect().size(), 1.0f /* FIXME ZOOM EFFECTED? */)
+                ? Style::evaluate(*startingPosition, data.containingBlockBoundingRect.rect().size(), Style::ZoomNeeded { })
                 : startingPositionForOffsetPosition(offsetPosition, data.containingBlockBoundingRect.rect(), *container);
         },
         [&](const auto&) { }
@@ -136,7 +136,7 @@ std::optional<MotionPathData> MotionPath::motionPathDataForRenderer(const Render
 static PathTraversalState traversalStateAtDistance(const Path& path, const Style::OffsetDistance& distance)
 {
     auto pathLength = path.length();
-    auto distanceValue = Style::evaluate(distance, pathLength, 1.0f /* FIXME ZOOM EFFECTED? */);
+    auto distanceValue = Style::evaluate(distance, pathLength, Style::ZoomNeeded { });
 
     float resolvedLength = 0;
     if (path.isClosed()) {
@@ -158,7 +158,7 @@ void MotionPath::applyMotionPathTransform(TransformationMatrix& matrix, const Tr
     auto anchor = transformOrigin;
     WTF::switchOn(offsetAnchor,
         [&](const Style::Position& position) {
-            anchor = Style::evaluate(position, boundingBox.size(), 1.0f /* FIXME ZOOM EFFECTED? */) + boundingBox.location();
+            anchor = Style::evaluate(position, boundingBox.size(), Style::ZoomNeeded { }) + boundingBox.location();
         },
         [&](const CSS::Keyword::Auto&) { }
     );

--- a/Source/WebCore/rendering/NinePieceImagePainter.cpp
+++ b/Source/WebCore/rendering/NinePieceImagePainter.cpp
@@ -79,7 +79,7 @@ static LayoutUnit computeSlice(const WidthValue& length, LayoutUnit width, Layou
 {
     return WTF::switchOn(length,
         [&](const typename WidthValue::LengthPercentage& value) {
-            return Style::evaluate(value, extent, 1.0f /* FIXME ZOOM EFFECTED? */);
+            return Style::evaluate(value, extent, Style::ZoomNeeded { });
         },
         [&](const typename WidthValue::Number& value) {
             return LayoutUnit { value.value * width };
@@ -230,7 +230,7 @@ static void paintNinePieceImage(const T& ninePieceImage, GraphicsContext& graphi
     ASSERT(styleImage->isLoaded(renderer));
 
     auto sourceSlices      = computeSlices(source, ninePieceImage.slice(), styleImage->imageScaleFactor());
-    auto destinationSlices = computeSlices(destination.size(), ninePieceImage.width(), Style::evaluate(style.borderWidth(), 1.0f /* FIXME ZOOM EFFECTED? */), sourceSlices);
+    auto destinationSlices = computeSlices(destination.size(), ninePieceImage.width(), Style::evaluate(style.borderWidth(), Style::ZoomNeeded { }), sourceSlices);
 
     scaleSlicesIfNeeded(destination.size(), destinationSlices, deviceScaleFactor);
 

--- a/Source/WebCore/rendering/PositionedLayoutConstraints.h
+++ b/Source/WebCore/rendering/PositionedLayoutConstraints.h
@@ -75,10 +75,10 @@ public:
     Style::MarginEdge marginAfter() const { return m_marginAfter; }
     Style::InsetEdge insetBefore() const { return m_insetBefore; }
     Style::InsetEdge insetAfter() const { return m_insetAfter; }
-    LayoutUnit marginBeforeValue() const { return Style::evaluateMinimum(m_marginBefore, m_containingInlineSize, 1.0f /* FIXME ZOOM EFFECTED? */); }
-    LayoutUnit marginAfterValue() const { return Style::evaluateMinimum(m_marginAfter, m_containingInlineSize, 1.0f /* FIXME ZOOM EFFECTED? */); }
-    LayoutUnit insetBeforeValue() const { return Style::evaluateMinimum(m_insetBefore, containingSize(), 1.0f /* FIXME ZOOM EFFECTED? */); }
-    LayoutUnit insetAfterValue() const { return Style::evaluateMinimum(m_insetAfter, containingSize(), 1.0f /* FIXME ZOOM EFFECTED? */); }
+    LayoutUnit marginBeforeValue() const { return Style::evaluateMinimum(m_marginBefore, m_containingInlineSize, Style::ZoomNeeded { }); }
+    LayoutUnit marginAfterValue() const { return Style::evaluateMinimum(m_marginAfter, m_containingInlineSize, Style::ZoomNeeded { }); }
+    LayoutUnit insetBeforeValue() const { return Style::evaluateMinimum(m_insetBefore, containingSize(), Style::ZoomNeeded { }); }
+    LayoutUnit insetAfterValue() const { return Style::evaluateMinimum(m_insetAfter, containingSize(), Style::ZoomNeeded { }); }
 
     LayoutUnit insetModifiedContainingSize() const { return m_insetModifiedContainingRange.size(); }
     LayoutRange insetModifiedContainingRange() const { return m_insetModifiedContainingRange; }

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -771,9 +771,9 @@ LayoutUnit RenderBlock::marginIntrinsicLogicalWidthForChild(RenderBox& child) co
     auto& marginRight = child.style().marginEnd(writingMode());
     LayoutUnit margin;
     if (auto fixedMarginLeft = marginLeft.tryFixed(); fixedMarginLeft && !shouldTrimChildMargin(MarginTrimType::InlineStart, child))
-        margin += fixedMarginLeft->evaluate(1.0f /* FIXME FIND ZOOM */);
+        margin += fixedMarginLeft->resolveZoom(Style::ZoomNeeded { });
     if (auto fixedMarginRight = marginRight.tryFixed(); fixedMarginRight && !shouldTrimChildMargin(MarginTrimType::InlineEnd, child))
-        margin += fixedMarginRight->evaluate(1.0f /* FIXME FIND ZOOM */);
+        margin += fixedMarginRight->resolveZoom(Style::ZoomNeeded { });
     return margin;
 }
 
@@ -1842,7 +1842,7 @@ LayoutUnit RenderBlock::textIndentOffset() const
     LayoutUnit cw;
     if (style().textIndent().length.isPercentOrCalculated())
         cw = contentBoxLogicalWidth();
-    return Style::evaluate(style().textIndent().length, cw, 1.0f /* FIXME ZOOM EFFECTED? */);
+    return Style::evaluate(style().textIndent().length, cw, Style::ZoomNeeded { });
 }
 
 LayoutUnit RenderBlock::logicalLeftOffsetForContent() const
@@ -2225,7 +2225,7 @@ void RenderBlock::computePreferredLogicalWidths()
 
     auto& styleToUse = style();
     auto logicalWidth = overridingLogicalWidthForFlexBasisComputation().value_or(styleToUse.logicalWidth());
-    if (auto fixedLogicalWidth = logicalWidth.tryFixed(); !isRenderTableCell() && fixedLogicalWidth && fixedLogicalWidth->isPositiveOrZero() && !(isDeprecatedFlexItem() && !static_cast<int>(fixedLogicalWidth->evaluate(1.0f /* FIXME FIND ZOOM */)))) {
+    if (auto fixedLogicalWidth = logicalWidth.tryFixed(); !isRenderTableCell() && fixedLogicalWidth && fixedLogicalWidth->isPositiveOrZero() && !(isDeprecatedFlexItem() && !static_cast<int>(fixedLogicalWidth->resolveZoom(Style::ZoomNeeded { })))) {
         m_minPreferredLogicalWidth = adjustContentBoxLogicalWidthForBoxSizing(*fixedLogicalWidth);
         m_maxPreferredLogicalWidth = m_minPreferredLogicalWidth;
     } else if (logicalWidth.isMaxContent()) {
@@ -2291,9 +2291,9 @@ void RenderBlock::computeBlockPreferredLogicalWidths(LayoutUnit& minLogicalWidth
         LayoutUnit marginStart;
         LayoutUnit marginEnd;
         if (auto fixedMarginStart = childStyle.marginStart(writingMode()).tryFixed())
-            marginStart += fixedMarginStart->evaluate(1.0f /* FIXME FIND ZOOM */);
+            marginStart += fixedMarginStart->resolveZoom(Style::ZoomNeeded { });
         if (auto fixedMarginEnd = childStyle.marginEnd(writingMode()).tryFixed())
-            marginEnd += fixedMarginEnd->evaluate(1.0f /* FIXME FIND ZOOM */);
+            marginEnd += fixedMarginEnd->resolveZoom(Style::ZoomNeeded { });
         auto margin = marginStart + marginEnd;
 
         LayoutUnit childMinPreferredLogicalWidth;
@@ -2367,7 +2367,7 @@ void RenderBlock::computeChildPreferredLogicalWidths(RenderBox& childBox, Layout
                 childBox.verticalBorderAndPaddingExtent(),
                 LayoutUnit { childBoxStyle.logicalAspectRatio() },
                 childBoxStyle.boxSizingForAspectRatio(),
-                LayoutUnit { fixedChildBoxStyleLogicalWidth->evaluate(1.0f /* FIXME FIND ZOOM */) },
+                LayoutUnit { fixedChildBoxStyleLogicalWidth->resolveZoom(Style::ZoomNeeded { }) },
                 style().aspectRatio(),
                 isRenderReplaced()
             );
@@ -3051,7 +3051,7 @@ std::optional<LayoutUnit> RenderBlock::availableLogicalHeightForPercentageComput
 
         auto& style = this->style();
         if (auto fixedLogicalHeight = style.logicalHeight().tryFixed()) {
-            auto contentBoxHeight = adjustContentBoxLogicalHeightForBoxSizing(LayoutUnit { fixedLogicalHeight->evaluate(1.0f /* FIXME FIND ZOOM */) });
+            auto contentBoxHeight = adjustContentBoxLogicalHeightForBoxSizing(LayoutUnit { fixedLogicalHeight->resolveZoom(Style::ZoomNeeded { }) });
             return std::max(0_lu, constrainContentBoxLogicalHeightByMinMax(contentBoxHeight - scrollbarLogicalHeight(), { }));
         }
 
@@ -3324,9 +3324,9 @@ bool RenderBlock::computePreferredWidthsForExcludedChildren(LayoutUnit& minWidth
     LayoutUnit marginStart;
     LayoutUnit marginEnd;
     if (auto fixedMarginStart = childStyle.marginStart(writingMode()).tryFixed())
-        marginStart += fixedMarginStart->evaluate(1.0f /* FIXME FIND ZOOM */);
+        marginStart += fixedMarginStart->resolveZoom(Style::ZoomNeeded { });
     if (auto fixedMarginEnd = childStyle.marginEnd(writingMode()).tryFixed())
-        marginEnd += fixedMarginEnd->evaluate(1.0f /* FIXME FIND ZOOM */);
+        marginEnd += fixedMarginEnd->resolveZoom(Style::ZoomNeeded { });
 
     auto margin = marginStart + marginEnd;
 

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -291,7 +291,7 @@ void RenderBlockFlow::adjustIntrinsicLogicalWidthsForColumns(LayoutUnit& minLogi
         LayoutUnit colGap = columnGap();
         LayoutUnit gapExtra = (columnCount - 1) * colGap;
         if (auto columnWidthLength = style().columnWidth().tryLength()) {
-            columnWidth = Style::evaluate(*columnWidthLength, 1.0f /* FIXME ZOOM EFFECTED? */);
+            columnWidth = Style::evaluate(*columnWidthLength, Style::ZoomNeeded { });
             minLogicalWidth = std::min(minLogicalWidth, columnWidth);
         } else
             minLogicalWidth = minLogicalWidth * columnCount + gapExtra;
@@ -355,7 +355,7 @@ LayoutUnit RenderBlockFlow::columnGap() const
 {
     if (style().columnGap().isNormal())
         return LayoutUnit(style().fontDescription().computedSize()); // "1em" is recommended as the normal gap setting. Matches <p> margins.
-    return Style::evaluate(style().columnGap(), contentBoxLogicalWidth(), 1.0f /* FIXME ZOOM EFFECTED? */);
+    return Style::evaluate(style().columnGap(), contentBoxLogicalWidth(), Style::ZoomNeeded { });
 }
 
 void RenderBlockFlow::computeColumnCountAndWidth()
@@ -373,7 +373,7 @@ void RenderBlockFlow::computeColumnCountAndWidth()
 
     LayoutUnit availWidth = desiredColumnWidth;
     LayoutUnit colGap = columnGap();
-    LayoutUnit colWidth = std::max(1_lu, LayoutUnit(Style::evaluate(style().columnWidth().tryLength().value_or(0_css_px), 1.0f /* FIXME ZOOM EFFECTED? */)));
+    LayoutUnit colWidth = std::max(1_lu, LayoutUnit(Style::evaluate(style().columnWidth().tryLength().value_or(0_css_px), Style::ZoomNeeded { })));
     unsigned colCount = std::max<unsigned>(1, style().columnCount().tryValue().value_or(1).value);
 
     if (style().columnWidth().isAuto() && !style().columnCount().isAuto()) {
@@ -1087,7 +1087,7 @@ void RenderBlockFlow::layoutBlockChild(RenderBox& child, MarginInfo& marginInfo,
 
     auto& childStyle = child.style();
     if (auto blockStepSizeForChild = childStyle.blockStepSize().tryLength(); blockStepSizeForChild && BlockStepSizing::childHasSupportedStyle(childStyle))
-        performBlockStepSizing(child, LayoutUnit(blockStepSizeForChild->evaluate(1.0f /* FIXME FIND ZOOM */)));
+        performBlockStepSizing(child, LayoutUnit(blockStepSizeForChild->resolveZoom(Style::ZoomNeeded { })));
 
     // Cache if we are at the top of the block right now.
     bool atBeforeSideOfBlock = marginInfo.atBeforeSideOfBlock();
@@ -4462,7 +4462,7 @@ static LayoutUnit getBorderPaddingMargin(const RenderBoxModelObject& child, bool
 {
     auto borderMarginWidth = [](LayoutUnit childValue, const Style::MarginEdge& margin) -> LayoutUnit {
         if (auto fixed = margin.tryFixed())
-            return LayoutUnit(fixed->evaluate(1.0f /* FIXME FIND ZOOM */));
+            return LayoutUnit(fixed->resolveZoom(Style::ZoomNeeded { }));
         if (margin.isAuto())
             return { };
         return childValue;
@@ -4470,7 +4470,7 @@ static LayoutUnit getBorderPaddingMargin(const RenderBoxModelObject& child, bool
 
     auto borderPaddingWidth = [](LayoutUnit childValue, const Style::PaddingEdge& padding) -> LayoutUnit {
         if (auto fixed = padding.tryFixed())
-            return LayoutUnit(fixed->evaluate(1.0f /* FIXME FIND ZOOM */));
+            return LayoutUnit(fixed->resolveZoom(Style::ZoomNeeded { }));
         return childValue;
     };
 
@@ -4567,14 +4567,14 @@ static inline std::optional<LayoutUnit> textIndentForBlockContainer(const Render
 {
     auto& style = renderer.style();
     if (auto fixedTextIndent = style.textIndent().length.tryFixed())
-        return !fixedTextIndent->isZero() ? std::make_optional(LayoutUnit { fixedTextIndent->evaluate(1.0f /* FIXME FIND ZOOM */) }) : std::nullopt;
+        return !fixedTextIndent->isZero() ? std::make_optional(LayoutUnit { fixedTextIndent->resolveZoom(Style::ZoomNeeded { }) }) : std::nullopt;
 
     auto indentValue = LayoutUnit { };
     if (auto* containingBlock = renderer.containingBlock()) {
         if (auto containingBlockFixedLogicalWidth = containingBlock->style().logicalWidth().tryFixed()) {
             // At this point of the shrink-to-fit computation, we don't have a used value for the containing block width
             // (that's exactly to what we try to contribute here) unless the computed value is fixed.
-            indentValue = Style::evaluate(style.textIndent().length, containingBlockFixedLogicalWidth->evaluate(1.0f /* FIXME FIND ZOOM */), 1.0f /* FIXME ZOOM EFFECTED? */);
+            indentValue = Style::evaluate(style.textIndent().length, containingBlockFixedLogicalWidth->resolveZoom(Style::ZoomNeeded { }), Style::ZoomNeeded { });
         }
     }
     return indentValue ? std::make_optional(indentValue) : std::nullopt;
@@ -4734,9 +4734,9 @@ void RenderBlockFlow::computeInlinePreferredLogicalWidths(LayoutUnit& minLogical
                         lastText = nullptr;
                     LayoutUnit margins;
                     if (auto fixedMarginStart = childStyle.marginStart(writingMode()).tryFixed())
-                        margins += LayoutUnit::fromFloatCeil(fixedMarginStart->evaluate(1.0f /* FIXME FIND ZOOM */));
+                        margins += LayoutUnit::fromFloatCeil(fixedMarginStart->resolveZoom(Style::ZoomNeeded { }));
                     if (auto fixedMarginEnd = childStyle.marginEnd(writingMode()).tryFixed())
-                        margins += LayoutUnit::fromFloatCeil(fixedMarginEnd->evaluate(1.0f /* FIXME FIND ZOOM */));
+                        margins += LayoutUnit::fromFloatCeil(fixedMarginEnd->resolveZoom(Style::ZoomNeeded { }));
                     childMin += margins.ceilToFloat();
                     childMax += margins.ceilToFloat();
                 }

--- a/Source/WebCore/rendering/RenderBoxModelObject.cpp
+++ b/Source/WebCore/rendering/RenderBoxModelObject.cpp
@@ -380,7 +380,7 @@ LayoutSize RenderBoxModelObject::relativePositionOffset() const
     auto topFixed = top.tryFixed();
     auto leftFixed = left.tryFixed();
     if (topFixed && leftFixed && bottom.isAuto() && right.isAuto() && containingBlock->writingMode().isAnyLeftToRight()) {
-        offset.expand(leftFixed->evaluate(1.0f /* FIXME FIND ZOOM */), topFixed->evaluate(1.0f /* FIXME FIND ZOOM */));
+        offset.expand(leftFixed->resolveZoom(Style::ZoomNeeded { }), topFixed->resolveZoom(Style::ZoomNeeded { }));
         return offset;
     }
 
@@ -403,11 +403,11 @@ LayoutSize RenderBoxModelObject::relativePositionOffset() const
         };
         if (!left.isAuto()) {
             if (!right.isAuto() && !containingBlock->writingMode().isAnyLeftToRight())
-                offset.setWidth(-Style::evaluate(right, !right.isFixed() ? availableWidth() : 0_lu, 1.0f /* FIXME ZOOM EFFECTED? */));
+                offset.setWidth(-Style::evaluate(right, !right.isFixed() ? availableWidth() : 0_lu, Style::ZoomNeeded { }));
             else
-                offset.expand(Style::evaluate(left, !left.isFixed() ? availableWidth() : 0_lu, 1.0f /* FIXME ZOOM EFFECTED? */), 0_lu);
+                offset.expand(Style::evaluate(left, !left.isFixed() ? availableWidth() : 0_lu, Style::ZoomNeeded { }), 0_lu);
         } else if (!right.isAuto())
-            offset.expand(-Style::evaluate(right, !right.isFixed() ? availableWidth() : 0_lu, 1.0f /* FIXME ZOOM EFFECTED? */), 0_lu);
+            offset.expand(-Style::evaluate(right, !right.isFixed() ? availableWidth() : 0_lu, Style::ZoomNeeded { }), 0_lu);
     }
 
     // If the containing block of a relatively positioned element does not
@@ -438,10 +438,10 @@ LayoutSize RenderBoxModelObject::relativePositionOffset() const
         // FIXME: The computation of the available height is repeated later for "bottom".
         // We could refactor this and move it to some common code for both ifs, however moving it outside of the ifs
         // is not possible as it'd cause performance regressions.
-        offset.expand(0_lu, Style::evaluate(top, !top.isFixed() ? availableHeight() : 0_lu, 1.0f /* FIXME ZOOM EFFECTED? */));
+        offset.expand(0_lu, Style::evaluate(top, !top.isFixed() ? availableHeight() : 0_lu, Style::ZoomNeeded { }));
     } else if (!bottom.isAuto() && (!bottom.isPercentOrCalculated() || containingBlockHasDefiniteHeight)) {
         // FIXME: Check comment above for "top", it applies here too.
-        offset.expand(0_lu, -Style::evaluate(bottom, !bottom.isFixed() ? availableHeight() : 0_lu, 1.0f /* FIXME ZOOM EFFECTED? */));
+        offset.expand(0_lu, -Style::evaluate(bottom, !bottom.isFixed() ? availableHeight() : 0_lu, Style::ZoomNeeded { }));
     }
     return offset;
 }
@@ -550,10 +550,10 @@ void RenderBoxModelObject::computeStickyPositionConstraints(StickyPositionViewpo
     // Sticky positioned element ignore any override logical width on the containing block (as they don't call
     // containingBlockLogicalWidthForContent). It's unclear whether this is totally fine.
     LayoutBoxExtent minMargin(
-        Style::evaluateMinimum(style().marginTop(), maxWidth, 1.0f /* FIXME ZOOM EFFECTED? */),
-        Style::evaluateMinimum(style().marginRight(), maxWidth, 1.0f /* FIXME ZOOM EFFECTED? */),
-        Style::evaluateMinimum(style().marginBottom(), maxWidth, 1.0f /* FIXME ZOOM EFFECTED? */),
-        Style::evaluateMinimum(style().marginLeft(), maxWidth, 1.0f /* FIXME ZOOM EFFECTED? */)
+        Style::evaluateMinimum(style().marginTop(), maxWidth, Style::ZoomNeeded { }),
+        Style::evaluateMinimum(style().marginRight(), maxWidth, Style::ZoomNeeded { }),
+        Style::evaluateMinimum(style().marginBottom(), maxWidth, Style::ZoomNeeded { }),
+        Style::evaluateMinimum(style().marginLeft(), maxWidth, Style::ZoomNeeded { })
     );
 
     // Compute the container-relative area within which the sticky element is allowed to move.
@@ -603,22 +603,22 @@ void RenderBoxModelObject::computeStickyPositionConstraints(StickyPositionViewpo
     constraints.setStickyBoxRect(stickyBoxRelativeToScrollingAncestor);
 
     if (!style().left().isAuto()) {
-        constraints.setLeftOffset(Style::evaluate(style().left(), constrainingRect.width(), 1.0f /* FIXME ZOOM EFFECTED? */));
+        constraints.setLeftOffset(Style::evaluate(style().left(), constrainingRect.width(), Style::ZoomNeeded { }));
         constraints.addAnchorEdge(ViewportConstraints::AnchorEdgeLeft);
     }
 
     if (!style().right().isAuto()) {
-        constraints.setRightOffset(Style::evaluate(style().right(), constrainingRect.width(), 1.0f /* FIXME ZOOM EFFECTED? */));
+        constraints.setRightOffset(Style::evaluate(style().right(), constrainingRect.width(), Style::ZoomNeeded { }));
         constraints.addAnchorEdge(ViewportConstraints::AnchorEdgeRight);
     }
 
     if (!style().top().isAuto()) {
-        constraints.setTopOffset(Style::evaluate(style().top(), constrainingRect.height(), 1.0f /* FIXME ZOOM EFFECTED? */));
+        constraints.setTopOffset(Style::evaluate(style().top(), constrainingRect.height(), Style::ZoomNeeded { }));
         constraints.addAnchorEdge(ViewportConstraints::AnchorEdgeTop);
     }
 
     if (!style().bottom().isAuto()) {
-        constraints.setBottomOffset(Style::evaluate(style().bottom(), constrainingRect.height(), 1.0f /* FIXME ZOOM EFFECTED? */));
+        constraints.setBottomOffset(Style::evaluate(style().bottom(), constrainingRect.height(), Style::ZoomNeeded { }));
         constraints.addAnchorEdge(ViewportConstraints::AnchorEdgeBottom);
     }
 }

--- a/Source/WebCore/rendering/RenderBoxModelObjectInlines.h
+++ b/Source/WebCore/rendering/RenderBoxModelObjectInlines.h
@@ -25,7 +25,7 @@
 
 namespace WebCore {
 
-inline LayoutUnit RenderBoxModelObject::borderAfter() const { return LayoutUnit(Style::evaluate(style().borderAfterWidth(), 1.0f /* FIXME FIND ZOOM */)); }
+inline LayoutUnit RenderBoxModelObject::borderAfter() const { return LayoutUnit(Style::evaluate(style().borderAfterWidth(), Style::ZoomNeeded { })); }
 inline LayoutUnit RenderBoxModelObject::borderAndPaddingAfter() const { return borderAfter() + paddingAfter(); }
 inline LayoutUnit RenderBoxModelObject::borderAndPaddingBefore() const { return borderBefore() + paddingBefore(); }
 inline LayoutUnit RenderBoxModelObject::borderAndPaddingLogicalHeight() const { return borderAndPaddingBefore() + borderAndPaddingAfter(); }
@@ -34,17 +34,17 @@ inline LayoutUnit RenderBoxModelObject::borderAndPaddingLogicalLeft() const { re
 inline LayoutUnit RenderBoxModelObject::borderAndPaddingLogicalRight() const { return writingMode().isHorizontal() ? borderRight() + paddingRight() : borderBottom() + paddingBottom(); }
 inline LayoutUnit RenderBoxModelObject::borderAndPaddingStart() const { return borderStart() + paddingStart(); }
 inline LayoutUnit RenderBoxModelObject::borderAndPaddingEnd() const { return borderEnd() + paddingEnd(); }
-inline LayoutUnit RenderBoxModelObject::borderBefore() const { return LayoutUnit(Style::evaluate(style().borderBeforeWidth(), 1.0f /* FIXME FIND ZOOM */)); }
-inline LayoutUnit RenderBoxModelObject::borderBottom() const { return LayoutUnit(Style::evaluate(style().borderBottomWidth(), 1.0f /* FIXME FIND ZOOM */)); }
-inline LayoutUnit RenderBoxModelObject::borderEnd() const { return LayoutUnit(Style::evaluate(style().borderEndWidth(), 1.0f /* FIXME FIND ZOOM */)); }
-inline LayoutUnit RenderBoxModelObject::borderLeft() const { return LayoutUnit(Style::evaluate(style().borderLeftWidth(), 1.0f /* FIXME FIND ZOOM */)); }
+inline LayoutUnit RenderBoxModelObject::borderBefore() const { return LayoutUnit(Style::evaluate(style().borderBeforeWidth(), Style::ZoomNeeded { })); }
+inline LayoutUnit RenderBoxModelObject::borderBottom() const { return LayoutUnit(Style::evaluate(style().borderBottomWidth(), Style::ZoomNeeded { })); }
+inline LayoutUnit RenderBoxModelObject::borderEnd() const { return LayoutUnit(Style::evaluate(style().borderEndWidth(), Style::ZoomNeeded { })); }
+inline LayoutUnit RenderBoxModelObject::borderLeft() const { return LayoutUnit(Style::evaluate(style().borderLeftWidth(), Style::ZoomNeeded { })); }
 inline LayoutUnit RenderBoxModelObject::borderLogicalHeight() const { return borderBefore() + borderAfter(); }
 inline LayoutUnit RenderBoxModelObject::borderLogicalLeft() const { return writingMode().isHorizontal() ? borderLeft() : borderTop(); }
 inline LayoutUnit RenderBoxModelObject::borderLogicalRight() const { return writingMode().isHorizontal() ? borderRight() : borderBottom(); }
 inline LayoutUnit RenderBoxModelObject::borderLogicalWidth() const { return borderStart() + borderEnd(); }
-inline LayoutUnit RenderBoxModelObject::borderRight() const { return LayoutUnit(Style::evaluate(style().borderRightWidth(), 1.0f /* FIXME FIND ZOOM */)); }
-inline LayoutUnit RenderBoxModelObject::borderStart() const { return LayoutUnit(Style::evaluate(style().borderStartWidth(), 1.0f /* FIXME FIND ZOOM */)); }
-inline LayoutUnit RenderBoxModelObject::borderTop() const { return LayoutUnit(Style::evaluate(style().borderTopWidth(), 1.0f /* FIXME FIND ZOOM */)); }
+inline LayoutUnit RenderBoxModelObject::borderRight() const { return LayoutUnit(Style::evaluate(style().borderRightWidth(), Style::ZoomNeeded { })); }
+inline LayoutUnit RenderBoxModelObject::borderStart() const { return LayoutUnit(Style::evaluate(style().borderStartWidth(), Style::ZoomNeeded { })); }
+inline LayoutUnit RenderBoxModelObject::borderTop() const { return LayoutUnit(Style::evaluate(style().borderTopWidth(), Style::ZoomNeeded { })); }
 inline LayoutUnit RenderBoxModelObject::computedCSSPaddingAfter() const { return resolveLengthPercentageUsingContainerLogicalWidth(style().paddingAfter()); }
 inline LayoutUnit RenderBoxModelObject::computedCSSPaddingBefore() const { return resolveLengthPercentageUsingContainerLogicalWidth(style().paddingBefore()); }
 inline LayoutUnit RenderBoxModelObject::computedCSSPaddingBottom() const { return resolveLengthPercentageUsingContainerLogicalWidth(style().paddingBottom()); }
@@ -81,7 +81,7 @@ inline LayoutUnit RenderBoxModelObject::verticalBorderExtent() const { return bo
 inline RectEdges<LayoutUnit> RenderBoxModelObject::borderWidths() const
 {
     return RectEdges<LayoutUnit>::map(style().borderWidth(), [&](auto width) {
-        return LayoutUnit { Style::evaluate(width, 1.0f /* FIXME FIND ZOOM */) };
+        return LayoutUnit { Style::evaluate(width, Style::ZoomNeeded { }) };
     });
 }
 
@@ -100,7 +100,7 @@ inline LayoutUnit RenderBoxModelObject::resolveLengthPercentageUsingContainerLog
     LayoutUnit containerWidth;
     if (value.isPercentOrCalculated())
         containerWidth = containingBlockLogicalWidthForContent();
-    return Style::evaluateMinimum(value, containerWidth, 1.0f /* FIXME ZOOM EFFECTED? */);
+    return Style::evaluateMinimum(value, containerWidth, Style::ZoomNeeded { });
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderDeprecatedFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderDeprecatedFlexibleBox.cpp
@@ -146,9 +146,9 @@ static LayoutUnit marginWidthForChild(RenderBox* child)
     // Fixed margins can be added in as is.
     LayoutUnit margin;
     if (auto fixedMarginLeft = child->style().marginLeft().tryFixed())
-        margin += fixedMarginLeft->evaluate(1.0f /* FIXME FIND ZOOM */);
+        margin += fixedMarginLeft->resolveZoom(Style::ZoomNeeded { });
     if (auto fixedMarginRight = child->style().marginRight().tryFixed())
-        margin += fixedMarginRight->evaluate(1.0f /* FIXME FIND ZOOM */);
+        margin += fixedMarginRight->resolveZoom(Style::ZoomNeeded { });
     return margin;
 }
 
@@ -1152,7 +1152,7 @@ LayoutUnit RenderDeprecatedFlexibleBox::allowedChildFlex(RenderBox* child, bool 
             LayoutUnit maxWidth = LayoutUnit::max();
             LayoutUnit width = contentWidthForChild(child);
             if (auto fixedMaxWidth = child->style().maxWidth().tryFixed())
-                maxWidth = fixedMaxWidth->evaluate(1.0f /* FIXME FIND ZOOM */);
+                maxWidth = fixedMaxWidth->resolveZoom(Style::ZoomNeeded { });
             else if (child->style().maxWidth().isIntrinsicKeyword())
                 maxWidth = child->maxPreferredLogicalWidth();
             else if (child->style().maxWidth().isMinIntrinsic())
@@ -1165,7 +1165,7 @@ LayoutUnit RenderDeprecatedFlexibleBox::allowedChildFlex(RenderBox* child, bool 
             LayoutUnit maxHeight = LayoutUnit::max();
             LayoutUnit height = contentHeightForChild(child);
             if (auto fixedMaxHeight = child->style().maxHeight().tryFixed())
-                maxHeight = fixedMaxHeight->evaluate(1.0f /* FIXME FIND ZOOM */);
+                maxHeight = fixedMaxHeight->resolveZoom(Style::ZoomNeeded { });
             if (maxHeight == LayoutUnit::max())
                 return maxHeight;
             return std::max<LayoutUnit>(0, maxHeight - height);
@@ -1177,7 +1177,7 @@ LayoutUnit RenderDeprecatedFlexibleBox::allowedChildFlex(RenderBox* child, bool 
         LayoutUnit minWidth = child->minPreferredLogicalWidth();
         LayoutUnit width = contentWidthForChild(child);
         if (auto fixedMinWidth = child->style().minWidth().tryFixed())
-            minWidth = fixedMinWidth->evaluate(1.0f /* FIXME FIND ZOOM */);
+            minWidth = fixedMinWidth->resolveZoom(Style::ZoomNeeded { });
         else if (child->style().minWidth().isIntrinsicKeyword())
             minWidth = child->maxPreferredLogicalWidth();
         else if (child->style().minWidth().isMinIntrinsic())
@@ -1190,7 +1190,7 @@ LayoutUnit RenderDeprecatedFlexibleBox::allowedChildFlex(RenderBox* child, bool 
     } else {
         auto& minHeight = child->style().minHeight();
         if (auto fixedMinHeight = minHeight.tryFixed()) {
-            LayoutUnit minHeight { fixedMinHeight->evaluate(1.0f /* FIXME FIND ZOOM */) };
+            LayoutUnit minHeight { fixedMinHeight->resolveZoom(Style::ZoomNeeded { }) };
             LayoutUnit height = contentHeightForChild(child);
             LayoutUnit allowedShrinkage = std::min<LayoutUnit>(0, minHeight - height);
             return allowedShrinkage;

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -1510,12 +1510,12 @@ bool RenderElement::repaintAfterLayoutIfNeeded(SingleThreadWeakPtr<const RenderL
                 auto borderBoxWidth = renderBox->width();
                 return std::max({
                     renderBox->borderRight(),
-                    Style::evaluate(style.borderTopRightRadius().width(), borderBoxWidth, 1.0f /* FIXME ZOOM EFFECTED? */),
-                    Style::evaluate(style.borderBottomRightRadius().width(), borderBoxWidth, 1.0f /* FIXME ZOOM EFFECTED? */),
+                    Style::evaluate(style.borderTopRightRadius().width(), borderBoxWidth, Style::ZoomNeeded { }),
+                    Style::evaluate(style.borderBottomRightRadius().width(), borderBoxWidth, Style::ZoomNeeded { }),
                 });
             };
             auto outlineRightInsetExtent = [&]() -> LayoutUnit {
-                auto offset = LayoutUnit { Style::evaluate(outlineStyle.outlineOffset(), 1.0f /* FIXME ZOOM EFFECTED? */) };
+                auto offset = LayoutUnit { Style::evaluate(outlineStyle.outlineOffset(), Style::ZoomNeeded { }) };
                 return offset < 0 ? -offset : 0_lu;
             };
             auto boxShadowRightInsetExtent = [&] {
@@ -1554,12 +1554,12 @@ bool RenderElement::repaintAfterLayoutIfNeeded(SingleThreadWeakPtr<const RenderL
                 auto borderBoxHeight = renderBox->height();
                 return std::max({
                     renderBox->borderBottom(),
-                    Style::evaluate(style.borderBottomLeftRadius().height(), borderBoxHeight, 1.0f /* FIXME ZOOM EFFECTED? */),
-                    Style::evaluate(style.borderBottomRightRadius().height(), borderBoxHeight, 1.0f /* FIXME ZOOM EFFECTED? */),
+                    Style::evaluate(style.borderBottomLeftRadius().height(), borderBoxHeight, Style::ZoomNeeded { }),
+                    Style::evaluate(style.borderBottomRightRadius().height(), borderBoxHeight, Style::ZoomNeeded { }),
                 });
             };
             auto outlineBottomInsetExtent = [&]() -> LayoutUnit {
-                auto offset = LayoutUnit { Style::evaluate(outlineStyle.outlineOffset(), 1.0f /* FIXME FIND ZOOM */) };
+                auto offset = LayoutUnit { Style::evaluate(outlineStyle.outlineOffset(), Style::ZoomNeeded { }) };
                 return offset < 0 ? -offset : 0_lu;
             };
             auto boxShadowBottomInsetExtent = [&]() -> LayoutUnit {
@@ -2120,22 +2120,22 @@ static bool useShrinkWrappedFocusRingForOutlineStyleAuto()
 
 static void drawFocusRing(GraphicsContext& context, const Path& path, const RenderStyle& style, const Color& color)
 {
-    context.drawFocusRing(path, Style::evaluate(style.outlineWidth(), 1.0f /* FIXME FIND ZOOM */), color);
+    context.drawFocusRing(path, Style::evaluate(style.outlineWidth(), Style::ZoomNeeded { }), color);
 }
 
 static void drawFocusRing(GraphicsContext& context, Vector<FloatRect> rects, const RenderStyle& style, const Color& color)
 {
 #if PLATFORM(MAC)
-    context.drawFocusRing(rects, 0, Style::evaluate(style.outlineWidth(), 1.0f /* FIXME FIND ZOOM */), color);
+    context.drawFocusRing(rects, 0, Style::evaluate(style.outlineWidth(), Style::ZoomNeeded { }), color);
 #else
-    context.drawFocusRing(rects, Style::evaluate(style.outlineOffset(), 1.0f /* FIXME FIND ZOOM */), Style::evaluate(style.outlineWidth(), 1.0f /* FIXME FIND ZOOM */), color);
+    context.drawFocusRing(rects, Style::evaluate(style.outlineOffset(), Style::ZoomNeeded { }), Style::evaluate(style.outlineWidth(), Style::ZoomNeeded { }), color);
 #endif
 }
 
 void RenderElement::paintFocusRing(const PaintInfo& paintInfo, const RenderStyle& style, const Vector<LayoutRect>& focusRingRects) const
 {
     ASSERT(style.outlineStyle() == OutlineStyle::Auto);
-    float outlineOffset = Style::evaluate(style.outlineOffset(), 1.0f /* FIXME FIND ZOOM */);
+    float outlineOffset = Style::evaluate(style.outlineOffset(), Style::ZoomNeeded { });
     Vector<FloatRect> pixelSnappedFocusRingRects;
     float deviceScaleFactor = document().deviceScaleFactor();
     for (auto rect : focusRingRects) {
@@ -2519,7 +2519,7 @@ static RenderObject::BlockContentHeightType includeNonFixedHeight(const RenderOb
         if (CheckedPtr block = dynamicDowncast<RenderBlock>(renderer)) {
             // For fixed height styles, if the overflow size of the element spills out of the specified
             // height, assume we can apply text auto-sizing.
-            if (block->effectiveOverflowY() == Overflow::Visible && fixedHeight->evaluate(1.0f /* FIXME FIND ZOOM */) < block->layoutOverflowRect().maxY())
+            if (block->effectiveOverflowY() == Overflow::Visible && fixedHeight->resolveZoom(Style::ZoomNeeded { }) < block->layoutOverflowRect().maxY())
                 return RenderObject::OverflowHeight;
         }
         return RenderObject::FixedHeight;

--- a/Source/WebCore/rendering/RenderFileUploadControl.cpp
+++ b/Source/WebCore/rendering/RenderFileUploadControl.cpp
@@ -296,7 +296,7 @@ void RenderFileUploadControl::computeIntrinsicLogicalWidths(LayoutUnit& minLogic
 
     auto& logicalWidth = style().logicalWidth();
     if (logicalWidth.isCalculated())
-        minLogicalWidth = std::max(0_lu, Style::evaluate(logicalWidth, 0_lu, 1.0f /* FIXME FIND ZOOM */));
+        minLogicalWidth = std::max(0_lu, Style::evaluate(logicalWidth, 0_lu, Style::ZoomNeeded { }));
     else if (!logicalWidth.isPercent())
         minLogicalWidth = maxLogicalWidth;
 }

--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -1109,7 +1109,7 @@ template<typename SizeType> LayoutUnit RenderFlexibleBox::computeMainSizeFromAsp
 
     auto crossSizeOptional = WTF::switchOn(crossSizeLength,
         [&](const SizeType::Fixed& fixedCrossSizeLength) -> std::optional<LayoutUnit> {
-            return LayoutUnit(fixedCrossSizeLength.evaluate(1.0f /* FIXME FIND ZOOM */));
+            return LayoutUnit(fixedCrossSizeLength.resolveZoom(Style::ZoomNeeded { }));
         },
         [&](const SizeType::Percentage& percentageCrossSizeLength) -> std::optional<LayoutUnit> {
             return mainAxisIsFlexItemInlineAxis(flexItem)
@@ -1647,7 +1647,7 @@ LayoutUnit RenderFlexibleBox::computeFlexItemMarginValue(const Style::MarginEdge
 {
     // When resolving the margins, we use the content size for resolving percent and calc (for percents in calc expressions) margins.
     // Fortunately, percent margins are always computed with respect to the block's width, even for margin-top and margin-bottom.
-    return Style::evaluateMinimum(margin, contentBoxLogicalWidth(), 1.0f /* FIXME FIND ZOOM */);
+    return Style::evaluateMinimum(margin, contentBoxLogicalWidth(), Style::ZoomNeeded { });
 }
 
 void RenderFlexibleBox::prepareOrderIteratorAndMargins()
@@ -2114,17 +2114,17 @@ LayoutUnit RenderFlexibleBox::computeCrossSizeForFlexItemUsingContainerCrossSize
         ASSERT(size.isFixed() || (size.isPercent() && availableLogicalHeightForPercentageComputation()));
         LayoutUnit definiteValue;
         if (auto fixedSize = size.tryFixed())
-            definiteValue = LayoutUnit { fixedSize->evaluate(1.0f /* FIXME FIND ZOOM */) };
+            definiteValue = LayoutUnit { fixedSize->resolveZoom(Style::ZoomNeeded { }) };
         else if (size.isPercent())
             definiteValue = availableLogicalHeightForPercentageComputation().value_or(0_lu);
 
         auto maximumSize = isHorizontal ? style().maxHeight() : style().maxWidth();
         if (auto fixedMaximumSize = maximumSize.tryFixed())
-            definiteValue = std::min(definiteValue, LayoutUnit { fixedMaximumSize->evaluate(1.0f /* FIXME FIND ZOOM */) });
+            definiteValue = std::min(definiteValue, LayoutUnit { fixedMaximumSize->resolveZoom(Style::ZoomNeeded { }) });
 
         auto minimumSize = isHorizontal ? style().minHeight() : style().minWidth();
         if (auto fixedMinimumSize = minimumSize.tryFixed())
-            definiteValue = std::max(definiteValue, LayoutUnit { fixedMinimumSize->evaluate(1.0f /* FIXME FIND ZOOM */) });
+            definiteValue = std::max(definiteValue, LayoutUnit { fixedMinimumSize->resolveZoom(Style::ZoomNeeded { }) });
 
         return definiteValue;
     };
@@ -2783,7 +2783,7 @@ LayoutUnit RenderFlexibleBox::computeGap(RenderFlexibleBox::GapType gapType) con
         return { };
 
     auto availableSize = usesRowGap ? availableLogicalHeightForPercentageComputation().value_or(0_lu) : contentBoxLogicalWidth();
-    return Style::evaluateMinimum(gap, availableSize, 1.0f /* FIXME FIND ZOOM */);
+    return Style::evaluateMinimum(gap, availableSize, Style::ZoomNeeded { });
 }
 
 bool RenderFlexibleBox::layoutUsingFlexFormattingContext()

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -699,7 +699,7 @@ LayoutUnit RenderGrid::gridGap(Style::GridTrackSizingDirection direction, std::o
         return downcast<RenderGrid>(parent())->gridGap(parentDirection);
     }
 
-    return Style::evaluate(gap, availableSize.value_or(0_lu), 1.0f /* FIXME FIND ZOOM */);
+    return Style::evaluate(gap, availableSize.value_or(0_lu), Style::ZoomNeeded { });
 }
 
 LayoutUnit RenderGrid::gridGap(Style::GridTrackSizingDirection direction) const
@@ -893,7 +893,7 @@ unsigned RenderGrid::computeAutoRepeatTracksCount(Style::GridTrackSizingDirectio
         auto& maxSize = isRowAxis ? style().logicalMaxWidth() : style().logicalMaxHeight();
         auto availableMaxSize = WTF::switchOn(maxSize,
             [&](const Style::MaximumSize::Fixed& fixedMaxSize) -> std::optional<LayoutUnit> {
-                auto maxSizeValue = LayoutUnit { fixedMaxSize.evaluate(1.0f /* FIXME FIND ZOOM */) };
+                auto maxSizeValue = LayoutUnit { fixedMaxSize.resolveZoom(Style::ZoomNeeded { }) };
                 return isRowAxis
                     ? adjustContentBoxLogicalWidthForBoxSizing(maxSizeValue)
                     : adjustContentBoxLogicalHeightForBoxSizing(maxSizeValue);
@@ -925,7 +925,7 @@ unsigned RenderGrid::computeAutoRepeatTracksCount(Style::GridTrackSizingDirectio
 
         auto availableMinSize = WTF::switchOn(minSize,
             [&](const Style::MinimumSize::Fixed& fixedMinSize) -> std::optional<LayoutUnit> {
-                auto minSizeValue = LayoutUnit { fixedMinSize.evaluate(1.0f /* FIXME FIND ZOOM */) };
+                auto minSizeValue = LayoutUnit { fixedMinSize.resolveZoom(Style::ZoomNeeded { }) };
                 return isRowAxis
                     ? adjustContentBoxLogicalWidthForBoxSizing(minSizeValue)
                     : adjustContentBoxLogicalHeightForBoxSizing(minSizeValue);
@@ -970,8 +970,8 @@ unsigned RenderGrid::computeAutoRepeatTracksCount(Style::GridTrackSizingDirectio
 
         auto contributingTrackSize = [&] {
             if (hasDefiniteMaxTrackSizingFunction && hasDefiniteMinTrackSizingFunction)
-                return std::max(Style::evaluate(minTrackSizingFunction.length(), *availableSize, 1.0f /* FIXME FIND ZOOM */), Style::evaluate(maxTrackSizingFunction.length(), *availableSize, 1.0f /* FIXME FIND ZOOM */));
-            return hasDefiniteMaxTrackSizingFunction ? Style::evaluate(maxTrackSizingFunction.length(), *availableSize, 1.0f /* FIXME FIND ZOOM */) : Style::evaluate(minTrackSizingFunction.length(), *availableSize, 1.0f /* FIXME FIND ZOOM */);
+                return std::max(Style::evaluate(minTrackSizingFunction.length(), *availableSize, Style::ZoomNeeded { }), Style::evaluate(maxTrackSizingFunction.length(), *availableSize, Style::ZoomNeeded { }));
+            return hasDefiniteMaxTrackSizingFunction ? Style::evaluate(maxTrackSizingFunction.length(), *availableSize, Style::ZoomNeeded { }) : Style::evaluate(minTrackSizingFunction.length(), *availableSize, Style::ZoomNeeded { });
         };
         autoRepeatTracksSize += contributingTrackSize();
     }
@@ -986,7 +986,7 @@ unsigned RenderGrid::computeAutoRepeatTracksCount(Style::GridTrackSizingDirectio
     for (const auto& track : trackSizes) {
         bool hasDefiniteMaxTrackBreadth = track.maxTrackBreadth().isLength() && !track.maxTrackBreadth().isContentSized();
         ASSERT(hasDefiniteMaxTrackBreadth || (track.minTrackBreadth().isLength() && !track.minTrackBreadth().isContentSized()));
-        tracksSize += Style::evaluate(hasDefiniteMaxTrackBreadth ? track.maxTrackBreadth().length() : track.minTrackBreadth().length(), availableSize.value(), 1.0f /* FIXME FIND ZOOM */);
+        tracksSize += Style::evaluate(hasDefiniteMaxTrackBreadth ? track.maxTrackBreadth().length() : track.minTrackBreadth().length(), availableSize.value(), Style::ZoomNeeded { });
     }
 
     // Add gutters as if auto repeat tracks were only repeated once. Gaps between different repetitions will be added later when

--- a/Source/WebCore/rendering/RenderImage.cpp
+++ b/Source/WebCore/rendering/RenderImage.cpp
@@ -688,7 +688,7 @@ void RenderImage::paintAreaElementFocusRing(PaintInfo& paintInfo, const LayoutPo
     if (!areaElementStyle)
         return;
 
-    float outlineWidth = Style::evaluate(areaElementStyle->outlineWidth(), 1.0f /* FIXME ZOOM EFFECTED? */);
+    float outlineWidth = Style::evaluate(areaElementStyle->outlineWidth(), Style::ZoomNeeded { });
     if (!outlineWidth)
         return;
 

--- a/Source/WebCore/rendering/RenderInline.cpp
+++ b/Source/WebCore/rendering/RenderInline.cpp
@@ -351,7 +351,7 @@ static LayoutUnit computeMargin(const RenderInline* renderer, const Style::Margi
 {
     return Style::evaluateMinimum(margin, [&] ALWAYS_INLINE_LAMBDA {
         return std::max<LayoutUnit>(0, renderer->containingBlock()->contentBoxLogicalWidth());
-    }, 1.0f /* FIXME FIND ZOOM */);
+    }, Style::ZoomNeeded { });
 }
 
 LayoutUnit RenderInline::marginLeft() const

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -2292,7 +2292,7 @@ FloatPoint RenderLayer::perspectiveOrigin() const
 {
     if (!renderer().hasTransformRelatedProperty())
         return { };
-    return Style::evaluate(renderer().style().perspectiveOrigin(), renderer().transformReferenceBoxRect(renderer().style()).size(), 1.0f /* FIXME FIND ZOOM */);
+    return Style::evaluate(renderer().style().perspectiveOrigin(), renderer().transformReferenceBoxRect(renderer().style()).size(), Style::ZoomNeeded { });
 }
 
 static inline bool isContainerForPositioned(RenderLayer& layer, PositionType position, bool establishesTopLayer)
@@ -2975,8 +2975,8 @@ LayoutSize RenderLayer::minimumSizeForResizing(float zoomFactor) const
 {
     // Use the resizer size as the strict minimum size
     auto resizerRect = overflowControlsRects().resizer;
-    LayoutUnit minWidth = Style::evaluateMinimum(renderer().style().minWidth(), renderer().containingBlock()->width(), 1.0f /* FIXME FIND ZOOM */);
-    LayoutUnit minHeight = Style::evaluateMinimum(renderer().style().minHeight(), renderer().containingBlock()->height(), 1.0f /* FIXME FIND ZOOM */);
+    LayoutUnit minWidth = Style::evaluateMinimum(renderer().style().minWidth(), renderer().containingBlock()->width(), Style::ZoomNeeded { });
+    LayoutUnit minHeight = Style::evaluateMinimum(renderer().style().minHeight(), renderer().containingBlock()->height(), Style::ZoomNeeded { });
     minWidth = std::max(LayoutUnit(minWidth / zoomFactor), LayoutUnit(resizerRect.width()));
     minHeight = std::max(LayoutUnit(minHeight / zoomFactor), LayoutUnit(resizerRect.height()));
     return LayoutSize(minWidth, minHeight);

--- a/Source/WebCore/rendering/RenderListBox.cpp
+++ b/Source/WebCore/rendering/RenderListBox.cpp
@@ -235,7 +235,7 @@ void RenderListBox::computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidth, L
 
     auto& logicalWidth = style().logicalWidth();
     if (logicalWidth.isCalculated())
-        minLogicalWidth = std::max(0_lu, Style::evaluate(logicalWidth, 0_lu, 1.0f /* FIXME ZOOM EFFECTED? */));
+        minLogicalWidth = std::max(0_lu, Style::evaluate(logicalWidth, 0_lu, Style::ZoomNeeded { }));
     else if (!logicalWidth.isPercent())
         minLogicalWidth = maxLogicalWidth;
 }

--- a/Source/WebCore/rendering/RenderListMarker.cpp
+++ b/Source/WebCore/rendering/RenderListMarker.cpp
@@ -268,9 +268,9 @@ void RenderListMarker::layout()
     setMarginEnd(0);
 
     if (auto fixedStartMargin = style().marginStart().tryFixed())
-        setMarginStart(LayoutUnit(fixedStartMargin->evaluate(1.0f /* FIXME FIND ZOOM */)));
+        setMarginStart(LayoutUnit(fixedStartMargin->resolveZoom(Style::ZoomNeeded { })));
     if (auto fixedEndMargin = style().marginEnd().tryFixed())
-        setMarginEnd(LayoutUnit(fixedEndMargin->evaluate(1.0f /* FIXME FIND ZOOM */)));
+        setMarginEnd(LayoutUnit(fixedEndMargin->resolveZoom(Style::ZoomNeeded { })));
 
     clearNeedsLayout();
 }

--- a/Source/WebCore/rendering/RenderMarquee.cpp
+++ b/Source/WebCore/rendering/RenderMarquee.cpp
@@ -297,7 +297,7 @@ void RenderMarquee::timerFired()
         }
         bool positive = range > 0;
         int clientSize = (isHorizontal() ? roundToInt(renderBox->clientWidth()) : roundToInt(renderBox->clientHeight()));
-        int increment = std::abs(Style::evaluate(m_layer->renderer().style().marqueeIncrement(), clientSize, 1.0f /* FIXME FIND ZOOM */));
+        int increment = std::abs(Style::evaluate(m_layer->renderer().style().marqueeIncrement(), clientSize, Style::ZoomNeeded { }));
         int currentPos = (isHorizontal() ? scrollableArea->scrollOffset().x() : scrollableArea->scrollOffset().y());
         newPos =  currentPos + (addIncrement ? increment : -increment);
         if (positive)

--- a/Source/WebCore/rendering/RenderMenuList.cpp
+++ b/Source/WebCore/rendering/RenderMenuList.cpp
@@ -230,7 +230,7 @@ void RenderMenuList::updateOptionsWidth()
             // Add in the option's text indent.  We can't calculate percentage values for now.
             float optionWidth = 0;
             if (auto* optionStyle = option->computedStyleForEditability())
-                optionWidth += Style::evaluate(optionStyle->textIndent().length, 0, 1.0f /* FIXME FIND ZOOM */);
+                optionWidth += Style::evaluate(optionStyle->textIndent().length, 0, Style::ZoomNeeded { });
             if (!text.isEmpty()) {
                 const FontCascade& font = style().fontCascade();
                 TextRun run = RenderBlock::constructTextRun(text, style());
@@ -350,7 +350,7 @@ void RenderMenuList::computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidth, 
     }
     auto& logicalWidth = style().logicalWidth();
     if (logicalWidth.isCalculated())
-        minLogicalWidth = std::max(0_lu, Style::evaluate(logicalWidth, 0_lu, 1.0f /* FIXME FIND ZOOM */));
+        minLogicalWidth = std::max(0_lu, Style::evaluate(logicalWidth, 0_lu, Style::ZoomNeeded { }));
     else if (!logicalWidth.isPercent())
         minLogicalWidth = maxLogicalWidth;
 }

--- a/Source/WebCore/rendering/RenderMultiColumnSet.cpp
+++ b/Source/WebCore/rendering/RenderMultiColumnSet.cpp
@@ -445,7 +445,7 @@ LayoutUnit RenderMultiColumnSet::columnGap() const
     auto& parentBlockGap = parentBlock.style().columnGap();
     if (parentBlockGap.isNormal())
         return LayoutUnit(parentBlock.style().fontDescription().computedSize()); // "1em" is recommended as the normal gap setting. Matches <p> margins.
-    return Style::evaluate(parentBlockGap, parentBlock.contentBoxLogicalWidth(), 1.0f /* FIXME FIND ZOOM */);
+    return Style::evaluate(parentBlockGap, parentBlock.contentBoxLogicalWidth(), Style::ZoomNeeded { });
 }
 
 unsigned RenderMultiColumnSet::columnCount() const
@@ -632,7 +632,7 @@ void RenderMultiColumnSet::paintColumnRules(PaintInfo& paintInfo, const LayoutPo
     const Color& ruleColor = blockStyle.visitedDependentColorWithColorFilter(CSSPropertyColumnRuleColor);
     bool ruleTransparent = blockStyle.columnRuleIsTransparent();
     BorderStyle ruleStyle = collapsedBorderStyle(blockStyle.columnRuleStyle());
-    LayoutUnit ruleThickness { Style::evaluate(blockStyle.columnRuleWidth(), 1.0f /* FIXME FIND ZOOM */) };
+    LayoutUnit ruleThickness { Style::evaluate(blockStyle.columnRuleWidth(), Style::ZoomNeeded { }) };
     LayoutUnit colGap = columnGap();
     bool renderRule = ruleStyle > BorderStyle::Hidden && !ruleTransparent;
     if (!renderRule)

--- a/Source/WebCore/rendering/RenderReplaced.cpp
+++ b/Source/WebCore/rendering/RenderReplaced.cpp
@@ -556,8 +556,8 @@ LayoutRect RenderReplaced::replacedContentRect(const LayoutSize& intrinsicSize) 
 
     auto& objectPosition = style().objectPosition();
 
-    LayoutUnit xOffset = Style::evaluate(objectPosition.x, contentRect.width() - finalRect.width(), 1.0f /* FIXME FIND ZOOM */);
-    LayoutUnit yOffset = Style::evaluate(objectPosition.y, contentRect.height() - finalRect.height(), 1.0f /* FIXME FIND ZOOM */);
+    LayoutUnit xOffset = Style::evaluate(objectPosition.x, contentRect.width() - finalRect.width(), Style::ZoomNeeded { });
+    LayoutUnit yOffset = Style::evaluate(objectPosition.y, contentRect.height() - finalRect.height(), Style::ZoomNeeded { });
 
     finalRect.move(xOffset, yOffset);
 
@@ -613,8 +613,8 @@ LayoutUnit RenderReplaced::computeConstrainedLogicalWidth() const
     LayoutUnit logicalWidth = isOutOfFlowPositioned() ? containingBlock()->clientLogicalWidth() : containingBlock()->contentBoxLogicalWidth();
 
     // This solves above equation for 'width' (== logicalWidth).
-    LayoutUnit marginStart = Style::evaluateMinimum(style().marginStart(), logicalWidth, 1.0f /* FIXME FIND ZOOM */);
-    LayoutUnit marginEnd = Style::evaluateMinimum(style().marginEnd(), logicalWidth, 1.0f /* FIXME FIND ZOOM */);
+    LayoutUnit marginStart = Style::evaluateMinimum(style().marginStart(), logicalWidth, Style::ZoomNeeded { });
+    LayoutUnit marginEnd = Style::evaluateMinimum(style().marginEnd(), logicalWidth, Style::ZoomNeeded { });
 
     return std::max(0_lu, (logicalWidth - (marginStart + marginEnd + borderLeft() + borderRight() + paddingLeft() + paddingRight())));
 }
@@ -631,13 +631,13 @@ void RenderReplaced::computeAspectRatioAdjustedIntrinsicLogicalWidths(LayoutUnit
     auto computedIntrinsicLogicalWidth = minLogicalWidth;
 
     if (auto fixedLogicalHeight = style.logicalHeight().tryFixed())
-        computedIntrinsicLogicalWidth = fixedLogicalHeight->evaluate(1.0f /* FIXME FIND ZOOM */) * computedAspectRatio;
+        computedIntrinsicLogicalWidth = fixedLogicalHeight->resolveZoom(Style::ZoomNeeded { }) * computedAspectRatio;
 
     if (auto fixedLogicalMaxHeight = style.logicalMaxHeight().tryFixed())
-        computedIntrinsicLogicalWidth = std::min(computedIntrinsicLogicalWidth, LayoutUnit { fixedLogicalMaxHeight->evaluate(1.0f /* FIXME FIND ZOOM */) * computedAspectRatio });
+        computedIntrinsicLogicalWidth = std::min(computedIntrinsicLogicalWidth, LayoutUnit { fixedLogicalMaxHeight->resolveZoom(Style::ZoomNeeded { }) * computedAspectRatio });
 
     if (auto fixedLogicalMinHeight = style.logicalMinHeight().tryFixed())
-        computedIntrinsicLogicalWidth = std::max(computedIntrinsicLogicalWidth, LayoutUnit { fixedLogicalMinHeight->evaluate(1.0f /* FIXME FIND ZOOM */) * computedAspectRatio });
+        computedIntrinsicLogicalWidth = std::max(computedIntrinsicLogicalWidth, LayoutUnit { fixedLogicalMinHeight->resolveZoom(Style::ZoomNeeded { }) * computedAspectRatio });
 
     minLogicalWidth = computedIntrinsicLogicalWidth;
     maxLogicalWidth = minLogicalWidth;

--- a/Source/WebCore/rendering/RenderScrollbarPart.cpp
+++ b/Source/WebCore/rendering/RenderScrollbarPart.cpp
@@ -87,21 +87,21 @@ void RenderScrollbarPart::layoutVerticalPart()
 static int calcScrollbarThicknessUsing(const Style::PreferredSize& preferredSize)
 {
     if (!preferredSize.isPercentOrCalculated() && !preferredSize.isIntrinsicOrLegacyIntrinsicOrAuto())
-        return Style::evaluateMinimum(preferredSize, 0_lu, 1.0f /* FIXME FIND ZOOM */);
+        return Style::evaluateMinimum(preferredSize, 0_lu, Style::ZoomNeeded { });
     return ScrollbarTheme::theme().scrollbarThickness();
 }
 
 static int calcScrollbarThicknessUsing(const Style::MinimumSize& minimumSize)
 {
     if ((!minimumSize.isPercentOrCalculated() && !minimumSize.isIntrinsicOrLegacyIntrinsicOrAuto()) || minimumSize.isAuto())
-        return Style::evaluateMinimum(minimumSize, 0_lu, 1.0f /* FIXME FIND ZOOM */);
+        return Style::evaluateMinimum(minimumSize, 0_lu, Style::ZoomNeeded { });
     return ScrollbarTheme::theme().scrollbarThickness();
 }
 
 static int calcScrollbarThicknessUsing(const Style::MaximumSize& maximumSize)
 {
     if (!maximumSize.isPercentOrCalculated() && !maximumSize.isIntrinsic() && !maximumSize.isLegacyIntrinsic())
-        return Style::evaluateMinimum(maximumSize, 0_lu, 1.0f /* FIXME FIND ZOOM */);
+        return Style::evaluateMinimum(maximumSize, 0_lu, Style::ZoomNeeded { });
     return ScrollbarTheme::theme().scrollbarThickness();
 }
 
@@ -115,8 +115,8 @@ void RenderScrollbarPart::computeScrollbarWidth()
     setWidth(std::max(minWidth, std::min(maxWidth, width)));
     
     // Buttons and track pieces can all have margins along the axis of the scrollbar. 
-    m_marginBox.setLeft(Style::evaluateMinimum(style().marginLeft(), 0_lu, 1.0f /* FIXME FIND ZOOM */));
-    m_marginBox.setRight(Style::evaluateMinimum(style().marginRight(), 0_lu, 1.0f /* FIXME FIND ZOOM */));
+    m_marginBox.setLeft(Style::evaluateMinimum(style().marginLeft(), 0_lu, Style::ZoomNeeded { }));
+    m_marginBox.setRight(Style::evaluateMinimum(style().marginRight(), 0_lu, Style::ZoomNeeded { }));
 }
 
 void RenderScrollbarPart::computeScrollbarHeight()
@@ -129,8 +129,8 @@ void RenderScrollbarPart::computeScrollbarHeight()
     setHeight(std::max(minHeight, std::min(maxHeight, height)));
 
     // Buttons and track pieces can all have margins along the axis of the scrollbar. 
-    m_marginBox.setTop(Style::evaluateMinimum(style().marginTop(), 0_lu, 1.0f /* FIXME FIND ZOOM */));
-    m_marginBox.setBottom(Style::evaluateMinimum(style().marginBottom(), 0_lu, 1.0f /* FIXME FIND ZOOM */));
+    m_marginBox.setTop(Style::evaluateMinimum(style().marginTop(), 0_lu, Style::ZoomNeeded { }));
+    m_marginBox.setBottom(Style::evaluateMinimum(style().marginBottom(), 0_lu, Style::ZoomNeeded { }));
 }
 
 void RenderScrollbarPart::styleDidChange(StyleDifference diff, const RenderStyle* oldStyle)

--- a/Source/WebCore/rendering/RenderSlider.cpp
+++ b/Source/WebCore/rendering/RenderSlider.cpp
@@ -84,7 +84,7 @@ void RenderSlider::computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidth, La
     maxLogicalWidth = defaultTrackLength * style().usedZoom();
     auto& logicalWidth = style().logicalWidth();
     if (logicalWidth.isCalculated())
-        minLogicalWidth = std::max(0_lu, Style::evaluate(logicalWidth, 0_lu, 1.0f /* FIXME FIND ZOOM */));
+        minLogicalWidth = std::max(0_lu, Style::evaluate(logicalWidth, 0_lu, Style::ZoomNeeded { }));
     else if (!logicalWidth.isPercent())
         minLogicalWidth = maxLogicalWidth;
 }

--- a/Source/WebCore/rendering/RenderTableCell.cpp
+++ b/Source/WebCore/rendering/RenderTableCell.cpp
@@ -196,7 +196,7 @@ Style::PreferredSize RenderTableCell::logicalWidthFromColumns(RenderTableCol* fi
             return colWidth;
         }
 
-        colWidthSum += fixedColWidth->evaluate(1.0f /* FIXME FIND ZOOM */);
+        colWidthSum += fixedColWidth->resolveZoom(Style::ZoomNeeded { });
         tableCol = tableCol->nextColumn();
         // If no next <col> tag found for the span we just return what we have for now.
         if (!tableCol)
@@ -237,7 +237,7 @@ void RenderTableCell::computePreferredLogicalWidths()
         // to make the minwidth of the cell into the fixed width. They do this
         // even in strict mode, so do not make this a quirk. Affected the top
         // of hiptop.com.
-        m_minPreferredLogicalWidth = std::max(LayoutUnit(fixedLogicalWidth->evaluate(1.0f /* FIXME FIND ZOOM */)), m_minPreferredLogicalWidth);
+        m_minPreferredLogicalWidth = std::max(LayoutUnit(fixedLogicalWidth->resolveZoom(Style::ZoomNeeded { })), m_minPreferredLogicalWidth);
     }
 }
 
@@ -367,7 +367,7 @@ LayoutUnit RenderTableCell::logicalHeightForRowSizing() const
     auto specifiedSize = !isOrthogonal() ? style().logicalHeight() : style().logicalWidth();
     if (!specifiedSize.isSpecified())
         return usedLogicalSize;
-    auto computedLogicaSize = Style::evaluate(specifiedSize, 0_lu, 1.0f /* FIXME FIND ZOOM */);
+    auto computedLogicaSize = Style::evaluate(specifiedSize, 0_lu, Style::ZoomNeeded { });
     // In strict mode, box-sizing: content-box do the right thing and actually add in the border and padding.
     // Call computedCSSPadding* directly to avoid including implicitPadding.
     if (!document().inQuirksMode() && style().boxSizing() != BoxSizing::BorderBox)

--- a/Source/WebCore/rendering/RenderTableSection.cpp
+++ b/Source/WebCore/rendering/RenderTableSection.cpp
@@ -81,7 +81,7 @@ static inline void updateLogicalHeightForCell(RenderTableSection::RowStruct& row
             if (auto percentageRowLogicalHeight = row.logicalHeight.tryPercentage(); !percentageRowLogicalHeight || percentageRowLogicalHeight->value < percentageLogicalHeight->value)
                 row.logicalHeight = logicalHeight;
         } else if (auto fixedLogicalHeight = logicalHeight.tryFixed()) {
-            if (auto fixedRowLogicalHeight = row.logicalHeight.tryFixed(); row.logicalHeight.isAuto() || (fixedRowLogicalHeight && fixedRowLogicalHeight->evaluate(1.0f /* FIXME FIND ZOOM */) < fixedLogicalHeight->evaluate(1.0f /* FIXME FIND ZOOM */)))
+            if (auto fixedRowLogicalHeight = row.logicalHeight.tryFixed(); row.logicalHeight.isAuto() || (fixedRowLogicalHeight && fixedRowLogicalHeight->resolveZoom(Style::ZoomNeeded { }) < fixedLogicalHeight->resolveZoom(Style::ZoomNeeded { })))
                 row.logicalHeight = logicalHeight;
         }
     }
@@ -219,9 +219,9 @@ void RenderTableSection::addCell(RenderTableCell* cell, RenderTableRow* row)
 static LayoutUnit resolveLogicalHeightForRow(const Style::PreferredSize& rowLogicalHeight)
 {
     if (auto fixedRowLogicalHeight = rowLogicalHeight.tryFixed())
-        return LayoutUnit(fixedRowLogicalHeight->evaluate(1.0f /* FIXME FIND ZOOM */));
+        return LayoutUnit(fixedRowLogicalHeight->resolveZoom(Style::ZoomNeeded { }));
     if (rowLogicalHeight.isCalculated())
-        return LayoutUnit(Style::evaluate(rowLogicalHeight, 0, 1.0f /* FIXME FIND ZOOM */));
+        return LayoutUnit(Style::evaluate(rowLogicalHeight, 0, Style::ZoomNeeded { }));
     return 0;
 }
 
@@ -787,7 +787,7 @@ LayoutUnit RenderTableSection::calcBlockDirectionOuterBorder(BlockBorderSide sid
 
     if (allHidden)
         return -1;
-    return CollapsedBorderValue::adjustedCollapsedBorderWidth(Style::evaluate(borderWidth, 1.0f /* FIXME FIND ZOOM */), document().deviceScaleFactor(), (side == BlockBorderSide::BorderAfter));
+    return CollapsedBorderValue::adjustedCollapsedBorderWidth(Style::evaluate(borderWidth, Style::ZoomNeeded { }), document().deviceScaleFactor(), (side == BlockBorderSide::BorderAfter));
 }
 
 LayoutUnit RenderTableSection::calcInlineDirectionOuterBorder(InlineBorderSide side) const
@@ -841,7 +841,7 @@ LayoutUnit RenderTableSection::calcInlineDirectionOuterBorder(InlineBorderSide s
 
     if (allHidden)
         return -1;
-    return CollapsedBorderValue::adjustedCollapsedBorderWidth(Style::evaluate(borderWidth, 1.0f /* FIXME FIND ZOOM */), document().deviceScaleFactor(), (side == InlineBorderSide::BorderStart) ? writingMode.isInlineFlipped() : !writingMode.isInlineFlipped());
+    return CollapsedBorderValue::adjustedCollapsedBorderWidth(Style::evaluate(borderWidth, Style::ZoomNeeded { }), document().deviceScaleFactor(), (side == InlineBorderSide::BorderStart) ? writingMode.isInlineFlipped() : !writingMode.isInlineFlipped());
 }
 
 void RenderTableSection::recalcOuterBorder()
@@ -1144,18 +1144,18 @@ void RenderTableSection::paintRowGroupBorderIfRequired(const PaintInfo& paintInf
     switch (borderSide) {
     case BoxSide::Top:
         paintRowGroupBorder(paintInfo, antialias, LayoutRect(paintOffset.x() + offsetLeftForRowGroupBorder(cell, rowGroupRect, row), rowGroupRect.y(), 
-            horizontalRowGroupBorderWidth(cell, rowGroupRect, row, column), LayoutUnit(Style::evaluate(style.borderTop().width(), 1.0f /* FIXME FIND ZOOM */))), BoxSide::Top, CSSPropertyBorderTopColor, style.borderTopStyle(), table()->style().borderTopStyle());
+            horizontalRowGroupBorderWidth(cell, rowGroupRect, row, column), LayoutUnit(Style::evaluate(style.borderTop().width(), Style::ZoomNeeded { }))), BoxSide::Top, CSSPropertyBorderTopColor, style.borderTopStyle(), table()->style().borderTopStyle());
         break;
     case BoxSide::Bottom:
         paintRowGroupBorder(paintInfo, antialias, LayoutRect(paintOffset.x() + offsetLeftForRowGroupBorder(cell, rowGroupRect, row), rowGroupRect.y() + rowGroupRect.height(), 
-            horizontalRowGroupBorderWidth(cell, rowGroupRect, row, column), LayoutUnit(Style::evaluate(style.borderBottom().width(), 1.0f /* FIXME FIND ZOOM */))), BoxSide::Bottom, CSSPropertyBorderBottomColor, style.borderBottomStyle(), table()->style().borderBottomStyle());
+            horizontalRowGroupBorderWidth(cell, rowGroupRect, row, column), LayoutUnit(Style::evaluate(style.borderBottom().width(), Style::ZoomNeeded { }))), BoxSide::Bottom, CSSPropertyBorderBottomColor, style.borderBottomStyle(), table()->style().borderBottomStyle());
         break;
     case BoxSide::Left:
-        paintRowGroupBorder(paintInfo, antialias, LayoutRect(rowGroupRect.x(), rowGroupRect.y() + offsetTopForRowGroupBorder(cell, borderSide, row), LayoutUnit(Style::evaluate(style.borderLeft().width(), 1.0f /* FIXME FIND ZOOM */)),
+        paintRowGroupBorder(paintInfo, antialias, LayoutRect(rowGroupRect.x(), rowGroupRect.y() + offsetTopForRowGroupBorder(cell, borderSide, row), LayoutUnit(Style::evaluate(style.borderLeft().width(), Style::ZoomNeeded { })),
             verticalRowGroupBorderHeight(cell, rowGroupRect, row)), BoxSide::Left, CSSPropertyBorderLeftColor, style.borderLeftStyle(), table()->style().borderLeftStyle());
         break;
     case BoxSide::Right:
-        paintRowGroupBorder(paintInfo, antialias, LayoutRect(rowGroupRect.x() + rowGroupRect.width(), rowGroupRect.y() + offsetTopForRowGroupBorder(cell, borderSide, row), LayoutUnit(Style::evaluate(style.borderRight().width(), 1.0f /* FIXME FIND ZOOM */)),
+        paintRowGroupBorder(paintInfo, antialias, LayoutRect(rowGroupRect.x() + rowGroupRect.width(), rowGroupRect.y() + offsetTopForRowGroupBorder(cell, borderSide, row), LayoutUnit(Style::evaluate(style.borderRight().width(), Style::ZoomNeeded { })),
             verticalRowGroupBorderHeight(cell, rowGroupRect, row)), BoxSide::Right, CSSPropertyBorderRightColor, style.borderRightStyle(), table()->style().borderRightStyle());
         break;
     default:

--- a/Source/WebCore/rendering/RenderTextControl.cpp
+++ b/Source/WebCore/rendering/RenderTextControl.cpp
@@ -195,7 +195,7 @@ void RenderTextControl::computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidt
 
     auto& logicalWidth = style().logicalWidth();
     if (logicalWidth.isCalculated())
-        minLogicalWidth = std::max(0_lu, Style::evaluate(logicalWidth, 0_lu, 1.0f /* FIXME FIND ZOOM */));
+        minLogicalWidth = std::max(0_lu, Style::evaluate(logicalWidth, 0_lu, Style::ZoomNeeded { }));
     else if (!logicalWidth.isPercent())
         minLogicalWidth = maxLogicalWidth;
 }

--- a/Source/WebCore/rendering/RenderTextInlines.h
+++ b/Source/WebCore/rendering/RenderTextInlines.h
@@ -26,8 +26,8 @@
 
 namespace WebCore {
 
-inline LayoutUnit RenderText::marginLeft() const { return Style::evaluateMinimum(style().marginLeft(), 0_lu, 1.0f /* FIXME FIND ZOOM */); }
-inline LayoutUnit RenderText::marginRight() const { return Style::evaluateMinimum(style().marginRight(), 0_lu, 1.0f /* FIXME FIND ZOOM */); }
+inline LayoutUnit RenderText::marginLeft() const { return Style::evaluateMinimum(style().marginLeft(), 0_lu, Style::ZoomNeeded { }); }
+inline LayoutUnit RenderText::marginRight() const { return Style::evaluateMinimum(style().marginRight(), 0_lu, Style::ZoomNeeded { }); }
 
 template <typename MeasureTextCallback>
 float RenderText::measureTextConsideringPossibleTrailingSpace(bool currentCharacterIsSpace, unsigned startIndex, unsigned wordLength, WordTrailingSpace& wordTrailingSpace, SingleThreadWeakHashSet<const Font>& fallbackFonts, MeasureTextCallback&& callback)

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -551,8 +551,8 @@ static void updateSliderTrackPartForRenderer(SliderTrackPart& sliderTrackPart, c
 
         auto fixedWidth = thumbStyle.width().tryFixed();
         auto fixedHeight = thumbStyle.height().tryFixed();
-        auto thumbWidth = fixedWidth ? static_cast<int>(fixedWidth->evaluate(1.0f /* FIXME FIND ZOOM */)) : 0;
-        auto thumbHeight = fixedHeight ? static_cast<int>(fixedHeight->evaluate(1.0f /* FIXME FIND ZOOM */)) : 0;
+        auto thumbWidth = fixedWidth ? static_cast<int>(fixedWidth->resolveZoom(Style::ZoomNeeded { })) : 0;
+        auto thumbHeight = fixedHeight ? static_cast<int>(fixedHeight->resolveZoom(Style::ZoomNeeded { })) : 0;
 
         thumbSize = { thumbWidth, thumbHeight };
     }
@@ -837,7 +837,7 @@ ControlStyle RenderTheme::extractControlStyleForRenderer(const RenderElement& re
         style->usedZoom(),
         style->usedAccentColor(renderObject.styleColorOptions()),
         style->visitedDependentColorWithColorFilter(CSSPropertyColor),
-        Style::evaluate(style->borderWidth(), 1.0f /* FIXME FIND ZOOM */)
+        Style::evaluate(style->borderWidth(), Style::ZoomNeeded { })
     };
 }
 
@@ -1395,26 +1395,26 @@ void RenderTheme::adjustButtonOrCheckboxOrColorWellOrInnerSpinButtonOrRadioStyle
         borderBox = Style::LineWidthBox { borderBox.left(), borderBox.top(), borderBox.right(), borderBox.bottom() };
 
     /* FIXME: FIND ZOOM */
-    if (Style::evaluate(borderBox.top(), 1.0f) != static_cast<int>(Style::evaluate(style.borderTopWidth(), 1.0f))) {
+    if (Style::evaluate(borderBox.top(), Style::ZoomNeeded { }) != static_cast<int>(Style::evaluate(style.borderTopWidth(), Style::ZoomNeeded { }))) {
         if (!borderBox.top().isZero())
             style.setBorderTopWidth(borderBox.top());
         else
             style.resetBorderTop();
     }
-    if (Style::evaluate(borderBox.right(), 1.0f) != static_cast<int>(Style::evaluate(style.borderRightWidth(), 1.0f))) {
+    if (Style::evaluate(borderBox.right(), Style::ZoomNeeded { }) != static_cast<int>(Style::evaluate(style.borderRightWidth(), Style::ZoomNeeded { }))) {
         if (!borderBox.right().isZero())
             style.setBorderRightWidth(borderBox.right());
         else
             style.resetBorderRight();
     }
-    if (Style::evaluate(borderBox.bottom(), 1.0f) != static_cast<int>(Style::evaluate(style.borderBottomWidth(), 1.0f))) {
+    if (Style::evaluate(borderBox.bottom(), Style::ZoomNeeded { }) != static_cast<int>(Style::evaluate(style.borderBottomWidth(), Style::ZoomNeeded { }))) {
         style.setBorderBottomWidth(borderBox.bottom());
         if (!borderBox.bottom().isZero())
             style.setBorderBottomWidth(borderBox.bottom());
         else
             style.resetBorderBottom();
     }
-    if (Style::evaluate(borderBox.left(), 1.0f) != static_cast<int>(Style::evaluate(style.borderLeftWidth(), 1.0f))) {
+    if (Style::evaluate(borderBox.left(), Style::ZoomNeeded { }) != static_cast<int>(Style::evaluate(style.borderLeftWidth(), Style::ZoomNeeded { }))) {
         style.setBorderLeftWidth(borderBox.left());
         if (!borderBox.left().isZero())
             style.setBorderLeftWidth(borderBox.left());
@@ -1449,11 +1449,11 @@ void RenderTheme::adjustButtonOrCheckboxOrColorWellOrInnerSpinButtonOrRadioStyle
 
     if (auto fixedOverrideMinWidth = minimumControlSize.width().tryFixed()) {
         if (auto fixedOriginalMinWidth = style.minWidth().tryFixed()) {
-            if (fixedOverrideMinWidth->evaluate(1.0f /* FIXME FIND ZOOM */) > fixedOriginalMinWidth->evaluate(1.0f /* FIXME FIND ZOOM */))
+            if (fixedOverrideMinWidth->resolveZoom(Style::ZoomNeeded { }) > fixedOriginalMinWidth->resolveZoom(Style::ZoomNeeded { }))
                 style.setMinWidth(Style::MinimumSize(minimumControlSize.width()));
         } else if (auto percentageOriginalMinWidth = style.minWidth().tryPercentage()) {
             // FIXME: This really makes no sense but matches existing behavior. Should use a `calc(max(override, original))` here instead.
-            if (fixedOverrideMinWidth->evaluate(1.0f /* FIXME FIND ZOOM */) > percentageOriginalMinWidth->value)
+            if (fixedOverrideMinWidth->resolveZoom(Style::ZoomNeeded { }) > percentageOriginalMinWidth->value)
                 style.setMinWidth(Style::MinimumSize(minimumControlSize.width()));
         } else if (fixedOverrideMinWidth->isPositive()) {
             style.setMinWidth(Style::MinimumSize(minimumControlSize.width()));
@@ -1461,7 +1461,7 @@ void RenderTheme::adjustButtonOrCheckboxOrColorWellOrInnerSpinButtonOrRadioStyle
     } else if (auto percentageOverrideMinWidth = minimumControlSize.width().tryPercentage()) {
         if (auto fixedOriginalMinWidth = style.minWidth().tryFixed()) {
             // FIXME: This really makes no sense but matches existing behavior. Should use a `calc(max(override, original))` here instead.
-            if (percentageOverrideMinWidth->value > fixedOriginalMinWidth->evaluate(1.0f /* FIXME FIND ZOOM */))
+            if (percentageOverrideMinWidth->value > fixedOriginalMinWidth->resolveZoom(Style::ZoomNeeded { }))
                 style.setMinWidth(Style::MinimumSize(minimumControlSize.width()));
         } else if (auto percentageOriginalMinWidth = style.minWidth().tryPercentage()) {
             if (percentageOverrideMinWidth->value > percentageOriginalMinWidth->value)
@@ -1472,11 +1472,11 @@ void RenderTheme::adjustButtonOrCheckboxOrColorWellOrInnerSpinButtonOrRadioStyle
     }
     if (auto fixedOverrideMinHeight = minimumControlSize.height().tryFixed()) {
         if (auto fixedOriginalMinHeight = style.minHeight().tryFixed()) {
-            if (fixedOverrideMinHeight->evaluate(1.0f /* FIXME FIND ZOOM */) > fixedOriginalMinHeight->evaluate(1.0f /* FIXME FIND ZOOM */))
+            if (fixedOverrideMinHeight->resolveZoom(Style::ZoomNeeded { }) > fixedOriginalMinHeight->resolveZoom(Style::ZoomNeeded { }))
                 style.setMinHeight(Style::MinimumSize(minimumControlSize.height()));
         } else if (auto percentageOriginalMinHeight = style.minHeight().tryPercentage()) {
             // FIXME: This really makes no sense but matches existing behavior. Should use a `calc(max(override, original))` here instead.
-            if (fixedOverrideMinHeight->evaluate(1.0f /* FIXME FIND ZOOM */) > percentageOriginalMinHeight->value)
+            if (fixedOverrideMinHeight->resolveZoom(Style::ZoomNeeded { }) > percentageOriginalMinHeight->value)
                 style.setMinHeight(Style::MinimumSize(minimumControlSize.height()));
         } else if (fixedOverrideMinHeight->isPositive()) {
             style.setMinHeight(Style::MinimumSize(minimumControlSize.height()));
@@ -1484,7 +1484,7 @@ void RenderTheme::adjustButtonOrCheckboxOrColorWellOrInnerSpinButtonOrRadioStyle
     } else if (auto percentageOverrideMinHeight = minimumControlSize.height().tryPercentage()) {
         if (auto fixedOriginalMinHeight = style.minHeight().tryFixed()) {
             // FIXME: This really makes no sense but matches existing behavior. Should use a `calc(max(override, original))` here instead.
-            if (percentageOverrideMinHeight->value > fixedOriginalMinHeight->evaluate(1.0f /* FIXME FIND ZOOM */))
+            if (percentageOverrideMinHeight->value > fixedOriginalMinHeight->resolveZoom(Style::ZoomNeeded { }))
                 style.setMinHeight(Style::MinimumSize(minimumControlSize.height()));
         } else if (auto percentageOriginalMinHeight = style.minHeight().tryPercentage()) {
             if (percentageOverrideMinHeight->value > percentageOriginalMinHeight->value)
@@ -1582,11 +1582,11 @@ void RenderTheme::paintSliderTicks(const RenderElement& renderer, const PaintInf
 
         int thumbWidth = 0;
         if (auto fixedWidth = thumbStyle.width().tryFixed())
-            thumbWidth = static_cast<int>(fixedWidth->evaluate(1.0f /* FIXME FIND ZOOM */));
+            thumbWidth = static_cast<int>(fixedWidth->resolveZoom(Style::ZoomNeeded { }));
 
         int thumbHeight = 0;
         if (auto fixedHeight = thumbStyle.height().tryFixed())
-            thumbHeight = static_cast<int>(fixedHeight->evaluate(1.0f /* FIXME FIND ZOOM */));
+            thumbHeight = static_cast<int>(fixedHeight->resolveZoom(Style::ZoomNeeded { }));
 
         thumbSize.setWidth(isHorizontal ? thumbWidth : thumbHeight);
         thumbSize.setHeight(isHorizontal ? thumbHeight : thumbWidth);

--- a/Source/WebCore/rendering/RenderTreeAsText.cpp
+++ b/Source/WebCore/rendering/RenderTreeAsText.cpp
@@ -275,7 +275,7 @@ void RenderTreeAsText::writeRenderObject(TextStream& ts, const RenderObject& o, 
                 ts << " [textStrokeColor="_s << serializationForRenderTreeAsText(textStrokeColor) << ']';
 
             if (renderElement->parent()->style().textStrokeWidth() != renderElement->style().textStrokeWidth() && renderElement->style().textStrokeWidth().isPositive())
-                ts << " [textStrokeWidth="_s << Style::evaluate(renderElement->style().textStrokeWidth(), 1.0f /* FIXME FIND ZOOM */) << ']';
+                ts << " [textStrokeWidth="_s << Style::evaluate(renderElement->style().textStrokeWidth(), Style::ZoomNeeded { }) << ']';
         }
 
         auto* box = dynamicDowncast<RenderBoxModelObject>(o);

--- a/Source/WebCore/rendering/TextBoxPainter.h
+++ b/Source/WebCore/rendering/TextBoxPainter.h
@@ -120,21 +120,21 @@ inline FloatSize TextBoxPainter::rotateShadowOffset(const SpaceSeparatedPoint<St
 {
     if (writingMode.isHorizontal()) {
         return {
-            offset.x().evaluate(1.0f /* FIXME FIND ZOOM */),
-            offset.y().evaluate(1.0f /* FIXME FIND ZOOM */),
+            offset.x().resolveZoom(Style::ZoomNeeded { }),
+            offset.y().resolveZoom(Style::ZoomNeeded { }),
         };
     }
 
     if (writingMode.isLineOverLeft()) { // sideways-lr
         return {
-            -offset.y().evaluate(1.0f /* FIXME FIND ZOOM */),
-             offset.x().evaluate(1.0f /* FIXME FIND ZOOM */),
+            -offset.y().resolveZoom(Style::ZoomNeeded { }),
+             offset.x().resolveZoom(Style::ZoomNeeded { }),
         };
     }
 
     return {
-         offset.y().evaluate(1.0f /* FIXME FIND ZOOM */),
-        -offset.x().evaluate(1.0f /* FIXME FIND ZOOM */),
+         offset.y().resolveZoom(Style::ZoomNeeded { }),
+        -offset.x().resolveZoom(Style::ZoomNeeded { }),
     };
 }
 

--- a/Source/WebCore/rendering/TextDecorationPainter.cpp
+++ b/Source/WebCore/rendering/TextDecorationPainter.cpp
@@ -281,7 +281,7 @@ void TextDecorationPainter::paintBackgroundDecorations(const RenderStyle& style,
 
             auto shadowOffset = TextBoxPainter::rotateShadowOffset(shadow.location, m_writingMode);
             shadowOffset.expand(0, -extraOffset);
-            m_context.setDropShadow({ shadowOffset, shadow.blur.evaluate(1.0f /* FIXME FIND ZOOM */), shadowColor, ShadowRadiusMode::Default });
+            m_context.setDropShadow({ shadowOffset, shadow.blur.resolveZoom(Style::ZoomNeeded { }), shadowColor, ShadowRadiusMode::Default });
 
             draw(&shadow);
         }

--- a/Source/WebCore/rendering/TextPainter.cpp
+++ b/Source/WebCore/rendering/TextPainter.cpp
@@ -55,7 +55,7 @@ ShadowApplier::ShadowApplier(const RenderStyle& style, GraphicsContext& context,
     }
 
     auto shadowOffset = TextBoxPainter::rotateShadowOffset(shadow->location, ignoreWritingMode ? WritingMode() : style.writingMode());
-    auto shadowRadius = shadow->blur.evaluate(1.0f /* FIXME FIND ZOOM */);
+    auto shadowRadius = shadow->blur.resolveZoom(Style::ZoomNeeded { });
     auto shadowColor = style.colorResolvingCurrentColor(shadow->color);
 
     colorFilter.transformColor(shadowColor);

--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
@@ -128,7 +128,7 @@ static void drawFocusRingForPathForVectorBasedControls(const RenderObject& box, 
     // macOS controls have never honored outline offset.
 #if PLATFORM(IOS_FAMILY)
     auto deviceScaleFactor = box.document().deviceScaleFactor();
-    auto outlineOffset = floorToDevicePixel(Style::evaluate(box.style().outlineOffset(), 1.0f /* FIXME FIND ZOOM */), deviceScaleFactor);
+    auto outlineOffset = floorToDevicePixel(Style::evaluate(box.style().outlineOffset(), Style::ZoomNeeded { }), deviceScaleFactor);
 
     if (outlineOffset > 0) {
         const auto center = rect.center();
@@ -2440,7 +2440,7 @@ bool RenderThemeCocoa::adjustButtonStyleForVectorBasedControls(RenderStyle& styl
     if (style.logicalWidth().isIntrinsicOrLegacyIntrinsicOrAuto() || style.logicalHeight().isAuto()) {
         auto minimumHeight = controlBaseHeight / controlBaseFontSize * style.fontDescription().computedSize();
         if (auto fixedValue = style.logicalMinHeight().tryFixed())
-            minimumHeight = std::max(minimumHeight, fixedValue->evaluate(1.0f /* FIXME FIND ZOOM */));
+            minimumHeight = std::max(minimumHeight, fixedValue->resolveZoom(Style::ZoomNeeded { }));
         // FIXME: This may need to be a layout time adjustment to support various
         // values like fit-content etc.
         style.setLogicalMinHeight(Style::MinimumSize::Fixed { minimumHeight });
@@ -2574,18 +2574,18 @@ bool RenderThemeCocoa::paintMenuListButtonDecorationsForVectorBasedControls(cons
 
     auto glyphPaddingEnd = logicalRect.width();
     if (auto fixedPaddingEnd = box.style().paddingEnd().tryFixed())
-        glyphPaddingEnd = fixedPaddingEnd->evaluate(1.0f /* FIXME FIND ZOOM */);
+        glyphPaddingEnd = fixedPaddingEnd->resolveZoom(Style::ZoomNeeded { });
 
     // Add RenderMenuList inner start padding for symmetry.
     if (CheckedPtr menulist = dynamicDowncast<RenderMenuList>(box); menulist && menulist->innerRenderer()) {
         if (auto innerPaddingStart = menulist->innerRenderer()->style().paddingStart().tryFixed())
-            glyphPaddingEnd += innerPaddingStart->evaluate(1.0f /* FIXME FIND ZOOM */);
+            glyphPaddingEnd += innerPaddingStart->resolveZoom(Style::ZoomNeeded { });
     }
 
     if (!style->writingMode().isInlineFlipped())
-        glyphOrigin.setX(logicalRect.maxX() - glyphSize.width() - Style::evaluate(box.style().borderEndWidth(), 1.0f /* FIXME FIND ZOOM */) - glyphPaddingEnd);
+        glyphOrigin.setX(logicalRect.maxX() - glyphSize.width() - Style::evaluate(box.style().borderEndWidth(), Style::ZoomNeeded { }) - glyphPaddingEnd);
     else
-        glyphOrigin.setX(logicalRect.x() + Style::evaluate(box.style().borderEndWidth(), 1.0f /* FIXME FIND ZOOM */) + glyphPaddingEnd);
+        glyphOrigin.setX(logicalRect.x() + Style::evaluate(box.style().borderEndWidth(), Style::ZoomNeeded { }) + glyphPaddingEnd);
 
     if (!isHorizontalWritingMode)
         glyphOrigin = glyphOrigin.transposedPoint();
@@ -3891,7 +3891,7 @@ float RenderThemeCocoa::adjustedMaximumLogicalWidthForControl(const RenderStyle&
 
         if (auto paddingEdgeInlineStartFixed = paddingEdgeInlineStart.tryFixed()) {
             if (auto paddingEdgeInlineEndFixed = paddingEdgeInlineEnd.tryFixed())
-                maximumLogicalWidth += paddingEdgeInlineStartFixed->evaluate(1.0f /* FIXME FIND ZOOM */) - paddingEdgeInlineEndFixed->evaluate(1.0f /* FIXME FIND ZOOM */);
+                maximumLogicalWidth += paddingEdgeInlineStartFixed->resolveZoom(Style::ZoomNeeded { }) - paddingEdgeInlineEndFixed->resolveZoom(Style::ZoomNeeded { });
         }
     }
 #else

--- a/Source/WebCore/rendering/ios/RenderThemeIOS.mm
+++ b/Source/WebCore/rendering/ios/RenderThemeIOS.mm
@@ -175,11 +175,11 @@ void RenderThemeIOS::adjustMinimumIntrinsicSizeForAppearance(StyleAppearance app
 
     if (auto fixedOverrideMinWidth = minimumControlSize.width().tryFixed()) {
         if (auto fixedOriginalMinWidth = style.minWidth().tryFixed()) {
-            if (fixedOverrideMinWidth->evaluate(1.0f /* FIXME FIND ZOOM */) > fixedOriginalMinWidth->evaluate(1.0f /* FIXME FIND ZOOM */))
+            if (fixedOverrideMinWidth->resolveZoom(Style::ZoomNeeded { }) > fixedOriginalMinWidth->resolveZoom(Style::ZoomNeeded { }))
                 style.setMinWidth(Style::MinimumSize(minimumControlSize.width()));
         } else if (auto percentageOriginalMinWidth = style.minWidth().tryPercentage()) {
             // FIXME: This really makes no sense but matches existing behavior. Should use a `calc(max(override, original))` here instead.
-            if (fixedOverrideMinWidth->evaluate(1.0f /* FIXME FIND ZOOM */) > percentageOriginalMinWidth->value)
+            if (fixedOverrideMinWidth->resolveZoom(Style::ZoomNeeded { }) > percentageOriginalMinWidth->value)
                 style.setMinWidth(Style::MinimumSize(minimumControlSize.width()));
         } else if (fixedOverrideMinWidth->isPositive()) {
             style.setMinWidth(Style::MinimumSize(minimumControlSize.width()));
@@ -187,7 +187,7 @@ void RenderThemeIOS::adjustMinimumIntrinsicSizeForAppearance(StyleAppearance app
     } else if (auto percentageOverrideMinWidth = minimumControlSize.width().tryPercentage()) {
         if (auto fixedOriginalMinWidth = style.minWidth().tryFixed()) {
             // FIXME: This really makes no sense but matches existing behavior. Should use a `calc(max(override, original))` here instead.
-            if (percentageOverrideMinWidth->value > fixedOriginalMinWidth->evaluate(1.0f /* FIXME FIND ZOOM */))
+            if (percentageOverrideMinWidth->value > fixedOriginalMinWidth->resolveZoom(Style::ZoomNeeded { }))
                 style.setMinWidth(Style::MinimumSize(minimumControlSize.width()));
         } else if (auto percentageOriginalMinWidth = style.minWidth().tryPercentage()) {
             if (percentageOverrideMinWidth->value > percentageOriginalMinWidth->value)
@@ -198,11 +198,11 @@ void RenderThemeIOS::adjustMinimumIntrinsicSizeForAppearance(StyleAppearance app
     }
     if (auto fixedOverrideMinHeight = minimumControlSize.height().tryFixed()) {
         if (auto fixedOriginalMinHeight = style.minHeight().tryFixed()) {
-            if (fixedOverrideMinHeight->evaluate(1.0f /* FIXME FIND ZOOM */) > fixedOriginalMinHeight->evaluate(1.0f /* FIXME FIND ZOOM */))
+            if (fixedOverrideMinHeight->resolveZoom(Style::ZoomNeeded { }) > fixedOriginalMinHeight->resolveZoom(Style::ZoomNeeded { }))
                 style.setMinHeight(Style::MinimumSize(minimumControlSize.height()));
         } else if (auto percentageOriginalMinHeight = style.minHeight().tryPercentage()) {
             // FIXME: This really makes no sense but matches existing behavior. Should use a `calc(max(override, original))` here instead.
-            if (fixedOverrideMinHeight->evaluate(1.0f /* FIXME FIND ZOOM */) > percentageOriginalMinHeight->value)
+            if (fixedOverrideMinHeight->resolveZoom(Style::ZoomNeeded { }) > percentageOriginalMinHeight->value)
                 style.setMinHeight(Style::MinimumSize(minimumControlSize.height()));
         } else if (fixedOverrideMinHeight->isPositive()) {
             style.setMinHeight(Style::MinimumSize(minimumControlSize.height()));
@@ -210,7 +210,7 @@ void RenderThemeIOS::adjustMinimumIntrinsicSizeForAppearance(StyleAppearance app
     } else if (auto percentageOverrideMinHeight = minimumControlSize.height().tryPercentage()) {
         if (auto fixedOriginalMinHeight = style.minHeight().tryFixed()) {
             // FIXME: This really makes no sense but matches existing behavior. Should use a `calc(max(override, original))` here instead.
-            if (percentageOverrideMinHeight->value > fixedOriginalMinHeight->evaluate(1.0f /* FIXME FIND ZOOM */))
+            if (percentageOverrideMinHeight->value > fixedOriginalMinHeight->resolveZoom(Style::ZoomNeeded { }))
                 style.setMinHeight(Style::MinimumSize(minimumControlSize.height()));
         } else if (auto percentageOriginalMinHeight = style.minHeight().tryPercentage()) {
             if (percentageOverrideMinHeight->value > percentageOriginalMinHeight->value)
@@ -383,7 +383,7 @@ Style::PaddingBox RenderThemeIOS::popupInternalPaddingBox(const RenderStyle& sty
     auto padding = emSize->resolveAsLength<float>({ style, nullptr, nullptr, nullptr });
 
     if (style.usedAppearance() == StyleAppearance::MenulistButton) {
-        auto value = toTruncatedPaddingEdge(padding + Style::evaluate(style.borderTopWidth(), 1.0f /* FIXME FIND ZOOM */));
+        auto value = toTruncatedPaddingEdge(padding + Style::evaluate(style.borderTopWidth(), Style::ZoomNeeded { }));
         if (style.writingMode().isBidiRTL())
             return { 0_css_px, 0_css_px, 0_css_px, value };
         return { 0_css_px, value, 0_css_px, 0_css_px };
@@ -610,9 +610,9 @@ void RenderThemeIOS::paintMenuListButtonDecorations(const RenderBox& box, const 
     FloatPoint glyphOrigin;
     glyphOrigin.setY(logicalRect.center().y() - glyphSize.height() / 2.0f);
     if (!style.writingMode().isInlineFlipped())
-        glyphOrigin.setX(logicalRect.maxX() - glyphSize.width() - Style::evaluate(box.style().borderEndWidth(), 1.0f /* FIXME FIND ZOOM */) - Style::evaluate(box.style().paddingEnd(), logicalRect.width(), 1.0f/* FIXME FIND ZOOM */));
+        glyphOrigin.setX(logicalRect.maxX() - glyphSize.width() - Style::evaluate(box.style().borderEndWidth(), Style::ZoomNeeded { }) - Style::evaluate(box.style().paddingEnd(), logicalRect.width(), Style::ZoomNeeded { }));
     else
-        glyphOrigin.setX(logicalRect.x() + Style::evaluate(box.style().borderEndWidth(), 1.0f /* FIXME FIND ZOOM */) + Style::evaluate(box.style().paddingEnd(), logicalRect.width(), 1.0f /* FIXME FIND ZOOM */));
+        glyphOrigin.setX(logicalRect.x() + Style::evaluate(box.style().borderEndWidth(), Style::ZoomNeeded { }) + Style::evaluate(box.style().paddingEnd(), logicalRect.width(), Style::ZoomNeeded { }));
 
     if (!isHorizontalWritingMode)
         glyphOrigin = glyphOrigin.transposedPoint();
@@ -942,7 +942,7 @@ void RenderThemeIOS::adjustButtonStyle(RenderStyle& style, const Element* elemen
     if (style.logicalWidth().isIntrinsicOrLegacyIntrinsicOrAuto() || style.logicalHeight().isAuto()) {
         auto minimumHeight = ControlBaseHeight / ControlBaseFontSize * style.fontDescription().computedSize();
         if (auto fixedLogicalMinHeight = style.logicalMinHeight().tryFixed())
-            minimumHeight = std::max(minimumHeight, fixedLogicalMinHeight->evaluate(1.0f /* FIXME FIND ZOOM */));
+            minimumHeight = std::max(minimumHeight, fixedLogicalMinHeight->resolveZoom(Style::ZoomNeeded { }));
         // FIXME: This may need to be a layout time adjustment to support various values like fit-content etc.
         style.setLogicalMinHeight(Style::MinimumSize::Fixed { minimumHeight });
     }
@@ -1744,10 +1744,10 @@ bool RenderThemeIOS::paintListButton(const RenderElement& box, const PaintInfo& 
     auto& context = paintInfo.context();
     GraphicsContextStateSaver stateSaver(context);
 
-    float paddingTop = Style::evaluate(style.paddingTop(), rect.height(), 1.0f /* FIXME FIND ZOOM */);
-    float paddingRight = Style::evaluate(style.paddingRight(), rect.width(), 1.0f /* FIXME FIND ZOOM */);
-    float paddingBottom = Style::evaluate(style.paddingBottom(), rect.height(), 1.0f /* FIXME FIND ZOOM */);
-    float paddingLeft = Style::evaluate(style.paddingLeft(), rect.width(), 1.0f /* FIXME FIND ZOOM */);
+    float paddingTop = Style::evaluate(style.paddingTop(), rect.height(), Style::ZoomNeeded { });
+    float paddingRight = Style::evaluate(style.paddingRight(), rect.width(), Style::ZoomNeeded { });
+    float paddingBottom = Style::evaluate(style.paddingBottom(), rect.height(), Style::ZoomNeeded { });
+    float paddingLeft = Style::evaluate(style.paddingLeft(), rect.width(), Style::ZoomNeeded { });
 
     FloatRect indicatorRect = rect;
     indicatorRect.move(paddingLeft, paddingTop);

--- a/Source/WebCore/rendering/mathml/RenderMathMLBlock.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLBlock.cpp
@@ -280,12 +280,12 @@ RenderMathMLBlock::SizeAppliedToMathContent RenderMathMLBlock::sizeAppliedToMath
     // FIXME: Resolve percentages.
     // https://github.com/w3c/mathml-core/issues/76
     if (auto fixedLogicalWidth = style().logicalWidth().tryFixed())
-        sizes.logicalWidth = fixedLogicalWidth->evaluate(1.0f /* FIXME FIND ZOOM */);
+        sizes.logicalWidth = fixedLogicalWidth->resolveZoom(Style::ZoomNeeded { });
 
     // FIXME: Resolve percentages.
     // https://github.com/w3c/mathml-core/issues/77
     if (auto fixedLogicalHeight = style().logicalHeight().tryFixed(); phase == LayoutPhase::Layout && fixedLogicalHeight)
-        sizes.logicalHeight = fixedLogicalHeight->evaluate(1.0f /* FIXME FIND ZOOM */);
+        sizes.logicalHeight = fixedLogicalHeight->resolveZoom(Style::ZoomNeeded { });
 
     return sizes;
 }

--- a/Source/WebCore/rendering/shapes/LayoutShape.cpp
+++ b/Source/WebCore/rendering/shapes/LayoutShape.cpp
@@ -121,14 +121,14 @@ Ref<const LayoutShape> LayoutShape::createShape(const Style::BasicShape& basicSh
             return createEllipseShape(logicalCenter, radii, logicalBoxSize.width());
         },
         [&](const Style::InsetFunction& inset) -> Ref<LayoutShape> {
-            float left = Style::evaluate(inset->insets.left(), boxWidth, 1.0f /* FIXME FIND ZOOM */);
-            float top = Style::evaluate(inset->insets.top(), boxHeight, 1.0f /* FIXME FIND ZOOM */);
+            float left = Style::evaluate(inset->insets.left(), boxWidth, Style::ZoomNeeded { });
+            float top = Style::evaluate(inset->insets.top(), boxHeight, Style::ZoomNeeded { });
 
             FloatRect rect {
                 left,
                 top,
-                std::max<float>(boxWidth - left - Style::evaluate(inset->insets.right(), boxWidth, 1.0f /* FIXME FIND ZOOM */), 0),
-                std::max<float>(boxHeight - top - Style::evaluate(inset->insets.bottom(), boxHeight, 1.0f /* FIXME FIND ZOOM */), 0)
+                std::max<float>(boxWidth - left - Style::evaluate(inset->insets.right(), boxWidth, Style::ZoomNeeded { }), 0),
+                std::max<float>(boxHeight - top - Style::evaluate(inset->insets.bottom(), boxHeight, Style::ZoomNeeded { }), 0)
             };
 
             auto logicalRect = physicalRectToLogical(rect, logicalBoxSize.height(), writingMode);
@@ -136,10 +136,10 @@ Ref<const LayoutShape> LayoutShape::createShape(const Style::BasicShape& basicSh
 
             auto boxSize = FloatSize(boxWidth, boxHeight);
             auto isBlockLeftToRight = writingMode.isBlockLeftToRight();
-            auto topLeftRadius = physicalSizeToLogical(Style::evaluate(horizontalWritingMode || isBlockLeftToRight ? inset->radii.topLeft() : inset->radii.topRight(), boxSize, 1.0f /* FIXME FIND ZOOM */), writingMode);
-            auto topRightRadius = physicalSizeToLogical(Style::evaluate(horizontalWritingMode ? inset->radii.topRight() : isBlockLeftToRight ? inset->radii.bottomLeft() : inset->radii.bottomRight(), boxSize, 1.0f /* FIXME FIND ZOOM */), writingMode);
-            auto bottomLeftRadius = physicalSizeToLogical(Style::evaluate(horizontalWritingMode ? inset->radii.bottomLeft() : isBlockLeftToRight ? inset->radii.topRight() : inset->radii.topLeft(), boxSize, 1.0f /* FIXME FIND ZOOM */), writingMode);
-            auto bottomRightRadius = physicalSizeToLogical(Style::evaluate(horizontalWritingMode ? inset->radii.bottomRight() : isBlockLeftToRight ? inset->radii.bottomRight() : inset->radii.bottomLeft(), boxSize, 1.0f /* FIXME FIND ZOOM */), writingMode);
+            auto topLeftRadius = physicalSizeToLogical(Style::evaluate(horizontalWritingMode || isBlockLeftToRight ? inset->radii.topLeft() : inset->radii.topRight(), boxSize, Style::ZoomNeeded { }), writingMode);
+            auto topRightRadius = physicalSizeToLogical(Style::evaluate(horizontalWritingMode ? inset->radii.topRight() : isBlockLeftToRight ? inset->radii.bottomLeft() : inset->radii.bottomRight(), boxSize, Style::ZoomNeeded { }), writingMode);
+            auto bottomLeftRadius = physicalSizeToLogical(Style::evaluate(horizontalWritingMode ? inset->radii.bottomLeft() : isBlockLeftToRight ? inset->radii.topRight() : inset->radii.topLeft(), boxSize, Style::ZoomNeeded { }), writingMode);
+            auto bottomRightRadius = physicalSizeToLogical(Style::evaluate(horizontalWritingMode ? inset->radii.bottomRight() : isBlockLeftToRight ? inset->radii.bottomRight() : inset->radii.bottomLeft(), boxSize, Style::ZoomNeeded { }), writingMode);
             auto cornerRadii = FloatRoundedRect::Radii(topLeftRadius, topRightRadius, bottomLeftRadius, bottomRightRadius);
             if (shouldFlipStartAndEndPoints(writingMode))
                 cornerRadii = { cornerRadii.topRight(), cornerRadii.topLeft(), cornerRadii.bottomRight(), cornerRadii.bottomLeft() };
@@ -151,7 +151,7 @@ Ref<const LayoutShape> LayoutShape::createShape(const Style::BasicShape& basicSh
             auto boxSize = FloatSize { boxWidth, boxHeight };
 
             auto vertices = polygon->vertices.value.map([&](const auto& vertex) {
-                return physicalPointToLogical(Style::evaluate(vertex, boxSize, 1.0f /* FIXME FIND ZOOM */) + borderBoxOffset, logicalBoxSize.height(), writingMode);
+                return physicalPointToLogical(Style::evaluate(vertex, boxSize, Style::ZoomNeeded { }) + borderBoxOffset, logicalBoxSize.height(), writingMode);
             });
 
             return createPolygonShape(WTFMove(vertices), logicalBoxSize.width());

--- a/Source/WebCore/rendering/shapes/ShapeOutsideInfo.cpp
+++ b/Source/WebCore/rendering/shapes/ShapeOutsideInfo.cpp
@@ -256,7 +256,7 @@ Ref<const LayoutShape> makeShapeForShapeOutside(const RenderBox& renderer)
     auto boxSize = computeLogicalBoxSize(renderer, isHorizontalWritingMode);
 
     auto logicalMargin = [&] {
-        auto shapeMargin = Style::evaluate(style.shapeMargin(), containingBlock.contentBoxLogicalWidth(), 1.0f /* FIXME FIND ZOOM */).toFloat();
+        auto shapeMargin = Style::evaluate(style.shapeMargin(), containingBlock.contentBoxLogicalWidth(), Style::ZoomNeeded { }).toFloat();
         return isnan(shapeMargin) ? 0.0f : shapeMargin;
     }();
 

--- a/Source/WebCore/rendering/style/AutosizeStatus.cpp
+++ b/Source/WebCore/rendering/style/AutosizeStatus.cpp
@@ -42,9 +42,9 @@ bool AutosizeStatus::probablyContainsASmallFixedNumberOfLines(const RenderStyle&
     auto& maxHeight = style.maxHeight();
     std::optional<float> heightOrMaxHeightAsLength;
     if (auto fixedMaxHeight = maxHeight.tryFixed())
-        heightOrMaxHeightAsLength = fixedMaxHeight->evaluate(1.0f /* FIXME FIND ZOOM */);
+        heightOrMaxHeightAsLength = fixedMaxHeight->resolveZoom(Style::ZoomNeeded { });
     else if (auto fixedHeight = style.height().tryFixed(); fixedHeight && (!maxHeight.isSpecified() || maxHeight.isNone()))
-        heightOrMaxHeightAsLength = fixedHeight->evaluate(1.0f /* FIXME FIND ZOOM */);
+        heightOrMaxHeightAsLength = fixedHeight->resolveZoom(Style::ZoomNeeded { });
 
     if (!heightOrMaxHeightAsLength)
         return false;

--- a/Source/WebCore/rendering/style/CollapsedBorderValue.h
+++ b/Source/WebCore/rendering/style/CollapsedBorderValue.h
@@ -39,7 +39,7 @@ public:
     }
 
     CollapsedBorderValue(const BorderValue& border, const Color& color, BorderPrecedence precedence)
-        : m_width(LayoutUnit(border.nonZero() ? Style::evaluate(border.width(), 1.0f /* FIXME ZOOM EFFECTED? */) : 0))
+        : m_width(LayoutUnit(border.nonZero() ? Style::evaluate(border.width(), Style::ZoomNeeded { }) : 0))
         , m_color(color)
         , m_style(static_cast<unsigned>(border.style()))
         , m_precedence(static_cast<unsigned>(precedence))

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -337,12 +337,12 @@ constexpr BlockStepInsert RenderStyle::initialBlockStepInsert() { return BlockSt
 constexpr BlockStepRound RenderStyle::initialBlockStepRound() { return BlockStepRound::Up; }
 inline Style::BlockStepSize RenderStyle::initialBlockStepSize() { return CSS::Keyword::None { }; }
 constexpr BorderCollapse RenderStyle::initialBorderCollapse() { return BorderCollapse::Separate; }
-constexpr Style::Length<CSS::Nonnegative> RenderStyle::initialBorderHorizontalSpacing() { return 0_css_px; }
+constexpr Style::WebkitBorderSpacing RenderStyle::initialBorderHorizontalSpacing() { return 0_css_px; }
 inline Style::BorderImage RenderStyle::initialBorderImage() { return Style::BorderImage { }; }
 inline Style::BorderImageSource RenderStyle::initialBorderImageSource() { return CSS::Keyword::None { }; }
 inline Style::BorderRadiusValue RenderStyle::initialBorderRadius() { return { 0_css_px, 0_css_px }; }
 constexpr BorderStyle RenderStyle::initialBorderStyle() { return BorderStyle::None; }
-constexpr Style::Length<CSS::Nonnegative> RenderStyle::initialBorderVerticalSpacing() { return 0_css_px; }
+constexpr Style::WebkitBorderSpacing RenderStyle::initialBorderVerticalSpacing() { return 0_css_px; }
 constexpr Style::LineWidth RenderStyle::initialBorderWidth() { return CSS::Keyword::Medium { }; }
 constexpr BoxAlignment RenderStyle::initialBoxAlign() { return BoxAlignment::Stretch; }
 constexpr BoxDecorationBreak RenderStyle::initialBoxDecorationBreak() { return BoxDecorationBreak::Slice; }

--- a/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
@@ -86,7 +86,7 @@ std::optional<FloatRect> SVGRenderSupport::computeFloatVisibleRectInContainer(co
         return FloatRect();
 
     FloatRect adjustedRect = rect;
-    adjustedRect.inflate(Style::evaluate(renderer.style().outlineWidth(), 1.0f /* FIXME ZOOM EFFECTED? */));
+    adjustedRect.inflate(Style::evaluate(renderer.style().outlineWidth(), Style::ZoomNeeded { }));
 
     // Translate to coords in our parent renderer, and then call computeFloatVisibleRectInContainer() on our parent.
     adjustedRect = renderer.localToParentTransform().mapRect(adjustedRect);

--- a/Source/WebCore/rendering/svg/SVGTextLayoutEngineBaseline.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextLayoutEngineBaseline.cpp
@@ -50,7 +50,7 @@ float SVGTextLayoutEngineBaseline::calculateBaselineShift(const SVGRenderStyle& 
             return m_font->metricsOfPrimaryFont().height() / 2;
         },
         [&](const Style::SVGBaselineShift::Length& length) -> float {
-            return Style::evaluate(length, m_font->size(), 1.0f /* FIXME ZOOM EFFECTED? */);
+            return Style::evaluate(length, m_font->size(), Style::ZoomNeeded { });
         }
     );
 }

--- a/Source/WebCore/rendering/updating/RenderTreeBuilder.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilder.cpp
@@ -1107,7 +1107,7 @@ void RenderTreeBuilder::reportVisuallyNonEmptyContent(const RenderElement& paren
             auto fixedHeight = style.height().tryFixed();
             if (!fixedWidth || !fixedHeight)
                 return { };
-            return std::make_optional(IntSize { static_cast<int>(fixedWidth->evaluate(1.0f /* FIXME FIND ZOOM */)), static_cast<int>(fixedHeight->evaluate(1.0f /* FIXME FIND ZOOM */)) });
+            return std::make_optional(IntSize { static_cast<int>(fixedWidth->resolveZoom(Style::ZoomNeeded { })), static_cast<int>(fixedHeight->resolveZoom(Style::ZoomNeeded { })) });
         };
         // SVG content tends to have a fixed size construct. However this is known to be inaccurate in certain cases (box-sizing: border-box) or especially when the parent box is oversized.
         auto candidateSize = IntSize { };

--- a/Source/WebCore/style/StyleExtractorCustom.h
+++ b/Source/WebCore/style/StyleExtractorCustom.h
@@ -389,7 +389,7 @@ template<CSSPropertyID propertyID, typename InsetEdgeApplier, typename NumberAsP
                     : box->containingBlockLogicalWidthForContent();
             }
         }
-        return numberAsPixelsApplier(Style::evaluate(inset, containingBlockSize, 1.0f /* FIXME FIND ZOOM */));
+        return numberAsPixelsApplier(Style::evaluate(inset, containingBlockSize, Style::ZoomNeeded { }));
     }
 
     // Return a "computed value" length.
@@ -1327,7 +1327,7 @@ inline void ExtractorCustom::extractLineHeightSerialization(ExtractorState& stat
         return;
     }
 
-    ExtractorSerializer::serializeNumberAsPixels(state, builder, context, floatValueForLength(length, 0, 1.0f /* FIX ME FIND ZOOM */));
+    ExtractorSerializer::serializeNumberAsPixels(state, builder, context, floatValueForLength(length, 0, 1.0f /* FIXME FIND ZOOM */));
 }
 
 inline Ref<CSSValue> ExtractorCustom::extractFontFamily(ExtractorState& state)
@@ -1662,7 +1662,7 @@ inline Ref<CSSValue> ExtractorCustom::extractMarginRight(ExtractorState& state)
         // RenderBox gives a marginRight() that is the distance between the right-edge of the child box
         // and the right-edge of the containing box, when display == DisplayType::Block. Let's calculate the absolute
         // value of the specified margin-right % instead of relying on RenderBox's marginRight() value.
-        value = Style::evaluateMinimum(marginRight, box->containingBlockLogicalWidthForContent(), 1.0f /* FIXME FIND ZOOM */);
+        value = Style::evaluateMinimum(marginRight, box->containingBlockLogicalWidthForContent(), Style::ZoomNeeded { });
     } else
         value = box->marginRight();
     return ExtractorConverter::convertNumberAsPixels(state, value);
@@ -1687,7 +1687,7 @@ inline void ExtractorCustom::extractMarginRightSerialization(ExtractorState& sta
         // RenderBox gives a marginRight() that is the distance between the right-edge of the child box
         // and the right-edge of the containing box, when display == DisplayType::Block. Let's calculate the absolute
         // value of the specified margin-right % instead of relying on RenderBox's marginRight() value.
-        value = Style::evaluateMinimum(marginRight, box->containingBlockLogicalWidthForContent(), 1.0f /* FIXME FIND ZOOM */);
+        value = Style::evaluateMinimum(marginRight, box->containingBlockLogicalWidthForContent(), Style::ZoomNeeded { });
     } else
         value = box->marginRight();
 
@@ -2803,8 +2803,8 @@ inline RefPtr<CSSValue> ExtractorCustom::extractPerspectiveOriginShorthand(Extra
     CSSValueListBuilder list;
     if (state.renderer) {
         auto box = state.renderer->transformReferenceBoxRect(state.style);
-        list.append(ExtractorConverter::convertNumberAsPixels(state, Style::evaluate(state.style.perspectiveOriginX(), box.width(), 1.0f /* FIXME FIND ZOOM */)));
-        list.append(ExtractorConverter::convertNumberAsPixels(state, Style::evaluate(state.style.perspectiveOriginY(), box.height(), 1.0f /* FIXME FIND ZOOM */)));
+        list.append(ExtractorConverter::convertNumberAsPixels(state, Style::evaluate(state.style.perspectiveOriginX(), box.width(), Style::ZoomNeeded { })));
+        list.append(ExtractorConverter::convertNumberAsPixels(state, Style::evaluate(state.style.perspectiveOriginY(), box.height(), Style::ZoomNeeded { })));
     } else {
         list.append(ExtractorConverter::convertStyleType(state, state.style.perspectiveOriginX()));
         list.append(ExtractorConverter::convertStyleType(state, state.style.perspectiveOriginY()));
@@ -2816,9 +2816,9 @@ inline void ExtractorCustom::extractPerspectiveOriginShorthandSerialization(Extr
 {
     if (state.renderer) {
         auto box = state.renderer->transformReferenceBoxRect(state.style);
-        ExtractorSerializer::serializeNumberAsPixels(state, builder, context, Style::evaluate(state.style.perspectiveOriginX(), box.width(), 1.0f /* FIXME FIND ZOOM */));
+        ExtractorSerializer::serializeNumberAsPixels(state, builder, context, Style::evaluate(state.style.perspectiveOriginX(), box.width(), Style::ZoomNeeded { }));
         builder.append(' ');
-        ExtractorSerializer::serializeNumberAsPixels(state, builder, context, Style::evaluate(state.style.perspectiveOriginY(), box.height(), 1.0f /* FIXME FIND ZOOM */));
+        ExtractorSerializer::serializeNumberAsPixels(state, builder, context, Style::evaluate(state.style.perspectiveOriginY(), box.height(), Style::ZoomNeeded { }));
     } else {
         ExtractorSerializer::serializeStyleType(state, builder, context, state.style.perspectiveOriginX());
         builder.append(' ');
@@ -3048,8 +3048,8 @@ inline RefPtr<CSSValue> ExtractorCustom::extractTransformOriginShorthand(Extract
     CSSValueListBuilder list;
     if (state.renderer) {
         auto box = state.renderer->transformReferenceBoxRect(state.style);
-        list.append(ExtractorConverter::convertNumberAsPixels(state, Style::evaluate(state.style.transformOriginX(), box.width(), 1.0f /* FIXME FIND ZOOM */)));
-        list.append(ExtractorConverter::convertNumberAsPixels(state, Style::evaluate(state.style.transformOriginY(), box.height(), 1.0f /* FIXME FIND ZOOM */)));
+        list.append(ExtractorConverter::convertNumberAsPixels(state, Style::evaluate(state.style.transformOriginX(), box.width(), Style::ZoomNeeded { })));
+        list.append(ExtractorConverter::convertNumberAsPixels(state, Style::evaluate(state.style.transformOriginY(), box.height(), Style::ZoomNeeded { })));
         if (auto transformOriginZ = state.style.transformOriginZ(); !transformOriginZ.isZero())
             list.append(ExtractorConverter::convertStyleType(state, transformOriginZ));
     } else {
@@ -3065,9 +3065,9 @@ inline void ExtractorCustom::extractTransformOriginShorthandSerialization(Extrac
 {
     if (state.renderer) {
         auto box = state.renderer->transformReferenceBoxRect(state.style);
-        ExtractorSerializer::serializeNumberAsPixels(state, builder, context, Style::evaluate(state.style.transformOriginX(), box.width(), 1.0f /* FIXME FIND ZOOM */));
+        ExtractorSerializer::serializeNumberAsPixels(state, builder, context, Style::evaluate(state.style.transformOriginX(), box.width(), Style::ZoomNeeded { }));
         builder.append(' ');
-        ExtractorSerializer::serializeNumberAsPixels(state, builder, context, Style::evaluate(state.style.transformOriginY(), box.height(), 1.0f /* FIXME FIND ZOOM */));
+        ExtractorSerializer::serializeNumberAsPixels(state, builder, context, Style::evaluate(state.style.transformOriginY(), box.height(), Style::ZoomNeeded { }));
         if (auto transformOriginZ = state.style.transformOriginZ(); !transformOriginZ.isZero()) {
             builder.append(' ');
             ExtractorSerializer::serializeStyleType(state, builder, context, transformOriginZ);

--- a/Source/WebCore/style/StyleResolveForFont.cpp
+++ b/Source/WebCore/style/StyleResolveForFont.cpp
@@ -360,7 +360,7 @@ static ResolvedFontSize fontSizeFromUnresolvedFontSize(const CSSPropertyParserHe
                         return { .size = 0.0f, .keyword = CSSValueInvalid };
 
                     return {
-                        .size = Style::evaluate(Style::toStyleNoConversionDataRequired(calc), parentSize, 1.0f /* FIXME FIND ZOOM */),
+                        .size = Style::evaluate(Style::toStyleNoConversionDataRequired(calc), parentSize, Style::ZoomNeeded { }),
                         .keyword = CSSValueInvalid
                     };
                 }

--- a/Source/WebCore/style/values/animations/StyleSingleAnimationRange.cpp
+++ b/Source/WebCore/style/values/animations/StyleSingleAnimationRange.cpp
@@ -51,7 +51,7 @@ static RefPtr<CSSNumericValue> toCSSNumericValue(const SingleAnimationRangeLengt
     // FIXME: This will fail for calc().
     return offset.isPercentOrCalculated()
         ? CSSNumericFactory::percent(offset.tryPercentage()->value)
-        : CSSNumericFactory::px(offset.tryFixed()->evaluate(1.0f /* FIXME FIND ZOOM */));
+        : CSSNumericFactory::px(offset.tryFixed()->resolveZoom(Style::ZoomNeeded { }));
 }
 
 TimelineRangeValue SingleAnimationRangeStart::toTimelineRangeValue() const

--- a/Source/WebCore/style/values/backgrounds/StyleLineWidth.cpp
+++ b/Source/WebCore/style/values/backgrounds/StyleLineWidth.cpp
@@ -74,13 +74,13 @@ auto CSSValueConversion<LineWidth>::operator()(BuilderState& state, const CSSVal
 
 // MARK: - Evaluate
 
-FloatBoxExtent Evaluation<LineWidthBox>::operator()(const LineWidthBox& value, float zoom)
+FloatBoxExtent Evaluation<LineWidthBox>::operator()(const LineWidthBox& value, ZoomNeeded token)
 {
     return {
-        evaluate(value.top(), zoom),
-        evaluate(value.right(), zoom),
-        evaluate(value.bottom(), zoom),
-        evaluate(value.left(), zoom),
+        evaluate(value.top(), token),
+        evaluate(value.right(), token),
+        evaluate(value.bottom(), token),
+        evaluate(value.left(), token),
     };
 }
 

--- a/Source/WebCore/style/values/backgrounds/StyleLineWidth.h
+++ b/Source/WebCore/style/values/backgrounds/StyleLineWidth.h
@@ -66,14 +66,14 @@ template<> struct CSSValueConversion<LineWidth> { auto operator()(BuilderState&,
 // MARK: - Evaluate
 
 template<> struct Evaluation<LineWidth> {
-    constexpr auto operator()(const LineWidth& value, float zoom) -> float
+    constexpr auto operator()(const LineWidth& value, ZoomNeeded token) -> float
     {
-        return value.value.evaluate(zoom);
+        return value.value.resolveZoom(token);
     }
 };
 
 template<> struct Evaluation<LineWidthBox> {
-    FloatBoxExtent operator()(const LineWidthBox&, float zoom);
+    FloatBoxExtent operator()(const LineWidthBox&, ZoomNeeded);
 };
 
 } // namespace Style

--- a/Source/WebCore/style/values/borders/StyleBorderRadius.cpp
+++ b/Source/WebCore/style/values/borders/StyleBorderRadius.cpp
@@ -85,23 +85,23 @@ auto CSSValueConversion<BorderRadiusValue>::operator()(BuilderState& state, cons
 
 // MARK: - Evaluation
 
-auto Evaluation<BorderRadius>::operator()(const BorderRadius& value, FloatSize referenceSize, float zoom) -> FloatRoundedRect::Radii
+auto Evaluation<BorderRadius>::operator()(const BorderRadius& value, FloatSize referenceSize, ZoomNeeded token) -> FloatRoundedRect::Radii
 {
     return {
-        evaluate(value.topLeft(), referenceSize, zoom /* FIXME FIND ZOOM */),
-        evaluate(value.topRight(), referenceSize, zoom /* FIXME FIND ZOOM */),
-        evaluate(value.bottomLeft(), referenceSize, zoom /* FIXME FIND ZOOM */),
-        evaluate(value.bottomRight(), referenceSize, zoom /* FIXME FIND ZOOM */),
+        evaluate(value.topLeft(), referenceSize, token),
+        evaluate(value.topRight(), referenceSize, token),
+        evaluate(value.bottomLeft(), referenceSize, token),
+        evaluate(value.bottomRight(), referenceSize, token),
     };
 }
 
-auto Evaluation<BorderRadius>::operator()(const BorderRadius& value, LayoutSize referenceSize, float zoom) -> LayoutRoundedRect::Radii
+auto Evaluation<BorderRadius>::operator()(const BorderRadius& value, LayoutSize referenceSize, ZoomNeeded token) -> LayoutRoundedRect::Radii
 {
     return {
-        evaluate(value.topLeft(), referenceSize, zoom /* FIXME FIND ZOOM */),
-        evaluate(value.topRight(), referenceSize, zoom /* FIXME FIND ZOOM */),
-        evaluate(value.bottomLeft(), referenceSize, zoom /* FIXME FIND ZOOM */),
-        evaluate(value.bottomRight(), referenceSize, zoom /* FIXME FIND ZOOM */),
+        evaluate(value.topLeft(), referenceSize, token),
+        evaluate(value.topRight(), referenceSize, token),
+        evaluate(value.bottomLeft(), referenceSize, token),
+        evaluate(value.bottomRight(), referenceSize, token),
     };
 }
 

--- a/Source/WebCore/style/values/borders/StyleBorderRadius.h
+++ b/Source/WebCore/style/values/borders/StyleBorderRadius.h
@@ -80,8 +80,8 @@ template<> struct CSSValueConversion<BorderRadiusValue> { auto operator()(Builde
 // MARK: - Evaluation
 
 template<> struct Evaluation<BorderRadius> {
-    auto operator()(const BorderRadius&, FloatSize, float zoom) -> FloatRoundedRect::Radii;
-    auto operator()(const BorderRadius&, LayoutSize, float zoom) -> LayoutRoundedRect::Radii;
+    auto operator()(const BorderRadius&, FloatSize, ZoomNeeded) -> FloatRoundedRect::Radii;
+    auto operator()(const BorderRadius&, LayoutSize, ZoomNeeded) -> LayoutRoundedRect::Radii;
 };
 
 } // namespace Style

--- a/Source/WebCore/style/values/borders/StyleBoxShadow.h
+++ b/Source/WebCore/style/values/borders/StyleBoxShadow.h
@@ -104,7 +104,7 @@ inline bool isInset(const BoxShadow& shadow)
 
 inline LayoutUnit paintingSpread(const BoxShadow& shadow)
 {
-    return LayoutUnit { shadow.spread.evaluate(1.0f /* FIXME FIND ZOOM */) };
+    return LayoutUnit { shadow.spread.resolveZoom(Style::ZoomNeeded { }) };
 }
 
 } // namespace Style

--- a/Source/WebCore/style/values/borders/StyleShadow.h
+++ b/Source/WebCore/style/values/borders/StyleShadow.h
@@ -49,7 +49,7 @@ LayoutUnit paintingExtent(Shadow auto const& shadow)
     // extends to infinity. In 8-bit contexts, however, rounding causes the effect to become
     // undetectable at around 1.4x the radius.
     constexpr const float radiusExtentMultiplier = 1.4;
-    return LayoutUnit { ceilf(shadow.blur.evaluate(1.0f /* FIXME FIND ZOOM */) * radiusExtentMultiplier) };
+    return LayoutUnit { ceilf(shadow.blur.resolveZoom(Style::ZoomNeeded { }) * radiusExtentMultiplier) };
 }
 
 LayoutUnit paintingExtentAndSpread(Shadow auto const& shadow)
@@ -70,10 +70,10 @@ template<Shadow ShadowType> auto shadowOutsetExtent(const Shadows<ShadowType>& s
 
         auto extentAndSpread = paintingExtentAndSpread(shadow);
 
-        left = std::min<LayoutUnit>(left, LayoutUnit(shadow.location.x().evaluate(1.0f /* FIXME FIND ZOOM */)) - extentAndSpread);
-        right = std::max<LayoutUnit>(right, LayoutUnit(shadow.location.x().evaluate(1.0f /* FIXME FIND ZOOM */)) + extentAndSpread);
-        top = std::min<LayoutUnit>(top, LayoutUnit(shadow.location.y().evaluate(1.0f /* FIXME FIND ZOOM */)) - extentAndSpread);
-        bottom = std::max<LayoutUnit>(bottom, LayoutUnit(shadow.location.y().evaluate(1.0f /* FIXME FIND ZOOM */)) + extentAndSpread);
+        left = std::min<LayoutUnit>(left, LayoutUnit(shadow.location.x().resolveZoom(Style::ZoomNeeded { })) - extentAndSpread);
+        right = std::max<LayoutUnit>(right, LayoutUnit(shadow.location.x().resolveZoom(Style::ZoomNeeded { })) + extentAndSpread);
+        top = std::min<LayoutUnit>(top, LayoutUnit(shadow.location.y().resolveZoom(Style::ZoomNeeded { })) - extentAndSpread);
+        bottom = std::max<LayoutUnit>(bottom, LayoutUnit(shadow.location.y().resolveZoom(Style::ZoomNeeded { })) + extentAndSpread);
     }
 
     return { top, right, bottom, left };
@@ -92,10 +92,10 @@ template<Shadow ShadowType> auto shadowInsetExtent(const Shadows<ShadowType>& sh
 
         auto extentAndSpread = paintingExtentAndSpread(shadow);
 
-        top = std::max<LayoutUnit>(top, LayoutUnit(shadow.location.y().evaluate(1.0f /* FIXME FIND ZOOM */)) + extentAndSpread);
-        right = std::min<LayoutUnit>(right, LayoutUnit(shadow.location.x().evaluate(1.0f /* FIXME FIND ZOOM */)) - extentAndSpread);
-        bottom = std::min<LayoutUnit>(bottom, LayoutUnit(shadow.location.y().evaluate(1.0f /* FIXME FIND ZOOM */)) - extentAndSpread);
-        left = std::max<LayoutUnit>(left, LayoutUnit(shadow.location.x().evaluate(1.0f /* FIXME FIND ZOOM */)) + extentAndSpread);
+        top = std::max<LayoutUnit>(top, LayoutUnit(shadow.location.y().resolveZoom(Style::ZoomNeeded { })) + extentAndSpread);
+        right = std::min<LayoutUnit>(right, LayoutUnit(shadow.location.x().resolveZoom(Style::ZoomNeeded { })) - extentAndSpread);
+        bottom = std::min<LayoutUnit>(bottom, LayoutUnit(shadow.location.y().resolveZoom(Style::ZoomNeeded { })) - extentAndSpread);
+        left = std::max<LayoutUnit>(left, LayoutUnit(shadow.location.x().resolveZoom(Style::ZoomNeeded { })) + extentAndSpread);
     }
 
     return { top, right, bottom, left };
@@ -112,8 +112,8 @@ template<Shadow ShadowType> auto shadowHorizontalExtent(const Shadows<ShadowType
 
         auto extentAndSpread = paintingExtentAndSpread(shadow);
 
-        left = std::min<LayoutUnit>(left, LayoutUnit(shadow.location.x().evaluate(1.0f /* FIXME FIND ZOOM */)) - extentAndSpread);
-        right = std::max<LayoutUnit>(right, LayoutUnit(shadow.location.x().evaluate(1.0f /* FIXME FIND ZOOM */)) + extentAndSpread);
+        left = std::min<LayoutUnit>(left, LayoutUnit(shadow.location.x().resolveZoom(Style::ZoomNeeded { })) - extentAndSpread);
+        right = std::max<LayoutUnit>(right, LayoutUnit(shadow.location.x().resolveZoom(Style::ZoomNeeded { })) + extentAndSpread);
     }
 
     return { left, right };
@@ -131,8 +131,8 @@ template<Shadow ShadowType> auto shadowVerticalExtent(const Shadows<ShadowType>&
         auto extentAndSpread = paintingExtentAndSpread(shadow);
 
         // FIXME: Why does this do a static cast to `int` but all of the other "extent" functions in this file do not?
-        top = std::min<LayoutUnit>(top, LayoutUnit(static_cast<int>(shadow.location.y().evaluate(1.0f /* FIXME FIND ZOOM */))) - extentAndSpread);
-        bottom = std::max<LayoutUnit>(bottom, LayoutUnit(static_cast<int>(shadow.location.y().evaluate(1.0f /* FIXME FIND ZOOM */))) + extentAndSpread);
+        top = std::min<LayoutUnit>(top, LayoutUnit(static_cast<int>(shadow.location.y().resolveZoom(Style::ZoomNeeded { }))) - extentAndSpread);
+        bottom = std::max<LayoutUnit>(bottom, LayoutUnit(static_cast<int>(shadow.location.y().resolveZoom(Style::ZoomNeeded { }))) + extentAndSpread);
     }
 
     return { top, bottom };

--- a/Source/WebCore/style/values/filter-effects/StyleBlurFunction.cpp
+++ b/Source/WebCore/style/values/filter-effects/StyleBlurFunction.cpp
@@ -42,7 +42,7 @@ Ref<FilterOperation> createFilterOperation(const CSS::Blur& filter, const Builde
 {
     float stdDeviation = 0;
     if (auto parameter = filter.value)
-        stdDeviation = toStyle(*parameter, state).evaluate(1.0f /* FIXME FIND ZOOM */);
+        stdDeviation = toStyle(*parameter, state).resolveZoom(Style::ZoomNeeded { });
     else
         stdDeviation = filterFunctionDefaultValue<CSS::BlurFunction::name>().value;
 

--- a/Source/WebCore/style/values/filter-effects/StyleDropShadowFunction.cpp
+++ b/Source/WebCore/style/values/filter-effects/StyleDropShadowFunction.cpp
@@ -51,9 +51,9 @@ CSS::DropShadow toCSSDropShadow(Ref<DropShadowFilterOperationWithStyleColor> ope
 
 Ref<FilterOperation> createFilterOperation(const CSS::DropShadow& filter, const BuilderState& state)
 {
-    int x = roundForImpreciseConversion<int>(toStyle(filter.location.x(), state).evaluate(1.0f /* FIXME FIND ZOOM */));
-    int y = roundForImpreciseConversion<int>(toStyle(filter.location.y(), state).evaluate(1.0f /* FIXME FIND ZOOM */));
-    int stdDeviation = filter.stdDeviation ? roundForImpreciseConversion<int>(toStyle(*filter.stdDeviation, state).evaluate(1.0f /* FIXME FIND ZOOM */)) : 0;
+    int x = roundForImpreciseConversion<int>(toStyle(filter.location.x(), state).resolveZoom(Style::ZoomNeeded { }));
+    int y = roundForImpreciseConversion<int>(toStyle(filter.location.y(), state).resolveZoom(Style::ZoomNeeded { }));
+    int stdDeviation = filter.stdDeviation ? roundForImpreciseConversion<int>(toStyle(*filter.stdDeviation, state).resolveZoom(Style::ZoomNeeded { })) : 0;
     auto color = filter.color ? toStyleColor(*filter.color, state, ForVisitedLink::No) : Style::Color { CurrentColor { } };
 
     return DropShadowFilterOperationWithStyleColor::create(

--- a/Source/WebCore/style/values/images/StyleGradient.cpp
+++ b/Source/WebCore/style/values/images/StyleGradient.cpp
@@ -129,7 +129,7 @@ static std::optional<float> resolveColorStopPosition(const GradientLinearColorSt
         [&](const typename LengthPercentage<>::Dimension& length) -> std::optional<float> {
             if (gradientLength <= 0)
                 return 0;
-            return length.evaluate(1.0f /* FIXME FIND ZOOM */) / gradientLength;
+            return length.resolveZoom(Style::ZoomNeeded { }) / gradientLength;
         },
         [&](const typename LengthPercentage<>::Percentage& percentage) -> std::optional<float> {
             return percentage.value / 100.0;
@@ -644,7 +644,7 @@ template<typename GradientAdapter, typename StyleGradient> GradientColorStops co
 
 static inline float positionFromValue(LengthWrapperBaseDerived auto const& coordinate, float widthOrHeight)
 {
-    return evaluate(coordinate, widthOrHeight, 1.0f /* FIXME ZOOM EFFECTED? */);
+    return evaluate(coordinate, widthOrHeight, Style::ZoomNeeded { });
 }
 
 static inline float positionFromValue(const NumberOrPercentage<>& coordinate, float widthOrHeight)
@@ -722,7 +722,7 @@ static std::pair<FloatPoint, FloatPoint> endPointsFromAngleForPrefixedVariants(f
 
 static float resolveRadius(const LengthPercentage<CSS::Nonnegative>& radius, float widthOrHeight)
 {
-    return evaluate(radius, widthOrHeight, 1.0f /* FIXME ZOOM EFFECTED? */);
+    return evaluate(radius, widthOrHeight, Style::ZoomNeeded { });
 }
 
 struct DistanceToCorner {
@@ -943,7 +943,7 @@ template<CSSValueID Name> static Ref<WebCore::Gradient> createPlatformGradient(c
     auto computeCircleRadius = [&](const Variant<RadialGradient::Circle::Length, RadialGradient::Extent>& circleLengthOrExtent, FloatPoint centerPoint) -> std::pair<float, float> {
         return WTF::switchOn(circleLengthOrExtent,
             [&](const RadialGradient::Circle::Length& circleLength) -> std::pair<float, float> {
-                return { circleLength.evaluate(1.0f /* FIXME FIND ZOOM */), 1 };
+                return { circleLength.resolveZoom(Style::ZoomNeeded { }), 1 };
             },
             [&](const RadialGradient::Extent& extent) -> std::pair<float, float> {
                 return WTF::switchOn(extent,

--- a/Source/WebCore/style/values/non-standard/StyleWebKitTextStrokeWidth.h
+++ b/Source/WebCore/style/values/non-standard/StyleWebKitTextStrokeWidth.h
@@ -54,8 +54,9 @@ template<> struct CSSValueConversion<WebkitTextStrokeWidth> { auto operator()(Bu
 // MARK: - Evaluate
 
 template<> struct Evaluation<WebkitTextStrokeWidth> {
-    constexpr auto operator()(const WebkitTextStrokeWidth& value, float zoom) -> float {
-        return value.value.evaluate(zoom);
+    constexpr auto operator()(const WebkitTextStrokeWidth& value, ZoomNeeded token) -> float
+    {
+        return value.value.resolveZoom(token);
     }
 };
 

--- a/Source/WebCore/style/values/primitives/StylePosition.cpp
+++ b/Source/WebCore/style/values/primitives/StylePosition.cpp
@@ -310,11 +310,11 @@ auto CSSValueConversion<PositionY>::operator()(BuilderState& state, const CSSVal
 
 // MARK: - Evaluation
 
-auto Evaluation<Position>::operator()(const Position& position, FloatSize referenceBox, float zoom) -> FloatPoint
+auto Evaluation<Position>::operator()(const Position& position, FloatSize referenceBox, ZoomNeeded token) -> FloatPoint
 {
     return {
-        evaluate(position.x, referenceBox.width(), zoom),
-        evaluate(position.y, referenceBox.height(), zoom)
+        evaluate(position.x, referenceBox.width(), token),
+        evaluate(position.y, referenceBox.height(), token)
     };
 }
 

--- a/Source/WebCore/style/values/primitives/StylePosition.h
+++ b/Source/WebCore/style/values/primitives/StylePosition.h
@@ -140,7 +140,7 @@ template<> struct CSSValueConversion<PositionY> { auto operator()(BuilderState&,
 // MARK: - Evaluation
 
 template<> struct Evaluation<Position> {
-    auto operator()(const Position&, FloatSize, float zoom) -> FloatPoint;
+    auto operator()(const Position&, FloatSize, ZoomNeeded) -> FloatPoint;
 };
 
 // MARK: - Platform

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumeric.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumeric.h
@@ -29,6 +29,7 @@
 #include <WebCore/StylePrimitiveNumericConcepts.h>
 #include <WebCore/StyleUnevaluatedCalculation.h>
 #include <WebCore/StyleValueTypes.h>
+#include <WebCore/StyleZoomNeededToken.h>
 #include <algorithm>
 #include <wtf/CompactVariant.h>
 #include <wtf/Forward.h>
@@ -132,12 +133,19 @@ template<CSS::Range R, typename V> struct PrimitiveNumeric<CSS::Length<R, V>> {
     {
     }
 
-    constexpr auto evaluate(float zoom) const
+    constexpr auto resolveZoom(ZoomNeeded) const
+        requires (range.zoomOptions == WebCore::CSS::RangeZoomOptions::Default)
+    {
+        return value;
+    }
+
+    constexpr auto resolveZoom(float zoom) const
+        requires (range.zoomOptions == WebCore::CSS::RangeZoomOptions::Unzoomed)
     {
         return value * zoom;
     }
 
-    constexpr auto unevaluatedValue() const { return value; }
+    constexpr auto unresolvedValue() const { return value; }
 
     constexpr bool isZero() const { return !value; }
     constexpr bool isPositive() const { return value > 0; }

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Blending.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Blending.h
@@ -73,7 +73,7 @@ template<auto R, typename V> struct Blending<Length<R, V>> {
         // that concept, and the `WebCore::Length` code path did clamping in the same fashion.
         // https://drafts.csswg.org/css-values/#combining-range
 
-        return StyleType { CSS::clampToRange<StyleType::range, typename StyleType::ResolvedValueType>(WebCore::blend(from.unevaluatedValue(), to.unevaluatedValue(), context)) };
+        return StyleType { CSS::clampToRange<StyleType::range, typename StyleType::ResolvedValueType>(WebCore::blend(from.unresolvedValue(), to.unresolvedValue(), context)) };
     }
 };
 

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+CSSValueConversion.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+CSSValueConversion.h
@@ -96,12 +96,20 @@ template<auto R, typename V> struct CSSValueConversion<Angle<R, V>> {
 };
 
 template<auto R, typename V> struct CSSValueConversion<Length<R, V>> {
+    static auto selectConversionData(BuilderState& builderState) -> CSSToLengthConversionData
+    {
+        if constexpr (R.zoomOptions == CSS::RangeZoomOptions::Default) {
+            return builderState.useSVGZoomRulesForLength()
+                ? builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f)
+                : builderState.cssToLengthConversionData();
+        } else if constexpr (R.zoomOptions == CSS::RangeZoomOptions::Unzoomed) {
+            return builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f);
+        }
+    }
     auto operator()(BuilderState& builderState, const CSSPrimitiveValue& value) -> Length<R, V>
     {
         Ref protectedValue = value;
-        auto conversionData = builderState.useSVGZoomRulesForLength()
-            ? builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f)
-            : builderState.cssToLengthConversionData();
+        auto conversionData = selectConversionData(builderState);
         return { CSS::clampToRange<R, V>(protectedValue->resolveAsLength<V>(conversionData)) };
     }
     auto operator()(BuilderState& builderState, const CSSValue& value) -> Length<R, V>
@@ -109,12 +117,10 @@ template<auto R, typename V> struct CSSValueConversion<Length<R, V>> {
         RefPtr protectedValue = requiredDowncast<CSSPrimitiveValue>(builderState, value);
         if (!protectedValue)
             return 0_css_px;
-        auto conversionData = builderState.useSVGZoomRulesForLength()
-            ? builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f)
-            : builderState.cssToLengthConversionData();
+
+        auto conversionData = selectConversionData(builderState);
         return { CSS::clampToRange<R, V>(protectedValue->resolveAsLength<V>(conversionData)) };
     }
-
     auto operator()(const CSSToLengthConversionData& conversionData, const CSSPrimitiveValue& value) -> Length<R, V>
     {
         Ref protectedValue = value;
@@ -168,12 +174,20 @@ template<auto R, typename V> struct CSSValueConversion<Flex<R, V>> {
 };
 
 template<auto R, typename V> struct CSSValueConversion<LengthPercentage<R, V>> {
+    static auto selectConversionData(BuilderState& builderState) -> CSSToLengthConversionData
+    {
+        if constexpr (LengthPercentage<R, V>::Dimension::range.zoomOptions == CSS::RangeZoomOptions::Default) {
+            return builderState.useSVGZoomRulesForLength()
+                ? builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f)
+                : builderState.cssToLengthConversionData();
+        } else if constexpr (LengthPercentage<R, V>::Dimension::range.zoomOptions == CSS::RangeZoomOptions::Unzoomed) {
+            return builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f);
+        }
+    }
     auto operator()(BuilderState& builderState, const CSSPrimitiveValue& value) -> LengthPercentage<R, V>
     {
         Ref protectedValue = value;
-        auto conversionData = builderState.useSVGZoomRulesForLength()
-            ? builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f)
-            : builderState.cssToLengthConversionData();
+        auto conversionData = selectConversionData(builderState);
         if (protectedValue->isPercentage())
             return typename LengthPercentage<R, V>::Percentage { CSS::clampToRange<R, V>(protectedValue->resolveAsPercentage<V>(conversionData)) };
         if (protectedValue->isCalculatedPercentageWithLength())
@@ -185,9 +199,7 @@ template<auto R, typename V> struct CSSValueConversion<LengthPercentage<R, V>> {
         RefPtr protectedValue = requiredDowncast<CSSPrimitiveValue>(builderState, value);
         if (!protectedValue)
             return 0_css_px;
-        auto conversionData = builderState.useSVGZoomRulesForLength()
-            ? builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f)
-            : builderState.cssToLengthConversionData();
+        auto conversionData = selectConversionData(builderState);
         if (protectedValue->isPercentage())
             return typename LengthPercentage<R, V>::Percentage { CSS::clampToRange<R, V>(protectedValue->resolveAsPercentage<V>(conversionData)) };
         if (protectedValue->isCalculatedPercentageWithLength())

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Calculation.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Calculation.h
@@ -55,7 +55,7 @@ template<auto R, typename V> Calculation::Child copyCalculation(const Percentage
 
 template<auto R, typename V> Calculation::Child copyCalculation(const Length<R, V>& value)
 {
-    return Calculation::dimension(value.unevaluatedValue());
+    return Calculation::dimension(value.unresolvedValue());
 }
 
 inline Calculation::Child copyCalculation(Numeric auto const& value)

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Logging.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Logging.h
@@ -40,7 +40,7 @@ WTF::TextStream& operator<<(WTF::TextStream& ts, Calc auto const& value)
 
 template<auto R, typename V> WTF::TextStream& operator<<(WTF::TextStream& ts, const Length<R, V>& value)
 {
-    return ts << CSS::serializationForCSS(CSS::defaultSerializationContext(), CSS::SerializableNumber { static_cast<double>(value.unevaluatedValue()), CSS::unitString(value.unit) });
+    return ts << CSS::serializationForCSS(CSS::defaultSerializationContext(), CSS::SerializableNumber { static_cast<double>(value.unresolvedValue()), CSS::unitString(value.unit) });
 }
 
 WTF::TextStream& operator<<(WTF::TextStream& ts, Numeric auto const& value)

--- a/Source/WebCore/style/values/primitives/StyleZoomNeededToken.h
+++ b/Source/WebCore/style/values/primitives/StyleZoomNeededToken.h
@@ -24,36 +24,11 @@
 
 #pragma once
 
-#include <WebCore/StylePrimitiveNumericTypes.h>
-
 namespace WebCore {
 namespace Style {
 
-// <'perspective'> = none | <length [0,∞]>
-// https://drafts.csswg.org/css-transforms-2/#propdef-perspective
-struct Perspective : ValueOrKeyword<Length<CSS::Nonnegative, float>, CSS::Keyword::None> {
-    using Base::Base;
-    using Length = typename Base::Value;
-
-    float usedPerspective() const { return std::max(1.0f, tryValue().value_or(1.0f).resolveZoom(Style::ZoomNeeded { })); }
-
-    bool isNone() const { return isKeyword(); }
-    bool isLength() const { return isValue(); }
-};
-static_assert(sizeof(Perspective) == sizeof(float));
-
-// MARK: - Conversion
-
-template<> struct CSSValueConversion<Perspective> { auto operator()(BuilderState&, const CSSValue&) -> Perspective; };
-
-// MARK: - Blending
-
-template<> struct Blending<Perspective> {
-    auto canBlend(const Perspective&, const Perspective&) -> bool;
-    auto blend(const Perspective&, const Perspective&, const BlendingContext&) -> Perspective;
-};
+// Token passed around to indicate that the evaluation will need zoom passed in the future.
+struct ZoomNeeded { };
 
 } // namespace Style
 } // namespace WebCore
-
-DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::Perspective)

--- a/Source/WebCore/style/values/scroll-snap/StyleScrollMargin.cpp
+++ b/Source/WebCore/style/values/scroll-snap/StyleScrollMargin.cpp
@@ -33,14 +33,14 @@
 namespace WebCore {
 namespace Style {
 
-LayoutUnit Evaluation<ScrollMarginEdge>::operator()(const ScrollMarginEdge& edge, LayoutUnit, float zoom)
+LayoutUnit Evaluation<ScrollMarginEdge>::operator()(const ScrollMarginEdge& edge, LayoutUnit, ZoomNeeded token)
 {
-    return LayoutUnit(edge.m_value.evaluate(zoom));
+    return LayoutUnit(edge.m_value.resolveZoom(token));
 }
 
-float Evaluation<ScrollMarginEdge>::operator()(const ScrollMarginEdge& edge, float, float zoom)
+float Evaluation<ScrollMarginEdge>::operator()(const ScrollMarginEdge& edge, float, ZoomNeeded token)
 {
-    return edge.m_value.evaluate(zoom);
+    return edge.m_value.resolveZoom(token);
 }
 
 auto CSSValueConversion<ScrollMarginEdge>::operator()(BuilderState& state, const CSSValue& value) -> ScrollMarginEdge
@@ -51,10 +51,10 @@ auto CSSValueConversion<ScrollMarginEdge>::operator()(BuilderState& state, const
 LayoutBoxExtent extentForRect(const ScrollMarginBox& margin, const LayoutRect& rect)
 {
     return LayoutBoxExtent {
-        Style::evaluate(margin.top(), rect.height(), 1.0f /* FIXME ZOOM EFFECTED? */),
-        Style::evaluate(margin.right(), rect.width(), 1.0f/* FIXME ZOOM EFFECTED? */),
-        Style::evaluate(margin.bottom(), rect.height(), 1.0f /* FIXME ZOOM EFFECTED? */),
-        Style::evaluate(margin.left(), rect.width(), 1.0f /* FIXME ZOOM EFFECTED? */),
+        Style::evaluate(margin.top(), rect.height(), Style::ZoomNeeded { }),
+        Style::evaluate(margin.right(), rect.width(), Style::ZoomNeeded { }),
+        Style::evaluate(margin.bottom(), rect.height(), Style::ZoomNeeded { }),
+        Style::evaluate(margin.left(), rect.width(), Style::ZoomNeeded { }),
     };
 }
 

--- a/Source/WebCore/style/values/scroll-snap/StyleScrollMargin.h
+++ b/Source/WebCore/style/values/scroll-snap/StyleScrollMargin.h
@@ -75,8 +75,8 @@ template<> struct CSSValueConversion<ScrollMarginEdge> { auto operator()(Builder
 // MARK: - Evaluation
 
 template<> struct Evaluation<ScrollMarginEdge> {
-    auto operator()(const ScrollMarginEdge&, LayoutUnit referenceLength, float zoom) -> LayoutUnit;
-    auto operator()(const ScrollMarginEdge&, float referenceLength, float zoom) -> float;
+    auto operator()(const ScrollMarginEdge&, LayoutUnit referenceLength, ZoomNeeded) -> LayoutUnit;
+    auto operator()(const ScrollMarginEdge&, float referenceLength, ZoomNeeded) -> float;
 };
 
 // MARK: - Extent

--- a/Source/WebCore/style/values/scroll-snap/StyleScrollPadding.cpp
+++ b/Source/WebCore/style/values/scroll-snap/StyleScrollPadding.cpp
@@ -31,11 +31,11 @@
 namespace WebCore {
 namespace Style {
 
-LayoutUnit Evaluation<ScrollPaddingEdge>::operator()(const ScrollPaddingEdge& edge, LayoutUnit referenceLength, float zoom)
+LayoutUnit Evaluation<ScrollPaddingEdge>::operator()(const ScrollPaddingEdge& edge, LayoutUnit referenceLength, ZoomNeeded token)
 {
     return WTF::switchOn(edge,
         [&](const ScrollPaddingEdge::Fixed& fixed) {
-            return LayoutUnit(fixed.evaluate(zoom));
+            return LayoutUnit(Style::evaluate(fixed, token));
         },
         [&](const ScrollPaddingEdge::Percentage& percentage) {
             return Style::evaluate(percentage, referenceLength);
@@ -49,11 +49,11 @@ LayoutUnit Evaluation<ScrollPaddingEdge>::operator()(const ScrollPaddingEdge& ed
     );
 }
 
-float Evaluation<ScrollPaddingEdge>::operator()(const ScrollPaddingEdge& edge, float referenceLength, float zoom)
+float Evaluation<ScrollPaddingEdge>::operator()(const ScrollPaddingEdge& edge, float referenceLength, ZoomNeeded token)
 {
     return WTF::switchOn(edge,
         [&](const ScrollPaddingEdge::Fixed& fixed) {
-            return fixed.evaluate(zoom);
+            return Style::evaluate(fixed, token);
         },
         [&](const ScrollPaddingEdge::Percentage& percentage) {
             return Style::evaluate(percentage, referenceLength);
@@ -67,13 +67,13 @@ float Evaluation<ScrollPaddingEdge>::operator()(const ScrollPaddingEdge& edge, f
     );
 }
 
-LayoutBoxExtent extentForRect(const ScrollPaddingBox& padding, const LayoutRect& rect, float zoom)
+LayoutBoxExtent extentForRect(const ScrollPaddingBox& padding, const LayoutRect& rect, Style::ZoomNeeded token)
 {
     return LayoutBoxExtent {
-        Style::evaluate(padding.top(), rect.height(), zoom),
-        Style::evaluate(padding.right(), rect.width(), zoom),
-        Style::evaluate(padding.bottom(), rect.height(), zoom),
-        Style::evaluate(padding.left(), rect.width(), zoom),
+        Style::evaluate(padding.top(), rect.height(), token),
+        Style::evaluate(padding.right(), rect.width(), token),
+        Style::evaluate(padding.bottom(), rect.height(), token),
+        Style::evaluate(padding.left(), rect.width(), token),
     };
 }
 

--- a/Source/WebCore/style/values/scroll-snap/StyleScrollPadding.h
+++ b/Source/WebCore/style/values/scroll-snap/StyleScrollPadding.h
@@ -46,13 +46,13 @@ using ScrollPaddingBox = MinimallySerializingSpaceSeparatedRectEdges<ScrollPaddi
 // MARK: - Evaluation
 
 template<> struct Evaluation<ScrollPaddingEdge> {
-    auto operator()(const ScrollPaddingEdge&, LayoutUnit referenceLength, float zoom) -> LayoutUnit;
-    auto operator()(const ScrollPaddingEdge&, float referenceLength, float zoom) -> float;
+    auto operator()(const ScrollPaddingEdge&, LayoutUnit referenceLength, Style::ZoomNeeded) -> LayoutUnit;
+    auto operator()(const ScrollPaddingEdge&, float referenceLength, Style::ZoomNeeded) -> float;
 };
 
 // MARK: - Extent
 
-LayoutBoxExtent extentForRect(const ScrollPaddingBox&, const LayoutRect&, float zoom);
+LayoutBoxExtent extentForRect(const ScrollPaddingBox&, const LayoutRect&, Style::ZoomNeeded);
 
 } // namespace Style
 } // namespace WebCore

--- a/Source/WebCore/style/values/shapes/StyleCircleFunction.cpp
+++ b/Source/WebCore/style/values/shapes/StyleCircleFunction.cpp
@@ -64,14 +64,14 @@ static const WebCore::Path& cachedCirclePath(const FloatRect& rect)
 
 FloatPoint resolvePosition(const Circle& value, FloatSize boundingBox)
 {
-    return value.position ? evaluate(*value.position, boundingBox, 1.0f /* FIXME ZOOM EFFECTED? */) : FloatPoint { boundingBox.width() / 2, boundingBox.height() / 2 };
+    return value.position ? evaluate(*value.position, boundingBox, Style::ZoomNeeded { }) : FloatPoint { boundingBox.width() / 2, boundingBox.height() / 2 };
 }
 
 float resolveRadius(const Circle& value, FloatSize boxSize, FloatPoint center)
 {
     return WTF::switchOn(value.radius,
         [&](const Circle::Length& length) -> float {
-            return evaluate(length, boxSize.diagonalLength() / std::numbers::sqrt2_v<float>, 1.0f /* FIXME ZOOM EFFECTED? */);
+            return evaluate(length, boxSize.diagonalLength() / std::numbers::sqrt2_v<float>, Style::ZoomNeeded { });
         },
         [&](const Circle::Extent& extent) -> float {
             return WTF::switchOn(extent,

--- a/Source/WebCore/style/values/shapes/StyleEllipseFunction.cpp
+++ b/Source/WebCore/style/values/shapes/StyleEllipseFunction.cpp
@@ -65,7 +65,7 @@ static const WebCore::Path& cachedEllipsePath(const FloatRect& rect)
 
 FloatPoint resolvePosition(const Ellipse& value, FloatSize boundingBox)
 {
-    return value.position ? evaluate(*value.position, boundingBox, 1.0f /* FIXME ZOOM EFFECTED? */) : FloatPoint { boundingBox.width() / 2, boundingBox.height() / 2 };
+    return value.position ? evaluate(*value.position, boundingBox, Style::ZoomNeeded { }) : FloatPoint { boundingBox.width() / 2, boundingBox.height() / 2 };
 }
 
 FloatSize resolveRadii(const Ellipse& value, FloatSize boxSize, FloatPoint center)
@@ -73,7 +73,7 @@ FloatSize resolveRadii(const Ellipse& value, FloatSize boxSize, FloatPoint cente
     auto sizeForAxis = [&](const Ellipse::RadialSize& radius, float centerValue, float dimensionSize) {
         return WTF::switchOn(radius,
             [&](const Ellipse::Length& length) -> float {
-                return evaluate(length, std::abs(dimensionSize), 1.0f /* FIXME FIND ZOOM */);
+                return evaluate(length, std::abs(dimensionSize), Style::ZoomNeeded { });
             },
             [&](const Ellipse::Extent& extent) -> float {
                 return WTF::switchOn(extent,

--- a/Source/WebCore/style/values/shapes/StyleInsetFunction.cpp
+++ b/Source/WebCore/style/values/shapes/StyleInsetFunction.cpp
@@ -63,16 +63,16 @@ WebCore::Path PathComputation<Inset>::operator()(const Inset& value, const Float
 {
     auto boundingSize = boundingBox.size();
 
-    auto left = evaluate(value.insets.left(), boundingSize.width(), 1.0f /* FIXME ZOOM EFFECTED? */);
-    auto top = evaluate(value.insets.top(), boundingSize.height(), 1.0f /* FIXME ZOOM EFFECTED? */);
+    auto left = evaluate(value.insets.left(), boundingSize.width(), Style::ZoomNeeded { });
+    auto top = evaluate(value.insets.top(), boundingSize.height(), Style::ZoomNeeded { });
     auto rect = FloatRect {
         left + boundingBox.x(),
         top + boundingBox.y(),
-        std::max<float>(boundingSize.width() - left - evaluate(value.insets.right(), boundingSize.width(), 1.0f /* FIXME ZOOM EFFECTED? */), 0),
-        std::max<float>(boundingSize.height() - top - evaluate(value.insets.bottom(), boundingSize.height(), 1.0f /* FIXME ZOOM EFFECTED? */), 0)
+        std::max<float>(boundingSize.width() - left - evaluate(value.insets.right(), boundingSize.width(), Style::ZoomNeeded { }), 0),
+        std::max<float>(boundingSize.height() - top - evaluate(value.insets.bottom(), boundingSize.height(), Style::ZoomNeeded { }), 0)
     };
 
-    auto radii = evaluate(value.radii, boundingSize, 1.0f /* FIXME FIND ZOOM */);
+    auto radii = evaluate(value.radii, boundingSize, Style::ZoomNeeded { });
     radii.scale(calcBorderRadiiConstraintScaleFor(rect, radii));
 
     return cachedRoundedInsetPath(FloatRoundedRect { rect, radii });

--- a/Source/WebCore/style/values/shapes/StylePolygonFunction.cpp
+++ b/Source/WebCore/style/values/shapes/StylePolygonFunction.cpp
@@ -63,7 +63,7 @@ WebCore::Path PathComputation<Polygon>::operator()(const Polygon& value, const F
     auto boundingLocation = boundingBox.location();
     auto boundingSize = boundingBox.size();
     auto points = value.vertices.value.map([&](const auto& vertex) {
-        return evaluate(vertex, boundingSize, 1.0f /* FIXME FIND ZOOM */) + boundingLocation;
+        return evaluate(vertex, boundingSize, Style::ZoomNeeded { }) + boundingLocation;
     });
     return cachedPolygonPath(points);
 }

--- a/Source/WebCore/style/values/shapes/StyleShapeFunction.cpp
+++ b/Source/WebCore/style/values/shapes/StyleShapeFunction.cpp
@@ -52,7 +52,7 @@ template<typename ControlPoint> static ControlPointAnchor evaluateControlPointAn
 
 template<typename ControlPoint> static FloatPoint evaluateControlPointOffset(const ControlPoint& value, const FloatSize& boxSize)
 {
-    return evaluate(value.offset, boxSize, 1.0f /* FIXME ZOOM EFFECTED? */);
+    return evaluate(value.offset, boxSize, Style::ZoomNeeded { });
 }
 
 template<typename ControlPoint> static FloatPoint resolveControlPoint(CommandAffinity affinity, FloatPoint currentPosition, FloatPoint segmentOffset, const ControlPoint& controlPoint, const FloatSize& boxSize)
@@ -118,32 +118,32 @@ private:
     std::optional<MoveToSegment> parseMoveToSegment(FloatPoint) override
     {
         if (!m_nextIndex)
-            return MoveToSegment { evaluate(m_start, m_boxSize, 1.0f /* FIXME ZOOM EFFECTED? */) };
+            return MoveToSegment { evaluate(m_start, m_boxSize, Style::ZoomNeeded { }) };
 
         auto& moveCommand = currentValue<MoveCommand>();
 
-        return MoveToSegment { evaluate(moveCommand.toBy, m_boxSize, 1.0f /* FIXME ZOOM EFFECTED? */) };
+        return MoveToSegment { evaluate(moveCommand.toBy, m_boxSize, Style::ZoomNeeded { }) };
     }
 
     std::optional<LineToSegment> parseLineToSegment(FloatPoint) override
     {
         auto& lineCommand = currentValue<LineCommand>();
 
-        return LineToSegment { evaluate(lineCommand.toBy, m_boxSize, 1.0f /* FIXME ZOOM EFFECTED? */) };
+        return LineToSegment { evaluate(lineCommand.toBy, m_boxSize, Style::ZoomNeeded { }) };
     }
 
     std::optional<LineToHorizontalSegment> parseLineToHorizontalSegment(FloatPoint) override
     {
         auto& lineCommand = currentValue<HLineCommand>();
 
-        return LineToHorizontalSegment { evaluate(lineCommand.toBy, m_boxSize.width(), 1.0f /* FIXME ZOOM EFFECTED? */) };
+        return LineToHorizontalSegment { evaluate(lineCommand.toBy, m_boxSize.width(), Style::ZoomNeeded { }) };
     }
 
     std::optional<LineToVerticalSegment> parseLineToVerticalSegment(FloatPoint) override
     {
         auto& lineCommand = currentValue<VLineCommand>();
 
-        return LineToVerticalSegment { evaluate(lineCommand.toBy, m_boxSize.height(), 1.0f /* FIXME ZOOM EFFECTED? */) };
+        return LineToVerticalSegment { evaluate(lineCommand.toBy, m_boxSize.height(), Style::ZoomNeeded { }) };
     }
 
     std::optional<CurveToCubicSegment> parseCurveToCubicSegment(FloatPoint currentPosition) override
@@ -152,7 +152,7 @@ private:
 
         return WTF::switchOn(curveCommand.toBy,
             [&](const auto& value) {
-                auto offset = evaluate(value.offset, m_boxSize, 1.0f /* FIXME ZOOM EFFECTED? */);
+                auto offset = evaluate(value.offset, m_boxSize, Style::ZoomNeeded { });
                 return CurveToCubicSegment {
                     resolveControlPoint(value.affinity, currentPosition, offset, value.controlPoint1, m_boxSize),
                     resolveControlPoint(value.affinity, currentPosition, offset, value.controlPoint2.value(), m_boxSize),
@@ -168,7 +168,7 @@ private:
 
         return WTF::switchOn(curveCommand.toBy,
             [&](const auto& value) {
-                auto offset = evaluate(value.offset, m_boxSize, 1.0f /* FIXME ZOOM EFFECTED? */);
+                auto offset = evaluate(value.offset, m_boxSize, Style::ZoomNeeded { });
                 return CurveToQuadraticSegment {
                     resolveControlPoint(value.affinity, currentPosition, offset, value.controlPoint1, m_boxSize),
                     offset
@@ -184,7 +184,7 @@ private:
         return WTF::switchOn(smoothCommand.toBy,
             [&](const auto& value) {
                 ASSERT(value.controlPoint);
-                auto offset = evaluate(value.offset, m_boxSize, 1.0f /* FIXME ZOOM EFFECTED? */);
+                auto offset = evaluate(value.offset, m_boxSize, Style::ZoomNeeded { });
                 return CurveToCubicSmoothSegment {
                     resolveControlPoint(value.affinity, currentPosition, offset, value.controlPoint.value(), m_boxSize),
                     offset
@@ -200,7 +200,7 @@ private:
         return WTF::switchOn(smoothCommand.toBy,
             [&](const auto& value) {
                 return CurveToQuadraticSmoothSegment {
-                    evaluate(value.offset, m_boxSize, 1.0f /* FIXME ZOOM EFFECTED? */)
+                    evaluate(value.offset, m_boxSize, Style::ZoomNeeded { })
                 };
             }
         );
@@ -210,14 +210,14 @@ private:
     {
         auto& arcCommand = currentValue<ArcCommand>();
 
-        auto radius = evaluate(arcCommand.size, m_boxSize, 1.0f /* FIXME ZOOM EFFECTED? */);
+        auto radius = evaluate(arcCommand.size, m_boxSize, Style::ZoomNeeded { });
         return ArcToSegment {
             .rx = radius.width(),
             .ry = radius.height(),
             .angle = narrowPrecisionToFloat(arcCommand.rotation.value),
             .largeArc = std::holds_alternative<CSS::Keyword::Large>(arcCommand.arcSize),
             .sweep = std::holds_alternative<CSS::Keyword::Cw>(arcCommand.arcSweep),
-            .targetPoint = evaluate(arcCommand.toBy, m_boxSize, 1.0f /* FIXME ZOOM EFFECTED? */)
+            .targetPoint = evaluate(arcCommand.toBy, m_boxSize, Style::ZoomNeeded { })
         };
     }
 

--- a/Source/WebCore/style/values/text-decoration/StyleTextDecorationThickness.cpp
+++ b/Source/WebCore/style/values/text-decoration/StyleTextDecorationThickness.cpp
@@ -49,7 +49,7 @@ float TextDecorationThickness::resolve(const RenderStyle& style) const
             return style.metricsOfPrimaryFont().underlineThickness().value_or(0);
         },
         [&](const TextDecorationThicknessLength& length) {
-            return Style::evaluate(length, style.computedFontSize(), 1.0f /* FIXME FIND ZOOM */);
+            return Style::evaluate(length, style.computedFontSize(), Style::ZoomNeeded { });
         }
     );
 }
@@ -64,7 +64,7 @@ float TextDecorationThickness::resolve(float fontSize, const FontMetrics& metric
             return metrics.underlineThickness().value_or(0);
         },
         [&](const TextDecorationThicknessLength& length) {
-            return Style::evaluate(length, fontSize, 1.0f /* FIXME FIND ZOOM */);
+            return Style::evaluate(length, fontSize, Style::ZoomNeeded { });
         }
     );
 }

--- a/Source/WebCore/style/values/text-decoration/StyleTextUnderlineOffset.cpp
+++ b/Source/WebCore/style/values/text-decoration/StyleTextUnderlineOffset.cpp
@@ -40,7 +40,7 @@ float TextUnderlineOffset::resolve(const RenderStyle& style, float autoValue) co
             return autoValue;
         },
         [&](const Fixed& fixed) -> float {
-            return fixed.evaluate(1.0f /* FIXME FIND ZOOM */);
+            return fixed.resolveZoom(Style::ZoomNeeded { });
         },
         [&](const auto& percentage) -> float {
             return Style::evaluate(percentage, style.computedFontSize());
@@ -55,7 +55,7 @@ float TextUnderlineOffset::resolve(float fontSize, float autoValue) const
             return autoValue;
         },
         [&](const Fixed& fixed) -> float {
-            return fixed.evaluate(1.0f /* FIXME FIND ZOOM */);
+            return fixed.resolveZoom(Style::ZoomNeeded { });
         },
         [&](const auto& percentage) -> float {
             return Style::evaluate(percentage, fontSize);

--- a/Source/WebCore/svg/SVGLengthContext.cpp
+++ b/Source/WebCore/svg/SVGLengthContext.cpp
@@ -114,7 +114,7 @@ template<typename SizeType> float SVGLengthContext::valueForSizeType(const SizeT
 {
     return WTF::switchOn(size,
         [&](const typename SizeType::Fixed& fixed) -> float {
-            return fixed.evaluate(1.0f /* FIXME FIND ZOOM */);
+            return fixed.resolveZoom(Style::ZoomNeeded { });
         },
         [&](const typename SizeType::Percentage& percentage) -> float {
             auto result = convertValueFromPercentageToUserUnits(percentage.value / 100, lengthMode);

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -3168,11 +3168,11 @@ header: <WebCore/StylePrimitiveNumericTypes.h>
 };
 
 [CustomHeader, Nested] struct WebCore::Style::LengthNonnegative {
-    float unevaluatedValue();
+    float unresolvedValue();
 };
 using WebCore::Style::LengthAll = WebCore::Style::Length<WebCore::CSS::All>;
 [CustomHeader, Nested] struct WebCore::Style::Length<WebCore::CSS::All> {
-    float unevaluatedValue();
+    float unresolvedValue();
 };
 
 [CustomHeader, Nested] struct WebCore::Style::Percentage<WebCore::CSS::Nonnegative> {

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -2060,9 +2060,9 @@ IntRect WebPage::absoluteInteractionBounds(const Node& node)
     auto& style = renderer->style();
     FloatRect boundingBox = renderer->absoluteBoundingBoxRect(true /* use transforms*/);
     // This is wrong. It's subtracting borders after converting to absolute coords on something that probably doesn't represent a rectangular element.
-    boundingBox.move(WebCore::Style::evaluate(style.borderLeftWidth(), 1.0f /* FIXME FIND ZOOM */), WebCore::Style::evaluate(style.borderTopWidth(), 1.0f /* FIXME FIND ZOOM */));
-    boundingBox.setWidth(boundingBox.width() - WebCore::Style::evaluate(style.borderLeftWidth(), 1.0f /* FIXME FIND ZOOM */) - WebCore::Style::evaluate(style.borderRightWidth(), 1.0f /* FIXME FIND ZOOM */));
-    boundingBox.setHeight(boundingBox.height() - WebCore::Style::evaluate(style.borderBottomWidth(), 1.0f /* FIXME FIND ZOOM */) - WebCore::Style::evaluate(style.borderTopWidth(), 1.0f /* FIXME FIND ZOOM */));
+    boundingBox.move(WebCore::Style::evaluate(style.borderLeftWidth(), WebCore::Style::ZoomNeeded { }), WebCore::Style::evaluate(style.borderTopWidth(), WebCore::Style::ZoomNeeded { }));
+    boundingBox.setWidth(boundingBox.width() - WebCore::Style::evaluate(style.borderLeftWidth(), WebCore::Style::ZoomNeeded { }) - WebCore::Style::evaluate(style.borderRightWidth(), WebCore::Style::ZoomNeeded { }));
+    boundingBox.setHeight(boundingBox.height() - WebCore::Style::evaluate(style.borderBottomWidth(), WebCore::Style::ZoomNeeded { }) - WebCore::Style::evaluate(style.borderTopWidth(), WebCore::Style::ZoomNeeded { }));
     return enclosingIntRect(boundingBox);
 }
 

--- a/Source/WebKitLegacy/mac/DOM/DOM.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOM.mm
@@ -448,9 +448,9 @@ id <DOMEventTarget> kit(EventTarget* target)
     auto& style = renderer->style();
     IntRect boundingBox = renderer->absoluteBoundingBoxRect(true /* use transforms*/);
 
-    boundingBox.move(WebCore::Style::evaluate(style.borderLeftWidth(), 1.0f /* FIXME FIND ZOOM */), WebCore::Style::evaluate(style.borderTopWidth(), 1.0f /* FIXME FIND ZOOM */));
-    boundingBox.setWidth(boundingBox.width() - WebCore::Style::evaluate(style.borderLeftWidth(), 1.0f /* FIXME FIND ZOOM */) - WebCore::Style::evaluate(style.borderRightWidth(), 1.0f /* FIXME FIND ZOOM */));
-    boundingBox.setHeight(boundingBox.height() - WebCore::Style::evaluate(style.borderBottomWidth(), 1.0f /* FIXME FIND ZOOM */) - WebCore::Style::evaluate(style.borderTopWidth(), 1.0f /* FIXME FIND ZOOM */));
+    boundingBox.move(WebCore::Style::evaluate(style.borderLeftWidth(), WebCore::Style::ZoomNeeded { }), WebCore::Style::evaluate(style.borderTopWidth(), WebCore::Style::ZoomNeeded { }));
+    boundingBox.setWidth(boundingBox.width() - WebCore::Style::evaluate(style.borderLeftWidth(), WebCore::Style::ZoomNeeded { }) - WebCore::Style::evaluate(style.borderRightWidth(), WebCore::Style::ZoomNeeded { }));
+    boundingBox.setHeight(boundingBox.height() - WebCore::Style::evaluate(style.borderBottomWidth(), WebCore::Style::ZoomNeeded { }) - WebCore::Style::evaluate(style.borderTopWidth(), WebCore::Style::ZoomNeeded { }));
 
     // FIXME: This function advertises returning a quad, but it actually returns a bounding box (so there is no rotation, for instance).
     return wkQuadFromFloatQuad(FloatQuad(boundingBox));


### PR DESCRIPTION
#### 8f8f4090009903e62a2046a94ac98298ed9053a6
<pre>
Encode whether zoom should be applied at style building or use time in the CSS::Range
<a href="https://bugs.webkit.org/show_bug.cgi?id=299385#">https://bugs.webkit.org/show_bug.cgi?id=299385#</a>

Reviewed by Antti Koivisto.

As a transitionary measure, until all zoom is applied at use time, where the zoom is
being applied is encoded in the CSS::Range and behavior is mediated based on that
compile time bit.

Also tightens things up by only allowing passing a zoom to Lengths with the bit set
and requiring all others to pass a token (Style::ZoomNeeded) indicating they still
need to be updated.

* Source/WebCore/Headers.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/accessibility/AXTableHelpers.cpp:
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
* Source/WebCore/animation/ScrollTimeline.cpp:
* Source/WebCore/animation/ScrollTimeline.h:
* Source/WebCore/animation/ViewTimeline.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+IntegerDefinitions.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+MetaConsumerDefinitions.h:
* Source/WebCore/css/values/primitives/CSSPrimitiveNumericRange.h:
* Source/WebCore/dom/Document.cpp:
* Source/WebCore/editing/Editor.cpp:
* Source/WebCore/html/NumberInputType.cpp:
* Source/WebCore/html/SearchInputType.cpp:
* Source/WebCore/layout/Verification.cpp:
* Source/WebCore/layout/formattingContexts/FormattingGeometry.cpp:
* Source/WebCore/layout/formattingContexts/FormattingGeometry.h:
* Source/WebCore/layout/formattingContexts/block/BlockFormattingGeometry.cpp:
* Source/WebCore/layout/formattingContexts/block/BlockFormattingQuirks.cpp:
* Source/WebCore/layout/formattingContexts/flex/FlexFormattingContext.cpp:
* Source/WebCore/layout/formattingContexts/flex/FlexFormattingUtils.cpp:
* Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.cpp:
* Source/WebCore/layout/formattingContexts/inline/InlineLevelBoxInlines.h:
* Source/WebCore/layout/formattingContexts/table/TableFormattingContext.cpp:
* Source/WebCore/layout/formattingContexts/table/TableFormattingQuirks.cpp:
* Source/WebCore/layout/formattingContexts/table/TableFormattingState.cpp:
* Source/WebCore/layout/formattingContexts/table/TableLayout.cpp:
* Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.cpp:
* Source/WebCore/layout/integration/flex/LayoutIntegrationFlexLayout.cpp:
* Source/WebCore/layout/layouttree/LayoutElementBox.cpp:
* Source/WebCore/page/IntersectionObserver.cpp:
* Source/WebCore/page/LocalFrameView.cpp:
* Source/WebCore/page/PrintContext.cpp:
* Source/WebCore/page/SpatialNavigation.cpp:
* Source/WebCore/page/ios/ContentChangeObserver.cpp:
* Source/WebCore/page/scrolling/ScrollSnapOffsetsInfo.cpp:
* Source/WebCore/platform/graphics/PathUtilities.cpp:
* Source/WebCore/rendering/AutoTableLayout.cpp:
* Source/WebCore/rendering/BackgroundPainter.cpp:
* Source/WebCore/rendering/BorderEdge.cpp:
* Source/WebCore/rendering/BorderPainter.cpp:
* Source/WebCore/rendering/BorderShape.cpp:
* Source/WebCore/rendering/EllipsisBoxPainter.cpp:
* Source/WebCore/rendering/FixedTableLayout.cpp:
* Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp:
* Source/WebCore/rendering/MotionPath.cpp:
* Source/WebCore/rendering/NinePieceImagePainter.cpp:
* Source/WebCore/rendering/PositionedLayoutConstraints.h:
* Source/WebCore/rendering/RenderBlock.cpp:
* Source/WebCore/rendering/RenderBlockFlow.cpp:
* Source/WebCore/rendering/RenderBox.cpp:
* Source/WebCore/rendering/RenderBoxModelObject.cpp:
* Source/WebCore/rendering/RenderBoxModelObjectInlines.h:
* Source/WebCore/rendering/RenderDeprecatedFlexibleBox.cpp:
* Source/WebCore/rendering/RenderElement.cpp:
* Source/WebCore/rendering/RenderFileUploadControl.cpp:
* Source/WebCore/rendering/RenderFlexibleBox.cpp:
* Source/WebCore/rendering/RenderGrid.cpp:
* Source/WebCore/rendering/RenderImage.cpp:
* Source/WebCore/rendering/RenderInline.cpp:
* Source/WebCore/rendering/RenderLayer.cpp:
* Source/WebCore/rendering/RenderListBox.cpp:
* Source/WebCore/rendering/RenderListMarker.cpp:
* Source/WebCore/rendering/RenderMarquee.cpp:
* Source/WebCore/rendering/RenderMenuList.cpp:
* Source/WebCore/rendering/RenderMultiColumnSet.cpp:
* Source/WebCore/rendering/RenderReplaced.cpp:
* Source/WebCore/rendering/RenderScrollbarPart.cpp:
* Source/WebCore/rendering/RenderSlider.cpp:
* Source/WebCore/rendering/RenderTable.cpp:
* Source/WebCore/rendering/RenderTableCell.cpp:
* Source/WebCore/rendering/RenderTableSection.cpp:
* Source/WebCore/rendering/RenderTextControl.cpp:
* Source/WebCore/rendering/RenderTextInlines.h:
* Source/WebCore/rendering/RenderTheme.cpp:
* Source/WebCore/rendering/RenderTreeAsText.cpp:
* Source/WebCore/rendering/TextBoxPainter.h:
* Source/WebCore/rendering/TextDecorationPainter.cpp:
* Source/WebCore/rendering/TextPainter.cpp:
* Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm:
* Source/WebCore/rendering/ios/RenderThemeIOS.mm:
* Source/WebCore/rendering/mathml/RenderMathMLBlock.cpp:
* Source/WebCore/rendering/shapes/LayoutShape.cpp:
* Source/WebCore/rendering/shapes/ShapeOutsideInfo.cpp:
* Source/WebCore/rendering/style/AutosizeStatus.cpp:
* Source/WebCore/rendering/style/CollapsedBorderValue.h:
* Source/WebCore/rendering/style/RenderStyle.cpp:
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
* Source/WebCore/rendering/svg/SVGRenderSupport.cpp:
* Source/WebCore/rendering/svg/SVGTextLayoutEngineBaseline.cpp:
* Source/WebCore/rendering/updating/RenderTreeBuilder.cpp:
* Source/WebCore/style/StyleExtractorCustom.h:
* Source/WebCore/style/StyleResolveForFont.cpp:
* Source/WebCore/style/values/animations/StyleSingleAnimationRange.cpp:
* Source/WebCore/style/values/backgrounds/StyleLineWidth.cpp:
* Source/WebCore/style/values/backgrounds/StyleLineWidth.h:
* Source/WebCore/style/values/borders/StyleBorderRadius.cpp:
* Source/WebCore/style/values/borders/StyleBorderRadius.h:
* Source/WebCore/style/values/borders/StyleBoxShadow.h:
* Source/WebCore/style/values/borders/StyleShadow.h:
* Source/WebCore/style/values/filter-effects/StyleBlurFunction.cpp:
* Source/WebCore/style/values/filter-effects/StyleDropShadowFunction.cpp:
* Source/WebCore/style/values/images/StyleGradient.cpp:
* Source/WebCore/style/values/non-standard/StyleWebKitBorderSpacing.h:
* Source/WebCore/style/values/non-standard/StyleWebKitTextStrokeWidth.h:
* Source/WebCore/style/values/primitives/StyleLengthWrapper+CSSValueConversion.h:
* Source/WebCore/style/values/primitives/StyleLengthWrapper.h:
* Source/WebCore/style/values/primitives/StyleLengthWrapperData.h:
* Source/WebCore/style/values/primitives/StylePosition.cpp:
* Source/WebCore/style/values/primitives/StylePosition.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumeric.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Blending.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+CSSValueConversion.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Calculation.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Evaluation.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Logging.h:
* Source/WebCore/style/values/primitives/StyleZoomNeededToken.h: Added.
* Source/WebCore/style/values/scroll-snap/StyleScrollMargin.cpp:
* Source/WebCore/style/values/scroll-snap/StyleScrollMargin.h:
* Source/WebCore/style/values/scroll-snap/StyleScrollPadding.cpp:
* Source/WebCore/style/values/scroll-snap/StyleScrollPadding.h:
* Source/WebCore/style/values/shapes/StyleCircleFunction.cpp:
* Source/WebCore/style/values/shapes/StyleEllipseFunction.cpp:
* Source/WebCore/style/values/shapes/StyleInsetFunction.cpp:
* Source/WebCore/style/values/shapes/StylePolygonFunction.cpp:
* Source/WebCore/style/values/shapes/StyleShapeFunction.cpp:
* Source/WebCore/style/values/text-decoration/StyleTextDecorationThickness.cpp:
* Source/WebCore/style/values/text-decoration/StyleTextUnderlineOffset.cpp:
* Source/WebCore/style/values/transforms/StylePerspective.h:
* Source/WebCore/svg/SVGLengthContext.cpp:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/300505@main">https://commits.webkit.org/300505@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d43e3a397a9c06cd9f0b9e27a99fed69e2032824

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122807 "17 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42519 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33209 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/129433 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74911 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/124683 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43238 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51112 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93333 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/61959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125759 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34473 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109935 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73973 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33453 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28092 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72925 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104172 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28305 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132159 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49752 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37875 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/101932 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50129 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106151 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101714 "Found 2 new API test failures: TestWTF:CompletionHandlerDeathTest.MainThreadHandlerOnThreadAssertsDeathTest, TestWTF:CompletionHandlerDeathTest.ConstructionThreadHandlerOnThreadAssertsDeathTest (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25834 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47090 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25278 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/46523 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/49712 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/55362 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49076 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/52428 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50759 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->