### PR TITLE
[JSC] Fix jitAllowlist option in regexp-exec-dfg-strength-reduction-regExpObjectNode.js

### DIFF
--- a/JSTests/stress/regexp-exec-dfg-strength-reduction-regExpObjectNode.js
+++ b/JSTests/stress/regexp-exec-dfg-strength-reduction-regExpObjectNode.js
@@ -1,4 +1,4 @@
-//@ runDefault("--forceEagerCompilation=1", "--useConcurrentJIT=0", "--jitAllowlist=\"<global>\"")
+//@ runDefault("--forceEagerCompilation=1", "--useConcurrentJIT=0", "--jitAllowlist=<global>")
 function foo(s, a0, a1, a2, a3) {
   'use strict';
   return /foo/.exec(s);


### PR DESCRIPTION
#### de655a1ae3faf3e92f099f43b095927f981d4f82
<pre>
[JSC] Fix jitAllowlist option in regexp-exec-dfg-strength-reduction-regExpObjectNode.js
<a href="https://bugs.webkit.org/show_bug.cgi?id=299677">https://bugs.webkit.org/show_bug.cgi?id=299677</a>
<a href="https://rdar.apple.com/161491332">rdar://161491332</a>

Reviewed by Yusuke Suzuki.

Remove manual quote escaping from --jitAllowlist option in test directive.
The test framework&apos;s argument parsing cannot properly handle embedded quotes
within argument strings, causing the test to fail when run through the
stress test framework. Let the framework handle shell metacharacter escaping
automatically.

Canonical link: <a href="https://commits.webkit.org/300653@main">https://commits.webkit.org/300653@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/728134bb1f1fc58f522482e0599a4c91cdc2a0ea

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123362 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43077 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33773 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130076 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/75484 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/86580a18-e9a0-43e8-b707-2ad6325e017e) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43800 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51671 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93771 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62215 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0851f933-9d66-4f47-879d-a08b80a31106) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126315 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34897 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110367 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74399 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/752eacb8-e9a5-4e81-8759-62bf0629fcc5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33864 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73591 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/115521 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104611 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28752 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132792 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/121893 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50312 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38286 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102262 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50688 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106591 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102115 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47467 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25689 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/47099 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19431 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50167 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/152248 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49638 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/38913 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/52988 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51316 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->