### PR TITLE
Reduce use of 'unsafe' in WebGPU+Swift

### DIFF
--- a/Source/WebGPU/WebGPU/Buffer.swift
+++ b/Source/WebGPU/WebGPU/Buffer.swift
@@ -44,7 +44,7 @@ public func Buffer_copyFrom_thunk(_ buffer: WebGPU.Buffer, from data: SpanConstU
 
 @_expose(Cxx)
 public func Buffer_getMappedRange_thunk(_ buffer: WebGPU.Buffer, offset: Int, size: Int) -> SpanUInt8 {
-    unsafe buffer.getMappedRange(offset: offset, size: size)
+    buffer.getMappedRange(offset: offset, size: size)
 }
 
 internal func computeRangeSize(size: Int, offset: Int) -> Int

--- a/Source/WebGPU/WebGPU/CommandEncoder.swift
+++ b/Source/WebGPU/WebGPU/CommandEncoder.swift
@@ -44,12 +44,12 @@ public func resolveQuerySet(commandEncoder: WebGPU.CommandEncoder, querySet: Web
 }
 
 @_expose(Cxx)
-public func CommandEncoder_copyBufferToTexture_thunk(commandEncoder: WebGPU.CommandEncoder, source: WGPUImageCopyBuffer, destination: WGPUImageCopyTexture, copySize: WGPUExtent3D){
+public func CommandEncoder_copyBufferToTexture_thunk(commandEncoder: WebGPU.CommandEncoder, source: WGPUImageCopyBuffer, destination: WGPUImageCopyTexture, copySize: WGPUExtent3D) {
     commandEncoder.copyBufferToTexture(source: source, destination: destination, copySize: copySize)
 }
 
 @_expose(Cxx)
-public func CommandEncoder_copyTextureToBuffer_thunk(commandEncoder: WebGPU.CommandEncoder, source: WGPUImageCopyTexture, destination: WGPUImageCopyBuffer, copySize: WGPUExtent3D){
+public func CommandEncoder_copyTextureToBuffer_thunk(commandEncoder: WebGPU.CommandEncoder, source: WGPUImageCopyTexture, destination: WGPUImageCopyBuffer, copySize: WGPUExtent3D) {
     commandEncoder.copyTextureToBuffer(source: source, destination: destination, copySize: copySize)
 }
 
@@ -72,6 +72,7 @@ public func CommandEncoder_beginRenderPass_thunk(commandEncoder: WebGPU.CommandE
 public func CommandEncoder_beginComputePass_thunk(commandEncoder: WebGPU.CommandEncoder, descriptor: WGPUComputePassDescriptor) -> WebGPU_Internal.RefComputePassEncoder {
     return commandEncoder.beginComputePass(descriptor: descriptor)
 }
+
 @_expose(Cxx)
 public func CommandEncoder_runClearEncoder_thunk(commandEncoder: WebGPU.CommandEncoder, attachmentsToClear: NSMutableDictionary, depthStencilAttachmentToClear: inout MTLTexture?, depthAttachmentToClear: Bool, stencilAttachmentToClear: Bool, depthClearValue: Double, stencilClearValue: UInt32, existingEncoder: MTLRenderCommandEncoder?) {
     let dInput = attachmentsToClear as? [NSNumber: TextureAndClearColor]
@@ -823,7 +824,7 @@ extension WebGPU.CommandEncoder {
     public func beginRenderPass(descriptor: WGPURenderPassDescriptor) -> WebGPU_Internal.RefRenderPassEncoder {
         let collection = CollectionOfOne(descriptor)
         let descriptorSpan = collection.span
-        var maxDrawCount = descriptorSpan[0].maxDrawCount
+        let maxDrawCount = descriptorSpan[0].maxDrawCount
 
         guard prepareTheEncoderState() else {
             self.generateInvalidEncoderStateError()
@@ -843,7 +844,7 @@ extension WebGPU.CommandEncoder {
         if let wgpuTimestampWrites = wgpuGetRenderPassDescriptorTimestampWrites(descriptorSpan)?[0] {
             let wgpuQuerySet = wgpuTimestampWrites.querySet
             let querySet = WebGPU.fromAPI(wgpuQuerySet)
-            counterSampleBuffer = unsafe querySet.counterSampleBufferWithOffset().first
+            counterSampleBuffer = querySet.counterSampleBufferWithOffset().first
         }
 
         if m_device.ptr().enableEncoderTimestamps() || counterSampleBuffer != nil {
@@ -2085,8 +2086,8 @@ extension WebGPU.CommandEncoder {
         var counterSampleBuffer: MTLCounterSampleBuffer? = nil
         var counterSampleBufferOffset: UInt32 = 0
         if let wgpuTimestampWrites = wgpuGetComputePassDescriptorTimestampWrites(collection.span)?[0] {
-            counterSampleBuffer = unsafe WebGPU.fromAPI(wgpuTimestampWrites.querySet).counterSampleBufferWithOffset().first
-            counterSampleBufferOffset = unsafe WebGPU.fromAPI(wgpuTimestampWrites.querySet).counterSampleBufferWithOffset().second
+            counterSampleBuffer = WebGPU.fromAPI(wgpuTimestampWrites.querySet).counterSampleBufferWithOffset().first
+            counterSampleBufferOffset = WebGPU.fromAPI(wgpuTimestampWrites.querySet).counterSampleBufferWithOffset().second
         }
 
         if m_device.ptr().enableEncoderTimestamps() || counterSampleBuffer != nil {

--- a/Source/WebGPU/WebGPU/Queue.h
+++ b/Source/WebGPU/WebGPU/Queue.h
@@ -68,7 +68,7 @@ public:
     void onSubmittedWorkDone(CompletionHandler<void(WGPUQueueWorkDoneStatus)>&& callback);
     void submit(Vector<Ref<WebGPU::CommandBuffer>>&& commands);
     void writeBuffer(Buffer&, uint64_t bufferOffset, std::span<uint8_t> data);
-    void writeBuffer(id<MTLBuffer>, uint64_t bufferOffset, std::span<uint8_t> data);
+    void writeBuffer(id<MTLBuffer>, uint64_t bufferOffset, std::span<uint8_t> data) HAS_SWIFTCXX_THUNK;
     void clearBuffer(id<MTLBuffer>, NSUInteger offset = 0, NSUInteger size = NSUIntegerMax);
     void writeTexture(const WGPUImageCopyTexture& destination, std::span<uint8_t> data, const WGPUTextureDataLayout&, const WGPUExtent3D& writeSize, bool skipValidation = false);
     void setLabel(String&&);
@@ -119,7 +119,7 @@ private:
 
     NSString* errorValidatingWriteTexture(const WGPUImageCopyTexture&, const WGPUTextureDataLayout&, const WGPUExtent3D&, size_t, const Texture&) const;
 
-    std::pair<id<MTLBuffer>, uint64_t> newTemporaryBufferWithBytes(const std::span<uint8_t> data, bool noCopy);
+    std::pair<id<MTLBuffer>, uint64_t> newTemporaryBufferWithBytes(std::span<uint8_t> data, bool noCopy);
 
     id<MTLCommandQueue> m_commandQueue { nil };
     id<MTLCommandBuffer> m_commandBuffer { nil };

--- a/Source/WebGPU/WebGPU/Queue.mm
+++ b/Source/WebGPU/WebGPU/Queue.mm
@@ -571,12 +571,6 @@ void Queue::writeBuffer(Buffer& buffer, uint64_t bufferOffset, std::span<uint8_t
             return;
         }
     }
-#if ENABLE(WEBGPU_SWIFT)
-    if (isWebGPUSwiftEnabled()) {
-        WebGPU::writeBuffer(this, &buffer, bufferOffset, data);
-        return;
-    }
-#endif
     writeBuffer(buffer.buffer(), bufferOffset, data);
 }
 
@@ -609,6 +603,13 @@ std::pair<id<MTLBuffer>, uint64_t> Queue::newTemporaryBufferWithBytes(std::span<
 
 void Queue::writeBuffer(id<MTLBuffer> buffer, uint64_t bufferOffset, std::span<uint8_t> data)
 {
+#if ENABLE(WEBGPU_SWIFT)
+    if (isWebGPUSwiftEnabled()) {
+        Queue_writeBuffer_thunk(this, buffer, bufferOffset, data);
+        return;
+    }
+#endif
+
     auto device = m_device.get();
     if (!device)
         return;


### PR DESCRIPTION
#### 29dc3ab6691480185716a98b13ea752b4ede85be
<pre>
Reduce use of &apos;unsafe&apos; in WebGPU+Swift
<a href="https://bugs.webkit.org/show_bug.cgi?id=299472">https://bugs.webkit.org/show_bug.cgi?id=299472</a>
<a href="https://rdar.apple.com/161268232">rdar://161268232</a>

Reviewed by Mike Wyrzykowski.

* Source/WebGPU/WebGPU/Buffer.swift:
(Buffer_getMappedRange_thunk(_:offset:size:)): Compiler said this &apos;unsafe&apos; wasn&apos;t needed.

* Source/WebGPU/WebGPU/CommandEncoder.swift:
(CommandEncoder_copyBufferToTexture_thunk(_:source:destination:copySize:)):
(CommandEncoder_copyTextureToBuffer_thunk(_:source:destination:copySize:)): Style fixups.
(WebGPU.beginRenderPass(_:)): Use &apos;let&apos; instead of &apos;var&apos; to address a warning.
(WebGPU.beginComputePass(_:)): Compiler said this &apos;unsafe&apos; wasn&apos;t needed.
* Source/WebGPU/WebGPU/Queue.h: Use a thunk for writeBuffer to match our standard
pattern and avoid an extra wrapper function. Remove &apos;const&apos; from newTemporaryBufferWithBytes
because it doesn&apos;t do anything.
* Source/WebGPU/WebGPU/Queue.mm:
(WebGPU::Queue::writeBuffer): No need for two code paths at the call site now
that we have a thunk.
* Source/WebGPU/WebGPU/Queue.swift:
(Queue_writeBuffer_thunk(_:buffer:bufferOffset:data:)): Move the conversion to
Swift Span into the thunk, to make clearer that the unsafety is at the point of
conversion.
(WebGPU.writeBuffer(_:bufferOffset:data:)): Use &apos;_&apos; to address a warning about
an unused variable. Removed some unsafe because we&apos;re using a safe MutableSpan&lt;T&gt;
now.

Canonical link: <a href="https://commits.webkit.org/300492@main">https://commits.webkit.org/300492@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c90a3b167bad255ebd8e08389831782e6d9a4e18

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122772 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/42484 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33174 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/129397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/74876 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/dbd58302-26d0-4892-b705-bd5e669f7f1a) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43203 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51077 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/129397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/74876 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cfa18280-c906-49c4-a87c-b5f1777bae09) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125724 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/34448 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/109904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/129397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c0f28e69-ce73-4034-8322-b594efd9c36c) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/33432 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/72887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/104148 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28272 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132124 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/49717 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/37850 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/101822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/50094 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106119 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/101694 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/25249 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/46487 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19383 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49574 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/55327 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/49041 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/52393 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/50724 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->