### PR TITLE
[Skia][clang] Unreviewed: fix build

### DIFF
--- a/Source/WebCore/platform/graphics/skia/SkiaReplayCanvas.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaReplayCanvas.cpp
@@ -89,8 +89,8 @@ void SkiaReplayCanvas::invokeDrawFunctionWithPaint(const SkPaint& paint, Functio
     auto* shader = paint.getShader();
 
     SkMatrix localMatrix;
-    SkTileMode mode[2];
-    auto* image = shader ? shader->isAImage(&localMatrix, mode) : nullptr;
+    std::array<SkTileMode, 2> mode;
+    auto* image = shader ? shader->isAImage(&localMatrix, mode.data()) : nullptr;
     if (auto wrappedImage = waitForRenderingCompletionAndRewrapImageIfNeeded(image)) {
         // FIXME: There is no way to get the SkSamplingOptions that were used to create the original shader.
         // Add Skia API? (SkImageShader stores SkSamplingOptions but is private and not installed).
@@ -106,8 +106,8 @@ void SkiaReplayCanvas::invokeDrawFunctionWithPaint(const SkPaint& paint, Functio
 void SkiaReplayCanvas::invokeDrawFunctionWithShader(const SkShader* shader, Function<void(const SkShader*)>&& drawFunction)
 {
     SkMatrix localMatrix;
-    SkTileMode mode[2];
-    auto* image = shader ? shader->isAImage(&localMatrix, mode) : nullptr;
+    std::array<SkTileMode, 2> mode;
+    auto* image = shader ? shader->isAImage(&localMatrix, mode.data()) : nullptr;
     if (auto wrappedImage = waitForRenderingCompletionAndRewrapImageIfNeeded(image)) {
         // FIXME: There is no way to get the SkSamplingOptions that were used to create the original shader.
         // Add Skia API? (SkImageShader stores SkSamplingOptions but is private and not installed).


### PR DESCRIPTION
#### b8c4993c53d28ea67dc6f34615f9732c57dc14d4
<pre>
[Skia][clang] Unreviewed: fix build
<a href="https://bugs.webkit.org/show_bug.cgi?id=299593">https://bugs.webkit.org/show_bug.cgi?id=299593</a>

* Source/WebCore/platform/graphics/skia/SkiaReplayCanvas.cpp:
(WebCore::SkiaReplayCanvas::invokeDrawFunctionWithPaint):
(WebCore::SkiaReplayCanvas::invokeDrawFunctionWithShader):

Canonical link: <a href="https://commits.webkit.org/300565@main">https://commits.webkit.org/300565@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aed515b1358225b103ea841ff859e1eb53fb75e3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123115 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42829 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33526 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/129775 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/75226 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/124992 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43553 "Failed to checkout and rebase branch from PR 51377") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51424 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/93588 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/75226 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126066 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/130/builds/43553 "Failed to checkout and rebase branch from PR 51377") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/110189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/74221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/130/builds/43553 "Failed to checkout and rebase branch from PR 51377") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/28345 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73290 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/130/builds/43553 "Failed to checkout and rebase branch from PR 51377") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/28571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132503 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/50065 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/38119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/102084 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50441 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/106410 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/101937 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47309 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/25513 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/46838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19400 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49920 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/55681 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/49388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/52740 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/51069 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->