### PR TITLE
TestWebKitAPI.WebKit.PreferenceChangesWithSuspendedProcess is flaky

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKit/PreferenceChanges.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/PreferenceChanges.mm
@@ -190,6 +190,9 @@ TEST(WebKit, PreferenceChangesWithSuspendedProcess)
         return [webView stringByEvaluatingJavaScript:js].intValue;
     };
 
+    unsigned tries = 0;
+    while (preferenceValue() != 1 && ++tries < 50)
+        TestWebKitAPI::Util::runFor(100_ms);
     EXPECT_EQ(preferenceValue(), 1);
 
     CLEAR_DEFAULTS();


### PR DESCRIPTION
#### 23825da6d4ece659e39f70fa10625e1627bb5502
<pre>
TestWebKitAPI.WebKit.PreferenceChangesWithSuspendedProcess is flaky
<a href="https://bugs.webkit.org/show_bug.cgi?id=298549">https://bugs.webkit.org/show_bug.cgi?id=298549</a>
<a href="https://rdar.apple.com/160139037">rdar://160139037</a>

Reviewed by Youenn Fablet.

It is possible there is some delay until the WebProcess gets notified of the
preference change so try and make the API test more robust to deal with this.

* Tools/TestWebKitAPI/Tests/WebKit/PreferenceChanges.mm:
(TEST(WebKit, PreferenceChangesWithSuspendedProcess)):

Canonical link: <a href="https://commits.webkit.org/300509@main">https://commits.webkit.org/300509@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8ad5ddc6f8f5bda9fffaacd825cbdd27262a0061

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122833 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42545 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33235 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/129459 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74938 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4311a541-6c51-4578-b3a9-1b1c3139a5c0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/124709 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43264 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51138 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93359 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/61978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/736fb98b-8194-463c-aea1-4d3b411074cb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125785 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34500 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109957 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/74000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2af6b9bf-e2ae-441c-ab05-e7f40215b35d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33479 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28114 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/72951 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104200 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28327 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132186 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49778 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37897 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/101862 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50155 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106171 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/101739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25842 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47111 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25298 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/46549 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49636 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49102 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/52454 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50785 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->