### PR TITLE
Add trace points to ThreadTimers

### DIFF
--- a/Source/WTF/wtf/SystemTracing.h
+++ b/Source/WTF/wtf/SystemTracing.h
@@ -42,7 +42,7 @@
 #define WEBKIT_COMPONENT 47
 
 // Trace point codes can be up to 14 bits (0-16383).
-// When adding or changing these codes, update Tools/Tracing/SystemTracePoints.plist to match.
+// When adding or changing these codes, update Source/WebKit/Resources/Signposts/SystemTracePoints.plist to match.
 enum TracePointCode {
     WTFRange = 0,
 
@@ -118,6 +118,10 @@ enum TracePointCode {
     ProgrammaticScroll,
     FixedContainerEdgeSamplingStart,
     FixedContainerEdgeSamplingEnd,
+    ThreadTimersStart,
+    ThreadTimersEnd,
+    TimerFiredStart,
+    TimerFiredEnd,
 
     WebKitRange = 10000,
     WebHTMLViewPaintStart,

--- a/Source/WTF/wtf/glib/SysprofAnnotator.h
+++ b/Source/WTF/wtf/glib/SysprofAnnotator.h
@@ -166,6 +166,8 @@ public:
         case WebXRCPFrameStartSubmissionStart:
         case WebXRCPFrameEndSubmissionStart:
         case WakeUpAndApplyDisplayListStart:
+        case ThreadTimersStart:
+        case TimerFiredStart:
             beginMark(nullptr, tracePointCodeName(code).spanIncludingNullTerminator(), "%s", "");
             break;
 
@@ -229,6 +231,8 @@ public:
         case WebXRCPFrameStartSubmissionEnd:
         case WebXRCPFrameEndSubmissionEnd:
         case WakeUpAndApplyDisplayListEnd:
+        case ThreadTimersEnd:
+        case TimerFiredEnd:
             endMark(nullptr, tracePointCodeName(code).spanIncludingNullTerminator(), "%s", "");
             break;
 
@@ -404,6 +408,12 @@ private:
         case FixedContainerEdgeSamplingStart:
         case FixedContainerEdgeSamplingEnd:
             return "FixedContainerEdgeSampling"_s;
+        case ThreadTimersStart:
+        case ThreadTimersEnd:
+            return "WebCoreThreadTimers"_s;
+        case TimerFiredStart:
+        case TimerFiredEnd:
+            return "WebCoreTimerExecution"_s;
 
         case WebHTMLViewPaintStart:
         case WebHTMLViewPaintEnd:

--- a/Source/WebKit/Resources/Signposts/SystemTracePoints.plist
+++ b/Source/WebKit/Resources/Signposts/SystemTracePoints.plist
@@ -562,6 +562,30 @@
              </dict>
              <dict>
                  <key>Name</key>
+                 <string>WebCore thread timers firing</string>
+                 <key>Type</key>
+                 <string>Interval</string>
+                 <key>Component</key>
+                 <string>47</string>
+                 <key>CodeBegin</key>
+                 <string>5058</string>
+                 <key>CodeEnd</key>
+                 <string>5059</string>
+             </dict>
+             <dict>
+                 <key>Name</key>
+                 <string>Timer execution</string>
+                 <key>Type</key>
+                 <string>Interval</string>
+                 <key>Component</key>
+                 <string>47</string>
+                 <key>CodeBegin</key>
+                 <string>5060</string>
+                 <key>CodeEnd</key>
+                 <string>5061</string>
+             </dict>
+             <dict>
+                 <key>Name</key>
                  <string>Paint WebHTMLView</string>
                  <key>Type</key>
                  <string>Interval</string>


### PR DESCRIPTION
#### c8a8757e0cd92a93e08d8b1da2e053ac574134db
<pre>
Add trace points to ThreadTimers
<a href="https://bugs.webkit.org/show_bug.cgi?id=299550">https://bugs.webkit.org/show_bug.cgi?id=299550</a>
<a href="https://rdar.apple.com/161353511">rdar://161353511</a>

Reviewed by Ben Nham.

Understanding how timers are scheduled or are being executed is very helpful
when investigating web site issues or understanding how the WebContent process
is being scheduled on cores. This change adds trace intervals for every ThreadTimer
wake-up and for the duration of every timer that is executed during that wake up.

No behavior change so no tests. Trace points are only active when the process is
actively being profiled by tracing tools (e.g. Instruments).

* Source/WTF/wtf/SystemTracing.h:
* Source/WTF/wtf/glib/SysprofAnnotator.h:
* Source/WebCore/platform/ThreadTimers.cpp:
(WebCore::ThreadTimers::sharedTimerFiredInternal):
* Source/WebKit/Resources/Signposts/SystemTracePoints.plist:

Canonical link: <a href="https://commits.webkit.org/300702@main">https://commits.webkit.org/300702@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c9248c39045e1c6f311a5c7c04e0cd2d1bd23866

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122971 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42685 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33382 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/129623 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/75080 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fd30c845-39b0-4a7d-ac47-1e4cc83b36c5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/124848 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43408 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51279 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93479 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62046 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/be69ad53-f580-41ed-8e2f-a3c2e92e057b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125922 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110074 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74104 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1500721d-6c1b-48ae-9293-5459f0622793) 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28227 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73126 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/115130 "Built successfully and passed tests") | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28438 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132353 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/121502 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49920 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38008 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101981 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50297 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106279 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101849 "Found 3 new API test failures: TestWTF:CompletionHandlerDeathTest.MainThreadHandlerOnThreadAssertsDeathTest, WebKitGTK/TestInspector:/webkit/WebKitWebInspector/manual-attach-detach, TestWTF:CompletionHandlerDeathTest.ConstructionThreadHandlerOnThreadAssertsDeathTest (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25996 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47212 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25406 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/46694 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49776 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/55536 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/151767 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49243 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/38811 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/52595 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50925 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->