### PR TITLE
[Style] Convert the 'font-palette' property to strong style types

### DIFF
--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -219,6 +219,7 @@ set(WebCore_PRIVATE_INCLUDE_DIRECTORIES
     "${WEBCORE_DIR}/style/values/fill-stroke"
     "${WEBCORE_DIR}/style/values/filter-effects"
     "${WEBCORE_DIR}/style/values/flexbox"
+    "${WEBCORE_DIR}/style/values/fonts"
     "${WEBCORE_DIR}/style/values/grid"
     "${WEBCORE_DIR}/style/values/images"
     "${WEBCORE_DIR}/style/values/inline"

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -3262,6 +3262,8 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     style/values/flexbox/StyleWebKitBoxFlexGroup.h
     style/values/flexbox/StyleWebKitBoxOrdinalGroup.h
 
+    style/values/fonts/StyleFontPalette.h
+
     style/values/grid/StyleGridNamedAreaMap.h
     style/values/grid/StyleGridNamedLinesMap.h
     style/values/grid/StyleGridOrderedNamedLinesMap.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -3209,6 +3209,7 @@ style/values/filter-effects/StyleOpacityFunction.cpp
 style/values/filter-effects/StyleSaturateFunction.cpp
 style/values/filter-effects/StyleSepiaFunction.cpp
 style/values/flexbox/StyleFlexBasis.cpp
+style/values/fonts/StyleFontPalette.cpp
 style/values/grid/StyleGridNamedLinesMap.cpp
 style/values/grid/StyleGridPosition.cpp
 style/values/grid/StyleGridPositionsResolver.cpp

--- a/Source/WebCore/css/CSSPrimitiveValue.h
+++ b/Source/WebCore/css/CSSPrimitiveValue.h
@@ -126,6 +126,7 @@ public:
 
     static Ref<CSSPrimitiveValue> createCustomIdent(String);
     bool isCustomIdent() const { return primitiveUnitType() == CSSUnitType::CustomIdent; }
+    String customIdent() const { ASSERT(isCustomIdent()); return stringValue(); }
 
     static Ref<CSSPrimitiveValue> createFontFamily(String);
     bool isFontFamily() const { return primitiveUnitType() == CSSUnitType::CSS_FONT_FAMILY; }

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -949,7 +949,8 @@
                 "animation-wrapper": "DiscreteWrapper",
                 "animation-wrapper-comment": "By default, font properties use DiscreteFontDescriptionTypedWrapper, so an explicit wrapper is needed here to override that.",
                 "animation-wrapper-requires-render-style": true,
-                "style-converter": "FontPalette",
+                "style-converter": "StyleType<FontPalette>",
+                "font-property-uses-render-style-for-access": true,
                 "font-property": true,
                 "high-priority": true,
                 "parser-grammar": "normal | light | dark | <palette-identifier>"

--- a/Source/WebCore/css/scripts/process-css-properties.py
+++ b/Source/WebCore/css/scripts/process-css-properties.py
@@ -485,6 +485,7 @@ class StylePropertyCodeGenProperties:
         Schema.Entry("font-description-name-for-methods", allowed_types=[str]),
         Schema.Entry("font-description-setter", allowed_types=[str]),
         Schema.Entry("font-property", allowed_types=[bool], default_value=False),
+        Schema.Entry("font-property-uses-render-style-for-access", allowed_types=[bool], default_value=False),
         Schema.Entry("high-priority", allowed_types=[bool], default_value=False),
         Schema.Entry("internal-only", allowed_types=[bool], default_value=False),
         Schema.Entry("logical-property-group", allowed_types=[dict]),
@@ -4041,10 +4042,16 @@ class GenerateStyleBuilderGenerated:
     # Font property setters.
 
     def _generate_font_property_initial_value_setter(self, to, property):
-        to.write(f"builderState.{property.codegen_properties.font_description_setter.replace('set', 'setFontDescription', 1)}(FontCascadeDescription::{property.codegen_properties.font_description_initial}());")
+        if property.codegen_properties.font_property_uses_render_style_for_access:
+            to.write(f"builderState.{property.codegen_properties.font_description_setter.replace('set', 'setFontDescription', 1)}(RenderStyle::{property.codegen_properties.render_style_initial}());")
+        else:
+            to.write(f"builderState.{property.codegen_properties.font_description_setter.replace('set', 'setFontDescription', 1)}(FontCascadeDescription::{property.codegen_properties.font_description_initial}());")
 
     def _generate_font_property_inherit_value_setter(self, to, property):
-        to.write(f"auto inheritedValue = builderState.parentFontDescription().{property.codegen_properties.font_description_getter}();")
+        if property.codegen_properties.font_property_uses_render_style_for_access:
+            to.write(f"auto inheritedValue = builderState.parentStyle().{property.codegen_properties.render_style_getter}();")
+        else:
+            to.write(f"auto inheritedValue = builderState.parentFontDescription().{property.codegen_properties.font_description_getter}();")
         to.write(f"builderState.{property.codegen_properties.font_description_setter.replace('set', 'setFontDescription', 1)}(WTFMove(inheritedValue));")
 
     def _generate_font_property_value_setter(self, to, property, value):

--- a/Source/WebCore/platform/graphics/FontCascadeDescription.h
+++ b/Source/WebCore/platform/graphics/FontCascadeDescription.h
@@ -144,7 +144,6 @@ public:
     static FontVariantEmoji initialVariantEmoji() { return FontVariantEmoji::Normal; }
     static FontOpticalSizing initialOpticalSizing() { return FontOpticalSizing::Enabled; }
     static const AtomString& initialSpecifiedLocale() { return nullAtom(); }
-    static FontPalette initialFontPalette() { return { FontPalette::Type::Normal, nullAtom() }; }
     static FontSizeAdjust initialFontSizeAdjust() { return { FontSizeAdjust::Metric::ExHeight }; }
     static TextSpacingTrim initialTextSpacingTrim() { return { }; }
     static TextAutospace initialTextAutospace() { return { }; }

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -2692,10 +2692,10 @@ void RenderStyle::setFontItalic(std::optional<FontSelectionValue> value)
     setFontDescription(WTFMove(description));
 }
 
-void RenderStyle::setFontPalette(const FontPalette& value)
+void RenderStyle::setFontPalette(Style::FontPalette&& value)
 {
     auto description = fontDescription();
-    description.setFontPalette(value);
+    description.setFontPalette(value.platform());
     setFontDescription(WTFMove(description));
 }
 

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -214,7 +214,6 @@ enum class WordBreak : uint8_t;
 
 struct CSSPropertiesBitSet;
 struct CounterDirectiveMap;
-struct FontPalette;
 struct FontSizeAdjust;
 struct GridTrackList;
 struct ImageOrientation;
@@ -266,6 +265,7 @@ struct Cursor;
 struct DynamicRangeLimit;
 struct Filter;
 struct FlexBasis;
+struct FontPalette;
 struct GapGutter;
 struct GridPosition;
 struct GridTemplateAreas;
@@ -716,7 +716,7 @@ public:
     inline FontSelectionValue fontWeight() const;
     inline FontSelectionValue fontWidth() const;
     inline std::optional<FontSelectionValue> fontItalic() const;
-    inline const FontPalette& fontPalette() const;
+    inline Style::FontPalette fontPalette() const;
     inline FontSizeAdjust fontSizeAdjust() const;
 
     inline const Style::TextIndent& textIndent() const;
@@ -1353,7 +1353,7 @@ public:
     void setFontWeight(FontSelectionValue);
     void setFontWidth(FontSelectionValue);
     void setFontItalic(std::optional<FontSelectionValue>);
-    void setFontPalette(const FontPalette&);
+    void setFontPalette(Style::FontPalette&&);
 
     void setColor(Color&&);
 
@@ -1936,6 +1936,7 @@ public:
     static constexpr PositionType initialPosition();
     static inline Style::VerticalAlign initialVerticalAlign();
     static constexpr Float initialFloating();
+    static inline Style::FontPalette initialFontPalette();
     static constexpr BreakBetween initialBreakBetween();
     static constexpr BreakInside initialBreakInside();
     static constexpr OptionSet<HangingPunctuation> initialHangingPunctuation();

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -43,6 +43,7 @@
 #include <WebCore/StyleFilterData.h>
 #include <WebCore/StyleFlexibleBoxData.h>
 #include <WebCore/StyleFontData.h>
+#include <WebCore/StyleFontPalette.h>
 #include <WebCore/StyleGridData.h>
 #include <WebCore/StyleGridItemData.h>
 #include <WebCore/StyleGridTrackSizingDirection.h>
@@ -217,7 +218,7 @@ inline Style::FlexGrow RenderStyle::flexGrow() const { return m_nonInheritedData
 inline Style::FlexShrink RenderStyle::flexShrink() const { return m_nonInheritedData->miscData->flexibleBox->flexShrink; }
 inline FlexWrap RenderStyle::flexWrap() const { return static_cast<FlexWrap>(m_nonInheritedData->miscData->flexibleBox->flexWrap); }
 inline std::optional<FontSelectionValue> RenderStyle::fontItalic() const { return fontDescription().italic(); }
-inline const FontPalette& RenderStyle::fontPalette() const { return fontDescription().fontPalette(); }
+inline Style::FontPalette RenderStyle::fontPalette() const { return fontDescription().fontPalette(); }
 inline FontSizeAdjust RenderStyle::fontSizeAdjust() const { return fontDescription().fontSizeAdjust(); }
 inline FontSelectionValue RenderStyle::fontWidth() const { return fontDescription().width(); }
 inline FontOpticalSizing RenderStyle::fontOpticalSizing() const { return fontDescription().opticalSizing(); }
@@ -394,6 +395,7 @@ constexpr Style::FlexGrow RenderStyle::initialFlexGrow() { return 0_css_number; 
 constexpr Style::FlexShrink RenderStyle::initialFlexShrink() { return 1_css_number; }
 constexpr FlexWrap RenderStyle::initialFlexWrap() { return FlexWrap::NoWrap; }
 constexpr Float RenderStyle::initialFloating() { return Float::None; }
+inline Style::FontPalette RenderStyle::initialFontPalette() { return CSS::Keyword::Normal { }; }
 inline Style::GridTrackSizes RenderStyle::initialGridAutoColumns() { return CSS::Keyword::Auto { }; }
 constexpr GridAutoFlow RenderStyle::initialGridAutoFlow() { return AutoFlowRow; }
 inline Style::GridTrackSizes RenderStyle::initialGridAutoRows() { return CSS::Keyword::Auto { }; }

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -50,7 +50,6 @@
 #include "CSSURLValue.h"
 #include "CSSValuePair.h"
 #include "CalculationValue.h"
-#include "FontPalette.h"
 #include "FontSelectionValueInlines.h"
 #include "FontSizeAdjust.h"
 #include "FrameDestructionObserverInlines.h"
@@ -147,7 +146,6 @@ public:
     static GlyphOrientation convertGlyphOrientation(BuilderState&, const CSSValue&);
     static GlyphOrientation convertGlyphOrientationOrAuto(BuilderState&, const CSSValue&);
     static WebCore::Length convertLineHeight(BuilderState&, const CSSValue&, float multiplier = 1.f);
-    static FontPalette convertFontPalette(BuilderState&, const CSSValue&);
 
     static OptionSet<HangingPunctuation> convertHangingPunctuation(BuilderState&, const CSSValue&);
 
@@ -792,26 +790,6 @@ inline WebCore::Length BuilderConverter::convertLineHeight(BuilderState& builder
     return WebCore::Length(primitiveValue->resolveAsNumber(conversionData) * 100.0, LengthType::Percent);
 }
 
-inline FontPalette BuilderConverter::convertFontPalette(BuilderState& builderState, const CSSValue& value)
-{
-    auto* primitiveValue = requiredDowncast<CSSPrimitiveValue>(builderState, value);
-    if (!primitiveValue)
-        return { };
-
-    switch (primitiveValue->valueID()) {
-    case CSSValueLight:
-        return { FontPalette::Type::Light, nullAtom() };
-    case CSSValueDark:
-        return { FontPalette::Type::Dark, nullAtom() };
-    case CSSValueInvalid:
-        ASSERT(primitiveValue->isCustomIdent());
-        return { FontPalette::Type::Custom, AtomString { primitiveValue->stringValue() } };
-    default:
-        ASSERT(primitiveValue->valueID() == CSSValueNormal || CSSPropertyParserHelpers::isSystemFontShorthand(primitiveValue->valueID()));
-        return { FontPalette::Type::Normal, nullAtom() };
-    }
-}
-    
 inline OptionSet<SpeakAs> BuilderConverter::convertSpeakAs(BuilderState&, const CSSValue& value)
 {
     auto result = RenderStyle::initialSpeakAs();

--- a/Source/WebCore/style/StyleBuilderState.h
+++ b/Source/WebCore/style/StyleBuilderState.h
@@ -49,7 +49,6 @@ class StyleResolver;
 class TextAutospace;
 class TextSpacingTrim;
 
-struct FontPalette;
 struct FontSizeAdjust;
 
 namespace CSSCalc {
@@ -65,6 +64,7 @@ namespace Style {
 
 class BuilderState;
 struct Color;
+struct FontPalette;
 
 void maybeUpdateFontForLetterSpacing(BuilderState&, CSSValue&);
 
@@ -160,7 +160,7 @@ public:
     void setFontDescriptionFamilies(Vector<AtomString>&);
     void setFontDescriptionIsSpecifiedFont(bool);
     void setFontDescriptionFeatureSettings(FontFeatureSettings&&);
-    void setFontDescriptionFontPalette(const FontPalette&);
+    void setFontDescriptionFontPalette(Style::FontPalette&&);
     void setFontDescriptionFontSizeAdjust(FontSizeAdjust);
     void setFontDescriptionFontSmoothing(FontSmoothingMode);
     void setFontDescriptionFontSynthesisSmallCaps(FontSynthesisLonghandValue);

--- a/Source/WebCore/style/StyleBuilderStateInlines.h
+++ b/Source/WebCore/style/StyleBuilderStateInlines.h
@@ -116,13 +116,13 @@ inline void BuilderState::setFontDescriptionFeatureSettings(FontFeatureSettings&
     fontCascade.updateRequiresShaping();
 }
 
-inline void BuilderState::setFontDescriptionFontPalette(const FontPalette& fontPalette)
+inline void BuilderState::setFontDescriptionFontPalette(Style::FontPalette&& fontPalette)
 {
-    if (m_style.fontDescription().fontPalette() == fontPalette)
+    if (m_style.fontDescription().fontPalette() == fontPalette.platform())
         return;
 
     m_fontDirty = true;
-    m_style.mutableFontDescriptionWithoutUpdate().setFontPalette(fontPalette);
+    m_style.mutableFontDescriptionWithoutUpdate().setFontPalette(fontPalette.platform());
 }
 
 inline void BuilderState::setFontDescriptionFontSizeAdjust(FontSizeAdjust fontSizeAdjust)

--- a/Source/WebCore/style/StyleExtractorConverter.h
+++ b/Source/WebCore/style/StyleExtractorConverter.h
@@ -183,7 +183,6 @@ public:
 
     static Ref<CSSValue> convertFontFamily(ExtractorState&, const AtomString&);
     static Ref<CSSValue> convertFontSizeAdjust(ExtractorState&, const FontSizeAdjust&);
-    static Ref<CSSValue> convertFontPalette(ExtractorState&, const FontPalette&);
     static Ref<CSSValue> convertFontWeight(ExtractorState&, FontSelectionValue);
     static Ref<CSSValue> convertFontWidth(ExtractorState&, FontSelectionValue);
     static Ref<CSSValue> convertFontFeatureSettings(ExtractorState&, const FontFeatureSettings&);
@@ -1039,21 +1038,6 @@ inline Ref<CSSValue> ExtractorConverter::convertFontSizeAdjust(ExtractorState& s
         return CSSPrimitiveValue::create(*value);
 
     return CSSValuePair::create(convert(state, metric), CSSPrimitiveValue::create(*value));
-}
-
-inline Ref<CSSValue> ExtractorConverter::convertFontPalette(ExtractorState&, const FontPalette& fontPalette)
-{
-    switch (fontPalette.type) {
-    case FontPalette::Type::Normal:
-        return CSSPrimitiveValue::create(CSSValueNormal);
-    case FontPalette::Type::Light:
-        return CSSPrimitiveValue::create(CSSValueLight);
-    case FontPalette::Type::Dark:
-        return CSSPrimitiveValue::create(CSSValueDark);
-    case FontPalette::Type::Custom:
-        return CSSPrimitiveValue::createCustomIdent(fontPalette.identifier);
-    }
-    RELEASE_ASSERT_NOT_REACHED();
 }
 
 inline Ref<CSSValue> ExtractorConverter::convertFontWeight(ExtractorState&, FontSelectionValue fontWeight)

--- a/Source/WebCore/style/StyleExtractorSerializer.h
+++ b/Source/WebCore/style/StyleExtractorSerializer.h
@@ -1023,25 +1023,6 @@ inline void ExtractorSerializer::serializeFontSizeAdjust(ExtractorState& state, 
     CSS::serializationForCSS(builder, context, CSS::NumberRaw<> { *value });
 }
 
-inline void ExtractorSerializer::serializeFontPalette(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, const FontPalette& fontPalette)
-{
-    switch (fontPalette.type) {
-    case FontPalette::Type::Normal:
-        serializationForCSS(builder, context, state.style, CSS::Keyword::Normal { });
-        return;
-    case FontPalette::Type::Light:
-        serializationForCSS(builder, context, state.style, CSS::Keyword::Light { });
-        return;
-    case FontPalette::Type::Dark:
-        serializationForCSS(builder, context, state.style, CSS::Keyword::Dark { });
-        return;
-    case FontPalette::Type::Custom:
-        serializationForCSS(builder, context, state.style, CustomIdentifier { fontPalette.identifier });
-        return;
-    }
-    RELEASE_ASSERT_NOT_REACHED();
-}
-
 inline void ExtractorSerializer::serializeFontWeight(ExtractorState&, StringBuilder& builder, const CSS::SerializationContext& context, FontSelectionValue fontWeight)
 {
     CSS::serializationForCSS(builder, context, CSS::NumberRaw<> { static_cast<float>(fontWeight) });

--- a/Source/WebCore/style/values/fonts/StyleFontPalette.cpp
+++ b/Source/WebCore/style/values/fonts/StyleFontPalette.cpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "StyleFontPalette.h"
+
+#include "CSSPropertyParserConsumer+Font.h"
+#include "StyleBuilderChecking.h"
+#include "StyleValueTypes+CSSValueConversion.h"
+
+namespace WebCore {
+namespace Style {
+
+// MARK: - Conversion
+
+auto CSSValueConversion<FontPalette>::operator()(BuilderState& state, const CSSValue& value) -> FontPalette
+{
+    RefPtr primitiveValue = requiredDowncast<CSSPrimitiveValue>(state, value);
+    if (!primitiveValue)
+        return CSS::Keyword::Normal { };
+
+    switch (auto valueID = primitiveValue->valueID(); valueID) {
+    case CSSValueNormal:
+        return CSS::Keyword::Normal { };
+    case CSSValueLight:
+        return CSS::Keyword::Light { };
+    case CSSValueDark:
+        return CSS::Keyword::Dark { };
+    case CSSValueInvalid:
+        return toStyleFromCSSValue<CustomIdentifier>(state, *primitiveValue);
+    default:
+        if (CSSPropertyParserHelpers::isSystemFontShorthand(valueID))
+            return CSS::Keyword::Normal { };
+
+        state.setCurrentPropertyInvalidAtComputedValueTime();
+        return CSS::Keyword::Normal { };
+    }
+}
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/fonts/StyleFontPalette.h
+++ b/Source/WebCore/style/values/fonts/StyleFontPalette.h
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/FontPalette.h>
+#include <WebCore/StyleValueTypes.h>
+
+namespace WebCore {
+namespace Style {
+
+// <'font-palette'> = normal | light | dark | <palette-identifier> | <palette-mix()>
+// FIXME: <palette-mix()> is not yet supported.
+// https://drafts.csswg.org/css-fonts/#propdef-font-palette
+struct FontPalette {
+    FontPalette(CSS::Keyword::Normal)
+        : m_platform { .type = WebCore::FontPalette::Type::Normal, .identifier = nullAtom() }
+    {
+    }
+
+    FontPalette(CSS::Keyword::Light)
+        : m_platform { .type = WebCore::FontPalette::Type::Light, .identifier = nullAtom() }
+    {
+    }
+
+    FontPalette(CSS::Keyword::Dark)
+        : m_platform { .type = WebCore::FontPalette::Type::Dark, .identifier = nullAtom() }
+    {
+    }
+
+    FontPalette(CustomIdentifier&& identifier)
+        : m_platform { .type = WebCore::FontPalette::Type::Custom, .identifier = WTFMove(identifier.value) }
+    {
+    }
+
+    FontPalette(WebCore::FontPalette&& platform)
+        : m_platform { WTFMove(platform) }
+    {
+    }
+
+    FontPalette(const WebCore::FontPalette& platform)
+        : m_platform { platform }
+    {
+    }
+
+    template<typename... F> decltype(auto) switchOn(F&&... f) const
+    {
+        auto visitor = WTF::makeVisitor(std::forward<F>(f)...);
+
+        switch (m_platform.type) {
+        case WebCore::FontPalette::Type::Normal:
+            return visitor(CSS::Keyword::Normal { });
+        case WebCore::FontPalette::Type::Light:
+            return visitor(CSS::Keyword::Light { });
+        case WebCore::FontPalette::Type::Dark:
+            return visitor(CSS::Keyword::Dark { });
+        case WebCore::FontPalette::Type::Custom:
+            return visitor(CustomIdentifier { m_platform.identifier });
+        }
+        RELEASE_ASSERT_NOT_REACHED();
+    }
+
+    const WebCore::FontPalette& platform() const { return m_platform; }
+
+    bool operator==(const FontPalette&) const = default;
+
+private:
+    WebCore::FontPalette m_platform;
+};
+
+// MARK: - Conversion
+
+template<> struct CSSValueConversion<FontPalette> { auto operator()(BuilderState&, const CSSValue&) -> FontPalette; };
+
+} // namespace Style
+} // namespace WebCore
+
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::FontPalette)

--- a/Tools/Scripts/webkitpy/style/checkers/jsonchecker.py
+++ b/Tools/Scripts/webkitpy/style/checkers/jsonchecker.py
@@ -409,6 +409,7 @@ class JSONCSSPropertiesChecker(JSONChecker):
             'font-description-name-for-methods': self.validate_string,
             'font-description-setter': self.validate_string,
             'font-property': self.validate_boolean,
+            'font-property-uses-render-style-for-access': self.validate_boolean,
             'high-priority': self.validate_boolean,
             'internal-only': self.validate_boolean,
             'logical-property-group': self.validate_logical_property_group,


### PR DESCRIPTION
#### 1d2d25211b121f13e05343b2f0eaf2afbae7af3b
<pre>
[Style] Convert the &apos;font-palette&apos; property to strong style types
<a href="https://bugs.webkit.org/show_bug.cgi?id=299455">https://bugs.webkit.org/show_bug.cgi?id=299455</a>

Reviewed by Darin Adler.

Converts the &apos;font-palette&apos; property to strong style types.

Rather than duplicating the state of `font-palette`, we wrap
the platform type `WebCore::FontPalette` in a strong style
type `Style::FontPalette` which has all the style level information
on it. We may have to change this in the future when we add
support for palette-mix(), as we likely don&apos;t want to store
that on the FontCascadeDescriptor itself.

* Source/WebCore/CMakeLists.txt:
* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
    - Add new files.

* Source/WebCore/css/CSSPrimitiveValue.h:
    - Add accessor for custom identifiers that asserts isCustomIdent().

* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/scripts/process-css-properties.py:
    - Add a new codegen property for indicating that a font property
      wants to use getter and initial from RenderStyle rather than
      FontCascadeDescription. This will be removed when all font properties
      work this way, but allows doing that work incrementally.

* Source/WebCore/platform/graphics/FontCascadeDescription.h:
(WebCore::FontCascadeDescription::initialFontPalette): Deleted.
    - Moved initialFontPalette to RenderStyle, where it semantically makes sense.
      FontCascadeDescription really shouldn&apos;t know about initial values as that
      is a style system concept.

* Source/WebCore/rendering/style/RenderStyle.cpp:
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
* Source/WebCore/style/StyleBuilderState.h:
* Source/WebCore/style/StyleBuilderStateInlines.h:
    - Pipe the wrapper around.

* Source/WebCore/style/StyleBuilderConverter.h:
* Source/WebCore/style/StyleExtractorConverter.h:
* Source/WebCore/style/StyleExtractorSerializer.h:
    - Remove old builder / extractor functions.

* Source/WebCore/style/values/StyleValueTypes+CSSValueConversion.h:
    - Add CSSPrimitiveValue overloads for the String, AtomString and CustomIdentifier
      converters to avoid some unnecessary checks when the caller already has one.

* Source/WebCore/style/values/fonts/StyleFontPalette.cpp: Added.
* Source/WebCore/style/values/fonts/StyleFontPalette.h: Added.
    - Adds new type with converter.

Canonical link: <a href="https://commits.webkit.org/300599@main">https://commits.webkit.org/300599@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b23381ab922d7c748a0048cb3a911461f16df913

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123215 "1 style error") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/42929 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33626 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/129922 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/75328 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/125092 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43653 "Built successfully") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51524 "Failed to checkout and rebase branch from PR 51269") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/93667 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/75328 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126168 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/34791 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/110265 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/74295 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/122571 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/33759 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/28421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73438 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104504 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28647 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132646 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/50165 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/123/builds/51524 "Failed to checkout and rebase branch from PR 51269") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/102162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/50541 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/106486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/102019 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25929 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/25588 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/46939 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/50020 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/55781 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49490 "Build is in progress. Recent messages:") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/52841 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/51169 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->