### PR TITLE
[visionOS] make docking works when AudioVideoRendererRemote is in use

### DIFF
--- a/Source/WebCore/platform/MediaStrategy.cpp
+++ b/Source/WebCore/platform/MediaStrategy.cpp
@@ -88,7 +88,7 @@ void MediaStrategy::addMockMediaSourceEngine()
 #endif
 
 #if ENABLE(VIDEO)
-RefPtr<AudioVideoRenderer> MediaStrategy::createAudioVideoRenderer(WTF::LoggerHelper* loggerHelper) const
+RefPtr<AudioVideoRenderer> MediaStrategy::createAudioVideoRenderer(WTF::LoggerHelper* loggerHelper, HTMLMediaElementIdentifier, MediaPlayerIdentifier) const
 {
 #if USE(AVFOUNDATION)
     ASSERT(loggerHelper);

--- a/Source/WebCore/platform/MediaStrategy.h
+++ b/Source/WebCore/platform/MediaStrategy.h
@@ -29,7 +29,9 @@
 #if PLATFORM(COCOA) && ENABLE(MEDIA_RECORDER)
 #include <WebCore/MediaRecorderPrivateWriter.h>
 #endif
+#include <WebCore/HTMLMediaElementIdentifier.h>
 #include <WebCore/MediaPlayerEnums.h>
+#include <WebCore/MediaPlayerIdentifier.h>
 #include <WebCore/NativeImage.h>
 #include <WebCore/NowPlayingManager.h>
 #include <wtf/BitSet.h>
@@ -56,7 +58,7 @@ public:
     virtual Ref<AudioDestination> createAudioDestination(const AudioDestinationCreationOptions&) = 0;
 #endif
 #if ENABLE(VIDEO)
-    virtual RefPtr<AudioVideoRenderer> createAudioVideoRenderer(WTF::LoggerHelper*) const;
+    virtual RefPtr<AudioVideoRenderer> createAudioVideoRenderer(WTF::LoggerHelper*, HTMLMediaElementIdentifier, MediaPlayerIdentifier) const;
     bool hasRemoteRendererFor(MediaPlayerMediaEngineIdentifier) const;
     void enableRemoteRenderer(MediaPlayerMediaEngineIdentifier, bool);
 #endif

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
@@ -29,6 +29,7 @@
 #if ENABLE(COCOA_WEBM_PLAYER)
 
 #include <WebCore/AudioVideoRenderer.h>
+#include <WebCore/HTMLMediaElementIdentifier.h>
 #include <WebCore/MediaPlayerPrivate.h>
 #include <WebCore/PlatformLayer.h>
 #include <WebCore/SourceBufferParserWebM.h>
@@ -301,7 +302,7 @@ private:
     void maybeFinishLoading();
     void readyToProcessData();
 
-    static Ref<AudioVideoRenderer> createRenderer(LoggerHelper&);
+    static Ref<AudioVideoRenderer> createRenderer(LoggerHelper&, HTMLMediaElementIdentifier, MediaPlayerIdentifier);
 
     URL m_assetURL;
     MediaPlayer::Preload m_preload { MediaPlayer::Preload::Auto };
@@ -382,8 +383,8 @@ private:
     String m_defaultSpatialTrackingLabel;
     String m_spatialTrackingLabel;
 #endif
-    const Ref<AudioVideoRenderer> m_renderer;
     const MediaPlayerIdentifier m_playerIdentifier;
+    const Ref<AudioVideoRenderer> m_renderer;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -79,10 +79,10 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(MediaPlayerPrivateWebM);
 
 static const MediaTime discontinuityTolerance = MediaTime(1, 1);
 
-Ref<AudioVideoRenderer> MediaPlayerPrivateWebM::createRenderer(LoggerHelper& loggerHelper)
+Ref<AudioVideoRenderer> MediaPlayerPrivateWebM::createRenderer(LoggerHelper& loggerHelper, HTMLMediaElementIdentifier mediaElementIdentifier, MediaPlayerIdentifier playerIdentifier)
 {
     if (hasPlatformStrategies()) {
-        if (RefPtr renderer = platformStrategies()->mediaStrategy()->createAudioVideoRenderer(&loggerHelper))
+        if (RefPtr renderer = platformStrategies()->mediaStrategy()->createAudioVideoRenderer(&loggerHelper, mediaElementIdentifier, playerIdentifier))
             return renderer.releaseNonNull();
     }
     return AudioVideoRendererAVFObjC::create(Ref { loggerHelper.logger() }, loggerHelper.logIdentifier());
@@ -95,8 +95,8 @@ MediaPlayerPrivateWebM::MediaPlayerPrivateWebM(MediaPlayer* player)
     , m_logger(player->mediaPlayerLogger())
     , m_logIdentifier(player->mediaPlayerLogIdentifier())
     , m_seekTimer(*this, &MediaPlayerPrivateWebM::seekInternal)
-    , m_renderer(createRenderer(*this))
     , m_playerIdentifier(MediaPlayerIdentifier::generate())
+    , m_renderer(createRenderer(*this, player->clientIdentifier(), m_playerIdentifier))
 {
     ALWAYS_LOG(LOGIDENTIFIER);
     m_parser->setLogger(m_logger, m_logIdentifier);

--- a/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.h
@@ -36,6 +36,7 @@
 #include "RemoteAudioVideoRendererState.h"
 #include "RemoteVideoFrameProxy.h"
 #include <WebCore/AudioVideoRenderer.h>
+#include <WebCore/HTMLMediaElementIdentifier.h>
 #include <WebCore/MediaPlayerEnums.h>
 #include <WebCore/MediaPromiseTypes.h>
 #include <wtf/Forward.h>
@@ -47,6 +48,8 @@
 
 namespace WebCore {
 class AudioVideoRenderer;
+struct MediaPlayerIdentifierType;
+using MediaPlayerIdentifier = ObjectIdentifier<MediaPlayerIdentifierType>;
 class TextTrackRepresentation;
 }
 
@@ -73,9 +76,11 @@ public:
 
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const;
 
+    RefPtr<WebCore::AudioVideoRenderer> rendererFor(std::optional<WebCore::MediaPlayerIdentifier>) const;
+
 private:
     // Messages
-    void create(RemoteAudioVideoRendererIdentifier);
+    void create(RemoteAudioVideoRendererIdentifier, WebCore::HTMLMediaElementIdentifier, WebCore::MediaPlayerIdentifier);
     void shutdown(RemoteAudioVideoRendererIdentifier);
 
     void setPreferences(RemoteAudioVideoRendererIdentifier, WebCore::VideoRendererPreferences);
@@ -143,6 +148,8 @@ private:
 
     struct RendererContext {
         RefPtr<WebCore::AudioVideoRenderer> renderer;
+        Markable<WebCore::HTMLMediaElementIdentifier> mediaElementIdentifier;
+        Markable<WebCore::MediaPlayerIdentifier> playerIdentifier;
 #if PLATFORM(COCOA)
         LayerHostingContextManager layerHostingContextManager;
 #endif

--- a/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.messages.in
@@ -31,7 +31,7 @@
     EnabledBy=UseGPUProcessForMediaEnabled
 ]
 messages -> RemoteAudioVideoRendererProxyManager {
-    Create(WebKit::RemoteAudioVideoRendererIdentifier identifier)
+    Create(WebKit::RemoteAudioVideoRendererIdentifier identifier, WebCore::MediaPlayerClientIdentifier mediaElementIdentifier, WebCore::MediaPlayerIdentifier playerIdentifier)
     Shutdown(WebKit::RemoteAudioVideoRendererIdentifier identifier)
 
     SetPreferences(WebKit::RemoteAudioVideoRendererIdentifier identifier, OptionSet<WebCore::VideoRendererPreference> preferences)

--- a/Source/WebKit/GPUProcess/media/cocoa/VideoReceiverEndpointManager.h
+++ b/Source/WebKit/GPUProcess/media/cocoa/VideoReceiverEndpointManager.h
@@ -34,6 +34,11 @@
 #include <wtf/LoggerHelper.h>
 #include <wtf/TZoneMalloc.h>
 
+namespace WebCore {
+class AudioVideoRenderer;
+class MediaPlayer;
+}
+
 namespace WebKit {
 
 class GPUConnectionToWebProcess;
@@ -69,6 +74,7 @@ private:
         Markable<WebCore::VideoReceiverEndpointIdentifier> endpointIdentifier;
     };
     HashMap<WebCore::HTMLMediaElementIdentifier, VideoReceiverEndpointCacheEntry> m_videoReceiverEndpointCache;
+    void setVideoTargetIfValidIdentifier(std::optional<WebCore::MediaPlayerIdentifier>, const WebCore::PlatformVideoTarget&) const;
 
     ThreadSafeWeakPtr<GPUConnectionToWebProcess> m_gpuConnection;
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp
@@ -71,12 +71,12 @@ WorkQueue& AudioVideoRendererRemote::queueSingleton()
     return workQueue.get();
 }
 
-Ref<AudioVideoRendererRemote> AudioVideoRendererRemote::create(LoggerHelper* loggerHelper, GPUProcessConnection& connection)
+Ref<AudioVideoRendererRemote> AudioVideoRendererRemote::create(LoggerHelper* loggerHelper, WebCore::HTMLMediaElementIdentifier mediaElementIdentifier, WebCore::MediaPlayerIdentifier playerIdentifier, GPUProcessConnection& connection)
 {
     assertIsMainThread();
 
     auto identifier = RemoteAudioVideoRendererIdentifier::generate();
-    connection.connection().send(Messages::RemoteAudioVideoRendererProxyManager::Create(identifier), 0);
+    connection.connection().send(Messages::RemoteAudioVideoRendererProxyManager::Create(identifier, mediaElementIdentifier, playerIdentifier), 0);
     return adoptRef(*new AudioVideoRendererRemote(loggerHelper, connection, identifier));
 }
 

--- a/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.h
@@ -34,6 +34,8 @@
 #include "VideoLayerRemote.h"
 #include "WorkQueueMessageReceiver.h"
 #include <WebCore/AudioVideoRenderer.h>
+#include <WebCore/HTMLMediaElementIdentifier.h>
+#include <WebCore/MediaPlayerIdentifier.h>
 #include <wtf/Forward.h>
 #include <wtf/LoggerHelper.h>
 #include <wtf/RefPtr.h>
@@ -60,7 +62,7 @@ class AudioVideoRendererRemote final
     , public GPUProcessConnection::Client
     , public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<AudioVideoRendererRemote> {
 public:
-    static Ref<AudioVideoRendererRemote> create(LoggerHelper*, GPUProcessConnection&);
+    static Ref<AudioVideoRendererRemote> create(LoggerHelper*, WebCore::HTMLMediaElementIdentifier, WebCore::MediaPlayerIdentifier, GPUProcessConnection&);
     ~AudioVideoRendererRemote();
 
     WTF_ABSTRACT_THREAD_SAFE_REF_COUNTED_AND_CAN_MAKE_WEAK_PTR_IMPL;

--- a/Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.cpp
@@ -72,9 +72,9 @@ Ref<WebCore::AudioDestination> WebMediaStrategy::createAudioDestination(const We
 #endif
 
 #if ENABLE(VIDEO) && ENABLE(GPU_PROCESS)
-RefPtr<AudioVideoRenderer> WebMediaStrategy::createAudioVideoRenderer(LoggerHelper* loggerHelper) const
+RefPtr<AudioVideoRenderer> WebMediaStrategy::createAudioVideoRenderer(LoggerHelper* loggerHelper, WebCore::HTMLMediaElementIdentifier mediaElementIdentifier, WebCore::MediaPlayerIdentifier playerIdentifier) const
 {
-    return AudioVideoRendererRemote::create(loggerHelper, WebProcess::singleton().ensureProtectedGPUProcessConnection());
+    return AudioVideoRendererRemote::create(loggerHelper, mediaElementIdentifier, playerIdentifier, WebProcess::singleton().ensureProtectedGPUProcessConnection());
 }
 #endif
 

--- a/Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.h
+++ b/Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.h
@@ -47,7 +47,7 @@ private:
     Ref<WebCore::AudioDestination> createAudioDestination(const WebCore::AudioDestinationCreationOptions&) override;
 #endif
 #if ENABLE(VIDEO) && ENABLE(GPU_PROCESS)
-    RefPtr<WebCore::AudioVideoRenderer> createAudioVideoRenderer(LoggerHelper*) const final;
+    RefPtr<WebCore::AudioVideoRenderer> createAudioVideoRenderer(LoggerHelper*, WebCore::HTMLMediaElementIdentifier, WebCore::MediaPlayerIdentifier) const final;
 #endif
     std::unique_ptr<WebCore::NowPlayingManager> createNowPlayingManager() const final;
     bool hasThreadSafeMediaSourceSupport() const final;


### PR DESCRIPTION
#### 8e796c93595830c20665c89edd6034f81960441f
<pre>
[visionOS] make docking works when AudioVideoRendererRemote is in use
<a href="https://bugs.webkit.org/show_bug.cgi?id=299520">https://bugs.webkit.org/show_bug.cgi?id=299520</a>
<a href="https://rdar.apple.com/161320965">rdar://161320965</a>

Reviewed by Andy Estes.

We make the VideoReceiverEndpointManager be aware of the existing AudioVideoRenderers.

When a new VideoTargetEndpoing is received, if the lookup for a MediaPlayer
matching the required identifier fails, we will look into the RemoteAudioVideoRendererProxyManager&apos;s AudioVideoRenderers instead.

We make the MediaPlayerPrivateRemote communicates to the RemoteAudioVideoRendererProxyManager
the HTMLMediaElementIdentifier and MediaPlayerIdentifier and store it alongside the RendererContext.

Manually tested on Vision Pro.

Canonical link: <a href="https://commits.webkit.org/300854@main">https://commits.webkit.org/300854@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dd475b5a2cc1ebf720786e1a50d8ba42563ac4ff

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124102 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/43800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34512 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130929 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/76224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/80d7e65e-9d38-463f-aaea-29689d4900e8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/125979 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44538 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/52400 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/94402 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/76224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c0a7c949-8b9d-45cf-9985-884dda553f63) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127056 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/35489 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/111011 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74994 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/895f6106-2f7a-4134-ab75-8f3bb15656f6) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/34437 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29175 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74414 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/105227 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29394 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133605 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/51038 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/52400 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/102868 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/51416 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107230 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102677 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26117 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/26284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/47917 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/50894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56665 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/50355 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/53703 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/52029 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->