### PR TITLE
An element with a background image does not always count as contentful to paint-timing

### DIFF
--- a/LayoutTests/performance-api/paint-timing/contentful-with-background-image-expected.txt
+++ b/LayoutTests/performance-api/paint-timing/contentful-with-background-image-expected.txt
@@ -1,0 +1,16 @@
+PASS entryList.getEntries().length is 1
+PASS entryList.getEntriesByName("first-contentful-paint").length is 1
+PASS entryList.getEntriesByType("paint").length is 1
+PASS didReceiveFirstContentfulPaint is false
+PASS fcpEntry.name is "first-contentful-paint"
+PASS fcpEntry.entryType is "paint"
+PASS didReceiveFirstContentfulPaint is true
+PASS performance.getEntries().length is 2
+PASS performance.getEntriesByName("first-contentful-paint").length is 1
+PASS performance.getEntriesByName("first-contentful-paint", "paint").length is 1
+PASS performance.getEntriesByType("paint").length is 1
+PASS PerformanceObserver first-contentful-paint callback wasn't fired again
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/performance-api/paint-timing/contentful-with-background-image.html
+++ b/LayoutTests/performance-api/paint-timing/contentful-with-background-image.html
@@ -1,0 +1,51 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+<script src="./resources/paint-api-utils.js"></script>
+<style>
+    .box {
+        width: 600px;
+        height: 500px;
+        background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB9YGARc5KB0XV+IAAAAddEVYdENvbW1lbnQAQ3JlYXRlZCB3aXRoIFRoZSBHSU1Q72QlbgAAAF1JREFUGNO9zL0NglAAxPEfdLTs4BZM4DIO4C7OwQg2JoQ9LE1exdlYvBBeZ7jqch9//q1uH4TLzw4d6+ErXMMcXuHWxId3KOETnnXXV6MJpcq2MLaI97CER3N0vr4MkhoXe0rZigAAAABJRU5ErkJggg==);
+    }
+</style>
+</head>
+<body>
+<div class="box"></div>
+<div id="console"></div>
+<script>
+window.jsTestIsAsync = true;
+
+(async () => {
+    window.didReceiveFirstContentfulPaint = false;
+    window.startTime = performance.now();
+    await waitForFCP();
+    await new Promise(resolve => {
+        const observer = new PerformanceObserver(entryList => {
+            window.entryList = entryList;
+            shouldBe('entryList.getEntries().length', "1");
+            shouldBe('entryList.getEntriesByName("first-contentful-paint").length', "1");
+            shouldBe('entryList.getEntriesByType("paint").length', "1");
+            window.fcpEntry = entryList.getEntries()[0];
+            shouldBeFalse('didReceiveFirstContentfulPaint');
+            shouldBe('fcpEntry.name', '"first-contentful-paint"');
+            shouldBe('fcpEntry.entryType', '"paint"');
+            didReceiveFirstContentfulPaint = true;
+            resolve();
+        });
+
+        observer.observe({ entryTypes: ['paint'] });
+    })
+    await waitForFCP();
+    shouldBeTrue('didReceiveFirstContentfulPaint');
+    shouldBe('performance.getEntries().length', "2");
+    shouldBe('performance.getEntriesByName("first-contentful-paint").length', "1");
+    shouldBe('performance.getEntriesByName("first-contentful-paint", "paint").length', "1");
+    shouldBe('performance.getEntriesByType("paint").length', "1");
+    testPassed("PerformanceObserver first-contentful-paint callback wasn't fired again ");
+    finishJSTest();
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
#### 55423322fb8348f488e1c3f39cb00af4a5610951
<pre>
An element with a background image does not always count as contentful to paint-timing
<a href="https://bugs.webkit.org/show_bug.cgi?id=299650">https://bugs.webkit.org/show_bug.cgi?id=299650</a>
<a href="https://rdar.apple.com/161456094">rdar://161456094</a>

Reviewed by Alan Baradlay.

`RenderBox::imageChanged()` has an early return when `!isComposited()`, which comes before
the call to `incrementVisuallyNonEmptyPixelCountIfNeeded()`, so a document with only an
element with a background image will never become contentful, and we&apos;ll never make a paint timing
entry.

Fix by calling `incrementVisuallyNonEmptyPixelCountIfNeeded()` before the early return.

A failure on `paint-timing/fcp-only/fcp-whitespace.html` then revealed that we&apos;re allowing
a zero-sized background image to contribute to visually non-empty, so add some code to check
for a non-zero background size. This isn&apos;t ideal; paint-timing really needs to use the same
paint-time hook as largest-contentful-paint, which gets the actual rectangle.

Test: performance-api/paint-timing/contentful-with-background-image.html

* LayoutTests/performance-api/paint-timing/contentful-with-background-image-expected.txt: Added.
* LayoutTests/performance-api/paint-timing/contentful-with-background-image.html: Added.
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::findLayerUsedImage):
(WebCore::RenderBox::imageChanged):

Canonical link: <a href="https://commits.webkit.org/300667@main">https://commits.webkit.org/300667@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d0989a0449a0a764588251cede91089fbb886eb3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123415 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43130 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33826 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130131 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/75546 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/684d6412-708d-4ca0-9890-d27915d0cf81) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/125292 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43853 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51724 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93809 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62256 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8ce4b596-1fb5-495f-b95c-c0d82f3ac394) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126368 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34942 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110417 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74436 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5b4a0fb7-d67f-4d6f-907d-66395e1b82fa) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33911 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28575 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73648 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104656 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28801 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132848 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50365 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38331 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102300 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50741 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106640 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102153 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25970 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47512 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25738 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/47167 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50220 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/55981 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49692 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53041 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51369 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->