### PR TITLE
[Style] Require an explicit type when calling Style::evaluate to make it clear which evaluation is being applied

### DIFF
--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -949,7 +949,7 @@ Path AccessibilityRenderObject::elementPath() const
         if (!needsPath)
             return { };
 
-        float outlineOffset = Style::evaluate(style.outlineOffset(), Style::ZoomNeeded { });
+        auto outlineOffset = Style::evaluate<float>(style.outlineOffset(), Style::ZoomNeeded { });
         float deviceScaleFactor = renderText->document().deviceScaleFactor();
         Vector<FloatRect> pixelSnappedRects;
         for (auto rect : rects) {

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp
@@ -793,7 +793,7 @@ AccessibilityObjectAtspi::TextAttributes AccessibilityObjectAtspi::textAttribute
         addAttributeIfNeeded("invisible"_s, style.visibility() == Visibility::Hidden ? "true"_s : "false"_s);
         addAttributeIfNeeded("editable"_s, m_coreObject->canSetValueAttribute() ? "true"_s : "false"_s);
         addAttributeIfNeeded("direction"_s, style.writingMode().isBidiLTR() ? "ltr"_s : "rtl"_s);
-        addAttributeIfNeeded("indent"_s, makeString(Style::evaluate(style.textIndent().length, m_coreObject->size().width(), Style::ZoomNeeded { })));
+        addAttributeIfNeeded("indent"_s, makeString(Style::evaluate<float>(style.textIndent().length, m_coreObject->size().width(), Style::ZoomNeeded { })));
 
         switch (style.textAlign()) {
         case TextAlignMode::Start:

--- a/Source/WebCore/animation/ScrollTimeline.cpp
+++ b/Source/WebCore/animation/ScrollTimeline.cpp
@@ -345,7 +345,7 @@ std::pair<WebAnimationTime, WebAnimationTime> ScrollTimeline::intervalForAttachm
     auto computedPercentageIfNecessary = [&](const auto& rangeOffset) {
         if (auto percentage = rangeOffset.tryPercentage())
             return percentage->value;
-        return Style::evaluate(rangeOffset, maxScrollOffset, Style::ZoomNeeded { }) / maxScrollOffset * 100;
+        return Style::evaluate<float>(rangeOffset, maxScrollOffset, Style::ZoomNeeded { }) / maxScrollOffset * 100;
     };
 
     return {

--- a/Source/WebCore/animation/ViewTimeline.cpp
+++ b/Source/WebCore/animation/ViewTimeline.cpp
@@ -41,6 +41,7 @@
 #include "ScrollAnchoringController.h"
 #include "ScrollingConstraints.h"
 #include "StyleLengthWrapper+DeprecatedCSSValueConversion.h"
+#include "StylePrimitiveNumericTypes+Evaluation.h"
 #include "StylePrimitiveNumericTypes+Logging.h"
 #include "StyleScrollPadding.h"
 #include "StyleSingleAnimationRange.h"
@@ -376,14 +377,14 @@ void ViewTimeline::cacheCurrentTime()
         float insetEnd = 0;
 
         if (m_insets.start().isAuto())
-            insetStart = Style::evaluate(scrollPadding(PaddingEdge::Start), scrollContainerSize, Style::ZoomNeeded { });
+            insetStart = Style::evaluate<float>(scrollPadding(PaddingEdge::Start), scrollContainerSize, Style::ZoomNeeded { });
         else
-            insetStart = Style::evaluate(m_insets.start(), scrollContainerSize, Style::ZoomNeeded { });
+            insetStart = Style::evaluate<float>(m_insets.start(), scrollContainerSize, Style::ZoomNeeded { });
 
         if (m_insets.end().isAuto())
-            insetEnd = Style::evaluate(scrollPadding(PaddingEdge::End), scrollContainerSize, Style::ZoomNeeded { });
+            insetEnd = Style::evaluate<float>(scrollPadding(PaddingEdge::End), scrollContainerSize, Style::ZoomNeeded { });
         else
-            insetEnd = Style::evaluate(m_insets.end(), scrollContainerSize, Style::ZoomNeeded { });
+            insetEnd = Style::evaluate<float>(m_insets.end(), scrollContainerSize, Style::ZoomNeeded { });
 
         StickinessAdjustmentData stickyData;
         if (auto stickyContainer = dynamicDowncast<RenderBoxModelObject>(this->stickyContainer())) {
@@ -583,7 +584,7 @@ std::pair<double, double> ViewTimeline::offsetIntervalForAttachmentRange(const S
     auto offsetForSingleTimelineRange = [&](const auto& rangeToConvert) {
         auto [conversionRangeStart, conversionRangeEnd] = intervalForTimelineRangeName(data, rangeToConvert.name());
         auto conversionRange = conversionRangeEnd - conversionRangeStart;
-        auto convertedValue = Style::evaluate(rangeToConvert.offset(), conversionRange, Style::ZoomNeeded { });
+        auto convertedValue = Style::evaluate<float>(rangeToConvert.offset(), conversionRange, Style::ZoomNeeded { });
         auto position = conversionRangeStart + convertedValue;
         return (position - data.rangeStart) / timelineRange;
     };
@@ -604,7 +605,7 @@ std::pair<WebAnimationTime, WebAnimationTime> ViewTimeline::intervalForAttachmen
 
     auto computeTime = [&](const auto& rangeToConvert) {
         auto mappedOffset = mapOffsetToTimelineRange(data, rangeToConvert.name(), [&](const float& subjectRange) {
-            return Style::evaluate(rangeToConvert.offset(), subjectRange, Style::ZoomNeeded { });
+            return Style::evaluate<float>(rangeToConvert.offset(), subjectRange, Style::ZoomNeeded { });
         });
         return WebAnimationTime::fromPercentage(mappedOffset * 100);
     };

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -296,6 +296,7 @@
 #include "StyleColorOptions.h"
 #include "StyleColorScheme.h"
 #include "StyleOriginatedTimelinesController.h"
+#include "StylePrimitiveNumericTypes+Evaluation.h"
 #include "StyleProperties.h"
 #include "StyleResolveForDocument.h"
 #include "StyleResolver.h"
@@ -3373,10 +3374,10 @@ void Document::pageSizeAndMarginsInPixels(int pageIndex, IntSize& pageSize, int&
 
     // The percentage is calculated with respect to the width even for margin top and bottom.
     // http://www.w3.org/TR/CSS2/box.html#margin-properties
-    marginTop = style->marginTop().isAuto() ? marginTop : Style::evaluate(style->marginTop(), pageSize.width(), Style::ZoomNeeded { });
-    marginRight = style->marginRight().isAuto() ? marginRight : Style::evaluate(style->marginRight(), pageSize.width(), Style::ZoomNeeded { });
-    marginBottom = style->marginBottom().isAuto() ? marginBottom : Style::evaluate(style->marginBottom(), pageSize.width(), Style::ZoomNeeded { });
-    marginLeft = style->marginLeft().isAuto() ? marginLeft : Style::evaluate(style->marginLeft(), pageSize.width(), Style::ZoomNeeded { });
+    marginTop = style->marginTop().isAuto() ? marginTop : Style::evaluate<int>(style->marginTop(), pageSize.width(), Style::ZoomNeeded { });
+    marginRight = style->marginRight().isAuto() ? marginRight : Style::evaluate<int>(style->marginRight(), pageSize.width(), Style::ZoomNeeded { });
+    marginBottom = style->marginBottom().isAuto() ? marginBottom : Style::evaluate<int>(style->marginBottom(), pageSize.width(), Style::ZoomNeeded { });
+    marginLeft = style->marginLeft().isAuto() ? marginLeft : Style::evaluate<int>(style->marginLeft(), pageSize.width(), Style::ZoomNeeded { });
 }
 
 void Document::fontsNeedUpdate(FontSelector&)

--- a/Source/WebCore/layout/Verification.cpp
+++ b/Source/WebCore/layout/Verification.cpp
@@ -190,12 +190,12 @@ static bool outputMismatchingBlockBoxInformationIfNeeded(TextStream& stream, con
         auto marginStart = LayoutUnit { };
         auto& marginStartStyle = layoutBox.style().marginStart();
         if (marginStartStyle.isFixed() || marginStartStyle.isPercent() || marginStartStyle.isCalculated())
-            marginStart = Style::evaluate(marginStartStyle, containingBlockWidth, Style::ZoomNeeded { });
+            marginStart = Style::evaluate<LayoutUnit>(marginStartStyle, containingBlockWidth, Style::ZoomNeeded { });
 
         auto marginEnd = LayoutUnit { };
         auto& marginEndStyle = layoutBox.style().marginEnd();
         if (marginEndStyle.isFixed() || marginEndStyle.isPercent() || marginEndStyle.isCalculated())
-            marginEnd = Style::evaluate(marginEndStyle, containingBlockWidth, Style::ZoomNeeded { });
+            marginEnd = Style::evaluate<LayoutUnit>(marginEndStyle, containingBlockWidth, Style::ZoomNeeded { });
 
         auto marginBefore = boxGeometry.marginBefore();
         auto marginAfter = boxGeometry.marginAfter();

--- a/Source/WebCore/layout/formattingContexts/FormattingGeometry.cpp
+++ b/Source/WebCore/layout/formattingContexts/FormattingGeometry.cpp
@@ -113,7 +113,7 @@ template<FormattingGeometry::HeightType heightType> std::optional<LayoutUnit> Fo
     if (!containingBlockHeight)
         return { };
 
-    return Style::evaluate(height, *containingBlockHeight, Style::ZoomNeeded { });
+    return Style::evaluate<LayoutUnit>(height, *containingBlockHeight, Style::ZoomNeeded { });
 }
 
 std::optional<LayoutUnit> FormattingGeometry::computedHeight(const Box& layoutBox, std::optional<LayoutUnit> containingBlockHeight) const
@@ -1084,8 +1084,14 @@ BoxGeometry::Edges FormattingGeometry::computedBorder(const Box& layoutBox) cons
     auto& style = layoutBox.style();
     LOG_WITH_STREAM(FormattingContextLayout, stream << "[Border] -> layoutBox: " << &layoutBox);
     return {
-        { LayoutUnit(Style::evaluate(style.borderLeftWidth(), Style::ZoomNeeded { })), LayoutUnit(Style::evaluate(style.borderRightWidth(), Style::ZoomNeeded { })) },
-        { LayoutUnit(Style::evaluate(style.borderTopWidth(), Style::ZoomNeeded { })), LayoutUnit(Style::evaluate(style.borderBottomWidth(), Style::ZoomNeeded { })) },
+        {
+            Style::evaluate<LayoutUnit>(style.borderLeftWidth(), Style::ZoomNeeded { }),
+            Style::evaluate<LayoutUnit>(style.borderRightWidth(), Style::ZoomNeeded { })
+        },
+        {
+            Style::evaluate<LayoutUnit>(style.borderTopWidth(), Style::ZoomNeeded { }),
+            Style::evaluate<LayoutUnit>(style.borderBottomWidth(), Style::ZoomNeeded { })
+        },
     };
 }
 
@@ -1097,8 +1103,13 @@ BoxGeometry::Edges FormattingGeometry::computedPadding(const Box& layoutBox, con
     auto& style = layoutBox.style();
     LOG_WITH_STREAM(FormattingContextLayout, stream << "[Padding] -> layoutBox: " << &layoutBox);
     return {
-        { Style::evaluate(style.paddingStart(), containingBlockWidth, Style::ZoomNeeded { }), Style::evaluate(style.paddingEnd(), containingBlockWidth, Style::ZoomNeeded { }) },
-        { Style::evaluate(style.paddingBefore(), containingBlockWidth, Style::ZoomNeeded { }), Style::evaluate(style.paddingAfter(), containingBlockWidth, Style::ZoomNeeded { }) }
+        {
+            Style::evaluate<LayoutUnit>(style.paddingStart(), containingBlockWidth, Style::ZoomNeeded { }),
+            Style::evaluate<LayoutUnit>(style.paddingEnd(), containingBlockWidth, Style::ZoomNeeded { }) },
+        {
+            Style::evaluate<LayoutUnit>(style.paddingBefore(), containingBlockWidth, Style::ZoomNeeded { }),
+            Style::evaluate<LayoutUnit>(style.paddingAfter(), containingBlockWidth, Style::ZoomNeeded { })
+        }
     };
 }
 

--- a/Source/WebCore/layout/formattingContexts/FormattingGeometry.h
+++ b/Source/WebCore/layout/formattingContexts/FormattingGeometry.h
@@ -130,14 +130,14 @@ std::optional<LayoutUnit> FormattingGeometry::computedValue(const auto& geometry
 {
     // In general, the computed value resolves the specified value as far as possible without laying out the content.
     if (geometryProperty.isSpecified())
-        return Style::evaluate(geometryProperty, containingBlockWidth, Style::ZoomNeeded { });
+        return Style::evaluate<LayoutUnit>(geometryProperty, containingBlockWidth, Style::ZoomNeeded { });
     return { };
 }
 
 std::optional<LayoutUnit> FormattingGeometry::fixedValue(const auto& geometryProperty) const
 {
     if (auto fixed = geometryProperty.tryFixed())
-        return LayoutUnit { fixed->resolveZoom(Style::ZoomNeeded { }) };
+        return LayoutUnit(fixed->resolveZoom(Style::ZoomNeeded { }));
     return { };
 }
 

--- a/Source/WebCore/layout/formattingContexts/block/BlockFormattingGeometry.cpp
+++ b/Source/WebCore/layout/formattingContexts/block/BlockFormattingGeometry.cpp
@@ -327,10 +327,10 @@ IntrinsicWidthConstraints BlockFormattingGeometry::intrinsicWidthConstraints(con
     auto fixedMarginBorderAndPadding = [&](auto& layoutBox) {
         auto& style = layoutBox.style();
         return fixedValue(style.marginStart()).value_or(0)
-            + LayoutUnit { Style::evaluate(style.borderLeftWidth(), Style::ZoomNeeded { }) }
+            + Style::evaluate<LayoutUnit>(style.borderLeftWidth(), Style::ZoomNeeded { })
             + fixedValue(style.paddingLeft()).value_or(0)
             + fixedValue(style.paddingRight()).value_or(0)
-            + LayoutUnit { Style::evaluate(style.borderRightWidth(), Style::ZoomNeeded { }) }
+            + Style::evaluate<LayoutUnit>(style.borderRightWidth(), Style::ZoomNeeded { })
             + fixedValue(style.marginEnd()).value_or(0);
     };
 

--- a/Source/WebCore/layout/formattingContexts/flex/FlexFormattingContext.cpp
+++ b/Source/WebCore/layout/formattingContexts/flex/FlexFormattingContext.cpp
@@ -35,6 +35,7 @@
 #include "LayoutState.h"
 #include "LengthFunctions.h"
 #include "RenderStyleInlines.h"
+#include "StylePrimitiveNumericTypes+Evaluation.h"
 #include <ranges>
 #include <wtf/FixedVector.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -91,9 +92,9 @@ FlexLayout::LogicalFlexItems FlexFormattingContext::convertFlexItemsToLogicalSpa
 
             auto propertyValueForLength = [&](auto& propertyValue, auto availableSize) -> std::optional<LayoutUnit> {
                 if (auto fixedPropertyValue = propertyValue.tryFixed())
-                    return LayoutUnit { fixedPropertyValue->resolveZoom(Style::ZoomNeeded { }) };
+                    return Style::evaluate<LayoutUnit>(*fixedPropertyValue, Style::ZoomNeeded { });
                 if (propertyValue.isSpecified() && availableSize)
-                    return Style::evaluate(propertyValue, *availableSize, Style::ZoomNeeded { });
+                    return Style::evaluate<LayoutUnit>(propertyValue, *availableSize, Style::ZoomNeeded { });
                 return { };
             };
 

--- a/Source/WebCore/layout/formattingContexts/flex/FlexFormattingUtils.cpp
+++ b/Source/WebCore/layout/formattingContexts/flex/FlexFormattingUtils.cpp
@@ -93,7 +93,7 @@ LayoutUnit FlexFormattingUtils::mainAxisGapValue(const ElementBox& flexContainer
     auto flexDirection = flexContainer.style().flexDirection();
     auto isMainAxisInlineAxis = flexDirection == FlexDirection::Row || flexDirection == FlexDirection::RowReverse;
     auto& gap = isMainAxisInlineAxis ? flexContainer.style().columnGap() : flexContainer.style().rowGap();
-    return Style::evaluateMinimum(gap, flexContainerContentBoxWidth, Style::ZoomNeeded { });
+    return Style::evaluateMinimum<LayoutUnit>(gap, flexContainerContentBoxWidth, Style::ZoomNeeded { });
 }
 
 LayoutUnit FlexFormattingUtils::crossAxisGapValue(const ElementBox& flexContainer, LayoutUnit flexContainerContentBoxHeight)
@@ -102,7 +102,7 @@ LayoutUnit FlexFormattingUtils::crossAxisGapValue(const ElementBox& flexContaine
     auto flexDirection = flexContainer.style().flexDirection();
     auto isMainAxisInlineAxis = flexDirection == FlexDirection::Row || flexDirection == FlexDirection::RowReverse;
     auto& gap = isMainAxisInlineAxis ? flexContainer.style().rowGap() : flexContainer.style().columnGap();
-    return Style::evaluateMinimum(gap, flexContainerContentBoxHeight, Style::ZoomNeeded { });
+    return Style::evaluateMinimum<LayoutUnit>(gap, flexContainerContentBoxHeight, Style::ZoomNeeded { });
 }
 
 // flex container  direction  flex item    main axis size

--- a/Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.cpp
@@ -179,7 +179,7 @@ InlineLayoutUnit InlineFormattingUtils::computedTextIndent(IsIntrinsicWidthMode 
         // https://drafts.csswg.org/css-text/#text-indent-property
         return { };
     }
-    return Style::evaluate(textIndentLength, availableWidth, Style::ZoomNeeded { });
+    return Style::evaluate<InlineLayoutUnit>(textIndentLength, availableWidth, Style::ZoomNeeded { });
 }
 
 InlineLayoutUnit InlineFormattingUtils::initialLineHeight(bool isFirstLine) const

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLevelBoxInlines.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLevelBoxInlines.h
@@ -40,7 +40,7 @@ template<typename PreferredLineHeightFunctor> InlineLevelBox::VerticalAlignment 
             return keyword;
         },
         [&](const Style::VerticalAlign::Length& length) -> InlineLevelBox::VerticalAlignment {
-            return InlineLayoutUnit { Style::evaluate(length, std::forward<PreferredLineHeightFunctor>(preferredLineHeightFunctor), Style::ZoomNeeded { }) };
+            return Style::evaluate<InlineLayoutUnit>(length, std::forward<PreferredLineHeightFunctor>(preferredLineHeightFunctor), Style::ZoomNeeded { });
         }
     );
 }

--- a/Source/WebCore/layout/formattingContexts/table/TableLayout.cpp
+++ b/Source/WebCore/layout/formattingContexts/table/TableLayout.cpp
@@ -342,7 +342,7 @@ TableFormattingContext::TableLayout::DistributedSpaces TableFormattingContext::T
                 return { fixed.resolveZoom(Style::ZoomNeeded { }), GridSpace::Type::Fixed };
             },
             [&](const Style::Percentage<CSS::Nonnegative, float>& percentage) -> std::pair<std::optional<float>, GridSpace::Type> {
-                return { Style::evaluate(percentage, availableHorizontalSpace), GridSpace::Type::Percent };
+                return { Style::evaluate<float>(percentage, availableHorizontalSpace), GridSpace::Type::Percent };
             }
         );
 

--- a/Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.cpp
@@ -79,7 +79,7 @@ static LayoutUnit usedValueOrZero(const Style::MarginEdge& marginEdge, std::opti
     if (marginEdge.isAuto() || !availableWidth)
         return { };
 
-    return Style::evaluateMinimum(marginEdge, *availableWidth, Style::ZoomNeeded { });
+    return Style::evaluateMinimum<LayoutUnit>(marginEdge, *availableWidth, Style::ZoomNeeded { });
 }
 
 static LayoutUnit usedValueOrZero(const Style::PaddingEdge& paddingEdge, std::optional<LayoutUnit> availableWidth)
@@ -90,7 +90,7 @@ static LayoutUnit usedValueOrZero(const Style::PaddingEdge& paddingEdge, std::op
     if (!availableWidth)
         return { };
 
-    return Style::evaluateMinimum(paddingEdge, *availableWidth, Style::ZoomNeeded { });
+    return Style::evaluateMinimum<LayoutUnit>(paddingEdge, *availableWidth, Style::ZoomNeeded { });
 }
 
 static inline void adjustBorderForTableAndFieldset(const RenderBoxModelObject& renderer, RectEdges<LayoutUnit>& borderWidths)
@@ -241,7 +241,7 @@ Layout::BoxGeometry::Edges BoxGeometryUpdater::logicalBorder(const RenderBoxMode
     auto& style = renderer.style();
 
     auto borderWidths = RectEdges<LayoutUnit>::map(style.borderWidth(), [](auto width) {
-        return LayoutUnit { Style::evaluate(width, Style::ZoomNeeded { }) };
+        return Style::evaluate<LayoutUnit>(width, Style::ZoomNeeded { });
     });
 
     if (!isIntrinsicWidthMode)

--- a/Source/WebCore/layout/integration/flex/LayoutIntegrationFlexLayout.cpp
+++ b/Source/WebCore/layout/integration/flex/LayoutIntegrationFlexLayout.cpp
@@ -72,27 +72,31 @@ static inline Layout::ConstraintsForFlexContent constraintsForFlexContent(const 
     auto verticalMarginBorderAndPadding = flexContainerRenderer.marginAndBorderAndPaddingBefore() + flexContainerRenderer.marginAndBorderAndPaddingAfter();
 
     auto widthValue = [&](auto& computedValue) -> std::optional<LayoutUnit> {
-        if (auto fixedWidth = computedValue.tryFixed())
-            return LayoutUnit { boxSizingIsContentBox ? fixedWidth->resolveZoom(Style::ZoomNeeded { }) : fixedWidth->resolveZoom(Style::ZoomNeeded { }) - horizontalMarginBorderAndPadding };
-
+        if (auto fixedWidth = computedValue.tryFixed()) {
+            auto value = Style::evaluate<LayoutUnit>(*fixedWidth, Style::ZoomNeeded { });
+            return boxSizingIsContentBox ? value : value - horizontalMarginBorderAndPadding;
+        }
         if (auto percentageWidth = computedValue.tryPercentage()) {
-            auto value = Style::evaluate(*percentageWidth, flexContainerRenderer.containingBlock()->logicalWidth());
-            return LayoutUnit { boxSizingIsContentBox ? value : value - horizontalMarginBorderAndPadding };
+            auto value = Style::evaluate<LayoutUnit>(*percentageWidth, flexContainerRenderer.containingBlock()->logicalWidth());
+            return boxSizingIsContentBox ? value : value - horizontalMarginBorderAndPadding;
         }
         return { };
     };
 
     auto heightValue = [&](auto& computedValue, bool callRendererForPercentValue = false) -> std::optional<LayoutUnit> {
-        if (auto fixedHeight = computedValue.tryFixed())
-            return LayoutUnit { boxSizingIsContentBox ? fixedHeight->resolveZoom(Style::ZoomNeeded { }) : fixedHeight->resolveZoom(Style::ZoomNeeded { }) - verticalMarginBorderAndPadding };
+        if (auto fixedHeight = computedValue.tryFixed()) {
+            auto value = Style::evaluate<LayoutUnit>(*fixedHeight, Style::ZoomNeeded { });
+            return boxSizingIsContentBox ? value : value - verticalMarginBorderAndPadding;
+        }
 
         if (auto percentageHeight = computedValue.tryPercentage()) {
             if (callRendererForPercentValue)
                 return flexContainerRenderer.computePercentageLogicalHeight(*percentageHeight, RenderBox::UpdatePercentageHeightDescendants::No);
 
             if (auto fixedContainingBlockHeight = flexContainerRenderer.containingBlock()->style().height().tryFixed()) {
-                auto value = Style::evaluate(*percentageHeight, fixedContainingBlockHeight->resolveZoom(Style::ZoomNeeded { }));
-                return LayoutUnit { boxSizingIsContentBox ? value : value - verticalMarginBorderAndPadding };
+                auto containingBlockHeightValue = Style::evaluate<LayoutUnit>(*fixedContainingBlockHeight, Style::ZoomNeeded { });
+                auto value = Style::evaluate<LayoutUnit>(*percentageHeight, containingBlockHeightValue);
+                return boxSizingIsContentBox ? value : value - verticalMarginBorderAndPadding;
             }
         }
         return { };

--- a/Source/WebCore/page/IntersectionObserver.cpp
+++ b/Source/WebCore/page/IntersectionObserver.cpp
@@ -333,8 +333,8 @@ static void expandRootBoundsWithRootMargin(FloatRect& rootBounds, const Intersec
 {
     auto zoomAdjustedLength = [](const IntersectionObserverMarginEdge& edge, float maximumValue, float zoomFactor) {
         if (auto percentage = edge.tryPercentage())
-            return Style::evaluate(*percentage, maximumValue);
-        return edge.tryFixed()->resolveZoom(Style::ZoomNeeded { }) * zoomFactor;
+            return Style::evaluate<float>(*percentage, maximumValue);
+        return Style::evaluate<float>(*edge.tryFixed(), Style::ZoomNeeded { }) * zoomFactor;
     };
 
     auto rootMarginEdges = FloatBoxExtent {
@@ -373,10 +373,10 @@ static std::optional<LayoutRect> computeClippedRectInRootContentsSpace(const Lay
 
     auto frameRect = renderer->view().frameView().layoutViewportRect();
     auto scrollMarginEdges = LayoutBoxExtent {
-        LayoutUnit(static_cast<int>(Style::evaluate(scrollMargin.top(), frameRect.height(), Style::ZoomNeeded { }))),
-        LayoutUnit(static_cast<int>(Style::evaluate(scrollMargin.right(), frameRect.width(), Style::ZoomNeeded { }))),
-        LayoutUnit(static_cast<int>(Style::evaluate(scrollMargin.bottom(), frameRect.height(), Style::ZoomNeeded { }))),
-        LayoutUnit(static_cast<int>(Style::evaluate(scrollMargin.left(), frameRect.width(), Style::ZoomNeeded { })))
+        LayoutUnit(Style::evaluate<int>(scrollMargin.top(), frameRect.height(), Style::ZoomNeeded { })),
+        LayoutUnit(Style::evaluate<int>(scrollMargin.right(), frameRect.width(), Style::ZoomNeeded { })),
+        LayoutUnit(Style::evaluate<int>(scrollMargin.bottom(), frameRect.height(), Style::ZoomNeeded { })),
+        LayoutUnit(Style::evaluate<int>(scrollMargin.left(), frameRect.width(), Style::ZoomNeeded { })),
     };
     frameRect.expand(scrollMarginEdges);
 

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -681,7 +681,7 @@ void LocalFrameView::applyPaginationToViewport()
         if (!columnGap.isNormal()) {
             auto* renderBox = dynamicDowncast<RenderBox>(documentOrBodyRenderer);
             if (auto* containerForPaginationGap = renderBox ? renderBox : documentOrBodyRenderer->containingBlock())
-                pagination.gap = Style::evaluate(columnGap, containerForPaginationGap->contentBoxLogicalWidth(), Style::ZoomNeeded { }).toUnsigned();
+                pagination.gap = Style::evaluate<LayoutUnit>(columnGap, containerForPaginationGap->contentBoxLogicalWidth(), Style::ZoomNeeded { }).toUnsigned();
         }
     }
     setPagination(pagination);
@@ -2464,7 +2464,7 @@ std::pair<FixedContainerEdges, WeakElementEdges> LocalFrameView::fixedContainerE
         if (!border->isVisible())
             return samplingRect;
 
-        auto borderWidth = Style::evaluate(border->width(), Style::ZoomNeeded { });
+        auto borderWidth = Style::evaluate<float>(border->width(), Style::ZoomNeeded { });
         if (borderWidth > thinBorderWidth)
             return samplingRect;
 

--- a/Source/WebCore/page/SpatialNavigation.cpp
+++ b/Source/WebCore/page/SpatialNavigation.cpp
@@ -523,9 +523,9 @@ LayoutRect nodeRectInAbsoluteCoordinates(const ContainerNode& containerNode, boo
         // the rect of the focused element.
         if (ignoreBorder) {
             auto& style = renderer->style();
-            rect.move(Style::evaluate(style.borderLeftWidth(), Style::ZoomNeeded { }), Style::evaluate(style.borderTopWidth(), Style::ZoomNeeded { }));
-            rect.setWidth(rect.width() - Style::evaluate(style.borderLeftWidth(), Style::ZoomNeeded { }) - Style::evaluate(style.borderRightWidth(), Style::ZoomNeeded { }));
-            rect.setHeight(rect.height() - Style::evaluate(style.borderTopWidth(), Style::ZoomNeeded { }) - Style::evaluate(style.borderBottomWidth(), Style::ZoomNeeded { }));
+            rect.move(Style::evaluate<LayoutUnit>(style.borderLeftWidth(), Style::ZoomNeeded { }), Style::evaluate<LayoutUnit>(style.borderTopWidth(), Style::ZoomNeeded { }));
+            rect.setWidth(rect.width() - Style::evaluate<LayoutUnit>(style.borderLeftWidth(), Style::ZoomNeeded { }) - Style::evaluate<LayoutUnit>(style.borderRightWidth(), Style::ZoomNeeded { }));
+            rect.setHeight(rect.height() - Style::evaluate<LayoutUnit>(style.borderTopWidth(), Style::ZoomNeeded { }) - Style::evaluate<LayoutUnit>(style.borderBottomWidth(), Style::ZoomNeeded { }));
         }
         return rect;
     }

--- a/Source/WebCore/platform/graphics/PathUtilities.cpp
+++ b/Source/WebCore/platform/graphics/PathUtilities.cpp
@@ -506,7 +506,7 @@ Path PathUtilities::pathWithShrinkWrappedRectsForOutline(const Vector<FloatRect>
     float outlineOffset, WritingMode writingMode, float deviceScaleFactor)
 {
     auto roundedRect = [radii, outlineOffset, deviceScaleFactor](const FloatRect& rect) {
-        auto adjustedRadii = adjustedRadiiForHuggingCurve(Style::evaluate(radii, rect.size(), Style::ZoomNeeded { }), outlineOffset);
+        auto adjustedRadii = adjustedRadiiForHuggingCurve(Style::evaluate<FloatRoundedRect::Radii>(radii, rect.size(), Style::ZoomNeeded { }), outlineOffset);
         adjustedRadii.scale(calcBorderRadiiConstraintScaleFor(rect, adjustedRadii));
 
         LayoutRoundedRect roundedRect(
@@ -543,8 +543,8 @@ Path PathUtilities::pathWithShrinkWrappedRectsForOutline(const Vector<FloatRect>
     auto firstLineRect = isLeftToRight ? rects.at(0) : rects.at(rects.size() - 1);
     auto lastLineRect = isLeftToRight ? rects.at(rects.size() - 1) : rects.at(0);
     // Adjust radius so that it matches the box border.
-    auto firstLineRadii = Style::evaluate(radii, firstLineRect.size(), Style::ZoomNeeded { });
-    auto lastLineRadii = Style::evaluate(radii, lastLineRect.size(), Style::ZoomNeeded { });
+    auto firstLineRadii = Style::evaluate<FloatRoundedRect::Radii>(radii, firstLineRect.size(), Style::ZoomNeeded { });
+    auto lastLineRadii = Style::evaluate<FloatRoundedRect::Radii>(radii, lastLineRect.size(), Style::ZoomNeeded { });
     firstLineRadii.scale(calcBorderRadiiConstraintScaleFor(firstLineRect, firstLineRadii));
     lastLineRadii.scale(calcBorderRadiiConstraintScaleFor(lastLineRect, lastLineRadii));
 

--- a/Source/WebCore/rendering/AutoTableLayout.cpp
+++ b/Source/WebCore/rendering/AutoTableLayout.cpp
@@ -578,7 +578,7 @@ void AutoTableLayout::layout()
         for (size_t i = 0; i < nEffCols; ++i) {
             auto& logicalWidth = m_layoutStruct[i].effectiveLogicalWidth;
             if (logicalWidth.isPercentOrCalculated()) {
-                float cellLogicalWidth = std::max<float>(m_layoutStruct[i].effectiveMinLogicalWidth, Style::evaluateMinimum(logicalWidth, tableLogicalWidth, Style::ZoomNeeded { }));
+                float cellLogicalWidth = std::max<float>(m_layoutStruct[i].effectiveMinLogicalWidth, Style::evaluateMinimum<float>(logicalWidth, tableLogicalWidth, Style::ZoomNeeded { }));
                 available += m_layoutStruct[i].computedLogicalWidth - cellLogicalWidth;
                 m_layoutStruct[i].computedLogicalWidth = cellLogicalWidth;
             }

--- a/Source/WebCore/rendering/BackgroundPainter.cpp
+++ b/Source/WebCore/rendering/BackgroundPainter.cpp
@@ -46,6 +46,7 @@
 #include "RenderTableCell.h"
 #include "RenderView.h"
 #include "StyleBoxShadow.h"
+#include "StylePrimitiveNumericTypes+Evaluation.h"
 #include "TextBoxPainter.h"
 
 namespace WebCore {
@@ -686,7 +687,7 @@ template<typename Layer> BackgroundImageGeometry BackgroundPainter::calculateFil
 
     LayoutSize spaceSize;
     LayoutSize phase;
-    auto computedXPosition = Style::evaluate(fillLayer.xPosition(), availableWidth, Style::ZoomNeeded { });
+    auto computedXPosition = Style::evaluate<LayoutUnit>(fillLayer.xPosition(), availableWidth, Style::ZoomNeeded { });
     if (backgroundRepeatX == FillRepeat::Round && positioningAreaSize.width() > 0 && tileSize.width() > 0) {
         int numTiles = std::max(1, roundToInt(positioningAreaSize.width() / tileSize.width()));
         if (!fillLayer.size().specifiedHeight() && backgroundRepeatY != FillRepeat::Round)
@@ -696,7 +697,7 @@ template<typename Layer> BackgroundImageGeometry BackgroundPainter::calculateFil
         phase.setWidth(tileSize.width() ? tileSize.width() - fmodf((computedXPosition + left), tileSize.width()) : 0);
     }
 
-    auto computedYPosition = Style::evaluate(fillLayer.yPosition(), availableHeight, Style::ZoomNeeded { });
+    auto computedYPosition = Style::evaluate<LayoutUnit>(fillLayer.yPosition(), availableHeight, Style::ZoomNeeded { });
     if (backgroundRepeatY == FillRepeat::Round && positioningAreaSize.height() > 0 && tileSize.height() > 0) {
         int numTiles = std::max(1, roundToInt(positioningAreaSize.height() / tileSize.height()));
         if (!fillLayer.size().specifiedWidth() && backgroundRepeatX != FillRepeat::Round)
@@ -802,21 +803,21 @@ template<typename Layer> LayoutSize BackgroundPainter::calculateFillTileSize(con
         [&](const Style::BackgroundSize::LengthSize& size) {
             auto tileSize = positioningAreaSize;
 
-            auto layerWidth = size.width();
-            auto layerHeight = size.height();
+            auto& layerWidth = size.width();
+            auto& layerHeight = size.height();
 
             if (auto fixed = layerWidth.tryFixed())
-                tileSize.setWidth(fixed->resolveZoom(Style::ZoomNeeded { }));
+                tileSize.setWidth(Style::evaluate<LayoutUnit>(*fixed, Style::ZoomNeeded { }));
             else if (layerWidth.isPercentOrCalculated()) {
-                auto resolvedWidth = Style::evaluate(layerWidth, positioningAreaSize.width(), Style::ZoomNeeded { });
+                auto resolvedWidth = Style::evaluate<LayoutUnit>(layerWidth, positioningAreaSize.width(), Style::ZoomNeeded { });
                 // Non-zero resolved value should always produce some content.
                 tileSize.setWidth(!resolvedWidth ? resolvedWidth : std::max(devicePixelSize, resolvedWidth));
             }
 
             if (auto fixed = layerHeight.tryFixed())
-                tileSize.setHeight(fixed->resolveZoom(Style::ZoomNeeded { }));
+                tileSize.setHeight(Style::evaluate<LayoutUnit>(*fixed, Style::ZoomNeeded { }));
             else if (layerHeight.isPercentOrCalculated()) {
-                auto resolvedHeight = Style::evaluate(layerHeight, positioningAreaSize.height(), Style::ZoomNeeded { });
+                auto resolvedHeight = Style::evaluate<LayoutUnit>(layerHeight, positioningAreaSize.height(), Style::ZoomNeeded { });
                 // Non-zero resolved value should always produce some content.
                 tileSize.setHeight(!resolvedHeight ? resolvedHeight : std::max(devicePixelSize, resolvedHeight));
             }

--- a/Source/WebCore/rendering/BorderEdge.cpp
+++ b/Source/WebCore/rendering/BorderEdge.cpp
@@ -51,7 +51,7 @@ BorderEdges borderEdges(const RenderStyle& style, float deviceScaleFactor, RectE
 {
     auto constructBorderEdge = [&](const RenderStyle& style, Style::LineWidth width, float inflation, CSSPropertyID borderColorProperty, BorderStyle borderStyle, bool isTransparent, bool isPresent) {
         auto color = setColorsToBlack ? Color::black : style.visitedDependentColorWithColorFilter(borderColorProperty);
-        auto evaluatedWidth = Style::evaluate(width, Style::ZoomNeeded { });
+        auto evaluatedWidth = Style::evaluate<float>(width, Style::ZoomNeeded { });
         auto inflatedWidth = evaluatedWidth ? evaluatedWidth + inflation : evaluatedWidth;
         return BorderEdge(inflatedWidth, color, borderStyle, !setColorsToBlack && isTransparent, isPresent, deviceScaleFactor);
     };
@@ -68,7 +68,7 @@ BorderEdges borderEdgesForOutline(const RenderStyle& style, BorderStyle borderSt
 {
     auto color = style.visitedDependentColorWithColorFilter(CSSPropertyOutlineColor);
     auto isTransparent = color.isValid() && !color.isVisible();
-    auto size = Style::evaluate(style.outlineWidth(), Style::ZoomNeeded { });
+    auto size = Style::evaluate<float>(style.outlineWidth(), Style::ZoomNeeded { });
     return {
         BorderEdge { size, color, borderStyle, isTransparent, true, deviceScaleFactor },
         BorderEdge { size, color, borderStyle, isTransparent, true, deviceScaleFactor },

--- a/Source/WebCore/rendering/BorderPainter.cpp
+++ b/Source/WebCore/rendering/BorderPainter.cpp
@@ -309,8 +309,8 @@ void BorderPainter::paintOutline(const LayoutRect& paintRect) const
     if (!borderStyle || *borderStyle == BorderStyle::None)
         return;
 
-    auto outlineWidth = LayoutUnit { Style::evaluate(styleToUse.outlineWidth(), Style::ZoomNeeded { }) };
-    auto outlineOffset = LayoutUnit { Style::evaluate(styleToUse.outlineOffset(), Style::ZoomNeeded { }) };
+    auto outlineWidth = Style::evaluate<LayoutUnit>(styleToUse.outlineWidth(), Style::ZoomNeeded { });
+    auto outlineOffset = Style::evaluate<LayoutUnit>(styleToUse.outlineOffset(), Style::ZoomNeeded { });
 
     auto outerRect = paintRect;
     outerRect.inflate(outlineOffset + outlineWidth);
@@ -351,8 +351,8 @@ void BorderPainter::paintOutline(const LayoutPoint& paintOffset, const Vector<La
     }
 
     auto& styleToUse = m_renderer->style();
-    auto outlineOffset = Style::evaluate(styleToUse.outlineOffset(), Style::ZoomNeeded { });
-    auto outlineWidth = Style::evaluate(styleToUse.outlineWidth(), Style::ZoomNeeded { });
+    auto outlineOffset = Style::evaluate<float>(styleToUse.outlineOffset(), Style::ZoomNeeded { });
+    auto outlineWidth = Style::evaluate<float>(styleToUse.outlineWidth(), Style::ZoomNeeded { });
     auto deviceScaleFactor = document().deviceScaleFactor();
 
     Vector<FloatRect> pixelSnappedRects;

--- a/Source/WebCore/rendering/BorderShape.cpp
+++ b/Source/WebCore/rendering/BorderShape.cpp
@@ -43,7 +43,7 @@ namespace WebCore {
 BorderShape BorderShape::shapeForBorderRect(const RenderStyle& style, const LayoutRect& borderRect, RectEdges<bool> closedEdges)
 {
     auto borderWidths = RectEdges<LayoutUnit>::map(style.borderWidth(), [](auto width) {
-        return LayoutUnit { Style::evaluate(width, Style::ZoomNeeded { }) };
+        return Style::evaluate<LayoutUnit>(width, Style::ZoomNeeded { });
     });
     return shapeForBorderRect(style, borderRect, borderWidths, closedEdges);
 }
@@ -59,7 +59,7 @@ BorderShape BorderShape::shapeForBorderRect(const RenderStyle& style, const Layo
     };
 
     if (style.hasBorderRadius()) {
-        auto radii = Style::evaluate(style.borderRadii(), borderRect.size(), Style::ZoomNeeded { });
+        auto radii = Style::evaluate<LayoutRoundedRectRadii>(style.borderRadii(), borderRect.size(), Style::ZoomNeeded { });
         radii.scale(calcBorderRadiiConstraintScaleFor(borderRect, radii));
 
         if (!closedEdges.top()) {
@@ -99,7 +99,7 @@ BorderShape BorderShape::shapeForOutsetRect(const RenderStyle& style, const Layo
     };
 
     if (style.hasBorderRadius()) {
-        auto radii = Style::evaluate(style.borderRadii(), borderRect.size(), Style::ZoomNeeded { });
+        auto radii = Style::evaluate<LayoutRoundedRectRadii>(style.borderRadii(), borderRect.size(), Style::ZoomNeeded { });
 
         auto leftOutset = std::max(borderRect.x() - outlineBoxRect.x(), 0_lu);
         auto topOutset = std::max(borderRect.y() - outlineBoxRect.y(), 0_lu);
@@ -138,7 +138,7 @@ BorderShape BorderShape::shapeForOutsetRect(const RenderStyle& style, const Layo
 BorderShape BorderShape::shapeForInsetRect(const RenderStyle& style, const LayoutRect& borderRect, const LayoutRect& insetRect)
 {
     if (style.hasBorderRadius()) {
-        auto radii = Style::evaluate(style.borderRadii(), borderRect.size(), Style::ZoomNeeded { });
+        auto radii = Style::evaluate<LayoutRoundedRectRadii>(style.borderRadii(), borderRect.size(), Style::ZoomNeeded { });
 
         auto leftInset = std::max(insetRect.x() - borderRect.x(), 0_lu);
         auto topInset = std::max(insetRect.y()- borderRect.y(), 0_lu);

--- a/Source/WebCore/rendering/FixedTableLayout.cpp
+++ b/Source/WebCore/rendering/FixedTableLayout.cpp
@@ -232,10 +232,10 @@ void FixedTableLayout::layout()
     // to 10px here, and will scale up to 20px in the final (80px, 20px).
     for (unsigned i = 0; i < nEffCols; i++) {
         if (auto fixedWidth = m_width[i].tryFixed()) {
-            calcWidth[i] = fixedWidth->resolveZoom(Style::ZoomNeeded { });
+            calcWidth[i] = Style::evaluate<float>(*fixedWidth, Style::ZoomNeeded { });
             totalFixedWidth += calcWidth[i];
         } else if (auto percentageWidth = m_width[i].tryPercentage()) {
-            calcWidth[i] = Style::evaluate(*percentageWidth, tableLogicalWidth);
+            calcWidth[i] = Style::evaluate<float>(*percentageWidth, tableLogicalWidth);
             totalPercentWidth += calcWidth[i];
             totalPercent += percentageWidth->value;
         } else if (m_width[i].isAuto()) {

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
@@ -263,7 +263,7 @@ LayoutUnit GridTrackSizingAlgorithm::initialBaseSize(const Style::GridTrackSize&
 
     auto& trackLength = gridLength.length();
     if (trackLength.isSpecified())
-        return Style::evaluate(trackLength, std::max<LayoutUnit>(availableSpace().value_or(0), 0), Style::ZoomNeeded { });
+        return Style::evaluate<LayoutUnit>(trackLength, std::max<LayoutUnit>(availableSpace().value_or(0), 0), Style::ZoomNeeded { });
 
     ASSERT(trackLength.isMinContent() || trackLength.isAuto() || trackLength.isMaxContent());
     return 0;
@@ -277,7 +277,7 @@ LayoutUnit GridTrackSizingAlgorithm::initialGrowthLimit(const Style::GridTrackSi
 
     auto& trackLength = gridLength.length();
     if (trackLength.isSpecified())
-        return Style::evaluate(trackLength, std::max<LayoutUnit>(availableSpace().value_or(0), 0), Style::ZoomNeeded { });
+        return Style::evaluate<LayoutUnit>(trackLength, std::max<LayoutUnit>(availableSpace().value_or(0), 0), Style::ZoomNeeded { });
 
     ASSERT(trackLength.isMinContent() || trackLength.isAuto() || trackLength.isMaxContent());
     return infinity;
@@ -300,7 +300,7 @@ void GridTrackSizingAlgorithm::sizeTrackToFitSingleSpanMasonryGroup(const GridSp
     else if (trackSize.hasMaxContentOrAutoMaxTrackBreadth()) {
         auto growthLimit = masonryIndefiniteItems.maxContentSize;
         if (trackSize.isFitContent())
-            growthLimit = std::min(growthLimit, Style::evaluate(trackSize.fitContentTrackLength(), availableSpace().value_or(0), Style::ZoomNeeded { }));
+            growthLimit = std::min(growthLimit, Style::evaluate<LayoutUnit>(trackSize.fitContentTrackLength(), availableSpace().value_or(0), Style::ZoomNeeded { }));
         track.setGrowthLimit(std::max(track.growthLimit(), growthLimit));
     }
 }
@@ -323,7 +323,7 @@ void GridTrackSizingAlgorithm::sizeTrackToFitNonSpanningItem(const GridSpan& spa
     } else if (trackSize.hasMaxContentOrAutoMaxTrackBreadth()) {
         LayoutUnit growthLimit = m_strategy->maxContentContributionForGridItem(gridItem, gridLayoutState);
         if (trackSize.isFitContent())
-            growthLimit = std::min(growthLimit, Style::evaluate(trackSize.fitContentTrackLength(), availableSpace().value_or(0), Style::ZoomNeeded { }));
+            growthLimit = std::min(growthLimit, Style::evaluate<LayoutUnit>(trackSize.fitContentTrackLength(), availableSpace().value_or(0), Style::ZoomNeeded { }));
         track.setGrowthLimit(std::max(track.growthLimit(), growthLimit));
     }
 }
@@ -828,7 +828,7 @@ std::optional<LayoutUnit> GridTrackSizingAlgorithm::estimatedGridAreaBreadthForG
         if (maxTrackSize.isContentSized() || maxTrackSize.isFlex() || GridLayoutFunctions::isRelativeGridTrackBreadthAsAuto(maxTrackSize, availableSpace(direction)))
             gridAreaIsIndefinite = true;
         else
-            gridAreaSize += Style::evaluate(maxTrackSize.length(), availableSize.value_or(0_lu), Style::ZoomNeeded { });
+            gridAreaSize += Style::evaluate<LayoutUnit>(maxTrackSize.length(), availableSize.value_or(0_lu), Style::ZoomNeeded { });
     }
 
     gridAreaSize += m_renderGrid->guttersSize(direction, span.startLine(), span.integerSpan(), availableSize);
@@ -1193,7 +1193,7 @@ LayoutUnit GridTrackSizingAlgorithmStrategy::minContributionForGridItem(RenderBo
             if (!trackSize.hasFixedMaxTrackBreadth())
                 allFixed = false;
             else if (allFixed)
-                maxBreadth += Style::evaluate(trackSize.maxTrackBreadth().length(), availableSpace().value_or(0_lu), Style::ZoomNeeded { });
+                maxBreadth += Style::evaluate<LayoutUnit>(trackSize.maxTrackBreadth().length(), availableSpace().value_or(0_lu), Style::ZoomNeeded { });
         }
         if (!allFixed)
             return minSize;
@@ -1647,7 +1647,7 @@ void GridTrackSizingAlgorithm::initializeTrackSizes()
         track.setInfinitelyGrowable(false);
 
         if (trackSize.isFitContent())
-            track.setGrowthLimitCap(Style::evaluate(trackSize.fitContentTrackLength(), maxSize, Style::ZoomNeeded { }));
+            track.setGrowthLimitCap(Style::evaluate<LayoutUnit>(trackSize.fitContentTrackLength(), maxSize, Style::ZoomNeeded { }));
         if (trackSize.isContentSized())
             m_contentSizedTracksIndex.append(i);
         if (trackSize.maxTrackBreadth().isFlex())
@@ -2041,7 +2041,7 @@ void GridTrackSizingAlgorithm::setup(Style::GridTrackSizingDirection direction, 
             const auto subgridSpan = m_renderGrid->gridSpanForGridItem(subgrid, Style::GridTrackSizingDirection::Columns);
             auto& subgridRowStartMargin = subgrid.style().marginBefore(m_renderGrid->writingMode());
             if (!subgridRowStartMargin.isAuto())
-                m_renderGrid->setMarginBeforeForChild(subgrid, Style::evaluateMinimum(subgridRowStartMargin, computeGridSpanSize(tracks(Style::GridTrackSizingDirection::Columns), subgridSpan, std::make_optional(m_renderGrid->gridItemOffset(direction)), m_renderGrid->guttersSize(Style::GridTrackSizingDirection::Columns, subgridSpan.startLine(), subgridSpan.integerSpan(), this->availableSpace(Style::GridTrackSizingDirection::Columns))), Style::ZoomNeeded { }));
+                m_renderGrid->setMarginBeforeForChild(subgrid, Style::evaluateMinimum<LayoutUnit>(subgridRowStartMargin, computeGridSpanSize(tracks(Style::GridTrackSizingDirection::Columns), subgridSpan, std::make_optional(m_renderGrid->gridItemOffset(direction)), m_renderGrid->guttersSize(Style::GridTrackSizingDirection::Columns, subgridSpan.startLine(), subgridSpan.integerSpan(), this->availableSpace(Style::GridTrackSizingDirection::Columns))), Style::ZoomNeeded { }));
         }
     };
     if (m_direction == Style::GridTrackSizingDirection::Rows && (m_sizingState == SizingState::RowSizingFirstIteration || m_sizingState == SizingState::RowSizingSecondIteration))

--- a/Source/WebCore/rendering/MotionPath.cpp
+++ b/Source/WebCore/rendering/MotionPath.cpp
@@ -93,16 +93,16 @@ std::optional<MotionPathData> MotionPath::motionPathDataForRenderer(const Render
 
     auto startingPositionForOffsetPosition = [&](const Style::OffsetPosition& offsetPosition, const FloatRect& referenceRect, RenderBlock& container) -> FloatPoint {
         return WTF::switchOn(offsetPosition,
-            [&](const CSS::Keyword::Normal&) -> FloatPoint {
+            [&](const CSS::Keyword::Normal&) {
                 // If offset-position is normal, the element does not have an offset starting position.
                 return normalPositionForOffsetPath(offsetPath, referenceRect);
             },
-            [&](const CSS::Keyword::Auto&) -> FloatPoint  {
+            [&](const CSS::Keyword::Auto&)  {
                 // If offset-position is auto, use top / left corner of the box.
                 return offsetFromContainer(renderer, container, referenceRect);
             },
-            [&](const Style::Position& position) -> FloatPoint {
-                return Style::evaluate(position, referenceRect.size(), Style::ZoomNeeded { });
+            [&](const Style::Position& position) {
+                return Style::evaluate<FloatPoint>(position, referenceRect.size(), Style::ZoomNeeded { });
             }
         );
     };
@@ -124,7 +124,7 @@ std::optional<MotionPathData> MotionPath::motionPathDataForRenderer(const Render
         [&](const Style::RayPath& offsetPath) {
             auto startingPosition = offsetPath.ray()->position;
             data.usedStartingPosition = startingPosition
-                ? Style::evaluate(*startingPosition, data.containingBlockBoundingRect.rect().size(), Style::ZoomNeeded { })
+                ? Style::evaluate<FloatPoint>(*startingPosition, data.containingBlockBoundingRect.rect().size(), Style::ZoomNeeded { })
                 : startingPositionForOffsetPosition(offsetPosition, data.containingBlockBoundingRect.rect(), *container);
         },
         [&](const auto&) { }
@@ -136,7 +136,7 @@ std::optional<MotionPathData> MotionPath::motionPathDataForRenderer(const Render
 static PathTraversalState traversalStateAtDistance(const Path& path, const Style::OffsetDistance& distance)
 {
     auto pathLength = path.length();
-    auto distanceValue = Style::evaluate(distance, pathLength, Style::ZoomNeeded { });
+    auto distanceValue = Style::evaluate<float>(distance, pathLength, Style::ZoomNeeded { });
 
     float resolvedLength = 0;
     if (path.isClosed()) {
@@ -158,7 +158,7 @@ void MotionPath::applyMotionPathTransform(TransformationMatrix& matrix, const Tr
     auto anchor = transformOrigin;
     WTF::switchOn(offsetAnchor,
         [&](const Style::Position& position) {
-            anchor = Style::evaluate(position, boundingBox.size(), Style::ZoomNeeded { }) + boundingBox.location();
+            anchor = Style::evaluate<FloatPoint>(position, boundingBox.size(), Style::ZoomNeeded { }) + boundingBox.location();
         },
         [&](const CSS::Keyword::Auto&) { }
     );

--- a/Source/WebCore/rendering/NinePieceImagePainter.cpp
+++ b/Source/WebCore/rendering/NinePieceImagePainter.cpp
@@ -79,7 +79,7 @@ static LayoutUnit computeSlice(const WidthValue& length, LayoutUnit width, Layou
 {
     return WTF::switchOn(length,
         [&](const typename WidthValue::LengthPercentage& value) {
-            return Style::evaluate(value, extent, Style::ZoomNeeded { });
+            return Style::evaluate<LayoutUnit>(value, extent, Style::ZoomNeeded { });
         },
         [&](const typename WidthValue::Number& value) {
             return LayoutUnit { value.value * width };
@@ -105,10 +105,10 @@ template<typename SliceValues>
 static LayoutBoxExtent computeSlices(const LayoutSize& size, const SliceValues& slices, int scaleFactor)
 {
     return {
-        std::min(size.height(),  Style::evaluate(slices.values.top(),    size.height())) * scaleFactor,
-        std::min(size.width(),   Style::evaluate(slices.values.right(),  size.width()))  * scaleFactor,
-        std::min(size.height(),  Style::evaluate(slices.values.bottom(), size.height())) * scaleFactor,
-        std::min(size.width(),   Style::evaluate(slices.values.left(),   size.width()))  * scaleFactor,
+        std::min(size.height(),  Style::evaluate<LayoutUnit>(slices.values.top(),    size.height())) * scaleFactor,
+        std::min(size.width(),   Style::evaluate<LayoutUnit>(slices.values.right(),  size.width()))  * scaleFactor,
+        std::min(size.height(),  Style::evaluate<LayoutUnit>(slices.values.bottom(), size.height())) * scaleFactor,
+        std::min(size.width(),   Style::evaluate<LayoutUnit>(slices.values.left(),   size.width()))  * scaleFactor,
     };
 }
 
@@ -230,7 +230,7 @@ static void paintNinePieceImage(const T& ninePieceImage, GraphicsContext& graphi
     ASSERT(styleImage->isLoaded(renderer));
 
     auto sourceSlices      = computeSlices(source, ninePieceImage.slice(), styleImage->imageScaleFactor());
-    auto destinationSlices = computeSlices(destination.size(), ninePieceImage.width(), Style::evaluate(style.borderWidth(), Style::ZoomNeeded { }), sourceSlices);
+    auto destinationSlices = computeSlices(destination.size(), ninePieceImage.width(), Style::evaluate<LayoutBoxExtent>(style.borderWidth(), Style::ZoomNeeded { }), sourceSlices);
 
     scaleSlicesIfNeeded(destination.size(), destinationSlices, deviceScaleFactor);
 

--- a/Source/WebCore/rendering/PositionedLayoutConstraints.h
+++ b/Source/WebCore/rendering/PositionedLayoutConstraints.h
@@ -75,10 +75,10 @@ public:
     Style::MarginEdge marginAfter() const { return m_marginAfter; }
     Style::InsetEdge insetBefore() const { return m_insetBefore; }
     Style::InsetEdge insetAfter() const { return m_insetAfter; }
-    LayoutUnit marginBeforeValue() const { return Style::evaluateMinimum(m_marginBefore, m_containingInlineSize, Style::ZoomNeeded { }); }
-    LayoutUnit marginAfterValue() const { return Style::evaluateMinimum(m_marginAfter, m_containingInlineSize, Style::ZoomNeeded { }); }
-    LayoutUnit insetBeforeValue() const { return Style::evaluateMinimum(m_insetBefore, containingSize(), Style::ZoomNeeded { }); }
-    LayoutUnit insetAfterValue() const { return Style::evaluateMinimum(m_insetAfter, containingSize(), Style::ZoomNeeded { }); }
+    LayoutUnit marginBeforeValue() const { return Style::evaluateMinimum<LayoutUnit>(m_marginBefore, m_containingInlineSize, Style::ZoomNeeded { }); }
+    LayoutUnit marginAfterValue() const { return Style::evaluateMinimum<LayoutUnit>(m_marginAfter, m_containingInlineSize, Style::ZoomNeeded { }); }
+    LayoutUnit insetBeforeValue() const { return Style::evaluateMinimum<LayoutUnit>(m_insetBefore, containingSize(), Style::ZoomNeeded { }); }
+    LayoutUnit insetAfterValue() const { return Style::evaluateMinimum<LayoutUnit>(m_insetAfter, containingSize(), Style::ZoomNeeded { }); }
 
     LayoutUnit insetModifiedContainingSize() const { return m_insetModifiedContainingRange.size(); }
     LayoutRange insetModifiedContainingRange() const { return m_insetModifiedContainingRange; }

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -1842,7 +1842,7 @@ LayoutUnit RenderBlock::textIndentOffset() const
     LayoutUnit cw;
     if (style().textIndent().length.isPercentOrCalculated())
         cw = contentBoxLogicalWidth();
-    return Style::evaluate(style().textIndent().length, cw, Style::ZoomNeeded { });
+    return Style::evaluate<LayoutUnit>(style().textIndent().length, cw, Style::ZoomNeeded { });
 }
 
 LayoutUnit RenderBlock::logicalLeftOffsetForContent() const

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -291,7 +291,7 @@ void RenderBlockFlow::adjustIntrinsicLogicalWidthsForColumns(LayoutUnit& minLogi
         LayoutUnit colGap = columnGap();
         LayoutUnit gapExtra = (columnCount - 1) * colGap;
         if (auto columnWidthLength = style().columnWidth().tryLength()) {
-            columnWidth = Style::evaluate(*columnWidthLength, Style::ZoomNeeded { });
+            columnWidth = Style::evaluate<LayoutUnit>(*columnWidthLength, Style::ZoomNeeded { });
             minLogicalWidth = std::min(minLogicalWidth, columnWidth);
         } else
             minLogicalWidth = minLogicalWidth * columnCount + gapExtra;
@@ -355,7 +355,7 @@ LayoutUnit RenderBlockFlow::columnGap() const
 {
     if (style().columnGap().isNormal())
         return LayoutUnit(style().fontDescription().computedSize()); // "1em" is recommended as the normal gap setting. Matches <p> margins.
-    return Style::evaluate(style().columnGap(), contentBoxLogicalWidth(), Style::ZoomNeeded { });
+    return Style::evaluate<LayoutUnit>(style().columnGap(), contentBoxLogicalWidth(), Style::ZoomNeeded { });
 }
 
 void RenderBlockFlow::computeColumnCountAndWidth()
@@ -373,7 +373,7 @@ void RenderBlockFlow::computeColumnCountAndWidth()
 
     LayoutUnit availWidth = desiredColumnWidth;
     LayoutUnit colGap = columnGap();
-    LayoutUnit colWidth = std::max(1_lu, LayoutUnit(Style::evaluate(style().columnWidth().tryLength().value_or(0_css_px), Style::ZoomNeeded { })));
+    LayoutUnit colWidth = std::max(1_lu, Style::evaluate<LayoutUnit>(style().columnWidth().tryLength().value_or(0_css_px), Style::ZoomNeeded { }));
     unsigned colCount = std::max<unsigned>(1, style().columnCount().tryValue().value_or(1).value);
 
     if (style().columnWidth().isAuto() && !style().columnCount().isAuto()) {
@@ -4572,9 +4572,10 @@ static inline std::optional<LayoutUnit> textIndentForBlockContainer(const Render
     auto indentValue = LayoutUnit { };
     if (auto* containingBlock = renderer.containingBlock()) {
         if (auto containingBlockFixedLogicalWidth = containingBlock->style().logicalWidth().tryFixed()) {
+            auto containingBlockFixedLogicalWidthValue = Style::evaluate<LayoutUnit>(*containingBlockFixedLogicalWidth, Style::ZoomNeeded { });
             // At this point of the shrink-to-fit computation, we don't have a used value for the containing block width
             // (that's exactly to what we try to contribute here) unless the computed value is fixed.
-            indentValue = Style::evaluate(style.textIndent().length, containingBlockFixedLogicalWidth->resolveZoom(Style::ZoomNeeded { }), Style::ZoomNeeded { });
+            indentValue = Style::evaluate<LayoutUnit>(style.textIndent().length, containingBlockFixedLogicalWidthValue, Style::ZoomNeeded { });
         }
     }
     return indentValue ? std::make_optional(indentValue) : std::nullopt;

--- a/Source/WebCore/rendering/RenderBoxModelObject.cpp
+++ b/Source/WebCore/rendering/RenderBoxModelObject.cpp
@@ -403,11 +403,11 @@ LayoutSize RenderBoxModelObject::relativePositionOffset() const
         };
         if (!left.isAuto()) {
             if (!right.isAuto() && !containingBlock->writingMode().isAnyLeftToRight())
-                offset.setWidth(-Style::evaluate(right, !right.isFixed() ? availableWidth() : 0_lu, Style::ZoomNeeded { }));
+                offset.setWidth(-Style::evaluate<LayoutUnit>(right, !right.isFixed() ? availableWidth() : 0_lu, Style::ZoomNeeded { }));
             else
-                offset.expand(Style::evaluate(left, !left.isFixed() ? availableWidth() : 0_lu, Style::ZoomNeeded { }), 0_lu);
+                offset.expand(Style::evaluate<LayoutUnit>(left, !left.isFixed() ? availableWidth() : 0_lu, Style::ZoomNeeded { }), 0_lu);
         } else if (!right.isAuto())
-            offset.expand(-Style::evaluate(right, !right.isFixed() ? availableWidth() : 0_lu, Style::ZoomNeeded { }), 0_lu);
+            offset.expand(-Style::evaluate<LayoutUnit>(right, !right.isFixed() ? availableWidth() : 0_lu, Style::ZoomNeeded { }), 0_lu);
     }
 
     // If the containing block of a relatively positioned element does not
@@ -438,10 +438,10 @@ LayoutSize RenderBoxModelObject::relativePositionOffset() const
         // FIXME: The computation of the available height is repeated later for "bottom".
         // We could refactor this and move it to some common code for both ifs, however moving it outside of the ifs
         // is not possible as it'd cause performance regressions.
-        offset.expand(0_lu, Style::evaluate(top, !top.isFixed() ? availableHeight() : 0_lu, Style::ZoomNeeded { }));
+        offset.expand(0_lu, Style::evaluate<LayoutUnit>(top, !top.isFixed() ? availableHeight() : 0_lu, Style::ZoomNeeded { }));
     } else if (!bottom.isAuto() && (!bottom.isPercentOrCalculated() || containingBlockHasDefiniteHeight)) {
         // FIXME: Check comment above for "top", it applies here too.
-        offset.expand(0_lu, -Style::evaluate(bottom, !bottom.isFixed() ? availableHeight() : 0_lu, Style::ZoomNeeded { }));
+        offset.expand(0_lu, -Style::evaluate<LayoutUnit>(bottom, !bottom.isFixed() ? availableHeight() : 0_lu, Style::ZoomNeeded { }));
     }
     return offset;
 }
@@ -550,10 +550,10 @@ void RenderBoxModelObject::computeStickyPositionConstraints(StickyPositionViewpo
     // Sticky positioned element ignore any override logical width on the containing block (as they don't call
     // containingBlockLogicalWidthForContent). It's unclear whether this is totally fine.
     LayoutBoxExtent minMargin(
-        Style::evaluateMinimum(style().marginTop(), maxWidth, Style::ZoomNeeded { }),
-        Style::evaluateMinimum(style().marginRight(), maxWidth, Style::ZoomNeeded { }),
-        Style::evaluateMinimum(style().marginBottom(), maxWidth, Style::ZoomNeeded { }),
-        Style::evaluateMinimum(style().marginLeft(), maxWidth, Style::ZoomNeeded { })
+        Style::evaluateMinimum<LayoutUnit>(style().marginTop(), maxWidth, Style::ZoomNeeded { }),
+        Style::evaluateMinimum<LayoutUnit>(style().marginRight(), maxWidth, Style::ZoomNeeded { }),
+        Style::evaluateMinimum<LayoutUnit>(style().marginBottom(), maxWidth, Style::ZoomNeeded { }),
+        Style::evaluateMinimum<LayoutUnit>(style().marginLeft(), maxWidth, Style::ZoomNeeded { })
     );
 
     // Compute the container-relative area within which the sticky element is allowed to move.
@@ -603,22 +603,22 @@ void RenderBoxModelObject::computeStickyPositionConstraints(StickyPositionViewpo
     constraints.setStickyBoxRect(stickyBoxRelativeToScrollingAncestor);
 
     if (!style().left().isAuto()) {
-        constraints.setLeftOffset(Style::evaluate(style().left(), constrainingRect.width(), Style::ZoomNeeded { }));
+        constraints.setLeftOffset(Style::evaluate<float>(style().left(), constrainingRect.width(), Style::ZoomNeeded { }));
         constraints.addAnchorEdge(ViewportConstraints::AnchorEdgeLeft);
     }
 
     if (!style().right().isAuto()) {
-        constraints.setRightOffset(Style::evaluate(style().right(), constrainingRect.width(), Style::ZoomNeeded { }));
+        constraints.setRightOffset(Style::evaluate<float>(style().right(), constrainingRect.width(), Style::ZoomNeeded { }));
         constraints.addAnchorEdge(ViewportConstraints::AnchorEdgeRight);
     }
 
     if (!style().top().isAuto()) {
-        constraints.setTopOffset(Style::evaluate(style().top(), constrainingRect.height(), Style::ZoomNeeded { }));
+        constraints.setTopOffset(Style::evaluate<float>(style().top(), constrainingRect.height(), Style::ZoomNeeded { }));
         constraints.addAnchorEdge(ViewportConstraints::AnchorEdgeTop);
     }
 
     if (!style().bottom().isAuto()) {
-        constraints.setBottomOffset(Style::evaluate(style().bottom(), constrainingRect.height(), Style::ZoomNeeded { }));
+        constraints.setBottomOffset(Style::evaluate<float>(style().bottom(), constrainingRect.height(), Style::ZoomNeeded { }));
         constraints.addAnchorEdge(ViewportConstraints::AnchorEdgeBottom);
     }
 }

--- a/Source/WebCore/rendering/RenderBoxModelObjectInlines.h
+++ b/Source/WebCore/rendering/RenderBoxModelObjectInlines.h
@@ -25,7 +25,7 @@
 
 namespace WebCore {
 
-inline LayoutUnit RenderBoxModelObject::borderAfter() const { return LayoutUnit(Style::evaluate(style().borderAfterWidth(), Style::ZoomNeeded { })); }
+inline LayoutUnit RenderBoxModelObject::borderAfter() const { return Style::evaluate<LayoutUnit>(style().borderAfterWidth(), Style::ZoomNeeded { }); }
 inline LayoutUnit RenderBoxModelObject::borderAndPaddingAfter() const { return borderAfter() + paddingAfter(); }
 inline LayoutUnit RenderBoxModelObject::borderAndPaddingBefore() const { return borderBefore() + paddingBefore(); }
 inline LayoutUnit RenderBoxModelObject::borderAndPaddingLogicalHeight() const { return borderAndPaddingBefore() + borderAndPaddingAfter(); }
@@ -34,17 +34,17 @@ inline LayoutUnit RenderBoxModelObject::borderAndPaddingLogicalLeft() const { re
 inline LayoutUnit RenderBoxModelObject::borderAndPaddingLogicalRight() const { return writingMode().isHorizontal() ? borderRight() + paddingRight() : borderBottom() + paddingBottom(); }
 inline LayoutUnit RenderBoxModelObject::borderAndPaddingStart() const { return borderStart() + paddingStart(); }
 inline LayoutUnit RenderBoxModelObject::borderAndPaddingEnd() const { return borderEnd() + paddingEnd(); }
-inline LayoutUnit RenderBoxModelObject::borderBefore() const { return LayoutUnit(Style::evaluate(style().borderBeforeWidth(), Style::ZoomNeeded { })); }
-inline LayoutUnit RenderBoxModelObject::borderBottom() const { return LayoutUnit(Style::evaluate(style().borderBottomWidth(), Style::ZoomNeeded { })); }
-inline LayoutUnit RenderBoxModelObject::borderEnd() const { return LayoutUnit(Style::evaluate(style().borderEndWidth(), Style::ZoomNeeded { })); }
-inline LayoutUnit RenderBoxModelObject::borderLeft() const { return LayoutUnit(Style::evaluate(style().borderLeftWidth(), Style::ZoomNeeded { })); }
+inline LayoutUnit RenderBoxModelObject::borderBefore() const { return Style::evaluate<LayoutUnit>(style().borderBeforeWidth(), Style::ZoomNeeded { }); }
+inline LayoutUnit RenderBoxModelObject::borderBottom() const { return Style::evaluate<LayoutUnit>(style().borderBottomWidth(), Style::ZoomNeeded { }); }
+inline LayoutUnit RenderBoxModelObject::borderEnd() const { return Style::evaluate<LayoutUnit>(style().borderEndWidth(), Style::ZoomNeeded { }); }
+inline LayoutUnit RenderBoxModelObject::borderLeft() const { return Style::evaluate<LayoutUnit>(style().borderLeftWidth(), Style::ZoomNeeded { }); }
 inline LayoutUnit RenderBoxModelObject::borderLogicalHeight() const { return borderBefore() + borderAfter(); }
 inline LayoutUnit RenderBoxModelObject::borderLogicalLeft() const { return writingMode().isHorizontal() ? borderLeft() : borderTop(); }
 inline LayoutUnit RenderBoxModelObject::borderLogicalRight() const { return writingMode().isHorizontal() ? borderRight() : borderBottom(); }
 inline LayoutUnit RenderBoxModelObject::borderLogicalWidth() const { return borderStart() + borderEnd(); }
-inline LayoutUnit RenderBoxModelObject::borderRight() const { return LayoutUnit(Style::evaluate(style().borderRightWidth(), Style::ZoomNeeded { })); }
-inline LayoutUnit RenderBoxModelObject::borderStart() const { return LayoutUnit(Style::evaluate(style().borderStartWidth(), Style::ZoomNeeded { })); }
-inline LayoutUnit RenderBoxModelObject::borderTop() const { return LayoutUnit(Style::evaluate(style().borderTopWidth(), Style::ZoomNeeded { })); }
+inline LayoutUnit RenderBoxModelObject::borderRight() const { return Style::evaluate<LayoutUnit>(style().borderRightWidth(), Style::ZoomNeeded { }); }
+inline LayoutUnit RenderBoxModelObject::borderStart() const { return Style::evaluate<LayoutUnit>(style().borderStartWidth(), Style::ZoomNeeded { }); }
+inline LayoutUnit RenderBoxModelObject::borderTop() const { return Style::evaluate<LayoutUnit>(style().borderTopWidth(), Style::ZoomNeeded { }); }
 inline LayoutUnit RenderBoxModelObject::computedCSSPaddingAfter() const { return resolveLengthPercentageUsingContainerLogicalWidth(style().paddingAfter()); }
 inline LayoutUnit RenderBoxModelObject::computedCSSPaddingBefore() const { return resolveLengthPercentageUsingContainerLogicalWidth(style().paddingBefore()); }
 inline LayoutUnit RenderBoxModelObject::computedCSSPaddingBottom() const { return resolveLengthPercentageUsingContainerLogicalWidth(style().paddingBottom()); }
@@ -81,7 +81,7 @@ inline LayoutUnit RenderBoxModelObject::verticalBorderExtent() const { return bo
 inline RectEdges<LayoutUnit> RenderBoxModelObject::borderWidths() const
 {
     return RectEdges<LayoutUnit>::map(style().borderWidth(), [&](auto width) {
-        return LayoutUnit { Style::evaluate(width, Style::ZoomNeeded { }) };
+        return Style::evaluate<LayoutUnit>(width, Style::ZoomNeeded { });
     });
 }
 
@@ -100,7 +100,7 @@ inline LayoutUnit RenderBoxModelObject::resolveLengthPercentageUsingContainerLog
     LayoutUnit containerWidth;
     if (value.isPercentOrCalculated())
         containerWidth = containingBlockLogicalWidthForContent();
-    return Style::evaluateMinimum(value, containerWidth, Style::ZoomNeeded { });
+    return Style::evaluateMinimum<LayoutUnit>(value, containerWidth, Style::ZoomNeeded { });
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -1510,12 +1510,12 @@ bool RenderElement::repaintAfterLayoutIfNeeded(SingleThreadWeakPtr<const RenderL
                 auto borderBoxWidth = renderBox->width();
                 return std::max({
                     renderBox->borderRight(),
-                    Style::evaluate(style.borderTopRightRadius().width(), borderBoxWidth, Style::ZoomNeeded { }),
-                    Style::evaluate(style.borderBottomRightRadius().width(), borderBoxWidth, Style::ZoomNeeded { }),
+                    Style::evaluate<LayoutUnit>(style.borderTopRightRadius().width(), borderBoxWidth, Style::ZoomNeeded { }),
+                    Style::evaluate<LayoutUnit>(style.borderBottomRightRadius().width(), borderBoxWidth, Style::ZoomNeeded { }),
                 });
             };
-            auto outlineRightInsetExtent = [&]() -> LayoutUnit {
-                auto offset = LayoutUnit { Style::evaluate(outlineStyle.outlineOffset(), Style::ZoomNeeded { }) };
+            auto outlineRightInsetExtent = [&] -> LayoutUnit {
+                auto offset = Style::evaluate<LayoutUnit>(outlineStyle.outlineOffset(), Style::ZoomNeeded { });
                 return offset < 0 ? -offset : 0_lu;
             };
             auto boxShadowRightInsetExtent = [&] {
@@ -1554,12 +1554,12 @@ bool RenderElement::repaintAfterLayoutIfNeeded(SingleThreadWeakPtr<const RenderL
                 auto borderBoxHeight = renderBox->height();
                 return std::max({
                     renderBox->borderBottom(),
-                    Style::evaluate(style.borderBottomLeftRadius().height(), borderBoxHeight, Style::ZoomNeeded { }),
-                    Style::evaluate(style.borderBottomRightRadius().height(), borderBoxHeight, Style::ZoomNeeded { }),
+                    Style::evaluate<LayoutUnit>(style.borderBottomLeftRadius().height(), borderBoxHeight, Style::ZoomNeeded { }),
+                    Style::evaluate<LayoutUnit>(style.borderBottomRightRadius().height(), borderBoxHeight, Style::ZoomNeeded { }),
                 });
             };
-            auto outlineBottomInsetExtent = [&]() -> LayoutUnit {
-                auto offset = LayoutUnit { Style::evaluate(outlineStyle.outlineOffset(), Style::ZoomNeeded { }) };
+            auto outlineBottomInsetExtent = [&] -> LayoutUnit {
+                auto offset = Style::evaluate<LayoutUnit>(outlineStyle.outlineOffset(), Style::ZoomNeeded { });
                 return offset < 0 ? -offset : 0_lu;
             };
             auto boxShadowBottomInsetExtent = [&]() -> LayoutUnit {
@@ -2120,22 +2120,22 @@ static bool useShrinkWrappedFocusRingForOutlineStyleAuto()
 
 static void drawFocusRing(GraphicsContext& context, const Path& path, const RenderStyle& style, const Color& color)
 {
-    context.drawFocusRing(path, Style::evaluate(style.outlineWidth(), Style::ZoomNeeded { }), color);
+    context.drawFocusRing(path, Style::evaluate<float>(style.outlineWidth(), Style::ZoomNeeded { }), color);
 }
 
 static void drawFocusRing(GraphicsContext& context, Vector<FloatRect> rects, const RenderStyle& style, const Color& color)
 {
 #if PLATFORM(MAC)
-    context.drawFocusRing(rects, 0, Style::evaluate(style.outlineWidth(), Style::ZoomNeeded { }), color);
+    context.drawFocusRing(rects, 0, Style::evaluate<float>(style.outlineWidth(), Style::ZoomNeeded { }), color);
 #else
-    context.drawFocusRing(rects, Style::evaluate(style.outlineOffset(), Style::ZoomNeeded { }), Style::evaluate(style.outlineWidth(), Style::ZoomNeeded { }), color);
+    context.drawFocusRing(rects, Style::evaluate<float>(style.outlineOffset(), Style::ZoomNeeded { }), Style::evaluate<float>(style.outlineWidth(), Style::ZoomNeeded { }), color);
 #endif
 }
 
 void RenderElement::paintFocusRing(const PaintInfo& paintInfo, const RenderStyle& style, const Vector<LayoutRect>& focusRingRects) const
 {
     ASSERT(style.outlineStyle() == OutlineStyle::Auto);
-    float outlineOffset = Style::evaluate(style.outlineOffset(), Style::ZoomNeeded { });
+    auto outlineOffset = Style::evaluate<float>(style.outlineOffset(), Style::ZoomNeeded { });
     Vector<FloatRect> pixelSnappedFocusRingRects;
     float deviceScaleFactor = document().deviceScaleFactor();
     for (auto rect : focusRingRects) {

--- a/Source/WebCore/rendering/RenderFileUploadControl.cpp
+++ b/Source/WebCore/rendering/RenderFileUploadControl.cpp
@@ -296,7 +296,7 @@ void RenderFileUploadControl::computeIntrinsicLogicalWidths(LayoutUnit& minLogic
 
     auto& logicalWidth = style().logicalWidth();
     if (logicalWidth.isCalculated())
-        minLogicalWidth = std::max(0_lu, Style::evaluate(logicalWidth, 0_lu, Style::ZoomNeeded { }));
+        minLogicalWidth = std::max(0_lu, Style::evaluate<LayoutUnit>(logicalWidth, 0_lu, Style::ZoomNeeded { }));
     else if (!logicalWidth.isPercent())
         minLogicalWidth = maxLogicalWidth;
 }

--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -1114,12 +1114,12 @@ template<typename SizeType> LayoutUnit RenderFlexibleBox::computeMainSizeFromAsp
         [&](const SizeType::Percentage& percentageCrossSizeLength) -> std::optional<LayoutUnit> {
             return mainAxisIsFlexItemInlineAxis(flexItem)
                 ? flexItem.computePercentageLogicalHeight(percentageCrossSizeLength)
-                : adjustBorderBoxLogicalWidthForBoxSizing(Style::evaluate(percentageCrossSizeLength, contentBoxWidth()));
+                : adjustBorderBoxLogicalWidthForBoxSizing(Style::evaluate<LayoutUnit>(percentageCrossSizeLength, contentBoxWidth()));
         },
         [&](const SizeType::Calc& calcCrossSizeLength) -> std::optional<LayoutUnit> {
             return mainAxisIsFlexItemInlineAxis(flexItem)
                 ? flexItem.computePercentageLogicalHeight(calcCrossSizeLength)
-                : adjustBorderBoxLogicalWidthForBoxSizing(Style::evaluate(calcCrossSizeLength, contentBoxWidth()));
+                : adjustBorderBoxLogicalWidthForBoxSizing(Style::evaluate<LayoutUnit>(calcCrossSizeLength, contentBoxWidth()));
         },
         [&](const CSS::Keyword::Auto&) -> std::optional<LayoutUnit> {
             ASSERT(flexItemCrossSizeShouldUseContainerCrossSize(flexItem));
@@ -1647,7 +1647,7 @@ LayoutUnit RenderFlexibleBox::computeFlexItemMarginValue(const Style::MarginEdge
 {
     // When resolving the margins, we use the content size for resolving percent and calc (for percents in calc expressions) margins.
     // Fortunately, percent margins are always computed with respect to the block's width, even for margin-top and margin-bottom.
-    return Style::evaluateMinimum(margin, contentBoxLogicalWidth(), Style::ZoomNeeded { });
+    return Style::evaluateMinimum<LayoutUnit>(margin, contentBoxLogicalWidth(), Style::ZoomNeeded { });
 }
 
 void RenderFlexibleBox::prepareOrderIteratorAndMargins()
@@ -2783,7 +2783,7 @@ LayoutUnit RenderFlexibleBox::computeGap(RenderFlexibleBox::GapType gapType) con
         return { };
 
     auto availableSize = usesRowGap ? availableLogicalHeightForPercentageComputation().value_or(0_lu) : contentBoxLogicalWidth();
-    return Style::evaluateMinimum(gap, availableSize, Style::ZoomNeeded { });
+    return Style::evaluateMinimum<LayoutUnit>(gap, availableSize, Style::ZoomNeeded { });
 }
 
 bool RenderFlexibleBox::layoutUsingFlexFormattingContext()

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -699,7 +699,7 @@ LayoutUnit RenderGrid::gridGap(Style::GridTrackSizingDirection direction, std::o
         return downcast<RenderGrid>(parent())->gridGap(parentDirection);
     }
 
-    return Style::evaluate(gap, availableSize.value_or(0_lu), Style::ZoomNeeded { });
+    return Style::evaluate<LayoutUnit>(gap, availableSize.value_or(0_lu), Style::ZoomNeeded { });
 }
 
 LayoutUnit RenderGrid::gridGap(Style::GridTrackSizingDirection direction) const
@@ -899,13 +899,13 @@ unsigned RenderGrid::computeAutoRepeatTracksCount(Style::GridTrackSizingDirectio
                     : adjustContentBoxLogicalHeightForBoxSizing(maxSizeValue);
             },
             [&](const Style::MaximumSize::Percentage& percentageMaxSize) -> std::optional<LayoutUnit> {
-                auto maxSizeValue = Style::evaluate(percentageMaxSize, containingBlockAvailableSize());
+                auto maxSizeValue = Style::evaluate<LayoutUnit>(percentageMaxSize, containingBlockAvailableSize());
                 return isRowAxis
                     ? adjustContentBoxLogicalWidthForBoxSizing(maxSizeValue)
                     : adjustContentBoxLogicalHeightForBoxSizing(maxSizeValue);
             },
             [&](const Style::MaximumSize::Calc& calcMaxSize) -> std::optional<LayoutUnit> {
-                auto maxSizeValue = Style::evaluate(calcMaxSize, containingBlockAvailableSize());
+                auto maxSizeValue = Style::evaluate<LayoutUnit>(calcMaxSize, containingBlockAvailableSize());
                 return isRowAxis
                     ? adjustContentBoxLogicalWidthForBoxSizing(maxSizeValue)
                     : adjustContentBoxLogicalHeightForBoxSizing(maxSizeValue);
@@ -931,13 +931,13 @@ unsigned RenderGrid::computeAutoRepeatTracksCount(Style::GridTrackSizingDirectio
                     : adjustContentBoxLogicalHeightForBoxSizing(minSizeValue);
             },
             [&](const Style::MinimumSize::Percentage& percentageMinSize) -> std::optional<LayoutUnit> {
-                auto minSizeValue = Style::evaluate(percentageMinSize, containingBlockAvailableSize());
+                auto minSizeValue = Style::evaluate<LayoutUnit>(percentageMinSize, containingBlockAvailableSize());
                 return isRowAxis
                     ? adjustContentBoxLogicalWidthForBoxSizing(minSizeValue)
                     : adjustContentBoxLogicalHeightForBoxSizing(minSizeValue);
             },
             [&](const Style::MinimumSize::Calc& calcMinSize) -> std::optional<LayoutUnit> {
-                auto minSizeValue = Style::evaluate(calcMinSize, containingBlockAvailableSize());
+                auto minSizeValue = Style::evaluate<LayoutUnit>(calcMinSize, containingBlockAvailableSize());
                 return isRowAxis
                     ? adjustContentBoxLogicalWidthForBoxSizing(minSizeValue)
                     : adjustContentBoxLogicalHeightForBoxSizing(minSizeValue);
@@ -970,8 +970,8 @@ unsigned RenderGrid::computeAutoRepeatTracksCount(Style::GridTrackSizingDirectio
 
         auto contributingTrackSize = [&] {
             if (hasDefiniteMaxTrackSizingFunction && hasDefiniteMinTrackSizingFunction)
-                return std::max(Style::evaluate(minTrackSizingFunction.length(), *availableSize, Style::ZoomNeeded { }), Style::evaluate(maxTrackSizingFunction.length(), *availableSize, Style::ZoomNeeded { }));
-            return hasDefiniteMaxTrackSizingFunction ? Style::evaluate(maxTrackSizingFunction.length(), *availableSize, Style::ZoomNeeded { }) : Style::evaluate(minTrackSizingFunction.length(), *availableSize, Style::ZoomNeeded { });
+                return std::max(Style::evaluate<LayoutUnit>(minTrackSizingFunction.length(), *availableSize, Style::ZoomNeeded { }), Style::evaluate<LayoutUnit>(maxTrackSizingFunction.length(), *availableSize, Style::ZoomNeeded { }));
+            return hasDefiniteMaxTrackSizingFunction ? Style::evaluate<LayoutUnit>(maxTrackSizingFunction.length(), *availableSize, Style::ZoomNeeded { }) : Style::evaluate<LayoutUnit>(minTrackSizingFunction.length(), *availableSize, Style::ZoomNeeded { });
         };
         autoRepeatTracksSize += contributingTrackSize();
     }
@@ -986,7 +986,7 @@ unsigned RenderGrid::computeAutoRepeatTracksCount(Style::GridTrackSizingDirectio
     for (const auto& track : trackSizes) {
         bool hasDefiniteMaxTrackBreadth = track.maxTrackBreadth().isLength() && !track.maxTrackBreadth().isContentSized();
         ASSERT(hasDefiniteMaxTrackBreadth || (track.minTrackBreadth().isLength() && !track.minTrackBreadth().isContentSized()));
-        tracksSize += Style::evaluate(hasDefiniteMaxTrackBreadth ? track.maxTrackBreadth().length() : track.minTrackBreadth().length(), availableSize.value(), Style::ZoomNeeded { });
+        tracksSize += Style::evaluate<LayoutUnit>(hasDefiniteMaxTrackBreadth ? track.maxTrackBreadth().length() : track.minTrackBreadth().length(), availableSize.value(), Style::ZoomNeeded { });
     }
 
     // Add gutters as if auto repeat tracks were only repeated once. Gaps between different repetitions will be added later when

--- a/Source/WebCore/rendering/RenderImage.cpp
+++ b/Source/WebCore/rendering/RenderImage.cpp
@@ -694,7 +694,7 @@ void RenderImage::paintAreaElementFocusRing(PaintInfo& paintInfo, const LayoutPo
     if (!areaElementStyle)
         return;
 
-    float outlineWidth = Style::evaluate(areaElementStyle->outlineWidth(), Style::ZoomNeeded { });
+    auto outlineWidth = Style::evaluate<float>(areaElementStyle->outlineWidth(), Style::ZoomNeeded { });
     if (!outlineWidth)
         return;
 

--- a/Source/WebCore/rendering/RenderInline.cpp
+++ b/Source/WebCore/rendering/RenderInline.cpp
@@ -349,7 +349,7 @@ LayoutPoint RenderInline::firstInlineBoxTopLeft() const
 
 static LayoutUnit computeMargin(const RenderInline* renderer, const Style::MarginEdge& margin)
 {
-    return Style::evaluateMinimum(margin, [&] ALWAYS_INLINE_LAMBDA {
+    return Style::evaluateMinimum<LayoutUnit>(margin, [&] ALWAYS_INLINE_LAMBDA {
         return std::max<LayoutUnit>(0, renderer->containingBlock()->contentBoxLogicalWidth());
     }, Style::ZoomNeeded { });
 }

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -2292,7 +2292,7 @@ FloatPoint RenderLayer::perspectiveOrigin() const
 {
     if (!renderer().hasTransformRelatedProperty())
         return { };
-    return Style::evaluate(renderer().style().perspectiveOrigin(), renderer().transformReferenceBoxRect(renderer().style()).size(), Style::ZoomNeeded { });
+    return Style::evaluate<FloatPoint>(renderer().style().perspectiveOrigin(), renderer().transformReferenceBoxRect(renderer().style()).size(), Style::ZoomNeeded { });
 }
 
 static inline bool isContainerForPositioned(RenderLayer& layer, PositionType position, bool establishesTopLayer)
@@ -2975,8 +2975,8 @@ LayoutSize RenderLayer::minimumSizeForResizing(float zoomFactor) const
 {
     // Use the resizer size as the strict minimum size
     auto resizerRect = overflowControlsRects().resizer;
-    LayoutUnit minWidth = Style::evaluateMinimum(renderer().style().minWidth(), renderer().containingBlock()->width(), Style::ZoomNeeded { });
-    LayoutUnit minHeight = Style::evaluateMinimum(renderer().style().minHeight(), renderer().containingBlock()->height(), Style::ZoomNeeded { });
+    auto minWidth = Style::evaluateMinimum<LayoutUnit>(renderer().style().minWidth(), renderer().containingBlock()->width(), Style::ZoomNeeded { });
+    auto minHeight = Style::evaluateMinimum<LayoutUnit>(renderer().style().minHeight(), renderer().containingBlock()->height(), Style::ZoomNeeded { });
     minWidth = std::max(LayoutUnit(minWidth / zoomFactor), LayoutUnit(resizerRect.width()));
     minHeight = std::max(LayoutUnit(minHeight / zoomFactor), LayoutUnit(resizerRect.height()));
     return LayoutSize(minWidth, minHeight);

--- a/Source/WebCore/rendering/RenderListBox.cpp
+++ b/Source/WebCore/rendering/RenderListBox.cpp
@@ -235,7 +235,7 @@ void RenderListBox::computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidth, L
 
     auto& logicalWidth = style().logicalWidth();
     if (logicalWidth.isCalculated())
-        minLogicalWidth = std::max(0_lu, Style::evaluate(logicalWidth, 0_lu, Style::ZoomNeeded { }));
+        minLogicalWidth = std::max(0_lu, Style::evaluate<LayoutUnit>(logicalWidth, 0_lu, Style::ZoomNeeded { }));
     else if (!logicalWidth.isPercent())
         minLogicalWidth = maxLogicalWidth;
 }

--- a/Source/WebCore/rendering/RenderMarquee.cpp
+++ b/Source/WebCore/rendering/RenderMarquee.cpp
@@ -297,7 +297,7 @@ void RenderMarquee::timerFired()
         }
         bool positive = range > 0;
         int clientSize = (isHorizontal() ? roundToInt(renderBox->clientWidth()) : roundToInt(renderBox->clientHeight()));
-        int increment = std::abs(Style::evaluate(m_layer->renderer().style().marqueeIncrement(), clientSize, Style::ZoomNeeded { }));
+        int increment = std::abs(Style::evaluate<float>(m_layer->renderer().style().marqueeIncrement(), clientSize, Style::ZoomNeeded { }));
         int currentPos = (isHorizontal() ? scrollableArea->scrollOffset().x() : scrollableArea->scrollOffset().y());
         newPos =  currentPos + (addIncrement ? increment : -increment);
         if (positive)

--- a/Source/WebCore/rendering/RenderMenuList.cpp
+++ b/Source/WebCore/rendering/RenderMenuList.cpp
@@ -230,7 +230,7 @@ void RenderMenuList::updateOptionsWidth()
             // Add in the option's text indent.  We can't calculate percentage values for now.
             float optionWidth = 0;
             if (auto* optionStyle = option->computedStyleForEditability())
-                optionWidth += Style::evaluate(optionStyle->textIndent().length, 0, Style::ZoomNeeded { });
+                optionWidth += Style::evaluate<float>(optionStyle->textIndent().length, 0, Style::ZoomNeeded { });
             if (!text.isEmpty()) {
                 const FontCascade& font = style().fontCascade();
                 TextRun run = RenderBlock::constructTextRun(text, style());
@@ -350,7 +350,7 @@ void RenderMenuList::computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidth, 
     }
     auto& logicalWidth = style().logicalWidth();
     if (logicalWidth.isCalculated())
-        minLogicalWidth = std::max(0_lu, Style::evaluate(logicalWidth, 0_lu, Style::ZoomNeeded { }));
+        minLogicalWidth = std::max(0_lu, Style::evaluate<LayoutUnit>(logicalWidth, 0_lu, Style::ZoomNeeded { }));
     else if (!logicalWidth.isPercent())
         minLogicalWidth = maxLogicalWidth;
 }

--- a/Source/WebCore/rendering/RenderMultiColumnSet.cpp
+++ b/Source/WebCore/rendering/RenderMultiColumnSet.cpp
@@ -445,7 +445,7 @@ LayoutUnit RenderMultiColumnSet::columnGap() const
     auto& parentBlockGap = parentBlock.style().columnGap();
     if (parentBlockGap.isNormal())
         return LayoutUnit(parentBlock.style().fontDescription().computedSize()); // "1em" is recommended as the normal gap setting. Matches <p> margins.
-    return Style::evaluate(parentBlockGap, parentBlock.contentBoxLogicalWidth(), Style::ZoomNeeded { });
+    return Style::evaluate<LayoutUnit>(parentBlockGap, parentBlock.contentBoxLogicalWidth(), Style::ZoomNeeded { });
 }
 
 unsigned RenderMultiColumnSet::columnCount() const
@@ -631,9 +631,9 @@ void RenderMultiColumnSet::paintColumnRules(PaintInfo& paintInfo, const LayoutPo
     const RenderStyle& blockStyle = parent()->style();
     const Color& ruleColor = blockStyle.visitedDependentColorWithColorFilter(CSSPropertyColumnRuleColor);
     bool ruleTransparent = blockStyle.columnRuleIsTransparent();
-    BorderStyle ruleStyle = collapsedBorderStyle(blockStyle.columnRuleStyle());
-    LayoutUnit ruleThickness { Style::evaluate(blockStyle.columnRuleWidth(), Style::ZoomNeeded { }) };
-    LayoutUnit colGap = columnGap();
+    auto ruleStyle = collapsedBorderStyle(blockStyle.columnRuleStyle());
+    auto ruleThickness = Style::evaluate<LayoutUnit>(blockStyle.columnRuleWidth(), Style::ZoomNeeded { });
+    auto colGap = columnGap();
     bool renderRule = ruleStyle > BorderStyle::Hidden && !ruleTransparent;
     if (!renderRule)
         return;

--- a/Source/WebCore/rendering/RenderReplaced.cpp
+++ b/Source/WebCore/rendering/RenderReplaced.cpp
@@ -556,8 +556,8 @@ LayoutRect RenderReplaced::replacedContentRect(const LayoutSize& intrinsicSize) 
 
     auto& objectPosition = style().objectPosition();
 
-    LayoutUnit xOffset = Style::evaluate(objectPosition.x, contentRect.width() - finalRect.width(), Style::ZoomNeeded { });
-    LayoutUnit yOffset = Style::evaluate(objectPosition.y, contentRect.height() - finalRect.height(), Style::ZoomNeeded { });
+    auto xOffset = Style::evaluate<LayoutUnit>(objectPosition.x, contentRect.width() - finalRect.width(), Style::ZoomNeeded { });
+    auto yOffset = Style::evaluate<LayoutUnit>(objectPosition.y, contentRect.height() - finalRect.height(), Style::ZoomNeeded { });
 
     finalRect.move(xOffset, yOffset);
 
@@ -613,8 +613,8 @@ LayoutUnit RenderReplaced::computeConstrainedLogicalWidth() const
     LayoutUnit logicalWidth = isOutOfFlowPositioned() ? containingBlock()->clientLogicalWidth() : containingBlock()->contentBoxLogicalWidth();
 
     // This solves above equation for 'width' (== logicalWidth).
-    LayoutUnit marginStart = Style::evaluateMinimum(style().marginStart(), logicalWidth, Style::ZoomNeeded { });
-    LayoutUnit marginEnd = Style::evaluateMinimum(style().marginEnd(), logicalWidth, Style::ZoomNeeded { });
+    auto marginStart = Style::evaluateMinimum<LayoutUnit>(style().marginStart(), logicalWidth, Style::ZoomNeeded { });
+    auto marginEnd = Style::evaluateMinimum<LayoutUnit>(style().marginEnd(), logicalWidth, Style::ZoomNeeded { });
 
     return std::max(0_lu, (logicalWidth - (marginStart + marginEnd + borderLeft() + borderRight() + paddingLeft() + paddingRight())));
 }

--- a/Source/WebCore/rendering/RenderScrollbarPart.cpp
+++ b/Source/WebCore/rendering/RenderScrollbarPart.cpp
@@ -87,21 +87,21 @@ void RenderScrollbarPart::layoutVerticalPart()
 static int calcScrollbarThicknessUsing(const Style::PreferredSize& preferredSize)
 {
     if (!preferredSize.isPercentOrCalculated() && !preferredSize.isIntrinsicOrLegacyIntrinsicOrAuto())
-        return Style::evaluateMinimum(preferredSize, 0_lu, Style::ZoomNeeded { });
+        return Style::evaluateMinimum<LayoutUnit>(preferredSize, 0_lu, Style::ZoomNeeded { });
     return ScrollbarTheme::theme().scrollbarThickness();
 }
 
 static int calcScrollbarThicknessUsing(const Style::MinimumSize& minimumSize)
 {
     if ((!minimumSize.isPercentOrCalculated() && !minimumSize.isIntrinsicOrLegacyIntrinsicOrAuto()) || minimumSize.isAuto())
-        return Style::evaluateMinimum(minimumSize, 0_lu, Style::ZoomNeeded { });
+        return Style::evaluateMinimum<LayoutUnit>(minimumSize, 0_lu, Style::ZoomNeeded { });
     return ScrollbarTheme::theme().scrollbarThickness();
 }
 
 static int calcScrollbarThicknessUsing(const Style::MaximumSize& maximumSize)
 {
     if (!maximumSize.isPercentOrCalculated() && !maximumSize.isIntrinsic() && !maximumSize.isLegacyIntrinsic())
-        return Style::evaluateMinimum(maximumSize, 0_lu, Style::ZoomNeeded { });
+        return Style::evaluateMinimum<LayoutUnit>(maximumSize, 0_lu, Style::ZoomNeeded { });
     return ScrollbarTheme::theme().scrollbarThickness();
 }
 
@@ -115,8 +115,8 @@ void RenderScrollbarPart::computeScrollbarWidth()
     setWidth(std::max(minWidth, std::min(maxWidth, width)));
     
     // Buttons and track pieces can all have margins along the axis of the scrollbar. 
-    m_marginBox.setLeft(Style::evaluateMinimum(style().marginLeft(), 0_lu, Style::ZoomNeeded { }));
-    m_marginBox.setRight(Style::evaluateMinimum(style().marginRight(), 0_lu, Style::ZoomNeeded { }));
+    m_marginBox.setLeft(Style::evaluateMinimum<LayoutUnit>(style().marginLeft(), 0_lu, Style::ZoomNeeded { }));
+    m_marginBox.setRight(Style::evaluateMinimum<LayoutUnit>(style().marginRight(), 0_lu, Style::ZoomNeeded { }));
 }
 
 void RenderScrollbarPart::computeScrollbarHeight()
@@ -129,8 +129,8 @@ void RenderScrollbarPart::computeScrollbarHeight()
     setHeight(std::max(minHeight, std::min(maxHeight, height)));
 
     // Buttons and track pieces can all have margins along the axis of the scrollbar. 
-    m_marginBox.setTop(Style::evaluateMinimum(style().marginTop(), 0_lu, Style::ZoomNeeded { }));
-    m_marginBox.setBottom(Style::evaluateMinimum(style().marginBottom(), 0_lu, Style::ZoomNeeded { }));
+    m_marginBox.setTop(Style::evaluateMinimum<LayoutUnit>(style().marginTop(), 0_lu, Style::ZoomNeeded { }));
+    m_marginBox.setBottom(Style::evaluateMinimum<LayoutUnit>(style().marginBottom(), 0_lu, Style::ZoomNeeded { }));
 }
 
 void RenderScrollbarPart::styleDidChange(StyleDifference diff, const RenderStyle* oldStyle)

--- a/Source/WebCore/rendering/RenderSlider.cpp
+++ b/Source/WebCore/rendering/RenderSlider.cpp
@@ -84,7 +84,7 @@ void RenderSlider::computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidth, La
     maxLogicalWidth = defaultTrackLength * style().usedZoom();
     auto& logicalWidth = style().logicalWidth();
     if (logicalWidth.isCalculated())
-        minLogicalWidth = std::max(0_lu, Style::evaluate(logicalWidth, 0_lu, Style::ZoomNeeded { }));
+        minLogicalWidth = std::max(0_lu, Style::evaluate<LayoutUnit>(logicalWidth, 0_lu, Style::ZoomNeeded { }));
     else if (!logicalWidth.isPercent())
         minLogicalWidth = maxLogicalWidth;
 }

--- a/Source/WebCore/rendering/RenderTable.cpp
+++ b/Source/WebCore/rendering/RenderTable.cpp
@@ -307,9 +307,9 @@ void RenderTable::updateLogicalWidth()
         setLogicalWidth(convertStyleLogicalWidthToComputedWidth(styleLogicalWidth, containerWidthInInlineDirection));
     else {
         // Subtract out any fixed margins from our available width for auto width tables.
-        LayoutUnit marginStart = Style::evaluateMinimum(style().marginStart(), availableLogicalWidth, Style::ZoomNeeded { });
-        LayoutUnit marginEnd = Style::evaluateMinimum(style().marginEnd(), availableLogicalWidth, Style::ZoomNeeded { });
-        LayoutUnit marginTotal = marginStart + marginEnd;
+        auto marginStart = Style::evaluateMinimum<LayoutUnit>(style().marginStart(), availableLogicalWidth, Style::ZoomNeeded { });
+        auto marginEnd = Style::evaluateMinimum<LayoutUnit>(style().marginEnd(), availableLogicalWidth, Style::ZoomNeeded { });
+        auto marginTotal = marginStart + marginEnd;
 
         // Subtract out our margins to get the available content width.
         LayoutUnit availableContentLogicalWidth = std::max<LayoutUnit>(0, containerWidthInInlineDirection - marginTotal);
@@ -360,8 +360,8 @@ void RenderTable::updateLogicalWidth()
         setMarginStart(marginValues.m_start);
         setMarginEnd(marginValues.m_end);
     } else {
-        setMarginStart(Style::evaluateMinimum(style().marginStart(), availableLogicalWidth, Style::ZoomNeeded { }));
-        setMarginEnd(Style::evaluateMinimum(style().marginEnd(), availableLogicalWidth, Style::ZoomNeeded { }));
+        setMarginStart(Style::evaluateMinimum<LayoutUnit>(style().marginStart(), availableLogicalWidth, Style::ZoomNeeded { }));
+        setMarginEnd(Style::evaluateMinimum<LayoutUnit>(style().marginEnd(), availableLogicalWidth, Style::ZoomNeeded { }));
     }
 }
 
@@ -378,7 +378,7 @@ template<typename SizeType> LayoutUnit RenderTable::convertStyleLogicalWidthToCo
     if (isCSSTable && styleLogicalWidth.isSpecified() && styleLogicalWidth.isPositive() && style().boxSizing() == BoxSizing::ContentBox)
         borders = borderStart() + borderEnd() + (collapseBorders() ? 0_lu : paddingStart() + paddingEnd());
 
-    return Style::evaluateMinimum(styleLogicalWidth, availableWidth, Style::ZoomNeeded { }) + borders;
+    return Style::evaluateMinimum<LayoutUnit>(styleLogicalWidth, availableWidth, Style::ZoomNeeded { }) + borders;
 }
 
 template<typename SizeType> LayoutUnit RenderTable::convertStyleLogicalHeightToComputedHeight(const SizeType& styleLogicalHeight)
@@ -1287,7 +1287,7 @@ LayoutUnit RenderTable::calcBorderStart() const
                 borderWidth = std::max(borderWidth, firstRowAdjoiningBorder.width());
         }
     }
-    return CollapsedBorderValue::adjustedCollapsedBorderWidth(Style::evaluate(borderWidth, Style::ZoomNeeded { }), document().deviceScaleFactor(), writingMode().isInlineFlipped());
+    return CollapsedBorderValue::adjustedCollapsedBorderWidth(Style::evaluate<float>(borderWidth, Style::ZoomNeeded { }), document().deviceScaleFactor(), writingMode().isInlineFlipped());
 }
 
 LayoutUnit RenderTable::calcBorderEnd() const
@@ -1342,7 +1342,7 @@ LayoutUnit RenderTable::calcBorderEnd() const
                 borderWidth = std::max(borderWidth, firstRowAdjoiningBorder.width());
         }
     }
-    return CollapsedBorderValue::adjustedCollapsedBorderWidth(Style::evaluate(borderWidth, Style::ZoomNeeded { }), document().deviceScaleFactor(), !writingMode().isInlineFlipped());
+    return CollapsedBorderValue::adjustedCollapsedBorderWidth(Style::evaluate<float>(borderWidth, Style::ZoomNeeded { }), document().deviceScaleFactor(), !writingMode().isInlineFlipped());
 }
 
 void RenderTable::recalcBordersInRowDirection()
@@ -1384,7 +1384,7 @@ LayoutUnit RenderTable::outerBorderBefore() const
     if (tb.style() == BorderStyle::Hidden)
         return 0;
     if (tb.style() > BorderStyle::Hidden) {
-        LayoutUnit collapsedBorderWidth = std::max(borderWidth, LayoutUnit(Style::evaluate(tb.width(), Style::ZoomNeeded { }) / 2));
+        LayoutUnit collapsedBorderWidth = std::max(borderWidth, LayoutUnit(Style::evaluate<float>(tb.width(), Style::ZoomNeeded { }) / 2));
         borderWidth = floorToDevicePixel(collapsedBorderWidth, document().deviceScaleFactor());
     }
     return borderWidth;
@@ -1406,7 +1406,7 @@ LayoutUnit RenderTable::outerBorderAfter() const
         return 0;
     if (tb.style() > BorderStyle::Hidden) {
         float deviceScaleFactor = document().deviceScaleFactor();
-        LayoutUnit collapsedBorderWidth = std::max(borderWidth, LayoutUnit((Style::evaluate(tb.width(), Style::ZoomNeeded { }) + (1 / deviceScaleFactor)) / 2));
+        LayoutUnit collapsedBorderWidth = std::max(borderWidth, LayoutUnit((Style::evaluate<float>(tb.width(), Style::ZoomNeeded { }) + (1 / deviceScaleFactor)) / 2));
         borderWidth = floorToDevicePixel(collapsedBorderWidth, deviceScaleFactor);
     }
     return borderWidth;
@@ -1423,7 +1423,7 @@ LayoutUnit RenderTable::outerBorderStart() const
     if (tb.style() == BorderStyle::Hidden)
         return 0;
     if (tb.style() > BorderStyle::Hidden)
-        return CollapsedBorderValue::adjustedCollapsedBorderWidth(Style::evaluate(tb.width(), Style::ZoomNeeded { }), document().deviceScaleFactor(), writingMode().isInlineFlipped());
+        return CollapsedBorderValue::adjustedCollapsedBorderWidth(Style::evaluate<float>(tb.width(), Style::ZoomNeeded { }), document().deviceScaleFactor(), writingMode().isInlineFlipped());
 
     bool allHidden = true;
     for (RenderTableSection* section = topSection(); section; section = sectionBelow(section)) {
@@ -1450,7 +1450,7 @@ LayoutUnit RenderTable::outerBorderEnd() const
     if (tb.style() == BorderStyle::Hidden)
         return 0;
     if (tb.style() > BorderStyle::Hidden)
-        return CollapsedBorderValue::adjustedCollapsedBorderWidth(Style::evaluate(tb.width(), Style::ZoomNeeded { }), document().deviceScaleFactor(), !writingMode().isInlineFlipped());
+        return CollapsedBorderValue::adjustedCollapsedBorderWidth(Style::evaluate<float>(tb.width(), Style::ZoomNeeded { }), document().deviceScaleFactor(), !writingMode().isInlineFlipped());
 
     bool allHidden = true;
     for (RenderTableSection* section = topSection(); section; section = sectionBelow(section)) {

--- a/Source/WebCore/rendering/RenderTableCell.cpp
+++ b/Source/WebCore/rendering/RenderTableCell.cpp
@@ -367,7 +367,7 @@ LayoutUnit RenderTableCell::logicalHeightForRowSizing() const
     auto specifiedSize = !isOrthogonal() ? style().logicalHeight() : style().logicalWidth();
     if (!specifiedSize.isSpecified())
         return usedLogicalSize;
-    auto computedLogicaSize = Style::evaluate(specifiedSize, 0_lu, Style::ZoomNeeded { });
+    auto computedLogicaSize = Style::evaluate<LayoutUnit>(specifiedSize, 0_lu, Style::ZoomNeeded { });
     // In strict mode, box-sizing: content-box do the right thing and actually add in the border and padding.
     // Call computedCSSPadding* directly to avoid including implicitPadding.
     if (!document().inQuirksMode() && style().boxSizing() != BoxSizing::BorderBox)

--- a/Source/WebCore/rendering/RenderTableSection.cpp
+++ b/Source/WebCore/rendering/RenderTableSection.cpp
@@ -219,9 +219,9 @@ void RenderTableSection::addCell(RenderTableCell* cell, RenderTableRow* row)
 static LayoutUnit resolveLogicalHeightForRow(const Style::PreferredSize& rowLogicalHeight)
 {
     if (auto fixedRowLogicalHeight = rowLogicalHeight.tryFixed())
-        return LayoutUnit(fixedRowLogicalHeight->resolveZoom(Style::ZoomNeeded { }));
+        return Style::evaluate<LayoutUnit>(*fixedRowLogicalHeight, Style::ZoomNeeded { });
     if (rowLogicalHeight.isCalculated())
-        return LayoutUnit(Style::evaluate(rowLogicalHeight, 0, Style::ZoomNeeded { }));
+        return Style::evaluate<LayoutUnit>(rowLogicalHeight, 0, Style::ZoomNeeded { });
     return 0;
 }
 
@@ -787,7 +787,7 @@ LayoutUnit RenderTableSection::calcBlockDirectionOuterBorder(BlockBorderSide sid
 
     if (allHidden)
         return -1;
-    return CollapsedBorderValue::adjustedCollapsedBorderWidth(Style::evaluate(borderWidth, Style::ZoomNeeded { }), document().deviceScaleFactor(), (side == BlockBorderSide::BorderAfter));
+    return CollapsedBorderValue::adjustedCollapsedBorderWidth(Style::evaluate<float>(borderWidth, Style::ZoomNeeded { }), document().deviceScaleFactor(), (side == BlockBorderSide::BorderAfter));
 }
 
 LayoutUnit RenderTableSection::calcInlineDirectionOuterBorder(InlineBorderSide side) const
@@ -841,7 +841,7 @@ LayoutUnit RenderTableSection::calcInlineDirectionOuterBorder(InlineBorderSide s
 
     if (allHidden)
         return -1;
-    return CollapsedBorderValue::adjustedCollapsedBorderWidth(Style::evaluate(borderWidth, Style::ZoomNeeded { }), document().deviceScaleFactor(), (side == InlineBorderSide::BorderStart) ? writingMode.isInlineFlipped() : !writingMode.isInlineFlipped());
+    return CollapsedBorderValue::adjustedCollapsedBorderWidth(Style::evaluate<float>(borderWidth, Style::ZoomNeeded { }), document().deviceScaleFactor(), (side == InlineBorderSide::BorderStart) ? writingMode.isInlineFlipped() : !writingMode.isInlineFlipped());
 }
 
 void RenderTableSection::recalcOuterBorder()
@@ -1143,20 +1143,68 @@ void RenderTableSection::paintRowGroupBorderIfRequired(const PaintInfo& paintInf
 
     switch (borderSide) {
     case BoxSide::Top:
-        paintRowGroupBorder(paintInfo, antialias, LayoutRect(paintOffset.x() + offsetLeftForRowGroupBorder(cell, rowGroupRect, row), rowGroupRect.y(), 
-            horizontalRowGroupBorderWidth(cell, rowGroupRect, row, column), LayoutUnit(Style::evaluate(style.borderTop().width(), Style::ZoomNeeded { }))), BoxSide::Top, CSSPropertyBorderTopColor, style.borderTopStyle(), table()->style().borderTopStyle());
+        paintRowGroupBorder(
+            paintInfo,
+            antialias,
+            LayoutRect {
+                paintOffset.x() + offsetLeftForRowGroupBorder(cell, rowGroupRect, row),
+                rowGroupRect.y(),
+                horizontalRowGroupBorderWidth(cell, rowGroupRect, row, column),
+                LayoutUnit { Style::evaluate<float>(style.borderTop().width(), Style::ZoomNeeded { }) },
+            },
+            BoxSide::Top,
+            CSSPropertyBorderTopColor,
+            style.borderTopStyle(),
+            table()->style().borderTopStyle()
+        );
         break;
     case BoxSide::Bottom:
-        paintRowGroupBorder(paintInfo, antialias, LayoutRect(paintOffset.x() + offsetLeftForRowGroupBorder(cell, rowGroupRect, row), rowGroupRect.y() + rowGroupRect.height(), 
-            horizontalRowGroupBorderWidth(cell, rowGroupRect, row, column), LayoutUnit(Style::evaluate(style.borderBottom().width(), Style::ZoomNeeded { }))), BoxSide::Bottom, CSSPropertyBorderBottomColor, style.borderBottomStyle(), table()->style().borderBottomStyle());
+        paintRowGroupBorder(
+            paintInfo,
+            antialias,
+            LayoutRect {
+                paintOffset.x() + offsetLeftForRowGroupBorder(cell, rowGroupRect, row),
+                rowGroupRect.y() + rowGroupRect.height(),
+                horizontalRowGroupBorderWidth(cell, rowGroupRect, row, column),
+                LayoutUnit { Style::evaluate<float>(style.borderBottom().width(), Style::ZoomNeeded { }) },
+            },
+            BoxSide::Bottom,
+            CSSPropertyBorderBottomColor,
+            style.borderBottomStyle(),
+            table()->style().borderBottomStyle()
+        );
         break;
     case BoxSide::Left:
-        paintRowGroupBorder(paintInfo, antialias, LayoutRect(rowGroupRect.x(), rowGroupRect.y() + offsetTopForRowGroupBorder(cell, borderSide, row), LayoutUnit(Style::evaluate(style.borderLeft().width(), Style::ZoomNeeded { })),
-            verticalRowGroupBorderHeight(cell, rowGroupRect, row)), BoxSide::Left, CSSPropertyBorderLeftColor, style.borderLeftStyle(), table()->style().borderLeftStyle());
+        paintRowGroupBorder(
+            paintInfo,
+            antialias,
+            LayoutRect {
+                rowGroupRect.x(),
+                rowGroupRect.y() + offsetTopForRowGroupBorder(cell, borderSide, row),
+                LayoutUnit { Style::evaluate<float>(style.borderLeft().width(), Style::ZoomNeeded { }) },
+                verticalRowGroupBorderHeight(cell, rowGroupRect, row),
+            },
+            BoxSide::Left,
+            CSSPropertyBorderLeftColor,
+            style.borderLeftStyle(),
+            table()->style().borderLeftStyle()
+        );
         break;
     case BoxSide::Right:
-        paintRowGroupBorder(paintInfo, antialias, LayoutRect(rowGroupRect.x() + rowGroupRect.width(), rowGroupRect.y() + offsetTopForRowGroupBorder(cell, borderSide, row), LayoutUnit(Style::evaluate(style.borderRight().width(), Style::ZoomNeeded { })),
-            verticalRowGroupBorderHeight(cell, rowGroupRect, row)), BoxSide::Right, CSSPropertyBorderRightColor, style.borderRightStyle(), table()->style().borderRightStyle());
+        paintRowGroupBorder(
+            paintInfo,
+            antialias,
+            LayoutRect {
+                rowGroupRect.x() + rowGroupRect.width(),
+                rowGroupRect.y() + offsetTopForRowGroupBorder(cell, borderSide, row),
+                LayoutUnit { Style::evaluate<float>(style.borderRight().width(), Style::ZoomNeeded { }) },
+                verticalRowGroupBorderHeight(cell, rowGroupRect, row),
+            },
+            BoxSide::Right,
+            CSSPropertyBorderRightColor,
+            style.borderRightStyle(),
+            table()->style().borderRightStyle()
+        );
         break;
     default:
         break;

--- a/Source/WebCore/rendering/RenderTextControl.cpp
+++ b/Source/WebCore/rendering/RenderTextControl.cpp
@@ -195,7 +195,7 @@ void RenderTextControl::computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidt
 
     auto& logicalWidth = style().logicalWidth();
     if (logicalWidth.isCalculated())
-        minLogicalWidth = std::max(0_lu, Style::evaluate(logicalWidth, 0_lu, Style::ZoomNeeded { }));
+        minLogicalWidth = std::max(0_lu, Style::evaluate<LayoutUnit>(logicalWidth, 0_lu, Style::ZoomNeeded { }));
     else if (!logicalWidth.isPercent())
         minLogicalWidth = maxLogicalWidth;
 }

--- a/Source/WebCore/rendering/RenderTextInlines.h
+++ b/Source/WebCore/rendering/RenderTextInlines.h
@@ -26,8 +26,8 @@
 
 namespace WebCore {
 
-inline LayoutUnit RenderText::marginLeft() const { return Style::evaluateMinimum(style().marginLeft(), 0_lu, Style::ZoomNeeded { }); }
-inline LayoutUnit RenderText::marginRight() const { return Style::evaluateMinimum(style().marginRight(), 0_lu, Style::ZoomNeeded { }); }
+inline LayoutUnit RenderText::marginLeft() const { return Style::evaluateMinimum<LayoutUnit>(style().marginLeft(), 0_lu, Style::ZoomNeeded { }); }
+inline LayoutUnit RenderText::marginRight() const { return Style::evaluateMinimum<LayoutUnit>(style().marginRight(), 0_lu, Style::ZoomNeeded { }); }
 
 template <typename MeasureTextCallback>
 float RenderText::measureTextConsideringPossibleTrailingSpace(bool currentCharacterIsSpace, unsigned startIndex, unsigned wordLength, WordTrailingSpace& wordTrailingSpace, SingleThreadWeakHashSet<const Font>& fallbackFonts, MeasureTextCallback&& callback)

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -77,6 +77,7 @@
 #include "SpinButtonElement.h"
 #include "StringTruncator.h"
 #include "StylePadding.h"
+#include "StylePrimitiveNumericTypes+Evaluation.h"
 #include "SwitchThumbPart.h"
 #include "SwitchTrackPart.h"
 #include "TextAreaPart.h"
@@ -837,7 +838,7 @@ ControlStyle RenderTheme::extractControlStyleForRenderer(const RenderElement& re
         style->usedZoom(),
         style->usedAccentColor(renderObject.styleColorOptions()),
         style->visitedDependentColorWithColorFilter(CSSPropertyColor),
-        Style::evaluate(style->borderWidth(), Style::ZoomNeeded { })
+        Style::evaluate<FloatBoxExtent>(style->borderWidth(), Style::ZoomNeeded { })
     };
 }
 
@@ -1395,26 +1396,26 @@ void RenderTheme::adjustButtonOrCheckboxOrColorWellOrInnerSpinButtonOrRadioStyle
         borderBox = Style::LineWidthBox { borderBox.left(), borderBox.top(), borderBox.right(), borderBox.bottom() };
 
     /* FIXME: FIND ZOOM */
-    if (Style::evaluate(borderBox.top(), Style::ZoomNeeded { }) != static_cast<int>(Style::evaluate(style.borderTopWidth(), Style::ZoomNeeded { }))) {
+    if (Style::evaluate<float>(borderBox.top(), Style::ZoomNeeded { }) != Style::evaluate<int>(style.borderTopWidth(), Style::ZoomNeeded { })) {
         if (!borderBox.top().isZero())
             style.setBorderTopWidth(borderBox.top());
         else
             style.resetBorderTop();
     }
-    if (Style::evaluate(borderBox.right(), Style::ZoomNeeded { }) != static_cast<int>(Style::evaluate(style.borderRightWidth(), Style::ZoomNeeded { }))) {
+    if (Style::evaluate<float>(borderBox.right(), Style::ZoomNeeded { }) != Style::evaluate<int>(style.borderRightWidth(), Style::ZoomNeeded { })) {
         if (!borderBox.right().isZero())
             style.setBorderRightWidth(borderBox.right());
         else
             style.resetBorderRight();
     }
-    if (Style::evaluate(borderBox.bottom(), Style::ZoomNeeded { }) != static_cast<int>(Style::evaluate(style.borderBottomWidth(), Style::ZoomNeeded { }))) {
+    if (Style::evaluate<float>(borderBox.bottom(), Style::ZoomNeeded { }) != Style::evaluate<int>(style.borderBottomWidth(), Style::ZoomNeeded { })) {
         style.setBorderBottomWidth(borderBox.bottom());
         if (!borderBox.bottom().isZero())
             style.setBorderBottomWidth(borderBox.bottom());
         else
             style.resetBorderBottom();
     }
-    if (Style::evaluate(borderBox.left(), Style::ZoomNeeded { }) != static_cast<int>(Style::evaluate(style.borderLeftWidth(), Style::ZoomNeeded { }))) {
+    if (Style::evaluate<float>(borderBox.left(), Style::ZoomNeeded { }) != Style::evaluate<int>(style.borderLeftWidth(), Style::ZoomNeeded { })) {
         style.setBorderLeftWidth(borderBox.left());
         if (!borderBox.left().isZero())
             style.setBorderLeftWidth(borderBox.left());

--- a/Source/WebCore/rendering/RenderTreeAsText.cpp
+++ b/Source/WebCore/rendering/RenderTreeAsText.cpp
@@ -275,7 +275,7 @@ void RenderTreeAsText::writeRenderObject(TextStream& ts, const RenderObject& o, 
                 ts << " [textStrokeColor="_s << serializationForRenderTreeAsText(textStrokeColor) << ']';
 
             if (renderElement->parent()->style().textStrokeWidth() != renderElement->style().textStrokeWidth() && renderElement->style().textStrokeWidth().isPositive())
-                ts << " [textStrokeWidth="_s << Style::evaluate(renderElement->style().textStrokeWidth(), Style::ZoomNeeded { }) << ']';
+                ts << " [textStrokeWidth="_s << Style::evaluate<float>(renderElement->style().textStrokeWidth(), Style::ZoomNeeded { }) << ']';
         }
 
         auto* box = dynamicDowncast<RenderBoxModelObject>(o);

--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
@@ -128,7 +128,7 @@ static void drawFocusRingForPathForVectorBasedControls(const RenderObject& box, 
     // macOS controls have never honored outline offset.
 #if PLATFORM(IOS_FAMILY)
     auto deviceScaleFactor = box.document().deviceScaleFactor();
-    auto outlineOffset = floorToDevicePixel(Style::evaluate(box.style().outlineOffset(), Style::ZoomNeeded { }), deviceScaleFactor);
+    auto outlineOffset = floorToDevicePixel(Style::evaluate<float>(box.style().outlineOffset(), Style::ZoomNeeded { }), deviceScaleFactor);
 
     if (outlineOffset > 0) {
         const auto center = rect.center();
@@ -2583,9 +2583,9 @@ bool RenderThemeCocoa::paintMenuListButtonDecorationsForVectorBasedControls(cons
     }
 
     if (!style->writingMode().isInlineFlipped())
-        glyphOrigin.setX(logicalRect.maxX() - glyphSize.width() - Style::evaluate(box.style().borderEndWidth(), Style::ZoomNeeded { }) - glyphPaddingEnd);
+        glyphOrigin.setX(logicalRect.maxX() - glyphSize.width() - Style::evaluate<float>(box.style().borderEndWidth(), Style::ZoomNeeded { }) - glyphPaddingEnd);
     else
-        glyphOrigin.setX(logicalRect.x() + Style::evaluate(box.style().borderEndWidth(), Style::ZoomNeeded { }) + glyphPaddingEnd);
+        glyphOrigin.setX(logicalRect.x() + Style::evaluate<float>(box.style().borderEndWidth(), Style::ZoomNeeded { }) + glyphPaddingEnd);
 
     if (!isHorizontalWritingMode)
         glyphOrigin = glyphOrigin.transposedPoint();

--- a/Source/WebCore/rendering/ios/RenderThemeIOS.mm
+++ b/Source/WebCore/rendering/ios/RenderThemeIOS.mm
@@ -383,7 +383,7 @@ Style::PaddingBox RenderThemeIOS::popupInternalPaddingBox(const RenderStyle& sty
     auto padding = emSize->resolveAsLength<float>({ style, nullptr, nullptr, nullptr });
 
     if (style.usedAppearance() == StyleAppearance::MenulistButton) {
-        auto value = toTruncatedPaddingEdge(padding + Style::evaluate(style.borderTopWidth(), Style::ZoomNeeded { }));
+        auto value = toTruncatedPaddingEdge(padding + Style::evaluate<float>(style.borderTopWidth(), Style::ZoomNeeded { }));
         if (style.writingMode().isBidiRTL())
             return { 0_css_px, 0_css_px, 0_css_px, value };
         return { 0_css_px, value, 0_css_px, 0_css_px };
@@ -610,9 +610,9 @@ void RenderThemeIOS::paintMenuListButtonDecorations(const RenderBox& box, const 
     FloatPoint glyphOrigin;
     glyphOrigin.setY(logicalRect.center().y() - glyphSize.height() / 2.0f);
     if (!style.writingMode().isInlineFlipped())
-        glyphOrigin.setX(logicalRect.maxX() - glyphSize.width() - Style::evaluate(box.style().borderEndWidth(), Style::ZoomNeeded { }) - Style::evaluate(box.style().paddingEnd(), logicalRect.width(), Style::ZoomNeeded { }));
+        glyphOrigin.setX(logicalRect.maxX() - glyphSize.width() - Style::evaluate<float>(box.style().borderEndWidth(), Style::ZoomNeeded { }) - Style::evaluate<float>(box.style().paddingEnd(), logicalRect.width(), Style::ZoomNeeded { }));
     else
-        glyphOrigin.setX(logicalRect.x() + Style::evaluate(box.style().borderEndWidth(), Style::ZoomNeeded { }) + Style::evaluate(box.style().paddingEnd(), logicalRect.width(), Style::ZoomNeeded { }));
+        glyphOrigin.setX(logicalRect.x() + Style::evaluate<float>(box.style().borderEndWidth(), Style::ZoomNeeded { }) + Style::evaluate<float>(box.style().paddingEnd(), logicalRect.width(), Style::ZoomNeeded { }));
 
     if (!isHorizontalWritingMode)
         glyphOrigin = glyphOrigin.transposedPoint();
@@ -1744,10 +1744,10 @@ bool RenderThemeIOS::paintListButton(const RenderElement& box, const PaintInfo& 
     auto& context = paintInfo.context();
     GraphicsContextStateSaver stateSaver(context);
 
-    float paddingTop = Style::evaluate(style.paddingTop(), rect.height(), Style::ZoomNeeded { });
-    float paddingRight = Style::evaluate(style.paddingRight(), rect.width(), Style::ZoomNeeded { });
-    float paddingBottom = Style::evaluate(style.paddingBottom(), rect.height(), Style::ZoomNeeded { });
-    float paddingLeft = Style::evaluate(style.paddingLeft(), rect.width(), Style::ZoomNeeded { });
+    auto paddingTop = Style::evaluate<float>(style.paddingTop(), rect.height(), Style::ZoomNeeded { });
+    auto paddingRight = Style::evaluate<float>(style.paddingRight(), rect.width(), Style::ZoomNeeded { });
+    auto paddingBottom = Style::evaluate<float>(style.paddingBottom(), rect.height(), Style::ZoomNeeded { });
+    auto paddingLeft = Style::evaluate<float>(style.paddingLeft(), rect.width(), Style::ZoomNeeded { });
 
     FloatRect indicatorRect = rect;
     indicatorRect.move(paddingLeft, paddingTop);

--- a/Source/WebCore/rendering/shapes/LayoutShape.cpp
+++ b/Source/WebCore/rendering/shapes/LayoutShape.cpp
@@ -121,14 +121,14 @@ Ref<const LayoutShape> LayoutShape::createShape(const Style::BasicShape& basicSh
             return createEllipseShape(logicalCenter, radii, logicalBoxSize.width());
         },
         [&](const Style::InsetFunction& inset) -> Ref<LayoutShape> {
-            float left = Style::evaluate(inset->insets.left(), boxWidth, Style::ZoomNeeded { });
-            float top = Style::evaluate(inset->insets.top(), boxHeight, Style::ZoomNeeded { });
+            auto left = Style::evaluate<float>(inset->insets.left(), boxWidth, Style::ZoomNeeded { });
+            auto top = Style::evaluate<float>(inset->insets.top(), boxHeight, Style::ZoomNeeded { });
 
             FloatRect rect {
                 left,
                 top,
-                std::max<float>(boxWidth - left - Style::evaluate(inset->insets.right(), boxWidth, Style::ZoomNeeded { }), 0),
-                std::max<float>(boxHeight - top - Style::evaluate(inset->insets.bottom(), boxHeight, Style::ZoomNeeded { }), 0)
+                std::max<float>(boxWidth - left - Style::evaluate<float>(inset->insets.right(), boxWidth, Style::ZoomNeeded { }), 0),
+                std::max<float>(boxHeight - top - Style::evaluate<float>(inset->insets.bottom(), boxHeight, Style::ZoomNeeded { }), 0)
             };
 
             auto logicalRect = physicalRectToLogical(rect, logicalBoxSize.height(), writingMode);
@@ -136,10 +136,10 @@ Ref<const LayoutShape> LayoutShape::createShape(const Style::BasicShape& basicSh
 
             auto boxSize = FloatSize(boxWidth, boxHeight);
             auto isBlockLeftToRight = writingMode.isBlockLeftToRight();
-            auto topLeftRadius = physicalSizeToLogical(Style::evaluate(horizontalWritingMode || isBlockLeftToRight ? inset->radii.topLeft() : inset->radii.topRight(), boxSize, Style::ZoomNeeded { }), writingMode);
-            auto topRightRadius = physicalSizeToLogical(Style::evaluate(horizontalWritingMode ? inset->radii.topRight() : isBlockLeftToRight ? inset->radii.bottomLeft() : inset->radii.bottomRight(), boxSize, Style::ZoomNeeded { }), writingMode);
-            auto bottomLeftRadius = physicalSizeToLogical(Style::evaluate(horizontalWritingMode ? inset->radii.bottomLeft() : isBlockLeftToRight ? inset->radii.topRight() : inset->radii.topLeft(), boxSize, Style::ZoomNeeded { }), writingMode);
-            auto bottomRightRadius = physicalSizeToLogical(Style::evaluate(horizontalWritingMode ? inset->radii.bottomRight() : isBlockLeftToRight ? inset->radii.bottomRight() : inset->radii.bottomLeft(), boxSize, Style::ZoomNeeded { }), writingMode);
+            auto topLeftRadius = physicalSizeToLogical(Style::evaluate<FloatSize>(horizontalWritingMode || isBlockLeftToRight ? inset->radii.topLeft() : inset->radii.topRight(), boxSize, Style::ZoomNeeded { }), writingMode);
+            auto topRightRadius = physicalSizeToLogical(Style::evaluate<FloatSize>(horizontalWritingMode ? inset->radii.topRight() : isBlockLeftToRight ? inset->radii.bottomLeft() : inset->radii.bottomRight(), boxSize, Style::ZoomNeeded { }), writingMode);
+            auto bottomLeftRadius = physicalSizeToLogical(Style::evaluate<FloatSize>(horizontalWritingMode ? inset->radii.bottomLeft() : isBlockLeftToRight ? inset->radii.topRight() : inset->radii.topLeft(), boxSize, Style::ZoomNeeded { }), writingMode);
+            auto bottomRightRadius = physicalSizeToLogical(Style::evaluate<FloatSize>(horizontalWritingMode ? inset->radii.bottomRight() : isBlockLeftToRight ? inset->radii.bottomRight() : inset->radii.bottomLeft(), boxSize, Style::ZoomNeeded { }), writingMode);
             auto cornerRadii = FloatRoundedRect::Radii(topLeftRadius, topRightRadius, bottomLeftRadius, bottomRightRadius);
             if (shouldFlipStartAndEndPoints(writingMode))
                 cornerRadii = { cornerRadii.topRight(), cornerRadii.topLeft(), cornerRadii.bottomRight(), cornerRadii.bottomLeft() };
@@ -151,7 +151,7 @@ Ref<const LayoutShape> LayoutShape::createShape(const Style::BasicShape& basicSh
             auto boxSize = FloatSize { boxWidth, boxHeight };
 
             auto vertices = polygon->vertices.value.map([&](const auto& vertex) {
-                return physicalPointToLogical(Style::evaluate(vertex, boxSize, Style::ZoomNeeded { }) + borderBoxOffset, logicalBoxSize.height(), writingMode);
+                return physicalPointToLogical(Style::evaluate<FloatPoint>(vertex, boxSize, Style::ZoomNeeded { }) + borderBoxOffset, logicalBoxSize.height(), writingMode);
             });
 
             return createPolygonShape(WTFMove(vertices), logicalBoxSize.width());

--- a/Source/WebCore/rendering/shapes/ShapeOutsideInfo.cpp
+++ b/Source/WebCore/rendering/shapes/ShapeOutsideInfo.cpp
@@ -256,7 +256,7 @@ Ref<const LayoutShape> makeShapeForShapeOutside(const RenderBox& renderer)
     auto boxSize = computeLogicalBoxSize(renderer, isHorizontalWritingMode);
 
     auto logicalMargin = [&] {
-        auto shapeMargin = Style::evaluate(style.shapeMargin(), containingBlock.contentBoxLogicalWidth(), Style::ZoomNeeded { }).toFloat();
+        auto shapeMargin = Style::evaluate<LayoutUnit>(style.shapeMargin(), containingBlock.contentBoxLogicalWidth(), Style::ZoomNeeded { }).toFloat();
         return isnan(shapeMargin) ? 0.0f : shapeMargin;
     }();
 

--- a/Source/WebCore/rendering/style/CollapsedBorderValue.h
+++ b/Source/WebCore/rendering/style/CollapsedBorderValue.h
@@ -39,7 +39,7 @@ public:
     }
 
     CollapsedBorderValue(const BorderValue& border, const Color& color, BorderPrecedence precedence)
-        : m_width(LayoutUnit(border.nonZero() ? Style::evaluate(border.width(), Style::ZoomNeeded { }) : 0))
+        : m_width(border.nonZero() ? Style::evaluate<LayoutUnit>(border.width(), Style::ZoomNeeded { }) : 0_lu)
         , m_color(color)
         , m_style(static_cast<unsigned>(border.style()))
         , m_precedence(static_cast<unsigned>(precedence))

--- a/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
@@ -86,7 +86,7 @@ std::optional<FloatRect> SVGRenderSupport::computeFloatVisibleRectInContainer(co
         return FloatRect();
 
     FloatRect adjustedRect = rect;
-    adjustedRect.inflate(Style::evaluate(renderer.style().outlineWidth(), Style::ZoomNeeded { }));
+    adjustedRect.inflate(Style::evaluate<float>(renderer.style().outlineWidth(), Style::ZoomNeeded { }));
 
     // Translate to coords in our parent renderer, and then call computeFloatVisibleRectInContainer() on our parent.
     adjustedRect = renderer.localToParentTransform().mapRect(adjustedRect);

--- a/Source/WebCore/rendering/svg/SVGTextLayoutEngineBaseline.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextLayoutEngineBaseline.cpp
@@ -50,7 +50,7 @@ float SVGTextLayoutEngineBaseline::calculateBaselineShift(const SVGRenderStyle& 
             return m_font->metricsOfPrimaryFont().height() / 2;
         },
         [&](const Style::SVGBaselineShift::Length& length) -> float {
-            return Style::evaluate(length, m_font->size(), Style::ZoomNeeded { });
+            return Style::evaluate<float>(length, m_font->size(), Style::ZoomNeeded { });
         }
     );
 }

--- a/Source/WebCore/style/StyleExtractorCustom.h
+++ b/Source/WebCore/style/StyleExtractorCustom.h
@@ -389,7 +389,7 @@ template<CSSPropertyID propertyID, typename InsetEdgeApplier, typename NumberAsP
                     : box->containingBlockLogicalWidthForContent();
             }
         }
-        return numberAsPixelsApplier(Style::evaluate(inset, containingBlockSize, Style::ZoomNeeded { }));
+        return numberAsPixelsApplier(Style::evaluate<LayoutUnit>(inset, containingBlockSize, Style::ZoomNeeded { }));
     }
 
     // Return a "computed value" length.
@@ -1662,7 +1662,7 @@ inline Ref<CSSValue> ExtractorCustom::extractMarginRight(ExtractorState& state)
         // RenderBox gives a marginRight() that is the distance between the right-edge of the child box
         // and the right-edge of the containing box, when display == DisplayType::Block. Let's calculate the absolute
         // value of the specified margin-right % instead of relying on RenderBox's marginRight() value.
-        value = Style::evaluateMinimum(marginRight, box->containingBlockLogicalWidthForContent(), Style::ZoomNeeded { });
+        value = Style::evaluateMinimum<float>(marginRight, box->containingBlockLogicalWidthForContent(), Style::ZoomNeeded { });
     } else
         value = box->marginRight();
     return ExtractorConverter::convertNumberAsPixels(state, value);
@@ -1687,7 +1687,7 @@ inline void ExtractorCustom::extractMarginRightSerialization(ExtractorState& sta
         // RenderBox gives a marginRight() that is the distance between the right-edge of the child box
         // and the right-edge of the containing box, when display == DisplayType::Block. Let's calculate the absolute
         // value of the specified margin-right % instead of relying on RenderBox's marginRight() value.
-        value = Style::evaluateMinimum(marginRight, box->containingBlockLogicalWidthForContent(), Style::ZoomNeeded { });
+        value = Style::evaluateMinimum<float>(marginRight, box->containingBlockLogicalWidthForContent(), Style::ZoomNeeded { });
     } else
         value = box->marginRight();
 
@@ -2803,8 +2803,8 @@ inline RefPtr<CSSValue> ExtractorCustom::extractPerspectiveOriginShorthand(Extra
     CSSValueListBuilder list;
     if (state.renderer) {
         auto box = state.renderer->transformReferenceBoxRect(state.style);
-        list.append(ExtractorConverter::convertNumberAsPixels(state, Style::evaluate(state.style.perspectiveOriginX(), box.width(), Style::ZoomNeeded { })));
-        list.append(ExtractorConverter::convertNumberAsPixels(state, Style::evaluate(state.style.perspectiveOriginY(), box.height(), Style::ZoomNeeded { })));
+        list.append(ExtractorConverter::convertNumberAsPixels(state, Style::evaluate<float>(state.style.perspectiveOriginX(), box.width(), Style::ZoomNeeded { })));
+        list.append(ExtractorConverter::convertNumberAsPixels(state, Style::evaluate<float>(state.style.perspectiveOriginY(), box.height(), Style::ZoomNeeded { })));
     } else {
         list.append(ExtractorConverter::convertStyleType(state, state.style.perspectiveOriginX()));
         list.append(ExtractorConverter::convertStyleType(state, state.style.perspectiveOriginY()));
@@ -2816,9 +2816,9 @@ inline void ExtractorCustom::extractPerspectiveOriginShorthandSerialization(Extr
 {
     if (state.renderer) {
         auto box = state.renderer->transformReferenceBoxRect(state.style);
-        ExtractorSerializer::serializeNumberAsPixels(state, builder, context, Style::evaluate(state.style.perspectiveOriginX(), box.width(), Style::ZoomNeeded { }));
+        ExtractorSerializer::serializeNumberAsPixels(state, builder, context, Style::evaluate<float>(state.style.perspectiveOriginX(), box.width(), Style::ZoomNeeded { }));
         builder.append(' ');
-        ExtractorSerializer::serializeNumberAsPixels(state, builder, context, Style::evaluate(state.style.perspectiveOriginY(), box.height(), Style::ZoomNeeded { }));
+        ExtractorSerializer::serializeNumberAsPixels(state, builder, context, Style::evaluate<float>(state.style.perspectiveOriginY(), box.height(), Style::ZoomNeeded { }));
     } else {
         ExtractorSerializer::serializeStyleType(state, builder, context, state.style.perspectiveOriginX());
         builder.append(' ');
@@ -3048,8 +3048,8 @@ inline RefPtr<CSSValue> ExtractorCustom::extractTransformOriginShorthand(Extract
     CSSValueListBuilder list;
     if (state.renderer) {
         auto box = state.renderer->transformReferenceBoxRect(state.style);
-        list.append(ExtractorConverter::convertNumberAsPixels(state, Style::evaluate(state.style.transformOriginX(), box.width(), Style::ZoomNeeded { })));
-        list.append(ExtractorConverter::convertNumberAsPixels(state, Style::evaluate(state.style.transformOriginY(), box.height(), Style::ZoomNeeded { })));
+        list.append(ExtractorConverter::convertNumberAsPixels(state, Style::evaluate<float>(state.style.transformOriginX(), box.width(), Style::ZoomNeeded { })));
+        list.append(ExtractorConverter::convertNumberAsPixels(state, Style::evaluate<float>(state.style.transformOriginY(), box.height(), Style::ZoomNeeded { })));
         if (auto transformOriginZ = state.style.transformOriginZ(); !transformOriginZ.isZero())
             list.append(ExtractorConverter::convertStyleType(state, transformOriginZ));
     } else {
@@ -3065,9 +3065,9 @@ inline void ExtractorCustom::extractTransformOriginShorthandSerialization(Extrac
 {
     if (state.renderer) {
         auto box = state.renderer->transformReferenceBoxRect(state.style);
-        ExtractorSerializer::serializeNumberAsPixels(state, builder, context, Style::evaluate(state.style.transformOriginX(), box.width(), Style::ZoomNeeded { }));
+        ExtractorSerializer::serializeNumberAsPixels(state, builder, context, Style::evaluate<float>(state.style.transformOriginX(), box.width(), Style::ZoomNeeded { }));
         builder.append(' ');
-        ExtractorSerializer::serializeNumberAsPixels(state, builder, context, Style::evaluate(state.style.transformOriginY(), box.height(), Style::ZoomNeeded { }));
+        ExtractorSerializer::serializeNumberAsPixels(state, builder, context, Style::evaluate<float>(state.style.transformOriginY(), box.height(), Style::ZoomNeeded { }));
         if (auto transformOriginZ = state.style.transformOriginZ(); !transformOriginZ.isZero()) {
             builder.append(' ');
             ExtractorSerializer::serializeStyleType(state, builder, context, transformOriginZ);

--- a/Source/WebCore/style/StyleResolveForFont.cpp
+++ b/Source/WebCore/style/StyleResolveForFont.cpp
@@ -331,7 +331,7 @@ static ResolvedFontSize fontSizeFromUnresolvedFontSize(const CSSPropertyParserHe
                     return CSS::switchOnUnitType(lengthPercentage.unit,
                         [&](CSS::PercentageUnit) -> ResolvedFontSize {
                             return {
-                                .size = Style::evaluate(Style::Percentage<> { narrowPrecisionToFloat(lengthPercentage.value) }, parentSize),
+                                .size = Style::evaluate<float>(Style::Percentage<> { narrowPrecisionToFloat(lengthPercentage.value) }, parentSize),
                                 .keyword = CSSValueInvalid
                             };
                         },
@@ -360,7 +360,7 @@ static ResolvedFontSize fontSizeFromUnresolvedFontSize(const CSSPropertyParserHe
                         return { .size = 0.0f, .keyword = CSSValueInvalid };
 
                     return {
-                        .size = Style::evaluate(Style::toStyleNoConversionDataRequired(calc), parentSize, Style::ZoomNeeded { }),
+                        .size = Style::evaluate<float>(Style::toStyleNoConversionDataRequired(calc), parentSize, Style::ZoomNeeded { }),
                         .keyword = CSSValueInvalid
                     };
                 }

--- a/Source/WebCore/style/values/backgrounds/StyleLineWidth.cpp
+++ b/Source/WebCore/style/values/backgrounds/StyleLineWidth.cpp
@@ -74,13 +74,23 @@ auto CSSValueConversion<LineWidth>::operator()(BuilderState& state, const CSSVal
 
 // MARK: - Evaluate
 
-FloatBoxExtent Evaluation<LineWidthBox>::operator()(const LineWidthBox& value, ZoomNeeded token)
+auto Evaluation<LineWidthBox, FloatBoxExtent>::operator()(const LineWidthBox& value, ZoomNeeded token) -> FloatBoxExtent
 {
     return {
-        evaluate(value.top(), token),
-        evaluate(value.right(), token),
-        evaluate(value.bottom(), token),
-        evaluate(value.left(), token),
+        evaluate<float>(value.top(), token),
+        evaluate<float>(value.right(), token),
+        evaluate<float>(value.bottom(), token),
+        evaluate<float>(value.left(), token),
+    };
+}
+
+auto Evaluation<LineWidthBox, LayoutBoxExtent>::operator()(const LineWidthBox& value, ZoomNeeded token) -> LayoutBoxExtent
+{
+    return {
+        evaluate<LayoutUnit>(value.top(), token),
+        evaluate<LayoutUnit>(value.right(), token),
+        evaluate<LayoutUnit>(value.bottom(), token),
+        evaluate<LayoutUnit>(value.left(), token),
     };
 }
 

--- a/Source/WebCore/style/values/backgrounds/StyleLineWidth.h
+++ b/Source/WebCore/style/values/backgrounds/StyleLineWidth.h
@@ -29,7 +29,10 @@
 
 namespace WebCore {
 
+class LayoutUnit;
+
 using FloatBoxExtent = RectEdges<float>;
+using LayoutBoxExtent = RectEdges<LayoutUnit>;
 
 namespace Style {
 
@@ -65,15 +68,18 @@ template<> struct CSSValueConversion<LineWidth> { auto operator()(BuilderState&,
 
 // MARK: - Evaluate
 
-template<> struct Evaluation<LineWidth> {
-    constexpr auto operator()(const LineWidth& value, ZoomNeeded token) -> float
+template<typename Result> struct Evaluation<LineWidth, Result> {
+    constexpr auto operator()(const LineWidth& value, ZoomNeeded token) -> Result
     {
-        return value.value.resolveZoom(token);
+        return Result(value.value.resolveZoom(token));
     }
 };
 
-template<> struct Evaluation<LineWidthBox> {
-    FloatBoxExtent operator()(const LineWidthBox&, ZoomNeeded);
+template<> struct Evaluation<LineWidthBox, FloatBoxExtent> {
+    auto operator()(const LineWidthBox&, ZoomNeeded) -> FloatBoxExtent;
+};
+template<> struct Evaluation<LineWidthBox, LayoutBoxExtent> {
+    auto operator()(const LineWidthBox&, ZoomNeeded) -> LayoutBoxExtent;
 };
 
 } // namespace Style

--- a/Source/WebCore/style/values/borders/StyleBorderRadius.cpp
+++ b/Source/WebCore/style/values/borders/StyleBorderRadius.cpp
@@ -85,23 +85,23 @@ auto CSSValueConversion<BorderRadiusValue>::operator()(BuilderState& state, cons
 
 // MARK: - Evaluation
 
-auto Evaluation<BorderRadius>::operator()(const BorderRadius& value, FloatSize referenceSize, ZoomNeeded token) -> FloatRoundedRect::Radii
+auto Evaluation<BorderRadius, FloatRoundedRect::Radii>::operator()(const BorderRadius& value, FloatSize referenceSize, ZoomNeeded token) -> FloatRoundedRect::Radii
 {
     return {
-        evaluate(value.topLeft(), referenceSize, token),
-        evaluate(value.topRight(), referenceSize, token),
-        evaluate(value.bottomLeft(), referenceSize, token),
-        evaluate(value.bottomRight(), referenceSize, token),
+        evaluate<FloatSize>(value.topLeft(), referenceSize, token),
+        evaluate<FloatSize>(value.topRight(), referenceSize, token),
+        evaluate<FloatSize>(value.bottomLeft(), referenceSize, token),
+        evaluate<FloatSize>(value.bottomRight(), referenceSize, token),
     };
 }
 
-auto Evaluation<BorderRadius>::operator()(const BorderRadius& value, LayoutSize referenceSize, ZoomNeeded token) -> LayoutRoundedRect::Radii
+auto Evaluation<BorderRadius, LayoutRoundedRect::Radii>::operator()(const BorderRadius& value, LayoutSize referenceSize, ZoomNeeded token) -> LayoutRoundedRect::Radii
 {
     return {
-        evaluate(value.topLeft(), referenceSize, token),
-        evaluate(value.topRight(), referenceSize, token),
-        evaluate(value.bottomLeft(), referenceSize, token),
-        evaluate(value.bottomRight(), referenceSize, token),
+        evaluate<LayoutSize>(value.topLeft(), referenceSize, token),
+        evaluate<LayoutSize>(value.topRight(), referenceSize, token),
+        evaluate<LayoutSize>(value.bottomLeft(), referenceSize, token),
+        evaluate<LayoutSize>(value.bottomRight(), referenceSize, token),
     };
 }
 

--- a/Source/WebCore/style/values/borders/StyleBorderRadius.h
+++ b/Source/WebCore/style/values/borders/StyleBorderRadius.h
@@ -79,8 +79,10 @@ template<> struct CSSValueConversion<BorderRadiusValue> { auto operator()(Builde
 
 // MARK: - Evaluation
 
-template<> struct Evaluation<BorderRadius> {
+template<> struct Evaluation<BorderRadius, FloatRoundedRect::Radii> {
     auto operator()(const BorderRadius&, FloatSize, ZoomNeeded) -> FloatRoundedRect::Radii;
+};
+template<> struct Evaluation<BorderRadius, LayoutRoundedRect::Radii> {
     auto operator()(const BorderRadius&, LayoutSize, ZoomNeeded) -> LayoutRoundedRect::Radii;
 };
 

--- a/Source/WebCore/style/values/filter-effects/StyleBrightnessFunction.cpp
+++ b/Source/WebCore/style/values/filter-effects/StyleBrightnessFunction.cpp
@@ -43,7 +43,7 @@ Ref<FilterOperation> createFilterOperation(const CSS::Brightness& filter, const 
 {
     double value;
     if (auto parameter = filter.value) {
-        value = evaluate(toStyle(*parameter, state));
+        value = evaluate<double>(toStyle(*parameter, state));
     } else
         value = filterFunctionDefaultValue<CSS::BrightnessFunction::name>().value;
 

--- a/Source/WebCore/style/values/filter-effects/StyleContrastFunction.cpp
+++ b/Source/WebCore/style/values/filter-effects/StyleContrastFunction.cpp
@@ -43,7 +43,7 @@ Ref<FilterOperation> createFilterOperation(const CSS::Contrast& filter, const Bu
 {
     double value;
     if (auto parameter = filter.value)
-        value = evaluate(toStyle(*parameter, state));
+        value = evaluate<double>(toStyle(*parameter, state));
     else
         value = filterFunctionDefaultValue<CSS::ContrastFunction::name>().value;
 

--- a/Source/WebCore/style/values/filter-effects/StyleGrayscaleFunction.cpp
+++ b/Source/WebCore/style/values/filter-effects/StyleGrayscaleFunction.cpp
@@ -43,7 +43,7 @@ Ref<FilterOperation> createFilterOperation(const CSS::Grayscale& filter, const B
 {
     double value;
     if (auto parameter = filter.value)
-        value = evaluate(toStyle(*parameter, state));
+        value = evaluate<double>(toStyle(*parameter, state));
     else
         value = filterFunctionDefaultValue<CSS::GrayscaleFunction::name>().value;
 

--- a/Source/WebCore/style/values/filter-effects/StyleInvertFunction.cpp
+++ b/Source/WebCore/style/values/filter-effects/StyleInvertFunction.cpp
@@ -43,7 +43,7 @@ Ref<FilterOperation> createFilterOperation(const CSS::Invert& filter, const Buil
 {
     double value;
     if (auto parameter = filter.value)
-        value = evaluate(toStyle(*parameter, state));
+        value = evaluate<double>(toStyle(*parameter, state));
     else
         value = filterFunctionDefaultValue<CSS::InvertFunction::name>().value;
     return BasicComponentTransferFilterOperation::create(value, filterFunctionOperationType<CSS::InvertFunction::name>());

--- a/Source/WebCore/style/values/filter-effects/StyleOpacityFunction.cpp
+++ b/Source/WebCore/style/values/filter-effects/StyleOpacityFunction.cpp
@@ -43,7 +43,7 @@ Ref<FilterOperation> createFilterOperation(const CSS::Opacity& filter, const Bui
 {
     double value;
     if (auto parameter = filter.value)
-        value = evaluate(toStyle(*parameter, state));
+        value = evaluate<double>(toStyle(*parameter, state));
     else
         value = filterFunctionDefaultValue<CSS::OpacityFunction::name>().value;
 

--- a/Source/WebCore/style/values/filter-effects/StyleSaturateFunction.cpp
+++ b/Source/WebCore/style/values/filter-effects/StyleSaturateFunction.cpp
@@ -43,7 +43,7 @@ Ref<FilterOperation> createFilterOperation(const CSS::Saturate& filter, const Bu
 {
     double value;
     if (auto parameter = filter.value)
-        value = evaluate(toStyle(*parameter, state));
+        value = evaluate<double>(toStyle(*parameter, state));
     else
         value = filterFunctionDefaultValue<CSS::SaturateFunction::name>().value;
 

--- a/Source/WebCore/style/values/filter-effects/StyleSepiaFunction.cpp
+++ b/Source/WebCore/style/values/filter-effects/StyleSepiaFunction.cpp
@@ -43,7 +43,7 @@ Ref<FilterOperation> createFilterOperation(const CSS::Sepia& filter, const Build
 {
     double value;
     if (auto parameter = filter.value)
-        value = evaluate(toStyle(*parameter, state));
+        value = evaluate<double>(toStyle(*parameter, state));
     else
         value = filterFunctionDefaultValue<CSS::SepiaFunction::name>().value;
 

--- a/Source/WebCore/style/values/images/StyleGradient.cpp
+++ b/Source/WebCore/style/values/images/StyleGradient.cpp
@@ -644,7 +644,7 @@ template<typename GradientAdapter, typename StyleGradient> GradientColorStops co
 
 static inline float positionFromValue(LengthWrapperBaseDerived auto const& coordinate, float widthOrHeight)
 {
-    return evaluate(coordinate, widthOrHeight, Style::ZoomNeeded { });
+    return evaluate<float>(coordinate, widthOrHeight, Style::ZoomNeeded { });
 }
 
 static inline float positionFromValue(const NumberOrPercentage<>& coordinate, float widthOrHeight)
@@ -722,7 +722,7 @@ static std::pair<FloatPoint, FloatPoint> endPointsFromAngleForPrefixedVariants(f
 
 static float resolveRadius(const LengthPercentage<CSS::Nonnegative>& radius, float widthOrHeight)
 {
-    return evaluate(radius, widthOrHeight, Style::ZoomNeeded { });
+    return evaluate<float>(radius, widthOrHeight, Style::ZoomNeeded { });
 }
 
 struct DistanceToCorner {

--- a/Source/WebCore/style/values/non-standard/StyleWebKitTextStrokeWidth.h
+++ b/Source/WebCore/style/values/non-standard/StyleWebKitTextStrokeWidth.h
@@ -53,7 +53,7 @@ template<> struct CSSValueConversion<WebkitTextStrokeWidth> { auto operator()(Bu
 
 // MARK: - Evaluate
 
-template<> struct Evaluation<WebkitTextStrokeWidth> {
+template<> struct Evaluation<WebkitTextStrokeWidth, float> {
     constexpr auto operator()(const WebkitTextStrokeWidth& value, ZoomNeeded token) -> float
     {
         return value.value.resolveZoom(token);

--- a/Source/WebCore/style/values/primitives/StyleLengthWrapper.h
+++ b/Source/WebCore/style/values/primitives/StyleLengthWrapper.h
@@ -35,7 +35,7 @@ namespace WebCore {
 namespace Style {
 
 template<typename, CSS::PrimitiveKeyword...> struct LengthWrapperBase;
-template<typename> struct MinimumEvaluation;
+template<typename, typename> struct MinimumEvaluation;
 
 // Transitionary type acting as a `Style::PrimitiveNumericOrKeyword<...>` but implemented by wrapping a `LengthWrapperData`.
 template<typename Numeric, CSS::PrimitiveKeyword... Ks> struct LengthWrapperBase {
@@ -147,8 +147,8 @@ template<typename Numeric, CSS::PrimitiveKeyword... Ks> struct LengthWrapperBase
 
 private:
     template<typename> friend struct ToPlatform;
-    template<typename> friend struct Evaluation;
-    template<typename> friend struct MinimumEvaluation;
+    template<typename, typename> friend struct Evaluation;
+    template<typename, typename> friend struct MinimumEvaluation;
     template<typename> friend struct Blending;
 
     static LengthWrapperData toData(const Specified& specified)
@@ -281,83 +281,56 @@ template<typename T> concept LengthWrapperBaseDerived = WTF::IsBaseOfTemplate<Le
 
 // MARK: - Evaluation
 
-template<LengthWrapperBaseDerived T> struct Evaluation<T> {
-    auto operator()(const T& value, NOESCAPE const Invocable<LayoutUnit()> auto& lazyMaximumValueFunctor, ZoomNeeded token) -> LayoutUnit
+template<LengthWrapperBaseDerived T, typename Result> struct Evaluation<T, Result> {
+    auto operator()(const T& value, NOESCAPE const Invocable<Result()> auto& lazyMaximumValueFunctor, ZoomNeeded token) -> Result
         requires (T::Fixed::range.zoomOptions == CSS::RangeZoomOptions::Default)
     {
-        return value.m_value.template valueForLengthWrapperDataWithLazyMaximum<LayoutUnit, LayoutUnit>(value.evaluationKind(), lazyMaximumValueFunctor, token);
+        return value.m_value.template valueForLengthWrapperDataWithLazyMaximum<Result, Result>(value.evaluationKind(), lazyMaximumValueFunctor, token);
     }
-    auto operator()(const T& value, NOESCAPE const Invocable<float()> auto& lazyMaximumValueFunctor, ZoomNeeded token) -> float
+    auto operator()(const T& value, Result maximumValue, ZoomNeeded token) -> Result
         requires (T::Fixed::range.zoomOptions == CSS::RangeZoomOptions::Default)
     {
-        return value.m_value.template valueForLengthWrapperDataWithLazyMaximum<float, float>(value.evaluationKind(), lazyMaximumValueFunctor, token);
-    }
-    auto operator()(const T& value, LayoutUnit maximumValue, ZoomNeeded token) -> LayoutUnit
-        requires (T::Fixed::range.zoomOptions == CSS::RangeZoomOptions::Default)
-    {
-        return value.m_value.template valueForLengthWrapperDataWithLazyMaximum<LayoutUnit, LayoutUnit>(value.evaluationKind(), [&] ALWAYS_INLINE_LAMBDA { return maximumValue; }, token);
-    }
-    auto operator()(const T& value, float maximumValue, ZoomNeeded token) -> float
-        requires (T::Fixed::range.zoomOptions == CSS::RangeZoomOptions::Default)
-    {
-        return value.m_value.template valueForLengthWrapperDataWithLazyMaximum<float, float>(value.evaluationKind(), [&] ALWAYS_INLINE_LAMBDA { return maximumValue; }, token);
+        return value.m_value.template valueForLengthWrapperDataWithLazyMaximum<Result, Result>(value.evaluationKind(), [&] ALWAYS_INLINE_LAMBDA { return maximumValue; }, token);
     }
 
-    auto operator()(const T& value, NOESCAPE const Invocable<LayoutUnit()> auto& lazyMaximumValueFunctor, float zoom) -> LayoutUnit
+    auto operator()(const T& value, NOESCAPE const Invocable<Result()> auto& lazyMaximumValueFunctor, float zoom) -> Result
         requires (T::Fixed::range.zoomOptions == CSS::RangeZoomOptions::Unzoomed)
     {
-        return value.m_value.template valueForLengthWrapperDataWithLazyMaximum<LayoutUnit, LayoutUnit>(value.evaluationKind(), lazyMaximumValueFunctor, zoom);
+        return value.m_value.template valueForLengthWrapperDataWithLazyMaximum<Result, Result>(value.evaluationKind(), lazyMaximumValueFunctor, zoom);
     }
-    auto operator()(const T& value, NOESCAPE const Invocable<float()> auto& lazyMaximumValueFunctor, float zoom) -> float
+    auto operator()(const T& value, Result maximumValue, float zoom) -> Result
         requires (T::Fixed::range.zoomOptions == CSS::RangeZoomOptions::Unzoomed)
     {
-        return value.m_value.template valueForLengthWrapperDataWithLazyMaximum<float, float>(value.evaluationKind(), lazyMaximumValueFunctor, zoom);
-    }
-    auto operator()(const T& value, LayoutUnit maximumValue, float zoom) -> LayoutUnit
-        requires (T::Fixed::range.zoomOptions == CSS::RangeZoomOptions::Unzoomed)
-    {
-        return value.m_value.template valueForLengthWrapperDataWithLazyMaximum<LayoutUnit, LayoutUnit>(value.evaluationKind(), [&] ALWAYS_INLINE_LAMBDA { return maximumValue; }, zoom);
-    }
-    auto operator()(const T& value, float maximumValue, float zoom) -> float
-        requires (T::Fixed::range.zoomOptions == CSS::RangeZoomOptions::Unzoomed)
-    {
-        return value.m_value.template valueForLengthWrapperDataWithLazyMaximum<float, float>(value.evaluationKind(), [&] ALWAYS_INLINE_LAMBDA { return maximumValue; }, zoom);
+        return value.m_value.template valueForLengthWrapperDataWithLazyMaximum<Result, Result>(value.evaluationKind(), [&] ALWAYS_INLINE_LAMBDA { return maximumValue; }, zoom);
     }
 };
 
-template<typename StyleType, typename Reference, typename Zoom> decltype(auto) evaluateMinimum(const StyleType& value, NOESCAPE Reference&& reference, Zoom&& zoom)
-{
-    return MinimumEvaluation<StyleType> { }(value, std::forward<Reference>(reference), std::forward<Zoom>(zoom));
-}
+template<typename Result> struct EvaluationMinimumInvoker {
+    template<typename StyleType, typename Reference, typename Zoom> decltype(auto) operator()(const StyleType& value, NOESCAPE Reference&& reference, Zoom&& zoom) const
+    {
+        return MinimumEvaluation<StyleType, Result> { }(value, std::forward<Reference>(reference), std::forward<Zoom>(zoom));
+    }
+};
+template<typename Result> inline constexpr EvaluationMinimumInvoker<Result> evaluateMinimum{};
 
-template<LengthWrapperBaseDerived T> struct MinimumEvaluation<T> {
-    auto operator()(const T& value, NOESCAPE const Invocable<LayoutUnit()> auto& lazyMaximumValueFunctor, ZoomNeeded token) -> LayoutUnit
+template<LengthWrapperBaseDerived T, typename Result> struct MinimumEvaluation<T, Result> {
+    auto operator()(const T& value, NOESCAPE const Invocable<Result()> auto& lazyMaximumValueFunctor, ZoomNeeded token) -> Result
         requires (T::Fixed::range.zoomOptions == CSS::RangeZoomOptions::Default)
     {
         return value.m_value.template minimumValueForLengthWrapperDataWithLazyMaximum<LayoutUnit, LayoutUnit>(value.evaluationKind(), lazyMaximumValueFunctor, token);
     }
-    auto operator()(const T& value, LayoutUnit maximumValue, ZoomNeeded token) -> LayoutUnit
-        requires (T::Fixed::range.zoomOptions == CSS::RangeZoomOptions::Default)
-    {
-        return value.m_value.template minimumValueForLengthWrapperDataWithLazyMaximum<LayoutUnit, LayoutUnit>(value.evaluationKind(), [&] ALWAYS_INLINE_LAMBDA { return maximumValue; }, token);
-    }
-    auto operator()(const T& value, float maximumValue, ZoomNeeded token) -> float
+    auto operator()(const T& value, Result maximumValue, ZoomNeeded token) -> Result
         requires (T::Fixed::range.zoomOptions == CSS::RangeZoomOptions::Default)
     {
         return value.m_value.template minimumValueForLengthWrapperDataWithLazyMaximum<LayoutUnit, LayoutUnit>(value.evaluationKind(), [&] ALWAYS_INLINE_LAMBDA { return LayoutUnit(maximumValue); }, token);
     }
 
-    auto operator()(const T& value, NOESCAPE const Invocable<LayoutUnit()> auto& lazyMaximumValueFunctor, float zoom) -> LayoutUnit
+    auto operator()(const T& value, NOESCAPE const Invocable<Result()> auto& lazyMaximumValueFunctor, float zoom) -> Result
         requires (T::Fixed::range.zoomOptions == CSS::RangeZoomOptions::Unzoomed)
     {
         return value.m_value.template minimumValueForLengthWrapperDataWithLazyMaximum<LayoutUnit, LayoutUnit>(value.evaluationKind(), lazyMaximumValueFunctor, zoom);
     }
-    auto operator()(const T& value, LayoutUnit maximumValue, float zoom) -> LayoutUnit
-        requires (T::Fixed::range.zoomOptions == CSS::RangeZoomOptions::Unzoomed)
-    {
-        return value.m_value.template minimumValueForLengthWrapperDataWithLazyMaximum<LayoutUnit, LayoutUnit>(value.evaluationKind(), [&] ALWAYS_INLINE_LAMBDA { return maximumValue; }, zoom);
-    }
-    auto operator()(const T& value, float maximumValue, float zoom) -> float
+    auto operator()(const T& value, Result maximumValue, float zoom) -> Result
         requires (T::Fixed::range.zoomOptions == CSS::RangeZoomOptions::Unzoomed)
     {
         return value.m_value.template minimumValueForLengthWrapperDataWithLazyMaximum<LayoutUnit, LayoutUnit>(value.evaluationKind(), [&] ALWAYS_INLINE_LAMBDA { return LayoutUnit(maximumValue); }, zoom);

--- a/Source/WebCore/style/values/primitives/StylePosition.cpp
+++ b/Source/WebCore/style/values/primitives/StylePosition.cpp
@@ -310,11 +310,11 @@ auto CSSValueConversion<PositionY>::operator()(BuilderState& state, const CSSVal
 
 // MARK: - Evaluation
 
-auto Evaluation<Position>::operator()(const Position& position, FloatSize referenceBox, ZoomNeeded token) -> FloatPoint
+auto Evaluation<Position, FloatPoint>::operator()(const Position& position, FloatSize referenceBox, ZoomNeeded token) -> FloatPoint
 {
     return {
-        evaluate(position.x, referenceBox.width(), token),
-        evaluate(position.y, referenceBox.height(), token)
+        evaluate<float>(position.x, referenceBox.width(), token),
+        evaluate<float>(position.y, referenceBox.height(), token)
     };
 }
 

--- a/Source/WebCore/style/values/primitives/StylePosition.h
+++ b/Source/WebCore/style/values/primitives/StylePosition.h
@@ -139,7 +139,7 @@ template<> struct CSSValueConversion<PositionY> { auto operator()(BuilderState&,
 
 // MARK: - Evaluation
 
-template<> struct Evaluation<Position> {
+template<> struct Evaluation<Position, FloatPoint> {
     auto operator()(const Position&, FloatSize, ZoomNeeded) -> FloatPoint;
 };
 

--- a/Source/WebCore/style/values/scroll-snap/StyleScrollMargin.cpp
+++ b/Source/WebCore/style/values/scroll-snap/StyleScrollMargin.cpp
@@ -28,33 +28,50 @@
 #include "LayoutRect.h"
 #include "StyleBuilderState.h"
 #include "StylePrimitiveNumericTypes+CSSValueConversion.h"
+#include "StylePrimitiveNumericTypes+Evaluation.h"
 #include <wtf/text/TextStream.h>
 
 namespace WebCore {
 namespace Style {
 
-LayoutUnit Evaluation<ScrollMarginEdge>::operator()(const ScrollMarginEdge& edge, LayoutUnit, ZoomNeeded token)
-{
-    return LayoutUnit(edge.m_value.resolveZoom(token));
-}
-
-float Evaluation<ScrollMarginEdge>::operator()(const ScrollMarginEdge& edge, float, ZoomNeeded token)
-{
-    return edge.m_value.resolveZoom(token);
-}
+// MARK: - Conversion
 
 auto CSSValueConversion<ScrollMarginEdge>::operator()(BuilderState& state, const CSSValue& value) -> ScrollMarginEdge
 {
     return ScrollMarginEdge { toStyleFromCSSValue<Length<>>(state, value) };
 }
 
+// MARK: - Evaluation
+
+auto Evaluation<ScrollMarginEdge, LayoutUnit>::operator()(const ScrollMarginEdge& edge, LayoutUnit, ZoomNeeded token) -> LayoutUnit
+{
+    return evaluate<LayoutUnit>(edge.m_value, token);
+}
+
+auto Evaluation<ScrollMarginEdge, LayoutUnit>::operator()(const ScrollMarginEdge& edge, ZoomNeeded token) -> LayoutUnit
+{
+    return evaluate<LayoutUnit>(edge.m_value, token);
+}
+
+auto Evaluation<ScrollMarginEdge, float>::operator()(const ScrollMarginEdge& edge, float, ZoomNeeded token) -> float
+{
+    return evaluate<float>(edge.m_value, token);
+}
+
+auto Evaluation<ScrollMarginEdge, float>::operator()(const ScrollMarginEdge& edge, ZoomNeeded token) -> float
+{
+    return evaluate<float>(edge.m_value, token);
+}
+
+// MARK: - Extent
+
 LayoutBoxExtent extentForRect(const ScrollMarginBox& margin, const LayoutRect& rect)
 {
     return LayoutBoxExtent {
-        Style::evaluate(margin.top(), rect.height(), Style::ZoomNeeded { }),
-        Style::evaluate(margin.right(), rect.width(), Style::ZoomNeeded { }),
-        Style::evaluate(margin.bottom(), rect.height(), Style::ZoomNeeded { }),
-        Style::evaluate(margin.left(), rect.width(), Style::ZoomNeeded { }),
+        evaluate<LayoutUnit>(margin.top(), rect.height(), ZoomNeeded { }),
+        evaluate<LayoutUnit>(margin.right(), rect.width(), ZoomNeeded { }),
+        evaluate<LayoutUnit>(margin.bottom(), rect.height(), ZoomNeeded { }),
+        evaluate<LayoutUnit>(margin.left(), rect.width(), ZoomNeeded { }),
     };
 }
 

--- a/Source/WebCore/style/values/scroll-snap/StyleScrollMargin.h
+++ b/Source/WebCore/style/values/scroll-snap/StyleScrollMargin.h
@@ -59,7 +59,8 @@ struct ScrollMarginEdge {
     bool operator==(const ScrollMarginEdge&) const = default;
 
 private:
-    friend struct Evaluation<ScrollMarginEdge>;
+    friend struct Evaluation<ScrollMarginEdge, LayoutUnit>;
+    friend struct Evaluation<ScrollMarginEdge, float>;
 
     Length<> m_value;
 };
@@ -74,9 +75,13 @@ template<> struct CSSValueConversion<ScrollMarginEdge> { auto operator()(Builder
 
 // MARK: - Evaluation
 
-template<> struct Evaluation<ScrollMarginEdge> {
+template<> struct Evaluation<ScrollMarginEdge, LayoutUnit> {
     auto operator()(const ScrollMarginEdge&, LayoutUnit referenceLength, ZoomNeeded) -> LayoutUnit;
+    auto operator()(const ScrollMarginEdge&, ZoomNeeded) -> LayoutUnit;
+};
+template<> struct Evaluation<ScrollMarginEdge, float> {
     auto operator()(const ScrollMarginEdge&, float referenceLength, ZoomNeeded) -> float;
+    auto operator()(const ScrollMarginEdge&, ZoomNeeded) -> float;
 };
 
 // MARK: - Extent

--- a/Source/WebCore/style/values/scroll-snap/StyleScrollPadding.cpp
+++ b/Source/WebCore/style/values/scroll-snap/StyleScrollPadding.cpp
@@ -31,17 +31,19 @@
 namespace WebCore {
 namespace Style {
 
-LayoutUnit Evaluation<ScrollPaddingEdge>::operator()(const ScrollPaddingEdge& edge, LayoutUnit referenceLength, ZoomNeeded token)
+// MARK: - Evaluation
+
+auto Evaluation<ScrollPaddingEdge, LayoutUnit>::operator()(const ScrollPaddingEdge& edge, LayoutUnit referenceLength, ZoomNeeded token) -> LayoutUnit
 {
     return WTF::switchOn(edge,
         [&](const ScrollPaddingEdge::Fixed& fixed) {
-            return LayoutUnit(Style::evaluate(fixed, token));
+            return evaluate<LayoutUnit>(fixed, token);
         },
         [&](const ScrollPaddingEdge::Percentage& percentage) {
-            return Style::evaluate(percentage, referenceLength);
+            return evaluate<LayoutUnit>(percentage, referenceLength);
         },
         [&](const ScrollPaddingEdge::Calc& calculated) {
-            return Style::evaluate(calculated, referenceLength);
+            return evaluate<LayoutUnit>(calculated, referenceLength);
         },
         [&](const CSS::Keyword::Auto&) {
             return 0_lu;
@@ -49,17 +51,17 @@ LayoutUnit Evaluation<ScrollPaddingEdge>::operator()(const ScrollPaddingEdge& ed
     );
 }
 
-float Evaluation<ScrollPaddingEdge>::operator()(const ScrollPaddingEdge& edge, float referenceLength, ZoomNeeded token)
+auto Evaluation<ScrollPaddingEdge, float>::operator()(const ScrollPaddingEdge& edge, float referenceLength, ZoomNeeded token) -> float
 {
     return WTF::switchOn(edge,
         [&](const ScrollPaddingEdge::Fixed& fixed) {
-            return Style::evaluate(fixed, token);
+            return evaluate<float>(fixed, token);
         },
         [&](const ScrollPaddingEdge::Percentage& percentage) {
-            return Style::evaluate(percentage, referenceLength);
+            return evaluate<float>(percentage, referenceLength);
         },
         [&](const ScrollPaddingEdge::Calc& calculated) {
-            return Style::evaluate(calculated, referenceLength);
+            return evaluate<float>(calculated, referenceLength);
         },
         [&](const CSS::Keyword::Auto&) {
             return 0.0f;
@@ -67,13 +69,13 @@ float Evaluation<ScrollPaddingEdge>::operator()(const ScrollPaddingEdge& edge, f
     );
 }
 
-LayoutBoxExtent extentForRect(const ScrollPaddingBox& padding, const LayoutRect& rect, Style::ZoomNeeded token)
+LayoutBoxExtent extentForRect(const ScrollPaddingBox& padding, const LayoutRect& rect, ZoomNeeded token)
 {
     return LayoutBoxExtent {
-        Style::evaluate(padding.top(), rect.height(), token),
-        Style::evaluate(padding.right(), rect.width(), token),
-        Style::evaluate(padding.bottom(), rect.height(), token),
-        Style::evaluate(padding.left(), rect.width(), token),
+        evaluate<LayoutUnit>(padding.top(), rect.height(), token),
+        evaluate<LayoutUnit>(padding.right(), rect.width(), token),
+        evaluate<LayoutUnit>(padding.bottom(), rect.height(), token),
+        evaluate<LayoutUnit>(padding.left(), rect.width(), token),
     };
 }
 

--- a/Source/WebCore/style/values/scroll-snap/StyleScrollPadding.h
+++ b/Source/WebCore/style/values/scroll-snap/StyleScrollPadding.h
@@ -45,14 +45,16 @@ using ScrollPaddingBox = MinimallySerializingSpaceSeparatedRectEdges<ScrollPaddi
 
 // MARK: - Evaluation
 
-template<> struct Evaluation<ScrollPaddingEdge> {
-    auto operator()(const ScrollPaddingEdge&, LayoutUnit referenceLength, Style::ZoomNeeded) -> LayoutUnit;
-    auto operator()(const ScrollPaddingEdge&, float referenceLength, Style::ZoomNeeded) -> float;
+template<> struct Evaluation<ScrollPaddingEdge, LayoutUnit> {
+    auto operator()(const ScrollPaddingEdge&, LayoutUnit referenceLength, ZoomNeeded) -> LayoutUnit;
+};
+template<> struct Evaluation<ScrollPaddingEdge, float> {
+    auto operator()(const ScrollPaddingEdge&, float referenceLength, ZoomNeeded) -> float;
 };
 
 // MARK: - Extent
 
-LayoutBoxExtent extentForRect(const ScrollPaddingBox&, const LayoutRect&, Style::ZoomNeeded);
+LayoutBoxExtent extentForRect(const ScrollPaddingBox&, const LayoutRect&, ZoomNeeded);
 
 } // namespace Style
 } // namespace WebCore

--- a/Source/WebCore/style/values/shapes/StyleCircleFunction.cpp
+++ b/Source/WebCore/style/values/shapes/StyleCircleFunction.cpp
@@ -64,14 +64,14 @@ static const WebCore::Path& cachedCirclePath(const FloatRect& rect)
 
 FloatPoint resolvePosition(const Circle& value, FloatSize boundingBox)
 {
-    return value.position ? evaluate(*value.position, boundingBox, Style::ZoomNeeded { }) : FloatPoint { boundingBox.width() / 2, boundingBox.height() / 2 };
+    return value.position ? evaluate<FloatPoint>(*value.position, boundingBox, Style::ZoomNeeded { }) : FloatPoint { boundingBox.width() / 2, boundingBox.height() / 2 };
 }
 
 float resolveRadius(const Circle& value, FloatSize boxSize, FloatPoint center)
 {
     return WTF::switchOn(value.radius,
         [&](const Circle::Length& length) -> float {
-            return evaluate(length, boxSize.diagonalLength() / std::numbers::sqrt2_v<float>, Style::ZoomNeeded { });
+            return evaluate<float>(length, boxSize.diagonalLength() / std::numbers::sqrt2_v<float>, Style::ZoomNeeded { });
         },
         [&](const Circle::Extent& extent) -> float {
             return WTF::switchOn(extent,

--- a/Source/WebCore/style/values/shapes/StyleEllipseFunction.cpp
+++ b/Source/WebCore/style/values/shapes/StyleEllipseFunction.cpp
@@ -65,7 +65,7 @@ static const WebCore::Path& cachedEllipsePath(const FloatRect& rect)
 
 FloatPoint resolvePosition(const Ellipse& value, FloatSize boundingBox)
 {
-    return value.position ? evaluate(*value.position, boundingBox, Style::ZoomNeeded { }) : FloatPoint { boundingBox.width() / 2, boundingBox.height() / 2 };
+    return value.position ? evaluate<FloatPoint>(*value.position, boundingBox, Style::ZoomNeeded { }) : FloatPoint { boundingBox.width() / 2, boundingBox.height() / 2 };
 }
 
 FloatSize resolveRadii(const Ellipse& value, FloatSize boxSize, FloatPoint center)
@@ -73,7 +73,7 @@ FloatSize resolveRadii(const Ellipse& value, FloatSize boxSize, FloatPoint cente
     auto sizeForAxis = [&](const Ellipse::RadialSize& radius, float centerValue, float dimensionSize) {
         return WTF::switchOn(radius,
             [&](const Ellipse::Length& length) -> float {
-                return evaluate(length, std::abs(dimensionSize), Style::ZoomNeeded { });
+                return evaluate<float>(length, std::abs(dimensionSize), Style::ZoomNeeded { });
             },
             [&](const Ellipse::Extent& extent) -> float {
                 return WTF::switchOn(extent,

--- a/Source/WebCore/style/values/shapes/StyleInsetFunction.cpp
+++ b/Source/WebCore/style/values/shapes/StyleInsetFunction.cpp
@@ -63,16 +63,16 @@ WebCore::Path PathComputation<Inset>::operator()(const Inset& value, const Float
 {
     auto boundingSize = boundingBox.size();
 
-    auto left = evaluate(value.insets.left(), boundingSize.width(), Style::ZoomNeeded { });
-    auto top = evaluate(value.insets.top(), boundingSize.height(), Style::ZoomNeeded { });
+    auto left = evaluate<float>(value.insets.left(), boundingSize.width(), Style::ZoomNeeded { });
+    auto top = evaluate<float>(value.insets.top(), boundingSize.height(), Style::ZoomNeeded { });
     auto rect = FloatRect {
         left + boundingBox.x(),
         top + boundingBox.y(),
-        std::max<float>(boundingSize.width() - left - evaluate(value.insets.right(), boundingSize.width(), Style::ZoomNeeded { }), 0),
-        std::max<float>(boundingSize.height() - top - evaluate(value.insets.bottom(), boundingSize.height(), Style::ZoomNeeded { }), 0)
+        std::max<float>(boundingSize.width() - left - evaluate<float>(value.insets.right(), boundingSize.width(), Style::ZoomNeeded { }), 0),
+        std::max<float>(boundingSize.height() - top - evaluate<float>(value.insets.bottom(), boundingSize.height(), Style::ZoomNeeded { }), 0)
     };
 
-    auto radii = evaluate(value.radii, boundingSize, Style::ZoomNeeded { });
+    auto radii = evaluate<FloatRoundedRect::Radii>(value.radii, boundingSize, Style::ZoomNeeded { });
     radii.scale(calcBorderRadiiConstraintScaleFor(rect, radii));
 
     return cachedRoundedInsetPath(FloatRoundedRect { rect, radii });

--- a/Source/WebCore/style/values/shapes/StylePolygonFunction.cpp
+++ b/Source/WebCore/style/values/shapes/StylePolygonFunction.cpp
@@ -63,7 +63,7 @@ WebCore::Path PathComputation<Polygon>::operator()(const Polygon& value, const F
     auto boundingLocation = boundingBox.location();
     auto boundingSize = boundingBox.size();
     auto points = value.vertices.value.map([&](const auto& vertex) {
-        return evaluate(vertex, boundingSize, Style::ZoomNeeded { }) + boundingLocation;
+        return evaluate<FloatPoint>(vertex, boundingSize, Style::ZoomNeeded { }) + boundingLocation;
     });
     return cachedPolygonPath(points);
 }

--- a/Source/WebCore/style/values/shapes/StyleShapeFunction.cpp
+++ b/Source/WebCore/style/values/shapes/StyleShapeFunction.cpp
@@ -52,7 +52,7 @@ template<typename ControlPoint> static ControlPointAnchor evaluateControlPointAn
 
 template<typename ControlPoint> static FloatPoint evaluateControlPointOffset(const ControlPoint& value, const FloatSize& boxSize)
 {
-    return evaluate(value.offset, boxSize, Style::ZoomNeeded { });
+    return evaluate<FloatPoint>(value.offset, boxSize, Style::ZoomNeeded { });
 }
 
 template<typename ControlPoint> static FloatPoint resolveControlPoint(CommandAffinity affinity, FloatPoint currentPosition, FloatPoint segmentOffset, const ControlPoint& controlPoint, const FloatSize& boxSize)
@@ -118,32 +118,32 @@ private:
     std::optional<MoveToSegment> parseMoveToSegment(FloatPoint) override
     {
         if (!m_nextIndex)
-            return MoveToSegment { evaluate(m_start, m_boxSize, Style::ZoomNeeded { }) };
+            return MoveToSegment { evaluate<FloatPoint>(m_start, m_boxSize, Style::ZoomNeeded { }) };
 
         auto& moveCommand = currentValue<MoveCommand>();
 
-        return MoveToSegment { evaluate(moveCommand.toBy, m_boxSize, Style::ZoomNeeded { }) };
+        return MoveToSegment { evaluate<FloatPoint>(moveCommand.toBy, m_boxSize, Style::ZoomNeeded { }) };
     }
 
     std::optional<LineToSegment> parseLineToSegment(FloatPoint) override
     {
         auto& lineCommand = currentValue<LineCommand>();
 
-        return LineToSegment { evaluate(lineCommand.toBy, m_boxSize, Style::ZoomNeeded { }) };
+        return LineToSegment { evaluate<FloatPoint>(lineCommand.toBy, m_boxSize, Style::ZoomNeeded { }) };
     }
 
     std::optional<LineToHorizontalSegment> parseLineToHorizontalSegment(FloatPoint) override
     {
         auto& lineCommand = currentValue<HLineCommand>();
 
-        return LineToHorizontalSegment { evaluate(lineCommand.toBy, m_boxSize.width(), Style::ZoomNeeded { }) };
+        return LineToHorizontalSegment { evaluate<float>(lineCommand.toBy, m_boxSize.width(), Style::ZoomNeeded { }) };
     }
 
     std::optional<LineToVerticalSegment> parseLineToVerticalSegment(FloatPoint) override
     {
         auto& lineCommand = currentValue<VLineCommand>();
 
-        return LineToVerticalSegment { evaluate(lineCommand.toBy, m_boxSize.height(), Style::ZoomNeeded { }) };
+        return LineToVerticalSegment { evaluate<float>(lineCommand.toBy, m_boxSize.height(), Style::ZoomNeeded { }) };
     }
 
     std::optional<CurveToCubicSegment> parseCurveToCubicSegment(FloatPoint currentPosition) override
@@ -152,7 +152,7 @@ private:
 
         return WTF::switchOn(curveCommand.toBy,
             [&](const auto& value) {
-                auto offset = evaluate(value.offset, m_boxSize, Style::ZoomNeeded { });
+                auto offset = evaluate<FloatPoint>(value.offset, m_boxSize, Style::ZoomNeeded { });
                 return CurveToCubicSegment {
                     resolveControlPoint(value.affinity, currentPosition, offset, value.controlPoint1, m_boxSize),
                     resolveControlPoint(value.affinity, currentPosition, offset, value.controlPoint2.value(), m_boxSize),
@@ -168,7 +168,7 @@ private:
 
         return WTF::switchOn(curveCommand.toBy,
             [&](const auto& value) {
-                auto offset = evaluate(value.offset, m_boxSize, Style::ZoomNeeded { });
+                auto offset = evaluate<FloatPoint>(value.offset, m_boxSize, Style::ZoomNeeded { });
                 return CurveToQuadraticSegment {
                     resolveControlPoint(value.affinity, currentPosition, offset, value.controlPoint1, m_boxSize),
                     offset
@@ -184,7 +184,7 @@ private:
         return WTF::switchOn(smoothCommand.toBy,
             [&](const auto& value) {
                 ASSERT(value.controlPoint);
-                auto offset = evaluate(value.offset, m_boxSize, Style::ZoomNeeded { });
+                auto offset = evaluate<FloatPoint>(value.offset, m_boxSize, Style::ZoomNeeded { });
                 return CurveToCubicSmoothSegment {
                     resolveControlPoint(value.affinity, currentPosition, offset, value.controlPoint.value(), m_boxSize),
                     offset
@@ -200,7 +200,7 @@ private:
         return WTF::switchOn(smoothCommand.toBy,
             [&](const auto& value) {
                 return CurveToQuadraticSmoothSegment {
-                    evaluate(value.offset, m_boxSize, Style::ZoomNeeded { })
+                    evaluate<FloatPoint>(value.offset, m_boxSize, Style::ZoomNeeded { })
                 };
             }
         );
@@ -210,14 +210,14 @@ private:
     {
         auto& arcCommand = currentValue<ArcCommand>();
 
-        auto radius = evaluate(arcCommand.size, m_boxSize, Style::ZoomNeeded { });
+        auto radius = evaluate<FloatSize>(arcCommand.size, m_boxSize, Style::ZoomNeeded { });
         return ArcToSegment {
             .rx = radius.width(),
             .ry = radius.height(),
             .angle = narrowPrecisionToFloat(arcCommand.rotation.value),
             .largeArc = std::holds_alternative<CSS::Keyword::Large>(arcCommand.arcSize),
             .sweep = std::holds_alternative<CSS::Keyword::Cw>(arcCommand.arcSweep),
-            .targetPoint = evaluate(arcCommand.toBy, m_boxSize, Style::ZoomNeeded { })
+            .targetPoint = evaluate<FloatPoint>(arcCommand.toBy, m_boxSize, Style::ZoomNeeded { })
         };
     }
 

--- a/Source/WebCore/style/values/text-decoration/StyleTextDecorationThickness.cpp
+++ b/Source/WebCore/style/values/text-decoration/StyleTextDecorationThickness.cpp
@@ -49,7 +49,7 @@ float TextDecorationThickness::resolve(const RenderStyle& style) const
             return style.metricsOfPrimaryFont().underlineThickness().value_or(0);
         },
         [&](const TextDecorationThicknessLength& length) {
-            return Style::evaluate(length, style.computedFontSize(), Style::ZoomNeeded { });
+            return Style::evaluate<float>(length, style.computedFontSize(), Style::ZoomNeeded { });
         }
     );
 }
@@ -64,7 +64,7 @@ float TextDecorationThickness::resolve(float fontSize, const FontMetrics& metric
             return metrics.underlineThickness().value_or(0);
         },
         [&](const TextDecorationThicknessLength& length) {
-            return Style::evaluate(length, fontSize, Style::ZoomNeeded { });
+            return Style::evaluate<float>(length, fontSize, Style::ZoomNeeded { });
         }
     );
 }

--- a/Source/WebCore/style/values/text-decoration/StyleTextUnderlineOffset.cpp
+++ b/Source/WebCore/style/values/text-decoration/StyleTextUnderlineOffset.cpp
@@ -40,10 +40,10 @@ float TextUnderlineOffset::resolve(const RenderStyle& style, float autoValue) co
             return autoValue;
         },
         [&](const Fixed& fixed) -> float {
-            return fixed.resolveZoom(Style::ZoomNeeded { });
+            return Style::evaluate<float>(fixed, Style::ZoomNeeded { });
         },
         [&](const auto& percentage) -> float {
-            return Style::evaluate(percentage, style.computedFontSize());
+            return Style::evaluate<float>(percentage, style.computedFontSize());
         }
     );
 }
@@ -55,10 +55,10 @@ float TextUnderlineOffset::resolve(float fontSize, float autoValue) const
             return autoValue;
         },
         [&](const Fixed& fixed) -> float {
-            return fixed.resolveZoom(Style::ZoomNeeded { });
+            return Style::evaluate<float>(fixed, Style::ZoomNeeded { });
         },
         [&](const auto& percentage) -> float {
-            return Style::evaluate(percentage, fontSize);
+            return Style::evaluate<float>(percentage, fontSize);
         }
     );
 }

--- a/Source/WebCore/svg/SVGLengthContext.cpp
+++ b/Source/WebCore/svg/SVGLengthContext.cpp
@@ -114,7 +114,7 @@ template<typename SizeType> float SVGLengthContext::valueForSizeType(const SizeT
 {
     return WTF::switchOn(size,
         [&](const typename SizeType::Fixed& fixed) -> float {
-            return fixed.resolveZoom(Style::ZoomNeeded { });
+            return Style::evaluate<float>(fixed, Style::ZoomNeeded { });
         },
         [&](const typename SizeType::Percentage& percentage) -> float {
             auto result = convertValueFromPercentageToUserUnits(percentage.value / 100, lengthMode);
@@ -124,7 +124,7 @@ template<typename SizeType> float SVGLengthContext::valueForSizeType(const SizeT
         },
         [&](const typename SizeType::Calc& calc) -> float {
             auto viewportSize = this->viewportSize().value_or(FloatSize { });
-            return Style::evaluate(calc, dimensionForLengthMode(lengthMode, viewportSize));
+            return Style::evaluate<float>(calc, dimensionForLengthMode(lengthMode, viewportSize));
         },
         [&](const auto&) -> float {
             return 0;

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -2060,9 +2060,9 @@ IntRect WebPage::absoluteInteractionBounds(const Node& node)
     auto& style = renderer->style();
     FloatRect boundingBox = renderer->absoluteBoundingBoxRect(true /* use transforms*/);
     // This is wrong. It's subtracting borders after converting to absolute coords on something that probably doesn't represent a rectangular element.
-    boundingBox.move(WebCore::Style::evaluate(style.borderLeftWidth(), WebCore::Style::ZoomNeeded { }), WebCore::Style::evaluate(style.borderTopWidth(), WebCore::Style::ZoomNeeded { }));
-    boundingBox.setWidth(boundingBox.width() - WebCore::Style::evaluate(style.borderLeftWidth(), WebCore::Style::ZoomNeeded { }) - WebCore::Style::evaluate(style.borderRightWidth(), WebCore::Style::ZoomNeeded { }));
-    boundingBox.setHeight(boundingBox.height() - WebCore::Style::evaluate(style.borderBottomWidth(), WebCore::Style::ZoomNeeded { }) - WebCore::Style::evaluate(style.borderTopWidth(), WebCore::Style::ZoomNeeded { }));
+    boundingBox.move(WebCore::Style::evaluate<float>(style.borderLeftWidth(), WebCore::Style::ZoomNeeded { }), WebCore::Style::evaluate<float>(style.borderTopWidth(), WebCore::Style::ZoomNeeded { }));
+    boundingBox.setWidth(boundingBox.width() - WebCore::Style::evaluate<float>(style.borderLeftWidth(), WebCore::Style::ZoomNeeded { }) - WebCore::Style::evaluate<float>(style.borderRightWidth(), WebCore::Style::ZoomNeeded { }));
+    boundingBox.setHeight(boundingBox.height() - WebCore::Style::evaluate<float>(style.borderBottomWidth(), WebCore::Style::ZoomNeeded { }) - WebCore::Style::evaluate<float>(style.borderTopWidth(), WebCore::Style::ZoomNeeded { }));
     return enclosingIntRect(boundingBox);
 }
 

--- a/Source/WebKitLegacy/mac/DOM/DOM.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOM.mm
@@ -448,9 +448,9 @@ id <DOMEventTarget> kit(EventTarget* target)
     auto& style = renderer->style();
     IntRect boundingBox = renderer->absoluteBoundingBoxRect(true /* use transforms*/);
 
-    boundingBox.move(WebCore::Style::evaluate(style.borderLeftWidth(), WebCore::Style::ZoomNeeded { }), WebCore::Style::evaluate(style.borderTopWidth(), WebCore::Style::ZoomNeeded { }));
-    boundingBox.setWidth(boundingBox.width() - WebCore::Style::evaluate(style.borderLeftWidth(), WebCore::Style::ZoomNeeded { }) - WebCore::Style::evaluate(style.borderRightWidth(), WebCore::Style::ZoomNeeded { }));
-    boundingBox.setHeight(boundingBox.height() - WebCore::Style::evaluate(style.borderBottomWidth(), WebCore::Style::ZoomNeeded { }) - WebCore::Style::evaluate(style.borderTopWidth(), WebCore::Style::ZoomNeeded { }));
+    boundingBox.move(WebCore::Style::evaluate<float>(style.borderLeftWidth(), WebCore::Style::ZoomNeeded { }), WebCore::Style::evaluate<float>(style.borderTopWidth(), WebCore::Style::ZoomNeeded { }));
+    boundingBox.setWidth(boundingBox.width() - WebCore::Style::evaluate<float>(style.borderLeftWidth(), WebCore::Style::ZoomNeeded { }) - WebCore::Style::evaluate<float>(style.borderRightWidth(), WebCore::Style::ZoomNeeded { }));
+    boundingBox.setHeight(boundingBox.height() - WebCore::Style::evaluate<float>(style.borderBottomWidth(), WebCore::Style::ZoomNeeded { }) - WebCore::Style::evaluate<float>(style.borderTopWidth(), WebCore::Style::ZoomNeeded { }));
 
     // FIXME: This function advertises returning a quad, but it actually returns a bounding box (so there is no rotation, for instance).
     return wkQuadFromFloatQuad(FloatQuad(boundingBox));


### PR DESCRIPTION
#### 435b3544fef113b86d1b5fda2069b629eb415c64
<pre>
[Style] Require an explicit type when calling Style::evaluate to make it clear which evaluation is being applied
<a href="https://bugs.webkit.org/show_bug.cgi?id=299528">https://bugs.webkit.org/show_bug.cgi?id=299528</a>

Reviewed by Antti Koivisto.

Replaces calls like:

  `Style::evaluate(length, containerLength, Style::ZoomNeeded { })`

with ones that explicitly indicate the result of the evaluation:

  `Style::evaluate&lt;LengthUnit&gt;(length, containerLength, Style::ZoomNeeded { })`

This allows for more clarity and makes disambiguation possible for more cases.

* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
* Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp:
* Source/WebCore/animation/ScrollTimeline.cpp:
* Source/WebCore/animation/ViewTimeline.cpp:
* Source/WebCore/dom/Document.cpp:
* Source/WebCore/layout/Verification.cpp:
* Source/WebCore/layout/formattingContexts/FormattingGeometry.cpp:
* Source/WebCore/layout/formattingContexts/FormattingGeometry.h:
* Source/WebCore/layout/formattingContexts/block/BlockFormattingGeometry.cpp:
* Source/WebCore/layout/formattingContexts/flex/FlexFormattingContext.cpp:
* Source/WebCore/layout/formattingContexts/flex/FlexFormattingUtils.cpp:
* Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.cpp:
* Source/WebCore/layout/formattingContexts/inline/InlineLevelBoxInlines.h:
* Source/WebCore/layout/formattingContexts/table/TableLayout.cpp:
* Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.cpp:
* Source/WebCore/layout/integration/flex/LayoutIntegrationFlexLayout.cpp:
* Source/WebCore/page/IntersectionObserver.cpp:
* Source/WebCore/page/LocalFrameView.cpp:
* Source/WebCore/page/SpatialNavigation.cpp:
* Source/WebCore/platform/graphics/PathUtilities.cpp:
* Source/WebCore/rendering/AutoTableLayout.cpp:
* Source/WebCore/rendering/BackgroundPainter.cpp:
* Source/WebCore/rendering/BorderEdge.cpp:
* Source/WebCore/rendering/BorderPainter.cpp:
* Source/WebCore/rendering/BorderShape.cpp:
* Source/WebCore/rendering/FixedTableLayout.cpp:
* Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp:
* Source/WebCore/rendering/MotionPath.cpp:
* Source/WebCore/rendering/NinePieceImagePainter.cpp:
* Source/WebCore/rendering/PositionedLayoutConstraints.h:
* Source/WebCore/rendering/RenderBlock.cpp:
* Source/WebCore/rendering/RenderBlockFlow.cpp:
* Source/WebCore/rendering/RenderBox.cpp:
* Source/WebCore/rendering/RenderBoxModelObject.cpp:
* Source/WebCore/rendering/RenderBoxModelObjectInlines.h:
* Source/WebCore/rendering/RenderElement.cpp:
* Source/WebCore/rendering/RenderFileUploadControl.cpp:
* Source/WebCore/rendering/RenderFlexibleBox.cpp:
* Source/WebCore/rendering/RenderGrid.cpp:
* Source/WebCore/rendering/RenderImage.cpp:
* Source/WebCore/rendering/RenderInline.cpp:
* Source/WebCore/rendering/RenderLayer.cpp:
* Source/WebCore/rendering/RenderListBox.cpp:
* Source/WebCore/rendering/RenderMarquee.cpp:
* Source/WebCore/rendering/RenderMenuList.cpp:
* Source/WebCore/rendering/RenderMultiColumnSet.cpp:
* Source/WebCore/rendering/RenderReplaced.cpp:
* Source/WebCore/rendering/RenderScrollbarPart.cpp:
* Source/WebCore/rendering/RenderSlider.cpp:
* Source/WebCore/rendering/RenderTable.cpp:
* Source/WebCore/rendering/RenderTableCell.cpp:
* Source/WebCore/rendering/RenderTableSection.cpp:
* Source/WebCore/rendering/RenderTextControl.cpp:
* Source/WebCore/rendering/RenderTextInlines.h:
* Source/WebCore/rendering/RenderTheme.cpp:
* Source/WebCore/rendering/RenderTreeAsText.cpp:
* Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm:
* Source/WebCore/rendering/ios/RenderThemeIOS.mm:
* Source/WebCore/rendering/shapes/LayoutShape.cpp:
* Source/WebCore/rendering/shapes/ShapeOutsideInfo.cpp:
* Source/WebCore/rendering/style/CollapsedBorderValue.h:
* Source/WebCore/rendering/style/RenderStyle.cpp:
* Source/WebCore/rendering/svg/SVGRenderSupport.cpp:
* Source/WebCore/rendering/svg/SVGTextLayoutEngineBaseline.cpp:
* Source/WebCore/style/StyleExtractorCustom.h:
* Source/WebCore/style/StyleResolveForFont.cpp:
* Source/WebCore/style/values/StyleValueTypes.h:
* Source/WebCore/style/values/backgrounds/StyleLineWidth.cpp:
* Source/WebCore/style/values/backgrounds/StyleLineWidth.h:
* Source/WebCore/style/values/borders/StyleBorderRadius.cpp:
* Source/WebCore/style/values/borders/StyleBorderRadius.h:
* Source/WebCore/style/values/filter-effects/StyleBrightnessFunction.cpp:
* Source/WebCore/style/values/filter-effects/StyleContrastFunction.cpp:
* Source/WebCore/style/values/filter-effects/StyleGrayscaleFunction.cpp:
* Source/WebCore/style/values/filter-effects/StyleInvertFunction.cpp:
* Source/WebCore/style/values/filter-effects/StyleOpacityFunction.cpp:
* Source/WebCore/style/values/filter-effects/StyleSaturateFunction.cpp:
* Source/WebCore/style/values/filter-effects/StyleSepiaFunction.cpp:
* Source/WebCore/style/values/images/StyleGradient.cpp:
* Source/WebCore/style/values/non-standard/StyleWebKitTextStrokeWidth.h:
* Source/WebCore/style/values/primitives/StyleLengthWrapper.h:
* Source/WebCore/style/values/primitives/StylePosition.cpp:
* Source/WebCore/style/values/primitives/StylePosition.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Evaluation.h:
* Source/WebCore/style/values/scroll-snap/StyleScrollMargin.cpp:
* Source/WebCore/style/values/scroll-snap/StyleScrollMargin.h:
* Source/WebCore/style/values/scroll-snap/StyleScrollPadding.cpp:
* Source/WebCore/style/values/scroll-snap/StyleScrollPadding.h:
* Source/WebCore/style/values/shapes/StyleCircleFunction.cpp:
* Source/WebCore/style/values/shapes/StyleEllipseFunction.cpp:
* Source/WebCore/style/values/shapes/StyleInsetFunction.cpp:
* Source/WebCore/style/values/shapes/StylePolygonFunction.cpp:
* Source/WebCore/style/values/shapes/StyleShapeFunction.cpp:
* Source/WebCore/style/values/text-decoration/StyleTextDecorationThickness.cpp:
* Source/WebCore/style/values/text-decoration/StyleTextUnderlineOffset.cpp:
* Source/WebCore/svg/SVGLengthContext.cpp:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
* Source/WebKitLegacy/mac/DOM/DOM.mm:

Canonical link: <a href="https://commits.webkit.org/300548@main">https://commits.webkit.org/300548@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b10a327b1638b93c33a5d9adcf57393c240f8572

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123054 "6 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42768 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33465 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/129710 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/75163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/124931 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43492 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51363 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/93537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/75163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126005 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/34666 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110133 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74169 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/33641 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/28293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73224 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/104377 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28514 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132440 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50004 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/38064 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/102039 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50380 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106354 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/101899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25878 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47264 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/25464 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/46777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49859 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/55620 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/49327 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/52679 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/51008 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->