### PR TITLE
[Site Isolation] Outer frame focus is not reset when focus is propagated to inner frame through tab navigation

### DIFF
--- a/LayoutTests/http/tests/site-isolation/focus-tab-navigation-activeElement-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/focus-tab-navigation-activeElement-expected.txt
@@ -1,0 +1,21 @@
+Tests tab navigation and Document.activeElement behavior with cross-origin iframes in site isolation mode
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS document.activeElement.tagName is 'BODY'
+PASS Initial state: inner Document.activeElement is BODY
+PASS document.activeElement.tagName is 'INPUT'
+PASS When outer input focused: outer Document.activeElement is INPUT
+PASS When outer input focused: inner Document.activeElement is BODY
+PASS Outer input blur handler fired
+PASS document.activeElement.tagName is 'IFRAME'
+PASS When inner input focused: outer Document.activeElement is IFRAME
+PASS Outer input blur handler was fired before inner input focus
+PASS When inner input focused: inner Document.activeElement is INPUT
+PASS successfullyParsed is true
+
+TEST COMPLETE
+This test verifies that Document.activeElement behaves correctly during tab navigation between main frame and cross-origin iframe in site isolation mode.
+
+

--- a/LayoutTests/http/tests/site-isolation/focus-tab-navigation-activeElement.html
+++ b/LayoutTests/http/tests/site-isolation/focus-tab-navigation-activeElement.html
@@ -1,0 +1,122 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<html>
+<script src="/js-test-resources/js-test.js"></script>
+<script src="/js-test-resources/ui-helper.js"></script>
+<script>
+description("Tests tab navigation and Document.activeElement behavior with cross-origin iframes in site isolation mode");
+jsTestIsAsync = true;
+
+let iframe;
+let outerInputBlurred = false;
+let innerInputFocused = false;
+let waitingForInnerFocusVerification = false;
+
+function checkInitialState() {
+    shouldBe("document.activeElement.tagName", "'BODY'");
+    iframe.contentWindow.postMessage({
+        type: 'checkActiveElement',
+        expected: 'BODY',
+        description: 'Initial state: inner Document.activeElement is BODY'
+    }, 'http://localhost:8000');
+}
+
+function checkInnerInputFocusState() {
+    shouldBe("document.activeElement.tagName", "'IFRAME'");
+    testPassed("When inner input focused: outer Document.activeElement is IFRAME");
+
+    if (outerInputBlurred)
+        testPassed("Outer input blur handler was fired before inner input focus");
+    else
+        testFailed("Outer input blur handler was NOT fired before inner input focus");
+
+    iframe.contentWindow.postMessage({
+        type: 'checkActiveElement',
+        expected: 'INPUT',
+        description: 'When inner input focused: inner Document.activeElement is INPUT'
+    }, 'http://localhost:8000');
+
+    waitingForInnerFocusVerification = false;
+}
+
+function tryCheckInnerFocusState() {
+    if (innerInputFocused && outerInputBlurred && waitingForInnerFocusVerification)
+        checkInnerInputFocusState();
+}
+
+async function handleMessage(event) {
+    if (event.data.type === 'activeElementCheck') {
+        if (event.data.success)
+            testPassed(event.data.message);
+        else
+            testFailed(event.data.message);
+
+        if (event.data.message.includes('Initial state'))
+            await UIHelper.keyDown("\t");
+        else if (event.data.message.includes('When outer input focused'))
+            await UIHelper.keyDown("\t");
+
+    } else if (event.data.type === 'innerInputFocused') {
+        innerInputFocused = true;
+        waitingForInnerFocusVerification = true;
+        tryCheckInnerFocusState();
+    } else if (event.data.type === 'finalCheck') {
+        if (event.data.success)
+            testPassed(event.data.message);
+        else
+            testFailed(event.data.message);
+
+        finishJSTest();
+    }
+}
+
+function onOuterInputFocus() {
+    shouldBe("document.activeElement.tagName", "'INPUT'");
+    testPassed("When outer input focused: outer Document.activeElement is INPUT");
+
+    iframe.contentWindow.postMessage({
+        type: 'checkActiveElement',
+        expected: 'BODY',
+        description: 'When outer input focused: inner Document.activeElement is BODY'
+    }, 'http://localhost:8000');
+}
+
+function onOuterInputBlur() {
+    outerInputBlurred = true;
+    testPassed("Outer input blur handler fired");
+    tryCheckInnerFocusState();
+}
+</script>
+
+<body>
+<p>This test verifies that Document.activeElement behaves correctly during tab navigation between main frame and cross-origin iframe in site isolation mode.</p>
+
+<input type="text" id="outerInput" placeholder="Outer frame input">
+<iframe id="testIframe" src="http://localhost:8000/site-isolation/resources/focus-tab-navigation-iframe.html" onload="onIframeLoad()"></iframe>
+
+<script>
+async function onIframeLoad() {
+    if (!iframe)
+        await setupTest();
+
+    checkInitialState();
+}
+
+async function setupTest() {
+    iframe = document.getElementById('testIframe');
+
+    testRunner?.dumpAsText();
+
+    await UIHelper.setHardwareKeyboardAttached(true);
+
+    window.addEventListener('message', handleMessage);
+
+    document.getElementById('outerInput').addEventListener('focus', onOuterInputFocus);
+    document.getElementById('outerInput').addEventListener('blur', onOuterInputBlur);
+}
+
+window.addEventListener('load', async () => {
+    await setupTest();
+});
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/resources/focus-tab-navigation-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/resources/focus-tab-navigation-iframe.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+<script>
+function handleMessage(event) {
+    if (event.data.type === 'checkActiveElement') {
+        let activeElement = document.activeElement;
+        let activeElementTag = activeElement ? activeElement.tagName : 'null';
+        let expected = event.data.expected;
+        let description = event.data.description || `Inner Document.activeElement is ${expected}`;
+
+        let success = activeElementTag === expected;
+        let message = success ? description : `Expected inner activeElement to be ${expected}, but was ${activeElementTag}`;
+
+        let messageType = description.includes('When inner input focused') ? 'finalCheck' : 'activeElementCheck';
+
+        event.source.postMessage({
+            type: messageType,
+            success: success,
+            message: message
+        }, event.origin);
+    }
+}
+
+function onInnerInputFocus() {
+    let activeElement = document.activeElement;
+    let activeElementTag = activeElement ? activeElement.tagName : 'null';
+
+    if (activeElementTag === 'INPUT') {
+        parent.postMessage({
+            type: 'innerInputFocused'
+        }, '*');
+    }
+}
+
+window.addEventListener('message', handleMessage);
+window.addEventListener('load', function() {
+    document.getElementById('innerInput').addEventListener('focus', onInnerInputFocus);
+});
+</script>
+
+<body>
+<p>Inner frame content</p>
+<input type="text" id="innerInput" placeholder="Inner frame input">
+</body>
+</html>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8266,3 +8266,5 @@ webkit.org/b/298974 fast/forms/ios/keyboard-restoration-after-element-replacemen
 webkit.org/b/280234 imported/w3c/web-platform-tests/html/dom/idlharness.https.html [ Skip ]
 
 webkit.org/b/299110 webrtc/calling-peerconnection-once-closed.html? [ Pass Failure ]
+
+webkit.org/b/299501 http/tests/site-isolation/focus-tab-navigation-activeElement.html [ Pass Failure ]

--- a/Source/WebCore/page/FocusController.cpp
+++ b/Source/WebCore/page/FocusController.cpp
@@ -548,9 +548,12 @@ FocusableElementSearchResult FocusController::findFocusableElementDescendingInto
     RefPtr element = startingElement;
     while (RefPtr owner = dynamicDowncast<HTMLFrameOwnerElement>(element)) {
         if (RefPtr remoteFrame = dynamicDowncast<RemoteFrame>(owner->contentFrame())) {
-            remoteFrame->client().findFocusableElementDescendingIntoRemoteFrame(direction, focusEventData, [](FoundElementInRemoteFrame found) {
+            RefPtr currentDocument = focusedLocalFrame() ? focusedLocalFrame()->document() : nullptr;
+            remoteFrame->client().findFocusableElementDescendingIntoRemoteFrame(direction, focusEventData, [currentDocument](FoundElementInRemoteFrame found) {
+                if (found == FoundElementInRemoteFrame::Yes && currentDocument)
+                    currentDocument->setFocusedElement(nullptr);
+
                 // FIXME: Implement sibling frame search by continuing here.
-                UNUSED_PARAM(found);
             });
 
             return { nullptr, ContinuedSearchInRemoteFrame::Yes };


### PR DESCRIPTION
#### 044e11849d85963696820cf52219199aad243d0e
<pre>
[Site Isolation] Outer frame focus is not reset when focus is propagated to inner frame through tab navigation
<a href="https://bugs.webkit.org/show_bug.cgi?id=299434">https://bugs.webkit.org/show_bug.cgi?id=299434</a>
<a href="https://rdar.apple.com/161192328">rdar://161192328</a>

Reviewed by Lily Spiniolas.

When we descend into subframes to find focusable elements, if the remote
frame finds an element, we need to make sure to unset the focused
element in our current frame.

Test: http/tests/site-isolation/focus-tab-navigation-activeElement.html

Test: http/tests/site-isolation/focus-tab-navigation-activeElement.html
* LayoutTests/http/tests/site-isolation/focus-tab-navigation-activeElement-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/focus-tab-navigation-activeElement.html: Added.
* LayoutTests/http/tests/site-isolation/resources/focus-tab-navigation-iframe.html: Added.
* LayoutTests/platform/ios/TestExpectations:

Mark the new test flaky on iOS pending webkit.org/b/299501.

* Source/WebCore/page/FocusController.cpp:
(WebCore::FocusController::findFocusableElementDescendingIntoSubframes):

Canonical link: <a href="https://commits.webkit.org/300500@main">https://commits.webkit.org/300500@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/289ba2eeb4f2181c1ad2cf4fd7c51ab25a811967

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122813 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/42620 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33215 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/129439 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74917 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/17004551-52c9-4a99-a511-6f8b755a9b9a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/124689 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43244 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51118 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93342 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/61961 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/206c00eb-87b5-4ea8-be0c-e81f806268a0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125765 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34481 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109941 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73978 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6868ecfe-c349-483c-9f60-1a5f0f8fc4fa) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33459 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28098 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72931 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104181 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28311 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132166 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49758 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37881 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/101934 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50135 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106155 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101721 "Found 3 new API test failures: WebKitGTK/TestInspector:/webkit/WebKitWebInspector/manual-attach-detach, TestWTF:CompletionHandlerDeathTest.MainThreadHandlerOnThreadAssertsDeathTest, TestWTF:CompletionHandlerDeathTest.ConstructionThreadHandlerOnThreadAssertsDeathTest (failure)") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/25841 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47096 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25283 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/46529 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19387 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49616 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/55368 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49082 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/52434 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50765 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->