### PR TITLE
[Site Isolation] Fix inspector test failures

### DIFF
--- a/Source/WebKit/UIProcess/Inspector/mac/WKInspectorViewController.mm
+++ b/Source/WebKit/UIProcess/Inspector/mac/WKInspectorViewController.mm
@@ -169,6 +169,9 @@ static void* const safeAreaInsetsKVOContext = (void*)&safeAreaInsetsKVOContext;
 
     preferences._diagnosticLoggingEnabled = YES;
 
+    // Disable Site Isolation for Web Inspector View.
+    preferences._siteIsolationEnabled = NO;
+
     [_configuration applyToWebViewConfiguration:configuration.get()];
     
     if (!!_delegate && [_delegate respondsToSelector:@selector(inspectorViewControllerInspectorIsUnderTest:)]) {


### PR DESCRIPTION
#### aa513ce79a0fdb8b765f64a88de9860d3aa7637e
<pre>
[Site Isolation] Fix inspector test failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=299640">https://bugs.webkit.org/show_bug.cgi?id=299640</a>
<a href="https://rdar.apple.com/161362146">rdar://161362146</a>

Reviewed by Devin Rousso.

Tests are failing because the web view for Web Inspector itself is created as SiteIsolationEnabled=true.
WebView should have Site Isolation disabled on Web Inspector view.

No new tests. The test result should be same with before.

* Source/WebKit/UIProcess/Inspector/mac/WKInspectorViewController.mm:
(-[WKInspectorViewController webViewConfiguration]):

Canonical link: <a href="https://commits.webkit.org/300625@main">https://commits.webkit.org/300625@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/70840cfe56b153248d6ae8b14b7b974b38d4e3e8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123278 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42992 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33689 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/129986 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/75391 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/49ac0a58-0d5c-49b4-935c-09c645875616) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43716 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51587 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93707 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/62165 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/15893aec-394b-4808-aef2-9b2d38e9ecdc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126231 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34834 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110303 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74335 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/baee62f0-d243-4997-b4f0-d29e781b637f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33799 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73504 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104548 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28688 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132704 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50228 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38220 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102197 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50604 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106527 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102052 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25946 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47404 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25626 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/47002 "The change is no longer eligible for processing.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50083 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/55844 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49554 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/52904 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51232 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->