### PR TITLE
[GTK][WPE] Rename confusing WebKitXRPermissionRequest API name

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitXRPermissionRequest.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitXRPermissionRequest.cpp
@@ -141,12 +141,12 @@ static void webkit_xr_permission_request_class_init(WebKitXRPermissionRequestCla
 }
 
 /**
- * webkit_xr_permission_request_get_security_origin
+ * webkit_xr_permission_request_get_security_origin:
  * @request: a #WebKitXRPermissionRequest
  *
- * Get the origin of this request.
+ * Gets the security origin that initiated the permission request.
  *
- * Returns: (transfer none): A #WebKitSecurityOrigin of @request
+ * Returns: (transfer none): the #WebKitSecurityOrigin that initiated the request
  *
  * Since: 2.52
  */
@@ -162,12 +162,12 @@ WebKitSecurityOrigin* webkit_xr_permission_request_get_security_origin(WebKitXRP
 }
 
 /**
- * webkit_xr_permission_request_get_session_mode
+ * webkit_xr_permission_request_get_session_mode:
  * @request: a #WebKitXRPermissionRequest
  *
- * Get the XRSessionMode of this request.
+ * Gets the session mode for which permission is being requested.
  *
- * Returns: The #WebKitXRSessionMode of @request
+ * Returns: a #WebKitXRSessionMode
  *
  * Since: 2.52
  */
@@ -183,10 +183,14 @@ WebKitXRSessionMode webkit_xr_permission_request_get_session_mode(WebKitXRPermis
 }
 
 /**
- * webkit_xr_permission_request_get_granted_features
+ * webkit_xr_permission_request_get_granted_features:
  * @request: a #WebKitXRPermissionRequest
  *
- * Get the previously granted features for the XR device.
+ * Gets the features requested by the origin for the XR device, which
+ * are either granted by default or have been explicitly granted by
+ * the user.
+ *
+ * Returns: a #WebKitXRSessionFeatures flag combination
  *
  * Since: 2.52
  */
@@ -202,12 +206,15 @@ WebKitXRSessionFeatures webkit_xr_permission_request_get_granted_features(WebKit
 }
 
 /**
- * webkit_xr_permission_request_get_consent_required_features
+ * webkit_xr_permission_request_get_consent_required_features:
  * @request: a #WebKitXRPermissionRequest
  *
- * Get the consent required features of this request.
+ * Gets the required features that need user consent.
  *
- * Returns: The consent required features of @request
+ * These features are automatically granted if the request is allowed with
+ * webkit_permission_request_allow().
+ *
+ * Returns: a #WebKitXRSessionFeatures flag combination
  *
  * Since: 2.52
  */
@@ -223,12 +230,16 @@ WebKitXRSessionFeatures webkit_xr_permission_request_get_consent_required_featur
 }
 
 /**
- * webkit_xr_permission_request_get_consent_optional_features
+ * webkit_xr_permission_request_get_consent_optional_features:
  * @request: a #WebKitXRPermissionRequest
  *
- * Get the consent optional features of this request.
+ * Gets the optional features that need user consent.
  *
- * Returns: The optional features of @request
+ * These features can be granted by calling
+ * webkit_xr_permission_request_set_granted_consent_optional_features()
+ * before allowing the request with webkit_permission_request_allow().
+ *
+ * Returns: a #WebKitXRSessionFeatures flag combination
  *
  * Since: 2.52
  */
@@ -244,12 +255,14 @@ WebKitXRSessionFeatures webkit_xr_permission_request_get_consent_optional_featur
 }
 
 /**
- * webkit_xr_permission_request_get_required_features_requested
+ * webkit_xr_permission_request_get_required_features_requested:
  * @request: a #WebKitXRPermissionRequest
  *
- * Get the requested required features of this request.
+ * Gets the full set of required features requested by the web application.
  *
- * Returns: The required features of @request
+ * This includes both already granted features and those requiring consent.
+ *
+ * Returns: a #WebKitXRSessionFeatures flag combination
  *
  * Since: 2.52
  */
@@ -265,14 +278,17 @@ WebKitXRSessionFeatures webkit_xr_permission_request_get_required_features_reque
 }
 
 /**
- * webkit_xr_permission_request_get_optional_features_requested
+ * webkit_xr_permission_request_get_optional_features_requested:
  * @request: a #WebKitXRPermissionRequest
  *
- * Get the requested optional features of this request.
+ * Gets the full set of optional features requested by the web application.
  *
- * Returns: The optional features of @request
+ * This includes both already granted features and those requiring consent.
+ *
+ * Returns: a #WebKitXRSessionFeatures flag combination
  *
  * Since: 2.52
+ *
  */
 WebKitXRSessionFeatures webkit_xr_permission_request_get_optional_features_requested(WebKitXRPermissionRequest* request)
 {
@@ -286,15 +302,21 @@ WebKitXRSessionFeatures webkit_xr_permission_request_get_optional_features_reque
 }
 
 /**
- * webkit_xr_permission_request_set_granted_features
+ * webkit_xr_permission_request_set_granted_consent_optional_features:
  * @request: a #WebKitXRPermissionRequest
  * @granted: granted features
  *
- * Set the granted features for the XR device.
+ * Sets which optional features should be granted if the permission request is allowed.
+ *
+ * This function should be called with a subset of the features from
+ * webkit_xr_permission_request_get_consent_optional_features() before calling
+ * webkit_permission_request_allow(). If the request is denied, no features are
+ * granted, regardless of what is set here.
  *
  * Since: 2.52
+ *
  */
-void webkit_xr_permission_request_set_granted_features(WebKitXRPermissionRequest* request, WebKitXRSessionFeatures granted)
+void webkit_xr_permission_request_set_granted_consent_optional_features(WebKitXRPermissionRequest* request, WebKitXRSessionFeatures granted)
 {
 #if ENABLE(WEBXR)
     g_return_if_fail(WEBKIT_IS_XR_PERMISSION_REQUEST(request));

--- a/Source/WebKit/UIProcess/API/glib/WebKitXRPermissionRequest.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitXRPermissionRequest.h.in
@@ -51,6 +51,8 @@ WEBKIT_DECLARE_FINAL_TYPE (WebKitXRPermissionRequest, webkit_xr_permission_reque
  *
  * Enum values representing the XR session mode.
  *
+ * See <https://immersive-web.github.io/webxr/#xrsessionmode-enum>
+ *
  * Since: 2.52
  */
 typedef enum {
@@ -70,6 +72,9 @@ typedef enum {
  *
  * Enum values representing the XR session features.
  *
+ * See <https://immersive-web.github.io/webxr/#xrreferencespace-interface>.
+ * And, see <https://immersive-web.github.io/webxr-hand-input/> for hand tracking.
+ *
  * Since: 2.52
  */
 typedef enum {
@@ -88,23 +93,23 @@ WEBKIT_API WebKitXRSessionMode
 webkit_xr_permission_request_get_session_mode                (WebKitXRPermissionRequest *request);
 
 WEBKIT_API WebKitXRSessionFeatures
-webkit_xr_permission_request_get_granted_features            (WebKitXRPermissionRequest *request);
+webkit_xr_permission_request_get_granted_features            (WebKitXRPermissionRequest *request) G_GNUC_WARN_UNUSED_RESULT;
 
 WEBKIT_API WebKitXRSessionFeatures
-webkit_xr_permission_request_get_consent_required_features   (WebKitXRPermissionRequest *request);
+webkit_xr_permission_request_get_consent_required_features   (WebKitXRPermissionRequest *request) G_GNUC_WARN_UNUSED_RESULT;
 
 WEBKIT_API WebKitXRSessionFeatures
-webkit_xr_permission_request_get_consent_optional_features   (WebKitXRPermissionRequest *request);
+webkit_xr_permission_request_get_consent_optional_features   (WebKitXRPermissionRequest *request) G_GNUC_WARN_UNUSED_RESULT;
 
 WEBKIT_API WebKitXRSessionFeatures
-webkit_xr_permission_request_get_required_features_requested (WebKitXRPermissionRequest *request);
+webkit_xr_permission_request_get_required_features_requested (WebKitXRPermissionRequest *request) G_GNUC_WARN_UNUSED_RESULT;
 
 WEBKIT_API WebKitXRSessionFeatures
-webkit_xr_permission_request_get_optional_features_requested (WebKitXRPermissionRequest *request);
+webkit_xr_permission_request_get_optional_features_requested (WebKitXRPermissionRequest *request) G_GNUC_WARN_UNUSED_RESULT;
 
 WEBKIT_API void
-webkit_xr_permission_request_set_granted_features            (WebKitXRPermissionRequest *request,
-                                                              WebKitXRSessionFeatures    granted);
+webkit_xr_permission_request_set_granted_consent_optional_features (WebKitXRPermissionRequest *request,
+                                                                    WebKitXRSessionFeatures    granted);
 
 G_END_DECLS
 

--- a/Tools/MiniBrowser/gtk/BrowserTab.c
+++ b/Tools/MiniBrowser/gtk/BrowserTab.c
@@ -456,7 +456,7 @@ static gboolean decidePermissionRequest(WebKitWebView *webView, WebKitPermission
             "origin=%s mode=%s granted=(%s) consentRequired=(%s) consentOptional=(%s) requiredFeaturesRequested=(%s) optionalFeaturesRequested=(%s)",
             originStr, webKitXRSessionModeToString(mode), grantedFeatures, consentRequiredFeatures, consentOptionalFeatures, requiredFeaturesRequested, optionalFeaturesRequested);
         /* Needs UI to select optional features to grant */
-        webkit_xr_permission_request_set_granted_features(xrRequest, webkit_xr_permission_request_get_consent_optional_features(xrRequest));
+        webkit_xr_permission_request_set_granted_consent_optional_features(xrRequest, webkit_xr_permission_request_get_consent_optional_features(xrRequest));
     } else {
         g_print("%s request not handled\n", G_OBJECT_TYPE_NAME(request));
         return FALSE;

--- a/Tools/MiniBrowser/wpe/main.cpp
+++ b/Tools/MiniBrowser/wpe/main.cpp
@@ -270,7 +270,7 @@ static gboolean decidePermissionRequest(WebKitWebView *, WebKitPermissionRequest
     if (WEBKIT_IS_XR_PERMISSION_REQUEST(request)) {
         WebKitXRPermissionRequest* xrRequest = WEBKIT_XR_PERMISSION_REQUEST(request);
         /* Grant all optional features */
-        webkit_xr_permission_request_set_granted_features(xrRequest, webkit_xr_permission_request_get_consent_optional_features(xrRequest));
+        webkit_xr_permission_request_set_granted_consent_optional_features(xrRequest, webkit_xr_permission_request_get_consent_optional_features(xrRequest));
     }
 
     webkit_permission_request_allow(request);


### PR DESCRIPTION
#### d974c6aa39e911b63bc261194edf0e9333dffcd1
<pre>
[GTK][WPE] Rename confusing WebKitXRPermissionRequest API name
<a href="https://bugs.webkit.org/show_bug.cgi?id=299414">https://bugs.webkit.org/show_bug.cgi?id=299414</a>

Reviewed by Sergio Villar Senin.

&lt;<a href="https://commits.webkit.org/299591@main">https://commits.webkit.org/299591@main</a>&gt; added 2 new API
webkit_xr_permission_request_{get,set}_granted_features. Despite the
names, they aren&apos;t a getter and setter pair.

Renamed webkit_xr_permission_request_set_granted_features to
webkit_xr_permission_request_set_granted_consent_optional_features.

And, refined the WebKitXRPermissionRequest API documents by adding URL
to the spec and more descriptions, and align with the API document
style.

* Source/WebKit/UIProcess/API/glib/WebKitXRPermissionRequest.cpp:
(webkit_xr_permission_request_set_granted_consent_optional_features):
(webkit_xr_permission_request_set_granted_features): Deleted.
* Source/WebKit/UIProcess/API/glib/WebKitXRPermissionRequest.h.in:
* Tools/MiniBrowser/gtk/BrowserTab.c:
(decidePermissionRequest):
* Tools/MiniBrowser/wpe/main.cpp:
(decidePermissionRequest):

Canonical link: <a href="https://commits.webkit.org/300450@main">https://commits.webkit.org/300450@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6d4cab6c4e48f0afcc5698273a490f28d53af56b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122568 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42276 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32961 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/129177 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74669 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/124444 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42994 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50869 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93172 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/61875 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125520 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34295 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109747 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73818 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33277 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27904 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72661 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103961 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28114 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131903 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49509 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37688 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101704 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49884 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105967 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101572 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46947 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25100 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/46279 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19367 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49367 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/55116 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48835 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/52186 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50516 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->