### PR TITLE
Use explicit size_t data type in loop declarations

### DIFF
--- a/Source/WebCore/css/parser/CSSParserToken.cpp
+++ b/Source/WebCore/css/parser/CSSParserToken.cpp
@@ -753,7 +753,7 @@ void CSSParserToken::serialize(StringBuilder& builder, const CSSParserToken* nex
         break;
     case NonNewlineWhitespaceToken: {
         auto count = mode == SerializationMode::CustomProperty ? m_whitespaceCount : 1;
-        for (auto i = 0u; i < count; ++i)
+        for (decltype(count) i = 0; i < count; ++i)
             builder.append(' ');
         break;
     }

--- a/Source/WebCore/platform/graphics/FloatRoundedRect.cpp
+++ b/Source/WebCore/platform/graphics/FloatRoundedRect.cpp
@@ -266,7 +266,7 @@ Region approximateAsRegion(const FloatRoundedRect& roundedRect, unsigned stepLen
         constexpr auto maximumCount = 20u;
         count = std::min(maximumCount, count);
 
-        for (auto i = 0u; i < count; ++i) {
+        for (decltype(count) i = 0; i < count; ++i) {
             auto angle = fromAngle + (i + 1) * (toAngle - fromAngle) / (count + 1);
             auto ellipsisPoint = LayoutPoint { axes.width() * cos(angle), axes.height() * sin(angle) };
             auto cornerRect = makeIntRect(corner, ellipsisCenter + ellipsisPoint);

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
@@ -695,7 +695,7 @@ void GridTrackSizingAlgorithm::convertIndefiniteItemsToDefiniteMasonry(const Std
     auto& allTracks = tracks(m_direction);
 
     for (auto& indefiniteItem : indefiniteSpanSizes) {
-        for (auto trackIndex = 0u; trackIndex < allTracks.size(); trackIndex++) {
+        for (size_t trackIndex = 0; trackIndex < allTracks.size(); trackIndex++) {
             auto endLine = trackIndex + indefiniteItem.first;
             auto itemSpan = GridSpan::translatedDefiniteGridSpan(trackIndex, endLine);
 
@@ -1479,7 +1479,7 @@ double IndefiniteSizeStrategy::findUsedFlexFraction(Vector<unsigned>& flexibleSi
         }
     } else {
         Vector<SingleThreadWeakPtr<RenderBox>> indefiniteItems;
-        for (auto trackIndex = 0u; trackIndex < m_algorithm.tracks(direction).size(); trackIndex++) {
+        for (size_t trackIndex = 0; trackIndex < m_algorithm.tracks(direction).size(); trackIndex++) {
             GridIterator iterator(grid, direction, trackIndex);
             while (auto* gridItem = iterator.nextGridItem()) {
                 if (Style::GridPositionsResolver::resolveGridPositionsFromStyle(*m_algorithm.renderGrid(), *gridItem, direction).isIndefinite())
@@ -1817,7 +1817,7 @@ void GridTrackSizingAlgorithm::computeDefiniteAndIndefiniteItemsForMasonry(StdMa
 
     auto& allTracks = tracks(m_direction);
     auto trackLength = allTracks.size();
-    for (auto trackIndex = 0u; trackIndex < trackLength; trackIndex++) {
+    for (size_t trackIndex = 0; trackIndex < trackLength; trackIndex++) {
         GridIterator iterator(m_grid, m_direction, trackIndex);
 
         while (CheckedPtr gridItem = iterator.nextGridItem()) {


### PR DESCRIPTION
#### 117e7e2cfe55a46c71219ee445a79fca1d9f3117
<pre>
Use explicit size_t data type in loop declarations
<a href="https://bugs.webkit.org/show_bug.cgi?id=299570">https://bugs.webkit.org/show_bug.cgi?id=299570</a>
<a href="https://rdar.apple.com/problem/161370294">rdar://problem/161370294</a>

Reviewed by Darin Adler.

* Source/WebCore/css/parser/CSSParserToken.cpp:
(WebCore::CSSParserToken::serialize const):
* Source/WebCore/platform/graphics/FloatRoundedRect.cpp:
(WebCore::approximateAsRegion):
* Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp:
(WebCore::GridTrackSizingAlgorithm::convertIndefiniteItemsToDefiniteMasonry):
(WebCore::IndefiniteSizeStrategy::findUsedFlexFraction const):
(WebCore::GridTrackSizingAlgorithm::computeDefiniteAndIndefiniteItemsForMasonry):

Canonical link: <a href="https://commits.webkit.org/300577@main">https://commits.webkit.org/300577@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b1001ddda07d0e01e35b886bdb1513f884f5dd8f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123046 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42760 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33457 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/129702 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/75155 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/124923 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43484 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51355 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93527 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62072 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125997 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34657 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110125 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74158 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33633 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28280 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73213 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104368 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28505 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132431 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49996 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38061 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102028 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50372 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106345 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101890 "Found 3 new API test failures: TestWTF:CompletionHandlerDeathTest.MainThreadHandlerOnThreadAssertsDeathTest, TestWTF:CompletionHandlerDeathTest.ConstructionThreadHandlerOnThreadAssertsDeathTest, WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/no-web-process-leak (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25908 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47257 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25456 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/46769 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49851 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/55612 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49319 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/52671 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51000 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->