### PR TITLE
[JSC] Replace static_cast with uncheckedDowncast for Wasm::Callee type safety

### DIFF
--- a/Source/JavaScriptCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/JavaScriptCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -49,7 +49,6 @@ interpreter/CallFrame.cpp
 interpreter/CallFrame.h
 interpreter/CallFrameInlines.h
 interpreter/Interpreter.cpp
-interpreter/StackVisitor.cpp
 jit/JITOperations.cpp
 jit/JITThunks.cpp
 jsc.cpp
@@ -108,7 +107,6 @@ runtime/JSString.h
 runtime/JSStringInlines.h
 runtime/JSTemplateObjectDescriptor.cpp
 runtime/ModuleProgramExecutable.cpp
-runtime/NativeCallee.cpp
 runtime/NativeExecutable.cpp
 runtime/ObjectConstructor.cpp
 runtime/ProgramExecutable.cpp
@@ -139,14 +137,10 @@ tools/HeapVerifier.cpp
 tools/JSDollarVM.cpp
 tools/VMInspector.cpp
 wasm/WasmCalleeGroup.cpp
-wasm/WasmFaultSignalHandler.cpp
 wasm/WasmIPIntSlowPaths.cpp
 wasm/WasmModule.cpp
-wasm/WasmOMGIRGenerator.cpp
-wasm/WasmOSREntryPlan.cpp
 wasm/WasmOperations.cpp
 wasm/WasmStreamingCompiler.cpp
-wasm/debugger/WasmDebugServerUtilities.cpp
 wasm/js/JSWebAssemblyException.cpp
 wasm/js/JSWebAssemblyGlobal.cpp
 wasm/js/JSWebAssemblyHelpers.h

--- a/Source/JavaScriptCore/assembler/LinkBuffer.cpp
+++ b/Source/JavaScriptCore/assembler/LinkBuffer.cpp
@@ -102,7 +102,7 @@ void LinkBuffer::logJITCodeForJITDump(CodeRef<LinkBufferPtrTag>& codeRef, ASCIIL
     case Profile::WasmOMG:
     case Profile::WasmBBQ: {
         if (m_ownerUID)
-            out.print(makeString(static_cast<Wasm::Callee*>(m_ownerUID)->indexOrName()));
+            out.print(makeString(uncheckedDowncast<Wasm::Callee>(reinterpret_cast<NativeCallee*>(m_ownerUID))->indexOrName()));
         else
             dumpSimpleName(out, simpleName);
         break;

--- a/Source/JavaScriptCore/interpreter/CallFrame.cpp
+++ b/Source/JavaScriptCore/interpreter/CallFrame.cpp
@@ -288,7 +288,7 @@ void CallFrame::dump(PrintStream& out) const
         switch (nativeCallee->category()) {
         case NativeCallee::Category::Wasm: {
 #if ENABLE(WEBASSEMBLY)
-            auto* wasmCallee = static_cast<Wasm::Callee*>(nativeCallee);
+            auto* wasmCallee = uncheckedDowncast<Wasm::Callee>(nativeCallee);
             out.print(Wasm::makeString(wasmCallee->indexOrName()), " [", wasmCallee->compilationMode(), " ", RawPointer(callee().rawPtr()), "]");
             out.print("(JSWebAssemblyInstance: ", RawPointer(wasmInstance()), ")");
 #else

--- a/Source/JavaScriptCore/interpreter/Interpreter.cpp
+++ b/Source/JavaScriptCore/interpreter/Interpreter.cpp
@@ -822,7 +822,7 @@ public:
             case NativeCallee::Category::Wasm: {
 #if ENABLE(WEBASSEMBLY)
                 if (m_catchableFromWasm) {
-                    auto* wasmCallee = static_cast<Wasm::Callee*>(nativeCallee);
+                    auto* wasmCallee = uncheckedDowncast<Wasm::Callee>(nativeCallee);
                     if (wasmCallee->hasExceptionHandlers()) {
                         JSWebAssemblyInstance* instance = m_callFrame->wasmInstance();
                         unsigned exceptionHandlerIndex = visitor->wasmCallSiteIndex().bits();

--- a/Source/JavaScriptCore/interpreter/StackVisitor.cpp
+++ b/Source/JavaScriptCore/interpreter/StackVisitor.cpp
@@ -200,7 +200,7 @@ void StackVisitor::readInlinableNativeCalleeFrame(CallFrame* callFrame)
     switch (callee.category()) {
     case NativeCallee::Category::Wasm: {
 #if ENABLE(WEBASSEMBLY)
-        auto& wasmCallee = static_cast<Wasm::Callee&>(callee);
+        auto& wasmCallee = uncheckedDowncast<Wasm::Callee>(callee);
         auto depth = m_frame.m_wasmDistanceFromDeepestInlineFrame;
         m_frame.m_callFrame = updatePreviousReturnPCIfNecessary(callFrame);
         m_frame.m_returnPC = m_previousReturnPC;
@@ -222,7 +222,7 @@ void StackVisitor::readInlinableNativeCalleeFrame(CallFrame* callFrame)
         if (!canInline)
             return;
 
-        const auto& omgCallee = *static_cast<const Wasm::OptimizingJITCallee*>(&wasmCallee);
+        const auto& omgCallee = uncheckedDowncast<const Wasm::OptimizingJITCallee>(wasmCallee);
         bool isInlined = false;
 
         // Because PC is just after the call instruction, to query to the origin for the call instruction, we decrease it by 1.
@@ -361,7 +361,7 @@ std::optional<RegisterAtOffsetList> StackVisitor::Frame::calleeSaveRegistersForU
         switch (nativeCallee->category()) {
         case NativeCallee::Category::Wasm: {
 #if ENABLE(WEBASSEMBLY)
-            auto* wasmCallee = static_cast<Wasm::Callee*>(nativeCallee);
+            auto* wasmCallee = uncheckedDowncast<Wasm::Callee>(nativeCallee);
             if (auto* calleeSaveRegisters = wasmCallee->calleeSaveRegisters())
                 return *calleeSaveRegisters;
 #endif // ENABLE(WEBASSEMBLY)

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -2345,7 +2345,7 @@ JSC_DEFINE_HOST_FUNCTION(functionCallerIsBBQOrOMGCompiled, (JSGlobalObject* glob
     ASSERT(wasmFrame.callerFrame()->callee().isNativeCallee());
     ASSERT(wasmFrame.callerFrame()->callee().asNativeCallee()->category() == NativeCallee::Category::Wasm);
 #if ENABLE(WEBASSEMBLY)
-    auto mode = static_cast<Wasm::Callee*>(wasmFrame.callerFrame()->callee().asNativeCallee())->compilationMode();
+    auto mode = uncheckedDowncast<Wasm::Callee>(wasmFrame.callerFrame()->callee().asNativeCallee())->compilationMode();
     return JSValue::encode(jsBoolean(isAnyBBQ(mode) || isAnyOMG(mode)));
 #endif
     RELEASE_ASSERT_NOT_REACHED();

--- a/Source/JavaScriptCore/runtime/NativeCallee.cpp
+++ b/Source/JavaScriptCore/runtime/NativeCallee.cpp
@@ -43,7 +43,7 @@ void NativeCallee::dump(PrintStream& out) const
     switch (category()) {
     case Category::Wasm: {
 #if ENABLE(WEBASSEMBLY)
-        static_cast<const Wasm::Callee*>(this)->dump(out);
+        uncheckedDowncast<const Wasm::Callee>(this)->dump(out);
 #endif
         break;
     }
@@ -60,7 +60,7 @@ void NativeCallee::operator delete(NativeCallee* callee, std::destroying_delete_
     switch (callee->category()) {
     case Category::Wasm: {
 #if ENABLE(WEBASSEMBLY)
-        Wasm::Callee::destroy(static_cast<Wasm::Callee*>(callee));
+        Wasm::Callee::destroy(uncheckedDowncast<Wasm::Callee>(callee));
 #endif
         break;
     }

--- a/Source/JavaScriptCore/runtime/SamplingProfiler.cpp
+++ b/Source/JavaScriptCore/runtime/SamplingProfiler.cpp
@@ -139,14 +139,14 @@ protected:
 #if ENABLE(WEBASSEMBLY)
                     // At this point, Wasm::Callee would be dying (ref count is 0), but its fields are still live.
                     // And we can safely copy Wasm::IndexOrName even when any lock is held by suspended threads.
-                    auto* wasmCallee = static_cast<Wasm::Callee*>(nativeCallee);
+                    auto* wasmCallee = uncheckedDowncast<Wasm::Callee>(nativeCallee);
                     stackTrace[m_depth].wasmCompilationMode = wasmCallee->compilationMode();
                     stackTrace[m_depth].wasmIndexOrName = wasmCallee->indexOrName();
                     stackTrace[m_depth].callSiteIndex = m_callFrame->unsafeCallSiteIndex();
 #if ENABLE(JIT)
                     // FIXME: We should be able to add all stack traces including inlined ones in SamplingProfiler.
                     if (wasmCallee->compilationMode() == Wasm::CompilationMode::OMGMode) {
-                        auto* omgCallee = static_cast<const Wasm::OptimizingJITCallee*>(wasmCallee);
+                        auto* omgCallee = uncheckedDowncast<const Wasm::OptimizingJITCallee>(wasmCallee);
                         bool isInlined = false;
                         auto origin = omgCallee->getOrigin(stackTrace[m_depth].callSiteIndex.bits(), 0, isInlined);
                         if (isInlined)

--- a/Source/JavaScriptCore/tools/JSDollarVM.cpp
+++ b/Source/JavaScriptCore/tools/JSDollarVM.cpp
@@ -2377,13 +2377,13 @@ JSC_DEFINE_HOST_FUNCTION(functionOMGTrue, (JSGlobalObject* globalObject, CallFra
             allFramesAreValid = false;
             return Wasm::CompilationMode::IPIntMode;
         }
-        return static_cast<Wasm::Callee*>(visitor->callee().asNativeCallee())->compilationMode();
+        return uncheckedDowncast<Wasm::Callee>(visitor->callee().asNativeCallee())->compilationMode();
     };
 
     auto expectWasmToJS = [&](StackVisitor& visitor) {
         if (visitor->codeType() != StackVisitor::Frame::Wasm
             || !visitor->callee().isNativeCallee()
-            || !isAnyWasmToJS(static_cast<Wasm::Callee*>(visitor->callee().asNativeCallee())->compilationMode())) {
+            || !isAnyWasmToJS(uncheckedDowncast<Wasm::Callee>(visitor->callee().asNativeCallee())->compilationMode())) {
             allFramesAreValid = false;
             return;
         }

--- a/Source/JavaScriptCore/wasm/WasmCallee.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCallee.cpp
@@ -92,14 +92,14 @@ inline void Callee::runWithDowncast(const Func& func)
 {
     switch (m_compilationMode) {
     case CompilationMode::IPIntMode:
-        func(static_cast<IPIntCallee*>(this));
+        func(uncheckedDowncast<IPIntCallee>(this));
         break;
     case CompilationMode::JSToWasmMode:
-        func(static_cast<JSToWasmCallee*>(this));
+        func(uncheckedDowncast<JSToWasmCallee>(this));
         break;
 #if ENABLE(WEBASSEMBLY_BBQJIT)
     case CompilationMode::BBQMode:
-        func(static_cast<BBQCallee*>(this));
+        func(uncheckedDowncast<BBQCallee>(this));
         break;
 #else
     case CompilationMode::BBQMode:
@@ -107,10 +107,10 @@ inline void Callee::runWithDowncast(const Func& func)
 #endif
 #if ENABLE(WEBASSEMBLY_OMGJIT)
     case CompilationMode::OMGMode:
-        func(static_cast<OMGCallee*>(this));
+        func(uncheckedDowncast<OMGCallee>(this));
         break;
     case CompilationMode::OMGForOSREntryMode:
-        func(static_cast<OMGOSREntryCallee*>(this));
+        func(uncheckedDowncast<OMGOSREntryCallee>(this));
         break;
 #else
     case CompilationMode::OMGMode:
@@ -119,14 +119,14 @@ inline void Callee::runWithDowncast(const Func& func)
 #endif
     case CompilationMode::JSToWasmICMode:
 #if ENABLE(JIT)
-        func(static_cast<JSToWasmICCallee*>(this));
+        func(uncheckedDowncast<JSToWasmICCallee>(this));
 #endif
         break;
     case CompilationMode::WasmToJSMode:
-        func(static_cast<WasmToJSCallee*>(this));
+        func(uncheckedDowncast<WasmToJSCallee>(this));
         break;
     case CompilationMode::WasmBuiltinMode:
-        func(static_cast<WasmBuiltinCallee*>(this));
+        func(uncheckedDowncast<WasmBuiltinCallee>(this));
         break;
     }
 }

--- a/Source/JavaScriptCore/wasm/WasmCallee.h
+++ b/Source/JavaScriptCore/wasm/WasmCallee.h
@@ -514,4 +514,78 @@ private:
 
 } } // namespace JSC::Wasm
 
+SPECIALIZE_TYPE_TRAITS_BEGIN(JSC::Wasm::Callee)
+    static bool isType(const JSC::NativeCallee& callee)
+    {
+        return callee.category() == JSC::NativeCallee::Category::Wasm;
+    }
+SPECIALIZE_TYPE_TRAITS_END()
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(JSC::Wasm::IPIntCallee)
+    static bool isType(const JSC::Wasm::Callee& callee)
+    {
+        return callee.compilationMode() == JSC::Wasm::CompilationMode::IPIntMode;
+    }
+SPECIALIZE_TYPE_TRAITS_END()
+
+#if ENABLE(WEBASSEMBLY_BBQJIT) || ENABLE(WEBASSEMBLY_OMGJIT)
+SPECIALIZE_TYPE_TRAITS_BEGIN(JSC::Wasm::OptimizingJITCallee)
+    static bool isType(const JSC::Wasm::Callee& callee)
+    {
+        return callee.compilationMode() == JSC::Wasm::CompilationMode::OMGMode
+            || callee.compilationMode() == JSC::Wasm::CompilationMode::OMGForOSREntryMode
+            || callee.compilationMode() == JSC::Wasm::CompilationMode::BBQMode;
+    }
+SPECIALIZE_TYPE_TRAITS_END()
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(JSC::Wasm::BBQCallee)
+    static bool isType(const JSC::Wasm::Callee& callee)
+    {
+        return callee.compilationMode() == JSC::Wasm::CompilationMode::BBQMode;
+    }
+SPECIALIZE_TYPE_TRAITS_END()
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(JSC::Wasm::OMGCallee)
+    static bool isType(const JSC::Wasm::Callee& callee)
+    {
+        return callee.compilationMode() == JSC::Wasm::CompilationMode::OMGMode;
+    }
+SPECIALIZE_TYPE_TRAITS_END()
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(JSC::Wasm::OMGOSREntryCallee)
+    static bool isType(const JSC::Wasm::Callee& callee)
+    {
+        return callee.compilationMode() == JSC::Wasm::CompilationMode::OMGForOSREntryMode;
+    }
+SPECIALIZE_TYPE_TRAITS_END()
+#endif // ENABLE(WEBASSEMBLY_BBQJIT) || ENABLE(WEBASSEMBLY_OMGJIT)
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(JSC::Wasm::JSToWasmCallee)
+    static bool isType(const JSC::Wasm::Callee& callee)
+    {
+        return callee.compilationMode() == JSC::Wasm::CompilationMode::JSToWasmMode;
+    }
+SPECIALIZE_TYPE_TRAITS_END()
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(JSC::Wasm::JSToWasmICCallee)
+    static bool isType(const JSC::Wasm::Callee& callee)
+    {
+        return callee.compilationMode() == JSC::Wasm::CompilationMode::JSToWasmICMode;
+    }
+SPECIALIZE_TYPE_TRAITS_END()
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(JSC::Wasm::WasmToJSCallee)
+    static bool isType(const JSC::Wasm::Callee& callee)
+    {
+        return callee.compilationMode() == JSC::Wasm::CompilationMode::WasmToJSMode;
+    }
+SPECIALIZE_TYPE_TRAITS_END()
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(JSC::Wasm::WasmBuiltinCallee)
+    static bool isType(const JSC::Wasm::Callee& callee)
+    {
+        return callee.compilationMode() == JSC::Wasm::CompilationMode::WasmBuiltinMode;
+    }
+SPECIALIZE_TYPE_TRAITS_END()
+
 #endif // ENABLE(WEBASSEMBLY)

--- a/Source/JavaScriptCore/wasm/WasmCalleeGroup.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCalleeGroup.cpp
@@ -241,7 +241,7 @@ void CalleeGroup::startInstallingCallee(const AbstractLocker& locker, FunctionCo
     ASSERT(slot);
 
     if (callee.compilationMode() == CompilationMode::OMGMode)
-        m_currentlyInstallingOptimizedCallees.m_omgCallee = Ref { static_cast<OMGCallee&>(callee) };
+        m_currentlyInstallingOptimizedCallees.m_omgCallee = Ref { uncheckedDowncast<OMGCallee>(callee) };
     else
         m_currentlyInstallingOptimizedCallees.m_omgCallee = slot->m_omgCallee;
 
@@ -249,7 +249,7 @@ void CalleeGroup::startInstallingCallee(const AbstractLocker& locker, FunctionCo
         Locker replacerLocker { m_currentlyInstallingOptimizedCallees.m_bbqCalleeLock };
         Locker locker { slot->m_bbqCalleeLock };
         if (callee.compilationMode() == CompilationMode::BBQMode)
-            m_currentlyInstallingOptimizedCallees.m_bbqCallee = Ref { static_cast<BBQCallee&>(callee) };
+            m_currentlyInstallingOptimizedCallees.m_bbqCallee = Ref { uncheckedDowncast<BBQCallee>(callee) };
         else
             m_currentlyInstallingOptimizedCallees.m_bbqCallee = slot->m_bbqCallee;
     }

--- a/Source/JavaScriptCore/wasm/WasmFaultSignalHandler.cpp
+++ b/Source/JavaScriptCore/wasm/WasmFaultSignalHandler.cpp
@@ -102,7 +102,7 @@ static SignalAction trapHandler(Signal signal, SigInfo& sigInfo, PlatformRegiste
                 for (auto* callee : calleeRegistry.allCallees()) {
                     if (callee->category() != NativeCallee::Category::Wasm)
                         continue;
-                    auto* wasmCallee = static_cast<Wasm::Callee*>(callee);
+                    auto* wasmCallee = uncheckedDowncast<Wasm::Callee>(callee);
                     auto [start, end] = wasmCallee->range();
                     dataLogLnIf(WasmFaultSignalHandlerInternal::verbose, "function start: ", RawPointer(start), " end: ", RawPointer(end));
                     if (start <= faultingInstruction && faultingInstruction < end) {

--- a/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
@@ -66,7 +66,7 @@ namespace JSC { namespace IPInt {
     } while (false)
 
 #define IPINT_CALLEE(callFrame) \
-    static_cast<Wasm::IPIntCallee*>(callFrame->callee().asNativeCallee())
+    (uncheckedDowncast<Wasm::IPIntCallee>(uncheckedDowncast<Wasm::Callee>(callFrame->callee().asNativeCallee())))
 
 // For operation calls that may throw an exception, we return (<val>, 0)
 // if it is fine, and (<exception value>, SlowPathExceptionTag) if it is not
@@ -302,7 +302,7 @@ WASM_IPINT_EXTERN_CPP_DECL(loop_osr, CallFrame* callFrame, uint8_t* pc, IPIntLoc
     if (!compiledCallee)
         WASM_RETURN_TWO(nullptr, nullptr);
 
-    auto* bbqCallee = static_cast<Wasm::BBQCallee*>(compiledCallee.get());
+    auto* bbqCallee = uncheckedDowncast<Wasm::BBQCallee>(compiledCallee.get());
     ASSERT(bbqCallee->compilationMode() == Wasm::CompilationMode::BBQMode);
     size_t osrEntryScratchBufferSize = bbqCallee->osrEntryScratchBufferSize();
     RELEASE_ASSERT(osrEntryScratchBufferSize >= callee->numLocals() + osrEntryData.numberOfStackValues + osrEntryData.tryDepth);

--- a/Source/JavaScriptCore/wasm/WasmIRGeneratorHelpers.h
+++ b/Source/JavaScriptCore/wasm/WasmIRGeneratorHelpers.h
@@ -169,7 +169,7 @@ static ALWAYS_INLINE void buildEntryBufferForCatch(Probe::Context& context)
     unsigned valueSize = (savedFPWidth == SavedFPWidth::SaveVectors) ? 2 : 1;
     CallFrame* callFrame = context.fp<CallFrame*>();
     CallSiteIndex callSiteIndex = callFrame->callSiteIndex();
-    OptimizingJITCallee* callee = std::bit_cast<OptimizingJITCallee*>(callFrame->callee().asNativeCallee());
+    OptimizingJITCallee* callee = uncheckedDowncast<OptimizingJITCallee>(uncheckedDowncast<Wasm::Callee>(callFrame->callee().asNativeCallee()));
     const StackMap& stackmap = callee->stackmap(callSiteIndex);
     JSWebAssemblyInstance* instance = context.gpr<JSWebAssemblyInstance*>(GPRInfo::wasmContextInstancePointer);
     EncodedJSValue exception = context.gpr<EncodedJSValue>(GPRInfo::returnValueGPR);

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -6754,7 +6754,7 @@ Expected<std::unique_ptr<InternalFunction>, String> parseAndCompileOMG(Compilati
         ASSERT(checkSize || !needsOverflowCheck);
         if (!needsOverflowCheck)
             checkSize = stackCheckNotNeeded;
-        static_cast<OMGOSREntryCallee*>(&callee)->setStackCheckSize(checkSize);
+        uncheckedDowncast<OMGOSREntryCallee>(callee).setStackCheckSize(checkSize);
     }
 
     return result;

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp
@@ -6309,7 +6309,7 @@ Expected<std::unique_ptr<InternalFunction>, String> parseAndCompileOMG(Compilati
         ASSERT(checkSize || !needsOverflowCheck);
         if (!needsOverflowCheck)
             checkSize = stackCheckNotNeeded;
-        static_cast<OMGOSREntryCallee*>(&callee)->setStackCheckSize(checkSize);
+        uncheckedDowncast<OMGOSREntryCallee>(callee).setStackCheckSize(checkSize);
     }
 
     return result;

--- a/Source/JavaScriptCore/wasm/WasmOSREntryPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOSREntryPlan.cpp
@@ -170,7 +170,7 @@ void OSREntryPlan::work()
         {
             switch (m_callee->compilationMode()) {
             case CompilationMode::BBQMode: {
-                BBQCallee* bbqCallee = static_cast<BBQCallee*>(m_callee.ptr());
+                BBQCallee* bbqCallee = uncheckedDowncast<BBQCallee>(m_callee.ptr());
                 Locker locker { bbqCallee->tierUpCounter().getLock() };
                 bbqCallee->setOSREntryCallee(callee.copyRef(), mode());
                 bbqCallee->tierUpCounter().osrEntryTriggers()[m_loopIndex] = TierUpCount::TriggerReason::CompilationDone;

--- a/Source/JavaScriptCore/wasm/WasmOperations.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOperations.cpp
@@ -156,7 +156,7 @@ JSC_DEFINE_JIT_OPERATION(operationJSToWasmEntryWrapperBuildReturnFrame, EncodedJ
     WasmOperationPrologueCallFrameTracer tracer(vm, callFrame, OUR_RETURN_ADDRESS);
 
     uint64_t* registerSpace = reinterpret_cast<uint64_t*>(sp);
-    auto* callee = static_cast<JSToWasmCallee*>(callFrame->callee().asNativeCallee());
+    auto* callee = uncheckedDowncast<JSToWasmCallee>(uncheckedDowncast<Wasm::Callee>(callFrame->callee().asNativeCallee()));
     ASSERT(callee->compilationMode() == CompilationMode::JSToWasmMode);
 
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -608,7 +608,7 @@ ALWAYS_INLINE void assertCalleeIsReferenced(CallFrame* frame, JSWebAssemblyInsta
 {
 #if ASSERT_ENABLED
     CalleeGroup& calleeGroup = *instance->calleeGroup();
-    Wasm::Callee* callee = static_cast<Wasm::Callee*>(frame->callee().asNativeCallee());
+    Wasm::Callee* callee = uncheckedDowncast<Wasm::Callee>(frame->callee().asNativeCallee());
     TriState status;
     {
         Locker locker { calleeGroup.m_lock };
@@ -949,7 +949,7 @@ inline bool shouldOMGJIT(JSWebAssemblyInstance* instance, unsigned functionIndex
 
 JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmTriggerTierUpNow, void, (CallFrame* callFrame, JSWebAssemblyInstance* instance))
 {
-    BBQCallee& callee = *static_cast<BBQCallee*>(callFrame->callee().asNativeCallee());
+    BBQCallee& callee = uncheckedDowncast<BBQCallee>(uncheckedDowncast<Wasm::Callee>(*callFrame->callee().asNativeCallee()));
     ASSERT(callee.compilationMode() == CompilationMode::BBQMode);
 
     Wasm::CalleeGroup& calleeGroup = *instance->calleeGroup();
@@ -975,7 +975,7 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmTriggerOSREntryNow, void, (Probe:
     auto functionIndex = osrEntryData.functionIndex();
     uint32_t loopIndex = osrEntryData.loopIndex();
     JSWebAssemblyInstance* instance = context.gpr<JSWebAssemblyInstance*>(GPRInfo::wasmContextInstancePointer);
-    BBQCallee& callee = *static_cast<BBQCallee*>(context.gpr<CallFrame*>(MacroAssembler::framePointerRegister)->callee().asNativeCallee());
+    BBQCallee& callee = uncheckedDowncast<BBQCallee>(uncheckedDowncast<Wasm::Callee>(*context.gpr<CallFrame*>(MacroAssembler::framePointerRegister)->callee().asNativeCallee()));
     ASSERT(callee.compilationMode() == Wasm::CompilationMode::BBQMode);
     ASSERT(callee.refCount());
     Wasm::CalleeGroup& calleeGroup = *instance->calleeGroup();
@@ -1191,7 +1191,7 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmLoopOSREnterBBQJIT, void, (Probe:
     unsigned loopIndex = osrEntryScratchBuffer[0]; // First entry in scratch buffer is the loop index when tiering up to BBQ.
 
     // We just populated the callee in the frame before we entered this operation, so let's use it.
-    BBQCallee& callee = *static_cast<BBQCallee*>(context.fp<CallFrame*>()->callee().asNativeCallee());
+    BBQCallee& callee = uncheckedDowncast<BBQCallee>(uncheckedDowncast<Wasm::Callee>(*context.fp<CallFrame*>()->callee().asNativeCallee()));
     ASSERT(callee.compilationMode() == Wasm::CompilationMode::BBQMode);
     ASSERT(callee.refCount());
     OSREntryData& entryData = callee.tierUpCounter().osrEntryData(loopIndex);
@@ -1249,7 +1249,7 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmLoopOSREnterBBQJIT, void, (Probe:
 #if ENABLE(WEBASSEMBLY_BBQJIT)
 JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmMaterializeBaselineData, void, (CallFrame* callFrame, JSWebAssemblyInstance* instance))
 {
-    BBQCallee& callee = *static_cast<BBQCallee*>(callFrame->callee().asNativeCallee());
+    BBQCallee& callee = uncheckedDowncast<BBQCallee>(uncheckedDowncast<Wasm::Callee>(*callFrame->callee().asNativeCallee()));
     ASSERT(callee.compilationMode() == CompilationMode::BBQMode);
 
     Wasm::CalleeGroup& calleeGroup = *instance->calleeGroup();

--- a/Source/JavaScriptCore/wasm/debugger/WasmDebugServerUtilities.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/WasmDebugServerUtilities.cpp
@@ -85,7 +85,7 @@ bool getWasmReturnPC(CallFrame* currentFrame, uint8_t*& returnPC, VirtualAddress
     if (caller->category() != NativeCallee::Category::Wasm)
         return false;
 
-    RefPtr wasmCaller = static_cast<const Wasm::Callee*>(caller.get());
+    RefPtr wasmCaller = uncheckedDowncast<const Wasm::Callee>(caller.get());
     if (wasmCaller->compilationMode() != Wasm::CompilationMode::IPIntMode)
         return false;
 
@@ -95,7 +95,7 @@ bool getWasmReturnPC(CallFrame* currentFrame, uint8_t*& returnPC, VirtualAddress
     returnPC = WTF::unalignedLoad<uint8_t*>(pcLocation);
 
     JSWebAssemblyInstance* callerInstance = callerFrame->wasmInstance();
-    RefPtr ipintCaller = static_cast<const Wasm::IPIntCallee*>(wasmCaller.get());
+    RefPtr ipintCaller = uncheckedDowncast<const Wasm::IPIntCallee>(wasmCaller.get());
     virtualReturnPC = VirtualAddress::toVirtual(callerInstance, ipintCaller->functionIndex(), returnPC);
     return true;
 }

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
@@ -257,7 +257,7 @@ void JSWebAssemblyInstance::finalizeCreation(VM& vm, JSGlobalObject* globalObjec
             // the import is a Wasm function or a builtin
             auto calleeBits = info->boxedCallee;
             if (calleeBits.isNativeCallee()) {
-                auto* callee = std::bit_cast<Callee*>(calleeBits.asNativeCallee());
+                auto* callee = uncheckedDowncast<Wasm::Callee>(calleeBits.asNativeCallee());
                 // if the callee is a builtin, info->importFunctionStub has already been set
                 if (callee->compilationMode() != CompilationMode::WasmBuiltinMode)
                     info->importFunctionStub = wasmCalleeGroup->wasmToWasmExitStub(functionSpaceIndex);

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
@@ -560,7 +560,7 @@ void WebAssemblyModuleRecord::initializeExports(JSGlobalObject* globalObject)
                 // No function import means the import is a wasm builtin.
                 // The boxed callee in callLinkInfo is a WasmBuiltinCallee with a pointer to the builtin.
                 auto* callLinkInfo = m_instance->importFunctionInfo(functionIndexSpace);
-                auto* callee = std::bit_cast<Wasm::WasmBuiltinCallee*>(callLinkInfo->boxedCallee.asNativeCallee());
+                auto* callee = uncheckedDowncast<Wasm::WasmBuiltinCallee>(uncheckedDowncast<Wasm::Callee>(callLinkInfo->boxedCallee.asNativeCallee()));
                 ASSERT(callee->compilationMode() == Wasm::CompilationMode::WasmBuiltinMode);
                 const WebAssemblyBuiltin* builtin = callee->builtin();
                 wrapper = builtin->jsWrapper(globalObject);


### PR DESCRIPTION
#### 48425afd643d6014a3caf223f5d2e1c1b738bd17
<pre>
[JSC] Replace static_cast with uncheckedDowncast for Wasm::Callee type safety
<a href="https://bugs.webkit.org/show_bug.cgi?id=299686">https://bugs.webkit.org/show_bug.cgi?id=299686</a>
<a href="https://rdar.apple.com/161498549">rdar://161498549</a>

Reviewed by Mark Lam.

This patch improves type safety in WebAssembly code by replacing static_cast
with uncheckedDowncast for Wasm::Callee and related types throughout the
runtime execution paths. The change adds runtime type validation to catch
type errors earlier in development.

The changes provide better debugging and type validation in WebAssembly code
without affecting conservative garbage collection or performance-critical paths.

Testing: Type traits are validated through existing WebAssembly tests that exercise
all uncheckedDowncast call sites. No additional unit tests are needed since these
are complex runtime instances requiring full compilation pipelines.

Canonical link: <a href="https://commits.webkit.org/300699@main">https://commits.webkit.org/300699@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ef9bb27c78cf9255108623fabec28247006edef2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123575 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/43290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33986 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/130342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/75718 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/125452 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/44013 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/51884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/130342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/75718 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126528 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/44013 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/110549 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/130342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/44013 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/28707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/73819 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/115734 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/44013 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/28931 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/133032 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/122107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/50526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/51884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/133032 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/50901 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/106770 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/133032 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/25994 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/25864 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/47337 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19448 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/50380 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56142 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/152461 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/49854 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/38986 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/53201 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/51529 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->