### PR TITLE
Address some safer CPP warnings in platform/network/mac

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
@@ -108,10 +108,6 @@ platform/mediastream/mac/AVVideoCaptureSource.mm
 platform/mediastream/mac/ScreenCaptureKitCaptureSource.mm
 platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.mm
 platform/network/cf/DNSResolveQueueCFNet.cpp
-platform/network/mac/AuthenticationMac.mm
-platform/network/mac/CredentialStorageMac.mm
-platform/network/mac/NetworkStateNotifierMac.cpp
-platform/network/mac/ResourceErrorMac.mm
 platform/network/mac/ResourceHandleMac.mm
 platform/network/mac/SynchronousLoaderClient.mm
 platform/network/mac/WebCoreResourceHandleAsOperationQueueDelegate.mm

--- a/Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
@@ -71,11 +71,8 @@ platform/libwebrtc/LibWebRTCVPXVideoDecoder.cpp
 platform/mediastream/mac/AVVideoCaptureSource.mm
 platform/mediastream/mac/CoreAudioSharedUnit.mm
 platform/mediastream/mac/RealtimeIncomingVideoSourceCocoa.mm
-platform/network/mac/NetworkStateNotifierMac.cpp
 platform/network/mac/ResourceHandleMac.mm
-platform/network/mac/UTIUtilities.mm
 platform/network/mac/WebCoreResourceHandleAsOperationQueueDelegate.mm
-platform/network/mac/WebCoreURLResponse.mm
 platform/text/cocoa/LocaleCocoa.mm
 rendering/AttachmentLayout.mm
 testing/Internals.mm

--- a/Source/WebCore/platform/network/cf/AuthenticationChallenge.h
+++ b/Source/WebCore/platform/network/cf/AuthenticationChallenge.h
@@ -42,6 +42,7 @@ public:
 
 #ifdef __OBJC__
     id sender() const { return m_sender.get(); }
+    RetainPtr<id> protectedSender() const { return sender(); }
     NSURLAuthenticationChallenge *nsURLAuthenticationChallenge() const { return m_nsChallenge.get(); }
     RetainPtr<NSURLAuthenticationChallenge> protectedNSURLAuthenticationChallenge() const { return m_nsChallenge; }
 #endif

--- a/Source/WebCore/platform/network/mac/AuthenticationMac.mm
+++ b/Source/WebCore/platform/network/mac/AuthenticationMac.mm
@@ -157,7 +157,7 @@ NSURLAuthenticationChallenge *mac(const AuthenticationChallenge& coreChallenge)
     if (coreChallenge.nsURLAuthenticationChallenge())
         return coreChallenge.nsURLAuthenticationChallenge();
         
-    return adoptNS([[NSURLAuthenticationChallenge alloc] initWithProtectionSpace:coreChallenge.protectionSpace().nsSpace() proposedCredential:coreChallenge.proposedCredential().nsCredential() previousFailureCount:coreChallenge.previousFailureCount() failureResponse:coreChallenge.failureResponse().nsURLResponse() error:coreChallenge.error() sender:coreChallenge.sender()]).autorelease();
+    return adoptNS([[NSURLAuthenticationChallenge alloc] initWithProtectionSpace:coreChallenge.protectionSpace().protectedNSSpace().get() proposedCredential:coreChallenge.proposedCredential().protectedNSCredential().get() previousFailureCount:coreChallenge.previousFailureCount() failureResponse:coreChallenge.failureResponse().protectedNSURLResponse().get() error:coreChallenge.error().protectedNSError().get() sender:coreChallenge.protectedSender().get()]).autorelease();
 }
 
 AuthenticationChallenge core(NSURLAuthenticationChallenge *macChallenge)

--- a/Source/WebCore/platform/network/mac/CredentialStorageMac.mm
+++ b/Source/WebCore/platform/network/mac/CredentialStorageMac.mm
@@ -34,8 +34,8 @@ namespace WebCore {
 
 Credential CredentialStorage::getFromPersistentStorage(const ProtectionSpace& protectionSpace)
 {
-    NSURLCredential *credential = [[NSURLCredentialStorage sharedCredentialStorage] defaultCredentialForProtectionSpace:protectionSpace.nsSpace()];
-    return credential ? Credential(credential) : Credential();
+    RetainPtr credential = [[NSURLCredentialStorage sharedCredentialStorage] defaultCredentialForProtectionSpace:protectionSpace.protectedNSSpace().get()];
+    return credential ? Credential(credential.get()) : Credential();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/network/mac/UTIUtilities.mm
+++ b/Source/WebCore/platform/network/mac/UTIUtilities.mm
@@ -117,7 +117,7 @@ struct UTIFromMIMETypeCachePolicy : TinyLRUCachePolicy<String, RetainPtr<NSStrin
 public:
     static RetainPtr<NSString> createValueForKey(const String& mimeType)
     {
-        if (auto type = UTIFromPotentiallyUnknownMIMEType(mimeType))
+        if (RetainPtr type = UTIFromPotentiallyUnknownMIMEType(mimeType))
             return type;
 
         if (RetainPtr type = [UTType typeWithMIMEType:mimeType.createNSString().get()])

--- a/Source/WebCore/platform/network/mac/WebCoreURLResponse.mm
+++ b/Source/WebCore/platform/network/mac/WebCoreURLResponse.mm
@@ -36,6 +36,7 @@
 #import <wtf/Assertions.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/SortedArrayMap.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 
 namespace WebCore {
 
@@ -202,10 +203,10 @@ NSURLResponse *synthesizeRedirectResponseIfNecessary(NSURLRequest *currentReques
 
 RetainPtr<CFStringRef> filePathExtension(CFURLResponseRef response)
 {
-    auto responseURL = CFURLResponseGetURL(response);
-    if (![(__bridge NSURL *)responseURL isFileURL])
+    RetainPtr responseURL = CFURLResponseGetURL(response);
+    if (![bridge_cast(responseURL.get()) isFileURL])
         return nullptr;
-    return adoptCF(CFURLCopyPathExtension(responseURL));
+    return adoptCF(CFURLCopyPathExtension(responseURL.get()));
 }
 
 }


### PR DESCRIPTION
#### 054284d17778a59f971ea6692ebf336d81b110a3
<pre>
Address some safer CPP warnings in platform/network/mac
<a href="https://bugs.webkit.org/show_bug.cgi?id=299418">https://bugs.webkit.org/show_bug.cgi?id=299418</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations:
* Source/WebCore/platform/network/cf/AuthenticationChallenge.h:
(WebCore::AuthenticationChallenge::protectedSender const):
* Source/WebCore/platform/network/mac/AuthenticationMac.mm:
(WebCore::mac):
* Source/WebCore/platform/network/mac/CredentialStorageMac.mm:
(WebCore::CredentialStorage::getFromPersistentStorage):
* Source/WebCore/platform/network/mac/NetworkStateNotifierMac.cpp:
(WebCore::NetworkStateNotifier::updateStateWithoutNotifying):
(WebCore::NetworkStateNotifier::startObserving):
* Source/WebCore/platform/network/mac/ResourceErrorMac.mm:
(WebCore::ResourceError::blockedKnownTracker const):
(WebCore::ResourceError::blockedTrackerHostName const):
(WebCore::ResourceError::hasMatchingFailingURLKeys const):
* Source/WebCore/platform/network/mac/UTIUtilities.mm:
(WebCore::UTIFromMIMETypeCachePolicy::createValueForKey):
* Source/WebCore/platform/network/mac/WebCoreURLResponse.mm:
(WebCore::filePathExtension):

Canonical link: <a href="https://commits.webkit.org/300460@main">https://commits.webkit.org/300460@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/96883f57dff0f65ccde9b497ed1ffc4f691c1d25

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122629 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42337 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33022 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/129240 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74733 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/124505 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43055 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50930 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93206 "2 flakes 15 failures") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/61899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/75c7b83d-94e3-4780-aac5-5425ec075090) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125581 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34327 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109791 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73852 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33311 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27944 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72725 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104013 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28153 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131964 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49570 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37736 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101738 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49945 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106006 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101606 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25798 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46978 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25143 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/46344 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49428 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/55177 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48898 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/52250 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50577 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->