### PR TITLE
[Screen Time] Unexpected power usage due to ScreenTimeWebExtension performing CA Commits when invisible

### DIFF
--- a/Source/WebCore/PAL/pal/cocoa/ScreenTimeSoftLink.h
+++ b/Source/WebCore/PAL/pal/cocoa/ScreenTimeSoftLink.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(SCREEN_TIME)
 
+#import <ScreenTime/STScreenTimeConfiguration.h>
 #import <ScreenTime/STWebHistory.h>
 #import <ScreenTime/STWebpageController.h>
 #import <wtf/SoftLinking.h>
@@ -34,5 +35,7 @@
 SOFT_LINK_FRAMEWORK_FOR_HEADER(PAL, ScreenTime)
 SOFT_LINK_CLASS_FOR_HEADER(PAL, STWebpageController)
 SOFT_LINK_CLASS_FOR_HEADER(PAL, STWebHistory)
+SOFT_LINK_CLASS_FOR_HEADER(PAL, STScreenTimeConfiguration)
+SOFT_LINK_CLASS_FOR_HEADER(PAL, STScreenTimeConfigurationObserver)
 
 #endif // ENABLE(SCREEN_TIME)

--- a/Source/WebCore/PAL/pal/cocoa/ScreenTimeSoftLink.mm
+++ b/Source/WebCore/PAL/pal/cocoa/ScreenTimeSoftLink.mm
@@ -27,6 +27,7 @@
 
 #if ENABLE(SCREEN_TIME)
 
+#import <ScreenTime/STScreenTimeConfiguration.h>
 #import <ScreenTime/STWebHistory.h>
 #import <ScreenTime/STWebpageController.h>
 #import <wtf/SoftLinking.h>
@@ -35,6 +36,7 @@ SOFT_LINK_FRAMEWORK_FOR_SOURCE_WITH_EXPORT(PAL, ScreenTime, PAL_EXPORT)
 
 SOFT_LINK_CLASS_FOR_SOURCE_WITH_EXPORT(PAL, ScreenTime, STWebpageController, PAL_EXPORT)
 SOFT_LINK_CLASS_FOR_SOURCE_WITH_EXPORT(PAL, ScreenTime, STWebHistory, PAL_EXPORT)
-
+SOFT_LINK_CLASS_FOR_SOURCE_WITH_EXPORT(PAL, ScreenTime, STScreenTimeConfiguration, PAL_EXPORT)
+SOFT_LINK_CLASS_FOR_SOURCE_WITH_EXPORT(PAL, ScreenTime, STScreenTimeConfigurationObserver, PAL_EXPORT)
 
 #endif // ENABLE(SCREEN_TIME)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -52,6 +52,7 @@
 #import <wtf/spi/cocoa/NSObjCRuntimeSPI.h>
 
 #if ENABLE(SCREEN_TIME)
+#import <ScreenTime/STScreenTimeConfiguration.h>
 #import <ScreenTime/STWebpageController.h>
 #endif
 
@@ -311,6 +312,7 @@ struct PerWebProcessState {
 
 #if ENABLE(SCREEN_TIME)
     RetainPtr<STWebpageController> _screenTimeWebpageController;
+    RetainPtr<STScreenTimeConfigurationObserver> _screenTimeConfigurationObserver;
 #if PLATFORM(MAC)
     RetainPtr<NSVisualEffectView> _screenTimeBlurredSnapshot;
 #else


### PR DESCRIPTION
#### d10f7ce53734b9bb35b3b3783ddf0f19b5559eed
<pre>
[Screen Time] Unexpected power usage due to ScreenTimeWebExtension performing CA Commits when invisible
<a href="https://bugs.webkit.org/show_bug.cgi?id=299634">https://bugs.webkit.org/show_bug.cgi?id=299634</a>
<a href="https://rdar.apple.com/156520177">rdar://156520177</a>

Reviewed by Tim Horton and Aditya Keerthi.

ScreenTimeWebExtension is performing more CA commits when
not rendering, than expected. As a result, there is more power usage
than anticipated.

As a temporary solution, only install the STWebpageController for
managed-users. This is achieved by using STScreenTimeConfigurationObserver
to observe the enforcesChildRestrictions property.

* Source/WebCore/PAL/pal/cocoa/ScreenTimeSoftLink.h:
* Source/WebCore/PAL/pal/cocoa/ScreenTimeSoftLink.mm:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _installScreenTimeWebpageControllerIfNeeded]):
(-[WKWebView _uninstallScreenTimeWebpageController]):
(-[WKWebView observeValueForKeyPath:ofObject:change:context:]):
(-[WKWebView _screenTimeConfigurationObserver]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:

Change all API tests to set enforcesChildRestrictions to YES after the
WKWebView is created but before _installScreenTimeWebpageControllerIfNeeded
is called. In a follow-up PR, I will be adding a KVO API test for
enforcesChildRestrictions.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/ScreenTime.mm:
(swizzleEnforcesChildRestrictions):
(testSuppressUsageRecordingWithDataStore):
(testShowsSystemScreenTimeBlockingView):
(testWebContentIsNotClickableShowingSystemScreenTimeBlockingView):
(TEST(ScreenTime, IsBlockedByScreenTimeTrue)):
(TEST(ScreenTime, IsBlockedByScreenTimeFalse)):
(TEST(ScreenTime, IsBlockedByScreenTimeMultiple)):
(TEST(ScreenTime, IsBlockedByScreenTimeKVO)):
(TEST(ScreenTime, IdentifierNil)):
(TEST(ScreenTime, IdentifierString)):
(TEST(ScreenTime, IdentifierStringWithRemoveData)):
(TEST(ScreenTime, WKWebViewFillsStackView)):
(TEST(ScreenTime, URLIsPlayingVideo)):
(TEST(ScreenTime, URLIsPictureInPicture)):
(TEST(ScreenTime, FetchData)):
(TEST(ScreenTime, RemoveDataWithTimeInterval)):
(TEST(ScreenTime, RemoveData)):
(TEST(ScreenTime, OffscreenSystemScreenTimeBlockingView)):
(TEST(ScreenTime, OffscreenBlurredScreenTimeBlockingView)):
(TEST(ScreenTime, DoNotDonateURLsInOccludedWebView)):
(TEST(ScreenTime, CreateControllerAfterOffscreenWebViewBecomesInWindow)):
(TEST(ScreenTime, ScreenTimeControllerSetsURLWhenOffscreenWebViewBecomesInWindow)):
(TEST(ScreenTime, ScreenTimeControllerInstalledAfterRestoreFromSessionState)):
(TEST(ScreenTime, ScreenTimeControllerViewOnlyInstalledForHTTPFamily)):
(TEST(ScreenTime, ScreenTimeControllerNotInstalledForNoChildRestrictions)):

Canonical link: <a href="https://commits.webkit.org/300778@main">https://commits.webkit.org/300778@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e899fb6146a2f60e21b70022eabb0d70f5610bed

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123810 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43525 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34222 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130590 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/75960 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d7bf1d90-8509-4c02-a0a7-ab053cebc4be) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/125687 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44249 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52119 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94158 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/62486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2c9c05cb-fbf0-4b36-b362-a1de17fd2be8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126763 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35257 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110761 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74758 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/80674f4a-8fd8-4b6d-8ec9-1e697c4deefd) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34212 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28922 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74072 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104983 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29145 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133285 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50762 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38655 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102629 "5 flakes 53 failures") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51137 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106981 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102458 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47810 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26063 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/47612 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19484 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50616 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56380 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50090 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53436 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51764 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->