### PR TITLE
[GTK][WPE][OpenXR] Allow running API tests without DMA buf support

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -5672,6 +5672,18 @@ OffscreenCanvasInWorkersEnabled:
       "PLATFORM(COCOA) || PLATFORM(GTK) || PLATFORM(WPE)": true
       default: false
 
+OpenXRDMABufRelaxedForTesting:
+  type: bool
+  status: internal
+  humanReadableName: "OpenXR DMA-BUF requirement relaxed for testing"
+  humanReadableDescription: "During testing, allows relaxing the requirement that the GL display used by the OpenXR coordinator has MESA_image_dma_buf_export"
+  webcoreBinding: none
+  condition: ENABLE(DEVELOPER_MODE) && USE(OPENXR)
+  exposed: [ WebKit ]
+  defaultValue:
+    WebKit:
+      default: false
+
 # FIXME: Reenable this on iOS once we can mitigate impact on memory use.
 OpportunisticSweepingAndGarbageCollectionEnabled:
   type: bool

--- a/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.h
+++ b/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.h
@@ -61,8 +61,8 @@ public:
 
 private:
     void createInstance();
-    RefPtr<WebCore::GLDisplay> createGLDisplay() const;
-    void initializeDevice();
+    RefPtr<WebCore::GLDisplay> createGLDisplay(bool isForTesting) const;
+    void initializeDevice(bool isForTesting);
     void initializeSystem();
     void initializeBlendModes();
     void collectViewConfigurations();

--- a/Tools/Scripts/webkitpy/port/monadodriver.py
+++ b/Tools/Scripts/webkitpy/port/monadodriver.py
@@ -48,10 +48,20 @@ class MonadoDriver(Driver):
     def __init__(self, *args, **kwargs):
         Driver.__init__(self, *args, **kwargs)
 
+    def _get_runtime_path(self, env):
+        # Older OpenXR loaders seem to have problems finding the JSON configuration file on their own
+        data_dirs = env.get("XDG_DATA_DIRS", "").split(":")
+        for data_dir in data_dirs:
+            candidate = os.path.join(data_dir, "openxr", "1", "openxr_monado.json")
+            if os.path.exists(candidate):
+                return candidate
+        return ""
+
     def _setup_environ_for_test(self):
         driver_environment = super(MonadoDriver, self)._setup_environ_for_test()
         driver_environment['WITH_OPENXR_RUNTIME'] = 'y'
         driver_environment['XRT_COMPOSITOR_NULL'] = 'TRUE'
+        driver_environment['XR_RUNTIME_JSON'] = self._get_runtime_path(driver_environment)
 
         monado_command = ['monado-service']
         with open(os.devnull, 'w') as devnull:

--- a/Tools/glib/api_test_runner.py
+++ b/Tools/glib/api_test_runner.py
@@ -191,8 +191,6 @@ class TestRunner(object):
         wpe_legacy_api = self._use_wpe_legacy_api()
         if self.is_webxr_test(test_program):
             env = self._monado_env | self._test_env
-            # WebXR tests use a null compositor
-            env.pop('LIBGL_ALWAYS_SOFTWARE', None)
         else:
             env = self._weston_env if self.is_wpe_platform_wayland_test(test_program) else self._test_env
             if self.is_wpe_platform_test(test_program):


### PR DESCRIPTION
#### a9128cbc5169da9bd9329f84b96f8208271e0900
<pre>
[GTK][WPE][OpenXR] Allow running API tests without DMA buf support
<a href="https://bugs.webkit.org/show_bug.cgi?id=299525">https://bugs.webkit.org/show_bug.cgi?id=299525</a>

Reviewed by Carlos Garcia Campos and Adrian Perez de Castro.

When an OpenXR coordinator is initializing, it requires the
MESA_image_dma_buf_export extension. However, when running tests
headless, like what we do in most bots, that extension is not available.

This change adds an internal web preference,
OpenXRDMABufRelaxedForTesting, (defaulting to false and only available
when building on developer mode) that lets the OpenXR coordinator accept
displays without that extension.

This is enough to run API tests with a headless environment and a null
compositor. Validating this change on the bots exposed a few additional
things: the tests can now run regardless of the value of
LIBGL_ALWAYS_SOFTWARE, and they need XR_RUNTIME_JSON to be defined in
order to find the runtime details.

Test: Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebXR.cpp
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml: the new
  internal preference allowing to relax the extension check.
* Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.cpp:
(WebKit::OpenXRCoordinator::getPrimaryDeviceInfo): Use the page proxy to
query the preferences, and pass it into initializeDevice.
(WebKit::OpenXRCoordinator::createGLDisplay const): Pass and use an
&quot;isTesting&quot; boolean.
(WebKit::OpenXRCoordinator::initializeDevice): Pass an isTesting
boolean.
* Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.h:
* Tools/Scripts/webkitpy/port/monadodriver.py:
(MonadoDriver._get_runtime_path):
(MonadoDriver._setup_environ_for_test):
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebXR.cpp:
(findFeature): helper function to get the web preference.
(relaxDMABufRequirement): helper function that enables a setting
relaxing the DMA-BUF requirement.
(WebXRTest::WebXRTest): relax the requirement by default in all WebXR
tests.
(testWebKitWebXRLeaveImmersiveModeAndWaitUntilImmersiveModeChanged): use
the new settings before loading the test.
(testWebKitXRPermissionRequest): Ditto.
* Tools/glib/api_test_runner.py:
(TestRunner._run_test_glib):

Canonical link: <a href="https://commits.webkit.org/301203@main">https://commits.webkit.org/301203@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4e959336a6fbeb2571c5a32e8b3f775d9f328d7f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125232 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44899 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35638 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132083 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77094 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127109 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45590 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53460 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95344 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/63284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128186 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36396 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111989 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75883 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/124588 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35296 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30157 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75561 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/117323 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106163 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30382 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134764 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/123750 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52041 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/39821 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103813 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52476 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108210 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103581 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26378 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48933 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27222 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49127 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51933 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57712 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/156773 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51298 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39256 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54651 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52989 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->