### PR TITLE
[Liquid Glass] [iOS] Scrollable modal popups on www.apple.com/environment are missing bottom color extensions

### DIFF
--- a/LayoutTests/fast/page-color-sampling/color-sampling-ignores-subscrollers-expected.txt
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-ignores-subscrollers-expected.txt
@@ -1,8 +1,0 @@
-PASS colors.top is null
-PASS colors.left is null
-PASS colors.right is null
-PASS colors.bottom is "rgb(225, 225, 225)"
-PASS successfullyParsed is true
-
-TEST COMPLETE
-

--- a/LayoutTests/fast/page-color-sampling/color-sampling-ignores-text.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-ignores-text.html
@@ -34,6 +34,8 @@
     jsTestIsAsync = true;
 
     addEventListener("load", async () => {
+        await UIHelper.setObscuredInsets(100, 0, 0, 0);
+
         let header = document.querySelector("header");
         sampledTopColors = []
         for (let i = 0; i < 10; ++i) {

--- a/LayoutTests/fast/page-color-sampling/color-sampling-stability-for-same-element-expected.txt
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-stability-for-same-element-expected.txt
@@ -1,11 +1,10 @@
-PASS colorsAfterScrollingDown.top is "rgb(200, 0, 0)"
 PASS colorsAfterScrollingDown.left is null
 PASS colorsAfterScrollingDown.right is null
 PASS colorsAfterScrollingDown.bottom is null
-PASS colorsAfterScrollingUp.top is "rgb(200, 0, 0)"
 PASS colorsAfterScrollingUp.left is null
 PASS colorsAfterScrollingUp.right is null
 PASS colorsAfterScrollingUp.bottom is null
+PASS colorsAfterScrollingDown.top is colorsAfterScrollingUp.top
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/page-color-sampling/color-sampling-stability-for-same-element.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-stability-for-same-element.html
@@ -55,7 +55,6 @@
         await UIHelper.ensurePresentationUpdate();
 
         colorsAfterScrollingDown = await UIHelper.fixedContainerEdgeColors();
-        shouldBeEqualToString("colorsAfterScrollingDown.top", "rgb(200, 0, 0)");
         shouldBeNull("colorsAfterScrollingDown.left");
         shouldBeNull("colorsAfterScrollingDown.right");
         shouldBeNull("colorsAfterScrollingDown.bottom");
@@ -64,10 +63,10 @@
         await UIHelper.ensurePresentationUpdate();
 
         colorsAfterScrollingUp = await UIHelper.fixedContainerEdgeColors();
-        shouldBeEqualToString("colorsAfterScrollingUp.top", "rgb(200, 0, 0)");
         shouldBeNull("colorsAfterScrollingUp.left");
         shouldBeNull("colorsAfterScrollingUp.right");
         shouldBeNull("colorsAfterScrollingUp.bottom");
+        shouldBe("colorsAfterScrollingDown.top", "colorsAfterScrollingUp.top");
 
         finishJSTest();
     });

--- a/LayoutTests/fast/page-color-sampling/color-sampling-with-subscroller-expected.txt
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-with-subscroller-expected.txt
@@ -1,0 +1,8 @@
+PASS colors.top is "rgb(0, 122, 255)"
+PASS colors.left is "multiple"
+PASS colors.right is "multiple"
+PASS colors.bottom is "rgb(225, 225, 225)"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/page-color-sampling/color-sampling-with-subscroller.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-with-subscroller.html
@@ -46,9 +46,9 @@
         await UIHelper.setObscuredInsets(50, 50, 50, 50);
         await UIHelper.ensurePresentationUpdate();
         colors = await UIHelper.fixedContainerEdgeColors();
-        shouldBeNull("colors.top");
-        shouldBeNull("colors.left");
-        shouldBeNull("colors.right");
+        shouldBeEqualToString("colors.top", "rgb(0, 122, 255)");
+        shouldBeEqualToString("colors.left", "multiple");
+        shouldBeEqualToString("colors.right", "multiple");
         shouldBeEqualToString("colors.bottom", "rgb(225, 225, 225)");
         finishJSTest();
     });


### PR DESCRIPTION
#### 35b0d66fd1b1db6a05ae3e5d6a0abd06db3fa673
<pre>
[Liquid Glass] [iOS] Scrollable modal popups on www.apple.com/environment are missing bottom color extensions
<a href="https://bugs.webkit.org/show_bug.cgi?id=299444">https://bugs.webkit.org/show_bug.cgi?id=299444</a>
<a href="https://rdar.apple.com/161252731">rdar://161252731</a>

Reviewed by Lily Spiniolas.

Make some more minor adjustments to the color sampling heuristic, which allow color extensions to
show up below overflow scrollable modal popups on www.apple.com/environment. This removes a check
that prevented us from sampling scrollable fixed/sticky containers for the purposes of color
extension, for two reasons:

-   The content along the bottom edge of the scrollable container could change when scrolling,
    causing the sampled color to change.

-   It avoided frequent color sampling when scrolling through Instagram feeds, which (alone) was
    leading to ~70% more power use on that website, just while watching content.

However, after that change was landed in 293340@main, a few key differences to the heuristic were
made, which should allow us to effectively undo that change without causing a huge spike in power
use on Instagram:

1.  Color sampling results are now cached per container, so as long as we hit-test to the same
    element, we&apos;ll avoid color sampling and instead keep the last color stable.

2.  Painting for the purposes of color sampling skips any non-viewport-constrained content, replaced
    renderers, and text, leading to a much cheaper cost.

As such, we end up running the color sampling algorithm just 1 additional time on Instagram after
this change (after the fixed element is inserted into the document and painted), and don&apos;t run it
again until the user navigates.

Test: fast/page-color-sampling/color-sampling-with-subscroller.html

* LayoutTests/fast/page-color-sampling/color-sampling-ignores-subscrollers-expected.txt: Removed.
* LayoutTests/fast/page-color-sampling/color-sampling-ignores-text.html:

Drive-by fix: stabilize this flaky test.

* LayoutTests/fast/page-color-sampling/color-sampling-stability-for-same-element-expected.txt:
* LayoutTests/fast/page-color-sampling/color-sampling-stability-for-same-element.html:

Rebaseline this test, by making it verify that the top sampled color remains unchanged when
scrolling down and then back up (rather than checking that it&apos;s a specific color).

* LayoutTests/fast/page-color-sampling/color-sampling-with-subscroller-expected.txt: Added.
* LayoutTests/fast/page-color-sampling/color-sampling-with-subscroller.html: Renamed from LayoutTests/fast/page-color-sampling/color-sampling-ignores-subscrollers.html.

Rename this test to `color-sampling-with-subscroller.html`, and instead have it verify that there
are sampled colors on all sides.

* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::fixedContainerEdges const):

See above.

Canonical link: <a href="https://commits.webkit.org/300473@main">https://commits.webkit.org/300473@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fb857723692c7ed1acace7c1a8dcc051ce30d0a6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122699 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42411 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33101 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/129320 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/74803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/24fa6af7-33ce-4d6e-a90f-b067f56bb7ef) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/124575 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43130 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51004 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93251 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/74803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6c209888-9032-4ba2-8793-5d5a62052ce2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125651 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34388 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109847 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73892 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ca2ed769-7287-4450-9b1b-83285dafe5a5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33375 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28002 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72807 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104087 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28213 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132048 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49644 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37787 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/101778 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50021 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106060 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/101653 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25812 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47021 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25195 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/46414 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49501 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/55254 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48968 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/52320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50651 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->