### PR TITLE
Add image painting hooks for LargestContentfulPaint

### DIFF
--- a/Source/WebCore/html/HTMLVideoElement.cpp
+++ b/Source/WebCore/html/HTMLVideoElement.cpp
@@ -344,8 +344,10 @@ void HTMLVideoElement::mediaPlayerFirstVideoFrameAvailable()
     if (RefPtr player = this->player())
         player->prepareForRendering();
 
-    if (CheckedPtr renderer = this->renderer())
+    if (CheckedPtr renderer = this->renderer()) {
         renderer->updateFromElement();
+        protectedDocument()->didPaintImage(*this, nullptr, renderer->videoBox());
+    }
 }
 
 std::optional<DestinationColorSpace> HTMLVideoElement::colorSpace() const

--- a/Source/WebCore/rendering/BackgroundPainter.cpp
+++ b/Source/WebCore/rendering/BackgroundPainter.cpp
@@ -531,8 +531,15 @@ template<typename Layer> void BackgroundPainter::paintFillLayerImpl(const Color&
                 bgImage->cachedImage()->addClientWaitingForAsyncDecoding(m_renderer);
             }
 
-            if (m_renderer.element() && !context.paintingDisabled())
-                m_renderer.element()->setHasEverPaintedImages(true);
+            if (!context.paintingDisabled()) {
+                if (m_renderer.element())
+                    m_renderer.element()->setHasEverPaintedImages(true);
+
+                if (bgImage->cachedImage()) {
+                    if (auto styleable = Styleable::fromRenderer(m_renderer))
+                        document().didPaintImage(styleable->element, bgImage->cachedImage(), geometry.destinationRect);
+                }
+            }
         }
     }
 }

--- a/Source/WebCore/rendering/RenderVideo.cpp
+++ b/Source/WebCore/rendering/RenderVideo.cpp
@@ -231,20 +231,25 @@ void RenderVideo::paintReplaced(PaintInfo& paintInfo, const LayoutPoint& paintOf
         return;
     }
 
-    LayoutRect rect = videoBox();
-    if (rect.isEmpty()) {
+    LayoutRect videoBoxRect = videoBox();
+    if (videoBoxRect.isEmpty()) {
         if (paintInfo.phase == PaintPhase::Foreground)
             page->addRelevantUnpaintedObject(*this, visualOverflowRect());
         return;
     }
-    rect.moveBy(paintOffset);
 
-    if (paintInfo.phase == PaintPhase::Foreground)
+    auto rect = videoBoxRect;
+    rect.moveBy(paintOffset);
+    GraphicsContext& context = paintInfo.context();
+
+    if (paintInfo.phase == PaintPhase::Foreground) {
         page->addRelevantRepaintedObject(*this, rect);
+        if (displayingPoster && !context.paintingDisabled())
+            protectedDocument()->didPaintImage(videoElement.get(), cachedImage(), videoBoxRect);
+    }
 
     LayoutRect contentRect = contentBoxRect();
     contentRect.moveBy(paintOffset);
-    GraphicsContext& context = paintInfo.context();
 
     if (context.detectingContentfulPaint()) {
         context.setContentfulPaintDetected();

--- a/Source/WebCore/rendering/svg/RenderSVGImage.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGImage.cpp
@@ -217,14 +217,19 @@ void RenderSVGImage::paintForeground(PaintInfo& paintInfo, const LayoutPoint& pa
 
     ImageDrawResult result = paintIntoRect(paintInfo, contentBoxRect, replacedContentRect);
 
-    if (cachedImage()) {
+    if (cachedImage() && !context.paintingDisabled()) {
         // For now, count images as unpainted if they are still progressively loading. We may want
         // to refine this in the future to account for the portion of the image that has painted.
-        FloatRect visibleRect = intersection(replacedContentRect, contentBoxRect);
+        replacedContentRect.moveBy(paintOffset);
+        auto visibleRect = intersection(replacedContentRect, contentBoxRect);
         if (cachedImage()->isLoading() || result == ImageDrawResult::DidRequestDecoding)
             page().addRelevantUnpaintedObject(*this, enclosingLayoutRect(visibleRect));
         else
             page().addRelevantRepaintedObject(*this, enclosingLayoutRect(visibleRect));
+
+        auto localVisibleRect = visibleRect;
+        localVisibleRect.moveBy(-paintOffset);
+        protectedDocument()->didPaintImage(protectedImageElement().get(), cachedImage(), localVisibleRect);
     }
 }
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.cpp
@@ -228,7 +228,12 @@ void LegacyRenderSVGImage::paintForeground(PaintInfo& paintInfo)
         style().dynamicRangeLimit().toPlatformDynamicRangeLimit()
     };
 
-    paintInfo.context().drawImage(*image, destRect, srcRect, options);
+    auto& context = paintInfo.context();
+    context.drawImage(*image, destRect, srcRect, options);
+
+    auto* cachedImage = imageResource().cachedImage();
+    if (cachedImage && !context.paintingDisabled())
+        protectedDocument()->didPaintImage(imageElement(), cachedImage, destRect);
 }
 
 void LegacyRenderSVGImage::invalidateBufferedForeground()


### PR DESCRIPTION
#### 6a82ed471a06d35d925b6ebd34b99f0b11c4309d
<pre>
Add image painting hooks for LargestContentfulPaint
<a href="https://bugs.webkit.org/show_bug.cgi?id=299458">https://bugs.webkit.org/show_bug.cgi?id=299458</a>
<a href="https://rdar.apple.com/161263606">rdar://161263606</a>

Reviewed by Dan Glastonbury.

Largest Contentful Paint[1] relies on the Paint Timing definition of
when elements are `contentful`. For image contentful elements, this includes
replaced elements showing images, videos with a poster or the first video
frame, elements with background-image etc.

To track these, call `document().didPaintImage()` in the relevant places;
we pass a rect which is the destination of the image in local coordinates,
since it&apos;s necessary to know the image placement within the element,
e.g. for multiple backgrounds.

We get to an Element via Styleable to account for images on pseudoelements.

Add checks for context.paintingDisabled() in a few places, to guard both
LCP and the existing `addRelevantUnpaintedObject()` which should never fire
for context-less paints.

Future changes will implement `didPaintImage()`.

[1] <a href="https://w3c.github.io/largest-contentful-paint/">https://w3c.github.io/largest-contentful-paint/</a>
[2] <a href="https://w3c.github.io/paint-timing/#contentful">https://w3c.github.io/paint-timing/#contentful</a>

* Source/WebCore/html/HTMLVideoElement.cpp:
(WebCore::HTMLVideoElement::mediaPlayerFirstVideoFrameAvailable):
* Source/WebCore/rendering/BackgroundPainter.cpp:
(WebCore::BackgroundPainter::paintFillLayerImpl const):
* Source/WebCore/rendering/RenderImage.cpp:
(WebCore::RenderImage::paintReplaced):
* Source/WebCore/rendering/RenderVideo.cpp:
(WebCore::RenderVideo::paintReplaced):
* Source/WebCore/rendering/svg/RenderSVGImage.cpp:
(WebCore::RenderSVGImage::paintForeground):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.cpp:
(WebCore::LegacyRenderSVGImage::paintForeground):

Canonical link: <a href="https://commits.webkit.org/300527@main">https://commits.webkit.org/300527@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/314b4b8971369c4f30d39187bf64fc010cc0c215

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122943 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/42657 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33354 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/129590 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/75051 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/33b15152-a409-412e-b140-053540313f4c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/124820 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43380 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51251 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/93461 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/75051 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/18795de7-408f-46da-85be-fef168485b5c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125894 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/34587 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/110045 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74078 "Found 2 new API test failures: TestWTF:WTF_Condition.OneProducerOneConsumerOneSlotTimeout, TestWTF:WTF_Condition.OneProducerOneConsumerOneSlot (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e1f01ca9-5230-4897-87fc-336b7e164f58) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/33567 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/28199 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73088 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/104295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28410 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132318 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/49892 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/37983 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/101962 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/50269 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106251 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/101831 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25861 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/25381 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/46666 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/49748 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/55508 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/49215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/52567 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/50897 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->