### PR TITLE
[GTK][WPE] Rename webkit_xr_permission_request_set_granted_consent_optional_features API

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitXRPermissionRequest.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitXRPermissionRequest.cpp
@@ -236,7 +236,7 @@ WebKitXRSessionFeatures webkit_xr_permission_request_get_consent_required_featur
  * Gets the optional features that need user consent.
  *
  * These features can be granted by calling
- * webkit_xr_permission_request_set_granted_consent_optional_features()
+ * webkit_xr_permission_request_set_granted_optional_features()
  * before allowing the request with webkit_permission_request_allow().
  *
  * Returns: a #WebKitXRSessionFeatures flag combination
@@ -302,7 +302,7 @@ WebKitXRSessionFeatures webkit_xr_permission_request_get_optional_features_reque
 }
 
 /**
- * webkit_xr_permission_request_set_granted_consent_optional_features:
+ * webkit_xr_permission_request_set_granted_optional_features:
  * @request: a #WebKitXRPermissionRequest
  * @granted: granted features
  *
@@ -316,7 +316,7 @@ WebKitXRSessionFeatures webkit_xr_permission_request_get_optional_features_reque
  * Since: 2.52
  *
  */
-void webkit_xr_permission_request_set_granted_consent_optional_features(WebKitXRPermissionRequest* request, WebKitXRSessionFeatures granted)
+void webkit_xr_permission_request_set_granted_optional_features(WebKitXRPermissionRequest* request, WebKitXRSessionFeatures granted)
 {
 #if ENABLE(WEBXR)
     g_return_if_fail(WEBKIT_IS_XR_PERMISSION_REQUEST(request));

--- a/Source/WebKit/UIProcess/API/glib/WebKitXRPermissionRequest.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitXRPermissionRequest.h.in
@@ -108,8 +108,8 @@ WEBKIT_API WebKitXRSessionFeatures
 webkit_xr_permission_request_get_optional_features_requested (WebKitXRPermissionRequest *request) G_GNUC_WARN_UNUSED_RESULT;
 
 WEBKIT_API void
-webkit_xr_permission_request_set_granted_consent_optional_features (WebKitXRPermissionRequest *request,
-                                                                    WebKitXRSessionFeatures    granted);
+webkit_xr_permission_request_set_granted_optional_features   (WebKitXRPermissionRequest *request,
+                                                              WebKitXRSessionFeatures    granted);
 
 G_END_DECLS
 

--- a/Tools/MiniBrowser/gtk/BrowserTab.c
+++ b/Tools/MiniBrowser/gtk/BrowserTab.c
@@ -456,7 +456,7 @@ static gboolean decidePermissionRequest(WebKitWebView *webView, WebKitPermission
             "origin=%s mode=%s granted=(%s) consentRequired=(%s) consentOptional=(%s) requiredFeaturesRequested=(%s) optionalFeaturesRequested=(%s)",
             originStr, webKitXRSessionModeToString(mode), grantedFeatures, consentRequiredFeatures, consentOptionalFeatures, requiredFeaturesRequested, optionalFeaturesRequested);
         /* Needs UI to select optional features to grant */
-        webkit_xr_permission_request_set_granted_consent_optional_features(xrRequest, webkit_xr_permission_request_get_consent_optional_features(xrRequest));
+        webkit_xr_permission_request_set_granted_optional_features(xrRequest, webkit_xr_permission_request_get_consent_optional_features(xrRequest));
     } else {
         g_print("%s request not handled\n", G_OBJECT_TYPE_NAME(request));
         return FALSE;

--- a/Tools/MiniBrowser/wpe/main.cpp
+++ b/Tools/MiniBrowser/wpe/main.cpp
@@ -270,7 +270,7 @@ static gboolean decidePermissionRequest(WebKitWebView *, WebKitPermissionRequest
     if (WEBKIT_IS_XR_PERMISSION_REQUEST(request)) {
         WebKitXRPermissionRequest* xrRequest = WEBKIT_XR_PERMISSION_REQUEST(request);
         /* Grant all optional features */
-        webkit_xr_permission_request_set_granted_consent_optional_features(xrRequest, webkit_xr_permission_request_get_consent_optional_features(xrRequest));
+        webkit_xr_permission_request_set_granted_optional_features(xrRequest, webkit_xr_permission_request_get_consent_optional_features(xrRequest));
     }
 
     webkit_permission_request_allow(request);


### PR DESCRIPTION
#### d2e5b82f71e84f1d1a1799617f35d32f6453bda7
<pre>
[GTK][WPE] Rename webkit_xr_permission_request_set_granted_consent_optional_features API
<a href="https://bugs.webkit.org/show_bug.cgi?id=299414">https://bugs.webkit.org/show_bug.cgi?id=299414</a>

Reviewed by Adrian Perez de Castro.

The API name is too long. Renamed
webkit_xr_permission_request_set_granted_consent_optional_features
webkit_xr_permission_request_set_granted_optional_features.

* Source/WebKit/UIProcess/API/glib/WebKitXRPermissionRequest.cpp:
(webkit_xr_permission_request_set_granted_optional_features):
(webkit_xr_permission_request_set_granted_consent_optional_features): Deleted.
* Source/WebKit/UIProcess/API/glib/WebKitXRPermissionRequest.h.in:
* Tools/MiniBrowser/gtk/BrowserTab.c:
(decidePermissionRequest):
* Tools/MiniBrowser/wpe/main.cpp:
(decidePermissionRequest):

Canonical link: <a href="https://commits.webkit.org/300484@main">https://commits.webkit.org/300484@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e09e93845ac9ed5a2ce7453c32021e9354219b73

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122651 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42363 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33053 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/129264 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74755 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/124527 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43082 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50956 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93221 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61905 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125603 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34343 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109802 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73865 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33330 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27958 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72749 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104040 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28169 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131995 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49596 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37746 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101757 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49972 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106018 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101622 "Found 2 new API test failures: TestWTF:CompletionHandlerDeathTest.MainThreadHandlerOnThreadAssertsDeathTest, TestWTF:CompletionHandlerDeathTest.ConstructionThreadHandlerOnThreadAssertsDeathTest (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46987 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25153 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/46366 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19378 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49453 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/55206 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48920 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/52272 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50603 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->