### PR TITLE
[libpas] Move pas_zero_memory into its own file

### DIFF
--- a/Source/bmalloc/CMakeLists.txt
+++ b/Source/bmalloc/CMakeLists.txt
@@ -683,6 +683,7 @@ set(bmalloc_PUBLIC_HEADERS
     libpas/src/libpas/pas_versioned_field.h
     libpas/src/libpas/pas_virtual_range.h
     libpas/src/libpas/pas_virtual_range_min_heap.h
+    libpas/src/libpas/pas_zero_memory.h
     libpas/src/libpas/pas_zero_mode.h
     libpas/src/libpas/thingy_heap_config.h
     libpas/src/libpas/thingy_heap.h

--- a/Source/bmalloc/bmalloc.xcodeproj/project.pbxproj
+++ b/Source/bmalloc/bmalloc.xcodeproj/project.pbxproj
@@ -606,6 +606,7 @@
 		DD4BEDE229CBA49700398E35 /* minalign32_heap.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F18F84125C3467700721C2A /* minalign32_heap.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD4BEDE329CBA49700398E35 /* pas_compact_expendable_memory.c in Sources */ = {isa = PBXBuildFile; fileRef = 2C48133C27406A3E006CAB55 /* pas_compact_expendable_memory.c */; };
 		DD4BEDE429CBA49700398E35 /* pas_status_reporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FC40A1B2451498400876DA0 /* pas_status_reporter.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		0100000D37BABA0A0A991999 /* pas_zero_memory.h in Headers */ = {isa = PBXBuildFile; fileRef = 0100000B37BABA0A0A991999 /* pas_zero_memory.h */; settings = {ATTRIBUTES = (Private, ); };};
 		DD4BEDE529CBA49700398E35 /* pagesize64k_heap_config.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F18F83F25C3467700721C2A /* pagesize64k_heap_config.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD4BEDE629CBA49700398E35 /* iso_heap.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FC409292451494300876DA0 /* iso_heap.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD4BEDE729CBA49700398E35 /* minalign32_heap_config.c in Sources */ = {isa = PBXBuildFile; fileRef = 0F18F84425C3467700721C2A /* minalign32_heap_config.c */; };
@@ -1350,6 +1351,7 @@
 		2C48133B27406A3E006CAB55 /* pas_large_expendable_memory.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pas_large_expendable_memory.c; path = libpas/src/libpas/pas_large_expendable_memory.c; sourceTree = "<group>"; };
 		2C48133C27406A3E006CAB55 /* pas_compact_expendable_memory.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pas_compact_expendable_memory.c; path = libpas/src/libpas/pas_compact_expendable_memory.c; sourceTree = "<group>"; };
 		2C48133D27406A3E006CAB55 /* pas_compact_expendable_memory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pas_compact_expendable_memory.h; path = libpas/src/libpas/pas_compact_expendable_memory.h; sourceTree = "<group>"; };
+		0100000B37BABA0A0A991999 /* pas_zero_memory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pas_zero_memory.h; path = libpas/src/libpas/pas_zero_memory.h; sourceTree = "<group>"; };
 		2C48133E27406A3E006CAB55 /* pas_expendable_memory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pas_expendable_memory.h; path = libpas/src/libpas/pas_expendable_memory.h; sourceTree = "<group>"; };
 		2C48133F27406A3E006CAB55 /* pas_large_expendable_memory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pas_large_expendable_memory.h; path = libpas/src/libpas/pas_large_expendable_memory.h; sourceTree = "<group>"; };
 		2C91E551271CE47A00D67FF9 /* pas_size_lookup_mode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pas_size_lookup_mode.h; path = libpas/src/libpas/pas_size_lookup_mode.h; sourceTree = "<group>"; };
@@ -2052,6 +2054,7 @@
 				0FC40ABE2451499000876DA0 /* pas_virtual_range.c */,
 				0FC40AED2451499300876DA0 /* pas_virtual_range.h */,
 				0FC40AE02451499200876DA0 /* pas_virtual_range_min_heap.h */,
+				0100000B37BABA0A0A991999 /* pas_zero_memory.h */,
 				0FC40AEA2451499300876DA0 /* pas_zero_mode.h */,
 				0F8700CE25B0CB03000E1ABF /* thingy_heap.c */,
 				0F8700CA25B0CB02000E1ABF /* thingy_heap.h */,
@@ -2740,6 +2743,7 @@
 				DD4BED3729CBA49700398E35 /* pas_versioned_field.h in Headers */,
 				DD4BED3B29CBA49700398E35 /* pas_virtual_range.h in Headers */,
 				DD4BECFD29CBA49700398E35 /* pas_virtual_range_min_heap.h in Headers */,
+				0100000D37BABA0A0A991999 /* pas_zero_memory.h in Headers */,
 				DD4BED6429CBA49700398E35 /* pas_zero_mode.h in Headers */,
 				DD4BEE2E29CBA4E300398E35 /* ProcessCheck.h in Headers */,
 				DD4BEE2A29CBA4E300398E35 /* ScopeExit.h in Headers */,

--- a/Source/bmalloc/bmalloc/VMAllocate.h
+++ b/Source/bmalloc/bmalloc/VMAllocate.h
@@ -34,6 +34,7 @@
 #include "Range.h"
 #include "Sizes.h"
 #include <algorithm>
+#include <cstddef>
 
 #if BOS(WINDOWS)
 #include <windows.h>
@@ -43,6 +44,7 @@
 #endif
 
 #if BOS(DARWIN)
+#include <mach/mach.h>
 #include <mach/vm_page_size.h>
 #endif
 

--- a/Source/bmalloc/libpas/libpas.xcodeproj/project.pbxproj
+++ b/Source/bmalloc/libpas/libpas.xcodeproj/project.pbxproj
@@ -1072,6 +1072,7 @@
 		0FC4EC32234A91E200B710A3 /* pas_status_reporter.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pas_status_reporter.c; sourceTree = "<group>"; };
 		0FC4EC33234A91E200B710A3 /* pas_string_stream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pas_string_stream.h; sourceTree = "<group>"; };
 		0FC4EC34234A91E200B710A3 /* pas_status_reporter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pas_status_reporter.h; sourceTree = "<group>"; };
+		0F99999B26AAAA0000111111 /* pas_zero_memory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pas_zero_memory.h; sourceTree = "<group>"; };
 		0FC4EC35234A91E300B710A3 /* pas_compute_summary_object_callbacks.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pas_compute_summary_object_callbacks.c; sourceTree = "<group>"; };
 		0FC4EC36234A91E300B710A3 /* pas_fd_stream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pas_fd_stream.h; sourceTree = "<group>"; };
 		0FC4EC782351707B00B710A3 /* pas_segregated_page_emptiness_kind.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pas_segregated_page_emptiness_kind.h; sourceTree = "<group>"; };
@@ -1971,6 +1972,7 @@
 				0F78088322FA22D200F37451 /* pas_virtual_range.c */,
 				0F78088222FA22D100F37451 /* pas_virtual_range.h */,
 				0F78088822FA534100F37451 /* pas_virtual_range_min_heap.h */,
+				0F99999B26AAAA0000111111 /* pas_zero_memory.h */,
 				0FDEA46D228B65430085E340 /* pas_zero_mode.h */,
 				0F8700A225B0A8C2000E1ABF /* thingy_heap.c */,
 				0F8700A325B0A8C2000E1ABF /* thingy_heap.h */,
@@ -2427,6 +2429,7 @@
 				0F68127022BD419E0036A02B /* pas_versioned_field.h in Headers */,
 				0F78088422FA22D200F37451 /* pas_virtual_range.h in Headers */,
 				0F78088E22FA534100F37451 /* pas_virtual_range_min_heap.h in Headers */,
+				0F99999D26AAAA0000111111 /* pas_zero_memory.h in Headers */,
 				0FE7EE3B22960142004F4166 /* pas_zero_mode.h in Headers */,
 				0F8700A825B0A8C2000E1ABF /* thingy_heap.h in Headers */,
 				0F8700AA25B0A8C3000E1ABF /* thingy_heap_config.h in Headers */,

--- a/Source/bmalloc/libpas/src/libpas/jit_heap_config.c
+++ b/Source/bmalloc/libpas/src/libpas/jit_heap_config.c
@@ -39,6 +39,7 @@
 #include "pas_root.h"
 #include "pas_segregated_page_config_inlines.h"
 #include "pas_stream.h"
+#include "pas_zero_memory.h"
 
 #if defined(PAS_BMALLOC)
 #include "BPlatform.h"

--- a/Source/bmalloc/libpas/src/libpas/pas_allocation_result.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_allocation_result.h
@@ -29,6 +29,7 @@
 #include <errno.h>
 #include "pas_internal_config.h"
 #include "pas_utils.h"
+#include "pas_zero_memory.h"
 #include "pas_zero_mode.h"
 
 PAS_BEGIN_EXTERN_C;

--- a/Source/bmalloc/libpas/src/libpas/pas_bitfit_page.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_bitfit_page.c
@@ -33,6 +33,7 @@
 #include "pas_bitfit_view.h"
 #include "pas_epoch.h"
 #include "pas_log.h"
+#include "pas_zero_memory.h"
 
 void pas_bitfit_page_construct(pas_bitfit_page* page,
                                pas_bitfit_view* view,

--- a/Source/bmalloc/libpas/src/libpas/pas_compact_heap_reservation.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_compact_heap_reservation.c
@@ -31,6 +31,7 @@
 
 #include "pas_heap_lock.h"
 #include "pas_page_malloc.h"
+#include "pas_zero_memory.h"
 
 #if PAS_PLATFORM(PLAYSTATION)
 #include <memory-extra.h>

--- a/Source/bmalloc/libpas/src/libpas/pas_enumerator.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_enumerator.c
@@ -38,6 +38,7 @@
 #include "pas_enumerator_region.h"
 #include "pas_ptr_hash_set.h"
 #include "pas_root.h"
+#include "pas_zero_memory.h"
 
 static void* allocate(size_t size, const char* name, pas_allocation_kind allocation_kind, void* arg)
 {

--- a/Source/bmalloc/libpas/src/libpas/pas_fast_large_free_heap.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_fast_large_free_heap.c
@@ -31,6 +31,7 @@
 
 #include "pas_generic_large_free_heap.h"
 #include "pas_utility_heap.h"
+#include "pas_zero_memory.h"
 
 /* It so happens that we can use this for both x (address) and y (size). */
 static PAS_ALWAYS_INLINE int key_compare_callback(void* raw_left,

--- a/Source/bmalloc/libpas/src/libpas/pas_fast_megapage_table.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_fast_megapage_table.c
@@ -24,6 +24,7 @@
  */
 
 #include "pas_config.h"
+#include "pas_zero_memory.h"
 
 #if LIBPAS_ENABLED
 

--- a/Source/bmalloc/libpas/src/libpas/pas_free_granules.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_free_granules.c
@@ -33,6 +33,7 @@
 #include "pas_heap_config.h"
 #include "pas_log.h"
 #include "pas_page_base_config.h"
+#include "pas_zero_memory.h"
 
 void pas_free_granules_compute_and_mark_decommitted(pas_free_granules* free_granules,
                                                     pas_page_granule_use_count* use_counts,

--- a/Source/bmalloc/libpas/src/libpas/pas_hashtable.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_hashtable.h
@@ -31,6 +31,7 @@
 #include "pas_enumerator.h"
 #include "pas_log.h"
 #include "pas_utils.h"
+#include "pas_zero_memory.h"
 
 PAS_BEGIN_EXTERN_C;
 

--- a/Source/bmalloc/libpas/src/libpas/pas_heap.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_heap.c
@@ -40,6 +40,7 @@
 #include "pas_primitive_heap_ref.h"
 #include "pas_probabilistic_guard_malloc_allocator.h"
 #include "pas_segregated_size_directory.h"
+#include "pas_zero_memory.h"
 
 pas_heap* pas_heap_create(pas_heap_ref* heap_ref,
                           pas_heap_ref_kind heap_ref_kind,

--- a/Source/bmalloc/libpas/src/libpas/pas_heap_config_utils.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_heap_config_utils.c
@@ -35,6 +35,7 @@
 #include "pas_large_heap_physical_page_sharing_cache.h"
 #include "pas_root.h"
 #include "pas_segregated_page.h"
+#include "pas_zero_memory.h"
 
 void pas_heap_config_utils_null_activate(void)
 {

--- a/Source/bmalloc/libpas/src/libpas/pas_immutable_vector.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_immutable_vector.h
@@ -30,6 +30,7 @@
 #include "pas_immortal_heap.h"
 #include "pas_log.h"
 #include "pas_utils.h"
+#include "pas_zero_memory.h"
 
 PAS_BEGIN_EXTERN_C;
 

--- a/Source/bmalloc/libpas/src/libpas/pas_large_heap_physical_page_sharing_cache.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_large_heap_physical_page_sharing_cache.c
@@ -35,6 +35,7 @@
 #include "pas_large_sharing_pool.h"
 #include "pas_page_malloc.h"
 #include "pas_page_sharing_pool.h"
+#include "pas_zero_memory.h"
 #include <stdio.h>
 
 pas_enumerable_range_list pas_large_heap_physical_page_sharing_cache_page_list;

--- a/Source/bmalloc/libpas/src/libpas/pas_large_sharing_pool.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_large_sharing_pool.c
@@ -41,6 +41,7 @@
 #include "pas_physical_memory_transaction.h"
 #include "pas_stream.h"
 #include "pas_utility_heap.h"
+#include "pas_zero_memory.h"
 
 bool pas_large_sharing_pool_enabled = true;
 pas_red_black_tree pas_large_sharing_tree = PAS_RED_BLACK_TREE_INITIALIZER;

--- a/Source/bmalloc/libpas/src/libpas/pas_local_allocator.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_local_allocator.c
@@ -36,6 +36,7 @@
 #include "pas_segregated_size_directory.h"
 #include "pas_segregated_view.h"
 #include "pas_utility_heap.h"
+#include "pas_zero_memory.h"
 
 #if PAS_LOCAL_ALLOCATOR_MEASURE_REFILL_EFFICIENCY
 double pas_local_allocator_refill_efficiency_sum = 0.;

--- a/Source/bmalloc/libpas/src/libpas/pas_local_allocator_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_local_allocator_inlines.h
@@ -47,6 +47,7 @@
 #include "pas_system_heap.h"
 #include "pas_thread_local_cache.h"
 #include "pas_thread_local_cache_node.h"
+#include "pas_zero_memory.h"
 
 PAS_BEGIN_EXTERN_C;
 

--- a/Source/bmalloc/libpas/src/libpas/pas_lock.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_lock.h
@@ -30,6 +30,7 @@
 #include "pas_race_test_hooks.h"
 #include "pas_utils.h"
 #include "pas_thread.h"
+#include "pas_zero_memory.h"
 
 PAS_BEGIN_EXTERN_C;
 

--- a/Source/bmalloc/libpas/src/libpas/pas_megapage_cache.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_megapage_cache.c
@@ -33,6 +33,7 @@
 #include "pas_internal_config.h"
 #include "pas_large_free_heap_config.h"
 #include "pas_payload_reservation_page_list.h"
+#include "pas_zero_memory.h"
 #include <stdio.h>
 
 typedef struct {

--- a/Source/bmalloc/libpas/src/libpas/pas_min_heap.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_min_heap.h
@@ -28,6 +28,7 @@
 
 #include "pas_allocation_config.h"
 #include "pas_utils.h"
+#include "pas_zero_memory.h"
 #include <stdio.h>
 
 PAS_BEGIN_EXTERN_C;

--- a/Source/bmalloc/libpas/src/libpas/pas_page_base_and_kind.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_page_base_and_kind.h
@@ -27,6 +27,7 @@
 #define PAS_PAGE_BASE_AND_KIND_H
 
 #include "pas_page_base.h"
+#include "pas_zero_memory.h"
 
 PAS_BEGIN_EXTERN_C;
 

--- a/Source/bmalloc/libpas/src/libpas/pas_page_malloc.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_page_malloc.c
@@ -31,10 +31,6 @@
 
 #include <errno.h>
 #include <math.h>
-#include "pas_config.h"
-#include "pas_internal_config.h"
-#include "pas_log.h"
-#include "pas_utils.h"
 #include <stdio.h>
 #include <string.h>
 #if !PAS_OS(WINDOWS)
@@ -45,6 +41,11 @@
 #include <mach/vm_page_size.h>
 #include <mach/vm_statistics.h>
 #endif
+
+#include "pas_internal_config.h"
+#include "pas_log.h"
+#include "pas_utils.h"
+#include "pas_zero_memory.h"
 
 size_t pas_page_malloc_num_allocated_bytes;
 size_t pas_page_malloc_cached_alignment;

--- a/Source/bmalloc/libpas/src/libpas/pas_physical_memory_transaction.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_physical_memory_transaction.c
@@ -28,6 +28,7 @@
 #if LIBPAS_ENABLED
 
 #include "pas_physical_memory_transaction.h"
+#include "pas_zero_memory.h"
 
 void pas_physical_memory_transaction_construct(pas_physical_memory_transaction* transaction)
 {

--- a/Source/bmalloc/libpas/src/libpas/pas_root.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_root.c
@@ -24,6 +24,7 @@
  */
 
 #include "pas_config.h"
+#include "pas_zero_memory.h"
 
 #if LIBPAS_ENABLED
 

--- a/Source/bmalloc/libpas/src/libpas/pas_segmented_vector.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_segmented_vector.h
@@ -30,6 +30,7 @@
 #include "pas_found_index.h"
 #include "pas_immortal_heap.h"
 #include "pas_utils.h"
+#include "pas_zero_memory.h"
 #include <stdalign.h>
 
 PAS_BEGIN_EXTERN_C;

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_heap.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_heap.c
@@ -44,6 +44,7 @@
 #include "pas_thread_local_cache.h"
 #include "pas_thread_local_cache_layout.h"
 #include "pas_utility_heap_config.h"
+#include "pas_zero_memory.h"
 
 unsigned pas_segregated_heap_num_size_lookup_rematerializations;
 

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_page.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_page.c
@@ -45,6 +45,7 @@
 #include "pas_segregated_page_inlines.h"
 #include "pas_segregated_size_directory.h"
 #include "pas_utility_heap_config.h"
+#include "pas_zero_memory.h"
 
 double pas_segregated_page_extra_wasteage_handicap_for_config_variant[
     PAS_NUM_SEGREGATED_PAGE_CONFIG_VARIANTS] = {

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_page_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_page_inlines.h
@@ -37,6 +37,7 @@
 #include "pas_segregated_shared_handle.h"
 #include "pas_segregated_shared_handle_inlines.h"
 #include "pas_thread_local_cache_node.h"
+#include "pas_zero_memory.h"
 
 PAS_BEGIN_EXTERN_C;
 

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_size_directory.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_size_directory.h
@@ -38,6 +38,7 @@
 #include "pas_page_granule_use_count.h"
 #include "pas_segregated_directory.h"
 #include "pas_segregated_size_directory_creation_mode.h"
+#include "pas_zero_memory.h"
 
 PAS_BEGIN_EXTERN_C;
 

--- a/Source/bmalloc/libpas/src/libpas/pas_simple_large_free_heap.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_simple_large_free_heap.c
@@ -35,6 +35,7 @@
 #include "pas_large_free.h"
 #include "pas_large_free_heap_config.h"
 #include "pas_log.h"
+#include "pas_zero_memory.h"
 #include <stdio.h>
 
 static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_LARGE_HEAPS);

--- a/Source/bmalloc/libpas/src/libpas/pas_status_reporter.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_status_reporter.c
@@ -62,6 +62,7 @@
 #include "pas_thread_local_cache_node.h"
 #include "pas_utility_heap.h"
 #include "pas_thread.h"
+#include "pas_zero_memory.h"
 #if !PAS_OS(WINDOWS)
 #include <unistd.h>
 #endif

--- a/Source/bmalloc/libpas/src/libpas/pas_string_stream.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_string_stream.c
@@ -31,6 +31,7 @@
 
 #include "pas_bootstrap_free_heap.h"
 #include "pas_snprintf.h"
+#include "pas_zero_memory.h"
 
 static PAS_FORMAT_PRINTF(2, 0) void string_stream_vprintf(pas_stream* stream, const char* format, va_list arg_list)
 {

--- a/Source/bmalloc/libpas/src/libpas/pas_thread_local_cache.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_thread_local_cache.c
@@ -43,6 +43,7 @@
 #include "pas_thread_local_cache_layout.h"
 #include "pas_thread_local_cache_node.h"
 #include "pas_thread_suspend_lock.h"
+#include "pas_zero_memory.h"
 #if !PAS_OS(WINDOWS)
 #include <unistd.h>
 #endif

--- a/Source/bmalloc/libpas/src/libpas/pas_thread_local_cache_layout.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_thread_local_cache_layout.h
@@ -34,6 +34,7 @@
 #include "pas_thread_local_cache_layout_entry.h"
 #include "pas_thread_local_cache_layout_node.h"
 #include "pas_utils.h"
+#include "pas_zero_memory.h"
 
 PAS_BEGIN_EXTERN_C;
 

--- a/Source/bmalloc/libpas/src/libpas/pas_tiny_large_map_entry.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_tiny_large_map_entry.h
@@ -29,6 +29,7 @@
 #include "pas_heap_table.h"
 #include "pas_large_map_entry.h"
 #include "pas_utils.h"
+#include "pas_zero_memory.h"
 
 PAS_BEGIN_EXTERN_C;
 

--- a/Source/bmalloc/libpas/src/libpas/pas_utils.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_utils.h
@@ -206,14 +206,6 @@ PAS_BEGIN_EXTERN_C;
 #define PAS_SHOULD_PROFILE_BASIC_HEAP_PAGE(size_category) (false)
 #endif
 
-static PAS_ALWAYS_INLINE void pas_zero_memory(void* memory, size_t size)
-{
-    PAS_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    PAS_PROFILE(ZERO_MEMORY, memory, size);
-    memset(memory, 0, size);
-    PAS_ALLOW_UNSAFE_BUFFER_USAGE_END
-}
-
 /* NOTE: panic format string must have \n at the end. */
 PAS_API PAS_NO_RETURN void pas_panic(const char* format, ...) PAS_FORMAT_PRINTF(1, 2);
 

--- a/Source/bmalloc/libpas/src/libpas/pas_zero_memory.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_zero_memory.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020 Apple Inc. All rights reserved.
+ * Copyright (c) 2018-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -20,39 +20,25 @@
  * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
  * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "pas_config.h"
+#ifndef PAS_ZERO_MEMORY_H
+#define PAS_ZERO_MEMORY_H
 
-#if LIBPAS_ENABLED
+#include "pas_utils.h"
+#include <stdint.h>
 
-#include "pas_baseline_allocator.h"
+PAS_BEGIN_EXTERN_C;
 
-#include "pas_segregated_size_directory.h"
-#include "pas_zero_memory.h"
-
-void pas_baseline_allocator_attach_directory(pas_baseline_allocator* allocator,
-                                             pas_segregated_size_directory* directory)
+static PAS_ALWAYS_INLINE void pas_zero_memory(void* memory, size_t size)
 {
-    PAS_ASSERT(!allocator->u.allocator.view);
-    
-    PAS_ASSERT(
-        PAS_BASELINE_LOCAL_ALLOCATOR_SIZE
-        >= pas_segregated_size_directory_local_allocator_size(directory));
-    
-    pas_local_allocator_construct(&allocator->u.allocator, directory);
+    PAS_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+    PAS_PROFILE(ZERO_MEMORY, memory, size);
+    memset(memory, 0, size);
+    PAS_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
-void pas_baseline_allocator_detach_directory(pas_baseline_allocator* allocator)
-{
-    PAS_ASSERT(allocator->u.allocator.view);
-    pas_local_allocator_stop(
-        &allocator->u.allocator,
-        pas_lock_lock_mode_lock,
-        pas_lock_is_not_held);
-    pas_zero_memory(&allocator->u.allocator, sizeof(pas_local_allocator)); /* Does not zero the bits,
-                                                                              which is OK. */
-}
+PAS_END_EXTERN_C;
 
-#endif /* LIBPAS_ENABLED */
+#endif // PAS_ZERO_MEMORY_H


### PR DESCRIPTION
#### bb082ecc001a8320b3f50c7d566db61204e082aa
<pre>
[libpas] Move pas_zero_memory into its own file
<a href="https://bugs.webkit.org/show_bug.cgi?id=299637">https://bugs.webkit.org/show_bug.cgi?id=299637</a>
<a href="https://rdar.apple.com/161439504">rdar://161439504</a>

Reviewed by Mark Lam and Yusuke Suzuki.

This is preparatory work for landing the MTE patch, as it breaks up a
dependency cycle that would otherwise be introduced between pas_mte.h
and pas_utils.h.

Canonical link: <a href="https://commits.webkit.org/300713@main">https://commits.webkit.org/300713@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ae2ef9f2318a1e01df56722790d02ab9897a9ef4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123583 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43298 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33994 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130350 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/75726 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/52eb2cd6-0363-4799-80a7-bfe03a6bb4bb) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44021 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51892 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93967 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/62371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/81b322fa-bfc9-4bf7-bab6-de559c75426c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126536 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35067 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110560 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74572 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0b3668c3-60ff-46dd-8e79-7218a2a07475) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34036 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28718 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73827 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/115742 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104786 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28942 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133041 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/122115 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50534 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38474 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102442 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50909 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106781 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102285 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26000 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47637 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25875 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/47345 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50388 "Built successfully") | | [❌ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/152469 "Hash ae2ef9f2 for PR 51411 does not build (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49862 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/152469 "Hash ae2ef9f2 for PR 51411 does not build (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53209 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51537 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->