### PR TITLE
CSS Anchor Positioning prevents display transition when used with transition-behavior: allow-discrete

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchored-transition-display-none-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchored-transition-display-none-expected.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+This is visible.

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchored-transition-display-none-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchored-transition-display-none-ref.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+This is visible.

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchored-transition-display-none.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchored-transition-display-none.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html id=html class="reftest-wait">
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1">
+<link rel="match" href="anchored-transition-display-none-ref.html">
+This is visible.
+<div>FAIL if this is visible</div>
+
+<style>
+div {
+  position-area: end;
+  position: absolute;
+  border: 1px solid;
+  transition-behavior: allow-discrete;
+  transition-duration: 0.01s;
+}
+</style>
+<script>
+    html.addEventListener('transitionend', () => {
+        html.classList.toggle('reftest-wait')
+    });
+
+    document.body.offsetLeft;
+    document.querySelector("div").style.display = "none";
+</script>
+

--- a/Source/WebCore/style/AnchorPositionEvaluator.cpp
+++ b/Source/WebCore/style/AnchorPositionEvaluator.cpp
@@ -1282,7 +1282,7 @@ void AnchorPositionEvaluator::updateAnchorPositionedStateForDefaultAnchorAndPosi
 
     // `position-visibility: no-overflow` should also work for non-anchor positioned out-of-flow boxes.
     // Create an empty anchor positioning state for it so we perform the required layout interleaving.
-    auto hasPositionVisibilityNoOverflow = style.hasOutOfFlowPosition() && style.positionVisibility().contains(PositionVisibility::NoOverflow);
+    auto hasPositionVisibilityNoOverflow = generatesBox(style) && style.hasOutOfFlowPosition() && style.positionVisibility().contains(PositionVisibility::NoOverflow);
 
     if (!shouldResolveDefaultAnchor && !hasPositionVisibilityNoOverflow)
         return;
@@ -1321,14 +1321,22 @@ auto AnchorPositionEvaluator::makeAnchorPositionedForAnchorMap(AnchorPositionedT
 
 bool AnchorPositionEvaluator::isAnchorPositioned(const RenderStyle& style)
 {
-    if (!style.hasOutOfFlowPosition())
+    return isStyleTimeAnchorPositioned(style) || isLayoutTimeAnchorPositioned(style);
+}
+
+bool AnchorPositionEvaluator::isStyleTimeAnchorPositioned(const RenderStyle& style)
+{
+    if (!generatesBox(style) || !style.hasOutOfFlowPosition())
         return false;
 
-    return isLayoutTimeAnchorPositioned(style) || style.usesAnchorFunctions();
+    return style.usesAnchorFunctions();
 }
 
 bool AnchorPositionEvaluator::isLayoutTimeAnchorPositioned(const RenderStyle& style)
 {
+    if (!generatesBox(style) || !style.hasOutOfFlowPosition())
+        return false;
+
     if (style.positionArea())
         return true;
 

--- a/Source/WebCore/style/AnchorPositionEvaluator.h
+++ b/Source/WebCore/style/AnchorPositionEvaluator.h
@@ -179,6 +179,7 @@ public:
     static AnchorToAnchorPositionedMap makeAnchorPositionedForAnchorMap(AnchorPositionedToAnchorMap&);
 
     static bool isAnchorPositioned(const RenderStyle&);
+    static bool isStyleTimeAnchorPositioned(const RenderStyle&);
     static bool isLayoutTimeAnchorPositioned(const RenderStyle&);
 
     static CSSPropertyID resolvePositionTryFallbackProperty(CSSPropertyID, WritingMode, const BuilderPositionTryFallback&);


### PR DESCRIPTION
#### a6a5ef3d9b99675a3cc547c7727d31a9b794e3e4
<pre>
CSS Anchor Positioning prevents display transition when used with transition-behavior: allow-discrete
<a href="https://bugs.webkit.org/show_bug.cgi?id=298680">https://bugs.webkit.org/show_bug.cgi?id=298680</a>
<a href="https://rdar.apple.com/160421419">rdar://160421419</a>

Reviewed by Tim Nguyen.

Transition to &apos;display:none&apos; combined with an anchor positioning property (like `position-area`) creates
a situation where the transition repeatedly restarts as we try and fail to resolve anchor positioning.

Tests: imported/w3c/web-platform-tests/css/css-anchor-position/anchored-transition-display-none-ref.html
       imported/w3c/web-platform-tests/css/css-anchor-position/anchored-transition-display-none.html
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchored-transition-display-none-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchored-transition-display-none-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchored-transition-display-none.html: Added.
* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::Style::AnchorPositionEvaluator::updateAnchorPositionedStateForDefaultAnchorAndPositionVisibility):
(WebCore::Style::AnchorPositionEvaluator::isAnchorPositioned):
(WebCore::Style::AnchorPositionEvaluator::isStyleTimeAnchorPositioned):
(WebCore::Style::AnchorPositionEvaluator::isLayoutTimeAnchorPositioned):

Styles that don&apos;t generate boxes (&apos;display:none&apos; and &apos;display:contents&apos;) are not anchor positioned.

* Source/WebCore/style/AnchorPositionEvaluator.h:

Canonical link: <a href="https://commits.webkit.org/300519@main">https://commits.webkit.org/300519@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e04350718b9b43497f3ac7f22566a3a45561a0ac

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122883 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42595 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33285 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/129525 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74989 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5a7f654d-fbd4-454c-8551-aa910a638365) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/124759 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43314 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51188 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93409 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/62004 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/154c447f-2f7e-4e52-9346-86a54091caaa) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125835 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34537 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109998 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74034 "Found 1 new API test failure: WPE/TestWebKitWebContext:/webkit/WebKitWebContext/no-web-process-leak (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a7a24112-4c00-4478-9a61-3542808b4c6a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33515 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28155 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73011 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104238 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28367 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132251 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49828 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37936 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/101912 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50205 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106211 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101780 "Found 3 new API test failures: WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/no-web-process-leak, TestWTF:CompletionHandlerDeathTest.MainThreadHandlerOnThreadAssertsDeathTest, TestWTF:CompletionHandlerDeathTest.ConstructionThreadHandlerOnThreadAssertsDeathTest (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25850 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47149 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25338 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/46600 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49686 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/55438 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/49153 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/52504 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50835 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->