### PR TITLE
Fix lifetime issues of objects related to DNS resolver

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/NetworkSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/NetworkSPI.h
@@ -95,7 +95,7 @@ typedef enum {
     nw_resolver_class_designated_direct = 2,
 } nw_resolver_class_t;
 
-nw_resolver_config_t nw_resolver_config_create(void);
+OS_OBJECT_RETURNS_RETAINED nw_resolver_config_t nw_resolver_config_create(void);
 void nw_resolver_config_set_protocol(nw_resolver_config_t, nw_resolver_protocol_t);
 void nw_resolver_config_set_class(nw_resolver_config_t, nw_resolver_class_t);
 void nw_resolver_config_add_match_domain(nw_resolver_config_t, const char *);

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -674,6 +674,10 @@ private:
         CompletionHandler<void()> completionHandler;
     };
     HashMap<TaskIdentifier, DeleteWebsiteDataTask> m_deleteWebsiteDataTasks;
+
+#if PLATFORM(IOS_SIMULATOR)
+    OSObjectPtr<nw_resolver_config_t> m_resolverConfig;
+#endif
 };
 
 #if !PLATFORM(COCOA)

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm
@@ -122,13 +122,16 @@ void NetworkProcess::platformInitializeNetworkProcessCocoa(const NetworkProcessC
 
 #if PLATFORM(IOS_SIMULATOR)
     // See TestController::cocoaPlatformInitialize for supporting a local DNS resolver on Mac.
-    if (parameters.localhostAliasesForTesting.contains("web-platform.test"_s)) {
-        nw_resolver_config_t resolverConfig = nw_resolver_config_create();
-        nw_resolver_config_set_protocol(resolverConfig, nw_resolver_protocol_dns53);
-        nw_resolver_config_set_class(resolverConfig, nw_resolver_class_designated_direct);
-        nw_resolver_config_add_name_server(resolverConfig, "127.0.0.1:8053");
-        nw_resolver_config_add_match_domain(resolverConfig, "test");
-        nw_privacy_context_require_encrypted_name_resolution(NW_DEFAULT_PRIVACY_CONTEXT, true, resolverConfig);
+    auto webPlatformTestDomain = "web-platform.test"_s;
+    if (parameters.localhostAliasesForTesting.contains(webPlatformTestDomain)) {
+        m_resolverConfig = adoptOSObject(nw_resolver_config_create());
+        if (auto resolverConfig = m_resolverConfig) {
+            nw_resolver_config_set_protocol(resolverConfig.get(), nw_resolver_protocol_dns53);
+            nw_resolver_config_set_class(resolverConfig.get(), nw_resolver_class_designated_direct);
+            nw_resolver_config_add_name_server(resolverConfig.get(), "127.0.0.1:8053");
+            nw_resolver_config_add_match_domain(resolverConfig.get(), webPlatformTestDomain.characters());
+            nw_privacy_context_require_encrypted_name_resolution(NW_DEFAULT_PRIVACY_CONTEXT, true, m_resolverConfig.get());
+        }
     }
 #endif
 

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -44,8 +44,13 @@
 #if PLATFORM(COCOA)
 #include "ClassMethodSwizzler.h"
 #include "InstanceMethodSwizzler.h"
+#if PLATFORM(MAC)
+#include <pal/spi/cocoa/NetworkSPI.h>
+#include <wtf/OSObjectPtr.h>
 #endif
+#endif // PLATFORM(COCOA)
 
+OBJC_CLASS NEPolicySession;
 OBJC_CLASS NSColor;
 OBJC_CLASS NSString;
 OBJC_CLASS UIKeyboardInputMode;
@@ -830,7 +835,11 @@ private:
     
 #if PLATFORM(COCOA)
     bool m_hasSetApplicationBundleIdentifier { false };
+#if PLATFORM(MAC)
+    RetainPtr<NEPolicySession> m_policySession;
+    OSObjectPtr<nw_resolver_config_t> m_resolverConfig;
 #endif
+#endif // PLATFORM(COCOA)
 
     bool m_isSpeechRecognitionPermissionGranted { false };
 

--- a/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
@@ -60,7 +60,6 @@
 #import <WebKit/_WKApplicationManifest.h>
 #import <WebKit/_WKWebsiteDataStoreConfiguration.h>
 #import <pal/spi/cocoa/LaunchServicesSPI.h>
-#import <pal/spi/cocoa/NetworkSPI.h>
 #import <wtf/BlockPtr.h>
 #import <wtf/CompletionHandler.h>
 #import <wtf/MainThread.h>
@@ -394,29 +393,34 @@ void TestController::cocoaDNSInitialize()
     [agentUUID.get() getUUIDBytes:agentUUIDBytes];
     NSLog(@"useLocalDNSResolver: agent UUID: %@.", agentUUID.get());
 
-    static nw_resolver_config_t resolverConfig = nw_resolver_config_create();
-    nw_resolver_config_set_protocol(resolverConfig, nw_resolver_protocol_dns53);
-    nw_resolver_config_set_class(resolverConfig, nw_resolver_class_designated_direct);
-    nw_resolver_config_add_name_server(resolverConfig, "127.0.0.1:8053");
-    nw_resolver_config_add_match_domain(resolverConfig, "test");
-    nw_resolver_config_set_identifier(resolverConfig, agentUUIDBytes);
-    bool published = nw_resolver_config_publish(resolverConfig);
-    if (!published) {
-        NSLog(@"Failed to register DNS resolver agent UUID: %@. Using local DNS resolver failed.", agentUUID.get());
-        return;
+    m_resolverConfig = adoptOSObject(nw_resolver_config_create());
+    if (auto resolverConfig = m_resolverConfig) {
+        nw_resolver_config_set_protocol(resolverConfig.get(), nw_resolver_protocol_dns53);
+        nw_resolver_config_set_class(resolverConfig.get(), nw_resolver_class_designated_direct);
+        nw_resolver_config_add_name_server(resolverConfig.get(), "127.0.0.1:8053");
+        auto webPlatformTestDomain = "web-platform.test"_s;
+        nw_resolver_config_add_match_domain(resolverConfig.get(), webPlatformTestDomain);
+        nw_resolver_config_set_identifier(resolverConfig.get(), agentUUIDBytes);
+        bool published = nw_resolver_config_publish(resolverConfig.get());
+        if (!published) {
+            NSLog(@"Failed to register DNS resolver agent UUID: %@. Using local DNS resolver failed.", agentUUID.get());
+            RELEASE_ASSERT_NOT_REACHED();
+        }
     }
 
     // The following NetworkExtension policy is needed so we can run tests while a VPN is connected
-    RetainPtr policySession = adoptNS([[NEPolicySession alloc] init]);
-    RetainPtr domainPolicy = adoptNS([[NEPolicy alloc] initWithOrder:1 result:[NEPolicyResult netAgentUUID:agentUUID.get()] conditions:@[ [NEPolicyCondition domain:@"test"] ]]);
-    [policySession.get() addPolicy:domainPolicy.get()];
+    m_policySession = adoptNS([[NEPolicySession alloc] init]);
+    if (auto policySession = m_policySession) {
+        RetainPtr domainPolicy = adoptNS([[NEPolicy alloc] initWithOrder:1 result:[NEPolicyResult netAgentUUID:agentUUID.get()] conditions:@[ [NEPolicyCondition domain:@"test"] ]]);
+        [policySession addPolicy:domainPolicy.get()];
 
-    NSString *agentString = agentUUID.get().UUIDString;
-    RetainPtr agentPolicy = adoptNS([[NEPolicy alloc] initWithOrder:1 result:[NEPolicyResult netAgentUUID:agentUUID.get()] conditions:@[ [NEPolicyCondition domain:agentString] ]]);
-    [policySession.get() addPolicy:agentPolicy.get()];
+        NSString *agentString = agentUUID.get().UUIDString;
+        RetainPtr agentPolicy = adoptNS([[NEPolicy alloc] initWithOrder:1 result:[NEPolicyResult netAgentUUID:agentUUID.get()] conditions:@[ [NEPolicyCondition domain:agentString] ]]);
+        [policySession addPolicy:agentPolicy.get()];
 
-    policySession.get().priority = NEPolicySessionPriorityHigh;
-    [policySession.get() apply];
+        policySession.get().priority = NEPolicySessionPriorityHigh;
+        [policySession apply];
+    }
 }
 #endif
 


### PR DESCRIPTION
#### f8f41229d5b3874a1c8ab09157f54fc2abbfd168
<pre>
Fix lifetime issues of objects related to DNS resolver
<a href="https://bugs.webkit.org/show_bug.cgi?id=299448">https://bugs.webkit.org/show_bug.cgi?id=299448</a>
<a href="https://rdar.apple.com/problem/161254921">rdar://problem/161254921</a>

Reviewed by Sihui Liu.

Store these objects in smart pointers in the TestController and NetworkProcess objects.

* Source/WebCore/PAL/pal/spi/cocoa/NetworkSPI.h:
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm:
(WebKit::NetworkProcess::platformInitializeNetworkProcessCocoa):
* Tools/WebKitTestRunner/TestController.h:
* Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm:
(WTR::TestController::cocoaDNSInitialize):

Canonical link: <a href="https://commits.webkit.org/300476@main">https://commits.webkit.org/300476@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0893dc5f5edc0cef274a40f9ec28ae3e0550b338

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122698 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42410 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33100 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/129318 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/74802 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/07ca79fa-55f9-4373-b5c1-e10e0c2858d0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/124574 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43129 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51003 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93250 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/74802 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5056998a-c17d-41c1-bf1d-ca9f08156a42) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125650 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34386 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109845 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73891 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/57a072bb-bad3-403e-a84e-a2da39fa5e03) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33373 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28000 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72806 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104085 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28211 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132047 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49643 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37786 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/101776 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50020 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106058 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101641 "Found 2 new API test failures: TestWTF:CompletionHandlerDeathTest.MainThreadHandlerOnThreadAssertsDeathTest, TestWTF:CompletionHandlerDeathTest.ConstructionThreadHandlerOnThreadAssertsDeathTest (failure)") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47020 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25193 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/46413 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19374 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49500 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/55253 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48967 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/52319 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50650 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->