### PR TITLE
REGRESSION(298844@main): [ iOS ] 6x http/tests/iframe-monitor (layout-tests) tests are constantly timing out

### DIFF
--- a/LayoutTests/http/tests/iframe-monitor/blob-resource.html
+++ b/LayoutTests/http/tests/iframe-monitor/blob-resource.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ IFrameResourceMonitoringEnabled=true ] -->
 <html>
 <head>
 <script src="/js-test-resources/js-test.js"></script>

--- a/LayoutTests/http/tests/iframe-monitor/cached-resource.html
+++ b/LayoutTests/http/tests/iframe-monitor/cached-resource.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ IFrameResourceMonitoringEnabled=true ] -->
 <html>
 <head>
 <script src="/js-test-resources/js-test.js"></script>

--- a/LayoutTests/http/tests/iframe-monitor/compressed-resource.html
+++ b/LayoutTests/http/tests/iframe-monitor/compressed-resource.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ IFrameResourceMonitoringEnabled=true ] -->
 <html>
 <head>
 <script src="/js-test-resources/js-test.js"></script>

--- a/LayoutTests/http/tests/iframe-monitor/dark-mode.html
+++ b/LayoutTests/http/tests/iframe-monitor/dark-mode.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ IFrameResourceMonitoringEnabled=true ] -->
 <html>
 <head>
     <script src="/js-test-resources/js-test.js"></script>

--- a/LayoutTests/http/tests/iframe-monitor/data-url-resource.html
+++ b/LayoutTests/http/tests/iframe-monitor/data-url-resource.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ IFrameResourceMonitoringEnabled=true ] -->
 <html>
 <head>
 <script src="/js-test-resources/js-test.js"></script>

--- a/LayoutTests/http/tests/iframe-monitor/eligibility.html
+++ b/LayoutTests/http/tests/iframe-monitor/eligibility.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ IFrameResourceMonitoringEnabled=true ] -->
 <html>
 <head>
 <script src="/js-test-resources/js-test.js"></script>

--- a/LayoutTests/http/tests/iframe-monitor/iframe-unload.html
+++ b/LayoutTests/http/tests/iframe-monitor/iframe-unload.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ IFrameResourceMonitoringEnabled=true ] -->
 <html>
 <head>
 <script src="/js-test-resources/js-test.js"></script>

--- a/LayoutTests/http/tests/iframe-monitor/just-use-eligible-subresource.html
+++ b/LayoutTests/http/tests/iframe-monitor/just-use-eligible-subresource.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ IFrameResourceMonitoringEnabled=true ] -->
 <html>
 
 <head>

--- a/LayoutTests/http/tests/iframe-monitor/throttler.html
+++ b/LayoutTests/http/tests/iframe-monitor/throttler.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ IFrameResourceMonitoringEnabled=true ] -->
 <html>
 <head>
 <script src="/js-test-resources/js-test.js"></script>

--- a/LayoutTests/http/tests/iframe-monitor/workers/service-worker-not-count-twice.html
+++ b/LayoutTests/http/tests/iframe-monitor/workers/service-worker-not-count-twice.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ IFrameResourceMonitoringEnabled=true ] -->
 <html>
 
 <head>

--- a/LayoutTests/http/tests/iframe-monitor/workers/service-worker.html
+++ b/LayoutTests/http/tests/iframe-monitor/workers/service-worker.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ IFrameResourceMonitoringEnabled=true ] -->
 <html>
 
 <head>

--- a/LayoutTests/http/tests/iframe-monitor/workers/shared-worker.html
+++ b/LayoutTests/http/tests/iframe-monitor/workers/shared-worker.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ IFrameResourceMonitoringEnabled=true ] -->
 <html>
 
 <head>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -89,6 +89,9 @@ media/wireless-route-monitoring.html [ Pass ]
 
 security/cocoa [ Pass ]
 
+# Cocoa only tests
+http/tests/iframe-monitor [ Pass ]
+
 # mac-only IPC test
 ipc/webpageproxy-correctionpanel-no-crash.html [ Skip ]
 

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -87,6 +87,9 @@ imported/w3c/web-platform-tests/css/css-pseudo/selection-over-highlight-001.html
 # Tests that require wheel events
 compositing/repaint/sticky-repaint-on-scroll.html [ Pass ]
 
+# Cocoa-only tests
+http/tests/iframe-monitor/ [ Pass ]
+
 # Some of these have failing results: webkit.org/b/293983
 imported/w3c/web-platform-tests/dom/events/scrolling/iframe-chains.html [ Pass ]
 imported/w3c/web-platform-tests/dom/events/scrolling/scroll-cross-origin-iframes.html [ Pass ]

--- a/LayoutTests/platform/visionos/TestExpectations
+++ b/LayoutTests/platform/visionos/TestExpectations
@@ -86,6 +86,7 @@ platform/visionos/transforms [ Pass ]
 imported/w3c/web-platform-tests/webxr [ Pass ]
 http/wpt/webxr [ Pass ]
 webxr [ Pass ]
+http/tests/iframe-monitor [ Pass ]
 
 ###################################################################################################
 ### START OF Legitimate failures (due to platform behavioral differences)


### PR DESCRIPTION
#### 59ed149dc908a18fc4084449c42a0200a7fbb710
<pre>
REGRESSION(298844@main): [ iOS ] 6x http/tests/iframe-monitor (layout-tests) tests are constantly timing out
<a href="https://bugs.webkit.org/show_bug.cgi?id=297599">https://bugs.webkit.org/show_bug.cgi?id=297599</a>
<a href="https://rdar.apple.com/158694239">rdar://158694239</a>

Reviewed by Basuke Suzuki.

This was caused by turning off the IFrameResourceMonitor feature in WKTR by default.
The tests should turn the feature back on and be re-enabled.

Still getting plenty of timeouts and failures in Site Isolation though so those need to be fixed before
un-skipping in that configuration. Additionally, this feature is only enabled in Cocoa ports so
limit un-skips there.

* LayoutTests/http/tests/iframe-monitor/blob-resource.html:
* LayoutTests/http/tests/iframe-monitor/cached-resource.html:
* LayoutTests/http/tests/iframe-monitor/compressed-resource.html:
* LayoutTests/http/tests/iframe-monitor/dark-mode.html:
* LayoutTests/http/tests/iframe-monitor/data-url-resource.html:
* LayoutTests/http/tests/iframe-monitor/eligibility.html:
* LayoutTests/http/tests/iframe-monitor/iframe-unload.html:
* LayoutTests/http/tests/iframe-monitor/just-use-eligible-subresource.html:
* LayoutTests/http/tests/iframe-monitor/throttler.html:
* LayoutTests/http/tests/iframe-monitor/workers/service-worker-not-count-twice.html:
* LayoutTests/http/tests/iframe-monitor/workers/service-worker.html:
* LayoutTests/http/tests/iframe-monitor/workers/shared-worker.html:
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:
* LayoutTests/platform/visionos/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/300506@main">https://commits.webkit.org/300506@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9b40a7d15ab310aa1b8c973137b7e0b951e57302

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122775 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42487 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33177 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/129400 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74879 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43206 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51080 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93309 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61942 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6c70eb7c-917e-4c8d-a0ab-30f726aaa591) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125727 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34447 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109910 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73948 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33436 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28065 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72890 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104147 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28278 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132127 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49720 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37849 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101823 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50097 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106125 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101697 "Found 1 new API test failure: WebKitGTK/TestInspector:/webkit/WebKitWebInspector/manual-attach-detach (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25840 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47069 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25254 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/46490 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49577 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49044 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/52396 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50727 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->