### PR TITLE
[Navigation API] navigation-api/per-entry-events/dispose-for-navigation-in-child.html is failing

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/per-entry-events/dispose-for-navigation-in-child-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/per-entry-events/dispose-for-navigation-in-child-expected.txt
@@ -1,6 +1,4 @@
 
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT Dispose events should fire when entries are removed by a navigation in a different frame Test timed out
+PASS Dispose events should fire when entries are removed by a navigation in a different frame
 

--- a/Source/WebCore/page/LocalDOMWindowProperty.cpp
+++ b/Source/WebCore/page/LocalDOMWindowProperty.cpp
@@ -42,6 +42,11 @@ LocalFrame* LocalDOMWindowProperty::frame() const
     return m_window ? protectedWindow()->localFrame() : nullptr;
 }
 
+RefPtr<LocalFrame> LocalDOMWindowProperty::protectedFrame() const
+{
+    return frame();
+}
+
 LocalDOMWindow* LocalDOMWindowProperty::window() const
 {
     return m_window.get();

--- a/Source/WebCore/page/LocalDOMWindowProperty.h
+++ b/Source/WebCore/page/LocalDOMWindowProperty.h
@@ -35,6 +35,7 @@ class LocalFrame;
 class LocalDOMWindowProperty {
 public:
     WEBCORE_EXPORT LocalFrame* frame() const;
+    RefPtr<LocalFrame> protectedFrame() const;
     LocalDOMWindow* window() const;
     RefPtr<LocalDOMWindow> protectedWindow() const { return window(); }
 

--- a/Source/WebCore/page/Navigation.h
+++ b/Source/WebCore/page/Navigation.h
@@ -213,6 +213,9 @@ private:
     size_t entryIndexOfKey(const String&) const;
     bool hasEntryWithKey(const String&) const;
 
+    void disposeOfForwardEntriesInParents(BackForwardItemIdentifier);
+    void recursivelyDisposeOfForwardEntriesInParents(BackForwardItemIdentifier, LocalFrame* navigatedFrame);
+
     std::optional<size_t> m_currentEntryIndex;
     RefPtr<NavigationTransition> m_transition;
     RefPtr<NavigationActivation> m_activation;


### PR DESCRIPTION
#### 204956f9a3a32504628ecf777ac3482c9a221560
<pre>
[Navigation API] navigation-api/per-entry-events/dispose-for-navigation-in-child.html is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=299628">https://bugs.webkit.org/show_bug.cgi?id=299628</a>
<a href="https://rdar.apple.com/161203486">rdar://161203486</a>

Reviewed by Basuke Suzuki.

Suppose we have a mainframe and an iframe and this series of navigations happens:
1. iframe fragment navigates to &quot;/#a&quot;
2. main frame fragment navigates to &quot;/#1&quot;
3. main frame fragment navigates to &quot;/#2&quot;
4. main frame fragment navigates to &quot;/#3&quot;
5. iframe goes back
6. iframe fragment navigates to &quot;/#b&quot;

After Step 5, the UI Process b/f list should be:

A) mainframe - URL -    ItemID A
   ** iframe - URL -    ItemID A
B) mainframe - URL -    ItemID B
   ** iframe - URL/#a - ItemID B
C) mainframe - URL/#1 - ItemID C
   ** iframe - URL/#a - ItemID C
D) mainframe - URL/#2 - ItemID D
   ** iframe - URL/#a - ItemID D
E) mainframe - URL/#3 - ItemID E
   ** iframe - URL/#a - ItemID E

The mainframe&apos;s Navigation object&apos;s m_entries should be:

A) mainframe - URL -    ItemID A
C) mainframe - URL/#1 - ItemID C
D) mainframe - URL/#2 - ItemID D
E) mainframe - URL/#3 - ItemID E  &lt;--- current index

The iframe&apos;s Navigation object&apos;s m_entries should be:

A) ** iframe - URL -    ItemID A  &lt;--- current index
E) ** iframe - URL/#a - ItemID E

According to this layout test, after Step 6:

The mainframe&apos;s Navigation object&apos;s m_entries should be:

A) mainframe - URL -    ItemID A  &lt;--- current index

The iframe&apos;s Navigation object&apos;s m_entries should be:

A) ** iframe - URL -    ItemID A
F) ** iframe - URL/#b - ItemID F  &lt;--- current index

So when a subframe has a PUSH same-document navigation and disposes of any
forward entries, any parent frame must do the same.

This test was failing because the parent frame was not disposing of its
forward entries. To fix this, we add a new function to recusively dispose
of all forward entries in any parent frames when a subframe has a PUSH
same-document navigation. We use the ItemID to determine what entry must
stay and then dispose of any entries that come after that one.

* LayoutTests/imported/w3c/web-platform-tests/navigation-api/per-entry-events/dispose-for-navigation-in-child-expected.txt:
* Source/WebCore/page/LocalDOMWindowProperty.cpp:
(WebCore::LocalDOMWindowProperty::protectedFrame const):
* Source/WebCore/page/LocalDOMWindowProperty.h:
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::updateNavigationEntry):
(WebCore::Navigation::disposeOfForwardEntriesInParents):

Call recursivelyDisposeOfForwardEntriesInParents on the main frame,
which will traverse down the frame tree, and for each frame until we reach the
subframe that actually navigated, dispose of any forward entries.

(WebCore::Navigation::recursivelyDisposeOfForwardEntriesInParents):
(WebCore::Navigation::updateForNavigation):

This is called for same-document navigations. If it&apos;s a PUSH navigation, call
disposeOfForwardEntriesInParents. The ItemID that we keep in these parent frames
is the current ItemID right before this PUSH operation happens.

* Source/WebCore/page/Navigation.h:

Canonical link: <a href="https://commits.webkit.org/300721@main">https://commits.webkit.org/300721@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2eebe062dffa425eb47144a5f88a5bf4a8224fa9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123344 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43059 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33755 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130057 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/75464 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9b2ca80d-04b7-4be6-9154-ccd54886756f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/125221 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43782 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51653 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93758 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62202 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/84c453ed-594a-441a-b2ed-8fefef15ef05) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126297 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34886 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110358 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74387 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e830183f-788d-4c52-822c-f8c95ea6a3d7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33852 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28517 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73573 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104600 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28743 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132773 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50294 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38274 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102251 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50670 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106582 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102104 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47457 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25680 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/47080 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19461 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50149 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/55910 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49620 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/52970 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51298 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->