### PR TITLE
[JSC] Attach AbstractHeap to Loads / Stores in OMG

### DIFF
--- a/Source/JavaScriptCore/b3/B3AbstractHeapRepository.cpp
+++ b/Source/JavaScriptCore/b3/B3AbstractHeapRepository.cpp
@@ -48,6 +48,7 @@
 #include "JSWeakMap.h"
 #include "JSWebAssemblyArray.h"
 #include "JSWebAssemblyInstance.h"
+#include "JSWebAssemblyStruct.h"
 #include "JSWrapperObject.h"
 #include "KeyAtomStringCache.h"
 #include "NumericStrings.h"
@@ -58,6 +59,8 @@
 #include "StructureRareDataInlines.h"
 #include "Symbol.h"
 #include "WasmGlobal.h"
+#include "WasmTable.h"
+#include "WasmTypeDefinition.h"
 #include "WebAssemblyModuleRecord.h"
 
 namespace JSC::B3 {
@@ -173,8 +176,8 @@ void AbstractHeapRepository::computeRangesAndDecorateInstructions()
     for (HeapForValue entry : m_heapForMemory) {
         auto* memoryValue = entry.value->as<MemoryValue>();
         memoryValue->setRange(rangeFor(entry.heap));
-        if (memoryValue->isLoad())
-            memoryValue->setReadsMutability(entry.heap->mutability());
+        if (memoryValue->isLoad() && entry.heap->mutability() == B3::Mutability::Immutable)
+            memoryValue->setReadsMutability(B3::Mutability::Immutable);
     }
     for (HeapForValue entry : m_heapForCCallRead)
         entry.value->as<CCallValue>()->effects.reads = rangeFor(entry.heap);

--- a/Source/JavaScriptCore/b3/B3AbstractHeapRepository.h
+++ b/Source/JavaScriptCore/b3/B3AbstractHeapRepository.h
@@ -134,8 +134,12 @@ namespace JSC::B3 {
     macro(JSScope_next, JSScope::offsetOfNext(), Mutability::Immutable) \
     macro(JSSymbolTableObject_symbolTable, JSSymbolTableObject::offsetOfSymbolTable(), Mutability::Mutable) \
     macro(JSWebAssemblyArray_size, JSWebAssemblyArray::offsetOfSize(), Mutability::Immutable) \
+    macro(JSWebAssemblyInstance_cachedMemorySize, JSWebAssemblyInstance::offsetOfCachedMemorySize(), Mutability::Mutable) \
+    macro(JSWebAssemblyInstance_cachedTable0Buffer, JSWebAssemblyInstance::offsetOfCachedTable0Buffer(), Mutability::Mutable) \
+    macro(JSWebAssemblyInstance_cachedTable0Length, JSWebAssemblyInstance::offsetOfCachedTable0Length(), Mutability::Mutable) \
     macro(JSWebAssemblyInstance_moduleRecord, JSWebAssemblyInstance::offsetOfModuleRecord(), Mutability::Mutable) \
     macro(JSWebAssemblyInstance_vm, JSWebAssemblyInstance::offsetOfVM(), Mutability::Immutable) \
+    macro(JSWebAssemblyStruct_size, JSWebAssemblyStruct::offsetOfSize(), Mutability::Immutable) \
     macro(NativeExecutable_asString, NativeExecutable::offsetOfAsString(), Mutability::Mutable) \
     macro(RegExpObject_regExpAndFlags, RegExpObject::offsetOfRegExpAndFlags(), Mutability::Mutable) \
     macro(RegExpObject_lastIndex, RegExpObject::offsetOfLastIndex(), Mutability::Mutable) \
@@ -179,12 +183,28 @@ namespace JSC::B3 {
     macro(VM_heap_mutatorShouldBeFenced, VM::offsetOfHeapMutatorShouldBeFenced(), Mutability::Mutable) \
     macro(VM_exception, VM::exceptionOffset(), Mutability::Mutable) \
     macro(WatchpointSet_state, WatchpointSet::offsetOfState(), Mutability::Mutable) \
+    macro(WasmFuncRefTable_functions, Wasm::FuncRefTable::offsetOfFunctions(), Mutability::Mutable) \
+    macro(WasmFuncRefTableFunction_boxedCallee, Wasm::FuncRefTable::Function::offsetOfFunction() + Wasm::WasmToWasmImportableFunction::offsetOfBoxedCallee(), Mutability::Mutable) \
+    macro(WasmFuncRefTableFunction_entrypointLoadLocation, Wasm::FuncRefTable::Function::offsetOfFunction() + Wasm::WasmToWasmImportableFunction::offsetOfEntrypointLoadLocation(), Mutability::Mutable) \
+    macro(WasmFuncRefTableFunction_rtt, Wasm::FuncRefTable::Function::offsetOfFunction() + Wasm::WasmToWasmImportableFunction::offsetOfRTT(), Mutability::Mutable) \
+    macro(WasmFuncRefTableFunction_targetInstance, Wasm::FuncRefTable::Function::offsetOfFunction() + Wasm::WasmToWasmImportableFunction::offsetOfTargetInstance(), Mutability::Mutable) \
     macro(WasmGlobal_value, Wasm::Global::offsetOfValue(), Mutability::Mutable) \
     macro(WasmGlobal_owner, Wasm::Global::offsetOfOwner(), Mutability::Immutable) \
+    macro(WasmGlobalValue_owner, Wasm::Global::Value::offsetOfOwner(), Mutability::Immutable) \
+    macro(WasmGlobalValue_value, Wasm::Global::Value::offsetOfValue(), Mutability::Mutable) \
+    macro(WasmWasmCallableFunctionLocation_value, Wasm::WasmCallableFunction::offsetOfValueOfLoadLocation(), Mutability::Mutable) \
+    macro(WasmRTT_displaySizeExcludingThis, Wasm::RTT::offsetOfDisplaySizeExcludingThis(), Mutability::Immutable) \
+    macro(WasmRTT_kind, Wasm::RTT::offsetOfKind(), Mutability::Immutable) \
+    macro(WasmTable_length, Wasm::Table::offsetOfLength(), Mutability::Mutable) \
     macro(WeakMapImpl_capacity, WeakMapImpl<WeakMapBucket<WeakMapBucketDataKey>>::offsetOfCapacity(), Mutability::Mutable) \
     macro(WeakMapImpl_buffer,  WeakMapImpl<WeakMapBucket<WeakMapBucketDataKey>>::offsetOfBuffer(), Mutability::Mutable) \
     macro(WeakMapBucket_value, WeakMapBucket<WeakMapBucketDataKeyValue>::offsetOfValue(), Mutability::Mutable) \
     macro(WeakMapBucket_key, WeakMapBucket<WeakMapBucketDataKeyValue>::offsetOfKey(), Mutability::Mutable) \
+    macro(WebAssemblyFunctionBase_boxedCallee, WebAssemblyFunctionBase::offsetOfBoxedCallee(), Mutability::Immutable) \
+    macro(WebAssemblyFunctionBase_entrypointLoadLocation, WebAssemblyFunctionBase::offsetOfEntrypointLoadLocation(), Mutability::Immutable) \
+    macro(WebAssemblyFunctionBase_rtt, WebAssemblyFunctionBase::offsetOfRTT(), Mutability::Immutable) \
+    macro(WebAssemblyFunctionBase_targetInstance, WebAssemblyFunctionBase::offsetOfTargetInstance(), Mutability::Immutable) \
+    macro(WebAssemblyGCStructure_rtt, WebAssemblyGCStructure::offsetOfRTT(), Mutability::Immutable) \
     macro(WebAssemblyModuleRecord_exportsObject, WebAssemblyModuleRecord::offsetOfExportsObject(), Mutability::Mutable) \
     macro(Symbol_symbolImpl, Symbol::offsetOfSymbolImpl(), Mutability::Immutable) \
 
@@ -208,9 +228,42 @@ namespace JSC::B3 {
     macro(variables, 0, sizeof(Register)) \
     macro(HasOwnPropertyCache, 0, sizeof(HasOwnPropertyCache::Entry)) \
     macro(SmallIntCache, 0, sizeof(NumericStrings::StringWithJSString)) \
+    macro(WasmRTT_data, Wasm::RTT::offsetOfData(), sizeof(RefPtr<const Wasm::RTT>)) \
+    macro(WebAssemblyGCStructure_inlinedTypeDisplays, WebAssemblyGCStructure::offsetOfInlinedTypeDisplay(), sizeof(RefPtr<const Wasm::RTT>)) \
 
 #define FOR_EACH_NUMBERED_ABSTRACT_HEAP(macro) \
-    macro(properties)
+    macro(properties) \
+    /* WasmGC Struct access are analyzed via field index and field type. We can include Wasm type definition to further make alias analysis better. */ \
+    macro(JSWebAssemblyStruct_i8) \
+    macro(JSWebAssemblyStruct_i16) \
+    macro(JSWebAssemblyStruct_i32) \
+    macro(JSWebAssemblyStruct_i64) \
+    macro(JSWebAssemblyStruct_f32) \
+    macro(JSWebAssemblyStruct_f64) \
+    macro(JSWebAssemblyStruct_v128) \
+    macro(JSWebAssemblyStruct_ref) \
+    /* WasmGC Array access are analyzed via element index and element type. Not using IndexedAbstractHeap right now intentionally since large Wasm array has different base offset. */ \
+    macro(JSWebAssemblyArray_i8) \
+    macro(JSWebAssemblyArray_i16) \
+    macro(JSWebAssemblyArray_i32) \
+    macro(JSWebAssemblyArray_i64) \
+    macro(JSWebAssemblyArray_f32) \
+    macro(JSWebAssemblyArray_f64) \
+    macro(JSWebAssemblyArray_v128) \
+    macro(JSWebAssemblyArray_ref) \
+    /* Embedded WasmGlobal access are analyzed via index and element type. */ \
+    macro(JSWebAssemblyInstance_embeddedGlobals_i32) \
+    macro(JSWebAssemblyInstance_embeddedGlobals_i64) \
+    macro(JSWebAssemblyInstance_embeddedGlobals_f32) \
+    macro(JSWebAssemblyInstance_embeddedGlobals_f64) \
+    macro(JSWebAssemblyInstance_embeddedGlobals_v128) \
+    macro(JSWebAssemblyInstance_embeddedGlobals_ref) \
+    \
+    macro(JSWebAssemblyInstance_portableGlobals) \
+    /* WasmGC structure access are analyzed via type index */ \
+    macro(JSWebAssemblyInstance_gcObjectStructureIDs) \
+    macro(JSWebAssemblyInstance_importFunctionStubs) \
+    macro(JSWebAssemblyInstance_tables) \
 
 // This class is meant to be cacheable between compilations, but it doesn't have to be.
 // Doing so saves on creation of nodes. But clearing it will save memory.

--- a/Source/JavaScriptCore/b3/B3HeapRange.h
+++ b/Source/JavaScriptCore/b3/B3HeapRange.h
@@ -36,8 +36,10 @@ namespace JSC { namespace B3 {
 // Alias analysis in B3 is done by checking if two integer ranges overlap. This is powerful enough
 // to be used for TBAA-style alias analysis used by the DFG, FTL, and LLVM: you just turn each node
 // in the tree of abstract heaps into a pre/post range.
+// We intentionally use uint64_t to handle uint32_t range in wasm memory access with constant address
+// inside the abstract heap tree.
 
-typedef Range<unsigned> HeapRange;
+using HeapRange = Range<uint64_t>;
 
 } } // namespace JSC::B3
 

--- a/Source/JavaScriptCore/wasm/WasmFormat.h
+++ b/Source/JavaScriptCore/wasm/WasmFormat.h
@@ -844,6 +844,9 @@ struct alignas(8) WasmCallableFunction {
     static constexpr ptrdiff_t offsetOfTargetInstance() { return OBJECT_OFFSETOF(WasmCallableFunction, targetInstance); }
     static constexpr ptrdiff_t offsetOfEntrypointLoadLocation() { return OBJECT_OFFSETOF(WasmCallableFunction, entrypointLoadLocation); }
 
+    // LoadLocation's dereference.
+    static constexpr ptrdiff_t offsetOfValueOfLoadLocation() { return 0; }
+
     bool isJS() const;
 
     CalleeBits boxedCallee { };

--- a/Source/JavaScriptCore/wasm/WasmGlobal.h
+++ b/Source/JavaScriptCore/wasm/WasmGlobal.h
@@ -52,6 +52,9 @@ public:
         uint64_t m_primitive;
         WriteBarrierBase<Unknown> m_externref;
         Value* m_pointer;
+
+        static constexpr ptrdiff_t offsetOfValue() { return 0; }
+        static constexpr ptrdiff_t offsetOfOwner() { return Global::offsetOfOwner() - Global::offsetOfValue(); }
     };
     static_assert(sizeof(Value) == 16, "Update IPInt if this changes");
 


### PR DESCRIPTION
#### bd4cba9aeaa54913c11630467ae56684210e217d
<pre>
[JSC] Attach AbstractHeap to Loads / Stores in OMG
<a href="https://bugs.webkit.org/show_bug.cgi?id=299405">https://bugs.webkit.org/show_bug.cgi?id=299405</a>
<a href="https://rdar.apple.com/problem/161210525">rdar://problem/161210525</a>

Reviewed by Yijia Huang.

This patch is annotating Loads / Stores in OMG with B3::AbstractHeap.
This allows B3 to do CSE, which does load elimination and store
elimination based on these information.

Because WasmGC struct and array has various different offsets and size,
we modeled them with B3::NumberedAbstractHeap which does not directly
use the index as the actual load/store offset. This is a bit more
abstracted thing: we use field index and field type to distinguish the
access sites. For WasmGC Struct, we can further do strict type-based
alias analysis (TBAA) with WasmGC types. But for now, we are just doing
a naive approach as a starting point.

Some of missing enhancement we would like to do in the next changes are,

1. Modeling Wasm memory access with B3::AbstractHeap. Probably we need
   to introduce B3::RangedAbtractHeap as Wasm memory access need to
   represent ranges And put it under typedArrayProperties heap kind).
2. Unified clean interface with FTL and OMG for them. Right now, we are
   intentionally doing much manual things in OMG since we need a bit
   more extension later (1) and we are still in the process of exploring
   how to unify these two interfaces with the enhancement.
3. B3 should remove `trap` flag for Load when leading memory access via
   WasmStructGet / WasmArraySize succeeds. This implies that we should
   eventually add WasmStructGet / WasmArraySize etc. higher concept, and
   lowering it into Load / Store in the later phase in B3. But right
   now, we are not doing it.

* Source/JavaScriptCore/b3/B3AbstractHeapRepository.cpp:
(JSC::B3::AbstractHeapRepository::computeRangesAndDecorateInstructions):
* Source/JavaScriptCore/b3/B3AbstractHeapRepository.h:
* Source/JavaScriptCore/b3/B3HeapRange.h:
* Source/JavaScriptCore/wasm/WasmFormat.h:
* Source/JavaScriptCore/wasm/WasmGlobal.h:
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::OMGIRGenerator::addCurrentMemory):
(JSC::Wasm::OMGIRGenerator::addMemoryFill):
(JSC::Wasm::OMGIRGenerator::addMemoryCopy):
(JSC::Wasm::OMGIRGenerator::getGlobal):
(JSC::Wasm::OMGIRGenerator::setGlobal):
(JSC::Wasm::OMGIRGenerator::emitWriteBarrier):
(JSC::Wasm::OMGIRGenerator::emitStructSet):
(JSC::Wasm::OMGIRGenerator::allocateWasmGCArray):
(JSC::Wasm::OMGIRGenerator::emitGetArraySizeWithNullCheck):
(JSC::Wasm::OMGIRGenerator::addArrayGet):
(JSC::Wasm::OMGIRGenerator::emitArraySetUncheckedWithoutWriteBarrier):
(JSC::Wasm::OMGIRGenerator::emitArraySetUnchecked):
(JSC::Wasm::OMGIRGenerator::addArraySet):
(JSC::Wasm::OMGIRGenerator::addArrayLen):
(JSC::Wasm::OMGIRGenerator::addStructGet):
(JSC::Wasm::OMGIRGenerator::emitRefTestOrCast):
(JSC::Wasm::OMGIRGenerator::allocatorForWasmGCHeapCellSize):
(JSC::Wasm::OMGIRGenerator::allocateWasmGCObject):
(JSC::Wasm::OMGIRGenerator::allocateWasmGCArrayUninitialized):
(JSC::Wasm::OMGIRGenerator::allocateWasmGCStructUninitialized):
(JSC::Wasm::OMGIRGenerator::mutatorFence):
(JSC::Wasm::OMGIRGenerator::emitLoadRTTFromObject):
(JSC::Wasm::OMGIRGenerator::emitDirectCall):
(JSC::Wasm::OMGIRGenerator::addCallIndirect):
(JSC::Wasm::OMGIRGenerator::addCallRef):

Canonical link: <a href="https://commits.webkit.org/300472@main">https://commits.webkit.org/300472@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a6cb8a5d36acdf462b016ce9e53f081938a056ac

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122714 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42426 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33116 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/129335 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/74818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/40edd4ba-06f1-415d-904d-a5f0eb4ec55c) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43145 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51019 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/129335 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/74818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2c490f02-367d-44be-889d-ba8780a632c8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125666 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34402 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109858 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/129335 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c9edfe96-773f-4a7a-808a-5ee12999b82b) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/33389 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/28013 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72822 "Built successfully") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/114868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/104102 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28225 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132063 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/121243 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49659 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37803 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/101788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50036 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106072 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/101656 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/47033 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/25206 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/46429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19372 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49516 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/55269 "Built successfully") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/151509 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/48983 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/151509 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/52335 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50666 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->