### PR TITLE
`lostpointercapture` may not be fired before other subsequent events for the pointer after capture is lost

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_lostpointercapture_for_disconnected_node-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_lostpointercapture_for_disconnected_node-expected.txt
@@ -6,11 +6,11 @@ Pointer Events Capture Test
 
 The following pointer types were detected: mouse.
 
-The following events were logged: pointerover@btnCapture, pointerenter@BODY, pointermove@btnCapture, pointerdown@btnCapture, pointerout@btnCapture, pointerover@target0, pointerenter@target0, gotpointercapture@target0, pointerover@target0, pointermove@target0, lostpointercapture@document, pointerout@target0, pointerleave@target0, pointerover@btnCapture, pointerenter@BODY, pointermove@btnCapture, pointermove@btnCapture, pointermove@btnCapture.
+The following events were logged: pointerover@btnCapture, pointerenter@BODY, pointermove@btnCapture, pointerdown@btnCapture, pointerout@btnCapture, pointerover@target0, pointerenter@target0, gotpointercapture@target0, lostpointercapture@document, pointerover@btnCapture, pointermove@btnCapture, pointermove@btnCapture, pointermove@btnCapture.
 
 
 PASS lostpointercapture event received
 PASS Lostpointercapture fires on document when target is removed
-FAIL lostpointercapture must be received before the next pointerevent after the node is disconnected assert_equals: No pointerevents should be received before lost capture is resolved expected "" but got "pointerover@target0, pointermove@target0"
+PASS lostpointercapture must be received before the next pointerevent after the node is disconnected
 PASS lostpointercapture is dispatched on the document
 

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/pointerevents/pointerevent_lostpointercapture_for_disconnected_node-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/pointerevents/pointerevent_lostpointercapture_for_disconnected_node-expected.txt
@@ -1,0 +1,16 @@
+Pointer Events - lostpointercapture when capturing element is removed
+
+
+
+Pointer Events Capture Test
+
+The following pointer types were detected: mouse.
+
+The following events were logged: pointerover@btnCapture, pointerenter@BODY, pointermove@btnCapture, pointerdown@btnCapture, pointerout@btnCapture, pointerover@target0, pointerenter@target0, gotpointercapture@target0, pointerover@btnCapture, pointerenter@BODY, pointermove@btnCapture, lostpointercapture@document, pointermove@btnCapture, pointermove@btnCapture, pointermove@btnCapture.
+
+
+PASS lostpointercapture event received
+PASS Lostpointercapture fires on document when target is removed
+FAIL lostpointercapture must be received before the next pointerevent after the node is disconnected assert_equals: No pointerevents should be received before lost capture is resolved expected "" but got "pointerover@btnCapture, pointerenter@BODY, pointermove@btnCapture"
+PASS lostpointercapture is dispatched on the document
+

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -5436,6 +5436,11 @@ MouseEventWithHitTestResults Document::prepareMouseEvent(const HitTestRequest& r
             auto& pointerCaptureController = page->pointerCaptureController();
             RefPtr previousCaptureElement = pointerCaptureController.pointerCaptureElement(this, event.pointerId());
             pointerCaptureController.processPendingPointerCapture(event.pointerId());
+
+            // Check if event processing should be suppressed due to the possible removal of the captured element.
+            if (pointerCaptureController.shouldSuppressEventProcessing(event.pointerId()))
+                return MouseEventWithHitTestResults(event, HitTestResult(LayoutPoint()));
+
             RefPtr captureElement = pointerCaptureController.pointerCaptureElement(this, event.pointerId());
             // If the capture element has changed while running the Process Pending Capture Element steps then
             // we need to indicate that when calling updateHoverActiveState to be sure that the :active and :hover

--- a/Source/WebCore/dom/EventDispatcher.cpp
+++ b/Source/WebCore/dom/EventDispatcher.cpp
@@ -40,6 +40,9 @@
 #include "LocalFrameView.h"
 #include "Logging.h"
 #include "MouseEvent.h"
+#include "Page.h"
+#include "PointerCaptureController.h"
+#include "PointerEvent.h"
 #include "ScopedEventQueue.h"
 #include "ScriptDisallowedScope.h"
 #include "ShadowRoot.h"
@@ -170,6 +173,12 @@ void EventDispatcher::dispatchEvent(Node& node, Event& event)
     ASSERT_WITH_SECURITY_IMPLICATION(ScriptDisallowedScope::InMainThread::isEventDispatchAllowedInSubtree(node));
 
     LOG_WITH_STREAM(Events, stream << "EventDispatcher::dispatchEvent " << event << " on node " << node);
+
+    // Clear pointer event suppression when lostpointercapture is dispatched.
+    if (RefPtr pointerEvent = dynamicDowncast<PointerEvent>(event); pointerEvent && pointerEvent->type() == eventNames().lostpointercaptureEvent) {
+        if (RefPtr page = node.document().page())
+            page->pointerCaptureController().clearEventSuppression(pointerEvent->pointerId());
+    }
 
     Ref protectedNode { node };
     Ref document = node.document();

--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -757,6 +757,8 @@ public:
 
     virtual bool usePluginRendererScrollableArea(LocalFrame&) const { return true; }
 
+    virtual bool supportsEventSuppression() { return true; }
+
     WEBCORE_EXPORT virtual ~ChromeClient();
 
 protected:

--- a/Source/WebCore/page/PointerCaptureController.cpp
+++ b/Source/WebCore/page/PointerCaptureController.cpp
@@ -166,7 +166,19 @@ void PointerCaptureController::elementWasRemovedSlow(Element& element)
             // at the document.
             ASSERT(isInBounds<PointerID>(pointerId));
             auto pointerType = capturingData->pointerType;
-            releasePointerCapture(&element, pointerId);
+
+            // Begin suppressing events for this processing cycle only.
+            capturingData->suppressEventProcessing = true;
+            capturingData->pendingTargetOverride = nullptr;
+
+            // Notify EventHandler that capture has changed.
+            if (capturingData->pointerType == mousePointerEventType()) {
+                if (RefPtr frame = element.document().frame())
+                    frame->eventHandler().pointerCaptureElementDidChange(nullptr);
+            }
+
+            updateHaveAnyCapturingElement();
+
             // FIXME: Spec doesn't specify which task source to use.
             element.document().queueTaskToDispatchEvent(TaskSource::UserInteraction, PointerEvent::create(eventNames().lostpointercaptureEvent, pointerId, pointerType));
             return;
@@ -632,6 +644,22 @@ void PointerCaptureController::processPendingPointerCapture(PointerID pointerId)
     capturingData->targetOverride = pendingTargetOverride;
 
     m_processingPendingPointerCapture = false;
+}
+
+void PointerCaptureController::clearEventSuppression(PointerID pointerId)
+{
+    RefPtr capturingData = m_activePointerIdsToCapturingData.get(pointerId);
+    if (capturingData)
+        capturingData->suppressEventProcessing = false;
+}
+
+bool PointerCaptureController::shouldSuppressEventProcessing(PointerID pointerId) const
+{
+    if (!m_page || !m_page->chrome().client().supportsEventSuppression())
+        return false;
+
+    RefPtr capturingData = m_activePointerIdsToCapturingData.get(pointerId);
+    return capturingData && capturingData->suppressEventProcessing;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/PointerCaptureController.h
+++ b/Source/WebCore/page/PointerCaptureController.h
@@ -73,6 +73,8 @@ public:
     void dispatchEvent(PointerEvent&, EventTarget*);
     WEBCORE_EXPORT void cancelPointer(PointerID, const IntPoint&, PointerEvent* existingCancelEvent = nullptr);
     void processPendingPointerCapture(PointerID);
+    void clearEventSuppression(PointerID);
+    bool shouldSuppressEventProcessing(PointerID) const;
 
 private:
     struct CapturingData : public RefCounted<CapturingData> {
@@ -104,6 +106,7 @@ private:
         bool isPrimary { false };
         bool preventsCompatibilityMouseEvents { false };
         bool pointerIsPressed { false };
+        bool suppressEventProcessing { false };
         MouseButton previousMouseButton { MouseButton::PointerHasNotChanged };
 
     private:

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.h
@@ -254,6 +254,8 @@ private:
 
     void requestCookieConsent(CompletionHandler<void(WebCore::CookieConsentDecisionResult)>&&) final;
 
+    bool supportsEventSuppression() final { return false; }
+
 #if ENABLE(VIDEO_PRESENTATION_MODE)
     bool m_mockVideoPresentationModeEnabled { false };
 #endif


### PR DESCRIPTION
#### 3867f3eb2f0ed74d7af6d6033a2d1e6190342dca
<pre>
`lostpointercapture` may not be fired before other subsequent events for the pointer after capture is lost
<a href="https://bugs.webkit.org/show_bug.cgi?id=299000">https://bugs.webkit.org/show_bug.cgi?id=299000</a>
<a href="https://rdar.apple.com/160752786">rdar://160752786</a>

Reviewed by Abrar Rahman Protyasha.

According to <a href="https://w3c.github.io/pointerevents/#dfn-lostpointercapture">https://w3c.github.io/pointerevents/#dfn-lostpointercapture</a>:
`lostpointercapture` &quot;MUST be fired prior to any subsequent events for the
pointer after capture was released.&quot; This is not always the case in WebKit;
we fail the third subtest of the wpt test
pointerevents/pointerevent_lostpointercapture_for_disconnected_node.html
as a result.

The cause of this bug is that, when an element with pointer capture is removed,
PointerCaptureController::elementWasRemovedSlow is called, and it queues the
dispatch of a `lostpointercaptureEvent` rather than immediately dispatching
due to it being in a script disallowed context. This results in a timing issue
where other pointer events may fire before `lostpointercaptureEvent`. To resolve
this, immediately clear the pointer capture target and pending target in
`lostpointercaptureEvent`, and begin suppressing event processing until the
`lostpointercaptureEvent` is received.

Event suppression works on a per-pointer basis, and is synchronously enabled in
`PointerCaptureController::elementWasRemovedSlow`. In `Document::prepareMouseEvent,`
we now return an empty result when the suppression flag is result to prevent
events from processing. When the `lostpointercapture` event is actually dispatched,
we detect it in `EventDispatcher::dispatchEvent`, and clear event suppression
accordingly.

These changes were originally made in 300168@main but were reverted due to it causing
an issue where webdriver would be unable to focus the frame when running certain WPT
tests. This issue was resolved by no longer immediately setting
`capturingData-&gt;targetOverride` to `nullptr` in
`PointerCaptureController::elementWasRemovedSlow` as it should not be updated until
later during the processing cycle.

No new tests (OOPS!).
* LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_lostpointercapture_for_disconnected_node-expected.txt:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/pointerevents/pointerevent_lostpointercapture_for_disconnected_node-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_lostpointercapture_for_disconnected_node-expected.txt.
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::prepareMouseEvent):
* Source/WebCore/dom/EventDispatcher.cpp:
(WebCore::EventDispatcher::dispatchEvent):
* Source/WebCore/page/ChromeClient.h:
(WebCore::ChromeClient::supportsEventSuppression):
* Source/WebCore/page/PointerCaptureController.cpp:
(WebCore::PointerCaptureController::elementWasRemovedSlow):
(WebCore::PointerCaptureController::clearEventSuppression):
(WebCore::PointerCaptureController::shouldSuppressEventProcessing const):
* Source/WebCore/page/PointerCaptureController.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3867f3eb2f0ed74d7af6d6033a2d1e6190342dca

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122816 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42528 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33218 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/129442 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74920 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bd84c411-0350-4575-8228-ccce85a72652) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/124692 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43247 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51121 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93345 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61964 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0a6f8c1a-e220-4893-9ec4-339ffbf16dea) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125768 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34479 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109943 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73988 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3041cfae-7c88-46df-aea0-ada130ff0780) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33458 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28179 "Found 1 new test failure: imported/w3c/web-platform-tests/pointerevents/pointerevent_lostpointercapture_for_disconnected_node.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72934 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104179 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28313 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132169 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49761 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37884 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101873 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50138 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106157 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101723 "Found 3 new API test failures: WebKitGTK/TestInspector:/webkit/WebKitWebInspector/manual-attach-detach, TestWTF:CompletionHandlerDeathTest.MainThreadHandlerOnThreadAssertsDeathTest, TestWTF:CompletionHandlerDeathTest.ConstructionThreadHandlerOnThreadAssertsDeathTest (failure)") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47095 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25285 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/46532 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49619 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/55371 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49085 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/52437 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50768 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->