### PR TITLE
"No new tests" text is duplicated when amending a commit

### DIFF
--- a/Tools/Scripts/hooks/prepare-commit-msg
+++ b/Tools/Scripts/hooks/prepare-commit-msg
@@ -112,10 +112,13 @@ def parseChanges(command, commit_message):
         return
     return changes
 
-def message(source=None, sha=None):
+def message(source=None, sha=None, mention_tests=True):
     commit_message = []
     amend_changes = None
     command = PREPARE_CHANGELOG_CMD
+
+    if not mention_tests:
+        command = command + ["--no-mention-tests"]
 
     if sha:
         commit_message.append('Amend changes:')
@@ -400,8 +403,8 @@ def main(file_name=None, source=None, sha=None):
                 sys.stderr.write(error.stderr)
 
     with open(file_name, 'w') as commit_message_file:
-        generated_msg, combined_changes, amend_changes = message(source=source, sha=sha)
         if sha:
+            generated_msg, combined_changes, amend_changes = message(source=source, sha=sha, mention_tests=False)
             git_log_msg = subprocess.run(
                 ['git', 'log', sha, '-1', '--pretty=format:%B'],
                 encoding='utf-8',
@@ -410,6 +413,7 @@ def main(file_name=None, source=None, sha=None):
             ).stdout
             commit_message_file.write(amended_message(git_log_msg, combined_changes, amend_changes, update_changelog))
         else:
+            generated_msg, combined_changes, amend_changes = message(source=source, sha=sha)
             commit_message_file.write(generated_msg)
 
         commit_message_file.write('''

--- a/Tools/Scripts/prepare-ChangeLog
+++ b/Tools/Scripts/prepare-ChangeLog
@@ -82,7 +82,7 @@ sub fetchRadarURLFromBugXMLData($$);
 sub findChangeLogs($$);
 sub generateFileList(\%$$$\%);
 sub generateFunctionLists($$$$$);
-sub generateNewChangeLogs($$$$$$$$$$$$$$$);
+sub generateNewChangeLogs($$$$$$$$$$$$$$$$);
 sub getLatestChangeLogs($);
 sub get_function_line_ranges($$);
 sub get_function_line_ranges_for_cpp($$);
@@ -141,6 +141,7 @@ sub main()
     my $spewDiff = $ENV{"PREPARE_CHANGELOG_DIFF"};
     my $updateChangeLogs = 1;
     my $onlyFiles = 0;
+    my $allowMentioningTests = 1;
     my $parseOptionsResult =
         GetOptions("diff|d!" => \$spewDiff,
                    "bug|b:i" => \$bugNumber,
@@ -157,25 +158,27 @@ sub main()
                    "open|o!" => \$openChangeLogs,
                    "write!" => \$writeChangeLogs,
                    "update!" => \$updateChangeLogs,
-                   "only-files" => \$onlyFiles);
+                   "only-files" => \$onlyFiles,
+                   "mention-tests!" => \$allowMentioningTests);
     if (!$parseOptionsResult || $showHelp) {
         print STDERR basename($0) . " [-b|--bug=<bugid>] [-d|--diff] [-h|--help] [-o|--open] [-g|--git-commit=<committish>] [--git-reviewer=<name>] [gitdir1 [gitdir2 ...]]\n";
-        print STDERR "  -b|--bug        Fill in the ChangeLog bug information from the given bug.\n";
-        print STDERR "  --description   One-line description that matches the bug title.\n";
-        print STDERR "  -d|--diff       Spew diff to stdout when running\n";
-        print STDERR "  --merge-base    Populate the ChangeLogs with the diff to this branch\n";
-        print STDERR "  -g|--git-commit Populate the ChangeLogs from the specified git commit\n";
-        print STDERR "  --git-index     Populate the ChangeLogs from the git index only\n";
-        print STDERR "  --git-reviewer  When populating the ChangeLogs from a git commit claim that the spcified name reviewed the change.\n";
-        print STDERR "                  This option is useful when the git commit lacks a Signed-Off-By: line\n";
-        print STDERR "  -h|--help       Show this help message\n";
-        print STDERR "  --[no-]style    Run check-webkit-style script when done (default: no-style)\n";
-        print STDERR "  -o|--open       Open ChangeLogs in an editor when done\n";
-        print STDERR "  --[no-]update   Update ChangeLogs from git before adding entry (default: update)\n";
-        print STDERR "  --[no-]write    Write ChangeLogs to disk (otherwise send new entries to stdout) (default: write)\n";
-        print STDERR "  --delimiters    When writing to stdout, label and print a \"~\" after each entry\n";
-        print STDERR "  --email=        Specify the email address to be used in the patch\n";
-        print STDERR "  --only-files    Exclude the standard changelog header and only include references to files.\n";
+        print STDERR "  -b|--bug             Fill in the ChangeLog bug information from the given bug.\n";
+        print STDERR "  --description        One-line description that matches the bug title.\n";
+        print STDERR "  -d|--diff            Spew diff to stdout when running\n";
+        print STDERR "  --merge-base         Populate the ChangeLogs with the diff to this branch\n";
+        print STDERR "  -g|--git-commit      Populate the ChangeLogs from the specified git commit\n";
+        print STDERR "  --git-index          Populate the ChangeLogs from the git index only\n";
+        print STDERR "  --git-reviewer       When populating the ChangeLogs from a git commit claim that the spcified name reviewed the change.\n";
+        print STDERR "                       This option is useful when the git commit lacks a Signed-Off-By: line\n";
+        print STDERR "  -h|--help            Show this help message\n";
+        print STDERR "  --[no-]style         Run check-webkit-style script when done (default: no-style)\n";
+        print STDERR "  -o|--open            Open ChangeLogs in an editor when done\n";
+        print STDERR "  --[no-]update        Update ChangeLogs from git before adding entry (default: update)\n";
+        print STDERR "  --[no-]write         Write ChangeLogs to disk (otherwise send new entries to stdout) (default: write)\n";
+        print STDERR "  --delimiters         When writing to stdout, label and print a \"~\" after each entry\n";
+        print STDERR "  --email=             Specify the email address to be used in the patch\n";
+        print STDERR "  --only-files         Exclude the standard changelog header and only include references to files.\n";
+        print STDERR "  --[no-]mention-tests Mention tests that are included, or OOPS if they are not; even for --only-files (default: true)\n";
         return 1;
     }
 
@@ -229,7 +232,7 @@ sub main()
     my ($filesInChangeLog, $prefixes) = findChangeLogs($functionLists, $writeChangeLogs);
     my $changeLogs = getLatestChangeLogs($prefixes);
 
-    generateNewChangeLogs($prefixes, $filesInChangeLog, $addedRegressionTests, $requiresTests, $functionLists, $bugURL, $bugDescription, $bugRadarURL, $name, $emailAddress, $gitReviewer, $gitCommit, $writeChangeLogs, $delimiters, $onlyFiles);
+    generateNewChangeLogs($prefixes, $filesInChangeLog, $addedRegressionTests, $requiresTests, $functionLists, $bugURL, $bugDescription, $bugRadarURL, $name, $emailAddress, $gitReviewer, $gitCommit, $writeChangeLogs, $delimiters, $onlyFiles, $allowMentioningTests);
 
     if ($writeChangeLogs) {
         print STDERR "-- Please remember to include a detailed description in your ChangeLog entry. --\n-- See <http://webkit.org/coding/contributing.html> for more info --\n";
@@ -593,9 +596,9 @@ sub resolveChangeLogsPath($@)
     return $command;
 }
 
-sub generateNewChangeLogs($$$$$$$$$$$$$$$)
+sub generateNewChangeLogs($$$$$$$$$$$$$$$$)
 {
-    my ($prefixes, $filesInChangeLog, $addedRegressionTests, $requiresTests, $functionLists, $bugURL, $bugDescription, $bugRadarURL, $name, $emailAddress, $gitReviewer, $gitCommit, $writeChangeLogs, $delimiters, $onlyFiles) = @_;
+    my ($prefixes, $filesInChangeLog, $addedRegressionTests, $requiresTests, $functionLists, $bugURL, $bugDescription, $bugRadarURL, $name, $emailAddress, $gitReviewer, $gitCommit, $writeChangeLogs, $delimiters, $onlyFiles, $allowMentioningTests) = @_;
 
     my $hasSourceChange = 0;
     while (my ($prefix, $files) = each(%$filesInChangeLog)) {
@@ -656,7 +659,7 @@ sub generateNewChangeLogs($$$$$$$$$$$$$$$)
             print CHANGE_LOG normalizeLineEndings($description . "\n", $endl) if $description;
         }
 
-        my $shouldMentionTests = @$requiresTests || $hasSourceChange;
+        my $shouldMentionTests = $allowMentioningTests && (@$requiresTests || $hasSourceChange);
 
         if ($shouldMentionTests) {
             if (@$addedRegressionTests) {


### PR DESCRIPTION
#### fca0e1c9487d3b23f124549fe893650ac5924e7d
<pre>
&quot;No new tests&quot; text is duplicated when amending a commit
<a href="https://bugs.webkit.org/show_bug.cgi?id=299557">https://bugs.webkit.org/show_bug.cgi?id=299557</a>
<a href="https://rdar.apple.com/161361290">rdar://161361290</a>

Reviewed by Ryan Haddad.

When amending a commit, we re-run prepare-ChangeLog and merge the output.
The logic to do so was built with the expectation that prepare-ChangeLog
would only output the file listing, but this is not the case now that we
have repaired the test warning/listing.

In order to fix this, provide a separate switch to disable the test warning,
and adopt it when amending. Ideally, we&apos;d update the test listing/warning state
based on the combined commit, but working out how to do that (since the test listing
is pretty freeform) is well outside the scope of fixing this bug.

* Tools/Scripts/hooks/prepare-commit-msg:
Avoid duplication by disabling test mentions when amending.

* Tools/Scripts/prepare-ChangeLog:
(main):
(generateNewChangeLogs):
Add a knob to disable test mentions.

Canonical link: <a href="https://commits.webkit.org/300609@main">https://commits.webkit.org/300609@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e3f86c70a7c3e8488e301cd07ffd4f940eb5c1fe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122989 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42703 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33400 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/129643 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/75098 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/89856bea-d809-4523-b229-b8191e8be6f1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/124866 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43426 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51297 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93503 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62054 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1875767b-4191-4793-bbff-d0f93a6d23ac) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125940 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34619 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110084 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74122 "Found 2 new API test failures: TestWTF:WTF_Condition.OneProducerOneConsumerOneSlotTimeout, TestWTF:WTF_Condition.OneProducerOneConsumerOneSlot (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/222b8c42-18b6-4b96-83f2-82cc526f952c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33596 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28237 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73148 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104329 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28452 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132373 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49938 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38018 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101993 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50315 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106293 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101861 "Found 3 new API test failures: TestWTF:CompletionHandlerDeathTest.MainThreadHandlerOnThreadAssertsDeathTest, WebKitGTK/TestInspector:/webkit/WebKitWebInspector/manual-attach-detach, TestWTF:CompletionHandlerDeathTest.ConstructionThreadHandlerOnThreadAssertsDeathTest (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25935 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47219 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25415 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/46712 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49794 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49262 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/52614 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50943 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->