### PR TITLE
Port General WebExtensionContext Functions to C++

### DIFF
--- a/Source/WebCore/en.lproj/Localizable.strings
+++ b/Source/WebCore/en.lproj/Localizable.strings
@@ -65,7 +65,7 @@
 "%@ Web Content (Prewarmed)" = "%@ Web Content (Prewarmed)";
 
 /* Extension's process name that appears in Activity Monitor where the parameter is the name of the extension */
-"%@ Web Extension" = "%@ Web Extension";
+"%s Web Extension" = "%s Web Extension";
 
 /* Visible name of Web Inspector's web process. The argument is the application name. */
 "%@ Web Inspector" = "%@ Web Inspector";

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp
@@ -33,12 +33,14 @@
 #include "APIContentRuleListStore.h"
 #include "InjectUserScriptImmediately.h"
 #include "Logging.h"
+#include "WebExtensionConstants.h"
 #include "WebExtensionContextParameters.h"
 #include "WebExtensionContextProxyMessages.h"
 #include "WebExtensionController.h"
 #include "WebExtensionPermission.h"
 #include "WebPageProxy.h"
 #include <WebCore/LocalizedStrings.h>
+#include <WebCore/TextResourceDecoder.h>
 #include <wtf/HashMap.h>
 #include <wtf/NeverDestroyed.h>
 
@@ -112,6 +114,139 @@ Vector<Ref<API::Error>> WebExtensionContext::errors()
     auto array = protectedExtension()->errors();
     array.appendVector(m_errors);
     return array;
+}
+
+String WebExtensionContext::stateFilePath() const
+{
+    if (!storageIsPersistent())
+        return nullString();
+    return FileSystem::pathByAppendingComponent(storageDirectory(), plistFileName());
+}
+
+void WebExtensionContext::setBaseURL(URL&& url)
+{
+    ASSERT(!isLoaded());
+    if (isLoaded())
+        return;
+
+    if (!url.isValid())
+        return;
+
+    m_baseURL = URL { url, "/"_s };
+}
+
+bool WebExtensionContext::isURLForThisExtension(const URL& url) const
+{
+    return url.isValid() && protocolHostAndPortAreEqual(baseURL(), url);
+}
+
+bool WebExtensionContext::isURLForAnyExtension(const URL& url)
+{
+    return url.isValid() && WebExtensionMatchPattern::extensionSchemes().contains(url.protocol().toString());
+}
+
+void WebExtensionContext::setUniqueIdentifier(String&& uniqueIdentifier)
+{
+    ASSERT(!isLoaded());
+    if (isLoaded())
+        return;
+
+    m_customUniqueIdentifier = !uniqueIdentifier.isEmpty();
+
+    if (uniqueIdentifier.isEmpty())
+        uniqueIdentifier = WTF::UUID::createVersion4().toString();
+
+    m_uniqueIdentifier = uniqueIdentifier;
+}
+
+RefPtr<WebExtensionLocalization> WebExtensionContext::localization()
+{
+    if (!m_localization)
+        m_localization = WebExtensionLocalization::create(protectedExtension()->localization()->localizationJSON(), baseURL().host().toString());
+    return m_localization;
+}
+
+RefPtr<API::Data> WebExtensionContext::localizedResourceData(const RefPtr<API::Data>& resourceData, const String& mimeType)
+{
+    if (!equalLettersIgnoringASCIICase(mimeType, "text/css"_s) || !resourceData)
+        return resourceData;
+
+    RefPtr decoder = WebCore::TextResourceDecoder::create(mimeType, PAL::UTF8Encoding());
+    auto stylesheetContents = decoder->decode(resourceData->span());
+
+    auto localizedString = localizedResourceString(stylesheetContents, mimeType);
+    if (localizedString == stylesheetContents)
+        return resourceData;
+
+    return API::Data::create(localizedString.utf8().span());
+}
+
+String WebExtensionContext::localizedResourceString(const String& resourceContents, const String& mimeType)
+{
+    if (!equalLettersIgnoringASCIICase(mimeType, "text/css"_s) || resourceContents.isEmpty() || !resourceContents.contains("__MSG_"_s))
+        return resourceContents;
+
+    RefPtr localization = this->localization();
+    if (!localization)
+        return resourceContents;
+
+    return localization->localizedStringForString(resourceContents);
+}
+
+void WebExtensionContext::setUnsupportedAPIs(HashSet<String>&& unsupported)
+{
+    ASSERT(!isLoaded());
+    if (isLoaded())
+        return;
+
+    m_unsupportedAPIs = WTFMove(unsupported);
+}
+
+URL WebExtensionContext::optionsPageURL() const
+{
+    RefPtr extension = m_extension;
+    if (!extension->hasOptionsPage())
+        return { };
+    return { m_baseURL, extension->optionsPagePath() };
+}
+
+URL WebExtensionContext::overrideNewTabPageURL() const
+{
+    RefPtr extension = m_extension;
+    if (!extension->hasOverrideNewTabPage())
+        return { };
+    return { m_baseURL, extension->overrideNewTabPagePath() };
+}
+
+void WebExtensionContext::setHasAccessToPrivateData(bool hasAccess)
+{
+    if (m_hasAccessToPrivateData == hasAccess)
+        return;
+
+    m_hasAccessToPrivateData = hasAccess;
+
+    if (!safeToInjectContent())
+        return;
+
+    if (m_hasAccessToPrivateData) {
+        addDeclarativeNetRequestRulesToPrivateUserContentControllers();
+
+        for (Ref controller : extensionController()->allPrivateUserContentControllers())
+            addInjectedContent(controller);
+
+#if ENABLE(INSPECTOR_EXTENSIONS)
+        loadInspectorBackgroundPagesForPrivateBrowsing();
+#endif
+    } else {
+        for (Ref controller : extensionController()->allPrivateUserContentControllers()) {
+            removeInjectedContent(controller);
+            controller->removeContentRuleList(uniqueIdentifier());
+        }
+
+#if ENABLE(INSPECTOR_EXTENSIONS)
+        unloadInspectorBackgroundPagesForPrivateBrowsing();
+#endif
+    }
 }
 
 const WebExtensionContext::PermissionsMap& WebExtensionContext::grantedPermissions()
@@ -1296,6 +1431,26 @@ void WebExtensionContext::addInjectedContent(WebUserContentControllerProxy& user
     }
 }
 
+bool WebExtensionContext::hasAccessToAllURLs()
+{
+    for (auto& pattern : currentPermissionMatchPatterns()) {
+        if (pattern->matchesAllURLs())
+            return true;
+    }
+
+    return false;
+}
+
+bool WebExtensionContext::hasAccessToAllHosts()
+{
+    for (auto& pattern : currentPermissionMatchPatterns()) {
+        if (pattern->matchesAllHosts())
+            return true;
+    }
+
+    return false;
+}
+
 void WebExtensionContext::removeInjectedContent()
 {
     if (!isLoaded())
@@ -1538,6 +1693,76 @@ WebExtensionContext::WebProcessProxySet WebExtensionContext::processes(EventList
     }
 
     return result;
+}
+
+String WebExtensionContext::processDisplayName()
+{
+    return WEB_UI_FORMAT_STRING("%s Web Extension", "Extension's process name that appears in Activity Monitor where the parameter is the name of the extension", protectedExtension()->displayShortName().utf8().data());
+}
+
+Vector<String> WebExtensionContext::corsDisablingPatterns()
+{
+    Vector<String> patterns;
+
+    auto grantedMatchPatterns = grantedPermissionMatchPatterns();
+    for (auto& entry : grantedMatchPatterns) {
+        Ref pattern = entry.key;
+        patterns.appendVector(pattern->expandedStrings());
+    }
+
+    removeRepeatedElements(patterns);
+
+    return patterns;
+}
+
+size_t WebExtensionContext::quotaForStorageType(WebExtensionDataType storageType)
+{
+    switch (storageType) {
+    case WebExtensionDataType::Local:
+        return hasPermission(WebExtensionPermission::unlimitedStorage()) ? webExtensionUnlimitedStorageQuotaBytes : webExtensionStorageAreaLocalQuotaBytes;
+    case WebExtensionDataType::Session:
+        return webExtensionStorageAreaSessionQuotaBytes;
+    case WebExtensionDataType::Sync:
+        return webExtensionStorageAreaSyncQuotaBytes;
+    }
+
+    ASSERT_NOT_REACHED();
+    return 0;
+}
+
+Ref<WebExtensionStorageSQLiteStore> WebExtensionContext::localStorageStore()
+{
+    if (!m_localStorageStore)
+        m_localStorageStore = WebExtensionStorageSQLiteStore::create(m_uniqueIdentifier, WebExtensionDataType::Local, storageDirectory(), storageIsPersistent() ? WebExtensionStorageSQLiteStore::UsesInMemoryDatabase::No : WebExtensionStorageSQLiteStore::UsesInMemoryDatabase::Yes);
+    return *m_localStorageStore;
+}
+
+Ref<WebExtensionStorageSQLiteStore> WebExtensionContext::sessionStorageStore()
+{
+    if (!m_sessionStorageStore)
+        m_sessionStorageStore = WebExtensionStorageSQLiteStore::create(m_uniqueIdentifier, WebExtensionDataType::Session, storageDirectory(), WebExtensionStorageSQLiteStore::UsesInMemoryDatabase::Yes);
+    return *m_sessionStorageStore;
+}
+
+Ref<WebExtensionStorageSQLiteStore> WebExtensionContext::syncStorageStore()
+{
+    if (!m_syncStorageStore)
+        m_syncStorageStore = WebExtensionStorageSQLiteStore::create(m_uniqueIdentifier, WebExtensionDataType::Sync, storageDirectory(), storageIsPersistent() ? WebExtensionStorageSQLiteStore::UsesInMemoryDatabase::No : WebExtensionStorageSQLiteStore::UsesInMemoryDatabase::Yes);
+    return *m_syncStorageStore;
+}
+
+Ref<WebExtensionStorageSQLiteStore> WebExtensionContext::storageForType(WebExtensionDataType storageType)
+{
+    switch (storageType) {
+    case WebExtensionDataType::Local:
+        return localStorageStore();
+    case WebExtensionDataType::Session:
+        return sessionStorageStore();
+    case WebExtensionDataType::Sync:
+        return syncStorageStore();
+    }
+
+    return sessionStorageStore();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -617,8 +617,8 @@ public:
     void enumerateExtensionPages(NOESCAPE Function<void(WebPageProxy&, bool& stop)>&&);
 
     WKWebView *relatedWebView();
-    NSString *processDisplayName();
-    NSArray *corsDisablingPatterns();
+    String processDisplayName();
+    Vector<String> corsDisablingPatterns();
     void updateCORSDisablingPatternsOnAllExtensionPages();
     WKWebViewConfiguration *webViewConfiguration(WebViewPurpose = WebViewPurpose::Any);
 


### PR DESCRIPTION
#### 57a0f2aa44b3bb9a099a247df7ff89e4dacbe4b0
<pre>
Port General WebExtensionContext Functions to C++
<a href="https://bugs.webkit.org/show_bug.cgi?id=299679">https://bugs.webkit.org/show_bug.cgi?id=299679</a>

Reviewed by Timothy Hatcher.

Port some general functions in WebExtensionContext to C++, allowing for their use in a future WebExtensionContextGtk.

* Source/WebCore/en.lproj/Localizable.strings:
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::updateCORSDisablingPatternsOnAllExtensionPages):
(WebKit::WebExtensionContext::webViewConfiguration):
(WebKit::WebExtensionContext::stateFilePath const): Deleted.
(WebKit::WebExtensionContext::setBaseURL): Deleted.
(WebKit::WebExtensionContext::isURLForThisExtension const): Deleted.
(WebKit::WebExtensionContext::isURLForAnyExtension): Deleted.
(WebKit::WebExtensionContext::setUniqueIdentifier): Deleted.
(WebKit::WebExtensionContext::localization): Deleted.
(WebKit::WebExtensionContext::localizedResourceData): Deleted.
(WebKit::WebExtensionContext::localizedResourceString): Deleted.
(WebKit::WebExtensionContext::setUnsupportedAPIs): Deleted.
(WebKit::WebExtensionContext::optionsPageURL const): Deleted.
(WebKit::WebExtensionContext::overrideNewTabPageURL const): Deleted.
(WebKit::WebExtensionContext::setHasAccessToPrivateData): Deleted.
(WebKit::WebExtensionContext::hasAccessToAllURLs): Deleted.
(WebKit::WebExtensionContext::hasAccessToAllHosts): Deleted.
(WebKit::WebExtensionContext::processDisplayName): Deleted.
(WebKit::WebExtensionContext::corsDisablingPatterns): Deleted.
(WebKit::WebExtensionContext::quotaForStorageType): Deleted.
(WebKit::WebExtensionContext::localStorageStore): Deleted.
(WebKit::WebExtensionContext::sessionStorageStore): Deleted.
(WebKit::WebExtensionContext::syncStorageStore): Deleted.
(WebKit::WebExtensionContext::storageForType): Deleted.
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp:
(WebKit::WebExtensionContext::stateFilePath const):
(WebKit::WebExtensionContext::setBaseURL):
(WebKit::WebExtensionContext::isURLForThisExtension const):
(WebKit::WebExtensionContext::isURLForAnyExtension):
(WebKit::WebExtensionContext::setUniqueIdentifier):
(WebKit::WebExtensionContext::localization):
(WebKit::WebExtensionContext::localizedResourceData):
(WebKit::WebExtensionContext::localizedResourceString):
(WebKit::WebExtensionContext::setUnsupportedAPIs):
(WebKit::WebExtensionContext::optionsPageURL const):
(WebKit::WebExtensionContext::overrideNewTabPageURL const):
(WebKit::WebExtensionContext::setHasAccessToPrivateData):
(WebKit::WebExtensionContext::hasAccessToAllURLs):
(WebKit::WebExtensionContext::hasAccessToAllHosts):
(WebKit::WebExtensionContext::processDisplayName):
(WebKit::WebExtensionContext::corsDisablingPatterns):
(WebKit::WebExtensionContext::quotaForStorageType):
(WebKit::WebExtensionContext::localStorageStore):
(WebKit::WebExtensionContext::sessionStorageStore):
(WebKit::WebExtensionContext::syncStorageStore):
(WebKit::WebExtensionContext::storageForType):

* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:

Canonical link: <a href="https://commits.webkit.org/300669@main">https://commits.webkit.org/300669@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f39af54b646779d7fbe0444ae4377c70a832ea21

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123367 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43082 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33778 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130081 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/75489 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/125244 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43805 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51676 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93774 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62217 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126320 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34900 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110372 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74402 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33867 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28530 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73596 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104614 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28756 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132797 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50317 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38291 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102264 "38 flakes 68 failures") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50693 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106595 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102117 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47471 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25693 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/47106 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19438 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50172 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/55933 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49643 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/52993 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51321 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->