### PR TITLE
[Site Isolation] Web Inspector: Register the frame target's agents for instrumentation

### DIFF
--- a/Source/WebCore/inspector/FrameInspectorController.h
+++ b/Source/WebCore/inspector/FrameInspectorController.h
@@ -53,6 +53,7 @@ class InspectorInstrumentation;
 class InstrumentingAgents;
 class LocalFrame;
 class WebInjectedScriptManager;
+struct FrameAgentContext;
 
 class FrameInspectorController final : public Inspector::InspectorEnvironment, public CanMakeWeakPtr<FrameInspectorController> {
     WTF_MAKE_NONCOPYABLE(FrameInspectorController);
@@ -68,6 +69,8 @@ public:
     WEBCORE_EXPORT void disconnectFrontend(Inspector::FrontendChannel&);
     WEBCORE_EXPORT void dispatchMessageFromFrontend(const String& message);
 
+    void inspectedFrameDestroyed();
+
     // InspectorEnvironment
     bool developerExtrasEnabled() const override;
     bool canAccessInspectedScriptState(JSC::JSGlobalObject*) const override;
@@ -81,6 +84,7 @@ public:
 private:
     friend class InspectorInstrumentation;
 
+    FrameAgentContext frameAgentContext();
     void createLazyAgents();
 
     WeakRef<LocalFrame> m_frame;

--- a/Source/WebCore/inspector/InspectorController.h
+++ b/Source/WebCore/inspector/InspectorController.h
@@ -118,6 +118,8 @@ public:
     InspectorBackendClient* inspectorBackendClient() const { return m_inspectorBackendClient.get(); }
     InspectorFrontendClient* inspectorFrontendClient() const { return m_inspectorFrontendClient; }
 
+    InstrumentingAgents& instrumentingAgents() const { return m_instrumentingAgents.get(); }
+
     Inspector::InspectorAgent& ensureInspectorAgent();
     InspectorDOMAgent& ensureDOMAgent();
     WEBCORE_EXPORT InspectorPageAgent& ensurePageAgent();

--- a/Source/WebCore/inspector/InspectorInstrumentation.cpp
+++ b/Source/WebCore/inspector/InspectorInstrumentation.cpp
@@ -39,6 +39,7 @@
 #include "DocumentLoader.h"
 #include "Event.h"
 #include "EventTargetInlines.h"
+#include "FrameInspectorController.h"
 #include "InspectorAnimationAgent.h"
 #include "InspectorCSSAgent.h"
 #include "InspectorCanvasAgent.h"
@@ -1292,7 +1293,7 @@ void InspectorInstrumentation::unregisterInstrumentingAgents(InstrumentingAgents
     }
 }
 
-InstrumentingAgents* InspectorInstrumentation::instrumentingAgents(const RenderObject& renderer)
+InstrumentingAgents& InspectorInstrumentation::instrumentingAgents(const RenderObject& renderer)
 {
     return instrumentingAgents(renderer.frame());
 }
@@ -1319,14 +1320,14 @@ InstrumentingAgents& InspectorInstrumentation::instrumentingAgents(ServiceWorker
     return globalScope.inspectorController().m_instrumentingAgents;
 }
 
-InstrumentingAgents* InspectorInstrumentation::instrumentingAgents(const LocalFrameView& frameView)
+InstrumentingAgents& InspectorInstrumentation::instrumentingAgents(const LocalFrameView& frameView)
 {
     return instrumentingAgents(frameView.frame());
 }
 
-InstrumentingAgents* InspectorInstrumentation::instrumentingAgents(const Frame& frame)
+InstrumentingAgents& InspectorInstrumentation::instrumentingAgents(const LocalFrame& frame)
 {
-    return instrumentingAgents(frame.page());
+    return frame.inspectorController().m_instrumentingAgents.get();
 }
 
 InstrumentingAgents* InspectorInstrumentation::instrumentingAgents(Document& document)

--- a/Source/WebCore/inspector/InspectorInstrumentation.h
+++ b/Source/WebCore/inspector/InspectorInstrumentation.h
@@ -242,7 +242,7 @@ public:
     static void loaderDetachedFromFrame(LocalFrame&, DocumentLoader&);
     static void frameStartedLoading(LocalFrame&);
     static void frameStoppedLoading(LocalFrame&);
-    static void didCompleteRenderingFrame(Frame&);
+    static void didCompleteRenderingFrame(LocalFrame&);
     static void accessibilitySettingsDidChange(Page&);
 #if ENABLE(DARK_MODE_CSS)
     static void defaultAppearanceDidChange(Page&);
@@ -536,24 +536,23 @@ private:
     static void renderLayerDestroyedImpl(InstrumentingAgents&, const RenderLayer&);
 
     static InstrumentingAgents& instrumentingAgents(Page&);
+    static InstrumentingAgents& instrumentingAgents(const LocalFrame&);
+    static InstrumentingAgents& instrumentingAgents(const LocalFrameView&);
     static InstrumentingAgents& instrumentingAgents(WorkerOrWorkletGlobalScope&);
     static InstrumentingAgents& instrumentingAgents(ServiceWorkerGlobalScope&);
+    static InstrumentingAgents& instrumentingAgents(const RenderObject&);
 
-    static InstrumentingAgents* instrumentingAgents(const LocalFrameView&);
-    static InstrumentingAgents* instrumentingAgents(const Frame&);
-    static InstrumentingAgents* instrumentingAgents(const Frame*);
+    static InstrumentingAgents* instrumentingAgents(const LocalFrame*);
     static InstrumentingAgents* instrumentingAgents(ScriptExecutionContext&);
     static InstrumentingAgents* instrumentingAgents(Document&);
     static InstrumentingAgents* instrumentingAgents(Document*);
-    static InstrumentingAgents* instrumentingAgents(const RenderObject&);
     static InstrumentingAgents* instrumentingAgents(WorkerOrWorkletGlobalScope*);
 };
 
 inline void InspectorInstrumentation::didClearWindowObjectInWorld(LocalFrame& frame, DOMWrapperWorld& world)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(frame))
-        didClearWindowObjectInWorldImpl(*agents, frame, world);
+    didClearWindowObjectInWorldImpl(instrumentingAgents(frame), frame, world);
 }
 
 inline bool InspectorInstrumentation::isDebuggerPaused(LocalFrame* frame)
@@ -624,15 +623,13 @@ inline void InspectorInstrumentation::didChangeRendererForDOMNode(Node& node)
 inline void InspectorInstrumentation::didAddOrRemoveScrollbars(LocalFrameView& frameView)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(frameView))
-        didAddOrRemoveScrollbarsImpl(*agents, frameView);
+    didAddOrRemoveScrollbarsImpl(instrumentingAgents(frameView), frameView);
 }
 
 inline void InspectorInstrumentation::didAddOrRemoveScrollbars(RenderObject& renderer)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(renderer))
-        didAddOrRemoveScrollbarsImpl(*agents, renderer);
+    didAddOrRemoveScrollbarsImpl(instrumentingAgents(renderer), renderer);
 }
 
 inline void InspectorInstrumentation::willModifyDOMAttr(Document& document, Element& element, const AtomString& oldValue, const AtomString& newValue)
@@ -679,8 +676,7 @@ inline void InspectorInstrumentation::documentDetached(Document& document)
 
 inline void InspectorInstrumentation::frameWindowDiscarded(LocalFrame& frame, LocalDOMWindow* domWindow)
 {
-    if (auto* agents = instrumentingAgents(frame))
-        frameWindowDiscardedImpl(*agents, domWindow);
+    frameWindowDiscardedImpl(instrumentingAgents(frame), domWindow);
 }
 
 inline void InspectorInstrumentation::mediaQueryResultChanged(Document& document)
@@ -790,17 +786,13 @@ inline void InspectorInstrumentation::mouseDidMoveOverElement(Page& page, const 
 inline bool InspectorInstrumentation::handleTouchEvent(LocalFrame& frame, Node& node)
 {
     FAST_RETURN_IF_NO_FRONTENDS(false);
-    if (auto* agents = instrumentingAgents(frame))
-        return handleTouchEventImpl(*agents, node);
-    return false;
+    return handleTouchEventImpl(instrumentingAgents(frame), node);
 }
 
 inline bool InspectorInstrumentation::handleMousePress(LocalFrame& frame)
 {
     FAST_RETURN_IF_NO_FRONTENDS(false);
-    if (auto* agents = instrumentingAgents(frame))
-        return handleMousePressImpl(*agents);
-    return false;
+    return handleMousePressImpl(instrumentingAgents(frame));
 }
 
 inline bool InspectorInstrumentation::forcePseudoState(const Element& element, CSSSelector::PseudoClass pseudoState)
@@ -871,37 +863,31 @@ inline bool InspectorInstrumentation::isEventListenerDisabled(EventTarget& targe
 inline int InspectorInstrumentation::willPostMessage(LocalFrame& frame)
 {
     FAST_RETURN_IF_NO_FRONTENDS(0);
-    if (auto* agents = instrumentingAgents(frame))
-        return willPostMessageImpl(*agents);
-    return 0;
+    return willPostMessageImpl(instrumentingAgents(frame));
 }
 
 inline void InspectorInstrumentation::didPostMessage(LocalFrame& frame, int postMessageIdentifier, JSC::JSGlobalObject& state)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(frame))
-        didPostMessageImpl(*agents, postMessageIdentifier, state);
+    didPostMessageImpl(instrumentingAgents(frame), postMessageIdentifier, state);
 }
 
 inline void InspectorInstrumentation::didFailPostMessage(LocalFrame& frame, int postMessageIdentifier)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(frame))
-        didFailPostMessageImpl(*agents, postMessageIdentifier);
+    didFailPostMessageImpl(instrumentingAgents(frame), postMessageIdentifier);
 }
 
 inline void InspectorInstrumentation::willDispatchPostMessage(LocalFrame& frame, int postMessageIdentifier)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(frame))
-        willDispatchPostMessageImpl(*agents, postMessageIdentifier);
+    willDispatchPostMessageImpl(instrumentingAgents(frame), postMessageIdentifier);
 }
 
 inline void InspectorInstrumentation::didDispatchPostMessage(LocalFrame& frame, int postMessageIdentifier)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(frame))
-        didDispatchPostMessageImpl(*agents, postMessageIdentifier);
+    didDispatchPostMessageImpl(instrumentingAgents(frame), postMessageIdentifier);
 }
 
 inline void InspectorInstrumentation::willCallFunction(ScriptExecutionContext* context, const String& scriptName, int scriptLine, int scriptColumn)
@@ -975,8 +961,7 @@ inline void InspectorInstrumentation::eventDidResetAfterDispatch(const Event& ev
 inline void InspectorInstrumentation::willEvaluateScript(LocalFrame& frame, const String& url, int lineNumber, int columnNumber)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(frame))
-        willEvaluateScriptImpl(*agents, url, lineNumber, columnNumber);
+    willEvaluateScriptImpl(instrumentingAgents(frame), url, lineNumber, columnNumber);
 }
 
 inline void InspectorInstrumentation::willEvaluateScript(WorkerOrWorkletGlobalScope& globalScope, const String& url, int lineNumber, int columnNumber)
@@ -988,8 +973,7 @@ inline void InspectorInstrumentation::willEvaluateScript(WorkerOrWorkletGlobalSc
 inline void InspectorInstrumentation::didEvaluateScript(LocalFrame& frame)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(frame))
-        didEvaluateScriptImpl(*agents);
+    didEvaluateScriptImpl(instrumentingAgents(frame));
 }
 
 inline void InspectorInstrumentation::didEvaluateScript(WorkerOrWorkletGlobalScope& globalScope)
@@ -1015,22 +999,19 @@ inline void InspectorInstrumentation::didFireTimer(ScriptExecutionContext& conte
 inline void InspectorInstrumentation::didInvalidateLayout(LocalFrame& frame)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(frame))
-        didInvalidateLayoutImpl(*agents);
+    didInvalidateLayoutImpl(instrumentingAgents(frame));
 }
 
 inline void InspectorInstrumentation::willLayout(LocalFrame& frame)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(frame))
-        willLayoutImpl(*agents);
+    willLayoutImpl(instrumentingAgents(frame));
 }
 
 inline void InspectorInstrumentation::didLayout(LocalFrame& frame, const Vector<FloatQuad>& layoutAreas)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(frame))
-        didLayoutImpl(*agents, layoutAreas);
+    didLayoutImpl(instrumentingAgents(frame), layoutAreas);
 }
 
 inline void InspectorInstrumentation::didScroll(Page& page)
@@ -1042,29 +1023,25 @@ inline void InspectorInstrumentation::didScroll(Page& page)
 inline void InspectorInstrumentation::willComposite(LocalFrame& frame)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(frame))
-        willCompositeImpl(*agents);
+    willCompositeImpl(instrumentingAgents(frame));
 }
 
 inline void InspectorInstrumentation::didComposite(LocalFrame& frame)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(frame))
-        didCompositeImpl(*agents);
+    didCompositeImpl(instrumentingAgents(frame));
 }
 
 inline void InspectorInstrumentation::willPaint(RenderObject& renderer)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(renderer))
-        return willPaintImpl(*agents);
+    willPaintImpl(instrumentingAgents(renderer));
 }
 
 inline void InspectorInstrumentation::didPaint(RenderObject& renderer, const LayoutRect& rect)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(renderer))
-        didPaintImpl(*agents, renderer, rect);
+    didPaintImpl(instrumentingAgents(renderer), renderer, rect);
 }
 
 inline void InspectorInstrumentation::willRecalculateStyle(Document& document)
@@ -1091,29 +1068,25 @@ inline void InspectorInstrumentation::didScheduleStyleRecalculation(Document& do
 inline void InspectorInstrumentation::applyUserAgentOverride(LocalFrame& frame, String& userAgent)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(frame))
-        applyUserAgentOverrideImpl(*agents, userAgent);
+    applyUserAgentOverrideImpl(instrumentingAgents(frame), userAgent);
 }
 
 inline void InspectorInstrumentation::applyEmulatedMedia(LocalFrame& frame, AtomString& media)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(frame))
-        applyEmulatedMediaImpl(*agents, media);
+    applyEmulatedMediaImpl(instrumentingAgents(frame), media);
 }
 
 inline void InspectorInstrumentation::flexibleBoxRendererBeganLayout(const RenderObject& renderer)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(renderer))
-        flexibleBoxRendererBeganLayoutImpl(*agents, renderer);
+    flexibleBoxRendererBeganLayoutImpl(instrumentingAgents(renderer), renderer);
 }
 
 inline void InspectorInstrumentation::flexibleBoxRendererWrappedToNextLine(const RenderObject& renderer, size_t lineStartItemIndex)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(renderer))
-        flexibleBoxRendererWrappedToNextLineImpl(*agents, renderer, lineStartItemIndex);
+    flexibleBoxRendererWrappedToNextLineImpl(instrumentingAgents(renderer), renderer, lineStartItemIndex);
 }
 
 inline void InspectorInstrumentation::willSendRequest(LocalFrame* frame, ResourceLoaderIdentifier identifier, DocumentLoader* loader, ResourceRequest& request, const ResourceResponse& redirectResponse, const CachedResource* cachedResource, ResourceLoader* resourceLoader)
@@ -1144,8 +1117,7 @@ inline void InspectorInstrumentation::didLoadResourceFromMemoryCache(Page& page,
 
 inline void InspectorInstrumentation::didReceiveResourceResponse(LocalFrame& frame, ResourceLoaderIdentifier identifier, DocumentLoader* loader, const ResourceResponse& response, ResourceLoader* resourceLoader)
 {
-    if (auto* agents = instrumentingAgents(frame))
-        didReceiveResourceResponseImpl(*agents, identifier, loader, response, resourceLoader);
+    didReceiveResourceResponseImpl(instrumentingAgents(frame), identifier, loader, response, resourceLoader);
 }
 
 inline void InspectorInstrumentation::didReceiveResourceResponse(ServiceWorkerGlobalScope& globalScope, ResourceLoaderIdentifier identifier, const ResourceResponse& response)
@@ -1200,22 +1172,19 @@ inline void InspectorInstrumentation::didFailLoading(ServiceWorkerGlobalScope& g
 inline void InspectorInstrumentation::continueAfterXFrameOptionsDenied(LocalFrame& frame, ResourceLoaderIdentifier identifier, DocumentLoader& loader, const ResourceResponse& response)
 {
     // Treat the same as didReceiveResponse.
-    if (auto* agents = instrumentingAgents(frame))
-        didReceiveResourceResponseImpl(*agents, identifier, &loader, response, nullptr);
+    didReceiveResourceResponseImpl(instrumentingAgents(frame), identifier, &loader, response, nullptr);
 }
 
 inline void InspectorInstrumentation::continueWithPolicyDownload(LocalFrame& frame, ResourceLoaderIdentifier identifier, DocumentLoader& loader, const ResourceResponse& response)
 {
     // Treat the same as didReceiveResponse.
-    if (auto* agents = instrumentingAgents(frame))
-        didReceiveResourceResponseImpl(*agents, identifier, &loader, response, nullptr);
+    didReceiveResourceResponseImpl(instrumentingAgents(frame), identifier, &loader, response, nullptr);
 }
 
 inline void InspectorInstrumentation::continueWithPolicyIgnore(LocalFrame& frame, ResourceLoaderIdentifier identifier, DocumentLoader& loader, const ResourceResponse& response)
 {
     // Treat the same as didReceiveResponse.
-    if (auto* agents = instrumentingAgents(frame))
-        didReceiveResourceResponseImpl(*agents, identifier, &loader, response, nullptr);
+    didReceiveResourceResponseImpl(instrumentingAgents(frame), identifier, &loader, response, nullptr);
 }
 
 inline void InspectorInstrumentation::willLoadXHRSynchronously(ScriptExecutionContext* context)
@@ -1256,8 +1225,7 @@ inline void InspectorInstrumentation::didReceiveScriptResponse(ScriptExecutionCo
 inline void InspectorInstrumentation::domContentLoadedEventFired(LocalFrame& frame)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(frame))
-        domContentLoadedEventFiredImpl(*agents, frame);
+    domContentLoadedEventFiredImpl(instrumentingAgents(frame), frame);
 }
 
 inline void InspectorInstrumentation::loadEventFired(LocalFrame* frame)
@@ -1270,49 +1238,42 @@ inline void InspectorInstrumentation::loadEventFired(LocalFrame* frame)
 inline void InspectorInstrumentation::frameDetachedFromParent(LocalFrame& frame)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(frame))
-        frameDetachedFromParentImpl(*agents, frame);
+    frameDetachedFromParentImpl(instrumentingAgents(frame), frame);
 }
 
 inline void InspectorInstrumentation::didCommitLoad(LocalFrame& frame, DocumentLoader* loader)
 {
-    if (auto* agents = instrumentingAgents(frame))
-        didCommitLoadImpl(*agents, frame, loader);
+    didCommitLoadImpl(instrumentingAgents(frame), frame, loader);
 }
 
 inline void InspectorInstrumentation::frameDocumentUpdated(LocalFrame& frame)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(frame))
-        frameDocumentUpdatedImpl(*agents, frame);
+    frameDocumentUpdatedImpl(instrumentingAgents(frame), frame);
 }
 
 inline void InspectorInstrumentation::loaderDetachedFromFrame(LocalFrame& frame, DocumentLoader& loader)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(frame))
-        loaderDetachedFromFrameImpl(*agents, loader);
+    loaderDetachedFromFrameImpl(instrumentingAgents(frame), loader);
 }
 
 inline void InspectorInstrumentation::frameStartedLoading(LocalFrame& frame)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(frame))
-        frameStartedLoadingImpl(*agents, frame);
+    frameStartedLoadingImpl(instrumentingAgents(frame), frame);
 }
 
-inline void InspectorInstrumentation::didCompleteRenderingFrame(Frame& frame)
+inline void InspectorInstrumentation::didCompleteRenderingFrame(LocalFrame& frame)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(frame))
-        didCompleteRenderingFrameImpl(*agents);
+    didCompleteRenderingFrameImpl(instrumentingAgents(frame));
 }
 
 inline void InspectorInstrumentation::frameStoppedLoading(LocalFrame& frame)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(frame))
-        frameStoppedLoadingImpl(*agents, frame);
+    frameStoppedLoadingImpl(instrumentingAgents(frame), frame);
 }
 
 inline void InspectorInstrumentation::accessibilitySettingsDidChange(Page& page)
@@ -1354,9 +1315,7 @@ inline bool InspectorInstrumentation::shouldInterceptRequest(const ResourceLoade
 inline bool InspectorInstrumentation::shouldInterceptResponse(const LocalFrame& frame, const ResourceResponse& response)
 {
     ASSERT(InspectorInstrumentationPublic::hasFrontends());
-    if (auto* agents = instrumentingAgents(frame))
-        return shouldInterceptResponseImpl(*agents, response);
-    return false;
+    return shouldInterceptResponseImpl(instrumentingAgents(frame), response);
 }
 
 inline void InspectorInstrumentation::interceptRequest(ResourceLoader& loader, Function<void(const ResourceRequest&)>&& handler)
@@ -1369,8 +1328,7 @@ inline void InspectorInstrumentation::interceptRequest(ResourceLoader& loader, F
 inline void InspectorInstrumentation::interceptResponse(const LocalFrame& frame, const ResourceResponse& response, ResourceLoaderIdentifier identifier, CompletionHandler<void(const ResourceResponse&, RefPtr<FragmentedSharedBuffer>)>&& handler)
 {
     ASSERT(InspectorInstrumentation::shouldInterceptResponse(frame, response));
-    if (auto* agents = instrumentingAgents(frame))
-        interceptResponseImpl(*agents, response, identifier, WTFMove(handler));
+    interceptResponseImpl(instrumentingAgents(frame), response, identifier, WTFMove(handler));
 }
 
 inline void InspectorInstrumentation::didDispatchDOMStorageEvent(Page& page, const String& key, const String& oldValue, const String& newValue, StorageType storageType, const SecurityOrigin& securityOrigin)
@@ -1576,8 +1534,7 @@ inline void InspectorInstrumentation::willDestroyWebAnimation(WebAnimation& anim
 
 inline void InspectorInstrumentation::addMessageToConsole(LocalFrame& frame, std::unique_ptr<Inspector::ConsoleMessage> message)
 {
-    if (auto* agents = instrumentingAgents(frame))
-        addMessageToConsoleImpl(*agents, WTFMove(message));
+    addMessageToConsoleImpl(instrumentingAgents(frame), WTFMove(message));
 }
 
 inline void InspectorInstrumentation::addMessageToConsole(WorkerOrWorkletGlobalScope& globalScope, std::unique_ptr<Inspector::ConsoleMessage> message)
@@ -1587,8 +1544,7 @@ inline void InspectorInstrumentation::addMessageToConsole(WorkerOrWorkletGlobalS
 
 inline void InspectorInstrumentation::consoleCount(LocalFrame& frame, JSC::JSGlobalObject* state, const String& label)
 {
-    if (auto* agents = instrumentingAgents(frame))
-        consoleCountImpl(*agents, state, label);
+    consoleCountImpl(instrumentingAgents(frame), state, label);
 }
 
 inline void InspectorInstrumentation::consoleCount(WorkerOrWorkletGlobalScope& globalScope, JSC::JSGlobalObject* state, const String& label)
@@ -1598,8 +1554,7 @@ inline void InspectorInstrumentation::consoleCount(WorkerOrWorkletGlobalScope& g
 
 inline void InspectorInstrumentation::consoleCountReset(LocalFrame& frame, JSC::JSGlobalObject* state, const String& label)
 {
-    if (auto* agents = instrumentingAgents(frame))
-        consoleCountResetImpl(*agents, state, label);
+    consoleCountResetImpl(instrumentingAgents(frame), state, label);
 }
 
 inline void InspectorInstrumentation::consoleCountReset(WorkerOrWorkletGlobalScope& globalScope, JSC::JSGlobalObject* state, const String& label)
@@ -1610,8 +1565,7 @@ inline void InspectorInstrumentation::consoleCountReset(WorkerOrWorkletGlobalSco
 inline void InspectorInstrumentation::takeHeapSnapshot(LocalFrame& frame, const String& title)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(frame))
-        takeHeapSnapshotImpl(*agents, title);
+    takeHeapSnapshotImpl(instrumentingAgents(frame), title);
 }
 
 inline void InspectorInstrumentation::takeHeapSnapshot(WorkerOrWorkletGlobalScope& globalScope, const String& title)
@@ -1622,8 +1576,7 @@ inline void InspectorInstrumentation::takeHeapSnapshot(WorkerOrWorkletGlobalScop
 
 inline void InspectorInstrumentation::startConsoleTiming(LocalFrame& frame, JSC::JSGlobalObject* exec, const String& label)
 {
-    if (auto* agents = instrumentingAgents(frame))
-        startConsoleTimingImpl(*agents, exec, label);
+    startConsoleTimingImpl(instrumentingAgents(frame), exec, label);
 }
 
 inline void InspectorInstrumentation::startConsoleTiming(WorkerOrWorkletGlobalScope& globalScope, JSC::JSGlobalObject* exec, const String& label)
@@ -1633,8 +1586,7 @@ inline void InspectorInstrumentation::startConsoleTiming(WorkerOrWorkletGlobalSc
 
 inline void InspectorInstrumentation::logConsoleTiming(LocalFrame& frame, JSC::JSGlobalObject* exec, const String& label, Ref<Inspector::ScriptArguments>&& arguments)
 {
-    if (auto* agents = instrumentingAgents(frame))
-        logConsoleTimingImpl(*agents, exec, label, WTFMove(arguments));
+    logConsoleTimingImpl(instrumentingAgents(frame), exec, label, WTFMove(arguments));
 }
 
 inline void InspectorInstrumentation::logConsoleTiming(WorkerOrWorkletGlobalScope& globalScope, JSC::JSGlobalObject* exec, const String& label, Ref<Inspector::ScriptArguments>&& arguments)
@@ -1644,8 +1596,7 @@ inline void InspectorInstrumentation::logConsoleTiming(WorkerOrWorkletGlobalScop
 
 inline void InspectorInstrumentation::stopConsoleTiming(LocalFrame& frame, JSC::JSGlobalObject* exec, const String& label)
 {
-    if (auto* agents = instrumentingAgents(frame))
-        stopConsoleTimingImpl(*agents, exec, label);
+    stopConsoleTimingImpl(instrumentingAgents(frame), exec, label);
 }
 
 inline void InspectorInstrumentation::stopConsoleTiming(WorkerOrWorkletGlobalScope& globalScope, JSC::JSGlobalObject* exec, const String& label)
@@ -1656,8 +1607,7 @@ inline void InspectorInstrumentation::stopConsoleTiming(WorkerOrWorkletGlobalSco
 inline void InspectorInstrumentation::consoleTimeStamp(LocalFrame& frame, Ref<Inspector::ScriptArguments>&& arguments)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(frame))
-        consoleTimeStampImpl(*agents, WTFMove(arguments));
+    consoleTimeStampImpl(instrumentingAgents(frame), WTFMove(arguments));
 }
 
 inline void InspectorInstrumentation::consoleTimeStamp(WorkerOrWorkletGlobalScope& globalScope, Ref<Inspector::ScriptArguments>&& arguments)
@@ -1669,8 +1619,7 @@ inline void InspectorInstrumentation::consoleTimeStamp(WorkerOrWorkletGlobalScop
 inline void InspectorInstrumentation::startProfiling(LocalFrame& frame, const String &title)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(frame))
-        startProfilingImpl(*agents, title);
+    startProfilingImpl(instrumentingAgents(frame), title);
 }
 
 inline void InspectorInstrumentation::startProfiling(WorkerOrWorkletGlobalScope& globalScope, const String &title)
@@ -1683,8 +1632,7 @@ inline void InspectorInstrumentation::stopProfiling(LocalFrame& frame, const Str
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
 
-    if (auto* agents = instrumentingAgents(frame))
-        stopProfilingImpl(*agents, title);
+    stopProfilingImpl(instrumentingAgents(frame), title);
 }
 
 inline void InspectorInstrumentation::stopProfiling(WorkerOrWorkletGlobalScope& globalScope, const String &title)
@@ -1773,9 +1721,9 @@ inline InstrumentingAgents* InspectorInstrumentation::instrumentingAgents(Script
     return context ? instrumentingAgents(*context) : nullptr;
 }
 
-inline InstrumentingAgents* InspectorInstrumentation::instrumentingAgents(const Frame* frame)
+inline InstrumentingAgents* InspectorInstrumentation::instrumentingAgents(const LocalFrame* frame)
 {
-    return frame ? instrumentingAgents(*frame) : nullptr;
+    return frame ? &instrumentingAgents(*frame) : nullptr;
 }
 
 inline InstrumentingAgents* InspectorInstrumentation::instrumentingAgents(Document* document)

--- a/Source/WebCore/inspector/InspectorWebAgentBase.h
+++ b/Source/WebCore/inspector/InspectorWebAgentBase.h
@@ -28,6 +28,7 @@
 
 #include <JavaScriptCore/InspectorAgentBase.h>
 #include <WebCore/InstrumentingAgents.h>
+#include <WebCore/LocalFrame.h>
 #include <WebCore/Page.h>
 #include <WebCore/WorkerOrWorkletGlobalScope.h>
 #include <wtf/WeakRef.h>
@@ -54,6 +55,16 @@ struct PageAgentContext : public WebAgentContext {
     }
 
     WeakRef<Page> inspectedPage;
+};
+
+struct FrameAgentContext : public WebAgentContext {
+    FrameAgentContext(WebAgentContext& context, LocalFrame& inspectedFrame)
+        : WebAgentContext(context)
+        , inspectedFrame(inspectedFrame)
+    {
+    }
+
+    WeakRef<LocalFrame> inspectedFrame;
 };
 
 struct WorkerAgentContext : public WebAgentContext {

--- a/Source/WebCore/inspector/InstrumentingAgents.cpp
+++ b/Source/WebCore/inspector/InstrumentingAgents.cpp
@@ -32,16 +32,25 @@
 #include "config.h"
 #include "InstrumentingAgents.h"
 #include <wtf/TZoneMallocInlines.h>
-
-
 namespace WebCore {
 
 using namespace Inspector;
 
+Ref<InstrumentingAgents> InstrumentingAgents::create(Inspector::InspectorEnvironment& environment)
+{
+    return adoptRef(*new InstrumentingAgents(environment, nullptr));
+}
+
+Ref<InstrumentingAgents> InstrumentingAgents::create(Inspector::InspectorEnvironment& environment, InstrumentingAgents& fallbackAgents)
+{
+    return adoptRef(*new InstrumentingAgents(environment, &fallbackAgents));
+}
+
 WTF_MAKE_TZONE_ALLOCATED_IMPL(InstrumentingAgents);
 
-InstrumentingAgents::InstrumentingAgents(InspectorEnvironment& environment)
+InstrumentingAgents::InstrumentingAgents(InspectorEnvironment& environment, InstrumentingAgents* fallbackAgents)
     : m_environment(environment)
+    , m_fallbackAgents(fallbackAgents)
 {
 }
 
@@ -53,5 +62,25 @@ void InstrumentingAgents::reset()
 FOR_EACH_INSPECTOR_AGENT(RESET_MEMBER_VARIABLE_FOR_INSPECTOR_AGENT)
 #undef RESET_MEMBER_VARIABLE_FOR_INSPECTOR_AGENT
 }
+
+// FIXME: <https://webkit.org/b/300646> To ease the transition of agents and functionalities from page target
+// to frame target, we added this fallback mechanism to let the frame use its page's agents as delegates
+// for agents not yet supported. Remove this once we complete implementing/migrating the frame target's agents.
+#define DEFINE_GETTER_SETTER_FOR_INSPECTOR_AGENT(Class, Name, Getter, Setter) \
+Class* InstrumentingAgents::Getter##Name() const \
+{ \
+    if (m_##Getter##Name) \
+        return m_##Getter##Name; \
+    if (RefPtr fallbackAgents = m_fallbackAgents.get()) \
+        return fallbackAgents->Getter##Name(); \
+    return nullptr; \
+} \
+void InstrumentingAgents::set##Setter##Name(Class* agent) \
+{ \
+    m_##Getter##Name = agent; \
+}
+
+FOR_EACH_INSPECTOR_AGENT(DEFINE_GETTER_SETTER_FOR_INSPECTOR_AGENT)
+#undef DEFINE_GETTER_SETTER_FOR_INSPECTOR_AGENT
 
 } // namespace WebCore

--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -242,6 +242,8 @@ LocalFrame::~LocalFrame()
 {
     setView(nullptr);
 
+    m_inspectorController->inspectedFrameDestroyed();
+
     Ref loader = this->loader();
     if (!loader->isComplete())
         loader->closeURL();
@@ -1666,7 +1668,7 @@ RefPtr<SecurityOrigin> LocalFrame::frameDocumentSecurityOrigin() const
     return nullptr;
 }
 
-Ref<FrameInspectorController> LocalFrame::protectedInspectorController()
+Ref<FrameInspectorController> LocalFrame::protectedInspectorController() const
 {
     return m_inspectorController.get();
 }

--- a/Source/WebCore/page/LocalFrame.h
+++ b/Source/WebCore/page/LocalFrame.h
@@ -354,7 +354,8 @@ public:
     bool frameCanCreatePaymentSession() const final;
 
     FrameInspectorController& inspectorController() { return m_inspectorController.get(); }
-    WEBCORE_EXPORT Ref<FrameInspectorController> protectedInspectorController();
+    const FrameInspectorController& inspectorController() const { return m_inspectorController.get(); }
+    WEBCORE_EXPORT Ref<FrameInspectorController> protectedInspectorController() const;
     FrameConsoleClient& console() { return m_consoleClient.get(); }
     const FrameConsoleClient& console() const { return m_consoleClient.get(); }
 

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -2550,7 +2550,8 @@ void Page::didCompleteRenderingFrame()
 
     // FIXME: This is where we'd call requestPostAnimationFrame callbacks: webkit.org/b/249798.
     // FIXME: Run WindowEventLoop tasks from here: webkit.org/b/249684.
-    InspectorInstrumentation::didCompleteRenderingFrame(m_mainFrame);
+    if (RefPtr localMainFrame = this->localMainFrame())
+        InspectorInstrumentation::didCompleteRenderingFrame(*localMainFrame);
 }
 
 void Page::didUpdateRendering()


### PR DESCRIPTION
#### 1fd298f8d706d1736b50f34c79d5b4bf32a32540
<pre>
[Site Isolation] Web Inspector: Register the frame target&apos;s agents for instrumentation
<a href="https://webkit.org/b/299607">https://webkit.org/b/299607</a>
<a href="https://rdar.apple.com/161414130">rdar://161414130</a>

Reviewed by BJ Burg.

This patch adds the registering and unregistering logic for the frame
target&apos;s agents. The plan is to slowly implement all agents of the
page target for the frame target, by mostly rewriting or moving them.
Given this anticipated transition, we also updated InstrumentingAgents
to allow the frame to use its page&apos;s agents as delegates replacing the
not yet implemented ones. This way, objects that interact with the
inspector or the inspector frontend can start viewing the frame as
having all agents that its page has, albeit without site isolation
support.

No new test as no new difference in behavior is expected.

* Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations:
* Source/WebCore/inspector/FrameInspectorController.cpp:
(WebCore::FrameInspectorController::FrameInspectorController):
(WebCore::FrameInspectorController::frameAgentContext):
(WebCore::FrameInspectorController::connectFrontend):
(WebCore::FrameInspectorController::disconnectFrontend):
(WebCore::FrameInspectorController::inspectedFrameDestroyed):
* Source/WebCore/inspector/FrameInspectorController.h:
* Source/WebCore/inspector/InspectorController.h:
   Add support to use another set of InstrumentingAgents to fallback to.

* Source/WebCore/inspector/InspectorInstrumentation.cpp:
(WebCore::InspectorInstrumentation::instrumentingAgents):
* Source/WebCore/inspector/InspectorInstrumentation.h:
(WebCore::InspectorInstrumentation::didClearWindowObjectInWorld):
(WebCore::InspectorInstrumentation::didAddOrRemoveScrollbars):
(WebCore::InspectorInstrumentation::frameWindowDiscarded):
(WebCore::InspectorInstrumentation::handleTouchEvent):
(WebCore::InspectorInstrumentation::handleMousePress):
(WebCore::InspectorInstrumentation::willPostMessage):
(WebCore::InspectorInstrumentation::didPostMessage):
(WebCore::InspectorInstrumentation::didFailPostMessage):
(WebCore::InspectorInstrumentation::willDispatchPostMessage):
(WebCore::InspectorInstrumentation::didDispatchPostMessage):
(WebCore::InspectorInstrumentation::willEvaluateScript):
(WebCore::InspectorInstrumentation::didEvaluateScript):
(WebCore::InspectorInstrumentation::didInvalidateLayout):
(WebCore::InspectorInstrumentation::willLayout):
(WebCore::InspectorInstrumentation::didLayout):
(WebCore::InspectorInstrumentation::willComposite):
(WebCore::InspectorInstrumentation::didComposite):
(WebCore::InspectorInstrumentation::willPaint):
(WebCore::InspectorInstrumentation::didPaint):
(WebCore::InspectorInstrumentation::applyUserAgentOverride):
(WebCore::InspectorInstrumentation::applyEmulatedMedia):
(WebCore::InspectorInstrumentation::flexibleBoxRendererBeganLayout):
(WebCore::InspectorInstrumentation::flexibleBoxRendererWrappedToNextLine):
(WebCore::InspectorInstrumentation::didReceiveResourceResponse):
(WebCore::InspectorInstrumentation::continueAfterXFrameOptionsDenied):
(WebCore::InspectorInstrumentation::continueWithPolicyDownload):
(WebCore::InspectorInstrumentation::continueWithPolicyIgnore):
(WebCore::InspectorInstrumentation::domContentLoadedEventFired):
(WebCore::InspectorInstrumentation::frameDetachedFromParent):
(WebCore::InspectorInstrumentation::didCommitLoad):
(WebCore::InspectorInstrumentation::frameDocumentUpdated):
(WebCore::InspectorInstrumentation::loaderDetachedFromFrame):
(WebCore::InspectorInstrumentation::frameStartedLoading):
(WebCore::InspectorInstrumentation::didCompleteRenderingFrame):
(WebCore::InspectorInstrumentation::frameStoppedLoading):
(WebCore::InspectorInstrumentation::shouldInterceptResponse):
(WebCore::InspectorInstrumentation::interceptResponse):
(WebCore::InspectorInstrumentation::addMessageToConsole):
(WebCore::InspectorInstrumentation::consoleCount):
(WebCore::InspectorInstrumentation::consoleCountReset):
(WebCore::InspectorInstrumentation::takeHeapSnapshot):
(WebCore::InspectorInstrumentation::startConsoleTiming):
(WebCore::InspectorInstrumentation::logConsoleTiming):
(WebCore::InspectorInstrumentation::stopConsoleTiming):
(WebCore::InspectorInstrumentation::consoleTimeStamp):
(WebCore::InspectorInstrumentation::startProfiling):
(WebCore::InspectorInstrumentation::stopProfiling):
(WebCore::InspectorInstrumentation::instrumentingAgents):
* Source/WebCore/inspector/InspectorWebAgentBase.h:
(WebCore::FrameAgentContext::FrameAgentContext):
   Register and unregister the frame&apos;s inspector agents, mimicking
   the page target&apos;s behavior for timing.

* Source/WebCore/inspector/InstrumentingAgents.cpp:
(WebCore::InstrumentingAgents::create):
(WebCore::InstrumentingAgents::InstrumentingAgents):
* Source/WebCore/inspector/InstrumentingAgents.h:
(WebCore::InstrumentingAgents::create): Deleted.
* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::~LocalFrame):
(WebCore::LocalFrame::protectedInspectorController const):
(WebCore::LocalFrame::protectedInspectorController): Deleted.
   Since the frame now always has an InstrumentingAgents object, make
   its getter return a reference instead of pointer.

* Source/WebCore/page/LocalFrame.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::didCompleteRenderingFrame):
   Adapt to the instrumentation function only accepting a LocalFrame,
   which was the behavior before the commit <a href="https://github.com/WebKit/WebKit/commit/a368459ce9a9e6b637a366dd90ba655f57031e23)">https://github.com/WebKit/WebKit/commit/a368459ce9a9e6b637a366dd90ba655f57031e23)</a>

Canonical link: <a href="https://commits.webkit.org/301485@main">https://commits.webkit.org/301485@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9f6274a412fdc11d31cc7065b595e46c91e04eca

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126016 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45670 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36446 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132851 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77842 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/70841290-0c9b-42f7-9f39-45be64156f04) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127887 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46340 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54215 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95984 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/64154 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bbd59489-7ca1-4100-8fd6-d28163e291ad) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128964 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37071 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112696 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76473 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/515fce6d-dc9b-4bd7-828f-a465e9e48dea) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35979 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30881 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76322 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106853 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31097 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135547 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52779 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40509 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104474 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53231 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108910 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104194 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26565 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49574 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27904 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50158 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52673 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58503 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52012 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55360 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53713 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->