### PR TITLE
Limit the events fired by a stopped MediaRecorder in case of change of track states

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-record/MediaRecorder-stop-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-record/MediaRecorder-stop-expected.txt
@@ -4,6 +4,8 @@ PASS MediaRecorder will stop recording and fire a stop event when stop() is call
 PASS MediaRecorder will not fire an exception when stopped after creation
 PASS MediaRecorder will not fire an exception when stopped after having just been stopped
 PASS MediaRecorder will not fire an exception when stopped after having just been spontaneously stopped
-FAIL MediaRecorder will fire start event even if stopped synchronously promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'navigator.mediaDevices.getUserMedia')"
-FAIL MediaRecorder will fire start event even if a track is removed synchronously promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'navigator.mediaDevices.getUserMedia')"
+PASS MediaRecorder will fire start event even if stopped synchronously
+PASS MediaRecorder will fire start event even if a track is removed synchronously
+PASS MediaRecorder will not fire an error event if a recorder is stopped synchronously after a track is removed
+PASS MediaRecorder will not fire an error event if a recorder is stopped synchronously after all tracks are ended
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-record/MediaRecorder-stop.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-record/MediaRecorder-stop.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!doctype html><!-- webkit-test-runner [ MediaCaptureRequiresSecureConnection=false ] -->
 <html>
 <head>
     <title>MediaRecorder Stop</title>
@@ -117,6 +117,12 @@
 
     promise_test(async t => {
         const stream = await navigator.mediaDevices.getUserMedia({ audio: true, video: true });
+        const audioTrack = stream.getAudioTracks()[0];
+        const videoTrack = stream.getVideoTracks()[0];
+        t.add_cleanup(() => {
+            audioTrack.stop();
+            videoTrack.stop();
+        });
         const recorder = new MediaRecorder(stream);
         let events = [];
         const startPromise = new Promise(resolve => recorder.onstart = resolve);
@@ -134,6 +140,12 @@
 
     promise_test(async t => {
         const stream = await navigator.mediaDevices.getUserMedia({ audio: true, video: true });
+        const audioTrack = stream.getAudioTracks()[0];
+        const videoTrack = stream.getVideoTracks()[0];
+        t.add_cleanup(() => {
+            audioTrack.stop();
+            videoTrack.stop();
+        });
         const recorder = new MediaRecorder(stream);
         let events = [];
         const startPromise = new Promise(resolve => recorder.onstart = resolve);
@@ -152,6 +164,66 @@
         await stopPromise;
         assert_array_equals(events, ["start", "error", "data", "stop"]);
     }, "MediaRecorder will fire start event even if a track is removed synchronously");
+
+    promise_test(async t => {
+        const stream = await navigator.mediaDevices.getUserMedia({ audio: true, video: true });
+        const audioTrack = stream.getAudioTracks()[0];
+        const videoTrack = stream.getVideoTracks()[0];
+        t.add_cleanup(() => {
+            audioTrack.stop();
+            videoTrack.stop();
+        });
+        const recorder = new MediaRecorder(stream);
+
+        let events = [];
+        recorder.onstart = ()=> events.push("start");
+        recorder.onstop = ()=> events.push("stop");
+        recorder.onerror = ()=> events.push("error");
+        recorder.ondataavailable = ()=> events.push("data");
+
+        recorder.start();
+        await new Promise(resolve => t.step_timeout(resolve, 0));
+
+        stream.removeTrack(stream.getAudioTracks()[0]);
+        recorder.stop();
+
+        while (events.size > 4)
+            await new Promise(resolve => t.step_timeout(resolve, 50));
+
+        await new Promise(resolve => t.step_timeout(resolve, 500));
+        assert_array_equals(events, ["start", "data", "stop"]);
+    }, "MediaRecorder will not fire an error event if a recorder is stopped synchronously after a track is removed");
+
+
+    promise_test(async t => {
+        const stream = await navigator.mediaDevices.getUserMedia({ audio: true, video: true });
+        const audioTrack = stream.getAudioTracks()[0];
+        const videoTrack = stream.getVideoTracks()[0];
+        t.add_cleanup(() => {
+            audioTrack.stop();
+            videoTrack.stop();
+        });
+        const recorder = new MediaRecorder(stream);
+
+        let events = [];
+        recorder.onstart = ()=> events.push("start");
+        recorder.onstop = ()=> events.push("stop");
+        recorder.onerror = ()=> events.push("error");
+        recorder.ondataavailable = ()=> events.push("data");
+
+        recorder.start();
+        await new Promise(resolve => t.step_timeout(resolve, 0));
+
+        audioTrack.stop();
+        videoTrack.stop();
+        recorder.stop();
+
+        while (events.size > 4)
+            await new Promise(resolve => t.step_timeout(resolve, 50));
+
+        await new Promise(resolve => t.step_timeout(resolve, 500));
+        assert_array_equals(events, ["start", "data", "stop"]);
+    }, "MediaRecorder will not fire an error event if a recorder is stopped synchronously after all tracks are ended");
 
 </script>
 </body>

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/mediacapture-record/MediaRecorder-stop-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/mediacapture-record/MediaRecorder-stop-expected.txt
@@ -1,9 +1,0 @@
-
-PASS MediaRecorder will stop recording and fire a stop event when all tracks are ended
-PASS MediaRecorder will stop recording and fire a stop event when stop() is called
-PASS MediaRecorder will not fire an exception when stopped after creation
-PASS MediaRecorder will not fire an exception when stopped after having just been stopped
-PASS MediaRecorder will not fire an exception when stopped after having just been spontaneously stopped
-FAIL MediaRecorder will fire start event even if stopped synchronously promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'navigator.mediaDevices.getUserMedia')"
-FAIL MediaRecorder will fire start event even if a track is removed synchronously promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'navigator.mediaDevices.getUserMedia')"
-

--- a/Source/WebCore/Modules/mediarecorder/MediaRecorder.cpp
+++ b/Source/WebCore/Modules/mediarecorder/MediaRecorder.cpp
@@ -383,6 +383,9 @@ void MediaRecorder::stopRecordingInternal(CompletionHandler<void()>&& completion
 void MediaRecorder::handleTrackChange()
 {
     queueTaskKeepingObjectAlive(*this, TaskSource::Networking, [](auto& recorder) {
+        if (recorder.state() == RecordingState::Inactive)
+            return;
+
         recorder.stopRecordingInternal([pendingActivity = recorder.makePendingActivity(recorder)] {
             Ref protectedRecorder = pendingActivity->object();
             queueTaskKeepingObjectAlive(protectedRecorder.get(), TaskSource::Networking, [](auto& recorder) {
@@ -418,6 +421,9 @@ void MediaRecorder::trackEnded(MediaStreamTrackPrivate&)
         return;
 
     queueTaskKeepingObjectAlive(*this, TaskSource::Networking, [](auto& recorder) {
+        if (recorder.state() == RecordingState::Inactive)
+            return;
+
         recorder.stopRecordingInternal([pendingActivity = recorder.makePendingActivity(recorder)] {
             queueTaskKeepingObjectAlive(pendingActivity->object(), TaskSource::Networking, [](auto& recorder) {
                 if (!recorder.m_isActive)


### PR DESCRIPTION
#### 9671d6e9c9773473d974c053cd8c7f1bc6a9788c
<pre>
Limit the events fired by a stopped MediaRecorder in case of change of track states
<a href="https://rdar.apple.com/161124260">rdar://161124260</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=299601">https://bugs.webkit.org/show_bug.cgi?id=299601</a>

Reviewed by Jean-Yves Avenard.

When a MediaRecorder is stopped just after its stream has changed (track stopped or track addition/removal),
we were previously firing error events, even though the actual recording stop was triggered by the web page.

We are now exiting early if the recorder is stopped while we process the stream changes.
This aligns with Chrome behavior.
After the patch, we get the same behavior for Firefox in one case and get closer to Firefox in another case.

* LayoutTests/imported/w3c/web-platform-tests/mediacapture-record/MediaRecorder-stop-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-record/MediaRecorder-stop.html:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/mediacapture-record/MediaRecorder-stop-expected.txt: Removed.
* Source/WebCore/Modules/mediarecorder/MediaRecorder.cpp:
(WebCore::MediaRecorder::handleTrackChange):
(WebCore::MediaRecorder::trackEnded):

Canonical link: <a href="https://commits.webkit.org/300682@main">https://commits.webkit.org/300682@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f7fd9f20b31c6625bc97580476f13d154804933c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123493 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43208 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33904 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130212 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/75633 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/dbe44fa7-177a-4243-ad78-62250c8abed5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/125370 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43931 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51802 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93875 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62319 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/65eb748d-4f16-4704-94e4-ded890df9e80) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126446 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35004 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110485 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74507 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33974 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28643 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73728 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104719 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28868 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132930 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50444 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38405 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102368 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50819 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106707 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102219 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25981 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47580 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25804 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/47252 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50298 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56059 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49772 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53119 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51447 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->