### PR TITLE
AX: Import svg-aam WPTs (9/28/25)

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg-aam/META.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg-aam/META.yml
@@ -1,3 +1,4 @@
 spec: https://w3c.github.io/svg-aam/
 suggested_reviewers:
   - cookiecrook
+  - sideshowbarker

--- a/LayoutTests/imported/w3c/web-platform-tests/svg-aam/name/comp_label-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg-aam/name/comp_label-expected.txt
@@ -1,0 +1,14 @@
+SVG-AAM: Label Tests
+
+Tests SVG-specific aria-label rules in SVG-AAM Â§8.1 Name and Description, but note the open issues in SVG-AAM #31.
+
+SVG a[aria-label]
+
+
+
+
+PASS [aria-labelledby] > circle
+PASS [aria-labelledby] > rect
+PASS [aria-labelledby] > polygon
+PASS [aria-labelledby] > g
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg-aam/name/comp_label.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg-aam/name/comp_label.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html>
+<head>
+  <title>Name Comp: Label</title>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/resources/testdriver.js"></script>
+  <script src="/resources/testdriver-vendor.js"></script>
+  <script src="/resources/testdriver-actions.js"></script>
+  <script src="/wai-aria/scripts/aria-utils.js"></script>
+</head>
+<body>
+
+<h1>SVG-AAM: Label Tests</h1>
+
+<p>Tests SVG-specific aria-label rules in <a href="https://w3c.github.io/svg-aam/#mapping_additional_nd">SVG-AAM §8.1 Name and Description</a>, but note the open issues in <a href="https://github.com/w3c/svg-aam/issues/31">SVG-AAM #31</a>.
+
+<h2>SVG a[aria-label]</h2>
+<svg viewbox="0 0 300 100">
+  <a href="#" aria-label="Athos" data-expectedlabel="Athos" xlink:title="circle link label" data-testname="[aria-labelledby] > circle" class="ex"><circle cx="26" cy="26" r="25"></circle></a>
+  <a href="#" aria-label="Porthos" data-expectedlabel="Porthos" xlink:title="rect link label" data-testname="[aria-labelledby] > rect" class="ex"><rect x="60" y="1" width="50" height="50"></rect></a>
+  <a href="#" aria-label="Aramis" data-expectedlabel="Aramis" xlink:title="polygon link label" data-testname="[aria-labelledby] > polygon" class="ex"><polygon points="100,100 150,25 150,75 200,0" fill="none" stroke="black"></polygon></a>
+</svg><br>
+<svg viewbox="0 0 200 90">
+  <a href="#" aria-label="D’Artagnan" data-expectedlabel="D’Artagnan" xlink:title="group link label" data-testname="[aria-labelledby] > g" class="ex">
+  <g fill="white" stroke="green" stroke-width="5">
+    <circle cx="40" cy="40" r="25" />
+    <circle cx="60" cy="60" r="25" />
+  </g>
+  </a>
+</svg>
+<br>
+
+<script>
+AriaUtils.verifyLabelsBySelector(".ex");
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg-aam/name/comp_labelledby-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg-aam/name/comp_labelledby-expected.txt
@@ -1,0 +1,32 @@
+SVG-AAM: Labelledby Tests
+
+Tests SVG-specific aria-labelledby rules in SVG-AAM Â§8.1 Name and Description, but note the open issues in SVG-AAM #31. Huey Dewey Louie Scrooge
+
+SVG a[aria-labelledby]
+
+
+
+SVG a[aria-label][aria-labelledby]
+
+
+
+SVG a[aria-labelledby="{[aria-label]} {[aria-label]} {[xlink:title]} {* > [title]}"]
+
+
+
+
+PASS [aria-labelledby] > circle
+PASS [aria-labelledby] > rect
+PASS [aria-labelledby] > polygon
+PASS [aria-labelledby] > g
+PASS [aria-label][aria-labelledby] > circle
+PASS [aria-label][aria-labelledby] > rect
+PASS [aria-label][aria-labelledby] > polygon
+PASS [aria-label][aria-labelledby] > g
+FAIL [aria-labelledby="{[aria-label]} {[xlink:title]} {* > [title]}"] > g assert_equals: <a href="#" aria-labelledby="nolan gilliam kaufman villeneuve" data-expectedlabel="Nolan Gilliam Kaufman Villeneuve" xlink:title="group link label" data-testname="[aria-labelledby=&quot;{[aria-label]} {[xlink:title]} {* &gt; [title]}&quot;] &gt; g" class="ex">
+  <g fill="white" stroke="green" stroke-width="5">
+    <circle cx="40" cy="40" r="25"></circle>
+    <circle cx="60" cy="60" r="25"></circle>
+  </g>
+  </a> expected "Nolan Gilliam Kaufman Villeneuve" but got "Nolan Gilliam"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg-aam/name/comp_labelledby.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg-aam/name/comp_labelledby.html
@@ -1,0 +1,76 @@
+<!doctype html>
+<html>
+<head>
+  <title>Name Comp: Labelledby</title>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/resources/testdriver.js"></script>
+  <script src="/resources/testdriver-vendor.js"></script>
+  <script src="/resources/testdriver-actions.js"></script>
+  <script src="/wai-aria/scripts/aria-utils.js"></script>
+</head>
+<body>
+
+<h1>SVG-AAM: Labelledby Tests</h1>
+
+<p>Tests SVG-specific aria-labelledby rules in <a href="https://w3c.github.io/svg-aam/#mapping_additional_nd">SVG-AAM §8.1 Name and Description</a>, but note the open issues in <a href="https://github.com/w3c/svg-aam/issues/31">SVG-AAM #31</a>.
+
+<span id="huey">Huey</span>
+<span id="dewey">Dewey</span>
+<span id="louie">Louie</span>
+<span id="scrooge">Scrooge</span>
+
+<h2>SVG a[aria-labelledby]</h2>
+<svg viewbox="0 0 300 100">
+  <a href="#" aria-labelledby="huey" data-expectedlabel="Huey" xlink:title="circle link label" data-testname="[aria-labelledby] > circle" class="ex"><circle cx="26" cy="26" r="25"></circle></a>
+  <a href="#" aria-labelledby="dewey" data-expectedlabel="Dewey" xlink:title="rect link label" data-testname="[aria-labelledby] > rect" class="ex"><rect x="60" y="1" width="50" height="50"></rect></a>
+  <a href="#" aria-labelledby="louie" data-expectedlabel="Louie" xlink:title="polygon link label" data-testname="[aria-labelledby] > polygon" class="ex"><polygon points="100,100 150,25 150,75 200,0" fill="none" stroke="black"></polygon></a>
+</svg><br>
+<svg viewbox="0 0 200 90">
+  <a href="#" aria-labelledby="scrooge" data-expectedlabel="Scrooge" xlink:title="group link label" data-testname="[aria-labelledby] > g" class="ex">
+  <g fill="white" stroke="green" stroke-width="5">
+    <circle cx="40" cy="40" r="25" />
+    <circle cx="60" cy="60" r="25" />
+  </g>
+  </a>
+</svg>
+<br>
+
+<h2>SVG a[aria-label][aria-labelledby]</h2>
+<svg viewbox="0 0 300 100">
+  <a href="#" aria-labelledby="huey" aria-label="Athos" data-expectedlabel="Huey" xlink:title="circle link label" data-testname="[aria-label][aria-labelledby] > circle" class="ex"><circle cx="26" cy="26" r="25"></circle></a>
+  <a href="#" aria-labelledby="dewey" aria-label="Porthos" data-expectedlabel="Dewey" xlink:title="rect link label" data-testname="[aria-label][aria-labelledby] > rect" class="ex"><rect x="60" y="1" width="50" height="50"></rect></a>
+  <a href="#" aria-labelledby="louie" aria-label="Aramis" data-expectedlabel="Louie" xlink:title="polygon link label" data-testname="[aria-label][aria-labelledby] > polygon" class="ex"><polygon points="100,100 150,25 150,75 200,0" fill="none" stroke="black"></polygon></a>
+</svg><br>
+<svg viewbox="0 0 200 90">
+  <a href="#" aria-labelledby="scrooge" aria-label="D’Artagnan" data-expectedlabel="Scrooge" xlink:title="group link label" data-testname="[aria-label][aria-labelledby] > g" class="ex">
+  <g fill="white" stroke="green" stroke-width="5">
+    <circle cx="40" cy="40" r="25" />
+    <circle cx="60" cy="60" r="25" />
+  </g>
+  </a>
+</svg>
+<br>
+
+<h2>SVG a[aria-labelledby="{[aria-label]} {[aria-label]} {[xlink:title]} {* > [title]}"]</h2>
+<svg viewbox="0 0 300 100">
+  <a id="nolan" href="#" aria-label="Nolan"><circle cx="26" cy="26" r="25"></circle></a>
+  <a id="gilliam" href="#" aria-label="Gilliam"><ellipse cx="250" cy="50" rx="30" ry="15"></ellipse></a>
+  <a id="kaufman" href="#" xlink:title="Kaufman"><rect x="60" y="1" width="50" height="50"></rect></a>
+  <polygon id="villeneuve" points="100,100 150,25 150,75 200,0" fill="none" stroke="black"><title>Villeneuve</title></polygon>
+</svg><br>
+<svg viewbox="0 0 200 90">
+  <a href="#" aria-labelledby="nolan gilliam kaufman villeneuve" data-expectedlabel="Nolan Gilliam Kaufman Villeneuve" xlink:title="group link label" data-testname="[aria-labelledby=&quot;{[aria-label]} {[xlink:title]} {* > [title]}&quot;] > g" class="ex">
+  <g fill="white" stroke="green" stroke-width="5">
+    <circle cx="40" cy="40" r="25" />
+    <circle cx="60" cy="60" r="25" />
+  </g>
+  </a>
+</svg>
+<br>
+
+<script>
+AriaUtils.verifyLabelsBySelector(".ex");
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg-aam/name/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg-aam/name/w3c-import.log
@@ -15,3 +15,5 @@ None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/svg-aam/name/comp_host_language_label.html
+/LayoutTests/imported/w3c/web-platform-tests/svg-aam/name/comp_label.html
+/LayoutTests/imported/w3c/web-platform-tests/svg-aam/name/comp_labelledby.html


### PR DESCRIPTION
#### df14118b0eb64982c718859d3a7659be81b5bf49
<pre>
AX: Import svg-aam WPTs (9/28/25)
<a href="https://bugs.webkit.org/show_bug.cgi?id=299704">https://bugs.webkit.org/show_bug.cgi?id=299704</a>
<a href="https://rdar.apple.com/161522398">rdar://161522398</a>

Reviewed by Joshua Hoffman.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/384eaa206c6b8a9ed44d32552764f73cebd7d0a7">https://github.com/web-platform-tests/wpt/commit/384eaa206c6b8a9ed44d32552764f73cebd7d0a7</a>

* LayoutTests/imported/w3c/web-platform-tests/svg-aam/META.yml:
* LayoutTests/imported/w3c/web-platform-tests/svg-aam/name/comp_label-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg-aam/name/comp_label.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg-aam/name/comp_labelledby-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg-aam/name/comp_labelledby.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg-aam/name/w3c-import.log:

Canonical link: <a href="https://commits.webkit.org/300692@main">https://commits.webkit.org/300692@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d0601039ce658bb9a890e81fe8c0d1ed26019d6e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123428 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43143 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33839 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130144 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/75561 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/43ae1376-f62c-416a-ba3f-60ea06c45424) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43866 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51737 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93818 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62264 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3daae330-2483-4c3c-9f27-b323573527be) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126381 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34950 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110425 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74445 "Found 2 new API test failures: TestWTF:WTF_Condition.OneProducerOneConsumerOneSlot, WPE/TestWebKitWebContext:/webkit/WebKitWebContext/no-web-process-leak (failure)") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33919 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28583 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73662 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104664 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28809 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132864 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50378 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38343 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102310 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50754 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106648 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102162 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25989 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47521 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25746 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/47182 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50233 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49705 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53054 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51382 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->