### PR TITLE
REGRESSION(299694@main): WebCoreLogDefinitions.h can become out-of-sync when building Release/Debug

### DIFF
--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -2745,11 +2745,11 @@ list(APPEND WebCore_SOURCES ${WebCore_DERIVED_SOURCES_DIR}/HTTPHeaderNames.cpp)
 
 # Log messages
 add_custom_command(
-    OUTPUT ${WebCore_DERIVED_SOURCES_DIR}/WebCoreLogDefinitions.h
+    OUTPUT ${WebCore_DERIVED_SOURCES_DIR}/WebCoreLogDefinitions.h ${WebCore_DERIVED_SOURCES_DIR}/WebCoreVirtualLogFunctions.h
     MAIN_DEPENDENCY ${WEBCORE_DIR}/platform/LogMessages.in
     DEPENDS ${WEBCORE_DIR}/Scripts/generate-log-declarations.py
     WORKING_DIRECTORY ${WebCore_DERIVED_SOURCES_DIR}
-    COMMAND ${PYTHON_EXECUTABLE} ${WEBCORE_DIR}/Scripts/generate-log-declarations.py ${WEBCORE_DIR}/platform/LogMessages.in ${WebCore_DERIVED_SOURCES_DIR}/WebCoreLogDefinitions.h
+    COMMAND ${PYTHON_EXECUTABLE} ${WEBCORE_DIR}/Scripts/generate-log-declarations.py ${WEBCORE_DIR}/platform/LogMessages.in ${WebCore_DERIVED_SOURCES_DIR}/WebCoreLogDefinitions.h ${WebCore_DERIVED_SOURCES_DIR}/WebCoreVirtualLogFunctions.h
     VERBATIM)
 list(APPEND WebCore_SOURCES ${WebCore_DERIVED_SOURCES_DIR}/WebCoreLogDefinitions.h)
 

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -3651,6 +3651,8 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     ${WebCore_DERIVED_SOURCES_DIR}/UserAgentParts.h
     ${WebCore_DERIVED_SOURCES_DIR}/UserAgentStyleSheets.h
     ${WebCore_DERIVED_SOURCES_DIR}/WebCoreJSBuiltinInternals.h
+    ${WebCore_DERIVED_SOURCES_DIR}/WebCoreLogDefinitions.h
+    ${WebCore_DERIVED_SOURCES_DIR}/WebCoreVirtualLogFunctions.h
     ${WebCore_DERIVED_SOURCES_DIR}/WebKitFontFamilyNames.h
     ${WebCore_DERIVED_SOURCES_DIR}/WritableStreamInternalsBuiltins.h
 )

--- a/Source/WebCore/platform/LogClient.h
+++ b/Source/WebCore/platform/LogClient.h
@@ -37,9 +37,7 @@ public:
     virtual void log(std::span<const uint8_t> logChannel, std::span<const uint8_t> logCategory, std::span<const uint8_t> logString, os_log_type_t) = 0;
     virtual bool isWebKitLogClient() const { return false; }
 
-#if __has_include("WebCoreVirtualLogFunctions.h")
-#include "WebCoreVirtualLogFunctions.h"
-#endif
+#include <WebCore/WebCoreVirtualLogFunctions.h>
 };
 
 WEBCORE_EXPORT std::unique_ptr<LogClient>& logClient();

--- a/Source/WebCore/platform/Logging.h
+++ b/Source/WebCore/platform/Logging.h
@@ -25,13 +25,10 @@
 
 #pragma once
 
+#include <WebCore/WebCoreLogDefinitions.h>
 #include <wtf/Assertions.h>
 #include <wtf/Forward.h>
 #include <wtf/StdLibExtras.h>
-
-#if __has_include("WebCoreLogDefinitions.h")
-#include "WebCoreLogDefinitions.h"
-#endif
 
 #define COMMA() ,
 #define OPTIONAL_ARGS(...) __VA_OPT__(COMMA() SAFE_PRINTF_TYPE(__VA_ARGS__))

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -392,15 +392,7 @@ SANDBOX_IMPORT_DIR=$(SDKROOT)/usr/local/share/sandbox/profiles/embedded/imports
 
 # Log messages
 
-all : WebCoreLogDefinitions.h WebKitLogDefinitions.h
-
-WEBCORE_LOG_DECLARATIONS_FILES = \
-    WebCoreLogDefinitions.h \
-    WebCoreVirtualLogFunctions.h \
-
-$(WEBCORE_LOG_DECLARATIONS_FILES) : $(WebCorePrivateHeaders)/LogMessages.in
-	@echo Creating WebCore log definitions $@
-	$(PYTHON) $(WebCorePrivateHeaders)/generate-log-declarations.py $< $(WEBCORE_LOG_DECLARATIONS_FILES)
+all : WebKitLogDefinitions.h
 
 WEBKIT_LOG_DECLARATIONS_FILES = \
     WebKitLogDefinitions.h \

--- a/Source/WebKit/Platform/LogClient.h
+++ b/Source/WebKit/Platform/LogClient.h
@@ -29,17 +29,12 @@
 #include "LogStreamIdentifier.h"
 #include "LogStreamMessages.h"
 #include "StreamClientConnection.h"
+#include "WebKitLogDefinitions.h"
 #include <WebCore/LogClient.h>
+#include <WebCore/WebCoreLogDefinitions.h>
 #include <wtf/Identified.h>
 #include <wtf/Lock.h>
 #include <wtf/Locker.h>
-
-#if __has_include("WebCoreLogDefinitions.h")
-#include "WebCoreLogDefinitions.h"
-#endif
-#if __has_include("WebKitLogDefinitions.h")
-#include "WebKitLogDefinitions.h"
-#endif
 
 namespace WebKit {
 

--- a/Source/WebKit/Platform/Logging.h
+++ b/Source/WebKit/Platform/Logging.h
@@ -29,9 +29,7 @@
 #include <wtf/Platform.h>
 #include <wtf/text/WTFString.h>
 
-#if __has_include("WebKitLogDefinitions.h")
 #include "WebKitLogDefinitions.h"
-#endif
 
 #define COMMA() ,
 #define OPTIONAL_ARGS(...) __VA_OPT__(COMMA()) __VA_ARGS__


### PR DESCRIPTION
#### 8f5afbee0d90e03b96370e4dfc441258ff110dfa
<pre>
REGRESSION(299694@main): WebCoreLogDefinitions.h can become out-of-sync when building Release/Debug
<a href="https://bugs.webkit.org/show_bug.cgi?id=299407">https://bugs.webkit.org/show_bug.cgi?id=299407</a>
<a href="https://rdar.apple.com/problem/161213885">rdar://problem/161213885</a>

Reviewed by Per Arne Vollan

In 299694@main, WebCoreLogDefinitions.h was added to the Xcode project at an absolute path,
rather than a relative one. This caused the build to fail when the current scheme did not
create a file at that path. Ironically, since the absolute path was to a location on my
filesystem, I was likely the only person affected.

Make the files in the Xcode project relative to the DerivedSources directory. Additionally
make them private headers, which will cause them to be copied into the WebCore.framework
and will allow them to be accessed by the WebKit build step. Make the same change to
WebCore/Headers.cmake for ports which use CMake. Since these headers are exported from
the WebCore build process, they no longer need to be re-generated by the WebKit build
process, so those steps have been removed from DerivedSources.make. Make the include
of these files non-conditional.

* Source/WebCore/CMakeLists.txt:
* Source/WebCore/Headers.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/LogClient.h:
* Source/WebCore/platform/Logging.h:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/Platform/LogClient.h:
* Source/WebKit/Platform/Logging.h:

Canonical link: <a href="https://commits.webkit.org/300488@main">https://commits.webkit.org/300488@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e6058e9d0975a68c2d754fb5449fa4d7c9e96515

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122684 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42396 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33086 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/129303 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74788 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d48d26d5-6bf1-407e-9444-c932f35b5733) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/124560 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43115 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50989 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93245 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61918 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a54d62c5-27fe-4284-a656-3f27cda8ab0b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125636 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34373 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109831 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73886 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6d69143a-4b15-411c-86fd-e6f0fbdcf3cb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33360 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27987 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72790 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104072 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28198 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132033 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49629 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37774 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101769 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50006 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106045 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101634 "Found 3 new API test failures: WebKitGTK/TestInspector:/webkit/WebKitWebInspector/manual-attach-detach, TestWTF:CompletionHandlerDeathTest.MainThreadHandlerOnThreadAssertsDeathTest, TestWTF:CompletionHandlerDeathTest.ConstructionThreadHandlerOnThreadAssertsDeathTest (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25821 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47009 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25180 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/46399 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49486 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/55239 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48953 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/52305 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50636 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->