### PR TITLE
[IPC] Fix unsafe buffer usage warning in IPCUtilitiesUnix.cpp

### DIFF
--- a/Source/WebKit/Platform/IPC/unix/IPCUtilitiesUnix.cpp
+++ b/Source/WebKit/Platform/IPC/unix/IPCUtilitiesUnix.cpp
@@ -33,11 +33,11 @@ namespace IPC {
 
 SocketPair createPlatformConnection(int socketType, unsigned options)
 {
-    int sockets[2];
+    std::array<int, 2> sockets;
 
 #if OS(LINUX)
     if ((options & SetCloexecOnServer) || (options & SetCloexecOnClient)) {
-        RELEASE_ASSERT(socketpair(AF_UNIX, socketType | SOCK_CLOEXEC, 0, sockets) != -1);
+        RELEASE_ASSERT(socketpair(AF_UNIX, socketType | SOCK_CLOEXEC, 0, sockets.data()) != -1);
 
         if (!(options & SetCloexecOnServer))
             RELEASE_ASSERT(unsetCloseOnExec(sockets[1]));
@@ -48,7 +48,7 @@ SocketPair createPlatformConnection(int socketType, unsigned options)
     }
 #endif
 
-    RELEASE_ASSERT(socketpair(AF_UNIX, socketType, 0, sockets) != -1);
+    RELEASE_ASSERT(socketpair(AF_UNIX, socketType, 0, sockets.data()) != -1);
 
     if (options & SetCloexecOnServer)
         RELEASE_ASSERT(setCloseOnExec(sockets[1]));


### PR DESCRIPTION
#### c8883707d25ec989d6c3df323e0800c2c3da2520
<pre>
[IPC] Fix unsafe buffer usage warning in IPCUtilitiesUnix.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=299513">https://bugs.webkit.org/show_bug.cgi?id=299513</a>

Reviewed by Nikolas Zimmermann.

* Source/WebKit/Platform/IPC/unix/IPCUtilitiesUnix.cpp:
(IPC::createPlatformConnection): Use an std::array for the pair of
socket file descriptors, instead of a plain array.

Canonical link: <a href="https://commits.webkit.org/300528@main">https://commits.webkit.org/300528@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df001a5ce5ff6852ef6cb9f2f072ea22fa7edefc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122856 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42568 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33258 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/129482 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74961 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43287 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51161 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93400 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61987 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125808 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34513 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109977 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74032 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33490 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72984 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104213 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28347 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132211 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49801 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37913 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101893 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50178 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106191 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/101837 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25865 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47128 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25318 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/46573 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49659 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/55411 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49126 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/52477 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50808 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->