### PR TITLE
REGRESSION (296827@main): Opacity/filter render incorrectly.

### DIFF
--- a/LayoutTests/css3/filters/filter-and-opacity-on-bitmap-2-expected.html
+++ b/LayoutTests/css3/filters/filter-and-opacity-on-bitmap-2-expected.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <style>
+    .box { 
+      display: block;
+      margin: 10px;
+      width: 200px;
+      height: 200px; 
+    } 
+    .control { 
+      filter: url(#erode); 
+    }
+    .container {
+      opacity: 0.5;
+    }
+</style>
+</head>
+<body>
+    <svg width="0" height="0">
+        <filter id="erode" filterUnits="userSpaceOnUse">
+            <feMorphology operator="erode" radius="2" />
+        </filter>
+    </svg>
+    <div class="container">
+        <img class="control box" src="resources/reference.png">
+    </div>
+</body>
+</html>

--- a/LayoutTests/css3/filters/filter-and-opacity-on-bitmap-2.html
+++ b/LayoutTests/css3/filters/filter-and-opacity-on-bitmap-2.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <style>
+    .box { 
+      display: block;
+      margin: 10px;
+      width: 200px;
+      height: 200px; 
+    } 
+    .test { 
+      filter: url(#erode); 
+      opacity: 0.5;
+    }
+  </style>
+</head>
+<body>
+    <svg width="0" height="0">
+        <filter id="erode" filterUnits="userSpaceOnUse">
+            <feMorphology operator="erode" radius="2" />
+        </filter>
+    </svg>
+    <img class="test box" src="resources/reference.png">
+</body>
+</html>

--- a/LayoutTests/css3/filters/filter-and-opacity-on-bitmap-expected.html
+++ b/LayoutTests/css3/filters/filter-and-opacity-on-bitmap-expected.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <style>
+    .box { 
+      display: block;
+      margin: 10px;
+      width: 200px;
+      height: 200px; 
+    } 
+    .control { 
+      filter: saturate(0); 
+    }
+    .container {
+      opacity: 0.5;
+    }
+</style>
+</head>
+<body>
+    <div class="container">
+        <img class="control box" src="resources/reference.png">
+    </div>
+</body>
+</html>

--- a/LayoutTests/css3/filters/filter-and-opacity-on-bitmap.html
+++ b/LayoutTests/css3/filters/filter-and-opacity-on-bitmap.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <style>
+    .box { 
+      display: block;
+      margin: 10px;
+      width: 200px;
+      height: 200px; 
+    } 
+    .test { 
+      filter: saturate(0); 
+      opacity: 0.5;
+    }
+  </style>
+</head>
+<body>
+    <img class="test box" src="resources/reference.png">
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderLayerInlines.h
+++ b/Source/WebCore/rendering/RenderLayerInlines.h
@@ -29,7 +29,7 @@
 
 namespace WebCore {
 
-inline bool RenderLayer::canPaintTransparencyWithSetOpacity() const { return isBitmapOnly() && !hasNonOpacityTransparency(); }
+inline bool RenderLayer::canPaintTransparencyWithSetOpacity() const { return isBitmapOnly() && !hasNonOpacityTransparency() && !hasFilter(); }
 inline bool RenderLayer::hasBackdropFilter() const { return renderer().hasBackdropFilter(); }
 inline bool RenderLayer::hasFilter() const { return renderer().hasFilter(); }
 inline bool RenderLayer::hasPerspective() const { return renderer().style().hasPerspective(); }


### PR DESCRIPTION
#### f066186761718ad23e0daecf7c48f75dffa38e7e
<pre>
REGRESSION (296827@main): Opacity/filter render incorrectly.
<a href="https://bugs.webkit.org/show_bug.cgi?id=299270">https://bugs.webkit.org/show_bug.cgi?id=299270</a>
&lt;<a href="https://rdar.apple.com/problem/161130683">rdar://problem/161130683</a>&gt;

Reviewed by Said Abou-Hallawa.

The canPaintTransparencyWithSetOpacity optimization only works if we have a
single bitmap paint that the opacity can be passed to.  When combined with a
filter effect that pushes a transparency layer, it no longer has any effect.

Test: css3/filters/filter-and-opacity-on-bitmap.html
* LayoutTests/css3/filters/filter-and-opacity-on-bitmap-expected.html: Added.
* LayoutTests/css3/filters/filter-and-opacity-on-bitmap.html: Added.
* LayoutTests/css3/filters/filter-and-opacity-on-bitmap-2-expected.html: Added.
* LayoutTests/css3/filters/filter-and-opacity-on-bitmap-2.html: Added.
* Source/WebCore/rendering/RenderLayerInlines.h:
(WebCore::RenderLayer::canPaintTransparencyWithSetOpacity const):

Canonical link: <a href="https://commits.webkit.org/300549@main">https://commits.webkit.org/300549@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/125ce3bff19ad1c4c3f3d0ba4bdc8498a0b14286

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123043 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42757 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33454 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/129697 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/75152 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/afd2e9b9-2113-4403-b957-f9380ea558dc) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/124920 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43481 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51352 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93524 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/75152 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e6e7997f-13e4-4822-a659-fd21633a1d95) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125994 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34654 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110123 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74155 "Found 2 new API test failures: TestWTF:WTF_Condition.OneProducerOneConsumerOneSlotTimeout, TestWTF:WTF_Condition.OneProducerOneConsumerOneSlot (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bdaba8b6-0352-4fdd-a046-ea141c3a27d6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33629 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28278 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73211 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104365 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28503 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132428 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49993 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38055 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102026 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50369 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106343 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/101888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25880 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47253 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25454 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/46766 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49848 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/55609 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49316 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/52668 "Built successfully") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50997 "Failed to checkout and rebase branch from PR 51232") | | | | 
<!--EWS-Status-Bubble-End-->