### PR TITLE
[Navigation API] Replace wrongly adds a new item to the UI Process b/f list

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/navigate-replace-cross-document-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/navigate-replace-cross-document-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL navigate() with history: 'replace' option assert_equals: expected 2 but got 3
+PASS navigate() with history: 'replace' option
 

--- a/Source/WebCore/history/BackForwardCache.cpp
+++ b/Source/WebCore/history/BackForwardCache.cpp
@@ -251,6 +251,12 @@ static bool canCachePage(Page& page)
         logBackForwardCacheFailureDiagnosticMessage(diagnosticLoggingClient, DiagnosticLoggingKeys::replaceKey());
         isCacheable = false;
         break;
+    case FrameLoadType::NavigationAPIReplace:
+        // No point writing to the cache on a replace, since we will just write over it again when we leave that page.
+        PCLOG("   -Load type is: NavigationAPIReplace"_s);
+        logBackForwardCacheFailureDiagnosticMessage(diagnosticLoggingClient, DiagnosticLoggingKeys::replaceKey());
+        isCacheable = false;
+        break;
     case FrameLoadType::ReloadFromOrigin: {
         // No point writing to the cache on a reload, since we will just write over it again when we leave that page.
         PCLOG("   -Load type is: ReloadFromOrigin"_s);

--- a/Source/WebCore/loader/FrameLoaderTypes.h
+++ b/Source/WebCore/loader/FrameLoaderTypes.h
@@ -79,7 +79,8 @@ enum class FrameLoadType : uint8_t {
     RedirectWithLockedBackForwardList, // FIXME: Merge "lockBackForwardList", "lockHistory", "quickRedirect" and "clientRedirect" into a single concept of redirect.
     MultipartReplace,
     ReloadFromOrigin,
-    ReloadExpiredOnly
+    ReloadExpiredOnly,
+    NavigationAPIReplace
 };
 
 enum class IsMetaRefresh : bool { No, Yes };

--- a/Source/WebCore/loader/HistoryController.cpp
+++ b/Source/WebCore/loader/HistoryController.cpp
@@ -267,6 +267,7 @@ void HistoryController::restoreDocumentState()
     case FrameLoadType::IndexedBackForward:
     case FrameLoadType::RedirectWithLockedBackForwardList:
     case FrameLoadType::Standard:
+    case FrameLoadType::NavigationAPIReplace:
         break;
     }
 

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -3935,6 +3935,9 @@ void Page::logNavigation(const Navigation& navigation)
     case FrameLoadType::ReloadExpiredOnly:
         navigationDescription = "reloadRevalidatingExpired"_s;
         break;
+    case FrameLoadType::NavigationAPIReplace:
+        navigationDescription = "navigationAPIReplace"_s;
+        break;
     case FrameLoadType::MultipartReplace:
     case FrameLoadType::RedirectWithLockedBackForwardList:
         // Not logging those for now.

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6183,7 +6183,8 @@ enum class WebCore::FrameLoadType : uint8_t {
     RedirectWithLockedBackForwardList,
     MultipartReplace,
     ReloadFromOrigin,
-    ReloadExpiredOnly
+    ReloadExpiredOnly,
+    NavigationAPIReplace
 };
 
 enum class WebCore::NavigationType : uint8_t {

--- a/Source/WebKitLegacy/mac/WebView/WebFrame.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebFrame.mm
@@ -1086,6 +1086,10 @@ static WebFrameLoadType toWebFrameLoadType(WebCore::FrameLoadType frameLoadType)
         return WebFrameLoadTypeSame;
     case FrameLoadType::RedirectWithLockedBackForwardList:
         return WebFrameLoadTypeInternal;
+    case FrameLoadType::NavigationAPIReplace:
+        // NOTE: WebKitLegacy does not support the Navigation API. This case is
+        // present just to ensure a successful build.
+        RELEASE_ASSERT_NOT_REACHED();
     case FrameLoadType::MultipartReplace:
         return WebFrameLoadTypeReplace;
     case FrameLoadType::ReloadFromOrigin:


### PR DESCRIPTION
#### 530b62a6cfaafc2c3611bb429317196f06930664
<pre>
[Navigation API] Replace wrongly adds a new item to the UI Process b/f list
<a href="https://bugs.webkit.org/show_bug.cgi?id=298465">https://bugs.webkit.org/show_bug.cgi?id=298465</a>
<a href="https://rdar.apple.com/159962421">rdar://159962421</a>

Reviewed by Basuke Suzuki.

The test navigate-replace-cross-document.html fails because the replace
operation adds a new item to the UI Process b/f list instead of replacing the
current one as it should.

The issue is that once the new URL is loaded, we call
HistoryController::updateForStandardLoad (which creates a new item and
appends this to the UI Process b/f list) instead of
HistoryController::updateForReloadOrReplace which will replace the
current item.

To fix this, we introduce a new FrameLoadType called NavigationAPIReplace.
FrameLoader::loadFrameRequest will set this as the load type on a Navigation API
replace operation. And on this load type, FrameLoader::transitionToCommitted will
call HistoryController::updateForReloadOrReplace.

* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/navigate-replace-cross-document-expected.txt:
* Source/WebCore/history/BackForwardCache.cpp:
(WebCore::canCachePage):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::isBackForwardLoadType):
(WebCore::isReload):
(WebCore::determineNavigationType):
(WebCore::FrameLoader::loadFrameRequest):

If the NavigationHistoryBehavior is Replace, this is a Navigation API
Replace operation, set the loadType to NavigationAPIReplace.

(WebCore::FrameLoader::transitionToCommitted):

If the FrameLoadType is NavigationAPIReplace, call
HistoryController::updateForReloadOrReplace.

(WebCore::FrameLoader::subresourceCachePolicy const):
(WebCore::FrameLoader::loadDifferentDocumentItem):
* Source/WebCore/loader/FrameLoaderTypes.h:

New FrameLoadType called NavigationAPIReplace.

* Source/WebCore/loader/HistoryController.cpp:
(WebCore::HistoryController::restoreDocumentState):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::logNavigation):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKitLegacy/mac/WebView/WebFrame.mm:
(toWebFrameLoadType):

Canonical link: <a href="https://commits.webkit.org/300563@main">https://commits.webkit.org/300563@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c244979065d4e7f8c15e4a8d1e53c9ad2c5a4d8c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123019 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42733 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33430 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/129673 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/75128 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/842e91bb-a807-46a3-8d00-de445d26fc86) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/124896 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43456 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51327 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93512 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/62067 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125970 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34641 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110109 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74140 "Found 1 new API test failure: WPE/TestWebKitNetworkSession:/webkit/WebKitNetworkSession/proxy (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f1add964-534c-4bd9-8f7e-017eaed8692e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33617 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28264 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73181 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104352 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28487 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132404 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49969 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38044 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102011 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50345 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106328 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101876 "Found 4 new API test failures: TestWTF:CompletionHandlerDeathTest.MainThreadHandlerOnThreadAssertsDeathTest, WebKitGTK/TestInspector:/webkit/WebKitWebInspector/manual-attach-detach, TestWTF:CompletionHandlerDeathTest.ConstructionThreadHandlerOnThreadAssertsDeathTest, WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/no-web-process-leak (failure)") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47242 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25440 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/46742 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19399 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49824 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/55585 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49292 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/52644 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50973 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->