### PR TITLE
[libpas] Clean up unnecessary includes to improve build speeds

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/pas_dyld_state.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_dyld_state.c
@@ -20,7 +20,7 @@
  * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
  * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include "pas_config.h"
@@ -34,11 +34,10 @@
 #include <mach/task.h>
 #include <mach/task_info.h>
 #endif
-#include "pas_log.h"
 
 #if PAS_OS(DARWIN)
 /* This is copied from dyld_process_info_internal.h
- 
+
    FIXME: Stop doing it this way. Dyld should give us the is_libsystem_initialized API
    somehow. */
 typedef struct {
@@ -58,7 +57,7 @@ bool pas_dyld_is_libsystem_initialized(void)
     dyld_all_image_infos_64* infos;
 
     infos = all_image_infos;
-    
+
     if (!infos) {
         task_dyld_info_data_t task_dyld_info;
         mach_msg_type_number_t count;
@@ -77,7 +76,7 @@ bool pas_dyld_is_libsystem_initialized(void)
         infos = (dyld_all_image_infos_64*)task_dyld_info.all_image_info_addr;
 
         pas_fence();
-        
+
         all_image_infos = infos;
     }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.c
@@ -30,12 +30,10 @@
 
 #include "pas_probabilistic_guard_malloc_allocator.h"
 
-#include "iso_heap_config.h"
 #include "pas_heap.h"
 #include "pas_large_utility_free_heap.h"
 #include "pas_random.h"
 #include "pas_utility_heap.h"
-#include "pas_utility_heap_support.h"
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
@@ -67,7 +65,7 @@ uint16_t pas_probabilistic_guard_malloc_counter = 0;
 bool pas_probabilistic_guard_malloc_can_use = false;
 bool pas_probabilistic_guard_malloc_is_initialized = false;
 
-/* 
+/*
  * Flag to indicate if PGM has enabled at all for this process,
  * even if it been subsequently disabled, or no guarded allocations have been made
 */
@@ -185,9 +183,9 @@ pas_allocation_result pas_probabilistic_guard_malloc_allocate(pas_large_heap* la
     virtualalloc_res = VirtualAlloc((void*) upper_guard, upper_guard_size, MEM_COMMIT, PAGE_NOACCESS);
     PAS_ASSERT(virtualalloc_res);
 
-    /* 
+    /*
      * ensure physical addresses are released
-     * loop using meminfo here if the upper guard free is failing 
+     * loop using meminfo here if the upper guard free is failing
      */
     bool virtualfree_res = VirtualFree((void*) lower_guard, lower_guard_size, MEM_DECOMMIT);
     PAS_ASSERT(virtualfree_res);

--- a/Source/bmalloc/libpas/src/libpas/pas_report_crash.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_report_crash.c
@@ -27,7 +27,6 @@
 
 #if LIBPAS_ENABLED
 
-#include "pas_ptr_hash_set.h"
 #include "pas_ptr_hash_map.h"
 #include "pas_root.h"
 


### PR DESCRIPTION
#### 4275b17a0dc82dd0754efe84099811d2116a8a40
<pre>
[libpas] Clean up unnecessary includes to improve build speeds
<a href="https://bugs.webkit.org/show_bug.cgi?id=299546">https://bugs.webkit.org/show_bug.cgi?id=299546</a>
<a href="https://rdar.apple.com/161350175">rdar://161350175</a>

Reviewed by Dan Hecht.

Clean up some unneeded includes in libpas to improve build speeds.

* Source/bmalloc/libpas/src/libpas/pas_dyld_state.c:
(pas_dyld_is_libsystem_initialized):
* Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.c:
(pas_probabilistic_guard_malloc_allocate):
* Source/bmalloc/libpas/src/libpas/pas_report_crash.c:
* Source/bmalloc/libpas/src/libpas/pas_scavenger.c:
(ensure_data_instance):
(get_time_in_milliseconds):
(timed_wait):
(scavenger_thread_main):
(pas_scavenger_did_create_eligible):
(pas_scavenger_notify_eligibility_if_needed):
(pas_scavenger_suspend):
(pas_scavenger_resume):
(pas_scavenger_clear_all_caches_except_remote_tlcs):
(pas_scavenger_clear_all_caches):
(pas_scavenger_decommit_free_memory):

Canonical link: <a href="https://commits.webkit.org/300913@main">https://commits.webkit.org/300913@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/681abcae4fb70933e540eb1a5a5d076559049877

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124299 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43982 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34709 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131136 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/76364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44727 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52584 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/94550 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/76364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127253 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35644 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111180 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75137 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f97d881a-06db-4f06-81c5-6ced909989b2) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/34587 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29340 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74616 "Built successfully") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/116437 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105389 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29563 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133805 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/122828 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51207 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/39047 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/103032 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51601 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107399 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102827 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26165 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48188 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26444 "Build is in progress. Recent messages:") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/48146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51071 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/153924 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/50508 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39116 "Passed tests") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/53864 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/52183 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->