### PR TITLE
NativeImages are slow to create from remote contexts

### DIFF
--- a/Source/WebCore/platform/graphics/Gradient.cpp
+++ b/Source/WebCore/platform/graphics/Gradient.cpp
@@ -51,8 +51,8 @@ Gradient::Gradient(Data&& data, ColorInterpolationMethod colorInterpolationMetho
 
 Gradient::~Gradient()
 {
-    for (auto& observer : m_observers)
-        observer.willDestroyGradient(*this);
+    for (CheckedRef observer : m_observers)
+        observer->willDestroyGradient(*this);
 }
 
 void Gradient::adjustParametersForTiledDrawing(FloatSize& size, FloatRect& srcRect, const FloatSize& spacing)

--- a/Source/WebCore/platform/graphics/NativeImage.cpp
+++ b/Source/WebCore/platform/graphics/NativeImage.cpp
@@ -37,29 +37,28 @@ namespace WebCore {
 WTF_MAKE_TZONE_ALLOCATED_IMPL(NativeImage);
 
 #if !USE(CG)
-RefPtr<NativeImage> NativeImage::create(PlatformImagePtr&& platformImage, RenderingResourceIdentifier identifier)
+RefPtr<NativeImage> NativeImage::create(PlatformImagePtr&& platformImage)
 {
     if (!platformImage)
         return nullptr;
-    return adoptRef(*new NativeImage(WTFMove(platformImage), identifier));
+    return adoptRef(*new NativeImage(WTFMove(platformImage)));
 }
 
-RefPtr<NativeImage> NativeImage::createTransient(PlatformImagePtr&& image, RenderingResourceIdentifier identifier)
+RefPtr<NativeImage> NativeImage::createTransient(PlatformImagePtr&& image)
 {
-    return create(WTFMove(image), identifier);
+    return create(WTFMove(image));
 }
 #endif
 
-NativeImage::NativeImage(PlatformImagePtr&& platformImage, RenderingResourceIdentifier renderingResourceIdentifier)
+NativeImage::NativeImage(PlatformImagePtr&& platformImage)
     : m_platformImage(WTFMove(platformImage))
-    , m_renderingResourceIdentifier(renderingResourceIdentifier)
 {
 }
 
 NativeImage::~NativeImage()
 {
-    for (auto& observer : m_observers)
-        observer.willDestroyNativeImage(*this);
+    for (CheckedRef observer : m_observers)
+        observer->willDestroyNativeImage(*this);
 }
 
 const PlatformImagePtr& NativeImage::platformImage() const

--- a/Source/WebCore/platform/graphics/NativeImage.h
+++ b/Source/WebCore/platform/graphics/NativeImage.h
@@ -44,21 +44,20 @@ class NativeImageBackend;
 struct Headroom;
 struct ImagePaintingOptions;
 
-class NativeImage final : public ThreadSafeRefCounted<NativeImage> {
+class NativeImage : public ThreadSafeRefCounted<NativeImage> {
     WTF_MAKE_TZONE_ALLOCATED(NativeImage);
 public:
-    static WEBCORE_EXPORT RefPtr<NativeImage> create(PlatformImagePtr&&, RenderingResourceIdentifier = RenderingResourceIdentifier::generate());
+    static WEBCORE_EXPORT RefPtr<NativeImage> create(PlatformImagePtr&&);
     // Creates a NativeImage that is intended to be drawn once or only few times. Signals the platform to avoid generating any caches for the image.
-    static WEBCORE_EXPORT RefPtr<NativeImage> createTransient(PlatformImagePtr&&, RenderingResourceIdentifier = RenderingResourceIdentifier::generate());
+    static WEBCORE_EXPORT RefPtr<NativeImage> createTransient(PlatformImagePtr&&);
 
-    WEBCORE_EXPORT ~NativeImage();
+    WEBCORE_EXPORT virtual ~NativeImage();
 
-    WEBCORE_EXPORT const PlatformImagePtr& platformImage() const;
-
-    WEBCORE_EXPORT IntSize size() const;
-    bool hasAlpha() const;
+    WEBCORE_EXPORT virtual const PlatformImagePtr& platformImage() const;
+    WEBCORE_EXPORT virtual IntSize size() const;
+    WEBCORE_EXPORT virtual bool hasAlpha() const;
     std::optional<Color> singlePixelSolidColor() const;
-    WEBCORE_EXPORT DestinationColorSpace colorSpace() const;
+    WEBCORE_EXPORT virtual DestinationColorSpace colorSpace() const;
     WEBCORE_EXPORT bool hasHDRContent() const;
     WEBCORE_EXPORT Headroom headroom() const;
 
@@ -81,11 +80,11 @@ public:
     }
 
 protected:
-    NativeImage(PlatformImagePtr&&, RenderingResourceIdentifier);
+    WEBCORE_EXPORT NativeImage(PlatformImagePtr&&);
 
-    PlatformImagePtr m_platformImage;
+    mutable PlatformImagePtr m_platformImage;
     mutable WeakHashSet<RenderingResourceObserver> m_observers;
-    RenderingResourceIdentifier m_renderingResourceIdentifier;
+    RenderingResourceIdentifier m_renderingResourceIdentifier { RenderingResourceIdentifier::generate() };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/RenderingResource.h
+++ b/Source/WebCore/platform/graphics/RenderingResource.h
@@ -30,28 +30,28 @@
 #include <wtf/WeakHashSet.h>
 
 namespace WebCore {
-class RenderingResourceObserver;
 namespace DisplayList {
 class DisplayList;
 }
 class Gradient;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::RenderingResourceObserver> : std::true_type { };
-}
-
-namespace WebCore {
 class NativeImage;
 
-class RenderingResourceObserver : public CanMakeWeakPtr<RenderingResourceObserver> {
+class RenderingResourceObserver {
 public:
+    using WeakValueType = RenderingResourceObserver;
     virtual ~RenderingResourceObserver() = default;
+
+    // CheckedPtr interface.
+    virtual uint32_t checkedPtrCount() const = 0;
+    virtual uint32_t checkedPtrCountWithoutThreadCheck() const = 0;
+    virtual void incrementCheckedPtrCount() const = 0;
+    virtual void decrementCheckedPtrCount() const = 0;
+
     virtual void willDestroyNativeImage(const NativeImage&) = 0;
     virtual void willDestroyGradient(const Gradient&) = 0;
     virtual void willDestroyFilter(RenderingResourceIdentifier) = 0;
     virtual void willDestroyDisplayList(const DisplayList::DisplayList&) = 0;
+
 protected:
     RenderingResourceObserver() = default;
 };

--- a/Source/WebCore/platform/graphics/cg/NativeImageCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/NativeImageCG.cpp
@@ -38,16 +38,16 @@
 namespace WebCore {
 
 
-RefPtr<NativeImage> NativeImage::create(PlatformImagePtr&& image, RenderingResourceIdentifier renderingResourceIdentifier)
+RefPtr<NativeImage> NativeImage::create(PlatformImagePtr&& image)
 {
     if (!image)
         return nullptr;
     if (CGImageGetWidth(image.get()) > std::numeric_limits<int>::max() || CGImageGetHeight(image.get()) > std::numeric_limits<int>::max())
         return nullptr;
-    return adoptRef(*new NativeImage(WTFMove(image), renderingResourceIdentifier));
+    return adoptRef(*new NativeImage(WTFMove(image)));
 }
 
-RefPtr<NativeImage> NativeImage::createTransient(PlatformImagePtr&& image, RenderingResourceIdentifier identifier)
+RefPtr<NativeImage> NativeImage::createTransient(PlatformImagePtr&& image)
 {
     if (!image)
         return nullptr;
@@ -59,7 +59,7 @@ RefPtr<NativeImage> NativeImage::createTransient(PlatformImagePtr&& image, Rende
         return nullptr;
     image = nullptr;
     CGImageSetCachingFlags(transientImage.get(), kCGImageCachingTransient);
-    return create(WTFMove(transientImage), identifier);
+    return create(WTFMove(transientImage));
 }
 
 IntSize NativeImage::size() const

--- a/Source/WebCore/platform/graphics/displaylists/DisplayList.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayList.cpp
@@ -46,8 +46,8 @@ DisplayList::DisplayList(Vector<Item>&& items)
 
 DisplayList::~DisplayList()
 {
-    for (auto& observer : m_observers)
-        observer.willDestroyDisplayList(*this);
+    for (CheckedRef observer : m_observers)
+        observer->willDestroyDisplayList(*this);
 }
 
 String DisplayList::asText(OptionSet<AsTextFlag> flags) const

--- a/Source/WebCore/platform/graphics/filters/FilterFunction.cpp
+++ b/Source/WebCore/platform/graphics/filters/FilterFunction.cpp
@@ -40,8 +40,8 @@ FilterFunction::FilterFunction(Type filterType, std::optional<RenderingResourceI
 
 FilterFunction::~FilterFunction()
 {
-    for (auto& observer : m_observers)
-        observer.willDestroyFilter(renderingResourceIdentifier());
+    for (CheckedRef observer : m_observers)
+        observer->willDestroyFilter(renderingResourceIdentifier());
 }
 
 AtomString FilterFunction::filterName(Type filterType)

--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.cpp
@@ -132,29 +132,14 @@ void RemoteImageBuffer::putPixelBuffer(const WebCore::PixelBufferSourceView& pix
     m_imageBuffer->putPixelBuffer(pixelBuffer, srcRect, destPoint, destFormat);
 }
 
-void RemoteImageBuffer::getShareableBitmap(WebCore::PreserveResolution preserveResolution, CompletionHandler<void(std::optional<WebCore::ShareableBitmap::Handle>&&)>&& completionHandler)
+void RemoteImageBuffer::copyNativeImage(RenderingResourceIdentifier imageIdentifier)
 {
     assertIsCurrent(workQueue());
-    std::optional<WebCore::ShareableBitmap::Handle> handle = [&]() -> std::optional<WebCore::ShareableBitmap::Handle> {
-        Ref<WebCore::ImageBuffer> imageBuffer = m_imageBuffer;
-        auto backendSize = imageBuffer->backendSize();
-        auto logicalSize = imageBuffer->logicalSize();
-        auto resultSize = preserveResolution == WebCore::PreserveResolution::Yes ? backendSize : imageBuffer->truncatedLogicalSize();
-        if (resultSize.isEmpty())
-            return std::nullopt;
-        auto bitmap = WebCore::ShareableBitmap::create({ resultSize, imageBuffer->colorSpace() });
-        if (!bitmap)
-            return std::nullopt;
-        auto handle = bitmap->createHandle();
-        if (m_renderingBackend->sharedResourceCache().resourceOwner())
-            handle->setOwnershipOfMemory(m_renderingBackend->sharedResourceCache().resourceOwner(), WebCore::MemoryLedger::Graphics);
-        auto context = bitmap->createGraphicsContext();
-        if (!context)
-            return std::nullopt;
-        context->drawImageBuffer(imageBuffer.get(), WebCore::FloatRect { { }, resultSize }, WebCore::FloatRect { { }, logicalSize }, { WebCore::CompositeOperator::Copy });
-        return handle;
-    }();
-    completionHandler(WTFMove(handle));
+    RefPtr image = m_imageBuffer->copyNativeImage();
+    // FIXME: Handle OOM.
+    MESSAGE_CHECK(image, "OOM");
+    bool success = m_renderingBackend->remoteResourceCache().cacheNativeImage(imageIdentifier, image.releaseNonNull());
+    MESSAGE_CHECK(success, "NativeImage already exists");
 }
 
 void RemoteImageBuffer::filteredNativeImage(Ref<WebCore::Filter> filter, CompletionHandler<void(std::optional<WebCore::ShareableBitmap::Handle>&&)>&& completionHandler)

--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.h
@@ -69,7 +69,7 @@ private:
     void getPixelBuffer(WebCore::PixelBufferFormat, WebCore::IntPoint srcPoint, WebCore::IntSize srcSize, CompletionHandler<void()>&&);
     void getPixelBufferWithNewMemory(WebCore::SharedMemory::Handle&&, WebCore::PixelBufferFormat, WebCore::IntPoint srcPoint, WebCore::IntSize srcSize, CompletionHandler<void()>&&);
     void putPixelBuffer(const WebCore::PixelBufferSourceView&, WebCore::IntPoint srcPoint, WebCore::IntSize srcSize, WebCore::IntPoint destPoint, WebCore::AlphaPremultiplication destFormat);
-    void getShareableBitmap(WebCore::PreserveResolution, CompletionHandler<void(std::optional<WebCore::ShareableBitmap::Handle>&&)>&&);
+    void copyNativeImage(WebCore::RenderingResourceIdentifier imageIdentifier);
     void filteredNativeImage(Ref<WebCore::Filter>, CompletionHandler<void(std::optional<WebCore::ShareableBitmap::Handle>&&)>&&);
     void convertToLuminanceMask();
     void transformToColorSpace(const WebCore::DestinationColorSpace&);

--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.messages.in
@@ -32,7 +32,7 @@ messages -> RemoteImageBuffer Stream {
     GetPixelBuffer(struct WebCore::PixelBufferFormat outputFormat, WebCore::IntPoint srcPoint, WebCore::IntSize srcSize) -> () Synchronous
     GetPixelBufferWithNewMemory(WebCore::SharedMemory::Handle handle, struct WebCore::PixelBufferFormat outputFormat, WebCore::IntPoint srcPoint, WebCore::IntSize srcSize) -> () Synchronous NotStreamEncodable
     PutPixelBuffer(WebCore::PixelBufferSourceView pixelBuffer, WebCore::IntPoint srcPoint, WebCore::IntSize srcSize, WebCore::IntPoint destPoint, enum:uint8_t WebCore::AlphaPremultiplication destFormat) StreamBatched
-    GetShareableBitmap(enum:bool WebCore::PreserveResolution preserveResolution) -> (std::optional<WebCore::ShareableBitmapHandle> handle) Synchronous NotStreamEncodableReply
+    CopyNativeImage(WebCore::RenderingResourceIdentifier image)
     FilteredNativeImage(Ref<WebCore::Filter> filter) -> (std::optional<WebCore::ShareableBitmapHandle> handle) Synchronous NotStreamEncodableReply
     ConvertToLuminanceMask()
     TransformToColorSpace(WebCore::DestinationColorSpace colorSpace)

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
@@ -157,6 +157,7 @@ private:
     void sinkDisplayListRecorderIntoDisplayList(RemoteDisplayListRecorderIdentifier, RemoteDisplayListIdentifier);
     void releaseDisplayList(RemoteDisplayListIdentifier);
     void destroyGetPixelBufferSharedMemory();
+    void nativeImageBitmap(WebCore::RenderingResourceIdentifier imageIdentifier, CompletionHandler<void(std::optional<WebCore::ShareableBitmap::Handle>)>&&);
     void cacheNativeImage(WebCore::ShareableBitmap::Handle&&, WebCore::RenderingResourceIdentifier);
     void releaseNativeImage(WebCore::RenderingResourceIdentifier);
     void cacheGradient(Ref<WebCore::Gradient>&&, RemoteGradientIdentifier);

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in
@@ -35,6 +35,7 @@ messages -> RemoteRenderingBackend Stream {
     ReleaseDisplayList(WebKit::RemoteDisplayListIdentifier identifier)
     GetImageBufferResourceLimitsForTesting() -> (struct WebCore::ImageBufferResourceLimits limits) Async
     DestroyGetPixelBufferSharedMemory()
+    NativeImageBitmap(WebCore::RenderingResourceIdentifier identifier) -> (std::optional<WebCore::ShareableBitmapHandle> handle) Synchronous NotStreamEncodableReply
     CacheNativeImage(WebCore::ShareableBitmapHandle handle, WebCore::RenderingResourceIdentifier renderingResourceIdentifier) NotStreamEncodable
     ReleaseNativeImage(WebCore::RenderingResourceIdentifier identifier)
     CacheFont(struct WebCore::FontInternalAttributes data, struct WebCore::FontPlatformDataAttributes platformData, std::optional<WebCore::RenderingResourceIdentifier> renderingResourceIdentifier) NotStreamEncodable

--- a/Source/WebKit/GPUProcess/graphics/RemoteResourceCache.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteResourceCache.cpp
@@ -42,10 +42,9 @@ RemoteResourceCache::RemoteResourceCache() = default;
 
 RemoteResourceCache::~RemoteResourceCache() = default;
 
-void RemoteResourceCache::cacheNativeImage(Ref<NativeImage>&& image)
+bool RemoteResourceCache::cacheNativeImage(WebCore::RenderingResourceIdentifier identifier, Ref<NativeImage>&& image)
 {
-    auto identifier = image->renderingResourceIdentifier();
-    m_nativeImages.add(identifier, WTFMove(image));
+    return m_nativeImages.add(identifier, WTFMove(image)).isNewEntry;
 }
 
 bool RemoteResourceCache::releaseNativeImage(RenderingResourceIdentifier identifier)

--- a/Source/WebKit/GPUProcess/graphics/RemoteResourceCache.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteResourceCache.h
@@ -52,7 +52,7 @@ public:
     RemoteResourceCache();
     ~RemoteResourceCache();
 
-    void cacheNativeImage(Ref<WebCore::NativeImage>&&);
+    bool cacheNativeImage(WebCore::RenderingResourceIdentifier, Ref<WebCore::NativeImage>&&);
     bool releaseNativeImage(WebCore::RenderingResourceIdentifier);
     RefPtr<WebCore::NativeImage> cachedNativeImage(WebCore::RenderingResourceIdentifier) const;
 

--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -797,6 +797,7 @@ WebProcess/GPU/graphics/RemoteGraphicsContextGLProxyFunctionsGenerated.cpp
 WebProcess/GPU/graphics/RemoteGraphicsContextProxy.cpp
 WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp
 WebProcess/GPU/graphics/RemoteImageBufferSetProxy.cpp
+WebProcess/GPU/graphics/RemoteNativeImageProxy.cpp
 WebProcess/GPU/graphics/RemoteSnapshotRecorderProxy.cpp
 WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
 WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -6806,6 +6806,8 @@
 		7BF128BE2B7E0757001D1B14 /* RemoteSharedResourceCacheProxy.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteSharedResourceCacheProxy.cpp; sourceTree = "<group>"; };
 		7BF19B5F290FC5B400EF322A /* IPCTesterReceiver.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IPCTesterReceiver.h; sourceTree = "<group>"; };
 		7BF19B60290FC5B400EF322A /* IPCTesterReceiver.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = IPCTesterReceiver.cpp; sourceTree = "<group>"; };
+		7BFE47312E8A96FB00F60A1C /* RemoteNativeImageProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteNativeImageProxy.h; sourceTree = "<group>"; };
+		7BFE47322E8A96FB00F60A1C /* RemoteNativeImageProxy.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteNativeImageProxy.cpp; sourceTree = "<group>"; };
 		7C065F2A1C8CD95F00C2D950 /* WebUserContentControllerDataTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebUserContentControllerDataTypes.h; sourceTree = "<group>"; };
 		7C135AA6173B0BCA00586AE2 /* WKPluginInformation.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WKPluginInformation.cpp; sourceTree = "<group>"; };
 		7C135AA7173B0BCA00586AE2 /* WKPluginInformation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKPluginInformation.h; sourceTree = "<group>"; };
@@ -13579,6 +13581,8 @@
 				A78A5FE52B0EE4C3005036D3 /* RemoteImageBufferSetProxy.cpp */,
 				A78A5FE62B0EE4C3005036D3 /* RemoteImageBufferSetProxy.h */,
 				A7B94DE32B5D9DBB0058780B /* RemoteImageBufferSetProxy.messages.in */,
+				7BFE47322E8A96FB00F60A1C /* RemoteNativeImageProxy.cpp */,
+				7BFE47312E8A96FB00F60A1C /* RemoteNativeImageProxy.h */,
 				5506409D2407160900AAE045 /* RemoteRenderingBackendProxy.cpp */,
 				5506409E2407160900AAE045 /* RemoteRenderingBackendProxy.h */,
 				550640A0240719E100AAE045 /* RemoteRenderingBackendProxy.messages.in */,

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h
@@ -106,8 +106,8 @@ private:
     void prepareForBackingStoreChange();
 
     void assertDispatcherIsCurrent() const;
-    template<typename T> void send(T&& message);
-    template<typename T> auto sendSync(T&& message);
+    template<typename T> void send(T&& message) const;
+    template<typename T> auto sendSync(T&& message) const;
     RefPtr<IPC::StreamClientConnection> connection() const;
     void didBecomeUnresponsive() const;
 

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteNativeImageProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteNativeImageProxy.cpp
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "RemoteNativeImageProxy.h"
+
+#if ENABLE(GPU_PROCESS)
+
+#include <WebCore/Color.h>
+#include <WebCore/GraphicsContext.h>
+#include <WebCore/ImageBuffer.h>
+#include <wtf/TZoneMallocInlines.h>
+
+namespace WebKit {
+using namespace WebCore;
+
+RemoteNativeImageProxyClient::RemoteNativeImageProxyClient() = default;
+
+RemoteNativeImageProxyClient::~RemoteNativeImageProxyClient() = default;
+
+static PlatformImagePtr placeholderPlatformImage()
+{
+    static LazyNeverDestroyed<PlatformImagePtr> image;
+    static std::once_flag onceFlag;
+    std::call_once(onceFlag, [] {
+        // Currently we return a placeholder that does not match the NativeImage
+        // size, colorspace, isAlpha properties.
+        RefPtr buffer = ImageBuffer::create(FloatSize { 1, 1 }, RenderingMode::Unaccelerated, RenderingPurpose::Unspecified, 1, DestinationColorSpace::SRGB(), ImageBufferFormat { PixelFormat::BGRA8 });
+        RELEASE_ASSERT(buffer);
+        buffer->context().fillRect({ 0, 0, 1, 1 }, Color::black);
+        RefPtr nativeImage = ImageBuffer::sinkIntoNativeImage(WTFMove(buffer));
+        RELEASE_ASSERT(nativeImage);
+        image.construct(nativeImage->platformImage());
+    });
+    return image;
+}
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteNativeImageProxy);
+
+Ref<RemoteNativeImageProxy> RemoteNativeImageProxy::create(const IntSize& size, PlatformColorSpace&& colorSpace, bool hasAlpha, WeakRef<RemoteNativeImageProxyClient>&& client)
+{
+    return adoptRef(*new RemoteNativeImageProxy(size, WTFMove(colorSpace), hasAlpha, WTFMove(client)));
+}
+
+RemoteNativeImageProxy::RemoteNativeImageProxy(const IntSize& size, PlatformColorSpace&& colorSpace, bool hasAlpha, WeakRef<RemoteNativeImageProxyClient>&& client)
+    : NativeImage(nullptr)
+    , m_client(WTFMove(client))
+    , m_size(size)
+    , m_colorSpace(WTFMove(colorSpace))
+    , m_hasAlpha(hasAlpha)
+{
+}
+
+RemoteNativeImageProxy::~RemoteNativeImageProxy()
+{
+    if (CheckedPtr client = m_client.get())
+        client->willDestroyRemoteNativeImageProxy(*this);
+}
+
+const PlatformImagePtr& RemoteNativeImageProxy::platformImage() const
+{
+    if (!m_platformImage) {
+        if (CheckedPtr client = m_client.get())
+            m_platformImage = client->platformImage(*this);
+    }
+    // The callers do not expect !platformImage().
+    if (!m_platformImage)
+        m_platformImage = placeholderPlatformImage();
+    return m_platformImage;
+}
+
+IntSize RemoteNativeImageProxy::size() const
+{
+    return m_size;
+}
+
+bool RemoteNativeImageProxy::hasAlpha() const
+{
+    return m_hasAlpha;
+}
+
+DestinationColorSpace RemoteNativeImageProxy::colorSpace() const
+{
+    // FIXME: Images are not in destination color space, they are in any color space.
+    return DestinationColorSpace { m_colorSpace };
+}
+
+}
+
+#endif

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteNativeImageProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteNativeImageProxy.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(GPU_PROCESS)
+
+#include <WebCore/IntSize.h>
+#include <WebCore/NativeImage.h>
+#include <WebCore/PlatformColorSpace.h>
+
+namespace WebKit {
+
+class RemoteNativeImageProxy;
+
+class RemoteNativeImageProxyClient {
+public:
+    using WeakValueType = RemoteNativeImageProxyClient;
+    virtual ~RemoteNativeImageProxyClient();
+
+    // CheckedPtr interface.
+    virtual uint32_t checkedPtrCount() const = 0;
+    virtual uint32_t checkedPtrCountWithoutThreadCheck() const = 0;
+    virtual void incrementCheckedPtrCount() const = 0;
+    virtual void decrementCheckedPtrCount() const = 0;
+
+    virtual void willDestroyRemoteNativeImageProxy(const RemoteNativeImageProxy&) = 0;
+    virtual WebCore::PlatformImagePtr platformImage(const RemoteNativeImageProxy&) = 0;
+
+protected:
+    RemoteNativeImageProxyClient();
+};
+
+class RemoteNativeImageProxy final : public WebCore::NativeImage {
+    WTF_MAKE_TZONE_ALLOCATED(RemoteNativeImageProxy);
+public:
+    static Ref<RemoteNativeImageProxy> create(const WebCore::IntSize&, WebCore::PlatformColorSpace&&, bool hasAlpha, WeakRef<RemoteNativeImageProxyClient>&&);
+    ~RemoteNativeImageProxy() override;
+    const WebCore::PlatformImagePtr& platformImage() const override;
+    WebCore::IntSize size() const override;
+    bool hasAlpha() const override;
+    WebCore::DestinationColorSpace colorSpace() const override;
+
+private:
+    RemoteNativeImageProxy(const WebCore::IntSize&, WebCore::PlatformColorSpace&&, bool hasAlpha, WeakRef<RemoteNativeImageProxyClient>&&);
+
+    WeakPtr<RemoteNativeImageProxyClient> m_client;
+    const WebCore::IntSize m_size;
+    const WebCore::PlatformColorSpace m_colorSpace;
+    const bool m_hasAlpha;
+};
+
+}
+
+#endif

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
@@ -182,7 +182,7 @@ void RemoteRenderingBackendProxy::didClose(IPC::Connection&)
     if (!m_connection)
         return;
     disconnectGPUProcess();
-    m_remoteResourceCacheProxy.disconnect();
+    m_remoteResourceCacheProxy->disconnect();
 
     for (auto& weakImageBuffer : m_imageBuffers.values()) {
         RefPtr imageBuffer = weakImageBuffer.get();
@@ -230,7 +230,7 @@ void RemoteRenderingBackendProxy::didBecomeUnresponsive()
 
 unsigned RemoteRenderingBackendProxy::nativeImageCountForTesting() const
 {
-    return m_remoteResourceCacheProxy.nativeImageCountForTesting();
+    return m_remoteResourceCacheProxy->nativeImageCountForTesting();
 }
 
 void RemoteRenderingBackendProxy::disconnectGPUProcess()
@@ -395,9 +395,14 @@ void RemoteRenderingBackendProxy::destroyGetPixelBufferSharedMemory()
     send(Messages::RemoteRenderingBackend::DestroyGetPixelBufferSharedMemory());
 }
 
-RefPtr<ShareableBitmap> RemoteRenderingBackendProxy::getShareableBitmap(RenderingResourceIdentifier imageBuffer, PreserveResolution preserveResolution)
+Ref<NativeImage> RemoteRenderingBackendProxy::createNativeImage(const IntSize& size, PlatformColorSpace&& colorSpace, bool hasAlpha)
 {
-    auto sendResult = sendSync(Messages::RemoteImageBuffer::GetShareableBitmap(preserveResolution), imageBuffer);
+    return m_remoteResourceCacheProxy->createNativeImage(size, WTFMove(colorSpace), hasAlpha);
+}
+
+RefPtr<ShareableBitmap> RemoteRenderingBackendProxy::nativeImageBitmap(const NativeImage& image)
+{
+    auto sendResult = sendSync(Messages::RemoteRenderingBackend::NativeImageBitmap(image.renderingResourceIdentifier()));
     if (!sendResult.succeeded())
         return { };
     auto [handle] = sendResult.takeReply();
@@ -486,7 +491,7 @@ void RemoteRenderingBackendProxy::releaseDisplayList(RemoteDisplayListIdentifier
 
 void RemoteRenderingBackendProxy::releaseMemory()
 {
-    m_remoteResourceCacheProxy.releaseMemory();
+    m_remoteResourceCacheProxy->releaseMemory();
     if (!m_connection)
         return;
     send(Messages::RemoteRenderingBackend::ReleaseMemory());
@@ -494,7 +499,7 @@ void RemoteRenderingBackendProxy::releaseMemory()
 
 void RemoteRenderingBackendProxy::releaseNativeImages()
 {
-    m_remoteResourceCacheProxy.releaseNativeImages();
+    m_remoteResourceCacheProxy->releaseNativeImages();
     if (!m_connection)
         return;
     send(Messages::RemoteRenderingBackend::ReleaseNativeImages());
@@ -603,7 +608,7 @@ void RemoteRenderingBackendProxy::finalizeRenderingUpdate()
 
 void RemoteRenderingBackendProxy::didPaintLayers()
 {
-    m_remoteResourceCacheProxy.didPaintLayers();
+    m_remoteResourceCacheProxy->didPaintLayers();
 }
 
 bool RemoteRenderingBackendProxy::dispatchMessage(IPC::Connection& connection, IPC::Decoder& decoder)

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
@@ -95,7 +95,7 @@ public:
 
     static bool canMapRemoteImageBufferBackendBackingStore();
 
-    RemoteResourceCacheProxy& remoteResourceCacheProxy() { return m_remoteResourceCacheProxy; }
+    RemoteResourceCacheProxy& remoteResourceCacheProxy() const { return m_remoteResourceCacheProxy; }
 
     void transferImageBuffer(std::unique_ptr<RemoteSerializedImageBufferProxy>, WebCore::ImageBuffer&);
     std::unique_ptr<RemoteSerializedImageBufferProxy> moveToSerializedBuffer(RemoteImageBufferProxy&);
@@ -106,7 +106,10 @@ public:
     RefPtr<RemoteImageBufferProxy> createImageBuffer(const WebCore::FloatSize&, WebCore::RenderingMode, WebCore::RenderingPurpose, float resolutionScale, const WebCore::DestinationColorSpace&, WebCore::ImageBufferFormat);
     void releaseImageBuffer(RemoteImageBufferProxy&);
     bool getPixelBufferForImageBuffer(WebCore::RenderingResourceIdentifier, const WebCore::PixelBufferFormat& destinationFormat, const WebCore::IntRect& srcRect, std::span<uint8_t> result);
-    RefPtr<WebCore::ShareableBitmap> getShareableBitmap(WebCore::RenderingResourceIdentifier, WebCore::PreserveResolution);
+    // Creates new pending remote NativeImage instance. The image should be associated to the content by the caller.
+    Ref<WebCore::NativeImage> createNativeImage(const WebCore::IntSize&, WebCore::PlatformColorSpace&&, bool hasAlpha);
+    // Returns backing store bitmap for the remote NativeImage.
+    RefPtr<WebCore::ShareableBitmap> nativeImageBitmap(const WebCore::NativeImage&);
     void cacheNativeImage(WebCore::ShareableBitmap::Handle&&, WebCore::RenderingResourceIdentifier);
     void releaseNativeImage(WebCore::RenderingResourceIdentifier);
     void cacheFont(const WebCore::Font::Attributes&, const WebCore::FontPlatformDataAttributes&, std::optional<WebCore::RenderingResourceIdentifier>);
@@ -221,7 +224,7 @@ private:
     RefPtr<IPC::StreamClientConnection> m_connection;
     RefPtr<RemoteSharedResourceCacheProxy> m_sharedResourceCache;
     RemoteRenderingBackendIdentifier m_identifier { RemoteRenderingBackendIdentifier::generate() };
-    RemoteResourceCacheProxy m_remoteResourceCacheProxy { *this };
+    const UniqueRef<RemoteResourceCacheProxy> m_remoteResourceCacheProxy { RemoteResourceCacheProxy::create(*this) };
     RefPtr<WebCore::SharedMemory> m_getPixelBufferSharedMemory;
     WebCore::Timer m_destroyGetPixelBufferSharedMemoryTimer { *this, &RemoteRenderingBackendProxy::destroyGetPixelBufferSharedMemory };
     HashMap<MarkSurfacesAsVolatileRequestIdentifier, CompletionHandler<void(bool)>> m_markAsVolatileRequests;

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp
@@ -34,6 +34,7 @@
 #include "RemoteRenderingBackendProxy.h"
 #include "WebProcess.h"
 #include <WebCore/FontCustomPlatformData.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 using namespace WebCore;
@@ -74,7 +75,12 @@ static std::optional<CreateShareableBitmapResult> createShareableBitmapForNative
     return CreateShareableBitmapResult { bitmap.releaseNonNull(), WTFMove(platformImage) };
 }
 
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteResourceCacheProxy);
 
+UniqueRef<RemoteResourceCacheProxy> RemoteResourceCacheProxy::create(RemoteRenderingBackendProxy& remoteRenderingBackendProxy)
+{
+    return UniqueRef<RemoteResourceCacheProxy> { *new RemoteResourceCacheProxy(remoteRenderingBackendProxy) };
+}
 
 RemoteResourceCacheProxy::RemoteResourceCacheProxy(RemoteRenderingBackendProxy& remoteRenderingBackendProxy)
     : m_remoteRenderingBackendProxy(remoteRenderingBackendProxy)
@@ -83,6 +89,14 @@ RemoteResourceCacheProxy::RemoteResourceCacheProxy(RemoteRenderingBackendProxy& 
 
 RemoteResourceCacheProxy::~RemoteResourceCacheProxy()
 {
+}
+
+Ref<NativeImage> RemoteResourceCacheProxy::createNativeImage(const IntSize& size, PlatformColorSpace&& colorSpace, bool hasAlpha)
+{
+    WeakRef weakThis = m_remoteNativeImageProxyClientWeakFactory.createWeakPtr(static_cast<RemoteNativeImageProxyClient&>(*this)).releaseNonNull();
+    Ref nativeImage = RemoteNativeImageProxy::create(size, WTFMove(colorSpace), hasAlpha, WTFMove(weakThis));
+    m_nativeImages.add(nativeImage.ptr(), NativeImageEntry { nullptr, true });
+    return nativeImage;
 }
 
 RemoteGradientIdentifier RemoteResourceCacheProxy::recordGradientUse(Gradient& gradient)
@@ -208,6 +222,27 @@ void RemoteResourceCacheProxy::willDestroyNativeImage(const NativeImage& image)
     if (!entry->existsInRemote)
         return;
     m_remoteRenderingBackendProxy->releaseNativeImage(image.renderingResourceIdentifier());
+}
+
+void RemoteResourceCacheProxy::willDestroyRemoteNativeImageProxy(const RemoteNativeImageProxy& image)
+{
+    willDestroyNativeImage(image);
+}
+
+PlatformImagePtr RemoteResourceCacheProxy::platformImage(const RemoteNativeImageProxy& image)
+{
+    auto it = m_nativeImages.find(&image);
+    RELEASE_ASSERT(it != m_nativeImages.end());
+    auto& entry = it->value;
+    if (!entry.existsInRemote)
+        return nullptr;
+    if (!entry.bitmap) {
+        auto bitmap = m_remoteRenderingBackendProxy->nativeImageBitmap(image);
+        if (!bitmap)
+            return nullptr;
+        entry.bitmap = WTFMove(bitmap);
+    }
+    return RefPtr { entry.bitmap }->createPlatformImage();
 }
 
 void RemoteResourceCacheProxy::willDestroyGradient(const Gradient& gradient)


### PR DESCRIPTION
#### 827b5833cabfb4d2444d2c4da95c8489fd4fcdc3
<pre>
NativeImages are slow to create from remote contexts
<a href="https://bugs.webkit.org/show_bug.cgi?id=266215">https://bugs.webkit.org/show_bug.cgi?id=266215</a>
<a href="https://rdar.apple.com/119489233">rdar://119489233</a>

Reviewed by Matt Woodrow.

RemoteImageBufferProxy::copyNativeImage() would transfer the rendering
from GPUP to WCP. This was slow, and in turn lead to introduction of
ImageBuffer as a source for all types of bitmap draws, since this
resource exist in GPUP. This in turn is problematic, as ImageBuffers
are inherently mutable and as such cannot be shared. ImageBuffer is
a draw target type of abstraction, where as NativeImage is draw source
type of abstraction.

Fix this by implementing RemoteImageBufferProxy::copyNativeImage()
as a command that creates the NativeImage in GPUP and returns a
RemoteNativeImageProxy for WCP code. The image is
constructed in GPUP and can be referred to in all the draw operations
taking NativeImage. If the image data is used locally, the
data is synchronized from GPUP to WCP at that point.

Since RemoteNativeImageProxyClient is using WeakPtrs similar to existing
RenderingResourceObserver, convert RemoteResourceCacheProxy as a
heap allocated type that can be used with CheckedPtr. Fix the tech
debt in RenderingResourceObserver, and make it CheckedPtr type instead
of opting in for smart pointer rule exception.

This commit introduces a edge-case regression where a GPUP process
crash will lose the GPUP-side NativeImage data in case it was not
explicitly used in WCP before. Currently there are no call sites that
form long-term references. Later commits will introduce best-effort
synchronization where the long-term held NativeImage data is
sent from GPUP to WCP.

Not many call sites use NativeImages. ImageBitmap is one such case.
This speeds up PerformanceTests/Canvas/drawImageSourceImageBitmapCanvas2D.html
from 850ms to 650ms, but future commits will improve this substantially
more.

This is first commit in a series that will convert all image source
holders to use NativeImage, improving performance and resource use.
In future commits, NativeImage will be also made thread-safe, so that
instances references can be shared as well as passed freely across
threads.

* Source/WebCore/platform/graphics/Gradient.cpp:
(WebCore::Gradient::~Gradient):
* Source/WebCore/platform/graphics/NativeImage.cpp:
(WebCore::NativeImage::create):
(WebCore::NativeImage::createTransient):
(WebCore::NativeImage::NativeImage):
(WebCore::NativeImage::~NativeImage):
* Source/WebCore/platform/graphics/NativeImage.h:
* Source/WebCore/platform/graphics/RenderingResource.h:
* Source/WebCore/platform/graphics/cg/NativeImageCG.cpp:
(WebCore::NativeImage::create):
(WebCore::NativeImage::createTransient):
* Source/WebCore/platform/graphics/displaylists/DisplayList.cpp:
(WebCore::DisplayList::DisplayList::~DisplayList):
* Source/WebCore/platform/graphics/filters/FilterFunction.cpp:
(WebCore::FilterFunction::~FilterFunction):
* Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.cpp:
(WebKit::RemoteImageBuffer::copyNativeImage):
(WebKit::RemoteImageBuffer::getShareableBitmap): Deleted.
* Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.h:
* Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.messages.in:
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp:
(WebKit::RemoteRenderingBackend::nativeImageBitmap):
(WebKit::RemoteRenderingBackend::cacheNativeImage):
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h:
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in:
* Source/WebKit/GPUProcess/graphics/RemoteResourceCache.cpp:
(WebKit::RemoteResourceCache::cacheNativeImage):
* Source/WebKit/GPUProcess/graphics/RemoteResourceCache.h:
* Source/WebKit/Sources.txt:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp:
(WebKit::RemoteImageBufferProxy::send const):
(WebKit::RemoteImageBufferProxy::sendSync const):
(WebKit::RemoteImageBufferProxy::copyNativeImage const):
(WebKit::RemoteImageBufferProxy::send): Deleted.
(WebKit::RemoteImageBufferProxy::sendSync): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteNativeImageProxy.cpp: Added.
(WebKit::placeholderPlatformImage):
(WebKit::RemoteNativeImageProxy::create):
(WebKit::RemoteNativeImageProxy::RemoteNativeImageProxy):
(WebKit::RemoteNativeImageProxy::~RemoteNativeImageProxy):
(WebKit::RemoteNativeImageProxy::platformImage const):
(WebKit::RemoteNativeImageProxy::size const):
(WebKit::RemoteNativeImageProxy::hasAlpha const):
(WebKit::RemoteNativeImageProxy::colorSpace const):
* Source/WebKit/WebProcess/GPU/graphics/RemoteNativeImageProxy.h: Added.
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp:
(WebKit::RemoteRenderingBackendProxy::didClose):
(WebKit::RemoteRenderingBackendProxy::nativeImageCountForTesting const):
(WebKit::RemoteRenderingBackendProxy::createNativeImage):
(WebKit::RemoteRenderingBackendProxy::nativeImageBitmap):
(WebKit::RemoteRenderingBackendProxy::releaseMemory):
(WebKit::RemoteRenderingBackendProxy::releaseNativeImages):
(WebKit::RemoteRenderingBackendProxy::didPaintLayers):
(WebKit::RemoteRenderingBackendProxy::getShareableBitmap): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h:
(WebKit::RemoteRenderingBackendProxy::remoteResourceCacheProxy):
* Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp:
(WebKit::RemoteResourceCacheProxy::create):
(WebKit::RemoteResourceCacheProxy::createNativeImage):
(WebKit::RemoteResourceCacheProxy::willDestroyRemoteNativeImageProxy):
(WebKit::RemoteResourceCacheProxy::platformImage):
* Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h:

Canonical link: <a href="https://commits.webkit.org/300811@main">https://commits.webkit.org/300811@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/97e7b8829fc91c6cf79fd3721520011c67a229c3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123713 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43428 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34124 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130488 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/75859 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b9f5d3ce-7880-4de5-816d-62c74e38e0f6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/125590 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44151 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52022 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94075 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62438 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/010dcea5-8a13-47b9-8e3c-c3a8dbd8c9ce) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126666 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35170 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110672 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74680 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7833dad9-15df-409d-9bef-769dbc033511) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34130 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28832 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73970 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104893 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29055 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133177 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50664 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38573 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102549 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51039 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106894 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102386 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26088 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47730 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25978 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/47576 "Hash 97e7b882 for PR 51251 does not build (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50518 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56280 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49993 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53339 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51667 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->