### PR TITLE
[Site Isolation] Clicking on the body of a frame to focus it should blur the active element

### DIFF
--- a/LayoutTests/http/tests/site-isolation/focus-click-navigation-activeElement-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/focus-click-navigation-activeElement-expected.txt
@@ -1,0 +1,21 @@
+Tests click navigation and Document.activeElement behavior with cross-origin iframes in site isolation mode
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS document.activeElement.tagName is 'BODY'
+PASS Initial state: inner Document.activeElement is BODY
+PASS document.activeElement.tagName is 'INPUT'
+PASS When outer input focused: outer Document.activeElement is INPUT
+PASS When outer input focused: inner Document.activeElement is BODY
+PASS Outer input blur handler fired
+PASS document.activeElement.tagName is 'IFRAME'
+PASS When inner input focused: outer Document.activeElement is IFRAME
+PASS Outer input blur handler was fired before inner input focus
+PASS When inner input focused: inner Document.activeElement is INPUT
+PASS successfullyParsed is true
+
+TEST COMPLETE
+This test verifies that Document.activeElement behaves correctly during click navigation between main frame and cross-origin iframe in site isolation mode.
+
+

--- a/LayoutTests/http/tests/site-isolation/focus-click-navigation-activeElement.html
+++ b/LayoutTests/http/tests/site-isolation/focus-click-navigation-activeElement.html
@@ -1,0 +1,137 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<html>
+<script src="/js-test-resources/js-test.js"></script>
+<script src="/js-test-resources/ui-helper.js"></script>
+<script>
+description("Tests click navigation and Document.activeElement behavior with cross-origin iframes in site isolation mode");
+jsTestIsAsync = true;
+
+let iframe;
+let outerInputBlurred = false;
+let innerInputFocused = false;
+let waitingForInnerFocusVerification = false;
+let innerFocusStateChecked = false;
+
+function checkInitialState() {
+    shouldBe("document.activeElement.tagName", "'BODY'");
+    iframe.contentWindow.postMessage({
+        type: 'checkActiveElement',
+        expected: 'BODY',
+        description: 'Initial state: inner Document.activeElement is BODY'
+    }, 'http://localhost:8000');
+}
+
+function checkInnerInputFocusState() {
+    if (innerFocusStateChecked)
+        return;
+    innerFocusStateChecked = true;
+
+    shouldBe("document.activeElement.tagName", "'IFRAME'");
+    testPassed("When inner input focused: outer Document.activeElement is IFRAME");
+
+    if (outerInputBlurred)
+        testPassed("Outer input blur handler was fired before inner input focus");
+    else
+        testFailed("Outer input blur handler was NOT fired before inner input focus");
+
+    iframe.contentWindow.postMessage({
+        type: 'checkActiveElement',
+        expected: 'INPUT',
+        description: 'When inner input focused: inner Document.activeElement is INPUT'
+    }, 'http://localhost:8000');
+
+    waitingForInnerFocusVerification = false;
+}
+
+function tryCheckInnerFocusState() {
+    if (innerInputFocused && outerInputBlurred && waitingForInnerFocusVerification)
+        checkInnerInputFocusState();
+}
+
+async function handleMessage(event) {
+    if (event.data.type === 'activeElementCheck') {
+        if (event.data.success)
+            testPassed(event.data.message);
+        else
+            testFailed(event.data.message);
+
+        if (event.data.message.includes('Initial state'))
+            await UIHelper.activateElement(document.getElementById('outerInput'));
+        else if (event.data.message.includes('When outer input focused')) {
+            const iframeRect = iframe.getBoundingClientRect();
+            const clickX = iframeRect.left + 100;
+            const clickY = iframeRect.top + 60;
+            await UIHelper.activateAt(clickX, clickY);
+        }
+
+    } else if (event.data.type === 'innerInputFocused') {
+        innerInputFocused = true;
+        waitingForInnerFocusVerification = true;
+        tryCheckInnerFocusState();
+    } else if (event.data.type === 'finalCheck') {
+        if (event.data.success)
+            testPassed(event.data.message);
+        else
+            testFailed(event.data.message);
+
+        finishJSTest();
+    }
+}
+
+function onOuterInputFocus() {
+    shouldBe("document.activeElement.tagName", "'INPUT'");
+    testPassed("When outer input focused: outer Document.activeElement is INPUT");
+
+    iframe.contentWindow.postMessage({
+        type: 'checkActiveElement',
+        expected: 'BODY',
+        description: 'When outer input focused: inner Document.activeElement is BODY'
+    }, 'http://localhost:8000');
+}
+
+function onOuterInputBlur() {
+    outerInputBlurred = true;
+    testPassed("Outer input blur handler fired");
+    tryCheckInnerFocusState();
+}
+</script>
+
+<body>
+<p>This test verifies that Document.activeElement behaves correctly during click navigation between main frame and cross-origin iframe in site isolation mode.</p>
+
+<input type="text" id="outerInput" placeholder="Outer frame input">
+<iframe id="testIframe" src="http://localhost:8000/site-isolation/resources/focus-click-navigation-iframe.html" onload="onIframeLoad()"></iframe>
+
+<script>
+let testStarted = false;
+
+async function onIframeLoad() {
+      if (testStarted)
+        return;
+
+      if (!iframe)
+          await setupTest();
+
+      testStarted = true;
+      checkInitialState();
+}
+
+async function setupTest() {
+    iframe = document.getElementById('testIframe');
+
+    testRunner?.dumpAsText();
+
+    await UIHelper.setHardwareKeyboardAttached(true);
+
+    window.addEventListener('message', handleMessage);
+
+    document.getElementById('outerInput').addEventListener('focus', onOuterInputFocus);
+    document.getElementById('outerInput').addEventListener('blur', onOuterInputBlur);
+}
+
+window.addEventListener('load', async () => {
+    await setupTest();
+});
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/focus-tab-navigation-activeElement.html
+++ b/LayoutTests/http/tests/site-isolation/focus-tab-navigation-activeElement.html
@@ -10,6 +10,7 @@ let iframe;
 let outerInputBlurred = false;
 let innerInputFocused = false;
 let waitingForInnerFocusVerification = false;
+let innerFocusStateChecked = false;
 
 function checkInitialState() {
     shouldBe("document.activeElement.tagName", "'BODY'");
@@ -21,6 +22,10 @@ function checkInitialState() {
 }
 
 function checkInnerInputFocusState() {
+    if (innerFocusStateChecked)
+        return;
+    innerFocusStateChecked = true;
+
     shouldBe("document.activeElement.tagName", "'IFRAME'");
     testPassed("When inner input focused: outer Document.activeElement is IFRAME");
 
@@ -94,11 +99,17 @@ function onOuterInputBlur() {
 <iframe id="testIframe" src="http://localhost:8000/site-isolation/resources/focus-tab-navigation-iframe.html" onload="onIframeLoad()"></iframe>
 
 <script>
-async function onIframeLoad() {
-    if (!iframe)
-        await setupTest();
+let testStarted = false;
 
-    checkInitialState();
+async function onIframeLoad() {
+      if (testStarted)
+        return;
+
+      if (!iframe)
+          await setupTest();
+
+      testStarted = true;
+      checkInitialState();
 }
 
 async function setupTest() {

--- a/LayoutTests/http/tests/site-isolation/resources/focus-click-navigation-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/resources/focus-click-navigation-iframe.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+<script>
+function handleMessage(event) {
+    if (event.data.type === 'checkActiveElement') {
+        let activeElement = document.activeElement;
+        let activeElementTag = activeElement ? activeElement.tagName : 'null';
+        let expected = event.data.expected;
+        let description = event.data.description || `Inner Document.activeElement is ${expected}`;
+
+        let success = activeElementTag === expected;
+        let message = success ? description : `Expected inner activeElement to be ${expected}, but was ${activeElementTag}`;
+
+        let messageType = description.includes('When inner input focused') ? 'finalCheck' : 'activeElementCheck';
+
+        event.source.postMessage({
+            type: messageType,
+            success: success,
+            message: message
+        }, event.origin);
+    }
+}
+
+function onInnerInputFocus() {
+    let activeElement = document.activeElement;
+    let activeElementTag = activeElement ? activeElement.tagName : 'null';
+
+    if (activeElementTag === 'INPUT') {
+        parent.postMessage({
+            type: 'innerInputFocused'
+        }, '*');
+    }
+}
+
+window.addEventListener('message', handleMessage);
+window.addEventListener('load', function() {
+    document.getElementById('innerInput').addEventListener('focus', onInnerInputFocus);
+});
+</script>
+
+<body>
+<p>Inner frame content</p>
+<input type="text" id="innerInput" placeholder="Inner frame input">
+</body>
+</html>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8262,6 +8262,10 @@ webkit.org/b/298974 fast/forms/ios/keyboard-restoration-after-element-replacemen
 
 webkit.org/b/280234 imported/w3c/web-platform-tests/html/dom/idlharness.https.html? [ Skip ]
 
-webkit.org/b/299501 http/tests/site-isolation/focus-tab-navigation-activeElement.html [ Pass Failure ]
+webkit.org/b/299567 editing/text-iterator/hidden-textarea-selection-quirk.html [ Timeout ]
 
 webkit.org/b/299811 fast/images/background-image-size-changes-fractional-position.html [ ImageOnlyFailure ]
+
+webkit.org/b/299501 http/tests/site-isolation/focus-tab-navigation-activeElement.html [ Pass Failure ]
+
+webkit.org/b/299501 http/tests/site-isolation/focus-click-navigation-activeElement.html [ Pass Failure ]

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2038,6 +2038,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     page/EventHandler.h
     page/EventTimingInteractionID.h
     page/FocusController.h
+    page/FocusControllerTypes.h
     page/FocusDirection.h
     page/FocusEventData.h
     page/FragmentDirective.h

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -6352,12 +6352,12 @@ void Document::invalidateRenderingDependentRegions()
 #endif
 }
 
-bool Document::setFocusedElement(Element* element)
+bool Document::setFocusedElement(Element* element, BroadcastFocusedElement broadcast)
 {
-    return setFocusedElement(element, { });
+    return setFocusedElement(element, { }, broadcast);
 }
 
-bool Document::setFocusedElement(Element* newFocusedElement, const FocusOptions& options)
+bool Document::setFocusedElement(Element* newFocusedElement, const FocusOptions& options, BroadcastFocusedElement broadcast)
 {
     // Make sure newFocusedElement is actually in this document
     if (newFocusedElement && (&newFocusedElement->document() != this))
@@ -6519,7 +6519,7 @@ bool Document::setFocusedElement(Element* newFocusedElement, const FocusOptions&
     }
 
     if (RefPtr page = this->page())
-        page->chrome().focusedElementChanged(protectedFocusedElement().get());
+        page->chrome().focusedElementChanged(protectedFocusedElement().get(), page->focusController().focusedLocalFrame(), options, broadcast);
 
     return true;
 }

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -34,6 +34,7 @@
 #include <WebCore/DocumentClasses.h>
 #include <WebCore/DocumentEnums.h>
 #include <WebCore/DocumentEventTiming.h>
+#include <WebCore/FocusControllerTypes.h>
 #include <WebCore/FontSelectorClient.h>
 #include <WebCore/FrameDestructionObserver.h>
 #include <WebCore/FrameIdentifier.h>
@@ -951,8 +952,8 @@ public:
     MouseEventWithHitTestResults prepareMouseEvent(const HitTestRequest&, const LayoutPoint&, const PlatformMouseEvent&);
     // Returns whether focus was blocked. A true value does not necessarily mean the element was focused.
     // The element could have already been focused or may not be focusable (e.g. <input disabled>).
-    WEBCORE_EXPORT bool setFocusedElement(Element*);
-    WEBCORE_EXPORT bool setFocusedElement(Element*, const FocusOptions&);
+    WEBCORE_EXPORT bool setFocusedElement(Element*, BroadcastFocusedElement = BroadcastFocusedElement::Yes);
+    WEBCORE_EXPORT bool setFocusedElement(Element*, const FocusOptions&, BroadcastFocusedElement = BroadcastFocusedElement::Yes);
     Element* focusedElement() const { return m_focusedElement.get(); }
     inline RefPtr<Element> protectedFocusedElement() const; // Defined in DocumentInlines.h.
     inline bool wasLastFocusByClick() const;

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -4174,7 +4174,7 @@ void Element::focus(const FocusOptions& options)
         // Focus and change event handlers can cause us to lose our last ref.
         // If a focus event handler changes the focus to a different node it
         // does not make sense to continue and update appearence.
-        if (!page->focusController().setFocusedElement(newTarget.get(), frame, optionsWithVisibility))
+        if (!page->focusController().setFocusedElement(newTarget.get(), frame.ptr(), optionsWithVisibility))
             return;
     }
 
@@ -4242,7 +4242,7 @@ void Element::blur()
 {
     if (treeScope().focusedElementInScope() == this) {
         if (RefPtr frame = document().frame())
-            frame->protectedPage()->focusController().setFocusedElement(nullptr, *frame);
+            frame->protectedPage()->focusController().setFocusedElement(nullptr, frame.get());
         else
             protectedDocument()->setFocusedElement(nullptr);
     }

--- a/Source/WebCore/editing/FrameSelection.cpp
+++ b/Source/WebCore/editing/FrameSelection.cpp
@@ -2487,8 +2487,7 @@ void FrameSelection::setFocusedElementIfNeeded(OptionSet<SetSelectionOption> opt
     if (caretBrowsing) {
         if (RefPtr anchor = enclosingAnchorElement(m_selection.base())) {
             CheckedRef focusController { document->page()->focusController() };
-            Ref frame = *document->frame();
-            focusController->setFocusedElement(anchor.get(), frame);
+            focusController->setFocusedElement(anchor.get(), document->protectedFrame().get());
             return;
         }
     }
@@ -2503,7 +2502,7 @@ void FrameSelection::setFocusedElementIfNeeded(OptionSet<SetSelectionOption> opt
                 FocusOptions focusOptions;
                 if (options & SetSelectionOption::ForBindings)
                     focusOptions.trigger = FocusTrigger::Bindings;
-                document->protectedPage()->focusController().setFocusedElement(target.get(), *document->protectedFrame(), focusOptions);
+                document->protectedPage()->focusController().setFocusedElement(target.get(), document->protectedFrame().get(), focusOptions);
                 return;
             }
             target = target->parentOrShadowHostElement();
@@ -2512,7 +2511,7 @@ void FrameSelection::setFocusedElementIfNeeded(OptionSet<SetSelectionOption> opt
     }
 
     if (caretBrowsing)
-        document->protectedPage()->focusController().setFocusedElement(nullptr, *document->protectedFrame());
+        document->protectedPage()->focusController().setFocusedElement(nullptr, document->protectedFrame().get());
 }
 
 void DragCaretController::paintDragCaret(LocalFrame* frame, GraphicsContext& p, const LayoutPoint& paintOffset) const

--- a/Source/WebCore/editing/cocoa/AutofillElements.cpp
+++ b/Source/WebCore/editing/cocoa/AutofillElements.cpp
@@ -27,6 +27,7 @@
 #include "AutofillElements.h"
 
 #include "FocusController.h"
+#include "FocusControllerTypes.h"
 #include "Logging.h"
 #include "Page.h"
 #include <wtf/TZoneMallocInlines.h>

--- a/Source/WebCore/loader/EmptyClients.h
+++ b/Source/WebCore/loader/EmptyClients.h
@@ -47,6 +47,8 @@ class DiagnosticLoggingClient;
 class EditorClient;
 class HTMLImageElement;
 class PageConfiguration;
+enum class BroadcastFocusedElement : bool;
+struct FocusOptions;
 
 class EmptyChromeClient : public ChromeClient {
     WTF_MAKE_TZONE_ALLOCATED(EmptyChromeClient);
@@ -64,7 +66,7 @@ class EmptyChromeClient : public ChromeClient {
     bool canTakeFocus(FocusDirection) const final { return false; }
     void takeFocus(FocusDirection) final { }
 
-    void focusedElementChanged(Element*) final { }
+    void focusedElementChanged(Element*, LocalFrame*, FocusOptions, BroadcastFocusedElement) final { }
     void focusedFrameChanged(Frame*) final { }
 
     RefPtr<Page> createWindow(LocalFrame&, const String&, const WindowFeatures&, const NavigationAction&) final { return nullptr; }

--- a/Source/WebCore/page/Chrome.cpp
+++ b/Source/WebCore/page/Chrome.cpp
@@ -42,6 +42,8 @@
 #include "FaceDetectorInterface.h"
 #include "FileList.h"
 #include "FloatRect.h"
+#include "FocusControllerTypes.h"
+#include "FocusOptions.h"
 #include "FrameLoader.h"
 #include "FrameTree.h"
 #include "Geolocation.h"
@@ -203,9 +205,9 @@ void Chrome::takeFocus(FocusDirection direction)
     m_client->takeFocus(direction);
 }
 
-void Chrome::focusedElementChanged(Element* element)
+void Chrome::focusedElementChanged(Element* element, LocalFrame* frame, FocusOptions options, BroadcastFocusedElement broadcast)
 {
-    m_client->focusedElementChanged(element);
+    m_client->focusedElementChanged(element, frame, options, broadcast);
 }
 
 void Chrome::focusedFrameChanged(Frame* frame)

--- a/Source/WebCore/page/Chrome.h
+++ b/Source/WebCore/page/Chrome.h
@@ -54,6 +54,7 @@ namespace WebGPU {
 class GPU;
 }
 
+enum class BroadcastFocusedElement : bool;
 enum class PlatformEventModifier : uint8_t;
 enum class TextDirection : bool;
 
@@ -85,6 +86,7 @@ class WorkerClient;
 struct AppHighlight;
 struct ContactInfo;
 struct ContactsRequestData;
+struct FocusOptions;
 struct ShareDataWithParsedURL;
 struct ViewportArguments;
 struct WindowFeatures;
@@ -163,7 +165,7 @@ public:
     bool canTakeFocus(FocusDirection) const;
     void takeFocus(FocusDirection);
 
-    void focusedElementChanged(Element*);
+    void focusedElementChanged(Element*, LocalFrame*, FocusOptions, BroadcastFocusedElement);
     void focusedFrameChanged(Frame*);
 
     WEBCORE_EXPORT RefPtr<Page> createWindow(LocalFrame&, const String& openedMainFrameName, const WindowFeatures&, const NavigationAction&);

--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -164,6 +164,7 @@ enum class ActivityStateForCPUSampling : uint8_t;
 enum class AXLoadingEvent : uint8_t;
 enum class AXNotification : uint8_t;
 enum class AXTextChange : uint8_t;
+enum class BroadcastFocusedElement : bool;
 enum class CookieConsentDecisionResult : uint8_t;
 enum class DidFilterLinkDecoration : bool { No, Yes };
 enum class IsLoggedIn : uint8_t;
@@ -216,7 +217,7 @@ public:
     virtual bool canTakeFocus(FocusDirection) const = 0;
     virtual void takeFocus(FocusDirection) = 0;
 
-    virtual void focusedElementChanged(Element*) = 0;
+    virtual void focusedElementChanged(Element*, LocalFrame*, FocusOptions, BroadcastFocusedElement) = 0;
     virtual void focusedFrameChanged(Frame*) = 0;
 
     // The Frame pointer provides the ChromeClient with context about which

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -3333,7 +3333,7 @@ bool EventHandler::dispatchMouseEvent(const AtomString& eventType, Node* targetN
 
     // If focus shift is blocked, we eat the event.
     RefPtr page = frame->page();
-    if (page && !page->focusController().setFocusedElement(element.get(), protectedFrame(), { { }, { }, { }, FocusTrigger::Click, { } }))
+    if (page && !page->focusController().setFocusedElement(element.get(), protectedFrame().ptr(), { { }, { }, { }, FocusTrigger::Click, { } }))
         return false;
 
     if (element && m_mouseDownDelegatedFocus)

--- a/Source/WebCore/page/FocusController.h
+++ b/Source/WebCore/page/FocusController.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <WebCore/ActivityState.h>
+#include <WebCore/FocusControllerTypes.h>
 #include <WebCore/FocusOptions.h>
 #include <WebCore/LayoutRect.h>
 #include <WebCore/LocalFrame.h>
@@ -51,23 +52,12 @@ class TreeScope;
 struct FocusCandidate;
 struct FocusEventData;
 
-enum class ContinuedSearchInRemoteFrame : bool { No, Yes };
-enum class FoundElementInRemoteFrame : bool { No, Yes };
-enum class RelinquishedFocusToChrome : bool { No, Yes };
-
-struct FocusableElementSearchResult {
-    RefPtr<Element> element;
-    ContinuedSearchInRemoteFrame continuedSearchInRemoteFrame { ContinuedSearchInRemoteFrame::No };
-    RelinquishedFocusToChrome relinquishedFocusToChrome { RelinquishedFocusToChrome::No };
-};
-
 class FocusController final : public CanMakeCheckedPtr<FocusController> {
     WTF_MAKE_TZONE_ALLOCATED(FocusController);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FocusController);
 public:
     explicit FocusController(Page&, OptionSet<ActivityState>);
 
-    enum class BroadcastFocusedFrame : bool { No, Yes };
     WEBCORE_EXPORT void setFocusedFrame(Frame*, BroadcastFocusedFrame = BroadcastFocusedFrame::Yes);
     Frame* focusedFrame() const { return m_focusedFrame.get(); }
     LocalFrame* focusedLocalFrame() const { return dynamicDowncast<LocalFrame>(m_focusedFrame.get()); }
@@ -77,7 +67,7 @@ public:
     WEBCORE_EXPORT bool setInitialFocus(FocusDirection, KeyboardEvent*);
     bool advanceFocus(FocusDirection, KeyboardEvent*, bool initialFocus = false);
 
-    WEBCORE_EXPORT bool setFocusedElement(Element*, LocalFrame&, const FocusOptions& = { });
+    WEBCORE_EXPORT bool setFocusedElement(Element*, Frame*, const FocusOptions& = { }, BroadcastFocusedElement = BroadcastFocusedElement::Yes);
 
     void setActivityState(OptionSet<ActivityState>);
 
@@ -144,6 +134,7 @@ private:
 
     WeakRef<Page> m_page;
     WeakPtr<Frame> m_focusedFrame;
+    WeakPtr<LocalFrame> m_focusedFrameBeforeRemoteFocusBroadcast;
     bool m_isChangingFocusedFrame;
     OptionSet<ActivityState> m_activityState;
 

--- a/Source/WebCore/page/FocusControllerTypes.h
+++ b/Source/WebCore/page/FocusControllerTypes.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/Element.h>
+#include <wtf/Forward.h>
+
+namespace WebCore {
+
+enum class BroadcastFocusedFrame : bool { No, Yes };
+enum class BroadcastFocusedElement : bool { No, Yes };
+enum class ContinuedSearchInRemoteFrame : bool { No, Yes };
+enum class FoundElementInRemoteFrame : bool { No, Yes };
+enum class RelinquishedFocusToChrome : bool { No, Yes };
+
+struct FocusableElementSearchResult {
+    RefPtr<Element> element;
+    ContinuedSearchInRemoteFrame continuedSearchInRemoteFrame { ContinuedSearchInRemoteFrame::No };
+    RelinquishedFocusToChrome relinquishedFocusToChrome { RelinquishedFocusToChrome::No };
+};
+
+} // namespace WebCore

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -1069,7 +1069,7 @@ def headers_for_type(type, for_implementation_file=False):
         'WebCore::FontPlatformDataAttributes': ['<WebCore/FontPlatformData.h>'],
         'WebCore::FontCustomPlatformSerializedData': ['<WebCore/FontCustomPlatformData.h>'],
         'WebCore::FontSmoothingMode': ['<WebCore/GraphicsTypes.h>'],
-        'WebCore::FoundElementInRemoteFrame': ['<WebCore/FocusController.h>'],
+        'WebCore::FoundElementInRemoteFrame': ['<WebCore/FocusControllerTypes.h>'],
         'WebCore::FragmentedSharedBuffer': ['<WebCore/SharedBuffer.h>'],
         'WebCore::FrameIdentifierID': ['"GeneratedSerializers.h"'],
         'WebCore::FrameLoadType': ['<WebCore/FrameLoaderTypes.h>'],

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -9402,7 +9402,7 @@ struct WebCore::HostingContext {
 #endif
 }
 
-header: <WebCore/FocusController.h>
+header: <WebCore/FocusControllerTypes.h>
 enum class WebCore::FoundElementInRemoteFrame : bool;
 
 struct WebCore::FocusEventData {
@@ -9452,3 +9452,36 @@ header: <WebCore/ImageAnalysisQueue.h>
     String target;
 };
 #endif
+
+enum class WebCore::SelectionRestorationMode : uint8_t {
+    RestoreOrSelectAll,
+    SelectAll,
+    PlaceCaretAtStart,
+};
+
+header: <WebCore/FocusOptions.h>
+[CustomHeader] enum class WebCore::FocusRemovalEventsMode : bool;
+
+header: <WebCore/FocusOptions.h>
+[CustomHeader] enum class WebCore::FocusTrigger : uint8_t {
+    Other,
+    Click,
+    Bindings
+};
+
+header: <WebCore/FocusOptions.h>
+[CustomHeader] enum class WebCore::FocusVisibility : uint8_t {
+    Invisible,
+    Visible,
+    ForceInvisible
+};
+
+struct WebCore::FocusOptions {
+    WebCore::SelectionRestorationMode selectionRestorationMode;
+    WebCore::FocusDirection direction;
+    WebCore::FocusRemovalEventsMode removalEventsMode;
+    WebCore::FocusTrigger trigger;
+    WebCore::FocusVisibility visibility;
+    bool preventScroll;
+    std::optional<bool> focusVisible;
+};

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -56,6 +56,7 @@
 #include "WebsiteDataStore.h"
 #include "WebsitePoliciesData.h"
 #include <WebCore/FocusController.h>
+#include <WebCore/FocusControllerTypes.h>
 #include <WebCore/FocusEventData.h>
 #include <WebCore/FrameTreeSyncData.h>
 #include <WebCore/Image.h>

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -271,6 +271,7 @@ struct DragItem;
 struct ElementContext;
 struct ExceptionDetails;
 struct FileChooserSettings;
+struct FocusOptions;
 struct FontAttributes;
 struct FrameIdentifierType;
 struct GrammarDetail;
@@ -3153,6 +3154,7 @@ private:
     static WebCore::ScreenOrientationType toScreenOrientationType(WebCore::IntDegrees);
 #endif
 
+    void focusedElementChanged(IPC::Connection&, const std::optional<WebCore::FrameIdentifier>&, WebCore::FocusOptions);
     void focusedFrameChanged(IPC::Connection&, const std::optional<WebCore::FrameIdentifier>&);
 
     void didFinishLoadingDataForCustomContentProvider(String&& suggestedFilename, std::span<const uint8_t>);

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -42,6 +42,7 @@ messages -> WebPageProxy {
     SetFocus(bool focused)
     TakeFocus(enum:uint8_t WebCore::FocusDirection direction)
     FocusFromServiceWorker() -> ()
+    FocusedElementChanged(std::optional<WebCore::FrameIdentifier> frameID, struct WebCore::FocusOptions options)
     FocusedFrameChanged(std::optional<WebCore::FrameIdentifier> frameID)
     SetRenderTreeSize(uint64_t treeSize)
     SetIsResizable(bool isResizable)

--- a/Source/WebKit/WebProcess/Plugins/PluginView.cpp
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.cpp
@@ -947,7 +947,7 @@ void PluginView::focusPluginElement()
 
     Ref pluginElement = m_pluginElement;
     if (RefPtr page = frame->page())
-        page->focusController().setFocusedElement(pluginElement.ptr(), *frame);
+        page->focusController().setFocusedElement(pluginElement.ptr(), frame.get());
     else
         frame->protectedDocument()->setFocusedElement(pluginElement.ptr());
 }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -34,12 +34,14 @@
 namespace WebCore {
 class HTMLImageElement;
 class RegistrableDomain;
+enum class BroadcastFocusedElement : bool;
 enum class CookieConsentDecisionResult : uint8_t;
 enum class DidFilterLinkDecoration : bool;
 enum class IsLoggedIn : uint8_t;
 enum class PointerLockRequestResult : uint8_t;
 enum class StorageAccessPromptWasShown : bool;
 enum class StorageAccessWasGranted : uint8_t;
+struct FocusOptions;
 struct SystemPreviewInfo;
 struct TextRecognitionOptions;
 }
@@ -80,7 +82,7 @@ private:
     bool canTakeFocus(WebCore::FocusDirection) const final;
     void takeFocus(WebCore::FocusDirection) final;
 
-    void focusedElementChanged(WebCore::Element*) final;
+    void focusedElementChanged(WebCore::Element*, WebCore::LocalFrame*, WebCore::FocusOptions, WebCore::BroadcastFocusedElement) final;
     void focusedFrameChanged(WebCore::Frame*) final;
 
     // The Frame pointer provides the ChromeClient with context about which

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp
@@ -31,6 +31,7 @@
 #include "WebFrameProxyMessages.h"
 #include "WebPage.h"
 #include "WebPageProxyMessages.h"
+#include <WebCore/FocusControllerTypes.h>
 #include <WebCore/FrameInlines.h>
 #include <WebCore/FrameLoadRequest.h>
 #include <WebCore/FrameTree.h>

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -72,6 +72,7 @@
 #include <WebCore/EventHandler.h>
 #include <WebCore/File.h>
 #include <WebCore/FocusController.h>
+#include <WebCore/FocusControllerTypes.h>
 #include <WebCore/FocusEventData.h>
 #include <WebCore/FrameLoader.h>
 #include <WebCore/FrameSnapshotting.h>
@@ -427,7 +428,7 @@ void WebFrame::loadDidCommitInAnotherProcess(std::optional<WebCore::LayerHosting
     m_coreFrame = newFrame.get();
 
     if (corePage->focusController().focusedFrame() == localFrame.get())
-        corePage->focusController().setFocusedFrame(newFrame.ptr(), FocusController::BroadcastFocusedFrame::No);
+        corePage->focusController().setFocusedFrame(newFrame.ptr(), WebCore::BroadcastFocusedFrame::No);
 
     localFrame->loader().detachFromParent();
 
@@ -524,7 +525,7 @@ void WebFrame::commitProvisionalFrame()
         document->didBecomeCurrentDocumentInFrame();
 
     if (corePage->focusController().focusedFrame() == remoteFrame.get())
-        corePage->focusController().setFocusedFrame(localFrame.get(), FocusController::BroadcastFocusedFrame::No);
+        corePage->focusController().setFocusedFrame(localFrame.get(), WebCore::BroadcastFocusedFrame::No);
 
     if (ownerElement)
         ownerElement->scheduleInvalidateStyleAndLayerComposition();

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -219,6 +219,8 @@
 #include <WebCore/ExceptionCode.h>
 #include <WebCore/File.h>
 #include <WebCore/FocusController.h>
+#include <WebCore/FocusControllerTypes.h>
+#include <WebCore/FocusOptions.h>
 #include <WebCore/FontAttributeChanges.h>
 #include <WebCore/FontAttributes.h>
 #include <WebCore/FormState.h>
@@ -10128,12 +10130,20 @@ void WebPage::dispatchLoadEventToFrameOwnerElement(WebCore::FrameIdentifier fram
         ownerElement->dispatchEvent(Event::create(eventNames().loadEvent, Event::CanBubble::No, Event::IsCancelable::No));
 }
 
+void WebPage::elementWasFocusedInAnotherProcess(WebCore::FrameIdentifier frameID, WebCore::FocusOptions options)
+{
+    RefPtr frame = WebProcess::singleton().webFrame(frameID);
+    if (!frame)
+        return;
+    protectedCorePage()->focusController().setFocusedElement(nullptr, frame->protectedCoreFrame().get(), options, WebCore::BroadcastFocusedElement::No);
+}
+
 void WebPage::frameWasFocusedInAnotherProcess(WebCore::FrameIdentifier frameID)
 {
     RefPtr frame = WebProcess::singleton().webFrame(frameID);
     if (!frame)
         return;
-    protectedCorePage()->focusController().setFocusedFrame(frame->protectedCoreFrame().get(), FocusController::BroadcastFocusedFrame::No);
+    protectedCorePage()->focusController().setFocusedFrame(frame->protectedCoreFrame().get(), WebCore::BroadcastFocusedFrame::No);
 }
 
 void WebPage::remotePostMessage(WebCore::FrameIdentifier source, const String& sourceOrigin, WebCore::FrameIdentifier target, std::optional<WebCore::SecurityOriginData>&& targetOrigin, const WebCore::MessageWithMessagePorts& message)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -293,6 +293,7 @@ struct DictationContextType;
 struct ElementContext;
 struct ExceptionData;
 struct ExceptionDetails;
+struct FocusOptions;
 struct FontAttributes;
 struct GlobalFrameIdentifier;
 struct GlobalWindowIdentifier;
@@ -2570,6 +2571,7 @@ private:
 
     void dispatchLoadEventToFrameOwnerElement(WebCore::FrameIdentifier);
 
+    void elementWasFocusedInAnotherProcess(WebCore::FrameIdentifier, WebCore::FocusOptions);
     void frameWasFocusedInAnotherProcess(WebCore::FrameIdentifier);
 
 #if ENABLE(WRITING_TOOLS)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -810,6 +810,7 @@ messages -> WebPage WantsAsyncDispatchMessage {
 
     DispatchLoadEventToFrameOwnerElement(WebCore::FrameIdentifier frameID)
 
+    ElementWasFocusedInAnotherProcess(WebCore::FrameIdentifier frameID, struct WebCore::FocusOptions options)
     FrameWasFocusedInAnotherProcess(WebCore::FrameIdentifier frameID)
 
     RemotePostMessage(WebCore::FrameIdentifier source, String sourceOrigin, WebCore::FrameIdentifier target, std::optional<WebCore::SecurityOriginData> targetOrigin, struct WebCore::MessageWithMessagePorts message)

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -101,6 +101,7 @@
 #import <WebCore/File.h>
 #import <WebCore/FloatQuad.h>
 #import <WebCore/FocusController.h>
+#import <WebCore/FocusControllerTypes.h>
 #import <WebCore/FontCache.h>
 #import <WebCore/FontCacheCoreText.h>
 #import <WebCore/GeometryUtilities.h>
@@ -6133,7 +6134,7 @@ void WebPage::focusTextInputContextAndPlaceCaret(const ElementContext& elementCo
     // because we only want to do so if the caret can be placed.
     UserGestureIndicator gestureIndicator { IsProcessingUserGesture::Yes, &target->document() };
     SetForScope userIsInteractingChange { m_userIsInteracting, true };
-    protectedCorePage()->focusController().setFocusedElement(target.get(), targetFrame);
+    protectedCorePage()->focusController().setFocusedElement(target.get(), targetFrame.ptr());
 
     // Setting the focused element could tear down the element's renderer. Check that we still have one.
     if (m_focusedElement != target || !target->renderer()) {

--- a/Source/WebKitLegacy/ios/WebCoreSupport/WebChromeClientIOS.h
+++ b/Source/WebKitLegacy/ios/WebCoreSupport/WebChromeClientIOS.h
@@ -28,6 +28,12 @@
 #import "WebChromeClient.h"
 #import <wtf/TZoneMalloc.h>
 
+namespace WebCore {
+enum class BroadcastFocusedElement : bool;
+class Frame;
+struct FocusOptions;
+}
+
 class WebChromeClientIOS final : public WebChromeClient {
     WTF_MAKE_TZONE_ALLOCATED(WebChromeClientIOS);
 public:
@@ -100,7 +106,7 @@ private:
     RefPtr<WebCore::SearchPopupMenu> createSearchPopupMenu(WebCore::PopupMenuClient&) const final;
     void relayAccessibilityNotification(String&&, RetainPtr<NSData>&&) const final { }
     void webAppOrientationsUpdated() final;
-    void focusedElementChanged(WebCore::Element*) final;
+    void focusedElementChanged(WebCore::Element*, WebCore::LocalFrame*, WebCore::FocusOptions, WebCore::BroadcastFocusedElement) final;
     void showPlaybackTargetPicker(bool hasVideo, WebCore::RouteSharingPolicy, const String&) final;
     RefPtr<WebCore::Icon> createIconForFiles(const Vector<String>& filenames) final;
 

--- a/Source/WebKitLegacy/ios/WebCoreSupport/WebChromeClientIOS.mm
+++ b/Source/WebKitLegacy/ios/WebCoreSupport/WebChromeClientIOS.mm
@@ -48,6 +48,9 @@
 #import <WebCore/DisabledAdaptations.h>
 #import <WebCore/FileChooser.h>
 #import <WebCore/FloatRect.h>
+#import <WebCore/FocusControllerTypes.h>
+#import <WebCore/FocusOptions.h>
+#import <WebCore/Frame.h>
 #import <WebCore/FrameDestructionObserverInlines.h>
 #import <WebCore/GraphicsLayer.h>
 #import <WebCore/HTMLInputElement.h>
@@ -363,7 +366,7 @@ void WebChromeClientIOS::webAppOrientationsUpdated()
     [[webView() _UIDelegateForwarder] webViewSupportedOrientationsUpdated:webView()];
 }
 
-void WebChromeClientIOS::focusedElementChanged(Element* element)
+void WebChromeClientIOS::focusedElementChanged(Element* element, LocalFrame*, FocusOptions, BroadcastFocusedElement)
 {
     if (!is<HTMLInputElement>(element))
         return;

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.h
@@ -33,8 +33,11 @@
 #import <wtf/TZoneMalloc.h>
 
 namespace WebCore {
+class Frame;
 class HTMLImageElement;
+enum class BroadcastFocusedElement : bool;
 enum class PointerLockRequestResult : uint8_t;
+struct FocusOptions;
 }
 
 @class WebView;
@@ -63,7 +66,7 @@ private:
     bool canTakeFocus(WebCore::FocusDirection) const final;
     void takeFocus(WebCore::FocusDirection) override;
 
-    void focusedElementChanged(WebCore::Element*) override;
+    void focusedElementChanged(WebCore::Element*, WebCore::LocalFrame*, WebCore::FocusOptions, WebCore::BroadcastFocusedElement) override;
     void focusedFrameChanged(WebCore::Frame*) final;
 
     RefPtr<WebCore::Page> createWindow(WebCore::LocalFrame&, const String& openedMainFrameName, const WebCore::WindowFeatures&, const WebCore::NavigationAction&) final;

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.mm
@@ -68,6 +68,9 @@
 #import <WebCore/FileChooser.h>
 #import <WebCore/FileIconLoader.h>
 #import <WebCore/FloatRect.h>
+#import <WebCore/FocusControllerTypes.h>
+#import <WebCore/FocusOptions.h>
+#import <WebCore/Frame.h>
 #import <WebCore/FrameDestructionObserverInlines.h>
 #import <WebCore/GraphicsLayer.h>
 #import <WebCore/HTMLInputElement.h>
@@ -241,7 +244,7 @@ void WebChromeClient::takeFocus(FocusDirection direction)
 #endif
 }
 
-void WebChromeClient::focusedElementChanged(Element* element)
+void WebChromeClient::focusedElementChanged(Element* element, LocalFrame*, FocusOptions, BroadcastFocusedElement)
 {
     if (!is<HTMLInputElement>(element))
         return;


### PR DESCRIPTION
#### d207618b6bf4aafb72d8dd9ad1dc44d97aff565f
<pre>
[Site Isolation] Clicking on the body of a frame to focus it should blur the active element
<a href="https://bugs.webkit.org/show_bug.cgi?id=299543">https://bugs.webkit.org/show_bug.cgi?id=299543</a>
<a href="https://rdar.apple.com/157077681">rdar://157077681</a>

Reviewed by Wenson Hsieh.

With site isolation, a page&apos;s focus management is driven per web content
process for said process&apos;s local frame set. This means there are
multiple focus controllers when a page has cross-origin iframes loaded.
If a user clicks on a focusable element in some cross-origin iframe, the
focus controller belonging to the web content process where said iframe
is a local frame will grant focus to the element. However, some other
web content process may still think focus belongs to an element in one
of its local frames, because that is what its focus controller believes.

In this patch, we alleviate this issue by introducing the ability to
broadcast focused element changes across web content processes. This is
similar in spirit to 268570@main, which introduced the same ability
except for when a focused frame changed.

To do so, we hook into the Document::setFocusedElement() flow and teach
Chrome(Client) about other data required to correctly broadcast this
change, namely the focused local frame where the change happened and the
focus options.

More details in-line.

Test: http/tests/site-isolation/focus-click-navigation-activeElement.html

* LayoutTests/http/tests/site-isolation/focus-click-navigation-activeElement-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/focus-click-navigation-activeElement.html: Added.
* LayoutTests/http/tests/site-isolation/focus-tab-navigation-activeElement.html:
* LayoutTests/http/tests/site-isolation/resources/focus-click-navigation-iframe.html: Added.
* LayoutTests/platform/ios/TestExpectations:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::setFocusedElement):
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::focus):
(WebCore::Element::blur):
* Source/WebCore/editing/FrameSelection.cpp:
(WebCore::FrameSelection::setFocusedElementIfNeeded):
* Source/WebCore/editing/cocoa/AutofillElements.cpp:
* Source/WebCore/loader/EmptyClients.h:
* Source/WebCore/page/Chrome.cpp:
(WebCore::Chrome::focusedElementChanged):
* Source/WebCore/page/Chrome.h:
* Source/WebCore/page/ChromeClient.h:
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::dispatchMouseEvent):
* Source/WebCore/page/FocusController.cpp:
(WebCore::FocusController::setFocusedFrame):
(WebCore::FocusController::findFocusableElementDescendingIntoSubframes):
(WebCore::FocusController::setFocusedElement):

* Source/WebCore/page/FocusController.h:
We track a m_focusedFrameBeforeRemoteFocusBroadcast pointer, which
corresponds to the focused frame that got reset by a remote broadcast.
We then consult this pointer when resetting element focus because of a
remote broadcast, too.

* Source/WebCore/page/FocusControllerTypes.h: Added.
We take the liberty to pull out some types used by FocusController
for cross process coordination into this header.

* Source/WebKit/Scripts/webkit/messages.py:
(headers_for_type):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::focusedElementChanged):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/WebProcess/Plugins/PluginView.cpp:
(WebKit::PluginView::focusPluginElement):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::focusedElementChanged):
(WebKit::WebChromeClient::focusedFrameChanged):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp:
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::loadDidCommitInAnotherProcess):
(WebKit::WebFrame::commitProvisionalFrame):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::elementWasFocusedInAnotherProcess):
(WebKit::WebPage::frameWasFocusedInAnotherProcess):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::focusTextInputContextAndPlaceCaret):
* Source/WebKitLegacy/ios/WebCoreSupport/WebChromeClientIOS.h:
* Source/WebKitLegacy/ios/WebCoreSupport/WebChromeClientIOS.mm:
(WebChromeClientIOS::focusedElementChanged):
* Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.mm:
(WebChromeClient::focusedElementChanged):

Canonical link: <a href="https://commits.webkit.org/300767@main">https://commits.webkit.org/300767@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/59d700a1901d0cf50f464beed5a5f6bed81ca581

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123739 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43454 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34150 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130515 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/75888 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c2970946-4ad5-4fe7-aa76-c8cdc6ceec42) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/125616 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44177 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52048 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94096 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62451 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cca4e750-0392-46f5-a7ee-56296bd35e64) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126692 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35192 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110694 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74703 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/21a82eba-ca79-4cba-b88d-d9838cda371d) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/123095 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34156 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28854 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73996 "Built successfully") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104915 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29077 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133203 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50690 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38596 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102572 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51065 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106916 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102407 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47751 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25999 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/47520 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19481 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50544 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56306 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50019 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53365 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51693 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->