### PR TITLE
Include additional translation in getBBox for SVGUseElement

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-05-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-05-expected.txt
@@ -23,8 +23,8 @@ FAIL path with fill and clipping assert_approx_equals: path4.getBBox().width {"f
 PASS path with fill
 FAIL path with stroke assert_approx_equals: path1.getBBox().x {"fill":false,"stroke":true,"markers":false,"clipped":false} expected 6.2 +/- 0.1 but got 10
 FAIL path with markers assert_approx_equals: path1.getBBox().width {"fill":false,"stroke":false,"markers":true,"clipped":false} expected 112 +/- 0.1 but got 100
-FAIL use with fill assert_approx_equals: use1.getBBox().x {"fill":true,"stroke":false,"markers":false,"clipped":false} expected 70 +/- 0.1 but got 20
-FAIL use with fill, stroke, markers and clipping assert_approx_equals: use1.getBBox().x {"fill":true,"stroke":true,"markers":true,"clipped":true} expected 70 +/- 0.1 but got 20
+PASS use with fill
+FAIL use with fill, stroke, markers and clipping assert_approx_equals: use1.getBBox().y {"fill":true,"stroke":true,"markers":true,"clipped":true} expected 66 +/- 0.1 but got 70
 FAIL foreignObject with fill assert_approx_equals: fo1.getBBox().x {"fill":true,"stroke":false,"markers":false,"clipped":false} expected 2 +/- 0.1 but got 0
 FAIL foreignObject with fill, stroke, markers and clipping assert_approx_equals: fo1.getBBox().x {"fill":true,"stroke":true,"markers":true,"clipped":true} expected 53 +/- 0.1 but got 0
 FAIL masking-path-07-b.html with fill, stroke, markers and clipping assert_approx_equals: rect-1.getBBox().x {"fill":true,"stroke":true,"markers":true,"clipped":true} expected 10 +/- 0.1 but got 0

--- a/LayoutTests/svg/custom/getBBox-use-expected.txt
+++ b/LayoutTests/svg/custom/getBBox-use-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Additional translation affects bounding box of <use>
+

--- a/LayoutTests/svg/custom/getBBox-use.html
+++ b/LayoutTests/svg/custom/getBBox-use.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<svg height="0">
+  <rect id="r" width="300" height="400"/>
+  <use xlink:href="#r" x="100" y="200"/>
+</svg>
+<script>
+test(function() {
+    var useBBox = document.querySelector('use').getBBox();
+    assert_equals(useBBox.x, 100);
+    assert_equals(useBBox.y, 200);
+    assert_equals(useBBox.width, 300);
+    assert_equals(useBBox.height, 400);
+}, 'Additional translation affects bounding box of <use>');
+</script>

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.h
@@ -1,8 +1,8 @@
 /*
  * Copyright (C) 2004, 2005, 2007 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) 2004, 2005, 2007 Rob Buis <buis@kde.org>
- * Copyright (C) 2009 Google, Inc. All rights reserved.
- * Copyright (C) 2009 Apple Inc. All rights reserved.
+ * Copyright (C) 2009-2015 Google, Inc. All rights reserved.
+ * Copyright (C) 2009-2025 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -40,6 +40,8 @@ public:
     bool isObjectBoundingBoxValid() const { return static_cast<bool>(m_objectBoundingBox); }
     bool isRepaintSuspendedForChildren() const { return m_repaintIsSuspendedForChildrenDuringLayout; }
 
+    FloatRect objectBoundingBox() const final { return m_objectBoundingBox.value_or(FloatRect()); }
+
 protected:
     LegacyRenderSVGContainer(Type, SVGElement&, RenderStyle&&, OptionSet<SVGModelObjectFlag> = { });
 
@@ -51,7 +53,6 @@ protected:
 
     void addFocusRingRects(Vector<LayoutRect>&, const LayoutPoint& additionalOffset, const RenderLayerModelObject* paintContainer = 0) const final;
 
-    FloatRect objectBoundingBox() const final { return m_objectBoundingBox.value_or(FloatRect()); }
     FloatRect strokeBoundingBox() const final;
     FloatRect repaintRectInLocalCoordinates(RepaintRectCalculation = RepaintRectCalculation::Fast) const final;
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGTransformableContainer.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGTransformableContainer.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2007 Eric Seidel <eric@webkit.org>
- * Copyright (C) 2009 Google, Inc.
+ * Copyright (C) 2015-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2009-2015 Google, Inc.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -36,6 +37,8 @@ public:
     const AffineTransform& localToParentTransform() const override { return m_localTransform; }
     void setNeedsTransformUpdate() override { m_needsTransformUpdate = true; }
     bool didTransformToRootUpdate() override { return m_didTransformToRootUpdate; }
+
+    const FloatSize& additionalTranslation() const { return m_additionalTranslation; }
 
 private:
     SVGGraphicsElement& graphicsElement();

--- a/Source/WebCore/svg/SVGUseElement.cpp
+++ b/Source/WebCore/svg/SVGUseElement.cpp
@@ -6,7 +6,7 @@
  * Copyright (C) 2012 University of Szeged
  * Copyright (C) 2012 Renata Hodovan <reni@webkit.org>
  * Copyright (C) 2015-2025 Apple Inc. All rights reserved.
- * Copyright (C) 2019 Google Inc. All rights reserved.
+ * Copyright (C) 2015-2019 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -150,6 +150,18 @@ void SVGUseElement::removedFromAncestor(RemovalType removalType, ContainerNode& 
 inline Document* SVGUseElement::externalDocument() const
 {
     return m_externalDocument ? m_externalDocument->document() : nullptr;
+}
+
+FloatRect SVGUseElement::getBBox(StyleUpdateStrategy styleUpdateStrategy)
+{
+    auto bbox = SVGGraphicsElement::getBBox(styleUpdateStrategy);
+    if (bbox.isEmpty())
+        return { };
+
+    auto* transformableContainer = dynamicDowncast<LegacyRenderSVGTransformableContainer>(renderer());
+    ASSERT(transformableContainer && transformableContainer->isObjectBoundingBoxValid());
+    bbox.move(transformableContainer->additionalTranslation());
+    return bbox;
 }
 
 void SVGUseElement::transferSizeAttributesToTargetClone(SVGElement& shadowElement) const

--- a/Source/WebCore/svg/SVGUseElement.h
+++ b/Source/WebCore/svg/SVGUseElement.h
@@ -1,7 +1,8 @@
 /*
  * Copyright (C) 2004, 2005, 2006, 2007, 2008 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) 2004, 2005, 2006, 2007 Rob Buis <buis@kde.org>
- * Copyright (C) 2015-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2015 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -74,6 +75,8 @@ private:
 
     Document* externalDocument() const;
     void updateExternalDocument();
+
+    FloatRect getBBox(StyleUpdateStrategy = AllowStyleUpdate) override;
 
     RefPtr<SVGElement> findTarget(AtomString* targetID = nullptr) const;
 


### PR DESCRIPTION
#### e53a0bba5e47721f29a3e0770dcb207dcc4d712e
<pre>
Include additional translation in getBBox for SVGUseElement
<a href="https://bugs.webkit.org/show_bug.cgi?id=264010">https://bugs.webkit.org/show_bug.cgi?id=264010</a>
<a href="https://rdar.apple.com/118082623">rdar://118082623</a>

Reviewed by Said Abou-Hallawa.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Merge: <a href="https://chromium.googlesource.com/chromium/blink/+/99b52757a16d0a300b77c83c27c443d70ba78f9c">https://chromium.googlesource.com/chromium/blink/+/99b52757a16d0a300b77c83c27c443d70ba78f9c</a>

RenderObject::objectBoundingBox() can&apos;t be used, because the additional
translation is included in the local-to-parent transform.

* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGTransformableContainer.h:
* Source/WebCore/svg/SVGUseElement.cpp:
(WebCore::SVGUseElement::getBBox):
* Source/WebCore/svg/SVGUseElement.h:
* LayoutTests/svg/custom/getBBox-use.html: Added.
* LayoutTests/svg/custom/getBBox-use-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-05-expected.txt: Progression

Canonical link: <a href="https://commits.webkit.org/302400@main">https://commits.webkit.org/302400@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6c9056690fa2692a9cc7e1f3a9471e4ce1c50b76

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128794 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/1051 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39624 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136176 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80166 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d7edb4bc-ea37-463c-a3cf-44f53a0dfb78) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130665 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/1002 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/928 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/98050 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65971 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/bfac4158-94e5-44c1-8bbd-76544f0d0171) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131741 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/754 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115407 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78659 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/98db4458-a138-4e23-925f-44f5a85987d0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/686 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33491 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79457 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109125 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33985 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138635 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/868 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/843 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106618 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/921 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111715 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106397 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27129 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/714 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30246 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53290 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/937 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64225 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/788 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/844 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/879 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->