### PR TITLE
[Swift in WebKit] Work towards modularizing JSC private headers (Part 4)

### DIFF
--- a/Source/WTF/wtf/PlatformHave.h
+++ b/Source/WTF/wtf/PlatformHave.h
@@ -246,7 +246,7 @@
 #define HAVE_ISDEBUGGERPRESENT 1
 #endif
 
-#if __has_include(<System/pthread_machdep.h>)
+#if __has_include(<pthread/tsd_private.h>)
 #define HAVE_FAST_TLS 1
 
 #if PLATFORM(MAC) \

--- a/Source/WTF/wtf/SequesteredImmortalHeap.h
+++ b/Source/WTF/wtf/SequesteredImmortalHeap.h
@@ -48,7 +48,7 @@
 #include <wtf/Threading.h>
 
 #if OS(DARWIN)
-#include <System/pthread_machdep.h>
+#include <pthread/tsd_private.h>
 #endif
 
 namespace WTF {

--- a/Source/WebCore/PAL/pal/spi/cocoa/FilePortSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/FilePortSPI.h
@@ -29,7 +29,7 @@ DECLARE_SYSTEM_HEADER
 
 #if USE(APPLE_INTERNAL_SDK)
 
-#include <System/sys/fileport.h>
+#include <sys/fileport.h>
 
 #else
 

--- a/Source/bmalloc/bmalloc/PerThread.h
+++ b/Source/bmalloc/bmalloc/PerThread.h
@@ -36,8 +36,8 @@
 #endif
 
 #if defined(__has_include)
-#if __has_include(<System/pthread_machdep.h>)
-#include <System/pthread_machdep.h>
+#if __has_include(<pthread/tsd_private.h>)
+#include <pthread/tsd_private.h>
 #define HAVE_PTHREAD_MACHDEP_H 1
 #else
 #define HAVE_PTHREAD_MACHDEP_H 0

--- a/Source/bmalloc/bmalloc/darwin/MemoryStatusSPI.h
+++ b/Source/bmalloc/bmalloc/darwin/MemoryStatusSPI.h
@@ -45,7 +45,7 @@ typedef struct memorystatus_memlimit_properties {
 #define MEMORYSTATUS_CMD_GET_PROCESS_IS_FREEZABLE 19
 
 }
-#endif // __has_include(<System/sys/kern_memorystatus.h>)
+#endif // __has_include(<sys/kern_memorystatus.h>)
 
 extern "C" {
 int memorystatus_control(uint32_t command, int32_t pid, uint32_t flags, void *buffer, size_t buffersize);

--- a/Source/bmalloc/libpas/src/libpas/pas_utils.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_utils.h
@@ -31,8 +31,8 @@
 /* These need to be included first. */
 #include "pas_thread.h"
 #if defined(__has_include)
-#if __has_include(<System/pthread_machdep.h>)
-#include <System/pthread_machdep.h>
+#if __has_include(<pthread/tsd_private.h>)
+#include <pthread/tsd_private.h>
 #define PAS_HAVE_PTHREAD_MACHDEP_H 1
 #else
 #define PAS_HAVE_PTHREAD_MACHDEP_H 0


### PR DESCRIPTION
#### ec059208e0d4fa23c3af7d1eb75debc5bba48e63
<pre>
[Swift in WebKit] Work towards modularizing JSC private headers (Part 4)
<a href="https://bugs.webkit.org/show_bug.cgi?id=299648">https://bugs.webkit.org/show_bug.cgi?id=299648</a>
<a href="https://rdar.apple.com/161454138">rdar://161454138</a>

Reviewed by Simon Fraser.

This is effectively a follow-up to 287041@main, and removes the rest of `&lt;System&gt;` imports.

* Source/WTF/wtf/PlatformHave.h:
* Source/WTF/wtf/SequesteredImmortalHeap.h:
* Source/WebCore/PAL/pal/spi/cocoa/FilePortSPI.h:
* Source/bmalloc/bmalloc/PerThread.h:
* Source/bmalloc/bmalloc/darwin/MemoryStatusSPI.h:
* Source/bmalloc/libpas/src/libpas/pas_utils.h:

Canonical link: <a href="https://commits.webkit.org/300624@main">https://commits.webkit.org/300624@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/030a699393c0b5cf2ea7e15a93d9593ddb4acca5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123283 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42997 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33694 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/129991 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/75397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/125160 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43721 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51592 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93711 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/75397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9afb17f3-ef46-446c-aee4-6e1f1ba12687) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126236 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34835 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110308 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74339 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e0ba8c6d-2fed-4ef4-be2a-fa7ac8321a74) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33800 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28467 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73509 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/115442 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104549 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28693 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132709 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/121814 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50233 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38226 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102201 "Found 1 new test failure: imported/blink/fast/pagination/viewport-y-horizontal-bt-rtl.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50609 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106532 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102056 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25945 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47409 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25631 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/47007 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50088 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/55849 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/152169 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49559 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/38886 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/52909 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51237 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->