### PR TITLE
REGRESSION(296297@main?):[ iOS, macOS wk2 ] webrtc/calling-peerconnection-once-closed.html is a flaky text failure

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8268,6 +8268,4 @@ webkit.org/b/298974 fast/forms/ios/keyboard-restoration-after-element-replacemen
 
 webkit.org/b/280234 imported/w3c/web-platform-tests/html/dom/idlharness.https.html [ Skip ]
 
-webkit.org/b/299110 webrtc/calling-peerconnection-once-closed.html? [ Pass Failure ]
-
 webkit.org/b/299501 http/tests/site-isolation/focus-tab-navigation-activeElement.html [ Pass Failure ]

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2417,5 +2417,3 @@ http/tests/webgpu/webgpu/web_platform/copyToTexture/ImageBitmap.html [ Pass Time
 webkit.org/b/298903 webrtc/video-rotation-black.html [ Pass Failure ]
 
 webkit.org/b/298416 [ Debug ] http/tests/websocket/construct-in-detached-frame.html [ Skip ]
-
-webkit.org/b/299110 webrtc/calling-peerconnection-once-closed.html [ Pass Failure ]

--- a/LayoutTests/webrtc/audio-video-element-playing.html
+++ b/LayoutTests/webrtc/audio-video-element-playing.html
@@ -19,6 +19,7 @@ promise_test(async (t) => {
     });
 
     const localStream = await navigator.mediaDevices.getUserMedia({ audio : true });
+    t.add_cleanup(() => localStream.getAudioTracks()[0].stop());
     pc1.addTrack(localStream.getAudioTracks()[0], localStream);
     pc1.addTransceiver("video", { streams : [localStream] });
 

--- a/LayoutTests/webrtc/calling-peerconnection-once-closed.html
+++ b/LayoutTests/webrtc/calling-peerconnection-once-closed.html
@@ -46,9 +46,10 @@ promise_test(() => {
     });
 }, "Ensuring closed connection addTransceiver does not crash");
 
-promise_test(() => {
+promise_test((t) => {
     return closedConnection().then((connection) => {
         return navigator.mediaDevices.getUserMedia({video: true}).then((stream) => {
+            t.add_cleanup(() => stream.getVideoTracks()[0].stop());
             assert_throws_dom("InvalidStateError", () => { connection.addTrack(stream.getVideoTracks()[0], stream); });
         });
     });


### PR DESCRIPTION
#### ebbe2606af734961ec984048b1cbb556d3e18e1f
<pre>
REGRESSION(296297@main?):[ iOS, macOS wk2 ] webrtc/calling-peerconnection-once-closed.html is a flaky text failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=299110">https://bugs.webkit.org/show_bug.cgi?id=299110</a>
<a href="https://rdar.apple.com/160874955">rdar://160874955</a>

Reviewed by Youenn Fablet.

Add cleanup steps to the tests to avoid spurious console messages.

* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:
* LayoutTests/webrtc/audio-video-element-playing.html:
* LayoutTests/webrtc/calling-peerconnection-once-closed.html:

Canonical link: <a href="https://commits.webkit.org/300513@main">https://commits.webkit.org/300513@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f38c7258fb5e973d2a78b027d77a0798364aacaa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122863 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42575 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33265 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/129497 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/74969 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/18acb0bd-46e5-4da5-832a-702200f05b52) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43294 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51168 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/129497 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/74969 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5755b88c-a13d-4e3c-abc6-e5e9233eddb4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125815 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34516 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109976 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/129497 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/352a6e90-0a5b-4439-9ff7-e78cd5a12f3b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33493 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28136 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/72991 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104216 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28346 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/132227 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49808 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37919 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/132227 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50185 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106190 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/132227 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25846 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47132 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25317 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/46580 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49666 "Built successfully") | | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/49133 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/52484 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/50815 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->