### PR TITLE
Web Inspector: Rename WI.DOMTreeElement.prototype._elementCloseTag

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/DOMTreeContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/DOMTreeContentView.js
@@ -188,7 +188,7 @@ WI.DOMTreeContentView = class DOMTreeContentView extends WI.ContentView
         while (treeElement && !treeElement.root) {
             // The close tag is contained within the element it closes. So skip it since we don't want to
             // show the same node twice in the hierarchy.
-            if (treeElement.isCloseTag()) {
+            if (treeElement.isElementCloseTag) {
                 treeElement = treeElement.parent;
                 continue;
             }

--- a/Source/WebInspectorUI/UserInterface/Views/DOMTreeElement.js
+++ b/Source/WebInspectorUI/UserInterface/Views/DOMTreeElement.js
@@ -30,15 +30,12 @@
 
 WI.DOMTreeElement = class DOMTreeElement extends WI.TreeElement
 {
-    constructor(node, elementCloseTag, {showBadges} = {})
+    constructor(node, {showBadges, isElementCloseTag} = {})
     {
         super("", node);
 
-        this._elementCloseTag = elementCloseTag;
-        this.hasChildren = !elementCloseTag && this._hasVisibleChildren();
-
-        if (this.representedObject.nodeType() === Node.ELEMENT_NODE && !elementCloseTag)
-            this._canAddAttributes = true;
+        this._isElementCloseTag = !!isElementCloseTag;
+        this.hasChildren = !this._isElementCloseTag && this._hasVisibleChildren();
         this._searchQuery = null;
         this._expandedChildrenLimit = WI.DOMTreeElement.InitialChildrenLimit;
         this._breakpointStatus = WI.DOMTreeElement.BreakpointStatus.None;
@@ -78,6 +75,7 @@ WI.DOMTreeElement = class DOMTreeElement extends WI.TreeElement
     // Public
 
     get statusImageElement() { return this._statusImageElement; }
+    get isElementCloseTag() { return this._isElementCloseTag; }
 
     get hasBreakpoint()
     {
@@ -134,11 +132,6 @@ WI.DOMTreeElement = class DOMTreeElement extends WI.TreeElement
 
         this._shouldHighlightAfterReveal = true;
         this.reveal();
-    }
-
-    isCloseTag()
-    {
-        return this._elementCloseTag;
     }
 
     highlightSearchResults(searchQuery)
@@ -278,7 +271,7 @@ WI.DOMTreeElement = class DOMTreeElement extends WI.TreeElement
     get expandedChildCount()
     {
         var count = this.children.length;
-        if (count && this.children[count - 1]._elementCloseTag)
+        if (count && this.children[count - 1].isElementCloseTag)
             count--;
         if (count && this.children[count - 1].expandAllButton)
             count--;
@@ -315,8 +308,8 @@ WI.DOMTreeElement = class DOMTreeElement extends WI.TreeElement
 
     showChildNode(node)
     {
-        console.assert(!this._elementCloseTag);
-        if (this._elementCloseTag)
+        console.assert(!this._isElementCloseTag);
+        if (this._isElementCloseTag)
             return null;
 
         var index = this._visibleChildren().indexOf(node);
@@ -461,7 +454,7 @@ WI.DOMTreeElement = class DOMTreeElement extends WI.TreeElement
 
     onpopulate()
     {
-        if (this.children.length || !this._hasVisibleChildren() || this._elementCloseTag)
+        if (this.children.length || !this._hasVisibleChildren() || this._isElementCloseTag)
             return;
 
         this.updateChildren();
@@ -474,15 +467,15 @@ WI.DOMTreeElement = class DOMTreeElement extends WI.TreeElement
 
     updateChildren(fullRefresh)
     {
-        if (this._elementCloseTag)
+        if (this._isElementCloseTag)
             return;
 
         this.representedObject.getChildNodes(this._updateChildren.bind(this, fullRefresh));
     }
 
-    insertChildElement(child, index, closingTag)
+    insertChildElement(child, index, {isElementCloseTag} = {})
     {
-        var newElement = new WI.DOMTreeElement(child, closingTag, {showBadges: this._showBadges});
+        var newElement = new WI.DOMTreeElement(child, {showBadges: this._showBadges, isElementCloseTag});
         newElement.selectable = this.treeOutline.selectable;
         this.insertChild(newElement, index);
         return newElement;
@@ -583,8 +576,8 @@ WI.DOMTreeElement = class DOMTreeElement extends WI.TreeElement
 
         // Insert closing tag tree element.
         var lastChild = this.children.lastValue;
-        if (node.nodeType() === Node.ELEMENT_NODE && (!lastChild || !lastChild._elementCloseTag))
-            this._closeTagTreeElement = this.insertChildElement(this.representedObject, this.children.length, true);
+        if (node.nodeType() === Node.ELEMENT_NODE && (!lastChild || !lastChild.isElementCloseTag))
+            this._closeTagTreeElement = this.insertChildElement(this.representedObject, this.children.length, {isElementCloseTag: true});
 
         // We want to restore the original selection and tree scroll position after a full refresh, if possible.
         if (fullRefresh && elementToSelect) {
@@ -665,7 +658,7 @@ WI.DOMTreeElement = class DOMTreeElement extends WI.TreeElement
 
     onexpand()
     {
-        if (this._elementCloseTag)
+        if (this._isElementCloseTag)
             return;
 
         if (!this.listItemElement)
@@ -681,7 +674,7 @@ WI.DOMTreeElement = class DOMTreeElement extends WI.TreeElement
 
     oncollapse()
     {
-        if (this._elementCloseTag)
+        if (this._isElementCloseTag)
             return;
 
         this.updateTitle();
@@ -746,7 +739,7 @@ WI.DOMTreeElement = class DOMTreeElement extends WI.TreeElement
         if (!this.editable)
             return false;
 
-        if (this._editing || this._elementCloseTag)
+        if (this._editing || this._isElementCloseTag)
             return;
 
         if (this._startEditingTarget(event.target))
@@ -936,7 +929,7 @@ WI.DOMTreeElement = class DOMTreeElement extends WI.TreeElement
 
         var listItem = this.listItemElement;
 
-        if (this._canAddAttributes) {
+        if (this.representedObject.nodeType() === Node.ELEMENT_NODE && !this._isElementCloseTag) {
             var attribute = listItem.getElementsByClassName("html-attribute")[0];
             if (attribute)
                 return this._startEditingAttribute(attribute, attribute.getElementsByClassName("html-attribute-value")[0]);
@@ -1548,7 +1541,7 @@ WI.DOMTreeElement = class DOMTreeElement extends WI.TreeElement
                 }
 
                 var tagName = node.nodeNameInCorrectCase();
-                if (this._elementCloseTag) {
+                if (this._isElementCloseTag) {
                     this._buildTagDOM({
                         parentElement: info.titleDOM,
                         tagName,
@@ -1956,7 +1949,7 @@ WI.DOMTreeElement = class DOMTreeElement extends WI.TreeElement
 
     _updatePseudoClassIndicator()
     {
-        if (!this.listItemElement || this._elementCloseTag)
+        if (!this.listItemElement || this._isElementCloseTag)
             return;
 
         if (this.representedObject.enabledPseudoClasses.length) {
@@ -2122,7 +2115,7 @@ WI.DOMTreeElement = class DOMTreeElement extends WI.TreeElement
 
     _createBadges()
     {
-        if (!this._showBadges || !this.listItemElement || this._elementCloseTag)
+        if (!this._showBadges || !this.listItemElement || this._isElementCloseTag)
             return;
 
         let hadBadge = this._elementForBadgeType.size;

--- a/Source/WebInspectorUI/UserInterface/Views/DOMTreeElementPathComponent.js
+++ b/Source/WebInspectorUI/UserInterface/Views/DOMTreeElementPathComponent.js
@@ -141,7 +141,7 @@ WI.DOMTreeElementPathComponent = class DOMTreeElementPathComponent extends WI.Hi
     {
         if (!this._domTreeElement.nextSibling)
             return null;
-        if (this._domTreeElement.nextSibling.isCloseTag())
+        if (this._domTreeElement.nextSibling.isElementCloseTag)
             return null;
         return new WI.DOMTreeElementPathComponent(this._domTreeElement.nextSibling);
     }

--- a/Source/WebInspectorUI/UserInterface/Views/DOMTreeOutline.js
+++ b/Source/WebInspectorUI/UserInterface/Views/DOMTreeOutline.js
@@ -173,18 +173,16 @@ WI.DOMTreeOutline = class DOMTreeOutline extends WI.TreeOutline
 
         this.removeChildren();
 
-        const elementCloseTag = false;
-
         var treeElement;
         if (this._includeRootDOMNode) {
-            treeElement = new WI.DOMTreeElement(this.rootDOMNode, elementCloseTag, {showBadges: this._showBadges});
+            treeElement = new WI.DOMTreeElement(this.rootDOMNode, {showBadges: this._showBadges});
             treeElement.selectable = this.selectable;
             this.appendChild(treeElement);
         } else {
             // FIXME: this could use findTreeElement to reuse a tree element if it already exists
             var node = this.rootDOMNode.firstChild;
             while (node) {
-                treeElement = new WI.DOMTreeElement(node, elementCloseTag, {showBadges: this._showBadges});
+                treeElement = new WI.DOMTreeElement(node, {showBadges: this._showBadges});
                 treeElement.selectable = this.selectable;
                 this.appendChild(treeElement);
                 node = node.nextSibling;
@@ -210,7 +208,7 @@ WI.DOMTreeOutline = class DOMTreeOutline extends WI.TreeOutline
         // as its parent.
         selectedTreeElements = selectedTreeElements.map((oldTreeElement) => {
             let treeElement = this.findTreeElement(oldTreeElement.representedObject);
-            if (treeElement && oldTreeElement.isCloseTag()) {
+            if (treeElement && oldTreeElement.isElementCloseTag) {
                 console.assert(treeElement.closeTagTreeElement, "Missing close tag TreeElement.", treeElement);
                 if (treeElement.closeTagTreeElement)
                     treeElement = treeElement.closeTagTreeElement;
@@ -371,7 +369,7 @@ WI.DOMTreeOutline = class DOMTreeOutline extends WI.TreeOutline
 
         this._treeElementsToRemove = null;
 
-        if (this.selectedTreeElement && !this.selectedTreeElement.isCloseTag()) {
+        if (this.selectedTreeElement && !this.selectedTreeElement.isElementCloseTag) {
             console.assert(this.selectedTreeElements.length === 1);
             this.selectedTreeElement.reveal();
         }
@@ -418,7 +416,7 @@ WI.DOMTreeOutline = class DOMTreeOutline extends WI.TreeOutline
 
     objectForSelection(treeElement)
     {
-        if (treeElement instanceof WI.DOMTreeElement && treeElement.isCloseTag()) {
+        if (treeElement instanceof WI.DOMTreeElement && treeElement.isElementCloseTag) {
             // SelectionController requires every selectable item to be unique.
             // The DOMTreeElement for a close tag has the same represented object
             // as its parent (the open tag). Return a proxy object associated
@@ -609,7 +607,7 @@ WI.DOMTreeOutline = class DOMTreeOutline extends WI.TreeOutline
             let parentNode = null;
             let anchorNode = null;
 
-            if (treeElement._elementCloseTag) {
+            if (treeElement.isElementCloseTag) {
                 // Drop onto closing tag -> insert as last child.
                 parentNode = treeElement.representedObject;
             } else {


### PR DESCRIPTION
#### cf37c23ad69cb407e17d9f132de8740e4ae7f54a
<pre>
Web Inspector: Rename WI.DOMTreeElement.prototype._elementCloseTag
<a href="https://bugs.webkit.org/show_bug.cgi?id=299519">https://bugs.webkit.org/show_bug.cgi?id=299519</a>
<a href="https://rdar.apple.com/161318308">rdar://161318308</a>

Reviewed by Devin Rousso.

While investigating <a href="https://commits.webkit.org/300471@main">https://commits.webkit.org/300471@main</a>, the naming of `_elementCloseTag` proved confusing at times.
It is a boolean indicating whether the `WI.DOMTreeElement` represents the closing tag of a DOM element.

There&apos;s a similarly named member, `_closeTagTreeElement`,
which references the actual element of the close tag in the DOM tree outline.

This patch renames `_elementCloseTag` to `isElementCloseTag`, renames the public getter,
and uses the same name across all call sites to make it easier to track across objects.

* Source/WebInspectorUI/UserInterface/Views/DOMTreeContentView.js:
(WI.DOMTreeContentView.prototype.get selectionPathComponents):
* Source/WebInspectorUI/UserInterface/Views/DOMTreeElement.js:
(WI.DOMTreeElement.prototype.get isElementCloseTag):
(WI.DOMTreeElement.prototype.get expandedChildCount):
(WI.DOMTreeElement.prototype.showChildNode):
(WI.DOMTreeElement.prototype.onpopulate):
(WI.DOMTreeElement.prototype.updateChildren):
(WI.DOMTreeElement.prototype.insertChildElement):
(WI.DOMTreeElement.prototype._updateChildren):
(WI.DOMTreeElement.prototype.onexpand):
(WI.DOMTreeElement.prototype.oncollapse):
(WI.DOMTreeElement.prototype.ondblclick):
(WI.DOMTreeElement.prototype._startEditing):
(WI.DOMTreeElement.prototype._nodeTitleInfo):
(WI.DOMTreeElement.prototype._updatePseudoClassIndicator):
(WI.DOMTreeElement.prototype._createBadges):
(WI.DOMTreeElement.prototype.isCloseTag): Deleted.
* Source/WebInspectorUI/UserInterface/Views/DOMTreeElementPathComponent.js:
(WI.DOMTreeElementPathComponent.prototype.get nextSibling):
* Source/WebInspectorUI/UserInterface/Views/DOMTreeOutline.js:
(WI.DOMTreeOutline.prototype.update):
(WI.DOMTreeOutline.prototype.ondelete):
(WI.DOMTreeOutline.prototype.objectForSelection):
(WI.DOMTreeOutline.prototype._ondrop):

Canonical link: <a href="https://commits.webkit.org/300703@main">https://commits.webkit.org/300703@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/543922c62714ece213d1819011a9ee905dd38efa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/123578 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/43293 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/138/builds/33989 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/130345 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/75721 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/44016 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/51887 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/130345 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/75721 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/126531 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/44016 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/138/builds/33989 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/130345 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/44016 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/138/builds/33989 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/73822 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/44016 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/33989 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/133036 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/50529 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/51887 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/133036 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/50904 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/138/builds/33989 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/133036 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25995 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/33989 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/47340 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/50383 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/56145 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/49857 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/53204 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/51532 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->