### PR TITLE
Re-sync largest-contentful-paint WPT

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/largest-contentful-paint/image-upscaling.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/largest-contentful-paint/image-upscaling.html
@@ -72,7 +72,7 @@
     promise_test(async t => {
       const { naturalSize, lcpSize } = await load_image_and_get_lcp_size(t,
         { transform: 'scale(0.5)' });
-      assert_equals(Math.floor(lcpSize), Math.floor(naturalSize / 4));
+      assert_approx_equals(Math.floor(lcpSize), Math.floor(naturalSize / 4), 2);
     }, 'A downscaled image (using scale) should report the displayed size');
 
     promise_test(async t => {


### PR DESCRIPTION
#### b0fbd95947f42dc8f45d683cd4f6a30f8e8fc338
<pre>
Re-sync largest-contentful-paint WPT
<a href="https://bugs.webkit.org/show_bug.cgi?id=299610">https://bugs.webkit.org/show_bug.cgi?id=299610</a>
<a href="https://rdar.apple.com/161415110">rdar://161415110</a>

Reviewed by Tim Nguyen.

Resync to pick up the fix for <a href="https://github.com/web-platform-tests/interop/issues/1189">https://github.com/web-platform-tests/interop/issues/1189</a>

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/2f93924802b9d9ae75fcfdb184702a1d0d50325b">https://github.com/web-platform-tests/wpt/commit/2f93924802b9d9ae75fcfdb184702a1d0d50325b</a>

* LayoutTests/imported/w3c/web-platform-tests/largest-contentful-paint/image-upscaling.html:

Canonical link: <a href="https://commits.webkit.org/300589@main">https://commits.webkit.org/300589@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1bf575e576f947734eec0b4c2f0a3554ec205686

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123165 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42879 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33576 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/129872 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/75277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/296d1c58-76b0-4442-9cf8-81300eb14a4f) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43603 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51474 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93624 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/75277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/eb05eecc-3e69-4685-8337-ed97a85200ce) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126116 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34753 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/110222 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74255 "Found 1 new API test failure: WPE/TestWebKitWebContext:/webkit/WebKitWebContext/no-web-process-leak (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7375c397-8273-44e0-86e3-5cd28a76aedf) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33721 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28378 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73386 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104465 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28604 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132586 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50115 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/38154 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102119 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50491 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106443 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101975 "Found 1 new API test failure: WebKitGTK/TestInspector:/webkit/WebKitWebInspector/manual-attach-detach (failure)") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25924 "") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/47350 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25546 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/46889 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19405 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49970 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49440 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/52790 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51119 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->