### PR TITLE
[GStreamer] Increase use of CStringView and other string management improvements

### DIFF
--- a/Source/WTF/wtf/glib/GSpanExtras.h
+++ b/Source/WTF/wtf/glib/GSpanExtras.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <wtf/Expected.h>
 #include <wtf/MallocSpan.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/glib/GRefPtr.h>
@@ -35,6 +36,8 @@ void g_strfreev(char**);
 }
 
 namespace WTF {
+
+class CStringView;
 
 struct GMalloc {
     static void* malloc(size_t size) { return g_malloc(size); }
@@ -78,8 +81,8 @@ GMallocSpan<char, Malloc> adoptGMallocString(char* str)
     WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
-WTF_EXPORT_PRIVATE GMallocSpan<char> gFileGetContents(const char* path, GUniqueOutPtr<GError>&);
-WTF_EXPORT_PRIVATE GMallocSpan<char*, GMallocStrv> gKeyFileGetKeys(GKeyFile*, const char* groupName, GUniqueOutPtr<GError>&);
+WTF_EXPORT_PRIVATE Expected<GMallocSpan<char>, GUniquePtr<GError>> gFileGetContents(CStringView);
+WTF_EXPORT_PRIVATE Expected<GMallocSpan<char*, GMallocStrv>, GUniquePtr<GError>> gKeyFileGetKeys(GKeyFile*, CStringView groupName);
 WTF_EXPORT_PRIVATE GMallocSpan<GParamSpec*> gObjectClassGetProperties(GObjectClass*);
 WTF_EXPORT_PRIVATE GMallocSpan<const char*> gVariantGetStrv(const GRefPtr<GVariant>&);
 

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerDataChannelHandler.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerDataChannelHandler.h
@@ -61,7 +61,7 @@ private:
     void close() final;
 
     void onMessageData(GBytes*);
-    void onMessageString(const char*);
+    void onMessageString(CStringView);
     void onError(GError*);
     void onClose();
 

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.h
@@ -165,7 +165,7 @@ private:
 
     ExceptionOr<Backends> createTransceiverBackends(const String& kind, const RTCRtpTransceiverInit&, GStreamerRtpSenderBackend::Source&&, PeerConnectionBackend::IgnoreNegotiationNeededFlag);
 
-    void processSDPMessage(const GstSDPMessage*, Function<void(unsigned index, StringView mid, const GstSDPMedia*)>);
+    void processSDPMessage(const GstSDPMessage*, Function<void(unsigned index, CStringView mid, const GstSDPMedia*)>);
 
     WARN_UNUSED_RETURN GRefPtr<GstPad> requestPad(const GRefPtr<GstCaps>&, const String& mediaStreamID);
 

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpTransceiverBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpTransceiverBackend.cpp
@@ -167,7 +167,7 @@ ExceptionOr<void> GStreamerRtpTransceiverBackend::setCodecPreferences(const Vect
             if (!key.startsWith("extmap-"_s))
                 return true;
 
-            extensions.add(key.toString(), String::fromLatin1(g_value_get_string(value)));
+            extensions.add(key, byteCast<char8_t>(unsafeSpan(g_value_get_string(value))));
             return true;
         });
     }

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.h
@@ -270,7 +270,7 @@ ExceptionOr<GUniquePtr<GstStructure>>fromRTCSendParameters(const RTCRtpSendParam
 
 std::optional<Ref<RTCCertificate>> generateCertificate(Ref<SecurityOrigin>&&, const PeerConnectionBackend::CertificateInformation&);
 
-bool sdpMediaHasAttributeKey(const GstSDPMedia*, const char* key);
+bool sdpMediaHasAttributeKey(const GstSDPMedia*, ASCIILiteral key);
 
 class UniqueSSRCGenerator : public ThreadSafeRefCounted<UniqueSSRCGenerator> {
     WTF_MAKE_TZONE_ALLOCATED(UniqueSSRCGenerator);

--- a/Source/WebCore/platform/audio/gstreamer/AudioEncoderGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/AudioEncoderGStreamer.cpp
@@ -254,8 +254,8 @@ String GStreamerInternalAudioEncoder::initialize(const String& codecName, const 
     GUniquePtr<char> name(gst_element_get_name(m_encoder.get()));
     auto nameView = StringView::fromLatin1(name.get());
     if (codecName.startsWith("mp4a"_s)) {
-        const char* streamFormat = config.isAacADTS.value_or(false) ? "adts" : "raw";
-        m_outputCaps = adoptGRef(gst_caps_new_simple("audio/mpeg", "mpegversion", G_TYPE_INT, 4, "stream-format", G_TYPE_STRING, streamFormat, nullptr));
+        m_outputCaps = adoptGRef(gst_caps_new_simple("audio/mpeg", "mpegversion", G_TYPE_INT, 4,
+            "stream-format", G_TYPE_STRING, config.isAacADTS.value_or(false) ? "adts" : "raw", nullptr));
         if (gstObjectHasProperty(m_encoder.get(), "bitrate"_s) && config.bitRate && config.bitRate < std::numeric_limits<int>::max())
             g_object_set(m_encoder.get(), "bitrate", static_cast<int>(config.bitRate), nullptr);
     } else if (codecName == "mp3"_s) {

--- a/Source/WebCore/platform/audio/gstreamer/AudioFileReaderGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/AudioFileReaderGStreamer.cpp
@@ -278,7 +278,7 @@ void AudioFileReader::handleMessage(GstMessage* message)
             gst_element_state_get_name(oldState), gst_element_state_get_name(newState), gst_element_state_get_name(pending));
 
         auto dotFileName = makeString(unsafeSpan(GST_OBJECT_NAME(m_pipeline.get())), '_', unsafeSpan(gst_element_state_get_name(oldState)), '_', unsafeSpan(gst_element_state_get_name(newState)));
-        GST_DEBUG_BIN_TO_DOT_FILE_WITH_TS(GST_BIN_CAST(m_pipeline.get()), GST_DEBUG_GRAPH_SHOW_ALL, dotFileName.utf8().data());
+        GST_DEBUG_BIN_TO_DOT_FILE_WITH_TS(GST_BIN_CAST(m_pipeline.get()), GST_DEBUG_GRAPH_SHOW_ALL, dotFileName.ascii().data());
         break;
     }
     case GST_MESSAGE_LATENCY:

--- a/Source/WebCore/platform/audio/gstreamer/PlatformRawAudioDataGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/PlatformRawAudioDataGStreamer.cpp
@@ -214,15 +214,15 @@ std::optional<Variant<Vector<std::span<uint8_t>>, Vector<std::span<int16_t>>, Ve
 }
 
 #ifndef GST_DISABLE_GST_DEBUG
-static const char* layoutToString(GstAudioLayout layout)
+static ASCIILiteral layoutToString(GstAudioLayout layout)
 {
     switch (layout) {
     case GST_AUDIO_LAYOUT_INTERLEAVED:
-        return "interleaved";
+        return "interleaved"_s;
     case GST_AUDIO_LAYOUT_NON_INTERLEAVED:
-        return "planar";
+        return "planar"_s;
     }
-    return "unknown";
+    return "unknown"_s;
 }
 #endif
 
@@ -239,8 +239,10 @@ void PlatformRawAudioData::copyTo(std::span<uint8_t> destination, AudioSampleFor
 #ifndef GST_DISABLE_GST_DEBUG
     [[maybe_unused]] auto [gstSourceFormat, sourceLayout] = convertAudioSampleFormatToGStreamerFormat(sourceFormat);
     auto [gstDestinationFormat, destinationLayout] = convertAudioSampleFormatToGStreamerFormat(format);
-    const char* destinationFormatDescription = gst_audio_format_to_string(gstDestinationFormat);
-    GST_TRACE("Copying %s %s data at planeIndex %zu, destination format is %s %s, source offset: %zu", layoutToString(sourceLayout), gst_audio_format_to_string(gstSourceFormat), planeIndex, layoutToString(destinationLayout), destinationFormatDescription, sourceOffset);
+    auto destinationFormatDescription = CStringView::unsafeFromUTF8(gst_audio_format_to_string(gstDestinationFormat));
+    GST_TRACE("Copying %s %s data at planeIndex %zu, destination format is %s %s, source offset: %zu",
+        layoutToString(sourceLayout).characters(), gst_audio_format_to_string(gstSourceFormat), planeIndex,
+        layoutToString(destinationLayout).characters(), destinationFormatDescription.utf8(), sourceOffset);
 #endif
 
     // Copy memory when:

--- a/Source/WebCore/platform/graphics/gstreamer/GLVideoSinkGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GLVideoSinkGStreamer.cpp
@@ -72,8 +72,8 @@ static void initializeDMABufAvailability()
         if (!gst_check_version(1, 20, 0))
             return;
 
-        auto value = unsafeSpan(g_getenv("WEBKIT_GST_DMABUF_SINK_DISABLED"));
-        s_isDMABufDisabled = value.data() && (equalLettersIgnoringASCIICase(value, "true"_s) || equalLettersIgnoringASCIICase(value, "1"_s));
+        auto value = CStringView::unsafeFromUTF8(g_getenv("WEBKIT_GST_DMABUF_SINK_DISABLED"));
+        s_isDMABufDisabled = !value.isEmpty() && (equalLettersIgnoringASCIICase(value.span(), "true"_s) || equalLettersIgnoringASCIICase(value.span(), "1"_s));
         if (!s_isDMABufDisabled && !DRMDeviceManager::singleton().mainGBMDevice(DRMDeviceManager::NodeType::Render))
             s_isDMABufDisabled = true;
     });

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerAudioMixer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerAudioMixer.cpp
@@ -88,8 +88,7 @@ void GStreamerAudioMixer::ensureState(GstStateChange stateChange)
 
 GRefPtr<GstPad> GStreamerAudioMixer::registerProducer(GstElement* interaudioSink, std::optional<int> forcedSampleRate)
 {
-    auto name = StringView::fromLatin1(GST_ELEMENT_NAME(interaudioSink));
-    GstElement* src = makeGStreamerElement("interaudiosrc"_s, name.toStringWithoutCopying());
+    GstElement* src = makeGStreamerElement("interaudiosrc"_s, unsafeSpan(GST_ELEMENT_NAME(interaudioSink)));
 
     g_object_set(src, "channel", GST_ELEMENT_NAME(interaudioSink), nullptr);
     g_object_set(interaudioSink, "channel", GST_ELEMENT_NAME(interaudioSink), nullptr);
@@ -158,9 +157,9 @@ void GStreamerAudioMixer::unregisterProducer(const GRefPtr<GstPad>& mixerPad)
     GST_DEBUG_BIN_TO_DOT_FILE_WITH_TS(GST_BIN_CAST(m_pipeline.get()), GST_DEBUG_GRAPH_SHOW_ALL, "audio-mixer-after-producer-unregistration");
 }
 
-void GStreamerAudioMixer::configureSourcePeriodTime(StringView sourceName, uint64_t periodTime)
+void GStreamerAudioMixer::configureSourcePeriodTime(CStringView sourceName, uint64_t periodTime)
 {
-    auto src = adoptGRef(gst_bin_get_by_name(GST_BIN_CAST(m_pipeline.get()), sourceName.toStringWithoutCopying().ascii().data()));
+    auto src = adoptGRef(gst_bin_get_by_name(GST_BIN_CAST(m_pipeline.get()), sourceName.utf8()));
     if (!src) [[unlikely]]
         return;
 

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerAudioMixer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerAudioMixer.h
@@ -23,6 +23,7 @@
 
 #include "GRefPtrGStreamer.h"
 #include <wtf/Forward.h>
+#include <wtf/text/CStringView.h>
 
 namespace WebCore {
 
@@ -36,7 +37,7 @@ public:
     GRefPtr<GstPad> registerProducer(GstElement*, std::optional<int> forcedSampleRate);
     void unregisterProducer(const GRefPtr<GstPad>&);
 
-    void configureSourcePeriodTime(StringView sourceName, uint64_t periodTime);
+    void configureSourcePeriodTime(CStringView sourceName, uint64_t periodTime);
 
 private:
     GStreamerAudioMixer();

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
@@ -96,7 +96,7 @@ bool isProtocolAllowed(const WTF::URL&);
 CStringView capsMediaType(const GstCaps*);
 std::optional<TrackID> getStreamIdFromPad(const GRefPtr<GstPad>&);
 std::optional<TrackID> getStreamIdFromStream(const GRefPtr<GstStream>&);
-std::optional<TrackID> parseStreamId(StringView stringId);
+std::optional<TrackID> parseStreamId(const String& stringId);
 bool doCapsHaveType(const GstCaps*, ASCIILiteral);
 bool areEncryptedCaps(const GstCaps*);
 Vector<String> extractGStreamerOptionsFromCommandLine();
@@ -107,7 +107,7 @@ void registerWebKitGStreamerElements();
 void registerWebKitGStreamerVideoEncoder();
 void deinitializeGStreamer();
 
-unsigned getGstPlayFlag(const char* nick);
+unsigned getGstPlayFlag(ASCIILiteral nick);
 uint64_t toGstUnsigned64Time(const WTF::MediaTime&);
 
 inline GstClockTime toGstClockTime(const WTF::MediaTime& mediaTime)
@@ -301,7 +301,7 @@ bool webkitGstSetElementStateSynchronously(GstElement*, GstState, Function<bool(
 GstBuffer* gstBufferNewWrappedFast(void* data, size_t length);
 
 // These functions should be used for elements not provided by WebKit itself and not provided by GStreamer -core.
-GstElement* makeGStreamerElement(ASCIILiteral factoryName, const String& name = emptyString());
+GstElement* makeGStreamerElement(CStringView factoryName, const String& name = emptyString());
 
 template<typename T>
 std::optional<T> gstStructureGet(const GstStructure*, CStringView key);
@@ -372,7 +372,7 @@ using GstId = GQuark;
 bool gstStructureForeach(const GstStructure*, Function<bool(GstId, const GValue*)>&&);
 void gstStructureIdSetValue(GstStructure*, GstId, const GValue*);
 bool gstStructureMapInPlace(GstStructure*, Function<bool(GstId, GValue*)>&&);
-StringView gstIdToString(GstId);
+String gstIdToString(GstId);
 void gstStructureFilterAndMapInPlace(GstStructure*, Function<bool(GstId, GValue*)>&&);
 
 #if USE(GBM)

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.h
@@ -115,7 +115,7 @@ public:
     Vector<RTCRtpCapabilities::HeaderExtensionCapability> audioRtpExtensions();
     Vector<RTCRtpCapabilities::HeaderExtensionCapability> videoRtpExtensions();
     RegistryLookupResult isRtpPacketizerSupported(const String& encoding);
-    bool isRtpHeaderExtensionSupported(StringView);
+    bool isRtpHeaderExtensionSupported(const String&);
 #endif
 
 protected:
@@ -139,7 +139,9 @@ protected:
         explicit ElementFactories(OptionSet<Type>);
         ~ElementFactories();
 
-        static const char* elementFactoryTypeToString(Type);
+#ifndef GST_DISABLE_GST_DEBUG
+        static ASCIILiteral elementFactoryTypeToString(Type);
+#endif
         GList* factory(Type) const;
 
         enum class CheckHardwareClassifier : bool { No, Yes };

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerSinksWorkarounds.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerSinksWorkarounds.cpp
@@ -53,19 +53,20 @@ enum class WorkaroundMode {
 #define WEBKIT_GST_WORKAROUND_BASE_SINK_POSITION_FLUSH_DEFAULT_MODE "UseIfNeeded"
 #endif
 
-static WorkaroundMode getWorkAroundModeFromEnvironment(const char* environmentVariableName, const char* defaultValue)
+static WorkaroundMode getWorkAroundModeFromEnvironment(ASCIILiteral environmentVariableName, ASCIILiteral defaultValue)
 {
-    const char* textValue = getenv(environmentVariableName);
+    auto textValue = CStringView::unsafeFromUTF8(getenv(environmentVariableName.characters()));
     if (!textValue)
         textValue = defaultValue;
 
-    if (!g_ascii_strcasecmp(textValue, "UseIfNeeded"))
+    if (equalIgnoringASCIICase(textValue.span(), "UseIfNeeded"_s))
         return WorkaroundMode::UseIfNeeded;
-    if (!g_ascii_strcasecmp(textValue, "ForceEnable"))
+    if (equalIgnoringASCIICase(textValue.span(), "ForceEnable"_s))
         return WorkaroundMode::ForceEnable;
-    if (!g_ascii_strcasecmp(textValue, "ForceDisable"))
+    if (equalIgnoringASCIICase(textValue.span(), "ForceDisable"_s))
         return WorkaroundMode::ForceDisable;
-    GST_ERROR("Invalid value for %s: '%s'. Accepted values are 'UseIfNeeded', 'ForceEnable' and 'ForceDisable'. Defaulting to `UseIfNeeded`...", environmentVariableName, textValue);
+    GST_ERROR("Invalid value for %s: '%s'. Accepted values are 'UseIfNeeded', 'ForceEnable' and 'ForceDisable'. Defaulting to `UseIfNeeded`...",
+        environmentVariableName.characters(), textValue.utf8());
     return WorkaroundMode::UseIfNeeded;
 }
 
@@ -104,7 +105,8 @@ private:
         GUniquePtr<char> versionString(gst_version_string());
         GST_DEBUG("BaseSinkPositionFlushWorkaroundProbe: running %s, the bug was fixed in 1.24.", versionString.get());
 #endif
-        WorkaroundMode mode = getWorkAroundModeFromEnvironment("WEBKIT_GST_WORKAROUND_BASE_SINK_POSITION_FLUSH", WEBKIT_GST_WORKAROUND_BASE_SINK_POSITION_FLUSH_DEFAULT_MODE);
+        WorkaroundMode mode = getWorkAroundModeFromEnvironment("WEBKIT_GST_WORKAROUND_BASE_SINK_POSITION_FLUSH"_s,
+            ASCIILiteral::fromLiteralUnsafe(WEBKIT_GST_WORKAROUND_BASE_SINK_POSITION_FLUSH_DEFAULT_MODE));
         if (mode == WorkaroundMode::ForceEnable) {
             GST_DEBUG("BaseSinkPositionFlushWorkaroundProbe: forcing workaround to be enabled.");
             return true;
@@ -209,7 +211,8 @@ private:
         GUniquePtr<char> version(gst_plugins_base_version_string());
         GST_DEBUG("AppSinkFlushCapsWorkaroundProbe: gst-plugins-base version is %s, bug was fixed in 1.21.1 and backported to 1.20.3.", version.get());
 #endif
-        WorkaroundMode mode = getWorkAroundModeFromEnvironment("WEBKIT_GST_WORKAROUND_APP_SINK_FLUSH_CAPS", WEBKIT_GST_WORKAROUND_APP_SINK_FLUSH_CAPS_DEFAULT_MODE);
+        WorkaroundMode mode = getWorkAroundModeFromEnvironment("WEBKIT_GST_WORKAROUND_APP_SINK_FLUSH_CAPS"_s,
+            ASCIILiteral::fromLiteralUnsafe(WEBKIT_GST_WORKAROUND_APP_SINK_FLUSH_CAPS_DEFAULT_MODE));
         if (mode == WorkaroundMode::ForceEnable) {
             GST_DEBUG("AppSinkFlushCapsWorkaroundProbe: forcing workaround to be enabled.");
             return true;

--- a/Source/WebCore/platform/graphics/gstreamer/MediaSampleGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaSampleGStreamer.cpp
@@ -149,7 +149,7 @@ void MediaSampleGStreamer::dump(PrintStream& out) const
     out.print("{PTS(", presentationTime(), "), DTS(", decodeTime(), "), duration(", duration(), "), flags(");
 
     bool anyFlags = false;
-    auto appendFlag = [&out, &anyFlags](const char* flagName) {
+    auto appendFlag = [&out, &anyFlags](ASCIILiteral flagName) {
         if (anyFlags)
             out.print(",");
         out.print(flagName);
@@ -157,13 +157,13 @@ void MediaSampleGStreamer::dump(PrintStream& out) const
     };
 
     if (flags() & MediaSample::IsSync)
-        appendFlag("sync");
+        appendFlag("sync"_s);
     if (flags() & MediaSample::IsNonDisplaying)
-        appendFlag("non-displaying");
+        appendFlag("non-displaying"_s);
     if (flags() & MediaSample::HasAlpha)
-        appendFlag("has-alpha");
+        appendFlag("has-alpha"_s);
     if (flags() & ~(MediaSample::IsSync | MediaSample::IsNonDisplaying | MediaSample::HasAlpha))
-        appendFlag("unknown-flag");
+        appendFlag("unknown-flag"_s);
 
     out.print("), trackId(", trackID(), "), presentationSize(", presentationSize().width(), "x", presentationSize().height(), ")}");
 }

--- a/Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.h
@@ -114,11 +114,10 @@ protected:
     bool updateTrackIDFromTags(const GRefPtr<GstTagList>&);
 
 private:
-    bool getLanguageCode(GstTagList* tags, String& value);
+    std::optional<String> getLanguageCode(GstTagList*);
     static String generateUniquePlaybin2StreamID(TrackType, unsigned index);
     static char prefixForType(TrackType);
-    template<class StringType>
-    bool getTag(GstTagList* tags, const gchar* tagName, StringType& value);
+    std::optional<String> getTag(GstTagList* tags, ASCIILiteral tagName);
 
     void streamChanged();
     void tagsChanged();

--- a/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp
@@ -385,13 +385,13 @@ RefPtr<VideoFrameGStreamer> VideoFrameGStreamer::createFromPixelBuffer(Ref<Pixel
     auto width = size.width();
     auto height = size.height();
 
-    auto formatName = unsafeSpan(gst_video_format_to_string(format));
-    GST_TRACE("Creating %s VideoFrame from pixel buffer", formatName.data());
+    auto formatName = CStringView::unsafeFromUTF8(gst_video_format_to_string(format));
+    GST_TRACE("Creating %s VideoFrame from pixel buffer", formatName.utf8());
 
     int frameRateNumerator, frameRateDenominator;
     gst_util_double_to_fraction(frameRate, &frameRateNumerator, &frameRateDenominator);
 
-    auto caps = adoptGRef(gst_caps_new_simple("video/x-raw", "format", G_TYPE_STRING, formatName.data(), "width", G_TYPE_INT, width, "height", G_TYPE_INT, height, nullptr));
+    auto caps = adoptGRef(gst_caps_new_simple("video/x-raw", "format", G_TYPE_STRING, formatName.utf8(), "width", G_TYPE_INT, width, "height", G_TYPE_INT, height, nullptr));
     if (frameRate)
         gst_caps_set_simple(caps.get(), "framerate", GST_TYPE_FRACTION, frameRateNumerator, frameRateDenominator, nullptr);
 
@@ -408,7 +408,7 @@ RefPtr<VideoFrameGStreamer> VideoFrameGStreamer::createFromPixelBuffer(Ref<Pixel
         width = destinationSize.width();
         height = destinationSize.height();
         GST_TRACE("Resizing frame from %dx%d to %dx%d", size.width(), size.height(), width, height);
-        auto outputCaps = adoptGRef(gst_caps_new_simple("video/x-raw", "format", G_TYPE_STRING, formatName.data(), "width", G_TYPE_INT, width,
+        auto outputCaps = adoptGRef(gst_caps_new_simple("video/x-raw", "format", G_TYPE_STRING, formatName.utf8(), "width", G_TYPE_INT, width,
             "height", G_TYPE_INT, height, nullptr));
         if (frameRate)
             gst_caps_set_simple(outputCaps.get(), "framerate", GST_TYPE_FRACTION, frameRateNumerator, frameRateDenominator, nullptr);
@@ -653,8 +653,8 @@ GRefPtr<GstSample> VideoFrameGStreamer::convert(GstVideoFormat format, const Int
 
     auto width = destinationSize.width();
     auto height = destinationSize.height();
-    auto formatName = unsafeSpan(gst_video_format_to_string(format));
-    auto outputCaps = adoptGRef(gst_caps_new_simple("video/x-raw", "format", G_TYPE_STRING, formatName.data(), "width", G_TYPE_INT, width, "height", G_TYPE_INT, height, "framerate", GST_TYPE_FRACTION, frameRateNumerator, frameRateDenominator, nullptr));
+    auto formatName = CStringView::unsafeFromUTF8(gst_video_format_to_string(format));
+    auto outputCaps = adoptGRef(gst_caps_new_simple("video/x-raw", "format", G_TYPE_STRING, formatName.utf8(), "width", G_TYPE_INT, width, "height", G_TYPE_INT, height, "framerate", GST_TYPE_FRACTION, frameRateNumerator, frameRateDenominator, nullptr));
 
     if (gst_caps_is_equal(caps, outputCaps.get()))
         return GRefPtr<GstSample>(m_sample);

--- a/Source/WebCore/platform/graphics/gstreamer/WebKitAudioSinkGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/WebKitAudioSinkGStreamer.cpp
@@ -100,7 +100,7 @@ static bool webKitAudioSinkConfigure(WebKitAudioSink* sink)
 
         auto sink = adoptGRef(gst_pad_get_parent_element(pad));
         uint64_t periodTime = gst_util_uint64_scale_ceil(AudioUtilities::renderQuantumSize, GST_SECOND, *sampleRate);
-        GStreamerAudioMixer::singleton().configureSourcePeriodTime(StringView::fromLatin1(GST_ELEMENT_NAME(sink.get())), periodTime);
+        GStreamerAudioMixer::singleton().configureSourcePeriodTime(CStringView::unsafeFromUTF8(GST_ELEMENT_NAME(sink.get())), periodTime);
         return GST_PAD_PROBE_OK;
     }), nullptr, nullptr);
     return true;

--- a/Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.h
@@ -40,7 +40,7 @@ G_BEGIN_DECLS
 #define WEBKIT_IS_WEB_SRC_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE ((klass), WEBKIT_TYPE_WEB_SRC))
 #define WEBKIT_WEB_SRC_CAST(obj)       ((WebKitWebSrc*)(obj))
 
-#define WEBKIT_WEB_SRC_RESOURCE_LOADER_CONTEXT_TYPE_NAME  "webkit.resource-loader"
+static constexpr auto WEBKIT_WEB_SRC_RESOURCE_LOADER_CONTEXT_TYPE_NAME = "webkit.resource-loader"_s;
 
 struct WebKitWebSrcPrivate;
 

--- a/Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.cpp
@@ -82,7 +82,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(CDMFactoryThunder);
 WTF_MAKE_TZONE_ALLOCATED_IMPL(CDMPrivateThunder);
 WTF_MAKE_TZONE_ALLOCATED_IMPL(CDMInstanceThunder);
 
-static CDMInstanceSession::SessionLoadFailure sessionLoadFailureFromThunder(const StringView& loadStatus)
+static CDMInstanceSession::SessionLoadFailure sessionLoadFailureFromThunder(const String& loadStatus)
 {
     if (loadStatus == "None"_s)
         return CDMInstanceSession::SessionLoadFailure::None;
@@ -388,26 +388,26 @@ void CDMInstanceSessionThunder::challengeGeneratedCallback(RefPtr<SharedBuffer>&
 }
 
 #if !defined(GST_DISABLE_GST_DEBUG) || !GST_DISABLE_GST_DEBUG
-static const char* toString(CDMInstanceSession::KeyStatus status)
+static ASCIILiteral toString(CDMInstanceSession::KeyStatus status)
 {
     switch (status) {
     case CDMInstanceSession::KeyStatus::Usable:
-        return "Usable";
+        return "Usable"_s;
     case CDMInstanceSession::KeyStatus::Expired:
-        return "Expired";
+        return "Expired"_s;
     case CDMInstanceSession::KeyStatus::Released:
-        return "Released";
+        return "Released"_s;
     case CDMInstanceSession::KeyStatus::OutputRestricted:
-        return "OutputRestricted";
+        return "OutputRestricted"_s;
     case CDMInstanceSession::KeyStatus::OutputDownscaled:
-        return "OutputDownscaled";
+        return "OutputDownscaled"_s;
     case CDMInstanceSession::KeyStatus::StatusPending:
-        return "StatusPending";
+        return "StatusPending"_s;
     case CDMInstanceSession::KeyStatus::InternalError:
-        return "InternalError";
+        return "InternalError"_s;
     default:
         ASSERT_NOT_REACHED();
-        return "unknown";
+        return "unknown"_s;
     }
 }
 #endif
@@ -442,7 +442,7 @@ void CDMInstanceSessionThunder::keyUpdatedCallback(KeyIDType&& keyID)
     GST_MEMDUMP("updated key", keyID.span().data(), keyID.size());
 
     auto keyStatus = status(keyID);
-    GST_DEBUG("updated with with key status %s", toString(keyStatus));
+    GST_DEBUG("updated with with key status %s", toString(keyStatus).characters());
 
     auto instance = cdmInstanceThunder();
     if (instance && GStreamerEMEUtilities::isPlayReadyKeySystem(instance->keySystem())) {
@@ -632,7 +632,7 @@ void CDMInstanceSessionThunder::loadSession(LicenseType, const String& sessionID
                 callback(std::nullopt, std::nullopt, std::nullopt, SuccessValue::Failed, sessionLoadFailureFromThunder({ }));
             else {
                 auto responseData = responseMessage->extractData();
-                StringView response(byteCast<Latin1Character>(responseData.span()));
+                auto response = String(byteCast<char8_t>(responseData.span()));
                 GST_DEBUG("Error message: %s", response.utf8().data());
                 callback(std::nullopt, std::nullopt, std::nullopt, SuccessValue::Failed, sessionLoadFailureFromThunder(response));
             }

--- a/Source/WebCore/platform/graphics/gstreamer/eme/GStreamerEMEUtilities.h
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/GStreamerEMEUtilities.h
@@ -28,9 +28,9 @@
 #include <gst/gst.h>
 #include <wtf/text/WTFString.h>
 
-#define WEBCORE_GSTREAMER_EME_UTILITIES_CLEARKEY_UUID "1077efec-c0b2-4d02-ace3-3c1e52e2fb4b"
-#define WEBCORE_GSTREAMER_EME_UTILITIES_WIDEVINE_UUID "edef8ba9-79d6-4ace-a3c8-27dcd51d21ed"
-#define WEBCORE_GSTREAMER_EME_UTILITIES_PLAYREADY_UUID "9a04f079-9840-4286-ab92-e65be0885f95"
+#define WEBCORE_GSTREAMER_EME_UTILITIES_CLEARKEY_UUID "1077efec-c0b2-4d02-ace3-3c1e52e2fb4b"_s
+#define WEBCORE_GSTREAMER_EME_UTILITIES_WIDEVINE_UUID "edef8ba9-79d6-4ace-a3c8-27dcd51d21ed"_s
+#define WEBCORE_GSTREAMER_EME_UTILITIES_PLAYREADY_UUID "9a04f079-9840-4286-ab92-e65be0885f95"_s
 
 GST_DEBUG_CATEGORY_EXTERN(webkit_media_common_encryption_decrypt_debug_category);
 
@@ -89,11 +89,11 @@ private:
 class GStreamerEMEUtilities {
 
 public:
-    static constexpr auto s_ClearKeyUUID = WEBCORE_GSTREAMER_EME_UTILITIES_CLEARKEY_UUID ""_s;
+    static constexpr auto s_ClearKeyUUID = WEBCORE_GSTREAMER_EME_UTILITIES_CLEARKEY_UUID;
     static constexpr auto s_ClearKeyKeySystem = "org.w3.clearkey"_s;
-    static constexpr auto s_WidevineUUID = WEBCORE_GSTREAMER_EME_UTILITIES_WIDEVINE_UUID ""_s;
+    static constexpr auto s_WidevineUUID = WEBCORE_GSTREAMER_EME_UTILITIES_WIDEVINE_UUID;
     static constexpr auto s_WidevineKeySystem = "com.widevine.alpha"_s;
-    static constexpr auto s_PlayReadyUUID = WEBCORE_GSTREAMER_EME_UTILITIES_PLAYREADY_UUID ""_s;
+    static constexpr auto s_PlayReadyUUID = WEBCORE_GSTREAMER_EME_UTILITIES_PLAYREADY_UUID;
     static constexpr std::array<ASCIILiteral, 2> s_PlayReadyKeySystems = { "com.microsoft.playready"_s,  "com.youtube.playready"_s };
     static constexpr auto s_unspecifiedUUID = GST_PROTECTION_UNSPECIFIED_SYSTEM_ID ""_s;
     static constexpr auto s_unspecifiedKeySystem = GST_PROTECTION_UNSPECIFIED_SYSTEM_ID ""_s;
@@ -107,9 +107,9 @@ public:
         return equalIgnoringASCIICase(keySystem, s_ClearKeyKeySystem);
     }
 
-    static bool isClearKeyUUID(const String& uuid)
+    static bool isClearKeyUUID(CStringView uuid)
     {
-        return equalIgnoringASCIICase(uuid, s_ClearKeyUUID);
+        return equalIgnoringASCIICase(uuid.span(), s_ClearKeyUUID);
     }
 
     static bool isWidevineKeySystem(const String& keySystem)
@@ -117,9 +117,9 @@ public:
         return equalIgnoringASCIICase(keySystem, s_WidevineKeySystem);
     }
 
-    static bool isWidevineUUID(const String& uuid)
+    static bool isWidevineUUID(CStringView uuid)
     {
-        return equalIgnoringASCIICase(uuid, s_WidevineUUID);
+        return equalIgnoringASCIICase(uuid.span(), s_WidevineUUID);
     }
 
     static bool isPlayReadyKeySystem(const String& keySystem)
@@ -127,9 +127,9 @@ public:
         return equalIgnoringASCIICase(keySystem, s_PlayReadyKeySystems[0]) || equalIgnoringASCIICase(keySystem, s_PlayReadyKeySystems[1]);
     }
 
-    static bool isPlayReadyUUID(const String& uuid)
+    static bool isPlayReadyUUID(CStringView uuid)
     {
-        return equalIgnoringASCIICase(uuid, s_PlayReadyUUID);
+        return equalIgnoringASCIICase(uuid.span(), s_PlayReadyUUID);
     }
 
     static bool isUnspecifiedKeySystem(const String& keySystem)
@@ -137,12 +137,12 @@ public:
         return equalIgnoringASCIICase(keySystem, s_unspecifiedKeySystem);
     }
 
-    static bool isUnspecifiedUUID(const String& uuid)
+    static bool isUnspecifiedUUID(CStringView uuid)
     {
-        return equalIgnoringASCIICase(uuid, s_unspecifiedUUID);
+        return equalIgnoringASCIICase(uuid.span(), s_unspecifiedUUID);
     }
 
-    static const char* keySystemToUuid(const String& keySystem)
+    static ASCIILiteral keySystemToUuid(const String& keySystem)
     {
         if (isClearKeyKeySystem(keySystem))
             return s_ClearKeyUUID;
@@ -160,7 +160,7 @@ public:
         return { };
     }
 
-    static ASCIILiteral uuidToKeySystem(const String& uuid)
+    static ASCIILiteral uuidToKeySystem(CStringView uuid)
     {
         if (isClearKeyUUID(uuid))
             return s_ClearKeyKeySystem;

--- a/Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.cpp
@@ -172,13 +172,14 @@ static GstCaps* transformCaps(GstBaseTransform* base, GstPadDirection direction,
                 gst_structure_remove_fields(outgoingStructure.get(), "base-profile", "codec_data", "height", "framerate", "level", "pixel-aspect-ratio", "profile", "rate", "width", nullptr);
 
                 auto name = WebCore::gstStructureGetName(incomingStructure);
-                gst_structure_set(outgoingStructure.get(), "protection-system", G_TYPE_STRING, klass->protectionSystemId(self),
+                gst_structure_set(outgoingStructure.get(), "protection-system", G_TYPE_STRING, klass->protectionSystemId(self).characters(),
                     "original-media-type", G_TYPE_STRING, name.utf8() , nullptr);
 
                 // GST_PROTECTION_UNSPECIFIED_SYSTEM_ID was added in the GStreamer
                 // developement git master which will ship as version 1.16.0.
-                gst_structure_set_name(outgoingStructure.get(), !g_strcmp0(klass->protectionSystemId(self),
-                    GST_PROTECTION_UNSPECIFIED_SYSTEM_ID) ? "application/x-webm-enc" : "application/x-cenc");
+                gst_structure_set_name(outgoingStructure.get(),
+                    WebCore::GStreamerEMEUtilities::isUnspecifiedUUID(klass->protectionSystemId(self))
+                    ? "application/x-webm-enc" : "application/x-cenc");
             }
         }
 

--- a/Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.h
@@ -57,7 +57,7 @@ struct _WebKitMediaCommonEncryptionDecrypt {
 struct _WebKitMediaCommonEncryptionDecryptClass {
     GstBaseTransformClass parentClass;
 
-    const char* (*protectionSystemId)(WebKitMediaCommonEncryptionDecrypt*);
+    ASCIILiteral (*protectionSystemId)(WebKitMediaCommonEncryptionDecrypt*);
     bool (*cdmProxyAttached)(WebKitMediaCommonEncryptionDecrypt*, const RefPtr<WebCore::CDMProxy>&);
     bool (*decrypt)(WebKitMediaCommonEncryptionDecrypt*, GstBuffer* ivBuffer, GstBuffer* keyIDBuffer, GstBuffer* buffer, unsigned subsamplesCount, GstBuffer* subsamplesBuffer);
 };

--- a/Source/WebCore/platform/graphics/gstreamer/eme/WebKitThunderDecryptorGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/WebKitThunderDecryptorGStreamer.cpp
@@ -36,7 +36,7 @@ struct WebKitMediaThunderDecryptPrivate {
     GRefPtr<GstCaps> inputCaps;
 };
 
-static const char* protectionSystemId(WebKitMediaCommonEncryptionDecrypt*);
+static ASCIILiteral protectionSystemId(WebKitMediaCommonEncryptionDecrypt*);
 static bool cdmProxyAttached(WebKitMediaCommonEncryptionDecrypt*, const RefPtr<CDMProxy>&);
 static bool decrypt(WebKitMediaCommonEncryptionDecrypt*, GstBuffer* iv, GstBuffer* keyid, GstBuffer* sample, unsigned subSamplesCount,
     GstBuffer* subSamples);
@@ -82,7 +82,7 @@ static GRefPtr<GstCaps> createSinkPadTemplateCaps()
     for (const auto& keySystem : supportedKeySystems) {
         for (const auto& mediaType : GStreamerEMEUtilities::s_cencEncryptionMediaTypes) {
             gst_caps_append_structure(caps.get(), gst_structure_new("application/x-cenc", "original-media-type", G_TYPE_STRING,
-                mediaType.characters(), "protection-system", G_TYPE_STRING, GStreamerEMEUtilities::keySystemToUuid(keySystem), nullptr));
+                mediaType.characters(), "protection-system", G_TYPE_STRING, GStreamerEMEUtilities::keySystemToUuid(keySystem).characters(), nullptr));
         }
     }
 
@@ -132,7 +132,7 @@ static void webkit_media_thunder_decrypt_class_init(WebKitMediaThunderDecryptCla
     commonClass->decrypt = GST_DEBUG_FUNCPTR(decrypt);
 }
 
-static const char* protectionSystemId(WebKitMediaCommonEncryptionDecrypt* decryptor)
+static ASCIILiteral protectionSystemId(WebKitMediaCommonEncryptionDecrypt* decryptor)
 {
     auto* self = WEBKIT_MEDIA_THUNDER_DECRYPT(decryptor);
     ASSERT(self->priv->cdmProxy);

--- a/Source/WebCore/platform/graphics/gstreamer/eme/WebKitThunderParser.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/WebKitThunderParser.cpp
@@ -87,7 +87,8 @@ static GRefPtr<GstCaps> createThunderParseSinkPadTemplateCaps()
     for (const auto& keySystem : supportedKeySystems) {
         for (const auto& mediaType : GStreamerEMEUtilities::s_cencEncryptionMediaTypes) {
             gst_caps_append_structure(caps.get(), gst_structure_new("application/x-cenc", "original-media-type", G_TYPE_STRING,
-                mediaType.characters(), "protection-system", G_TYPE_STRING, GStreamerEMEUtilities::keySystemToUuid(keySystem), nullptr));
+                mediaType.characters(), "protection-system", G_TYPE_STRING,
+                GStreamerEMEUtilities::keySystemToUuid(keySystem).characters(), nullptr));
         }
     }
 

--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.h
@@ -42,7 +42,7 @@ typedef MediaSourcePrivateGStreamer::RegisteredTrack RegisteredTrack;
 #if !LOG_DISABLED || ENABLE(ENCRYPTED_MEDIA)
 struct PadProbeInformation {
     AppendPipeline* appendPipeline;
-    const char* description;
+    ASCIILiteral description;
     gulong probeId;
 };
 #endif
@@ -60,10 +60,6 @@ public:
     MediaPlayerPrivateGStreamerMSE* playerPrivate() { return m_playerPrivate; }
 
 private:
-#ifndef GST_DISABLE_GST_DEBUG
-    static const char * streamTypeToString(StreamType);
-#endif
-
     struct Track {
         // Track objects are created on pad-added for the first initialization segment, and destroyed after
         // the pipeline state has been set to GST_STATE_NULL.

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
@@ -60,15 +60,15 @@
 #include <wtf/text/StringToIntegerConversion.h>
 
 #ifndef GST_DISABLE_GST_DEBUG
-static const char* dumpReadyState(WebCore::MediaPlayer::ReadyState readyState)
+static ASCIILiteral dumpReadyState(WebCore::MediaPlayer::ReadyState readyState)
 {
     switch (readyState) {
-    case WebCore::MediaPlayer::ReadyState::HaveNothing: return "HaveNothing";
-    case WebCore::MediaPlayer::ReadyState::HaveMetadata: return "HaveMetadata";
-    case WebCore::MediaPlayer::ReadyState::HaveCurrentData: return "HaveCurrentData";
-    case WebCore::MediaPlayer::ReadyState::HaveFutureData: return "HaveFutureData";
-    case WebCore::MediaPlayer::ReadyState::HaveEnoughData: return "HaveEnoughData";
-    default: return "(unknown)";
+    case WebCore::MediaPlayer::ReadyState::HaveNothing: return "HaveNothing"_s;
+    case WebCore::MediaPlayer::ReadyState::HaveMetadata: return "HaveMetadata"_s;
+    case WebCore::MediaPlayer::ReadyState::HaveCurrentData: return "HaveCurrentData"_s;
+    case WebCore::MediaPlayer::ReadyState::HaveFutureData: return "HaveFutureData"_s;
+    case WebCore::MediaPlayer::ReadyState::HaveEnoughData: return "HaveEnoughData"_s;
+    default: return "(unknown)"_s;
     }
 }
 #endif // GST_DISABLE_GST_DEBUG
@@ -387,8 +387,9 @@ void MediaPlayerPrivateGStreamerMSE::readyStateFromMediaSourceChanged()
     if (mediaSourceReadyState == m_mediaSourceReadyState)
         return;
 
-    GST_DEBUG("MediaSource called setReadyState(%p): %s -> %s Current player state: %s Waiting for preroll: %s", this,
-        dumpReadyState(m_mediaSourceReadyState), dumpReadyState(mediaSourceReadyState), dumpReadyState(m_readyState), boolForPrinting(m_isWaitingForPreroll));
+    GST_DEBUG("MediaSource called setReadyState(%p): %s -> %s Current player state: %s Waiting for preroll: %s", this
+        , dumpReadyState(m_mediaSourceReadyState).characters(), dumpReadyState(mediaSourceReadyState).characters()
+        , dumpReadyState(m_readyState).characters(), boolForPrinting(m_isWaitingForPreroll));
     m_mediaSourceReadyState = mediaSourceReadyState;
 
     if (mediaSourceReadyState < MediaPlayer::ReadyState::HaveCurrentData || !hasVideo() || !m_isWaitingForPreroll)
@@ -400,7 +401,8 @@ void MediaPlayerPrivateGStreamerMSE::propagateReadyStateToPlayer()
     ASSERT(m_mediaSourceReadyState < MediaPlayer::ReadyState::HaveCurrentData || !hasVideo() || !m_isWaitingForPreroll);
     if (m_readyState == m_mediaSourceReadyState)
         return;
-    GST_DEBUG("Propagating MediaSource readyState %s to player ready state (currently %s)", dumpReadyState(m_mediaSourceReadyState), dumpReadyState(m_readyState));
+    GST_DEBUG("Propagating MediaSource readyState %s to player ready state (currently %s)",
+        dumpReadyState(m_mediaSourceReadyState).characters(), dumpReadyState(m_readyState).characters());
 
     m_readyState = m_mediaSourceReadyState;
     updateStates(); // Set the pipeline to PLAYING or PAUSED if necessary.

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.cpp
@@ -138,19 +138,19 @@ void MediaSourcePrivateGStreamer::markEndOfStream(EndOfStreamStatus endOfStreamS
         return;
 
 #ifndef GST_DISABLE_GST_DEBUG
-    const char* statusString = nullptr;
+    ASCIILiteral statusString;
     switch (endOfStreamStatus) {
     case EndOfStreamStatus::NoError:
-        statusString = "no-error";
+        statusString = "no-error"_s;
         break;
     case EndOfStreamStatus::DecodeError:
-        statusString = "decode-error";
+        statusString = "decode-error"_s;
         break;
     case EndOfStreamStatus::NetworkError:
-        statusString = "network-error";
+        statusString = "network-error"_s;
         break;
     }
-    GST_DEBUG_OBJECT(player->pipeline(), "Marking EOS, status is %s", statusString);
+    GST_DEBUG_OBJECT(player->pipeline(), "Marking EOS, status is %s", statusString.characters());
 #endif
     if (endOfStreamStatus == EndOfStreamStatus::NoError) {
         auto bufferedRanges = buffered();

--- a/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
@@ -218,18 +218,18 @@ static GstStreamType gstStreamType(TrackPrivateBaseGStreamer::TrackType type)
 }
 
 #ifndef GST_DISABLE_GST_DEBUG
-static const char* streamTypeToString(TrackPrivateBaseGStreamer::TrackType type)
+static ASCIILiteral streamTypeToString(TrackPrivateBaseGStreamer::TrackType type)
 {
     switch (type) {
     case TrackPrivateBaseGStreamer::TrackType::Audio:
-        return "Audio";
+        return "Audio"_s;
     case TrackPrivateBaseGStreamer::TrackType::Video:
-        return "Video";
+        return "Video"_s;
     case TrackPrivateBaseGStreamer::TrackType::Text:
-        return "Text";
+        return "Text"_s;
     default:
     case TrackPrivateBaseGStreamer::TrackType::Unknown:
-        return "Unknown";
+        return "Unknown"_s;
     }
 }
 #endif // GST_DISABLE_GST_DEBUG
@@ -309,7 +309,8 @@ void webKitMediaSrcEmitStreams(WebKitMediaSrc* source, const Vector<RefPtr<Media
     source->priv->collection = adoptGRef(gst_stream_collection_new("WebKitMediaSrc"));
     for (const auto& track : tracks) {
 #ifndef GST_DISABLE_GST_DEBUG
-        GST_DEBUG_OBJECT(source, "Adding stream with trackId '%" PRIu64 "' of type %s with caps %" GST_PTR_FORMAT, track->id(), streamTypeToString(track->type()), track->initialCaps().get());
+        GST_DEBUG_OBJECT(source, "Adding stream with trackId '%" PRIu64 "' of type %s with caps %" GST_PTR_FORMAT,
+            track->id(), streamTypeToString(track->type()).characters(), track->initialCaps().get());
 #endif // GST_DISABLE_GST_DEBUG
         if (source->priv->streams.contains(track->id())) {
             GST_ERROR_OBJECT(source, "stream with trackId '%" PRIu64 "' already exists", track->id());

--- a/Source/WebCore/platform/gstreamer/GStreamerCodecUtilities.h
+++ b/Source/WebCore/platform/gstreamer/GStreamerCodecUtilities.h
@@ -24,13 +24,14 @@
 #include "GRefPtrGStreamer.h"
 #include "IntSize.h"
 #include <wtf/Forward.h>
+#include <wtf/text/CStringView.h>
 
 namespace WebCore {
 
 namespace GStreamerCodecUtilities {
 
-std::pair<const char*, const char*> parseH264ProfileAndLevel(const String& codec);
-const char* parseHEVCProfile(const String& codec);
+std::pair<CStringView, String> parseH264ProfileAndLevel(const String& codec);
+CStringView parseHEVCProfile(const String& codec);
 std::pair<GRefPtr<GstCaps>, GRefPtr<GstCaps>> capsFromCodecString(const String&, const IntSize&, std::optional<double> frameRate = std::nullopt);
 
 } // namespace GStreamerCodecUtilities

--- a/Source/WebCore/platform/gstreamer/GStreamerElementHarness.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerElementHarness.cpp
@@ -613,7 +613,8 @@ void MermaidBuilder::dumpElement(GStreamerElementHarness& harness, GstElement* e
         element= harness.element();
     auto elementId = makeString(unsafeSpan(GST_ELEMENT_NAME(element)), '_', m_elementCounter);
     m_elementCounter++;
-    m_stringBuilder.append("subgraph "_s, elementId, " [<center>"_s, unsafeSpan(G_OBJECT_TYPE_NAME(element)), "\\n<small>"_s, unsafeSpan(GST_ELEMENT_NAME(element)), "]\n"_s);
+    m_stringBuilder.append("subgraph "_s, elementId, " [<center>"_s, unsafeSpan(G_OBJECT_TYPE_NAME(element)),
+        "\\n<small>"_s, unsafeSpan(GST_ELEMENT_NAME(element)), "]\n"_s);
 
     if (GST_IS_BIN(element)) {
         for (auto element : GstIteratorAdaptor<GstElement>(gst_bin_iterate_recurse(GST_BIN_CAST(element))))
@@ -671,7 +672,7 @@ String MermaidBuilder::describeCaps(const GRefPtr<GstCaps>& caps)
             GUniquePtr<char> serializedValue(gst_value_serialize(value));
             String valueString = unsafeSpan(serializedValue.get());
             if (valueString.length() > 25)
-                builder.append(valueString.substring(0, 25), unsafeSpan("…"));
+                builder.append(valueString.substring(0, 25), "…"_s);
             else
                 builder.append(valueString);
             builder.append("<br/>"_s);
@@ -690,7 +691,7 @@ std::span<const uint8_t> MermaidBuilder::span() const
 void GStreamerElementHarness::dumpGraph(ASCIILiteral filenamePrefix)
 {
 #ifndef GST_DISABLE_GST_DEBUG
-    const char* dumpPath = g_getenv("WEBKIT_GST_HARNESS_DUMP_DIR");
+    auto dumpPath = CStringView::unsafeFromUTF8(g_getenv("WEBKIT_GST_HARNESS_DUMP_DIR"));
     if (!dumpPath)
         return;
 
@@ -700,7 +701,7 @@ void GStreamerElementHarness::dumpGraph(ASCIILiteral filenamePrefix)
 
     MermaidBuilder builder;
     builder.process(*this);
-    auto path = FileSystem::pathByAppendingComponent(String::fromUTF8(dumpPath), filename);
+    auto path = FileSystem::pathByAppendingComponent(String(dumpPath.span()), filename);
     FileSystem::overwriteEntireFile(path, builder.span());
 #else
     UNUSED_PARAM(filenamePrefix);

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkRialto.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkRialto.cpp
@@ -41,10 +41,10 @@ GStreamerQuirkRialto::GStreamerQuirkRialto()
 {
     GST_DEBUG_CATEGORY_INIT(webkit_rialto_quirks_debug, "webkitquirksrialto", 0, "WebKit Rialto Quirks");
 
-    std::array<const char *, 2> rialtoSinks = { "rialtomsevideosink", "rialtomseaudiosink" };
+    std::array<ASCIILiteral, 2> rialtoSinks = { "rialtomsevideosink"_s, "rialtomseaudiosink"_s };
 
-    for (const auto* sink : rialtoSinks) {
-        auto sinkFactory = adoptGRef(gst_element_factory_find(sink));
+    for (auto sink : rialtoSinks) {
+        auto sinkFactory = adoptGRef(gst_element_factory_find(sink.characters()));
         if (!sinkFactory) [[unlikely]]
             continue;
 
@@ -78,7 +78,7 @@ bool GStreamerQuirkRialto::isPlatformSupported() const
 
 void GStreamerQuirkRialto::configureElement(GstElement* element, const OptionSet<ElementRuntimeCharacteristics>&)
 {
-    if (!g_strcmp0(G_OBJECT_TYPE_NAME(G_OBJECT(element)), "GstURIDecodeBin3")) {
+    if (equal(unsafeSpan(G_OBJECT_TYPE_NAME(G_OBJECT(element))), "GstURIDecodeBin3"_s)) {
         GRefPtr<GstCaps> defaultCaps;
         g_object_get(element, "caps", &defaultCaps.outPtr(), nullptr);
         defaultCaps = adoptGRef(gst_caps_merge(gst_caps_ref(m_sinkCaps.get()), defaultCaps.leakRef()));

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkWesteros.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkWesteros.cpp
@@ -71,7 +71,8 @@ void GStreamerQuirkWesteros::configureElement(GstElement* element, const OptionS
     if (!characteristics.contains(ElementRuntimeCharacteristics::IsMediaStream))
         return;
 
-    if (!g_strcmp0(G_OBJECT_TYPE_NAME(G_OBJECT(element)), "GstWesterosSink") && gstObjectHasProperty(element, "immediate-output"_s)) {
+    if (equal(unsafeSpan(G_OBJECT_TYPE_NAME(G_OBJECT(element))), "GstWesterosSink"_s)
+        && gstObjectHasProperty(element, "immediate-output"_s)) {
         GST_INFO("Enable 'immediate-output' in WesterosSink");
         g_object_set(element, "immediate-output", TRUE, nullptr);
     }

--- a/Source/WebCore/platform/gstreamer/WebKitFliteSourceGStreamer.cpp
+++ b/Source/WebCore/platform/gstreamer/WebKitFliteSourceGStreamer.cpp
@@ -228,13 +228,13 @@ static Vector<GUniquePtr<cst_voice>>& fliteVoices()
     return voices;
 }
 
-static cst_voice* fliteVoice(const char* name)
+static cst_voice* fliteVoice(const String& name)
 {
     if (!name)
         return nullptr;
 
     for (auto& voice : fliteVoices()) {
-        if (String::fromUTF8(voice->name) == String::fromUTF8(name))
+        if (equal(name, byteCast<char8_t>(unsafeSpan(voice->name))))
             return voice.get();
     }
 
@@ -266,7 +266,7 @@ void webKitFliteSrcSetUtterance(WebKitFliteSrc* src, const PlatformSpeechSynthes
 
     cst_voice* voice = nullptr;
     if (platformSpeechSynthesisVoice && !platformSpeechSynthesisVoice->name().isEmpty())
-        voice = fliteVoice(platformSpeechSynthesisVoice->name().utf8().data());
+        voice = fliteVoice(platformSpeechSynthesisVoice->name());
 
     // We use the first registered voice as default, where no voice is specified.
     priv->currentVoice = voice ? voice : fliteVoices()[0].get();

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCapturer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCapturer.h
@@ -39,7 +39,7 @@ public:
     ~GStreamerAudioCapturer() = default;
 
     GstElement* createConverter() final;
-    const char* name() final { return "Audio"; }
+    ASCIILiteral name() final { return "Audio"_s; }
 
     bool setSampleRate(int);
 

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.h
@@ -72,7 +72,7 @@ public:
     GstElement* makeElement(ASCIILiteral factoryName);
     virtual GstElement* createSource();
     GstElement* source() { return m_src.get();  }
-    virtual const char* name() = 0;
+    virtual ASCIILiteral name() = 0;
 
     GstElement* sink() const { return m_sink.get(); }
 

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.cpp
@@ -148,7 +148,7 @@ String GStreamerIncomingTrackProcessor::mediaStreamIdFromPad()
     }
 
     GUniquePtr<gchar> name(gst_pad_get_name(m_pad.get()));
-    mediaStreamId = String::fromLatin1(name.get());
+    mediaStreamId = String(byteCast<char8_t>(unsafeSpan(name.get())));
     GST_DEBUG_OBJECT(m_bin.get(), "msid set from webrtcbin src pad name: %s", mediaStreamId.utf8().data());
     return mediaStreamId;
 }
@@ -168,12 +168,12 @@ void GStreamerIncomingTrackProcessor::retrieveMediaStreamAndTrackIdFromSDP()
     if (!media) [[unlikely]]
         return;
 
-    const char* msidAttribute = gst_sdp_media_get_attribute_val(media, "msid");
+    auto msidAttribute = CStringView::unsafeFromUTF8(gst_sdp_media_get_attribute_val(media, "msid"));
     if (!msidAttribute)
         return;
 
-    GST_LOG_OBJECT(m_bin.get(), "SDP media msid attribute value: %s", msidAttribute);
-    auto components = String::fromUTF8(msidAttribute).split(' ');
+    GST_LOG_OBJECT(m_bin.get(), "SDP media msid attribute value: %s", msidAttribute.utf8());
+    auto components = String(msidAttribute.span()).split(' ');
     if (components.size() != 2)
         return;
 

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerMockDevice.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerMockDevice.cpp
@@ -56,22 +56,22 @@ GstDevice* webkitMockDeviceCreate(const CaptureDevice& captureDevice)
 {
     GST_DEBUG_CATEGORY_INIT(webkitGstMockDeviceDebug, "webkitmockdevice", 0, "Mock Device");
 
-    const char* deviceClass;
+    ASCIILiteral deviceClass;
     GRefPtr<GstCaps> caps;
 
     switch (captureDevice.type()) {
     case CaptureDevice::DeviceType::Camera:
     case CaptureDevice::DeviceType::Screen:
     case CaptureDevice::DeviceType::Window:
-        deviceClass = "Video/Source";
+        deviceClass = "Video/Source"_s;
         caps = adoptGRef(gst_caps_new_empty_simple("video/x-raw"));
         break;
     case CaptureDevice::DeviceType::Microphone:
-        deviceClass = "Audio/Source";
+        deviceClass = "Audio/Source"_s;
         caps = adoptGRef(gst_caps_new_empty_simple("audio/x-raw"));
         break;
     default:
-        deviceClass = "unknown/unknown";
+        deviceClass = "unknown/unknown"_s;
         caps = adoptGRef(gst_caps_new_any());
         break;
     }
@@ -79,7 +79,8 @@ GstDevice* webkitMockDeviceCreate(const CaptureDevice& captureDevice)
     auto displayName = captureDevice.label();
     GUniquePtr<GstStructure> properties(gst_structure_new("webkit-mock-device", "persistent-id", G_TYPE_STRING, captureDevice.persistentId().ascii().data(), "is-default", G_TYPE_BOOLEAN, captureDevice.isDefault(), nullptr));
     GST_DEBUG("Creating mock device with name %s and properties %" GST_PTR_FORMAT, displayName.utf8().data(), properties.get());
-    auto* device = WEBKIT_MOCK_DEVICE_CAST(g_object_new(GST_TYPE_MOCK_DEVICE, "display-name", displayName.utf8().data(), "device-class", deviceClass, "caps", caps.get(), "properties", properties.get(), nullptr));
+    auto* device = WEBKIT_MOCK_DEVICE_CAST(g_object_new(GST_TYPE_MOCK_DEVICE, "display-name", displayName.utf8().data(),
+        "device-class", deviceClass.characters(), "caps", caps.get(), "properties", properties.get(), nullptr));
     gst_object_ref_sink(device);
     return GST_DEVICE_CAST(device);
 }

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerRTPPacketizer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerRTPPacketizer.cpp
@@ -143,7 +143,7 @@ void GStreamerRTPPacketizer::ensureMidExtension(const String& mid)
 
         m_midExtension = extension;
         GST_DEBUG_OBJECT(m_bin.get(), "Using mid extension %" GST_PTR_FORMAT, m_midExtension.get());
-        g_object_set(extension, "mid", mid.utf8().data(), nullptr);
+        g_object_set(extension, "mid", mid.ascii().data(), nullptr);
         GST_DEBUG_OBJECT(m_bin.get(), "Existing mid extension updated with mid %s", mid.utf8().data());
         break;
     }

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.cpp
@@ -231,9 +231,9 @@ bool GStreamerVideoCapturer::setFrameRate(double frameRate)
     return true;
 }
 
-static std::optional<int> getMaxIntValueFromStructure(const GstStructure* structure, const char* fieldName)
+static std::optional<int> getMaxIntValueFromStructure(const GstStructure* structure, ASCIILiteral fieldName)
 {
-    const GValue* value = gst_structure_get_value(structure, fieldName);
+    const GValue* value = gst_structure_get_value(structure, fieldName.characters());
     if (!value)
         return std::nullopt;
 
@@ -267,9 +267,9 @@ static std::optional<int> getMaxIntValueFromStructure(const GstStructure* struct
     return (maxInt > -G_MAXINT) ? std::make_optional<>(maxInt) : std::nullopt;
 }
 
-static std::optional<double> getMaxFractionValueFromStructure(const GstStructure* structure, const char* fieldName)
+static std::optional<double> getMaxFractionValueFromStructure(const GstStructure* structure, ASCIILiteral fieldName)
 {
-    const GValue* value = gst_structure_get_value(structure, fieldName);
+    const GValue* value = gst_structure_get_value(structure, fieldName.characters());
     if (!value)
         return std::nullopt;
 
@@ -356,15 +356,15 @@ void GStreamerVideoCapturer::reconfigure()
 
     gst_caps_foreach(deviceCaps.get(),
         reinterpret_cast<GstCapsForeachFunc>(+[](GstCapsFeatures*, GstStructure* structure, MimeTypeSelector* selector) -> gboolean {
-            auto width = getMaxIntValueFromStructure(structure, "width");
+            auto width = getMaxIntValueFromStructure(structure, "width"_s);
             if (!width.has_value())
                 return TRUE;
 
-            auto height = getMaxIntValueFromStructure(structure, "height");
+            auto height = getMaxIntValueFromStructure(structure, "height"_s);
             if (!height.has_value())
                 return TRUE;
 
-            auto frameRate = getMaxFractionValueFromStructure(structure, "framerate");
+            auto frameRate = getMaxFractionValueFromStructure(structure, "framerate"_s);
             if (!frameRate.has_value())
                 return TRUE;
 

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.h
@@ -42,7 +42,7 @@ public:
     void tearDown(bool disconnectSignals) final;
     void setupPipeline() final;
     GstElement* createConverter() final;
-    const char* name() final { return "Video"; }
+    ASCIILiteral name() final { return "Video"_s; }
 
     using SinkVideoFrameCallback = Function<void(Ref<VideoFrameGStreamer>&&)>;
     void setSinkVideoFrameCallback(SinkVideoFrameCallback&&);

--- a/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoDecoderFactory.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoDecoderFactory.cpp
@@ -279,9 +279,9 @@ public:
         return { sdpVideoFormat() };
     }
 
-    static GRefPtr<GstElementFactory> GstDecoderFactory(const char* capsStr)
+    static GRefPtr<GstElementFactory> GstDecoderFactory(ASCIILiteral capsStr)
     {
-        return GStreamerRegistryScanner::singleton().isCodecSupported(GStreamerRegistryScanner::Configuration::Decoding, String::fromUTF8(capsStr), false).factory;
+        return GStreamerRegistryScanner::singleton().isCodecSupported(GStreamerRegistryScanner::Configuration::Decoding, capsStr, false).factory;
     }
 
     bool HasGstDecoder()
@@ -289,10 +289,10 @@ public:
         return GstDecoderFactory(Caps());
     }
 
-    virtual const gchar* Caps() = 0;
+    virtual ASCIILiteral Caps() = 0;
     virtual webrtc::VideoCodecType CodecType() = 0;
     const char* ImplementationName() const override { return "GStreamer"; }
-    virtual const gchar* Name() = 0;
+    virtual ASCIILiteral Name() = 0;
     virtual webrtc::SdpVideoFormat sdpVideoFormat() = 0;
 
 protected:
@@ -341,8 +341,8 @@ public:
         m_caps = adoptGRef(gst_caps_new_simple(Caps(), "width", G_TYPE_INT, width, "height", G_TYPE_INT, height,
             "alignment", G_TYPE_STRING, "au", nullptr));
     }
-    const gchar* Caps() final { return "video/x-h264"; }
-    const gchar* Name() final { return "h264"; }
+    ASCIILiteral Caps() final { return "video/x-h264"_s; }
+    ASCIILiteral Name() final { return "h264"_s; }
     webrtc::SdpVideoFormat sdpVideoFormat() final { return webrtc::SdpVideoFormat::H264(); }
     webrtc::VideoCodecType CodecType() final { return webrtc::kVideoCodecH264; }
 
@@ -355,14 +355,14 @@ public:
 class VP8Decoder : public GStreamerWebRTCVideoDecoder {
 public:
     VP8Decoder() { }
-    const gchar* Caps() final { return "video/x-vp8"; }
-    const gchar* Name() final { return "vp8"; }
+    ASCIILiteral Caps() final { return "video/x-vp8"_s; }
+    ASCIILiteral Name() final { return "vp8"_s; }
     webrtc::SdpVideoFormat sdpVideoFormat() final { return webrtc::SdpVideoFormat::VP8(); }
 
     webrtc::VideoCodecType CodecType() final { return webrtc::kVideoCodecVP8; }
     static std::unique_ptr<webrtc::VideoDecoder> Create(const webrtc::Environment& environment)
     {
-        auto factory = GstDecoderFactory("video/x-vp8");
+        auto factory = GstDecoderFactory("video/x-vp8"_s);
         if (factory) {
             const auto* factoryName = GST_OBJECT_NAME(GST_OBJECT(factory.get()));
             if (!g_strcmp0(factoryName, "vp8dec") || !g_strcmp0(factoryName, "vp8alphadecodebin")) {
@@ -381,8 +381,8 @@ public:
         : m_isSupportingVP9Profile0(isSupportingVP9Profile0)
         , m_isSupportingVP9Profile2(isSupportingVP9Profile2) { };
 
-    const gchar* Caps() final { return "video/x-vp9"; }
-    const gchar* Name() final { return "vp9"; }
+    ASCIILiteral Caps() final { return "video/x-vp9"_s; }
+    ASCIILiteral Name() final { return "vp9"_s; }
     webrtc::SdpVideoFormat sdpVideoFormat() final { return webrtc::SdpVideoFormat::VP9Profile0(); }
 
     webrtc::VideoCodecType CodecType() final { return webrtc::kVideoCodecVP9; }

--- a/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp
@@ -4447,13 +4447,13 @@ gboolean webkit_settings_apply_from_key_file(WebKitSettings* settings, GKeyFile*
     }
 
     GUniqueOutPtr<GError> getKeysError;
-    auto allKeys = gKeyFileGetKeys(keyFile, groupName, getKeysError);
-    if (getKeysError) [[unlikely]] {
-        g_propagate_error(error, getKeysError.release());
+    auto allKeys = gKeyFileGetKeys(keyFile, CStringView::unsafeFromUTF8(groupName));
+    if (!allKeys) [[unlikely]] {
+        g_propagate_error(error, allKeys.error().release());
         return FALSE;
     }
 
-    for (const char* key : allKeys.span()) {
+    for (const char* key : allKeys->span()) {
         if (!g_ptr_array_find_with_equal_func(propertyNames.get(), static_cast<gconstpointer>(key), g_str_equal, nullptr)) {
             g_set_error(error, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_INVALID_VALUE, "The %s group contains an invalid setting: %s", groupName, key);
             return FALSE;

--- a/Tools/TestWebKitAPI/Tests/WebCore/gstreamer/GStreamerTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/gstreamer/GStreamerTest.cpp
@@ -125,37 +125,37 @@ TEST_F(GStreamerTest, hevcProfileParsing)
 {
     using namespace GStreamerCodecUtilities;
 
-    ASSERT_STREQ(parseHEVCProfile("hev1.1.6.L93.B0"_s), "main");
-    ASSERT_STREQ(parseHEVCProfile("hev1.2.4.L93.B0"_s), "main-10");
-    ASSERT_STREQ(parseHEVCProfile("hev1.3.E.L93.B0"_s), "main-still-picture");
-    ASSERT_STREQ(parseHEVCProfile("hev1.4.10.L186.BF.C8"_s), "monochrome");
-    ASSERT_STREQ(parseHEVCProfile("hev1.4.10.L30.BD.C8"_s), "monochrome-10");
-    ASSERT_STREQ(parseHEVCProfile("hev1.4.10.L30.B9.C8"_s), "monochrome-12");
-    ASSERT_STREQ(parseHEVCProfile("hev1.4.10.L30.B1.C8"_s), "monochrome-16");
-    ASSERT_STREQ(parseHEVCProfile("hev1.4.10.L30.B9.88"_s), "main-12");
+    ASSERT_EQ(parseHEVCProfile("hev1.1.6.L93.B0"_s), "main"_s);
+    ASSERT_EQ(parseHEVCProfile("hev1.2.4.L93.B0"_s), "main-10"_s);
+    ASSERT_EQ(parseHEVCProfile("hev1.3.E.L93.B0"_s), "main-still-picture"_s);
+    ASSERT_EQ(parseHEVCProfile("hev1.4.10.L186.BF.C8"_s), "monochrome"_s);
+    ASSERT_EQ(parseHEVCProfile("hev1.4.10.L30.BD.C8"_s), "monochrome-10"_s);
+    ASSERT_EQ(parseHEVCProfile("hev1.4.10.L30.B9.C8"_s), "monochrome-12"_s);
+    ASSERT_EQ(parseHEVCProfile("hev1.4.10.L30.B1.C8"_s), "monochrome-16"_s);
+    ASSERT_EQ(parseHEVCProfile("hev1.4.10.L30.B9.88"_s), "main-12"_s);
 
-    ASSERT_STREQ(parseHEVCProfile("hev1.4.10.L30.BE.08"_s), "main-444");
-    ASSERT_STREQ(parseHEVCProfile("hev1.4.10.L30.BC.08"_s), "main-444-10");
-    ASSERT_STREQ(parseHEVCProfile("hev1.4.10.L30.B8.08"_s), "main-444-12");
+    ASSERT_EQ(parseHEVCProfile("hev1.4.10.L30.BE.08"_s), "main-444"_s);
+    ASSERT_EQ(parseHEVCProfile("hev1.4.10.L30.BC.08"_s), "main-444-10"_s);
+    ASSERT_EQ(parseHEVCProfile("hev1.4.10.L30.B8.08"_s), "main-444-12"_s);
 
-    ASSERT_STREQ(parseHEVCProfile("hev1.4.10.L30.BF.A8"_s), "main-intra");
-    ASSERT_STREQ(parseHEVCProfile("hev1.4.10.L30.BD.A8"_s), "main-10-intra");
-    ASSERT_STREQ(parseHEVCProfile("hev1.4.10.L30.B9.A8"_s), "main-12-intra");
+    ASSERT_EQ(parseHEVCProfile("hev1.4.10.L30.BF.A8"_s), "main-intra"_s);
+    ASSERT_EQ(parseHEVCProfile("hev1.4.10.L30.BD.A8"_s), "main-10-intra"_s);
+    ASSERT_EQ(parseHEVCProfile("hev1.4.10.L30.B9.A8"_s), "main-12-intra"_s);
 
-    ASSERT_STREQ(parseHEVCProfile("hev1.4.10.L30.BE.28"_s), "main-444-intra");
-    ASSERT_STREQ(parseHEVCProfile("hev1.4.10.L60.BC.28"_s), "main-444-10-intra");
-    ASSERT_STREQ(parseHEVCProfile("hev1.4.10.L30.B0.20"_s), "main-444-16-intra");
+    ASSERT_EQ(parseHEVCProfile("hev1.4.10.L30.BE.28"_s), "main-444-intra"_s);
+    ASSERT_EQ(parseHEVCProfile("hev1.4.10.L60.BC.28"_s), "main-444-10-intra"_s);
+    ASSERT_EQ(parseHEVCProfile("hev1.4.10.L30.B0.20"_s), "main-444-16-intra"_s);
 
-    ASSERT_STREQ(parseHEVCProfile("hev1.5.20.L30.BE.0C"_s), "high-throughput-444");
-    ASSERT_STREQ(parseHEVCProfile("hev1.5.20.L30.BC.0C"_s), "high-throughput-444-10");
-    ASSERT_STREQ(parseHEVCProfile("hev1.5.20.L30.B0.0C"_s), "high-throughput-444-14");
-    ASSERT_STREQ(parseHEVCProfile("hev1.5.20.L30.B0.24"_s), "high-throughput-444-16-intra");
+    ASSERT_EQ(parseHEVCProfile("hev1.5.20.L30.BE.0C"_s), "high-throughput-444"_s);
+    ASSERT_EQ(parseHEVCProfile("hev1.5.20.L30.BC.0C"_s), "high-throughput-444-10"_s);
+    ASSERT_EQ(parseHEVCProfile("hev1.5.20.L30.B0.0C"_s), "high-throughput-444-14"_s);
+    ASSERT_EQ(parseHEVCProfile("hev1.5.20.L30.B0.24"_s), "high-throughput-444-16-intra"_s);
 
-    ASSERT_STREQ(parseHEVCProfile("hev1.9.200.L30.BF.8C"_s), "screen-extended-main");
-    ASSERT_STREQ(parseHEVCProfile("hev1.9.200.L30.BD.8C"_s), "screen-extended-main-10");
-    ASSERT_STREQ(parseHEVCProfile("hev1.9.200.L30.BE.0C"_s), "screen-extended-main-444");
-    ASSERT_STREQ(parseHEVCProfile("hev1.9.200.L30.BC.0C"_s), "screen-extended-main-444-10");
-    ASSERT_STREQ(parseHEVCProfile("hev1.9.200.L30.B0.0C"_s), "screen-extended-high-throughput-444-14");
+    ASSERT_EQ(parseHEVCProfile("hev1.9.200.L30.BF.8C"_s), "screen-extended-main"_s);
+    ASSERT_EQ(parseHEVCProfile("hev1.9.200.L30.BD.8C"_s), "screen-extended-main-10"_s);
+    ASSERT_EQ(parseHEVCProfile("hev1.9.200.L30.BE.0C"_s), "screen-extended-main-444"_s);
+    ASSERT_EQ(parseHEVCProfile("hev1.9.200.L30.BC.0C"_s), "screen-extended-main-444-10"_s);
+    ASSERT_EQ(parseHEVCProfile("hev1.9.200.L30.B0.0C"_s), "screen-extended-high-throughput-444-14"_s);
 }
 
 TEST_F(GStreamerTest, capsFromCodecString)


### PR DESCRIPTION
#### 9d73b18d5e881855c5eeff6c3b07600a3252eb6d
<pre>
[GStreamer] Increase use of CStringView and other string management improvements
<a href="https://bugs.webkit.org/show_bug.cgi?id=299443">https://bugs.webkit.org/show_bug.cgi?id=299443</a>

Reviewed by Philippe Normand.

We are increasing the use of CStringView, also assuming that all input is UTF8 and that it might need to be converted in
order to interact with other WebKit classes.

Test: Covered by existing tests.

* Source/WTF/wtf/glib/GSpanExtras.cpp:
(WTF::gFileGetContents):
(WTF::gKeyFileGetKeys):
* Source/WTF/wtf/glib/GSpanExtras.h:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerDataChannelHandler.cpp:
(WebCore::GStreamerDataChannelHandler::GStreamerDataChannelHandler):
(WebCore::GStreamerDataChannelHandler::onMessageString):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerDataChannelHandler.h:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp:
(WebCore::GStreamerMediaEndpoint::maybeInsertNetSimForElement):
(WebCore::fetchDescription):
(WebCore::getMediaStreamIdsFromSDPMedia):
(WebCore::GStreamerMediaEndpoint::linkOutgoingSources):
(WebCore::GStreamerMediaEndpoint::doSetRemoteDescription):
(WebCore::GStreamerMediaEndpoint::processSDPMessage):
(WebCore::GStreamerMediaEndpoint::isIceGatheringComplete):
(WebCore::GStreamerMediaEndpoint::initiate):
(WebCore::GStreamerMediaEndpoint::trackIdFromSDPMedia):
(WebCore::GStreamerMediaEndpoint::connectPad):
(WebCore::GStreamerMediaEndpoint::canTrickleIceCandidates const):
(WebCore::GStreamerMediaEndpoint::completeSDPAnswer):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.h:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpTransceiverBackend.cpp:
(WebCore::GStreamerRtpTransceiverBackend::setCodecPreferences):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp:
(WebCore::x509Serialize):
(WebCore::privateKeySerialize):
(WebCore::sdpMediaHasAttributeKey):
(WebCore::getDirectionFromSDPMedia):
(WebCore::capsFromSDPMedia):
(WebCore::setSsrcAudioLevelVadOn):
(WebCore::SDPStringBuilder::appendConnection):
(WebCore::SDPStringBuilder::appendMedia):
(WebCore::SDPStringBuilder::SDPStringBuilder):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.h:
* Source/WebCore/platform/audio/gstreamer/AudioEncoderGStreamer.cpp:
(WebCore::GStreamerInternalAudioEncoder::initialize):
* Source/WebCore/platform/audio/gstreamer/AudioFileReaderGStreamer.cpp:
(WebCore::AudioFileReader::handleMessage):
* Source/WebCore/platform/audio/gstreamer/PlatformRawAudioDataGStreamer.cpp:
(WebCore::layoutToString):
(WebCore::PlatformRawAudioData::copyTo):
* Source/WebCore/platform/graphics/gstreamer/GLVideoSinkGStreamer.cpp:
(initializeDMABufAvailability):
* Source/WebCore/platform/graphics/gstreamer/GStreamerAudioMixer.cpp:
(WebCore::GStreamerAudioMixer::registerProducer):
(WebCore::GStreamerAudioMixer::configureSourcePeriodTime):
* Source/WebCore/platform/graphics/gstreamer/GStreamerAudioMixer.h:
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp:
(WebCore::getStreamIdFromPad):
(WebCore::getStreamIdFromStream):
(WebCore::parseStreamId):
(WebCore::extractGStreamerOptionsFromCommandLine):
(WebCore::ensureGStreamerInitialized):
(WebCore::registerWebKitGStreamerElements):
(WebCore::deinitializeGStreamer):
(WebCore::getGstPlayFlag):
(WebCore::makeGStreamerElement):
(WebCore::gstStructureValueToJSON):
(WebCore::gstStructureToJSON):
(WebCore::gstElementMatchesFactoryAndHasProperty):
(WebCore::gstIdToString):
(WebCore::buildDMABufCaps):
(WebCore::requestGLContext):
(WebCore::setGstElementGLContext):
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h:
* Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp:
(WebCore::GStreamerRegistryScanner::ElementFactories::elementFactoryTypeToString):
(WebCore::GStreamerRegistryScanner::ElementFactories::hasElementForCaps const):
(WebCore::GStreamerRegistryScanner::initializeDecoders):
(WebCore::GStreamerRegistryScanner::isAVC1CodecSupported const):
(WebCore::probeRtpExtensions):
(WebCore::GStreamerRegistryScanner::isRtpHeaderExtensionSupported):
* Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.h:
* Source/WebCore/platform/graphics/gstreamer/GStreamerSinksWorkarounds.cpp:
(WebCore::getWorkAroundModeFromEnvironment):
(WebCore::BaseSinkPositionFlushWorkaroundProbe::checkIsNeeded):
(WebCore::AppSinkFlushCapsWorkaroundProbe::checkIsNeeded):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::elementIdChanged const):
(WebCore::MediaPlayerPrivateGStreamer::handleNeedContextMessage):
(WebCore::MediaPlayerPrivateGStreamer::handleMessage):
(WebCore::MediaPlayerPrivateGStreamer::configureParsebin):
(WebCore::MediaPlayerPrivateGStreamer::configureElement):
(WebCore::MediaPlayerPrivateGStreamer::configureDownloadBuffer):
(WebCore::MediaPlayerPrivateGStreamer::loadNextLocation):
(WebCore::MediaPlayerPrivateGStreamer::createVideoSinkGL):
(WebCore::MediaPlayerPrivateGStreamer::parseInitDataFromProtectionMessage):
(WebCore::MediaPlayerPrivateGStreamer::handleProtectionEvent):
* Source/WebCore/platform/graphics/gstreamer/MediaSampleGStreamer.cpp:
(WebCore::MediaSampleGStreamer::dump const):
* Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.cpp:
(WebCore::TrackPrivateBaseGStreamer::tagsChanged):
(WebCore::TrackPrivateBaseGStreamer::getLanguageCode):
(WebCore::TrackPrivateBaseGStreamer::getTag):
(WebCore::TrackPrivateBaseGStreamer::notifyTrackOfTagsChanged):
* Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.h:
* Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp:
(WebCore::VideoFrameGStreamer::createFromPixelBuffer):
(WebCore::VideoFrameGStreamer::convert):
* Source/WebCore/platform/graphics/gstreamer/WebKitAudioSinkGStreamer.cpp:
(webKitAudioSinkConfigure):
* Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp:
(webKitWebSrcSetExtraHeader):
(webKitWebSrcMakeRequest):
(convertPlaybinURI):
(webKitWebSrcSetUri):
* Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.h:
* Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.cpp:
(WebCore::sessionLoadFailureFromThunder):
(WebCore::toString):
(WebCore::CDMInstanceSessionThunder::keyUpdatedCallback):
(WebCore::CDMInstanceSessionThunder::loadSession):
* Source/WebCore/platform/graphics/gstreamer/eme/GStreamerEMEUtilities.h:
(WebCore::GStreamerEMEUtilities::isClearKeyUUID):
(WebCore::GStreamerEMEUtilities::isWidevineUUID):
(WebCore::GStreamerEMEUtilities::isPlayReadyUUID):
(WebCore::GStreamerEMEUtilities::isUnspecifiedUUID):
(WebCore::GStreamerEMEUtilities::keySystemToUuid):
(WebCore::GStreamerEMEUtilities::uuidToKeySystem):
* Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.cpp:
(transformCaps):
* Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.h:
* Source/WebCore/platform/graphics/gstreamer/eme/WebKitThunderDecryptorGStreamer.cpp:
(createSinkPadTemplateCaps):
(protectionSystemId):
* Source/WebCore/platform/graphics/gstreamer/eme/WebKitThunderParser.cpp:
(createThunderParseSinkPadTemplateCaps):
* Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp:
(WebCore::serialize):
(WebCore::AppendPipeline::didReceiveInitializationSegment):
(WebCore::AppendPipeline::Track::initializeElements):
(WebCore::appendPipelinePadProbeDebugInformation):
(WebCore::AppendPipeline::streamTypeToString): Deleted.
* Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.h:
* Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp:
(dumpReadyState):
(WebCore::MediaPlayerPrivateGStreamerMSE::readyStateFromMediaSourceChanged):
(WebCore::MediaPlayerPrivateGStreamerMSE::propagateReadyStateToPlayer):
* Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.cpp:
(WebCore::MediaSourcePrivateGStreamer::markEndOfStream):
* Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp:
(streamTypeToString):
(webKitMediaSrcEmitStreams):
* Source/WebCore/platform/gstreamer/GStreamerCodecUtilities.cpp:
(WebCore::GStreamerCodecUtilities::parseH264ProfileAndLevel):
(WebCore::h264CapsFromCodecString):
(WebCore::GStreamerCodecUtilities::parseHEVCProfile):
(WebCore::h265CapsFromCodecString):
(WebCore::av1CapsFromCodecString):
(): Deleted.
* Source/WebCore/platform/gstreamer/GStreamerCodecUtilities.h:
* Source/WebCore/platform/gstreamer/GStreamerElementHarness.cpp:
(WebCore::MermaidBuilder::dumpElement):
(WebCore::MermaidBuilder::describeCaps):
(WebCore::GStreamerElementHarness::dumpGraph):
* Source/WebCore/platform/gstreamer/GStreamerQuirkBroadcom.cpp:
(WebCore::GStreamerQuirkBroadcom::configureElement):
* Source/WebCore/platform/gstreamer/GStreamerQuirkBroadcomBase.cpp:
(WebCore::GStreamerQuirkBroadcomBase::correctBufferingPercentage const):
(WebCore::GStreamerQuirkBroadcomBase::setupBufferingPercentageCorrection const):
* Source/WebCore/platform/gstreamer/GStreamerQuirkRialto.cpp:
(WebCore::GStreamerQuirkRialto::GStreamerQuirkRialto):
(WebCore::GStreamerQuirkRialto::configureElement):
* Source/WebCore/platform/gstreamer/GStreamerQuirkWesteros.cpp:
(WebCore::GStreamerQuirkWesteros::configureElement):
* Source/WebCore/platform/gstreamer/GStreamerQuirks.cpp:
(WebCore::GStreamerQuirksManager::GStreamerQuirksManager):
* Source/WebCore/platform/gstreamer/WebKitFliteSourceGStreamer.cpp:
(fliteVoice):
(webKitFliteSrcSetUtterance):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCapturer.h:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.cpp:
(WebCore::GStreamerCaptureDeviceManager::captureDeviceFromGstDevice):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.h:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.cpp:
(WebCore::GStreamerIncomingTrackProcessor::mediaStreamIdFromPad):
(WebCore::GStreamerIncomingTrackProcessor::retrieveMediaStreamAndTrackIdFromSDP):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerMockDevice.cpp:
(webkitMockDeviceCreate):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerRTPPacketizer.cpp:
(WebCore::GStreamerRTPPacketizer::ensureMidExtension):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.cpp:
(WebCore::getMaxIntValueFromStructure):
(WebCore::getMaxFractionValueFromStructure):
(WebCore::GStreamerVideoCapturer::reconfigure):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.h:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerWebRTCLogSink.cpp:
(WebCore::GStreamerWebRTCLogSink::start):
* Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoDecoderFactory.cpp:
(WebCore::GStreamerWebRTCVideoDecoder::GstDecoderFactory):
(WebCore::VP8Decoder::Create):
* Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp:
(webkit_settings_apply_from_key_file):
* Tools/TestWebKitAPI/Tests/WebCore/gstreamer/GStreamerTest.cpp:
(TestWebKitAPI::TEST_F(GStreamerTest, hevcProfileParsing)):

Canonical link: <a href="https://commits.webkit.org/304152@main">https://commits.webkit.org/304152@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c7bf12781366b045593af2568535a812600665c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/134751 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/7195 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/45999 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/142271 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/86674 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/136621 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/7805 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/7047 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/102987 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/86674 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/137698 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/5499 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/120778 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/83802 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/5344 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/2950 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/2860 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/126789 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/114571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/38926 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/144966 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/133258 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/6871 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/39506 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/111377 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/6942 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/5763 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/111686 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28319 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/5174 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/117058 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/60777 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/6919 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/35243 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/166163 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/6720 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/70500 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43428 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/6956 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/6829 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->