### PR TITLE
Simplify some character-related code to ease future changes to Latin1Character

### DIFF
--- a/Source/JavaScriptCore/heap/HeapSnapshotBuilder.cpp
+++ b/Source/JavaScriptCore/heap/HeapSnapshotBuilder.cpp
@@ -278,11 +278,6 @@ enum class NodeFlags {
     ElementSubtype = 1 << 2,
 };
 
-static uint8_t edgeTypeToNumber(EdgeType type)
-{
-    return static_cast<uint8_t>(type);
-}
-
 static ASCIILiteral edgeTypeToString(EdgeType type)
 {
     switch (type) {
@@ -450,7 +445,7 @@ String HeapSnapshotBuilder::json()
         firstEdge = false;
 
         // <fromNodeId>, <toNodeId>, <edgeTypeIndex>, <edgeExtraData>
-        json.append(edge.from.identifier, ',', edge.to.identifier, ',', edgeTypeToNumber(edge.type), ',');
+        json.append(edge.from.identifier, ',', edge.to.identifier, ',', edge.type, ',');
         switch (edge.type) {
         case EdgeType::Property:
         case EdgeType::Variable: {

--- a/Source/WTF/wtf/HexNumber.cpp
+++ b/Source/WTF/wtf/HexNumber.cpp
@@ -31,6 +31,13 @@ namespace WTF {
 
 namespace Internal {
 
+static const std::array<Latin1Character, 16>& hexDigitsForMode(HexConversionMode mode)
+{
+    static constexpr std::array<Latin1Character, 16> lowercaseHexDigits { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f' };
+    static constexpr std::array<Latin1Character, 16> uppercaseHexDigits { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F' };
+    return mode == Lowercase ? lowercaseHexDigits : uppercaseHexDigits;
+}
+
 std::span<Latin1Character> appendHex(std::span<Latin1Character> buffer, std::uintmax_t number, unsigned minimumDigits, HexConversionMode mode)
 {
     size_t startIndex = buffer.size();

--- a/Source/WTF/wtf/HexNumber.h
+++ b/Source/WTF/wtf/HexNumber.h
@@ -30,13 +30,6 @@ enum HexConversionMode { Lowercase, Uppercase };
 
 namespace Internal {
 
-inline const std::array<Latin1Character, 16>& hexDigitsForMode(HexConversionMode mode)
-{
-    static constexpr std::array<Latin1Character, 16> lowercaseHexDigits { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f' };
-    static constexpr std::array<Latin1Character, 16> uppercaseHexDigits { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F' };
-    return mode == Lowercase ? lowercaseHexDigits : uppercaseHexDigits;
-}
-
 WTF_EXPORT_PRIVATE std::span<Latin1Character> appendHex(std::span<Latin1Character> buffer, std::uintmax_t number, unsigned minimumDigits, HexConversionMode);
 
 template<size_t arraySize, typename NumberType>

--- a/Source/WebCore/Modules/url-pattern/URLPatternParser.cpp
+++ b/Source/WebCore/Modules/url-pattern/URLPatternParser.cpp
@@ -310,7 +310,7 @@ String generateSegmentWildcardRegexp(const URLPatternStringOptions& options)
 template<typename CharacterType>
 static String escapeRegexStringForCharacters(std::span<const CharacterType> characters)
 {
-    static constexpr std::array regexEscapeCharacters { '.', '+', '*', '?', '^', '$', '{', '}', '(', ')', '[', ']', '|', '/', '\\' }; // NOLINT
+    static constexpr auto regexEscapeCharacters = std::to_array<const CharacterType>({ '.', '+', '*', '?', '^', '$', '{', '}', '(', ')', '[', ']', '|', '/', '\\' }); // NOLINT
 
     StringBuilder result;
     result.reserveCapacity(characters.size());
@@ -508,7 +508,7 @@ String generatePatternString(const Vector<Part>& partList, const URLPatternStrin
 template<typename CharacterType>
 static String escapePatternStringForCharacters(std::span<const CharacterType> characters)
 {
-    static constexpr std::array escapeCharacters { '+', '*', '?', ':', '(', ')', '\\', '{', '}' }; // NOLINT
+    static constexpr auto escapeCharacters = std::to_array<const CharacterType>({ '+', '*', '?', ':', '(', ')', '\\', '{', '}' }); // NOLINT
 
     StringBuilder result;
     result.reserveCapacity(characters.size());


### PR DESCRIPTION
#### 711eab3243f081e0cc07d349e1c9b98033482d16
<pre>
Simplify some character-related code to ease future changes to Latin1Character
<a href="https://bugs.webkit.org/show_bug.cgi?id=299671">https://bugs.webkit.org/show_bug.cgi?id=299671</a>
<a href="https://rdar.apple.com/161487282">rdar://161487282</a>

Reviewed by Sam Weinig.

* Source/JavaScriptCore/heap/HeapSnapshotBuilder.cpp:
(JSC::edgeTypeToNumber): Deleted.
(JSC::HeapSnapshotBuilder::json): Remove call to edgeTypeToNumber function so we can
serialize the edge type enumeration as a number. It&apos;s not needed because serialization
done by StringBuilder::append already serializes enumerations as their underlying=
numeric values.

* Source/WTF/wtf/HexNumber.cpp:
(WTF::Internal::hexDigitsForMode): Moved this function out of the header since it&apos;s
only used in this file.
* Source/WTF/wtf/HexNumber.h:
(WTF::Internal::hexDigitsForMode): Deleted.

* Source/WebCore/Modules/url-pattern/URLPatternParser.cpp:
(WebCore::URLPatternUtilities::escapeRegexStringForCharacters): Use an array of
CharacterType rather than an array of char.
(WebCore::URLPatternUtilities::escapePatternStringForCharacters): Ditto.

Canonical link: <a href="https://commits.webkit.org/300658@main">https://commits.webkit.org/300658@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e8c3a032f089f608978d39c38279bf1214413860

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123350 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43065 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33761 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130063 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/75470 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d6048003-8679-4950-af52-32c725818a47) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/125227 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43788 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51659 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93762 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62207 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/974240c7-e7b1-4bf7-b78c-07d89d28fbd4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126303 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34891 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110362 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74391 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/784ecca0-a8ef-4fd0-9c35-ef939adbf670) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33858 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28521 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73579 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/115509 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104605 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28747 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132779 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/121881 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50300 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38298 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102256 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50676 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106586 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102109 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25966 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47462 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25684 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/47087 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50155 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/55916 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/152236 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49626 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/38910 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/52976 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51304 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->