### PR TITLE
AX: AXCoreObject::supportsPressAction should return true for things that gain cursor:pointer when hovered

### DIFF
--- a/LayoutTests/accessibility/mac/supports-press-action-cursor-on-hover-expected.txt
+++ b/LayoutTests/accessibility/mac/supports-press-action-cursor-on-hover-expected.txt
@@ -1,0 +1,12 @@
+This test ensures we support the press action for elements that gain cursor:pointer on hover.
+
+PASS: text.role === 'AXRole: AXStaticText'
+PASS: text.isPressActionSupported() === false
+PASS: text.isPressActionSupported() === true
+PASS: text.isPressActionSupported() === false
+PASS: text.isPressActionSupported() === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+4:00pm

--- a/LayoutTests/accessibility/mac/supports-press-action-cursor-on-hover.html
+++ b/LayoutTests/accessibility/mac/supports-press-action-cursor-on-hover.html
@@ -1,0 +1,47 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+<style id="style">
+</style>
+</head>
+<body>
+
+<div id="div" role="group" onclick="console.log('performed important action')" style="width: 75px; height: 75px;">4:00pm</div>
+
+<script>
+var output = "This test ensures we support the press action for elements that gain cursor:pointer on hover.\n\n";
+
+function replaceStyle(styleString) { document.getElementById("style").textContent = styleString; }
+function appendStyle(styleString) { document.getElementById("style").textContent += styleString; }
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var text = accessibilityController.accessibleElementById("div").childAtIndex(0);
+    output += expect("text.role", "'AXRole: AXStaticText'");
+    output += expect("text.isPressActionSupported()", "false");
+
+    // For performance, we only perform the heuristic to check for cursor:pointer on hover for things that have borders.
+    const borderStyle = "#div { border: 2px solid black; }\n";
+
+    replaceStyle(borderStyle.concat("#div:hover { cursor:pointer; }"));
+    setTimeout(async function() {
+        output += await expectAsync("text.isPressActionSupported()", "true");
+
+        appendStyle("#div { pointer-events: none; }");
+        output += await expectAsync("text.isPressActionSupported()", "false");
+
+        document.getElementById("div").setAttribute("custom-button", "true");
+        replaceStyle(borderStyle.concat("[custom-button='true']:hover { cursor: pointer; }"));
+        output += await expectAsync("text.isPressActionSupported()", "true");
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>
+

--- a/Source/WebCore/accessibility/AXCoreObject.cpp
+++ b/Source/WebCore/accessibility/AXCoreObject.cpp
@@ -1413,54 +1413,65 @@ bool AXCoreObject::supportsPressAction() const
         // other appropriate ARIA markup indicating interactivity (e.g. by applying role="button"). We can repair these
         // scenarios by checking for a clickable ancestor. But want to do so selectively, as naively exposing press on
         // every text can be annoying as some screenreaders read "clickable" for each static text.
-        if (!hasCursorPointer()) {
+        bool foundCursor = hasCursorPointer();
+
+        RefPtr clickableAncestor = Accessibility::findAncestor(*this, /* includeSelf */ true, /* matchFunction */ [&foundCursor] (const auto& ancestor) {
+            if (!foundCursor)
+                foundCursor = ancestor.hasCursorPointer() || ancestor.showsCursorOnHover();
+            return ancestor.hasClickHandler();
+        }, /* stopTraversalFunction */ [] (const auto& ancestor) {
+            // Stop traversing and return nullptr if we walk over an implicitly interactive element on our
+            // way to the click handler, as we can rely on the semantics of that element to imply pressability.
+            // Also stop when encountering the body or main to avoid exposing pressability for everything in
+            // web apps that implement an event-delegation mechanism.
+            auto role = ancestor.role();
+            return ancestor.isImplicitlyInteractive() || role == AccessibilityRole::LandmarkMain || role == AccessibilityRole::Presentational || ancestor.hasBodyTag();
+        });
+
+        if (!clickableAncestor)
+            return false;
+
+        if (!foundCursor) {
             // If the author hasn't provided a pointer cursor, the visual experience also doesn't express
             // pressability, so return.
             return false;
         }
 
-        if (RefPtr clickableAncestor = Accessibility::clickableSelfOrAncestor(*this, /* stopFunction */ [&] (const auto& ancestor) {
-            // Stop iterating and return nullptr if we walk over an implicitly interactive element on our way to the
-            // click handler, as we can rely on the semantics of that element to imply pressability. Also stop when
-            // encountering the body or main to avoid exposing pressability for everything in web apps that implement
-            // an event-delegation mechanism.
-            return ancestor.isImplicitlyInteractive() || ancestor.role() == AccessibilityRole::LandmarkMain || ancestor.hasBodyTag();
-        })) {
-            unsigned matches = 0;
-            unsigned candidatesChecked = 0;
-            RefPtr candidate = clickableAncestor;
-            while ((candidate = candidate->nextInPreOrder(/* updateChildren */ true, /* stayWithin */ clickableAncestor.get()))) {
-                if (candidate->isStaticText() || candidate->isControl() || candidate->isImage() || candidate->isHeading() || candidate->isLink()) {
-                    if (!candidate->isIgnored()) {
-                        if (!matches && this != candidate.get()) {
-                            // Only support press action for the first descendant. Some ATs, like VoiceOver, use the result of this function
-                            // to read "clickable", but reading it for every descendant of the clickable ancestor would be excessive.
-                            return false;
-                        }
-                        ++matches;
-                    }
-
-                    static constexpr unsigned MAX_MATCHES = 6;
-                    if (matches >= MAX_MATCHES) {
-                        // If something has more than the arbitrarily-chosen number of valid matches,
-                        // this click handler is probably too coarse to be useful.
+        unsigned matches = 0;
+        unsigned candidatesChecked = 0;
+        RefPtr candidate = clickableAncestor;
+        while ((candidate = candidate->nextInPreOrder(/* updateChildren */ true, /* stayWithin */ clickableAncestor.get()))) {
+            if (candidate->isStaticText() || candidate->isControl() || candidate->isImage() || candidate->isHeading() || candidate->isLink()) {
+                if (!candidate->isIgnored()) {
+                    if (!matches && this != candidate.get()) {
+                        // Only support press action for the first descendant. Some ATs, like VoiceOver, use the result of this function
+                        // to read "clickable", but reading it for every descendant of the clickable ancestor would be excessive.
                         return false;
                     }
+                    ++matches;
                 }
 
-                ++candidatesChecked;
-                static constexpr unsigned MAX_CANDIDATES = 256;
-                if (candidatesChecked > MAX_CANDIDATES) {
-                    // If we've walked over the arbitrarily-chosen max number of potential candidates,
-                    // this click handler is probably too coarse to be useful, and too much traversing
-                    // can harm performance.
+                static constexpr unsigned MAX_MATCHES = 6;
+                if (matches >= MAX_MATCHES) {
+                    // If something has more than the arbitrarily-chosen number of valid matches,
+                    // this click handler is probably too coarse to be useful.
                     return false;
                 }
             }
-            // If we get here, and matches is greater than zero, we can assume we were the first matching
-            // candidate for the click handler, and that there weren't too many matches or candidates checked.
-            return matches > 0;
+
+            ++candidatesChecked;
+            static constexpr unsigned MAX_CANDIDATES = 256;
+            if (candidatesChecked > MAX_CANDIDATES) {
+                // If we've walked over the arbitrarily-chosen max number of potential candidates,
+                // this click handler is probably too coarse to be useful, and too much traversing
+                // can harm performance.
+                return false;
+            }
         }
+
+        // If we get here, and matches is greater than zero, we can assume we were the first matching
+        // candidate for the click handler, and that there weren't too many matches or candidates checked.
+        return matches > 0;
     }
     return false;
 }

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -1225,6 +1225,7 @@ public:
 
     virtual bool hasClickHandler() const = 0;
     virtual bool hasCursorPointer() const = 0;
+    virtual bool showsCursorOnHover() const = 0;
     AXCoreObject* clickableSelfOrNonInteractiveAncestor();
     virtual AXCoreObject* clickableSelfOrAncestor(ClickHandlerFilter = ClickHandlerFilter::ExcludeBody) const = 0;
     virtual AXCoreObject* focusableAncestor() = 0;

--- a/Source/WebCore/accessibility/AXLogger.cpp
+++ b/Source/WebCore/accessibility/AXLogger.cpp
@@ -1160,6 +1160,9 @@ TextStream& operator<<(WTF::TextStream& stream, AXProperty property)
     case AXProperty::SetSize:
         stream << "SetSize";
         break;
+    case AXProperty::ShowsCursorOnHover:
+        stream << "ShowsCursorOnHover";
+        break;
     case AXProperty::SortDirection:
         stream << "SortDirection";
         break;

--- a/Source/WebCore/accessibility/AXNotifications.h
+++ b/Source/WebCore/accessibility/AXNotifications.h
@@ -94,6 +94,7 @@ namespace WebCore {
     macro(SelectedStateChanged) \
     macro(SelectedTextChanged) \
     macro(SetSizeChanged) \
+    macro(StyleChanged) \
     macro(TextColorChanged) \
     macro(TextCompositionBegan) \
     macro(TextCompositionEnded) \

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -1961,6 +1961,10 @@ void AXObjectCache::onStyleChange(Element& element, OptionSet<Style::Change> cha
 
     if (oldStyle->cursorType() != newStyle->cursorType())
         postNotification(*object, AXNotification::CursorTypeChanged);
+
+    // Certain properties (e.g. AXProperty::ShowsCursorOnHover) cannot easily
+    // be diffed here so post this general notification for those.
+    updateIsolatedTree(*object, AXNotification::StyleChanged);
 #endif // ENABLE(ACCESSIBILITY_ISOLATED_TREE)
 }
 
@@ -4984,6 +4988,9 @@ void AXObjectCache::updateIsolatedTree(const Vector<std::pair<Ref<AccessibilityO
             break;
         case AXNotification::SpeakAsChanged:
             tree->queueNodeUpdate(notification.first->objectID(), { AXProperty::SpeakAs });
+            break;
+        case AXNotification::StyleChanged:
+            tree->queueNodeUpdate(notification.first->objectID(), { AXProperty::ShowsCursorOnHover });
             break;
         case AXNotification::TextColorChanged:
             tree->updatePropertiesForSelfAndDescendants(notification.first.get(), { AXProperty::TextColor });

--- a/Source/WebCore/accessibility/AXUtilities.cpp
+++ b/Source/WebCore/accessibility/AXUtilities.cpp
@@ -27,6 +27,9 @@
 
 #include "AXLoggerBase.h"
 #include "AXObjectCache.h"
+#include "CSSPrimitiveValueMappings.h"
+#include "CSSProperty.h"
+#include "CSSValueList.h"
 #include "Document.h"
 #include "ElementInlines.h"
 #include "HTMLImageElement.h"
@@ -35,7 +38,9 @@
 #include "HTMLNames.h"
 #include "Node.h"
 #include "RenderImage.h"
+#include "RenderStyleConstants.h"
 #include "RenderTreeBuilder.h"
+#include "StylePropertiesInlines.h"
 #include <wtf/CheckedPtr.h>
 #include <wtf/RefPtr.h>
 
@@ -475,6 +480,21 @@ bool needsLayoutOrStyleRecalc(const Document& document)
             return true;
     }
     return document.hasPendingStyleRecalc();
+}
+
+std::optional<CursorType> cursorTypeFrom(const StyleProperties& properties)
+{
+    for (auto property : properties) {
+        if (property.id() == CSSPropertyCursor) {
+            if (RefPtr primitiveValue = dynamicDowncast<CSSPrimitiveValue>(property.value()))
+                return fromCSSValue<CursorType>(*primitiveValue);
+            if (RefPtr valueList = dynamicDowncast<CSSValueList>(property.value()); valueList && valueList->size() >= 2) {
+                if (RefPtr primitiveValue = dynamicDowncast<CSSPrimitiveValue>((*valueList)[valueList->size() - 1]))
+                    return fromCSSValue<CursorType>(*primitiveValue);
+            }
+        }
+    }
+    return std::nullopt;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/accessibility/AXUtilities.h
+++ b/Source/WebCore/accessibility/AXUtilities.h
@@ -41,6 +41,7 @@ class Node;
 class RenderImage;
 class RenderStyle;
 class RenderObject;
+class StyleProperties;
 
 bool hasRole(Element&, StringView role);
 bool hasAnyRole(Element&, Vector<StringView>&& roles);
@@ -79,5 +80,7 @@ WTF::TextStream& operator<<(WTF::TextStream&, AXNotification);
 void dumpAccessibilityTreeToStderr(Document&);
 
 String roleToString(AccessibilityRole);
+
+std::optional<CursorType> cursorTypeFrom(const StyleProperties&);
 
 } // WebCore

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.h
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.h
@@ -198,6 +198,11 @@ public:
         CheckedPtr style = this->style();
         return style && style->cursorType() == CursorType::Pointer;
     }
+    bool showsCursorOnHover() const final;
+    // Returns true if the node associated with this object has a computed
+    // style of pointer-events:none.
+    bool hasPointerEventsNone() const;
+
     void setIsExpanded(bool) final;
 
     Element* actionElement() const override;

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -795,6 +795,7 @@ public:
 
     bool hasClickHandler() const override { return false; }
     bool hasCursorPointer() const override { return false; };
+    bool showsCursorOnHover() const override { return false; }
     AccessibilityObject* clickableSelfOrAncestor(ClickHandlerFilter filter = ClickHandlerFilter::ExcludeBody) const final { return Accessibility::clickableSelfOrAncestor(*this, filter); };
     AccessibilityObject* focusableAncestor() final { return Accessibility::focusableAncestor(*this); }
     AccessibilityObject* editableAncestor() const final { return Accessibility::editableAncestor(*this); };

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -69,6 +69,7 @@ public:
     bool isExposableTable() const final { return boolAttributeValue(AXProperty::IsExposableTable); }
     bool hasClickHandler() const final { return boolAttributeValue(AXProperty::HasClickHandler); }
     bool hasCursorPointer() const final { return boolAttributeValue(AXProperty::HasCursorPointer);  }
+    bool showsCursorOnHover() const final { return boolAttributeValue(AXProperty::ShowsCursorOnHover); }
     FloatRect relativeFrame() const final;
 
     bool hasAttachmentTag() const final { return elementName() == ElementName::HTML_attachment; }

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -819,6 +819,9 @@ void AXIsolatedTree::updateNodeProperties(AccessibilityObject& axObject, const A
             properties.append({ AXProperty::SupportsKeyShortcuts, axObject.supportsKeyShortcuts() });
             properties.append({ AXProperty::KeyShortcuts, axObject.keyShortcuts().isolatedCopy() });
             break;
+        case AXProperty::ShowsCursorOnHover:
+            properties.append({ AXProperty::ShowsCursorOnHover, axObject.showsCursorOnHover() });
+            break;
         case AXProperty::SupportsARIAOwns:
             properties.append({ AXProperty::SupportsARIAOwns, axObject.supportsARIAOwns() });
             break;
@@ -1727,6 +1730,8 @@ std::optional<AXPropertyFlag> convertToPropertyFlag(AXProperty property)
         return AXPropertyFlag::IsExposedTableRow;
     case AXProperty::IsVisited:
         return AXPropertyFlag::IsVisited;
+    case AXProperty::ShowsCursorOnHover:
+        return AXPropertyFlag::ShowsCursorOnHover;
     case AXProperty::SupportsCheckedState:
         return AXPropertyFlag::SupportsCheckedState;
     case AXProperty::SupportsDragging:
@@ -1858,6 +1863,7 @@ IsolatedObjectData createIsolatedObjectData(const Ref<AccessibilityObject>& axOb
         // These properties are cached for all objects, ignored and unignored.
         setProperty(AXProperty::HasClickHandler, object.hasClickHandler());
         setProperty(AXProperty::HasCursorPointer, object.hasCursorPointer());
+        setProperty(AXProperty::ShowsCursorOnHover, object.showsCursorOnHover());
         auto elementName = object.elementName();
         if (shouldCacheElementName(elementName))
             setProperty(AXProperty::ElementName, elementName);

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
@@ -56,7 +56,7 @@ class AXObjectCache;
 class AccessibilityObject;
 enum class AXStreamOptions : uint16_t;
 
-static constexpr uint16_t lastPropertyFlagIndex = 26;
+static constexpr uint16_t lastPropertyFlagIndex = 27;
 // The most common boolean properties are stored in a bitfield rather than in a HashMap.
 // If you edit these, make sure the corresponding AXProperty is ordered correctly in that
 // enum, and update lastPropertyFlagIndex above.
@@ -83,11 +83,12 @@ enum class AXPropertyFlag : uint32_t {
     IsTextEmissionBehaviorNewline                 = 1 << 18,
     IsTextEmissionBehaviorDoubleNewline           = 1 << 19,
     IsVisited                                     = 1 << 20,
-    SupportsCheckedState                          = 1 << 21,
-    SupportsDragging                              = 1 << 22,
-    SupportsExpanded                              = 1 << 23,
-    SupportsPath                                  = 1 << 24,
-    SupportsPosInSet                              = 1 << 25,
+    ShowsCursorOnHover                            = 1 << 21,
+    SupportsCheckedState                          = 1 << 22,
+    SupportsDragging                              = 1 << 23,
+    SupportsExpanded                              = 1 << 24,
+    SupportsPath                                  = 1 << 25,
+    SupportsPosInSet                              = 1 << 26,
     SupportsSetSize                               = 1 << lastPropertyFlagIndex
 };
 
@@ -113,11 +114,12 @@ enum class AXProperty : uint16_t {
     IsTextEmissionBehaviorNewline = 18,
     IsTextEmissionBehaviorDoubleNewline = 19,
     IsVisited = 20,
-    SupportsCheckedState = 21,
-    SupportsDragging = 22,
-    SupportsExpanded = 23,
-    SupportsPath = 24,
-    SupportsPosInSet = 25,
+    ShowsCursorOnHover = 21,
+    SupportsCheckedState = 22,
+    SupportsDragging = 23,
+    SupportsExpanded = 24,
+    SupportsPath = 25,
+    SupportsPosInSet = 26,
     SupportsSetSize = lastPropertyFlagIndex,
     // End bool attributes that are matched in order by AXPropertyFlag.
 


### PR DESCRIPTION
#### 333cd57d38cc0a37ede57091338c86bbbb50ba19
<pre>
AX: AXCoreObject::supportsPressAction should return true for things that gain cursor:pointer when hovered
<a href="https://bugs.webkit.org/show_bug.cgi?id=299566">https://bugs.webkit.org/show_bug.cgi?id=299566</a>
<a href="https://rdar.apple.com/161365477">rdar://161365477</a>

Reviewed by Joshua Hoffman.

In effort to not overly advertise press action, AXCoreObject::supportsPressAction only returns true for static text
and images that have cursor:pointer when hovered. However, sometimes web authors have CSS that only activates cursor:pointer
when an element is hovered, dodging this heuristic.

With this commit, we now detect if something were to be cursor:pointer when hovered. This allows us to advertise press
action on a real webpage that we wouldn&apos;t have otherwise been able to.

* LayoutTests/accessibility/mac/supports-press-action-cursor-on-hover-expected.txt: Added.
* LayoutTests/accessibility/mac/supports-press-action-cursor-on-hover.html: Added.
* Source/WebCore/accessibility/AXCoreObject.cpp:
(WebCore::AXCoreObject::supportsPressAction const):
* Source/WebCore/accessibility/AXCoreObject.h:
* Source/WebCore/accessibility/AXLogger.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/accessibility/AXNotifications.h:
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::onStyleChange):
(WebCore::AXObjectCache::updateIsolatedTree):
* Source/WebCore/accessibility/AXUtilities.cpp:
(WebCore::cursorTypeFrom):
* Source/WebCore/accessibility/AXUtilities.h:
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::showsCursorOnHover const):
(WebCore::AccessibilityNodeObject::hasPointerEventsNone const):
* Source/WebCore/accessibility/AccessibilityNodeObject.h:
* Source/WebCore/accessibility/AccessibilityObject.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::updateNodeProperties):
(WebCore::convertToPropertyFlag):
(WebCore::createIsolatedObjectData):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h:

Canonical link: <a href="https://commits.webkit.org/300579@main">https://commits.webkit.org/300579@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0df66588324116489fba702c4376f3a19e2a4fdb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123077 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42791 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33488 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/129733 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/75186 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6571bf82-4ce7-4085-bc81-5b452f84aed7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/124954 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43515 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51386 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93554 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/62083 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7b781ab2-04e8-40f0-b45b-3350a2f2c347) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126028 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34684 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110150 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74187 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9c5ed1f0-af44-4990-bf4f-ab763012ba2b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33656 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28306 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73250 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104394 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28532 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132464 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50027 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38084 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102056 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50403 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106371 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101910 "Found 3 new API test failures: TestWTF:CompletionHandlerDeathTest.MainThreadHandlerOnThreadAssertsDeathTest, WebKitGTK/TestInspector:/webkit/WebKitWebInspector/manual-attach-detach, TestWTF:CompletionHandlerDeathTest.ConstructionThreadHandlerOnThreadAssertsDeathTest (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25911 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47279 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25481 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/46800 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49882 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/55643 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49350 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/52702 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51031 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->