### PR TITLE
Web Inspector: Elements: Unable to navigate with keyboard past `<style>` element in DOM tree

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/DOMTreeContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/DOMTreeContentView.js
@@ -423,7 +423,7 @@ WI.DOMTreeContentView = class DOMTreeContentView extends WI.ContentView
     {
         super.sizeDidChange();
 
-        this._domTreeOutline.selectDOMNode(this._domTreeOutline.selectedDOMNode());
+        this._domTreeOutline.selectedTreeElement?.reveal();
     }
 
     layout()

--- a/Source/WebInspectorUI/UserInterface/Views/DOMTreeOutline.js
+++ b/Source/WebInspectorUI/UserInterface/Views/DOMTreeOutline.js
@@ -421,7 +421,7 @@ WI.DOMTreeOutline = class DOMTreeOutline extends WI.TreeOutline
         if (treeElement instanceof WI.DOMTreeElement && treeElement.isCloseTag()) {
             // SelectionController requires every selectable item to be unique.
             // The DOMTreeElement for a close tag has the same represented object
-            // as it's parent (the open tag). Return a proxy object associated
+            // as its parent (the open tag). Return a proxy object associated
             // with the tree element for the close tag so it can be selected.
             if (!treeElement.__closeTagProxyObject)
                 treeElement.__closeTagProxyObject = {__proxyObjectTreeElement: treeElement};


### PR DESCRIPTION
#### 44655d4ac52531716690a293dc8ead0393f8bb22
<pre>
Web Inspector: Elements: Unable to navigate with keyboard past `&lt;style&gt;` element in DOM tree
<a href="https://bugs.webkit.org/show_bug.cgi?id=299445">https://bugs.webkit.org/show_bug.cgi?id=299445</a>
<a href="https://rdar.apple.com/159841729">rdar://159841729</a>

Reviewed by Devin Rousso.

When selecting nodes in the DOM tree outline, only the suitable details sidebar panels are shown.
For a text node, like the contents of a `&lt;style&gt;` node, only the Node details sidebar is shown,
while Styles, Computed, Layout, Fonts, and Changes are removed.

Navigating between different nodes types triggers relayout in `WI.DOMTreeContentView`
as the details sidebars are added or removed.

The view resize handler in `WI.DOMTreeContentView.prototype.sizeDidChange()`
re-selects the selected node in order to scroll it back into the viewport if needed.
This was implemented in <a href="https://commits.webkit.org/204576@main">https://commits.webkit.org/204576@main</a>

The DOM node is associated with both the opening and closing tags in the DOM tree outline.
But when re-selecting the DOM node, there&apos;s no context about which of the tags was previously selected.

Keyboard navigation correctly goes from the text node to the closing `&lt;style&gt;` tag.
But the action in the resize handler causes the the opening `&lt;style&gt;` to be selected. A loop is created.

There is no need to re-select the DOM node (and unnecessarily wasteful for all the sidebars),
It&apos;s enough to bring its corresponding DOM tree outline element back into view.

* Source/WebInspectorUI/UserInterface/Views/DOMTreeContentView.js:
(WI.DOMTreeContentView.prototype.sizeDidChange):
* Source/WebInspectorUI/UserInterface/Views/DOMTreeOutline.js:
(WI.DOMTreeOutline.prototype.objectForSelection):

Canonical link: <a href="https://commits.webkit.org/300471@main">https://commits.webkit.org/300471@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c56fd5207af189d11bb0cc16d5cf674ed8277712

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122705 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42417 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33107 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/129326 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/74809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b6c6def2-5c2d-45ae-baa1-1e8e7035a827) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43136 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51010 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/93255 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/74809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/809d7e18-c2c8-4d1e-94a4-5b9caf49f13a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125657 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34389 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109853 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/73896 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/652a82a1-a35a-4910-9d07-3020226e3d35) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33376 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28008 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72813 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104088 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/28220 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132054 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49650 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/37794 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/101782 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50027 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106067 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/101648 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25811 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47022 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25201 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/46420 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49507 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/55260 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/48974 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/52326 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50657 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->