### PR TITLE
[OpenXR] Fix unsafe buffer usage in OpenXRLayer.cpp

### DIFF
--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRLayer.cpp
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRLayer.cpp
@@ -62,7 +62,7 @@ OpenXRLayer::~OpenXRLayer()
     ASSERT(WebCore::GLContext::current());
 #if USE(GBM)
     if (m_fbosForBlitting[0])
-        glDeleteFramebuffers(2, m_fbosForBlitting);
+        glDeleteFramebuffers(m_fbosForBlitting.size(), m_fbosForBlitting.data());
     for (auto texture : m_exportedTexturesMap.values())
         glDeleteTextures(1, &texture);
 #endif
@@ -426,7 +426,7 @@ XrCompositionLayerBaseHeader* OpenXRLayerProjection::endFrame(const XRDeviceLaye
 #if OS(ANDROID) || USE(GBM)
     if (needsBlitTexture()) {
         if (!m_fbosForBlitting[0])
-            glGenFramebuffers(2, m_fbosForBlitting);
+            glGenFramebuffers(m_fbosForBlitting.size(), m_fbosForBlitting.data());
         blitTexture();
     }
 #endif

--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRLayer.h
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRLayer.h
@@ -78,7 +78,7 @@ protected:
 
 #if USE(GBM) || OS(ANDROID)
     HashMap<PlatformGLObject, PlatformGLObject> m_exportedTexturesMap;
-    PlatformGLObject m_fbosForBlitting[2] { 0, 0 };
+    std::array<PlatformGLObject, 2> m_fbosForBlitting { 0, 0 };
 #endif
 #if USE(GBM)
     RefPtr<WebCore::GBMDevice> m_gbmDevice;


### PR DESCRIPTION
#### 8c603d7d3af2a653c21859596c8105f1a9790c57
<pre>
[OpenXR] Fix unsafe buffer usage in OpenXRLayer.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=299489">https://bugs.webkit.org/show_bug.cgi?id=299489</a>

Reviewed by Chris Dumez.

Use an std::array for OpenXRLayer::m_fbosForBlitting, instead
of a plain array.

Canonical link: <a href="https://commits.webkit.org/300512@main">https://commits.webkit.org/300512@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ed6fd11d14fcfa42e0fc72a186cc362516baefe2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122769 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42481 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33171 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/129394 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74873 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43200 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51074 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93306 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61941 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125721 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34445 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109907 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73945 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33430 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72884 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104145 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28275 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132121 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49714 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37847 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101821 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50091 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106122 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101693 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25845 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47068 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25252 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/46568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49571 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/55324 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49038 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/52390 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50721 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->