### PR TITLE
[css-anchor-position-1] StyleRulePositionTry doesn't properly make a copy of itself

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-rule-caching-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-rule-caching-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Modifying one sheet containing @position-try rule doesn't affect another sheet
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-rule-caching.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-rule-caching.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+
+<title>Tests that given two sheets containing the same @position-try, modifying one sheet doesn't affect the other sheet</title>
+
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#fallback-rule">
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+  test(() => {
+    const style1 = new CSSStyleSheet();
+    const style2 = new CSSStyleSheet();
+
+    const cssText = "@position-try --try { position-area: center }";
+    style1.replaceSync(cssText);
+    style2.replaceSync(cssText);
+
+    style1.cssRules[0].style.positionArea = "bottom right";
+
+    assert_equals(style2.cssRules[0].style.positionArea, "center");
+  }, "Modifying one sheet containing @position-try rule doesn't affect another sheet");
+</script>

--- a/Source/WebCore/css/CSSPositionTryRule.cpp
+++ b/Source/WebCore/css/CSSPositionTryRule.cpp
@@ -43,6 +43,13 @@ StyleRulePositionTry::StyleRulePositionTry(AtomString&& name, Ref<StylePropertie
 {
 }
 
+StyleRulePositionTry::StyleRulePositionTry(const StyleRulePositionTry& o)
+    : StyleRuleBase(o)
+    , m_name(o.m_name)
+    , m_properties(o.protectedProperties()->mutableCopy())
+{
+}
+
 MutableStyleProperties& StyleRulePositionTry::mutableProperties()
 {
     Ref properties = m_properties;
@@ -87,6 +94,8 @@ String CSSPositionTryRule::cssText() const
 void CSSPositionTryRule::reattach(StyleRuleBase& rule)
 {
     m_positionTryRule = downcast<StyleRulePositionTry>(rule);
+    if (RefPtr propertiesCSSOMWrapper = m_propertiesCSSOMWrapper)
+        propertiesCSSOMWrapper->reattach(protectedPositionTryRule()->protectedMutableProperties());
 }
 
 AtomString CSSPositionTryRule::name() const

--- a/Source/WebCore/css/CSSPositionTryRule.h
+++ b/Source/WebCore/css/CSSPositionTryRule.h
@@ -46,9 +46,11 @@ public:
     StyleProperties& properties() const { return m_properties; }
     Ref<StyleProperties> protectedProperties() const { return m_properties; }
     MutableStyleProperties& mutableProperties();
+    Ref<MutableStyleProperties> protectedMutableProperties() { return mutableProperties(); }
 
 private:
     explicit StyleRulePositionTry(AtomString&& name, Ref<StyleProperties>&&);
+    StyleRulePositionTry(const StyleRulePositionTry&);
 
     AtomString m_name;
     Ref<StyleProperties> m_properties;


### PR DESCRIPTION
#### aa9513d94b685a3151b8d171bd3eea8c47638db9
<pre>
[css-anchor-position-1] StyleRulePositionTry doesn&apos;t properly make a copy of itself
<a href="https://rdar.apple.com/161205381">rdar://161205381</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=299402">https://bugs.webkit.org/show_bug.cgi?id=299402</a>

Reviewed by Antti Koivisto.

WebKit implements stylesheet caching, such that two stylesheets of identical
content share the same StyleSheetContents. When JavaScript code mutates a
@position-try, CSSPositionTryDescriptors (JS object representing the rule) signals
the CSSStylesheet containing the CSSPositionTryRule that it will be mutated
(CSSPositionTryDescriptors::set* -&gt; PropertySetCSSDescriptors::setPropertyInternal -&gt;
PropertySetCSSDescriptors::willMutate -&gt; CSSStyleSheet::willMutateRules).
CSSStyleSheet holds a StyleSheetContents that stores the content of the stylesheet,
and because of StyleSheetContents sharing, mutating the CSSStyleSheet requires
(1) cloning the StyleSheetContents into a separate copy, so when the stylesheet mutates,
    it doesn&apos;t affect other CSSStyleSheet sharing the StyleSheetContents
(2) Within CSSStyleSheet, each rule has a CSSOM wrapper object that attaches to
    the rule object in StyleSheetContents. After (1), the CSSOM wrapper objects have
    to be re-attached to the copied rule.

There are two bugs in StyleRulePositionTry that leads to the StyleRulePositionTry not
being copied properly:
* Cloning StyleSheetContents involves cloning all rules within it by calling ::copy()
  of the rule object. StyleRulePositionTry::copy() calls the copy constructor of
  StyleRulePositionTry, but the copy constructor is default, which doesn&apos;t deep copy
  the properties within the rule.
* (2) is done by calling CSSPositionTryRule::reattach, but it doesn&apos;t actually reattach
  itself to the new rule. So any mutation on CSSPositionTryRule ends up in the rule object
  before the clone.

If two CSSStyleSheet have identical content at the beginning, then they initially share
a StyleSheetContents. If one CSSStyleSheet content mutates, its StyleSheetContents is cloned
into a copy separate from the other CSSStyleSheet. But if the CSSStyleSheet contains a
@position-try rule, since StyleRulePositionTry doesn&apos;t clone itself properly, the new
StyleRulePositionTry and old StyleRulePositionTry ends up pointing to the same properties
object. Then, when one CSSStyleSheet mutates, the mutation is visible in the other CSSStyleSheet.

Test: imported/w3c/web-platform-tests/css/css-anchor-position/position-try-rule-caching.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-rule-caching-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-rule-caching.html: Added.
* Source/WebCore/css/CSSPositionTryRule.cpp:
(WebCore::StyleRulePositionTry::StyleRulePositionTry):
    - Make a copy of the StyleProperties.

(WebCore::CSSPositionTryRule::reattach):
    - Actually re-attach the CSSOM wrapper to the new rule object.

* Source/WebCore/css/CSSPositionTryRule.h:

Canonical link: <a href="https://commits.webkit.org/300553@main">https://commits.webkit.org/300553@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5883ef5a773d46df626e5aa7c23497d2eb9803c7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123009 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42723 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33420 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/129663 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/75118 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6c3a8c6d-79dd-4b4c-9777-b65a618d03aa) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/124886 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43446 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51317 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93508 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/62060 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1a0ecb9f-8376-48e4-b99c-d5c68d7c7a62) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125960 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34631 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110101 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74135 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7c7e09de-6200-4595-880d-97b86a7822f0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33607 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28255 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73171 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104342 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28473 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132393 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49968 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38034 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102004 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50335 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106314 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101872 "Found 3 new API test failures: WebKitGTK/TestWebsiteData:/webkit/WebKitWebsiteData/service-worker-registrations, WebKitGTK/TestInspector:/webkit/WebKitWebInspector/manual-attach-detach, TestWTF:CompletionHandlerDeathTest.MainThreadHandlerOnThreadAssertsDeathTest (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25884 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47234 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25432 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/46732 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49814 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/55574 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49282 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/52634 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50963 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->