### PR TITLE
[SwiftBrowser] Improve Feature Flags view

### DIFF
--- a/Tools/SwiftBrowser/Source/Views/SettingsView.swift
+++ b/Tools/SwiftBrowser/Source/Views/SettingsView.swift
@@ -155,6 +155,42 @@ private struct FeatureFlagToggle: View {
     }
 }
 
+private struct SearchField: NSViewRepresentable {
+    @Binding
+    var text: String
+
+    var placeholder: String = "Search"
+
+    func makeNSView(context: Context) -> NSSearchField {
+        let searchField = NSSearchField()
+        searchField.placeholderString = placeholder
+        searchField.delegate = context.coordinator
+        return searchField
+    }
+
+    func updateNSView(_ nsView: NSSearchField, context: Context) {
+        nsView.stringValue = text
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+
+    class Coordinator: NSObject, NSSearchFieldDelegate {
+        let parent: SearchField
+
+        init(_ parent: SearchField) {
+            self.parent = parent
+        }
+
+        func controlTextDidChange(_ obj: Notification) {
+            if let searchField = obj.object as? NSSearchField {
+                parent.text = searchField.stringValue
+            }
+        }
+    }
+}
+
 private struct FeatureFlagsView: View {
     @Environment(FeatureFlagsModel.self)
     var model
@@ -168,20 +204,27 @@ private struct FeatureFlagsView: View {
         @Bindable
         var model = model
 
-        List {
-            ForEach(groupedFeatures, id: \.category.rawValue) { group in
-                Section(group.category.description) {
-                    ForEach(group.features) { feature in
-                        FeatureFlagToggle(
-                            value: $model.customizedFeatures[feature.key, default: feature.defaultValue],
-                            feature: feature
-                        )
+        // FIXME: This should use `.searchable()` once the placement options become flexible enough.
+        Group {
+            HStack {
+                Spacer()
+                SearchField(text: $model.searchQuery)
+            }
+            List {
+                ForEach(groupedFeatures, id: \.category.rawValue) { group in
+                    Section(group.category.description) {
+                        ForEach(group.features) { feature in
+                            FeatureFlagToggle(
+                                value: $model.customizedFeatures[feature.key, default: feature.defaultValue],
+                                feature: feature
+                            )
+                        }
                     }
                 }
             }
+            .listStyle(.inset)
+            .frame(height: 400)
         }
-        .listStyle(.inset)
-        .searchable(text: $model.searchQuery, placement: .sidebar, prompt: "Search")
     }
 
     var body: some View {


### PR DESCRIPTION
#### 9afb059770f82cd15d24c59780df1d68d08ca41e
<pre>
[SwiftBrowser] Improve Feature Flags view
<a href="https://bugs.webkit.org/show_bug.cgi?id=299509">https://bugs.webkit.org/show_bug.cgi?id=299509</a>
<a href="https://rdar.apple.com/161306138">rdar://161306138</a>

Reviewed by NOBODY (OOPS!).

The following changes were made:

- Show searchbar in a separate toolbar instead of showing it next to the tabs and shifting them:

This involved using a creating a searchbar manually instead of using `.searchable()`, since the placement options were limited.
The new SearchField component wraps NSSearchField from AppKit to avoid having to re-create the searchbar style from scratch, since SwiftUI does not provide it by default.

- Increase the height of the list so more feature flags are visible at once

No new tests (OOPS!).
* Tools/SwiftBrowser/Source/Views/SettingsView.swift:
(SearchField.text):
(SearchField.placeholder):
(SearchField.makeNSView(_:)):
(SearchField.updateNSView(_:context:)):
(SearchField.makeCoordinator):
(Coordinator.controlTextDidChange(_:)):
(FeatureFlagsView.featureList):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9afb059770f82cd15d24c59780df1d68d08ca41e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122845 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42557 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33247 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/129471 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74950 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8c5bb816-d590-41c0-8fef-4e610c8a75a1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/124721 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43276 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51150 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93366 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61984 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bc5c28bf-ab19-4392-af90-76f43f4abfb2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125797 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34505 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109967 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74006 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2e083139-0825-4953-99e6-563889e22bb0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33482 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28124 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72973 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104205 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28337 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132198 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49790 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37906 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101884 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50167 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106181 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101754 "Found 3 new API test failures: WebKitGTK/TestInspector:/webkit/WebKitWebInspector/custom-container-destroyed, TestWTF:CompletionHandlerDeathTest.MainThreadHandlerOnThreadAssertsDeathTest, TestWTF:CompletionHandlerDeathTest.ConstructionThreadHandlerOnThreadAssertsDeathTest (failure)") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47122 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25308 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/46561 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49648 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49114 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/52466 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50797 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->