### PR TITLE
wip

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1935,6 +1935,7 @@ layout/formattingContexts/flex/FlexFormattingUtils.cpp
 layout/formattingContexts/flex/FlexLayout.cpp
 layout/formattingContexts/grid/GridFormattingContext.cpp
 layout/formattingContexts/grid/GridLayout.cpp
+layout/formattingContexts/grid/GridLayoutUtils.cpp
 layout/formattingContexts/grid/ImplicitGrid.cpp
 layout/formattingContexts/grid/PlacedGridItem.cpp
 layout/formattingContexts/grid/TrackSizingAlgorithm.cpp

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -4331,6 +4331,8 @@
 		A5A9934C1E3809CF005B5E4D /* JSPerformanceObserverEntryList.h in Headers */ = {isa = PBXBuildFile; fileRef = A5A993471E380999005B5E4D /* JSPerformanceObserverEntryList.h */; };
 		A5AE5E1A2DE0CCD80038B9AC /* GridSpan.h in Headers */ = {isa = PBXBuildFile; fileRef = A5AE5E172DE0CCD80038B9AC /* GridSpan.h */; };
 		A5AFABC32E8C5D5000485152 /* GridLayoutUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = A5AFABC12E8C5D4900485152 /* GridLayoutUtils.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A5AFABD72E8D932300485152 /* GridItemRect.h in Headers */ = {isa = PBXBuildFile; fileRef = A5AFABD62E8D931F00485152 /* GridItemRect.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A5AFABD92E8D97F600485152 /* UsedTrackSizes.h in Headers */ = {isa = PBXBuildFile; fileRef = A5AFABD82E8D97F100485152 /* UsedTrackSizes.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A5AFB350115151A700B045CB /* StepRange.h in Headers */ = {isa = PBXBuildFile; fileRef = A5AFB34E115151A700B045CB /* StepRange.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A5AFB350115151A700B045CC /* SwitchTrigger.h in Headers */ = {isa = PBXBuildFile; fileRef = A5AFB34E115151A700B045CC /* SwitchTrigger.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A5B342862E77F75A009BFF3F /* PlacedGridItem.h in Headers */ = {isa = PBXBuildFile; fileRef = A5B342842E77F755009BFF3F /* PlacedGridItem.h */; };
@@ -16905,6 +16907,8 @@
 		A5AE5E172DE0CCD80038B9AC /* GridSpan.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GridSpan.h; sourceTree = "<group>"; };
 		A5AFABC12E8C5D4900485152 /* GridLayoutUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GridLayoutUtils.h; sourceTree = "<group>"; };
 		A5AFABC22E8C5D4900485152 /* GridLayoutUtils.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = GridLayoutUtils.cpp; sourceTree = "<group>"; };
+		A5AFABD62E8D931F00485152 /* GridItemRect.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GridItemRect.h; sourceTree = "<group>"; };
+		A5AFABD82E8D97F100485152 /* UsedTrackSizes.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UsedTrackSizes.h; sourceTree = "<group>"; };
 		A5AFB34D115151A700B045CB /* StepRange.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StepRange.cpp; sourceTree = "<group>"; };
 		A5AFB34E115151A700B045CB /* StepRange.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StepRange.h; sourceTree = "<group>"; };
 		A5AFB34E115151A700B045CC /* SwitchTrigger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SwitchTrigger.h; sourceTree = "<group>"; };
@@ -32728,6 +32732,7 @@
 				A5FA57652E85F40600EF058F /* GridAreaLines.h */,
 				A585CC3E2E566A7800A69390 /* GridFormattingContext.cpp */,
 				A585CC3D2E566A7800A69390 /* GridFormattingContext.h */,
+				A5AFABD62E8D931F00485152 /* GridItemRect.h */,
 				A585CC402E566A7800A69390 /* GridLayout.cpp */,
 				A585CC3F2E566A7800A69390 /* GridLayout.h */,
 				A5AFABC22E8C5D4900485152 /* GridLayoutUtils.cpp */,
@@ -32742,6 +32747,7 @@
 				A5FA579D2E86FF5F00EF058F /* TrackSizingFunctions.h */,
 				A5582D612E72254700F97055 /* UnplacedGridItem.cpp */,
 				A5582D602E72254700F97055 /* UnplacedGridItem.h */,
+				A5AFABD82E8D97F100485152 /* UsedTrackSizes.h */,
 			);
 			path = grid;
 			sourceTree = "<group>";
@@ -43246,6 +43252,7 @@
 				CD3E251C18046B0600E27F56 /* GridArea.h in Headers */,
 				A5FA57662E85F40D00EF058F /* GridAreaLines.h in Headers */,
 				A585CC442E566A7800A69390 /* GridFormattingContext.h in Headers */,
+				A5AFABD72E8D932300485152 /* GridItemRect.h in Headers */,
 				A585CC452E566A7800A69390 /* GridLayout.h in Headers */,
 				A54CAA142C409C4500D6A999 /* GridLayoutState.h in Headers */,
 				A5AFABC32E8C5D5000485152 /* GridLayoutUtils.h in Headers */,
@@ -47068,6 +47075,7 @@
 				900C20872CAF8243002C79C5 /* URLPatternResult.h in Headers */,
 				903C7E222CC246DA00245C29 /* URLPatternTokenizer.h in Headers */,
 				7CC289DF1AA0FE5D009A9CE3 /* URLRegistry.h in Headers */,
+				A5AFABD92E8D97F600485152 /* UsedTrackSizes.h in Headers */,
 				A72763BF16689BFB002FCACB /* UserActionElementSet.h in Headers */,
 				868160D618766A130021E79D /* UserActivity.h in Headers */,
 				A3AF9D8620326861006CAD06 /* UserAgent.h in Headers */,

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -4330,6 +4330,7 @@
 		A5A9934A1E3809CB005B5E4D /* JSPerformanceObserverCallback.h in Headers */ = {isa = PBXBuildFile; fileRef = A5A993451E380999005B5E4D /* JSPerformanceObserverCallback.h */; };
 		A5A9934C1E3809CF005B5E4D /* JSPerformanceObserverEntryList.h in Headers */ = {isa = PBXBuildFile; fileRef = A5A993471E380999005B5E4D /* JSPerformanceObserverEntryList.h */; };
 		A5AE5E1A2DE0CCD80038B9AC /* GridSpan.h in Headers */ = {isa = PBXBuildFile; fileRef = A5AE5E172DE0CCD80038B9AC /* GridSpan.h */; };
+		A5AFABC32E8C5D5000485152 /* GridLayoutUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = A5AFABC12E8C5D4900485152 /* GridLayoutUtils.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A5AFB350115151A700B045CB /* StepRange.h in Headers */ = {isa = PBXBuildFile; fileRef = A5AFB34E115151A700B045CB /* StepRange.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A5AFB350115151A700B045CC /* SwitchTrigger.h in Headers */ = {isa = PBXBuildFile; fileRef = A5AFB34E115151A700B045CC /* SwitchTrigger.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A5B342862E77F75A009BFF3F /* PlacedGridItem.h in Headers */ = {isa = PBXBuildFile; fileRef = A5B342842E77F755009BFF3F /* PlacedGridItem.h */; };
@@ -16902,6 +16903,8 @@
 		A5A993471E380999005B5E4D /* JSPerformanceObserverEntryList.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSPerformanceObserverEntryList.h; sourceTree = "<group>"; };
 		A5AA6E9B2C6A857D0037DB40 /* GridLayoutState.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = GridLayoutState.cpp; sourceTree = "<group>"; };
 		A5AE5E172DE0CCD80038B9AC /* GridSpan.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GridSpan.h; sourceTree = "<group>"; };
+		A5AFABC12E8C5D4900485152 /* GridLayoutUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GridLayoutUtils.h; sourceTree = "<group>"; };
+		A5AFABC22E8C5D4900485152 /* GridLayoutUtils.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = GridLayoutUtils.cpp; sourceTree = "<group>"; };
 		A5AFB34D115151A700B045CB /* StepRange.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StepRange.cpp; sourceTree = "<group>"; };
 		A5AFB34E115151A700B045CB /* StepRange.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StepRange.h; sourceTree = "<group>"; };
 		A5AFB34E115151A700B045CC /* SwitchTrigger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SwitchTrigger.h; sourceTree = "<group>"; };
@@ -32727,6 +32730,8 @@
 				A585CC3D2E566A7800A69390 /* GridFormattingContext.h */,
 				A585CC402E566A7800A69390 /* GridLayout.cpp */,
 				A585CC3F2E566A7800A69390 /* GridLayout.h */,
+				A5AFABC22E8C5D4900485152 /* GridLayoutUtils.cpp */,
+				A5AFABC12E8C5D4900485152 /* GridLayoutUtils.h */,
 				A5FA576D2E85F8A400EF058F /* GridTypeAliases.h */,
 				A532262E2E7492C100DDFA5E /* ImplicitGrid.cpp */,
 				A532262D2E7492C100DDFA5E /* ImplicitGrid.h */,
@@ -43243,6 +43248,7 @@
 				A585CC442E566A7800A69390 /* GridFormattingContext.h in Headers */,
 				A585CC452E566A7800A69390 /* GridLayout.h in Headers */,
 				A54CAA142C409C4500D6A999 /* GridLayoutState.h in Headers */,
+				A5AFABC32E8C5D5000485152 /* GridLayoutUtils.h in Headers */,
 				A51432582DE0CE6E0059FFA1 /* GridSpan.h in Headers */,
 				A5AE5E1A2DE0CCD80038B9AC /* GridSpan.h in Headers */,
 				E12DE7181E4B74A600F9ACCF /* GridTrackSizingAlgorithm.h in Headers */,

--- a/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp
@@ -114,6 +114,21 @@ PlacedGridItems GridFormattingContext::constructPlacedGridItems(const GridAreas&
     for (auto [ unplacedGridItem, gridAreaLines ] : gridAreas) {
 
         CheckedRef gridItemStyle = unplacedGridItem.m_layoutBox->style();
+
+        auto usedJustifySelf = [&] {
+            if (auto gridItemJustifySelf = gridItemStyle->justifySelf(); gridItemJustifySelf.position() != ItemPosition::Auto)
+                return gridItemJustifySelf;
+            auto& formattingContextRootStyle = root().style();
+            return formattingContextRootStyle.justifyItems();
+        };
+
+        auto usedAlignSelf = [&] {
+            if (auto gridItemAlignSelf = gridItemStyle->alignSelf(); gridItemAlignSelf.position() != ItemPosition::Auto)
+                return gridItemAlignSelf;
+            auto& formattingContextRootStyle = root().style();
+            return formattingContextRootStyle.alignItems();
+        };
+
         PlacedGridItem::ComputedSizes inlineAxisSizes {
             gridItemStyle->width(),
             gridItemStyle->minWidth(),
@@ -130,7 +145,7 @@ PlacedGridItems GridFormattingContext::constructPlacedGridItems(const GridAreas&
             gridItemStyle->marginBottom()
         };
 
-        placedGridItems.constructAndAppend(unplacedGridItem, gridAreaLines, inlineAxisSizes, blockAxisSizes);
+        placedGridItems.constructAndAppend(unplacedGridItem, gridAreaLines, inlineAxisSizes, blockAxisSizes, usedJustifySelf(), usedAlignSelf());
     }
     return placedGridItems;
 }

--- a/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp
@@ -27,6 +27,7 @@
 #include "GridFormattingContext.h"
 
 #include "GridLayout.h"
+#include "LayoutBoxGeometry.h"
 #include "LayoutChildIterator.h"
 #include "PlacedGridItem.h"
 #include "RenderStyleInlines.h"
@@ -41,6 +42,7 @@ namespace Layout {
 GridFormattingContext::GridFormattingContext(const ElementBox& gridBox, LayoutState& layoutState)
     : m_gridBox(gridBox)
     , m_globalLayoutState(layoutState)
+    , m_integrationUtils(layoutState)
 {
 }
 
@@ -131,6 +133,12 @@ PlacedGridItems GridFormattingContext::constructPlacedGridItems(const GridAreas&
         placedGridItems.constructAndAppend(unplacedGridItem, gridAreaLines, inlineAxisSizes, blockAxisSizes);
     }
     return placedGridItems;
+}
+
+const BoxGeometry GridFormattingContext::geometryForGridItem(const ElementBox& gridItem) const
+{
+    ASSERT(gridItem.isGridItem());
+    return layoutState().geometryForBox(gridItem);
 }
 
 } // namespace Layout

--- a/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp
@@ -30,6 +30,7 @@
 #include "GridLayout.h"
 #include "LayoutBoxGeometry.h"
 #include "GridLayoutUtils.h"
+#include "LayoutBoxGeometry.h"
 #include "LayoutChildIterator.h"
 #include "PlacedGridItem.h"
 #include "RenderStyleInlines.h"
@@ -121,6 +122,7 @@ void GridFormattingContext::layout(GridLayoutConstraints layoutConstraints)
         }
     };
     mapGridItemLocationsToGrid();
+    setGridItemGeometries(gridItemRects);
 }
 
 PlacedGridItems GridFormattingContext::constructPlacedGridItems(const GridAreas& gridAreas) const
@@ -166,10 +168,34 @@ PlacedGridItems GridFormattingContext::constructPlacedGridItems(const GridAreas&
     return placedGridItems;
 }
 
-const BoxGeometry GridFormattingContext::geometryForGridItem(const ElementBox& gridItem) const
+const BoxGeometry GridFormattingContext::geometryForGridItem(const Box& gridItem) const
 {
     ASSERT(gridItem.isGridItem());
     return layoutState().geometryForBox(gridItem);
+}
+
+BoxGeometry& GridFormattingContext::geometryForGridItem(const Box& gridItem)
+{
+    ASSERT(gridItem.isGridItem());
+    return m_globalLayoutState->ensureGeometryForBox(gridItem);
+}
+
+void GridFormattingContext::setGridItemGeometries(const GridItemRects& gridItemRects)
+{
+    for (auto& gridItemRect : gridItemRects) {
+        auto& boxGeometry = geometryForGridItem(gridItemRect.m_layoutBox);
+        auto& gridItemBorderBox = gridItemRect.m_borderBoxRect;
+
+        auto& margins = gridItemRect.m_margins;
+        boxGeometry.setHorizontalMargin({ margins.left(), margins.right() });
+        boxGeometry.setVerticalMargin({ margins.top(), margins.bottom() });
+
+        boxGeometry.setTopLeft(gridItemBorderBox.location());
+        auto contentBoxInlineSize = gridItemBorderBox.width() - boxGeometry.horizontalBorderAndPadding();
+        auto contentBoxBlockSize = gridItemBorderBox.height() - boxGeometry.verticalBorderAndPadding();
+
+        boxGeometry.setContentBoxSize({ contentBoxInlineSize, contentBoxBlockSize });
+    }
 }
 
 } // namespace Layout

--- a/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp
@@ -26,13 +26,16 @@
 #include "config.h"
 #include "GridFormattingContext.h"
 
+#include "GridItemRect.h"
 #include "GridLayout.h"
 #include "LayoutBoxGeometry.h"
+#include "GridLayoutUtils.h"
 #include "LayoutChildIterator.h"
 #include "PlacedGridItem.h"
 #include "RenderStyleInlines.h"
 #include "StylePrimitiveNumeric.h"
 #include "UnplacedGridItem.h"
+#include "UsedTrackSizes.h"
 
 #include <wtf/Vector.h>
 
@@ -104,7 +107,20 @@ UnplacedGridItems GridFormattingContext::constructUnplacedGridItems() const
 void GridFormattingContext::layout(GridLayoutConstraints layoutConstraints)
 {
     auto unplacedGridItems = constructUnplacedGridItems();
-    GridLayout { *this }.layout(layoutConstraints, unplacedGridItems);
+    auto [ usedTrackSizes, gridItemRects ] = GridLayout { *this }.layout(layoutConstraints, unplacedGridItems);
+
+    // Grid layout positions each item within its containing block which is the grid area.
+    // Here we translate it to the coordinate space of the grid.
+    auto mapGridItemLocationsToGrid = [&] {
+        for (auto& gridItemRect : gridItemRects) {
+            auto& gridAreaLines = gridItemRect.gridAreaLines;
+            auto columnLocation = GridLayoutUtils::computeTrackLocation(gridAreaLines.columnStartLine, usedTrackSizes.columnSizes);
+            auto rowLocation = GridLayoutUtils::computeTrackLocation(gridAreaLines.rowStartLine, usedTrackSizes.rowSizes);
+
+            gridItemRect.m_borderBoxRect.moveBy({ columnLocation, rowLocation });
+        }
+    };
+    mapGridItemLocationsToGrid();
 }
 
 PlacedGridItems GridFormattingContext::constructPlacedGridItems(const GridAreas& gridAreas) const

--- a/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.h
@@ -62,12 +62,14 @@ public:
 
     const IntegrationUtils& integrationUtils() const { return m_integrationUtils; }
 
-    const BoxGeometry geometryForGridItem(const ElementBox& gridItem) const;
+    const BoxGeometry geometryForGridItem(const Box& gridItem) const;
 
 private:
     UnplacedGridItems constructUnplacedGridItems() const;
 
     const LayoutState& layoutState() const { return m_globalLayoutState; }
+    BoxGeometry& geometryForGridItem(const Box& gridItem);
+    void setGridItemGeometries(const GridItemRects&);
 
     const CheckedRef<const ElementBox> m_gridBox;
     const CheckedRef<LayoutState> m_globalLayoutState;

--- a/Source/WebCore/layout/formattingContexts/grid/GridItemRect.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridItemRect.h
@@ -25,27 +25,19 @@
 
 #pragma once
 
-namespace WebCore {
+#include "GridAreaLines.h"
 
-class LayoutUnit;
+namespace WebCore {
 
 namespace Layout {
 
-class PlacedGridItem;
-class UnplacedGridItem;
+struct GridItemRect {
 
-struct GridAreaLines;
-struct GridItemRect;
-struct TrackSizingFunctions;
-struct UnsizedTrack;
+LayoutRect m_borderBoxRect;
+RectEdges<LayoutUnit> m_margins;
+const GridAreaLines gridAreaLines;
+const CheckedRef<const ElementBox> m_layoutBox;
+};
 
-using GridAreas = HashMap<UnplacedGridItem, GridAreaLines>;
-using GridCell = Vector<UnplacedGridItem, 1>;
-using GridItemRects = Vector<GridItemRect>;
-using GridMatrix = Vector<Vector<GridCell>>;
-using PlacedGridItems = Vector<PlacedGridItem>;
-using TrackSizes = Vector<LayoutUnit>;
-using TrackSizingFunctionsList = Vector<TrackSizingFunctions>;
-using UnsizedTracks = Vector<UnsizedTrack>;
 } // namespace Layout
-} // namespace WebCore
+} // namespacec WebCore

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
@@ -125,6 +125,67 @@ void GridLayout::layout(GridFormattingContext::GridLayoutConstraints, const Unpl
     // https://drafts.csswg.org/css-grid-1/#alignment
     auto usedInlineMargins = computeInlineMargins(placedGridItems);
     auto usedBlockMargins = computeBlockMargins(placedGridItems);
+
+    // https://drafts.csswg.org/css-grid-1/#alignment
+    // After a grid container’s grid tracks have been sized, and the dimensions of all grid items
+    // are finalized, grid items can be aligned within their grid areas.
+    auto inlineAxisPositions = performInlineAxisSelfAlignment(placedGridItems, usedInlineMargins);
+    auto blockAxisPositions = performBlockAxisSelfAlignment(placedGridItems, usedBlockMargins);
+
+    UNUSED_VARIABLE(inlineAxisPositions);
+    UNUSED_VARIABLE(blockAxisPositions);
+}
+
+GridLayout::BorderBoxPositions GridLayout::performInlineAxisSelfAlignment(const PlacedGridItems& placedGridItems, const Vector<UsedMargins>& inlineMargins)
+{
+    BorderBoxPositions borderBoxPositions;
+    borderBoxPositions.reserveInitialCapacity(placedGridItems.size());
+
+    auto computeMarginBoxPosition = [](const PlacedGridItem& placedGridItem) -> LayoutUnit {
+        switch (placedGridItem.inlineAxisAlignment().position()) {
+        case ItemPosition::FlexStart:
+        case ItemPosition::SelfStart:
+        case ItemPosition::Start:
+            return { };
+        default:
+            ASSERT_NOT_IMPLEMENTED_YET();
+            return { };
+        }
+    };
+
+    for (size_t gridItemIndex = 0; gridItemIndex < placedGridItems.size(); ++gridItemIndex) {
+        auto& gridItem = placedGridItems[gridItemIndex];
+        auto marginBoxPosition = computeMarginBoxPosition(gridItem);
+        borderBoxPositions.append(marginBoxPosition + inlineMargins[gridItemIndex].marginStart);
+    }
+
+    return borderBoxPositions;
+}
+
+GridLayout::BorderBoxPositions GridLayout::performBlockAxisSelfAlignment(const PlacedGridItems& placedGridItems, const Vector<UsedMargins>& blockMargins)
+{
+    BorderBoxPositions borderBoxPositions;
+    borderBoxPositions.reserveInitialCapacity(placedGridItems.size());
+
+    auto computeMarginBoxPosition = [](const PlacedGridItem& placedGridItem) -> LayoutUnit {
+        switch (placedGridItem.blockAxisAlignment().position()) {
+        case ItemPosition::FlexStart:
+        case ItemPosition::SelfStart:
+        case ItemPosition::Start:
+            return { };
+        default:
+            ASSERT_NOT_IMPLEMENTED_YET();
+            return { };
+        }
+    };
+
+    for (size_t gridItemIndex = 0; gridItemIndex < placedGridItems.size(); ++gridItemIndex) {
+        auto& gridItem = placedGridItems[gridItemIndex];
+        auto marginBoxPosition = computeMarginBoxPosition(gridItem);
+        borderBoxPositions.append(marginBoxPosition + blockMargins[gridItemIndex].marginStart);
+    }
+
+    return borderBoxPositions;
 }
 
 TrackSizingFunctionsList GridLayout::trackSizingFunctions(size_t implicitGridTracksCount, const Vector<Style::GridTrackSize> gridTemplateTrackSizes)

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
@@ -27,6 +27,7 @@
 #include "GridLayout.h"
 
 #include "GridAreaLines.h"
+#include "GridItemRect.h"
 #include "GridLayoutUtils.h"
 #include "ImplicitGrid.h"
 #include "RenderStyleInlines.h"
@@ -37,15 +38,11 @@
 #include "TrackSizingAlgorithm.h"
 #include "TrackSizingFunctions.h"
 #include "UnplacedGridItem.h"
+#include "UsedTrackSizes.h"
 #include <wtf/Vector.h>
 
 namespace WebCore {
 namespace Layout {
-
-struct UsedTrackSizes {
-    TrackSizes columnSizes;
-    TrackSizes rowSizes;
-};
 
 struct UsedMargins {
     LayoutUnit marginStart;
@@ -96,7 +93,7 @@ auto GridLayout::placeGridItems(const UnplacedGridItems& unplacedGridItems, cons
 }
 
 // https://drafts.csswg.org/css-grid-1/#layout-algorithm
-void GridLayout::layout(GridFormattingContext::GridLayoutConstraints, const UnplacedGridItems& unplacedGridItems)
+std::pair<UsedTrackSizes, GridItemRects> GridLayout::layout(GridFormattingContext::GridLayoutConstraints, const UnplacedGridItems& unplacedGridItems)
 {
     CheckedRef gridContainerStyle = this->gridContainerStyle();
     auto& gridTemplateColumnsTrackSizes = gridContainerStyle->gridTemplateColumns().sizes;
@@ -132,8 +129,28 @@ void GridLayout::layout(GridFormattingContext::GridLayoutConstraints, const Unpl
     auto inlineAxisPositions = performInlineAxisSelfAlignment(placedGridItems, usedInlineMargins);
     auto blockAxisPositions = performBlockAxisSelfAlignment(placedGridItems, usedBlockMargins);
 
-    UNUSED_VARIABLE(inlineAxisPositions);
-    UNUSED_VARIABLE(blockAxisPositions);
+    GridItemRects gridItemRects;
+    gridItemRects.reserveInitialCapacity(placedGridItems.size());
+
+    for (size_t gridItemIndex = 0; gridItemIndex < placedGridItems.size(); ++gridItemIndex) {
+        auto borderBoxRect =  LayoutRect { inlineAxisPositions[gridItemIndex], blockAxisPositions[gridItemIndex],
+            usedInlineSizes[gridItemIndex], usedBlockSizes[gridItemIndex]
+        };
+
+        auto& gridItemInlineMargins = usedInlineMargins[gridItemIndex];
+        auto& gridItemBlockMargins = usedBlockMargins[gridItemIndex];
+        auto marginEdges = RectEdges<LayoutUnit> {
+            gridItemBlockMargins.marginStart,
+            gridItemInlineMargins.marginEnd,
+            gridItemBlockMargins.marginEnd,
+            gridItemInlineMargins.marginStart
+        };
+
+        auto& placedGridItem = placedGridItems[gridItemIndex];
+        gridItemRects.constructAndAppend(borderBoxRect, marginEdges, placedGridItem.gridAreaLines(), placedGridItem.layoutBox());
+    }
+
+    return { usedTrackSizes, gridItemRects };
 }
 
 GridLayout::BorderBoxPositions GridLayout::performInlineAxisSelfAlignment(const PlacedGridItems& placedGridItems, const Vector<UsedMargins>& inlineMargins)

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
@@ -27,8 +27,10 @@
 #include "GridLayout.h"
 
 #include "GridAreaLines.h"
+#include "GridLayoutUtils.h"
 #include "ImplicitGrid.h"
 #include "RenderStyleInlines.h"
+#include "LayoutBoxGeometry.h"
 #include "LayoutElementBox.h"
 #include "NotImplemented.h"
 #include "PlacedGridItem.h"
@@ -48,6 +50,11 @@ struct UsedTrackSizes {
 struct UsedMargins {
     LayoutUnit marginStart;
     LayoutUnit marginEnd;
+};
+
+struct UsedGridItemSizes {
+    LayoutUnit inlineAxisSize;
+    LayoutUnit blockAxisSize;
 };
 
 GridLayout::GridLayout(const GridFormattingContext& gridFormattingContext)
@@ -107,15 +114,17 @@ void GridLayout::layout(GridFormattingContext::GridLayoutConstraints, const Unpl
     auto rowTrackSizingFunctionsList = trackSizingFunctions(implicitGridRowsCount, gridTemplateRowsTrackSizes);
 
     // 3. Given the resulting grid container size, run the Grid Sizing Algorithm to size the grid.
-    auto [ usedColumnSizes, usedRowSizes ] = performGridSizingAlgorithm(placedGridItems, columnTrackSizingFunctionsList, rowTrackSizingFunctionsList);
+    UsedTrackSizes usedTrackSizes = performGridSizingAlgorithm(placedGridItems, columnTrackSizingFunctionsList, rowTrackSizingFunctionsList);
 
-    UNUSED_VARIABLE(usedColumnSizes);
-    UNUSED_VARIABLE(usedRowSizes);
+    // 4. Lay out the grid items into their respective containing blocks. Each grid area’s
+    // width and height are considered definite for this purpose.
+    auto [ usedInlineSizes, usedBlockSizes ] = layoutGridItems(placedGridItems, usedTrackSizes);
+    UNUSED_VARIABLE(usedInlineSizes);
+    UNUSED_VARIABLE(usedBlockSizes);
 
     // https://drafts.csswg.org/css-grid-1/#alignment
     auto usedInlineMargins = computeInlineMargins(placedGridItems);
     auto usedBlockMargins = computeBlockMargins(placedGridItems);
-
 }
 
 TrackSizingFunctionsList GridLayout::trackSizingFunctions(size_t implicitGridTracksCount, const Vector<Style::GridTrackSize> gridTemplateTrackSizes)
@@ -239,6 +248,32 @@ Vector<UsedMargins> GridLayout::computeBlockMargins(const PlacedGridItems& place
 
         return UsedMargins { marginStart(), marginEnd() };
     });
+}
+
+// https://drafts.csswg.org/css-grid-1/#grid-item-sizing
+std::pair<GridLayout::UsedInlineSizes, GridLayout::UsedBlockSizes> GridLayout::layoutGridItems(const PlacedGridItems& placedGridItems, const UsedTrackSizes&) const
+{
+    UsedInlineSizes usedInlineSizes;
+    UsedBlockSizes usedBlockSizes;
+    auto gridItemsCount = placedGridItems.size();
+    usedInlineSizes.reserveInitialCapacity(gridItemsCount);
+    usedBlockSizes.reserveInitialCapacity(gridItemsCount);
+
+    auto& formattingContext = this->formattingContext();
+    auto& integrationUtils = formattingContext.integrationUtils();
+    for (auto& gridItem : placedGridItems) {
+        auto& gridItemBoxGeometry = formattingContext.geometryForGridItem(gridItem.layoutBox());
+
+        auto usedInlineSizeForGridItem = GridLayoutUtils::usedInlineSizeForGridItem(gridItem) + gridItemBoxGeometry.horizontalBorderAndPadding();
+        usedInlineSizes.append(usedInlineSizeForGridItem);
+
+        auto usedBlockSizeForGridItem = GridLayoutUtils::usedBlockSizeForGridItem(gridItem) + gridItemBoxGeometry.verticalBorderAndPadding();
+        usedBlockSizes.append(usedBlockSizeForGridItem);
+
+        auto& layoutBox = gridItem.layoutBox();
+        integrationUtils.layoutWithFormattingContextForBox(layoutBox, usedInlineSizeForGridItem, usedBlockSizeForGridItem);
+    }
+    return { usedInlineSizes, usedBlockSizes };
 }
 
 const ElementBox& GridLayout::gridContainer() const

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayout.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayout.h
@@ -62,7 +62,7 @@ class GridLayout {
 public:
     GridLayout(const GridFormattingContext&);
 
-    void layout(GridFormattingContext::GridLayoutConstraints, const UnplacedGridItems&);
+    std::pair<UsedTrackSizes, GridItemRects> layout(GridFormattingContext::GridLayoutConstraints, const UnplacedGridItems&);
 
 private:
 

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayout.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayout.h
@@ -72,6 +72,9 @@ private:
 
     static UsedTrackSizes performGridSizingAlgorithm(const PlacedGridItems&, const TrackSizingFunctionsList& columnTrackSizingFunctionsList, const TrackSizingFunctionsList& rowTrackSizingFunctionsList);
 
+    using UsedInlineSizes = Vector<LayoutUnit>;
+    using UsedBlockSizes = Vector<LayoutUnit>;
+    std::pair<UsedInlineSizes, UsedBlockSizes> layoutGridItems(const PlacedGridItems&, const UsedTrackSizes&) const;
 
     static Vector<UsedMargins> computeInlineMargins(const PlacedGridItems&);
     static Vector<UsedMargins> computeBlockMargins(const PlacedGridItems&);

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayout.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayout.h
@@ -79,6 +79,10 @@ private:
     static Vector<UsedMargins> computeInlineMargins(const PlacedGridItems&);
     static Vector<UsedMargins> computeBlockMargins(const PlacedGridItems&);
 
+    using BorderBoxPositions = Vector<LayoutUnit>;
+    static BorderBoxPositions performInlineAxisSelfAlignment(const PlacedGridItems&, const Vector<UsedMargins>&);
+    static BorderBoxPositions performBlockAxisSelfAlignment(const PlacedGridItems&, const Vector<UsedMargins>&);
+
     const GridFormattingContext& formattingContext() const { return m_gridFormattingContext.get(); }
 
     const ElementBox& gridContainer() const;

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp
@@ -23,56 +23,33 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
-
-#include "GridTypeAliases.h"
-#include "LayoutIntegrationUtils.h"
-#include "LayoutState.h"
-#include "LayoutUnit.h"
-#include <wtf/CheckedRef.h>
+#include "config.h"
+#include "GridLayoutUtils.h"
 
 namespace WebCore {
 namespace Layout {
+namespace GridLayoutUtils {
 
-class ElementBox;
-class PlacedGridItem;
+LayoutUnit usedInlineSizeForGridItem(const PlacedGridItem& placedGridItem)
+{
+    auto& inlineAxisSizes = placedGridItem.inlineAxisSizes();
+    if (auto fixedInlineSize = inlineAxisSizes.preferredSize.tryFixed())
+        return LayoutUnit { fixedInlineSize->resolveZoom(Style::ZoomNeeded { }) };
 
-class UnplacedGridItem;
+    ASSERT_NOT_IMPLEMENTED_YET();
+    return { };
+}
 
-struct GridAreaLines;
-struct UnplacedGridItems;
+LayoutUnit usedBlockSizeForGridItem(const PlacedGridItem& placedGridItem)
+{
+    auto& blockAxisSizes = placedGridItem.blockAxisSizes();
+    if (auto fixedBlockSize = blockAxisSizes.preferredSize.tryFixed())
+        return LayoutUnit { fixedBlockSize->resolveZoom(Style::ZoomNeeded { }) };
 
-class GridFormattingContext : public CanMakeCheckedPtr<GridFormattingContext> {
-    WTF_MAKE_TZONE_OR_ISO_ALLOCATED(GridFormattingContext);
-    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(GridFormattingContext);
-public:
+    ASSERT_NOT_IMPLEMENTED_YET();
+    return { };
+}
 
-    struct GridLayoutConstraints {
-        std::optional<LayoutUnit> inlineAxisAvailableSpace;
-        std::optional<LayoutUnit> blockAxisAvailableSpace;
-    };
-
-    GridFormattingContext(const ElementBox& gridBox, LayoutState&);
-
-    void layout(GridLayoutConstraints);
-
-    PlacedGridItems constructPlacedGridItems(const GridAreas&) const;
-
-    const ElementBox& root() const { return m_gridBox; }
-
-    const IntegrationUtils& integrationUtils() const { return m_integrationUtils; }
-
-    const BoxGeometry geometryForGridItem(const ElementBox& gridItem) const;
-
-private:
-    UnplacedGridItems constructUnplacedGridItems() const;
-
-    const LayoutState& layoutState() const { return m_globalLayoutState; }
-
-    const CheckedRef<const ElementBox> m_gridBox;
-    const CheckedRef<LayoutState> m_globalLayoutState;
-    const IntegrationUtils m_integrationUtils;
-};
-
-} // namespace Layout
-} // namespace WebCore
+}
+}
+}

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp
@@ -50,6 +50,13 @@ LayoutUnit usedBlockSizeForGridItem(const PlacedGridItem& placedGridItem)
     return { };
 }
 
+
+LayoutUnit computeTrackLocation(size_t trackIndex, const TrackSizes& trackSizes)
+{
+    auto trackSizesBefore = trackSizes.subspan(0, trackIndex);
+    return std::reduce(trackSizesBefore.begin(), trackSizesBefore.end());
+}
+
 }
 }
 }

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.h
@@ -38,6 +38,8 @@ namespace GridLayoutUtils {
 LayoutUnit usedInlineSizeForGridItem(const PlacedGridItem&);
 LayoutUnit usedBlockSizeForGridItem(const PlacedGridItem&);
 
+LayoutUnit computeTrackLocation(size_t trackIndex, const TrackSizes&);
+
 } // namespace GridLayoutUtils
 } // namespace Layout
 } // namespace WebCore

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.h
@@ -25,54 +25,19 @@
 
 #pragma once
 
-#include "GridTypeAliases.h"
-#include "LayoutIntegrationUtils.h"
-#include "LayoutState.h"
-#include "LayoutUnit.h"
-#include <wtf/CheckedRef.h>
-
 namespace WebCore {
+
+class LayoutUnit;
+
 namespace Layout {
 
-class ElementBox;
 class PlacedGridItem;
 
-class UnplacedGridItem;
+namespace GridLayoutUtils {
 
-struct GridAreaLines;
-struct UnplacedGridItems;
+LayoutUnit usedInlineSizeForGridItem(const PlacedGridItem&);
+LayoutUnit usedBlockSizeForGridItem(const PlacedGridItem&);
 
-class GridFormattingContext : public CanMakeCheckedPtr<GridFormattingContext> {
-    WTF_MAKE_TZONE_OR_ISO_ALLOCATED(GridFormattingContext);
-    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(GridFormattingContext);
-public:
-
-    struct GridLayoutConstraints {
-        std::optional<LayoutUnit> inlineAxisAvailableSpace;
-        std::optional<LayoutUnit> blockAxisAvailableSpace;
-    };
-
-    GridFormattingContext(const ElementBox& gridBox, LayoutState&);
-
-    void layout(GridLayoutConstraints);
-
-    PlacedGridItems constructPlacedGridItems(const GridAreas&) const;
-
-    const ElementBox& root() const { return m_gridBox; }
-
-    const IntegrationUtils& integrationUtils() const { return m_integrationUtils; }
-
-    const BoxGeometry geometryForGridItem(const ElementBox& gridItem) const;
-
-private:
-    UnplacedGridItems constructUnplacedGridItems() const;
-
-    const LayoutState& layoutState() const { return m_globalLayoutState; }
-
-    const CheckedRef<const ElementBox> m_gridBox;
-    const CheckedRef<LayoutState> m_globalLayoutState;
-    const IntegrationUtils m_integrationUtils;
-};
-
+} // namespace GridLayoutUtils
 } // namespace Layout
 } // namespace WebCore

--- a/Source/WebCore/layout/formattingContexts/grid/PlacedGridItem.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/PlacedGridItem.cpp
@@ -33,10 +33,13 @@ namespace WebCore {
 namespace Layout {
 
 PlacedGridItem::PlacedGridItem(const UnplacedGridItem& unplacedGridItem, GridAreaLines gridAreaLines,
-    ComputedSizes inlineAxisSizes, ComputedSizes blockAxisSizes)
+    const ComputedSizes& inlineAxisSizes, const ComputedSizes& blockAxisSizes, const StyleSelfAlignmentData& inlineAxisAlignment,
+    const StyleSelfAlignmentData& blockAxisAlignment)
     : m_layoutBox(unplacedGridItem.m_layoutBox)
     , m_inlineAxisSizes(inlineAxisSizes)
     , m_blockAxisSizes(blockAxisSizes)
+    , m_inlineAxisAlignment(inlineAxisAlignment)
+    , m_blockAxisAlignment(blockAxisAlignment)
     , m_gridAreaLines(gridAreaLines)
 {
 }

--- a/Source/WebCore/layout/formattingContexts/grid/PlacedGridItem.h
+++ b/Source/WebCore/layout/formattingContexts/grid/PlacedGridItem.h
@@ -59,6 +59,8 @@ public:
     size_t rowStartLine() const { return m_gridAreaLines.rowStartLine; }
     size_t rowEndLine() const { return m_gridAreaLines.rowEndLine; }
 
+    const ElementBox& layoutBox() const { return m_layoutBox; }
+
 private:
     const CheckedRef<const ElementBox> m_layoutBox;
 

--- a/Source/WebCore/layout/formattingContexts/grid/PlacedGridItem.h
+++ b/Source/WebCore/layout/formattingContexts/grid/PlacedGridItem.h
@@ -31,6 +31,7 @@
 #include "StyleMaximumSize.h"
 #include "StyleMinimumSize.h"
 #include "StylePreferredSize.h"
+#include "StyleSelfAlignmentData.h"
 #include <wtf/HashTraits.h>
 
 namespace WebCore {
@@ -49,7 +50,8 @@ public:
         Style::MarginEdge marginEnd;
     };
 
-    PlacedGridItem(const UnplacedGridItem&, GridAreaLines, ComputedSizes inlineAxisSizes, ComputedSizes blockAxisSizes);
+    PlacedGridItem(const UnplacedGridItem&, GridAreaLines, const ComputedSizes& inlineAxisSizes, const ComputedSizes& blockAxisSizes,
+    const StyleSelfAlignmentData& inlineAxisAlignment, const StyleSelfAlignmentData& blockAxisAlignment);
 
     const ComputedSizes& inlineAxisSizes() const { return m_inlineAxisSizes; }
     const ComputedSizes& blockAxisSizes() const { return m_blockAxisSizes; }
@@ -61,11 +63,17 @@ public:
 
     const ElementBox& layoutBox() const { return m_layoutBox; }
 
+    const StyleSelfAlignmentData& inlineAxisAlignment() const { return m_inlineAxisAlignment; }
+    const StyleSelfAlignmentData& blockAxisAlignment() const { return m_blockAxisAlignment; }
+
 private:
     const CheckedRef<const ElementBox> m_layoutBox;
 
     const ComputedSizes m_inlineAxisSizes;
     const ComputedSizes m_blockAxisSizes;
+
+    const StyleSelfAlignmentData m_inlineAxisAlignment;
+    const StyleSelfAlignmentData m_blockAxisAlignment;
 
     GridAreaLines m_gridAreaLines;
 };

--- a/Source/WebCore/layout/formattingContexts/grid/PlacedGridItem.h
+++ b/Source/WebCore/layout/formattingContexts/grid/PlacedGridItem.h
@@ -63,6 +63,8 @@ public:
 
     const ElementBox& layoutBox() const { return m_layoutBox; }
 
+    const GridAreaLines& gridAreaLines() const { return m_gridAreaLines; }
+
     const StyleSelfAlignmentData& inlineAxisAlignment() const { return m_inlineAxisAlignment; }
     const StyleSelfAlignmentData& blockAxisAlignment() const { return m_blockAxisAlignment; }
 

--- a/Source/WebCore/layout/formattingContexts/grid/UsedTrackSizes.h
+++ b/Source/WebCore/layout/formattingContexts/grid/UsedTrackSizes.h
@@ -22,30 +22,16 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
-
 #pragma once
 
+#include "GridTypeAliases.h"
+
 namespace WebCore {
-
-class LayoutUnit;
-
 namespace Layout {
+struct UsedTrackSizes {
+    TrackSizes columnSizes;
+    TrackSizes rowSizes;
+};
+}
+}
 
-class PlacedGridItem;
-class UnplacedGridItem;
-
-struct GridAreaLines;
-struct GridItemRect;
-struct TrackSizingFunctions;
-struct UnsizedTrack;
-
-using GridAreas = HashMap<UnplacedGridItem, GridAreaLines>;
-using GridCell = Vector<UnplacedGridItem, 1>;
-using GridItemRects = Vector<GridItemRect>;
-using GridMatrix = Vector<Vector<GridCell>>;
-using PlacedGridItems = Vector<PlacedGridItem>;
-using TrackSizes = Vector<LayoutUnit>;
-using TrackSizingFunctionsList = Vector<TrackSizingFunctions>;
-using UnsizedTracks = Vector<UnsizedTrack>;
-} // namespace Layout
-} // namespace WebCore

--- a/Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp
+++ b/Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp
@@ -26,17 +26,298 @@
 #include "config.h"
 #include "LayoutIntegrationGridCoverage.h"
 
+#include "RenderChildIterator.h"
 #include "RenderGrid.h"
+#include "StyleLengthWrapperData.h"
 
 namespace WebCore {
 namespace LayoutIntegration {
 
+enum class AvoidanceReason : uint64_t {
+    GridHasNonFixedWidth = 1LLU << 0,
+    GridHasNonFixedHeight = 1LLU << 1,
+    GridHasVerticalWritingMode = 1LLU << 2,
+    GridHasMarginTrim = 1LLU << 3,
+    GridIsNotInBFC = 1LLU << 6,
+    GridNeedsBaseline = 1LLU << 7,
+    GridHasOutOfFlowChild = 1LLU << 8,
+    GridHasNonVisibleOverflow = 1LLU << 9,
+    GridHasUnsupportedRenderer = 1LLU << 10,
+    GridIsEmpty = 1LLU << 11,
+    GridHasNonInitialMinWidth = 1LLU << 12,
+    GridHasNonInitialMaxWidth = 1LLU << 13,
+    GridHasNonInitialMinHeight = 1LLU << 14,
+    GridHasNonInitialMaxHeight = 1LLU << 15,
+    GridItemHasNonFixedWidth = 1LLU << 16,
+    GridItemHasNonFixedHeight = 1LLU << 17,
+    GridHasNonZeroMinWidth = 1LLU << 18,
+    GridItemHasNonInitialMaxWidth = 1LLU << 19,
+    GridItemHasNonZeroMinHeight = 1LLU << 20,
+    GridItemHasNonInitialMaxHeight = 1LLU << 21,
+    GridItemHasBorder = 1LLU << 22,
+    GridItemHasPadding = 1LLU << 23,
+    GridItemHasMargin = 1LLU << 24,
+    GridItemHasVerticalWritingMode = 1LLU << 25,
+    GridItemHasAspectRatio = 1LLU << 26,
+    GridItemHasUnsupportedInlineAxisAlignment = 1LLU << 27,
+    GridItemHasUnsupportedBlockAxisAlignment = 1LLU << 28,
+    GridItemHasNonVisibleOverflow = 1LLU << 29,
+    GridItemHasContainsSize = 1LLU << 30,
+    GridItemHasUnsupportedColumnPlacement = 1LLU << 31,
+    GridItemHasUnsupportedRowPlacement = 1LLU << 32,
+    GridItemSpansMultipleColumns = 1LLU << 33,
+    GridItemSpansMultipleRows = 1LLU << 34,
+    GridItemIsPlacedOutsideExplicitGrid = 1LLU << 35,
+    GridHasNonInitialGridTemplateAreas = 1LLU << 36,
+    GridHasNamedLines = 1LLU << 37,
+    GridHasNonInitialGridAutoFlow = 1LLU << 38,
+    GridHasGaps = 1LLU << 39,
+    GridHasNonInitialInlineAxisContentAlignment = 1LLU << 40,
+    GridHasNonInitialBlockAxisContentAlignment = 1LLU << 41,
+    GridIsOutOfFlow = 1LLU << 44,
+    GridHasContainsSize = 1LLU << 45,
+    GridHasUnsupportedGridTemplateColumns = 1LLU << 46,
+    GridHasUnsupportedGridTemplateRows = 1LLU << 47
+};
+
+static std::optional<AvoidanceReason> gridLayoutAvoidanceReason(const RenderGrid& renderGrid)
+{
+    auto& renderGridStyle = renderGrid.style();
+    
+    if (!renderGridStyle.writingMode().isHorizontal())
+        return AvoidanceReason::GridHasVerticalWritingMode;
+
+    if (!renderGridStyle.width().isFixed())
+        return AvoidanceReason::GridHasNonFixedWidth;
+
+    if (!renderGridStyle.height().isFixed())
+        return AvoidanceReason::GridHasNonFixedHeight;
+
+    if (!renderGridStyle.marginTrim().isEmpty())
+        return AvoidanceReason::GridHasMarginTrim;
+
+    if (!renderGridStyle.isOverflowVisible())
+        return AvoidanceReason::GridHasNonVisibleOverflow;
+
+    if (!renderGrid.firstInFlowChild())
+        return AvoidanceReason::GridIsEmpty;
+
+    if (renderGridStyle.display() == DisplayType::InlineGrid)
+        return AvoidanceReason::GridNeedsBaseline;
+
+    if (renderGridStyle.gridAutoFlow() != GridAutoFlow::AutoFlowRow)
+        return AvoidanceReason::GridHasNonInitialGridAutoFlow;
+
+    if (!renderGridStyle.rowGap().isNormal() || !renderGridStyle.columnGap().isNormal())
+        return AvoidanceReason::GridHasGaps;
+
+    if (renderGrid.isOutOfFlowPositioned())
+        return AvoidanceReason::GridIsOutOfFlow;
+
+    if (!renderGridStyle.gridTemplateAreas().isNone())
+        return AvoidanceReason::GridHasNonInitialGridTemplateAreas;
+
+    auto& gridTemplateColumns = renderGridStyle.gridTemplateColumns();
+    auto& gridTemplateColumnsTrackList = gridTemplateColumns.list;
+    if (gridTemplateColumnsTrackList.isEmpty())
+        return AvoidanceReason::GridHasUnsupportedGridTemplateColumns;
+
+    for (auto& columnsTrackListEntry : gridTemplateColumnsTrackList) {
+
+        auto avoidanceReason = WTF::switchOn(columnsTrackListEntry, 
+            [&](const Style::GridTrackSize& trackSize) -> std::optional<AvoidanceReason> {
+                // Since a GridTrackSize type of Breadth sets the MinTrackBreadth and
+                // MaxTrackBreadth to the same value we only need to check one.
+                if (!trackSize.isBreadth() || !trackSize.minTrackBreadth().isLength())
+                      return AvoidanceReason::GridHasUnsupportedGridTemplateColumns;
+
+                auto& gridTrackBreadthLength = trackSize.minTrackBreadth().length();
+                if (!gridTrackBreadthLength.isFixed())
+                      return AvoidanceReason::GridHasUnsupportedGridTemplateColumns;
+                return std::nullopt;
+            },
+            [&](const Vector<String>& names) -> std::optional<AvoidanceReason> {
+                for (auto& name : names) {
+                    if (!name.isEmpty())
+                        return AvoidanceReason::GridHasUnsupportedGridTemplateColumns; 
+                }
+                return std::nullopt; 
+            },
+            [&](const Style::GridTrackEntryRepeat&) {
+               return std::make_optional(AvoidanceReason::GridHasUnsupportedGridTemplateColumns); 
+            },
+            [&](const Style::GridTrackEntryAutoRepeat&) {
+               return std::make_optional(AvoidanceReason::GridHasUnsupportedGridTemplateColumns); 
+            },
+            [&](const Style::GridTrackEntrySubgrid&) {
+               return std::make_optional(AvoidanceReason::GridHasUnsupportedGridTemplateColumns); 
+            },
+            [&](const Style::GridTrackEntryMasonry&) {
+               return std::make_optional(AvoidanceReason::GridHasUnsupportedGridTemplateColumns); 
+            }
+        );
+
+        if (avoidanceReason)
+            return avoidanceReason;
+    }
+
+    auto& gridTemplateRows = renderGridStyle.gridTemplateRows();
+    auto& gridTemplateRowsTrackList = gridTemplateRows.list;
+    if (gridTemplateRowsTrackList.isEmpty())
+        return AvoidanceReason::GridHasUnsupportedGridTemplateRows;
+
+    for (auto& rowsTrackListEntry : gridTemplateRowsTrackList) {
+        auto avoidanceReason = WTF::switchOn(rowsTrackListEntry, 
+            [&](const Style::GridTrackSize& trackSize) -> std::optional<AvoidanceReason> {
+                // Since a GridTrackSize type of Breadth sets the MinTrackBreadth and
+                // MaxTrackBreadth to the same value we only need to check one.
+                if (!trackSize.isBreadth() || !trackSize.minTrackBreadth().isLength())
+                      return AvoidanceReason::GridHasUnsupportedGridTemplateRows;
+
+                auto& gridTrackBreadthLength = trackSize.minTrackBreadth().length();
+                if (!gridTrackBreadthLength.isFixed())
+                      return AvoidanceReason::GridHasUnsupportedGridTemplateRows;
+                return std::nullopt;
+            },
+            [&](const Vector<String>& names) -> std::optional<AvoidanceReason> {
+                for (auto& name : names) {
+                    if (!name.isEmpty())
+                        return AvoidanceReason::GridHasUnsupportedGridTemplateColumns; 
+                }
+                return std::nullopt; 
+            },
+            [&](const Style::GridTrackEntryRepeat&) {
+               return std::make_optional(AvoidanceReason::GridHasUnsupportedGridTemplateColumns); 
+            },
+            [&](const Style::GridTrackEntryAutoRepeat&) {
+               return std::make_optional(AvoidanceReason::GridHasUnsupportedGridTemplateColumns); 
+            },
+            [&](const Style::GridTrackEntrySubgrid&) {
+               return std::make_optional(AvoidanceReason::GridHasUnsupportedGridTemplateColumns); 
+            },
+            [&](const Style::GridTrackEntryMasonry&) {
+               return std::make_optional(AvoidanceReason::GridHasUnsupportedGridTemplateColumns); 
+            }
+        );
+
+        if (avoidanceReason)
+            return avoidanceReason;
+    }
+    
+    auto isInBFC = [&] {
+        // FIXME: This may be somewhat expensive in some deeply nested cases.
+        for (auto* containingBlock = renderGrid.containingBlock(); containingBlock && !is<RenderView>(*containingBlock); containingBlock = containingBlock->containingBlock()) {
+            if (containingBlock->style().display() != DisplayType::Block)
+                return false;
+            if (containingBlock->createsNewFormattingContext())
+                return true;
+        }
+        return true;
+    };
+
+    if (!isInBFC())
+        return AvoidanceReason::GridIsNotInBFC;
+
+    if (renderGridStyle.containsSize())
+        return AvoidanceReason::GridHasContainsSize;
+
+
+    auto explicitColumnsCount = gridTemplateColumns.sizes.size() + 1;
+    auto explicitRowsCount = gridTemplateRows.sizes.size() + 1;
+    for (auto& gridItem : childrenOfType<RenderBox>(renderGrid)) {
+        if (!gridItem.isRenderBlockFlow())
+            return AvoidanceReason::GridHasUnsupportedRenderer;
+
+        if (gridItem.isOutOfFlowPositioned()) 
+            return AvoidanceReason::GridHasOutOfFlowChild;
+
+        auto& gridItemStyle = gridItem.style();
+
+        auto& columnStart = gridItemStyle.gridItemColumnStart();
+        if (!columnStart.isExplicit() || !columnStart.namedGridLine().isEmpty() || columnStart.explicitPosition() < 0 || columnStart.explicitPosition() > static_cast<int>(explicitColumnsCount))
+            return AvoidanceReason::GridItemHasUnsupportedColumnPlacement;
+
+        auto& columnEnd = gridItemStyle.gridItemColumnEnd();
+        if (!columnEnd.isExplicit() || !columnEnd.namedGridLine().isEmpty() || columnEnd.explicitPosition() < 0 || columnEnd.explicitPosition() > static_cast<int>(explicitColumnsCount))
+            return AvoidanceReason::GridItemHasUnsupportedColumnPlacement;
+
+        auto& rowStart = gridItemStyle.gridItemRowStart();
+        if (!rowStart.isExplicit() || !rowStart.namedGridLine().isEmpty() || rowStart.explicitPosition() < 0 || rowStart.explicitPosition() > static_cast<int>(explicitRowsCount))
+            return AvoidanceReason::GridItemHasUnsupportedRowPlacement;
+
+        auto& rowEnd = gridItemStyle.gridItemRowEnd();
+        if (!rowEnd.isExplicit() || !rowEnd.namedGridLine().isEmpty() || rowEnd.explicitPosition() < 0 || rowEnd.explicitPosition() > static_cast<int>(explicitRowsCount))
+            return AvoidanceReason::GridItemHasUnsupportedRowPlacement;
+
+        if (!gridItemStyle.width().isFixed())
+            return AvoidanceReason::GridItemHasNonFixedWidth;
+
+        if (gridItemStyle.writingMode().isVertical())
+            return AvoidanceReason::GridItemHasVerticalWritingMode;
+
+        if (!gridItemStyle.height().isFixed())
+            return AvoidanceReason::GridItemHasNonFixedHeight;
+
+        if (gridItemStyle.hasAspectRatio())
+            return AvoidanceReason::GridItemHasAspectRatio;
+
+        if (auto fixedMinWidth = gridItemStyle.minWidth().tryFixed(); fixedMinWidth && fixedMinWidth->unresolvedValue())
+            return AvoidanceReason::GridHasNonZeroMinWidth;
+
+        if (!gridItemStyle.maxWidth().isNone())
+            return AvoidanceReason::GridItemHasNonInitialMaxWidth;
+
+        if (auto fixedMinHeight = gridItemStyle.minHeight().tryFixed(); fixedMinHeight && fixedMinHeight->unresolvedValue())
+            return AvoidanceReason::GridItemHasNonZeroMinHeight;
+
+        if (!gridItemStyle.maxHeight().isNone())
+            return AvoidanceReason::GridItemHasNonInitialMaxHeight;
+
+        if (!gridItemStyle.isOverflowVisible())
+            return AvoidanceReason::GridItemHasNonVisibleOverflow;
+
+        auto& justifySelf = gridItemStyle.justifySelf();
+        if (justifySelf.position() != ItemPosition::Start && justifySelf.overflow() != OverflowAlignment::Default
+            && justifySelf.positionType() != ItemPositionType::NonLegacy)
+            return AvoidanceReason::GridItemHasUnsupportedInlineAxisAlignment;
+
+        auto& alignSelf = gridItemStyle.alignSelf();
+        if (alignSelf.position() != ItemPosition::Start && alignSelf.overflow() != OverflowAlignment::Default
+            && alignSelf.positionType() != ItemPositionType::NonLegacy)
+            return AvoidanceReason::GridItemHasUnsupportedBlockAxisAlignment;
+
+        if (gridItemStyle.containsSize())
+            return AvoidanceReason::GridItemHasContainsSize;
+
+        if (gridItemStyle.border().hasBorder())
+            return AvoidanceReason::GridItemHasBorder;
+
+        auto gridItemHasPadding = [&] {
+            return gridItemStyle.paddingBox().anyOf([](const Style::PaddingEdge& paddingEdge) {
+                return paddingEdge.isPossiblyZero();
+            });
+        };
+        if (gridItemHasPadding())
+            return AvoidanceReason::GridItemHasPadding;
+
+        auto gridItemHasMargins = [&] {
+            return gridItemStyle.marginBox().anyOf([](const Style::MarginEdge& marginEdge) {
+                return marginEdge.isPossiblyZero();
+            });
+        };
+        if (gridItemHasMargins())
+            return AvoidanceReason::GridItemHasMargin;
+    }
+    return { };
+}
+
 bool canUseForGridLayout(const RenderGrid& renderGrid)
 {
     // Grid integration is not enabled yet.
-    if (!renderGrid.document().settings().gridFormattingContextIntegrationEnabled())
-        return false;
-    return false;
+    //if (!renderGrid.document().settings().gridFormattingContextIntegrationEnabled())
+    //    return false;
+
+    return !gridLayoutAvoidanceReason(renderGrid);
 }
 
 } // namespace LayoutIntegration

--- a/Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.cpp
+++ b/Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.cpp
@@ -72,9 +72,40 @@ static inline Layout::GridFormattingContext::GridLayoutConstraints constraintsFo
     };
 }
 
+void GridLayout::updateGridItemRenderers()
+{
+    for (auto& layoutBox : formattingContextBoxes(gridBox())) {
+        auto& renderer = downcast<RenderBox>(*layoutBox.rendererForIntegration());
+        auto& gridItemGeometry = layoutState().geometryForBox(layoutBox);
+        auto borderBoxRect = Layout::BoxGeometry::borderBoxRect(gridItemGeometry);
+
+        renderer.setLocation(borderBoxRect.topLeft());
+        renderer.setWidth(borderBoxRect.width());
+        renderer.setHeight(borderBoxRect.height());
+
+        renderer.setMarginBefore(gridItemGeometry.marginBefore());
+        renderer.setMarginAfter(gridItemGeometry.marginAfter());
+        renderer.setMarginStart(gridItemGeometry.marginStart());
+        renderer.setMarginAfter(gridItemGeometry.marginAfter());
+    }
+}
+
+void GridLayout::updateFormattingContextRootRenderer()
+{
+    auto& renderGrid = gridBoxRenderer();
+    auto& currentGrid = renderGrid.currentGrid();
+    currentGrid.setNeedsItemsPlacement(false);
+    OrderIteratorPopulator orderIteratorPopulator(currentGrid.orderIterator());
+
+    for (auto& layoutBox : formattingContextBoxes(gridBox()))
+        orderIteratorPopulator.collectChild(downcast<RenderBox>(*layoutBox.rendererForIntegration()));
+}
+
 void GridLayout::layout()
 {
     Layout::GridFormattingContext { gridBox(), layoutState() }.layout(constraintsForGridContent(gridBox()));
+    updateGridItemRenderers();
+    updateFormattingContextRootRenderer();
 }
 
 TextStream& operator<<(TextStream& stream, const GridLayout& layout)

--- a/Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.h
+++ b/Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.h
@@ -53,6 +53,9 @@ public:
     friend WTF::TextStream& operator<<(WTF::TextStream&, const GridLayout&);
 
 private:
+    void updateGridItemRenderers();
+    void updateFormattingContextRootRenderer();
+
     const Layout::ElementBox& gridBox() const { return *m_gridBox; }
     Layout::ElementBox& gridBox() { return *m_gridBox; }
 

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -554,6 +554,7 @@ bool RenderGrid::layoutUsingGridFormattingContext()
     gridLayout.updateFormattingContextGeometries();
 
     gridLayout.layout();
+    updateLogicalHeight();
     return true;
 }
 


### PR DESCRIPTION
#### e323d27e38c2bcb43c6cf4148a7e6f9d32e3cd99
<pre>
wip
</pre>
----------------------------------------------------------------------
#### dedeca60441a1966e206063bcc57224a85de6efd
<pre>
[GFC][Integration] Update box geometries and renderers after layout.
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

No new tests (OOPS!).
* Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp:
(WebCore::Layout::GridFormattingContext::layout):
(WebCore::Layout::GridFormattingContext::geometryForGridItem const):
(WebCore::Layout::GridFormattingContext::geometryForGridItem):
(WebCore::Layout::GridFormattingContext::setGridItemGeometries):
* Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.h:
* Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.cpp:
(WebCore::LayoutIntegration::GridLayout::updateGridItemRenderers):
(WebCore::LayoutIntegration::GridLayout::updateFormattingContextRootRenderer):
(WebCore::LayoutIntegration::GridLayout::layout):
* Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.h:
* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::layoutUsingGridFormattingContext):
</pre>
----------------------------------------------------------------------
#### 12c8091c0111b1ef2699e744c3fce635cae0e4a0
<pre>
[GFC] Return GridItemRects from layout.
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

No new tests (OOPS!).
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp:
(WebCore::Layout::GridFormattingContext::layout):
* Source/WebCore/layout/formattingContexts/grid/GridItemRect.h: Copied from Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.h.
* Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp:
(WebCore::Layout::GridLayout::layout):
* Source/WebCore/layout/formattingContexts/grid/GridLayout.h:
* Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp:
(WebCore::Layout::GridLayoutUtils::computeTrackLocation):
* Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.h:
* Source/WebCore/layout/formattingContexts/grid/GridTypeAliases.h:
* Source/WebCore/layout/formattingContexts/grid/PlacedGridItem.h:
(WebCore::Layout::PlacedGridItem::gridAreaLines const):
* Source/WebCore/layout/formattingContexts/grid/UsedTrackSizes.h: Copied from Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.h.
</pre>
----------------------------------------------------------------------
#### 80da19fe4e0a5784bae3c4e669c3fb7b5cfcaed6
<pre>
[GFC] Add initial alignment support with start alignment.
<a href="https://bugs.webkit.org/show_bug.cgi?id=300058">https://bugs.webkit.org/show_bug.cgi?id=300058</a>
<a href="https://rdar.apple.com/problem/161856764">rdar://problem/161856764</a>

Reviewed by NOBODY (OOPS!).

This patch adds the overall logic that we will use to support aligning
grid items after we have determined their sizes. Note that since
alignment is done with respect to the grid area, which acts as the
containing block for the grid item, the border box position that is
returned will be in the coordinate space of the grid area.

With this patch, we only support start alignment for the flex items, so
there is realistically no movement that is needed for the grid item&apos;s
margin box, so the final border box position will just be the same as
the value of the top margin. In order to support other alignment values,
we will likely need the size of the grid area along with the border box
dimensions of the grid item.

* Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp:
(WebCore::Layout::GridFormattingContext::constructPlacedGridItems const):
In order to perform alignment, we will need the align-self and
justify-self values for the grid item. If the value for this property is
not auto, then that is the value that will be used; otherwise, we refer to
the value of align-items/justify-items on the grid.

* Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp:
(WebCore::Layout::GridLayout::layout):

(WebCore::Layout::GridLayout::performInlineAxisSelfAlignment):
(WebCore::Layout::GridLayout::performBlockAxisSelfAlignment):
The basic idea between these two functions is the same: first, we need to
find out what the margin box position will be to satisfy the needs of
the alignment value, and from there, we can just add in the start margin
to get the final position of the item&apos;s border box. Since the most basic
version of start alignment (without considering any sort of safety) does
not move the item from the start of the grid area, we can just return a
value of 0 to indicate that it is at the start of the grid area.
</pre>
----------------------------------------------------------------------
#### 7695dea546d5c4f2f3401183446957e8b7e93c98
<pre>
[GFC] Initial implementation of grid item layout.
<a href="https://bugs.webkit.org/show_bug.cgi?id=300062">https://bugs.webkit.org/show_bug.cgi?id=300062</a>
<a href="https://rdar.apple.com/problem/161860162">rdar://problem/161860162</a>

Reviewed by NOBODY (OOPS!).

This patch provides the initial implementation of grid item layout as
described in the final step of the &quot;Grid Layout Algorithm,&quot;:
<a href="https://drafts.csswg.org/css-grid-1/#layout-algorithm">https://drafts.csswg.org/css-grid-1/#layout-algorithm</a>

At this point we have resolved the grid area sizes for each grid item.
As a result, we have a definite containing block size for the grid item
so we can resolve the size of the item if needed to provide as
constraints for layout of its contents. For now we keep this as simple
as possible since we will only allow content in which the grid item has
a fixed width and size. This is done via some utility functions that
determine the used width and heights of the items and then pass these
values into our integration API as constraints for the box&apos;s formatting
context.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e323d27e38c2bcb43c6cf4148a7e6f9d32e3cd99

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124334 "34 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44016 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34744 "Hash e323d27e for PR 51423 does not build (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131173 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76387 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/126211 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44761 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52614 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94579 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62745 "") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127288 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35676 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/138/builds/34744 "Hash e323d27e for PR 51423 does not build (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75166 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34615 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/138/builds/34744 "Hash e323d27e for PR 51423 does not build (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74650 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105421 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/138/builds/34744 "Hash e323d27e for PR 51423 does not build (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133839 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51235 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39072 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103059 "Found 1 new test failure: imported/blink/fast/pagination/viewport-y-horizontal-bt-rtl.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51632 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/138/builds/34744 "Hash e323d27e for PR 51423 does not build (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102855 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48218 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/138/builds/34744 "Hash e323d27e for PR 51423 does not build (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48170 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51101 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56886 "Found 10 new failures in layout/integration/grid/LayoutIntegrationGridCoverage.cpp, layout/integration/grid/LayoutIntegrationGridLayout.cpp") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50534 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53890 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52209 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->