### PR TITLE
Always-on scrollbars are not symmetrical in the track

### DIFF
--- a/LayoutTests/platform/mac-wk2/fast/scrolling/rtl-scrollbars-animation-property-expected.txt
+++ b/LayoutTests/platform/mac-wk2/fast/scrolling/rtl-scrollbars-animation-property-expected.txt
@@ -1,11 +1,11 @@
-layer at (0,0) size 786x2000
-  RenderView at (0,0) size 786x600
-layer at (0,0) size 786x216
-  RenderBlock {HTML} at (0,0) size 786x216
-    RenderBody {BODY} at (8,8) size 770x200
-layer at (8,8) size 200x200 clip at (22,8) size 186x186 scrollHeight 2000 scrollbarHasRTLLayoutDirection
+layer at (0,0) size 783x2000
+  RenderView at (0,0) size 783x600
+layer at (0,0) size 783x216
+  RenderBlock {HTML} at (0,0) size 783x216
+    RenderBody {BODY} at (8,8) size 767x200
+layer at (8,8) size 200x200 clip at (25,8) size 183x183 scrollHeight 2000 scrollbarHasRTLLayoutDirection
   RenderBlock (relative positioned) {DIV} at (0,0) size 200x200
-layer at (22,8) size 1x2000 backgroundClip at (22,8) size 186x186 clip at (22,8) size 186x186
-  RenderBlock (positioned) {DIV} at (14,0) size 1x2000
+layer at (25,8) size 1x2000 backgroundClip at (25,8) size 183x183 clip at (25,8) size 183x183
+  RenderBlock (positioned) {DIV} at (17,0) size 1x2000
 layer at (0,0) size 1x2000
   RenderBlock (positioned) {DIV} at (0,0) size 1x2000

--- a/Source/WebCore/platform/mac/ScrollbarThemeMac.mm
+++ b/Source/WebCore/platform/mac/ScrollbarThemeMac.mm
@@ -234,7 +234,7 @@ int ScrollbarThemeMac::scrollbarThickness(ScrollbarWidth scrollbarWidth, Scrollb
         return 0;
     NSScrollerImp *scrollerImp = [NSScrollerImp scrollerImpWithStyle:ScrollerStyle::recommendedScrollerStyle() controlSize:nsControlSizeFromScrollbarWidth(scrollbarWidth) horizontal:NO replacingScrollerImp:nil];
     [scrollerImp setExpanded:(expansionState == ScrollbarExpansionState::Expanded)];
-    return [scrollerImp trackBoxWidth];
+    return [[scrollerImp class] scrollerWidth];
     END_BLOCK_OBJC_EXCEPTIONS
 }
 


### PR DESCRIPTION
#### e417ae6c5c6f268d2e5025bb68f165a594a063ac
<pre>
Always-on scrollbars are not symmetrical in the track
<a href="https://bugs.webkit.org/show_bug.cgi?id=299577">https://bugs.webkit.org/show_bug.cgi?id=299577</a>
<a href="https://rdar.apple.com/161372025">rdar://161372025</a>

Reviewed by Aditya Keerthi.

Calling `[scrollerImp trackBoxWidth]` on a legacy scrollbar incorrectly includes the
track side gap only once, resulting in WebKit computing a scrollbar width of 14
when it should be 17.

Using +scrollerWidth avoids this problem.

* LayoutTests/platform/mac-wk2/fast/scrolling/rtl-scrollbars-animation-property-expected.txt:
* Source/WebCore/platform/mac/ScrollbarThemeMac.mm:
(WebCore::ScrollbarThemeMac::scrollbarThickness):

Canonical link: <a href="https://commits.webkit.org/302222@main">https://commits.webkit.org/302222@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/65b5df16cad11554932b2e9199e190f293cdd0ef

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128367 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/643 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39199 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135760 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79833 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5bafdd19-aacd-4e92-b5fe-d0dc94b99538) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130239 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/579 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/515 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97714 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65617 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5f833541-c277-4a40-b312-75e484f2ba45) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131315 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/402 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115011 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78308 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9455afac-63ba-4c9b-9365-b5307a4a48c6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/380 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33118 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79046 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108770 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33602 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138212 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/488 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/456 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106248 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/525 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111352 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106052 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27023 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/396 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29899 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52804 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/539 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/63716 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/435 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/501 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/499 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->