### PR TITLE
[iOS] Make it possible to use WebKit1 without a web thread

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2387,6 +2387,7 @@ platform/VideoDecoder.cpp
 platform/VideoEncoder.cpp
 platform/VideoFrame.cpp
 platform/VideoPixelFormat.cpp
+platform/WebCoreMainThread.cpp
 platform/WebCorePersistentCoders.cpp
 platform/Widget.cpp
 platform/animation/AcceleratedEffect.cpp

--- a/Source/WebCore/platform/WebCoreMainThread.cpp
+++ b/Source/WebCore/platform/WebCoreMainThread.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WebCoreMainThread.h"
+
+#include <JavaScriptCore/InitializeThreading.h>
+#include <WebCore/WebCoreJITOperations.h>
+#include <wtf/MainThread.h>
+#include <wtf/RunLoop.h>
+
+namespace WebCore {
+
+bool shouldUseWebThread()
+{
+#if PLATFORM(IOS_FAMILY) && !ENABLE(WEB_THREAD_DISABLEMENT)
+    return true;
+#else
+    return false;
+#endif
+}
+
+void initializeMainThreadIfNeeded()
+{
+    if (shouldUseWebThread())
+        return;
+
+    JSC::initialize();
+    WTF::initializeMainThread();
+    WebCore::populateJITOperations();
+}
+
+}
+

--- a/Source/WebCore/platform/WebCoreMainThread.h
+++ b/Source/WebCore/platform/WebCoreMainThread.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace WebCore {
+
+WEBCORE_EXPORT bool shouldUseWebThread();
+WEBCORE_EXPORT void initializeMainThreadIfNeeded();
+
+} // namespace WebCore

--- a/Source/WebCore/platform/ios/wak/WebCoreThread.mm
+++ b/Source/WebCore/platform/ios/wak/WebCoreThread.mm
@@ -873,6 +873,12 @@ void _WebThreadUnlock()
 
 bool WebThreadIsLocked(void)
 {
+#if ENABLE(WEB_THREAD_DISABLEMENT)
+    // This is temporarily needed to avoid assertions in code assuming the web thread is used.
+    if (!WebThreadIsEnabled())
+        return true;
+#endif
+
     if (WebThreadIsCurrent())
         return webThreadLockCount;
 

--- a/Source/WebKitLegacy/mac/History/WebBackForwardList.mm
+++ b/Source/WebKitLegacy/mac/History/WebBackForwardList.mm
@@ -44,6 +44,7 @@
 #import <WebCore/Settings.h>
 #import <WebCore/ThreadCheck.h>
 #import <WebCore/WebCoreJITOperations.h>
+#import <WebCore/WebCoreMainThread.h>
 #import <WebCore/WebCoreObjCExtras.h>
 #import <wtf/Assertions.h>
 #import <wtf/MainThread.h>
@@ -97,11 +98,7 @@ WebBackForwardList *kit(BackForwardList* backForwardList)
 
 + (void)initialize
 {
-#if !PLATFORM(IOS_FAMILY)
-    JSC::initialize();
-    WTF::initializeMainThread();
-    WebCore::populateJITOperations();
-#endif
+    WebCore::initializeMainThreadIfNeeded();
 }
 
 - (id)init

--- a/Source/WebKitLegacy/mac/History/WebHistoryItem.mm
+++ b/Source/WebKitLegacy/mac/History/WebHistoryItem.mm
@@ -48,6 +48,7 @@
 #import <WebCore/Image.h>
 #import <WebCore/ThreadCheck.h>
 #import <WebCore/WebCoreJITOperations.h>
+#import <WebCore/WebCoreMainThread.h>
 #import <WebCore/WebCoreObjCExtras.h>
 #import <wtf/Assertions.h>
 #import <wtf/MainThread.h>
@@ -125,11 +126,7 @@ void WKNotifyHistoryItemChanged()
 
 + (void)initialize
 {
-#if !PLATFORM(IOS_FAMILY)
-    JSC::initialize();
-    WTF::initializeMainThread();
-    WebCore::populateJITOperations();
-#endif
+    WebCore::initializeMainThreadIfNeeded();
 }
 
 - (instancetype)init

--- a/Source/WebKitLegacy/mac/Misc/WebCache.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebCache.mm
@@ -40,6 +40,7 @@
 #import <WebCore/NetworkStorageSession.h>
 #import <WebCore/StorageSessionProvider.h>
 #import <WebCore/WebCoreJITOperations.h>
+#import <WebCore/WebCoreMainThread.h>
 #import <wtf/MainThread.h>
 #import <wtf/RunLoop.h>
 
@@ -62,11 +63,7 @@ class DefaultStorageSessionProvider : public WebCore::StorageSessionProvider {
 
 + (void)initialize
 {
-#if !PLATFORM(IOS_FAMILY)
-    JSC::initialize();
-    WTF::initializeMainThread();
-    WebCore::populateJITOperations();
-#endif
+    WebCore::initializeMainThreadIfNeeded();
 }
 
 + (NSArray *)statistics

--- a/Source/WebKitLegacy/mac/Misc/WebElementDictionary.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebElementDictionary.mm
@@ -42,6 +42,7 @@
 #import <WebCore/ImageAdapter.h>
 #import <WebCore/LocalFrame.h>
 #import <WebCore/WebCoreJITOperations.h>
+#import <WebCore/WebCoreMainThread.h>
 #import <WebCore/WebCoreObjCExtras.h>
 #import <WebKitLegacy/DOMCore.h>
 #import <WebKitLegacy/DOMExtensions.h>
@@ -71,11 +72,7 @@ static void cacheValueForKey(const void *key, const void *value, void *self)
 
 + (void)initialize
 {
-#if !PLATFORM(IOS_FAMILY)
-    JSC::initialize();
-    WTF::initializeMainThread();
-    WebCore::populateJITOperations();
-#endif
+    WebCore::initializeMainThreadIfNeeded();
 }
 
 + (void)initializeLookupTable

--- a/Source/WebKitLegacy/mac/Misc/WebIconDatabase.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebIconDatabase.mm
@@ -34,6 +34,7 @@
 #import <WebCore/Image.h>
 #import <WebCore/ThreadCheck.h>
 #import <WebCore/WebCoreJITOperations.h>
+#import <WebCore/WebCoreMainThread.h>
 #import <wtf/MainThread.h>
 #import <wtf/NeverDestroyed.h>
 #import <wtf/RunLoop.h>
@@ -97,9 +98,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 + (void)initialize
 {
-    JSC::initialize();
-    WTF::initializeMainThread();
-    WebCore::populateJITOperations();
+    WebCore::initializeMainThreadIfNeeded();
 }
 
 + (WebIconDatabase *)sharedIconDatabase

--- a/Source/WebKitLegacy/mac/Misc/WebStringTruncator.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebStringTruncator.mm
@@ -33,6 +33,7 @@
 #import <WebCore/FontPlatformData.h>
 #import <WebCore/StringTruncator.h>
 #import <WebCore/WebCoreJITOperations.h>
+#import <WebCore/WebCoreMainThread.h>
 #import <wtf/MainThread.h>
 #import <wtf/NeverDestroyed.h>
 
@@ -51,9 +52,7 @@ static WebCore::FontCascade& fontFromNSFont(NSFont *font)
 
 + (void)initialize
 {
-    JSC::initialize();
-    WTF::initializeMainThread();
-    WebCore::populateJITOperations();
+    WebCore::initializeMainThreadIfNeeded();
 }
 
 + (NSString *)centerTruncateString:(NSString *)string toWidth:(float)maxWidth

--- a/Source/WebKitLegacy/mac/Plugins/WebBasePluginPackage.mm
+++ b/Source/WebKitLegacy/mac/Plugins/WebBasePluginPackage.mm
@@ -33,6 +33,7 @@
 #import "WebPluginPackage.h"
 #import <JavaScriptCore/InitializeThreading.h>
 #import <WebCore/WebCoreJITOperations.h>
+#import <WebCore/WebCoreMainThread.h>
 #import <algorithm>
 #import <mach-o/arch.h>
 #import <mach-o/fat.h>
@@ -58,11 +59,7 @@ static constexpr auto QuickTimeCocoaPluginIdentifier = "com.apple.quicktime.webp
 
 + (void)initialize
 {
-#if !PLATFORM(IOS_FAMILY)
-    JSC::initialize();
-    WTF::initializeMainThread();
-    WebCore::populateJITOperations();
-#endif
+    WebCore::initializeMainThreadIfNeeded();
 }
 
 + (WebBasePluginPackage *)pluginWithPath:(NSString *)pluginPath

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.mm
@@ -82,6 +82,7 @@
 #import <WebCore/VisibleUnits.h>
 #import <WebCore/WebContentReader.h>
 #import <WebCore/WebCoreJITOperations.h>
+#import <WebCore/WebCoreMainThread.h>
 #import <WebCore/WebCoreObjCExtras.h>
 #import <pal/spi/cocoa/NSAttributedStringSPI.h>
 #import <pal/spi/mac/NSSpellCheckerSPI.h>
@@ -137,11 +138,7 @@ static WebViewInsertAction kit(EditorInsertAction action)
 
 + (void)initialize
 {
-#if !PLATFORM(IOS_FAMILY)
-    JSC::initialize();
-    WTF::initializeMainThread();
-    WebCore::populateJITOperations();
-#endif
+    WebCore::initializeMainThreadIfNeeded();
 }
 
 - (id)initWithUndoStep:(Ref<UndoStep>&&)step

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm
@@ -116,6 +116,7 @@
 #import <WebCore/SharedBuffer.h>
 #import <WebCore/SubresourceLoader.h>
 #import <WebCore/WebCoreJITOperations.h>
+#import <WebCore/WebCoreMainThread.h>
 #import <WebCore/WebCoreObjCExtras.h>
 #import <WebCore/WebScriptObjectPrivate.h>
 #import <WebCore/Widget.h>
@@ -2041,11 +2042,7 @@ void WebFrameLoaderClient::finishedLoadingIcon(WebCore::FragmentedSharedBuffer* 
 
 + (void)initialize
 {
-#if !PLATFORM(IOS_FAMILY)
-    JSC::initialize();
-    WTF::initializeMainThread();
-    WebCore::populateJITOperations();
-#endif
+    WebCore::initializeMainThreadIfNeeded();
 }
 
 - (id)initWithFrame:(NakedPtr<WebCore::LocalFrame>)frame policyFunction:(WebCore::FramePolicyFunction&&)policyFunction defaultPolicy:(WebCore::PolicyAction)defaultPolicy

--- a/Source/WebKitLegacy/mac/WebView/WebArchive.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebArchive.mm
@@ -37,6 +37,7 @@
 #import <WebCore/LegacyWebArchive.h>
 #import <WebCore/ThreadCheck.h>
 #import <WebCore/WebCoreJITOperations.h>
+#import <WebCore/WebCoreMainThread.h>
 #import <WebCore/WebCoreObjCExtras.h>
 #import <wtf/MainThread.h>
 #import <wtf/RunLoop.h>
@@ -68,11 +69,7 @@ static NSString * const WebSubframeArchivesKey = @"WebSubframeArchives";
 
 + (void)initialize
 {
-#if !PLATFORM(IOS_FAMILY)
-    JSC::initialize();
-    WTF::initializeMainThread();
-    WebCore::populateJITOperations();
-#endif
+    WebCore::initializeMainThreadIfNeeded();
 }
 
 - (instancetype)init

--- a/Source/WebKitLegacy/mac/WebView/WebDataSource.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebDataSource.mm
@@ -55,6 +55,7 @@
 #import <WebCore/ResourceRequest.h>
 #import <WebCore/SharedBuffer.h>
 #import <WebCore/WebCoreJITOperations.h>
+#import <WebCore/WebCoreMainThread.h>
 #import <WebCore/WebCoreObjCExtras.h>
 #import <WebCore/WebCoreURLResponse.h>
 #import <WebKitLegacy/DOMHTML.h>
@@ -152,13 +153,8 @@ void addTypesFromClass(NSMutableDictionary *allTypes, Class objCClass, NSArray *
 
 + (void)initialize
 {
-    if (self == [WebDataSource class]) {
-#if !PLATFORM(IOS_FAMILY)
-        JSC::initialize();
-        WTF::initializeMainThread();
-        WebCore::populateJITOperations();
-#endif
-    }
+    if (self == [WebDataSource class])
+        WebCore::initializeMainThreadIfNeeded();
 }
 
 - (NSError *)_mainDocumentError

--- a/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
@@ -132,6 +132,7 @@
 #import <WebCore/TextIndicator.h>
 #import <WebCore/TextUndoInsertionMarkupMac.h>
 #import <WebCore/WebCoreJITOperations.h>
+#import <WebCore/WebCoreMainThread.h>
 #import <WebCore/WebCoreNSFontManagerExtras.h>
 #import <WebCore/WebCoreObjCExtras.h>
 #import <WebCore/WebNSAttributedStringExtras.h>
@@ -1040,17 +1041,14 @@ static NSControlStateValue kit(TriState state)
 
 @implementation WebHTMLViewPrivate
 
-#if PLATFORM(MAC)
-
 + (void)initialize
 {
     // FIXME: Shouldn't all of this move into +[WebHTMLView initialize]?
     // And some of this work is likely redundant since +[WebHTMLView initialize] is guaranteed to run first.
 
-    JSC::initialize();
-    WTF::initializeMainThread();
-    WebCore::populateJITOperations();
+    WebCore::initializeMainThreadIfNeeded();
 
+#if PLATFORM(MAC)
     if (!oldSetCursorForMouseLocationIMP) {
         Method setCursorMethod = class_getInstanceMethod([NSWindow class], @selector(_setCursorForMouseLocation:));
         ASSERT(setCursorMethod);
@@ -1059,9 +1057,8 @@ static NSControlStateValue kit(TriState state)
     }
 
     method_exchangeImplementations(class_getInstanceMethod([NSView class], @selector(setNeedsDisplayInRect:)), class_getInstanceMethod([NSView class], @selector(_web_setNeedsDisplayInRect:)));
-}
-
 #endif
+}
 
 - (void)dealloc
 {
@@ -2545,18 +2542,14 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 @implementation WebHTMLView
 
-#if PLATFORM(MAC)
-
 + (void)initialize
 {
+#if PLATFORM(MAC)
     [NSApp registerServicesMenuSendTypes:[[self class] _selectionPasteboardTypes] returnTypes:[[self class] _insertablePasteboardTypes]];
-
-    JSC::initialize();
-    WTF::initializeMainThread();
-    WebCore::populateJITOperations();
-}
-
 #endif
+
+    WebCore::initializeMainThreadIfNeeded();
+}
 
 - (id)initWithFrame:(NSRect)frame
 {

--- a/Source/WebKitLegacy/mac/WebView/WebPreferences.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebPreferences.mm
@@ -46,6 +46,7 @@
 #import <WebCore/NetworkStorageSession.h>
 #import <WebCore/Settings.h>
 #import <WebCore/WebCoreJITOperations.h>
+#import <WebCore/WebCoreMainThread.h>
 #import <pal/spi/cf/CFNetworkSPI.h>
 #import <pal/text/TextEncodingRegistry.h>
 #import <wtf/BlockPtr.h>
@@ -383,11 +384,7 @@ public:
 // if we ever have more than one WebPreferences object, this would move to init
 + (void)initialize
 {
-#if PLATFORM(MAC)
-    JSC::initialize();
-    WTF::initializeMainThread();
-    WebCore::populateJITOperations();
-#endif
+    WebCore::initializeMainThreadIfNeeded();
 
     NSDictionary *dict = [NSDictionary dictionaryWithObjectsAndKeys:
         INITIALIZE_DEFAULT_PREFERENCES_DICTIONARY_FROM_GENERATED_PREFERENCES

--- a/Source/WebKitLegacy/mac/WebView/WebResource.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebResource.mm
@@ -39,6 +39,7 @@
 #import <WebCore/LegacyWebArchive.h>
 #import <WebCore/ThreadCheck.h>
 #import <WebCore/WebCoreJITOperations.h>
+#import <WebCore/WebCoreMainThread.h>
 #import <WebCore/WebCoreObjCExtras.h>
 #import <WebCore/WebCoreURLResponse.h>
 #import <pal/text/TextEncoding.h>
@@ -67,11 +68,7 @@ static NSString * const WebResourceResponseKey =          @"WebResourceResponse"
 
 + (void)initialize
 {
-#if !PLATFORM(IOS_FAMILY)
-    JSC::initialize();
-    WTF::initializeMainThread();
-    WebCore::populateJITOperations();
-#endif
+    WebCore::initializeMainThreadIfNeeded();
 }
 
 - (instancetype)init

--- a/Source/WebKitLegacy/mac/WebView/WebTextIterator.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebTextIterator.mm
@@ -31,6 +31,7 @@
 #import <WebCore/Range.h>
 #import <WebCore/TextIterator.h>
 #import <WebCore/WebCoreJITOperations.h>
+#import <WebCore/WebCoreMainThread.h>
 #import <wtf/MainThread.h>
 #import <wtf/RunLoop.h>
 #import <wtf/Vector.h>
@@ -46,11 +47,7 @@
 
 + (void)initialize
 {
-#if !PLATFORM(IOS_FAMILY)
-    JSC::initialize();
-    WTF::initializeMainThread();
-    WebCore::populateJITOperations();
-#endif
+    WebCore::initializeMainThreadIfNeeded();
 }
 
 @end

--- a/Source/WebKitLegacy/mac/WebView/WebViewData.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebViewData.mm
@@ -42,6 +42,7 @@
 #import <WebCore/RunLoopObserver.h>
 #import <WebCore/ValidationBubble.h>
 #import <WebCore/WebCoreJITOperations.h>
+#import <WebCore/WebCoreMainThread.h>
 #import <pal/spi/mac/NSWindowSPI.h>
 #import <wtf/MainThread.h>
 #import <wtf/RunLoop.h>
@@ -103,11 +104,7 @@ int pluginDatabaseClientCount = 0;
 
 + (void)initialize
 {
-#if !PLATFORM(IOS_FAMILY)
-    JSC::initialize();
-    WTF::initializeMainThread();
-    WebCore::populateJITOperations();
-#endif
+    WebCore::initializeMainThreadIfNeeded();
 }
 
 - (id)init 

--- a/Tools/DumpRenderTree/mac/DumpRenderTree.mm
+++ b/Tools/DumpRenderTree/mac/DumpRenderTree.mm
@@ -66,6 +66,7 @@
 #import <JavaScriptCore/TestRunnerUtils.h>
 #import <WebCore/LogInitialization.h>
 #import <WebCore/NetworkStorageSession.h>
+#import <WebCore/WebCoreMainThread.h>
 #import <WebKit/DOMElement.h>
 #import <WebKit/DOMExtensions.h>
 #import <WebKit/DOMRange.h>
@@ -1176,9 +1177,7 @@ void dumpRenderTree(int argc, const char *argv[])
     addTestPluginsToPluginSearchPath(argv[0]);
 
     JSC::Options::machExceptionHandlerSandboxPolicy = JSC::Options::SandboxPolicy::Allow;
-    JSC::initialize();
-    WTF::initializeMainThread();
-    WebCoreTestSupport::populateJITOperations();
+    WebCore::initializeMainThreadIfNeeded();
 
     if (forceComplexText)
         [WebView _setAlwaysUsesComplexTextCodePath:YES];

--- a/Tools/TestWebKitAPI/Tests/WebKitLegacy/ios/JSLockTakesWebThreadLock.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitLegacy/ios/JSLockTakesWebThreadLock.mm
@@ -49,12 +49,12 @@ TEST(WebKitLegacy, JSLockTakesWebThreadLock)
     EXPECT_TRUE(!!jsContext.get());
 
     RetainPtr<JSVirtualMachine> jsVM = [jsContext virtualMachine];
-    EXPECT_TRUE([jsVM isWebThreadAware]);
+    EXPECT_TRUE(!WebThreadIsEnabled() || [jsVM isWebThreadAware]);
 
     // Release WebThread lock.
     Util::spinRunLoop(1);
 
-    EXPECT_FALSE(WebThreadIsLocked());
+    EXPECT_FALSE(WebThreadIsEnabled() && WebThreadIsLocked());
     // XMLHttpRequest has Timer, which has thread afinity.
     [jsContext evaluateScript:@"for (var i = 0; i < 1e3; ++i) { var request = new XMLHttpRequest; request.property = new Array(10000); }"];
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitLegacy/ios/WebGLNoCrashOnOtherThreadAccess.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitLegacy/ios/WebGLNoCrashOnOtherThreadAccess.mm
@@ -132,7 +132,6 @@ TEST(WebKitLegacy, WebGLNoCrashOnOtherThreadAccess)
     RetainPtr<UIWebView> uiWebView = adoptNS([[UIWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [uiWindow addSubview:uiWebView.get()];
 
-    ASSERT_TRUE(WebThreadIsEnabled());
     SetContextCGL clientContextCGL1;
     SetContextEAGL clientContextEAGL1;
     UNUSED_VARIABLE(clientContextCGL1);
@@ -175,7 +174,7 @@ function runTestAsync()
 
     RetainPtr<JSContext> jsContext = [uiWebView valueForKeyPath:@"documentView.webView.mainFrame.javaScriptContext"];
     RetainPtr<JSVirtualMachine> jsVM = [jsContext virtualMachine];
-    EXPECT_TRUE([jsVM isWebThreadAware]);
+    EXPECT_TRUE(!WebThreadIsEnabled() || [jsVM isWebThreadAware]);
 
     // Start to run WebGL on web thread.
     [uiWebView stringByEvaluatingJavaScriptFromString:@"runTestAsync();"];

--- a/Tools/TestWebKitAPI/Tests/WebKitLegacy/ios/WebGLPrepareDisplayOnWebThread.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitLegacy/ios/WebGLPrepareDisplayOnWebThread.mm
@@ -93,12 +93,12 @@ TEST(WebKitLegacy, WebGLPrepareDisplayOnWebThread)
     EXPECT_TRUE(!!jsContext.get());
 
     RetainPtr<JSVirtualMachine> jsVM = [jsContext virtualMachine];
-    EXPECT_TRUE([jsVM isWebThreadAware]);
+    EXPECT_TRUE(!WebThreadIsEnabled() || [jsVM isWebThreadAware]);
 
     // Release WebThread lock.
     Util::spinRunLoop(1);
 
-    EXPECT_FALSE(WebThreadIsLocked());
+    EXPECT_FALSE(WebThreadIsEnabled() && WebThreadIsLocked());
 
     [jsContext evaluateScript:@"loadColorIntoTexture(128, 128, 255, 255)"];
     [jsContext evaluateScript:@"draw()"];


### PR DESCRIPTION
#### 038f40cdb52d8dd888549503a56cca3a1c692d45
<pre>
[iOS] Make it possible to use WebKit1 without a web thread
<a href="https://bugs.webkit.org/show_bug.cgi?id=176812">https://bugs.webkit.org/show_bug.cgi?id=176812</a>

Reviewed by Ryosuke Niwa.

Make it possible to use WebKit1 without a web thread.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/WebCoreMainThread.cpp: Added.
(WebCore::shouldUseWebThread):
(WebCore::initializeMainThreadIfNeeded):
* Source/WebCore/platform/WebCoreMainThread.h: Added.
* Source/WebCore/platform/ios/wak/WebCoreThread.mm:
(WebThreadIsLocked):
* Source/WebKitLegacy/mac/History/WebBackForwardList.mm:
(+[WebBackForwardList initialize]):
* Source/WebKitLegacy/mac/History/WebHistoryItem.mm:
(+[WebHistoryItem initialize]):
* Source/WebKitLegacy/mac/Misc/WebCache.mm:
(+[WebCache initialize]):
* Source/WebKitLegacy/mac/Misc/WebElementDictionary.mm:
(+[WebElementDictionary initialize]):
* Source/WebKitLegacy/mac/Misc/WebIconDatabase.mm:
* Source/WebKitLegacy/mac/Misc/WebStringTruncator.mm:
(+[WebStringTruncator initialize]):
* Source/WebKitLegacy/mac/Plugins/WebBasePluginPackage.mm:
(+[WebBasePluginPackage initialize]):
* Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.mm:
(+[WebUndoStep initialize]):
* Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm:
(+[WebFramePolicyListener initialize]):
* Source/WebKitLegacy/mac/WebView/WebArchive.mm:
(+[WebArchivePrivate initialize]):
* Source/WebKitLegacy/mac/WebView/WebDataSource.mm:
(+[WebDataSource initialize]):
(-[WebDataSource _mainDocumentError]): Deleted.
* Source/WebKitLegacy/mac/WebView/WebHTMLView.mm:
(+[WebHTMLViewPrivate initialize]):
(+[WebHTMLView initialize]):
* Source/WebKitLegacy/mac/WebView/WebPreferences.mm:
(+[WebPreferences initialize]):
* Source/WebKitLegacy/mac/WebView/WebResource.mm:
(+[WebResourcePrivate initialize]):
* Source/WebKitLegacy/mac/WebView/WebTextIterator.mm:
(+[WebTextIteratorPrivate initialize]):
* Source/WebKitLegacy/mac/WebView/WebView.mm:
(+[WebView enableWebThread]):
(+[WebView initialize]):
(-[WebView stopLoadingAndClear]):
* Source/WebKitLegacy/mac/WebView/WebViewData.mm:
(+[WebViewPrivate initialize]):
* Tools/DumpRenderTree/mac/DumpRenderTree.mm:
(dumpRenderTree):
* Tools/TestWebKitAPI/Tests/WebKitLegacy/ios/JSLockTakesWebThreadLock.mm:
(TestWebKitAPI::TEST(WebKitLegacy, JSLockTakesWebThreadLock)):
* Tools/TestWebKitAPI/Tests/WebKitLegacy/ios/WebGLNoCrashOnOtherThreadAccess.mm:
(TestWebKitAPI::TEST(WebKitLegacy, WebGLNoCrashOnOtherThreadAccess)):
* Tools/TestWebKitAPI/Tests/WebKitLegacy/ios/WebGLPrepareDisplayOnWebThread.mm:
(TestWebKitAPI::TEST(WebKitLegacy, WebGLPrepareDisplayOnWebThread)):

Canonical link: <a href="https://commits.webkit.org/300662@main">https://commits.webkit.org/300662@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af05ae2e8343816ee251ae318133123a8fc12f93

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123374 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43089 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33785 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130088 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/75498 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/39cb0b5b-dfaf-4fc8-9cf9-a4ca94876404) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/125251 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43812 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51683 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93781 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62222 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3c6c69bf-36a7-483e-82a6-3d78400c77e2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126327 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34908 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110382 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74409 "Found 2 new API test failures: TestWTF:WTF_Condition.OneProducerOneConsumerOneSlotTimeout, TestWTF:WTF_Condition.OneProducerOneConsumerOneSlot (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e0f8f5bc-8f5d-43fa-bfff-15197f7d60f0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33875 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28540 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73605 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104622 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28766 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132805 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50324 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38299 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102272 "Found 1 new test failure: imported/blink/fast/pagination/viewport-y-horizontal-bt-rtl.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50700 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106605 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102125 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25967 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47479 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25703 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/47114 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50179 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/55940 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49650 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53000 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51328 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->