### PR TITLE
Remove internals.setHasHDRContentForTesting()

### DIFF
--- a/LayoutTests/fast/images/hdr-background-image.html
+++ b/LayoutTests/fast/images/hdr-background-image.html
@@ -20,52 +20,17 @@
 </style>
 <body>
     <div style="position: fixed; top: 10px; left: 10px;">
-        <div class="container">&nbsp;</div>
+        <div class="sdr container">&nbsp;</div>
     </div>
     <div style="position: fixed; top: 10px; left: 220px;">
-        <div class="container">&nbsp;</div>
+        <div class="hdr container">&nbsp;</div>
     </div>
     <div style="position: fixed; top: 10px; left: 430px;">
-        <div class="container">&nbsp;</div>
+        <div class="hdr-sdr container">&nbsp;</div>
     </div>
     <script>
-        if (window.internals && window.testRunner) {
-            internals.clearMemoryCache();
+        if (window.internals && window.testRunner)
             internals.setScreenContentsFormatsForTesting(["RGBA8", "RGBA16F"]);
-            testRunner.waitUntilDone();
-        }
-
-        let images = [];
-        let imageSources = ["resources/red-400x400.png", "resources/gainmap-red-green-1920x1920.jpg"];
-
-        function loadImages() {
-            return imageSources.map((imageSource) => {
-                return new Promise((resolve) => {
-                    let image = new Image;
-                    image.onload = (e) => {
-                        resolve({ width: image.width, height: image.height });
-                    };
-                    image.src = imageSource;
-                    images.push(image);             
-                });
-            });
-        }
- 
-        (async () => {
-            await Promise.all(loadImages());
-
-            if (window.internals)
-                internals.setHasHDRContentForTesting(images[1]);
-
-            const containerElements = document.querySelectorAll("div.container");
-
-            containerElements[0].classList.add("sdr");
-            containerElements[1].classList.add("hdr");
-            containerElements[2].classList.add("hdr-sdr");
-
-            if (window.testRunner)
-                testRunner.notifyDone();
-        })();
     </script>
 </body>
 </html>

--- a/LayoutTests/fast/images/hdr-basic-image-dynamic-range-limit.html
+++ b/LayoutTests/fast/images/hdr-basic-image-dynamic-range-limit.html
@@ -22,33 +22,14 @@
 </style>
 <body>
     <div class="standard box">
-        <img class="image-box">
+        <img class="image-box" src="resources/gainmap-red-green-1920x1920.jpg">
     </div>
     <div class="no-limit box">
-        <img class="image-box">
+        <img class="image-box" src="resources/gainmap-red-green-1920x1920.jpg">
     </div>
     <script>
-        if (window.internals && window.testRunner) {
-            internals.clearMemoryCache();
+        if (window.internals && window.testRunner)
             internals.setScreenContentsFormatsForTesting(["RGBA8", "RGBA16F"]);
-            testRunner.waitUntilDone();
-        }
-
-        var image = new Image;
-        image.onload = (() => {
-            if (window.internals)
-                internals.setHasHDRContentForTesting(image);
-
-            const elements = document.querySelectorAll("img");
-
-            elements.forEach((element) => {
-                element.src = image.src;
-            });
-
-            if (window.testRunner)
-                testRunner.notifyDone();
-        });
-        image.src = "resources/gainmap-red-green-1920x1920.jpg";
     </script>
 </body>
 </html>

--- a/LayoutTests/fast/images/hdr-basic-image.html
+++ b/LayoutTests/fast/images/hdr-basic-image.html
@@ -10,33 +10,14 @@
 </style>
 <body>
     <div style="position: fixed; top: 10px; left: 10px;">
-        <img class="image-box">
+        <img class="image-box" src="resources/gainmap-red-green-1920x1920.jpg">
     </div>
     <div style="position: fixed; top: 10px; left: 220px;">
-        <div class="image-box"></div>
+        <div class="image-box" style="background-image: url(resources/gainmap-red-green-1920x1920.jpg);"></div>
     </div>
     <script>
-        if (window.internals && window.testRunner) {
-            internals.clearMemoryCache();
+        if (window.internals && window.testRunner)
             internals.setScreenContentsFormatsForTesting(["RGBA8", "RGBA16F"]);
-            testRunner.waitUntilDone();
-        }
-
-        var image = new Image;
-        image.onload = (() => {
-            if (window.internals)
-                internals.setHasHDRContentForTesting(image);
-
-            var divElement = document.querySelector("div.image-box");
-            divElement.style.backgroundImage = 'url(' + image.src + ')';
-
-            var imgElement = document.querySelector("img.image-box");
-            imgElement.src = image.src;
-
-            if (window.testRunner)
-                testRunner.notifyDone();
-        });
-        image.src = "resources/gainmap-red-green-1920x1920.jpg";
     </script>
 </body>
 </html>

--- a/LayoutTests/fast/images/hdr-border-image.html
+++ b/LayoutTests/fast/images/hdr-border-image.html
@@ -16,48 +16,14 @@
 </style>
 <body>
     <div style="position: fixed; top: 10px; left: 10px;">
-        <div class="container">&nbsp;</div>
+        <div class="sdr container">&nbsp;</div>
     </div>
     <div style="position: fixed; top: 10px; left: 220px;">
-        <div class="container">&nbsp;</div>
+        <div class="hdr container">&nbsp;</div>
     </div>
     <script>
-        if (window.internals && window.testRunner) {
-            internals.clearMemoryCache();
+        if (window.internals && window.testRunner)
             internals.setScreenContentsFormatsForTesting(["RGBA8", "RGBA16F"]);
-            testRunner.waitUntilDone();
-        }
-
-        let images = [];
-        let imageSources = ["resources/red-400x400.png", "resources/gainmap-red-green-1920x1920.jpg"];
-
-        function loadImages() {
-            return imageSources.map((imageSource) => {
-                return new Promise((resolve) => {
-                    let image = new Image;
-                    image.onload = (e) => {
-                        resolve({ width: image.width, height: image.height });
-                    };
-                    image.src = imageSource;
-                    images.push(image);             
-                });
-            });
-        }
- 
-        (async () => {
-            await Promise.all(loadImages());
-
-            if (window.internals)
-                internals.setHasHDRContentForTesting(images[1]);
-
-            const containerElements = document.querySelectorAll("div.container");
-
-            containerElements[0].classList.add("sdr");
-            containerElements[1].classList.add("hdr");
-
-            if (window.testRunner)
-                testRunner.notifyDone();
-        })();
     </script>
 </body>
 </html>

--- a/LayoutTests/fast/images/hdr-image-layer-sdr-dynamic-range-limit.html
+++ b/LayoutTests/fast/images/hdr-image-layer-sdr-dynamic-range-limit.html
@@ -22,34 +22,15 @@
 <body>
     <div class="composited">
         <div class="standard box">
-            <img class="image-box">
+            <img class="image-box" src="resources/gainmap-red-green-1920x1920.jpg">
         </div>
         <div class="no-limit box">
-            <img class="image-box">
+            <img class="image-box" src="resources/gainmap-red-green-1920x1920.jpg">
         </div>
     </div>
     <script>
-        if (window.internals && window.testRunner) {
-            internals.clearMemoryCache();
+        if (window.internals && window.testRunner)
             internals.setScreenContentsFormatsForTesting(["RGBA8", "RGBA16F"]);
-            testRunner.waitUntilDone();
-        }
-
-        var image = new Image;
-        image.onload = (() => {
-            if (window.internals)
-                internals.setHasHDRContentForTesting(image);
-
-            const elements = document.querySelectorAll("img");
-
-            elements.forEach((element) => {
-                element.src = image.src;
-            });
-
-            if (window.testRunner)
-                testRunner.notifyDone();
-        });
-        image.src = "resources/gainmap-red-green-1920x1920.jpg";
     </script>
 </body>
 </html>

--- a/LayoutTests/fast/images/hdr-pseudo-before-image.html
+++ b/LayoutTests/fast/images/hdr-pseudo-before-image.html
@@ -24,48 +24,14 @@
 </style>
 <body>
     <div style="position: fixed; top: 10px; left: 10px;">
-        <div class="container">&nbsp;</div>
+        <div class="sdr container">&nbsp;</div>
     </div>
     <div style="position: fixed; top: 10px; left: 220px;">
-        <div class="container">&nbsp;</div>
+        <div class="hdr container">&nbsp;</div>
     </div>
     <script>
-        if (window.internals && window.testRunner) {
-            internals.clearMemoryCache();
+        if (window.internals && window.testRunner)
             internals.setScreenContentsFormatsForTesting(["RGBA8", "RGBA16F"]);
-            testRunner.waitUntilDone();
-        }
-
-        let images = [];
-        let imageSources = ["resources/red-400x400.png", "resources/gainmap-red-green-1920x1920.jpg"];
-
-        function loadImages() {
-            return imageSources.map((imageSource) => {
-                return new Promise((resolve) => {
-                    let image = new Image;
-                    image.onload = (e) => {
-                        resolve({ width: image.width, height: image.height });
-                    };
-                    image.src = imageSource;
-                    images.push(image);             
-                });
-            });
-        }
- 
-        (async () => {
-            await Promise.all(loadImages());
-
-            if (window.internals)
-                internals.setHasHDRContentForTesting(images[1]);
-
-            const containerElements = document.querySelectorAll("div.container");
-
-            containerElements[0].classList.add("sdr");
-            containerElements[1].classList.add("hdr");
-
-            if (window.testRunner)
-                testRunner.notifyDone();
-        })();
     </script>
 </body>
 </html>

--- a/LayoutTests/fast/images/hdr-svg-inline-image.html
+++ b/LayoutTests/fast/images/hdr-svg-inline-image.html
@@ -11,28 +11,12 @@
 <body>
     <div style="position: fixed; top: 10px; left: 10px;">
         <svg class="image-box">
-            <image width="100%" height="100%"/>
+            <image width="100%" height="100%" href="resources/gainmap-red-green-1920x1920.jpg" />
         </svg>
     </div>
     <script>
-        if (window.internals && window.testRunner) {
-            internals.clearMemoryCache();
+        if (window.internals && window.testRunner)
             internals.setScreenContentsFormatsForTesting(["RGBA8", "RGBA16F"]);
-            testRunner.waitUntilDone();
-        }
-
-        var image = new Image;
-        image.onload = (() => {
-            if (window.internals)
-                internals.setHasHDRContentForTesting(image);
-
-            var imageElement = document.querySelector("svg.image-box image");
-            imageElement.setAttribute("href", image.src);
-
-            if (window.testRunner)
-                testRunner.notifyDone();
-        });
-        image.src = "resources/gainmap-red-green-1920x1920.jpg";
     </script>
 </body>
 </html>

--- a/Source/WebCore/platform/graphics/BitmapImage.cpp
+++ b/Source/WebCore/platform/graphics/BitmapImage.cpp
@@ -123,20 +123,12 @@ ImageDrawResult BitmapImage::draw(GraphicsContext& context, const FloatRect& des
         if (orientation == ImageOrientation::Orientation::FromImage)
             orientation = currentFrameOrientation();
 
-#if !HAVE(SUPPORT_HDR_DISPLAY_APIS)
-        if (hasHDRContentForTesting() && options.dynamicRangeLimit() != PlatformDynamicRangeLimit::standard())
-            fillWithSolidColor(context, destinationRect, Color::green, options.compositeOperator());
-        else {
-#endif
-            auto headroom = options.headroom();
+        auto headroom = options.headroom();
 
-            if (headroom == Headroom::FromImage)
-                headroom = currentFrameHeadroom(shouldDecodeToHDR);
+        if (headroom == Headroom::FromImage)
+            headroom = currentFrameHeadroom(shouldDecodeToHDR);
 
-            context.drawNativeImage(*nativeImage, destinationRect, adjustedSourceRect, { options, orientation, headroom });
-#if !HAVE(SUPPORT_HDR_DISPLAY_APIS)
-        }
-#endif
+        context.drawNativeImage(*nativeImage, destinationRect, adjustedSourceRect, { options, orientation, headroom });
     }
 
     if (auto observer = imageObserver())
@@ -150,10 +142,7 @@ void BitmapImage::drawPattern(GraphicsContext& context, const FloatRect& destina
     if (tileRect.isEmpty())
         return;
 
-    auto headroom = options.headroom();
-    if (headroom == Headroom::FromImage && hasHDRContentForTesting())
-        fillWithSolidColor(context, destinationRect, Color::gold, options.compositeOperator());
-    else if (context.drawLuminanceMask())
+    if (context.drawLuminanceMask())
         drawLuminanceMaskPattern(context, destinationRect, tileRect, transform, phase, spacing, options);
     else
         Image::drawPattern(context, destinationRect, tileRect, transform, phase, spacing, { options, ImageOrientation::Orientation::FromImage });

--- a/Source/WebCore/platform/graphics/BitmapImage.h
+++ b/Source/WebCore/platform/graphics/BitmapImage.h
@@ -91,7 +91,6 @@ public:
     bool isAsyncDecodingEnabledForTesting() const { return m_source->isAsyncDecodingEnabledForTesting(); }
     void setMinimumDecodingDurationForTesting(Seconds duration) { m_source->setMinimumDecodingDurationForTesting(duration); }
     void setClearDecoderAfterAsyncFrameRequestForTesting(bool enabled) { m_source->setClearDecoderAfterAsyncFrameRequestForTesting(enabled); }
-    void setHasHDRContentForTesting() { m_source->setHasHDRContentForTesting(); }
     unsigned decodeCountForTesting() const { return m_source->decodeCountForTesting(); }
     unsigned blankDrawCountForTesting() const { return m_source->blankDrawCountForTesting(); }
 
@@ -128,8 +127,6 @@ private:
     // Image methods
     bool isBitmapImage() const final { return true; }
     bool isAnimating() const final { return m_source->isAnimating(); }
-
-    bool hasHDRContentForTesting() const { return m_source->hasHDRContentForTesting(); }
 
     ImageDrawResult draw(GraphicsContext&, const FloatRect& destinationRect, const FloatRect& sourceRect, ImagePaintingOptions = { }) final;
     void drawPattern(GraphicsContext&, const FloatRect& destinationRect, const FloatRect& tileRect, const AffineTransform& patternTransform, const FloatPoint& phase, const FloatSize& spacing, ImagePaintingOptions = { }) final;

--- a/Source/WebCore/platform/graphics/BitmapImageSource.cpp
+++ b/Source/WebCore/platform/graphics/BitmapImageSource.cpp
@@ -673,17 +673,6 @@ ImageOrientation BitmapImageSource::frameOrientationAtIndex(unsigned index) cons
     return const_cast<BitmapImageSource&>(*this).frameAtIndexCacheIfNeeded(index).orientation();
 }
 
-void BitmapImageSource::setHasHDRContentForTesting()
-{
-    if (m_hasHDRContentForTesting)
-        return;
-
-    m_hasHDRContentForTesting = true;
-
-    if (auto imageObserver = this->imageObserver())
-        imageObserver->imageContentChanged(*m_bitmapImage);
-}
-
 DecodingStatus BitmapImageSource::frameDecodingStatusAtIndex(unsigned index) const
 {
     return const_cast<BitmapImageSource&>(*this).frameAtIndexCacheIfNeeded(index).decodingStatus();

--- a/Source/WebCore/platform/graphics/BitmapImageSource.h
+++ b/Source/WebCore/platform/graphics/BitmapImageSource.h
@@ -162,7 +162,7 @@ private:
     DestinationColorSpace colorSpace() const final { return m_descriptor.colorSpace(); }
     std::optional<Color> singlePixelSolidColor() const final { return m_descriptor.singlePixelSolidColor(); }
     bool hasHDRGainMap() const final { return m_descriptor.hasHDRGainMap(); }
-    bool hasHDRContent() const final { return m_descriptor.hasHDRGainMap() || m_descriptor.hasHDRColorSpace() || hasHDRContentForTesting(); }
+    bool hasHDRContent() const final { return m_descriptor.hasHDRGainMap() || m_descriptor.hasHDRColorSpace(); }
 
     String uti() const final { return m_descriptor.uti(); }
     String filenameExtension() const final { return m_descriptor.filenameExtension(); }
@@ -194,8 +194,6 @@ private:
     void setClearDecoderAfterAsyncFrameRequestForTesting(bool enabled) final { m_clearDecoderAfterAsyncFrameRequestForTesting = enabled; }
     void setAsyncDecodingEnabledForTesting(bool enabled) final { m_isAsyncDecodingEnabledForTesting = enabled; }
     bool isAsyncDecodingEnabledForTesting() const final { return m_isAsyncDecodingEnabledForTesting; }
-    void setHasHDRContentForTesting() final;
-    bool hasHDRContentForTesting() const final { return m_hasHDRContentForTesting; }
 
     void dump(TextStream&) const final;
 
@@ -221,7 +219,6 @@ private:
     unsigned m_blankDrawCountForTesting { 0 };
     bool m_isAsyncDecodingEnabledForTesting { false };
     bool m_clearDecoderAfterAsyncFrameRequestForTesting { false };
-    bool m_hasHDRContentForTesting { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/ImageSource.h
+++ b/Source/WebCore/platform/graphics/ImageSource.h
@@ -112,8 +112,6 @@ public:
     virtual void setClearDecoderAfterAsyncFrameRequestForTesting(bool) { RELEASE_ASSERT_NOT_REACHED(); }
     virtual void setAsyncDecodingEnabledForTesting(bool) { RELEASE_ASSERT_NOT_REACHED(); }
     virtual bool isAsyncDecodingEnabledForTesting() const { return false; }
-    virtual void setHasHDRContentForTesting() { RELEASE_ASSERT_NOT_REACHED(); }
-    virtual bool hasHDRContentForTesting() const { return false; }
 
     virtual void dump(WTF::TextStream&) const { }
 };

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -1275,12 +1275,6 @@ void Internals::setForceUpdateImageDataEnabledForTesting(HTMLImageElement& eleme
         cachedImage->setForceUpdateImageDataEnabledForTesting(enabled);
 }
 
-void Internals::setHasHDRContentForTesting(HTMLImageElement& element)
-{
-    if (auto* bitmapImage = bitmapImageFromImageElement(element))
-        bitmapImage->setHasHDRContentForTesting();
-}
-
 #if ENABLE(WEB_CODECS)
 bool Internals::hasPendingActivity(const WebCodecsVideoDecoder& decoder) const
 {

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -269,7 +269,6 @@ public:
     unsigned remoteImagesCountForTesting() const;
     void setAsyncDecodingEnabledForTesting(HTMLImageElement&, bool enabled);
     void setForceUpdateImageDataEnabledForTesting(HTMLImageElement&, bool enabled);
-    void setHasHDRContentForTesting(HTMLImageElement&);
 
 #if ENABLE(WEB_CODECS)
     bool hasPendingActivity(const WebCodecsVideoDecoder&) const;

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -750,7 +750,6 @@ enum ContentsFormat {
     unsigned long remoteImagesCountForTesting();
     undefined setAsyncDecodingEnabledForTesting(HTMLImageElement element, boolean enabled);
     undefined setForceUpdateImageDataEnabledForTesting(HTMLImageElement element, boolean enabled);
-    undefined setHasHDRContentForTesting(HTMLImageElement element);
 
     [Conditional=WEB_CODECS] boolean hasPendingActivity(WebCodecsVideoDecoder decoder);
 


### PR DESCRIPTION
#### ac89c45183d7be739c4995320fb81c6df601a0b8
<pre>
Remove internals.setHasHDRContentForTesting()
<a href="https://bugs.webkit.org/show_bug.cgi?id=299554">https://bugs.webkit.org/show_bug.cgi?id=299554</a>
<a href="https://rdar.apple.com/161359764">rdar://161359764</a>

Reviewed by NOBODY (OOPS!).

This was needed to fake an HDR image and use it in ref tests. Now after supporting
HDR fully, this setting can be removed and a real HDR can be used instead. This
also cleans up the image painting code.

* LayoutTests/fast/images/hdr-background-image.html:
* LayoutTests/fast/images/hdr-basic-image-dynamic-range-limit.html:
* LayoutTests/fast/images/hdr-basic-image.html:
* LayoutTests/fast/images/hdr-border-image.html:
* LayoutTests/fast/images/hdr-image-layer-sdr-dynamic-range-limit.html:
* LayoutTests/fast/images/hdr-pseudo-before-image.html:
* LayoutTests/fast/images/hdr-svg-inline-image.html:
* Source/WebCore/platform/graphics/BitmapImage.cpp:
(WebCore::BitmapImage::draw):
(WebCore::BitmapImage::drawPattern):
* Source/WebCore/platform/graphics/BitmapImage.h:
* Source/WebCore/platform/graphics/BitmapImageSource.cpp:
(WebCore::BitmapImageSource::setHasHDRContentForTesting): Deleted.
* Source/WebCore/platform/graphics/BitmapImageSource.h:
* Source/WebCore/platform/graphics/ImageSource.h:
(WebCore::ImageSource::isAsyncDecodingEnabledForTesting const):
(WebCore::ImageSource::setHasHDRContentForTesting): Deleted.
(WebCore::ImageSource::hasHDRContentForTesting const): Deleted.
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::setHasHDRContentForTesting): Deleted.
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ac89c45183d7be739c4995320fb81c6df601a0b8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122985 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42699 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33396 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/129639 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/75094 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1cadea41-efbf-4d64-9d2e-2a9bc67f42b7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/124862 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43422 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51293 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93490 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62050 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9d92c48e-d2e7-43d7-b190-80ca6fab56fb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125936 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34615 "Found 16 new test failures: compositing/hdr/hdr-background-image.html compositing/hdr/hdr-basic-image-dynamic-range-limit.html compositing/hdr/hdr-basic-image.html compositing/hdr/hdr-border-image.html compositing/hdr/hdr-pseudo-before-image.html compositing/hdr/hdr-svg-inline-image.html compositing/hdr/iframe-gains-hdr-image.html compositing/hdr/iframe-with-hdr-image.html compositing/hdr/layer-gains-hdr-image.html fast/images/hdr-background-image.html ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110085 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74119 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/34644bec-af18-47c9-8d4a-2ad3ad1f685c) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33592 "Exiting early after 10 failures. 10 tests run. 7 failures") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28238 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73144 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104325 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28453 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132368 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49934 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38016 "Found 16 new test failures: compositing/hdr/hdr-background-image.html compositing/hdr/hdr-basic-image-dynamic-range-limit.html compositing/hdr/hdr-basic-image.html compositing/hdr/hdr-border-image.html compositing/hdr/hdr-pseudo-before-image.html compositing/hdr/hdr-svg-inline-image.html compositing/hdr/iframe-gains-hdr-image.html compositing/hdr/iframe-with-hdr-image.html compositing/hdr/layer-gains-hdr-image.html fast/images/hdr-background-image.html ... (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101990 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50311 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106294 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101859 "Found 3 new API test failures: TestWTF:CompletionHandlerDeathTest.MainThreadHandlerOnThreadAssertsDeathTest, WebKitGTK/TestInspector:/webkit/WebKitWebInspector/manual-attach-detach, TestWTF:CompletionHandlerDeathTest.ConstructionThreadHandlerOnThreadAssertsDeathTest (failure)") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47222 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25416 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/46708 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49790 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/55550 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49257 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/52610 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50939 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->