### PR TITLE
REGRESSION: "Use Apple Vision Pro" button disappears on FX Alien Earth Website in Safari after entering Spatial viewer and exiting

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/fullscreen/rendering/exit-fullscreen-scroll-to-unscrollable-area-overflow-hidden-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/fullscreen/rendering/exit-fullscreen-scroll-to-unscrollable-area-overflow-hidden-expected.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<body>
+<div class="container">
+  <div style="width: 2500px; height: 500px; background-color: green;"></div>
+  <button id="fullscreen-button" style="margin-top: 2px; border: 1px solid black; border-radius: 0; background-color: white;"> Request fullscreen!</button>
+  PASS if visually equal after exiting fullscreen (no scrolling has happened).
+</div>
+<style>
+.container { overflow: hidden; position: relative; }
+</style>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/fullscreen/rendering/exit-fullscreen-scroll-to-unscrollable-area-overflow-hidden-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/fullscreen/rendering/exit-fullscreen-scroll-to-unscrollable-area-overflow-hidden-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<body>
+<div class="container">
+  <div style="width: 2500px; height: 500px; background-color: green;"></div>
+  <button id="fullscreen-button" style="margin-top: 2px; border: 1px solid black; border-radius: 0; background-color: white;"> Request fullscreen!</button>
+  PASS if visually equal after exiting fullscreen (no scrolling has happened).
+</div>
+<style>
+.container { overflow: hidden; position: relative; }
+</style>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/fullscreen/rendering/exit-fullscreen-scroll-to-unscrollable-area-overflow-hidden.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/fullscreen/rendering/exit-fullscreen-scroll-to-unscrollable-area-overflow-hidden.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<head>
+  <link rel="match" href="exit-fullscreen-scroll-to-unscrollable-area-overflow-hidden-ref.html">
+  <link rel="author" title="Vitor Roriz" href="https://github.com/vitorroriz">
+  <style>
+    .container { overflow: hidden; position: relative; }
+    .image { position: absolute; left: 100vw; }
+  </style>
+</head>
+
+<body>
+  <div class="container">
+    <div style="width: 2500px; height: 500px; background-color: green;"></div>
+        <button id="fullscreen-button" style="margin-top: 2px; border: 1px solid black; border-radius: 0; background-color: white;"> Request fullscreen!</button>
+    <img id="target" src="../../images/red.png" class="image">
+    PASS if visually equal after exiting fullscreen (no scrolling has happened).
+  </div>
+
+  <script src="/resources/testdriver.js"></script>
+  <script src="/resources/testdriver-vendor.js"></script>
+  <script>
+  const fullscreenButton = document.getElementById('fullscreen-button');
+  const image = document.getElementById('target');
+  fullscreenButton.onclick = () => { image.requestFullscreen(); }
+  document.onfullscreenchange = () => {
+    if (document.fullscreenElement) {
+      // entering fullscreen
+      document.exitFullscreen();
+    } else {
+      // exiting fullscreen
+      document.documentElement.classList.remove("reftest-wait");
+    }
+  };
+  test_driver.click(fullscreenButton);
+  </script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/fullscreen/rendering/exit-fullscreen-scroll-to-unscrollable-area-overflow-x-hidden-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/fullscreen/rendering/exit-fullscreen-scroll-to-unscrollable-area-overflow-x-hidden-expected.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<body>
+<div class="container">
+  <div style="width: 2500px; height: 500px; background-color: green;"></div>
+  <button id="fullscreen-button" style="margin-top: 2px; border: 1px solid black; border-radius: 0; background-color: white;"> Request fullscreen!</button>
+  PASS if visually equal after exiting fullscreen (no scrolling has happened).
+</div>
+<style>
+.container { overflow: hidden scroll; position: relative; scrollbar-width: none; }
+</style>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/fullscreen/rendering/exit-fullscreen-scroll-to-unscrollable-area-overflow-x-hidden-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/fullscreen/rendering/exit-fullscreen-scroll-to-unscrollable-area-overflow-x-hidden-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<body>
+<div class="container">
+  <div style="width: 2500px; height: 500px; background-color: green;"></div>
+  <button id="fullscreen-button" style="margin-top: 2px; border: 1px solid black; border-radius: 0; background-color: white;"> Request fullscreen!</button>
+  PASS if visually equal after exiting fullscreen (no scrolling has happened).
+</div>
+<style>
+.container { overflow: hidden scroll; position: relative; scrollbar-width: none; }
+</style>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/fullscreen/rendering/exit-fullscreen-scroll-to-unscrollable-area-overflow-x-hidden.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/fullscreen/rendering/exit-fullscreen-scroll-to-unscrollable-area-overflow-x-hidden.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<head>
+  <link rel="match" href="exit-fullscreen-scroll-to-unscrollable-area-ref.html">
+  <link rel="author" title="Vitor Roriz" href="https://github.com/vitorroriz">
+  <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-18" />
+  <style>
+    .container { overflow: hidden scroll; position: relative; scrollbar-width: none; }
+    .image { position: absolute; left: 100vw; }
+  </style>
+</head>
+
+<body>
+  <div class="container">
+    <div style="width: 2500px; height: 500px; background-color: green;"></div>
+    <button id="fullscreen-button" style="margin-top: 2px; border: 1px solid black; border-radius: 0; background-color: white;"> Request fullscreen!</button>
+    <img id="target" src="../../images/red.png" class="image">
+    PASS if visually equal after exiting fullscreen (no scrolling has happened).
+  </div>
+
+  <script src="/resources/testdriver.js"></script>
+  <script src="/resources/testdriver-vendor.js"></script>
+  <script>
+  const fullscreenButton = document.getElementById('fullscreen-button');
+  const image = document.getElementById('target');
+  fullscreenButton.onclick = () => { image.requestFullscreen(); }
+  document.onfullscreenchange = () => {
+    if (document.fullscreenElement) {
+      // entering fullscreen
+      document.exitFullscreen();
+    } else {
+      // exiting fullscreen
+      document.documentElement.classList.remove("reftest-wait");
+    }
+  };
+  test_driver.click(fullscreenButton);
+  </script>
+</body>
+</html>

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -1283,18 +1283,26 @@ void Element::scrollIntoViewIfNeeded(bool centerIfNeeded)
     LocalFrameView::scrollRectToVisible(absoluteBounds, *renderer, insideFixed, { SelectionRevealMode::Reveal, alignX, alignY, ShouldAllowCrossOriginScrolling::No });
 }
 
-void Element::scrollIntoViewIfNotVisible(bool centerIfNotVisible)
+void Element::scrollIntoViewIfNotVisible(bool centerIfNotVisible, AllowScrollingOverflowHidden allowScrollingOverflowHidden)
 {
     protectedDocument()->updateLayoutIgnorePendingStylesheets(LayoutOptions::UpdateCompositingLayers);
 
     CheckedPtr renderer = this->renderer();
     if (!renderer)
         return;
-    
+
     bool insideFixed;
     LayoutRect absoluteBounds = renderer->absoluteAnchorRectWithScrollMargin(&insideFixed).marginRect;
     auto align = centerIfNotVisible ? ScrollAlignment::alignCenterIfNotVisible : ScrollAlignment::alignToEdgeIfNotVisible;
-    LocalFrameView::scrollRectToVisible(absoluteBounds, *renderer, insideFixed, { SelectionRevealMode::Reveal, align, align, ShouldAllowCrossOriginScrolling::No });
+    ScrollRectToVisibleOptions options = {
+        .revealMode = SelectionRevealMode::Reveal,
+        .alignX = align,
+        .alignY = align,
+        .shouldAllowCrossOriginScrolling = ShouldAllowCrossOriginScrolling::No,
+        .allowScrollingOverflowHidden = allowScrollingOverflowHidden
+    };
+
+    LocalFrameView::scrollRectToVisible(absoluteBounds, *renderer, insideFixed, options);
 }
 
 void Element::scrollBy(const ScrollToOptions& options)

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -112,6 +112,7 @@ enum class ShadowRootDelegatesFocus : bool { No, Yes };
 enum class ShadowRootMode : uint8_t;
 enum class ShadowRootClonable : bool { No, Yes };
 enum class ShadowRootSerializable : bool { No, Yes };
+enum class AllowScrollingOverflowHidden : bool { No, Yes };
 enum class VisibilityAdjustment : uint8_t;
 
 // https://github.com/whatwg/html/pull/9841
@@ -299,7 +300,7 @@ public:
     WEBCORE_EXPORT void scrollIntoView(std::optional<Variant<bool, ScrollIntoViewOptions>>&& arg);
     WEBCORE_EXPORT void scrollIntoView(bool alignToTop = true);
     WEBCORE_EXPORT void scrollIntoViewIfNeeded(bool centerIfNeeded = true);
-    WEBCORE_EXPORT void scrollIntoViewIfNotVisible(bool centerIfNotVisible = true);
+    WEBCORE_EXPORT void scrollIntoViewIfNotVisible(bool centerIfNotVisible = true, AllowScrollingOverflowHidden = AllowScrollingOverflowHidden::Yes);
 
     void scrollBy(const ScrollToOptions&);
     void scrollBy(double x, double y);

--- a/Source/WebCore/platform/ScrollAlignment.cpp
+++ b/Source/WebCore/platform/ScrollAlignment.cpp
@@ -49,6 +49,7 @@
 
 namespace WebCore {
 
+const ScrollAlignment ScrollAlignment::noScroll = { Behavior::NoScroll, Behavior::NoScroll, Behavior::NoScroll };
 const ScrollAlignment ScrollAlignment::alignCenterIfNotVisible = { Behavior::NoScroll, Behavior::AlignCenter, Behavior::NoScroll };
 const ScrollAlignment ScrollAlignment::alignToEdgeIfNotVisible = { Behavior::NoScroll, Behavior::AlignToClosestEdge, Behavior::NoScroll };
 const ScrollAlignment ScrollAlignment::alignCenterIfNeeded = { Behavior::NoScroll, Behavior::AlignCenter, Behavior::AlignToClosestEdge };

--- a/Source/WebCore/platform/ScrollAlignment.h
+++ b/Source/WebCore/platform/ScrollAlignment.h
@@ -51,7 +51,7 @@ namespace WebCore {
 
 struct ScrollAlignment {
 
-    enum class Behavior {
+    enum class Behavior : uint8_t {
         NoScroll,
         AlignCenter,
         AlignTop,
@@ -67,6 +67,7 @@ struct ScrollAlignment {
     void disableLegacyHorizontalVisibilityThreshold() { m_enableLegacyHorizontalVisibilityThreshold = false; }
     bool legacyHorizontalVisibilityThresholdEnabled() const { return m_enableLegacyHorizontalVisibilityThreshold; }
 
+    static const ScrollAlignment noScroll;
     static const ScrollAlignment alignCenterIfNotVisible;
     static const ScrollAlignment alignToEdgeIfNotVisible;
     WEBCORE_EXPORT static const ScrollAlignment alignCenterIfNeeded;

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -2935,10 +2935,15 @@ LayoutSize RenderLayer::offsetFromAncestor(const RenderLayer* ancestorLayer, Col
     return toLayoutSize(convertToLayerCoords(ancestorLayer, LayoutPoint(), adjustForColumns));
 }
 
-bool RenderLayer::shouldTryToScrollForScrollIntoView() const
+bool RenderLayer::shouldTryToScrollForScrollIntoView(const ScrollRectToVisibleOptions& options) const
 {
     if (!renderer().isRenderBox() || !renderer().hasNonVisibleOverflow())
         return false;
+
+    if (options.allowScrollingOverflowHidden == AllowScrollingOverflowHidden::No) {
+        if (renderer().style().overflowX() == Overflow::Hidden && renderer().style().overflowY() == Overflow::Hidden)
+            return false;
+    }
 
     // Don't scroll to reveal an overflow layer that is restricted by the -webkit-line-clamp property.
     // FIXME: Is this still needed? It used to be relevant for Safari RSS.

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -142,11 +142,12 @@ enum class ShouldAllowCrossOriginScrolling : bool { No, Yes };
 
 struct ScrollRectToVisibleOptions {
     SelectionRevealMode revealMode { SelectionRevealMode::Reveal };
-    const ScrollAlignment& alignX { ScrollAlignment::alignCenterIfNeeded };
-    const ScrollAlignment& alignY { ScrollAlignment::alignCenterIfNeeded };
+    ScrollAlignment alignX { ScrollAlignment::alignCenterIfNeeded };
+    ScrollAlignment alignY { ScrollAlignment::alignCenterIfNeeded };
     ShouldAllowCrossOriginScrolling shouldAllowCrossOriginScrolling { ShouldAllowCrossOriginScrolling::No };
     ScrollBehavior behavior { ScrollBehavior::Auto };
     OnlyAllowForwardScrolling onlyAllowForwardScrolling { OnlyAllowForwardScrolling::No };
+    AllowScrollingOverflowHidden allowScrollingOverflowHidden { AllowScrollingOverflowHidden::Yes };
     std::optional<LayoutRect> visibilityCheckRect { std::nullopt };
 };
 
@@ -502,7 +503,7 @@ public:
     void updateScrollbarSteps();
 
     // Returns true if this RenderLayer is a candidate for scrolling during scrollIntoView operations.
-    bool shouldTryToScrollForScrollIntoView() const;
+    bool shouldTryToScrollForScrollIntoView(const ScrollRectToVisibleOptions&) const;
     void autoscroll(const IntPoint&);
 
     bool canResize() const;

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
@@ -544,7 +544,7 @@ void WebFullScreenManager::didExitFullScreen(CompletionHandler<void()>&& complet
     // Ensure the element (and all its parent fullscreen elements) that just exited fullscreen are still in view:
     while (!fullscreenElements.isEmpty()) {
         auto element = fullscreenElements.takeLast();
-        element->scrollIntoViewIfNotVisible(true);
+        element->scrollIntoViewIfNotVisible(true, AllowScrollingOverflowHidden::No);
     }
 
     clearElement();


### PR DESCRIPTION
#### 33ebcf97f481d763ede9c79c154235240f291c77
<pre>
REGRESSION: &quot;Use Apple Vision Pro&quot; button disappears on FX Alien Earth Website in Safari after entering Spatial viewer and exiting
<a href="https://bugs.webkit.org/show_bug.cgi?id=299646">https://bugs.webkit.org/show_bug.cgi?id=299646</a>
<a href="https://rdar.apple.com/158351089">rdar://158351089</a>

Reviewed by Simon Fraser.

WebFullScreenManager::didExitFullScreen issues a scrollIntoViewIfNotVisible.
This allows for scrolling into an an area that is unscrollable for the user.
We are adding a new option (ShouldAvoidScrollingToUnscrollableArea) to
ScrollRectToVisibleOptions such that ::didExitFullScreen can opt-out for
this behavior.

Tests: imported/w3c/web-platform-tests/fullscreen/rendering/exit-fullscreen-scroll-to-unscrollable-area-overflow-hidden.html
       imported/w3c/web-platform-tests/fullscreen/rendering/exit-fullscreen-scroll-to-unscrollable-area-overflow-x-hidden-ref.html
       imported/w3c/web-platform-tests/fullscreen/rendering/exit-fullscreen-scroll-to-unscrollable-area-overflow-x-hidden.html
       imported/w3c/web-platform-tests/fullscreen/rendering/exit-fullscreen-scroll-to-unscrollable-area-ref.html
* LayoutTests/imported/w3c/web-platform-tests/fullscreen/rendering/exit-fullscreen-scroll-to-unscrollable-area-overflow-hidden-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/fullscreen/rendering/exit-fullscreen-scroll-to-unscrollable-area-overflow-hidden.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/fullscreen/rendering/exit-fullscreen-scroll-to-unscrollable-area-overflow-x-hidden-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/fullscreen/rendering/exit-fullscreen-scroll-to-unscrollable-area-overflow-x-hidden-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/fullscreen/rendering/exit-fullscreen-scroll-to-unscrollable-area-overflow-x-hidden.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/fullscreen/rendering/exit-fullscreen-scroll-to-unscrollable-area-ref.html: Added.
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::scrollIntoViewIfNotVisible):
* Source/WebCore/dom/Element.h:
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::scrollToFocusedElementInternal):
(WebCore::adjustScrollRectToVisibleOptionsForHiddenOverflow):
(WebCore::LocalFrameView::scrollRectToVisible):
* Source/WebCore/platform/ScrollAlignment.cpp:
* Source/WebCore/platform/ScrollAlignment.h:
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::shouldTryToScrollForScrollIntoView const):
* Source/WebCore/rendering/RenderLayer.h:
* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp:
(WebKit::WebFullScreenManager::didExitFullScreen):

Canonical link: <a href="https://commits.webkit.org/300851@main">https://commits.webkit.org/300851@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8abe960ddff28f56494a22fb201f23fb5a918fa1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124081 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/43784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34492 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130910 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/76211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/125958 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44518 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52383 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/94388 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/76211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127035 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/35477 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110998 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74980 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/34425 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29162 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74394 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/105215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29381 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133582 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/51022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38874 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/102855 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51399 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107217 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102666 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26113 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/48023 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/26273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/47900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/50877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56648 "Built successfully") | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50340 "Build is in progress. Recent messages:") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/53687 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/52014 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->