### PR TITLE
[Site Isolation] Web Inspector: Only LocalFrame should require frame target and inspector controller

### DIFF
--- a/Source/WebCore/inspector/FrameInspectorController.cpp
+++ b/Source/WebCore/inspector/FrameInspectorController.cpp
@@ -55,7 +55,7 @@ using namespace Inspector;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(FrameInspectorController);
 
-FrameInspectorController::FrameInspectorController(Frame& frame)
+FrameInspectorController::FrameInspectorController(LocalFrame& frame)
     : m_frame(frame)
     , m_instrumentingAgents(InstrumentingAgents::create(*this))
     , m_injectedScriptManager(makeUniqueRef<WebInjectedScriptManager>(*this, WebInjectedScriptHost::create()))

--- a/Source/WebCore/inspector/FrameInspectorController.h
+++ b/Source/WebCore/inspector/FrameInspectorController.h
@@ -47,18 +47,18 @@ class FrontendRouter;
 
 namespace WebCore {
 
-class Frame;
 class InspectorBackendClient;
 class InspectorFrontendClient;
 class InspectorInstrumentation;
 class InstrumentingAgents;
+class LocalFrame;
 class WebInjectedScriptManager;
 
 class FrameInspectorController final : public Inspector::InspectorEnvironment, public CanMakeWeakPtr<FrameInspectorController> {
     WTF_MAKE_NONCOPYABLE(FrameInspectorController);
     WTF_MAKE_TZONE_ALLOCATED(FrameInspectorController);
 public:
-    FrameInspectorController(Frame&);
+    FrameInspectorController(LocalFrame&);
     ~FrameInspectorController() override;
 
     WEBCORE_EXPORT void ref() const;
@@ -83,7 +83,7 @@ private:
 
     void createLazyAgents();
 
-    WeakRef<Frame> m_frame;
+    WeakRef<LocalFrame> m_frame;
     const Ref<InstrumentingAgents> m_instrumentingAgents;
     const UniqueRef<WebInjectedScriptManager> m_injectedScriptManager;
     const Ref<Inspector::FrontendRouter> m_frontendRouter;

--- a/Source/WebCore/page/DOMWindow.cpp
+++ b/Source/WebCore/page/DOMWindow.cpp
@@ -138,7 +138,7 @@ void DOMWindow::close()
 
 FrameConsoleClient* DOMWindow::console() const
 {
-    RefPtr frame = this->frame();
+    RefPtr frame = dynamicDowncast<LocalFrame>(this->frame());
     return frame ? &frame->console() : nullptr;
 }
 

--- a/Source/WebCore/page/Frame.cpp
+++ b/Source/WebCore/page/Frame.cpp
@@ -27,9 +27,7 @@
 #include "Frame.h"
 
 #include "ContainerNodeInlines.h"
-#include "FrameConsoleClient.h"
 #include "FrameInlines.h"
-#include "FrameInspectorController.h"
 #include "FrameLoader.h"
 #include "FrameLoaderClient.h"
 #include "HTMLFrameOwnerElement.h"
@@ -121,8 +119,6 @@ Frame::Frame(Page& page, FrameIdentifier frameID, FrameType frameType, HTMLFrame
     , m_navigationScheduler(makeUniqueRefWithoutRefCountedCheck<NavigationScheduler>(*this))
     , m_opener(opener)
     , m_frameTreeSyncData(WTFMove(frameTreeSyncData))
-    , m_inspectorController(makeUniqueRefWithoutRefCountedCheck<FrameInspectorController>(*this))
-    , m_consoleClient(makeUniqueRef<FrameConsoleClient>(*this))
 {
     relaxAdoptionRequirement();
     if (parent && addToFrameTree == AddToFrameTree::Yes)
@@ -338,11 +334,6 @@ bool Frame::frameCanCreatePaymentSession() const
     // Prefer the LocalFrame code path when site isolation is disabled.
     ASSERT(m_settings->siteIsolationEnabled());
     return m_frameTreeSyncData->frameCanCreatePaymentSession;
-}
-
-Ref<FrameInspectorController> Frame::protectedInspectorController()
-{
-    return m_inspectorController.get();
 }
 
 bool Frame::isPrinting() const

--- a/Source/WebCore/page/Frame.h
+++ b/Source/WebCore/page/Frame.h
@@ -41,8 +41,6 @@ namespace WebCore {
 class DOMWindow;
 class Event;
 class FloatSize;
-class FrameConsoleClient;
-class FrameInspectorController;
 class FrameLoaderClient;
 class FrameLoadRequest;
 class FrameView;
@@ -149,11 +147,6 @@ public:
     FrameTreeSyncData& frameTreeSyncData() const { return m_frameTreeSyncData.get(); }
     WEBCORE_EXPORT virtual RefPtr<SecurityOrigin> frameDocumentSecurityOrigin() const = 0;
 
-    FrameInspectorController& inspectorController() { return m_inspectorController.get(); }
-    WEBCORE_EXPORT Ref<FrameInspectorController> protectedInspectorController();
-    FrameConsoleClient& console() { return m_consoleClient.get(); }
-    const FrameConsoleClient& console() const { return m_consoleClient.get(); }
-
     WEBCORE_EXPORT virtual void setPrinting(bool printing, FloatSize pageSize, FloatSize originalPageSize, float maximumShrinkRatio, AdjustViewSize, NotifyUIProcess = NotifyUIProcess::Yes);
     WEBCORE_EXPORT bool isPrinting() const;
 
@@ -182,9 +175,6 @@ private:
     bool m_isPrinting { false };
 
     Ref<FrameTreeSyncData> m_frameTreeSyncData;
-
-    const UniqueRef<FrameInspectorController> m_inspectorController;
-    const UniqueRef<FrameConsoleClient> m_consoleClient;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/FrameConsoleClient.cpp
+++ b/Source/WebCore/page/FrameConsoleClient.cpp
@@ -36,6 +36,7 @@
 #include "Document.h"
 #include "ElementChildIteratorInlines.h"
 #include "Frame.h"
+#include "FrameInlines.h"
 #include "FrameSnapshotting.h"
 #include "HTMLCanvasElement.h"
 #include "HTMLImageElement.h"
@@ -96,7 +97,7 @@ using namespace Inspector;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(FrameConsoleClient);
 
-FrameConsoleClient::FrameConsoleClient(Frame& frame)
+FrameConsoleClient::FrameConsoleClient(LocalFrame& frame)
     : m_frame(frame)
 {
 }
@@ -139,10 +140,7 @@ void FrameConsoleClient::logMessageToSystemConsole(const Inspector::ConsoleMessa
 
 void FrameConsoleClient::addMessage(std::unique_ptr<Inspector::ConsoleMessage>&& consoleMessage)
 {
-    RefPtr frame = dynamicDowncast<LocalFrame>(m_frame.get());
-    if (!frame)
-        return;
-
+    Ref frame = m_frame.get();
     RefPtr page = frame->page();
     if (!page)
         return;
@@ -173,7 +171,7 @@ void FrameConsoleClient::addMessage(std::unique_ptr<Inspector::ConsoleMessage>&&
 #if ENABLE(WEBDRIVER_BIDI)
     AutomationInstrumentation::addMessageToConsole(consoleMessage);
 #endif
-    InspectorInstrumentation::addMessageToConsole(*frame, WTFMove(consoleMessage));
+    InspectorInstrumentation::addMessageToConsole(frame.get(), WTFMove(consoleMessage));
 }
 
 void FrameConsoleClient::addMessage(MessageSource source, MessageLevel level, const String& message, unsigned long requestIdentifier, Document* document)
@@ -209,10 +207,6 @@ void FrameConsoleClient::addMessage(MessageSource source, MessageLevel level, co
 
 void FrameConsoleClient::messageWithTypeAndLevel(MessageType type, MessageLevel level, JSC::JSGlobalObject* lexicalGlobalObject, Ref<Inspector::ScriptArguments>&& arguments)
 {
-    RefPtr frame = dynamicDowncast<LocalFrame>(m_frame.get());
-    if (!frame)
-        return;
-
     String messageText;
     std::span<const String> additionalArguments;
     Vector<String> messageArgumentsVector = arguments->getArgumentsAsStrings();
@@ -230,7 +224,8 @@ void FrameConsoleClient::messageWithTypeAndLevel(MessageType type, MessageLevel 
 #if ENABLE(WEBDRIVER_BIDI)
     AutomationInstrumentation::addMessageToConsole(message);
 #endif
-    InspectorInstrumentation::addMessageToConsole(*frame, WTFMove(message));
+    Ref frame = m_frame.get();
+    InspectorInstrumentation::addMessageToConsole(frame.get(), WTFMove(message));
 
     RefPtr page = frame->page();
     if (!page)
@@ -252,84 +247,57 @@ void FrameConsoleClient::messageWithTypeAndLevel(MessageType type, MessageLevel 
 
 void FrameConsoleClient::count(JSC::JSGlobalObject* lexicalGlobalObject, const String& label)
 {
-    RefPtr frame = dynamicDowncast<LocalFrame>(m_frame.get());
-    if (!frame)
-        return;
-
-    InspectorInstrumentation::consoleCount(*frame, lexicalGlobalObject, label);
+    Ref frame = m_frame.get();
+    InspectorInstrumentation::consoleCount(frame.get(), lexicalGlobalObject, label);
 }
 
 void FrameConsoleClient::countReset(JSC::JSGlobalObject* lexicalGlobalObject, const String& label)
 {
-    RefPtr frame = dynamicDowncast<LocalFrame>(m_frame.get());
-    if (!frame)
-        return;
-
-    InspectorInstrumentation::consoleCountReset(*frame, lexicalGlobalObject, label);
+    Ref frame = m_frame.get();
+    InspectorInstrumentation::consoleCountReset(frame.get(), lexicalGlobalObject, label);
 }
 
 void FrameConsoleClient::profile(JSC::JSGlobalObject*, const String& title)
 {
-    RefPtr frame = dynamicDowncast<LocalFrame>(m_frame.get());
-    if (!frame)
-        return;
-
-    InspectorInstrumentation::startProfiling(*frame, title);
+    Ref frame = m_frame.get();
+    InspectorInstrumentation::startProfiling(frame.get(), title);
 }
 
 void FrameConsoleClient::profileEnd(JSC::JSGlobalObject*, const String& title)
 {
-    RefPtr frame = dynamicDowncast<LocalFrame>(m_frame.get());
-    if (!frame)
-        return;
-
+    Ref frame = m_frame.get();
     // FIXME: <https://webkit.org/b/153499> Web Inspector: console.profile should use the new Sampling Profiler
-    InspectorInstrumentation::stopProfiling(*frame, title);
+    InspectorInstrumentation::stopProfiling(frame.get(), title);
 }
 
 void FrameConsoleClient::takeHeapSnapshot(JSC::JSGlobalObject*, const String& title)
 {
-    RefPtr frame = dynamicDowncast<LocalFrame>(m_frame.get());
-    if (!frame)
-        return;
-
-    InspectorInstrumentation::takeHeapSnapshot(*frame, title);
+    Ref frame = m_frame.get();
+    InspectorInstrumentation::takeHeapSnapshot(frame.get(), title);
 }
 
 void FrameConsoleClient::time(JSC::JSGlobalObject* lexicalGlobalObject, const String& label)
 {
-    RefPtr frame = dynamicDowncast<LocalFrame>(m_frame.get());
-    if (!frame)
-        return;
-
-    InspectorInstrumentation::startConsoleTiming(*frame, lexicalGlobalObject, label);
+    Ref frame = m_frame.get();
+    InspectorInstrumentation::startConsoleTiming(frame.get(), lexicalGlobalObject, label);
 }
 
 void FrameConsoleClient::timeLog(JSC::JSGlobalObject* lexicalGlobalObject, const String& label, Ref<ScriptArguments>&& arguments)
 {
-    RefPtr frame = dynamicDowncast<LocalFrame>(m_frame.get());
-    if (!frame)
-        return;
-
-    InspectorInstrumentation::logConsoleTiming(*frame, lexicalGlobalObject, label, WTFMove(arguments));
+    Ref frame = m_frame.get();
+    InspectorInstrumentation::logConsoleTiming(frame.get(), lexicalGlobalObject, label, WTFMove(arguments));
 }
 
 void FrameConsoleClient::timeEnd(JSC::JSGlobalObject* lexicalGlobalObject, const String& label)
 {
-    RefPtr frame = dynamicDowncast<LocalFrame>(m_frame.get());
-    if (!frame)
-        return;
-
-    InspectorInstrumentation::stopConsoleTiming(*frame, lexicalGlobalObject, label);
+    Ref frame = m_frame.get();
+    InspectorInstrumentation::stopConsoleTiming(frame.get(), lexicalGlobalObject, label);
 }
 
 void FrameConsoleClient::timeStamp(JSC::JSGlobalObject*, Ref<ScriptArguments>&& arguments)
 {
-    RefPtr frame = dynamicDowncast<LocalFrame>(m_frame.get());
-    if (!frame)
-        return;
-
-    InspectorInstrumentation::consoleTimeStamp(*frame, WTFMove(arguments));
+    Ref frame = m_frame.get();
+    InspectorInstrumentation::consoleTimeStamp(frame.get(), WTFMove(arguments));
 }
 
 static JSC::JSObject* objectArgumentAt(ScriptArguments& arguments, unsigned index)
@@ -434,10 +402,9 @@ void FrameConsoleClient::screenshot(JSC::JSGlobalObject* lexicalGlobalObject, Re
 
                 if (dataURL.isEmpty()) {
                     if (!snapshot) {
-                        if (RefPtr localFrame = dynamicDowncast<LocalFrame>(m_frame.get())) {
-                            if (RefPtr localMainFrame = localFrame->localMainFrame())
-                                snapshot = WebCore::snapshotNode(*localMainFrame, *node, { { }, PixelFormat::BGRA8, DestinationColorSpace::SRGB() });
-                        }
+                        Ref frame = m_frame.get();
+                        if (RefPtr localMainFrame = frame->localMainFrame())
+                            snapshot = WebCore::snapshotNode(*localMainFrame, *node, { { }, PixelFormat::BGRA8, DestinationColorSpace::SRGB() });
                     }
 
                     if (snapshot)
@@ -469,11 +436,10 @@ void FrameConsoleClient::screenshot(JSC::JSGlobalObject* lexicalGlobalObject, Re
         } else if (auto* rect = JSDOMRectReadOnly::toWrapped(vm, possibleTarget)) {
             target = possibleTarget;
             if (InspectorInstrumentation::hasFrontends()) [[unlikely]] {
-                if (RefPtr localFrame = dynamicDowncast<LocalFrame>(m_frame.get())) {
-                    if (RefPtr localMainFrame = localFrame->localMainFrame()) {
-                        if (auto snapshot = WebCore::snapshotFrameRect(*localMainFrame, enclosingIntRect(rect->toFloatRect()), { { }, PixelFormat::BGRA8, DestinationColorSpace::SRGB() }))
-                            dataURL = snapshot->toDataURL("image/png"_s, std::nullopt, PreserveResolution::Yes);
-                    }
+                Ref frame = m_frame.get();
+                if (RefPtr localMainFrame = frame->localMainFrame()) {
+                    if (auto snapshot = WebCore::snapshotFrameRect(*localMainFrame, enclosingIntRect(rect->toFloatRect()), { { }, PixelFormat::BGRA8, DestinationColorSpace::SRGB() }))
+                        dataURL = snapshot->toDataURL("image/png"_s, std::nullopt, PreserveResolution::Yes);
                 }
             }
         } else {
@@ -487,13 +453,12 @@ void FrameConsoleClient::screenshot(JSC::JSGlobalObject* lexicalGlobalObject, Re
 
     if (InspectorInstrumentation::hasFrontends()) [[unlikely]] {
         if (!target) {
-            if (RefPtr localFrame = dynamicDowncast<LocalFrame>(m_frame.get())) {
-                if (RefPtr localMainFrame = localFrame->localMainFrame()) {
-                    // If no target is provided, capture an image of the viewport.
-                    auto viewportRect = localMainFrame->view()->unobscuredContentRect();
-                    if (auto snapshot = WebCore::snapshotFrameRect(*localMainFrame, viewportRect, { { }, PixelFormat::BGRA8, DestinationColorSpace::SRGB() }))
-                        dataURL = snapshot->toDataURL("image/png"_s, std::nullopt, PreserveResolution::Yes);
-                }
+            Ref frame = m_frame.get();
+            if (RefPtr localMainFrame = frame->localMainFrame()) {
+                // If no target is provided, capture an image of the viewport.
+                auto viewportRect = localMainFrame->view()->unobscuredContentRect();
+                if (auto snapshot = WebCore::snapshotFrameRect(*localMainFrame, viewportRect, { { }, PixelFormat::BGRA8, DestinationColorSpace::SRGB() }))
+                    dataURL = snapshot->toDataURL("image/png"_s, std::nullopt, PreserveResolution::Yes);
             }
         }
 

--- a/Source/WebCore/page/FrameConsoleClient.h
+++ b/Source/WebCore/page/FrameConsoleClient.h
@@ -47,14 +47,14 @@ using JSC::MessageType;
 namespace WebCore {
 
 class Document;
-class Frame;
+class LocalFrame;
 class StringCallback;
 
 class WEBCORE_EXPORT FrameConsoleClient final : public JSC::ConsoleClient, public CanMakeCheckedPtr<FrameConsoleClient> {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(FrameConsoleClient, WEBCORE_EXPORT);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FrameConsoleClient);
 public:
-    explicit FrameConsoleClient(Frame&);
+    explicit FrameConsoleClient(LocalFrame&);
     virtual ~FrameConsoleClient();
 
     FrameConsoleClient(const FrameConsoleClient&) = delete;
@@ -93,7 +93,7 @@ private:
     void recordEnd(JSC::JSGlobalObject*, Ref<Inspector::ScriptArguments>&&) override;
     void screenshot(JSC::JSGlobalObject*, Ref<Inspector::ScriptArguments>&&) override;
 
-    WeakRef<Frame> m_frame;
+    WeakRef<LocalFrame> m_frame;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -55,7 +55,9 @@
 #include "EventNames.h"
 #include "FloatQuad.h"
 #include "FocusController.h"
+#include "FrameConsoleClient.h"
 #include "FrameDestructionObserver.h"
+#include "FrameInspectorController.h"
 #include "FrameLoader.h"
 #include "FrameSelection.h"
 #include "GraphicsContext.h"
@@ -189,6 +191,8 @@ LocalFrame::LocalFrame(Page& page, ClientCreator&& clientCreator, FrameIdentifie
     , m_rootFrame(WebCore::rootFrame(*this, parent))
     , m_sandboxFlags(sandboxFlags)
     , m_eventHandler(makeUniqueRef<EventHandler>(*this))
+    , m_inspectorController(makeUniqueRefWithoutRefCountedCheck<FrameInspectorController>(*this))
+    , m_consoleClient(makeUniqueRef<FrameConsoleClient>(*this))
 {
     ProcessWarming::initializeNames();
     StaticCSSValuePool::init();
@@ -1620,6 +1624,11 @@ RefPtr<SecurityOrigin> LocalFrame::frameDocumentSecurityOrigin() const
         return &document->securityOrigin();
 
     return nullptr;
+}
+
+Ref<FrameInspectorController> LocalFrame::protectedInspectorController()
+{
+    return m_inspectorController.get();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/LocalFrame.h
+++ b/Source/WebCore/page/LocalFrame.h
@@ -72,6 +72,8 @@ class EventHandler;
 class FloatPoint;
 class FloatSize;
 class FrameDestructionObserver;
+class FrameConsoleClient;
+class FrameInspectorController;
 class FrameLoader;
 class FrameSelection;
 class HTMLFrameOwnerElement;
@@ -346,6 +348,11 @@ public:
 
     bool frameCanCreatePaymentSession() const final;
 
+    FrameInspectorController& inspectorController() { return m_inspectorController.get(); }
+    WEBCORE_EXPORT Ref<FrameInspectorController> protectedInspectorController();
+    FrameConsoleClient& console() { return m_consoleClient.get(); }
+    const FrameConsoleClient& console() const { return m_consoleClient.get(); }
+
 protected:
     void frameWasDisconnectedFromOwner() const final;
 
@@ -418,6 +425,9 @@ private:
     SandboxFlags m_sandboxFlags;
     const UniqueRef<EventHandler> m_eventHandler;
     std::unique_ptr<HashSet<RegistrableDomain>> m_storageAccessExceptionDomains;
+
+    const UniqueRef<FrameInspectorController> m_inspectorController;
+    const UniqueRef<FrameConsoleClient> m_consoleClient;
 };
 
 WTF::TextStream& operator<<(WTF::TextStream&, const LocalFrame&);

--- a/Source/WebKit/WebProcess/Inspector/WebFrameInspectorTarget.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebFrameInspectorTarget.cpp
@@ -28,9 +28,9 @@
 
 #include "WebFrame.h"
 #include "WebFrameInspectorTargetFrontendChannel.h"
-#include <WebCore/Frame.h>
 #include <WebCore/FrameInspectorController.h>
 #include <WebCore/InspectorController.h>
+#include <WebCore/LocalFrame.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 
@@ -65,7 +65,7 @@ void WebFrameInspectorTarget::connect(Inspector::FrontendChannel::ConnectionType
     Ref frame = m_frame.get();
     m_channel = makeUnique<WebFrameInspectorTargetFrontendChannel>(frame, identifier(), connectionType);
 
-    if (RefPtr coreFrame = frame->coreFrame())
+    if (RefPtr coreFrame = frame->coreLocalFrame())
         coreFrame->protectedInspectorController()->connectFrontend(*m_channel);
 }
 
@@ -74,7 +74,7 @@ void WebFrameInspectorTarget::disconnect()
     if (!m_channel)
         return;
 
-    if (RefPtr coreFrame = protectedFrame()->coreFrame())
+    if (RefPtr coreFrame = protectedFrame()->coreLocalFrame())
         coreFrame->protectedInspectorController()->disconnectFrontend(*m_channel);
 
     m_channel.reset();
@@ -82,7 +82,7 @@ void WebFrameInspectorTarget::disconnect()
 
 void WebFrameInspectorTarget::sendMessageToTargetBackend(const String& message)
 {
-    if (RefPtr coreFrame = protectedFrame()->coreFrame())
+    if (RefPtr coreFrame = protectedFrame()->coreLocalFrame())
         coreFrame->protectedInspectorController()->dispatchMessageFromFrontend(message);
 }
 

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.h
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.h
@@ -293,6 +293,8 @@ private:
 
     void findFocusableElementDescendingIntoRemoteFrame(WebCore::FocusDirection, const WebCore::FocusEventData&, CompletionHandler<void(WebCore::FoundElementInRemoteFrame)>&&);
 
+    WebFrameInspectorTarget& ensureInspectorTarget();
+
     WeakPtr<WebCore::Frame> m_coreFrame;
     WeakPtr<WebPage> m_page;
     RefPtr<WebCore::LocalFrame> m_provisionalFrame;
@@ -316,7 +318,7 @@ private:
     Markable<WebCore::LayerHostingContextIdentifier> m_layerHostingContextIdentifier;
     Markable<WebCore::FrameIdentifier> m_frameIDBeforeProvisionalNavigation;
 
-    const UniqueRef<WebFrameInspectorTarget> m_inspectorTarget;
+    std::unique_ptr<WebFrameInspectorTarget> m_inspectorTarget;
 };
 
 } // namespace WebKit


### PR DESCRIPTION
#### 82afbdc83517546bfe9bdf4a65e4a46c944d9d6f
<pre>
[Site Isolation] Web Inspector: Only LocalFrame should require frame target and inspector controller
<a href="https://webkit.org/b/299493">https://webkit.org/b/299493</a>
<a href="https://rdar.apple.com/161281114">rdar://161281114</a>

Reviewed by BJ Burg.

Given only LocalFrame should end up handling inspector commands and
events, it should be worthwhile to tweak the design so that a frame
target corresponds to a local frame rather than any frame. This should
help simplify our architecture as we start implementing domains for the
frame target (so that e.g. we don&apos;t need to check whether the inspected
frame is local or remote all the time).

Here&apos;s how frame targets are handled now in each process/component:
- In UI process, it was already the case that the number of frame target
  proxies (WebFrameInspectorTargetProxy) equals to the number of local
  frames there are, due to each proxy associating with a WebFrameProxy.
- In WebCore, only LocalFrame now creates an inspector controller (FrameInspectorController)
  to provide the inspector agents.
- In WebKit, WebFrame now only creates an inspector target (WebFrameInspectorTarget)
  if it&apos;s local. This is now also done lazily as inspection is needed.

With this change, future inspector-related objects working with frames
can start targeting local frames instead. There&apos;s currently few use
cases needing to adapt to this change, in WindowProxy, DOMWindow, and
FrameConsoleClient, which are updated by this patch as well.

No new tests as there&apos;s no intended noticeable changes in behavior.
Existing inspector tests should cover use cases related to this change.

* Source/WebCore/inspector/FrameInspectorController.cpp:
(WebCore::FrameInspectorController::FrameInspectorController):
* Source/WebCore/inspector/FrameInspectorController.h:
* Source/WebCore/page/Frame.cpp:
(WebCore::Frame::Frame):
(WebCore::Frame::protectedInspectorController): Deleted.
* Source/WebCore/page/Frame.h:
(WebCore::Frame::inspectorController): Deleted.
(WebCore::Frame::console): Deleted.
(WebCore::Frame::console const): Deleted.
* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::LocalFrame):
(WebCore::LocalFrame::protectedInspectorController):
* Source/WebCore/page/LocalFrame.h:
   In WebCore, only LocalFrame now has an inspector controller.

* Source/WebCore/page/FrameConsoleClient.cpp:
(WebCore::FrameConsoleClient::FrameConsoleClient):
(WebCore::FrameConsoleClient::addMessage):
(WebCore::FrameConsoleClient::messageWithTypeAndLevel):
(WebCore::FrameConsoleClient::count):
(WebCore::FrameConsoleClient::countReset):
(WebCore::FrameConsoleClient::profile):
(WebCore::FrameConsoleClient::profileEnd):
(WebCore::FrameConsoleClient::takeHeapSnapshot):
(WebCore::FrameConsoleClient::time):
(WebCore::FrameConsoleClient::timeLog):
(WebCore::FrameConsoleClient::timeEnd):
(WebCore::FrameConsoleClient::timeStamp):
(WebCore::FrameConsoleClient::screenshot):
* Source/WebCore/page/FrameConsoleClient.h:
   Given FrameConsoleClient only operated on local frames, make it also
   now only owned by LocalFrame instead.

* Source/WebCore/bindings/js/WindowProxy.cpp:
(WebCore::WindowProxy::setDOMWindow):
* Source/WebCore/page/DOMWindow.cpp:
(WebCore::DOMWindow::console const):
   Adapt to now only LocalFrame has a console client.

* Source/WebKit/WebProcess/Inspector/WebFrameInspectorTarget.cpp:
(WebKit::WebFrameInspectorTarget::connect):
(WebKit::WebFrameInspectorTarget::disconnect):
(WebKit::WebFrameInspectorTarget::sendMessageToTargetBackend):
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::WebFrame):
(WebKit::WebFrame::ensureInspectorTarget):
(WebKit::WebFrame::connectInspector):
(WebKit::WebFrame::disconnectInspector):
(WebKit::WebFrame::sendMessageToInspectorTarget):
* Source/WebKit/WebProcess/WebPage/WebFrame.h:
   Make only local WebFrames create an inspector target, which is now
   lazily initialized.

Canonical link: <a href="https://commits.webkit.org/300543@main">https://commits.webkit.org/300543@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/30c4d874e4076607491d332afb67b8f2a5e75bf7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123002 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42716 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33413 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/129656 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/75111 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/805c1beb-8765-4d04-850f-bad866e8b401) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/124879 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43439 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51310 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/93506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/75111 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/90109589-c347-4ac2-842e-f6204a3e4543) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125953 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34626 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110100 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74133 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3f878400-5f7d-496b-b37e-38bcd1045194) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/33606 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28254 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73167 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104337 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28472 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132386 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49951 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38029 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/102003 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50328 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106313 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/101871 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25875 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47237 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25431 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/46725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49807 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/55567 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49275 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/52627 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/50956 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->