### PR TITLE
Watchtime Presentation Type metrics are inaccurate

### DIFF
--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -1155,6 +1155,7 @@ private:
     bool isWatchtimeTimerActive() const;
     void startWatchtimeTimer();
     void pauseWatchtimeTimer();
+    void fireAndRestartWatchtimeTimer();
     void invalidateWatchtimeTimer();
     void watchtimeTimerFired();
     void startBufferingStopwatch();


### PR DESCRIPTION
#### 9b976665c9d449751eb0f39607dacfa82e3d7e02
<pre>
Watchtime Presentation Type metrics are inaccurate
<a href="https://rdar.apple.com/161267622">rdar://161267622</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=299468">https://bugs.webkit.org/show_bug.cgi?id=299468</a>

Reviewed by Eric Carlson.

A suspiciously large number of watchtime logs show a presentation type of &quot;none&quot;, which indicates
the playing video element has no RenderVideo attached and is therefore playing outside of the DOM.
The suspicion is that by the time the watchtime timer is invalidated (during page navigation, e.g.)
that the video&apos;s renderer has already been torn down, making it appear that the previous watchtime
interval was spent without a renderer.

Account for this behavior by prematurely firing the watchtime timer when a video is about to lose
or gain a renderer, and re-use this mechanism for when the video is about to become or leave fullscreen
mode. This should make the watchtime logs more accurate.

Separately, it was noticed that a lot of watchtime logs on Mac reported that AirPlay was active.
It appears that on the Mac, the MediaPlayer will report that the current playback target is AirPlay
in situations where AirPlay is not actually occurring. Add a conditional that checks that the current
external playback is active and additionally that the target is AirPlay.

* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::willAttachRenderers):
(WebCore::HTMLMediaElement::willDetachRenderers):
(WebCore::HTMLMediaElement::setWirelessPlaybackTarget):
(WebCore::HTMLMediaElement::enterFullscreen):
(WebCore::HTMLMediaElement::willBecomeFullscreenElement):
(WebCore::HTMLMediaElement::willStopBeingFullscreenElement):
(WebCore::HTMLMediaElement::isWatchtimeTimerActive const):
(WebCore::HTMLMediaElement::fireAndRestartWatchtimeTimer):
(WebCore::HTMLMediaElement::watchtimeTimerFired):
* Source/WebCore/html/HTMLMediaElement.h:

Canonical link: <a href="https://commits.webkit.org/300516@main">https://commits.webkit.org/300516@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/39da128954818248d0662327b0d13386688c126e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122739 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42451 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33141 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/129366 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74843 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cf86fcc8-ce01-4d19-ae93-b43b6d2bd92a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/124615 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43170 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51044 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93283 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61931 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a1874ced-b0e9-4470-9fee-04cac802cdf4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125691 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34422 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109878 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/74061 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/47e074e8-37b1-4dc8-ae8d-67ab10dddf81) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33407 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28033 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72848 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104122 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28246 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132094 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49684 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37823 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101805 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50061 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106093 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101673 "Found 3 new API test failures: WebKitGTK/TestInspector:/webkit/WebKitWebInspector/manual-attach-detach, TestWTF:CompletionHandlerDeathTest.MainThreadHandlerOnThreadAssertsDeathTest, TestWTF:CompletionHandlerDeathTest.ConstructionThreadHandlerOnThreadAssertsDeathTest (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25849 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47048 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25226 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/46454 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49541 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/55294 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/151534 "Build is in progress. Recent messages:") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49008 "Built successfully") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/151534 "Build is in progress. Recent messages:") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/52360 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50691 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->