### PR TITLE
Re-sync WPT tests for pointer events

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_click_is_a_pointerevent.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_click_is_a_pointerevent.html
@@ -76,25 +76,6 @@ promise_test(async test => {
 }, "click using " + pointer_type + " is a PointerEvent with correct properties"
     + " when no other PointerEvent listeners are present");
 
-promise_test(async test => {
-  await subframe_loaded;
-
-  const target = frames[0];
-  let pointerdown_promise = getEvent("pointerdown", target, test);
-  let pointerup_promise = getEvent("pointerup", target, test);
-  let click_promise = getEvent("click", target, test);
-
-  await clickInTarget(pointer_type, frames[0].document.body);
-
-  let pointerdown_event = await pointerdown_promise;
-  let pointerup_event = await pointerup_promise;
-  let click_event = await click_promise;
-
-  assertClickProperties(click_event, frames[0], pointerdown_event, pointerup_event);
-}, "click using " + pointer_type + " is a PointerEvent with correct properties"
-    + " in a subframe");
-
-
 // Run this part of the test only once, since it doesn't rely on the pointer_type.
 if (pointer_type == "mouse") {
   promise_test(async test => {
@@ -120,4 +101,25 @@ if (pointer_type == "mouse") {
   }, "click using " + pointer_type + " is a PointerEvent with correct properties"
       + " using non-pointing device");
 }
+
+promise_test(async test => {
+  // This subtest must be run last as workaround for a WebKit issue where webdriver
+  // fails to correctly direct focus after clicking outside of the frame. This bug
+  // does not occur during normal browsing. https://webkit.org/b/298676
+  await subframe_loaded;
+
+  const target = frames[0];
+  let pointerdown_promise = getEvent("pointerdown", target, test);
+  let pointerup_promise = getEvent("pointerup", target, test);
+  let click_promise = getEvent("click", target, test);
+
+  await clickInTarget(pointer_type, frames[0].document.body);
+
+  let pointerdown_event = await pointerdown_promise;
+  let pointerup_event = await pointerup_promise;
+  let click_event = await click_promise;
+
+  assertClickProperties(click_event, frames[0], pointerdown_event, pointerup_event);
+}, "click using " + pointer_type + " is a PointerEvent with correct properties"
+    + " in a subframe");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_click_is_a_pointerevent_mouse-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_click_is_a_pointerevent_mouse-expected.txt
@@ -4,6 +4,6 @@ Harness Error (TIMEOUT), message = null
 
 PASS click using mouse is a PointerEvent with correct properties
 PASS click using mouse is a PointerEvent with correct properties when no other PointerEvent listeners are present
+PASS click using mouse is a PointerEvent with correct properties using non-pointing device
 TIMEOUT click using mouse is a PointerEvent with correct properties in a subframe Test timed out
-NOTRUN click using mouse is a PointerEvent with correct properties using non-pointing device
 

--- a/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_pointerrawupdate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_pointerrawupdate-expected.txt
@@ -1,11 +1,4 @@
-pointerrawupdate
 
-Test Description: This test checks that pointerrawupdate is not dispatched on non-SecureContext.
-
-Move your mouse within the black box.
-
-Press left button down and then press middle button while holding down left button. Then release the buttons
-
-
-PASS pointerrawupdate event not received
+PASS pointerrawupdate event is not fired
+PASS onpointerrawupdate is not exposed
 

--- a/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_pointerrawupdate.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_pointerrawupdate.html
@@ -1,79 +1,63 @@
 <!doctype html>
-<html>
-    <head>
-        <title>pointerrawupdate</title>
-        <meta name="viewport" content="width=device-width">
-        <link rel="stylesheet" type="text/css" href="pointerevent_styles.css">
-        <script src="/resources/testharness.js"></script>
-        <script src="/resources/testharnessreport.js"></script>
-        <script src="/resources/testdriver.js"></script>
-        <script src="/resources/testdriver-actions.js"></script>
-        <script src="/resources/testdriver-vendor.js"></script>
-        <!-- Additional helper script for common checks across event types -->
-        <script type="text/javascript" src="pointerevent_support.js"></script>
-    </head>
-    <body onload="run()">
-        <h2>pointerrawupdate</h2>
-        <h4>Test Description: This test checks that pointerrawupdate is not dispatched on non-SecureContext. </h4>
-        <p>Move your mouse within the black box.</p>
-        <p>Press left button down and then press middle button while holding down left button. Then release the buttons</p>
-        <div id="target0"></div>
-        <script>
-            var test_pointerrawupdate = async_test("pointerrawupdate event not received");
-            var actions_promise;
+<title>No pointerrawupdate in non-secure contexts</title>
+<link rel="help"
+  href="https://w3c.github.io/pointerevents/#the-pointerrawupdate-event">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script type="text/javascript" src="pointerevent_support.js"></script>
+<style>
+  #target {
+    width: 50px;
+    height: 50px;
+  }
+</style>
+<div id="target"></div>
+<script>
+  "use strict";
 
-            var pointerrawupdateReceived = false;
-            var pointerdownReceived = false;
-            var pointerrawupdateFromButtonChangeReceived = false;
+  let event_log = [];
+  const eventLogger = e => event_log.push(e.type);
 
-            function run() {
-                var target0 = document.getElementById("target0");
+  const target = document.getElementById("target");
+  ["pointerrawupdate", "pointerdown", "pointermove", "pointerup"].forEach(
+      ename => target.addEventListener(ename, eventLogger));
 
-                on_event(target0, "pointerrawupdate", function (event) {
-                    pointerrawupdateReceived = true;
-                    if (pointerdownReceived && event.button != -1)
-                      pointerrawupdateFromButtonChangeReceived = true;
-                });
-                on_event(target0, "pointermove", function (event) {
-                    test_pointerrawupdate.step(function() {
-                        assert_false(pointerrawupdateReceived,
-                                    "Pointerrawupdate event should not have been received before pointermove.");
-                        }, "Pointerrawupdate event should have been received before pointermove.");
-                });
-                on_event(target0, "pointerdown", function (event) {
-                    pointerdownReceived = true;
-                });
-                on_event(target0, "pointerup", function (event) {
-                    test_pointerrawupdate.step(function() {
-                        assert_false(pointerrawupdateFromButtonChangeReceived,
-                                    "Pointerrawupdate event should not have been received from chorded button changes.");
-                        }, "Pointerrawupdate event should have been received from chorded button changes.");
+  promise_test(async test => {
+    let pointerup_promise = getEvent("pointerup", target, test);
 
-                    test_pointerrawupdate.step(function() {
-                        assert_false("onpointerrawupdate" in window,
-                                    "Window should not have event handler onpointerrawupdate");
-                        assert_false("onpointerrawupdate" in window.document,
-                                    "Document should not have event handler onpointerrawupdate");
-                        assert_false("onpointerrawupdate" in window.document.documentElement,
-                                     "Element should not have event handler onpointerrawupdate");
-                        }, "onpointerrawupdate should be exposed only in SecureContext");
+    var actions = new test_driver.Actions();
+    actions = actions.pointerMove(0, 0, {origin: target})
+        .pointerDown({button: actions.ButtonType.LEFT})
+        .pointerDown({button: actions.ButtonType.MIDDLE})
+        .pointerUp({button: actions.ButtonType.MIDDLE})
+        .pointerUp({button: actions.ButtonType.LEFT});
 
-                    // Make sure the test finishes after all the input actions are completed.
-                    actions_promise.then( () => {
-                        test_pointerrawupdate.done();
-                    });
-                });
-                var actions = new test_driver.Actions();
-                actions_promise = actions.pointerMove(0, 0, {origin: target0, button: actions.ButtonType.LEFT})
-                    .pointerDown({button: actions.ButtonType.LEFT})
-                    .pointerDown({button: actions.ButtonType.MIDDLE})
-                    .pointerUp({button: actions.ButtonType.MIDDLE})
-                    .pointerUp({button: actions.ButtonType.LEFT})
-                    .send();
-            }
+    await actions.send();
+    await pointerup_promise;
 
-        </script>
-        <div id="complete-notice">
-        </div>
-    </body>
-</html>
+    // Main assertion for this test.  Note that secure contexts are covered in
+    // pointerevent_pointerrawupdate.https.html.
+    assert_false(event_log.includes("pointerrawupdate"),
+        "pointerrawupdate received");
+
+    // A sanity check that other events are fired correctly.  Note that chorded
+    // buttons fire pointermoves.
+    const expected_events = [
+      "pointermove", "pointerdown", "pointermove", "pointermove", "pointerup"
+    ];
+    assert_equals(event_log.toString(), expected_events.toString(),
+        "events received");
+  }, "pointerrawupdate event is not fired");
+
+  promise_test(async test => {
+    assert_false("onpointerrawupdate" in window,
+        "Window should not have event handler onpointerrawupdate");
+    assert_false("onpointerrawupdate" in window.document,
+        "Document should not have event handler onpointerrawupdate");
+    assert_false("onpointerrawupdate" in window.document.documentElement,
+        "Element should not have event handler onpointerrawupdate");
+  }, "onpointerrawupdate is not exposed");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_pointerrawupdate.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_pointerrawupdate.https-expected.txt
@@ -1,11 +1,4 @@
-pointerrawupdate
 
-Test Description: This test checks if pointerrawupdate is dispatched correctly.
-
-Move your mouse within the black box.
-
-Press left button down and then press middle button while holding down left button. Then release the buttons
-
-
-FAIL pointerrawupdate event received assert_true: Pointerrawupdate event should have been received before pointermove. expected true got false
+FAIL pointerrawupdate event is fired assert_true: pointerrawupdate received expected true got false
+FAIL onpointerrawupdate is exposed assert_true: Window should have event handler onpointerrawupdate expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_pointerrawupdate.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_pointerrawupdate.https.html
@@ -1,69 +1,65 @@
 <!doctype html>
-<html>
-    <head>
-        <title>pointerrawupdate</title>
-        <meta name="viewport" content="width=device-width">
-        <link rel="stylesheet" type="text/css" href="pointerevent_styles.css">
-        <script src="/resources/testharness.js"></script>
-        <script src="/resources/testharnessreport.js"></script>
-        <script src="/resources/testdriver.js"></script>
-        <script src="/resources/testdriver-actions.js"></script>
-        <script src="/resources/testdriver-vendor.js"></script>
-        <!-- Additional helper script for common checks across event types -->
-        <script type="text/javascript" src="pointerevent_support.js"></script>
-    </head>
-    <body onload="run()">
-        <h2>pointerrawupdate</h2>
-        <h4>Test Description: This test checks if pointerrawupdate is dispatched correctly. </h4>
-        <p>Move your mouse within the black box.</p>
-        <p>Press left button down and then press middle button while holding down left button. Then release the buttons</p>
-        <div id="target0"></div>
-        <script>
-            var test_pointerrawupdate = async_test("pointerrawupdate event received");
-            var actions_promise;
+<title>Firing of pointerrawupdate in secure contexts</title>
+<link rel="help"
+  href="https://w3c.github.io/pointerevents/#the-pointerrawupdate-event">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script type="text/javascript" src="pointerevent_support.js"></script>
+<style>
+  #target {
+    width: 50px;
+    height: 50px;
+  }
+</style>
+<div id="target"></div>
+<script>
+  "use strict";
 
-            var pointerrawupdateReceived = false;
-            var pointerdownReceived = false;
-            var pointerrawupdateFromButtonChangeReceived = false;
+  let event_log = [];
+  const eventLogger = e => event_log.push(e.type);
 
-            function run() {
-                var target0 = document.getElementById("target0");
+  const target = document.getElementById("target");
+  ["pointerrawupdate", "pointerdown", "pointermove", "pointerup"].forEach(
+      ename => target.addEventListener(ename, eventLogger));
 
-                on_event(target0, "pointerrawupdate", function (event) {
-                    pointerrawupdateReceived = true;
-                    if (pointerdownReceived && event.button != -1)
-                      pointerrawupdateFromButtonChangeReceived = true;
-                });
-                on_event(target0, "pointermove", function (event) {
-                    test_pointerrawupdate.step(function() {
-                        assert_true(pointerrawupdateReceived,
-                                    "Pointerrawupdate event should have been received before pointermove.");
-                        }, "Pointerrawupdate event should have been received before pointermove.");
-                });
-                on_event(target0, "pointerdown", function (event) {
-                    pointerdownReceived = true;
-                });
-                on_event(target0, "pointerup", function (event) {
-                    test_pointerrawupdate.step(function() {
-                        assert_true(pointerrawupdateFromButtonChangeReceived,
-                                    "Pointerrawupdate event should have been received from chorded button changes.");
-                        }, "Pointerrawupdate event should have been received from chorded button changes.");
-                    // Make sure the test finishes after all the input actions are completed.
-                    actions_promise.then( () => {
-                        test_pointerrawupdate.done();
-                    });
-                });
-                var actions = new test_driver.Actions();
-                actions_promise = actions.pointerMove(0, 0, {origin: target0, button: actions.ButtonType.LEFT})
-                    .pointerDown({button: actions.ButtonType.LEFT})
-                    .pointerDown({button: actions.ButtonType.MIDDLE})
-                    .pointerUp({button: actions.ButtonType.MIDDLE})
-                    .pointerUp({button: actions.ButtonType.LEFT})
-                    .send();
-            }
+  promise_test(async test => {
+    let pointerup_promise = getEvent("pointerup", target, test);
 
-        </script>
-        <div id="complete-notice">
-        </div>
-    </body>
-</html>
+    var actions = new test_driver.Actions();
+    actions = actions.pointerMove(0, 0, {origin: target})
+        .pointerDown({button: actions.ButtonType.LEFT})
+        .pointerDown({button: actions.ButtonType.MIDDLE})
+        .pointerUp({button: actions.ButtonType.MIDDLE})
+        .pointerUp({button: actions.ButtonType.LEFT});
+
+    await actions.send();
+    await pointerup_promise;
+
+    // Main assertion for this test. Note that non-secure contexts are covered
+    // in pointerevent_pointerrawupdate.html.
+    assert_true(event_log.includes("pointerrawupdate"),
+        "pointerrawupdate received");
+
+    // Assert the order of pointerrawupdate with respect to other events. Note
+    // that chorded buttons fire pointermoves.
+    const expected_events = [
+      "pointerrawupdate", "pointermove", "pointerdown",
+      "pointerrawupdate", "pointermove", "pointerrawupdate", "pointermove",
+      "pointerup"
+    ];
+    assert_equals(event_log.toString(), expected_events.toString(),
+        "events received");
+  }, "pointerrawupdate event is fired");
+
+  promise_test(async test => {
+    assert_true("onpointerrawupdate" in window,
+        "Window should have event handler onpointerrawupdate");
+    assert_true("onpointerrawupdate" in window.document,
+        "Document should have event handler onpointerrawupdate");
+    assert_true("onpointerrawupdate" in window.document.documentElement,
+        "Element should have event handler onpointerrawupdate");
+  }, "onpointerrawupdate is exposed");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_touch-propagates-when-target-is-video_touch-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_touch-propagates-when-target-is-video_touch-expected.txt
@@ -1,0 +1,5 @@
+
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT Touch-generated events should propagate to the parent when a video element is the target Test timed out
+

--- a/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_touch-propagates-when-target-is-video_touch.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_touch-propagates-when-target-is-video_touch.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Touch-generated events should propagate to the parent when a video element is the target</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<div id="log"></div>
+
+<div id="parent">
+  <video controls="" preload="auto" width="480" height="320"></video>
+</div>
+
+<script>
+const parent = document.getElementById('parent');
+const video = document.querySelector('video');
+
+const xPosition = Math.ceil(video.offsetLeft + 2);
+const yPosition = Math.ceil(video.offsetTop + 2);
+
+promise_test(async t => {
+  await new Promise(r => {
+    const expectedEventLog = ['touchstart-VIDEO', 'touchmove-VIDEO', 'touchend-VIDEO'];
+    const eventLogRecorder = [];
+    const eventNames = ['touchstart', 'touchmove', 'touchend'];
+
+    for (eventName of eventNames) {
+      parent.addEventListener(eventName, event => {
+        eventLogRecorder.push(`${event.type}-${event.target.nodeName}`);
+        if (event.type === 'touchend') {
+          assert_array_equals(eventLogRecorder, expectedEventLog);
+          r();
+        }
+      });
+    }
+    let actions = new test_driver.Actions();
+    actions
+      .addPointer("touchPointer", "touch")
+      .setPointer("touchPointer")
+      .pointerMove(xPosition, yPosition)
+      .pointerDown()
+      .pointerMove(3, 3, video)
+      .pointerUp()
+      .send();
+  });
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/pointerevents/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/pointerevents/w3c-import.log
@@ -160,6 +160,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_touch-action-table-none-test_touch.html
 /LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_touch-action-verification.html
 /LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_touch-adjustment_click_target.html
+/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_touch-propagates-when-target-is-video_touch.html
 /LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointermove_after_pointerover_target_removed.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerup_after_pointerdown_target_removed.html
 /LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerup_button_value_matches_corresponding_pointerdown.html

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -4812,6 +4812,7 @@ webkit.org/b/263473 imported/w3c/web-platform-tests/pointerevents/crashtests/lon
 webkit.org/b/263473 imported/w3c/web-platform-tests/pointerevents/pointerevent_click_during_parent_capture.html?pointerType=touch&preventDefault= [ Skip ]
 webkit.org/b/263473 imported/w3c/web-platform-tests/pointerevents/pointerevent_click_during_parent_capture.html?pointerType=touch&preventDefault=pointerdown [ Skip ]
 webkit.org/b/263473 imported/w3c/web-platform-tests/pointerevents/pointerevent_click_during_parent_capture.html?pointerType=touch&preventDefault=touchstart [ Skip ]
+webkit.org/b/263473 imported/w3c/web-platform-tests/pointerevents/pointerevent_touch-propagates-when-target-is-video_touch.html [ Skip ]
 
 webkit.org/b/290133 svg/dom/SVGGeometry-isPointInFill-with-null-path.html [ Skip ]
 

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/pointerevents/pointerevent_pointerrawupdate-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/pointerevents/pointerevent_pointerrawupdate-expected.txt
@@ -1,0 +1,4 @@
+
+FAIL pointerrawupdate event is not fired assert_equals: events received expected "pointermove,pointerdown,pointermove,pointermove,pointerup" but got "pointermove,pointerdown,pointermove,pointermove,pointermove,pointerup,pointermove"
+PASS onpointerrawupdate is not exposed
+

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -1397,6 +1397,7 @@ imported/w3c/web-platform-tests/pointerevents/pointerevent_releasepointercapture
 imported/w3c/web-platform-tests/pointerevents/pointerevent_setpointercapture_override_pending_capture_element.html?touch [ Skip ]
 imported/w3c/web-platform-tests/pointerevents/pointerevent_setpointercapture_to_same_element_twice.html?touch [ Skip ]
 imported/w3c/web-platform-tests/pointerevents/pointerevent_pointerrawupdate_changes_pointer_capture.https.html [ Skip ]
+imported/w3c/web-platform-tests/pointerevents/pointerevent_touch-propagates-when-target-is-video_touch.html [ Skip ]
 
 webkit.org/b/274686 imported/w3c/web-platform-tests/pointerevents/pointerevent_capture_mouse_and_release_and_capture_again.html [ Skip ]
 


### PR DESCRIPTION
#### fc9a23851031b923769cf1642c8cb289d511fcf3
<pre>
Re-sync WPT tests for pointer events
<a href="https://bugs.webkit.org/show_bug.cgi?id=299625">https://bugs.webkit.org/show_bug.cgi?id=299625</a>
<a href="https://rdar.apple.com/161428181">rdar://161428181</a>

Reviewed by Abrar Rahman Protyasha and Tim Nguyen.

Resync pointerevents directory.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/3d29e5a2a14777cdf35c53820baf14a04d3ecf72">https://github.com/web-platform-tests/wpt/commit/3d29e5a2a14777cdf35c53820baf14a04d3ecf72</a>

* LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_click_is_a_pointerevent.html:
* LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_click_is_a_pointerevent_mouse-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_pointerrawupdate-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_pointerrawupdate.html:
* LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_pointerrawupdate.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_pointerrawupdate.https.html:
* LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_touch-propagates-when-target-is-video_touch-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_touch-propagates-when-target-is-video_touch.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/pointerevents/w3c-import.log:
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/pointerevents/pointerevent_pointerrawupdate-expected.txt: Added.
* LayoutTests/platform/mac/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/300788@main">https://commits.webkit.org/300788@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/599fe07dfd523c7fb694d7ab2408a5b10369f724

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123855 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43570 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34267 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130641 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76006 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/590e86cd-5f47-4452-9da4-01b2451b5540) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44294 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52164 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94198 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/62505 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/299fa13c-fd34-4e3d-8719-8dde83e3d3cc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126808 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35283 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110799 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74796 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5d02faae-d8c5-4db4-9d8f-d24b9ab83c91) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34239 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28960 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74118 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105010 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29183 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133335 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50808 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38689 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102665 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51182 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107019 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102494 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26062 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47833 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26096 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/47657 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50661 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50135 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53481 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51809 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->