### PR TITLE
[Tools][CISupport] start-local-buildbot-server updates for launching upgraded 4.3.0 server

### DIFF
--- a/Tools/CISupport/Shared/steps.py
+++ b/Tools/CISupport/Shared/steps.py
@@ -44,6 +44,12 @@ GITHUB_URL = 'https://github.com/'
 SCAN_BUILD_OUTPUT_DIR = 'scan-build-output'
 LLVM_DIR = 'llvm-project'
 
+try:
+    # For Buildbot < 3.0
+    shellCommand = shell.ShellCommandNewStyle
+except AttributeError:
+    shellCommand = shell.ShellCommand
+
 
 class ShellMixin(object):
     WINDOWS_SHELL_PLATFORMS = ['win', 'playstation']
@@ -113,7 +119,7 @@ class SetBuildSummary(buildstep.BuildStep, AddToLogMixin):
         return defer.returnValue(SUCCESS)
 
 
-class InstallCMake(shell.ShellCommandNewStyle):
+class InstallCMake(shellCommand):
     name = 'install-cmake'
     haltOnFailure = True
     summary = 'Successfully installed CMake'
@@ -151,7 +157,7 @@ class InstallCMake(shell.ShellCommandNewStyle):
         return {u'step': self.summary}
 
 
-class InstallNinja(shell.ShellCommandNewStyle, ShellMixin):
+class InstallNinja(shellCommand, ShellMixin):
     name = 'install-ninja'
     haltOnFailure = True
     summary = 'Successfully installed Ninja'
@@ -189,7 +195,7 @@ class InstallNinja(shell.ShellCommandNewStyle, ShellMixin):
         return {u'step': self.summary}
 
 
-class GetLLVMVersion(shell.ShellCommandNewStyle, ShellMixin):
+class GetLLVMVersion(shellCommand, ShellMixin):
     name = 'get-llvm-version'
     summary = 'Found LLVM version'
 
@@ -316,7 +322,7 @@ class UpdateClang(steps.ShellSequence, ShellMixin):
         return {'step': self.summary}
 
 
-class PrintClangVersion(shell.ShellCommandNewStyle):
+class PrintClangVersion(shellCommand):
     name = 'print-clang-version'
     haltOnFailure = False
     flunkOnFailure = False
@@ -339,7 +345,7 @@ class PrintClangVersion(shell.ShellCommandNewStyle):
             return {'step': match.group(0)}
 
 
-class PrintClangVersion(shell.ShellCommandNewStyle):
+class PrintClangVersion(shellCommand):
     name = 'print-clang-version'
     haltOnFailure = False
     flunkOnFailure = False
@@ -389,7 +395,7 @@ class PrintClangVersionAfterUpdate(PrintClangVersion, ShellMixin):
         return super().getResultSummary()
 
 
-class PruneCoreSymbolicationdCacheIfTooLarge(shell.ShellCommandNewStyle):
+class PruneCoreSymbolicationdCacheIfTooLarge(shellCommand):
     name = "prune-coresymbolicationd-cache-if-too-large"
     description = ["pruning coresymbolicationd cache to < 10GB"]
     descriptionDone = ["pruned coresymbolicationd cache"]

--- a/Tools/CISupport/start-local-buildbot-server
+++ b/Tools/CISupport/start-local-buildbot-server
@@ -273,19 +273,26 @@ class BuildbotTestRunner(object):
             print('Setting up buildbot dependencies on the virtualenv ... ')
             # The idea is to install the very same version of buildbot and its
             # dependencies than the ones used for running https://build.webkit.org/about
-            buildbot_version = '2.10.5'
+            is_ews = self._subdir_with_configuration.endswith('ews-build')
+            buildbot_version = '2.10.5' if is_ews else '4.3.0'
+            twisted_version = '21.2.0' if is_ews else '23.10.0'
+            requests_version = '2.21.0' if is_ews else '2.26.0'
+            lz4_version = '1.1.0' if is_ews else '4.3.2'
+            mock_version = '4' if is_ews else '5.2.0'
+            rapidfuzz_version = '2.11.1' if is_ews else '3.4.0'
             pip_cmd = [virtualenv_pip, 'install',
-                       'buildbot=={}'.format(buildbot_version),
-                       'buildbot-console-view=={}'.format(buildbot_version),
-                       'buildbot-grid-view=={}'.format(buildbot_version),
-                       'buildbot-waterfall-view=={}'.format(buildbot_version),
-                       'buildbot-worker=={}'.format(buildbot_version),
-                       'buildbot-www=={}'.format(buildbot_version),
-                       'lz4==1.1.0',
-                       'mock==4',
-                       'rapidfuzz==2.11.1',
-                       'requests==2.21.0',
-                       'twisted==21.2.0']
+                       f'buildbot=={buildbot_version}',
+                       f'buildbot-console-view=={buildbot_version}',
+                       f'buildbot-grid-view=={buildbot_version}',
+                       f'buildbot-waterfall-view=={buildbot_version}',
+                       f'buildbot-worker=={buildbot_version}',
+                       f'buildbot-www=={buildbot_version}',
+                       f'lz4=={lz4_version}',
+                       f'mock=={mock_version}',
+                       f'rapidfuzz=={rapidfuzz_version}',
+                       f'requests=={requests_version}',
+                       f'twisted=={twisted_version}',
+                       'zope.interface==7.0.1']
             pip_process = subprocess.Popen(pip_cmd, cwd=self._base_workdir_temp,
                                            stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
             stdout, stderr = pip_process.communicate()


### PR DESCRIPTION
#### cbbc725a28574835111ae0edd2f6298651ac7a5f
<pre>
[Tools][CISupport] start-local-buildbot-server updates for launching upgraded 4.3.0 server
<a href="https://bugs.webkit.org/show_bug.cgi?id=299552">https://bugs.webkit.org/show_bug.cgi?id=299552</a>

Reviewed by Aakash Jain.

The test tool start-local-buildbot-server stopped working with
the post-commit configuration after the upgrade of the buildbot
server at 300152@main

Fix that by intalling different versions on the venv depending
on the config selected (ews or post-commit) and accounting for
the rename of ShellCommandNewStyle to ShellCommand in the new
version.

* Tools/CISupport/Shared/steps.py:
(InstallCMake):
(InstallNinja):
(GetLLVMVersion):
(PrintClangVersion):
(PruneCoreSymbolicationdCacheIfTooLarge):
* Tools/CISupport/start-local-buildbot-server:
(BuildbotTestRunner._setup_virtualenv):

Canonical link: <a href="https://commits.webkit.org/300676@main">https://commits.webkit.org/300676@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ea294467dfe75101b24bab971a9d65df9a86e986

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122974 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42688 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33385 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/129631 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/75083 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/124851 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43411 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51282 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93497 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62048 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125925 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34608 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110075 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74111 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33585 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28228 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73129 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104317 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28439 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132356 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49923 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38009 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101983 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/122394 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50300 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106280 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101852 "Found 3 new API test failures: TestWTF:CompletionHandlerDeathTest.MainThreadHandlerOnThreadAssertsDeathTest, WebKitGTK/TestInspector:/webkit/WebKitWebInspector/manual-attach-detach, TestWTF:CompletionHandlerDeathTest.ConstructionThreadHandlerOnThreadAssertsDeathTest (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47216 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25407 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/46697 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19441 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49779 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49246 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/52598 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50928 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->