### PR TITLE
Address safer cpp warnings in WebCore/storage/

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -854,9 +854,6 @@ rendering/updating/RenderTreeBuilderRuby.cpp
 rendering/updating/RenderTreeBuilderTable.cpp
 rendering/updating/RenderTreeUpdater.cpp
 rendering/updating/RenderTreeUpdaterGeneratedContent.cpp
-storage/Storage.cpp
-storage/StorageMap.cpp
-storage/StorageNamespaceProvider.cpp
 style/ChildChangeInvalidation.cpp
 style/ChildChangeInvalidation.h
 style/ElementRuleCollector.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -444,7 +444,6 @@ rendering/updating/RenderTreeBuilderMathML.cpp
 rendering/updating/RenderTreePosition.cpp
 rendering/updating/RenderTreeUpdater.cpp
 rendering/updating/RenderTreeUpdaterGeneratedContent.cpp
-storage/Storage.cpp
 style/AttributeChangeInvalidation.cpp
 style/ClassChangeInvalidation.cpp
 style/ElementRuleCollector.cpp

--- a/Source/WebCore/storage/Storage.cpp
+++ b/Source/WebCore/storage/Storage.cpp
@@ -88,7 +88,7 @@ String Storage::getItem(const String& key) const
 
 ExceptionOr<void> Storage::setItem(const String& key, const String& value)
 {
-    auto* frame = this->frame();
+    RefPtr frame = this->frame();
     if (!frame)
         return Exception { ExceptionCode::InvalidAccessError };
 
@@ -104,7 +104,7 @@ ExceptionOr<void> Storage::setItem(const String& key, const String& value)
 
 ExceptionOr<void> Storage::removeItem(const String& key)
 {
-    auto* frame = this->frame();
+    RefPtr frame = this->frame();
     if (!frame)
         return Exception { ExceptionCode::InvalidAccessError };
 
@@ -117,7 +117,7 @@ ExceptionOr<void> Storage::removeItem(const String& key)
 
 ExceptionOr<void> Storage::clear()
 {
-    auto* frame = this->frame();
+    RefPtr frame = this->frame();
     if (!frame)
         return Exception { ExceptionCode::InvalidAccessError };
 
@@ -150,7 +150,7 @@ Ref<StorageArea> Storage::protectedArea() const
 
 bool Storage::requiresScriptTrackingPrivacyProtection() const
 {
-    RefPtr document = window() ? window()->document() : nullptr;
+    RefPtr document = window() ? protectedWindow()->document() : nullptr;
     return document && document->requiresScriptTrackingPrivacyProtection(ScriptTrackingPrivacyCategory::LocalStorage);
 }
 

--- a/Source/WebCore/storage/StorageMap.cpp
+++ b/Source/WebCore/storage/StorageMap.cpp
@@ -110,7 +110,7 @@ void StorageMap::setItem(const String& key, const String& value, String& oldValu
 
     // Implement copy-on-write semantics.
     if (m_impl->refCount() > 1)
-        m_impl = m_impl->copy();
+        m_impl = Ref { m_impl }->copy();
 
     m_impl->map.set(key, value);
     m_impl->currentSize = newSize;
@@ -141,7 +141,7 @@ void StorageMap::removeItem(const String& key, String& oldValue)
         m_impl->map.remove(iter);
     else {
         // Implement copy-on-write semantics.
-        m_impl = m_impl->copy();
+        m_impl = Ref { m_impl }->copy();
         m_impl->map.remove(key);
     }
 

--- a/Source/WebCore/storage/StorageNamespaceProvider.cpp
+++ b/Source/WebCore/storage/StorageNamespaceProvider.cpp
@@ -54,11 +54,11 @@ Ref<StorageArea> StorageNamespaceProvider::localStorageArea(Document& document)
 
     RefPtr<StorageNamespace> storageNamespace;
     if (document.canAccessResource(ScriptExecutionContext::ResourceType::LocalStorage) == ScriptExecutionContext::HasResourceAccess::DefaultForThirdParty)
-        storageNamespace = transientLocalStorageNamespace(document.topOrigin(), document.page()->sessionID());
+        storageNamespace = transientLocalStorageNamespace(document.protectedTopOrigin().get(), document.protectedPage()->sessionID());
     else
-        storageNamespace = localStorageNamespace(document.page()->sessionID());
+        storageNamespace = localStorageNamespace(document.protectedPage()->sessionID());
 
-    return storageNamespace->storageArea(document.securityOrigin());
+    return storageNamespace->storageArea(document.protectedSecurityOrigin().get());
 }
 
 Ref<StorageArea> StorageNamespaceProvider::sessionStorageArea(Document& document)
@@ -67,13 +67,13 @@ Ref<StorageArea> StorageNamespaceProvider::sessionStorageArea(Document& document
     // so the Document had better still actually have a Page.
     ASSERT(document.page());
 
-    return sessionStorageNamespace(document.topOrigin(), *document.page())->storageArea(document.securityOrigin());
+    return sessionStorageNamespace(document.protectedTopOrigin().get(), *document.protectedPage())->storageArea(document.protectedSecurityOrigin().get());
 }
 
 StorageNamespace& StorageNamespaceProvider::localStorageNamespace(PAL::SessionID sessionID)
 {
     if (!m_localStorageNamespace)
-        m_localStorageNamespace = createLocalStorageNamespace(localStorageDatabaseQuotaInBytes, sessionID);
+        lazyInitialize(m_localStorageNamespace, createLocalStorageNamespace(localStorageDatabaseQuotaInBytes, sessionID));
 
     ASSERT(m_localStorageNamespace->sessionID() == sessionID);
     return *m_localStorageNamespace;

--- a/Source/WebCore/storage/StorageNamespaceProvider.h
+++ b/Source/WebCore/storage/StorageNamespaceProvider.h
@@ -69,7 +69,7 @@ private:
     virtual Ref<StorageNamespace> createLocalStorageNamespace(unsigned quota, PAL::SessionID) = 0;
     virtual Ref<StorageNamespace> createTransientLocalStorageNamespace(SecurityOrigin&, unsigned quota, PAL::SessionID) = 0;
 
-    RefPtr<StorageNamespace> m_localStorageNamespace;
+    const RefPtr<StorageNamespace> m_localStorageNamespace;
     HashMap<SecurityOriginData, RefPtr<StorageNamespace>> m_transientLocalStorageNamespaces;
 
     unsigned m_sessionStorageQuota { 0 };


### PR DESCRIPTION
#### e91ccc455d84812412266830592380022604a255
<pre>
Address safer cpp warnings in WebCore/storage/
<a href="https://bugs.webkit.org/show_bug.cgi?id=299413">https://bugs.webkit.org/show_bug.cgi?id=299413</a>

Reviewed by Rupin Mittal.

* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebCore/storage/Storage.cpp:
(WebCore::Storage::setItem):
(WebCore::Storage::removeItem):
(WebCore::Storage::clear):
(WebCore::Storage::requiresScriptTrackingPrivacyProtection const):
* Source/WebCore/storage/StorageMap.cpp:
(WebCore::StorageMap::setItem):
(WebCore::StorageMap::removeItem):
* Source/WebCore/storage/StorageNamespaceProvider.cpp:
(WebCore::StorageNamespaceProvider::localStorageArea):
(WebCore::StorageNamespaceProvider::sessionStorageArea):
(WebCore::StorageNamespaceProvider::localStorageNamespace):
* Source/WebCore/storage/StorageNamespaceProvider.h:

Canonical link: <a href="https://commits.webkit.org/300453@main">https://commits.webkit.org/300453@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1407737e51a1f26c4b81c2697d24980115ff017f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122559 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42267 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32952 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/129168 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74660 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9f5667ac-98ce-4e1a-9139-c2aeb3c05d3d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/124435 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42985 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50860 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93164 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/61872 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/df847faa-5cb4-44c4-953d-6b45e618c2fd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125511 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34283 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109731 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73810 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6a78351f-b5f4-4919-9eca-ff537e5781ff) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33266 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27888 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72652 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103944 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28098 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131894 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49500 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Debug-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101694 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49875 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105951 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101562 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25792 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46936 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25085 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/46270 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49358 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/55107 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48826 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/52177 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50507 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->