### PR TITLE
[WIP] Testing SIMD IPInt calls

### DIFF
--- a/JSTests/wasm/stress/simd-instructions-calls.js
+++ b/JSTests/wasm/stress/simd-instructions-calls.js
@@ -1,0 +1,348 @@
+//@ requireOptions("--useWasmSIMD=1", "--useWasmTailCalls=1")
+//@ skip if !$isSIMDPlatform
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+const verbose = false;
+
+function logV(...args) {
+    if (verbose)
+        console.log(...args);
+}
+
+const testCases = [
+    {
+        name: "simple_swap_v128",
+        signature: {
+            params: ['v128', 'v128'],
+            results: ['v128', 'v128']
+        },
+        // Maps result index → parameter index (swap the two parameters)
+        resultMapping: [1, 0]  // result[0] = param[1], result[1] = param[0] (swapped)
+    },
+    {
+        name: "simple_10_results_stack_v128_v128",
+        signature: {
+            params: ['v128', 'f64'],
+            results: ['v128', 'f64', 'v128', 'f64', 'v128', 'f64', 'v128', 'f64', 'v128', 'v128']
+        },
+        resultMapping: [0, 1, 0, 1, 0, 1, 0, 1, 0, 0]
+    },
+    {
+        name: "simple_10_results_stack_f64_f64",
+        signature: {
+            params: ['v128', 'f64'],
+            results: ['v128', 'f64', 'v128', 'f64', 'v128', 'f64', 'v128', 'f64', 'f64', 'f64']
+        },
+        resultMapping: [0, 1, 0, 1, 0, 1, 0, 1, 1, 1]
+    },
+    {
+        name: "simple_10_results_stack_f64_v128",
+        signature: {
+            params: ['v128', 'f64'],
+            results: ['v128', 'f64', 'v128', 'f64', 'v128', 'f64', 'v128', 'f64', 'f64', 'v128']
+        },
+        resultMapping: [0, 1, 0, 1, 0, 1, 0, 1, 1, 0]
+    },
+        {
+        name: "simple_10_results_stack_v128_f64",
+        signature: {
+            params: ['v128', 'f64'],
+            results: ['v128', 'f64', 'v128', 'f64', 'v128', 'f64', 'v128', 'f64', 'v128', 'f64']
+        },
+        resultMapping: [0, 1, 0, 1, 0, 1, 0, 1, 0, 1]
+    },
+        {
+        name: "simple_20_results_stack_i64_v128_i64_v128",
+        signature: {
+            params: ['i64', 'f64'],
+            results: ['i64', 'f64', 'i64', 'f64', 'i64', 'f64', 'i64', 'f64', 'i64', 'f64', 'i64', 'f64', 'i64', 'f64', 'i64', 'f64', 'i64', 'f64', 'i64', 'f64'] // 10 results
+        },
+        resultMapping: [0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1]
+    },
+    {
+        name: "many_args_alternating_f64_v128",
+        signature: {
+            params: ['f64', 'v128', 'f64', 'v128', 'f64', 'v128', 'f64', 'v128', 'f64', 'v128', 'f64', 'v128', 'i32'],
+            results: ['v128']
+        },
+        resultMapping: [11]
+    },
+    {
+        name: "many_args_alternating_v128_f64",
+        signature: {
+            params: ['v128', 'f64', 'v128', 'f64', 'v128', 'f64', 'v128', 'f64', 'v128', 'f64', 'v128', 'f64', 'v128'],
+            results: ['v128']
+        },
+        resultMapping: [10]
+    },
+    {
+        name: "many_args_alternating_many_results_reversed",
+        signature: {
+            params: ['v128', 'f64', 'v128', 'f64', 'v128', 'f64', 'v128', 'f64', 'v128', 'f64', 'v128', 'f64'],
+            results: ['f64', 'v128', 'f64', 'v128', 'f64', 'v128', 'f64', 'v128', 'f64', 'v128', 'f64', 'v128'],
+        },
+        resultMapping: [11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0]
+    },
+    {
+        name: "many_args_alternating_many_results_shifted",
+        signature: {
+            params: ['v128', 'f64', 'v128', 'f64', 'v128', 'f64', 'v128', 'f64', 'v128', 'f64', 'v128', 'f64'],
+            results: ['v128', 'f64', 'v128', 'f64', 'v128', 'f64', 'v128', 'f64', 'v128', 'f64', 'v128', 'f64'],
+        },
+        resultMapping: [2, 5, 6, 7, 8, 9, 10, 11, 0, 1, 2, 3]
+    },
+    {
+        name: "stack_args_no_stack_returns",
+        signature: {
+            params: ['f64', 'v128', 'f64', 'v128', 'v128', 'f64', 'f64', 'v128', 'f64', 'f64', 'v128', 'f64', 'v128'],
+            results: ['f64', 'f64', 'f64', 'f64', 'v128', 'v128', 'v128']
+        },
+        resultMapping: [8, 5, 9, 11, 12, 3, 10]
+    },
+    {
+        name: "no_stack_args_with_stack_returns",
+        signature: {
+            params: ['f64', 'f64', 'f64', 'f64', 'v128', 'v128', 'v128'],
+            results: ['f64', 'v128', 'f64', 'v128', 'v128', 'f64', 'f64', 'v128', 'f64', 'f64', 'v128', 'f64', 'v128']
+        },
+        resultMapping: [1, 6, 0, 4, 5, 1, 2, 6, 3, 0, 4, 1, 5]
+    },
+    {
+        name: "pure_v128_many_results",
+        signature: {
+            params: ['v128', 'v128', 'v128', 'v128', 'v128', 'v128', 'v128', 'v128', 'v128'],
+            results: ['v128', 'v128', 'v128', 'v128', 'v128', 'v128', 'v128', 'v128', 'v128', 'v128', 'v128', 'v128', 'v128']
+        },
+        resultMapping: [0, 1, 2, 3, 4, 5, 6, 7, 8, 0, 1, 2, 3]
+    },
+    {
+        name: "odd_results_v128_f64",
+        signature: {
+            params: ['v128', 'v128', 'v128', 'v128', 'v128', 'f64', 'f64', 'f64', 'f64'],
+            results: ['v128', 'f64', 'v128', 'f64', 'v128', 'f64', 'v128', 'f64', 'v128'] // 9 results (odd)
+        },
+        resultMapping: [0, 5, 1, 6, 2, 7, 3, 8, 4]
+    },
+    {
+        name: "alternating_25_results",
+        signature: {
+            params: ['v128', 'v128', 'v128', 'v128', 'v128', 'f64', 'f64', 'f64', 'f64'],
+            results: new Array(25).fill(null).map((_, i) => i % 2 === 0 ? 'v128' : 'f64')
+        },
+        resultMapping: new Array(25).fill(null).map((_, i) => i % 2 === 0 ? (i % 10) % 5 : 5 + (i % 8) % 4)
+    },
+    {
+        name: "v128_20_results",
+        signature: {
+            params: ['v128', 'v128', 'v128', 'v128', 'v128', 'v128', 'v128', 'v128', 'v128'], // 9 v128 params
+            results: new Array(20).fill('v128') // 20 v128 results
+        },
+        resultMapping: new Array(20).fill(null).map((_, i) => i % 9)
+    },
+    {
+        name: "random_case_1",
+        signature: {
+            params: ['f64', 'v128', 'i64', 'f64', 'v128', 'i64', 'v128', 'f64', 'i64', 'v128', 'f64', 'i64', 'v128', 'f64'], // 14 params
+            results: ['v128', 'f64', 'i64', 'v128', 'f64', 'i64', 'v128', 'f64', 'i64', 'v128', 'f64', 'i64', 'v128', 'f64', 'i64', 'v128', 'f64', 'i64'] // 18 results
+        },
+        resultMapping: [1, 0, 2, 4, 3, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 4, 7, 11]
+    },
+    {
+        name: "random_case_2",
+        signature: {
+            params: ['v128', 'i64', 'v128', 'f64', 'v128', 'i64', 'f64', 'v128', 'i64', 'f64', 'v128', 'i64'], // 12 params
+            results: ['i64', 'v128', 'f64', 'i64', 'v128', 'f64', 'i64', 'v128', 'f64', 'i64', 'v128', 'f64', 'i64', 'v128', 'f64', 'i64', 'v128', 'f64', 'i64', 'v128', 'f64'] // 21 results
+        },
+        resultMapping: [1, 0, 3, 5, 2, 6, 8, 4, 9, 11, 7, 3, 1, 0, 6, 5, 2, 9, 8, 4, 3]
+    },
+        {
+        name: "random_case_3",
+        signature: {
+            params: ['f64', 'f64', 'v128', 'i64', 'v128', 'f64', 'i64', 'v128', 'f64', 'i64', 'v128', 'f64', 'i64', 'v128', 'f64', 'i64'], // 16 params
+            results: ['v128', 'i64', 'f64', 'v128', 'i64', 'f64', 'v128', 'i64', 'f64', 'v128', 'i64', 'f64', 'v128'] // 13 results
+        },
+        resultMapping: [2, 3, 0, 4, 6, 1, 7, 9, 8, 10, 12, 11, 13]
+    },
+]
+
+function generateSignature(name, params, results) {
+    const paramStr = params.map((type, i) => `(param $p${i} ${type})`).join(' ');
+    const resultStr = results.map(type => `(result ${type})`).join(' ');
+    return `(func $${name} ${paramStr} ${resultStr}`;
+}
+
+function generateCalleeBody(resultMapping) {
+    return resultMapping.map(paramIndex => `(local.get $p${paramIndex})`).join('\n        ');
+}
+
+function generateCallerBody(callOp, testCase) {
+    let body = '';
+
+    const inputs = generateInputs(testCase.signature.params);
+
+    for (let i = 0; i < inputs.length; i++) {
+        const input = inputs[i];
+        const type = testCase.signature.params[i];
+
+        if (Array.isArray(input)) {
+            body += `        (v128.const i32x4 0x${input[0].toString(16)} 0x${input[1].toString(16)} 0x${input[2].toString(16)} 0x${input[3].toString(16)})\n`;
+        } else {
+            const value = (type === 'i32' || type === 'i64') ? Math.floor(input) : input;
+            body += `        (${type}.const ${value})\n`;
+        }
+    }
+
+    body += `        (${callOp} $${testCase.name}_callee)`;
+    return body;
+}
+
+function generateInputs(params) {
+    return params.map((type, i) => {
+        if (type === 'v128') {
+            const base = 0x1000 + i * 0x100;
+            return [base, base + 0x10, base + 0x20, base + 0x30];
+        } else if (type === 'f64' || type === 'f32') {
+            return 10.5 + i;
+        } else if (type === 'i32' || type === 'i64') {
+            return 1000 + i;
+        }
+    });
+}
+
+function buildWAT(callOp, testCases) {
+    let functions = '';
+    let exports = '';
+
+    for (const testCase of testCases) {
+        const calleeName = `${testCase.name}_callee`;
+        const callerName = `${testCase.name}_caller`;
+
+        // Generate callee function
+        functions += generateSignature(calleeName, testCase.signature.params, testCase.signature.results) + '\n';
+        functions += '        ' + generateCalleeBody(testCase.resultMapping) + '\n';
+        functions += '    )\n\n';
+
+        // Generate caller function (same result signature as callee)
+        functions += `    (func $${callerName} ${testCase.signature.results.map(type => `(result ${type})`).join(' ')}\n`;
+        functions += generateCallerBody(callOp, testCase) + '\n';
+        functions += '    )\n\n';
+
+        // Generate export wrapper (just calls caller and stores results)
+        exports += `    (func (export "${testCase.name}") (param $result_addr i32)\n`;
+
+        // Add local declarations for temporary storage
+        for (let i = 0; i < testCase.signature.results.length; i++) {
+            const type = testCase.signature.results[i];
+            exports += `        (local $temp${i} ${type})\n`;
+        }
+
+        exports += `        (call $${callerName})\n`;
+
+        // Pop results from stack in reverse order into locals
+        for (let i = testCase.signature.results.length - 1; i >= 0; i--) {
+            exports += `        (local.set $temp${i})\n`;
+        }
+
+        // Store results to memory with 16-byte spacing, in forward order
+        for (let i = 0; i < testCase.signature.results.length; i++) {
+            const offset = i * 16;
+            const type = testCase.signature.results[i];
+            exports += `        (${type}.store offset=${offset} (local.get $result_addr) (local.get $temp${i}))\n`;
+        }
+        exports += '    )\n\n';
+    }
+
+    return `
+(module
+    (memory (export "memory") 1)
+
+${functions}
+${exports}
+)
+`;
+}
+
+async function runTests(callOp, testCases) {
+    const wat = buildWAT(callOp, testCases);
+    logV(`\n=== Generated WAT for ${callOp} ===`);
+    logV(wat);
+    logV('=== End WAT ===\n');
+
+    const instance = await instantiate(wat, {}, { simd: true, tail_call: true });
+    const { memory } = instance.exports;
+
+    const f64View = new Float64Array(memory.buffer);
+    const i32View = new Int32Array(memory.buffer);
+    const i64View = new BigInt64Array(memory.buffer);
+
+    function getI32x4(byteOffset) {
+        const i32Offset = byteOffset / 4;
+        return [i32View[i32Offset], i32View[i32Offset + 1], i32View[i32Offset + 2], i32View[i32Offset + 3]];
+    }
+
+    function getF64(byteOffset) {
+        return f64View[byteOffset / 8];
+    }
+
+    function getI64(byteOffset) {
+        return i64View[byteOffset / 8];
+    }
+
+    function verifyTestCase(testCase, resultAddr, expectedInputs) {
+        // Verify results match expected values based on result mapping
+        // Results are stored at 16-byte intervals: result[0] at offset 0, result[1] at offset 16, etc.
+        for (let i = 0; i < testCase.signature.results.length; i++) {
+            const offset = i * 16;
+            const type = testCase.signature.results[i];
+            const mappedParamIndex = testCase.resultMapping[i];
+            const expectedValue = expectedInputs[mappedParamIndex];
+
+            if (type === 'f64') {
+                const actual = getF64(offset);
+                assert.eq(actual, expectedValue, `Result ${i} (f64) should be ${expectedValue}, got ${actual}`);
+                logV(`    Result ${i} (f64): ${actual} ✓`);
+            } else if (type === 'i64') {
+                const actual = getI64(offset);
+                const expectedBigInt = BigInt(expectedValue);
+                assert.eq(actual, expectedBigInt, `Result ${i} (i64) should be ${expectedBigInt}, got ${actual}`);
+                logV(`    Result ${i} (i64): ${actual} ✓`);
+            } else if (type === 'v128') {
+                const actual = getI32x4(offset);
+                for (let j = 0; j < 4; j++) {
+                    assert.eq(actual[j], expectedValue[j], `Result ${i} (v128) lane ${j} should be 0x${expectedValue[j].toString(16)}, got 0x${actual[j].toString(16)}`);
+                }
+                logV(`    Result ${i} (v128): [0x${actual.map(x => x.toString(16)).join(', 0x')}] ✓`);
+            }
+        }
+    }
+
+    logV(`Testing with ${callOp}...`);
+
+    for (const testCase of testCases) {
+        logV(`  Running ${testCase.name}...`);
+        const resultAddr = 0;
+        const expectedInputs = generateInputs(testCase.signature.params);
+
+        // Run multiple times to trigger tier-up (100 iterations to ensure BBQ compilation)
+        for (let iteration = 0; iteration < wasmTestLoopCount; iteration++) {
+            // Clear memory
+            for (let i = 0; i < 256; i++)
+                i32View[i] = 0;
+
+            // Run the test case and verify
+            instance.exports[testCase.name](resultAddr);
+            verifyTestCase(testCase, resultAddr, expectedInputs);
+        }
+    }
+}
+
+async function test() {
+    const operations = ['call', 'return_call'];
+
+    for (const callOp of operations) {
+        await runTests(callOp, testCases);
+    }
+}
+
+await assert.asyncTest(test())

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.h
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.h
@@ -703,7 +703,8 @@ extern "C" void SYSV_ABI ipint_entry_simd();
     m(0x0e, argumINT_fa6) \
     m(0x0f, argumINT_fa7) \
     m(0x10, argumINT_stack) \
-    m(0x11, argumINT_end) \
+    m(0x11, argumINT_stack_vector) \
+    m(0x12, argumINT_end) \
 
 #define FOR_EACH_IPINT_SLOW_PATH(m) \
     m(0x00, local_get_slow_path) \
@@ -727,14 +728,18 @@ extern "C" void SYSV_ABI ipint_entry_simd();
     m(0x0d, mint_fa5) \
     m(0x0e, mint_fa6) \
     m(0x0f, mint_fa7) \
-    m(0x10, mint_stackzero) \
-    m(0x11, mint_stackeight) \
-    m(0x12, mint_tail_stackzero) \
-    m(0x13, mint_tail_stackeight) \
-    m(0x14, mint_gap) \
-    m(0x15, mint_tail_gap) \
-    m(0x16, mint_tail_call) \
-    m(0x17, mint_call) \
+    m(0x10, mint_call_argument_dec_sp) \
+    m(0x11, mint_call_argument_store_0) \
+    m(0x12, mint_call_argument_dec_sp_store_8) \
+    m(0x13, mint_call_argument_dec_sp_store_vector_0) \
+    m(0x14, mint_call_argument_dec_sp_store_vector_8) \
+    m(0x15, mint_tail_call_argument_dec_sp) \
+    m(0x16, mint_tail_call_argument_store_0) \
+    m(0x17, mint_tail_call_argument_dec_sp_store_8) \
+    m(0x18, mint_tail_call_argument_dec_sp_store_vector_0) \
+    m(0x19, mint_tail_call_argument_dec_sp_store_vector_8) \
+    m(0x1a, mint_tail_call) \
+    m(0x1b, mint_call) \
 
 #define FOR_EACH_IPINT_MINT_RETURN_OPCODE(m) \
     m(0x00, mint_r0) \
@@ -753,8 +758,8 @@ extern "C" void SYSV_ABI ipint_entry_simd();
     m(0x0d, mint_fr5) \
     m(0x0e, mint_fr6) \
     m(0x0f, mint_fr7) \
-    m(0x10, mint_stack) \
-    m(0x11, mint_stack_gap) \
+    m(0x10, mint_result_stack) \
+    m(0x11, mint_result_stack_vector) \
     m(0x12, mint_end) \
 
 #define FOR_EACH_IPINT_UINT_OPCODE(m) \
@@ -775,7 +780,8 @@ extern "C" void SYSV_ABI ipint_entry_simd();
     m(0x0e, uint_fr6) \
     m(0x0f, uint_fr7) \
     m(0x10, uint_stack) \
-    m(0x11, uint_ret) \
+    m(0x11, uint_stack_vector) \
+    m(0x12, uint_ret) \
 
 #if !ENABLE(C_LOOP) && (CPU(ADDRESS64) && (CPU(ARM64) || CPU(X86_64)) || (CPU(ADDRESS32) && CPU(ARM_THUMB2)))
 FOR_EACH_IPINT_OPCODE(IPINT_VALIDATE_DEFINE_FUNCTION);

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
@@ -390,9 +390,7 @@ if ARM64 or ARM64E
 elsif X86_64
     loadb [MC], sc1
     addq 1, MC
-    bilt sc1, 0x12, .safe
-    break
-.safe:
+    bigteq sc1, (constexpr IPInt::UIntBytecode::NumOpcodes), _ipint_uint_dispatch_err
     lshiftq 6, sc1
     leap (_uint_begin - _mint_entry_relativePCBase)[PC, sc1], sc1
     jmp sc1
@@ -417,7 +415,7 @@ end)
 if X86_64
     loadp UnboxedWasmCalleeStackSlot[cfr], ws0
 end
-    loadi Wasm::IPIntCallee::m_highestReturnStackOffset[ws0], sc0
+    loadi Wasm::IPIntCallee::m_topOfReturnStackFPOffset[ws0], sc0
     addp cfr, sc0
 
     initPCRelative(mint_entry, PC)
@@ -10042,8 +10040,8 @@ macro mintPop(reg)
     addq V128ISize, mintSS
 end
 
-macro mintPopF(reg)
-    loadd [mintSS], reg
+macro mintPopV(reg)
+    loadv [mintSS], reg
     addq V128ISize, mintSS
 end
 
@@ -10100,9 +10098,6 @@ end
     const targetEntrypoint = sc2
     const targetInstance = sc3
 
-    # sc2 = target entrypoint
-    # sc3 = target instance
-
     move r0, targetEntrypoint
     move r1, targetInstance
 
@@ -10126,7 +10121,7 @@ end
     # arg
     # ...
     # arg
-    # arg             <- initial SP
+    # arg             <- initial SP (wasm stack)
 
     # store sp as our shadow stack for arguments later
     move sp, t4
@@ -10137,7 +10132,7 @@ end
     # arg
     # ...
     # arg
-    # arg             <- sc0 = initial sp
+    # arg             <- t4 = initial SP (wasm stack)
     # reserved
     # reserved        <- sp
 
@@ -10152,11 +10147,11 @@ end
     # arg
     # ...
     # arg
-    # arg             <- sc0 = initial sp
+    # arg             <- t4 = initial SP (wasm stack)
     # reserved
     # reserved
     # t3, PC
-    # PL, wasmInstance
+    # PL, wasmInstance <- t2 = native argument stack (pushed by mINT)
     # call frame
     # call frame
     # call frame
@@ -10169,8 +10164,8 @@ end
     storep IPIntCallFunctionSlot, CodeBlock - CallerFrameAndPCSize[sp]
 
     push targetEntrypoint, targetInstance
-    move t2, sc3
 
+    move t2, sc3
     move t4, mintSS
 
     # need a common entrypoint because of x86 PC base
@@ -10230,8 +10225,8 @@ end
     addp FirstArgumentOffset, sc2
     addp t3, sc2
 
-    #  <caller frame>
-    #  return val                  <- sc2
+    #  <caller frame>              <- sc2
+    #  return val
     #  return val
     #  argument
     #  argument
@@ -10265,8 +10260,8 @@ end
 
     push t0, t1
 
-    #  <caller frame>
-    #  return val                  <- sc2
+    #  <caller frame>              <- sc2
+    #  return val
     #  return val
     #  argument
     #  argument
@@ -10353,78 +10348,126 @@ else
 end
 
 mintAlign(_fa0)
-    mintPopF(wfa0)
+    mintPopV(wfa0)
     mintArgDispatch()
 
 mintAlign(_fa1)
-    mintPopF(wfa1)
+    mintPopV(wfa1)
     mintArgDispatch()
 
 mintAlign(_fa2)
-    mintPopF(wfa2)
+    mintPopV(wfa2)
     mintArgDispatch()
 
 mintAlign(_fa3)
-    mintPopF(wfa3)
+    mintPopV(wfa3)
     mintArgDispatch()
 
 mintAlign(_fa4)
-    mintPopF(wfa4)
+    mintPopV(wfa4)
     mintArgDispatch()
 
 mintAlign(_fa5)
-    mintPopF(wfa5)
+    mintPopV(wfa5)
     mintArgDispatch()
 
 mintAlign(_fa6)
-    mintPopF(wfa6)
+    mintPopV(wfa6)
     mintArgDispatch()
 
 mintAlign(_fa7)
-    mintPopF(wfa7)
+    mintPopV(wfa7)
     mintArgDispatch()
 
 # Note that the regular call and tail call opcodes will be implemented slightly differently.
 # Regular calls have to save space for return values, while tail calls are reusing the stack frame
 # and thus do not have to care.
 
-mintAlign(_stackzero)
+# CallArgumentBytecode::CallArgDecSP (0x10)
+mintAlign(_call_argument_dec_sp)
+    subp 2 * SlotSize, sc3
+    mintArgDispatch()
+
+# CallArgumentBytecode::CallArgStore0 (0x11)
+mintAlign(_call_argument_store_0)
     mintPop(sc2)
     storeq sc2, [sc3]
     mintArgDispatch()
 
-mintAlign(_stackeight)
+# CallArgumentBytecode::CallArgDecSPStore8 (0x12)
+mintAlign(_call_argument_dec_sp_store_8)
     mintPop(sc2)
-    subp 16, sc3
+    subp 2 * SlotSize, sc3
     storeq sc2, 8[sc3]
     mintArgDispatch()
 
-# Since we're writing into the same frame, we're going to first push stack arguments onto the stack.
+# CallArgumentBytecode::CallArgDecSPStoreVector0 (0x13)
+mintAlign(_call_argument_dec_sp_store_vector_0)
+    subp 2 * SlotSize, sc3
+    loadq [mintSS], sc2
+    storeq sc2, [sc3]
+    loadq 8[mintSS], sc2
+    storeq sc2, 8[sc3]
+    addq StackValueSize, mintSS
+    mintArgDispatch()
+
+# CallArgumentBytecode::TailCallArgDecSPStoreVector8 (0x14)
+mintAlign(_call_argument_dec_sp_store_vector_8)
+    subp 2 * SlotSize, sc3
+    loadq [mintSS], sc2
+    storeq sc2, 8[sc3]
+    loadq 8[mintSS], sc2
+    storeq sc2, 16[sc3]
+    addq StackValueSize, mintSS
+    mintArgDispatch()
+
+# For tail calls, we're writing into the same frame. We're going to first push stack arguments onto the stack.
 # Once we're done, we'll copy them back down into the new frame, to avoid having to deal with writing over
 # arguments lower down on the stack.
 
-mintAlign(_tail_stackzero)
+# CallArgumentBytecode::TailCallArgDecSP (0x15)
+mintAlign(_tail_call_argument_dec_sp)
+    subp 2 * SlotSize, sp
+    mintArgDispatch()
+
+# CallArgumentBytecode::TailCallArgStore0 (0x16)
+mintAlign(_tail_call_argument_store_0)
     mintPop(sc3)
     storeq sc3, [sp]
     mintArgDispatch()
 
-mintAlign(_tail_stackeight)
+# CallArgumentBytecode::TailCallArgDecSPStore8 (0x17)
+mintAlign(_tail_call_argument_dec_sp_store_8)
     mintPop(sc3)
-    subp 16, sp
+    subp 2 * SlotSize, sp
     storeq sc3, 8[sp]
     mintArgDispatch()
 
-mintAlign(_gap)
-    subp 16, sc3
+# CallArgumentBytecode::TailCallArgDecSPStoreVector0 (0x18)
+mintAlign(_tail_call_argument_dec_sp_store_vector_0)
+    subp 2 * SlotSize, sp
+    loadq [mintSS], sc3
+    storeq sc3, [sp]
+    loadq 8[mintSS], sc3
+    storeq sc3, 8[sp]
+    addq StackValueSize, mintSS
     mintArgDispatch()
 
-mintAlign(_tail_gap)
-    subp 16, sp
+# CallArgumentBytecode::TailCallArgDecSPStoreVector8 (0x19)
+mintAlign(_tail_call_argument_dec_sp_store_vector_8)
+    subp 2 * SlotSize, sp
+    loadq [mintSS], sc3
+    storeq sc3, 8[sp]
+    loadq 8[mintSS], sc3
+    storeq sc3, 16[sp]
+    addq StackValueSize, mintSS
     mintArgDispatch()
 
+# CallArgumentBytecode::TailCall (0x1a)
 mintAlign(_tail_call)
     jmp .ipint_perform_tail_call
 
+# CallArgumentBytecode::Call (0x1b)
 mintAlign(_call)
     pop wasmInstance, ws0
     # pop targetInstance, targetEntrypoint
@@ -10483,13 +10526,15 @@ _wasm_ipint_call_return_location_wide32:
     const mintRetSrc = sc1
     const mintRetDst = sc2
 
-    loadi IPInt::CallReturnMetadata::firstStackArgumentSPOffset[MC], mintRetSrc
+    loadi IPInt::CallReturnMetadata::firstStackResultSPOffset[MC], mintRetSrc
     advanceMC(IPInt::CallReturnMetadata::resultBytecode)
     leap [sp, mintRetSrc], mintRetSrc
 
+    # load "saved t3" from the stack
 if ARM64 or ARM64E
     loadp (2 * SlotSize)[sc3], mintRetDst
 elsif X86_64
+    # XXX: why this difference?
     loadp (3 * SlotSize)[sc3], mintRetDst
 end
 
@@ -10605,15 +10650,21 @@ mintAlign(_fr7)
     storev wfa7, [mintRetDst]
     mintRetDispatch()
 
-mintAlign(_stack)
+# CallResultBytecode::ResultStack (0x10)
+mintAlign(_result_stack)
     loadq [mintRetSrc], sc0
     addp SlotSize, mintRetSrc
     subp StackValueSize, mintRetDst
     storeq sc0, [mintRetDst]
     mintRetDispatch()
 
-mintAlign(_stack_gap)
-    addp SlotSize, mintRetSrc
+# CallResultBytecode::ResultStackVector (0x11)
+mintAlign(_result_stack_vector)
+    # safe to use wfa0 since frN bytecodes always come before vector stack result
+    loadv [mintRetSrc], wfa0
+    addp 2 * SlotSize, mintRetSrc
+    subp StackValueSize, mintRetDst
+    storev wfa0, [mintRetDst]
     mintRetDispatch()
 
 mintAlign(_end)
@@ -10627,12 +10678,12 @@ mintAlign(_end)
     # return result     <- mintRetDst => new SP
     # t3, PC
     # PL, wasmInstance  <- sc3
-    # call frame return <- sp
+    # call frame return <- mintRetSrc
     # call frame return
     # call frame
     # call frame
     # call frame
-    # call frame
+    # call frame        <- sp
 
     # note: we don't care about t3 anymore
 if ARM64 or ARM64E
@@ -10662,8 +10713,8 @@ end
 
 .ipint_perform_tail_call:
 
-    #  <caller frame>
-    #  return val                  <- sc2
+    #  <caller frame>              <- sc2
+    #  return val
     #  return val
     #  argument
     #  argument
@@ -10672,11 +10723,11 @@ end
     #  call frame
     #  call frame                  <- cfr
     #  (IPInt locals)
-    #  (IPInt stack)
+    #  (IPInt stack)               <- sc1 (was shadow stack, now dead and can re-use)
     #  argument 0
     #  ...
     #  argument n-1
-    #  argument n                  <- sc1
+    #  argument n
     #  entrypoint, targetInstance
     #  callee, function info
     #  saved MC/PC
@@ -10686,14 +10737,14 @@ end
     #  stack arguments
     #  stack arguments             <- sp
 
-    # load the size of stack values in, and subtract that from sc2
+    # load the size of the arguments and results space, and subtract that from sc2
     loadi [MC], sc3
-    mulp -SlotSize, sc3
+    negq sc3
 
-    # copy from sc2 downwards
+    # copy args to sc2 region
     validateOpcodeConfig(sc0)
 .ipint_tail_call_copy_stackargs_loop:
-    btiz sc3, .ipint_tail_call_copy_stackargs_loop_end
+    bqgteq sc3, 0, .ipint_tail_call_copy_stackargs_loop_end
 if ARM64 or ARM64E
     loadpairq [sp], sc0, sc1
     storepairq sc0, sc1, [sc2, sc3]
@@ -10712,7 +10763,6 @@ end
 
     # reload it here, which isn't optimal, but we don't really have registers
     loadi [MC], sc3
-    mulq SlotSize, sc3
     subp sc3, sc2
 
     # re-setup the call frame, and load our return address in
@@ -10753,7 +10803,7 @@ end
     #  argument 0
     #  ...
     #  argument n-1
-    #  argument n                  <- sc1
+    #  argument n
 
     # on ARM: lr = return address
 
@@ -10848,43 +10898,57 @@ else
 end
 
 uintAlign(_fr0)
-    popFloat64(wfa0)
+    popVec(wfa0)
     uintDispatch()
 
 uintAlign(_fr1)
-    popFloat64(wfa1)
+    popVec(wfa1)
     uintDispatch()
 
 uintAlign(_fr2)
-    popFloat64(wfa2)
+    popVec(wfa2)
     uintDispatch()
 
 uintAlign(_fr3)
-    popFloat64(wfa3)
+    popVec(wfa3)
     uintDispatch()
 
 uintAlign(_fr4)
-    popFloat64(wfa4)
+    popVec(wfa4)
     uintDispatch()
 
 uintAlign(_fr5)
-    popFloat64(wfa5)
+    popVec(wfa5)
     uintDispatch()
 
 uintAlign(_fr6)
-    popFloat64(wfa6)
+    popVec(wfa6)
     uintDispatch()
 
 uintAlign(_fr7)
-    popFloat64(wfa7)
+    popVec(wfa7)
     uintDispatch()
 
 # destination on stack is sc0
 
 uintAlign(_stack)
     popInt64(sc1, sc2)
+    subp SlotSize, sc0
     storeq sc1, [sc0]
-    subp 8, sc0
+    uintDispatch()
+
+uintAlign(_stack_vector)
+    subp 2 * SlotSize, sc0
+    if ARM64 or ARM64E
+        loadpairq [sp], sc1, sc2
+        storepairq sc1, sc2, [sc0]
+    else
+        loadq [sp], sc1
+        loadq 8[sp], sc2
+        storeq sc1, [sc0]
+        storeq sc2, 8[sc0]
+    end
+    addq StackValueSize, sp
     uintDispatch()
 
 uintAlign(_ret)
@@ -10967,49 +11031,56 @@ else
 end
 
 argumINTAlign(_fa0)
-    stored wfa0, [argumINTDst]
+    storev wfa0, [argumINTDst]
     addp LocalSize, argumINTDst
     argumINTDispatch()
 
 argumINTAlign(_fa1)
-    stored wfa1, [argumINTDst]
+    storev wfa1, [argumINTDst]
     addp LocalSize, argumINTDst
     argumINTDispatch()
 
 argumINTAlign(_fa2)
-    stored wfa2, [argumINTDst]
+    storev wfa2, [argumINTDst]
     addp LocalSize, argumINTDst
     argumINTDispatch()
 
 argumINTAlign(_fa3)
-    stored wfa3, [argumINTDst]
+    storev wfa3, [argumINTDst]
     addp LocalSize, argumINTDst
     argumINTDispatch()
 
 argumINTAlign(_fa4)
-    stored wfa4, [argumINTDst]
+    storev wfa4, [argumINTDst]
     addp LocalSize, argumINTDst
     argumINTDispatch()
 
 argumINTAlign(_fa5)
-    stored wfa5, [argumINTDst]
+    storev wfa5, [argumINTDst]
     addp LocalSize, argumINTDst
     argumINTDispatch()
 
 argumINTAlign(_fa6)
-    stored wfa6, [argumINTDst]
+    storev wfa6, [argumINTDst]
     addp LocalSize, argumINTDst
     argumINTDispatch()
 
 argumINTAlign(_fa7)
-    stored wfa7, [argumINTDst]
+    storev wfa7, [argumINTDst]
     addp LocalSize, argumINTDst
     argumINTDispatch()
 
 argumINTAlign(_stack)
     loadq [argumINTSrc], csr0
-    addp 8, argumINTSrc
+    addp SlotSize, argumINTSrc
     storeq csr0, [argumINTDst]
+    addp LocalSize, argumINTDst
+    argumINTDispatch()
+
+argumINTAlign(_stack_vector)
+    loadv [argumINTSrc], ft0
+    addp 2 * SlotSize, argumINTSrc
+    storev ft0, [argumINTDst]
     addp LocalSize, argumINTDst
     argumINTDispatch()
 

--- a/Source/JavaScriptCore/wasm/WasmCallee.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCallee.cpp
@@ -232,7 +232,7 @@ IPIntCallee::IPIntCallee(FunctionIPIntMetadataGenerator& generator, FunctionSpac
     , m_metadata(WTFMove(generator.m_metadata))
     , m_argumINTBytecode(WTFMove(generator.m_argumINTBytecode))
     , m_uINTBytecode(WTFMove(generator.m_uINTBytecode))
-    , m_highestReturnStackOffset(generator.m_highestReturnStackOffset)
+    , m_topOfReturnStackFPOffset(generator.m_topOfReturnStackFPOffset)
     , m_localSizeToAlloc(roundUpToMultipleOf<2>(generator.m_numLocals))
     , m_numRethrowSlotsToAlloc(generator.m_numAlignedRethrowSlots)
     , m_numLocals(generator.m_numLocals)

--- a/Source/JavaScriptCore/wasm/WasmCallee.h
+++ b/Source/JavaScriptCore/wasm/WasmCallee.h
@@ -466,7 +466,7 @@ private:
     Vector<uint8_t> m_argumINTBytecode;
     Vector<uint8_t> m_uINTBytecode;
 
-    unsigned m_highestReturnStackOffset;
+    unsigned m_topOfReturnStackFPOffset;
 
     unsigned m_localSizeToAlloc;
     unsigned m_numRethrowSlotsToAlloc;

--- a/Source/JavaScriptCore/wasm/WasmCallingConvention.h
+++ b/Source/JavaScriptCore/wasm/WasmCallingConvention.h
@@ -83,12 +83,12 @@ enum class CallRole : uint8_t {
 
 struct CallInformation {
     CallInformation() = default;
-    CallInformation(ArgumentLocation passedThisArgument, Vector<ArgumentLocation, 8>&& parameters, Vector<ArgumentLocation, 1>&& returnValues, size_t stackOffset, size_t stackValues)
+    CallInformation(ArgumentLocation passedThisArgument, Vector<ArgumentLocation, 8>&& parameters, Vector<ArgumentLocation, 1>&& returnValues, size_t totalSize, size_t headerSize)
         : thisArgument(passedThisArgument)
         , params(WTFMove(parameters))
         , results(WTFMove(returnValues))
-        , headerAndArgumentStackSizeInBytes(stackOffset)
-        , numberOfStackValues(stackValues)
+        , headerAndArgumentStackSizeInBytes(totalSize)
+        , headerSizeInBytes(headerSize)
     { }
 
     RegisterAtOffsetList computeResultsOffsetList()
@@ -113,7 +113,7 @@ struct CallInformation {
     Vector<ArgumentLocation, 1> results { };
     // As a callee this includes CallerFrameAndPC as a caller it does not.
     size_t headerAndArgumentStackSizeInBytes { 0 };
-    size_t numberOfStackValues { 0 };
+    size_t headerSizeInBytes { 0 }; // Includes thisArgument
 };
 
 class WasmCallingConvention {
@@ -184,7 +184,6 @@ private:
         RELEASE_ASSERT_NOT_REACHED();
     }
 
-public:
     uint32_t numberOfStackResults(const FunctionSignature& signature) const
     {
         const uint32_t gprCount = jsrArgs.size();
@@ -236,61 +235,7 @@ public:
         return stackCount;
     }
 
-    uint32_t numberOfStackArguments(const FunctionSignature& signature) const
-    {
-        const uint32_t gprCount = jsrArgs.size();
-        const uint32_t fprCount = fprArgs.size();
-        uint32_t gprIndex = 0;
-        uint32_t fprIndex = 0;
-        uint32_t stackCount = 0;
-        for (uint32_t i = 0; i < signature.argumentCount(); i++) {
-            switch (signature.argumentType(i).kind) {
-            case TypeKind::I32:
-            case TypeKind::I64:
-            case TypeKind::Exnref:
-            case TypeKind::Externref:
-            case TypeKind::Funcref:
-            case TypeKind::RefNull:
-            case TypeKind::Ref:
-                if (gprIndex < gprCount)
-                    ++gprIndex;
-                else
-                    ++stackCount;
-                break;
-            case TypeKind::F32:
-            case TypeKind::F64:
-            case TypeKind::V128:
-                if (fprIndex < fprCount)
-                    ++fprIndex;
-                else
-                    ++stackCount;
-                break;
-            case TypeKind::Void:
-            case TypeKind::Func:
-            case TypeKind::Struct:
-            case TypeKind::Structref:
-            case TypeKind::Array:
-            case TypeKind::Arrayref:
-            case TypeKind::Eqref:
-            case TypeKind::Anyref:
-            case TypeKind::Noexnref:
-            case TypeKind::Noneref:
-            case TypeKind::Nofuncref:
-            case TypeKind::Noexternref:
-            case TypeKind::I31ref:
-            case TypeKind::Sub:
-            case TypeKind::Subfinal:
-            case TypeKind::Rec:
-                RELEASE_ASSERT_NOT_REACHED();
-            }
-        }
-        return stackCount;
-    }
-
-    uint32_t numberOfStackValues(const FunctionSignature& signature) const
-    {
-        return std::max(numberOfStackArguments(signature), numberOfStackResults(signature));
-    }
+public:
 
     CallInformation callInformationFor(const TypeDefinition& type, CallRole role = CallRole::Caller) const
     {
@@ -307,33 +252,31 @@ public:
             headerSize -= sizeof(CallerFrameAndPC);
 
         ArgumentLocation thisArgument = { role == CallRole::Caller ? ValueLocation::stackArgument(headerSize) : ValueLocation::stack(headerSize), widthForBytes(sizeof(void*)) };
-        headerSize += sizeof(Register);
+        headerSize += sizeof(Register); // thisArgument
 
         size_t argStackOffset = headerSize;
         Vector<ArgumentLocation, 8> params(signature.argumentCount(),
             [&](unsigned index) {
                 return marshallLocation(role, signature.argumentType(index), gpArgumentCount, fpArgumentCount, argStackOffset);
             });
-        uint32_t stackArgs = argStackOffset - headerSize;
-        size_t stackArguments = 0;
-        if (gpArgumentCount > jsrArgs.size())
-            stackArguments += (gpArgumentCount - jsrArgs.size());
-        if (fpArgumentCount > fprArgs.size())
-            stackArguments += (fpArgumentCount - fprArgs.size());
-        ASSERT(stackArguments == numberOfStackArguments(signature));
+        uint32_t stackArgsInBytes = argStackOffset - headerSize;
 
         gpArgumentCount = 0;
         fpArgumentCount = 0;
         size_t stackResults = numberOfStackResults(signature);
-        uint32_t stackResultsInBytes = stackResults * sizeof(Register);
-        uint32_t stackCountAligned = WTF::roundUpToMultipleOf<stackAlignmentBytes()>(std::max(stackArgs, stackResultsInBytes));
-        size_t resultStackOffset = headerSize + stackCountAligned - stackResultsInBytes;
+        // N.B. this is inaccurate for vector results. In that case and when the actual result space is larger than the argument space, there is a quirk in
+        // the calling convention where the argument and result space is not minimal, i.e. arguments and results don't overlap as much as they could.
+        uint32_t estimatedStackResultsInBytes = stackResults * sizeof(Register);
+        uint32_t estimatedTotalArgAndResultsInBytes = WTF::roundUpToMultipleOf<stackAlignmentBytes()>(std::max(stackArgsInBytes, estimatedStackResultsInBytes));
+        size_t resultStackOffset = headerSize + estimatedTotalArgAndResultsInBytes - estimatedStackResultsInBytes;
         Vector<ArgumentLocation, 1> results(signature.returnCount(),
             [&](unsigned index) {
                 return marshallLocation(role, signature.returnType(index), gpArgumentCount, fpArgumentCount, resultStackOffset);
             });
+        size_t totalFrameSize = resultStackOffset;
+        ASSERT(totalFrameSize >= argStackOffset);
 
-        return { thisArgument, WTFMove(params), WTFMove(results), std::max(argStackOffset, resultStackOffset), std::max(stackArguments, stackResults) };
+        return { thisArgument, WTFMove(params), WTFMove(results), totalFrameSize, headerSize };
     }
 
     RegisterSet argumentGPRs() const { return RegisterSetBuilder::argumentGPRs(); }
@@ -405,13 +348,14 @@ public:
 
         ArgumentLocation thisArgument = { role == CallRole::Caller ? ValueLocation::stackArgument(stackOffset) : ValueLocation::stack(stackOffset), widthForBytes(sizeof(void*)) };
         stackOffset += sizeof(Register);
+        size_t headerSize = stackOffset;
 
         Vector<ArgumentLocation, 8> params(signature.argumentCount(),
             [&](unsigned index) {
                 return marshallLocation(role, signature.argumentType(index), gpArgumentCount, fpArgumentCount, stackOffset);
             });
         Vector<ArgumentLocation, 1> results { ArgumentLocation { ValueLocation { JSRInfo::returnValueJSR }, Width64 } };
-        return { thisArgument, WTFMove(params), WTFMove(results), stackOffset, 0U };
+        return { thisArgument, WTFMove(params), WTFMove(results), stackOffset, headerSize };
     }
 
     const Vector<JSValueRegs> jsrArgs;

--- a/Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.h
@@ -123,7 +123,7 @@ private:
     std::span<const uint8_t> m_bytecode;
     MetadataBuffer m_metadata { };
     Vector<uint8_t, 8> m_uINTBytecode { };
-    unsigned m_highestReturnStackOffset;
+    unsigned m_topOfReturnStackFPOffset;
 
     uint32_t m_bytecodeOffset { 0 };
     unsigned m_maxFrameSizeInV128 { 0 };

--- a/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
@@ -519,9 +519,9 @@ public:
     inline void assertAboutStackSize(bool condition)
     {
         // There's a few cases that we only want to assert our stack contents if SIMD isn't enabled.
-        // Since IPInt doesn't support SIMD, we don't update the stack size correctly, but this is
+        // When !useWasmIPIntSIMD, we don't update the stack size correctly, but this is
         // not an issue because the code never gets run.
-        ASSERT_UNUSED(condition, m_usesSIMD || condition);
+        ASSERT_UNUSED(condition, (m_usesSIMD && !Options::useWasmIPIntSIMD()) || condition);
     }
 
     void setParser(FunctionParser<IPIntGenerator>* parser) { m_parser = parser; };
@@ -530,7 +530,7 @@ public:
         return m_parser->offset() - m_parser->currentOpcodeStartingOffset();
     }
     void addCallCommonData(const FunctionSignature&, const CallInformation&);
-    void addTailCallCommonData(const FunctionSignature&);
+    void addTailCallCommonData(const FunctionSignature&, const CallInformation&);
     void didFinishParsingLocals()
     {
         m_metadata->m_bytecodeOffset = m_parser->offset();
@@ -648,6 +648,8 @@ private:
     CallInformation m_cachedCallInformation { };
     const FunctionSignature* m_cachedSignature { nullptr };
     Vector<uint8_t, 16> m_cachedCallBytecode;
+
+    Checked<int32_t> m_argumentAndResultsStackSize;
 
     bool m_usesRethrow { false };
     bool m_usesSIMD { false };
@@ -896,7 +898,11 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addTableCopy(unsigned dstTableI
 PartialResult WARN_UNUSED_RETURN IPIntGenerator::addArguments(const TypeDefinition &signature)
 {
     auto sig = signature.as<FunctionSignature>();
-    CallInformation callCC = wasmCallingConvention().callInformationFor(*sig, CallRole::Callee);
+    const CallInformation callCC = wasmCallingConvention().callInformationFor(*sig, CallRole::Callee);
+
+    ASSERT(callCC.headerAndArgumentStackSizeInBytes >= callCC.headerSizeInBytes);
+    m_argumentAndResultsStackSize = WTF::roundUpToMultipleOf<stackAlignmentBytes()>(callCC.headerAndArgumentStackSizeInBytes) - callCC.headerSizeInBytes;
+    ASSERT(!(m_argumentAndResultsStackSize % 16)); // mINT requires this
 
     auto numArgs = sig->argumentCount();
     m_metadata->m_numLocals += numArgs;
@@ -916,7 +922,9 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addArguments(const TypeDefiniti
     // 0x11: end
 
     for (size_t i = 0; i < numArgs; ++i) {
-        auto loc = callCC.params[i].location;
+        const ArgumentLocation& argLoc = callCC.params[i];
+        const ValueLocation& loc = argLoc.location;
+
         if (loc.isGPR()) {
 #if USE(JSVALUE64)
             ASSERT_UNUSED(NUM_ARGUMINT_GPRS, GPRInfo::toArgumentIndex(loc.jsr().gpr()) < NUM_ARGUMINT_GPRS);
@@ -928,9 +936,19 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addArguments(const TypeDefiniti
 #endif
         } else if (loc.isFPR()) {
             ASSERT_UNUSED(NUM_ARGUMINT_FPRS, FPRInfo::toArgumentIndex(loc.fpr()) < NUM_ARGUMINT_FPRS);
-            m_metadata->m_argumINTBytecode.append(static_cast<uint8_t>(IPInt::ArgumINTBytecode::RegFPR) + FPRInfo::toArgumentIndex(loc.fpr()));
-        } else if (loc.isStack()) {
-            m_metadata->m_argumINTBytecode.append(static_cast<uint8_t>(IPInt::ArgumINTBytecode::Stack));
+            m_metadata->m_argumINTBytecode.append(static_cast<uint8_t>(IPInt::ArgumINTBytecode::ArgFPR) + FPRInfo::toArgumentIndex(loc.fpr()));
+        } else {
+            RELEASE_ASSERT(loc.isStack());
+            switch (argLoc.width) {
+            case Width::Width64:
+                m_metadata->m_argumINTBytecode.append(static_cast<uint8_t>(IPInt::ArgumINTBytecode::Stack));
+                break;
+            case Width::Width128:
+                m_metadata->m_argumINTBytecode.append(static_cast<uint8_t>(IPInt::ArgumINTBytecode::StackVector));
+                break;
+            default:
+                RELEASE_ASSERT_NOT_REACHED("No argumINT bytecode for result width");
+            }
         }
     }
     m_metadata->m_argumINTBytecode.append(static_cast<uint8_t>(IPInt::ArgumINTBytecode::End));
@@ -2728,33 +2746,41 @@ auto IPIntGenerator::endTopLevel(BlockSignature signature, const Stack& expressi
 
 // Calls
 
-void IPIntGenerator::addCallCommonData(const FunctionSignature&, const CallInformation& callConvention)
+// Appends the bytecode to setup the arguments and perform a call / tail-call. Note that the resulting bytecode is backwards.
+template<bool isTailCall>
+static void addCallArgumentBytecode(Vector<uint8_t, 16>& results, const CallInformation& callConvention)
 {
-    // CallCommonData payload is the same for the same CallInformation.
-    // We use previously generated payload if we hit the cache!
-    if (!m_cachedCallBytecode.isEmpty()) {
-        size_t size = m_metadata->m_metadata.size();
-        m_metadata->addBlankSpace(m_cachedCallBytecode.size());
-        memcpy(m_metadata->m_metadata.mutableSpan().data() + size, m_cachedCallBytecode.span().data(), m_cachedCallBytecode.size());
-        return;
-    }
-
-    uint16_t stackArgs = 0;
-
     constexpr static int NUM_MINT_CALL_GPRS = 8;
     constexpr static int NUM_MINT_CALL_FPRS = 8;
     ASSERT_UNUSED(NUM_MINT_CALL_GPRS, wasmCallingConvention().jsrArgs.size() <= NUM_MINT_CALL_GPRS);
     ASSERT_UNUSED(NUM_MINT_CALL_FPRS, wasmCallingConvention().fprArgs.size() <= NUM_MINT_CALL_FPRS);
 
-    auto toSpan = [&](auto& metadata) {
-        auto start = std::bit_cast<const uint8_t*>(&metadata);
-        return std::span { start, start + sizeof(metadata) };
+    // Translate Call bytecodes to TailCall bytecodes when isTailCall.
+    auto toBytecodeUint8 = [](IPInt::CallArgumentBytecode bytecode) {
+        constexpr uint8_t tailBytecodeOffset = static_cast<uint8_t>(IPInt::CallArgumentBytecode::TailCallArgDecSP) - static_cast<uint8_t>(IPInt::CallArgumentBytecode::CallArgDecSP);
+        uint8_t bytecodeUint8 = static_cast<uint8_t>(bytecode);
+        ASSERT(static_cast<uint8_t>(IPInt::CallArgumentBytecode::CallArgDecSP) <= bytecodeUint8
+            && bytecodeUint8 <= static_cast<uint8_t>(IPInt::CallArgumentBytecode::CallArgDecSPStoreVector8));
+
+        if constexpr (isTailCall)
+            bytecodeUint8 += tailBytecodeOffset;
+        return bytecodeUint8;
     };
 
-    m_cachedCallBytecode.append(static_cast<uint8_t>(IPInt::CallArgumentBytecode::Call));
-    m_cachedCallBytecode.appendUsingFunctor(callConvention.params.size(),
+    results.append(static_cast<uint8_t>(isTailCall ? IPInt::CallArgumentBytecode::TailCall : IPInt::CallArgumentBytecode::Call));
+
+    intptr_t spOffset = callConvention.headerSizeInBytes;
+
+    auto isAligned16 = [&spOffset]() ALWAYS_INLINE_LAMBDA {
+        return !(spOffset & 0xf);
+    };
+
+    ASSERT(isAligned16());
+    results.appendUsingFunctor(callConvention.params.size(),
         [&](unsigned index) -> uint8_t {
-            auto loc = callConvention.params[index].location;
+            const ArgumentLocation& argLoc = callConvention.params[index];
+            const ValueLocation& loc = argLoc.location;
+
             if (loc.isGPR()) {
 #if USE(JSVALUE64)
                 ASSERT_UNUSED(NUM_MINT_CALL_GPRS, GPRInfo::toArgumentIndex(loc.jsr().gpr()) < NUM_MINT_CALL_GPRS);
@@ -2770,43 +2796,58 @@ void IPIntGenerator::addCallCommonData(const FunctionSignature&, const CallInfor
                 ASSERT_UNUSED(NUM_MINT_CALL_FPRS, FPRInfo::toArgumentIndex(loc.fpr()) < NUM_MINT_CALL_FPRS);
                 return static_cast<uint8_t>(IPInt::CallArgumentBytecode::ArgumentFPR) + FPRInfo::toArgumentIndex(loc.fpr());
             }
-
-            if (loc.isStackArgument()) {
-                if (stackArgs++ & 1)
-                    return static_cast<uint8_t>(IPInt::CallArgumentBytecode::ArgumentStackUnaligned);
-                return static_cast<uint8_t>(IPInt::CallArgumentBytecode::ArgumentStackAligned);
+            RELEASE_ASSERT(loc.isStackArgument());
+            // mINT bytecode handlers assume this; if it fails, mINT needs updating
+            ASSERT(loc.offsetFromSP() == spOffset);
+            IPInt::CallArgumentBytecode bytecode;
+            switch (argLoc.width) {
+            case Width64:
+                bytecode = isAligned16() ? IPInt::CallArgumentBytecode::CallArgStore0 : IPInt::CallArgumentBytecode::CallArgDecSPStore8;
+                spOffset += 8; // These bytecodes store 8-bytes
+                break;
+            case Width128:
+                bytecode = isAligned16() ? IPInt::CallArgumentBytecode::CallArgDecSPStoreVector0 : IPInt::CallArgumentBytecode::CallArgDecSPStoreVector8;
+                spOffset += 16; // These bytecodes store 16-bytes
+                break;
+            default:
+                RELEASE_ASSERT_NOT_REACHED("No bytecode for stack argument location width");
             }
-
-            RELEASE_ASSERT_NOT_REACHED();
-            return 0;
+            return toBytecodeUint8(bytecode);
         });
-    if (stackArgs & 1) {
-        ++stackArgs;
-        m_cachedCallBytecode.append(static_cast<uint8_t>(IPInt::CallArgumentBytecode::StackAlign));
+
+    if (!isAligned16()) {
+        // In this case, the final argument ended up unaligned w.r.t. 16-byte stack alignment,
+        // so this allocates that top pair of stack slots. The lower 8-bytes have already been
+        // counted by spOffset.
+        spOffset += 8;
+        results.append(toBytecodeUint8(IPInt::CallArgumentBytecode::CallArgDecSP));
     }
+    intptr_t frameSize = roundUpToMultipleOf<stackAlignmentBytes()>(callConvention.headerAndArgumentStackSizeInBytes);
+    ASSERT(frameSize >= spOffset);
 
-    for (unsigned i = stackArgs; i < callConvention.numberOfStackValues; i += 2)
-        m_cachedCallBytecode.append(static_cast<uint8_t>(IPInt::CallArgumentBytecode::StackAlign));
+    ASSERT(isAligned16());
+    // Pad out the argument / result stack space not occupied by the pushed arguments
+    for (; spOffset < frameSize; spOffset += 16) // This bytecode pads by 16-bytes
+        results.append(toBytecodeUint8(IPInt::CallArgumentBytecode::CallArgDecSP));
+    ASSERT(spOffset == frameSize);
+}
 
-    m_cachedCallBytecode.reverse();
-
-    IPInt::CallReturnMetadata commonReturn {
-        .stackFrameSize = static_cast<uint32_t>(callConvention.headerAndArgumentStackSizeInBytes),
-        .firstStackArgumentSPOffset = 0,
-        .resultBytecode = { }
-    };
-
+static intptr_t addCallResultBytecode(Vector<uint8_t, 16>& results, const CallInformation& callConvention)
+{
     constexpr static int NUM_MINT_RET_GPRS = 8;
     constexpr static int NUM_MINT_RET_FPRS = 8;
     ASSERT_UNUSED(NUM_MINT_RET_GPRS, wasmCallingConvention().jsrArgs.size() <= NUM_MINT_RET_GPRS);
     ASSERT_UNUSED(NUM_MINT_RET_FPRS, wasmCallingConvention().fprArgs.size() <= NUM_MINT_RET_FPRS);
 
-    bool hasSeenStackArgument = false;
+    intptr_t firstStackResultSPOffset = 0;
+    bool hasSeenStackResult = false;
+    intptr_t spOffset = 0;
 
-    Vector<uint8_t, 16> returnBytecode;
-    returnBytecode.appendUsingFunctor(callConvention.results.size(),
+    results.appendUsingFunctor(callConvention.results.size(),
         [&](unsigned index) -> uint8_t {
-            auto loc = callConvention.results[index].location;
+            const ArgumentLocation& argLoc = callConvention.results[index];
+            const ValueLocation& loc = argLoc.location;
+
             if (loc.isGPR()) {
                 ASSERT_UNUSED(NUM_MINT_RET_GPRS, GPRInfo::toArgumentIndex(loc.jsr().payloadGPR()) < NUM_MINT_RET_GPRS);
 #if USE(JSVALUE64)
@@ -2820,22 +2861,63 @@ void IPIntGenerator::addCallCommonData(const FunctionSignature&, const CallInfor
                 ASSERT_UNUSED(NUM_MINT_RET_FPRS, FPRInfo::toArgumentIndex(loc.fpr()) < NUM_MINT_RET_FPRS);
                 return static_cast<uint8_t>(IPInt::CallResultBytecode::ResultFPR) + FPRInfo::toArgumentIndex(loc.fpr());
             }
+            RELEASE_ASSERT(loc.isStackArgument());
 
-            if (loc.isStackArgument()) {
-                if (!hasSeenStackArgument) {
-                    hasSeenStackArgument = true;
-                    // If our first argument starts further down the frame, we need to push a bunch of empty values
-                    // If our first stack argument is in an "odd" slot, we need to skip one slot.
-                    commonReturn.firstStackArgumentSPOffset = loc.offsetFromSP();
-                }
-                return static_cast<uint8_t>(IPInt::CallResultBytecode::ResultStack);
+            if (!hasSeenStackResult) {
+                hasSeenStackResult = true;
+                // mINT needs to be able to locate the first stack result
+                spOffset = loc.offsetFromSP();
+                firstStackResultSPOffset = spOffset;
             }
-
-            RELEASE_ASSERT_NOT_REACHED();
-            return 0;
+            // mINT bytecode handlers assume this; if it fails, mINT needs updating
+            ASSERT(loc.offsetFromSP() == spOffset);
+            switch (argLoc.width) {
+            case Width::Width64:
+                spOffset += 8; // This bytecode pops 8-bytes
+                return static_cast<uint8_t>(IPInt::CallResultBytecode::ResultStack);
+            case Width::Width128:
+                spOffset += 16; // This bytecode pops 16-bytes
+                return static_cast<uint8_t>(IPInt::CallResultBytecode::ResultStackVector);
+            default:
+                ASSERT_NOT_REACHED("No bytecode for stack result location width");
+                return 0;
+            }
         });
-    returnBytecode.append(static_cast<uint8_t>(IPInt::CallResultBytecode::End));
 
+    results.append(static_cast<uint8_t>(IPInt::CallResultBytecode::End));
+    return firstStackResultSPOffset;
+}
+
+void IPIntGenerator::addCallCommonData(const FunctionSignature&, const CallInformation& callConvention)
+{
+    // cachedCallInformationFor() invalidates this cache on a miss, so if the cache is populated,
+    // it was a cache hit and we can use the previously generated payload.
+    if (!m_cachedCallBytecode.isEmpty()) {
+        size_t size = m_metadata->m_metadata.size();
+        m_metadata->addBlankSpace(m_cachedCallBytecode.size());
+        memcpy(m_metadata->m_metadata.mutableSpan().data() + size, m_cachedCallBytecode.span().data(), m_cachedCallBytecode.size());
+        return;
+    }
+
+    addCallArgumentBytecode<false>(m_cachedCallBytecode, callConvention);
+    m_cachedCallBytecode.reverse();
+
+    Checked<uint32_t> frameSize = WTF::roundUpToMultipleOf<stackAlignmentBytes()>(callConvention.headerAndArgumentStackSizeInBytes);
+    IPInt::CallReturnMetadata commonReturn {
+        .stackFrameSize = frameSize,
+        .firstStackResultSPOffset = 0, // TBD
+        .resultBytecode = { }
+    };
+
+    Vector<uint8_t, 16> returnBytecode;
+    Checked<uint32_t> firstStackResultSPOffset = addCallResultBytecode(returnBytecode, callConvention);
+
+    commonReturn.firstStackResultSPOffset = firstStackResultSPOffset;
+
+    auto toSpan = [&](auto& metadata) {
+        auto start = std::bit_cast<const uint8_t*>(&metadata);
+        return std::span { start, start + sizeof(metadata) };
+    };
     m_cachedCallBytecode.append(toSpan(commonReturn));
     m_cachedCallBytecode.append(returnBytecode.span());
 
@@ -2844,106 +2926,60 @@ void IPIntGenerator::addCallCommonData(const FunctionSignature&, const CallInfor
     memcpy(m_metadata->m_metadata.mutableSpan().data() + size, m_cachedCallBytecode.mutableSpan().data(), m_cachedCallBytecode.size());
 }
 
-void IPIntGenerator::addTailCallCommonData(const FunctionSignature& signature)
+void IPIntGenerator::addTailCallCommonData(const FunctionSignature&, const CallInformation& callConvention)
 {
-    auto& callConvention = cachedCallInformationFor(signature);
-    uint16_t stackArgs = 0;
-
-    constexpr static int NUM_MINT_CALL_GPRS = 8;
-    constexpr static int NUM_MINT_CALL_FPRS = 8;
-    ASSERT_UNUSED(NUM_MINT_CALL_GPRS, wasmCallingConvention().jsrArgs.size() <= NUM_MINT_CALL_GPRS);
-    ASSERT_UNUSED(NUM_MINT_CALL_FPRS, wasmCallingConvention().fprArgs.size() <= NUM_MINT_CALL_FPRS);
-
     Vector<uint8_t, 16> mINTBytecode;
-    mINTBytecode.append(static_cast<uint8_t>(IPInt::CallArgumentBytecode::TailCall));
-    mINTBytecode.appendUsingFunctor(callConvention.params.size(),
-        [&](unsigned index) -> uint8_t {
-            auto loc = callConvention.params[index].location;
-            if (loc.isGPR()) {
-#if USE(JSVALUE64)
-                ASSERT_UNUSED(NUM_MINT_CALL_GPRS, GPRInfo::toArgumentIndex(loc.jsr().gpr()) < NUM_MINT_CALL_GPRS);
-                return static_cast<uint8_t>(IPInt::CallArgumentBytecode::ArgumentGPR) + GPRInfo::toArgumentIndex(loc.jsr().gpr());
-#elif USE(JSVALUE32_64)
-                ASSERT_UNUSED(NUM_MINT_CALL_GPRS, GPRInfo::toArgumentIndex(loc.jsr().payloadGPR()) < NUM_MINT_CALL_GPRS);
-                ASSERT_UNUSED(NUM_MINT_CALL_GPRS, GPRInfo::toArgumentIndex(loc.jsr().tagGPR()) < NUM_MINT_CALL_GPRS);
-                return static_cast<uint8_t>(IPInt::CallArgumentBytecode::ArgumentGPR) + GPRInfo::toArgumentIndex(loc.jsr().gpr(WhichValueWord::PayloadWord)) / 2;
-#endif
-            }
-
-            if (loc.isFPR()) {
-                ASSERT_UNUSED(NUM_MINT_CALL_FPRS, FPRInfo::toArgumentIndex(loc.fpr()) < NUM_MINT_CALL_FPRS);
-                return static_cast<uint8_t>(IPInt::CallArgumentBytecode::ArgumentFPR) + FPRInfo::toArgumentIndex(loc.fpr());
-            }
-
-            if (loc.isStackArgument()) {
-                if (stackArgs++ & 1)
-                    return static_cast<uint8_t>(IPInt::CallArgumentBytecode::TailArgumentStackUnaligned);
-                return static_cast<uint8_t>(IPInt::CallArgumentBytecode::TailArgumentStackAligned);
-            }
-
-            RELEASE_ASSERT_NOT_REACHED();
-            return 0;
-        });
-    if (stackArgs & 1) {
-        ++stackArgs;
-        mINTBytecode.append(static_cast<uint8_t>(IPInt::CallArgumentBytecode::TailStackAlign));
-    }
-
-    for (unsigned i = stackArgs, limit = WTF::roundUpToMultipleOf(stackAlignmentRegisters(), callConvention.numberOfStackValues); i < limit; i += stackAlignmentRegisters())
-        mINTBytecode.append(static_cast<uint8_t>(IPInt::CallArgumentBytecode::TailStackAlign));
+    addCallArgumentBytecode<true>(mINTBytecode, callConvention);
 
     auto size = m_metadata->m_metadata.size();
     m_metadata->addBlankSpace(mINTBytecode.size());
     std::ranges::reverse_copy(mINTBytecode, m_metadata->m_metadata.mutableSpan().data() + size);
 
-    uint32_t numStackValues = WTF::roundUpToMultipleOf(stackAlignmentRegisters(), callConvention.numberOfStackValues);
+    size_t stackArgumentsAndResultsInBytes = roundUpToMultipleOf<stackAlignmentBytes()>(callConvention.headerAndArgumentStackSizeInBytes) - callConvention.headerSizeInBytes;
+    // The WASM stack slots are always 16-bytes.
+    size_t extraWasmStackInBytes = roundUpToMultipleOf<16>(stackArgumentsAndResultsInBytes);
+    if (m_stackSize + extraWasmStackInBytes / 16 > m_maxStackSize)
+        m_maxStackSize = m_stackSize + extraWasmStackInBytes / 16;
 
-    // each stack value is 8B, so to calculate stack size in V128, we need to divide by two
-    if (m_stackSize + numStackValues / 2 > m_maxStackSize)
-        m_maxStackSize = m_stackSize + numStackValues / 2;
-
-    ASSERT(!(numStackValues % 2));
-    m_metadata->appendMetadata(numStackValues);
+    ASSERT(!(stackArgumentsAndResultsInBytes % 16)); // mINT requires this for 16-bytes at a time tail-call arguments copy
+    m_metadata->appendMetadata(stackArgumentsAndResultsInBytes);
 }
 
 PartialResult WARN_UNUSED_RETURN IPIntGenerator::addCall(unsigned callProfileIndex, FunctionSpaceIndex index, const TypeDefinition& type, ArgumentList&, ResultList& results, CallType callType)
 {
     const FunctionSignature& signature = *type.as<FunctionSignature>();
+    const CallInformation& callConvention = cachedCallInformationFor(signature);
+
     if (callType == CallType::TailCall) {
         // on a tail call, we need to:
         // roll back to old SP, shift SP to accommodate arguments
         // put arguments into registers / sp (reutilize mINT)
         // jump to entrypoint
         changeStackSize(-signature.argumentCount());
-        const auto& callingConvention = wasmCallingConvention();
         m_metadata->setTailCall(index, m_info.isImportedFunctionFromFunctionIndexSpace(index));
-
-        const TypeIndex callerTypeIndex = m_info.internalFunctionTypeIndices[m_functionIndex];
-        const TypeDefinition& callerTypeDefinition = TypeInformation::get(callerTypeIndex).expand();
-        uint32_t callerStackArgs = WTF::roundUpToMultipleOf(stackAlignmentRegisters(), callingConvention.numberOfStackValues(*callerTypeDefinition.as<FunctionSignature>()));
 
         IPInt::TailCallMetadata functionIndexMetadata {
             .length = safeCast<uint8_t>(getCurrentInstructionLength()),
             .callProfileIndex = callProfileIndex,
             .functionIndex = index,
-            .callerStackArgSize = static_cast<int32_t>(callerStackArgs * sizeof(Register)),
+            .callerStackArgSize = static_cast<int32_t>(m_argumentAndResultsStackSize),
             .argumentBytecode = { }
         };
         m_metadata->appendMetadata(functionIndexMetadata);
-        addTailCallCommonData(signature);
+        addTailCallCommonData(signature, callConvention);
         return { };
     }
 
-    auto& callConvention = cachedCallInformationFor(signature);
     results.appendUsingFunctor(signature.returnCount(), [](unsigned) { return Value { }; });
     changeStackSize(signature.returnCount() - signature.argumentCount());
 
+    Checked<uint32_t> frameSize = WTF::roundUpToMultipleOf<stackAlignmentBytes()>(callConvention.headerAndArgumentStackSizeInBytes);
     IPInt::CallMetadata functionIndexMetadata {
         .length = safeCast<uint8_t>(getCurrentInstructionLength()),
         .callProfileIndex = callProfileIndex,
         .functionIndex = index,
         .signature = {
-            static_cast<uint32_t>(callConvention.headerAndArgumentStackSizeInBytes),
+            frameSize,
             static_cast<uint16_t>(signature.returnCount() > signature.argumentCount() ? signature.returnCount() - signature.argumentCount() : 0),
             static_cast<uint16_t>(signature.argumentCount())
         },
@@ -2957,6 +2993,8 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addCall(unsigned callProfileInd
 PartialResult WARN_UNUSED_RETURN IPIntGenerator::addCallIndirect(unsigned callProfileIndex, unsigned tableIndex, const TypeDefinition& originalSignature, ArgumentList&, ResultList& results, CallType callType)
 {
     const FunctionSignature& signature = *originalSignature.expand().as<FunctionSignature>();
+    const CallInformation& callConvention = cachedCallInformationFor(signature);
+
     if (callType == CallType::TailCall) {
         const unsigned callIndex = 1;
         changeStackSize(-signature.argumentCount() - callIndex);
@@ -2966,37 +3004,31 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addCallIndirect(unsigned callPr
         // roll back to old SP, shift SP to accommodate arguments
         // put arguments into registers / sp (reutilize mINT)
         // jump to entrypoint
-        const auto& callingConvention = wasmCallingConvention();
-
-        const TypeIndex callerTypeIndex = m_info.internalFunctionTypeIndices[m_functionIndex];
-        const TypeDefinition& callerTypeDefinition = TypeInformation::get(callerTypeIndex).expand();
-        uint32_t callerStackArgs = WTF::roundUpToMultipleOf(stackAlignmentRegisters(), callingConvention.numberOfStackValues(*callerTypeDefinition.as<FunctionSignature>()));
-
         IPInt::TailCallIndirectMetadata functionIndexMetadata {
             .length = safeCast<uint8_t>(getCurrentInstructionLength()),
             .callProfileIndex = callProfileIndex,
             .tableIndex = tableIndex,
             .rtt = m_metadata->addSignature(originalSignature),
-            .callerStackArgSize = static_cast<int32_t>(callerStackArgs * sizeof(Register)),
+            .callerStackArgSize = static_cast<int32_t>(m_argumentAndResultsStackSize),
             .argumentBytecode = { }
         };
         m_metadata->appendMetadata(functionIndexMetadata);
-        addTailCallCommonData(signature);
+        addTailCallCommonData(signature, callConvention);
         return { };
     }
 
-    auto& callConvention = cachedCallInformationFor(signature);
     results.appendUsingFunctor(signature.returnCount(), [](unsigned) { return Value { }; });
     const unsigned callIndex = 1;
     changeStackSize(signature.returnCount() - signature.argumentCount() - callIndex);
 
+    Checked<uint32_t> frameSize = WTF::roundUpToMultipleOf<stackAlignmentBytes()>(callConvention.headerAndArgumentStackSizeInBytes);
     IPInt::CallIndirectMetadata functionIndexMetadata {
         .length = safeCast<uint8_t>(getCurrentInstructionLength()),
         .callProfileIndex = callProfileIndex,
         .tableIndex = tableIndex,
         .rtt = m_metadata->addSignature(originalSignature),
         .signature = {
-            static_cast<uint32_t>(callConvention.headerAndArgumentStackSizeInBytes),
+            frameSize,
             static_cast<uint16_t>(signature.returnCount() > signature.argumentCount() ? signature.returnCount() - signature.argumentCount() : 0),
             static_cast<uint16_t>(signature.argumentCount())
         },
@@ -3011,6 +3043,8 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addCallIndirect(unsigned callPr
 PartialResult WARN_UNUSED_RETURN IPIntGenerator::addCallRef(unsigned callProfileIndex, const TypeDefinition& originalSignature, ArgumentList&, ResultList& results, CallType callType)
 {
     const FunctionSignature& signature = *originalSignature.expand().as<FunctionSignature>();
+    const CallInformation& callConvention = cachedCallInformationFor(signature);
+
     if (callType == CallType::TailCall) {
         const unsigned callIndex = 1;
         changeStackSize(-signature.argumentCount() - callIndex);
@@ -3020,33 +3054,27 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addCallRef(unsigned callProfile
         // roll back to old SP, shift SP to accommodate arguments
         // put arguments into registers / sp (reutilize mINT)
         // jump to entrypoint
-        const auto& callingConvention = wasmCallingConvention();
-
-        const TypeIndex callerTypeIndex = m_info.internalFunctionTypeIndices[m_functionIndex];
-        const TypeDefinition& callerTypeDefinition = TypeInformation::get(callerTypeIndex).expand();
-        uint32_t callerStackArgs = WTF::roundUpToMultipleOf(stackAlignmentRegisters(), callingConvention.numberOfStackValues(*callerTypeDefinition.as<FunctionSignature>()));
-
         IPInt::TailCallRefMetadata callMetadata {
             .length = safeCast<uint8_t>(getCurrentInstructionLength()),
             .callProfileIndex = callProfileIndex,
-            .callerStackArgSize = static_cast<int32_t>(callerStackArgs * sizeof(Register)),
+            .callerStackArgSize = static_cast<int32_t>(m_argumentAndResultsStackSize),
             .argumentBytecode = { }
         };
         m_metadata->appendMetadata(callMetadata);
-        addTailCallCommonData(signature);
+        addTailCallCommonData(signature, callConvention);
         return { };
     }
 
-    auto& callConvention = cachedCallInformationFor(signature);
     results.appendUsingFunctor(signature.returnCount(), [](unsigned) { return Value { }; });
     const unsigned callRef = 1;
     changeStackSize(signature.returnCount() - signature.argumentCount() - callRef);
 
+    Checked<uint32_t> frameSize = WTF::roundUpToMultipleOf<stackAlignmentBytes()>(callConvention.headerAndArgumentStackSizeInBytes);
     IPInt::CallRefMetadata callMetadata {
         .length = safeCast<uint8_t>(getCurrentInstructionLength()),
         .callProfileIndex = callProfileIndex,
         .signature = {
-            static_cast<uint32_t>(callConvention.headerAndArgumentStackSizeInBytes),
+            frameSize,
             static_cast<uint16_t>(signature.returnCount() > signature.argumentCount() ? signature.returnCount() - signature.argumentCount() : 0),
             static_cast<uint16_t>(signature.argumentCount())
         },

--- a/Source/JavaScriptCore/wasm/WasmIPIntGenerator.h
+++ b/Source/JavaScriptCore/wasm/WasmIPIntGenerator.h
@@ -181,14 +181,26 @@ struct CallSignatureMetadata {
 enum class CallArgumentBytecode : uint8_t { // (mINT)
     ArgumentGPR = 0x0, // 0x00 - 0x07: push into a0, a1, ...
     ArgumentFPR = 0x8, // 0x08 - 0x0f: push into fa0, fa1, ...
-    ArgumentStackAligned = 0x10, // 0x10: pop stack value, push onto stack[0]
-    ArgumentStackUnaligned = 0x11, // 0x11: pop stack value, add another 16B for params, push onto stack[8]
-    TailArgumentStackAligned = 0x12, // 0x12: pop stack value, push onto stack[0]
-    TailArgumentStackUnaligned = 0x13, // 0x13: pop stack value, add another 16B for params, push onto stack[8]
-    StackAlign = 0x14, // 0x14: add another 16B for params
-    TailStackAlign = 0x15, // 0x15: add another 16B for params
-    TailCall = 0x16, // 0x16: tail call
-    Call = 0x17, // 0x17: regular call
+
+    // Note: addCallArgumentBytecode() requires that the corresponding CallArg and TailCallArg bytecodes
+    // have a constant offset from each other
+
+    // For Call, SP is actually a shadow stack, not the machine SP
+    CallArgDecSP = 0x10, // Decrement SP by 16
+    CallArgStore0 = 0x11, // Store 8-bytes to [SP]
+    CallArgDecSPStore8 = 0x12, // Decrement SP by 16 and store 8-bytes to 8[SP]
+    CallArgDecSPStoreVector0 = 0x13, // Decrement SP by 16 and store 16-bytes to [SP]
+    CallArgDecSPStoreVector8 = 0x14, // Decrement SP by 16 and store 16-bytes to 8[SP]
+
+    // Equivalent to the Call bytecodes above, but operates on machine SP directly
+    TailCallArgDecSP = 0x15,
+    TailCallArgStore0 = 0x16,
+    TailCallArgDecSPStore8 = 0x17,
+    TailCallArgDecSPStoreVector0 = 0x18,
+    TailCallArgDecSPStoreVector8 = 0x19,
+
+    TailCall = 0x1a,
+    Call = 0x1b,
 
     NumOpcodes // this must be the last element of the enum!
 };
@@ -246,16 +258,16 @@ struct TailCallRefMetadata {
 enum class CallResultBytecode : uint8_t { // (mINT)
     ResultGPR = 0x0, // 0x00 - 0x07: r0 - r7
     ResultFPR = 0x8, // 0x08 - 0x0f: fr0 - fr7
-    ResultStack = 0x10, // 0x10: stack
-    StackGap = 0x11, // 0x11: skip a slot on the stack
-    End = 0x12, // 0x12: end
+    ResultStack = 0x10,
+    ResultStackVector = 0x11,
+    End = 0x12,
 
     NumOpcodes // this must be the last element of the enum!
 };
 
 struct CallReturnMetadata {
     uint32_t stackFrameSize; // 4B for stack frame size
-    uint32_t firstStackArgumentSPOffset; // 4B for stack argument offset
+    uint32_t firstStackResultSPOffset; // 4B for stack argument offset
     CallResultBytecode resultBytecode[0];
 };
 
@@ -263,9 +275,10 @@ struct CallReturnMetadata {
 
 enum class ArgumINTBytecode: uint8_t {
     ArgGPR = 0x0, // 0x00 - 0x07: r0 - r7
-    RegFPR = 0x8, // 0x08 - 0x0f: fr0 - fr7
-    Stack = 0x10, // 0x0c: stack
-    End = 0x11, // 0x0d: end
+    ArgFPR = 0x8, // 0x08 - 0x0f: fr0 - fr7
+    Stack = 0x10,
+    StackVector = 0x11,
+    End = 0x12,
 
     NumOpcodes // this must be the last element of the enum!
 };
@@ -273,8 +286,9 @@ enum class ArgumINTBytecode: uint8_t {
 enum class UIntBytecode: uint8_t {
     RetGPR = 0x0, // 0x00 - 0x07: r0 - r7
     RetFPR = 0x8, // 0x08 - 0x0f: fr0 - fr7
-    Stack = 0x10, // 0x0c: stack
-    End = 0x11, // 0x0d: end
+    Stack = 0x10,
+    StackVector = 0x11,
+    End = 0x12,
 
     NumOpcodes // this must be the last element of the enum!
 };


### PR DESCRIPTION
#### a88c6fbd835e38ffa00569e52636b2a1181f37f6
<pre>
[WIP] Testing SIMD IPInt calls

Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

Test: JSTests/wasm/stress/simd-instructions-calls.js
* JSTests/wasm/stress/simd-instructions-calls.js: Added.
(logV):
(i.i.2.0.i.10.5.5):
(resultMapping.new.Array.fill.map):
(generateSignature):
* Source/JavaScriptCore/llint/InPlaceInterpreter.h:
* Source/JavaScriptCore/llint/InPlaceInterpreter32_64.asm:
* Source/JavaScriptCore/llint/InPlaceInterpreter64.asm:
* Source/JavaScriptCore/wasm/WasmCallee.cpp:
(JSC::Wasm::IPIntCallee::IPIntCallee):
* Source/JavaScriptCore/wasm/WasmCallee.h:
* Source/JavaScriptCore/wasm/WasmCallingConvention.h:
(JSC::Wasm::CallInformation::CallInformation):
(JSC::Wasm::WasmCallingConvention::callInformationFor const):
(JSC::Wasm::JSCallingConvention::callInformationFor const):
(JSC::Wasm::WasmCallingConvention::numberOfStackArguments const): Deleted.
(JSC::Wasm::WasmCallingConvention::numberOfStackValues const): Deleted.
* Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.cpp:
(JSC::Wasm::FunctionIPIntMetadataGenerator::addReturnData):
* Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.h:
* Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp:
(JSC::Wasm::IPIntGenerator::assertAboutStackSize):
(JSC::Wasm::IPIntGenerator::addArguments):
(JSC::Wasm::addCallArgumentBytecode):
(JSC::Wasm::addCallResultBytecode):
(JSC::Wasm::IPIntGenerator::addCallCommonData):
(JSC::Wasm::IPIntGenerator::addTailCallCommonData):
(JSC::Wasm::IPIntGenerator::addCall):
(JSC::Wasm::IPIntGenerator::addCallIndirect):
(JSC::Wasm::IPIntGenerator::addCallRef):
* Source/JavaScriptCore/wasm/WasmIPIntGenerator.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a88c6fbd835e38ffa00569e52636b2a1181f37f6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123047 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42761 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33458 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/129703 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/75156 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7dc1268e-7f59-442d-8997-d7215e94c303) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43485 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51356 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93529 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62076 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6bcb08eb-f38f-440f-adc9-4a16d2d47a62) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125998 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34656 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110127 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74160 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c3a2420e-951b-4337-bed7-0bde7003fe81) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33632 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28282 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73215 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/115206 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104367 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28507 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132433 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/121578 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49997 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38058 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102031 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50373 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106347 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101893 "Found 2 new API test failures: TestWTF:CompletionHandlerDeathTest.MainThreadHandlerOnThreadAssertsDeathTest, TestWTF:CompletionHandlerDeathTest.ConstructionThreadHandlerOnThreadAssertsDeathTest (failure)") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47255 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25458 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/46770 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49852 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/55613 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/151843 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49320 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/38823 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/52672 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51001 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->