### PR TITLE
MiniBrowser address bar immediately relinquishes focus when tab focusing out from web content

### DIFF
--- a/Source/WebCore/page/FocusController.cpp
+++ b/Source/WebCore/page/FocusController.cpp
@@ -637,7 +637,7 @@ bool FocusController::advanceFocusInDocumentOrder(FocusDirection direction, cons
     RefPtr startingNode = document->focusNavigationStartingNode(direction);
     auto findResult = findAndFocusElementInDocumentOrderStartingWithFrame(*frame, startingNode, startingNode, direction, focusEventData, initialFocus, ContinuingRemoteSearch::No);
 
-    return findResult.element;
+    return findResult.element || findResult.relinquishedFocusToChrome == RelinquishedFocusToChrome::Yes;
 }
 
 FocusableElementSearchResult FocusController::findAndFocusElementInDocumentOrderStartingWithFrame(Ref<LocalFrame> frame, RefPtr<Node> scopeNode, RefPtr<Node> startingNode, FocusDirection direction, const FocusEventData& focusEventData, InitialFocus initialFocus, ContinuingRemoteSearch continuingRemoteSearch)
@@ -667,8 +667,10 @@ FocusableElementSearchResult FocusController::findAndFocusElementInDocumentOrder
 
         // We didn't find a node to focus, so we should try to pass focus to Chrome.
         if (initialFocus == InitialFocus::No) {
-            if (relinquishFocusToChrome(direction))
+            if (relinquishFocusToChrome(direction)) {
+                findResult.relinquishedFocusToChrome = RelinquishedFocusToChrome::Yes;
                 return findResult;
+            }
         }
 
         // Chrome doesn't want focus, so we should wrap focus.

--- a/Source/WebCore/page/FocusController.h
+++ b/Source/WebCore/page/FocusController.h
@@ -53,10 +53,12 @@ struct FocusEventData;
 
 enum class ContinuedSearchInRemoteFrame : bool { No, Yes };
 enum class FoundElementInRemoteFrame : bool { No, Yes };
+enum class RelinquishedFocusToChrome : bool { No, Yes };
 
 struct FocusableElementSearchResult {
     RefPtr<Element> element;
     ContinuedSearchInRemoteFrame continuedSearchInRemoteFrame { ContinuedSearchInRemoteFrame::No };
+    RelinquishedFocusToChrome relinquishedFocusToChrome { RelinquishedFocusToChrome::No };
 };
 
 class FocusController final : public CanMakeCheckedPtr<FocusController> {


### PR DESCRIPTION
#### 24de837345794a299744beac26de7e2000253de8
<pre>
MiniBrowser address bar immediately relinquishes focus when tab focusing out from web content
<a href="https://rdar.apple.com/160792178">rdar://160792178</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=299392">https://bugs.webkit.org/show_bug.cgi?id=299392</a>

Reviewed by Abrar Rahman Protyasha.

If we relinquish focus to the chrome client, we should also mark the event as handled.
Otherwise, WebKit will automatically forward it along to AppKit for further processing.

Test: Tools/TestWebKitAPI/Tests/mac/FocusWebView.mm

* Source/WebCore/page/FocusController.cpp:
(WebCore::FocusController::advanceFocusInDocumentOrder):
(WebCore::FocusController::findAndFocusElementInDocumentOrderStartingWithFrame):
* Source/WebCore/page/FocusController.h:

* Tools/TestWebKitAPI/Tests/mac/FocusWebView.mm:
(-[TestNSTextView keyDown:]):
(-[TestNSTextView acceptsFirstResponder]):
(-[TestNSTextView canBecomeKeyView]):
(-[TestNSTextView becomeFirstResponder]):
(-[TestNSTextView resignFirstResponder]):
(TestWebKitAPI::AdvanceFocusRelinquishToChrome)):
(TestWebKitAPI::TEST(FocusWebView, DoNotFocusWebViewWhenUnparented)): Deleted.

Canonical link: <a href="https://commits.webkit.org/300442@main">https://commits.webkit.org/300442@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/64c3b716654f37d98e2e289e610ac5949346c1dc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122543 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42251 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32936 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/129152 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74644 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/490c6348-0f37-4955-a52f-436d6fd4fdc1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/124419 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42969 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50844 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93149 "5 flakes 16 failures") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/61861 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125495 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34272 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109722 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73796 "Found 1 new API test failure: TestWTF:WTF_Condition.OneProducerOneConsumerOneSlot (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/16822ce8-3167-49ac-835d-ffde852b46cd) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33255 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27879 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72636 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103929 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28089 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131878 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49484 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37663 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101682 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49859 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105942 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101550 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25782 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46927 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25077 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/46254 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49342 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/55091 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48810 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/52161 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50491 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->