### PR TITLE
Address "memset with non-trivially copyable type" compiler warnings

### DIFF
--- a/Source/ThirdParty/ANGLE/include/GLSLANG/ShaderLang.h
+++ b/Source/ThirdParty/ANGLE/include/GLSLANG/ShaderLang.h
@@ -157,8 +157,8 @@ struct ShPixelLocalStorageOptions
 struct ShCompileOptions
 {
     ShCompileOptions();
-    ShCompileOptions(const ShCompileOptions &other);
-    ShCompileOptions &operator=(const ShCompileOptions &other);
+    ShCompileOptions(const ShCompileOptions &other) = default;
+    ShCompileOptions &operator=(const ShCompileOptions &other) = default;
 
     // Translates intermediate tree to glsl, hlsl, msl, or SPIR-V binary.  Can be queried by
     // calling sh::GetObjectCode().
@@ -488,8 +488,8 @@ using ShHashFunction64 = khronos_uint64_t (*)(const char *, size_t);
 struct ShBuiltInResources
 {
     ShBuiltInResources();
-    ShBuiltInResources(const ShBuiltInResources &other);
-    ShBuiltInResources &operator=(const ShBuiltInResources &other);
+    ShBuiltInResources(const ShBuiltInResources &) = default;
+    ShBuiltInResources &operator=(const ShBuiltInResources &) = default;
 
     // Constants.
     int MaxVertexAttribs;

--- a/Source/ThirdParty/ANGLE/src/compiler/translator/ShaderLang.cpp
+++ b/Source/ThirdParty/ANGLE/src/compiler/translator/ShaderLang.cpp
@@ -979,27 +979,7 @@ ShCompileOptions::ShCompileOptions()
     memset(this, 0, sizeof(*this));
 }
 
-ShCompileOptions::ShCompileOptions(const ShCompileOptions &other)
-{
-    memcpy(this, &other, sizeof(*this));
-}
-ShCompileOptions &ShCompileOptions::operator=(const ShCompileOptions &other)
-{
-    memcpy(this, &other, sizeof(*this));
-    return *this;
-}
-
 ShBuiltInResources::ShBuiltInResources()
 {
     memset(this, 0, sizeof(*this));
-}
-
-ShBuiltInResources::ShBuiltInResources(const ShBuiltInResources &other)
-{
-    memcpy(this, &other, sizeof(*this));
-}
-ShBuiltInResources &ShBuiltInResources::operator=(const ShBuiltInResources &other)
-{
-    memcpy(this, &other, sizeof(*this));
-    return *this;
 }


### PR DESCRIPTION
#### 71f57f57431b1431e004252cde0071c4bd44f48b
<pre>
Address &quot;memset with non-trivially copyable type&quot; compiler warnings
<a href="https://bugs.webkit.org/show_bug.cgi?id=299350">https://bugs.webkit.org/show_bug.cgi?id=299350</a>
<a href="https://rdar.apple.com/157029861">rdar://157029861</a>

Reviewed by Dan Glastonbury.

Make these two types be trivially copyable so that the warning abotu
memset doesn&apos;t trigger.

* Source/ThirdParty/ANGLE/include/GLSLANG/ShaderLang.h:
* Source/ThirdParty/ANGLE/src/compiler/translator/ShaderLang.cpp:
(ShBuiltInResources::ShBuiltInResources):
(ShCompileOptions::operator=): Deleted.
(ShBuiltInResources::operator=): Deleted.

Canonical link: <a href="https://commits.webkit.org/300483@main">https://commits.webkit.org/300483@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/58394800d8cb17518b74e1059407146e6dc7d2a6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122514 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42222 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32907 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/129131 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74613 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/620ac028-4d4c-476c-be57-a4243fc21fb7) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42940 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50815 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93138 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61852 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cdc55695-4528-486b-97f4-0c79ed3ab8a3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125466 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34251 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109695 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73784 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8f392026-5afa-4b5e-9b55-5857b8064c0b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33239 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27851 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72605 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103900 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28062 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131846 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49455 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37643 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101661 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49830 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105915 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101529 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25818 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46904 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25051 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/46224 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49313 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48780 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/52131 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50462 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->