### PR TITLE
[JSC] WASM IPInt SIMD: add support for v128 arguments and results in IPInt call and tail-call instructions

### DIFF
--- a/JSTests/wasm/stress/simd-instructions-calls.js
+++ b/JSTests/wasm/stress/simd-instructions-calls.js
@@ -1,0 +1,348 @@
+//@ requireOptions("--useWasmSIMD=1", "--useWasmTailCalls=1")
+//@ skip if !$isSIMDPlatform
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+const verbose = false;
+
+function logV(...args) {
+    if (verbose)
+        console.log(...args);
+}
+
+const testCases = [
+    {
+        name: "simple_swap_v128",
+        signature: {
+            params: ['v128', 'v128'],
+            results: ['v128', 'v128']
+        },
+        // Maps result index → parameter index (swap the two parameters)
+        resultMapping: [1, 0]  // result[0] = param[1], result[1] = param[0] (swapped)
+    },
+    {
+        name: "simple_10_results_stack_v128_v128",
+        signature: {
+            params: ['v128', 'f64'],
+            results: ['v128', 'f64', 'v128', 'f64', 'v128', 'f64', 'v128', 'f64', 'v128', 'v128']
+        },
+        resultMapping: [0, 1, 0, 1, 0, 1, 0, 1, 0, 0]
+    },
+    {
+        name: "simple_10_results_stack_f64_f64",
+        signature: {
+            params: ['v128', 'f64'],
+            results: ['v128', 'f64', 'v128', 'f64', 'v128', 'f64', 'v128', 'f64', 'f64', 'f64']
+        },
+        resultMapping: [0, 1, 0, 1, 0, 1, 0, 1, 1, 1]
+    },
+    {
+        name: "simple_10_results_stack_f64_v128",
+        signature: {
+            params: ['v128', 'f64'],
+            results: ['v128', 'f64', 'v128', 'f64', 'v128', 'f64', 'v128', 'f64', 'f64', 'v128']
+        },
+        resultMapping: [0, 1, 0, 1, 0, 1, 0, 1, 1, 0]
+    },
+        {
+        name: "simple_10_results_stack_v128_f64",
+        signature: {
+            params: ['v128', 'f64'],
+            results: ['v128', 'f64', 'v128', 'f64', 'v128', 'f64', 'v128', 'f64', 'v128', 'f64']
+        },
+        resultMapping: [0, 1, 0, 1, 0, 1, 0, 1, 0, 1]
+    },
+        {
+        name: "simple_20_results_stack_i64_v128_i64_v128",
+        signature: {
+            params: ['i64', 'f64'],
+            results: ['i64', 'f64', 'i64', 'f64', 'i64', 'f64', 'i64', 'f64', 'i64', 'f64', 'i64', 'f64', 'i64', 'f64', 'i64', 'f64', 'i64', 'f64', 'i64', 'f64'] // 10 results
+        },
+        resultMapping: [0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1]
+    },
+    {
+        name: "many_args_alternating_f64_v128",
+        signature: {
+            params: ['f64', 'v128', 'f64', 'v128', 'f64', 'v128', 'f64', 'v128', 'f64', 'v128', 'f64', 'v128', 'i32'],
+            results: ['v128']
+        },
+        resultMapping: [11]
+    },
+    {
+        name: "many_args_alternating_v128_f64",
+        signature: {
+            params: ['v128', 'f64', 'v128', 'f64', 'v128', 'f64', 'v128', 'f64', 'v128', 'f64', 'v128', 'f64', 'v128'],
+            results: ['v128']
+        },
+        resultMapping: [10]
+    },
+    {
+        name: "many_args_alternating_many_results_reversed",
+        signature: {
+            params: ['v128', 'f64', 'v128', 'f64', 'v128', 'f64', 'v128', 'f64', 'v128', 'f64', 'v128', 'f64'],
+            results: ['f64', 'v128', 'f64', 'v128', 'f64', 'v128', 'f64', 'v128', 'f64', 'v128', 'f64', 'v128'],
+        },
+        resultMapping: [11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0]
+    },
+    {
+        name: "many_args_alternating_many_results_shifted",
+        signature: {
+            params: ['v128', 'f64', 'v128', 'f64', 'v128', 'f64', 'v128', 'f64', 'v128', 'f64', 'v128', 'f64'],
+            results: ['v128', 'f64', 'v128', 'f64', 'v128', 'f64', 'v128', 'f64', 'v128', 'f64', 'v128', 'f64'],
+        },
+        resultMapping: [2, 5, 6, 7, 8, 9, 10, 11, 0, 1, 2, 3]
+    },
+    {
+        name: "stack_args_no_stack_returns",
+        signature: {
+            params: ['f64', 'v128', 'f64', 'v128', 'v128', 'f64', 'f64', 'v128', 'f64', 'f64', 'v128', 'f64', 'v128'],
+            results: ['f64', 'f64', 'f64', 'f64', 'v128', 'v128', 'v128']
+        },
+        resultMapping: [8, 5, 9, 11, 12, 3, 10]
+    },
+    {
+        name: "no_stack_args_with_stack_returns",
+        signature: {
+            params: ['f64', 'f64', 'f64', 'f64', 'v128', 'v128', 'v128'],
+            results: ['f64', 'v128', 'f64', 'v128', 'v128', 'f64', 'f64', 'v128', 'f64', 'f64', 'v128', 'f64', 'v128']
+        },
+        resultMapping: [1, 6, 0, 4, 5, 1, 2, 6, 3, 0, 4, 1, 5]
+    },
+    {
+        name: "pure_v128_many_results",
+        signature: {
+            params: ['v128', 'v128', 'v128', 'v128', 'v128', 'v128', 'v128', 'v128', 'v128'],
+            results: ['v128', 'v128', 'v128', 'v128', 'v128', 'v128', 'v128', 'v128', 'v128', 'v128', 'v128', 'v128', 'v128']
+        },
+        resultMapping: [0, 1, 2, 3, 4, 5, 6, 7, 8, 0, 1, 2, 3]
+    },
+    {
+        name: "odd_results_v128_f64",
+        signature: {
+            params: ['v128', 'v128', 'v128', 'v128', 'v128', 'f64', 'f64', 'f64', 'f64'],
+            results: ['v128', 'f64', 'v128', 'f64', 'v128', 'f64', 'v128', 'f64', 'v128'] // 9 results (odd)
+        },
+        resultMapping: [0, 5, 1, 6, 2, 7, 3, 8, 4]
+    },
+    {
+        name: "alternating_25_results",
+        signature: {
+            params: ['v128', 'v128', 'v128', 'v128', 'v128', 'f64', 'f64', 'f64', 'f64'],
+            results: new Array(25).fill(null).map((_, i) => i % 2 === 0 ? 'v128' : 'f64')
+        },
+        resultMapping: new Array(25).fill(null).map((_, i) => i % 2 === 0 ? (i % 10) % 5 : 5 + (i % 8) % 4)
+    },
+    {
+        name: "v128_20_results",
+        signature: {
+            params: ['v128', 'v128', 'v128', 'v128', 'v128', 'v128', 'v128', 'v128', 'v128'], // 9 v128 params
+            results: new Array(20).fill('v128') // 20 v128 results
+        },
+        resultMapping: new Array(20).fill(null).map((_, i) => i % 9)
+    },
+    {
+        name: "random_case_1",
+        signature: {
+            params: ['f64', 'v128', 'i64', 'f64', 'v128', 'i64', 'v128', 'f64', 'i64', 'v128', 'f64', 'i64', 'v128', 'f64'], // 14 params
+            results: ['v128', 'f64', 'i64', 'v128', 'f64', 'i64', 'v128', 'f64', 'i64', 'v128', 'f64', 'i64', 'v128', 'f64', 'i64', 'v128', 'f64', 'i64'] // 18 results
+        },
+        resultMapping: [1, 0, 2, 4, 3, 5, 6, 7, 8, 9, 10, 11, 12, 13, 8, 4, 7, 11]
+    },
+    {
+        name: "random_case_2",
+        signature: {
+            params: ['v128', 'i64', 'v128', 'f64', 'v128', 'i64', 'f64', 'v128', 'i64', 'f64', 'v128', 'i64'], // 12 params
+            results: ['i64', 'v128', 'f64', 'i64', 'v128', 'f64', 'i64', 'v128', 'f64', 'i64', 'v128', 'f64', 'i64', 'v128', 'f64', 'i64', 'v128', 'f64', 'i64', 'v128', 'f64'] // 21 results
+        },
+        resultMapping: [1, 0, 3, 5, 2, 6, 8, 4, 9, 11, 7, 3, 1, 0, 6, 5, 2, 9, 8, 4, 3]
+    },
+        {
+        name: "random_case_3",
+        signature: {
+            params: ['f64', 'f64', 'v128', 'i64', 'v128', 'f64', 'i64', 'v128', 'f64', 'i64', 'v128', 'f64', 'i64', 'v128', 'f64', 'i64'], // 16 params
+            results: ['v128', 'i64', 'f64', 'v128', 'i64', 'f64', 'v128', 'i64', 'f64', 'v128', 'i64', 'f64', 'v128'] // 13 results
+        },
+        resultMapping: [2, 3, 0, 4, 6, 1, 7, 9, 8, 10, 12, 11, 13]
+    },
+]
+
+function generateSignature(name, params, results) {
+    const paramStr = params.map((type, i) => `(param $p${i} ${type})`).join(' ');
+    const resultStr = results.map(type => `(result ${type})`).join(' ');
+    return `(func $${name} ${paramStr} ${resultStr}`;
+}
+
+function generateCalleeBody(resultMapping) {
+    return resultMapping.map(paramIndex => `(local.get $p${paramIndex})`).join('\n        ');
+}
+
+function generateCallerBody(callOp, testCase) {
+    let body = '';
+
+    const inputs = generateInputs(testCase.signature.params);
+
+    for (let i = 0; i < inputs.length; i++) {
+        const input = inputs[i];
+        const type = testCase.signature.params[i];
+
+        if (Array.isArray(input)) {
+            body += `        (v128.const i32x4 0x${input[0].toString(16)} 0x${input[1].toString(16)} 0x${input[2].toString(16)} 0x${input[3].toString(16)})\n`;
+        } else {
+            const value = (type === 'i32' || type === 'i64') ? Math.floor(input) : input;
+            body += `        (${type}.const ${value})\n`;
+        }
+    }
+
+    body += `        (${callOp} $${testCase.name}_callee)`;
+    return body;
+}
+
+function generateInputs(params) {
+    return params.map((type, i) => {
+        if (type === 'v128') {
+            const base = 0x1000 + i * 0x100;
+            return [base, base + 0x10, base + 0x20, base + 0x30];
+        } else if (type === 'f64' || type === 'f32') {
+            return 10.5 + i;
+        } else if (type === 'i32' || type === 'i64') {
+            return 1000 + i;
+        }
+    });
+}
+
+function buildWAT(callOp, testCases) {
+    let functions = '';
+    let exports = '';
+
+    for (const testCase of testCases) {
+        const calleeName = `${testCase.name}_callee`;
+        const callerName = `${testCase.name}_caller`;
+
+        // Generate callee function
+        functions += generateSignature(calleeName, testCase.signature.params, testCase.signature.results) + '\n';
+        functions += '        ' + generateCalleeBody(testCase.resultMapping) + '\n';
+        functions += '    )\n\n';
+
+        // Generate caller function (same result signature as callee)
+        functions += `    (func $${callerName} ${testCase.signature.results.map(type => `(result ${type})`).join(' ')}\n`;
+        functions += generateCallerBody(callOp, testCase) + '\n';
+        functions += '    )\n\n';
+
+        // Generate export wrapper (just calls caller and stores results)
+        exports += `    (func (export "${testCase.name}") (param $result_addr i32)\n`;
+
+        // Add local declarations for temporary storage
+        for (let i = 0; i < testCase.signature.results.length; i++) {
+            const type = testCase.signature.results[i];
+            exports += `        (local $temp${i} ${type})\n`;
+        }
+
+        exports += `        (call $${callerName})\n`;
+
+        // Pop results from stack in reverse order into locals
+        for (let i = testCase.signature.results.length - 1; i >= 0; i--) {
+            exports += `        (local.set $temp${i})\n`;
+        }
+
+        // Store results to memory with 16-byte spacing, in forward order
+        for (let i = 0; i < testCase.signature.results.length; i++) {
+            const offset = i * 16;
+            const type = testCase.signature.results[i];
+            exports += `        (${type}.store offset=${offset} (local.get $result_addr) (local.get $temp${i}))\n`;
+        }
+        exports += '    )\n\n';
+    }
+
+    return `
+(module
+    (memory (export "memory") 1)
+
+${functions}
+${exports}
+)
+`;
+}
+
+async function runTests(callOp, testCases) {
+    const wat = buildWAT(callOp, testCases);
+    logV(`\n=== Generated WAT for ${callOp} ===`);
+    logV(wat);
+    logV('=== End WAT ===\n');
+
+    const instance = await instantiate(wat, {}, { simd: true, tail_call: true });
+    const { memory } = instance.exports;
+
+    const f64View = new Float64Array(memory.buffer);
+    const i32View = new Int32Array(memory.buffer);
+    const i64View = new BigInt64Array(memory.buffer);
+
+    function getI32x4(byteOffset) {
+        const i32Offset = byteOffset / 4;
+        return [i32View[i32Offset], i32View[i32Offset + 1], i32View[i32Offset + 2], i32View[i32Offset + 3]];
+    }
+
+    function getF64(byteOffset) {
+        return f64View[byteOffset / 8];
+    }
+
+    function getI64(byteOffset) {
+        return i64View[byteOffset / 8];
+    }
+
+    function verifyTestCase(testCase, resultAddr, expectedInputs) {
+        // Verify results match expected values based on result mapping
+        // Results are stored at 16-byte intervals: result[0] at offset 0, result[1] at offset 16, etc.
+        for (let i = 0; i < testCase.signature.results.length; i++) {
+            const offset = i * 16;
+            const type = testCase.signature.results[i];
+            const mappedParamIndex = testCase.resultMapping[i];
+            const expectedValue = expectedInputs[mappedParamIndex];
+
+            if (type === 'f64') {
+                const actual = getF64(offset);
+                assert.eq(actual, expectedValue, `Result ${i} (f64) should be ${expectedValue}, got ${actual}`);
+                logV(`    Result ${i} (f64): ${actual} ✓`);
+            } else if (type === 'i64') {
+                const actual = getI64(offset);
+                const expectedBigInt = BigInt(expectedValue);
+                assert.eq(actual, expectedBigInt, `Result ${i} (i64) should be ${expectedBigInt}, got ${actual}`);
+                logV(`    Result ${i} (i64): ${actual} ✓`);
+            } else if (type === 'v128') {
+                const actual = getI32x4(offset);
+                for (let j = 0; j < 4; j++) {
+                    assert.eq(actual[j], expectedValue[j], `Result ${i} (v128) lane ${j} should be 0x${expectedValue[j].toString(16)}, got 0x${actual[j].toString(16)}`);
+                }
+                logV(`    Result ${i} (v128): [0x${actual.map(x => x.toString(16)).join(', 0x')}] ✓`);
+            }
+        }
+    }
+
+    logV(`Testing with ${callOp}...`);
+
+    for (const testCase of testCases) {
+        logV(`  Running ${testCase.name}...`);
+        const resultAddr = 0;
+        const expectedInputs = generateInputs(testCase.signature.params);
+
+        // Run multiple times to trigger tier-up (100 iterations to ensure BBQ compilation)
+        for (let iteration = 0; iteration < wasmTestLoopCount; iteration++) {
+            // Clear memory
+            for (let i = 0; i < 256; i++)
+                i32View[i] = 0;
+
+            // Run the test case and verify
+            instance.exports[testCase.name](resultAddr);
+            verifyTestCase(testCase, resultAddr, expectedInputs);
+        }
+    }
+}
+
+async function test() {
+    const operations = ['call', 'return_call'];
+
+    for (const callOp of operations) {
+        await runTests(callOp, testCases);
+    }
+}
+
+await assert.asyncTest(test())

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.h
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.h
@@ -703,7 +703,8 @@ extern "C" void SYSV_ABI ipint_entry_simd();
     m(0x0e, argumINT_fa6) \
     m(0x0f, argumINT_fa7) \
     m(0x10, argumINT_stack) \
-    m(0x11, argumINT_end) \
+    m(0x11, argumINT_stack_vector) \
+    m(0x12, argumINT_end) \
 
 #define FOR_EACH_IPINT_SLOW_PATH(m) \
     m(0x00, local_get_slow_path) \
@@ -727,14 +728,18 @@ extern "C" void SYSV_ABI ipint_entry_simd();
     m(0x0d, mint_fa5) \
     m(0x0e, mint_fa6) \
     m(0x0f, mint_fa7) \
-    m(0x10, mint_stackzero) \
-    m(0x11, mint_stackeight) \
-    m(0x12, mint_tail_stackzero) \
-    m(0x13, mint_tail_stackeight) \
-    m(0x14, mint_gap) \
-    m(0x15, mint_tail_gap) \
-    m(0x16, mint_tail_call) \
-    m(0x17, mint_call) \
+    m(0x10, mint_call_argument_dec_sp) \
+    m(0x11, mint_call_argument_store_0) \
+    m(0x12, mint_call_argument_dec_sp_store_8) \
+    m(0x13, mint_call_argument_dec_sp_store_vector_0) \
+    m(0x14, mint_call_argument_dec_sp_store_vector_8) \
+    m(0x15, mint_tail_call_argument_dec_sp) \
+    m(0x16, mint_tail_call_argument_store_0) \
+    m(0x17, mint_tail_call_argument_dec_sp_store_8) \
+    m(0x18, mint_tail_call_argument_dec_sp_store_vector_0) \
+    m(0x19, mint_tail_call_argument_dec_sp_store_vector_8) \
+    m(0x1a, mint_tail_call) \
+    m(0x1b, mint_call) \
 
 #define FOR_EACH_IPINT_MINT_RETURN_OPCODE(m) \
     m(0x00, mint_r0) \
@@ -753,8 +758,8 @@ extern "C" void SYSV_ABI ipint_entry_simd();
     m(0x0d, mint_fr5) \
     m(0x0e, mint_fr6) \
     m(0x0f, mint_fr7) \
-    m(0x10, mint_stack) \
-    m(0x11, mint_stack_gap) \
+    m(0x10, mint_result_stack) \
+    m(0x11, mint_result_stack_vector) \
     m(0x12, mint_end) \
 
 #define FOR_EACH_IPINT_UINT_OPCODE(m) \
@@ -775,7 +780,8 @@ extern "C" void SYSV_ABI ipint_entry_simd();
     m(0x0e, uint_fr6) \
     m(0x0f, uint_fr7) \
     m(0x10, uint_stack) \
-    m(0x11, uint_ret) \
+    m(0x11, uint_stack_vector) \
+    m(0x12, uint_ret) \
 
 #if !ENABLE(C_LOOP) && (CPU(ADDRESS64) && (CPU(ARM64) || CPU(X86_64)) || (CPU(ADDRESS32) && CPU(ARM_THUMB2)))
 FOR_EACH_IPINT_OPCODE(IPINT_VALIDATE_DEFINE_FUNCTION);

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
@@ -408,9 +408,7 @@ if ARM64 or ARM64E
 elsif X86_64
     loadb [MC], sc1
     addq 1, MC
-    bilt sc1, 0x12, .safe
-    break
-.safe:
+    bigteq sc1, (constexpr IPInt::UIntBytecode::NumOpcodes), _ipint_uint_dispatch_err
     lshiftq 6, sc1
     leap (_uint_begin - _mint_entry_relativePCBase)[PC, sc1], sc1
     jmp sc1
@@ -435,7 +433,7 @@ end)
 if X86_64
     loadp UnboxedWasmCalleeStackSlot[cfr], ws0
 end
-    loadi Wasm::IPIntCallee::m_highestReturnStackOffset[ws0], sc0
+    loadi Wasm::IPIntCallee::m_topOfReturnStackFPOffset[ws0], sc0
     addp cfr, sc0
 
     initPCRelative(mint_entry, PC)
@@ -10063,8 +10061,8 @@ macro mintPop(reg)
     addq V128ISize, mintSS
 end
 
-macro mintPopF(reg)
-    loadd [mintSS], reg
+macro mintPopV(reg)
+    loadv [mintSS], reg
     addq V128ISize, mintSS
 end
 
@@ -10121,9 +10119,6 @@ end
     const targetEntrypoint = sc2
     const targetInstance = sc3
 
-    # sc2 = target entrypoint
-    # sc3 = target instance
-
     move r0, targetEntrypoint
     move r1, targetInstance
 
@@ -10147,7 +10142,7 @@ end
     # arg
     # ...
     # arg
-    # arg             <- initial SP
+    # arg             <- initial SP (wasm stack)
 
     # store sp as our shadow stack for arguments later
     move sp, t4
@@ -10158,7 +10153,7 @@ end
     # arg
     # ...
     # arg
-    # arg             <- sc0 = initial sp
+    # arg             <- t4 = initial SP (wasm stack)
     # reserved
     # reserved        <- sp
 
@@ -10173,11 +10168,11 @@ end
     # arg
     # ...
     # arg
-    # arg             <- sc0 = initial sp
+    # arg             <- t4 = initial SP (wasm stack)
     # reserved
     # reserved
     # t3, PC
-    # PL, wasmInstance
+    # PL, wasmInstance <- t2 = native argument stack (pushed by mINT)
     # call frame
     # call frame
     # call frame
@@ -10190,8 +10185,8 @@ end
     storep IPIntCallFunctionSlot, CodeBlock - CallerFrameAndPCSize[sp]
 
     push targetEntrypoint, targetInstance
-    move t2, sc3
 
+    move t2, sc3
     move t4, mintSS
 
     # need a common entrypoint because of x86 PC base
@@ -10251,8 +10246,8 @@ end
     addp FirstArgumentOffset, sc2
     addp t3, sc2
 
-    #  <caller frame>
-    #  return val                  <- sc2
+    #  <caller frame>              <- sc2
+    #  return val
     #  return val
     #  argument
     #  argument
@@ -10286,8 +10281,8 @@ end
 
     push t0, t1
 
-    #  <caller frame>
-    #  return val                  <- sc2
+    #  <caller frame>              <- sc2
+    #  return val
     #  return val
     #  argument
     #  argument
@@ -10374,78 +10369,126 @@ else
 end
 
 mintAlign(_fa0)
-    mintPopF(wfa0)
+    mintPopV(wfa0)
     mintArgDispatch()
 
 mintAlign(_fa1)
-    mintPopF(wfa1)
+    mintPopV(wfa1)
     mintArgDispatch()
 
 mintAlign(_fa2)
-    mintPopF(wfa2)
+    mintPopV(wfa2)
     mintArgDispatch()
 
 mintAlign(_fa3)
-    mintPopF(wfa3)
+    mintPopV(wfa3)
     mintArgDispatch()
 
 mintAlign(_fa4)
-    mintPopF(wfa4)
+    mintPopV(wfa4)
     mintArgDispatch()
 
 mintAlign(_fa5)
-    mintPopF(wfa5)
+    mintPopV(wfa5)
     mintArgDispatch()
 
 mintAlign(_fa6)
-    mintPopF(wfa6)
+    mintPopV(wfa6)
     mintArgDispatch()
 
 mintAlign(_fa7)
-    mintPopF(wfa7)
+    mintPopV(wfa7)
     mintArgDispatch()
 
 # Note that the regular call and tail call opcodes will be implemented slightly differently.
 # Regular calls have to save space for return values, while tail calls are reusing the stack frame
 # and thus do not have to care.
 
-mintAlign(_stackzero)
+# CallArgumentBytecode::CallArgDecSP (0x10)
+mintAlign(_call_argument_dec_sp)
+    subp 2 * SlotSize, sc3
+    mintArgDispatch()
+
+# CallArgumentBytecode::CallArgStore0 (0x11)
+mintAlign(_call_argument_store_0)
     mintPop(sc2)
     storeq sc2, [sc3]
     mintArgDispatch()
 
-mintAlign(_stackeight)
+# CallArgumentBytecode::CallArgDecSPStore8 (0x12)
+mintAlign(_call_argument_dec_sp_store_8)
     mintPop(sc2)
-    subp 16, sc3
+    subp 2 * SlotSize, sc3
     storeq sc2, 8[sc3]
     mintArgDispatch()
 
-# Since we're writing into the same frame, we're going to first push stack arguments onto the stack.
+# CallArgumentBytecode::CallArgDecSPStoreVector0 (0x13)
+mintAlign(_call_argument_dec_sp_store_vector_0)
+    subp 2 * SlotSize, sc3
+    loadq [mintSS], sc2
+    storeq sc2, [sc3]
+    loadq 8[mintSS], sc2
+    storeq sc2, 8[sc3]
+    addq StackValueSize, mintSS
+    mintArgDispatch()
+
+# CallArgumentBytecode::TailCallArgDecSPStoreVector8 (0x14)
+mintAlign(_call_argument_dec_sp_store_vector_8)
+    subp 2 * SlotSize, sc3
+    loadq [mintSS], sc2
+    storeq sc2, 8[sc3]
+    loadq 8[mintSS], sc2
+    storeq sc2, 16[sc3]
+    addq StackValueSize, mintSS
+    mintArgDispatch()
+
+# For tail calls, we're writing into the same frame. We're going to first push stack arguments onto the stack.
 # Once we're done, we'll copy them back down into the new frame, to avoid having to deal with writing over
 # arguments lower down on the stack.
 
-mintAlign(_tail_stackzero)
+# CallArgumentBytecode::TailCallArgDecSP (0x15)
+mintAlign(_tail_call_argument_dec_sp)
+    subp 2 * SlotSize, sp
+    mintArgDispatch()
+
+# CallArgumentBytecode::TailCallArgStore0 (0x16)
+mintAlign(_tail_call_argument_store_0)
     mintPop(sc3)
     storeq sc3, [sp]
     mintArgDispatch()
 
-mintAlign(_tail_stackeight)
+# CallArgumentBytecode::TailCallArgDecSPStore8 (0x17)
+mintAlign(_tail_call_argument_dec_sp_store_8)
     mintPop(sc3)
-    subp 16, sp
+    subp 2 * SlotSize, sp
     storeq sc3, 8[sp]
     mintArgDispatch()
 
-mintAlign(_gap)
-    subp 16, sc3
+# CallArgumentBytecode::TailCallArgDecSPStoreVector0 (0x18)
+mintAlign(_tail_call_argument_dec_sp_store_vector_0)
+    subp 2 * SlotSize, sp
+    loadq [mintSS], sc3
+    storeq sc3, [sp]
+    loadq 8[mintSS], sc3
+    storeq sc3, 8[sp]
+    addq StackValueSize, mintSS
     mintArgDispatch()
 
-mintAlign(_tail_gap)
-    subp 16, sp
+# CallArgumentBytecode::TailCallArgDecSPStoreVector8 (0x19)
+mintAlign(_tail_call_argument_dec_sp_store_vector_8)
+    subp 2 * SlotSize, sp
+    loadq [mintSS], sc3
+    storeq sc3, 8[sp]
+    loadq 8[mintSS], sc3
+    storeq sc3, 16[sp]
+    addq StackValueSize, mintSS
     mintArgDispatch()
 
+# CallArgumentBytecode::TailCall (0x1a)
 mintAlign(_tail_call)
     jmp .ipint_perform_tail_call
 
+# CallArgumentBytecode::Call (0x1b)
 mintAlign(_call)
     pop wasmInstance, ws0
     # pop targetInstance, targetEntrypoint
@@ -10504,10 +10547,11 @@ _wasm_ipint_call_return_location_wide32:
     const mintRetSrc = sc1
     const mintRetDst = sc2
 
-    loadi IPInt::CallReturnMetadata::firstStackArgumentSPOffset[MC], mintRetSrc
+    loadi IPInt::CallReturnMetadata::firstStackResultSPOffset[MC], mintRetSrc
     advanceMC(IPInt::CallReturnMetadata::resultBytecode)
     leap [sp, mintRetSrc], mintRetSrc
 
+    # load "saved t3" from the stack
 if ARM64 or ARM64E
     loadp (2 * SlotSize)[sc3], mintRetDst
 elsif X86_64
@@ -10626,15 +10670,21 @@ mintAlign(_fr7)
     storev wfa7, [mintRetDst]
     mintRetDispatch()
 
-mintAlign(_stack)
+# CallResultBytecode::ResultStack (0x10)
+mintAlign(_result_stack)
     loadq [mintRetSrc], sc0
     addp SlotSize, mintRetSrc
     subp StackValueSize, mintRetDst
     storeq sc0, [mintRetDst]
     mintRetDispatch()
 
-mintAlign(_stack_gap)
-    addp SlotSize, mintRetSrc
+# CallResultBytecode::ResultStackVector (0x11)
+mintAlign(_result_stack_vector)
+    # safe to use wfa0 since frN bytecodes always come before vector stack result
+    loadv [mintRetSrc], wfa0
+    addp 2 * SlotSize, mintRetSrc
+    subp StackValueSize, mintRetDst
+    storev wfa0, [mintRetDst]
     mintRetDispatch()
 
 mintAlign(_end)
@@ -10648,12 +10698,12 @@ mintAlign(_end)
     # return result     <- mintRetDst => new SP
     # t3, PC
     # PL, wasmInstance  <- sc3
-    # call frame return <- sp
+    # call frame return <- mintRetSrc
     # call frame return
     # call frame
     # call frame
     # call frame
-    # call frame
+    # call frame        <- sp
 
     # note: we don't care about t3 anymore
 if ARM64 or ARM64E
@@ -10683,8 +10733,8 @@ end
 
 .ipint_perform_tail_call:
 
-    #  <caller frame>
-    #  return val                  <- sc2
+    #  <caller frame>              <- sc2
+    #  return val
     #  return val
     #  argument
     #  argument
@@ -10693,11 +10743,11 @@ end
     #  call frame
     #  call frame                  <- cfr
     #  (IPInt locals)
-    #  (IPInt stack)
+    #  (IPInt stack)               <- sc1 (was shadow stack, now dead and can re-use)
     #  argument 0
     #  ...
     #  argument n-1
-    #  argument n                  <- sc1
+    #  argument n
     #  entrypoint, targetInstance
     #  callee, function info
     #  saved MC/PC
@@ -10707,14 +10757,14 @@ end
     #  stack arguments
     #  stack arguments             <- sp
 
-    # load the size of stack values in, and subtract that from sc2
+    # load the size of the arguments and results space, and subtract that from sc2
     loadi [MC], sc3
-    mulp -SlotSize, sc3
+    negq sc3
 
-    # copy from sc2 downwards
+    # copy args to sc2 region
     validateOpcodeConfig(sc0)
 .ipint_tail_call_copy_stackargs_loop:
-    btiz sc3, .ipint_tail_call_copy_stackargs_loop_end
+    bqgteq sc3, 0, .ipint_tail_call_copy_stackargs_loop_end
 if ARM64 or ARM64E
     loadpairq [sp], sc0, sc1
     storepairq sc0, sc1, [sc2, sc3]
@@ -10733,7 +10783,6 @@ end
 
     # reload it here, which isn't optimal, but we don't really have registers
     loadi [MC], sc3
-    mulq SlotSize, sc3
     subp sc3, sc2
 
     # re-setup the call frame, and load our return address in
@@ -10774,7 +10823,7 @@ end
     #  argument 0
     #  ...
     #  argument n-1
-    #  argument n                  <- sc1
+    #  argument n
 
     # on ARM: lr = return address
 
@@ -10869,43 +10918,57 @@ else
 end
 
 uintAlign(_fr0)
-    popFloat64(wfa0)
+    popVec(wfa0)
     uintDispatch()
 
 uintAlign(_fr1)
-    popFloat64(wfa1)
+    popVec(wfa1)
     uintDispatch()
 
 uintAlign(_fr2)
-    popFloat64(wfa2)
+    popVec(wfa2)
     uintDispatch()
 
 uintAlign(_fr3)
-    popFloat64(wfa3)
+    popVec(wfa3)
     uintDispatch()
 
 uintAlign(_fr4)
-    popFloat64(wfa4)
+    popVec(wfa4)
     uintDispatch()
 
 uintAlign(_fr5)
-    popFloat64(wfa5)
+    popVec(wfa5)
     uintDispatch()
 
 uintAlign(_fr6)
-    popFloat64(wfa6)
+    popVec(wfa6)
     uintDispatch()
 
 uintAlign(_fr7)
-    popFloat64(wfa7)
+    popVec(wfa7)
     uintDispatch()
 
 # destination on stack is sc0
 
 uintAlign(_stack)
     popInt64(sc1, sc2)
+    subp SlotSize, sc0
     storeq sc1, [sc0]
-    subp 8, sc0
+    uintDispatch()
+
+uintAlign(_stack_vector)
+    subp 2 * SlotSize, sc0
+    if ARM64 or ARM64E
+        loadpairq [sp], sc1, sc2
+        storepairq sc1, sc2, [sc0]
+    else
+        loadq [sp], sc1
+        loadq 8[sp], sc2
+        storeq sc1, [sc0]
+        storeq sc2, 8[sc0]
+    end
+    addq StackValueSize, sp
     uintDispatch()
 
 uintAlign(_ret)
@@ -10988,49 +11051,56 @@ else
 end
 
 argumINTAlign(_fa0)
-    stored wfa0, [argumINTDst]
+    storev wfa0, [argumINTDst]
     addp LocalSize, argumINTDst
     argumINTDispatch()
 
 argumINTAlign(_fa1)
-    stored wfa1, [argumINTDst]
+    storev wfa1, [argumINTDst]
     addp LocalSize, argumINTDst
     argumINTDispatch()
 
 argumINTAlign(_fa2)
-    stored wfa2, [argumINTDst]
+    storev wfa2, [argumINTDst]
     addp LocalSize, argumINTDst
     argumINTDispatch()
 
 argumINTAlign(_fa3)
-    stored wfa3, [argumINTDst]
+    storev wfa3, [argumINTDst]
     addp LocalSize, argumINTDst
     argumINTDispatch()
 
 argumINTAlign(_fa4)
-    stored wfa4, [argumINTDst]
+    storev wfa4, [argumINTDst]
     addp LocalSize, argumINTDst
     argumINTDispatch()
 
 argumINTAlign(_fa5)
-    stored wfa5, [argumINTDst]
+    storev wfa5, [argumINTDst]
     addp LocalSize, argumINTDst
     argumINTDispatch()
 
 argumINTAlign(_fa6)
-    stored wfa6, [argumINTDst]
+    storev wfa6, [argumINTDst]
     addp LocalSize, argumINTDst
     argumINTDispatch()
 
 argumINTAlign(_fa7)
-    stored wfa7, [argumINTDst]
+    storev wfa7, [argumINTDst]
     addp LocalSize, argumINTDst
     argumINTDispatch()
 
 argumINTAlign(_stack)
     loadq [argumINTSrc], csr0
-    addp 8, argumINTSrc
+    addp SlotSize, argumINTSrc
     storeq csr0, [argumINTDst]
+    addp LocalSize, argumINTDst
+    argumINTDispatch()
+
+argumINTAlign(_stack_vector)
+    loadv [argumINTSrc], ft0
+    addp 2 * SlotSize, argumINTSrc
+    storev ft0, [argumINTDst]
     addp LocalSize, argumINTDst
     argumINTDispatch()
 

--- a/Source/JavaScriptCore/wasm/WasmCallee.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCallee.cpp
@@ -232,7 +232,7 @@ IPIntCallee::IPIntCallee(FunctionIPIntMetadataGenerator& generator, FunctionSpac
     , m_metadata(WTFMove(generator.m_metadata))
     , m_argumINTBytecode(WTFMove(generator.m_argumINTBytecode))
     , m_uINTBytecode(WTFMove(generator.m_uINTBytecode))
-    , m_highestReturnStackOffset(generator.m_highestReturnStackOffset)
+    , m_topOfReturnStackFPOffset(generator.m_topOfReturnStackFPOffset)
     , m_localSizeToAlloc(roundUpToMultipleOf<2>(generator.m_numLocals))
     , m_numRethrowSlotsToAlloc(generator.m_numAlignedRethrowSlots)
     , m_numLocals(generator.m_numLocals)

--- a/Source/JavaScriptCore/wasm/WasmCallee.h
+++ b/Source/JavaScriptCore/wasm/WasmCallee.h
@@ -466,7 +466,7 @@ private:
     Vector<uint8_t> m_argumINTBytecode;
     Vector<uint8_t> m_uINTBytecode;
 
-    unsigned m_highestReturnStackOffset;
+    unsigned m_topOfReturnStackFPOffset;
 
     unsigned m_localSizeToAlloc;
     unsigned m_numRethrowSlotsToAlloc;

--- a/Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.h
@@ -123,7 +123,7 @@ private:
     std::span<const uint8_t> m_bytecode;
     MetadataBuffer m_metadata { };
     Vector<uint8_t, 8> m_uINTBytecode { };
-    unsigned m_highestReturnStackOffset;
+    unsigned m_topOfReturnStackFPOffset;
 
     uint32_t m_bytecodeOffset { 0 };
     unsigned m_maxFrameSizeInV128 { 0 };

--- a/Source/JavaScriptCore/wasm/WasmIPIntGenerator.h
+++ b/Source/JavaScriptCore/wasm/WasmIPIntGenerator.h
@@ -183,14 +183,26 @@ struct CallSignatureMetadata {
 enum class CallArgumentBytecode : uint8_t { // (mINT)
     ArgumentGPR = 0x0, // 0x00 - 0x07: push into a0, a1, ...
     ArgumentFPR = 0x8, // 0x08 - 0x0f: push into fa0, fa1, ...
-    ArgumentStackAligned = 0x10, // 0x10: pop stack value, push onto stack[0]
-    ArgumentStackUnaligned = 0x11, // 0x11: pop stack value, add another 16B for params, push onto stack[8]
-    TailArgumentStackAligned = 0x12, // 0x12: pop stack value, push onto stack[0]
-    TailArgumentStackUnaligned = 0x13, // 0x13: pop stack value, add another 16B for params, push onto stack[8]
-    StackAlign = 0x14, // 0x14: add another 16B for params
-    TailStackAlign = 0x15, // 0x15: add another 16B for params
-    TailCall = 0x16, // 0x16: tail call
-    Call = 0x17, // 0x17: regular call
+
+    // Note: addCallArgumentBytecode() requires that the corresponding CallArg and TailCallArg bytecodes
+    // have a constant offset from each other
+
+    // For Call, SP is actually a shadow stack, not the machine SP
+    CallArgDecSP = 0x10, // Decrement SP by 16
+    CallArgStore0 = 0x11, // Store 8-bytes to [SP]
+    CallArgDecSPStore8 = 0x12, // Decrement SP by 16 and store 8-bytes to 8[SP]
+    CallArgDecSPStoreVector0 = 0x13, // Decrement SP by 16 and store 16-bytes to [SP]
+    CallArgDecSPStoreVector8 = 0x14, // Decrement SP by 16 and store 16-bytes to 8[SP]
+
+    // Equivalent to the Call bytecodes above, but operates on machine SP directly
+    TailCallArgDecSP = 0x15,
+    TailCallArgStore0 = 0x16,
+    TailCallArgDecSPStore8 = 0x17,
+    TailCallArgDecSPStoreVector0 = 0x18,
+    TailCallArgDecSPStoreVector8 = 0x19,
+
+    TailCall = 0x1a,
+    Call = 0x1b,
 
     NumOpcodes // this must be the last element of the enum!
 };
@@ -248,16 +260,16 @@ struct TailCallRefMetadata {
 enum class CallResultBytecode : uint8_t { // (mINT)
     ResultGPR = 0x0, // 0x00 - 0x07: r0 - r7
     ResultFPR = 0x8, // 0x08 - 0x0f: fr0 - fr7
-    ResultStack = 0x10, // 0x10: stack
-    StackGap = 0x11, // 0x11: skip a slot on the stack
-    End = 0x12, // 0x12: end
+    ResultStack = 0x10,
+    ResultStackVector = 0x11,
+    End = 0x12,
 
     NumOpcodes // this must be the last element of the enum!
 };
 
 struct CallReturnMetadata {
     uint32_t stackFrameSize; // 4B for stack frame size
-    uint32_t firstStackArgumentSPOffset; // 4B for stack argument offset
+    uint32_t firstStackResultSPOffset; // 4B for stack argument offset
     CallResultBytecode resultBytecode[0];
 };
 
@@ -265,9 +277,10 @@ struct CallReturnMetadata {
 
 enum class ArgumINTBytecode: uint8_t {
     ArgGPR = 0x0, // 0x00 - 0x07: r0 - r7
-    RegFPR = 0x8, // 0x08 - 0x0f: fr0 - fr7
-    Stack = 0x10, // 0x0c: stack
-    End = 0x11, // 0x0d: end
+    ArgFPR = 0x8, // 0x08 - 0x0f: fr0 - fr7
+    Stack = 0x10,
+    StackVector = 0x11,
+    End = 0x12,
 
     NumOpcodes // this must be the last element of the enum!
 };
@@ -275,8 +288,9 @@ enum class ArgumINTBytecode: uint8_t {
 enum class UIntBytecode: uint8_t {
     RetGPR = 0x0, // 0x00 - 0x07: r0 - r7
     RetFPR = 0x8, // 0x08 - 0x0f: fr0 - fr7
-    Stack = 0x10, // 0x0c: stack
-    End = 0x11, // 0x0d: end
+    Stack = 0x10,
+    StackVector = 0x11,
+    End = 0x12,
 
     NumOpcodes // this must be the last element of the enum!
 };


### PR DESCRIPTION
#### 73f0c9d430cbc013ee54681b495425edd921da0c
<pre>
[JSC] WASM IPInt SIMD: add support for v128 arguments and results in IPInt call and tail-call instructions
<a href="https://bugs.webkit.org/show_bug.cgi?id=299606">https://bugs.webkit.org/show_bug.cgi?id=299606</a>
<a href="https://rdar.apple.com/161412501">rdar://161412501</a>

Reviewed by Yusuke Suzuki.

Supporting v128 call/tail-call argument and results requires removing
the various assumptions that IPInt makes that callframe arguments are
fixed sizes, as follows:

* CallInformation abstraction changes:

- CallInformation was exposing the number of argument/result stack
values in the callframe. WasmIPIntGenerator was using this information
and assuming fixed size arguments/results. This breaks the abstraction
since native callframes have variable sized elements. Instead, expose
the byte sizes of the header region and total size (already exposed).
These are redundant with the argument and result location lists but
are a useful summary for the clients.

* Bytecode generation updates:

- Update the bytecode generators to not assume uniform argument/result
sizes. Add various asserts that verifies that the bytecode metadata
and interpreters are in agreement and will tell us what &quot;small&quot;
bytecode needs to be updated if/when we change the wasm calling
convention. We could make the bytecode more generic but I didn&apos;t do
that in this change to minimize risk.

- m_highestReturnStackOffset was storing address of the top return
value. Now, m_topOfReturnStackFPOffset stores the address of the first
byte above the top return
value.

- The trailing metadata for mINT tail call now stores the size of the
argument space rather than the number of arguments, and the
corresponding loop in ipint_perform_tail_call that copies this region
is updated.

* Bytecode interpreter updates:

- All the &quot;small&quot; interpreter bytecodes that operate on FP registers
now operate on the full 128-bits rather than 64-bits.

- Introduce argumINT, uINT, and mINT bytecodes to handle vectors.
Also rename existing ones for clarity and consistency. Also make
bytecode enum values and handlers similarly named for clarity.

- Fix a hardcoded uintDispatch bounds check.

* Stack management fixes:

- The uINT destination stack (for copying results into the caller&apos;s
callframe when returning) was an empty descending stack, meaning each
bytecode allocated the space for the next result, assuming each result
is 8-bytes. But since callframe results aren&apos;t fixed size, change this
to a full descending stack so that each bytecode allocates its own
stack space since each bytecode knows the size of its result.

* Misc cleanup:

- Don&apos;t skip the WASM stack size asserts when useWasmIPIntSIMD is enabled.

- Factor redundant mINT argument bytecode generators into a single generator.

* Testing:

- Add a table driven test to make it easier to verify call and
tail-call frame construction cases. Each test case specifies the
signature of the callee and how callee results should be constructed
based on the arguments, and then the test harness generates the WAT
for the test case. I plan to extend this later to add more dimensions
to the test matrix, for example, to explicitly cover calling between
tiers and the indirect/ref call types.

Test: JSTests/wasm/stress/simd-instructions-calls.js
* JSTests/wasm/stress/simd-instructions-calls.js: Added.
(logV):
(i.i.2.0.i.10.5.5):
(resultMapping.new.Array.fill.map):
(generateSignature):
* Source/JavaScriptCore/llint/InPlaceInterpreter.h:
* Source/JavaScriptCore/llint/InPlaceInterpreter32_64.asm:
* Source/JavaScriptCore/llint/InPlaceInterpreter64.asm:
* Source/JavaScriptCore/wasm/WasmCallee.cpp:
(JSC::Wasm::IPIntCallee::IPIntCallee):
* Source/JavaScriptCore/wasm/WasmCallee.h:
* Source/JavaScriptCore/wasm/WasmCallingConvention.h:
(JSC::Wasm::CallInformation::CallInformation):
(JSC::Wasm::WasmCallingConvention::callInformationFor const):
(JSC::Wasm::JSCallingConvention::callInformationFor const):
(JSC::Wasm::WasmCallingConvention::numberOfStackArguments const): Deleted.
(JSC::Wasm::WasmCallingConvention::numberOfStackValues const): Deleted.
* Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.cpp:
(JSC::Wasm::FunctionIPIntMetadataGenerator::addReturnData):
* Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.h:
* Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp:
(JSC::Wasm::IPIntGenerator::assertAboutStackSize):
(JSC::Wasm::IPIntGenerator::addArguments):
(JSC::Wasm::addCallArgumentBytecode):
(JSC::Wasm::addCallResultBytecode):
(JSC::Wasm::IPIntGenerator::addCallCommonData):
(JSC::Wasm::IPIntGenerator::addTailCallCommonData):
(JSC::Wasm::IPIntGenerator::addCall):
(JSC::Wasm::IPIntGenerator::addCallIndirect):
(JSC::Wasm::IPIntGenerator::addCallRef):
* Source/JavaScriptCore/wasm/WasmIPIntGenerator.h:

Canonical link: <a href="https://commits.webkit.org/300695@main">https://commits.webkit.org/300695@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/65c01a1a73f311c672990ac0a697def4ff816fee

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123276 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42990 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33687 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/129984 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/75389 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d01bd61d-bdfd-42a9-9cad-b6d72a54afc0) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43714 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51585 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93706 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62163 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cda834c1-9866-41c7-a06c-0a16bb287571) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126229 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34831 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110301 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74334 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3fa109c4-a5bb-4aeb-a104-02d29598c070) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33796 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28460 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73502 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/115435 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104545 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28686 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132702 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/121807 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50226 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38218 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102196 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50602 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106525 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102051 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25990 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47402 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25624 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/47000 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50081 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/55842 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/152162 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49552 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/38883 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/52902 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51230 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->