### PR TITLE
Address some safer cpp failures in WebKit/NetworkProcess/cocoa & WebKit/Platform/IPC

### DIFF
--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -2362,7 +2362,9 @@ void NetworkSessionCocoa::setProxyConfigData(const Vector<std::pair<Vector<uint8
         else
             zeroBytes(identifier);
 
-        auto nwProxyConfig = adoptNS(createProxyConfig(config.first.span().data(), config.first.size(), identifier));
+        // This is correct but static analysis does not seem to recognize that `createProxyConfig` returns
+        // a +1 value.
+        SUPPRESS_RETAINPTR_CTOR_ADOPT auto nwProxyConfig = adoptNS(createProxyConfig(config.first.span().data(), config.first.size(), identifier));
 
         if (requiresHTTPProtocols(nwProxyConfig.get()))
             recreateSessions = true;

--- a/Source/WebKit/Platform/IPC/ArgumentCoders.h
+++ b/Source/WebKit/Platform/IPC/ArgumentCoders.h
@@ -186,7 +186,7 @@ template<typename T> struct ArgumentCoder<std::optional<T>> {
         }
 
         encoder << true;
-        encoder << std::forward<U>(optional).value();
+        SUPPRESS_UNCHECKED_ARG encoder << std::forward<U>(optional).value();
     }
 
     template<typename Decoder>
@@ -199,7 +199,7 @@ template<typename T> struct ArgumentCoder<std::optional<T>> {
             auto value = decoder.template decode<T>();
             if (!value)
                 return std::nullopt;
-            return std::optional<std::optional<T>>(WTFMove(*value));
+            SUPPRESS_UNCHECKED_ARG return std::optional<std::optional<T>>(WTFMove(*value));
         }
         return std::optional<std::optional<T>>(std::optional<T>(std::nullopt));
     }
@@ -239,7 +239,7 @@ template<typename T, typename U> struct ArgumentCoder<std::pair<T, U>> {
     static void encode(Encoder& encoder, V&& pair)
     {
         static_assert(std::is_same_v<std::remove_cvref_t<V>, std::pair<T, U>>);
-        encoder << std::get<0>(std::forward<V>(pair)) << std::get<1>(std::forward<V>(pair));
+        SUPPRESS_UNCHECKED_ARG encoder << std::get<0>(std::forward<V>(pair)) << std::get<1>(std::forward<V>(pair));
     }
 
     template<typename Decoder>
@@ -253,7 +253,7 @@ template<typename T, typename U> struct ArgumentCoder<std::pair<T, U>> {
         if (!second)
             return std::nullopt;
 
-        return std::make_optional<std::pair<T, U>>(WTFMove(*first), WTFMove(*second));
+        SUPPRESS_UNCHECKED_ARG return std::make_optional<std::pair<T, U>>(WTFMove(*first), WTFMove(*second));
     }
 };
 
@@ -262,7 +262,7 @@ template<typename T> struct ArgumentCoder<RefPtr<T>> {
     static void encode(Encoder& encoder, const RefPtr<U>& object)
     {
         if (object)
-            encoder << true << *object;
+            SUPPRESS_FORWARD_DECL_ARG encoder << true << *object;
         else
             encoder << false;
     }
@@ -286,7 +286,7 @@ template<typename T> struct ArgumentCoder<Ref<T>> {
     template<typename Encoder, typename U = T>
     static void encode(Encoder& encoder, const Ref<U>& object)
     {
-        encoder << object.get();
+        SUPPRESS_FORWARD_DECL_ARG encoder << object.get();
     }
 
     template<typename Decoder, typename U = T>
@@ -307,7 +307,7 @@ template<typename T> struct ArgumentCoder<std::unique_ptr<T>> {
         static_assert(std::is_same_v<std::remove_cvref_t<U>, std::unique_ptr<T>>);
 
         if (object)
-            encoder << true << WTF::forward_like<U>(*object);
+            SUPPRESS_UNCHECKED_ARG encoder << true << WTF::forward_like<U>(*object);
         else
             encoder << false;
     }
@@ -323,7 +323,7 @@ template<typename T> struct ArgumentCoder<std::unique_ptr<T>> {
             auto object = decoder.template decode<T>();
             if (!object)
                 return std::nullopt;
-            return std::make_optional<std::unique_ptr<T>>(makeUnique<T>(WTFMove(*object)));
+            SUPPRESS_UNCHECKED_ARG return std::make_optional<std::unique_ptr<T>>(makeUnique<T>(WTFMove(*object)));
         }
         return std::make_optional<std::unique_ptr<T>>();
     }
@@ -376,7 +376,7 @@ template<typename... Elements> struct ArgumentCoder<std::tuple<Elements...>> {
             return decode(decoder, WTFMove(decodedObjects)..., WTFMove(optional));
         } else {
             static_assert((std::is_same_v<DecodedTypes, Elements> && ...));
-            return std::make_optional<std::tuple<Elements...>>(*WTFMove(decodedObjects)...);
+            SUPPRESS_UNCHECKED_ARG return std::make_optional<std::tuple<Elements...>>(*WTFMove(decodedObjects)...);
         }
     }
 };
@@ -461,8 +461,8 @@ template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t min
         static_assert(std::is_same_v<std::remove_cvref_t<U>, Vector<T, inlineCapacity, OverflowHandler, minCapacity>>);
 
         encoder << static_cast<uint64_t>(vector.size());
-        for (auto&& item : vector)
-            encoder << WTF::forward_like<U>(item);
+        SUPPRESS_UNCHECKED_LOCAL for (auto&& item : vector)
+            SUPPRESS_UNCHECKED_ARG encoder << WTF::forward_like<U>(item);
     }
 
     template<typename Decoder>
@@ -491,7 +491,7 @@ template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t min
             auto element = decoder.template decode<T>();
             if (!element)
                 return std::nullopt;
-            vector.append(WTFMove(*element));
+            SUPPRESS_UNCHECKED_ARG vector.append(WTFMove(*element));
         }
         vector.shrinkToFit();
         return vector;

--- a/Source/WebKit/Platform/IPC/Encoder.h
+++ b/Source/WebKit/Platform/IPC/Encoder.h
@@ -82,7 +82,7 @@ public:
     template<typename T>
     Encoder& operator<<(T&& t)
     {
-        ArgumentCoder<std::remove_cvref_t<T>, void>::encode(*this, std::forward<T>(t));
+        SUPPRESS_FORWARD_DECL_ARG ArgumentCoder<std::remove_cvref_t<T>, void>::encode(*this, std::forward<T>(t));
         return *this;
     }
 

--- a/Source/WebKit/Platform/IPC/MessageSenderInlines.h
+++ b/Source/WebKit/Platform/IPC/MessageSenderInlines.h
@@ -27,6 +27,7 @@
 
 #include "Connection.h"
 #include "MessageSender.h"
+#include <wtf/CompletionHandler.h>
 
 namespace IPC {
 
@@ -61,7 +62,7 @@ template<typename MessageType, typename C> inline std::optional<AsyncReplyID> Me
 template<typename MessageType> inline bool MessageSender::sendWithoutUsingIPCConnection(MessageType&& message) const
 {
     static_assert(!MessageType::isSync);
-    auto encoder = makeUniqueRef<IPC::Encoder>(MessageType::name(), messageSenderDestinationID());
+    SUPPRESS_FORWARD_DECL_ARG auto encoder = makeUniqueRef<IPC::Encoder>(MessageType::name(), messageSenderDestinationID());
     message.encode(encoder.get());
 
     return performSendWithoutUsingIPCConnection(WTFMove(encoder));
@@ -101,7 +102,7 @@ template<typename MessageType, typename C> inline bool MessageSender::sendWithAs
             cancelReplyWithoutUsingConnection<MessageType>(WTFMove(completionHandler));
     };
 
-    return performSendWithAsyncReplyWithoutUsingIPCConnection(WTFMove(encoder), WTFMove(asyncHandler));
+    SUPPRESS_FORWARD_DECL_ARG return performSendWithAsyncReplyWithoutUsingIPCConnection(WTFMove(encoder), WTFMove(asyncHandler));
 }
 
 template<typename MessageType> inline bool MessageSender::send(MessageType&& message)

--- a/Source/WebKit/Platform/IPC/cocoa/ConnectionCocoa.mm
+++ b/Source/WebKit/Platform/IPC/cocoa/ConnectionCocoa.mm
@@ -198,7 +198,7 @@ void Connection::platformOpen()
     // Change the message queue length for the receive port.
     setMachPortQueueLength(m_receivePort, largeOutgoingMessageQueueCountThreshold);
 
-    m_receiveSource = adoptOSObject(dispatch_source_create(DISPATCH_SOURCE_TYPE_MACH_RECV, m_receivePort, 0, m_connectionQueue->dispatchQueue()));
+    m_receiveSource = adoptOSObject(dispatch_source_create(DISPATCH_SOURCE_TYPE_MACH_RECV, m_receivePort, 0, m_connectionQueue->protectedDispatchQueue().get()));
     dispatch_source_set_event_handler(m_receiveSource.get(), [this, protectedThis = Ref { *this }] {
         receiveSourceEventHandler();
     });
@@ -343,7 +343,7 @@ void Connection::initializeSendSource()
         return;
     RELEASE_ASSERT(m_sendPort != MACH_PORT_NULL);
 
-    m_sendSource = adoptOSObject(dispatch_source_create(DISPATCH_SOURCE_TYPE_MACH_SEND, m_sendPort, DISPATCH_MACH_SEND_POSSIBLE, m_connectionQueue->dispatchQueue()));
+    m_sendSource = adoptOSObject(dispatch_source_create(DISPATCH_SOURCE_TYPE_MACH_SEND, m_sendPort, DISPATCH_MACH_SEND_POSSIBLE, m_connectionQueue->protectedDispatchQueue().get()));
     dispatch_source_set_registration_handler(m_sendSource.get(), [this, protectedThis = Ref { *this }] {
         if (!m_sendSource)
             return;

--- a/Source/WebKit/Platform/IPC/cocoa/DaemonConnectionCocoa.mm
+++ b/Source/WebKit/Platform/IPC/cocoa/DaemonConnectionCocoa.mm
@@ -93,7 +93,9 @@ template<typename Traits>
 void ConnectionToMachService<Traits>::send(typename Traits::MessageType messageType, EncodedMessage&& message) const
 {
     initializeConnectionIfNeeded();
-    Connection::send(dictionaryFromMessage(messageType, WTFMove(message)).get());
+    OSObjectPtr dictionary = dictionaryFromMessage(messageType, WTFMove(message));
+    // FIXME: This is a safer cpp false positive (rdar://161383542).
+    SUPPRESS_UNRETAINED_ARG Connection::send(dictionary.get());
 }
 
 template<typename Traits>
@@ -102,7 +104,9 @@ void ConnectionToMachService<Traits>::sendWithReply(typename Traits::MessageType
     ASSERT(RunLoop::isMain());
     initializeConnectionIfNeeded();
 
-    Connection::sendWithReply(dictionaryFromMessage(messageType, WTFMove(message)).get(), [completionHandler = WTFMove(completionHandler)] (xpc_object_t reply) mutable {
+    OSObjectPtr dictionary = dictionaryFromMessage(messageType, WTFMove(message));
+    // FIXME: This is a safer cpp false positive (rdar://161383542).
+    SUPPRESS_UNRETAINED_ARG Connection::sendWithReply(dictionary.get(), [completionHandler = WTFMove(completionHandler)] (xpc_object_t reply) mutable {
         if (xpc_get_type(reply) != XPC_TYPE_DICTIONARY) {
             if (reply == XPC_ERROR_CONNECTION_INTERRUPTED)
                 LOG_ERROR("ConnectionToMachService::sendWithReply: connection is interrupted");

--- a/Source/WebKit/SaferCPPExpectations/ForwardDeclCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/ForwardDeclCheckerExpectations
@@ -1,6 +1,4 @@
 Platform/IPC/ArgumentCoders.h
-Platform/IPC/Encoder.h
-Platform/IPC/MessageSenderInlines.h
 UIProcess/WebProcessPool.h
 WebProcess/Extensions/Bindings/JSWebExtensionWrapper.h
 WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp

--- a/Source/WebKit/SaferCPPExpectations/RetainPtrCtorAdoptCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/RetainPtrCtorAdoptCheckerExpectations
@@ -1,4 +1,3 @@
-NetworkProcess/cocoa/NetworkSessionCocoa.mm
 NetworkProcess/mac/SecItemShim.cpp
 Platform/cf/ModuleCF.cpp
 Shared/API/Cocoa/WKRemoteObjectCoder.mm

--- a/Source/WebKit/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
@@ -1,4 +1,3 @@
-Platform/IPC/ArgumentCoders.h
 WebProcess/FullScreen/WebFullScreenManager.cpp
 WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
 WebProcess/InjectedBundle/InjectedBundleHitTestResult.cpp

--- a/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
@@ -1,7 +1,5 @@
 GeneratedWebKitSecureCoding.mm
 NetworkProcess/mac/NetworkProcessMac.mm
-Platform/IPC/cocoa/ConnectionCocoa.mm
-Platform/IPC/cocoa/DaemonConnectionCocoa.mm
 Shared/API/Cocoa/RemoteObjectRegistry.mm
 Shared/API/Cocoa/WKBrowsingContextHandle.mm
 Shared/API/Cocoa/WKRemoteObjectCoder.mm


### PR DESCRIPTION
#### 7b666829e63d82cf162e67607fa74e1922dc7448
<pre>
Address some safer cpp failures in WebKit/NetworkProcess/cocoa &amp; WebKit/Platform/IPC
<a href="https://bugs.webkit.org/show_bug.cgi?id=299576">https://bugs.webkit.org/show_bug.cgi?id=299576</a>

Reviewed by Ryosuke Niwa.

* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
(WebKit::NetworkSessionCocoa::setProxyConfigData):
* Source/WebKit/Platform/IPC/ArgumentCoders.h:
(IPC::ArgumentCoder&lt;std::optional&lt;T&gt;&gt;::encode):
(IPC::ArgumentCoder&lt;std::optional&lt;T&gt;&gt;::decode):
(IPC::ArgumentCoder&lt;RefPtr&lt;T&gt;&gt;::encode):
(IPC::ArgumentCoder&lt;Ref&lt;T&gt;&gt;::encode):
(IPC::ArgumentCoder&lt;std::unique_ptr&lt;T&gt;&gt;::encode):
(IPC::ArgumentCoder&lt;std::unique_ptr&lt;T&gt;&gt;::decode):
* Source/WebKit/Platform/IPC/Encoder.h:
* Source/WebKit/Platform/IPC/MessageSenderInlines.h:
(IPC::MessageSender::sendWithoutUsingIPCConnection const):
(IPC::MessageSender::sendWithAsyncReplyWithoutUsingIPCConnection const):
* Source/WebKit/Platform/IPC/cocoa/ConnectionCocoa.mm:
(IPC::Connection::platformOpen):
(IPC::Connection::initializeSendSource):
* Source/WebKit/Platform/IPC/cocoa/DaemonConnectionCocoa.mm:
(WebKit::Daemon::ConnectionToMachService&lt;Traits&gt;::send const):
(WebKit::Daemon::ConnectionToMachService&lt;Traits&gt;::sendWithReply const):
* Source/WebKit/SaferCPPExpectations/ForwardDeclCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/RetainPtrCtorAdoptCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations:

Canonical link: <a href="https://commits.webkit.org/300630@main">https://commits.webkit.org/300630@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f6c41025675dc6c707f24c86d14ebbae2e199f4d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123299 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43014 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33710 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130008 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/75414 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f0becde5-e1bf-4698-b399-e872fef895a1) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43737 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51608 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93726 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/62179 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cf3178a0-c070-407f-9f5b-400ac0d40226) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126252 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34850 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110322 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74356 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cad646f0-5c55-4747-861c-c2c97930d691) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33816 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73527 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104564 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28707 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132727 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50249 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38238 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102218 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50625 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106546 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102071 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25951 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47422 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25644 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/47024 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50104 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/55865 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49575 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/52925 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51253 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->