### PR TITLE
[GFC] Initial implementation of grid and track sizing with fixed sized tracks.

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1924,6 +1924,7 @@ layout/formattingContexts/grid/GridFormattingContext.cpp
 layout/formattingContexts/grid/GridLayout.cpp
 layout/formattingContexts/grid/ImplicitGrid.cpp
 layout/formattingContexts/grid/PlacedGridItem.cpp
+layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
 layout/formattingContexts/grid/UnplacedGridItem.cpp
 layout/formattingContexts/inline/AbstractLineBuilder.cpp
 layout/formattingContexts/inline/InlineContentAligner.cpp

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
@@ -30,6 +30,8 @@
 #include "PlacedGridItem.h"
 #include "RenderStyleInlines.h"
 #include "LayoutElementBox.h"
+#include "NotImplemented.h"
+#include "TrackSizingAlgorithm.h"
 #include "UnplacedGridItem.h"
 #include <wtf/Vector.h>
 
@@ -74,8 +76,14 @@ void GridLayout::layout(GridFormattingContext::GridLayoutConstraints, const Unpl
     // 1. Run the Grid Item Placement Algorithm to resolve the placement of all grid items in the grid.
     auto [ placedGridItems, implicitGridColumnsCount, implicitGridRowsCount ] = placeGridItems(unplacedGridItems, gridTemplateColumnsTrackSizes, gridTemplateRowsTrackSizes);
 
-    auto columnTrackSizingFunctions = trackSizingFunctions(implicitGridColumnsCount, gridTemplateColumnsTrackSizes);
-    auto rowTrackSizingFunctions = trackSizingFunctions(implicitGridRowsCount, gridTemplateRowsTrackSizes);
+    auto columnTrackSizingFunctionsList = trackSizingFunctions(implicitGridColumnsCount, gridTemplateColumnsTrackSizes);
+    auto rowTrackSizingFunctionsList = trackSizingFunctions(implicitGridRowsCount, gridTemplateRowsTrackSizes);
+
+    // 3. Given the resulting grid container size, run the Grid Sizing Algorithm to size the grid.
+    auto [ usedColumnSizes, usedRowSizes ] = performGridSizingAlgorithm(placedGridItems, columnTrackSizingFunctionsList, rowTrackSizingFunctionsList);
+
+    UNUSED_VARIABLE(usedColumnSizes);
+    UNUSED_VARIABLE(usedRowSizes);
 }
 
 GridLayout::TrackSizingFunctionsList GridLayout::trackSizingFunctions(size_t implicitGridTracksCount, const Vector<Style::GridTrackSize> gridTemplateTrackSizes)
@@ -118,6 +126,35 @@ GridLayout::TrackSizingFunctionsList GridLayout::trackSizingFunctions(size_t imp
 
         return TrackSizingFunctions { minTrackSizingFunction(), maxTrackSizingFunction() };
     });
+}
+
+// https://www.w3.org/TR/css-grid-1/#algo-grid-sizing
+GridLayout::UsedTrackSizes GridLayout::performGridSizingAlgorithm(const PlacedGridItems& placedGridItems,
+    const TrackSizingFunctionsList& columnTrackSizingFunctionsList, const TrackSizingFunctionsList& rowTrackSizingFunctionsList)
+{
+    // 1. First, the track sizing algorithm is used to resolve the sizes of the grid columns.
+    auto columnSizes = TrackSizingAlgorithm::sizeTracks(placedGridItems, columnTrackSizingFunctionsList);
+
+    // 2. Next, the track sizing algorithm resolves the sizes of the grid rows.
+    auto rowSizes = TrackSizingAlgorithm::sizeTracks(placedGridItems, rowTrackSizingFunctionsList);
+
+    // 3. Then, if the min-content contribution of any grid item has changed based on the
+    // row sizes and alignment calculated in step 2, re-resolve the sizes of the grid
+    // columns with the new min-content and max-content contributions (once only).
+    auto resolveGridColumnSizesIfAnyMinContentContributionChanged = [] {
+        notImplemented();
+    };
+    UNUSED_VARIABLE(resolveGridColumnSizesIfAnyMinContentContributionChanged);
+
+    // 4. Next, if the min-content contribution of any grid item has changed based on the
+    // column sizes and alignment calculated in step 3, re-resolve the sizes of the grid
+    // rows with the new min-content and max-content contributions (once only).
+    auto resolveGridRowSizesIfAnyMinContentContributionChanged = [] {
+        notImplemented();
+    };
+    UNUSED_VARIABLE(resolveGridRowSizesIfAnyMinContentContributionChanged);
+
+    return { columnSizes, rowSizes };
 }
 
 const ElementBox& GridLayout::gridContainer() const

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayout.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayout.h
@@ -37,6 +37,7 @@ struct GridTrackSize;
 
 namespace Layout {
 
+class ImplicitGrid;
 class PlacedGridItem;
 class UnplacedGridItem;
 struct UnplacedGridItems;
@@ -46,17 +47,26 @@ public:
     GridLayout(const GridFormattingContext&);
 
     void layout(GridFormattingContext::GridLayoutConstraints, const UnplacedGridItems&);
-private:
+
     struct TrackSizingFunctions {
         Style::GridTrackBreadth min { CSS::Keyword::Auto { } };
         Style::GridTrackBreadth max { CSS::Keyword::Auto { } };
     };
+
+private:
     using PlacedGridItems = Vector<PlacedGridItem>;
     using TrackSizingFunctionsList = Vector<TrackSizingFunctions>;
 
     static auto placeGridItems(const UnplacedGridItems&, const Vector<Style::GridTrackSize>& gridTemplateColumnsTrackSizes,
         const Vector<Style::GridTrackSize>& gridTemplateRowsTrackSizes);
     static TrackSizingFunctionsList trackSizingFunctions(size_t implicitGridTracksCount, const Vector<Style::GridTrackSize> gridTemplateTrackSizes);
+
+    struct UsedTrackSizes {
+        using TrackSizes = Vector<LayoutUnit>;
+        TrackSizes columnSizes;
+        TrackSizes rowSizes;
+    };
+    static UsedTrackSizes performGridSizingAlgorithm(const PlacedGridItems&, const TrackSizingFunctionsList& columnTrackSizingFunctionsList, const TrackSizingFunctionsList& rowTrackSizingFunctionsList);
 
     const ElementBox& gridContainer() const;
     const RenderStyle& gridContainerStyle() const;

--- a/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
@@ -1,0 +1,129 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "TrackSizingAlgorithm.h"
+
+#include "NotImplemented.h"
+
+namespace WebCore {
+namespace Layout {
+
+// https://drafts.csswg.org/css-grid-1/#algo-track-sizing
+TrackSizingAlgorithm::TrackSizes TrackSizingAlgorithm::sizeTracks(const PlacedGridItems&, const TrackSizingFunctionsList& trackSizingFunctions)
+{
+    // 1. Initialize Track Sizes
+    auto unsizedTracks = initializeTrackSizes(trackSizingFunctions);
+
+    // 2. Resolve Intrinsic Track Sizes
+    auto resolveIntrinsicTrackSizes = [] {
+        notImplemented();
+    };
+    UNUSED_VARIABLE(resolveIntrinsicTrackSizes);
+
+    // 3. Maximize Tracks
+    auto maximizeTracks = [] {
+        notImplemented();
+    };
+    UNUSED_VARIABLE(maximizeTracks);
+
+    // 4. Expand Flexible Tracks
+    auto expandFlexibleTracks = [] {
+        notImplemented();
+    };
+    UNUSED_VARIABLE(expandFlexibleTracks);
+
+    // 5. Expand Stretched auto Tracks
+    auto expandStretchedAutoTracks = [] {
+        notImplemented();
+    };
+    UNUSED_VARIABLE(expandStretchedAutoTracks);
+
+    // Each track has a base size, a <length> which grows throughout the algorithm and
+    // which will eventually be the track’s final size...
+    return unsizedTracks.map([](const UnsizedTrack& unsizedTrack) {
+        return unsizedTrack.baseSize;
+    });
+}
+
+// https://www.w3.org/TR/css-grid-1/#algo-init
+TrackSizingAlgorithm::UnsizedTracks TrackSizingAlgorithm::initializeTrackSizes(const TrackSizingFunctionsList& trackSizingFunctionsList)
+{
+    return trackSizingFunctionsList.map([](const GridLayout::TrackSizingFunctions& trackSizingFunctions) -> UnsizedTrack {
+        // For each track, if the track’s min track sizing function is:
+        auto baseSize = [&] -> LayoutUnit {
+            auto& minTrackSizingFunction = trackSizingFunctions.min;
+
+            // A fixed sizing function
+            // Resolve to an absolute length and use that size as the track’s initial base size.
+            if (minTrackSizingFunction.isLength()) {
+                auto& trackBreadthLength = minTrackSizingFunction.length();
+                if (auto fixedValue = trackBreadthLength.tryFixed())
+                    return LayoutUnit { fixedValue->value };
+
+                if (auto percentValue = trackBreadthLength.tryPercentage()) {
+                    ASSERT_NOT_IMPLEMENTED_YET();
+                    return { };
+                }
+
+            }
+
+            // An intrinsic sizing function
+            // Use an initial base size of zero.
+            if (minTrackSizingFunction.isContentSized())
+                return { };
+
+            ASSERT_NOT_REACHED();
+            return { };
+        };
+
+        // For each track, if the track’s max track sizing function is:
+        auto growthLimit = [&] -> LayoutUnit {
+            auto& maxTrackSizingFunction = trackSizingFunctions.max;
+
+            // A fixed sizing function
+            // Resolve to an absolute length and use that size as the track’s initial growth limit.
+            if (maxTrackSizingFunction.isLength()) {
+                auto trackBreadthLength = maxTrackSizingFunction.length();
+                if (auto fixedValue = trackBreadthLength.tryFixed())
+                    return LayoutUnit { fixedValue->value };
+            }
+
+            // An intrinsic sizing function
+            // A flexible sizing function
+            // Use an initial growth limit of infinity.
+            if (maxTrackSizingFunction.isContentSized() || maxTrackSizingFunction.isFlex())
+                return LayoutUnit::max();
+
+            ASSERT_NOT_REACHED();
+            return { };
+        };
+
+        return { baseSize(), growthLimit(), trackSizingFunctions };
+    });
+}
+
+} // namespace Layout
+} // namespace WebCore

--- a/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.h
+++ b/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "GridLayout.h"
+#include "LayoutUnit.h"
+
+namespace WebCore {
+
+namespace Layout {
+
+class PlacedGridItem;
+
+using PlacedGridItems = Vector<PlacedGridItem>;
+using TrackSizingFunctionsList = Vector<GridLayout::TrackSizingFunctions>;
+
+class TrackSizingAlgorithm {
+public:
+    using TrackSizes = Vector<LayoutUnit>;
+    static TrackSizes sizeTracks(const PlacedGridItems&, const TrackSizingFunctionsList&);
+
+private:
+    struct UnsizedTrack {
+        LayoutUnit baseSize;
+        LayoutUnit growthLimit;
+        const GridLayout::TrackSizingFunctions trackSizingFunction;
+    };
+    using UnsizedTracks = Vector<UnsizedTrack>;
+
+    static UnsizedTracks initializeTrackSizes(const TrackSizingFunctionsList&);
+};
+
+} // namespace WebCore
+} // namespace Layout
+


### PR DESCRIPTION
#### 72484044d578b61dd47382f9a28c0376ea3015dd
<pre>
[GFC] Initial implementation of grid and track sizing with fixed sized tracks.
<a href="https://bugs.webkit.org/show_bug.cgi?id=299406">https://bugs.webkit.org/show_bug.cgi?id=299406</a>
<a href="https://rdar.apple.com/problem/161210933">rdar://problem/161210933</a>

Reviewed by Alan Baradlay.

Adds the initial support and implementation of track sizing with a focus
on fixed-size columns and rows. Like the patches before, we provide the
overall architecture that will be fleshed out over a series of patches.

At a high level, this code should eventually fully implement the &quot;Grid
Sizing Algorithm&quot; and &quot;Track Sizing Algorithm,&quot; portions of the spec:
<a href="https://drafts.csswg.org/css-grid-1/#algo-grid-sizing">https://drafts.csswg.org/css-grid-1/#algo-grid-sizing</a>
<a href="https://drafts.csswg.org/css-grid-1/#algo-track-sizing">https://drafts.csswg.org/css-grid-1/#algo-track-sizing</a>

For simplicity, we only implement steps one and two of the grid sizing
algorithm: first pass of column sizing and first pass of row sizing.
Since we are dealing with fixed-size tracks, we do not need to worry
about the available space portion of the text.

As input to this, we need the PlacedGridItems along with the track sizing
functions for each track. We output the used track sizes that come as a
result of the steps in the algorithm. Needless to say, this input and
output may need to change as we consider the more complicated and
involved portions of the algorithm, but this seems sufficient for now.

One thing that may be notable is that for the most part, the spec does
not distinguish between columns and rows in the steps of the track
sizing algorithm (i.e. it operates on a set of tracks without regard
to the dimension), so we will attempt to do the same in the code.
One small exception to this is that depending on which step we
are in within the grid sizing algorithm, the available space for the track
sizing algorithm may change.

* Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp: Added.
(WebCore::Layout::TrackSizingAlgorithm::sizeTracks):
(WebCore::Layout::TrackSizingAlgorithm::initializeTrackSizes):
For fixed size tracks this is fairly straightforward since both the base
size and growth limit get set to the size specified for the track.

Canonical link: <a href="https://commits.webkit.org/300467@main">https://commits.webkit.org/300467@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8f32f146aa298942380c281cf04f5d7e6e649f16

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122532 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42240 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32925 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/129141 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74631 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/684df74b-c1b3-40ab-a233-f8c47c54ec6a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/124408 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42958 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50833 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93143 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61857 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7c583a55-d424-4641-a9d2-91f219162563) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125484 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34260 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109706 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73790 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a82dadb9-2ddc-4ea0-8429-7ee9e996b3e4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33245 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27863 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72625 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103913 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28073 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131864 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49473 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37654 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101675 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49848 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105926 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101543 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25806 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46918 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25062 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/46242 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49331 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/55080 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48798 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/52149 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50480 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->