### PR TITLE
REGRESSION (286540@main): google.com: Can't paste into textarea in AI mode

### DIFF
--- a/LayoutTests/editing/selection/ios/show-edit-menu-with-transparent-caret-expected.txt
+++ b/LayoutTests/editing/selection/ios/show-edit-menu-with-transparent-caret-expected.txt
@@ -1,0 +1,12 @@
+Textarea Layer Toggle Test
+
+
+Verifies that edit menu can be shown on textarea with caret-color: transparent during rapid layer changes
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+PASS Revealed edit menu
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/selection/ios/show-edit-menu-with-transparent-caret.html
+++ b/LayoutTests/editing/selection/ios/show-edit-menu-with-transparent-caret.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true SelectionHonorsOverflowScrolling=true ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta charset="utf-8">
+<script src="../../../resources/ui-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+<style>
+body, html {
+    font-size: 16px;
+    font-family: system-ui;
+    margin: 0;
+    padding: 20px;
+}
+
+textarea {
+    width: 200px;
+    height: 100px;
+    font-size: 16px;
+    padding: 10px;
+    border: 2px solid tomato;
+    caret-color: transparent;
+    transition: none;
+}
+
+.composited {
+    will-change: transform;
+    border: 2px solid seagreen;
+}
+</style>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description("Verifies that edit menu can be shown on textarea with caret-color: transparent during rapid layer changes");
+
+    const textarea = document.querySelector("textarea");
+    setInterval(() => {
+        textarea.classList.toggle("composited");
+    }, 30);
+
+    await UIHelper.activateElementAndWaitForInputSession(textarea);
+    await UIHelper.waitForDoubleTapDelay();
+    await UIHelper.activateElement(textarea);
+    await UIHelper.waitForMenuToShow();
+
+    testPassed("Revealed edit menu");
+    textarea.blur();
+    await UIHelper.waitForKeyboardToHide();
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <h1>Textarea Layer Toggle Test</h1>
+    <textarea>Hello</textarea>
+    <div id="description"></div>
+    <div id="console"></div>
+</body>
+</html>

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -734,13 +734,9 @@ void WebPage::getPlatformEditorStateCommon(const LocalFrame& frame, EditorState&
         postLayoutData.selectionIsTransparentOrFullyClipped = selectionIsTransparentOrFullyClipped(selection);
 
 #if PLATFORM(IOS_FAMILY)
-    bool honorOverflowScrolling = m_page->settings().selectionHonorsOverflowScrolling();
-    if (enclosingFormControl || !honorOverflowScrolling)
+    if (enclosingFormControl || !m_page->settings().selectionHonorsOverflowScrolling())
         result.visualData->selectionClipRect = result.visualData->editableRootBounds;
-
-    if (honorOverflowScrolling)
-        computeEnclosingLayerID(result, selection);
-#endif // PLATFORM(IOS_FAMILY)
+#endif
 }
 
 void WebPage::getPDFFirstPageSize(WebCore::FrameIdentifier frameID, CompletionHandler<void(WebCore::FloatSize)>&& completionHandler)


### PR DESCRIPTION
#### af48e73321b74d30b06433c6a868a21a1a9a6a01
<pre>
REGRESSION (286540@main): google.com: Can&apos;t paste into textarea in AI mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=299574">https://bugs.webkit.org/show_bug.cgi?id=299574</a>
<a href="https://rdar.apple.com/158901941">rdar://158901941</a>

Reviewed by Lily Spiniolas and Ryosuke Niwa.

The textarea element in Google search&apos;s AI mode renders a fake caret with a DOM element that runs a
periodic animation, and suppresses the native caret UI using `caret-color: transparent;`. This
allows them to paint the &quot;caret&quot; with different colors a few times a second.

The way this is implemented, however, causes the selection to become hosted inside a different
composited layer every time the color changes. After enabling &quot;Selection Honors Overflow Scrolling&quot;,
this causes us to update the native selection UI frequently by calling `-selectionChanged`, due to
the fact that the caret view is constantly being reparented. Subsequently, this causes the edit menu
to immediately dismiss when tapping to try and present it.

To fix this, we simply fall back to hosting the caret selection views in `WKContentView`, in the
case where the caret is transparent. Since the selection UI is hidden anyways due to the transparent
`caret-color`, we don&apos;t actually need to host the selection in a composited view to ensure that it
visually scrolls along with subscrollable containers (and/or clipped by other composited containers
on top of it).

Test: editing/selection/ios/show-edit-menu-with-transparent-caret.html

* LayoutTests/editing/selection/ios/show-edit-menu-with-transparent-caret-expected.txt: Added.
* LayoutTests/editing/selection/ios/show-edit-menu-with-transparent-caret.html: Added.
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::getPlatformEditorStateCommon const):

Move this logic into `getPlatformEditorState`, so that we can check the caret color and other
post-layout data before finding the enclosing layer.

* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::getPlatformEditorState const):

Canonical link: <a href="https://commits.webkit.org/300554@main">https://commits.webkit.org/300554@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bd6db0861e36b633d6c7d25a0f7a33715cb649cb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123058 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42772 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33469 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/129714 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/75167 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/82e5e3c4-5d4e-423e-868e-1c2748c75888) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43496 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51367 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93536 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/75167 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e030e335-3fd1-49a5-ae8f-d619a5807f29) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126009 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34663 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110136 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74168 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6f9238a8-f107-4664-9c87-11ee2d0a669d) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/33639 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28291 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73228 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104374 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28517 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132444 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50008 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38071 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102037 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50384 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106357 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/101898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25886 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47262 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25467 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/46781 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49863 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/55624 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49331 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/52683 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/51012 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->