### PR TITLE
[JSC] FTL materialization is missing several internal object types

### DIFF
--- a/JSTests/stress/ftl-materialization-missing.js
+++ b/JSTests/stress/ftl-materialization-missing.js
@@ -1,0 +1,25 @@
+//@ runDefault("--useConcurrentJIT=0", "--jitPolicyScale=0")
+try {
+var BUGNUMBER = 730831;
+var summary = "Date.prototype.toISOString returns an invalid ISO-8601 string";
+print((BUGNUMBER + ": ") + summary);
+function iso(a10) {
+    const v12 = new Date(a10);
+    return v12.toISOString();
+}
+for (let v14 = 0; v14 < 67; v14++) {
+    const v16 = [print];
+    Reflect.apply(summary.matchAll, summary, v16);
+}
+function utc(a20, a21, a22, a23, a24, a25, a26) {
+    const v29 = new Date_1(0);
+    var date = v29;
+    date.setUTCFullYear(a20, a21 - 1, a22);
+    date.setUTCHours(a23, a24, a25, a26);
+    return date.getTime();
+}
+var maxDateSimple = utc(9999, 12, 31, 23, 59, 59, 999);
+var minDateSimple = utc(0, 1, 1, 0, 0, 0, 0);
+var maxDateExtended = utc(+275760, 9, 13, 0, 0, 0, 0);
+var minDateExtended = utc(-271821, 4, 20, 0, 0, 0, 0);
+} catch { }


### PR DESCRIPTION
#### a72d19840714f8aab734f54ee719c3c75068fcab
<pre>
[JSC] FTL materialization is missing several internal object types
<a href="https://bugs.webkit.org/show_bug.cgi?id=299457">https://bugs.webkit.org/show_bug.cgi?id=299457</a>
<a href="https://rdar.apple.com/161147884">rdar://161147884</a>

Reviewed by Keith Miller.

FTL materialization is missing several internal object types. This patch
adds them.

Test: JSTests/stress/ftl-materialization-missing.js
* JSTests/stress/ftl-materialization-missing.js: Added.
(try.iso):
(try.utc):
* Source/JavaScriptCore/ftl/FTLOperations.cpp:
(JSC::FTL::JSC_DEFINE_NOEXCEPT_JIT_OPERATION):

Canonical link: <a href="https://commits.webkit.org/300485@main">https://commits.webkit.org/300485@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b8fae36e51a7ab059cbf6758233d055e2a6c376d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122731 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42443 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33133 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/129352 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/74835 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7fba5302-e0b1-486b-a741-5e592c917064) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43162 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51036 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93274 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/74835 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/aedd5874-5824-4bf4-a092-966bcd9e8b58) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125683 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34412 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109876 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73914 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6b383ac2-5ce7-47e8-9d65-70d3c36626c4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33400 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28031 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72839 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/114885 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104112 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28244 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132080 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/121260 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49676 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37812 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/101797 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50053 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106091 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/101665 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47044 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25224 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/46446 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19380 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49533 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/55286 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/151526 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49000 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/38748 "Passed tests") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/52352 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50683 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->