### PR TITLE
[visionOS] Add VideoReceiverEndpointManager class

### DIFF
--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
@@ -76,6 +76,10 @@
 #include "IPCTester.h"
 #endif
 
+#if ENABLE(LINEAR_MEDIA_PLAYER)
+#include <wtf/LazyUniqueRef.h>
+#endif
+
 namespace WTF {
 enum class Critical : bool;
 enum class Synchronous : bool;
@@ -107,6 +111,7 @@ class RemoteRenderingBackend;
 class RemoteSampleBufferDisplayLayerManager;
 class RemoteSharedResourceCache;
 class UserMediaCaptureManagerProxy;
+class VideoReceiverEndpointManager;
 struct GPUProcessConnectionParameters;
 struct MediaOverridesForTesting;
 struct RemoteAudioSessionConfiguration;
@@ -217,6 +222,9 @@ public:
 #if ENABLE(VIDEO)
     RemoteMediaPlayerManagerProxy& remoteMediaPlayerManagerProxy() { return m_remoteMediaPlayerManagerProxy.get(); }
     Ref<RemoteMediaPlayerManagerProxy> protectedRemoteMediaPlayerManagerProxy();
+#endif
+#if ENABLE(LINEAR_MEDIA_PLAYER)
+    VideoReceiverEndpointManager& videoReceiverEndpointManager();
 #endif
 #if USE(AUDIO_SESSION)
     RemoteAudioSessionProxyManager& audioSessionManager();
@@ -375,6 +383,9 @@ private:
 #if ENABLE(VIDEO)
     RefPtr<RemoteMediaResourceManager> m_remoteMediaResourceManager WTF_GUARDED_BY_CAPABILITY(mainThread);
     Ref<RemoteMediaPlayerManagerProxy> m_remoteMediaPlayerManagerProxy;
+#endif
+#if ENABLE(LINEAR_MEDIA_PLAYER)
+    const LazyUniqueRef<GPUConnectionToWebProcess, VideoReceiverEndpointManager> m_videoReceiverEndpointManager;
 #endif
     PAL::SessionID m_sessionID;
 #if PLATFORM(COCOA) && ENABLE(MEDIA_STREAM)

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerManagerProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerManagerProxy.h
@@ -43,9 +43,6 @@
 #include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/WeakPtr.h>
 
-#if ENABLE(LINEAR_MEDIA_PLAYER)
-#include <WebCore/VideoReceiverEndpoint.h>
-#endif
 #if ENABLE(MEDIA_SOURCE)
 #include "RemoteMediaSourceIdentifier.h"
 #endif
@@ -91,13 +88,6 @@ public:
 
     std::optional<WebCore::ShareableBitmap::Handle> bitmapImageForCurrentTime(WebCore::MediaPlayerIdentifier);
 
-#if ENABLE(LINEAR_MEDIA_PLAYER)
-    WebCore::PlatformVideoTarget videoTargetForIdentifier(const std::optional<WebCore::VideoReceiverEndpointIdentifier>&);
-    WebCore::PlatformVideoTarget takeVideoTargetForMediaElementIdentifier(WebCore::HTMLMediaElementIdentifier, WebCore::MediaPlayerIdentifier);
-    void handleVideoReceiverEndpointMessage(const VideoReceiverEndpointMessage&);
-    void handleVideoReceiverSwapEndpointsMessage(const VideoReceiverSwapEndpointsMessage&);
-#endif
-
 #if ENABLE(MEDIA_SOURCE)
     RefPtr<RemoteMediaSourceProxy> pendingMediaSource(RemoteMediaSourceIdentifier);
     void registerMediaSource(RemoteMediaSourceIdentifier, RemoteMediaSourceProxy&);
@@ -128,15 +118,6 @@ private:
 
     HashMap<WebCore::MediaPlayerIdentifier, Ref<RemoteMediaPlayerProxy>> m_proxies;
     ThreadSafeWeakPtr<GPUConnectionToWebProcess> m_gpuConnectionToWebProcess;
-
-#if ENABLE(LINEAR_MEDIA_PLAYER)
-    HashMap<WebCore::VideoReceiverEndpointIdentifier, WebCore::PlatformVideoTarget> m_videoTargetCache;
-    struct VideoRecevierEndpointCacheEntry {
-        Markable<WebCore::MediaPlayerIdentifier> playerIdentifier;
-        Markable<WebCore::VideoReceiverEndpointIdentifier> endpointIdentifier;
-    };
-    HashMap<WebCore::HTMLMediaElementIdentifier, VideoRecevierEndpointCacheEntry> m_videoReceiverEndpointCache;
-#endif
 
 #if ENABLE(MEDIA_SOURCE)
     HashMap<RemoteMediaSourceIdentifier, RefPtr<RemoteMediaSourceProxy>> m_pendingMediaSources;

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
@@ -74,6 +74,10 @@
 #include <WebCore/VideoFrameCV.h>
 #endif
 
+#if ENABLE(LINEAR_MEDIA_PLAYER)
+#include "VideoReceiverEndpointManager.h"
+#endif
+
 #include <wtf/NativePromise.h>
 
 namespace WebKit {
@@ -960,8 +964,10 @@ bool RemoteMediaPlayerProxy::mediaPlayerShouldCheckHardwareSupport() const
 WebCore::PlatformVideoTarget RemoteMediaPlayerProxy::mediaPlayerVideoTarget() const
 {
 #if ENABLE(LINEAR_MEDIA_PLAYER)
-    if (m_manager)
-        return m_manager->takeVideoTargetForMediaElementIdentifier(m_clientIdentifier, m_id);
+    if (m_manager) {
+        if (RefPtr gpuConnectionToWebProcess = m_manager->gpuConnectionToWebProcess())
+            return gpuConnectionToWebProcess->videoReceiverEndpointManager().takeVideoTargetForMediaElementIdentifier(m_clientIdentifier, m_id);
+    }
 #endif
     return nullptr;
 }

--- a/Source/WebKit/GPUProcess/media/cocoa/VideoReceiverEndpointManager.h
+++ b/Source/WebKit/GPUProcess/media/cocoa/VideoReceiverEndpointManager.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(GPU_PROCESS) && ENABLE(LINEAR_MEDIA_PLAYER)
+
+#include <WebCore/HTMLMediaElementIdentifier.h>
+#include <WebCore/MediaPlayerIdentifier.h>
+#include <WebCore/VideoReceiverEndpoint.h>
+#include <WebCore/VideoTarget.h>
+#include <wtf/LoggerHelper.h>
+#include <wtf/TZoneMalloc.h>
+
+namespace WebKit {
+
+class GPUConnectionToWebProcess;
+class VideoReceiverEndpointMessage;
+class VideoReceiverSwapEndpointsMessage;
+
+class VideoReceiverEndpointManager final
+#if !RELEASE_LOG_DISABLED
+    : private LoggerHelper
+#endif
+{
+    WTF_MAKE_TZONE_ALLOCATED(VideoReceiverEndpointManager);
+public:
+    VideoReceiverEndpointManager(GPUConnectionToWebProcess&);
+    WebCore::PlatformVideoTarget videoTargetForIdentifier(const std::optional<WebCore::VideoReceiverEndpointIdentifier>&);
+    WebCore::PlatformVideoTarget takeVideoTargetForMediaElementIdentifier(WebCore::HTMLMediaElementIdentifier, WebCore::MediaPlayerIdentifier);
+    void handleVideoReceiverEndpointMessage(const VideoReceiverEndpointMessage&);
+    void handleVideoReceiverSwapEndpointsMessage(const VideoReceiverSwapEndpointsMessage&);
+
+#if !RELEASE_LOG_DISABLED
+    ASCIILiteral logClassName() const final { return "VideoReceiverEndpointManager"; }
+    WTFLogChannel& logChannel() const final;
+    uint64_t logIdentifier() const final { return m_logIdentifier; }
+    const Logger& logger() const final { return m_logger; }
+#endif
+
+private:
+    RefPtr<GPUConnectionToWebProcess> protectedConnection() const { return m_gpuConnection.get(); }
+
+    HashMap<WebCore::VideoReceiverEndpointIdentifier, WebCore::PlatformVideoTarget> m_videoTargetCache;
+    struct VideoReceiverEndpointCacheEntry {
+        Markable<WebCore::MediaPlayerIdentifier> playerIdentifier;
+        Markable<WebCore::VideoReceiverEndpointIdentifier> endpointIdentifier;
+    };
+    HashMap<WebCore::HTMLMediaElementIdentifier, VideoReceiverEndpointCacheEntry> m_videoReceiverEndpointCache;
+
+    ThreadSafeWeakPtr<GPUConnectionToWebProcess> m_gpuConnection;
+#if !RELEASE_LOG_DISABLED
+    uint64_t m_logIdentifier { 0 };
+    const Ref<Logger> m_logger;
+#endif
+};
+
+} // namespace WebKit
+
+#endif

--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCEndpointMessages.mm
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCEndpointMessages.mm
@@ -30,7 +30,7 @@
 #import "GPUProcess.h"
 #import "LaunchServicesDatabaseManager.h"
 #import "LaunchServicesDatabaseXPCConstants.h"
-#import "RemoteMediaPlayerManagerProxy.h"
+#import "VideoReceiverEndpointManager.h"
 #import "VideoReceiverEndpointMessage.h"
 #import "XPCEndpoint.h"
 #import <wtf/RunLoop.h>
@@ -61,7 +61,7 @@ static void handleVideoReceiverEndpointMessage(xpc_object_t message)
         return;
 
     if (RefPtr webProcessConnection = GPUProcess::singleton().webProcessConnection(*endpointMessage.processIdentifier()))
-        webProcessConnection->remoteMediaPlayerManagerProxy().handleVideoReceiverEndpointMessage(endpointMessage);
+        webProcessConnection->videoReceiverEndpointManager().handleVideoReceiverEndpointMessage(endpointMessage);
 }
 
 static void handleVideoReceiverSwapEndpointsMessage(xpc_object_t message)
@@ -74,7 +74,7 @@ static void handleVideoReceiverSwapEndpointsMessage(xpc_object_t message)
         return;
 
     if (RefPtr webProcessConnection = GPUProcess::singleton().webProcessConnection(*endpointMessage.processIdentifier()))
-        webProcessConnection->remoteMediaPlayerManagerProxy().handleVideoReceiverSwapEndpointsMessage(endpointMessage);
+        webProcessConnection->videoReceiverEndpointManager().handleVideoReceiverSwapEndpointsMessage(endpointMessage);
 }
 #endif
 

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -78,7 +78,7 @@ GPUProcess/mac/GPUProcessMac.mm
 GPUProcess/mac/LocalAudioSessionRoutingArbitrator.cpp
 GPUProcess/media/RemoteAudioSourceProviderProxy.cpp
 GPUProcess/media/RemoteImageDecoderAVFProxy.cpp
-GPUProcess/media/cocoa/RemoteMediaPlayerManagerProxyCocoa.mm
+GPUProcess/media/cocoa/VideoReceiverEndpointManager.mm
 GPUProcess/media/cocoa/RemoteMediaPlayerProxyCocoa.mm
 GPUProcess/media/ios/RemoteMediaSessionHelperProxy.cpp
 GPUProcess/webrtc/LibWebRTCCodecsProxy.mm @no-unify

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -5980,6 +5980,8 @@
 		51C0C9791DDD78540032CAD3 /* _WKLinkIconParameters.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKLinkIconParameters.h; sourceTree = "<group>"; };
 		51C0C97A1DDD78540032CAD3 /* _WKLinkIconParameters.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKLinkIconParameters.mm; sourceTree = "<group>"; };
 		51C0C97B1DDD78540032CAD3 /* _WKLinkIconParametersInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKLinkIconParametersInternal.h; sourceTree = "<group>"; };
+		51C5B7D62E8412A7005C9555 /* VideoReceiverEndpointManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VideoReceiverEndpointManager.h; sourceTree = "<group>"; };
+		51C5B7D72E8412A7005C9555 /* VideoReceiverEndpointManager.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = VideoReceiverEndpointManager.mm; sourceTree = "<group>"; };
 		51C8E19B1F21617200BF731B /* WebIconDatabase.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebIconDatabase.h; sourceTree = "<group>"; };
 		51CD1C591B3493A900142CA5 /* WKSecurityOriginRef.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WKSecurityOriginRef.cpp; sourceTree = "<group>"; };
 		51CD1C5A1B3493A900142CA5 /* WKSecurityOriginRef.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKSecurityOriginRef.h; sourceTree = "<group>"; };
@@ -8122,7 +8124,6 @@
 		CDAC20F323FC383A0021DEE3 /* RemoteCDMFactoryProxyMessages.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RemoteCDMFactoryProxyMessages.h; sourceTree = "<group>"; };
 		CDAC20F423FC383A0021DEE3 /* RemoteCDMProxyMessages.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RemoteCDMProxyMessages.h; sourceTree = "<group>"; };
 		CDAC20F523FC383B0021DEE3 /* RemoteCDMInstanceProxyMessageReceiver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteCDMInstanceProxyMessageReceiver.cpp; sourceTree = "<group>"; };
-		CDAD8DEC2BEC37BB00107D24 /* RemoteMediaPlayerManagerProxyCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = RemoteMediaPlayerManagerProxyCocoa.mm; sourceTree = "<group>"; };
 		CDB2A1ED2697925C006B235C /* GPUProcessProxyCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = GPUProcessProxyCocoa.mm; sourceTree = "<group>"; };
 		CDB96AD32AB379C9007A90D3 /* WKVideoView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WKVideoView.h; path = ios/WKVideoView.h; sourceTree = "<group>"; };
 		CDB96AD42AB379CA007A90D3 /* WKVideoView.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = WKVideoView.mm; path = ios/WKVideoView.mm; sourceTree = "<group>"; };
@@ -11128,8 +11129,9 @@
 		1D0ECEA923FC84BB00D172F6 /* cocoa */ = {
 			isa = PBXGroup;
 			children = (
-				CDAD8DEC2BEC37BB00107D24 /* RemoteMediaPlayerManagerProxyCocoa.mm */,
 				1D0ECEAA23FC858400D172F6 /* RemoteMediaPlayerProxyCocoa.mm */,
+				51C5B7D62E8412A7005C9555 /* VideoReceiverEndpointManager.h */,
+				51C5B7D72E8412A7005C9555 /* VideoReceiverEndpointManager.mm */,
 			);
 			path = cocoa;
 			sourceTree = "<group>";


### PR DESCRIPTION
#### 9e97ba025925ac0cb733e8babbe6d979dd8beb25
<pre>
[visionOS] Add VideoReceiverEndpointManager class
<a href="https://bugs.webkit.org/show_bug.cgi?id=299500">https://bugs.webkit.org/show_bug.cgi?id=299500</a>
<a href="https://rdar.apple.com/161291402">rdar://161291402</a>

Reviewed by Youenn Fablet.

In preparation for the upcoming AudioVideoRendererRemote/RemoteAudioVideoRendererProxy
we move the handling and tracking of the currently assigned VideoTarget to
its own class.

No change is observable behaviour.
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp:
(WebKit::m_videoReceiverEndpointManager):
(WebKit::GPUConnectionToWebProcess::videoReceiverEndpointManager):
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h:
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerManagerProxy.h:
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp:
(WebKit::RemoteMediaPlayerProxy::mediaPlayerVideoTarget const):
* Source/WebKit/GPUProcess/media/cocoa/VideoReceiverEndpointManager.h: Added.
* Source/WebKit/GPUProcess/media/cocoa/VideoReceiverEndpointManager.mm: Renamed from Source/WebKit/GPUProcess/media/cocoa/RemoteMediaPlayerManagerProxyCocoa.mm.
(WebKit::VideoReceiverEndpointManager::VideoReceiverEndpointManager):
(WebKit::m_logger):
(WebKit::VideoReceiverEndpointManager::videoTargetForIdentifier):
(WebKit::VideoReceiverEndpointManager::takeVideoTargetForMediaElementIdentifier):
(WebKit::VideoReceiverEndpointManager::handleVideoReceiverEndpointMessage):
(WebKit::VideoReceiverEndpointManager::handleVideoReceiverSwapEndpointsMessage):
(WebKit::VideoReceiverEndpointManager::logChannel const):
* Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCEndpointMessages.mm:
(WebKit::handleVideoReceiverEndpointMessage):
(WebKit::handleVideoReceiverSwapEndpointsMessage):
* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/300616@main">https://commits.webkit.org/300616@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/16b6c22bbac5ec3e5ad98f297f9d0cf5d92a1b26

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123265 "1 style error") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/42979 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33676 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/129973 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/75378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6336c8d4-1177-4dfd-bb79-5f42f6f06dc6) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43703 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51574 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/93697 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/75378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/184e2202-efea-44de-908c-5d920ecfbc1d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126218 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/34824 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110289 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74325 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4dd4b109-a230-49b2-9c22-caf20dbfb6fc) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/33788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73491 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/104538 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28671 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132691 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/50215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/38212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/102185 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/50591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106510 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/102041 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25937 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25612 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/46989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/50070 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/55831 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/49541 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/52891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/51219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->