### PR TITLE
Replace the struct template used in BreakLines::nextBreakablePosition with a simpler struct

### DIFF
--- a/Source/WebCore/rendering/BreakLines.h
+++ b/Source/WebCore/rendering/BreakLines.h
@@ -97,22 +97,6 @@ private:
         // If we pull more logic into isBreakable, these may need to be distinguished.
     };
 
-    template<typename CharacterType>
-    struct CharacterInfo {
-        CharacterType id { 0 };
-        BreakClass type { kIndeterminate };
-        CharacterInfo(CharacterType character = 0)
-            : id(character)
-            , type(kIndeterminate)
-        { }
-        inline void set(CharacterType character)
-        {
-            id = character;
-            type = kIndeterminate;
-        }
-        operator CharacterType() const { return id; }
-    };
-
     class LineBreakTable {
     public:
         static constexpr char16_t firstCharacter = '!';
@@ -149,45 +133,48 @@ inline bool BreakLines::isBreakableSpace(char16_t character)
 }
 
 template<typename CharacterType, BreakLines::LineBreakRules shortcutRules, BreakLines::WordBreakBehavior words, BreakLines::NoBreakSpaceBehavior nonBreakingSpaceBehavior>
-inline size_t BreakLines::nextBreakablePosition(CachedLineBreakIteratorFactory& lineBreakIteratorFactory, std::span<const CharacterType> string, size_t startPosition)
+inline size_t BreakLines::nextBreakablePosition(CachedLineBreakIteratorFactory& factory, std::span<const CharacterType> string, size_t startPosition)
 {
+    struct CharacterInfo {
+        char16_t character { 0 };
+        BreakClass type { kIndeterminate };
+    };
+
     // Don't break if positioned at start of primary context and there is no prior context.
-    auto priorContextLength = lineBreakIteratorFactory.priorContext().length();
-    if (!startPosition && !priorContextLength) {
+    auto& priorContext = factory.priorContext();
+    if (!startPosition && !priorContext.length()) {
         if (string.size() <= 1)
             return string.size();
         startPosition++;
     }
 
-    CharacterInfo<CharacterType> beforeBefore(startPosition > 1 ? string[startPosition - 2]
-        : static_cast<CharacterType>(lineBreakIteratorFactory.priorContext().secondToLastCharacter()));
-    CharacterInfo<CharacterType> before(startPosition > 0 ? string[startPosition - 1]
-        : static_cast<CharacterType>(lineBreakIteratorFactory.priorContext().lastCharacter()));
-    CharacterInfo<CharacterType> after;
+    CharacterInfo beforeBefore { startPosition > 1 ? char16_t { string[startPosition - 2] } : priorContext.secondToLastCharacter() };
+    CharacterInfo before { startPosition > 0 ? char16_t { string[startPosition - 1] } : priorContext.lastCharacter() };
+    CharacterInfo after;
 
     std::optional<size_t> nextBreak;
     for (size_t i = startPosition; i < string.size(); beforeBefore = before, before = after, ++i) {
-        after.set(string[i]);
+        after = { string[i] };
 
         // Breakable spaces.
-        if (isBreakableSpace<nonBreakingSpaceBehavior>(after))
+        if (isBreakableSpace<nonBreakingSpaceBehavior>(after.character))
             return i;
 
         // ASCII rapid lookup.
         if constexpr (shortcutRules == LineBreakRules::Normal) { // Not valid for 'loose' line-breaking.
             // Don't allow line breaking between '-' and a digit if the '-' may mean a minus sign in the context,
             // while allow breaking in 'ABCD-1234' and '1234-5678' which may be in long URLs.
-            if (before == '-' && isASCIIDigit(after)) {
-                if (isASCIIAlphanumeric(beforeBefore))
+            if (before.character == '-' && isASCIIDigit(after.character)) {
+                if (isASCIIAlphanumeric(beforeBefore.character))
                     return i;
                 continue;
             }
 
             // If both characters are ASCII, use a lookup table for enhanced speed
             // and for compatibility with other browsers (see comments on lineBreakTable for details).
-            if (before <= lineBreakTable.lastCharacter && after <= lineBreakTable.lastCharacter) {
-                if (before >= lineBreakTable.firstCharacter && after >= lineBreakTable.firstCharacter) {
-                    if (lineBreakTable.unsafeLookup(before, after))
+            if (before.character <= lineBreakTable.lastCharacter && after.character <= lineBreakTable.lastCharacter) {
+                if (before.character >= lineBreakTable.firstCharacter && after.character >= lineBreakTable.firstCharacter) {
+                    if (lineBreakTable.unsafeLookup(before.character, after.character))
                         return i;
                 } // Else at least one is an ASCII control character; don't break.
                 continue;
@@ -197,8 +184,8 @@ inline size_t BreakLines::nextBreakablePosition(CachedLineBreakIteratorFactory& 
         // Non-ASCII rapid lookup.
         if constexpr (words != WordBreakBehavior::AutoPhrase) {
             if (!before.type)
-                before.type = classify<shortcutRules, nonBreakingSpaceBehavior>(before);
-            after.type = classify<shortcutRules, nonBreakingSpaceBehavior>(after);
+                before.type = classify<shortcutRules, nonBreakingSpaceBehavior>(before.character);
+            after.type = classify<shortcutRules, nonBreakingSpaceBehavior>(after.character);
             // Short-circuit the commonest cases: letter + letter.
             unsigned pair = before.type | after.type;
             // AL+AL SP+AL SP+QU AL+QU QU+QU QU+AL (after's SP is already filtered out).
@@ -235,20 +222,18 @@ inline size_t BreakLines::nextBreakablePosition(CachedLineBreakIteratorFactory& 
         }
 
         // ICU lookup (slow).
-        if (!nextBreak || nextBreak.value() < i) {
-            auto& breakIterator = lineBreakIteratorFactory.get();
-            nextBreak = breakIterator.following(i - 1);
-        }
+        if (!nextBreak || nextBreak.value() < i)
+            nextBreak = factory.get().following(i - 1);
         // Fast forward while our behavior matches ICU.
         if (nextBreak && i < nextBreak.value()) {
             for (size_t max = std::min(nextBreak.value(), string.size() - 1); i < max; beforeBefore = before, before = after, ++i) {
-                CharacterType lookahead = string[i + 1];
+                char16_t lookahead = string[i + 1];
                 if ((lookahead <= lineBreakTable.lastCharacter && !isASCIIAlpha(lookahead))
                     || (nonBreakingSpaceBehavior == NoBreakSpaceBehavior::Break && lookahead == noBreakSpace))
                     break;
             }
         }
-        if (i == nextBreak && !isBreakableSpace<nonBreakingSpaceBehavior>(before))
+        if (i == nextBreak && !isBreakableSpace<nonBreakingSpaceBehavior>(before.character))
             return i;
     }
 


### PR DESCRIPTION
#### 63cf646f23f915728d273d5af077b3a69f102ca2
<pre>
Replace the struct template used in BreakLines::nextBreakablePosition with a simpler struct
<a href="https://bugs.webkit.org/show_bug.cgi?id=299672">https://bugs.webkit.org/show_bug.cgi?id=299672</a>
<a href="https://rdar.apple.com/161487336">rdar://161487336</a>

Reviewed by Alan Baradlay.

* Source/WebCore/rendering/BreakLines.h:
(WebCore::BreakLines::nextBreakablePosition): Moved the struct into this function, and used it in a more
straightforward way, obviating the need for function members.

Canonical link: <a href="https://commits.webkit.org/300657@main">https://commits.webkit.org/300657@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/89bb349dee21bfb9df384d7bf0a792d5e48cc28d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123351 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43066 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33762 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130065 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/75471 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ff860376-9ca8-4193-a678-9ebf8aa3fb00) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/125228 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43789 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51660 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93763 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62208 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/31ece2f1-4d80-41d0-9b59-f119945a75bb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126304 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34890 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110363 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74392 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2cf33d06-7d07-492d-b7af-31ef8fd38fe0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33857 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28522 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73580 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104604 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28748 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132780 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50301 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38279 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102255 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50677 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106587 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102108 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25964 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47461 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25685 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/47088 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50156 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/55917 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49627 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/52977 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51305 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->