### PR TITLE
[GFC] Allow multiple grid items per cell.

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/ImplicitGrid.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/ImplicitGrid.cpp
@@ -38,7 +38,7 @@ namespace Layout {
 // implicit grid as exactly the explicit grid and allow placement to add implicit
 // tracks and grow the grid.
 ImplicitGrid::ImplicitGrid(size_t gridTemplateColumnsCount, size_t gridTemplateRowsCount)
-    : m_gridMatrix(Vector(gridTemplateRowsCount, Vector<std::optional<UnplacedGridItem>>(gridTemplateColumnsCount)))
+    : m_gridMatrix(Vector(gridTemplateRowsCount, Vector<GridCell>(gridTemplateColumnsCount)))
 {
 }
 
@@ -95,7 +95,7 @@ void ImplicitGrid::insertUnplacedGridItem(const UnplacedGridItem& unplacedGridIt
     auto rowsRange = WTF::Range(explicitRowStart, explicitRowEnd);
     for (auto rowIndex = rowsRange.begin(); rowIndex < rowsRange.end(); ++rowIndex) {
         for (auto columnIndex = columnsRange.begin(); columnIndex < columnsRange.end(); ++columnIndex)
-            m_gridMatrix[rowIndex][columnIndex] = unplacedGridItem;
+            m_gridMatrix[rowIndex][columnIndex].append(unplacedGridItem);
     }
 
 }
@@ -108,12 +108,13 @@ PlacedGridItems ImplicitGrid::placedGridItems() const
     for (size_t rowIndex = 0; rowIndex < m_gridMatrix.size(); ++rowIndex) {
         for (size_t columnIndex = 0; columnIndex < m_gridMatrix[rowIndex].size(); ++columnIndex) {
 
-            auto unplacedGridItem = m_gridMatrix[rowIndex][columnIndex];
-            if (!unplacedGridItem || processedUnplacedGridItems.contains(*unplacedGridItem))
-                continue;
-
-            processedUnplacedGridItems.add(*unplacedGridItem);
-            placedGridItems.append({ *unplacedGridItem, { columnIndex, columnIndex + 1, rowIndex, rowIndex + 1 } });
+            const auto& gridCell = m_gridMatrix[rowIndex][columnIndex];
+            for (const auto& unplacedGridItem : gridCell) {
+                if (processedUnplacedGridItems.contains(unplacedGridItem))
+                    continue;
+                processedUnplacedGridItems.add(unplacedGridItem);
+                placedGridItems.append({ unplacedGridItem, { columnIndex, columnIndex + 1, rowIndex, rowIndex + 1 } });
+            }
         }
     }
     return placedGridItems;

--- a/Source/WebCore/layout/formattingContexts/grid/ImplicitGrid.h
+++ b/Source/WebCore/layout/formattingContexts/grid/ImplicitGrid.h
@@ -35,6 +35,7 @@ class PlacedGridItem;
 class UnplacedGridItem;
 
 using PlacedGridItems = Vector<PlacedGridItem>;
+using GridCell = Vector<UnplacedGridItem, 1>;
 
 // https://drafts.csswg.org/css-grid-1/#implicit-grids
 class ImplicitGrid {
@@ -49,7 +50,7 @@ public:
     PlacedGridItems placedGridItems() const;
 
 private:
-    using GridMatrix = Vector<Vector<std::optional<UnplacedGridItem>>>;
+    using GridMatrix = Vector<Vector<GridCell>>;
     GridMatrix m_gridMatrix;
 };
 


### PR DESCRIPTION
#### e63caae02dde189728872847cfbde070ba474f36
<pre>
[GFC] Allow multiple grid items per cell.
<a href="https://bugs.webkit.org/show_bug.cgi?id=299381">https://bugs.webkit.org/show_bug.cgi?id=299381</a>
&lt;<a href="https://rdar.apple.com/161180373">rdar://161180373</a>&gt;

Reviewed by Sammy Gill.

This PR updates the ImplicitGrid&apos;s GridMatrix to hold multiple grid items
in a vector, defaulting to holding the first of which inline (the usual case).

Combined changes:
* Source/WebCore/layout/formattingContexts/grid/ImplicitGrid.cpp:
(WebCore::Layout::ImplicitGrid::ImplicitGrid):
(WebCore::Layout::ImplicitGrid::insertUnplacedGridItem):
(WebCore::Layout::ImplicitGrid::placedGridItems const):
* Source/WebCore/layout/formattingContexts/grid/ImplicitGrid.h:

Canonical link: <a href="https://commits.webkit.org/300438@main">https://commits.webkit.org/300438@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eba9d190daf1a81e9eaa54cde6ae720749a757d9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122489 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42197 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32882 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/129092 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74588 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/433e3f57-21b4-4221-a6da-123fa01ea20e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/124365 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42915 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50790 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93115 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/61842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/21cb473f-4ed3-4c42-9d38-af318fdca939) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125441 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34230 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109674 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73758 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d70fe8b2-347d-4ca0-b883-178b3ac363dd) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33217 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27831 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72580 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103873 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28042 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131821 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49430 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37622 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101647 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49804 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105895 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101515 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25778 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46884 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25033 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/46199 "The change is no longer eligible for processing.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49288 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/55037 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48755 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/52105 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50437 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->