### PR TITLE
[JSC] Handle missing test executables gracefully in run-javascriptcore-tests

### DIFF
--- a/Tools/Scripts/run-javascriptcore-tests
+++ b/Tools/Scripts/run-javascriptcore-tests
@@ -701,18 +701,27 @@ sub runTest {
 
     my $testResult = 0;
     my $lastOptimizeLevel;
-
-    open(TEST, "-|", "@command 2>&1") or die "Failed to run @command";
     my $testOutput = "";
-    while ( my $line = <TEST> ) {
-        $testOutput .= $line;
+    my $missingExecutable = 0;
+
+    # Check if the test executable exists before trying to run it
+    my $testExecutable = $command[0];
+    if (!-e $testExecutable) {
+        print "FAIL: $testName executable not found at $testExecutable\n";
+        $testResult = 1;
+        $missingExecutable = 1;
+    } else {
+        open(TEST, "-|", "@command 2>&1") or die "Failed to run @command";
+        while ( my $line = <TEST> ) {
+            $testOutput .= $line;
+        }
+        $testResult = close(TEST) ? 0 : $?;
+        print "$testOutput" if ($verbose or $testResult);
     }
-    $testResult = close(TEST) ? 0 : $?;
     $reportData{$testName} = $testResult ? {actual => "FAIL"} : {actual => "PASS"};
 
     my $exitStatus = exitStatus($testResult);
 
-    print "$testOutput" if ($verbose or $testResult);
     print "$testName completed with rc=$testResult ($exitStatus)\n\n";
 
     if ($testResult) {
@@ -724,7 +733,8 @@ sub runTest {
         $jsonData{$jsonTestStatusName} = $testStatus;
     }
 
-    if ($testResult && $failFast) {
+    # Only trigger fail-fast for actual test failures, not missing executables
+    if ($testResult && $failFast && !$missingExecutable) {
         reportTestFailures();
         writeJsonDataIfApplicable();
 


### PR DESCRIPTION
#### db1e3bbb3be2ef6103bb0c0fa81fe1c3e5c0b5c0
<pre>
[JSC] Handle missing test executables gracefully in run-javascriptcore-tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=299684">https://bugs.webkit.org/show_bug.cgi?id=299684</a>
<a href="https://rdar.apple.com/161496792">rdar://161496792</a>

Reviewed by Yusuke Suzuki.

When test executables are missing from build archives, the test runner would
crash with a fatal error, preventing other tests from running.

This change makes the test runner handle missing executables gracefully:
- Check if executable exists before attempting to run it
- Log a clear failure message when executable is missing
- Mark as test failure but continue with remaining tests
- Don&apos;t trigger fail-fast behavior for missing executables

This allows CI to report missing executables as test failures while continuing
to run the full test suite, rather than crashing the entire process.

Canonical link: <a href="https://commits.webkit.org/300660@main">https://commits.webkit.org/300660@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dde331aaa649da628d1c68f4e4cf71c93eda39c0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123382 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43097 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33793 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130096 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/75506 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f8928fe8-cc27-4edb-9bed-109b2cf21994) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/125259 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43820 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51691 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93788 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/62229 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8a3be08d-bb60-4beb-9889-9206e8c24608) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126335 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34917 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110390 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74415 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/74ac44ec-6d48-4a20-b881-c0529bc4065d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33885 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28548 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73613 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/115541 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104631 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28774 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132813 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/121913 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50332 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38306 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102278 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50708 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106613 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102131 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47488 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25711 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/47122 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19434 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50187 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/152268 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49658 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/38921 "Found 5 new JSC binary failures: testair, testapi, testb3, testdfg, testmasm, Found 8 new JSC stress test failures: wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.default-wasm, wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.wasm-bbq, wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.wasm-bbq-no-consts, wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.wasm-collect-continuously, wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.wasm-eager, wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.wasm-eager-jettison, wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.wasm-no-cjit, wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.wasm-slow-memory (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53008 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51336 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->