### PR TITLE
Introduce InternalWritableStreamWriter as a first step towards supporting piping from readable byte streams

### DIFF
--- a/Source/WebCore/Modules/streams/WritableStream.cpp
+++ b/Source/WebCore/Modules/streams/WritableStream.cpp
@@ -102,6 +102,20 @@ void WritableStream::errorIfPossible(Exception&& e)
     m_internalWritableStream->errorIfPossible(WTFMove(e));
 }
 
+WritableStream::State WritableStream::state() const
+{
+    auto* globalObject = m_internalWritableStream->globalObject();
+    if (!globalObject)
+        return State::Errored;
+
+    auto state = m_internalWritableStream->state(*globalObject);
+    if (state == "writable"_s)
+        return State::Writable;
+    if (state == "closed"_s)
+        return State::Closed;
+    return State::Errored;
+}
+
 JSC::JSValue JSWritableStream::abort(JSC::JSGlobalObject& globalObject, JSC::CallFrame& callFrame)
 {
     return wrapped().internalWritableStream().abortForBindings(globalObject, callFrame.argument(0));

--- a/Source/WebCore/Modules/streams/WritableStream.h
+++ b/Source/WebCore/Modules/streams/WritableStream.h
@@ -60,6 +60,9 @@ public:
     };
     virtual Type type() const { return Type::Default; }
 
+    enum class State : uint8_t { Writable, Closed, Errored };
+    State state() const;
+
 protected:
     static ExceptionOr<Ref<WritableStream>> create(JSC::JSGlobalObject&, JSC::JSValue, JSC::JSValue);
     static ExceptionOr<Ref<InternalWritableStream>> createInternalWritableStream(JSDOMGlobalObject&, Ref<WritableStreamSink>&&);

--- a/Source/WebCore/Modules/streams/WritableStreamInternals.js
+++ b/Source/WebCore/Modules/streams/WritableStreamInternals.js
@@ -807,3 +807,27 @@ function writableStreamDefaultControllerWrite(controller, chunk, chunkSize)
         @writableStreamDefaultControllerErrorIfNeeded(controller, e);
     }
 }
+
+function writableStreamState(stream)
+{
+    @assert(@isWritableStream(stream));
+    return @getByIdDirectPrivate(stream, "state");
+}
+
+function writableStreamStoredError(stream)
+{
+    @assert(@isWritableStream(stream));
+    return @getByIdDirectPrivate(stream, "storedError");
+}
+
+function writableStreamDefaultWriterClosedPromise(writer)
+{
+    @assert(@isWritableStreamDefaultWriter(writer));
+    return @getByIdDirectPrivate(writer, "closedPromise").promise;
+}
+
+function writableStreamDefaultWriterReadyPromise(writer)
+{
+    @assert(@isWritableStreamDefaultWriter(writer));
+    return @getByIdDirectPrivate(writer, "readyPromise").promise;
+}

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -646,6 +646,7 @@ bindings/js/IDBBindingUtilities.cpp
 bindings/js/InternalReadableStream.cpp
 bindings/js/InternalReadableStreamDefaultReader.cpp
 bindings/js/InternalWritableStream.cpp
+bindings/js/InternalWritableStreamWriter.cpp
 bindings/js/JSAbortSignalCustom.cpp
 bindings/js/JSAbstractRangeCustom.cpp
 bindings/js/JSAnimationEffectCustom.cpp

--- a/Source/WebCore/bindings/js/InternalWritableStream.h
+++ b/Source/WebCore/bindings/js/InternalWritableStream.h
@@ -50,6 +50,12 @@ public:
     void closeIfPossible();
     void errorIfPossible(Exception&&);
 
+    JSC::JSValue abort(JSC::JSGlobalObject&, JSC::JSValue);
+    String state(JSC::JSGlobalObject& globalObject) const;
+    bool closeQueuedOrInFlight();
+
+    ExceptionOr<JSC::JSValue> storedError() const;
+
 private:
     InternalWritableStream(JSDOMGlobalObject& globalObject, JSC::JSObject& jsObject)
         : DOMGuarded<JSC::JSObject>(globalObject, jsObject)

--- a/Source/WebCore/bindings/js/InternalWritableStreamWriter.cpp
+++ b/Source/WebCore/bindings/js/InternalWritableStreamWriter.cpp
@@ -1,0 +1,232 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "InternalWritableStreamWriter.h"
+
+#include "JSDOMPromise.h"
+#include "WritableStream.h"
+
+namespace WebCore {
+
+static ExceptionOr<JSC::JSValue> invokeWritableStreamWriterFunction(JSC::JSGlobalObject& globalObject, const JSC::Identifier& identifier, const JSC::MarkedArgumentBuffer& arguments)
+{
+    JSC::VM& vm = globalObject.vm();
+    JSC::JSLockHolder lock(vm);
+
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    auto function = globalObject.get(&globalObject, identifier);
+    ASSERT(!!scope.exception() || function.isCallable());
+    scope.assertNoExceptionExceptTermination();
+    RETURN_IF_EXCEPTION(scope, Exception { ExceptionCode::ExistingExceptionError });
+
+    auto callData = JSC::getCallData(function);
+
+    auto result = call(&globalObject, function, callData, JSC::jsUndefined(), arguments);
+    RETURN_IF_EXCEPTION(scope, Exception { ExceptionCode::ExistingExceptionError });
+
+    return result;
+}
+
+ExceptionOr<Ref<InternalWritableStreamWriter>> acquireWritableStreamDefaultWriter(JSDOMGlobalObject& globalObject, WritableStream& destination)
+{
+    auto* clientData = downcast<JSVMClientData>(globalObject.vm().clientData);
+    auto& privateName = clientData->builtinFunctions().writableStreamInternalsBuiltins().acquireWritableStreamDefaultWriterPrivateName();
+
+    JSC::MarkedArgumentBuffer arguments;
+    arguments.append(destination.internalWritableStream());
+
+    auto result = invokeWritableStreamWriterFunction(globalObject, privateName, arguments);
+    if (result.hasException())
+        return Exception { ExceptionCode::ExistingExceptionError };
+
+    ASSERT(result.returnValue().isObject());
+    return InternalWritableStreamWriter::create(globalObject, *result.returnValue().toObject(&globalObject));
+}
+
+int writableStreamDefaultWriterGetDesiredSize(InternalWritableStreamWriter& writer)
+{
+    auto* globalObject = writer.globalObject();
+    if (!globalObject)
+        return 0;
+
+    auto* clientData = downcast<JSVMClientData>(globalObject->vm().clientData);
+    auto& privateName = clientData->builtinFunctions().writableStreamInternalsBuiltins().writableStreamDefaultWriterGetDesiredSizePrivateName();
+
+    JSC::MarkedArgumentBuffer arguments;
+    arguments.append(writer.guardedObject());
+
+    auto result = invokeWritableStreamWriterFunction(*globalObject, privateName, arguments);
+    return result.returnValue().toNumber(globalObject);
+}
+
+RefPtr<DOMPromise> writableStreamDefaultWriterCloseWithErrorPropagation(InternalWritableStreamWriter& writer)
+{
+    auto* globalObject = writer.globalObject();
+    if (!globalObject)
+        return nullptr;
+
+    auto* clientData = downcast<JSVMClientData>(globalObject->vm().clientData);
+    auto& privateName = clientData->builtinFunctions().writableStreamInternalsBuiltins().writableStreamDefaultWriterCloseWithErrorPropagationPrivateName();
+
+    JSC::MarkedArgumentBuffer arguments;
+    arguments.append(writer.guardedObject());
+
+    auto result = invokeWritableStreamWriterFunction(*globalObject, privateName, arguments);
+    if (result.hasException())
+        return nullptr;
+
+    auto* promise = jsCast<JSC::JSPromise*>(result.returnValue());
+    if (!promise)
+        return nullptr;
+
+    return DOMPromise::create(*globalObject, *promise);
+}
+
+void writableStreamDefaultWriterRelease(InternalWritableStreamWriter& writer)
+{
+    auto* globalObject = writer.globalObject();
+    if (!globalObject || !writer.guardedObject())
+        return;
+
+    auto* clientData = downcast<JSVMClientData>(globalObject->vm().clientData);
+    auto& privateName = clientData->builtinFunctions().writableStreamInternalsBuiltins().writableStreamDefaultWriterReleasePrivateName();
+
+    JSC::MarkedArgumentBuffer arguments;
+    arguments.append(writer.guardedObject());
+
+    invokeWritableStreamWriterFunction(*globalObject, privateName, arguments);
+}
+
+RefPtr<DOMPromise> writableStreamDefaultWriterWrite(InternalWritableStreamWriter& writer, JSC::JSValue value)
+{
+    auto* globalObject = writer.globalObject();
+    if (!globalObject)
+        return nullptr;
+
+    auto* clientData = downcast<JSVMClientData>(globalObject->vm().clientData);
+    auto& privateName = clientData->builtinFunctions().writableStreamInternalsBuiltins().writableStreamDefaultWriterWritePrivateName();
+
+    JSC::MarkedArgumentBuffer arguments;
+    arguments.append(writer.guardedObject());
+    arguments.append(value);
+
+    auto result = invokeWritableStreamWriterFunction(*globalObject, privateName, arguments);
+    if (result.hasException())
+        return nullptr;
+
+    auto* promise = jsCast<JSC::JSPromise*>(result.returnValue());
+    if (!promise)
+        return nullptr;
+
+    return DOMPromise::create(*globalObject, *promise);
+}
+
+void InternalWritableStreamWriter::onClosedPromiseRejection(Function<void(JSDOMGlobalObject&, JSC::JSValue)>&& callback)
+{
+    auto* globalObject = this->globalObject();
+    if (!globalObject)
+        return;
+
+    auto* clientData = downcast<JSVMClientData>(globalObject->vm().clientData);
+    auto& privateName = clientData->builtinFunctions().writableStreamInternalsBuiltins().writableStreamDefaultWriterClosedPromisePrivateName();
+
+    JSC::MarkedArgumentBuffer arguments;
+    arguments.append(guardedObject());
+
+    auto result = invokeWritableStreamWriterFunction(*globalObject, privateName, arguments);
+    if (result.hasException())
+        return;
+
+    auto* promise = jsCast<JSC::JSPromise*>(result.returnValue());
+    if (!promise)
+        return;
+
+    Ref domPromise = DOMPromise::create(*globalObject, *promise);
+    domPromise->whenSettled([domPromise, callback = WTFMove(callback)]() mutable {
+        if (domPromise->status() != DOMPromise::Status::Rejected || !domPromise->globalObject())
+            return;
+        callback(*domPromise->globalObject(), domPromise->result());
+    });
+}
+
+void InternalWritableStreamWriter::onClosedPromiseResolution(Function<void()>&& callback)
+{
+    auto* globalObject = this->globalObject();
+    if (!globalObject)
+        return;
+
+    auto* clientData = downcast<JSVMClientData>(globalObject->vm().clientData);
+    auto& privateName = clientData->builtinFunctions().writableStreamInternalsBuiltins().writableStreamDefaultWriterClosedPromisePrivateName();
+
+    JSC::MarkedArgumentBuffer arguments;
+    arguments.append(guardedObject());
+
+    auto result = invokeWritableStreamWriterFunction(*globalObject, privateName, arguments);
+    if (result.hasException())
+        return;
+
+    auto* promise = jsCast<JSC::JSPromise*>(result.returnValue());
+    if (!promise)
+        return;
+
+    Ref domPromise = DOMPromise::create(*globalObject, *promise);
+    domPromise->whenSettled([domPromise, callback = WTFMove(callback)]() mutable {
+        if (domPromise->status() != DOMPromise::Status::Fulfilled)
+            return;
+        callback();
+    });
+}
+
+void InternalWritableStreamWriter::whenReady(Function<void ()>&& callback)
+{
+    auto* globalObject = this->globalObject();
+    if (!globalObject)
+        return;
+
+    auto* clientData = downcast<JSVMClientData>(globalObject->vm().clientData);
+    auto& privateName = clientData->builtinFunctions().writableStreamInternalsBuiltins().writableStreamDefaultWriterReadyPromisePrivateName();
+
+    JSC::MarkedArgumentBuffer arguments;
+    arguments.append(guardedObject());
+
+    auto result = invokeWritableStreamWriterFunction(*globalObject, privateName, arguments);
+    if (result.hasException())
+        return;
+
+    auto* promise = jsCast<JSC::JSPromise*>(result.returnValue());
+    if (!promise)
+        return;
+
+    Ref domPromise = DOMPromise::create(*globalObject, *promise);
+    domPromise->whenSettled([domPromise, callback = WTFMove(callback)]() mutable {
+        if (domPromise->status() != DOMPromise::Status::Fulfilled)
+            return;
+        callback();
+    });
+}
+
+}

--- a/Source/WebCore/bindings/js/InternalWritableStreamWriter.h
+++ b/Source/WebCore/bindings/js/InternalWritableStreamWriter.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "JSDOMGuardedObject.h"
+#include <JavaScriptCore/JSObject.h>
+
+namespace WebCore {
+
+class WritableStream;
+
+class InternalWritableStreamWriter final : public DOMGuarded<JSC::JSObject> {
+public:
+    static Ref<InternalWritableStreamWriter> create(JSDOMGlobalObject& globalObject, JSC::JSObject& writer)
+    {
+        return adoptRef(*new InternalWritableStreamWriter(globalObject, writer));
+    }
+
+    void whenReady(Function<void()>&&);
+    void onClosedPromiseRejection(Function<void(JSDOMGlobalObject&, JSC::JSValue)>&&);
+    void onClosedPromiseResolution(Function<void()>&&);
+
+private:
+    InternalWritableStreamWriter(JSDOMGlobalObject& globalObject, JSC::JSObject& writer)
+        : DOMGuarded<JSC::JSObject>(globalObject, writer)
+    {
+    }
+};
+
+ExceptionOr<Ref<InternalWritableStreamWriter>> acquireWritableStreamDefaultWriter(JSDOMGlobalObject&, WritableStream&);
+int writableStreamDefaultWriterGetDesiredSize(InternalWritableStreamWriter&);
+RefPtr<DOMPromise> writableStreamDefaultWriterCloseWithErrorPropagation(InternalWritableStreamWriter&);
+void writableStreamDefaultWriterRelease(InternalWritableStreamWriter&);
+RefPtr<DOMPromise> writableStreamDefaultWriterWrite(InternalWritableStreamWriter&, JSC::JSValue);
+}


### PR DESCRIPTION
#### 4f7c00e3626b9ed202a12f86969befd8b1ae7261
<pre>
Introduce InternalWritableStreamWriter as a first step towards supporting piping from readable byte streams
<a href="https://rdar.apple.com/161244618">rdar://161244618</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=299437">https://bugs.webkit.org/show_bug.cgi?id=299437</a>

Reviewed by Chris Dumez.

* Source/WebCore/bindings/js/InternalWritableStreamWriter.cpp: Added.
(WebCore::invokeWritableStreamWriterFunction):
(WebCore::acquireWritableStreamDefaultWriter):
(WebCore::writableStreamDefaultWriterGetDesiredSize):
(WebCore::writableStreamDefaultWriterCloseWithErrorPropagation):
(WebCore::writableStreamDefaultWriterRelease):
(WebCore::writableStreamDefaultWriterWrite):
(WebCore::InternalWritableStreamWriter::onClosedPromiseRejection):
(WebCore::InternalWritableStreamWriter::onClosedPromiseResolution):
(WebCore::InternalWritableStreamWriter::whenReady):
* Source/WebCore/bindings/js/InternalWritableStreamWriter.h: Added.

Canonical link: <a href="https://commits.webkit.org/300679@main">https://commits.webkit.org/300679@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8d5a449c4dc142456264a57598e5689c7f92c646

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123494 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43209 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33905 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130222 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/75634 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3760b569-2291-4f93-a76b-45f1e8e8d4ff) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/125371 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43932 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51803 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93879 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/62323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e5117d4a-da71-4c6c-8eca-5e907f767087) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126447 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35010 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110487 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74511 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/25c88400-152d-42a9-9c1d-3939cdcce070) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33980 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28645 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73729 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104726 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28870 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132932 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50445 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38404 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102367 "Found 1 new test failure: imported/blink/fast/pagination/viewport-y-horizontal-bt-rtl.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50820 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106709 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102218 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25980 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47575 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25806 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/47253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50299 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56060 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49773 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53120 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51448 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->