### PR TITLE
[JSC] JSTests/stress/async-stack-trace-nested-deep.js is too slow

### DIFF
--- a/JSTests/stress/async-stack-trace-nested-deep.js
+++ b/JSTests/stress/async-stack-trace-nested-deep.js
@@ -1,4 +1,5 @@
 //@ requireOptions("--useAsyncStackTrace=1")
+//@ slow!
 
 const source = "async-stack-trace-nested-deep.js";
 
@@ -34,7 +35,6 @@ function shouldThrowAsync(run, errorType, message, stackFunctions) {
 
     const stackLines = stackTrace.split('\n').filter(line => line.trim());
 
-    let stackLineIndex = 0;
     for (let i = 0; i < stackFunctions.length; i++) {
         const [expectedFunction, expectedLocation] = stackFunctions[i];
         const isNativeCode = expectedLocation === "[native code]" 
@@ -645,7 +645,8 @@ async function problematicFunction() {
     throw new Error("error");
 }
 
-for (let i = 0; i < testLoopCount; i++) {
+let count = (testLoopCount / 10) | 0; // This test is too slow.
+for (let i = 0; i < count; i++) {
     shouldThrowAsync(
         async function test () {
             await level1();
@@ -755,8 +756,8 @@ for (let i = 0; i < testLoopCount; i++) {
             ["async level2", "73:17"],
             ["async level1", "67:17"],
             ["drainMicrotasks", "[native code]"],
-            ["shouldThrowAsync", "19:20"],
-            ["global code", "649:21"]
+            ["shouldThrowAsync", "20:20"],
+            ["global code", "650:21"]
         ],
     );
     drainMicrotasks();


### PR DESCRIPTION
#### ab69f543072bfeaa6153bdc889ebc17ac5b1bb6d
<pre>
[JSC] JSTests/stress/async-stack-trace-nested-deep.js is too slow
<a href="https://bugs.webkit.org/show_bug.cgi?id=299652">https://bugs.webkit.org/show_bug.cgi?id=299652</a>
<a href="https://rdar.apple.com/161457597">rdar://161457597</a>

Reviewed by Sosuke Suzuki.

JSTests/stress/async-stack-trace-nested-deep.js is very slow even in
Release build. And it is causing timeout for Debug build. First, let&apos;s
annotate it as `slow!`. Also reduce the count as this test does not
finish reasonably.

* JSTests/stress/async-stack-trace-nested-deep.js:
(shouldThrowAsync):

Canonical link: <a href="https://commits.webkit.org/300649@main">https://commits.webkit.org/300649@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f749e78f214923fd7dc9d5affc0c605a7b97fa97

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123339 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43054 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33750 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130052 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/75458 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a49d2d50-8a67-4a3f-9d36-b954f28ecd88) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43777 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51648 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93755 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62196 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7e8c857b-c384-40ff-906f-82649c016b10) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126292 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34880 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110349 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74384 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d881bba0-556a-4d1c-a754-7d56b7706a02) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33846 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73568 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/115498 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104594 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28734 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132768 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/121870 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50289 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38268 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102246 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50665 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106573 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102099 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47450 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25671 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/47075 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19428 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50144 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/152225 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49615 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/38905 "Found 8 new JSC stress test failures: wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.default-wasm, wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.wasm-bbq, wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.wasm-bbq-no-consts, wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.wasm-collect-continuously, wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.wasm-eager, wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.wasm-eager-jettison, wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.wasm-no-cjit, wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.wasm-slow-memory (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/52965 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51293 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->