### PR TITLE
[JSC] Add stack overflow checks to LiteralParser::parse

### DIFF
--- a/JSTests/stress/dont-crash-on-stack-overflow-JSON-parse-deeply-nested-with-reviver.js
+++ b/JSTests/stress/dont-crash-on-stack-overflow-JSON-parse-deeply-nested-with-reviver.js
@@ -1,0 +1,34 @@
+//@ runDefault("--maxPerThreadStackUsage=5242880")
+
+// This test should gracefully fail with a stack
+// overflow error which we can catch.
+
+obj = {}
+
+// create the deeply nested JSON objects
+for (let i = 0; i < 4600; ++i) {
+ obj = {obj};
+}
+
+let identityReviver = (key, value) => {
+  // perform no computation and leave values unchanged
+  value
+}
+
+// Pass in an identity reviver function to JSON.parse. 
+// https://tc39.es/ecma262/multipage/structured-data.html#sec-json.parse
+// Stack overflow still ocurrs with an identity reviver. 
+// The actual compuation of the reviver function is not 
+// relevant.
+// Still do need to pass in a reviver function because 
+// otherwise jsonParseSlow will not be called 
+// (see logic in jsonProtoFuncParse of JSONObject.cpp).
+let stringified = JSON.stringify(obj);
+try {
+    let parsed = JSON.parse(stringified, identityReviver);
+} catch(e) {
+    if (e != "RangeError: Maximum call stack size exceeded.")
+        throw "FAILED";
+    else
+        print("Gracefully caught stack overflow error")
+}

--- a/Source/JavaScriptCore/runtime/LiteralParser.cpp
+++ b/Source/JavaScriptCore/runtime/LiteralParser.cpp
@@ -1529,6 +1529,8 @@ JSValue LiteralParser<CharType, reviverMode>::parseRecursively(VM& vm, uint8_t* 
     return object;
 }
 
+constexpr unsigned maximumRangesStackRecursion = 4500;
+
 template <typename CharType, JSONReviverMode reviverMode>
 JSValue LiteralParser<CharType, reviverMode>::parse(VM& vm, ParserState initialState, JSONRanges* sourceRanges)
 {
@@ -1546,6 +1548,9 @@ JSValue LiteralParser<CharType, reviverMode>::parse(VM& vm, ParserState initialS
             m_objectStack.appendWithCrashOnOverflow(array);
             if constexpr (reviverMode == JSONReviverMode::Enabled) {
                 if (sourceRanges) {
+                    if (m_rangesStack.size() >= maximumRangesStackRecursion) [[unlikely]]
+                        return throwStackOverflowError(m_globalObject, scope);
+
                     unsigned startOffset = static_cast<unsigned>(m_lexer.currentTokenStart() - m_lexer.start());
                     m_rangesStack.append({
                         sourceRanges->record(array),
@@ -1612,6 +1617,9 @@ JSValue LiteralParser<CharType, reviverMode>::parse(VM& vm, ParserState initialS
             JSObject* object = constructEmptyObject(m_globalObject);
             if constexpr (reviverMode == JSONReviverMode::Enabled) {
                 if (sourceRanges) {
+                    if (m_rangesStack.size() >= maximumRangesStackRecursion) [[unlikely]]
+                        return throwStackOverflowError(m_globalObject, scope);
+
                     unsigned startOffset = static_cast<unsigned>(m_lexer.currentTokenStart() - m_lexer.start());
                     m_rangesStack.append({
                         sourceRanges->record(object),


### PR DESCRIPTION
#### 06f13ed8ff1643051c8cfdad88aebc438e57c0e5
<pre>
[JSC] Add stack overflow checks to LiteralParser::parse
<a href="https://bugs.webkit.org/show_bug.cgi?id=299452">https://bugs.webkit.org/show_bug.cgi?id=299452</a>
<a href="https://rdar.apple.com/158627869">rdar://158627869</a>

Reviewed by Yusuke Suzuki.

This patch adds checks to LiteralParser::parse to prevent against stack overflows with
deeply nested JSON. Without these checks, JSC will crash with a stack overflow
when the destructor for `ranges` is called at the end of `jsonParseSlow`&apos;s scope.

These checks prevent `ranges` from having too many recursive levels and gracefully throws a
stack overflow error before the recursive chain of destructors can be called.

These checks are guarded by a `if constexpr (reviverMode == JSONReviverMode::Enabled)`, meaning
they will only apply in the case where a reviver function is provided and the jsonParseSlow path
is called.

Test: JSTests/stress/dont-crash-on-stack-overflow-JSON-parse-deeply-nested-with-reviver.js
* JSTests/stress/dont-crash-on-stack-overflow-JSON-parse-deeply-nested-with-reviver.js: Added.
(let.identityReviver):
(catch):
* Source/JavaScriptCore/runtime/LiteralParser.cpp:
(JSC::reviverMode&gt;::parse):

Canonical link: <a href="https://commits.webkit.org/301098@main">https://commits.webkit.org/301098@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/750d001b88c530703f0df67b4207eee0e539e8fe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124921 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44590 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35327 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131769 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/76808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45283 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53157 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95074 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/76808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127875 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36132 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111720 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75623 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/35067 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29874 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75248 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/117023 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105892 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30105 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134441 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/123440 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51752 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39553 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103549 "") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52173 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107934 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103324 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26308 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48666 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26957 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/48773 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51631 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57435 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/156466 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51015 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39186 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54371 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52708 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->