### PR TITLE
[Navigation API] Fix scroll behavior for reload navigations with fragments.

### DIFF
--- a/LayoutTests/http/wpt/navigation-api/scroll-behavior/after-transition-reload-expected.txt
+++ b/LayoutTests/http/wpt/navigation-api/scroll-behavior/after-transition-reload-expected.txt
@@ -1,0 +1,3 @@
+
+PASS scroll: after-transition should work on a reload navigation
+

--- a/LayoutTests/http/wpt/navigation-api/scroll-behavior/after-transition-reload.html
+++ b/LayoutTests/http/wpt/navigation-api/scroll-behavior/after-transition-reload.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<div id="buffer" style="height: 1000px; width: 1000px;"></div>
+<div id="frag"></div>
+<div style="height: 1000px; width: 1000px;"></div>
+<script>
+promise_test(async t => {
+  // Wait for after the load event so that the navigation doesn't get converted
+  // into a replace navigation.
+  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  assert_equals(window.scrollY, 0);
+  await navigation.navigate("#frag").finished;
+  // Scroll down 10px from #frag
+  window.scrollBy(0, 10);
+  let scrollY_frag_plus_10 = window.scrollY;
+
+  let intercept_resolve;
+  let navigate_event;
+  navigation.onnavigate = e => {
+    navigate_event = e;
+    e.intercept({ handler: () => new Promise(r => intercept_resolve = r),
+                  scroll: "after-transition" });
+  };
+  let reload_promises = navigation.reload();
+  await reload_promises.committed;
+
+  // Removing the <div id="buffer"> should scroll up 1000px if scroll anchoring is enabled.
+  assert_equals(window.scrollY, scrollY_frag_plus_10);
+  buffer.remove();
+  let scrollY_after_buffer_remove = window.scrollY;
+  // Don't assert the exact value after buffer removal since it depends on scroll anchoring.
+
+  // Finishing should restore scroll to #frag's position
+  intercept_resolve();
+  await reload_promises.finished;
+  assert_not_equals(window.scrollY, scrollY_after_buffer_remove);
+
+  // After restoration, we should be at #frag's position
+  // The scroll should be restored to make #frag visible at the same viewport position
+  let frag_element = document.getElementById("frag");
+  let frag_top = frag_element.offsetTop;
+  assert_equals(window.scrollY, frag_top);
+}, "scroll: after-transition should work on a reload navigation");
+</script>
+</body>

--- a/LayoutTests/http/wpt/navigation-api/scroll-behavior/manual-scroll-reload-expected.txt
+++ b/LayoutTests/http/wpt/navigation-api/scroll-behavior/manual-scroll-reload-expected.txt
@@ -1,0 +1,3 @@
+
+PASS scroll: scroll() should work on a reload navigation
+

--- a/LayoutTests/http/wpt/navigation-api/scroll-behavior/manual-scroll-reload.html
+++ b/LayoutTests/http/wpt/navigation-api/scroll-behavior/manual-scroll-reload.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<div id="buffer" style="height: 1000px; width: 1000px;"></div>
+<div id="frag"></div>
+<div style="height: 1000px; width: 1000px;"></div>
+<script>
+promise_test(async t => {
+  // Wait for after the load event so that the navigation doesn't get converted
+  // into a replace navigation.
+  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+  assert_equals(window.scrollY, 0);
+  await navigation.navigate("#frag").finished;
+  // Scroll down 10px from #frag
+  window.scrollBy(0, 10);
+  let scrollY_frag_plus_10 = window.scrollY;
+
+  let intercept_resolve;
+  let navigate_event;
+  navigation.onnavigate = e => {
+    navigate_event = e;
+    e.intercept({ handler: () => new Promise(r => intercept_resolve = r),
+                  scroll: "manual" });
+  };
+  let reload_promises = navigation.reload();
+  await reload_promises.committed;
+
+  // Removing the <div id="buffer"> should scroll up 1000px if scroll anchoring is enabled.
+  assert_equals(window.scrollY, scrollY_frag_plus_10);
+  buffer.remove();
+  let scrollY_after_buffer_remove = window.scrollY;
+  // Don't assert the exact value after buffer removal since it depends on scroll anchoring.
+
+  // After restoration, we should be at #frag's position
+  // The scroll should be restored to make #frag visible at the same viewport position
+  navigate_event.scroll();
+  let frag_element = document.getElementById("frag");
+  let frag_top = frag_element.offsetTop;
+  assert_equals(window.scrollY, frag_top);
+  assert_not_equals(window.scrollY, scrollY_after_buffer_remove);
+
+  // Finishing should not scroll.
+  intercept_resolve();
+  await reload_promises.finished;
+  assert_equals(window.scrollY, frag_top);
+}, "scroll: scroll() should work on a reload navigation");
+</script>
+</body>

--- a/Source/WebCore/page/NavigateEvent.cpp
+++ b/Source/WebCore/page/NavigateEvent.cpp
@@ -125,9 +125,13 @@ void NavigateEvent::processScrollBehavior(Document& document)
     ASSERT(m_interceptionState == InterceptionState::Committed);
     m_interceptionState = InterceptionState::Scrolled;
 
-    if (m_navigationType == NavigationNavigationType::Traverse || m_navigationType == NavigationNavigationType::Reload)
+    if (m_navigationType == NavigationNavigationType::Traverse || m_navigationType == NavigationNavigationType::Reload) {
+        if (m_navigationType == NavigationNavigationType::Reload && document.url().hasFragmentIdentifier()) {
+            if (document.frame()->view()->scrollToFragment(document.url()))
+                return;
+        }
         document.frame()->loader().history().restoreScrollPositionAndViewState();
-    else if (!document.frame()->view()->scrollToFragment(document.url())) {
+    } else if (!document.frame()->view()->scrollToFragment(document.url())) {
         if (!document.url().hasFragmentIdentifier())
             document.frame()->view()->scrollTo({ 0, 0 });
     }


### PR DESCRIPTION
#### 9bea292f61680741e575beca2c4f6e3f6001666f
<pre>
[Navigation API] Fix scroll behavior for reload navigations with fragments.
<a href="https://bugs.webkit.org/show_bug.cgi?id=299544">https://bugs.webkit.org/show_bug.cgi?id=299544</a>
<a href="https://rdar.apple.com/161349628">rdar://161349628</a>

Reviewed by Rupin Mittal and Chris Dumez.

The NavigateEvent::processScrollBehavior() method was treating all reload navigations
identically by calling restoreScrollPositionAndViewState(), which restores the previously
saved scroll position. This ignored the fact that reload navigations with fragment
identifiers should scroll to the fragment position instead.

Tests: http/wpt/navigation-api/scroll-behavior/after-transition-reload.html
       http/wpt/navigation-api/scroll-behavior/manual-scroll-reload.html
* LayoutTests/http/wpt/navigation-api/scroll-behavior/after-transition-reload-expected.txt: Added.
* LayoutTests/http/wpt/navigation-api/scroll-behavior/after-transition-reload.html: Added.
* LayoutTests/http/wpt/navigation-api/scroll-behavior/manual-scroll-reload-expected.txt: Added.
* LayoutTests/http/wpt/navigation-api/scroll-behavior/manual-scroll-reload.html: Added.
* Source/WebCore/page/NavigateEvent.cpp:
(WebCore::NavigateEvent::processScrollBehavior):

Canonical link: <a href="https://commits.webkit.org/300546@main">https://commits.webkit.org/300546@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/63f34777ce302b31f8b2b39acca32f8275c5d8ba

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122956 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42670 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33367 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/129607 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/75064 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/88568e44-4b05-4653-a894-b7a3b5b52171) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/124833 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43393 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51264 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93469 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/62038 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9eb90aa4-65e3-4e06-9094-37eb423c1311) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125907 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34595 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110059 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74089 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/47582e6d-22b7-46e6-adfd-15f8a8b2b567) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33574 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28211 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73106 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104303 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28422 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132334 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49905 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37999 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101972 "Failed to checkout and rebase branch from PR 51332") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50282 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106263 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101842 "Found 3 new API test failures: TestWTF:CompletionHandlerDeathTest.MainThreadHandlerOnThreadAssertsDeathTest, WebKitGTK/TestInspector:/webkit/WebKitWebInspector/manual-attach-detach, TestWTF:CompletionHandlerDeathTest.ConstructionThreadHandlerOnThreadAssertsDeathTest (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25877 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47197 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25392 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/46679 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49761 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/55521 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49228 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/52580 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50910 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->