### PR TITLE
Sticky elements at the edge of the viewport can disappear when rubber band scrolling.

### DIFF
--- a/LayoutTests/fast/scrolling/ios/sticky-during-rubberband-offscreen-expected.txt
+++ b/LayoutTests/fast/scrolling/ios/sticky-during-rubberband-offscreen-expected.txt
@@ -1,0 +1,28 @@
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (backingStoreAttached 1)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (backingStoreAttached 1)
+      (children 1
+        (GraphicsLayer
+          (position 1.00 0.00)
+          (approximate position 1.00 0.00)
+          (preserves3D 1)
+          (backingStoreAttached 0)
+          (children 1
+            (GraphicsLayer
+              (bounds 640.00 20.00)
+              (contentsOpaque 1)
+              (backingStoreAttached 1)
+            )
+          )
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/fast/scrolling/ios/sticky-during-rubberband-offscreen.html
+++ b/LayoutTests/fast/scrolling/ios/sticky-during-rubberband-offscreen.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+
+<html>
+<head>
+    <style>
+        body {
+            margin: 0;
+        }
+
+        .sticky-container {
+            border: 1px solid black;
+            height: 400px;
+            width: 80%;
+            margin-top: -10px;
+        }
+
+        .sticky {
+            position: sticky;
+            top: 0px;
+            height: 20px;
+            width: 100%;
+            background-color: green;
+        }
+    </style>
+    <script src="../../../resources/ui-helper.js"></script>
+    <script>
+        if (window.testRunner) {
+            testRunner.dumpAsText();
+            testRunner.waitUntilDone();
+        }
+        window.addEventListener('load', async () => {
+            await UIHelper.immediateScrollTo(0, 40, true);
+            await UIHelper.ensurePresentationUpdate();
+            var out = document.getElementById('out');
+            out.innerText = internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_BACKING_STORE_ATTACHED);
+            if (window.testRunner)
+                testRunner.notifyDone();
+        }, false);
+    </script>
+</head>
+<body>
+
+<div class="sticky-container">
+    <div class="sticky"></div>
+</div>
+<pre id="out"></pre>
+
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -566,6 +566,8 @@ public:
     void setBehavesAsFixed(bool);
     bool behavesAsFixed() const { return m_behavesAsFixed; }
 
+    bool behavesAsSticky() const { return m_hasStickyAncestor || renderer().isStickilyPositioned(); }
+
     struct PaintedContentRequest {
         PaintedContentRequest() = default;
         PaintedContentRequest(const RenderLayer& owningLayer);

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -1087,7 +1087,7 @@ void RenderLayerBacking::updateAllowsBackingStoreDetaching(bool allowDetachingFo
             m_scrolledContentsLayer->setAllowsBackingStoreDetaching(allowDetaching);
     };
 
-    if (!m_owningLayer.behavesAsFixed()) {
+    if (!m_owningLayer.behavesAsFixed() && !m_owningLayer.behavesAsSticky()) {
         setAllowsBackingStoreDetaching(true);
         return;
     }

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -1241,7 +1241,7 @@ static bool canSkipComputeCompositingRequirementsForSubtree(const RenderLayer& l
 
 bool RenderLayerCompositor::allowBackingStoreDetachingForFixedPosition(RenderLayer& layer, const LayoutRect& absoluteBounds)
 {
-    ASSERT_UNUSED(layer, layer.behavesAsFixed());
+    ASSERT_UNUSED(layer, layer.behavesAsFixed() || layer.behavesAsSticky());
 
     // We'll allow detaching if the layer is outside the layout viewport. Fixed layers inside
     // the layout viewport can be revealed by async scrolling, so we want to pin their backing store.
@@ -1387,7 +1387,7 @@ void RenderLayerCompositor::computeCompositingRequirements(RenderLayer* ancestor
         layerWillComposite();
         currentState.subtreeIsCompositing = true;
         becameCompositedAfterDescendantTraversal = true;
-        if (layer.behavesAsFixed())
+        if (layer.behavesAsFixed() || layer.behavesAsSticky())
             allowsBackingStoreDetachingForFixed = allowBackingStoreDetachingForFixedPosition(layer, layerExtent.bounds);
     };
 
@@ -1397,7 +1397,7 @@ void RenderLayerCompositor::computeCompositingRequirements(RenderLayer* ancestor
         computeExtent(overlapMap, layer, layerExtent);
         currentState.ancestorHasTransformAnimation |= layerExtent.hasTransformAnimation;
 
-        if (!allowsBackingStoreDetachingForFixed && layer.behavesAsFixed())
+        if (!allowsBackingStoreDetachingForFixed && (layer.behavesAsFixed() || layer.behavesAsSticky()))
             currentState.ancestorAllowsBackingStoreDetachingForFixed = allowsBackingStoreDetachingForFixed = allowBackingStoreDetachingForFixedPosition(layer, layerExtent.bounds);
 
         // Too hard to compute animated bounds if both us and some ancestor is animating transform.


### PR DESCRIPTION
#### 8a1585ea9d5f7640950c6adc88119cd724987f25
<pre>
Sticky elements at the edge of the viewport can disappear when rubber band scrolling.
<a href="https://bugs.webkit.org/show_bug.cgi?id=298709">https://bugs.webkit.org/show_bug.cgi?id=298709</a>
&lt;<a href="https://rdar.apple.com/problem/160385933">rdar://problem/160385933</a>&gt;

Reviewed by Simon Fraser.

During rubber-banding the WebContent side layers don&apos;t get scrolled (only the
UI-side does), but the visible content rect that we use to compute layer visible
rects does.  If a sticky layer ends up outside this rect (which doesn&apos;t account
for the &apos;stuck&apos;-ness), then we detach the backing store.

Update the existing RenderLayerBacking::updateAllowsBackingStoreDetaching to
account for sticky, as well as the existing handling of fixed.

Test: fast/scrolling/ios/sticky-during-rubberband-offscreen.html
* LayoutTests/fast/scrolling/ios/sticky-during-rubberband-offscreen-expected.txt: Added.
* LayoutTests/fast/scrolling/ios/sticky-during-rubberband-offscreen.html: Added.
* Source/WebCore/rendering/RenderLayer.h:
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::updateAllowsBackingStoreDetaching):
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::allowBackingStoreDetachingForFixedPosition):
(WebCore::RenderLayerCompositor::computeCompositingRequirements):

Canonical link: <a href="https://commits.webkit.org/300544@main">https://commits.webkit.org/300544@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/08037cd5ba9985910624a014216ed5c368660020

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122975 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42689 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33386 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/129628 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/75084 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1cd217b2-54dd-480c-aa45-7420975a85c3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/124852 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43412 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51283 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93482 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/62047 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/94c24516-2dd3-4a4d-866e-9194d7d48f64) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125926 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34610 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110077 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74114 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b28a0594-3137-464d-845f-321a855862fd) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33588 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28230 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73133 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104320 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28443 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132357 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49924 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38010 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101984 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50301 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106284 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/101853 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25876 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47221 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25409 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/46698 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49780 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/55540 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49247 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/52599 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50929 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->