### PR TITLE
WebPage::close is never called for some pages when Site Isolation is enabled

### DIFF
--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -5282,7 +5282,7 @@ void WebPageProxy::commitProvisionalPage(IPC::Connection& connection, FrameIdent
         m_mainFrameWebsitePolicies = mainFrameWebsitePolicies->copy();
 
     // There is no way we'll be able to return to the page in the previous page so close it.
-    if (!didSuspendPreviousPage && shouldClosePreviousPage())
+    if (!didSuspendPreviousPage)
         send(Messages::WebPage::Close());
 
     const auto oldWebPageID = m_webPageID;
@@ -5293,11 +5293,6 @@ void WebPageProxy::commitProvisionalPage(IPC::Connection& connection, FrameIdent
     // FIXME: <rdar://121240770> This is a hack. There seems to be a bug in our interaction with WebPageInspectorController.
     if (!preferences->siteIsolationEnabled())
         m_inspectorController->didCommitProvisionalPage(oldWebPageID, m_webPageID);
-}
-
-bool WebPageProxy::shouldClosePreviousPage()
-{
-    return !protectedPreferences()->siteIsolationEnabled();
 }
 
 void WebPageProxy::destroyProvisionalPage()

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2966,8 +2966,6 @@ private:
     void didFinishLoadForResource(WebCore::ResourceLoaderIdentifier, WebCore::FrameIdentifier, WebCore::ResourceError&&);
 #endif
 
-    bool shouldClosePreviousPage();
-
 #if ENABLE(MEDIA_STREAM)
     UserMediaPermissionRequestManagerProxy& userMediaPermissionRequestManager();
     Ref<UserMediaPermissionRequestManagerProxy> protectedUserMediaPermissionRequestManager();


### PR DESCRIPTION
#### 92689c8232ff9a5fdd2ea72a6ec9f920f202135d
<pre>
WebPage::close is never called for some pages when Site Isolation is enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=299638">https://bugs.webkit.org/show_bug.cgi?id=299638</a>
<a href="https://rdar.apple.com/161442673">rdar://161442673</a>

Reviewed by NOBODY (OOPS!).

WIP

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::commitProvisionalPage):
(WebKit::WebPageProxy::shouldClosePreviousPage): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/92689c8232ff9a5fdd2ea72a6ec9f920f202135d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123250 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42964 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33661 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/129958 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/75363 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d833a0ac-514c-459f-b31c-77cfb2bcabbf) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43688 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51559 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93689 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62156 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/96d10fdd-91e2-4fa6-bd17-fe3f02433712) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126203 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34818 "Found 4 new test failures: http/tests/site-isolation/frame-access-after-window-open.html http/tests/site-isolation/iframe-and-window-open.html http/tests/site-isolation/window-open-with-name-cross-site.html http/tests/site-isolation/window-open-with-name.html (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110282 "Found 5 new API test failures: TestWebKitAPI.SiteIsolation.BasicPostMessageWindowOpen, TestWebKitAPI.SiteIsolation.OpenedWindowFocusDelegates, TestWebKitAPI.SiteIsolation.LoadStringAfterOpen, TestWebKitAPI.SiteIsolation.FocusOpenedWindow, TestWebKitAPI.SiteIsolation.CloseAfterWindowOpen (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74317 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3c3042b9-8a5e-4c90-bf17-47671a98aa75) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33784 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73473 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104532 "Found 4 new API test failures: TestWebKitAPI.SiteIsolation.BasicPostMessageWindowOpen, TestWebKitAPI.SiteIsolation.LoadStringAfterOpen, TestWebKitAPI.SiteIsolation.FocusOpenedWindow, TestWebKitAPI.SiteIsolation.CloseAfterWindowOpen (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28664 "Found 4 new test failures: http/tests/site-isolation/frame-access-after-window-open.html http/tests/site-isolation/iframe-and-window-open.html http/tests/site-isolation/window-open-with-name-cross-site.html http/tests/site-isolation/window-open-with-name.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132676 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50200 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38207 "Found 3 new test failures: http/tests/site-isolation/frame-access-after-window-open.html http/tests/site-isolation/iframe-and-window-open.html http/tests/site-isolation/window-open-with-name.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102176 "Found 1 new test failure: imported/blink/fast/pagination/viewport-y-horizontal-bt-rtl.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50576 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106503 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102032 "Found 1 new API test failure: WebKitGTK/TestInspector:/webkit/WebKitWebInspector/manual-attach-detach (failure)") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47392 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25605 "Found 4 new test failures: http/tests/site-isolation/frame-access-after-window-open.html http/tests/site-isolation/iframe-and-window-open.html http/tests/site-isolation/window-open-with-name-cross-site.html http/tests/site-isolation/window-open-with-name.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/46974 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50055 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/55816 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49526 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/52876 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51204 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->