### PR TITLE
Address Safer CPP warnings in some WebKit2 Cocoa files

### DIFF
--- a/Source/WebKit/Platform/IPC/Connection.h
+++ b/Source/WebKit/Platform/IPC/Connection.h
@@ -340,6 +340,7 @@ public:
 
 #if OS(DARWIN)
     xpc_connection_t xpcConnection() const { return m_xpcConnection.get(); }
+    OSObjectPtr<xpc_connection_t> protectedXPCConnection() const { return xpcConnection(); }
     std::optional<audit_token_t> getAuditToken();
     pid_t remoteProcessID() const;
 #endif

--- a/Source/WebKit/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -1,2 +1,1 @@
 Platform/IPC/StreamClientConnection.h
-Shared/Cocoa/AuxiliaryProcessCocoa.mm

--- a/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
@@ -1,6 +1,5 @@
 GeneratedWebKitSecureCoding.mm
 NetworkProcess/mac/NetworkProcessMac.mm
-Shared/API/Cocoa/RemoteObjectRegistry.mm
 Shared/API/Cocoa/WKBrowsingContextHandle.mm
 Shared/API/Cocoa/WKRemoteObjectCoder.mm
 Shared/API/Cocoa/_WKFrameHandle.mm
@@ -16,7 +15,6 @@ Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm
 Shared/ApplePay/mac/WebPaymentCoordinatorProxyMac.mm
 Shared/Cocoa/APIObject.mm
 Shared/Cocoa/ArgumentCodersCocoa.mm
-Shared/Cocoa/AuxiliaryProcessCocoa.mm
 Shared/Cocoa/CompletionHandlerCallChecker.mm
 Shared/Cocoa/CoreIPCContacts.mm
 Shared/Cocoa/CoreIPCPassKit.mm
@@ -76,7 +74,6 @@ UIProcess/API/mac/WKWebViewMac.mm
 UIProcess/API/mac/WKWebViewTestingMac.mm
 UIProcess/Authentication/cocoa/AuthenticationChallengeProxyCocoa.mm
 UIProcess/Automation/mac/WebAutomationSessionMac.mm
-UIProcess/Cocoa/BrowsingWarningCocoa.mm
 UIProcess/Cocoa/DiagnosticLoggingClient.mm
 UIProcess/Cocoa/GlobalFindInPageState.mm
 UIProcess/Cocoa/MediaPermissionUtilities.mm

--- a/Source/WebKit/Shared/API/Cocoa/RemoteObjectRegistry.mm
+++ b/Source/WebKit/Shared/API/Cocoa/RemoteObjectRegistry.mm
@@ -80,7 +80,7 @@ void RemoteObjectRegistry::sendUnusedReply(uint64_t replyID)
 
 void RemoteObjectRegistry::invokeMethod(const RemoteObjectInvocation& invocation)
 {
-    [m_remoteObjectRegistry _invokeMethod:invocation];
+    [m_remoteObjectRegistry.get() _invokeMethod:invocation];
 }
 
 void RemoteObjectRegistry::callReplyBlock(IPC::Connection& connection, uint64_t replyID, const UserData& blockInvocation)
@@ -89,7 +89,7 @@ void RemoteObjectRegistry::callReplyBlock(IPC::Connection& connection, uint64_t 
     ASSERT_UNUSED(wasRemoved, wasRemoved);
 
     @try {
-        [m_remoteObjectRegistry _callReplyWithID:replyID blockInvocation:blockInvocation];
+        [m_remoteObjectRegistry.get() _callReplyWithID:replyID blockInvocation:blockInvocation];
     } @catch (NSException *exception) {
         NSLog(@"Warning: Exception caught during handling of received message, marking message invalid .\nException: %@", exception);
         IPC::markCurrentlyDispatchedMessageAsInvalid(connection);
@@ -101,7 +101,7 @@ void RemoteObjectRegistry::releaseUnusedReplyBlock(uint64_t replyID)
     bool wasRemoved = m_pendingReplies.remove(replyID);
     ASSERT_UNUSED(wasRemoved, wasRemoved);
 
-    [m_remoteObjectRegistry _releaseReplyWithID:replyID];
+    [m_remoteObjectRegistry.get() _releaseReplyWithID:replyID];
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -5121,12 +5121,12 @@ static void convertAndAddHighlight(Vector<Ref<WebCore::SharedMemory>>& buffers, 
 
 + (NSURL *)_confirmMalwareSentinel
 {
-    return WebKit::BrowsingWarning::confirmMalwareSentinel();
+    return WebKit::BrowsingWarning::confirmMalwareSentinel().autorelease();
 }
 
 + (NSURL *)_visitUnsafeWebsiteSentinel
 {
-    return WebKit::BrowsingWarning::visitUnsafeWebsiteSentinel();
+    return WebKit::BrowsingWarning::visitUnsafeWebsiteSentinel().autorelease();
 }
 
 - (void)_isJITEnabled:(void(^)(BOOL))completionHandler

--- a/Source/WebKit/UIProcess/BrowsingWarning.h
+++ b/Source/WebKit/UIProcess/BrowsingWarning.h
@@ -70,8 +70,8 @@ public:
 #endif
     const Data& data() const { return m_data; }
 
-    static NSURL *visitUnsafeWebsiteSentinel();
-    static NSURL *confirmMalwareSentinel();
+    static RetainPtr<NSURL> visitUnsafeWebsiteSentinel();
+    static RetainPtr<NSURL> confirmMalwareSentinel();
 
 private:
 #if HAVE(SAFE_BROWSING)

--- a/Source/WebKit/UIProcess/Cocoa/BrowsingWarningCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/BrowsingWarningCocoa.mm
@@ -150,23 +150,23 @@ static NSMutableAttributedString *browsingDetailsText(const URL& url, SSBService
         RetainPtr visitUnsafeWebsite = WEB_UI_NSSTRING(@"visit this unsafe website", "Action from safe browsing warning");
 
         RetainPtr attributedString = adoptNS([[NSMutableAttributedString alloc] initWithString:adoptNS([[NSString alloc] initWithFormat:@"%@ %@\n\n%@", phishingDescription.get(), learnMore.get(), phishingActions.get()]).get()]);
-        addLinkAndReplace(attributedString.get(), learnMore.get(), learnMore.get(), learnMoreURL(result));
+        addLinkAndReplace(attributedString.get(), learnMore.get(), learnMore.get(), RetainPtr { learnMoreURL(result) }.get());
         replace(attributedString.get(), @"%provider-display-name%", localizedProviderDisplayName(result).createNSString().get());
         replace(attributedString.get(), @"%provider%", localizedProviderShortName(result).createNSString().get());
         addLinkAndReplace(attributedString.get(), @"%report-an-error%", reportAnError.get(), reportAnErrorURL(url, result).get());
-        addLinkAndReplace(attributedString.get(), @"%bypass-link%", visitUnsafeWebsite.get(), BrowsingWarning::visitUnsafeWebsiteSentinel());
+        addLinkAndReplace(attributedString.get(), @"%bypass-link%", visitUnsafeWebsite.get(), BrowsingWarning::visitUnsafeWebsiteSentinel().get());
         return attributedString.autorelease();
     }
 
     auto malwareOrUnwantedSoftwareDetails = [&] (NSString *description, NSString *statusStringToReplace, bool confirmMalware) {
         auto malwareDescription = adoptNS([[NSMutableAttributedString alloc] initWithString:description]);
         replace(malwareDescription.get(), @"%safeBrowsingProvider%", localizedProviderDisplayName(result).createNSString().get());
-        auto statusLink = adoptNS([[NSMutableAttributedString alloc] initWithString:WEB_UI_NSSTRING(@"the status of “%site%”", "Part of malware description")]);
+        auto statusLink = adoptNS([[NSMutableAttributedString alloc] initWithString:RetainPtr { WEB_UI_NSSTRING(@"the status of “%site%”", "Part of malware description") }.get()]);
         replace(statusLink.get(), @"%site%", url.host().createNSString().get());
         addLinkAndReplace(malwareDescription.get(), statusStringToReplace, [statusLink string], malwareDetailsURL(url, result).get());
 
-        auto ifYouUnderstand = adoptNS([[NSMutableAttributedString alloc] initWithString:WEB_UI_NSSTRING(@"If you understand the risks involved, you can %visit-this-unsafe-site-link%.", "Action from safe browsing warning")]);
-        addLinkAndReplace(ifYouUnderstand.get(), @"%visit-this-unsafe-site-link%", WEB_UI_NSSTRING(@"visit this unsafe website", "Action from safe browsing warning"), confirmMalware ? BrowsingWarning::confirmMalwareSentinel() : BrowsingWarning::visitUnsafeWebsiteSentinel());
+        auto ifYouUnderstand = adoptNS([[NSMutableAttributedString alloc] initWithString:RetainPtr { WEB_UI_NSSTRING(@"If you understand the risks involved, you can %visit-this-unsafe-site-link%.", "Action from safe browsing warning") }.get()]);
+        addLinkAndReplace(ifYouUnderstand.get(), @"%visit-this-unsafe-site-link%", RetainPtr { WEB_UI_NSSTRING(@"visit this unsafe website", "Action from safe browsing warning") }.get(), confirmMalware ? BrowsingWarning::confirmMalwareSentinel().get() : BrowsingWarning::visitUnsafeWebsiteSentinel().get());
 
         [malwareDescription appendAttributedString:adoptNS([[NSMutableAttributedString alloc] initWithString:@"\n\n"]).get()];
         [malwareDescription appendAttributedString:ifYouUnderstand.get()];
@@ -174,9 +174,9 @@ static NSMutableAttributedString *browsingDetailsText(const URL& url, SSBService
     };
 
     if (result.isMalware)
-        return malwareOrUnwantedSoftwareDetails(WEB_UI_NSSTRING(@"Warnings are shown for websites where malicious software has been detected. You can check the %status-link% on the %safeBrowsingProvider% diagnostic page.", "Malware warning description"), @"%status-link%", true);
+        return malwareOrUnwantedSoftwareDetails(RetainPtr { WEB_UI_NSSTRING(@"Warnings are shown for websites where malicious software has been detected. You can check the %status-link% on the %safeBrowsingProvider% diagnostic page.", "Malware warning description") }.get(), @"%status-link%", true);
     ASSERT(result.isUnwantedSoftware);
-    return malwareOrUnwantedSoftwareDetails(WEB_UI_NSSTRING(@"Warnings are shown for websites where harmful software has been detected. You can check %the-status-of-site% on the %safeBrowsingProvider% diagnostic page.", "Unwanted software warning description"), @"%the-status-of-site%", false);
+    return malwareOrUnwantedSoftwareDetails(RetainPtr { WEB_UI_NSSTRING(@"Warnings are shown for websites where harmful software has been detected. You can check %the-status-of-site% on the %safeBrowsingProvider% diagnostic page.", "Unwanted software warning description") }.get(), @"%the-status-of-site%", false);
 }
 
 static NSMutableAttributedString *browsingDetailsText(const URL& url, BrowsingWarning::Data data)
@@ -206,14 +206,14 @@ BrowsingWarning::BrowsingWarning(URL&& url, String&& title, String&& warning, Re
 {
 }
 
-NSURL *BrowsingWarning::visitUnsafeWebsiteSentinel()
+RetainPtr<NSURL> BrowsingWarning::visitUnsafeWebsiteSentinel()
 {
-    return [NSURL URLWithString:@"WKVisitUnsafeWebsiteSentinel"];
+    return adoptNS([[NSURL alloc] initWithString:@"WKVisitUnsafeWebsiteSentinel"]);
 }
 
-NSURL *BrowsingWarning::confirmMalwareSentinel()
+RetainPtr<NSURL> BrowsingWarning::confirmMalwareSentinel()
 {
-    return [NSURL URLWithString:@"WKConfirmMalwareSentinel"];
+    return adoptNS([[NSURL alloc] initWithString:@"WKConfirmMalwareSentinel"]);
 }
 
 }

--- a/Source/WebKit/UIProcess/Cocoa/_WKWarningView.mm
+++ b/Source/WebKit/UIProcess/Cocoa/_WKWarningView.mm
@@ -571,10 +571,10 @@ static RetainPtr<ViewType> makeLabel(NSAttributedString *attributedString)
     if (!_completionHandler)
         return;
 
-    if ([link isEqual:WebKit::BrowsingWarning::visitUnsafeWebsiteSentinel()])
+    if ([link isEqual:WebKit::BrowsingWarning::visitUnsafeWebsiteSentinel().get()])
         return _completionHandler(WebKit::ContinueUnsafeLoad::Yes);
 
-    if ([link isEqual:WebKit::BrowsingWarning::confirmMalwareSentinel()]) {
+    if ([link isEqual:WebKit::BrowsingWarning::confirmMalwareSentinel().get()]) {
 #if PLATFORM(MAC)
         auto alert = adoptNS([NSAlert new]);
         [alert setMessageText:WEB_UI_NSSTRING(@"Are you sure you wish to go to this site?", "Malware confirmation dialog title")];


### PR DESCRIPTION
#### 9099735832a5fe01486db417d70f213c5b613e5f
<pre>
Address Safer CPP warnings in some WebKit2 Cocoa files
<a href="https://bugs.webkit.org/show_bug.cgi?id=299659">https://bugs.webkit.org/show_bug.cgi?id=299659</a>

Reviewed by Geoffrey Garen.

* Source/WebKit/Platform/IPC/Connection.h:
(IPC::Connection::protectedXPCConnection const):
* Source/WebKit/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations:
* Source/WebKit/Shared/API/Cocoa/RemoteObjectRegistry.mm:
(WebKit::RemoteObjectRegistry::invokeMethod):
(WebKit::RemoteObjectRegistry::callReplyBlock):
(WebKit::RemoteObjectRegistry::releaseUnusedReplyBlock):
* Source/WebKit/Shared/Cocoa/AuxiliaryProcessCocoa.mm:
(WebKit::AuxiliaryProcess::parentProcessHasEntitlement):
(WebKit::AuxiliaryProcess::registerWithStateDumper):
(WebKit::AuxiliaryProcess::isSystemWebKit):
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(+[WKWebView _confirmMalwareSentinel]):
(+[WKWebView _visitUnsafeWebsiteSentinel]):
* Source/WebKit/UIProcess/BrowsingWarning.h:
* Source/WebKit/UIProcess/Cocoa/BrowsingWarningCocoa.mm:
(WebKit::browsingDetailsText):
(WebKit::BrowsingWarning::visitUnsafeWebsiteSentinel):
(WebKit::BrowsingWarning::confirmMalwareSentinel):
* Source/WebKit/UIProcess/Cocoa/_WKWarningView.mm:
(-[_WKWarningView clickedOnLink:]):

Canonical link: <a href="https://commits.webkit.org/300668@main">https://commits.webkit.org/300668@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/034c20e617e4ac7a0538c519d118eafae59e798d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123387 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43102 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33798 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130101 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/75511 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/78972e33-b465-43a9-a61c-1e0860e08618) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43825 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51696 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93792 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62232 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/019a8702-1b4f-44b3-9232-545d91c57412) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126340 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34922 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110395 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74419 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/47fb0e4a-7a9d-433a-8658-87434d8e543c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33890 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73618 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104636 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28779 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132818 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50337 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38312 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102282 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50713 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106618 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102135 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25971 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47493 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25716 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/47127 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50192 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/55953 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49664 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53013 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51341 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->