### PR TITLE
[iOS Firefox] Audio continues to play after closing a soundcloud.com tab

### DIFF
--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
@@ -73,6 +73,7 @@ enum class SDKAlignedBehavior {
     ModernCompabilityModeByDefault,
     MutationEventsDisabledByDefault,
     NavigationActionSourceFrameNonNull,
+    AllowBackgroundAudioPlayback,
     NoClientCertificateLookup,
     NoExpandoIndexedPropertiesOnWindow,
     NoPokerBrosBuiltInTagQuirk,
@@ -201,6 +202,8 @@ WTF_EXPORT_PRIVATE bool isMobileStore();
 WTF_EXPORT_PRIVATE bool isUNIQLOApp();
 WTF_EXPORT_PRIVATE bool isDOFUSTouch();
 WTF_EXPORT_PRIVATE bool isMyRideK12();
+WTF_EXPORT_PRIVATE bool isFirefox();
+WTF_EXPORT_PRIVATE bool isFirefoxFocus();
 
 } // IOSApplication
 

--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.mm
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.mm
@@ -238,6 +238,9 @@ static SDKAlignedBehaviors computeSDKAlignedBehaviors()
     if (linkedBefore(dyld_2024_SU_F_os_versions, DYLD_IOS_VERSION_18_5, DYLD_MACOSX_VERSION_15_5))
         disableBehavior(SDKAlignedBehavior::NavigationActionSourceFrameNonNull);
 
+    if (linkedBefore(dyld_2025_SU_B_os_versions, DYLD_IOS_VERSION_26_1, DYLD_MACOSX_VERSION_26_1))
+        disableBehavior(SDKAlignedBehavior::AllowBackgroundAudioPlayback);
+
     disableAdditionalSDKAlignedBehaviors(behaviors);
 
     return behaviors;
@@ -596,6 +599,18 @@ bool IOSApplication::isMyRideK12()
 {
     static bool isMyRideK12 = applicationBundleIsEqualTo("com.tylertech.myridek12"_s);
     return isMyRideK12;
+}
+
+bool IOSApplication::isFirefox()
+{
+    static bool isFirefox = applicationBundleIsEqualTo("org.mozilla.ios.Firefox"_s);
+    return isFirefox;
+}
+
+bool IOSApplication::isFirefoxFocus()
+{
+    static bool isFirefoxFocus = applicationBundleIsEqualTo("org.mozilla.ios.Focus"_s);
+    return isFirefoxFocus;
 }
 
 bool IOSApplication::isHimalaya()

--- a/Source/WTF/wtf/spi/darwin/dyldSPI.h
+++ b/Source/WTF/wtf/spi/darwin/dyldSPI.h
@@ -111,6 +111,10 @@ DECLARE_SYSTEM_HEADER
 #define DYLD_IOS_VERSION_18_5 0x00120500
 #endif
 
+#ifndef DYLD_IOS_VERSION_26_1
+#define DYLD_IOS_VERSION_26_1 0x001a0100
+#endif
+
 #ifndef DYLD_MACOSX_VERSION_10_13
 #define DYLD_MACOSX_VERSION_10_13 0x000A0D00
 #endif
@@ -183,6 +187,10 @@ DECLARE_SYSTEM_HEADER
 #define DYLD_MACOSX_VERSION_15_5 0x000f0500
 #endif
 
+#ifndef DYLD_MACOSX_VERSION_26_1
+#define DYLD_MACOSX_VERSION_26_1 0x001a0100
+#endif
+
 #else
 
 typedef uint32_t dyld_platform_t;
@@ -220,6 +228,7 @@ typedef struct {
 #define DYLD_IOS_VERSION_18_2 0x00120200
 #define DYLD_IOS_VERSION_18_4 0x00120400
 #define DYLD_IOS_VERSION_18_5 0x00120500
+#define DYLD_IOS_VERSION_26_1 0x001a0100
 
 #define DYLD_MACOSX_VERSION_10_10 0x000A0A00
 #define DYLD_MACOSX_VERSION_10_11 0x000A0B00
@@ -244,6 +253,7 @@ typedef struct {
 #define DYLD_MACOSX_VERSION_15_2 0x000f0200
 #define DYLD_MACOSX_VERSION_15_4 0x000f0400
 #define DYLD_MACOSX_VERSION_15_5 0x000f0500
+#define DYLD_MACOSX_VERSION_26_1 0x001a0100
 
 #endif
 
@@ -347,6 +357,10 @@ WTF_EXTERN_C_BEGIN
 
 #ifndef dyld_2024_SU_F_os_versions
 #define dyld_2024_SU_F_os_versions ({ (dyld_build_version_t) { 0, 0 }; })
+#endif
+
+#ifndef dyld_2025_SU_B_os_versions
+#define dyld_2025_SU_B_os_versions ({ (dyld_build_version_t) { 0, 0 }; })
 #endif
 
 uint32_t dyld_get_program_sdk_version();

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -691,7 +691,7 @@ void HTMLMediaElement::initializeMediaSession()
     if (document->settings().invisibleAutoplayNotPermitted())
         m_mediaSession->addBehaviorRestriction(MediaElementSession::InvisibleAutoplayNotPermitted);
 
-    if (document->settings().requiresPageVisibilityToPlayAudio())
+    if (document->settings().requiresPageVisibilityToPlayAudio() || document->quirks().requirePageVisibilityToPlayAudioQuirk())
         m_mediaSession->addBehaviorRestriction(MediaElementSession::RequirePageVisibilityToPlayAudio);
 
     if (document->ownerElement() || !document->isMediaDocument()) {

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -1506,6 +1506,16 @@ bool Quirks::shouldFlipScreenDimensions() const
 #endif
 }
 
+// Firefox and Firefox Focus (rdar://159977164)
+bool Quirks::requirePageVisibilityToPlayAudioQuirk() const
+{
+#if PLATFORM(IOS_FAMILY)
+    return needsQuirks() && m_quirksData.requirePageVisibilityToPlayAudioQuirk;
+#else
+    return false;
+#endif
+}
+
 // This section is dedicated to UA override for iPad. iPads (but iPad Mini) are sending a desktop user agent
 // to websites. In some cases, the website breaks in some ways, not expecting a touch interface for the website.
 // Controls not active or too small, form factor, etc. In this case it is better to send the iPad Mini UA.
@@ -3062,6 +3072,8 @@ void Quirks::determineRelevantQuirks()
     m_quirksData.shouldDisableLazyIframeLoadingQuirk = shouldDisableLazyIframeLoadingQuirk;
     // DOFUS Touch app (rdar://112679186)
     m_quirksData.needsResettingTransitionCancelsRunningTransitionQuirk = needsResettingTransitionCancelsRunningTransitionQuirk;
+
+    m_quirksData.requirePageVisibilityToPlayAudioQuirk = (WTF::IOSApplication::isFirefox() || WTF::IOSApplication::isFirefoxFocus()) && !linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::AllowBackgroundAudioPlayback);
 #endif
 
 #if PLATFORM(MAC)

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -90,6 +90,7 @@ public:
     bool shouldPreventOrientationMediaQueryFromEvaluatingToLandscape() const;
     bool shouldFlipScreenDimensions() const;
     bool shouldAllowDownloadsInSpiteOfCSP() const;
+    bool requirePageVisibilityToPlayAudioQuirk() const;
 
     WEBCORE_EXPORT bool shouldDispatchSyntheticMouseEventsWhenModifyingSelection() const;
     WEBCORE_EXPORT bool shouldSuppressAutocorrectionAndAutocapitalizationInHiddenEditableAreas() const;

--- a/Source/WebCore/page/QuirksData.h
+++ b/Source/WebCore/page/QuirksData.h
@@ -114,6 +114,7 @@ struct WEBCORE_EXPORT QuirksData {
     bool shouldSuppressAutocorrectionAndAutocapitalizationInHiddenEditableAreasQuirk : 1 { false };
     bool shouldSynthesizeTouchEventsAfterNonSyntheticClickQuirk : 1 { false };
     bool shouldTreatAddingMouseOutEventListenerAsContentChange : 1 { false };
+    bool requirePageVisibilityToPlayAudioQuirk : 1 { false };
 #endif // PLATFORM(IOS_FAMILY)
 
 #if PLATFORM(IOS) || PLATFORM(VISION)


### PR DESCRIPTION
#### 648f50b900d7eb98ee010e598ebc52428b7a309d
<pre>
[iOS Firefox] Audio continues to play after closing a soundcloud.com tab
<a href="https://bugs.webkit.org/show_bug.cgi?id=299545">https://bugs.webkit.org/show_bug.cgi?id=299545</a>
<a href="https://rdar.apple.com/159977164">rdar://159977164</a>

Reviewed by Jer Noble.

When Firefox &quot;closes&quot; a tab in their tab overview panel, the WKWebView is hidden but not
closed. Because nothing is done to stop media playback, if audio is playing when the
user closes the tab it will continue to play. The only way to stop playback is to quit
Firefox or open a new url. Fix this by adding a linked-on-or-after Quirk to prevent
background audio playback.

* Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h:
* Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.mm:
(WTF::computeSDKAlignedBehaviors):
(WTF::IOSApplication::isFirefox):
(WTF::IOSApplication::isFirefoxFocus):
* Source/WTF/wtf/spi/darwin/dyldSPI.h:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::initializeMediaSession):
* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::requirePageVisibilityToPlayAudioQuirk const):
(WebCore::Quirks::determineRelevantQuirks):
* Source/WebCore/page/Quirks.h:
* Source/WebCore/page/QuirksData.h:

Canonical link: <a href="https://commits.webkit.org/300584@main">https://commits.webkit.org/300584@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3a965fdd5dd5c9e0bdac1fe96600810c1eca78c7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122961 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42675 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33372 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/129612 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/75069 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f99ffb71-e02c-4b43-83f9-353adf6a49cf) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/124838 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43398 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51269 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93474 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62039 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/722d5abe-f94d-4ff4-98d4-a6dc66f2f974) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125912 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34602 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110068 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74096 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c312998e-edf3-47d6-8638-aa788e1f451f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33581 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28221 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73114 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/115120 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104311 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28432 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132341 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/121492 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49910 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38001 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101978 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/forms/constraints/infinite_backtracking.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50287 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106273 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101847 "Found 2 new API test failures: WebKitGTK/TestInspector:/webkit/WebKitWebInspector/manual-attach-detach, TestWTF:CompletionHandlerDeathTest.ConstructionThreadHandlerOnThreadAssertsDeathTest (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25916 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47205 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25400 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/46684 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49766 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/55526 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/151757 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49233 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/38809 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/52585 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50915 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->