### PR TITLE
[JSC] Support `Promise.race` in async stack trace

### DIFF
--- a/JSTests/stress/async-stack-trace-promise-race-basic.js
+++ b/JSTests/stress/async-stack-trace-promise-race-basic.js
@@ -1,0 +1,117 @@
+//@ requireOptions("--useAsyncStackTrace=1")
+
+const source = "async-stack-trace-promise-race-basic.js";
+
+function nop() {}
+
+function shouldThrowAsync(run, errorType, message, stackFunctions) {
+    let actual;
+    var hadError = false;
+    run().then(
+        function (value) {
+            actual = value;
+        },
+        function (error) {
+            hadError = true;
+            actual = error;
+        },
+    );
+    drainMicrotasks();
+    if (!hadError) {
+        throw new Error("Expected " + run + "() to throw " + errorType.name + ", but did not throw.");
+    }
+    if (!(actual instanceof errorType)) {
+        throw new Error("Expected " + run + "() to throw " + errorType.name + ", but threw '" + actual + "'");
+    }
+    if (message !== void 0 && actual.message !== message) {
+        throw new Error("Expected " + run + "() to throw '" + message + "', but threw '" + actual.message + "'");
+    }
+
+    const stackTrace = actual.stack;
+    if (!stackTrace) {
+        throw new Error("Expected error to have stack trace, but it was undefined");
+    }
+
+    const stackLines = stackTrace.split('\n').filter(line => line.trim());
+
+    for (let i = 0; i < stackFunctions.length; i++) {
+        const [expectedFunction, expectedLocation] = stackFunctions[i];
+        const isNativeCode = expectedLocation === "[native code]" 
+        const stackLine = stackLines[i];
+
+        let found = false;
+
+        if (isNativeCode) {
+            if (stackLine === `${expectedFunction}@[native code]`)
+                found = true;
+        } else {
+            if (stackLine === `${expectedFunction}@${source}:${expectedLocation}`)
+                found = true;
+            if (stackLine === `${expectedFunction}@${source}`)
+                found = true;
+        }
+
+        if (!found) {
+            throw new Error(
+                `Expected stack trace to contain '${expectedFunction}' at '${expectedLocation}', but got '${stackLine}'` +
+                `\nActual stack trace:\n${stackTrace}\n`
+            );
+        }
+    }
+}
+
+{
+  async function fine() { }
+  async function thrower() { await fine(); throw new Error('error'); }
+  async function run() { await Promise.race([thrower()]); }
+
+  for (let i = 0; i < testLoopCount; i++) {
+    shouldThrowAsync(
+      async function test() {
+        await run();
+      }, Error, 'error', [
+        ["thrower", "65:59"],
+        ["async run", "66:44"],
+        ["async test", "71:18"],
+        ["drainMicrotasks", "[native code]"],
+        ["shouldThrowAsync", "19:20"],
+        ["global code", "69:21"]
+      ] 
+    );
+    drainMicrotasks();
+  }
+}
+
+{
+  async function task1() {
+    
+    await nop();
+  
+    throw new Error("error from task1");
+  }
+  async function task2() {
+    await nop();
+
+
+
+    throw new Error('error from task2');
+  }
+  async function task3() { await 1; throw new Error("error from task3"); }
+  async function run() { await Promise.race([task1(), task2(), task3()]); }
+
+  for (let i = 0; i < testLoopCount; i++) {
+    shouldThrowAsync(
+      async function test() {
+        await run();
+      }, Error, 'error from task1' , [
+        ["task1", "90:20"],
+        ["async run", "100:44"],
+        ["async test", "105:18"],
+        ["drainMicrotasks", "[native code]"],
+        ["shouldThrowAsync", "19:20"],
+        ["global code", "103:21"]
+      ]
+    );
+    drainMicrotasks();
+  }
+}

--- a/Source/JavaScriptCore/builtins/PromiseConstructor.js
+++ b/Source/JavaScriptCore/builtins/PromiseConstructor.js
@@ -330,7 +330,11 @@ function race(iterable)
 
         for (var value of iterable) {
             var nextPromise = promiseResolve.@call(this, value);
-            nextPromise.then(resolve, reject);
+            var then = nextPromise.then;
+            if (@isPromise(nextPromise) && then === @defaultPromiseThen)
+                @performPromiseThen(nextPromise, resolve, reject, @undefined, /* context */ promise);
+            else
+                nextPromise.then(resolve, reject);
         }
     } catch (error) {
         reject.@call(@undefined, error);

--- a/Source/JavaScriptCore/interpreter/Interpreter.cpp
+++ b/Source/JavaScriptCore/interpreter/Interpreter.cpp
@@ -497,7 +497,7 @@ void Interpreter::getAsyncStackTrace(JSCell* owner, Vector<StackFrame>& results,
             }
         }
 
-        // handle `Promise.any`
+        // handle `Promise.any` and `Promise.race`
         if (auto* contextPromise = jsDynamicCast<JSPromise*>(promiseContext)) {
             if (JSValue parentContext = getContextValueFromPromise(contextPromise)) {
                 if (auto* generator = jsDynamicCast<JSGenerator*>(parentContext))


### PR DESCRIPTION
#### eb9fff6095737c19d0890ae608fe8fa22ca74a85
<pre>
[JSC] Support `Promise.race` in async stack trace
<a href="https://bugs.webkit.org/show_bug.cgi?id=299675">https://bugs.webkit.org/show_bug.cgi?id=299675</a>

Reviewed by Yusuke Suzuki.

This patch changes async stack trace to support `Promise.race`.

Test: JSTests/stress/async-stack-trace-promise-race-basic.js
* JSTests/stress/async-stack-trace-promise-race-basic.js: Added.
(nop):
(shouldThrowAsync):
(throw.new.Error.async fine):
(throw.new.Error.async thrower):
(throw.new.Error.async run):
(async task1):
(async task2):
(async task3):
(async run):
(throw.new.Error.async drainMicrotasks):
* Source/JavaScriptCore/builtins/PromiseConstructor.js:
(race):
* Source/JavaScriptCore/interpreter/Interpreter.cpp:
(JSC::Interpreter::getAsyncStackTrace):

Canonical link: <a href="https://commits.webkit.org/300795@main">https://commits.webkit.org/300795@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f41a3532827140c3cd70377131053744a71a5299

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123354 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43069 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33765 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130068 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/75476 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43792 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51663 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93766 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62211 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126307 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34893 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110365 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74395 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33860 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28524 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73583 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/115513 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104607 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28750 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132783 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/121885 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50304 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38281 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102258 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50680 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106589 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102111 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26070 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47464 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25687 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/47091 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50159 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/55920 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/152240 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49630 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/38911 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/52980 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51308 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->