### PR TITLE
[GTK][WPE] Incorrect rendering of layers with fractional transforms

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/perspective-transforms-equivalence.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/perspective-transforms-equivalence.html
@@ -9,7 +9,7 @@
 Perspective with different transforms can have small anti-aliasing
 pixel differences, so the test should fuzzy patch to the ref.
 -->
-<meta name="fuzzy" content="maxDifference=0-178;totalPixels=0-538">
+<meta name="fuzzy" content="maxDifference=0-94;totalPixels=0-538">
 <style>
 
 #container {

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1253,6 +1253,8 @@ imported/w3c/web-platform-tests/focus/activeelement-after-nested-loses-focus.htm
 # Assertion failure in Release build with ASSERT_ENABLED
 webkit.org/b/279421 imported/w3c/web-platform-tests/css/css-multicol/crashtests/inline-float-parallel-flow.html [ Skip ]
 
+imported/w3c/web-platform-tests/css/css-view-transitions/inline-with-offset-from-containing-block.html [ ImageOnlyFailure ]
+
 #////////////////////////////////////////////////////////////////////////////////////////
 # End of CSS-related bugs
 #////////////////////////////////////////////////////////////////////////////////////////

--- a/LayoutTests/platform/glib/fast/layers/fractional-transforms-expected.html
+++ b/LayoutTests/platform/glib/fast/layers/fractional-transforms-expected.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <style>
+      body {
+          margin: 0;
+      }
+      div {
+          position: fixed;
+          left: 0px;
+          top: 0px;
+          transform: translate(660.499px, 468px);
+          border: 1px solid blue;
+          width: 100px;
+          height: 100px;
+      }
+    </style>
+  </head>
+  <body>
+    <div></div>
+  </body>
+</html>
+

--- a/LayoutTests/platform/glib/fast/layers/fractional-transforms.html
+++ b/LayoutTests/platform/glib/fast/layers/fractional-transforms.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <style>
+      body {
+          margin: 0;
+      }
+      div {
+          position: fixed;
+          left: 0px;
+          top: 0px;
+          transform: translate(660.5px, 468px);
+          border: 1px solid blue;
+          width: 100px;
+          height: 100px;
+      }
+    </style>
+  </head>
+  <body>
+    <div></div>
+  </body>
+</html>
+

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -1620,7 +1620,6 @@ http/tests/css/css-masking/mask-external-svg-mask.html [ ImageOnlyFailure ]
 http/tests/css/css-masking/mask-inline-svg-image.html [ ImageOnlyFailure ]
 http/tests/css/css-masking/mask-inline-svg-mask.html [ ImageOnlyFailure ]
 
-imported/w3c/web-platform-tests/css/css-view-transitions/inline-with-offset-from-containing-block.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/geometry/reftests/circle-003.svg [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/painting/reftests/marker-path-001.svg [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/painting/reftests/marker-path-011.svg [ ImageOnlyFailure ]

--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -22,11 +22,8 @@ webkit.org/b/136754 imported/w3c/web-platform-tests/css/css-flexbox/flexbox_flex
 imported/w3c/web-platform-tests/css/css-flexbox/grid-flex-item-007.html [ Pass ]
 
 imported/w3c/web-platform-tests/css/compositing/mix-blend-mode/mix-blend-mode-intermediate-element-overflow-hidden-and-border-radius.html [ Pass ]
-imported/w3c/web-platform-tests/css/css-animations/nested-scale-animations.html [ Pass ]
-imported/w3c/web-platform-tests/css/css-animations/transform-animation-under-large-scale.html [ Pass ]
 
 imported/w3c/web-platform-tests/css/css-images/out-of-range-color-stop-conic.html [ Pass ]
-imported/w3c/web-platform-tests/css/css-transforms/3d-scene-with-iframe-001.html [ Pass ]
 
 imported/w3c/web-platform-tests/css/css-view-transitions/navigation/skip-outbound-vt-before-reveal.html [ Pass ]
 

--- a/Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp
+++ b/Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp
@@ -115,11 +115,10 @@ BitmapTexture::BitmapTexture(const IntSize& size, OptionSet<Flags> flags)
 void BitmapTexture::createTexture()
 {
     ASSERT(!m_id);
-    auto filter = m_flags.contains(Flags::UseNearestTextureFilter) ? GL_NEAREST : GL_LINEAR;
     glGenTextures(1, &m_id);
     glBindTexture(GL_TEXTURE_2D, m_id);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, filter);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, filter);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 }

--- a/Source/WebCore/platform/graphics/texmap/BitmapTexture.h
+++ b/Source/WebCore/platform/graphics/texmap/BitmapTexture.h
@@ -59,7 +59,6 @@ public:
         BackedByDMABuf = 1 << 2,
         ForceLinearBuffer = 1 << 3,
 #endif
-        UseNearestTextureFilter = 1 << 4
     };
 
     static Ref<BitmapTexture> create(const IntSize& size, OptionSet<Flags> flags = { })

--- a/Source/WebCore/platform/graphics/texmap/BitmapTexturePool.cpp
+++ b/Source/WebCore/platform/graphics/texmap/BitmapTexturePool.cpp
@@ -59,7 +59,6 @@ Ref<BitmapTexture> BitmapTexturePool::acquireTexture(const IntSize& size, Option
                 && entry.m_texture->flags().contains(BitmapTexture::Flags::BackedByDMABuf) == flags.contains(BitmapTexture::Flags::BackedByDMABuf)
                 && entry.m_texture->flags().contains(BitmapTexture::Flags::ForceLinearBuffer) == flags.contains(BitmapTexture::Flags::ForceLinearBuffer)
 #endif
-                && entry.m_texture->flags().contains(BitmapTexture::Flags::UseNearestTextureFilter) == flags.contains(BitmapTexture::Flags::UseNearestTextureFilter)
                 && entry.m_texture->flags().contains(BitmapTexture::Flags::DepthBuffer) == flags.contains(BitmapTexture::Flags::DepthBuffer);
         });
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreTile.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreTile.cpp
@@ -65,7 +65,7 @@ void CoordinatedBackingStoreTile::processPendingUpdates(TextureMapper& textureMa
         FloatRect unscaledTileRect(update.tileRect);
         unscaledTileRect.scale(1. / m_scale);
 
-        OptionSet<BitmapTexture::Flags> flags { BitmapTexture::Flags::UseNearestTextureFilter };
+        OptionSet<BitmapTexture::Flags> flags { };
         if (update.buffer->supportsAlpha())
             flags.add(BitmapTexture::Flags::SupportsAlpha);
 


### PR DESCRIPTION
#### bc616c7ed15a7fb8c1fcac2e781f5c4b1e9918c3
<pre>
[GTK][WPE] Incorrect rendering of layers with fractional transforms
<a href="https://bugs.webkit.org/show_bug.cgi?id=299602">https://bugs.webkit.org/show_bug.cgi?id=299602</a>

Reviewed by Nikolas Zimmermann.

When composited layers have 2D/3D transforms set, it&apos;s possible
that on GL level, the textures representing those layers will be
drawn off the integer boundaries hence leading to each texel covering
more than one target pixel. In such case, the GL will use magnification
filter to ensure the results are as expected. To ensure layers are
visually where they should be, the only possible filter to use is
GL_LINEAR as GL_NEAREST may effectively offset the layer.

This change effectively reverts a part of 49ef300 that introduced
GL_NEAREST. Additionally, this change adds a test case that reproduces
the problem and aligns test expectations to account for a few layout
test failures. Those failures are irrelevant, as the test cases are
invalid themselves as they effectively test the interpolation method
which is not specified and may vary between browser engines.

Canonical link: <a href="https://commits.webkit.org/300746@main">https://commits.webkit.org/300746@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a3f839778e6174c67cff1812ed7fc062b6fd3f0c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123537 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43252 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33948 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130264 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/75679 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/125414 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43975 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51846 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93969 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62343 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126490 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35033 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110518 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74544 "Found 1 new API test failure: TestWTF:WTF_Condition.OneProducerOneConsumerOneSlotTimeout (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34004 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28675 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73778 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104750 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28900 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132985 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50488 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38436 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102414 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50863 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106739 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102256 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47603 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25836 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/47297 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19469 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50342 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56103 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49816 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53163 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51491 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->