### PR TITLE
[Style] Convert the 'font-weight' property to strong style types

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -3276,6 +3276,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     style/values/flexbox/StyleWebKitBoxOrdinalGroup.h
 
     style/values/fonts/StyleFontPalette.h
+    style/values/fonts/StyleFontWeight.h
     style/values/fonts/StyleFontWidth.h
 
     style/values/grid/StyleGridNamedAreaMap.h

--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -724,6 +724,7 @@ style/Styleable.h
 style/values/color/StyleColor.cpp
 style/values/color/StyleKeywordColor.cpp
 style/values/content/StyleContent.cpp
+style/values/fonts/StyleFontWeight.cpp
 style/values/grid/StyleGridPositionsResolver.cpp
 style/values/primitives/StyleLengthResolution.cpp
 svg/SVGAElement.cpp

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -3215,6 +3215,7 @@ style/values/filter-effects/StyleSaturateFunction.cpp
 style/values/filter-effects/StyleSepiaFunction.cpp
 style/values/flexbox/StyleFlexBasis.cpp
 style/values/fonts/StyleFontPalette.cpp
+style/values/fonts/StyleFontWeight.cpp
 style/values/fonts/StyleFontWidth.cpp
 style/values/grid/StyleGridNamedLinesMap.cpp
 style/values/grid/StyleGridPosition.cpp

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -724,12 +724,13 @@
                 "lighter"
             ],
             "codegen-properties": {
-                "animation-wrapper": "FontWeightWrapper",
-                "animation-wrapper-requires-override-parameters": [],
+                "animation-wrapper": "StyleTypeWrapper",
+                "animation-wrapper-requires-render-style": true,
                 "font-description-name-for-methods": "Weight",
+                "font-property-uses-render-style-for-access": true,
                 "font-property": true,
                 "high-priority": true,
-                "style-converter": "FontWeight",
+                "style-converter": "StyleType<FontWeight>",
                 "parser-grammar": "<font-weight-absolute> | bolder | lighter",
                 "parser-exported": true
             },

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -2634,10 +2634,10 @@ void RenderStyle::setFontVariationSettings(FontVariationSettings settings)
     setFontDescription(WTFMove(description));
 }
 
-void RenderStyle::setFontWeight(FontSelectionValue value)
+void RenderStyle::setFontWeight(Style::FontWeight value)
 {
     auto description = fontDescription();
-    description.setWeight(value);
+    description.setWeight(value.platform());
     setFontDescription(WTFMove(description));
 }
 

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -272,6 +272,7 @@ struct DynamicRangeLimit;
 struct Filter;
 struct FlexBasis;
 struct FontPalette;
+struct FontWeight;
 struct FontWidth;
 struct GapGutter;
 struct GridPosition;
@@ -728,10 +729,10 @@ public:
 
     inline FontOpticalSizing fontOpticalSizing() const;
     inline FontVariationSettings fontVariationSettings() const;
-    inline FontSelectionValue fontWeight() const;
     inline std::optional<FontSelectionValue> fontItalic() const;
     inline Style::FontPalette fontPalette() const;
     inline FontSizeAdjust fontSizeAdjust() const;
+    inline Style::FontWeight fontWeight() const;
     inline Style::FontWidth fontWidth() const;
 
     inline const Style::TextIndent& textIndent() const;
@@ -1366,9 +1367,9 @@ public:
 
     void setFontOpticalSizing(FontOpticalSizing);
     void setFontVariationSettings(FontVariationSettings);
-    void setFontWeight(FontSelectionValue);
     void setFontItalic(std::optional<FontSelectionValue>);
     void setFontPalette(Style::FontPalette&&);
+    void setFontWeight(Style::FontWeight);
     void setFontWidth(Style::FontWidth);
 
     void setColor(Color&&);
@@ -1962,6 +1963,7 @@ public:
     static inline Style::VerticalAlign initialVerticalAlign();
     static constexpr Float initialFloating();
     static inline Style::FontPalette initialFontPalette();
+    static inline Style::FontWeight initialFontWeight();
     static inline Style::FontWidth initialFontWidth();
     static constexpr BreakBetween initialBreakBetween();
     static constexpr BreakInside initialBreakInside();

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -45,6 +45,7 @@
 #include <WebCore/StyleFlexibleBoxData.h>
 #include <WebCore/StyleFontData.h>
 #include <WebCore/StyleFontPalette.h>
+#include <WebCore/StyleFontWeight.h>
 #include <WebCore/StyleFontWidth.h>
 #include <WebCore/StyleGridData.h>
 #include <WebCore/StyleGridItemData.h>
@@ -226,7 +227,7 @@ inline Style::FontPalette RenderStyle::fontPalette() const { return fontDescript
 inline FontSizeAdjust RenderStyle::fontSizeAdjust() const { return fontDescription().fontSizeAdjust(); }
 inline FontOpticalSizing RenderStyle::fontOpticalSizing() const { return fontDescription().opticalSizing(); }
 inline FontVariationSettings RenderStyle::fontVariationSettings() const { return fontDescription().variationSettings(); }
-inline FontSelectionValue RenderStyle::fontWeight() const { return fontDescription().weight(); }
+inline Style::FontWeight RenderStyle::fontWeight() const { return fontDescription().weight(); }
 inline Style::FontWidth RenderStyle::fontWidth() const { return fontDescription().width(); }
 inline const Style::GapGutter& RenderStyle::gap(Style::GridTrackSizingDirection direction) const { return direction == Style::GridTrackSizingDirection::Columns ? columnGap() : rowGap(); }
 inline const Style::GridTrackSizes& RenderStyle::gridAutoColumns() const { return m_nonInheritedData->rareData->grid->m_gridAutoColumns; }
@@ -400,6 +401,7 @@ constexpr Style::FlexShrink RenderStyle::initialFlexShrink() { return 1_css_numb
 constexpr FlexWrap RenderStyle::initialFlexWrap() { return FlexWrap::NoWrap; }
 constexpr Float RenderStyle::initialFloating() { return Float::None; }
 inline Style::FontPalette RenderStyle::initialFontPalette() { return CSS::Keyword::Normal { }; }
+inline Style::FontWeight RenderStyle::initialFontWeight() { return CSS::Keyword::Normal { }; }
 inline Style::FontWidth RenderStyle::initialFontWidth() { return CSS::Keyword::Normal { }; }
 inline Style::GridTrackSizes RenderStyle::initialGridAutoColumns() { return CSS::Keyword::Auto { }; }
 constexpr GridAutoFlow RenderStyle::initialGridAutoFlow() { return AutoFlowRow; }

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -135,7 +135,6 @@ public:
 
     static FontSizeAdjust convertFontSizeAdjust(BuilderState&, const CSSValue&);
     static std::optional<FontSelectionValue> convertFontStyleFromValue(BuilderState&, const CSSValue&);
-    static FontSelectionValue convertFontWeight(BuilderState&, const CSSValue&);
     static FontFeatureSettings convertFontFeatureSettings(BuilderState&, const CSSValue&);
     static FontVariationSettings convertFontVariationSettings(BuilderState&, const CSSValue&);
     static PaintOrder convertPaintOrder(BuilderState&, const CSSValue&);
@@ -498,11 +497,6 @@ inline float zoomWithTextZoomFactor(BuilderState& builderState)
 inline std::optional<FontSelectionValue> BuilderConverter::convertFontStyleFromValue(BuilderState& builderState, const CSSValue& value)
 {
     return fontStyleFromCSSValue(builderState, value);
-}
-
-inline FontSelectionValue BuilderConverter::convertFontWeight(BuilderState& builderState, const CSSValue& value)
-{
-    return fontWeightFromCSSValue(builderState, value);
 }
 
 inline FontFeatureSettings BuilderConverter::convertFontFeatureSettings(BuilderState& builderState, const CSSValue& value)

--- a/Source/WebCore/style/StyleBuilderState.h
+++ b/Source/WebCore/style/StyleBuilderState.h
@@ -65,6 +65,7 @@ namespace Style {
 class BuilderState;
 struct Color;
 struct FontPalette;
+struct FontWeight;
 struct FontWidth;
 
 void maybeUpdateFontForLetterSpacingOrWordSpacing(BuilderState&, CSSValue&);
@@ -177,7 +178,7 @@ public:
     void setFontDescriptionVariantEmoji(FontVariantEmoji);
     void setFontDescriptionVariantPosition(FontVariantPosition);
     void setFontDescriptionVariationSettings(FontVariationSettings&&);
-    void setFontDescriptionWeight(FontSelectionValue);
+    void setFontDescriptionWeight(FontWeight);
     void setFontDescriptionWidth(FontWidth);
     void setFontDescriptionVariantAlternates(const FontVariantAlternates&);
     void setFontDescriptionVariantEastAsianVariant(FontVariantEastAsianVariant);

--- a/Source/WebCore/style/StyleBuilderStateInlines.h
+++ b/Source/WebCore/style/StyleBuilderStateInlines.h
@@ -271,13 +271,13 @@ inline void BuilderState::setFontDescriptionVariationSettings(FontVariationSetti
     m_style.mutableFontDescriptionWithoutUpdate().setVariationSettings(WTFMove(variationSettings));
 }
 
-inline void BuilderState::setFontDescriptionWeight(FontSelectionValue weight)
+inline void BuilderState::setFontDescriptionWeight(FontWeight weight)
 {
-    if (m_style.fontDescription().weight() == weight)
+    if (m_style.fontDescription().weight() == weight.platform())
         return;
 
     m_fontDirty = true;
-    m_style.mutableFontDescriptionWithoutUpdate().setWeight(weight);
+    m_style.mutableFontDescriptionWithoutUpdate().setWeight(weight.platform());
 }
 
 inline void BuilderState::setFontDescriptionWidth(FontWidth width)

--- a/Source/WebCore/style/StyleExtractorConverter.h
+++ b/Source/WebCore/style/StyleExtractorConverter.h
@@ -182,7 +182,6 @@ public:
 
     static Ref<CSSValue> convertFontFamily(ExtractorState&, const AtomString&);
     static Ref<CSSValue> convertFontSizeAdjust(ExtractorState&, const FontSizeAdjust&);
-    static Ref<CSSValue> convertFontWeight(ExtractorState&, FontSelectionValue);
     static Ref<CSSValue> convertFontFeatureSettings(ExtractorState&, const FontFeatureSettings&);
     static Ref<CSSValue> convertFontVariationSettings(ExtractorState&, const FontVariationSettings&);
 
@@ -1036,11 +1035,6 @@ inline Ref<CSSValue> ExtractorConverter::convertFontSizeAdjust(ExtractorState& s
         return CSSPrimitiveValue::create(*value);
 
     return CSSValuePair::create(convert(state, metric), CSSPrimitiveValue::create(*value));
-}
-
-inline Ref<CSSValue> ExtractorConverter::convertFontWeight(ExtractorState&, FontSelectionValue fontWeight)
-{
-    return CSSPrimitiveValue::create(static_cast<float>(fontWeight));
 }
 
 inline Ref<CSSValue> ExtractorConverter::convertFontFeatureSettings(ExtractorState& state, const FontFeatureSettings& fontFeatureSettings)

--- a/Source/WebCore/style/StyleExtractorSerializer.h
+++ b/Source/WebCore/style/StyleExtractorSerializer.h
@@ -116,7 +116,6 @@ public:
     static void serializeFontFamily(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const AtomString&);
     static void serializeFontSizeAdjust(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const FontSizeAdjust&);
     static void serializeFontPalette(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const FontPalette&);
-    static void serializeFontWeight(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, FontSelectionValue);
     static void serializeFontFeatureSettings(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const FontFeatureSettings&);
     static void serializeFontVariationSettings(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const FontVariationSettings&);
 
@@ -1020,11 +1019,6 @@ inline void ExtractorSerializer::serializeFontSizeAdjust(ExtractorState& state, 
     serialize(state, builder, context, metric);
     builder.append(' ');
     CSS::serializationForCSS(builder, context, CSS::NumberRaw<> { *value });
-}
-
-inline void ExtractorSerializer::serializeFontWeight(ExtractorState&, StringBuilder& builder, const CSS::SerializationContext& context, FontSelectionValue fontWeight)
-{
-    CSS::serializationForCSS(builder, context, CSS::NumberRaw<> { static_cast<float>(fontWeight) });
 }
 
 inline void ExtractorSerializer::serializeFontFeatureSettings(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, const FontFeatureSettings& fontFeatureSettings)

--- a/Source/WebCore/style/StyleInterpolationWrappers.h
+++ b/Source/WebCore/style/StyleInterpolationWrappers.h
@@ -536,20 +536,6 @@ public:
 
 #endif
 
-class FontWeightWrapper final : public Wrapper<FontSelectionValue> {
-    WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(FontWeightWrapper, Animation);
-public:
-    FontWeightWrapper()
-        : Wrapper(CSSPropertyFontWeight, &RenderStyle::fontWeight, &RenderStyle::setFontWeight)
-    {
-    }
-
-    void interpolate(RenderStyle& destination, const RenderStyle& from, const RenderStyle& to, const Context& context) const final
-    {
-        (destination.*m_setter)(FontSelectionValue(std::clamp(blendFunc(static_cast<float>(this->value(from)), static_cast<float>(this->value(to)), context), 1.0f, 1000.0f)));
-    }
-};
-
 class FontStyleWrapper final : public Wrapper<std::optional<FontSelectionValue>> {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(FontStyleWrapper, Animation);
 public:

--- a/Source/WebCore/style/StyleResolveForFont.cpp
+++ b/Source/WebCore/style/StyleResolveForFont.cpp
@@ -85,38 +85,6 @@ FontSelectionValue fontWeightFromCSSValueDeprecated(const CSSValue& value)
     }
 }
 
-FontSelectionValue fontWeightFromCSSValue(BuilderState& builderState, const CSSValue& value)
-{
-    RefPtr primitiveValue = requiredDowncast<CSSPrimitiveValue>(builderState, value);
-    if (!primitiveValue)
-        return { };
-
-    auto& conversionData = builderState.cssToLengthConversionData();
-
-    if (primitiveValue->isNumber())
-        return FontSelectionValue(clampTo<float>(primitiveValue->resolveAsNumber(conversionData), 1, 1000));
-
-    ASSERT(primitiveValue->isValueID());
-    auto valueID = primitiveValue->valueID();
-
-    if (CSSPropertyParserHelpers::isSystemFontShorthand(valueID))
-        return SystemFontDatabase::singleton().systemFontShorthandWeight(CSSPropertyParserHelpers::lowerFontShorthand(valueID));
-
-    switch (valueID) {
-    case CSSValueNormal:
-        return normalWeightValue();
-    case CSSValueBold:
-        return boldWeightValue();
-    case CSSValueBolder:
-        return FontCascadeDescription::bolderWeight(conversionData.parentStyle()->fontDescription().weight());
-    case CSSValueLighter:
-        return FontCascadeDescription::lighterWeight(conversionData.parentStyle()->fontDescription().weight());
-    default:
-        ASSERT_NOT_REACHED();
-        return normalWeightValue();
-    }
-}
-
 static FontSelectionValue fontWeightFromUnresolvedFontWeight(const CSSPropertyParserHelpers::UnresolvedFontWeight& unresolvedWeight, const FontCascadeDescription& fontDescription)
 {
     return WTF::switchOn(unresolvedWeight,

--- a/Source/WebCore/style/StyleResolveForFont.h
+++ b/Source/WebCore/style/StyleResolveForFont.h
@@ -56,7 +56,6 @@ namespace Style {
 class BuilderState;
 
 FontSelectionValue fontWeightFromCSSValueDeprecated(const CSSValue&);
-FontSelectionValue fontWeightFromCSSValue(BuilderState&, const CSSValue&);
 
 FontSelectionValue fontStretchFromCSSValueDeprecated(const CSSValue&);
 

--- a/Source/WebCore/style/values/fonts/StyleFontWeight.cpp
+++ b/Source/WebCore/style/values/fonts/StyleFontWeight.cpp
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "StyleFontWeight.h"
+
+#include "CSSPropertyParserConsumer+Font.h"
+#include "FontCascadeDescription.h"
+#include "RenderStyle.h"
+#include "StyleBuilderChecking.h"
+#include "StylePrimitiveNumericTypes+Blending.h"
+#include "StylePrimitiveNumericTypes+CSSValueConversion.h"
+#include "SystemFontDatabase.h"
+
+namespace WebCore {
+namespace Style {
+
+// MARK: - Conversion
+
+auto CSSValueConversion<FontWeight>::operator()(BuilderState& state, const CSSValue& value) -> FontWeight
+{
+    RefPtr primitiveValue = requiredDowncast<CSSPrimitiveValue>(state, value);
+    if (!primitiveValue)
+        return CSS::Keyword::Normal { };
+
+    switch (auto valueID = primitiveValue->valueID(); valueID) {
+    case CSSValueInvalid:
+        return toStyleFromCSSValue<FontWeight::Number>(state, *primitiveValue);
+    case CSSValueNormal:
+        return CSS::Keyword::Normal { };
+    case CSSValueBold:
+        return CSS::Keyword::Bold { };
+    case CSSValueBolder:
+        return FontCascadeDescription::bolderWeight(state.parentStyle().fontDescription().weight());
+    case CSSValueLighter:
+        return FontCascadeDescription::lighterWeight(state.parentStyle().fontDescription().weight());
+    default:
+        if (CSSPropertyParserHelpers::isSystemFontShorthand(valueID))
+            return SystemFontDatabase::singleton().systemFontShorthandWeight(CSSPropertyParserHelpers::lowerFontShorthand(valueID));
+
+        state.setCurrentPropertyInvalidAtComputedValueTime();
+        return CSS::Keyword::Normal { };
+    }
+}
+
+// MARK: Blending
+
+auto Blending<FontWeight>::blend(const FontWeight& a, const FontWeight& b, const BlendingContext& context) -> FontWeight
+{
+    return Style::blend(a.number(), b.number(), context);
+}
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/fonts/StyleFontWeight.h
+++ b/Source/WebCore/style/values/fonts/StyleFontWeight.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/FontSelectionAlgorithm.h>
+#include <WebCore/StylePrimitiveNumericTypes.h>
+
+namespace WebCore {
+namespace Style {
+
+// <'font-weight'> = normal | bold | bolder | lighter | <number [1,1000]>
+// NOTE: Computed value is always resolved to a <number [1,1000]>.
+// https://drafts.csswg.org/css-fonts-4/#propdef-font-weight
+struct FontWeight {
+    using Number = Style::Number<CSS::Range{1, 1000}>;
+
+    FontWeight(CSS::Keyword::Normal) : m_platform { normalWeightValue() } { }
+    FontWeight(CSS::Keyword::Bold) : m_platform { boldWeightValue() } { }
+    FontWeight(Number number) : m_platform { FontSelectionValue::clampFloat(number.value) } { }
+
+    FontWeight(FontSelectionValue platform) : m_platform { platform } { }
+
+    Number number() const { return Number { static_cast<float>(m_platform) }; }
+
+    template<typename... F> decltype(auto) switchOn(F&&... f) const
+    {
+        auto visitor = WTF::makeVisitor(std::forward<F>(f)...);
+        return visitor(number());
+    }
+
+    FontSelectionValue platform() const { return m_platform; }
+
+    bool operator==(const FontWeight&) const = default;
+
+private:
+    FontSelectionValue m_platform;
+};
+
+// MARK: - Conversion
+
+template<> struct CSSValueConversion<FontWeight> { auto operator()(BuilderState&, const CSSValue&) -> FontWeight; };
+
+// MARK: - Blending
+
+template<> struct Blending<FontWeight> {
+    auto blend(const FontWeight&, const FontWeight&, const BlendingContext&) -> FontWeight;
+};
+
+} // namespace Style
+} // namespace WebCore
+
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::FontWeight)


### PR DESCRIPTION
#### 884c867cce85f731c4112c5175f40bd1013e33a0
<pre>
[Style] Convert the &apos;font-weight&apos; property to strong style types
<a href="https://bugs.webkit.org/show_bug.cgi?id=299700">https://bugs.webkit.org/show_bug.cgi?id=299700</a>

Reviewed by Darin Adler.

Converts the &apos;font-weight&apos; property to use strong style types.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/rendering/style/RenderStyle.cpp:
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
* Source/WebCore/style/StyleBuilderConverter.h:
* Source/WebCore/style/StyleBuilderState.h:
* Source/WebCore/style/StyleBuilderStateInlines.h:
* Source/WebCore/style/StyleExtractorConverter.h:
* Source/WebCore/style/StyleExtractorSerializer.h:
* Source/WebCore/style/StyleInterpolationWrappers.h:
* Source/WebCore/style/StyleResolveForFont.cpp:
* Source/WebCore/style/StyleResolveForFont.h:
* Source/WebCore/style/values/fonts/StyleFontWeight.cpp: Added.
* Source/WebCore/style/values/fonts/StyleFontWeight.h: Added.

Canonical link: <a href="https://commits.webkit.org/300729@main">https://commits.webkit.org/300729@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/be6f8a87c51a050d1a2ab5e9e6b3e3ea17885f5a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123669 "8 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43384 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34080 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130443 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/75814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/125546 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44107 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51978 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94036 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/75814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126622 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35134 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110633 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74639 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34097 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28792 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73918 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104855 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29015 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133133 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50620 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38539 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102511 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50995 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106854 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102350 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26020 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47697 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25941 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/47438 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50474 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56236 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49948 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53295 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51623 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->