### PR TITLE
[LCP] Implement LCP for images

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -276,9 +276,6 @@ imported/w3c/web-platform-tests/fs/ [ Skip ]
 storage/filesystemaccess/ [ Skip ]
 storage/storagemanager/ [ Skip ]
 
-# Not implemented yet.
-imported/w3c/web-platform-tests/largest-contentful-paint/ [ Skip ]
-
 # Not implemented, but resources referenced by largest-contentful-paint.
 imported/w3c/web-platform-tests/element-timing/ [ Skip ]
 
@@ -1296,6 +1293,20 @@ webkit.org/b/214677 imported/w3c/web-platform-tests/event-timing/first-input-int
 # Missing automation:
 webkit.org/b/214677 imported/w3c/web-platform-tests/event-timing/event-click-visibilitychange.html [ Skip ]
 webkit.org/b/214677 imported/w3c/web-platform-tests/event-timing/selection-autoscroll.html [ Skip ]
+
+# Only partially implemented.
+imported/w3c/web-platform-tests/largest-contentful-paint/ [ Skip ]
+imported/w3c/web-platform-tests/largest-contentful-paint/animated/observe-cross-origin-tao-animated-image.tentative.html [ Pass ]
+imported/w3c/web-platform-tests/largest-contentful-paint/background-image-set-image.html [ Pass ]
+imported/w3c/web-platform-tests/largest-contentful-paint/broken-image-icon.html [ Pass ]
+imported/w3c/web-platform-tests/largest-contentful-paint/idlharness.html [ Pass ]
+imported/w3c/web-platform-tests/largest-contentful-paint/iframe-content-not-observed.html [ Pass ]
+imported/w3c/web-platform-tests/largest-contentful-paint/image-sw-same-origin.https.html [ Pass ]
+imported/w3c/web-platform-tests/largest-contentful-paint/image-upscaling.html [ Pass ]
+imported/w3c/web-platform-tests/largest-contentful-paint/invisible-images.html [ Pass ]
+imported/w3c/web-platform-tests/largest-contentful-paint/larger-image.html [ Pass ]
+imported/w3c/web-platform-tests/largest-contentful-paint/supported-lcp-type.html [ Pass ]
+imported/w3c/web-platform-tests/largest-contentful-paint/video-play-after-poster.html [ Pass ]
 
 imported/w3c/web-platform-tests/mediacapture-streams/MediaStreamTrack-MediaElement-disabled-video-is-black.https.html [ Pass Failure ]
 imported/w3c/web-platform-tests/mediacapture-streams/MediaDevices-enumerateDevices-per-origin-ids.sub.https.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/largest-contentful-paint/animated/observe-cross-origin-animated-image.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/largest-contentful-paint/animated/observe-cross-origin-animated-image.tentative-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Same origin animated image is observable and has a first frame.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/largest-contentful-paint/animated/observe-cross-origin-tao-animated-image.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/largest-contentful-paint/animated/observe-cross-origin-tao-animated-image.tentative-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Same origin animated image is observable and has a first frame.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/largest-contentful-paint/background-image-set-image-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/largest-contentful-paint/background-image-set-image-expected.txt
@@ -1,0 +1,5 @@
+fallback
+
+
+PASS Background image-set images should be eligible for LCP candidates
+

--- a/LayoutTests/imported/w3c/web-platform-tests/largest-contentful-paint/broken-image-icon-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/largest-contentful-paint/broken-image-icon-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS The broken image icon should not emit an LCP entry.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/largest-contentful-paint/idlharness-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/largest-contentful-paint/idlharness-expected.txt
@@ -1,0 +1,31 @@
+
+
+PASS idl_test setup
+PASS idl_test validation
+PASS LargestContentfulPaint includes PaintTimingMixin: member names are unique
+PASS Element includes ParentNode: member names are unique
+PASS Element includes NonDocumentTypeChildNode: member names are unique
+PASS Element includes ChildNode: member names are unique
+PASS Element includes Slottable: member names are unique
+PASS LargestContentfulPaint interface: existence and properties of interface object
+PASS LargestContentfulPaint interface object length
+PASS LargestContentfulPaint interface object name
+PASS LargestContentfulPaint interface: existence and properties of interface prototype object
+PASS LargestContentfulPaint interface: existence and properties of interface prototype object's "constructor" property
+PASS LargestContentfulPaint interface: existence and properties of interface prototype object's @@unscopables property
+PASS LargestContentfulPaint interface: attribute loadTime
+PASS LargestContentfulPaint interface: attribute size
+PASS LargestContentfulPaint interface: attribute id
+PASS LargestContentfulPaint interface: attribute url
+PASS LargestContentfulPaint interface: attribute element
+PASS LargestContentfulPaint interface: operation toJSON()
+PASS LargestContentfulPaint must be primary interface of lcp
+PASS Stringification of lcp
+PASS LargestContentfulPaint interface: lcp must inherit property "loadTime" with the proper type
+PASS LargestContentfulPaint interface: lcp must inherit property "size" with the proper type
+PASS LargestContentfulPaint interface: lcp must inherit property "id" with the proper type
+PASS LargestContentfulPaint interface: lcp must inherit property "url" with the proper type
+PASS LargestContentfulPaint interface: lcp must inherit property "element" with the proper type
+PASS LargestContentfulPaint interface: lcp must inherit property "toJSON()" with the proper type
+FAIL LargestContentfulPaint interface: default toJSON operation on lcp assert_true: property "navigationId" should be present in the output of LargestContentfulPaint.prototype.toJSON() expected true got false
+

--- a/LayoutTests/imported/w3c/web-platform-tests/largest-contentful-paint/iframe-content-not-observed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/largest-contentful-paint/iframe-content-not-observed-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Element in child iframe is not observed, even if same-origin.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/largest-contentful-paint/image-sw-same-origin.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/largest-contentful-paint/image-sw-same-origin.https-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Same-origin images served from a service-worker should have a correct renderTime
+

--- a/LayoutTests/imported/w3c/web-platform-tests/largest-contentful-paint/image-upscaling-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/largest-contentful-paint/image-upscaling-expected.txt
@@ -1,0 +1,12 @@
+
+PASS Non-scaled image should report the natural size
+PASS A downscaled image (width/height) should report the displayed size
+PASS A downscaled image (using scale) should report the displayed size
+PASS An upscaled image (width/height) should report the natural size
+PASS An upscaled image (using scale) should report the natural size
+PASS An upscaled image (using object-size) should report the natural size
+PASS Intersecting element with partial-intersecting image to report image intersection
+PASS A background image larger than the container should report the container size
+PASS A background image smaller than the container should report the natural size
+PASS A scaled-down background image should report the background size
+

--- a/LayoutTests/imported/w3c/web-platform-tests/largest-contentful-paint/invisible-images-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/largest-contentful-paint/invisible-images-expected.txt
@@ -1,0 +1,5 @@
+
+
+
+PASS Images with opacity: 0, visibility: hidden, or display: none are not observable by LargestContentfulPaint.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/largest-contentful-paint/larger-image-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/largest-contentful-paint/larger-image-expected.txt
@@ -1,0 +1,8 @@
+This is some text! :)
+
+
+More text!
+
+
+PASS Largest Contentful Paint: largest image is reported.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/largest-contentful-paint/supported-lcp-type-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/largest-contentful-paint/supported-lcp-type-expected.txt
@@ -1,0 +1,3 @@
+
+PASS supportedEntryTypes contains 'largest-contentful-paint'.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/largest-contentful-paint/video-play-after-poster-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/largest-contentful-paint/video-play-after-poster-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Video with poster should not emit a second LCP entry after playing.
+

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -42,6 +42,9 @@ imported/w3c/web-platform-tests/video-rvfc/request-video-frame-callback-during-x
 
 webkit.org/b/235072 imported/w3c/web-platform-tests/video-rvfc/request-video-frame-callback-repeating.html [ Skip ]
 
+# DumpRenderTree's window does not autodisplay, breaking LCP tests (webkit.org/b/244756)
+imported/w3c/web-platform-tests/largest-contentful-paint/ [ Skip ]
+
 http/tests/webcodecs [ Skip ]
 http/wpt/webcodecs [ Skip ]
 imported/w3c/web-platform-tests/webcodecs [ Skip ]

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -4215,7 +4215,8 @@ LargeImageAsyncDecodingEnabled:
 
 LargestContentfulPaintEnabled:
   type: bool
-  status: unstable
+  status: testable
+  category: dom
   humanReadableName: "Largest Contentful Paint"
   humanReadableDescription: "Enable Largest Contentful Paint performance entries"
   defaultValue:

--- a/Source/WebCore/page/LargestContentfulPaintData.h
+++ b/Source/WebCore/page/LargestContentfulPaintData.h
@@ -66,6 +66,13 @@ private:
     static bool isEligibleForLargestContentfulPaint(const Element&, float effectiveVisualArea);
 
     void potentiallyAddLargestContentfulPaintEntry(Element&, CachedImage*, FloatRect imageLocalRect, FloatRect intsectionRect, DOMHighResTimeStamp);
+
+    float m_largestPaintArea { 0 };
+
+    WeakHashMap<Element, WeakHashSet<CachedImage>, WeakPtrImplWithEventTargetData> m_imageContentSet;
+    WeakHashMap<Element, WeakHashMap<CachedImage, FloatRect>, WeakPtrImplWithEventTargetData> m_pendingImageRecords;
+
+    RefPtr<LargestContentfulPaint> m_pendingEntry;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 56565b0ae7fda4b9fd71d1e6268962b7b7b89282
<pre>
[LCP] Implement LCP for images
<a href="https://bugs.webkit.org/show_bug.cgi?id=299562">https://bugs.webkit.org/show_bug.cgi?id=299562</a>
<a href="https://rdar.apple.com/161362865">rdar://161362865</a>

Reviewed by Tim Nguyen.

Implement `LargestContentfulPaintData::didPaintImage()`, which checks if the image has been seen before
(via `m_imageContentSet`), triggers a rendering update if needed so that the next frame enqueues the paint
timing entry. We store a localRect per image, to avoid having to compute this layer (since these might
be CSS background images, each with different geometry). If a given image on an element exists more than
once, we only need to track the larger rect.

In the next event loop, `takePendingEntry()` will be called, which iterates the image records, calling
`potentiallyAddLargestContentfulPaintEntry()` for each. This follows the logic at [1]. Despite the spec
talking about &quot;trusted scroll events&quot;, what Chrome actually does is track user scrolls [2]; this
is tested by WPT.

The current largest contentful size is tracked in `m_largestPaintArea`; we only issue an entry
if the new one is larger.

Enable a subset of the LCP tests that mostly pass now that we are emitting LCP entries.

[1] <a href="https://w3c.github.io/largest-contentful-paint/#sec-add-lcp-entry">https://w3c.github.io/largest-contentful-paint/#sec-add-lcp-entry</a>
[2] <a href="https://github.com/w3c/largest-contentful-paint/issues/105">https://github.com/w3c/largest-contentful-paint/issues/105</a>

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/largest-contentful-paint/animated/observe-cross-origin-animated-image.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/largest-contentful-paint/animated/observe-cross-origin-tao-animated-image.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/largest-contentful-paint/background-image-set-image-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/largest-contentful-paint/broken-image-icon-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/largest-contentful-paint/idlharness-expected.txt: Added.
    Fail is because we don&apos;t support navigationId: <a href="https://bugs.webkit.org/show_bug.cgi?id=299564">https://bugs.webkit.org/show_bug.cgi?id=299564</a>
* LayoutTests/imported/w3c/web-platform-tests/largest-contentful-paint/iframe-content-not-observed-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/largest-contentful-paint/image-sw-same-origin.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/largest-contentful-paint/image-upscaling-expected.txt: Added.
    Fail is tracked by <a href="https://github.com/web-platform-tests/interop/issues/1189">https://github.com/web-platform-tests/interop/issues/1189</a>
* LayoutTests/imported/w3c/web-platform-tests/largest-contentful-paint/invisible-images-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/largest-contentful-paint/larger-image-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/largest-contentful-paint/supported-lcp-type-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/largest-contentful-paint/video-play-after-poster-expected.txt: Added.
* LayoutTests/platform/mac-wk1/TestExpectations: Skip LCP tests in WK1. DRT&apos;s window does not autodisplay, which
means that paints don&apos;t happen until the end of the test. Maybe we&apos;ll fix this one day: webkit.org/b/244756.
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/page/LargestContentfulPaintData.cpp:
(WebCore::LargestContentfulPaintData::isEligibleForLargestContentfulPaint):
(WebCore::LargestContentfulPaintData::potentiallyAddLargestContentfulPaintEntry):
(WebCore::LargestContentfulPaintData::takePendingEntry):
(WebCore::LargestContentfulPaintData::didPaintImage):
* Source/WebCore/page/LargestContentfulPaintData.h:

Canonical link: <a href="https://commits.webkit.org/300622@main">https://commits.webkit.org/300622@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/975af7bdd9e45a847f8dd50c9c1dfbe8920f7a65

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123290 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43004 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33701 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/129998 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/75404 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e286ab9c-9939-4813-b209-b4064ec7ecc2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/125167 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43728 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51599 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/93720 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/75404 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3cabcaa8-0c39-4e74-9d39-efd2e29f7711) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126243 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34843 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/110317 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/74350 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8999fe24-d7d2-4772-a464-7e517d744dea) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/33809 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/28476 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73516 "Built successfully") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/115449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104557 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28702 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132717 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/121821 "Built successfully and passed tests") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/50240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/38231 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/102208 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50616 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106541 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102063 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25943 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47414 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/25640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/47014 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50095 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/55856 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/152176 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/49566 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/38889 "Passed tests") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/52916 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/51244 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->