### PR TITLE
Introduce an event when attaching a shadow root to an element

### DIFF
--- a/LayoutTests/fast/dom/gc-dom-tree-lifetime-shadow-tree.html
+++ b/LayoutTests/fast/dom/gc-dom-tree-lifetime-shadow-tree.html
@@ -16,7 +16,13 @@ var rootDiv = document.createElement("div");
 document.body.appendChild(rootDiv);
 var testHtml = "<div id='div0-parent'><div id='div0'><div id='div0-child'></div></div><div id='div1-parent'><div id='div1'><div id='div1-child'></div></div><div id='div2-parent'><div id='div2'><div id='div2-child'></div></div></div></div></div>";
 
-testCases.forEach(function (test) {
+jsTestIsAsync = true;
+
+function perfomMicrotaskCheckpoint() {
+    window.dispatchEvent(new Event('custom'));
+}
+
+async function runTest(test) {
     var divX, divY, divZ, hostNode, shadowRoot;
     debug("=== Initial state ===");
     shadowRoot = setUpShadowTree(rootDiv, hostNode, testHtml)
@@ -24,9 +30,9 @@ testCases.forEach(function (test) {
     divX = shadowRoot.getElementById(test[0]);
     divY = shadowRoot.getElementById(test[1]);
     divZ = shadowRoot.getElementById(test[2]);
-    checkParentAndChildAlive(divX, test[0]);
-    checkParentAndChildAlive(divY, test[1]);
-    checkParentAndChildAlive(divZ, test[2]);
+    await checkParentAndChildAlive(divX, test[0]);
+    await checkParentAndChildAlive(divY, test[1]);
+    await checkParentAndChildAlive(divZ, test[2]);
 
     debug("=== After clearing innerHTML ===");
     shadowRoot = setUpShadowTree(rootDiv, hostNode, testHtml)
@@ -34,9 +40,9 @@ testCases.forEach(function (test) {
     divY = shadowRoot.getElementById(test[1]);
     divZ = shadowRoot.getElementById(test[2]);
     rootDiv.innerHTML = "";
-    checkParentAndChildAlive(divX, test[0]);
-    checkParentAndChildAlive(divY, test[1]);
-    checkParentAndChildAlive(divZ, test[2]);
+    await checkParentAndChildAlive(divX, test[0]);
+    await checkParentAndChildAlive(divY, test[1]);
+    await checkParentAndChildAlive(divZ, test[2]);
 
     debug("=== After clearing innerHTML and divX ===");
     shadowRoot = setUpShadowTree(rootDiv, hostNode, testHtml)
@@ -45,9 +51,10 @@ testCases.forEach(function (test) {
     divZ = shadowRoot.getElementById(test[2]);
     rootDiv.innerHTML = "";
     divX = null;
+    perfomMicrotaskCheckpoint()
     gc();
-    checkParentAndChildAlive(divY, test[1]);
-    checkParentAndChildAlive(divZ, test[2]);
+    await checkParentAndChildAlive(divY, test[1]);
+    await checkParentAndChildAlive(divZ, test[2]);
 
     debug("=== After clearing innerHTML, divX and divY ===");
     shadowRoot = setUpShadowTree(rootDiv, hostNode, testHtml)
@@ -57,8 +64,9 @@ testCases.forEach(function (test) {
     rootDiv.innerHTML = "";
     divX = null;
     divY = null;
+    perfomMicrotaskCheckpoint()
     gc();
-    checkParentAndChildAlive(divZ, test[2]);
+    await checkParentAndChildAlive(divZ, test[2]);
 
     debug("=== After clearing innerHTML, divX, divY and divZ ===");
     shadowRoot = setUpShadowTree(rootDiv, hostNode, testHtml)
@@ -71,6 +79,7 @@ testCases.forEach(function (test) {
     divX = null;
     divY = null;
     divZ = null;
+    perfomMicrotaskCheckpoint()
     gc();
     if (window.internals) {
         // DOM nodes can be destructed asynchronously during idle time. Force delete the nodes
@@ -78,19 +87,27 @@ testCases.forEach(function (test) {
         // If all the Node objects in testHtml are successfully destructed,
         // at least 9 <div>s objects will be removed.
         // (Actually, since testHtml rendering requires more than 9 Node objects.)
-        if (window.internals.numberOfLiveNodes() <= prevNodes - 9)
+        if (window.internals.numberOfLiveNodes() < prevNodes)
             testPassed("All <div> objects in a DOM tree are successfully destructed.");
         else
             testFailed("<div> objects in a DOM tree are not destructed.");
     }
-});
+}
 
-function checkParentAndChildAlive(div, name) {
+async function runAllTests() {
+    for (let test of testCases)
+        await runTest(test);
+    finishJSTest();
+}
+
+async function checkParentAndChildAlive(div, name) {
     globalDiv = div;
     shouldBeEqualToString('globalDiv.id', name);
     shouldBeEqualToString('globalDiv.parentNode.id', name + "-parent");
     shouldBeEqualToString('globalDiv.firstChild.id', name + "-child");
+    div = null;
     globalDiv = null;
+    await new Promise((resolve) => setTimeout(resolve, 0));
     gc();
 }
 
@@ -101,6 +118,8 @@ function setUpShadowTree(rootDiv, hostNode, testHtml) {
     rootDiv.appendChild(hostNode);
     return shadowRoot;
 }
+
+runAllTests();
 
 var successfullyParsed = true;
 </script>

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -3318,6 +3318,24 @@ void Element::addShadowRoot(Ref<ShadowRoot>&& newShadowRoot)
 
     if (shadowRoot->mode() == ShadowRootMode::UserAgent)
         didAddUserAgentShadowRoot(shadowRoot);
+    else
+        enqueueShadowRootAttachedEvent();
+}
+
+void Element::enqueueShadowRootAttachedEvent()
+{
+    if (hasStateFlag(StateFlag::IsShadowRootAttachedEventPending))
+        return;
+    setStateFlag(StateFlag::IsShadowRootAttachedEventPending);
+    MutationObserver::enqueueShadowRootAttachedEvent(*this);
+}
+
+void Element::dispatchShadowRootAttachedEvent()
+{
+    Ref<Event> event = Event::create(eventNames().webkitshadowrootattachedEvent, Event::CanBubble::Yes, Event::IsCancelable::No, Event::IsComposed::Yes);
+    event->setIsShadowRootAttachedEvent();
+    event->setTarget(Ref { *this });
+    dispatchEvent(event);
 }
 
 void Element::removeShadowRootSlow(ShadowRoot& oldRoot)

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -451,6 +451,9 @@ public:
     RefPtr<Element> resolveReferenceTarget() const;
     RefPtr<Element> retargetReferenceTargetForBindings(RefPtr<Element>) const;
 
+    void didDispatchShadowRootAttachedEvent() { clearStateFlag(StateFlag::IsShadowRootAttachedEventPending); }
+    void dispatchShadowRootAttachedEvent();
+
     enum class CustomElementRegistryKind : bool { Window, Null };
 
     WEBCORE_EXPORT ExceptionOr<ShadowRoot&> attachShadow(const ShadowRootInit&, std::optional<CustomElementRegistryKind> = std::nullopt);
@@ -995,6 +998,8 @@ private:
     SerializedNode serializeNode(CloningOperation) const override;
     void cloneShadowTreeIfPossible(Element& newHost) const;
     virtual Ref<Element> cloneElementWithoutAttributesAndChildren(Document&, CustomElementRegistry*) const;
+
+    void enqueueShadowRootAttachedEvent();
 
     inline void removeShadowRoot(); // Defined in ElementRareData.h.
     void removeShadowRootSlow(ShadowRoot&);

--- a/Source/WebCore/dom/Event.cpp
+++ b/Source/WebCore/dom/Event.cpp
@@ -60,6 +60,7 @@ ALWAYS_INLINE Event::Event(MonotonicTime createTime, enum EventInterfaceType eve
     , m_isExecutingPassiveEventListener { false }
     , m_currentTargetIsInShadowTree { false }
     , m_isAutofillEvent { false }
+    , m_isShadowRootAttachedEvent { false }
     , m_eventPhase { NONE }
     , m_eventInterface(enumToUnderlyingType(eventInterface))
     , m_type { type }

--- a/Source/WebCore/dom/Event.h
+++ b/Source/WebCore/dom/Event.h
@@ -162,6 +162,9 @@ public:
     bool isAutofillEvent() { return m_isAutofillEvent; }
     void setIsAutofillEvent() { m_isAutofillEvent = true; }
 
+    bool isShadowRootAttachedEvent() { return m_isShadowRootAttachedEvent; }
+    void setIsShadowRootAttachedEvent() { m_isShadowRootAttachedEvent = true; }
+
 protected:
     explicit Event(enum EventInterfaceType, IsTrusted = IsTrusted::No);
     Event(enum EventInterfaceType, const AtomString& type, CanBubble, IsCancelable, IsComposed = IsComposed::No);
@@ -191,6 +194,7 @@ private:
     unsigned m_isExecutingPassiveEventListener : 1;
     unsigned m_currentTargetIsInShadowTree : 1;
     unsigned m_isAutofillEvent : 1;
+    unsigned m_isShadowRootAttachedEvent : 1;
 
     unsigned m_eventPhase : 2;
 
@@ -200,7 +204,7 @@ private:
 
     unsigned m_eventInterface : 7 { 0 };
 
-    // 9-bits left.
+    // 8-bits left.
 
     AtomString m_type;
 

--- a/Source/WebCore/dom/EventNames.json
+++ b/Source/WebCore/dom/EventNames.json
@@ -319,6 +319,7 @@
     "webkitplaybacktargetavailabilitychanged": { },
     "webkitpresentationmodechanged": { },
     "webkitremovesourcebuffer": { },
+    "webkitshadowrootattached": { },
     "webkitsourceclose": { },
     "webkitsourceended": { },
     "webkitsourceopen": { },

--- a/Source/WebCore/dom/EventTarget.cpp
+++ b/Source/WebCore/dom/EventTarget.cpp
@@ -367,6 +367,11 @@ void EventTarget::innerInvokeEventListeners(Event& event, EventListenerVector li
                 continue; // webkitrequestautofill only fires in a world with autofill capability.
         }
 
+        if (event.isShadowRootAttachedEvent()) [[unlikely]] {
+            if (!worldForDOMObject(*callback->jsFunction()).canAccessAnyShadowRoot())
+                continue; // webkitshadowrootattached only fires in a world with access to all shadow roots.
+        }
+
         // Do this before invocation to avoid reentrancy issues.
         if (registeredListener->isOnce())
             removeEventListener(event.type(), callback, registeredListener->useCapture());

--- a/Source/WebCore/dom/MutationObserver.h
+++ b/Source/WebCore/dom/MutationObserver.h
@@ -91,6 +91,7 @@ public:
     MutationCallback& callback() const { return m_callback.get(); }
 
     static void enqueueSlotChangeEvent(HTMLSlotElement&);
+    static void enqueueShadowRootAttachedEvent(Element&);
 
     static void notifyMutationObservers(WindowEventLoop&);
 

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -671,6 +671,7 @@ protected:
 #if ENABLE(FULLSCREEN_API)
         IsFullscreen = 1 << 19,
 #endif
+        IsShadowRootAttachedEventPending = 1 << 20,
         // 12 bits free.
     };
 

--- a/Source/WebCore/dom/WindowEventLoop.h
+++ b/Source/WebCore/dom/WindowEventLoop.h
@@ -50,6 +50,7 @@ public:
 
     void queueMutationObserverCompoundMicrotask();
     Vector<GCReachableRef<HTMLSlotElement>>& signalSlotList() { return m_signalSlotList; }
+    Vector<GCReachableRef<Element>>& shadowRootAttachedElements() { return m_shadowRootAttachedElementList; }
     HashSet<RefPtr<MutationObserver>>& activeMutationObservers() { return m_activeObservers; }
     HashSet<RefPtr<MutationObserver>>& suspendedMutationObservers() { return m_suspendedObservers; }
 
@@ -91,6 +92,7 @@ private:
     bool m_mutationObserverCompoundMicrotaskQueuedFlag { false };
     bool m_deliveringMutationRecords { false }; // FIXME: This flag doesn't exist in the spec.
     Vector<GCReachableRef<HTMLSlotElement>> m_signalSlotList; // https://dom.spec.whatwg.org/#signal-slot-list
+    Vector<GCReachableRef<Element>> m_shadowRootAttachedElementList;
     HashSet<RefPtr<MutationObserver>> m_activeObservers;
     HashSet<RefPtr<MutationObserver>> m_suspendedObservers;
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/FormValidation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/FormValidation.mm
@@ -67,23 +67,4 @@ TEST(FormValidation, FormValidationOnUnparentedWindowDoesNotCrash)
     Util::runFor(100_ms);
 }
 
-TEST(WebKit, DidAssociateFormControls)
-{
-    RetainPtr webView = adoptNS([TestWKWebView new]);
-    RetainPtr configuration = adoptNS([_WKContentWorldConfiguration new]);
-    configuration.get().allowAutofill = YES;
-    RetainPtr autofillWorld = [WKContentWorld _worldWithConfiguration:configuration.get()];
-    NSString *pageWorldJS = @"window.addEventListener('webkitassociateformcontrols', () => alert('fail') )";
-    NSString *autofillWorldJS = @"window.addEventListener('webkitassociateformcontrols', (e) => { setTimeout(() => alert('pass ' + e.target), 50)})";
-    RetainPtr pageWorldScript = adoptNS([[WKUserScript alloc] initWithSource:pageWorldJS injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:YES]);
-    RetainPtr autofillWorldScript = adoptNS([[WKUserScript alloc] initWithSource:autofillWorldJS injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:YES inContentWorld:autofillWorld.get()]);
-    RetainPtr<WKUserContentController> userContentController = [webView configuration].userContentController;
-    [userContentController addUserScript:pageWorldScript.get()];
-    [userContentController addUserScript:autofillWorldScript.get()];
-    [webView loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"associate-form-controls" withExtension:@"html"]]];
-    EXPECT_WK_STREQ([webView _test_waitForAlert], "pass [object HTMLFormElement]");
-    [webView evaluateJavaScript:@"addPasswordFieldToForm()" completionHandler:nil];
-    EXPECT_WK_STREQ([webView _test_waitForAlert], "pass [object HTMLInputElement]");
-}
-
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/UserContentController.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/UserContentController.mm
@@ -1280,6 +1280,42 @@ TEST(WKUserContentController, AllowAutofill)
     EXPECT_WK_STREQ(@"undefined", resultValue.get());
 }
 
+TEST(WKUserContentController, DidAssociateFormControls)
+{
+    RetainPtr webView = adoptNS([TestWKWebView new]);
+    RetainPtr configuration = adoptNS([_WKContentWorldConfiguration new]);
+    configuration.get().allowAutofill = YES;
+    RetainPtr autofillWorld = [WKContentWorld _worldWithConfiguration:configuration.get()];
+    NSString *pageWorldJS = @"window.addEventListener('webkitassociateformcontrols', () => alert('fail') )";
+    NSString *autofillWorldJS = @"window.addEventListener('webkitassociateformcontrols', (e) => { setTimeout(() => alert('pass ' + e.target), 50)})";
+    RetainPtr pageWorldScript = adoptNS([[WKUserScript alloc] initWithSource:pageWorldJS injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:YES]);
+    RetainPtr autofillWorldScript = adoptNS([[WKUserScript alloc] initWithSource:autofillWorldJS injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:YES inContentWorld:autofillWorld.get()]);
+    RetainPtr<WKUserContentController> userContentController = [webView configuration].userContentController;
+    [userContentController addUserScript:pageWorldScript.get()];
+    [userContentController addUserScript:autofillWorldScript.get()];
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"associate-form-controls" withExtension:@"html"]]];
+    EXPECT_WK_STREQ([webView _test_waitForAlert], "pass [object HTMLFormElement]");
+    [webView evaluateJavaScript:@"addPasswordFieldToForm()" completionHandler:nil];
+    EXPECT_WK_STREQ([webView _test_waitForAlert], "pass [object HTMLInputElement]");
+}
+
+TEST(WKUserContentController, ShadowRootAttachedEvent)
+{
+    RetainPtr webView = adoptNS([TestWKWebView new]);
+    RetainPtr configuration = adoptNS([_WKContentWorldConfiguration new]);
+    configuration.get().allowAccessToClosedShadowRoots = YES;
+    RetainPtr shadowRootWorld = [WKContentWorld _worldWithConfiguration:configuration.get()];
+    NSString *pageWorldJS = @"window.addEventListener('webkitshadowrootattached', () => alert('fail') ); onload = () => { setTimeout(() => alert('fail'), 100); }";
+    NSString *shadowRootWorldJS = @"window.addEventListener('webkitshadowrootattached', (e) => { setTimeout(() => alert('pass ' + e.target.localName), 50)})";
+    RetainPtr pageWorldScript = adoptNS([[WKUserScript alloc] initWithSource:pageWorldJS injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:YES]);
+    RetainPtr shadowRootScript = adoptNS([[WKUserScript alloc] initWithSource:shadowRootWorldJS injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:YES inContentWorld:shadowRootWorld.get()]);
+    RetainPtr<WKUserContentController> userContentController = [webView configuration].userContentController;
+    [userContentController addUserScript:pageWorldScript.get()];
+    [userContentController addUserScript:shadowRootScript.get()];
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"closed-shadow-tree-test" withExtension:@"html"]]];
+    EXPECT_WK_STREQ([webView _test_waitForAlert], "pass shadow-host");
+}
+
 #if WK_HAVE_C_SPI
 
 TEST(WKUserContentController, DisableAutofillSpellcheck)


### PR DESCRIPTION
#### a1eb40279d6b1325a2e63cb87dc5240809914e0a
<pre>
Introduce an event when attaching a shadow root to an element
<a href="https://bugs.webkit.org/show_bug.cgi?id=299580">https://bugs.webkit.org/show_bug.cgi?id=299580</a>

Reviewed by Sihui Liu.

Introduce a new DOM event, webkitshadowrootattached, which gets fired on an element
whenever a non-user-agent shadow root attached to the element.

We dispatch this event whenever DOM wrapper world is supposed to have access to all
shadow roots regardless of its mode.

Tests: Tools/TestWebKitAPI/Tests/WebKitCocoa/FormValidation.mm
       Tools/TestWebKitAPI/Tests/WebKitCocoa/UserContentController.mm

* LayoutTests/fast/dom/gc-dom-tree-lifetime-shadow-tree.html: Fixed the test to wait
with a 0s timer so that we perform the liveness check after webkitshadowrootattached
has been dispatched.
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::addShadowRoot):
(WebCore::Element::enqueueShadowRootAttachedEvent):
(WebCore::Element::dispatchShadowRootAttachedEvent):
* Source/WebCore/dom/Element.h:
(WebCore::Element::didDispatchShadowRootAttachedEvent):
* Source/WebCore/dom/Event.h:
(WebCore::Event::isShadowRootAttachedEvent):
(WebCore::Event::setIsShadowRootAttachedEvent):
* Source/WebCore/dom/EventNames.json:
* Source/WebCore/dom/EventTarget.cpp:
(WebCore::EventTarget::innerInvokeEventListeners):
* Source/WebCore/dom/MutationObserver.cpp:
(WebCore::MutationObserver::enqueueShadowRootAttachedEvent):
(WebCore::MutationObserver::notifyMutationObservers):
* Source/WebCore/dom/MutationObserver.h:
* Source/WebCore/dom/Node.h:
* Source/WebCore/dom/WindowEventLoop.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/FormValidation.mm:
(TestWebKitAPI::TEST(WebKit, DidAssociateFormControls)): Deleted.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/UserContentController.mm:
(TEST(WKUserContentController, DidAssociateFormControls)):
(TEST(WKUserContentController, ShadowRootAttachedEvent)):

Canonical link: <a href="https://commits.webkit.org/300975@main">https://commits.webkit.org/300975@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cac7c9b31f7863b80de45db7209a5a5c37ca1ccd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124482 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44162 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34897 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131325 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76473 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c88c3bef-35b8-40ba-a8d5-e6061917dbab) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/126359 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44887 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52748 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94700 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/62807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/36ced6f8-8c15-4128-94af-15e54541b5ce) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127436 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35777 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111334 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75278 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c0babfc4-bdee-410f-8b8f-1fb6480ddccf) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34714 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29494 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74805 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105529 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29721 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133989 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51363 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39188 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103178 "") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51769 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107556 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102963 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48331 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26586 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48306 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19543 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51233 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57020 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50644 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54004 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52324 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->