### PR TITLE
Address Safer cpp warnings in NetworkProcess/cache & NetworkProcess/webrtc

### DIFF
--- a/Source/WTF/wtf/WorkQueue.h
+++ b/Source/WTF/wtf/WorkQueue.h
@@ -54,6 +54,7 @@ public:
 
 #if USE(COCOA_EVENT_LOOP)
     dispatch_queue_t dispatchQueue() const { return m_dispatchQueue.get(); }
+    RetainPtr<dispatch_queue_t> protectedDispatchQueue() const { return dispatchQueue(); }
 #endif
 
     virtual void ref() const = 0;

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheData.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheData.h
@@ -91,6 +91,7 @@ public:
 
 #if PLATFORM(COCOA)
     dispatch_data_t dispatchData() const { return m_dispatchData.get(); }
+    RetainPtr<dispatch_data_t> protectedDispatchData() const;
 #endif
 
 #if USE(GLIB)

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheDataCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheDataCocoa.mm
@@ -53,6 +53,11 @@ Data::Data(Vector<uint8_t>&& data)
 {
 }
 
+RetainPtr<dispatch_data_t> Data::protectedDispatchData() const
+{
+    return dispatchData();
+}
+
 Data Data::empty()
 {
     return { OSObjectPtr<dispatch_data_t> { dispatch_data_empty } };
@@ -90,7 +95,7 @@ bool Data::apply(NOESCAPE const Function<bool(std::span<const uint8_t>)>& applie
 
 Data Data::subrange(size_t offset, size_t size) const
 {
-    return { adoptOSObject(dispatch_data_create_subrange(dispatchData(), offset, size)) };
+    return { adoptOSObject(dispatch_data_create_subrange(protectedDispatchData().get(), offset, size)) };
 }
 
 Data concatenate(const Data& a, const Data& b)
@@ -99,7 +104,7 @@ Data concatenate(const Data& a, const Data& b)
         return b;
     if (b.isNull())
         return a;
-    return { adoptOSObject(dispatch_data_create_concat(a.dispatchData(), b.dispatchData())) };
+    return { adoptOSObject(dispatch_data_create_concat(a.protectedDispatchData().get(), b.protectedDispatchData().get())) };
 }
 
 Data Data::adoptMap(FileSystem::MappedFileData&& mappedFile, FileSystem::FileHandle&& outputHandle)

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheIOChannelCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheIOChannelCocoa.mm
@@ -96,7 +96,7 @@ IOChannel::~IOChannel()
 void IOChannel::read(size_t offset, size_t size, Ref<WTF::WorkQueueBase>&& queue, Function<void(Data&&, int error)>&& completionHandler)
 {
     bool didCallCompletionHandler = false;
-    dispatch_io_read(m_dispatchIO.get(), offset, size, queue->dispatchQueue(), makeBlockPtr([protectedThis = Ref { *this }, queue, completionHandler = WTFMove(completionHandler), didCallCompletionHandler](bool done, dispatch_data_t fileData, int error) mutable {
+    dispatch_io_read(m_dispatchIO.get(), offset, size, queue->protectedDispatchQueue().get(), makeBlockPtr([protectedThis = Ref { *this }, queue, completionHandler = WTFMove(completionHandler), didCallCompletionHandler](bool done, dispatch_data_t fileData, int error) mutable {
         ASSERT_UNUSED(done, done || !didCallCompletionHandler);
         if (didCallCompletionHandler)
             return;
@@ -110,7 +110,7 @@ void IOChannel::read(size_t offset, size_t size, Ref<WTF::WorkQueueBase>&& queue
 void IOChannel::write(size_t offset, const Data& data, Ref<WTF::WorkQueueBase>&& queue, Function<void(int error)>&& completionHandler)
 {
     RetainPtr dispatchData = data.dispatchData();
-    dispatch_io_write(m_dispatchIO.get(), offset, dispatchData.get(), queue->dispatchQueue(), makeBlockPtr([protectedThis = Ref { *this }, queue, completionHandler = WTFMove(completionHandler)](bool done, dispatch_data_t, int error) mutable {
+    dispatch_io_write(m_dispatchIO.get(), offset, dispatchData.get(), queue->protectedDispatchQueue().get(), makeBlockPtr([protectedThis = Ref { *this }, queue, completionHandler = WTFMove(completionHandler)](bool done, dispatch_data_t, int error) mutable {
         if (!done) {
             RELEASE_LOG_ERROR(NetworkCacheStorage, "IOChannel::write only part of data is written.");
             return;

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.cpp
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.cpp
@@ -31,6 +31,7 @@
 #include "Connection.h"
 #include "Logging.h"
 #include "NetworkRTCProvider.h"
+#include "NetworkRTCSharedMonitor.h"
 #include "WebRTCMonitorMessages.h"
 #include <WebCore/Timer.h>
 #include <ifaddrs.h>
@@ -82,146 +83,12 @@ private:
     RTCNetwork::IPAddress m_ipv6;
 };
 
-class NetworkRTCSharedMonitor {
-public:
-    NetworkRTCSharedMonitor();
-
-    void addListener(NetworkRTCMonitor&);
-    void removeListener(NetworkRTCMonitor&);
-
-    const RTCNetwork::IPAddress& ipv4() const { return m_ipv4; }
-    const RTCNetwork::IPAddress& ipv6()  const { return m_ipv6; }
-
-    webrtc::AdapterType adapterTypeFromInterfaceName(const char*) const;
-
-#if PLATFORM(COCOA)
-    void updateNetworksFromPath(nw_path_t);
-#endif
-
-private:
-    void start();
-    void stop();
-
-    void updateNetworks();
-    void updateNetworksOnQueue();
-
-    void onGatheredNetworks(RTCNetwork::IPAddress&&, RTCNetwork::IPAddress&&, HashMap<String, RTCNetwork>&&);
-
-    WeakHashSet<NetworkRTCMonitor> m_observers;
-
-    Ref<ConcurrentWorkQueue> m_queue;
-    WebCore::Timer m_updateNetworksTimer;
-
-    bool m_didReceiveResults { false };
-    Vector<RTCNetwork> m_networkList;
-    RTCNetwork::IPAddress m_ipv4;
-    RTCNetwork::IPAddress m_ipv6;
-    int m_networkLastIndex { 0 };
-    HashMap<String, RTCNetwork> m_networkMap;
-#if PLATFORM(COCOA)
-    RetainPtr<nw_path_monitor> m_nwMonitor;
-    HashMap<String, webrtc::AdapterType> m_adapterTypes;
-#endif
-};
-
-static NetworkRTCSharedMonitor& networkSharedMonitor()
-{
-    static NeverDestroyed<NetworkRTCSharedMonitor> networkSharedMonitor;
-    return networkSharedMonitor.get();
-}
-
-#if PLATFORM(COCOA)
-static RetainPtr<nw_path_monitor> createNWPathMonitor()
-{
-    auto nwMonitor = adoptCF(nw_path_monitor_create());
-    nw_path_monitor_set_queue(nwMonitor.get(), mainDispatchQueueSingleton());
-    nw_path_monitor_set_update_handler(nwMonitor.get(), makeBlockPtr([](nw_path_t path) {
-        networkSharedMonitor().updateNetworksFromPath(path);
-    }).get());
-    return nwMonitor;
-}
-#endif
-
-NetworkRTCSharedMonitor::NetworkRTCSharedMonitor()
-    : m_queue(ConcurrentWorkQueue::create("NetworkRTCSharedMonitor queue"_s))
-    , m_updateNetworksTimer([] { networkSharedMonitor().updateNetworks(); })
-{
-}
-
-void NetworkRTCSharedMonitor::addListener(NetworkRTCMonitor& monitor)
-{
-    if (m_didReceiveResults)
-        monitor.onNetworksChanged(m_networkList, m_ipv4, m_ipv6);
-
-    bool shouldStart = m_observers.isEmptyIgnoringNullReferences();
-    m_observers.add(monitor);
-
-    RELEASE_LOG(WebRTC, "NetworkRTCSharedMonitor::addListener shouldStart=%d didReceiveResults=%d listener=%p", shouldStart, m_didReceiveResults, &monitor);
-
-    if (!shouldStart)
-        return;
-
-#if PLATFORM(COCOA)
-    if (monitor.rtcProvider().webRTCInterfaceMonitoringViaNWEnabled()) {
-        if (auto nwMonitor = std::exchange(m_nwMonitor, { }))
-            nw_path_monitor_cancel(m_nwMonitor.get());
-
-        RELEASE_LOG(WebRTC, "NetworkRTCSharedMonitor::createNWPathMonitor");
-
-        m_nwMonitor = createNWPathMonitor();
-        nw_path_monitor_start(m_nwMonitor.get());
-        return;
-    }
-#endif
-
-    updateNetworks();
-    m_updateNetworksTimer.startRepeating(2_s);
-}
-
-void NetworkRTCSharedMonitor::removeListener(NetworkRTCMonitor& monitor)
-{
-    m_observers.remove(monitor);
-
-    bool shouldStop = m_observers.isEmptyIgnoringNullReferences();
-
-    RELEASE_LOG(WebRTC, "NetworkRTCSharedMonitor::removeListener shouldStop=%d listener=%p", shouldStop, &monitor);
-
-    if (!shouldStop)
-        return;
-
-#if PLATFORM(COCOA)
-    if (auto nwMonitor = std::exchange(m_nwMonitor, { }))
-        nw_path_monitor_cancel(nwMonitor.get());
-#endif
-
-    m_updateNetworksTimer.stop();
-}
-
 static std::optional<std::pair<RTCNetwork::InterfaceAddress, RTCNetwork::IPAddress>> addressFromInterface(const struct ifaddrs& interface)
 {
     RTCNetwork::IPAddress address { *interface.ifa_addr };
     RTCNetwork::IPAddress mask { *interface.ifa_netmask };
     return std::make_pair(RTCNetwork::InterfaceAddress { address, webrtc::IPV6_ADDRESS_FLAG_NONE }, mask);
 }
-
-#if PLATFORM(COCOA)
-static webrtc::AdapterType interfaceAdapterType(nw_interface_t interface)
-{
-    switch (nw_interface_get_type(interface)) {
-    case nw_interface_type_other:
-        return webrtc::ADAPTER_TYPE_VPN;
-    case nw_interface_type_wifi:
-        return webrtc::ADAPTER_TYPE_WIFI;
-    case nw_interface_type_cellular:
-        return webrtc::ADAPTER_TYPE_CELLULAR;
-    case nw_interface_type_wired:
-        return webrtc::ADAPTER_TYPE_ETHERNET;
-    case nw_interface_type_loopback:
-        return webrtc::ADAPTER_TYPE_LOOPBACK;
-    }
-    return webrtc::ADAPTER_TYPE_UNKNOWN;
-}
-#endif
 
 static HashMap<String, RTCNetwork> gatherNetworkMap()
 {
@@ -258,7 +125,7 @@ static HashMap<String, RTCNetwork> gatherNetworkMap()
         auto networkKey = makeString(name, "-"_s, prefixLength, "-"_s, std::span { prefixString });
 
         networkMap.ensure(networkKey, [&] {
-            auto interfaceType = networkSharedMonitor().adapterTypeFromInterfaceName(iterator->ifa_name);
+            auto interfaceType = NetworkRTCSharedMonitor::singleton().adapterTypeFromInterfaceName(iterator->ifa_name);
             return RTCNetwork { name, networkKey.utf8().span(), address->second, prefixLength, interfaceType, 0, 0, true, false, scopeID, { } };
         }).iterator->value.ips.append(address->first);
     }
@@ -346,54 +213,6 @@ static std::optional<RTCNetwork::IPAddress> getDefaultIPAddress(bool useIPv4)
     return getSocketLocalAddress(socket, useIPv4);
 }
 
-webrtc::AdapterType NetworkRTCSharedMonitor::adapterTypeFromInterfaceName(const char* interfaceName) const
-{
-#if PLATFORM(COCOA)
-    auto iterator = m_adapterTypes.find(String::fromUTF8(interfaceName));
-    if (iterator != m_adapterTypes.end())
-        return iterator->value;
-#endif
-    return webrtc::GetAdapterTypeFromName(interfaceName);
-}
-
-void NetworkRTCSharedMonitor::updateNetworks()
-{
-    auto aggregator = CallbackAggregator::create([] (auto&& ipv4, auto&& ipv6, auto&& networkList) mutable {
-        networkSharedMonitor().onGatheredNetworks(WTFMove(ipv4), WTFMove(ipv6), WTFMove(networkList));
-    });
-    Ref protectedQueue = m_queue;
-    protectedQueue->dispatch([aggregator] {
-        bool useIPv4 = true;
-        if (auto address = getDefaultIPAddress(useIPv4))
-            aggregator->setIPv4(WTFMove(*address));
-    });
-    protectedQueue->dispatch([aggregator] {
-        bool useIPv4 = false;
-        if (auto address = getDefaultIPAddress(useIPv4))
-            aggregator->setIPv6(WTFMove(*address));
-    });
-    protectedQueue->dispatch([aggregator] {
-        aggregator->setNetworkMap(gatherNetworkMap());
-    });
-}
-
-#if PLATFORM(COCOA)
-void NetworkRTCSharedMonitor::updateNetworksFromPath(nw_path_t path)
-{
-    RELEASE_LOG(WebRTC, "NetworkRTCSharedMonitor::updateNetworksFromPath");
-
-    auto status = nw_path_get_status(path);
-    if (status != nw_path_status_satisfied && status != nw_path_status_satisfiable)
-        return;
-
-    nw_path_enumerate_interfaces(path, makeBlockPtr([](nw_interface_t interface) -> bool {
-        networkSharedMonitor().m_adapterTypes.set(String::fromUTF8(nw_interface_get_name(interface)), interfaceAdapterType(interface));
-        return true;
-    }).get());
-    updateNetworks();
-}
-#endif
-
 static bool isEqual(const RTCNetwork::InterfaceAddress& a, const RTCNetwork::InterfaceAddress& b)
 {
     return a.rtcAddress() == b.rtcAddress();
@@ -435,55 +254,6 @@ static bool sortNetworks(const RTCNetwork& a, const RTCNetwork& b)
     return codePointCompare(StringView { a.description.span() }, StringView { b.description.span() }) < 0;
 }
 
-void NetworkRTCSharedMonitor::onGatheredNetworks(RTCNetwork::IPAddress&& ipv4, RTCNetwork::IPAddress&& ipv6, HashMap<String, RTCNetwork>&& networkMap)
-{
-    if (!m_didReceiveResults) {
-        m_didReceiveResults = true;
-        m_networkMap = WTFMove(networkMap);
-        m_ipv4 = WTFMove(ipv4);
-        m_ipv6 = WTFMove(ipv6);
-
-        for (auto& network : m_networkMap.values())
-            network.id = ++m_networkLastIndex;
-    } else {
-        bool didChange = networkMap.size() != networkMap.size();
-        for (auto& keyValue : networkMap) {
-            auto iterator = m_networkMap.find(keyValue.key);
-            bool isFound = iterator != m_networkMap.end();
-            keyValue.value.id = isFound ? iterator->value.id : ++m_networkLastIndex;
-            didChange |= !isFound || hasNetworkChanged(keyValue.value, iterator->value);
-        }
-        if (!didChange) {
-            for (auto& keyValue : m_networkMap) {
-                if (!networkMap.contains(keyValue.key)) {
-                    didChange = true;
-                    break;
-                }
-            }
-        }
-        if (!didChange && (ipv4.isUnspecified() || isEqual(ipv4, m_ipv4)) && (ipv6.isUnspecified() || isEqual(ipv6, m_ipv6)))
-            return;
-
-        m_networkMap = WTFMove(networkMap);
-        if (!ipv4.isUnspecified())
-            m_ipv4 = WTFMove(ipv4);
-        if (!ipv6.isUnspecified())
-            m_ipv6 = WTFMove(ipv6);
-    }
-    RELEASE_LOG(WebRTC, "NetworkRTCSharedMonitor::onGatheredNetworks - networks changed");
-
-    auto networkList = copyToVector(m_networkMap.values());
-    std::ranges::sort(networkList, sortNetworks);
-
-    int preference = std::max(127zu, networkList.size());
-    for (auto& network : networkList)
-        network.preference = preference--;
-
-    m_observers.forEach([this](auto& observer) {
-        Ref { observer }->onNetworksChanged(m_networkList, m_ipv4, m_ipv6);
-    });
-}
-
 NetworkRTCMonitor::NetworkRTCMonitor(NetworkRTCProvider& rtcProvider)
     : m_rtcProvider(rtcProvider)
 {
@@ -491,7 +261,7 @@ NetworkRTCMonitor::NetworkRTCMonitor(NetworkRTCProvider& rtcProvider)
 
 NetworkRTCMonitor::~NetworkRTCMonitor()
 {
-    networkSharedMonitor().removeListener(*this);
+    NetworkRTCSharedMonitor::singleton().removeListener(*this);
 }
 
 NetworkRTCProvider& NetworkRTCMonitor::rtcProvider()
@@ -501,12 +271,12 @@ NetworkRTCProvider& NetworkRTCMonitor::rtcProvider()
 
 const RTCNetwork::IPAddress& NetworkRTCMonitor::ipv4() const
 {
-    return networkSharedMonitor().ipv4();
+    return NetworkRTCSharedMonitor::singleton().ipv4();
 }
 
 const RTCNetwork::IPAddress& NetworkRTCMonitor::ipv6()  const
 {
-    return networkSharedMonitor().ipv6();
+    return NetworkRTCSharedMonitor::singleton().ipv6();
 }
 
 void NetworkRTCMonitor::startUpdatingIfNeeded()
@@ -514,7 +284,7 @@ void NetworkRTCMonitor::startUpdatingIfNeeded()
 #if ASSERT_ENABLED
     m_isStarted = true;
 #endif
-    networkSharedMonitor().addListener(*this);
+    NetworkRTCSharedMonitor::singleton().addListener(*this);
 }
 
 void NetworkRTCMonitor::stopUpdating()
@@ -522,7 +292,7 @@ void NetworkRTCMonitor::stopUpdating()
 #if ASSERT_ENABLED
     m_isStarted = false;
 #endif
-    networkSharedMonitor().removeListener(*this);
+    NetworkRTCSharedMonitor::singleton().removeListener(*this);
 }
 
 void NetworkRTCMonitor::onNetworksChanged(const Vector<RTCNetwork>& networkList, const RTCNetwork::IPAddress& ipv4, const RTCNetwork::IPAddress& ipv6)

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCSharedMonitor.cpp
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCSharedMonitor.cpp
@@ -1,0 +1,174 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#if USE(LIBWEBRTC)
+#include "NetworkRTCSharedMonitor.h"
+
+#include <wtf/NeverDestroyed.h>
+
+namespace WebKit {
+
+NetworkRTCSharedMonitor& NetworkRTCSharedMonitor::singleton()
+{
+    static NeverDestroyed<NetworkRTCSharedMonitor> instance;
+    return instance.get();
+}
+
+NetworkRTCSharedMonitor::NetworkRTCSharedMonitor()
+    : m_queue(ConcurrentWorkQueue::create("NetworkRTCSharedMonitor queue"_s))
+    , m_updateNetworksTimer([this] { updateNetworks(); })
+{
+}
+
+NetworkRTCSharedMonitor::~NetworkRTCSharedMonitor() = default;
+
+void NetworkRTCSharedMonitor::addListener(NetworkRTCMonitor& monitor)
+{
+    if (m_didReceiveResults)
+        monitor.onNetworksChanged(m_networkList, m_ipv4, m_ipv6);
+
+    bool shouldStart = m_observers.isEmptyIgnoringNullReferences();
+    m_observers.add(monitor);
+
+    RELEASE_LOG(WebRTC, "NetworkRTCSharedMonitor::addListener shouldStart=%d didReceiveResults=%d listener=%p", shouldStart, m_didReceiveResults, &monitor);
+
+    if (!shouldStart)
+        return;
+
+#if PLATFORM(COCOA)
+    if (monitor.rtcProvider().webRTCInterfaceMonitoringViaNWEnabled()) {
+        setupNWPathMonitor();
+        return;
+    }
+#endif
+
+    updateNetworks();
+    m_updateNetworksTimer.startRepeating(2_s);
+}
+
+void NetworkRTCSharedMonitor::removeListener(NetworkRTCMonitor& monitor)
+{
+    m_observers.remove(monitor);
+
+    bool shouldStop = m_observers.isEmptyIgnoringNullReferences();
+
+    RELEASE_LOG(WebRTC, "NetworkRTCSharedMonitor::removeListener shouldStop=%d listener=%p", shouldStop, &monitor);
+
+    if (!shouldStop)
+        return;
+
+#if PLATFORM(COCOA)
+    if (auto nwMonitor = std::exchange(m_nwMonitor, { }))
+        nw_path_monitor_cancel(nwMonitor.get());
+#endif
+
+    m_updateNetworksTimer.stop();
+}
+
+webrtc::AdapterType NetworkRTCSharedMonitor::adapterTypeFromInterfaceName(const char* interfaceName) const
+{
+#if PLATFORM(COCOA)
+    auto iterator = m_adapterTypes.find(String::fromUTF8(interfaceName));
+    if (iterator != m_adapterTypes.end())
+        return iterator->value;
+#endif
+    return webrtc::GetAdapterTypeFromName(interfaceName);
+}
+
+void NetworkRTCSharedMonitor::updateNetworks()
+{
+    auto aggregator = CallbackAggregator::create([] (auto&& ipv4, auto&& ipv6, auto&& networkList) mutable {
+        NetworkRTCSharedMonitor::singleton().onGatheredNetworks(WTFMove(ipv4), WTFMove(ipv6), WTFMove(networkList));
+    });
+    Ref protectedQueue = m_queue;
+    protectedQueue->dispatch([aggregator] {
+        bool useIPv4 = true;
+        if (auto address = getDefaultIPAddress(useIPv4))
+            aggregator->setIPv4(WTFMove(*address));
+    });
+    protectedQueue->dispatch([aggregator] {
+        bool useIPv4 = false;
+        if (auto address = getDefaultIPAddress(useIPv4))
+            aggregator->setIPv6(WTFMove(*address));
+    });
+    protectedQueue->dispatch([aggregator] {
+        aggregator->setNetworkMap(gatherNetworkMap());
+    });
+}
+
+void NetworkRTCSharedMonitor::onGatheredNetworks(RTCNetwork::IPAddress&& ipv4, RTCNetwork::IPAddress&& ipv6, HashMap<String, RTCNetwork>&& networkMap)
+{
+    if (!m_didReceiveResults) {
+        m_didReceiveResults = true;
+        m_networkMap = WTFMove(networkMap);
+        m_ipv4 = WTFMove(ipv4);
+        m_ipv6 = WTFMove(ipv6);
+
+        for (auto& network : m_networkMap.values())
+            network.id = ++m_networkLastIndex;
+    } else {
+        bool didChange = networkMap.size() != networkMap.size();
+        for (auto& keyValue : networkMap) {
+            auto iterator = m_networkMap.find(keyValue.key);
+            bool isFound = iterator != m_networkMap.end();
+            keyValue.value.id = isFound ? iterator->value.id : ++m_networkLastIndex;
+            didChange |= !isFound || hasNetworkChanged(keyValue.value, iterator->value);
+        }
+        if (!didChange) {
+            for (auto& keyValue : m_networkMap) {
+                if (!networkMap.contains(keyValue.key)) {
+                    didChange = true;
+                    break;
+                }
+            }
+        }
+        if (!didChange && (ipv4.isUnspecified() || isEqual(ipv4, m_ipv4)) && (ipv6.isUnspecified() || isEqual(ipv6, m_ipv6)))
+            return;
+
+        m_networkMap = WTFMove(networkMap);
+        if (!ipv4.isUnspecified())
+            m_ipv4 = WTFMove(ipv4);
+        if (!ipv6.isUnspecified())
+            m_ipv6 = WTFMove(ipv6);
+    }
+    RELEASE_LOG(WebRTC, "NetworkRTCSharedMonitor::onGatheredNetworks - networks changed");
+
+    auto networkList = copyToVector(m_networkMap.values());
+    std::ranges::sort(networkList, sortNetworks);
+
+    int preference = std::max(127zu, networkList.size());
+    for (auto& network : networkList)
+        network.preference = preference--;
+
+    m_observers.forEach([this](auto& observer) {
+        Ref { observer }->onNetworksChanged(m_networkList, m_ipv4, m_ipv6);
+    });
+}
+
+} // namespace WebKit
+
+#endif // USE(LIBWEBRTC)

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCSharedMonitor.h
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCSharedMonitor.h
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if USE(LIBWEBRTC)
+
+#include "RTCNetwork.h"
+#include <wtf/Forward.h>
+#include <wtf/RetainPtr.h>
+
+#if PLATFORM(COCOA)
+#include <pal/spi/cocoa/NetworkSPI.h>
+#endif
+
+namespace WebKit {
+
+class NetworkRTCSharedMonitor {
+public:
+    static NetworkRTCSharedMonitor& singleton();
+    ~NetworkRTCSharedMonitor();
+
+    void addListener(NetworkRTCMonitor&);
+    void removeListener(NetworkRTCMonitor&);
+
+    const RTCNetwork::IPAddress& ipv4() const { return m_ipv4; }
+    const RTCNetwork::IPAddress& ipv6()  const { return m_ipv6; }
+
+    webrtc::AdapterType adapterTypeFromInterfaceName(const char*) const;
+
+#if PLATFORM(COCOA)
+    void updateNetworksFromPath(nw_path_t);
+#endif
+
+private:
+    friend NeverDestroyed<NetworkRTCSharedMonitor>;
+
+    NetworkRTCSharedMonitor();
+
+#if PLATFORM(COCOA)
+    void setupNWPathMonitor();
+#endif
+
+    void start();
+    void stop();
+
+    void updateNetworks();
+    void updateNetworksOnQueue();
+
+    void onGatheredNetworks(RTCNetwork::IPAddress&&, RTCNetwork::IPAddress&&, HashMap<String, RTCNetwork>&&);
+
+    WeakHashSet<NetworkRTCMonitor> m_observers;
+
+    Ref<ConcurrentWorkQueue> m_queue;
+    WebCore::Timer m_updateNetworksTimer;
+
+    bool m_didReceiveResults { false };
+    Vector<RTCNetwork> m_networkList;
+    RTCNetwork::IPAddress m_ipv4;
+    RTCNetwork::IPAddress m_ipv6;
+    int m_networkLastIndex { 0 };
+    HashMap<String, RTCNetwork> m_networkMap;
+#if PLATFORM(COCOA)
+    RetainPtr<nw_path_monitor_t> m_nwMonitor;
+    HashMap<String, webrtc::AdapterType> m_adapterTypes;
+#endif
+};
+
+} // namespace WebKit
+
+#endif // USE(LIBWEBRTC)

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCSharedMonitorCocoa.mm
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCSharedMonitorCocoa.mm
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#if USE(LIBWEBRTC)
+#import "NetworkRTCSharedMonitor.h"
+
+#import <wtf/BlockPtr.h>
+#import <wtf/RetainPtr.h>
+#import <wtf/darwin/DispatchExtras.h>
+
+namespace WebKit {
+
+static RetainPtr<nw_path_monitor_t> createNWPathMonitor()
+{
+    RetainPtr nwMonitor = adoptNS(nw_path_monitor_create());
+    nw_path_monitor_set_queue(nwMonitor.get(), mainDispatchQueueSingleton());
+    nw_path_monitor_set_update_handler(nwMonitor.get(), makeBlockPtr([](nw_path_t path) {
+        NetworkRTCSharedMonitor::singleton().updateNetworksFromPath(path);
+    }).get());
+    return nwMonitor;
+}
+
+static webrtc::AdapterType interfaceAdapterType(nw_interface_t interface)
+{
+    switch (nw_interface_get_type(interface)) {
+    case nw_interface_type_other:
+        return webrtc::ADAPTER_TYPE_VPN;
+    case nw_interface_type_wifi:
+        return webrtc::ADAPTER_TYPE_WIFI;
+    case nw_interface_type_cellular:
+        return webrtc::ADAPTER_TYPE_CELLULAR;
+    case nw_interface_type_wired:
+        return webrtc::ADAPTER_TYPE_ETHERNET;
+    case nw_interface_type_loopback:
+        return webrtc::ADAPTER_TYPE_LOOPBACK;
+    }
+    return webrtc::ADAPTER_TYPE_UNKNOWN;
+}
+
+void NetworkRTCSharedMonitor::setupNWPathMonitor()
+{
+    if (auto nwMonitor = std::exchange(m_nwMonitor, { }))
+        nw_path_monitor_cancel(m_nwMonitor.get());
+
+    RELEASE_LOG(WebRTC, "NetworkRTCSharedMonitor::createNWPathMonitor");
+
+    m_nwMonitor = createNWPathMonitor();
+    nw_path_monitor_start(m_nwMonitor.get());
+}
+
+void NetworkRTCSharedMonitor::updateNetworksFromPath(nw_path_t path)
+{
+    RELEASE_LOG(WebRTC, "NetworkRTCSharedMonitor::updateNetworksFromPath");
+
+    auto status = nw_path_get_status(path);
+    if (status != nw_path_status_satisfied && status != nw_path_status_satisfiable)
+        return;
+
+    nw_path_enumerate_interfaces(path, makeBlockPtr([](nw_interface_t interface) -> bool {
+        NetworkRTCSharedMonitor::singleton().m_adapterTypes.set(String::fromUTF8(nw_interface_get_name(interface)), interfaceAdapterType(interface));
+        return true;
+    }).get());
+    updateNetworks();
+}
+
+} // namespace WebKit
+
+#endif // USE(LIBWEBRTC)

--- a/Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportSessionCocoa.mm
@@ -26,11 +26,15 @@
 #import "config.h"
 #import "NetworkTransportSession.h"
 
+#import "AuthenticationChallengeDisposition.h"
 #import "AuthenticationManager.h"
 #import "NetworkConnectionToWebProcess.h"
+#import "NetworkProcess.h"
+#import "NetworkSessionCocoa.h"
 #import "NetworkTransportStream.h"
 #import <Security/Security.h>
 #import <WebCore/AuthenticationChallenge.h>
+#import <WebCore/ClientOrigin.h>
 #import <WebCore/Exception.h>
 #import <WebCore/ExceptionCode.h>
 #import <pal/spi/cocoa/NetworkSPI.h>

--- a/Source/WebKit/SaferCPPExpectations/RetainPtrCtorAdoptCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/RetainPtrCtorAdoptCheckerExpectations
@@ -1,6 +1,5 @@
 NetworkProcess/cocoa/NetworkSessionCocoa.mm
 NetworkProcess/mac/SecItemShim.cpp
-NetworkProcess/webrtc/NetworkRTCMonitor.cpp
 Platform/cf/ModuleCF.cpp
 Shared/API/Cocoa/WKRemoteObjectCoder.mm
 Shared/API/Cocoa/_WKRemoteObjectRegistry.mm

--- a/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
@@ -1,12 +1,8 @@
 GeneratedWebKitSecureCoding.mm
 NetworkProcess/Authentication/cocoa/AuthenticationManagerCocoa.mm
 NetworkProcess/PrivateClickMeasurement/cocoa/PrivateClickMeasurementNetworkLoaderCocoa.mm
-NetworkProcess/cache/NetworkCacheDataCocoa.mm
-NetworkProcess/cache/NetworkCacheIOChannelCocoa.mm
 NetworkProcess/cocoa/LaunchServicesDatabaseObserver.mm
 NetworkProcess/mac/NetworkProcessMac.mm
-NetworkProcess/webrtc/NetworkRTCTCPSocketCocoa.mm
-NetworkProcess/webrtc/NetworkRTCUDPSocketCocoa.mm
 Platform/IPC/cocoa/ConnectionCocoa.mm
 Platform/IPC/cocoa/DaemonConnectionCocoa.mm
 Platform/cocoa/PaymentAuthorizationPresenter.mm

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -62,7 +62,9 @@ NetworkProcess/mac/SecItemShim.cpp
 
 NetworkProcess/webrtc/LibWebRTCSocketClient.cpp
 NetworkProcess/webrtc/NetworkRTCMonitor.cpp
+NetworkProcess/webrtc/NetworkRTCSharedMonitorCocoa.mm
 NetworkProcess/webrtc/NetworkRTCProvider.cpp
+NetworkProcess/webrtc/NetworkRTCSharedMonitor.cpp
 NetworkProcess/webrtc/NetworkRTCTCPSocketCocoa.mm
 NetworkProcess/webrtc/NetworkRTCUDPSocketCocoa.mm
 

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1155,6 +1155,7 @@
 		4671FF1F23217EFF001B64C7 /* WebResourceLoadObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = 4671FF1D23217EFF001B64C7 /* WebResourceLoadObserver.h */; };
 		467E43E82243FF7D00B13924 /* WebProcessDataStoreParameters.h in Headers */ = {isa = PBXBuildFile; fileRef = 467E43E72243FF6D00B13924 /* WebProcessDataStoreParameters.h */; };
 		46809A7C23D9225E00C297D0 /* WebCookieCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 46809A7A23D9225300C297D0 /* WebCookieCache.h */; };
+		46851A9E2E83D642000A59E2 /* NetworkRTCSharedMonitor.h in Headers */ = {isa = PBXBuildFile; fileRef = 46851A9C2E83D636000A59E2 /* NetworkRTCSharedMonitor.h */; };
 		4691CB9B27B2DD2D00B29AAF /* RemoteWorkerType.h in Headers */ = {isa = PBXBuildFile; fileRef = 4691CB9A27B2DD1800B29AAF /* RemoteWorkerType.h */; };
 		46A2B6091E5676A600C3DEDA /* BackgroundProcessResponsivenessTimer.h in Headers */ = {isa = PBXBuildFile; fileRef = 46A2B6071E5675A200C3DEDA /* BackgroundProcessResponsivenessTimer.h */; };
 		46B0524722668D8500265B97 /* WebDeviceOrientationAndMotionAccessController.h in Headers */ = {isa = PBXBuildFile; fileRef = 46B0524422668D2300265B97 /* WebDeviceOrientationAndMotionAccessController.h */; };
@@ -5624,6 +5625,9 @@
 		4683569B21E81CC7006E27A3 /* ProvisionalPageProxy.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ProvisionalPageProxy.cpp; sourceTree = "<group>"; };
 		468386672763FAB100CF9182 /* WebSharedWorkerServerConnection.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebSharedWorkerServerConnection.h; sourceTree = "<group>"; };
 		468386682763FAB100CF9182 /* WebSharedWorkerServerConnection.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebSharedWorkerServerConnection.cpp; sourceTree = "<group>"; };
+		46851A9B2E83D222000A59E2 /* NetworkRTCSharedMonitorCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = NetworkRTCSharedMonitorCocoa.mm; sourceTree = "<group>"; };
+		46851A9C2E83D636000A59E2 /* NetworkRTCSharedMonitor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NetworkRTCSharedMonitor.h; sourceTree = "<group>"; };
+		46851A9D2E83D636000A59E2 /* NetworkRTCSharedMonitor.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = NetworkRTCSharedMonitor.cpp; sourceTree = "<group>"; };
 		4689B90F2756D1430007C651 /* RemoteWebLockRegistry.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteWebLockRegistry.h; sourceTree = "<group>"; };
 		4689B9102756D1430007C651 /* RemoteWebLockRegistry.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteWebLockRegistry.cpp; sourceTree = "<group>"; };
 		4691CB9A27B2DD1800B29AAF /* RemoteWorkerType.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteWorkerType.h; sourceTree = "<group>"; };
@@ -12860,6 +12864,9 @@
 				41DC45951E3D6E1E00B11F51 /* NetworkRTCProvider.cpp */,
 				41DC45941E3D6E1E00B11F51 /* NetworkRTCProvider.h */,
 				41DC45981E3D6ED600B11F51 /* NetworkRTCProvider.messages.in */,
+				46851A9D2E83D636000A59E2 /* NetworkRTCSharedMonitor.cpp */,
+				46851A9C2E83D636000A59E2 /* NetworkRTCSharedMonitor.h */,
+				46851A9B2E83D222000A59E2 /* NetworkRTCSharedMonitorCocoa.mm */,
 				410BA13A257135F2002E2F8A /* NetworkRTCTCPSocketCocoa.h */,
 				410BA139257135F2002E2F8A /* NetworkRTCTCPSocketCocoa.mm */,
 				41DD72A7267B8C3100A90C71 /* NetworkRTCUDPSocketCocoa.h */,
@@ -17676,6 +17683,7 @@
 				5C1426F01C23F80900D41183 /* NetworkResourceLoadParameters.h in Headers */,
 				413075AC1DE85F370039EC69 /* NetworkRTCMonitor.h in Headers */,
 				41DC45961E3D6E2200B11F51 /* NetworkRTCProvider.h in Headers */,
+				46851A9E2E83D642000A59E2 /* NetworkRTCSharedMonitor.h in Headers */,
 				5C20CBA01BB1ECD800895BB1 /* NetworkSession.h in Headers */,
 				532159551DBAE7290054AA3C /* NetworkSessionCocoa.h in Headers */,
 				417915B92257046F00D6F97E /* NetworkSocketChannel.h in Headers */,


### PR DESCRIPTION
#### f233a205318f3c5975be354ffec3f5ea8a30e4ec
<pre>
Address Safer cpp warnings in NetworkProcess/cache &amp; NetworkProcess/webrtc
<a href="https://bugs.webkit.org/show_bug.cgi?id=299428">https://bugs.webkit.org/show_bug.cgi?id=299428</a>

Reviewed by Geoffrey Garen.

Address Safer cpp warnings in NetworkProcess/cache &amp; NetworkProcess/webrtc.
I had to move some code to a .mm file so that static analysis would properly
recognize the need for `adoptNS()`.

* Source/WTF/wtf/WorkQueue.h:
(WTF::WorkQueueBase::protectedDispatchQueue const):
* Source/WebKit/NetworkProcess/cache/NetworkCacheData.h:
* Source/WebKit/NetworkProcess/cache/NetworkCacheDataCocoa.mm:
(WebKit::NetworkCache::Data::protectedDispatchData const):
(WebKit::NetworkCache::Data::subrange const):
(WebKit::NetworkCache::concatenate):
* Source/WebKit/NetworkProcess/cache/NetworkCacheIOChannelCocoa.mm:
(WebKit::NetworkCache::IOChannel::read):
(WebKit::NetworkCache::IOChannel::write):
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.cpp:
(WebKit::gatherNetworkMap):
(WebKit::NetworkRTCMonitor::~NetworkRTCMonitor):
(WebKit::NetworkRTCMonitor::ipv4 const):
(WebKit::NetworkRTCMonitor::ipv6 const):
(WebKit::NetworkRTCMonitor::startUpdatingIfNeeded):
(WebKit::NetworkRTCMonitor::stopUpdating):
(WebKit::NetworkRTCSharedMonitor::ipv4 const): Deleted.
(WebKit::NetworkRTCSharedMonitor::ipv6 const): Deleted.
(WebKit::networkSharedMonitor): Deleted.
(WebKit::createNWPathMonitor): Deleted.
(WebKit::NetworkRTCSharedMonitor::NetworkRTCSharedMonitor): Deleted.
(WebKit::NetworkRTCSharedMonitor::addListener): Deleted.
(WebKit::NetworkRTCSharedMonitor::removeListener): Deleted.
(WebKit::interfaceAdapterType): Deleted.
(WebKit::NetworkRTCSharedMonitor::adapterTypeFromInterfaceName const): Deleted.
(WebKit::NetworkRTCSharedMonitor::updateNetworks): Deleted.
(WebKit::NetworkRTCSharedMonitor::updateNetworksFromPath): Deleted.
(WebKit::NetworkRTCSharedMonitor::onGatheredNetworks): Deleted.
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCSharedMonitor.cpp: Added.
(WebKit::NetworkRTCSharedMonitor::singleton):
(WebKit::NetworkRTCSharedMonitor::NetworkRTCSharedMonitor):
(WebKit::NetworkRTCSharedMonitor::addListener):
(WebKit::NetworkRTCSharedMonitor::removeListener):
(WebKit::NetworkRTCSharedMonitor::adapterTypeFromInterfaceName const):
(WebKit::NetworkRTCSharedMonitor::updateNetworks):
(WebKit::NetworkRTCSharedMonitor::onGatheredNetworks):
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCSharedMonitor.h: Added.
(WebKit::NetworkRTCSharedMonitor::ipv4 const):
(WebKit::NetworkRTCSharedMonitor::ipv6 const):
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCSharedMonitorCocoa.mm: Added.
(WebKit::createNWPathMonitor):
(WebKit::interfaceAdapterType):
(WebKit::NetworkRTCSharedMonitor::setupNWPathMonitor):
(WebKit::NetworkRTCSharedMonitor::updateNetworksFromPath):
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCTCPSocketCocoa.mm:
(WebKit::tcpSocketQueueSingleton):
(WebKit::NetworkRTCTCPSocketCocoa::NetworkRTCTCPSocketCocoa):
(WebKit::NetworkRTCTCPSocketCocoa::getInterfaceName):
(WebKit::tcpSocketQueue): Deleted.
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCUDPSocketCocoa.mm:
(WebKit::udpSocketQueueSingleton):
(WebKit::NetworkRTCUDPSocketCocoaConnections::NetworkRTCUDPSocketCocoaConnections):
(WebKit::NetworkRTCUDPSocketCocoaConnections::setupNWConnection):
(WebKit::udpSocketQueue): Deleted.
* Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportSessionCocoa.mm:
* Source/WebKit/SaferCPPExpectations/RetainPtrCtorAdoptCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations:
* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/300507@main">https://commits.webkit.org/300507@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8cb6fd9202e753dfe06aedcb5a8aacaff3c62ff0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122823 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42535 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33225 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/129449 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74927 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a7cca7fe-fe0c-4e61-8dbd-0e853f69d7b2) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43254 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/51219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93355 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/61975 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5d62a87e-7faf-492e-bddf-abdd44ab8581) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125775 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34490 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109952 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/73997 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0609a5cc-332c-4da1-831e-a0eaf0b5db3a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33468 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28109 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72941 "Built successfully") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/115066 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104190 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28322 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132176 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/121352 "Built successfully and passed tests") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/49860 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/51219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/101858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50145 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106166 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/101733 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25835 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47104 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25293 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/46539 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49626 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/55378 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/151618 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49092 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/38770 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/52444 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50775 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->