### PR TITLE
Simplify character handling and speed up compile of WGSL parser

### DIFF
--- a/Source/WebGPU/WGSL/Lexer.cpp
+++ b/Source/WebGPU/WGSL/Lexer.cpp
@@ -27,6 +27,7 @@
 #include "Lexer.h"
 
 #include "ConstantValue.h"
+#include "Token.h"
 #include <charconv>
 #include <wtf/FastFloat.h>
 #include <wtf/SortedArrayMap.h>
@@ -73,7 +74,31 @@ static unsigned isIdentifierContinue(Latin1Character character, std::span<const 
     return isASCIIAlphanumeric(character) || character == '_';
 }
 
-template <typename T>
+template<typename CharacterType>
+Token Lexer<CharacterType>::makeToken(TokenType type)
+{
+    return { type, m_tokenStartingPosition, currentTokenLength() };
+}
+
+template<typename CharacterType>
+Token Lexer<CharacterType>::makeFloatToken(TokenType type, double floatValue)
+{
+    return { type, m_tokenStartingPosition, currentTokenLength(), floatValue };
+}
+
+template<typename CharacterType>
+Token Lexer<CharacterType>::makeIntegerToken(TokenType type, int64_t integerValue)
+{
+    return { type, m_tokenStartingPosition, currentTokenLength(), integerValue };
+}
+
+template<typename CharacterType>
+Token Lexer<CharacterType>::makeIdentifierToken(String&& identifier)
+{
+    return { WGSL::TokenType::Identifier, m_tokenStartingPosition, currentTokenLength(), WTFMove(identifier) };
+}
+
+template<typename T>
 Vector<Token> Lexer<T>::lex()
 {
     Vector<Token> tokens;

--- a/Source/WebGPU/WGSL/Lexer.h
+++ b/Source/WebGPU/WGSL/Lexer.h
@@ -25,28 +25,22 @@
 
 #pragma once
 
-#include "Token.h"
-#include <wtf/ASCIICType.h>
+#include "SourceSpan.h"
 #include <wtf/text/StringParsingBuffer.h>
-#include <wtf/text/WTFString.h>
 
 namespace WGSL {
+
+enum class TokenType : uint32_t;
+
+struct Token;
 
 template<typename T>
 class Lexer {
 public:
-    Lexer(const String& wgsl)
+    Lexer(std::span<const T> code)
+        : m_code { code }
+        , m_current { m_code.hasCharactersRemaining() ? m_code[0] : T { } }
     {
-        if constexpr (std::is_same<T, Latin1Character>::value)
-            m_code = wgsl.span8();
-        else {
-            static_assert(std::is_same<T, char16_t>::value, "The lexer expects its template parameter to be either Latin1Character or char16_t");
-            m_code = wgsl.span16();
-            ASSERT(!(wgsl.sizeInBytes() % 2));
-        }
-
-        m_current = m_code.hasCharactersRemaining() ? m_code[0] : 0;
-        m_currentPosition = { 1, 0, 0 };
     }
 
     Vector<Token> lex();
@@ -58,24 +52,10 @@ private:
     unsigned currentOffset() const { return m_currentPosition.offset; }
     unsigned currentTokenLength() const { return currentOffset() - m_tokenStartingPosition.offset; }
 
-    Token makeToken(TokenType type)
-    {
-        return { type, m_tokenStartingPosition, currentTokenLength() };
-    }
-    Token makeFloatToken(TokenType type, double floatValue)
-    {
-        return { type, m_tokenStartingPosition, currentTokenLength(), floatValue };
-    }
-
-    Token makeIntegerToken(TokenType type, int64_t integerValue)
-    {
-        return { type, m_tokenStartingPosition, currentTokenLength(), integerValue };
-    }
-
-    Token makeIdentifierToken(String&& identifier)
-    {
-        return { WGSL::TokenType::Identifier, m_tokenStartingPosition, currentTokenLength(), WTFMove(identifier) };
-    }
+    Token makeToken(TokenType);
+    Token makeFloatToken(TokenType, double);
+    Token makeIntegerToken(TokenType, int64_t);
+    Token makeIdentifierToken(String&&);
 
     T shift(unsigned = 1);
     T peek(unsigned = 0);
@@ -84,9 +64,9 @@ private:
     void skipLineComment();
     bool skipWhitespaceAndComments();
 
-    T m_current;
     StringParsingBuffer<T> m_code;
-    SourcePosition m_currentPosition { 0, 0, 0 };
+    T m_current;
+    SourcePosition m_currentPosition { 1, 0, 0 };
     SourcePosition m_tokenStartingPosition { 0, 0, 0 };
 };
 

--- a/Source/WebGPU/WGSL/Parser.cpp
+++ b/Source/WebGPU/WGSL/Parser.cpp
@@ -30,7 +30,6 @@
 #include "Lexer.h"
 #include "ParserPrivate.h"
 #include "WGSLShaderModule.h"
-
 #include <wtf/Deque.h>
 #include <wtf/HashSet.h>
 #include <wtf/SetForScope.h>
@@ -320,10 +319,10 @@ static AST::UnaryOperation toUnaryOperation(const Token& token)
     }
 }
 
-template<typename Lexer>
+template<typename CharacterType>
 std::optional<FailedCheck> parse(ShaderModule& shaderModule)
 {
-    Lexer lexer(shaderModule.source());
+    Lexer lexer(shaderModule.source().span<CharacterType>());
     Parser parser(shaderModule, lexer);
     auto result = parser.parseShader();
     if (!result.has_value())
@@ -334,8 +333,8 @@ std::optional<FailedCheck> parse(ShaderModule& shaderModule)
 std::optional<FailedCheck> parse(ShaderModule& shaderModule)
 {
     if (shaderModule.source().is8Bit())
-        return parse<Lexer<Latin1Character>>(shaderModule);
-    return parse<Lexer<char16_t>>(shaderModule);
+        return parse<Latin1Character>(shaderModule);
+    return parse<char16_t>(shaderModule);
 }
 
 template<typename Lexer>

--- a/Source/WebGPU/WGSL/ParserPrivate.h
+++ b/Source/WebGPU/WGSL/ParserPrivate.h
@@ -37,6 +37,7 @@
 #include "ASTVariable.h"
 #include "CompilationMessage.h"
 #include "Lexer.h"
+#include "Token.h"
 #include "WGSLShaderModule.h"
 #include <wtf/Ref.h>
 

--- a/Tools/TestWebKitAPI/Tests/WGSL/ConstLiteralTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WGSL/ConstLiteralTests.cpp
@@ -33,7 +33,7 @@
 static Expected<std::pair<WGSL::ShaderModule, WGSL::AST::Expression::Ref>, WGSL::Error> parseLCharPrimaryExpression(const String& input)
 {
     WGSL::ShaderModule shaderModule(input, { });
-    WGSL::Lexer<Latin1Character> lexer(input);
+    WGSL::Lexer lexer(input.span<Latin1Character>());
     WGSL::Parser parser(shaderModule, lexer);
 
     auto expression = parser.parsePrimaryExpression();

--- a/Tools/TestWebKitAPI/Tests/WGSL/LexerTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WGSL/LexerTests.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "Lexer.h"
 
+#include "Token.h"
+
 namespace TestWGSLAPI {
 
 class TestLexer : public WGSL::Lexer<Latin1Character> {
@@ -33,7 +35,7 @@ class TestLexer : public WGSL::Lexer<Latin1Character> {
 
 public:
     TestLexer(const String& input)
-        : Base(input)
+        : Base(input.span<Latin1Character>())
         , m_tokens(Base::lex())
     {
     }


### PR DESCRIPTION
#### 0b0ff310ee75769d5f5462a560aac7f7c44287da
<pre>
Simplify character handling and speed up compile of WGSL parser
<a href="https://bugs.webkit.org/show_bug.cgi?id=299674">https://bugs.webkit.org/show_bug.cgi?id=299674</a>
<a href="https://rdar.apple.com/161488196">rdar://161488196</a>

Reviewed by Sam Weinig.

* Source/WebGPU/WGSL/Lexer.cpp:
(WGSL::Lexer&lt;CharacterType&gt;::makeToken): Moved this out of the header.
(WGSL::Lexer&lt;CharacterType&gt;::makeFloatToken): Ditto.
(WGSL::Lexer&lt;CharacterType&gt;::makeIntegerToken): Ditto.
(WGSL::Lexer&lt;CharacterType&gt;::makeIdentifierToken): Ditto.

* Source/WebGPU/WGSL/Lexer.h: Reduced includes.
Added a forward declaration for TokenType.
(WGSL::Lexer::Lexer): Take a span instead of a String.
(WGSL::Lexer::makeToken): Deleted.
(WGSL::Lexer::makeFloatToken): Deleted.
(WGSL::Lexer::makeIntegerToken): Deleted.
(WGSL::Lexer::makeIdentifierToken): Deleted.

* Source/WebGPU/WGSL/Parser.cpp:
(WGSL::parse): Changed the template argument to be a character type
rather than a Lexer classs type. Pass a span into the Lexer constructor.

* Source/WebGPU/WGSL/ParserPrivate.h: Moved the include of &quot;Token.h&quot;
here from Lexer.h.

* Tools/TestWebKitAPI/Tests/WGSL/ConstLiteralTests.cpp:
(parseLCharPrimaryExpression): Pass a span instead of a String.

* Tools/TestWebKitAPI/Tests/WGSL/LexerTests.cpp:
(TestWGSLAPI::TestLexer::TestLexer): Added an include of &quot;Token.h&quot;.

Canonical link: <a href="https://commits.webkit.org/300659@main">https://commits.webkit.org/300659@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d246bd3ac2e2594efbfcc9a521111595e6e916f3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123383 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43098 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33794 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130097 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/75507 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6b4bb785-a36c-4ffb-b195-d5a93898a045) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/125260 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43821 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51692 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/93790 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/75507 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e3af2ec5-1835-4816-9c7a-16bd7214918d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126336 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34918 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110391 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/74417 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/570a0efc-7d0d-4484-ab4b-b82ee8640cf7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33886 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/28549 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73614 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104632 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28775 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132814 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50333 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38308 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/102280 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50709 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106614 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102133 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25965 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47489 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25712 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/47123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50188 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/55949 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49659 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53009 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51337 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->