### PR TITLE
[MSE][GStreamer] Support markEndOfStream() before appendBuffer()

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -220,6 +220,7 @@ public:
     bool handleNeedContextMessage(GstMessage*);
 
     void handleStreamCollectionMessage(GstMessage*);
+    void handleSyncErrorMessage(GstMessage*);
     void handleMessage(GstMessage*);
 
     void triggerRepaint(GRefPtr<GstSample>&&);
@@ -363,6 +364,8 @@ protected:
     bool isPipelineWaitingPreroll(GstState current, GstState pending, GstStateChangeReturn) const;
     bool isPipelineWaitingPreroll() const;
 
+    void didEnd();
+
     Ref<MainThreadNotifier<MainThreadNotification>> m_notifier;
     ThreadSafeWeakPtr<MediaPlayer> m_player;
     String m_referrer;
@@ -445,6 +448,7 @@ protected:
     std::optional<GstVideoDecoderPlatform> m_videoDecoderPlatform;
     GstSeekFlags m_seekFlags;
     bool m_ignoreErrors { false };
+    Atomic<unsigned> m_queuedSyncErrors { 0 };
 
     TrackIDHashMap<Ref<AudioTrackPrivateGStreamer>> m_audioTracks;
     TrackIDHashMap<Ref<VideoTrackPrivateGStreamer>> m_videoTracks;
@@ -497,7 +501,6 @@ private:
     bool isMuted() const;
     void commitLoad();
     void fillTimerFired();
-    void didEnd();
     void setPlaybackFlags(bool isMediaStream);
     void recalculateDurationIfNeeded() const; // It's called from other const methods.
 


### PR DESCRIPTION
#### b1ff5913b21169adf6d94f74538d8ee90188abb6
<pre>
[MSE][GStreamer] Support markEndOfStream() before appendBuffer()
<a href="https://bugs.webkit.org/show_bug.cgi?id=278726">https://bugs.webkit.org/show_bug.cgi?id=278726</a>

Reviewed by Xabier Rodriguez-Calvar.

In the past, WebKit MSE couldn&apos;t complete playback when JavaScript
performs MediaSource.markEndOfStream() before appending any samples with
SourceBuffer.appendBuffer(). A previous patch added that support, but
still the error keeps happening under some circumstances downstream
(wpe-2.46, GStreamer 1.18) as well as upstream (where it was believed
not to happen in GStreamer 1.24).

This happens when the test case is exercised in a loop and the race
condition for an error occurs while errors are ignored, but the
GstMessage with the error takes a moment to propagate to the main thread
(when the errors are no longer ignored).

See: <a href="https://github.com/WebPlatformForEmbedded/WPEWebKit/issues/1558">https://github.com/WebPlatformForEmbedded/WPEWebKit/issues/1558</a>

This patch now applies the fix to any GStreamer version (because the
issue appears in all of them). When an EOS without buffers happens, the
pipeline goes to READY, and errors are ignored. The m_ignoreErrors flag
is kept enabled while the pipeline is being set to READY, but if any
error has been detected by the sync message handler, it stays enabled
until the last enqueued error is processed by the main thread. In any
case m_ignoreErrors is only changed from the main thread (in different
loop cycles in the worst case, but always from the main thread) and
doesn&apos;t need concurrent access protection.

As mentioned in the previous paragraph, a new sync error signal listener
has been added. This listener doesn&apos;t do any actual error processing,
just increases the m_queuedSyncErrors counter. The async message handler
will end up getting the error message anyway. That&apos;s where the message
will be ignored (if the m_ignoreErrors flag is set) and, ignored or not,
the m_queuedSyncErrors counter will be decremented. Note that this
counter is an Atomic, in order to support access from the (potentially)
non-main thread that handles the sync error signal, from the main thread
that ends up processing the error, and from the main thread that
processes setEosWithNoBuffers().

If an error has happened, an EOS in the pipeline is simulated by calling
didEnd(), the same method that would be called if such an EOS had
happened. This call usually triggers a pipeline teardown and the further
destruction of the player private. This may trigger a
gst_bus_set_flushing() call and cause the error message to never be
dispatched to the main thread. While this may mean that the
m_queuedSyncErrors counter is never decremented, this isn&apos;t a real
problem, since the player is being destructed anyway and nobody cares
about the count anymore.

* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::handleSyncErrorMessage): Detect errors as they happen, in the same thread where they were generated (often a non-main thread). The count of m_queuedSyncErrors is atomically increased to indicate the main thread that there are error messages pending to process. There&apos;s no need to forward the processing to the main thread, since the bus will eventually dispatch it asynchronously.
(WebCore::MediaPlayerPrivateGStreamer::handleMessage): If the last error is being processed while in a &quot;ignore errors&quot; state, reset the state to false. Also, exit early if we were in &quot;ignore errors&quot; state. In any case (early or standard exit), decrease the m_queuedSyncErrors count atomically.
(WebCore::MediaPlayerPrivateGStreamer::createGSTPlayBin): Process error messages synchronously with the handleSyncErrorMessage() handler.
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h: didEnd() is now protected, so it can be called by the subclass. Added the m_queuedSyncErrors atomic counter to signal how many errors are waiting to be processed by the main thread.
* Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp:
(WebCore::MediaPlayerPrivateGStreamerMSE::setEosWithNoBuffers): Ignore the errors on all GStreamer versions by declaring m_ignoreErrors as true. If pending error messages are enqueued, report EOS by calling didEnd() (m_ignoreErrors will be reset when the last error is processed). If no pending error messages appeared, just reset the m_ignoreErrors flag here.

Canonical link: <a href="https://commits.webkit.org/300605@main">https://commits.webkit.org/300605@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5e9fe3b56bec9d98202ccc8e36260b180c523246

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123206 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42920 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33617 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/129913 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/75318 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/125083 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43644 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51515 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93657 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/75318 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126159 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34785 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110258 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74287 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33754 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28415 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73429 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104498 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28640 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132629 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50156 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38180 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102148 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50532 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106479 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102006 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25932 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47371 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25582 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/46930 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50011 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/55772 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49481 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/52832 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51160 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->