### PR TITLE
[SaferCPP] Lambda capture issues in WebCore Editor/Navigator

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -34,7 +34,6 @@ css/StyleRule.cpp
 dom/ContentVisibilityDocumentState.cpp
 dom/CustomElementDefaultARIA.cpp
 dom/RejectedPromiseTracker.cpp
-editing/Editor.cpp
 html/FormAssociatedCustomElement.cpp
 html/track/TrackBase.cpp
 inspector/InspectorOverlay.cpp
@@ -43,7 +42,6 @@ loader/NetscapePlugInStreamLoader.cpp
 loader/WorkerThreadableLoader.cpp
 page/ImageAnalysisQueue.cpp
 page/IntelligenceTextEffectsSupport.cpp
-page/Navigator.cpp
 page/ShareDataReader.cpp
 page/cocoa/ResourceUsageOverlayCocoa.mm
 page/writing-tools/WritingToolsController.mm

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -4257,8 +4257,8 @@ void Editor::scanSelectionForTelephoneNumbers()
 
     m_detectedTelephoneNumberRanges.clear();
     
-    auto notifyController = makeScopeExit([&] {
-        if (RefPtr page = document().page())
+    auto notifyController = makeScopeExit([protectedThis = Ref { *this }] {
+        if (RefPtr page = protectedThis->document().page())
             page->protectedServicesOverlayController()->selectedTelephoneNumberRangesChanged();
     });
 

--- a/Source/WebCore/page/Navigator.cpp
+++ b/Source/WebCore/page/Navigator.cpp
@@ -194,8 +194,12 @@ void Navigator::share(Document& document, const ShareData& data, Ref<DeferredPro
         if (m_loader)
             m_loader->cancel();
 
-        m_loader = ShareDataReader::create([this, promise = WTFMove(promise)](ExceptionOr<ShareDataWithParsedURL&> readData) mutable {
-            showShareData(readData, WTFMove(promise));
+        m_loader = ShareDataReader::create([weakThis = WeakPtr { *this }, promise = WTFMove(promise)](ExceptionOr<ShareDataWithParsedURL&> readData) mutable {
+            RefPtr protectedThis = weakThis.get();
+            if (!protectedThis)
+                return;
+
+            protectedThis->showShareData(readData, WTFMove(promise));
         });
         m_loader->start(&document, WTFMove(shareData));
         return;


### PR DESCRIPTION
#### 513a0e4e8545ca8a06675690455db332866343f1
<pre>
[SaferCPP] Lambda capture issues in WebCore Editor/Navigator
<a href="https://bugs.webkit.org/show_bug.cgi?id=299540">https://bugs.webkit.org/show_bug.cgi?id=299540</a>
<a href="https://rdar.apple.com/161348962">rdar://161348962</a>

Reviewed by NOBODY (OOPS!).

Editor.cpp warning was:
&quot;Implicitly captured raw-pointer &apos;this&apos; to uncounted type is unsafe&quot;.
Fixing by explicitly capturing this pointer and wrapping it in Ref.

Navigator.cpp warning was:
&quot;Captured raw-pointer &apos;this&apos; to uncounted type is unsafe&quot;.
Fixing by capturing a WeakPtr to this and converting it to a RefPtr
with null check when the lambda is invoked.

* Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations:
* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::scanSelectionForTelephoneNumbers):
* Source/WebCore/page/Navigator.cpp:
(WebCore::Navigator::share):
</pre>