### PR TITLE
Web Inspector: Implement the Console domain and agent for the frame target type

### DIFF
--- a/LayoutTests/http/tests/inspector/console/message-from-iframe-expected.txt
+++ b/LayoutTests/http/tests/inspector/console/message-from-iframe-expected.txt
@@ -1,46 +1,46 @@
 CONSOLE MESSAGE: Hello from http://127.0.0.1:8000/inspector/console/resources/console-messages.html
 CONSOLE MESSAGE: Warning from http://127.0.0.1:8000/inspector/console/resources/console-messages.html
 CONSOLE MESSAGE: Error from http://127.0.0.1:8000/inspector/console/resources/console-messages.html
-CONSOLE MESSAGE: iframe is loaded in http://127.0.0.1:8000/inspector/console/message-from-iframe.html
+CONSOLE MESSAGE: iframe 1 is loaded in http://127.0.0.1:8000/inspector/console/message-from-iframe.html
 CONSOLE MESSAGE: Hello from http://localhost:8000/inspector/console/resources/console-messages.html
 CONSOLE MESSAGE: Warning from http://localhost:8000/inspector/console/resources/console-messages.html
 CONSOLE MESSAGE: Error from http://localhost:8000/inspector/console/resources/console-messages.html
-CONSOLE MESSAGE: iframe is loaded in http://127.0.0.1:8000/inspector/console/message-from-iframe.html
+CONSOLE MESSAGE: iframe 2 is loaded in http://127.0.0.1:8000/inspector/console/message-from-iframe.html
 CONSOLE MESSAGE: Hello from http://127.0.0.1:8000/inspector/console/resources/console-messages.html
 CONSOLE MESSAGE: Warning from http://127.0.0.1:8000/inspector/console/resources/console-messages.html
 CONSOLE MESSAGE: Error from http://127.0.0.1:8000/inspector/console/resources/console-messages.html
 CONSOLE MESSAGE: iframe is loaded in iframe http://127.0.0.1:8000/inspector/console/resources/embedded-same-origin.html
-CONSOLE MESSAGE: iframe is loaded in http://127.0.0.1:8000/inspector/console/message-from-iframe.html
+CONSOLE MESSAGE: iframe 3 is loaded in http://127.0.0.1:8000/inspector/console/message-from-iframe.html
 CONSOLE MESSAGE: Hello from http://127.0.0.1:8000/inspector/console/resources/console-messages.html
 CONSOLE MESSAGE: Warning from http://127.0.0.1:8000/inspector/console/resources/console-messages.html
 CONSOLE MESSAGE: Error from http://127.0.0.1:8000/inspector/console/resources/console-messages.html
 CONSOLE MESSAGE: iframe is loaded in http://localhost:8000/inspector/console/resources/embedded-cross-origin.html
-CONSOLE MESSAGE: iframe is loaded in http://127.0.0.1:8000/inspector/console/message-from-iframe.html
+CONSOLE MESSAGE: iframe 4 is loaded in http://127.0.0.1:8000/inspector/console/message-from-iframe.html
 
 == Running test suite: MessageFromIFrame
 -- Running test case: MessageFromIFrame.SameOriginIFrame
 Got message: Hello from http://127.0.0.1:8000/inspector/console/resources/console-messages.html
 Got message: Warning from http://127.0.0.1:8000/inspector/console/resources/console-messages.html
 Got message: Error from http://127.0.0.1:8000/inspector/console/resources/console-messages.html
-Got message: iframe is loaded in http://127.0.0.1:8000/inspector/console/message-from-iframe.html
+Got message: iframe 1 is loaded in http://127.0.0.1:8000/inspector/console/message-from-iframe.html
 
 -- Running test case: MessageFromIFrame.CrossOriginIFrame
 Got message: Hello from http://localhost:8000/inspector/console/resources/console-messages.html
 Got message: Warning from http://localhost:8000/inspector/console/resources/console-messages.html
 Got message: Error from http://localhost:8000/inspector/console/resources/console-messages.html
-Got message: iframe is loaded in http://127.0.0.1:8000/inspector/console/message-from-iframe.html
+Got message: iframe 2 is loaded in http://127.0.0.1:8000/inspector/console/message-from-iframe.html
 
 -- Running test case: MessageFromIFrame.GrandChildSameOriginIFrameInSameOrigin
 Got message: Hello from http://127.0.0.1:8000/inspector/console/resources/console-messages.html
 Got message: Warning from http://127.0.0.1:8000/inspector/console/resources/console-messages.html
 Got message: Error from http://127.0.0.1:8000/inspector/console/resources/console-messages.html
 Got message: iframe is loaded in iframe http://127.0.0.1:8000/inspector/console/resources/embedded-same-origin.html
-Got message: iframe is loaded in http://127.0.0.1:8000/inspector/console/message-from-iframe.html
+Got message: iframe 3 is loaded in http://127.0.0.1:8000/inspector/console/message-from-iframe.html
 
 -- Running test case: MessageFromIFrame.GrandChildSameOriginIFrameInCrossOrigin
 Got message: Hello from http://127.0.0.1:8000/inspector/console/resources/console-messages.html
 Got message: Warning from http://127.0.0.1:8000/inspector/console/resources/console-messages.html
 Got message: Error from http://127.0.0.1:8000/inspector/console/resources/console-messages.html
 Got message: iframe is loaded in http://localhost:8000/inspector/console/resources/embedded-cross-origin.html
-Got message: iframe is loaded in http://127.0.0.1:8000/inspector/console/message-from-iframe.html
+Got message: iframe 4 is loaded in http://127.0.0.1:8000/inspector/console/message-from-iframe.html
 

--- a/LayoutTests/http/tests/inspector/console/message-from-iframe.html
+++ b/LayoutTests/http/tests/inspector/console/message-from-iframe.html
@@ -1,10 +1,10 @@
 <script src="/inspector/resources/inspector-test.js"></script>
 <script>
     // Utilities for page code.
-    function addIFrame(url) {
-        const iframe = document.createElement("iframe");
+    function addIFrame(iframeID, url) {
+        let iframe = document.createElement("iframe");
         iframe.src = url;
-        iframe.onload = () => console.log("iframe is loaded in " + location.href);
+        iframe.onload = () => console.log(`iframe ${iframeID} is loaded in ${location.href}`);
         document.body.appendChild(iframe);
     }
 
@@ -34,25 +34,25 @@
         suite.addTestCase({
             name: "MessageFromIFrame.SameOriginIFrame",
             description: "console message comming from same origin iframe",
-            test: (resolve) => runMessageTest(resolve, 4, `addIFrame("resources/console-messages.html")`),
+            test: (resolve) => runMessageTest(resolve, 4, `addIFrame(1, "resources/console-messages.html")`),
         });
 
         suite.addTestCase({
             name: "MessageFromIFrame.CrossOriginIFrame",
             description: "console message comming from cross origin iframe",
-            test: (resolve) => runMessageTest(resolve, 4, `addIFrame("http://localhost:8000/inspector/console/resources/console-messages.html")`),
+            test: (resolve) => runMessageTest(resolve, 4, `addIFrame(2, "http://localhost:8000/inspector/console/resources/console-messages.html")`),
         });
 
         suite.addTestCase({
             name: "MessageFromIFrame.GrandChildSameOriginIFrameInSameOrigin",
             description: "console message comming from same origin grand-child iframe in same origin iframe",
-            test: (resolve) => runMessageTest(resolve, 5, `addIFrame("resources/embedded-same-origin.html")`),
+            test: (resolve) => runMessageTest(resolve, 5, `addIFrame(3, "resources/embedded-same-origin.html")`),
         });
 
         suite.addTestCase({
             name: "MessageFromIFrame.GrandChildSameOriginIFrameInCrossOrigin",
             description: "console message comming from same origin grand-child iframe in cross origin iframe",
-            test: (resolve) => runMessageTest(resolve, 5, `addIFrame("http://localhost:8000/inspector/console/resources/embedded-cross-origin.html")`),
+            test: (resolve) => runMessageTest(resolve, 5, `addIFrame(4, "http://localhost:8000/inspector/console/resources/embedded-cross-origin.html")`),
         });
 
         suite.runTestCasesAndFinish();

--- a/LayoutTests/inspector/console/clearMessages.html
+++ b/LayoutTests/inspector/console/clearMessages.html
@@ -11,7 +11,7 @@ function test()
         name: "CallClearMessages",
         description: "Calling the Console.clearMessages command should trigger Console.messagesCleared.",
         test(resolve, reject) {
-            ConsoleAgent.clearMessages();
+            WI.mainFrameTarget.ConsoleAgent.clearMessages();
 
             WI.consoleManager.awaitEvent(WI.ConsoleManager.Event.MessageAdded)
             .then((event) => {

--- a/LayoutTests/inspector/console/messagesCleared.html
+++ b/LayoutTests/inspector/console/messagesCleared.html
@@ -17,7 +17,7 @@ function test()
             })
             .then(resolve, reject);
 
-            ConsoleAgent.clearMessages();
+            WI.mainFrameTarget.ConsoleAgent.clearMessages();
         }
     });
 

--- a/LayoutTests/inspector/console/setConsoleClearAPIEnabled.html
+++ b/LayoutTests/inspector/console/setConsoleClearAPIEnabled.html
@@ -11,7 +11,7 @@ function test()
         name: "Console.setConsoleClearAPIEnabled.API.Disabled",
         description: "Check that console.clear() doesn't clear the console when disallowed.",
         async test() {
-            await ConsoleAgent.setConsoleClearAPIEnabled(false);
+            await WI.mainFrameTarget.ConsoleAgent.setConsoleClearAPIEnabled(false);
 
             let cleared = false;
             let clearedListener = WI.consoleManager.addEventListener(WI.ConsoleManager.Event.Cleared, (event) => {
@@ -34,7 +34,7 @@ function test()
         name: "Console.setConsoleClearAPIEnabled.API.Enabled",
         description: "Check that console.clear() does clear the console when allowed.",
         async test() {
-            await ConsoleAgent.setConsoleClearAPIEnabled(true);
+            await WI.mainFrameTarget.ConsoleAgent.setConsoleClearAPIEnabled(true);
 
             let cleared = false;
             let clearedListener = WI.consoleManager.addEventListener(WI.ConsoleManager.Event.Cleared, (event) => {
@@ -57,7 +57,7 @@ function test()
         name: "Console.setConsoleClearAPIEnabled.Frontend.Disabled",
         description: "Check that the frontend can still clear the console when console.clear() is disallowed.",
         async test() {
-            await ConsoleAgent.setConsoleClearAPIEnabled(false);
+            await WI.mainFrameTarget.ConsoleAgent.setConsoleClearAPIEnabled(false);
 
             let messageAdded = false;
             let messageAddedListener = WI.consoleManager.addEventListener(WI.ConsoleManager.Event.MessageAdded, (event) => {
@@ -78,7 +78,7 @@ function test()
         name: "Console.setConsoleClearAPIEnabled.Frontend.Enabled",
         description: "Check that the frontend can still clear the console when console.clear() is allowed.",
         async test() {
-            await ConsoleAgent.setConsoleClearAPIEnabled(true);
+            await WI.mainFrameTarget.ConsoleAgent.setConsoleClearAPIEnabled(true);
 
             let messageAdded = false;
             let messageAddedListener = WI.consoleManager.addEventListener(WI.ConsoleManager.Event.MessageAdded, (event) => {

--- a/LayoutTests/inspector/console/webcore-logging.html
+++ b/LayoutTests/inspector/console/webcore-logging.html
@@ -45,7 +45,7 @@ function test()
         name: "Console.Logging.BasicProperties",
         description: "Check initial properties.",
         test(resolve, reject) {
-            ConsoleAgent.getLoggingChannels((error, channels) => {
+            WI.mainFrameTarget.ConsoleAgent.getLoggingChannels((error, channels) => {
                 if (error) {
                     InspectorTest.fail(`ConsoleAgent.getLoggingChannels() failed with error ${error}`);
                     reject();
@@ -70,7 +70,7 @@ function test()
         name: "Console.Logging.InvalidLevel",
         description: "setLoggingChannelLevel should reject invalid log channel level.",
         test(resolve, reject) {
-            ConsoleAgent.setLoggingChannelLevel(WI.ConsoleMessage.MessageSource.Media, "DOES_NOT_EXIST", (error) => {
+            WI.mainFrameTarget.ConsoleAgent.setLoggingChannelLevel(WI.ConsoleMessage.MessageSource.Media, "DOES_NOT_EXIST", (error) => {
                 if (!error) {
                     InspectorTest.fail("Should have an error with invalid level.");
                     reject();
@@ -113,13 +113,13 @@ function test()
         name: "Console.Logging.MediaLogging",
         description: "<video> logging when enabled.",
         test(resolve, reject) {
-            ConsoleAgent.clearMessages();
+            WI.mainFrameTarget.ConsoleAgent.clearMessages();
 
             let channel = WI.consoleManager.customLoggingChannels.find(channel => channel.source === WI.ConsoleMessage.MessageSource.Media);
             InspectorTest.expectThat(channel.level === WI.LoggingChannel.Level.Off, "Media logging disabled.");
 
-            ConsoleAgent.setLoggingChannelLevel(channel.source, WI.LoggingChannel.Level.Basic)
-            ConsoleAgent.getLoggingChannels((error, channels) => {
+            WI.mainFrameTarget.ConsoleAgent.setLoggingChannelLevel(channel.source, WI.LoggingChannel.Level.Basic)
+            WI.mainFrameTarget.ConsoleAgent.getLoggingChannels((error, channels) => {
                 if (error) {
                     InspectorTest.fail(`ConsoleAgent.getLoggingChannels() failed with error ${error}`);
                     reject();
@@ -133,7 +133,7 @@ function test()
                     InspectorTest.assert(message instanceof WI.ConsoleMessage);
                     InspectorTest.expectThat(message.source === WI.ConsoleMessage.MessageSource.Media, "Media log message should have source 'media'.");
                     WI.consoleManager.removeEventListener(WI.ConsoleManager.Event.MessageAdded, logListener, null);
-                    ConsoleAgent.setLoggingChannelLevel(mediaChannel.source, WI.LoggingChannel.Level.Off)
+                    WI.mainFrameTarget.ConsoleAgent.setLoggingChannelLevel(mediaChannel.source, WI.LoggingChannel.Level.Off)
                     resolve();
                 });
 
@@ -147,13 +147,13 @@ function test()
         name: "Console.Logging.LogAsJSONWithoutRepeat",
         description: "JSON messages logged correctly.",
         test(resolve, reject) {
-            ConsoleAgent.clearMessages();
+            WI.mainFrameTarget.ConsoleAgent.clearMessages();
 
             let channel = WI.consoleManager.customLoggingChannels.find(channel => channel.source === WI.ConsoleMessage.MessageSource.Media);
             InspectorTest.expectThat(channel.level === WI.LoggingChannel.Level.Off, "Media logging disabled.");
 
-            ConsoleAgent.setLoggingChannelLevel(channel.source, WI.LoggingChannel.Level.Verbose)
-            ConsoleAgent.getLoggingChannels((error, channels) => {
+            WI.mainFrameTarget.ConsoleAgent.setLoggingChannelLevel(channel.source, WI.LoggingChannel.Level.Verbose)
+            WI.mainFrameTarget.ConsoleAgent.getLoggingChannels((error, channels) => {
                 if (error) {
                     InspectorTest.fail(`ConsoleAgent.getLoggingChannels() failed with error ${error}`);
                     reject();
@@ -174,7 +174,7 @@ function test()
                         if (++messageCount === 3) {
                             InspectorTest.log("Received three JSON messages.");
                             WI.consoleManager.removeEventListener(WI.ConsoleManager.Event.MessageAdded, logListener, null);
-                            ConsoleAgent.setLoggingChannelLevel(mediaChannel.source, WI.LoggingChannel.Level.Off)
+                            WI.mainFrameTarget.ConsoleAgent.setLoggingChannelLevel(mediaChannel.source, WI.LoggingChannel.Level.Off)
                             resolve();
                         }
                     }

--- a/LayoutTests/inspector/console/x-frame-options-message-expected.txt
+++ b/LayoutTests/inspector/console/x-frame-options-message-expected.txt
@@ -3,7 +3,5 @@ CONSOLE MESSAGE: The X-Frame-Option 'deny' supplied in a <meta> element was igno
 
 == Running test suite: Console.XFrameOptionsMessages
 -- Running test case: XFrameOptionsDeny
-Evaluating expression: triggerXFrameOptionDeny();
-PASS: ConsoleMessage type should be 'security'.
-PASS: ConsoleMessage level should be 'error'.
+{"targetType":"frame","messageText":"The X-Frame-Option 'deny' supplied in a <meta> element was ignored. X-Frame-Options may only be provided by an HTTP header sent with the document.","source":"security","level":"error"}
 

--- a/LayoutTests/inspector/console/x-frame-options-message.html
+++ b/LayoutTests/inspector/console/x-frame-options-message.html
@@ -1,33 +1,26 @@
 <!doctype html>
 <html>
 <head>
-<script src="../../http/tests/inspector/resources/protocol-test.js"></script>
-<script src="../../http/tests/inspector/resources/console-test.js"></script>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
 <script>
 function test()
 {
-    let suite = ProtocolTest.createAsyncSuite("Console.XFrameOptionsMessages");
+    let suite = InspectorTest.createAsyncSuite("Console.XFrameOptionsMessages");
 
-    ProtocolTest.Console.addTestCase(suite, {
+    suite.addTestCase({
         name: "XFrameOptionsDeny",
         description: "Ensure that a console message is logged when enforcing an X-Frame-Options policy. In this case, setting X-Frame-Options: 'deny' means the iframe does not want to be embedded in the test page.",
-        expression: "triggerXFrameOptionDeny();",
-        expected: {source: 'security', level: 'error'}
+        test(resolve) {
+            WI.consoleManager.addEventListener(WI.ConsoleManager.Event.MessageAdded, (event) => {
+                let { target, messageText, source, level } = event.data.message;
+                InspectorTest.log({ targetType: target.type, messageText, source, level });
+                resolve();
+            });
+            InspectorTest.evaluateInPage(`triggerXFrameOptionDeny()`);
+        }
     });
 
-    InspectorProtocol.awaitCommand({
-        method: "Console.enable",
-        params: {}
-    })
-    .then(function() {
-        suite.runTestCasesAndFinish();
-    })
-    .catch(fatalError);
-
-    function fatalError(e) {
-        ProtocolTest.log("Test failed with fatal error: " + JSON.stringify(e));
-        ProtocolTest.completeTest();
-    }
+    suite.runTestCasesAndFinish();
 }
 </script>
 </head>

--- a/LayoutTests/inspector/debugger/async-stack-trace-truncate-expected.txt
+++ b/LayoutTests/inspector/debugger/async-stack-trace-truncate-expected.txt
@@ -1,4 +1,4 @@
-CONSOLE MESSAGE: Reached 1 million iterations
+CONSOLE MESSAGE: Reached maximum iterations
 Tests for truncating async stack traces that exceed the maximum async stack trace depth.
 
 

--- a/LayoutTests/inspector/debugger/async-stack-trace-truncate.html
+++ b/LayoutTests/inspector/debugger/async-stack-trace-truncate.html
@@ -24,10 +24,11 @@ function triggerDeeplyNestedAsyncMicrotask() {
     return new Promise((resolve, reject) => {
         function recursiveMicrotask(iteration = 0) {
             queueMicrotask(() => {
-                if (iteration !== 0 && (iteration % 1_000_000) == 0) {
+                const maxIterations = 100_000;
+                if (iteration === maxIterations) {
                     try {
                         // Throwing will log the error to the console.
-                        throw "Reached 1 million iterations";
+                        throw `Reached maximum iterations`;
                     } catch (error) {
                         console.error(error);
                         resolve();
@@ -112,7 +113,7 @@ function test()
             // Clear the console to release ownership of the logged stack trace.
             InspectorTest.log("Clearing console.")
             let consoleClearedEvent = WI.consoleManager.awaitEvent(WI.ConsoleManager.Event.Cleared);
-            ConsoleAgent.clearMessages();
+            WI.mainFrameTarget.ConsoleAgent.clearMessages();
             await consoleClearedEvent;
 
             InspectorTest.log("Running GC.")

--- a/LayoutTests/inspector/runtime/saveResult.html
+++ b/LayoutTests/inspector/runtime/saveResult.html
@@ -144,7 +144,7 @@ function test()
         description: "Clearing the console should reset the $n values.",
         test(resolve, reject) {
             let value = 999;
-            ConsoleAgent.clearMessages();
+            WI.mainFrameTarget.ConsoleAgent.clearMessages();
             RuntimeAgent.saveResult(createCallArgumentWithValue(value), (error, savedResultIndex) => {
                 InspectorTest.assert(!error, "Should not be a protocol error.");
                 InspectorTest.expectThat(savedResultIndex === 1, `Value ${value} should become $1.`);

--- a/LayoutTests/inspector/shadow-realm-console-expected.txt
+++ b/LayoutTests/inspector/shadow-realm-console-expected.txt
@@ -5,9 +5,9 @@ We really just want to test that the shadow realm's console output gets redirect
 == Running test suite: ShadowRealm.Console.basic
 -- Running test case: ShadowRealm.Console.basic.log
 PASS: message text should be 'hello'
-PASS: message target should be the main page
+PASS: message target should be the main frame
 
 -- Running test case: ShadowRealm.Console.nested.log
 PASS: message text should be 'hello'
-PASS: message target should be the main page
+PASS: message target should be the main frame
 

--- a/LayoutTests/inspector/shadow-realm-console.html
+++ b/LayoutTests/inspector/shadow-realm-console.html
@@ -30,7 +30,7 @@
                 ]);
                 let {message} = messageAddedEvent.data;
                 InspectorTest.expectEqual(message.messageText, "hello", "message text should be 'hello'");
-                InspectorTest.expectEqual(message.target, WI.mainTarget, "message target should be the main page");
+                InspectorTest.expectEqual(message.target, WI.mainFrameTarget, "message target should be the main frame");
             }
         });
 
@@ -44,7 +44,7 @@
                 ]);
                 let {message} = messageAddedEvent.data;
                 InspectorTest.expectEqual(message.messageText, "hello", "message text should be 'hello'");
-                InspectorTest.expectEqual(message.target, WI.mainTarget, "message target should be the main page");
+                InspectorTest.expectEqual(message.target, WI.mainFrameTarget, "message target should be the main frame");
             }
         });
 

--- a/Source/JavaScriptCore/inspector/protocol/Console.json
+++ b/Source/JavaScriptCore/inspector/protocol/Console.json
@@ -2,7 +2,7 @@
     "domain": "Console",
     "description": "Console domain defines methods and events for interaction with the JavaScript console. Console collects messages created by means of the <a href='http://getfirebug.com/wiki/index.php/Console_API'>JavaScript Console API</a>. One needs to enable this domain using <code>enable</code> command in order to start receiving the console messages. Browser collects messages issued while console domain is not enabled as well and reports them using <code>messageAdded</code> notification upon enabling.",
     "debuggableTypes": ["itml", "javascript", "page", "service-worker", "web-page", "wasm-debugger"],
-    "targetTypes": ["itml", "javascript", "page", "service-worker", "worker", "wasm-debugger"],
+    "targetTypes": ["itml", "javascript", "frame", "service-worker", "worker", "wasm-debugger"],
     "types": [
         {
             "id": "ChannelSource",

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -132,6 +132,7 @@ set(WebCore_PRIVATE_INCLUDE_DIRECTORIES
     "${WEBCORE_DIR}/html/track"
     "${WEBCORE_DIR}/inspector"
     "${WEBCORE_DIR}/inspector/agents"
+    "${WEBCORE_DIR}/inspector/agents/frame"
     "${WEBCORE_DIR}/inspector/agents/page"
     "${WEBCORE_DIR}/inspector/agents/worker"
     "${WEBCORE_DIR}/layout"

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -491,7 +491,6 @@ inspector/agents/InspectorTimelineAgent.cpp
 inspector/agents/InspectorWorkerAgent.cpp
 inspector/agents/page/PageAuditAgent.cpp
 inspector/agents/page/PageCanvasAgent.cpp
-inspector/agents/page/PageConsoleAgent.cpp
 inspector/agents/page/PageDOMDebuggerAgent.cpp
 inspector/agents/page/PageDebuggerAgent.cpp
 inspector/agents/page/PageNetworkAgent.cpp

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1891,9 +1891,9 @@ inspector/agents/InspectorWorkerAgent.cpp
 inspector/agents/WebConsoleAgent.cpp
 inspector/agents/WebDebuggerAgent.cpp
 inspector/agents/WebHeapAgent.cpp
+inspector/agents/frame/FrameConsoleAgent.cpp
 inspector/agents/page/PageAuditAgent.cpp
 inspector/agents/page/PageCanvasAgent.cpp
-inspector/agents/page/PageConsoleAgent.cpp
 inspector/agents/page/PageDOMDebuggerAgent.cpp
 inspector/agents/page/PageDebuggerAgent.cpp
 inspector/agents/page/PageHeapAgent.cpp

--- a/Source/WebCore/inspector/FrameInspectorController.h
+++ b/Source/WebCore/inspector/FrameInspectorController.h
@@ -53,6 +53,7 @@ class InspectorFrontendClient;
 class InspectorInstrumentation;
 class InstrumentingAgents;
 class LocalFrame;
+class PageInspectorController;
 class WebInjectedScriptManager;
 struct FrameAgentContext;
 
@@ -61,7 +62,7 @@ class FrameInspectorController final : public Inspector::InspectorEnvironment, p
     WTF_MAKE_TZONE_ALLOCATED(FrameInspectorController);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FrameInspectorController);
 public:
-    FrameInspectorController(LocalFrame&);
+    FrameInspectorController(LocalFrame&, PageInspectorController&);
     ~FrameInspectorController() override;
 
     // AbstractCanMakeCheckedPtr overrides

--- a/Source/WebCore/inspector/PageInspectorController.cpp
+++ b/Source/WebCore/inspector/PageInspectorController.cpp
@@ -58,7 +58,6 @@
 #include "Page.h"
 #include "PageAuditAgent.h"
 #include "PageCanvasAgent.h"
-#include "PageConsoleAgent.h"
 #include "PageDOMDebuggerAgent.h"
 #include "PageDebugger.h"
 #include "PageDebuggerAgent.h"
@@ -105,12 +104,6 @@ PageInspectorController::PageInspectorController(Page& page, std::unique_ptr<Ins
     , m_inspectorBackendClient(WTFMove(inspectorBackendClient))
 {
     ASSERT_ARG(inspectorBackendClient, m_inspectorBackendClient);
-
-    auto pageContext = pageAgentContext();
-
-    auto consoleAgent = makeUniqueRef<PageConsoleAgent>(pageContext);
-    m_instrumentingAgents->setWebConsoleAgent(consoleAgent.ptr());
-    m_agents.append(WTFMove(consoleAgent));
 }
 
 PageInspectorController::~PageInspectorController()

--- a/Source/WebCore/inspector/agents/frame/FrameConsoleAgent.h
+++ b/Source/WebCore/inspector/agents/frame/FrameConsoleAgent.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2011 Google Inc. All rights reserved.
- * Copyright (C) 2015 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -37,19 +37,19 @@
 
 namespace WebCore {
 
-class PageConsoleAgent final : public WebConsoleAgent {
-    WTF_MAKE_NONCOPYABLE(PageConsoleAgent);
-    WTF_MAKE_TZONE_ALLOCATED(PageConsoleAgent);
+class FrameConsoleAgent final : public WebConsoleAgent {
+    WTF_MAKE_NONCOPYABLE(FrameConsoleAgent);
+    WTF_MAKE_TZONE_ALLOCATED(FrameConsoleAgent);
 public:
-    PageConsoleAgent(PageAgentContext&);
-    ~PageConsoleAgent();
+    FrameConsoleAgent(FrameAgentContext&);
+    ~FrameConsoleAgent();
 
     // ConsoleBackendDispatcherHandler
     Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Inspector::Protocol::Console::Channel>>> getLoggingChannels();
     Inspector::Protocol::ErrorStringOr<void> setLoggingChannelLevel(Inspector::Protocol::Console::ChannelSource, Inspector::Protocol::Console::ChannelLevel);
 
 private:
-    WeakRef<Page> m_inspectedPage;
+    WeakRef<Frame> m_inspectedFrame;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -196,7 +196,7 @@ LocalFrame::LocalFrame(Page& page, ClientCreator&& clientCreator, FrameIdentifie
     , m_sandboxFlags(sandboxFlags)
     , m_parentFrameOrOpenerReferrerPolicy(referrerPolicy)
     , m_eventHandler(makeUniqueRef<EventHandler>(*this))
-    , m_inspectorController(makeUniqueRefWithoutRefCountedCheck<FrameInspectorController>(*this))
+    , m_inspectorController(makeUniqueRefWithoutRefCountedCheck<FrameInspectorController>(*this, page.protectedInspectorController()))
     , m_consoleClient(makeUniqueRef<FrameConsoleClient>(*this))
 {
     ProcessWarming::initializeNames();

--- a/Source/WebInspectorUI/UserInterface/Controllers/ConsoleManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/ConsoleManager.js
@@ -90,8 +90,7 @@ WI.ConsoleManager = class ConsoleManager extends WI.Object
 
     initializeTarget(target)
     {
-        // FIXME: <https://webkit.org/b/298911> Add Console support for FrameTarget.
-        if (target instanceof WI.FrameTarget)
+        if (!target.hasDomain("Console"))
             return;
 
         // Intentionally defer ConsoleAgent initialization to the end. We do this so that any
@@ -169,8 +168,15 @@ WI.ConsoleManager = class ConsoleManager extends WI.Object
         // COMPATIBILITY (macOS 13.0, iOS 16.0): `stackTrace` was an array of `Console.CallFrame`.
         if (Array.isArray(stackTrace))
             stackTrace = {callFrames: stackTrace};
-        if (stackTrace)
-            stackTrace = WI.StackTrace.fromPayload(target, stackTrace);
+
+        if (stackTrace) {
+            let supportedTarget = target;
+            if (target.type === WI.TargetType.Frame) {
+                // FIXME: <https://webkit.org/b/298909> Add Debugger support for FrameTarget.
+                supportedTarget = WI.assumingMainTarget();
+            }
+            stackTrace = WI.StackTrace.fromPayload(supportedTarget, stackTrace);
+        }
 
         const request = null;
         let message = new WI.ConsoleMessage(target, source, level, text, type, url, line, column, repeatCount, parameters, stackTrace, request, timestamp);
@@ -256,11 +262,8 @@ WI.ConsoleManager = class ConsoleManager extends WI.Object
         this._clearMessagesRequested = true;
 
         for (let target of WI.targets) {
-            // FIXME: <https://webkit.org/b/298911> Add Console support for FrameTarget.
-            if (target instanceof WI.FrameTarget)
-                continue;
-
-            target.ConsoleAgent.clearMessages();
+            if (target.hasDomain("Console"))
+                target.ConsoleAgent.clearMessages();
         }
     }
 

--- a/Source/WebInspectorUI/UserInterface/Protocol/RemoteObject.js
+++ b/Source/WebInspectorUI/UserInterface/Protocol/RemoteObject.js
@@ -38,6 +38,11 @@ WI.RemoteObject = class RemoteObject
         console.assert(!target || target instanceof WI.Target);
 
         this._target = target || WI.mainTarget;
+        if (this._target.type === WI.TargetType.Frame) {
+            // FIXME: <https://webkit.org/b/298909> Add Debugger support for FrameTarget.
+            // FIXME: <https://webkit.org/b/298910> Add Runtime support for FrameTarget.
+            this._target = WI.assumingMainTarget();
+        }
         this._type = type;
         this._subtype = subtype;
 

--- a/Source/WebInspectorUI/UserInterface/Protocol/Target.js
+++ b/Source/WebInspectorUI/UserInterface/Protocol/Target.js
@@ -57,10 +57,10 @@ WI.Target = class Target extends WI.Object
 
         // Agents we always expect in every target.
         if (!(this instanceof WI.FrameTarget)) {
-            // FIXME: <https://webkit.org/b/298909, https://webkit.org/b/298910, https://webkit.org/b/298911> Add support for Runtime, Debugger, and Console domains for FrameTarget.
+            // FIXME: <https://webkit.org/b/298910> Add Runtime support for FrameTarget.
+            // FIXME: <https://webkit.org/b/298909> Add Debugger support for FrameTarget.
             console.assert(this.hasDomain("Target") || this.hasDomain("Runtime"));
             console.assert(this.hasDomain("Target") || this.hasDomain("Debugger"));
-            console.assert(this.hasDomain("Target") || this.hasDomain("Console"));
         }
     }
 
@@ -86,10 +86,8 @@ WI.Target = class Target extends WI.Object
         // previous initialization messages will have their responses arrive before a stream
         // of console message added events come in after enabling Console.
         // See WI.ConsoleManager.prototype.initializeTarget.
-        if (!(this instanceof WI.FrameTarget)) {
-            // FIXME: <https://webkit.org/b/298911> Add Console support for FrameTarget.
+        if (this.hasDomain("Console"))
             this.ConsoleAgent.enable();
-        }
 
         setTimeout(() => {
             // Use this opportunity to run any one time frontend initialization

--- a/Source/WebInspectorUI/UserInterface/Test/Test.js
+++ b/Source/WebInspectorUI/UserInterface/Test/Test.js
@@ -174,6 +174,14 @@ WI.updateDockingAvailability = () => {};
 WI.updateVisibilityState = () => {};
 WI.updateFindString = () => {};
 
+// Assists in the transition of moving agent implementations from page to frame.
+Object.defineProperty(WI, "mainFrameTarget",
+{
+    get() {
+        return WI.targets.find((x) => x.type === WI.TargetType.Frame && x.parentTarget === WI.backendTarget);
+    }
+});
+
 // FIXME: <https://webkit.org/b/201149> Web Inspector: replace all uses of `window.*Agent` with a target-specific call
 (function() {
     function makeAgentGetter(domainName) {
@@ -187,7 +195,6 @@ WI.updateFindString = () => {};
     makeAgentGetter("CPUProfiler");
     makeAgentGetter("CSS");
     makeAgentGetter("Canvas");
-    makeAgentGetter("Console");
     makeAgentGetter("DOM");
     makeAgentGetter("DOMDebugger");
     makeAgentGetter("DOMStorage");

--- a/Source/WebInspectorUI/UserInterface/Views/SettingsTabContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/SettingsTabContentView.js
@@ -390,11 +390,8 @@ WI.SettingsTabContentView = class SettingsTabContentView extends WI.TabContentVi
                 logEditor.value = channel.level;
                 logEditor.addEventListener(WI.SettingEditor.Event.ValueDidChange, function(event) {
                     for (let target of WI.targets) {
-                        // FIXME: <https://webkit.org/b/298911> Add Console support for FrameTarget.
-                        if (target instanceof WI.FrameTarget)
-                            continue;
-
-                        target.ConsoleAgent.setLoggingChannelLevel(channel.source, this.value);
+                        if (target.hasDomain("Console"))
+                            target.ConsoleAgent.setLoggingChannelLevel(channel.source, this.value);
                     }
                 }, logEditor);
             }


### PR DESCRIPTION
#### 7face0d04d81d87f81283963bcf1664f7de6dd80
<pre>
Web Inspector: Implement the Console domain and agent for the frame target type
<a href="https://webkit.org/b/298911">https://webkit.org/b/298911</a>
<a href="https://rdar.apple.com/161133171">rdar://161133171</a>

Reviewed by BJ Burg.

Implement the commands and events in the console inspector domain for,
the frame target type, replacing the existing console agent of the page
target. After this patch, commands and events of the console domain
delegate to the frame+FrameInspectorController instead of page+InspectorController.

Fix inspector tests involving window.ConsoleAgent to instead listen to
the main frame&apos;s console agent for messages instead, to reflect this
movement.

No new tests. Recently added test sets from [1] and [2] should cover
cases involving iframes and the console. Two tests were modified to
account for the slight, non-user-facing changes of console&apos;s behavior.
The user-facing behavior should stay the same as the current
single-process model.

- [1]: <a href="https://github.com/WebKit/WebKit/pull/52264">https://github.com/WebKit/WebKit/pull/52264</a>
- [2]: <a href="https://github.com/WebKit/WebKit/pull/52398">https://github.com/WebKit/WebKit/pull/52398</a>

* LayoutTests/http/tests/inspector/console/message-from-iframe-expected.txt:
* LayoutTests/http/tests/inspector/console/message-from-iframe.html:
   Log a distinct identifier for each frame to prevent the console
   messages coming from the page to be identified as a repeat and
   reported as a PreviousMessageRepeatCountUpdated event rather than
   MessageAdded. (This is the expected behavior now as far as how
   multi-target console works, since in the backend it&apos;s not easy to
   detect a message isn&apos;t a repeat because of an earlier message from
   a different target. For more info, see the fix to <a href="https://webkit.org/b/300728.)">https://webkit.org/b/300728.)</a>

* LayoutTests/inspector/console/clearMessages.html:
* LayoutTests/inspector/console/messagesCleared.html:
* LayoutTests/inspector/console/setConsoleClearAPIEnabled.html:
* LayoutTests/inspector/console/webcore-logging.html:
* LayoutTests/inspector/console/x-frame-options-message-expected.txt:
* LayoutTests/inspector/console/x-frame-options-message.html:
   Rewrite the protocol test with an inspector test as the message comes
   from a frame other than the main frame; protocol tests only target
   the main frame now, as of <a href="https://webkit.org/b/301304.">https://webkit.org/b/301304.</a>

* LayoutTests/inspector/runtime/saveResult.html:
* LayoutTests/inspector/shadow-realm-console-expected.txt:
* LayoutTests/inspector/shadow-realm-console.html:
   Console messages come from the main frame instead of the page now.

* LayoutTests/inspector/debugger/async-stack-trace-truncate.html:
* LayoutTests/inspector/debugger/async-stack-trace-truncate-expected.txt:
   The test CheckDeeplyNestedDoesNotCrash may timeout with one million
   iterations on debug builds. Change to 100k iterations which still
   verifies the point.

* Source/JavaScriptCore/inspector/protocol/Console.json:
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/inspector/FrameInspectorController.cpp:
(WebCore::FrameInspectorController::FrameInspectorController):
* Source/WebCore/inspector/FrameInspectorController.h:
* Source/WebCore/inspector/PageInspectorController.cpp:
(WebCore::PageInspectorController::PageInspectorController):
* Source/WebCore/inspector/agents/frame/FrameConsoleAgent.cpp: Renamed from Source/WebCore/inspector/agents/page/PageConsoleAgent.cpp.
(WebCore::FrameConsoleAgent::FrameConsoleAgent):
(WebCore::FrameConsoleAgent::getLoggingChannels):
(WebCore::FrameConsoleAgent::setLoggingChannelLevel):
* Source/WebCore/inspector/agents/frame/FrameConsoleAgent.h: Renamed from Source/WebCore/inspector/agents/page/PageConsoleAgent.h.
* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::LocalFrame):
* Source/WebInspectorUI/UserInterface/Controllers/ConsoleManager.js:
(WI.ConsoleManager.prototype.initializeTarget):
(WI.ConsoleManager.prototype.messageWasAdded):
(WI.ConsoleManager.prototype.requestClearMessages):
* Source/WebInspectorUI/UserInterface/Protocol/RemoteObject.js:
(WI.RemoteObject):
* Source/WebInspectorUI/UserInterface/Protocol/Target.js:
(WI.Target.prototype.initialize):
* Source/WebInspectorUI/UserInterface/Test/Test.js:
* Source/WebInspectorUI/UserInterface/Views/SettingsTabContentView.js:
(WI.SettingsTabContentView.prototype._createConsoleSettingsView):

Canonical link: <a href="https://commits.webkit.org/304493@main">https://commits.webkit.org/304493@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/189cc280c81f803064eeb13799a91ec3c5a913f2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/135675 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8049 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/46967 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/143391 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/87332 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6bff56d2-5f4c-43d6-b934-736517a71144) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/137544 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/8693 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7894 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/103685 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/71650 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0b4bc453-5783-49cd-8efe-6e88db4de710) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/138621 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/6268 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/121623 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/84558 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8572c733-9d1a-4ac0-86d6-93b69e5a501e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6034 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/3649 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/3997 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/127666 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/115259 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/39809 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/146139 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/134159 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/7729 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/40378 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112047 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/7766 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/6498 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/112421 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28536 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/5898 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117923 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/61693 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/7782 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36031 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/166990 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/7526 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/71335 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43592 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/7746 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/7624 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->