### PR TITLE
LargestContentfulPaint: hook up dispatch of LargestContentfulPaint entry

### DIFF
--- a/Source/WebCore/page/LargestContentfulPaint.cpp
+++ b/Source/WebCore/page/LargestContentfulPaint.cpp
@@ -26,16 +26,22 @@
 #include "config.h"
 #include "LargestContentfulPaint.h"
 
+#include "Element.h"
+#include "LargestContentfulPaintData.h"
+
 namespace WebCore {
 
 LargestContentfulPaint::LargestContentfulPaint(DOMHighResTimeStamp timeStamp)
-    : PerformanceEntry(emptyString(), timeStamp, timeStamp) // FIXME: Timestamps
+    : PerformanceEntry(emptyString(), timeStamp, timeStamp)
 {
 }
 
+LargestContentfulPaint::~LargestContentfulPaint() = default;
+
 DOMHighResTimeStamp LargestContentfulPaint::paintTime() const
 {
-    return 0;
+    // https://github.com/w3c/largest-contentful-paint/issues/145
+    return m_renderTime;
 }
 
 std::optional<DOMHighResTimeStamp> LargestContentfulPaint::presentationTime() const
@@ -45,32 +51,76 @@ std::optional<DOMHighResTimeStamp> LargestContentfulPaint::presentationTime() co
 
 DOMHighResTimeStamp LargestContentfulPaint::loadTime() const
 {
-    return 0;
+    return m_loadTime;
+}
+
+void LargestContentfulPaint::setLoadTime(DOMHighResTimeStamp loadTime)
+{
+    m_loadTime = loadTime;
 }
 
 DOMHighResTimeStamp LargestContentfulPaint::renderTime() const
 {
-    return 0;
+    return m_renderTime;
+}
+
+void LargestContentfulPaint::setRenderTime(DOMHighResTimeStamp renderTime)
+{
+    m_renderTime = renderTime;
+}
+
+DOMHighResTimeStamp LargestContentfulPaint::startTime() const
+{
+    return m_renderTime ? m_renderTime : m_loadTime;
 }
 
 unsigned LargestContentfulPaint::size() const
 {
-    return 0;
+    return m_pixelArea;
+}
+
+void LargestContentfulPaint::setSize(unsigned size)
+{
+    m_pixelArea = size;
 }
 
 String LargestContentfulPaint::id() const
 {
-    return emptyString();
+    return m_id;
+}
+
+void LargestContentfulPaint::setID(const String& idString)
+{
+    m_id = idString;
 }
 
 String LargestContentfulPaint::url() const
 {
-    return emptyString();
+    return m_urlString;
+}
+
+void LargestContentfulPaint::setURLString(const String& urlString)
+{
+    m_urlString = urlString;
 }
 
 Element* LargestContentfulPaint::element() const
 {
-    return nullptr;
+    RefPtr element = m_element;
+    if (!element)
+        return nullptr;
+
+    // The spec requires that the element accessor re-check connectedness.
+    // https://w3c.github.io/largest-contentful-paint/#ref-for-dom-largestcontentfulpaint-element
+    if (!LargestContentfulPaintData::isExposedForPaintTiming(*element))
+        return nullptr;
+
+    return element.get();
+}
+
+void LargestContentfulPaint::setElement(Element* element)
+{
+    m_element = element;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/LargestContentfulPaint.h
+++ b/Source/WebCore/page/LargestContentfulPaint.h
@@ -27,6 +27,7 @@
 
 #include "DOMHighResTimeStamp.h"
 #include "PerformanceEntry.h"
+#include <wtf/RefPtr.h>
 
 namespace WebCore {
 
@@ -39,7 +40,7 @@ public:
         return adoptRef(*new LargestContentfulPaint(timeStamp));
     }
 
-    ~LargestContentfulPaint() = default;
+    ~LargestContentfulPaint();
 
     // PaintTimingMixin
     DOMHighResTimeStamp paintTime() const;
@@ -47,19 +48,39 @@ public:
 
     // LargestContentfulPaint
     DOMHighResTimeStamp loadTime() const;
+    void setLoadTime(DOMHighResTimeStamp);
+
     DOMHighResTimeStamp renderTime() const;
+    void setRenderTime(DOMHighResTimeStamp);
+
+    DOMHighResTimeStamp startTime() const final;
+
     unsigned size() const;
+    void setSize(unsigned);
+
     String id() const;
+    void setID(const String&);
+
     String url() const;
+    void setURLString(const String&);
+
     Element* element() const;
+    void setElement(Element*);
 
     ASCIILiteral entryType() const final { return "largest-contentful-paint"_s; }
 
 protected:
-    LargestContentfulPaint(DOMHighResTimeStamp);
+    explicit LargestContentfulPaint(DOMHighResTimeStamp);
 
 private:
     Type performanceEntryType() const final { return Type::LargestContentfulPaint; }
+
+    RefPtr<Element> m_element;
+    DOMHighResTimeStamp m_loadTime { 0 };
+    DOMHighResTimeStamp m_renderTime { 0 };
+    String m_urlString;
+    String m_id;
+    unsigned m_pixelArea { 0 };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/Performance.h
+++ b/Source/WebCore/page/Performance.h
@@ -55,6 +55,7 @@ class Document;
 class DocumentLoadTiming;
 class DocumentLoader;
 class EventCounts;
+class LargestContentfulPaint;
 class NetworkLoadMetrics;
 class PerformanceUserTiming;
 class PerformanceEntry;
@@ -113,7 +114,8 @@ public:
     void navigationFinished(MonotonicTime loadEventEnd);
     void addResourceTiming(ResourceTiming&&);
 
-    void reportFirstContentfulPaint();
+    void reportFirstContentfulPaint(DOMHighResTimeStamp);
+    void reportLargestContentfulPaint(Ref<LargestContentfulPaint>&&);
 
     void removeAllObservers();
     void registerPerformanceObserver(PerformanceObserver&);
@@ -178,6 +180,7 @@ private:
 
     RefPtr<PerformanceNavigationTiming> m_navigationTiming;
     RefPtr<PerformancePaintTiming> m_firstContentfulPaint;
+    RefPtr<PerformanceEntry> m_largestContentfulPaint;
     std::unique_ptr<PerformanceUserTiming> m_userTiming;
 
     ListHashSet<RefPtr<PerformanceObserver>> m_observers;


### PR DESCRIPTION
#### 11946321bfefdf9138ecf2b8416c40339a30f8e8
<pre>
LargestContentfulPaint: hook up dispatch of LargestContentfulPaint entry
<a href="https://bugs.webkit.org/show_bug.cgi?id=299469">https://bugs.webkit.org/show_bug.cgi?id=299469</a>
<a href="https://rdar.apple.com/161267849">rdar://161267849</a>

Reviewed by Ryosuke Niwa.

Flesh out LargestContentfulPaint, which is the PerformanceEntry that is exposed to script;
return the correct timestamps (requesting some clarification via [1]), store the id, url
etc, and check that the element is still eligible on the `element()` getter, per spec.

Fix `Document::enqueuePaintTimingEntryIfNeeded()` to enqueue the paint timing entry,
using the same timestamp as `firstContentfulPaint` if appropriate.

Comment some functions in `Performance` where `largest-contentful-paint` is
explicitly not present in `getEntries()`[2], since LCP can only be used via
`PerformanceObserver.observe()`. However, Performance needs to store the LCP entry,
and include it in `appendBufferedEntriesByType()` to support a `PerformanceObserver` which
starts observing after LCP entries have been generated. This is tested by WPT.

This code is not yet exercised.

[1] <a href="https://github.com/w3c/largest-contentful-paint/issues/145">https://github.com/w3c/largest-contentful-paint/issues/145</a>
[2] <a href="https://developer.mozilla.org/en-US/docs/Web/API/Performance/getEntriesByType">https://developer.mozilla.org/en-US/docs/Web/API/Performance/getEntriesByType</a>

This will be tested by largest-contentful-paint WPTs

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::enqueuePaintTimingEntryIfNeeded):
* Source/WebCore/page/LargestContentfulPaint.cpp:
(WebCore::LargestContentfulPaint::LargestContentfulPaint):
(WebCore::LargestContentfulPaint::paintTime const):
(WebCore::LargestContentfulPaint::loadTime const):
(WebCore::LargestContentfulPaint::setLoadTime):
(WebCore::LargestContentfulPaint::renderTime const):
(WebCore::LargestContentfulPaint::setRenderTime):
(WebCore::LargestContentfulPaint::startTime const):
(WebCore::LargestContentfulPaint::size const):
(WebCore::LargestContentfulPaint::setSize):
(WebCore::LargestContentfulPaint::id const):
(WebCore::LargestContentfulPaint::setID):
(WebCore::LargestContentfulPaint::url const):
(WebCore::LargestContentfulPaint::setURLString):
(WebCore::LargestContentfulPaint::element const):
(WebCore::LargestContentfulPaint::setElement):
* Source/WebCore/page/LargestContentfulPaint.h:
* Source/WebCore/page/Performance.cpp:
(WebCore::Performance::getEntries const):
(WebCore::Performance::getEntriesByType const):
(WebCore::Performance::getEntriesByName const):
(WebCore::Performance::appendBufferedEntriesByType const):
(WebCore::Performance::reportFirstContentfulPaint):
(WebCore::Performance::reportLargestContentfulPaint):
* Source/WebCore/page/Performance.h:

Canonical link: <a href="https://commits.webkit.org/300530@main">https://commits.webkit.org/300530@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4f876ba7ec3cdd9f055dab67391a4999ae2730c6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122937 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42651 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33348 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/129584 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/75045 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0048545c-0433-434b-94d4-df8616cdba11) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/124814 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43374 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51245 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/93457 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/75045 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a6e388b8-73ab-4c3b-800b-28e462bed73d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125888 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34583 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110041 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74074 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/02fa35ed-746a-49fd-b7fa-384ed1b403e9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33563 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28195 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73081 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/104291 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28406 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132312 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49886 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37981 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/101957 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50263 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106247 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/101824 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25863 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47190 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25377 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/46660 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49742 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/55502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/49209 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/52561 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/50891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->