### PR TITLE
Add casts that will be needed once Latin1Character is a distinct type

### DIFF
--- a/Source/JavaScriptCore/API/JSScript.mm
+++ b/Source/JavaScriptCore/API/JSScript.mm
@@ -146,7 +146,7 @@ static bool validateBytecodeCachePath(NSURL* cachePath, NSError** error)
     auto result = adoptNS([[JSScript alloc] init]);
     result->m_virtualMachine = vm;
     result->m_type = type;
-    result->m_source = String(StringImpl::createWithoutCopying(fileData->span()));
+    result->m_source = StringImpl::createWithoutCopying(byteCast<Latin1Character>(fileData->span()));
     result->m_mappedSource = WTFMove(*fileData);
     result->m_sourceURL = sourceURL;
     result->m_cachePath = cachePath;

--- a/Source/JavaScriptCore/API/JSStringRefCF.cpp
+++ b/Source/JavaScriptCore/API/JSStringRefCF.cpp
@@ -47,7 +47,7 @@ JSStringRef JSStringCreateWithCFString(CFStringRef string)
 
     Vector<Latin1Character, 1024> lcharBuffer(length);
     CFIndex usedBufferLength;
-    CFIndex convertedSize = CFStringGetBytes(string, CFRangeMake(0, length), kCFStringEncodingISOLatin1, 0, false, lcharBuffer.mutableSpan().data(), length, &usedBufferLength);
+    CFIndex convertedSize = CFStringGetBytes(string, CFRangeMake(0, length), kCFStringEncodingISOLatin1, 0, false, byteCast<UInt8>(lcharBuffer.mutableSpan().data()), length, &usedBufferLength);
     if (static_cast<size_t>(convertedSize) == length && static_cast<size_t>(usedBufferLength) == length)
         return &OpaqueJSString::create(lcharBuffer.span()).leakRef();
 
@@ -64,7 +64,7 @@ CFStringRef JSStringCopyCFString(CFAllocatorRef allocator, JSStringRef string)
 
     if (string->is8Bit()) {
         auto characters = string->span8();
-        return CFStringCreateWithBytes(allocator, characters.data(), characters.size(), kCFStringEncodingISOLatin1, false);
+        return CFStringCreateWithBytes(allocator, byteCast<UInt8>(characters.data()), characters.size(), kCFStringEncodingISOLatin1, false);
     }
     auto characters = string->span16();
     return CFStringCreateWithCharacters(allocator, reinterpret_cast<const UniChar*>(characters.data()), characters.size());

--- a/Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorSocket.cpp
+++ b/Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorSocket.cpp
@@ -262,7 +262,7 @@ String RemoteInspector::backendCommands() const
 
     auto contents = FileSystem::readEntireFile(m_backendCommandsPath);
 
-    return contents ? String::adopt(WTFMove(*contents)) : emptyString();
+    return contents ? String { byteCast<Latin1Character>(contents->span()) } : emptyString();
 }
 
 // RemoteInspectorConnectionClient handlers

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototype.cpp
@@ -235,7 +235,6 @@ JSC_DEFINE_HOST_FUNCTION(uint8ArrayPrototypeToHex, (JSGlobalObject* globalObject
 
     std::span<Latin1Character> buffer;
     auto result = StringImpl::createUninitialized(length * 2, buffer);
-    Latin1Character* bufferEnd = std::to_address(buffer.end());
     constexpr size_t stride = 8; // Because loading uint8x8_t.
     if (length >= stride) {
         auto encodeVector = [&](auto input) {
@@ -261,11 +260,10 @@ JSC_DEFINE_HOST_FUNCTION(uint8ArrayPrototypeToHex, (JSGlobalObject* globalObject
         };
 
         const auto* cursor = data;
-        auto* output = buffer.data();
-        for (; cursor + stride <= end; cursor += stride, output += stride * 2)
+        for (auto* output = byteCast<uint8_t>(buffer.data()); cursor + stride <= end; cursor += stride, output += stride * 2)
             simde_vst1q_u8(output, encodeVector(simde_vld1_u8(cursor)));
         if (cursor < end)
-            simde_vst1q_u8(bufferEnd - stride * 2, encodeVector(simde_vld1_u8(end - stride)));
+            simde_vst1q_u8(byteCast<uint8_t>(std::to_address(buffer.end())) - stride * 2, encodeVector(simde_vld1_u8(end - stride)));
     } else {
         const auto* cursor = data;
         auto* output = buffer.data();

--- a/Source/JavaScriptCore/runtime/LiteralParser.cpp
+++ b/Source/JavaScriptCore/runtime/LiteralParser.cpp
@@ -932,7 +932,7 @@ ALWAYS_INLINE TokenType LiteralParser<CharType, reviverMode>::Lexer::lexString(L
     if (m_mode == StrictJSON) {
         ASSERT(terminator == '"');
         if constexpr (hint == JSONIdentifierHint::MaybeIdentifier) {
-            while (m_ptr < m_end && isSafeStringCharacterForIdentifier<SafeStringCharacterSet::Strict>(*m_ptr, '"'))
+            while (m_ptr < m_end && isSafeStringCharacterForIdentifier<SafeStringCharacterSet::Strict>(*m_ptr, terminator))
                 ++m_ptr;
         } else {
             using UnsignedType = SIMD::SameSizeUnsignedInteger<CharType>;
@@ -947,8 +947,8 @@ ALWAYS_INLINE TokenType LiteralParser<CharType, reviverMode>::Lexer::lexString(L
                 return SIMD::findFirstNonZeroIndex(mask);
             };
 
-            auto scalarMatch = [&](auto character) ALWAYS_INLINE_LAMBDA {
-                return !isSafeStringCharacter<SafeStringCharacterSet::Strict>(character, '"');
+            auto scalarMatch = [&](CharType character) ALWAYS_INLINE_LAMBDA {
+                return !isSafeStringCharacter<SafeStringCharacterSet::Strict>(character, terminator);
             };
 
             m_ptr = SIMD::find(std::span { m_ptr, m_end }, vectorMatch, scalarMatch);

--- a/Source/WTF/wtf/URLParser.cpp
+++ b/Source/WTF/wtf/URLParser.cpp
@@ -2113,10 +2113,9 @@ void URLParser::appendNumberToASCIIBuffer(UnsignedIntegerType number)
     std::array<Latin1Character, bufferSize> buffer;
     size_t index = bufferSize;
     do {
-        buffer[--index] = (number % 10) + '0';
+        buffer[--index] = static_cast<char>((number % 10) + '0');
         number /= 10;
     } while (number);
-
     appendToASCIIBuffer(std::span { buffer }.subspan(index));
 }
 

--- a/Source/WTF/wtf/cf/CFURLExtras.cpp
+++ b/Source/WTF/wtf/cf/CFURLExtras.cpp
@@ -59,7 +59,7 @@ String bytesAsString(CFURLRef url)
     RELEASE_ASSERT(bytesLength <= static_cast<CFIndex>(String::MaxLength));
     std::span<Latin1Character> buffer;
     auto result = String::createUninitialized(bytesLength, buffer);
-    CFURLGetBytes(url, buffer.data(), buffer.size());
+    CFURLGetBytes(url, byteCast<UInt8>(buffer.data()), buffer.size());
     return result;
 }
 
@@ -93,7 +93,7 @@ bool isSameOrigin(CFURLRef a, const URL& b)
     auto aBytes = bytesAsVector(a);
     RELEASE_ASSERT(aBytes.size() <= String::MaxLength);
 
-    StringView aString { aBytes.span() };
+    StringView aString { byteCast<Latin1Character>(aBytes.span()) };
     StringView bString { b.string() };
 
     if (!b.hasPath())

--- a/Source/WTF/wtf/cf/URLCF.cpp
+++ b/Source/WTF/wtf/cf/URLCF.cpp
@@ -47,7 +47,7 @@ RetainPtr<CFURLRef> URL::createCFURL(const String& string)
 {
     if (string.is8Bit() && string.containsOnlyASCII()) [[likely]] {
         auto characters = string.span8();
-        return adoptCF(CFURLCreateAbsoluteURLWithBytes(nullptr, characters.data(), characters.size(), kCFStringEncodingUTF8, nullptr, true));
+        return adoptCF(CFURLCreateAbsoluteURLWithBytes(nullptr, byteCast<UInt8>(characters.data()), characters.size(), kCFStringEncodingUTF8, nullptr, true));
     }
     CString utf8 = string.utf8();
     auto utf8Span = utf8.span();

--- a/Source/WTF/wtf/cocoa/NSURLExtras.mm
+++ b/Source/WTF/wtf/cocoa/NSURLExtras.mm
@@ -322,7 +322,7 @@ NSData *originalURLData(NSURL *URL)
 
 NSString *userVisibleString(NSURL *URL)
 {
-    return URLHelpers::userVisibleURL(span(originalURLData(URL))).createNSString().autorelease();
+    return URLHelpers::userVisibleURL(byteCast<Latin1Character>(span(originalURLData(URL)))).createNSString().autorelease();
 }
 
 BOOL isUserVisibleURL(NSString *string)

--- a/Source/WTF/wtf/persistence/PersistentCoders.cpp
+++ b/Source/WTF/wtf/persistence/PersistentCoders.cpp
@@ -100,7 +100,7 @@ void Coder<String>::encodeForPersistence(Encoder& encoder, const String& string)
     encoder << string.length() << is8Bit;
 
     if (is8Bit)
-        encoder.encodeFixedLengthData(string.span8());
+        encoder.encodeFixedLengthData(asBytes(string.span8()));
     else
         encoder.encodeFixedLengthData(asBytes(string.span16()));
 }

--- a/Source/WTF/wtf/text/StringBuilder.h
+++ b/Source/WTF/wtf/text/StringBuilder.h
@@ -296,7 +296,7 @@ inline unsigned StringBuilder::capacity() const
 
 inline char16_t StringBuilder::operator[](unsigned i) const
 {
-    return is8Bit() ? span8()[i] : span16()[i];
+    return is8Bit() ? char16_t { span8()[i] } : span16()[i];
 }
 
 inline bool StringBuilder::is8Bit() const

--- a/Source/WTF/wtf/text/WTFString.cpp
+++ b/Source/WTF/wtf/text/WTFString.cpp
@@ -51,8 +51,9 @@ String::String(std::span<const Latin1Character> characters)
 {
 }
 
+// Construct a string with Latin-1 data.
 String::String(std::span<const char> characters)
-    : m_impl(characters.data() ? RefPtr { StringImpl::create(byteCast<uint8_t>(characters)) } : nullptr)
+    : m_impl(characters.data() ? RefPtr { StringImpl::create(byteCast<Latin1Character>(characters)) } : nullptr)
 {
 }
 
@@ -393,7 +394,7 @@ CString String::ascii() const
 
         size_t characterBufferIndex = 0;
         for (auto character : characters)
-            characterBuffer[characterBufferIndex++] = character && (character < 0x20 || character > 0x7f) ? '?' : character;
+            characterBuffer[characterBufferIndex++] = character && (character < 0x20 || character > 0x7f) ? '?' : byteCast<char>(character);
 
         return result;        
     }

--- a/Source/WTF/wtf/text/cf/StringCF.cpp
+++ b/Source/WTF/wtf/text/cf/StringCF.cpp
@@ -43,7 +43,7 @@ String::String(CFStringRef str)
     {
         StringBuffer<Latin1Character> buffer(size);
         CFIndex usedBufLen;
-        CFIndex convertedSize = CFStringGetBytes(str, CFRangeMake(0, size), kCFStringEncodingISOLatin1, 0, false, buffer.characters(), size, &usedBufLen);
+        CFIndex convertedSize = CFStringGetBytes(str, CFRangeMake(0, size), kCFStringEncodingISOLatin1, 0, false, byteCast<UInt8>(buffer.characters()), size, &usedBufLen);
         if (convertedSize == size && usedBufLen == size) {
             m_impl = StringImpl::adopt(WTFMove(buffer));
             return;

--- a/Source/WTF/wtf/text/cf/StringImplCF.cpp
+++ b/Source/WTF/wtf/text/cf/StringImplCF.cpp
@@ -121,7 +121,7 @@ RetainPtr<CFStringRef> StringImpl::createCFString()
     if (!m_length || !isMainThread()) {
         if (is8Bit()) {
             auto characters = span8();
-            return adoptCF(CFStringCreateWithBytes(nullptr, characters.data(), characters.size(), kCFStringEncodingISOLatin1, false));
+            return adoptCF(CFStringCreateWithBytes(nullptr, byteCast<UInt8>(characters.data()), characters.size(), kCFStringEncodingISOLatin1, false));
         }
         auto characters = span16();
         return adoptCF(CFStringCreateWithCharacters(nullptr, reinterpret_cast<const UniChar*>(characters.data()), characters.size()));
@@ -135,7 +135,7 @@ RetainPtr<CFStringRef> StringImpl::createCFString()
     RetainPtr<CFStringRef> string;
     if (is8Bit()) {
         auto characters = span8();
-        string = adoptCF(CFStringCreateWithBytesNoCopy(allocator, characters.data(), characters.size(), kCFStringEncodingISOLatin1, false, kCFAllocatorNull));
+        string = adoptCF(CFStringCreateWithBytesNoCopy(allocator, byteCast<UInt8>(characters.data()), characters.size(), kCFStringEncodingISOLatin1, false, kCFAllocatorNull));
     } else {
         auto characters = span16();
         string = adoptCF(CFStringCreateWithCharactersNoCopy(allocator, reinterpret_cast<const UniChar*>(characters.data()), characters.size(), kCFAllocatorNull));

--- a/Source/WTF/wtf/text/cf/StringViewCF.cpp
+++ b/Source/WTF/wtf/text/cf/StringViewCF.cpp
@@ -37,7 +37,7 @@ RetainPtr<CFStringRef> StringView::createCFString() const
 {
     if (is8Bit()) {
         auto characters = span8();
-        return adoptCF(CFStringCreateWithBytes(kCFAllocatorDefault, characters.data(), characters.size(), kCFStringEncodingISOLatin1, false));
+        return adoptCF(CFStringCreateWithBytes(kCFAllocatorDefault, byteCast<UInt8>(characters.data()), characters.size(), kCFStringEncodingISOLatin1, false));
     }
     auto characters = span16();
     return adoptCF(CFStringCreateWithCharacters(kCFAllocatorDefault, reinterpret_cast<const UniChar*>(characters.data()), characters.size()));
@@ -47,7 +47,7 @@ RetainPtr<CFStringRef> StringView::createCFStringWithoutCopying() const
 {
     if (is8Bit()) {
         auto characters = span8();
-        return adoptCF(CFStringCreateWithBytesNoCopy(kCFAllocatorDefault, characters.data(), characters.size(), kCFStringEncodingISOLatin1, false, kCFAllocatorNull));
+        return adoptCF(CFStringCreateWithBytesNoCopy(kCFAllocatorDefault, byteCast<UInt8>(characters.data()), characters.size(), kCFStringEncodingISOLatin1, false, kCFAllocatorNull));
     }
     auto characters = span16();
     return adoptCF(CFStringCreateWithCharactersNoCopy(kCFAllocatorDefault, reinterpret_cast<const UniChar*>(characters.data()), characters.size(), kCFAllocatorNull));

--- a/Source/WebCore/Modules/encryptedmedia/InitDataRegistry.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/InitDataRegistry.cpp
@@ -69,9 +69,9 @@ static std::optional<Vector<Ref<SharedBuffer>>> extractKeyIDsKeyids(const Shared
     // https://w3c.github.io/encrypted-media/format-registry/initdata/keyids.html#format
     if (buffer.size() > std::numeric_limits<unsigned>::max())
         return std::nullopt;
-    String json { buffer.span() };
 
-    auto value = JSON::Value::parseJSON(json);
+    // FIXME: Specification says this should be parsed as UTF-8, not Latin-1.
+    auto value = JSON::Value::parseJSON(byteCast<Latin1Character>(buffer.span()));
     if (!value)
         return std::nullopt;
 

--- a/Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp
@@ -227,7 +227,7 @@ void PeerConnectionBackend::handleLogMessage(const WTFLogChannel& channel, WTFLo
 
     // Check if the third message is a multi-lines string, concatenating such message would look ugly in log events.
     if (values.size() >= 3 && values[2].value.find("\r\n"_s) != notFound)
-        event = generateJSONLogEvent(MessageLogEvent { values[1].value, { values[2].value.span8() } }, false);
+        event = generateJSONLogEvent(MessageLogEvent { values[1].value, { byteCast<uint8_t>(values[2].value.span8()) } }, false);
     else {
         StringBuilder builder;
         for (auto& value : values.subvector(1))

--- a/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformerCocoa.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformerCocoa.cpp
@@ -37,12 +37,12 @@ namespace WebCore {
 
 ExceptionOr<Vector<uint8_t>> RTCRtpSFrameTransformer::computeSaltKey(const Vector<uint8_t>& rawKey)
 {
-    return deriveHDKFSHA256Bits(rawKey.subspan(0, 16), "SFrame10"_span8, "salt"_span8, 96);
+    return deriveHDKFSHA256Bits(rawKey.subspan(0, 16), byteCast<uint8_t>("SFrame10"_span), byteCast<uint8_t>("salt"_span), 96);
 }
 
 static ExceptionOr<Vector<uint8_t>> createBaseSFrameKey(const Vector<uint8_t>& rawKey)
 {
-    return deriveHDKFSHA256Bits(rawKey.subspan(0, 16), "SFrame10"_span8, "key"_span8, 128);
+    return deriveHDKFSHA256Bits(rawKey.subspan(0, 16), byteCast<uint8_t>("SFrame10"_span), byteCast<uint8_t>("key"_span), 128);
 }
 
 ExceptionOr<Vector<uint8_t>> RTCRtpSFrameTransformer::computeAuthenticationKey(const Vector<uint8_t>& rawKey)
@@ -51,7 +51,7 @@ ExceptionOr<Vector<uint8_t>> RTCRtpSFrameTransformer::computeAuthenticationKey(c
     if (key.hasException())
         return key;
 
-    return deriveHDKFSHA256Bits(key.returnValue().subspan(0, 16), "SFrame10 AES CM AEAD"_span8, "auth"_span8, 256);
+    return deriveHDKFSHA256Bits(key.returnValue().subspan(0, 16), byteCast<uint8_t>("SFrame10 AES CM AEAD"_span), byteCast<uint8_t>("auth"_span), 256);
 }
 
 ExceptionOr<Vector<uint8_t>> RTCRtpSFrameTransformer::computeEncryptionKey(const Vector<uint8_t>& rawKey)
@@ -60,7 +60,7 @@ ExceptionOr<Vector<uint8_t>> RTCRtpSFrameTransformer::computeEncryptionKey(const
     if (key.hasException())
         return key;
 
-    return deriveHDKFSHA256Bits(key.returnValue().subspan(0, 16), "SFrame10 AES CM AEAD"_span8, "enc"_span8, 128);
+    return deriveHDKFSHA256Bits(key.returnValue().subspan(0, 16), byteCast<uint8_t>("SFrame10 AES CM AEAD"_span), byteCast<uint8_t>("enc"_span), 128);
 }
 
 ExceptionOr<Vector<uint8_t>> RTCRtpSFrameTransformer::decryptData(std::span<const uint8_t> data, const Vector<uint8_t>& iv, const Vector<uint8_t>& key)

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerDtlsTransportBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerDtlsTransportBackend.cpp
@@ -82,12 +82,10 @@ void GStreamerDtlsTransportBackendObserver::stateChanged()
             GUniqueOutPtr<char> remoteCertificate;
             GUniqueOutPtr<char> certificate;
             g_object_get(m_backend.get(), "remote-certificate", &remoteCertificate.outPtr(), "certificate", &certificate.outPtr(), nullptr);
-
             if (remoteCertificate)
-                certificates.append(JSC::ArrayBuffer::create(unsafeSpan8(remoteCertificate.get())));
-
+                certificates.append(JSC::ArrayBuffer::create(byteCast<uint8_t>(unsafeSpan(remoteCertificate.get()))));
             if (certificate)
-                certificates.append(JSC::ArrayBuffer::create(unsafeSpan8(certificate.get())));
+                certificates.append(JSC::ArrayBuffer::create(byteCast<uint8_t>(unsafeSpan(certificate.get()))));
         }
         m_client->onStateChanged(toRTCDtlsTransportState(state), WTFMove(certificates));
     });

--- a/Source/WebCore/Modules/push-api/PushMessageCrypto.cpp
+++ b/Source/WebCore/Modules/push-api/PushMessageCrypto.cpp
@@ -152,7 +152,7 @@ std::optional<Vector<uint8_t>> decryptAES128GCMPayload(const ClientKeys& clientK
      * CEK = HMAC-SHA-256(PRK, cek_info || 0x01)[0..15]
      */
     static const auto cekInfo = "Content-Encoding: aes128gcm\x00\x01"_span8;
-    auto cek = hmacSHA256(prk, cekInfo);
+    auto cek = hmacSHA256(prk, byteCast<uint8_t>(cekInfo));
     cek.shrink(16);
 
     /*
@@ -161,7 +161,7 @@ std::optional<Vector<uint8_t>> decryptAES128GCMPayload(const ClientKeys& clientK
      * NONCE = HMAC-SHA-256(PRK, nonce_info || 0x01)[0..11]
      */
     static const auto nonceInfo = "Content-Encoding: nonce\x00\x01"_span8;
-    auto nonce = hmacSHA256(prk, nonceInfo);
+    auto nonce = hmacSHA256(prk, byteCast<uint8_t>(nonceInfo));
     nonce.shrink(12);
 
     // Finally, decrypt with AES128GCM and return the unpadded plaintext.
@@ -238,7 +238,7 @@ std::optional<Vector<uint8_t>> decryptAESGCMPayload(const ClientKeys& clientKeys
      */
     static const auto authInfo = "Content-Encoding: auth\x00\x01"_span8;
     auto prkCombine = hmacSHA256(clientKeys.sharedAuthSecret, *ecdhSecretResult);
-    auto ikm = hmacSHA256(prkCombine, authInfo);
+    auto ikm = hmacSHA256(prkCombine, byteCast<uint8_t>(authInfo));
     auto prk = hmacSHA256(salt, ikm);
 
     /*

--- a/Source/WebCore/Modules/websockets/WebSocketHandshake.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocketHandshake.cpp
@@ -87,9 +87,10 @@ static String hostName(const URL& url, bool secure)
 static constexpr size_t maxInputSampleSize = 128;
 static String trimInputSample(std::span<const uint8_t> input)
 {
+    // FIXME: Unclear why this is Latin-1 and not UTF-8.
     if (input.size() <= maxInputSampleSize)
-        return input;
-    return makeString(input.first(maxInputSampleSize), horizontalEllipsis);
+        return byteCast<Latin1Character>(input);
+    return makeString(byteCast<Latin1Character>(input.first(maxInputSampleSize)), horizontalEllipsis);
 }
 
 static String generateSecWebSocketKey()
@@ -412,24 +413,24 @@ int WebSocketHandshake::readStatusLine(std::span<const uint8_t> header, int& sta
         return lineLength;
     }
 
-    StringView httpStatusLine(header.first(*firstSpaceIndex));
+    StringView httpStatusLine(byteCast<Latin1Character>(header.first(*firstSpaceIndex)));
     if (!headerHasValidHTTPVersion(httpStatusLine)) {
         m_failureReason = makeString("Invalid HTTP version string: "_s, httpStatusLine);
         return lineLength;
     }
 
-    StringView statusCodeString(header.subspan(*firstSpaceIndex + 1, *secondSpaceIndex - *firstSpaceIndex - 1));
-    if (statusCodeString.length() != 3) // Status code must consist of three digits.
+    auto statusCodeString = byteCast<Latin1Character>(header.subspan(*firstSpaceIndex + 1, *secondSpaceIndex - *firstSpaceIndex - 1));
+    if (statusCodeString.size() != 3) // Status code must consist of three digits.
         return lineLength;
-    for (int i = 0; i < 3; ++i) {
-        if (!isASCIIDigit(statusCodeString[i])) {
+    for (auto digit : statusCodeString) {
+        if (!isASCIIDigit(digit)) {
             m_failureReason = makeString("Invalid status code: "_s, statusCodeString);
             return lineLength;
         }
     }
 
     statusCode = parseInteger<int>(statusCodeString).value();
-    statusText = String(header.subspan(*secondSpaceIndex + 1, index - *secondSpaceIndex - 3)); // Exclude "\r\n".
+    statusText = String(byteCast<Latin1Character>(header.subspan(*secondSpaceIndex + 1, index - *secondSpaceIndex - 3))); // Exclude "\r\n".
     return lineLength;
 }
 

--- a/Source/WebCore/bindings/js/ScriptBufferSourceProvider.h
+++ b/Source/WebCore/bindings/js/ScriptBufferSourceProvider.h
@@ -112,7 +112,7 @@ private:
                 m_scriptHash = StringHasher::computeHashAndMaskTop8Bits(m_contiguousBuffer->span());
         }
         if (*m_containsOnlyASCII)
-            return m_contiguousBuffer->span();
+            return byteCast<Latin1Character>(m_contiguousBuffer->span());
 
         if (!m_cachedScriptString) {
             m_cachedScriptString = m_scriptBuffer.toString();

--- a/Source/WebCore/bindings/js/SerializedScriptValue.cpp
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.cpp
@@ -3598,9 +3598,9 @@ private:
             if (span.size() < length)
                 return false;
             if (shouldAtomize == ShouldAtomize::Yes)
-                str = AtomString(consumeSpan(span, length));
+                str = AtomString(byteCast<Latin1Character>(consumeSpan(span, length)));
             else
-                str = String(consumeSpan(span, length));
+                str = String(byteCast<Latin1Character>(consumeSpan(span, length)));
             return true;
         }
 

--- a/Source/WebCore/contentextensions/DFABytecodeInterpreter.cpp
+++ b/Source/WebCore/contentextensions/DFABytecodeInterpreter.cpp
@@ -211,7 +211,7 @@ inline void DFABytecodeInterpreter::interpretJumpTable(std::span<const Latin1Cha
 {
     DFABytecodeJumpSize jumpSize = getJumpSize(m_bytecode, programCounter);
 
-    char c = urlIndex < url.size() ? url[urlIndex] : 0;
+    char c = urlIndex < url.size() ? byteCast<char>(url[urlIndex]) : 0;
     char character = caseSensitive ? c : toASCIILower(c);
     uint8_t firstCharacter = getBits<uint8_t>(m_bytecode, programCounter + sizeof(DFABytecodeInstruction));
     uint8_t lastCharacter = getBits<uint8_t>(m_bytecode, programCounter + sizeof(DFABytecodeInstruction) + sizeof(uint8_t));
@@ -304,7 +304,7 @@ auto DFABytecodeInterpreter::interpret(const String& urlString, ResourceFlags fl
                     goto nextDFA;
 
                 // Check to see if the next character in the url is the value stored with the bytecode.
-                char character = urlIndex < url.size() ? url[urlIndex] : 0;
+                char character = urlIndex < url.size() ? byteCast<char>(url[urlIndex]) : 0;
                 DFABytecodeJumpSize jumpSize = getJumpSize(m_bytecode, programCounter);
                 if (character == getBits<uint8_t>(m_bytecode, programCounter + sizeof(DFABytecodeInstruction))) {
                     uint32_t jumpLocation = programCounter + sizeof(DFABytecodeInstruction) + sizeof(uint8_t);
@@ -320,7 +320,7 @@ auto DFABytecodeInterpreter::interpret(const String& urlString, ResourceFlags fl
                     goto nextDFA;
 
                 // Check to see if the next character in the url is the value stored with the bytecode.
-                char character = urlIndex < url.size() ? toASCIILower(url[urlIndex]) : 0;
+                char character = urlIndex < url.size() ? byteCast<char>(toASCIILower(url[urlIndex])) : 0;
                 DFABytecodeJumpSize jumpSize = getJumpSize(m_bytecode, programCounter);
                 if (character == getBits<uint8_t>(m_bytecode, programCounter + sizeof(DFABytecodeInstruction))) {
                     uint32_t jumpLocation = programCounter + sizeof(DFABytecodeInstruction) + sizeof(uint8_t);
@@ -348,7 +348,7 @@ auto DFABytecodeInterpreter::interpret(const String& urlString, ResourceFlags fl
                 if (urlIndex > url.size())
                     goto nextDFA;
                 
-                char character = urlIndex < url.size() ? url[urlIndex] : 0;
+                char character = urlIndex < url.size() ? byteCast<char>(url[urlIndex]) : 0;
                 DFABytecodeJumpSize jumpSize = getJumpSize(m_bytecode, programCounter);
                 if (character >= getBits<uint8_t>(m_bytecode, programCounter + sizeof(DFABytecodeInstruction))
                     && character <= getBits<uint8_t>(m_bytecode, programCounter + sizeof(DFABytecodeInstruction) + sizeof(uint8_t))) {
@@ -364,7 +364,7 @@ auto DFABytecodeInterpreter::interpret(const String& urlString, ResourceFlags fl
                 if (urlIndex > url.size())
                     goto nextDFA;
                 
-                char character = urlIndex < url.size() ? toASCIILower(url[urlIndex]) : 0;
+                char character = urlIndex < url.size() ? byteCast<char>(toASCIILower(url[urlIndex])) : 0;
                 DFABytecodeJumpSize jumpSize = getJumpSize(m_bytecode, programCounter);
                 if (character >= getBits<uint8_t>(m_bytecode, programCounter + sizeof(DFABytecodeInstruction))
                     && character <= getBits<uint8_t>(m_bytecode, programCounter + sizeof(DFABytecodeInstruction) + sizeof(uint8_t))) {

--- a/Source/WebCore/crypto/SubtleCrypto.cpp
+++ b/Source/WebCore/crypto/SubtleCrypto.cpp
@@ -1235,9 +1235,8 @@ void SubtleCrypto::unwrapKey(JSC::JSGlobalObject& state, KeyFormat format, Buffe
             auto& vm = state.vm();
             auto scope = DECLARE_THROW_SCOPE(vm);
 
-            String jwkString(bytes.span());
             JSLockHolder locker(vm);
-            auto jwkObject = JSONParse(&state, jwkString);
+            auto jwkObject = JSONParse(&state, byteCast<Latin1Character>(bytes.span()));
             if (!jwkObject) {
                 promise->reject(ExceptionCode::DataError, "WrappedKey cannot be converted to a JSON object"_s);
                 return;

--- a/Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm
+++ b/Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm
@@ -387,7 +387,7 @@ static void replaceRichContentWithAttachments(LocalFrame& frame, DocumentFragmen
         // See `HTMLConverter.mm` for more details.
         if (info.fileName.startsWith(WebContentReader::placeholderAttachmentFilenamePrefix)) {
             RefPtr document = frame.document();
-            if (RefPtr existingAttachment = document->attachmentForIdentifier({ info.data->span() })) {
+            if (RefPtr existingAttachment = document->attachmentForIdentifier({ byteCast<Latin1Character>(info.data->span()) })) {
                 parent->replaceChild(*existingAttachment.get(), WTFMove(originalElement));
                 continue;
             }

--- a/Source/WebCore/fileapi/FileReaderLoader.cpp
+++ b/Source/WebCore/fileapi/FileReaderLoader.cpp
@@ -333,7 +333,7 @@ String FileReaderLoader::stringResult()
         // No conversion is needed.
         break;
     case ReadAsBinaryString:
-        m_stringResult = protectedRawData()->span().first(m_bytesLoaded);
+        m_stringResult = byteCast<Latin1Character>(protectedRawData()->span().first(m_bytesLoaded));
         break;
     case ReadAsText:
         convertToText();

--- a/Source/WebCore/html/FTPDirectoryDocument.cpp
+++ b/Source/WebCore/html/FTPDirectoryDocument.cpp
@@ -294,7 +294,7 @@ bool FTPDirectoryDocumentParser::loadDocumentTemplate()
         return false;
     }
 
-    HTMLDocumentParser::insert(String(templateDocumentData.get()->span()));
+    HTMLDocumentParser::insert(String(byteCast<Latin1Character>(templateDocumentData.get()->span())));
 
     Ref document = *this->document();
 

--- a/Source/WebCore/html/parser/HTMLEntityParser.cpp
+++ b/Source/WebCore/html/parser/HTMLEntityParser.cpp
@@ -123,7 +123,7 @@ public:
     explicit StringParsingBufferSource(StringParsingBuffer<CharacterType>&);
 
     static bool isEmpty() { return false; }
-    char16_t currentCharacter() const { return m_source.atEnd() ? 0 : *m_source; }
+    char16_t currentCharacter() const { return m_source.atEnd() ? 0 : char16_t { *m_source }; }
     void advance() { m_source.advance(); }
     void pushEverythingBack() { m_source.setPosition(m_startPosition); }
     void pushBackButKeep(unsigned keepCount) { m_source.setPosition(m_startPosition.subspan(keepCount)); }

--- a/Source/WebCore/html/track/VTTScanner.h
+++ b/Source/WebCore/html/track/VTTScanner.h
@@ -240,7 +240,7 @@ inline void VTTScanner::seekTo(Position position)
 
 inline char16_t VTTScanner::currentChar() const
 {
-    return m_is8Bit ? m_data.characters8.front() : m_data.characters16.front();
+    return m_is8Bit ? char16_t { m_data.characters8.front() } : m_data.characters16.front();
 }
 
 inline void VTTScanner::advance(size_t amount)

--- a/Source/WebCore/html/track/WebVTTParser.cpp
+++ b/Source/WebCore/html/track/WebVTTParser.cpp
@@ -236,7 +236,7 @@ void WebVTTParser::parse()
 void WebVTTParser::fileFinished()
 {
     ASSERT(m_state != Finished);
-    parseBytes("\n\n"_span8);
+    parseBytes(byteCast<uint8_t>("\n\n"_span));
     m_state = Finished;
 }
 

--- a/Source/WebCore/loader/FTPDirectoryParser.cpp
+++ b/Source/WebCore/loader/FTPDirectoryParser.cpp
@@ -830,7 +830,7 @@ FTPEntryType parseOneFTPLine(std::span<Latin1Character> line, ListState& state, 
                         }
                     }
                 } else if ((toklen[0] == 10 || toklen[0] == 11)
-                    && WTF::contains("-bcdlpsw?DFam"_span, tokens[0][0])) {
+                    && WTF::contains(byteCast<Latin1Character>("-bcdlpsw?DFam"_span), tokens[0][0])) {
                     p = tokens[0].subspan(1);
                     if ((p[0] == 'r' || p[0] == '-') && (p[1] == 'w' || p[1] == '-') && (p[3] == 'r' || p[3] == '-') && (p[4] == 'w' || p[4] == '-') && (p[6] == 'r' || p[6] == '-') && (p[7] == 'w' || p[7] == '-')) {
                     /* 'x'/p[9] can be S|s|x|-|T|t or implementation specific */

--- a/Source/WebCore/loader/FormSubmission.cpp
+++ b/Source/WebCore/loader/FormSubmission.cpp
@@ -78,7 +78,7 @@ static void appendMailtoPostFormDataToURL(URL& url, const FormData& data, const 
 
     Vector<uint8_t> bodyData("body="_span);
     FormDataBuilder::encodeStringAsFormData(bodyData, body.utf8());
-    body = makeStringByReplacingAll(bodyData.span(), '+', "%20"_s);
+    body = makeStringByReplacingAll(byteCast<Latin1Character>(bodyData.span()), '+', "%20"_s);
 
     auto query = url.query();
     if (query.isEmpty())
@@ -224,7 +224,7 @@ Ref<FormSubmission> FormSubmission::create(HTMLFormElement& form, HTMLFormContro
 
     if (isMultiPartForm) {
         formData = FormData::createMultiPart(domFormData);
-        boundary = String(formData->boundary());
+        boundary = String(byteCast<Latin1Character>(formData->boundary().span()));
     } else {
         formData = FormData::create(domFormData, attributes.method() == Method::Get ? FormData::EncodingType::FormURLEncoded : FormData::parseEncodingType(encodingType));
         if (copiedAttributes.method() == Method::Post && isMailtoForm) {

--- a/Source/WebCore/loader/TextResourceDecoder.cpp
+++ b/Source/WebCore/loader/TextResourceDecoder.cpp
@@ -345,7 +345,7 @@ bool TextResourceDecoder::hasEqualEncodingForCharset(const String& charset) cons
 // Returns the position of the encoding string.
 static size_t findXMLEncoding(std::span<const uint8_t> string, size_t& encodingLength)
 {
-    size_t position = find(string, "encoding"_span8);
+    size_t position = find(string, byteCast<uint8_t>("encoding"_span));
     if (position == notFound)
         return notFound;
     position += 8;
@@ -442,7 +442,7 @@ bool TextResourceDecoder::checkForCSSCharset(std::span<const uint8_t> data, bool
 
     data = m_buffer.span();
 
-    if (skipCharactersExactly(data, "@charset \""_span8)) {
+    if (skipCharactersExactly(data, byteCast<uint8_t>("@charset \""_span))) {
         size_t index = 0;
         while (index < data.size() && data[index] != '"')
             ++index;
@@ -450,8 +450,8 @@ bool TextResourceDecoder::checkForCSSCharset(std::span<const uint8_t> data, bool
         if (index == data.size())
             return false;
 
-        auto encodingName = data.first(index);
-        
+        auto encodingName = byteCast<Latin1Character>(data.first(index));
+
         ++index;
         if (index == data.size())
             return false;
@@ -492,9 +492,9 @@ bool TextResourceDecoder::checkForHeadCharset(std::span<const uint8_t> data, boo
 
     // Handle XML declaration, which can have encoding in it. This encoding is honored even for HTML documents.
     // It is an error for an XML declaration not to be at the start of an XML document, and it is ignored in HTML documents in such case.
-    static constexpr std::array<uint8_t, 5> xmlPrefix { '<', '?', 'x', 'm', 'l' };
-    static constexpr std::array<uint8_t, 6> xmlPrefixLittleEndian { '<', 0, '?', 0, 'x', 0 };
-    static constexpr std::array<uint8_t, 6> xmlPrefixBigEndian { 0, '<', 0, '?', 0, 'x' };
+    static constexpr std::array<Latin1Character, 5> xmlPrefix { '<', '?', 'x', 'm', 'l' };
+    static constexpr std::array<Latin1Character, 6> xmlPrefixLittleEndian { '<', 0, '?', 0, 'x', 0 };
+    static constexpr std::array<Latin1Character, 6> xmlPrefixBigEndian { 0, '<', 0, '?', 0, 'x' };
     if (spanHasPrefix(bufferData, std::span { xmlPrefix })) {
         auto xmlDeclarationEnd = bufferData;
         skipUntil(xmlDeclarationEnd, '>');
@@ -504,7 +504,7 @@ bool TextResourceDecoder::checkForHeadCharset(std::span<const uint8_t> data, boo
         size_t length = 0;
         size_t position = findXMLEncoding(bufferData.first(xmlDeclarationEnd.data() - bufferData.data()), length);
         if (position != notFound)
-            setEncoding(findTextEncoding(bufferData.subspan(position, length)), EncodingFromXMLHeader);
+            setEncoding(findTextEncoding(byteCast<Latin1Character>(bufferData.subspan(position, length))), EncodingFromXMLHeader);
         // continue looking for a charset - it may be specified in an HTTP-Equiv meta
     } else if (spanHasPrefix(bufferData, std::span { xmlPrefixLittleEndian })) {
         setEncoding(PAL::UTF16LittleEndianEncoding(), AutoDetectedEncoding);

--- a/Source/WebCore/loader/cache/CachedScript.cpp
+++ b/Source/WebCore/loader/cache/CachedScript.cpp
@@ -89,7 +89,7 @@ StringView CachedScript::script(ShouldDecodeAsUTF8Only shouldDecodeAsUTF8Only)
     }
 
     if (m_decodingState == DataAndDecodedStringHaveSameBytes)
-        return { contiguousData->span() };
+        return { byteCast<Latin1Character>(contiguousData->span()) };
 
     bool shouldForceRedecoding = m_wasForceDecodedAsUTF8 != (shouldDecodeAsUTF8Only == ShouldDecodeAsUTF8Only::Yes);
     if (!m_script || shouldForceRedecoding) {
@@ -136,7 +136,7 @@ JSC::CodeBlockHash CachedScript::codeBlockHashConcurrently(int startOffset, int 
         Ref contiguousData = downcast<SharedBuffer>(*data);
 
         if (PAL::TextEncoding(encoding()).isByteBasedEncoding() && contiguousData->size() && charactersAreAllASCII(contiguousData->span())) {
-            StringView entireSource { contiguousData->span() };
+            StringView entireSource { byteCast<Latin1Character>(contiguousData->span()) };
             return JSC::CodeBlockHash { entireSource.substring(startOffset, endOffset - startOffset), entireSource, kind };
         }
 
@@ -154,7 +154,7 @@ JSC::CodeBlockHash CachedScript::codeBlockHashConcurrently(int startOffset, int 
         return JSC::CodeBlockHash { entireSource.substring(startOffset, endOffset - startOffset), entireSource, kind };
     }
     case DataAndDecodedStringHaveSameBytes: {
-        StringView entireSource { downcast<SharedBuffer>(*data).span() };
+        StringView entireSource { byteCast<Latin1Character>(downcast<SharedBuffer>(*data).span()) };
         return JSC::CodeBlockHash { entireSource.substring(startOffset, endOffset - startOffset), entireSource, kind };
     }
 

--- a/Source/WebCore/platform/encryptedmedia/CDMUtilities.cpp
+++ b/Source/WebCore/platform/encryptedmedia/CDMUtilities.cpp
@@ -45,17 +45,15 @@ RefPtr<JSON::Object> parseJSONObject(const SharedBuffer& buffer)
         return nullptr;
 
     // Parse the buffer contents as JSON, returning the root object (if any).
-    String json { buffer.span() };
-
-    auto value = JSON::Value::parseJSON(json);
+    auto value = JSON::Value::parseJSON(byteCast<Latin1Character>(buffer.span()));
     if (!value)
         return nullptr;
 
     return value->asObject();
 }
 
-};
+}
 
-};
+}
 
 #endif // ENABLE(ENCRYPTED_MEDIA)

--- a/Source/WebCore/platform/graphics/avfoundation/CDMFairPlayStreaming.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/CDMFairPlayStreaming.cpp
@@ -96,9 +96,8 @@ static Vector<Ref<SharedBuffer>> extractSinfData(const SharedBuffer& buffer)
     // JSON of the format: "{ sinf: [ <base64-encoded-string> ] }"
     if (buffer.size() > std::numeric_limits<unsigned>::max())
         return { };
-    String json { buffer.makeContiguous()->span() };
 
-    auto value = JSON::Value::parseJSON(json);
+    auto value = JSON::Value::parseJSON(byteCast<Latin1Character>(buffer.makeContiguous()->span()));
     if (!value)
         return { };
 
@@ -218,9 +217,8 @@ std::optional<Vector<Ref<SharedBuffer>>> CDMPrivateFairPlayStreaming::extractKey
     // JSON of the format: "{ "codc" : [integer],  "mtyp" : [integer],  "cont" : "mpts"} }"
     if (buffer.size() > std::numeric_limits<unsigned>::max())
         return { };
-    String json { buffer.makeContiguous()->span() };
 
-    auto value = JSON::Value::parseJSON(json);
+    auto value = JSON::Value::parseJSON(byteCast<Latin1Character>(buffer.makeContiguous()->span()));
     if (!value)
         return { };
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
@@ -338,7 +338,7 @@ static RefPtr<JSON::Value> parseJSONValue(const SharedBuffer& buffer)
         return nullptr;
 
     // Parse the buffer contents as JSON, returning the root object (if any).
-    return JSON::Value::parseJSON(buffer.makeContiguous()->span());
+    return JSON::Value::parseJSON(byteCast<Latin1Character>(buffer.makeContiguous()->span()));
 }
 
 bool CDMInstanceFairPlayStreamingAVFObjC::supportsPersistableState()

--- a/Source/WebCore/platform/graphics/freetype/FontCacheFreeType.cpp
+++ b/Source/WebCore/platform/graphics/freetype/FontCacheFreeType.cpp
@@ -496,7 +496,7 @@ static String fontNameMapName(FT_Face face, unsigned id)
         switch (name.platform_id) {
         case TT_PLATFORM_MACINTOSH:
             if (name.encoding_id == TT_MAC_ID_ROMAN)
-                return String({ name.string, name.string_len });
+                return String({ byteCast<Latin1Character>(name.string), name.string_len });
             // FIXME: implement other macintosh encodings.
             break;
         case TT_PLATFORM_APPLE_UNICODE:

--- a/Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.cpp
@@ -330,7 +330,7 @@ public:
         unsigned offset = 0u;
         if (buffer->size() >= 7) {
             auto data = buffer->read(0, 7);
-            StringView dataString(data.span());
+            StringView dataString(byteCast<Latin1Character>(data.span()));
             if (dataString.endsWith(":Type:"_s)) {
                 m_type.emplace(static_cast<WebCore::MediaKeyMessageType>(dataString.characterAt(0) - '0'));
                 offset = 7;
@@ -631,7 +631,7 @@ void CDMInstanceSessionThunder::loadSession(LicenseType, const String& sessionID
                 callback(std::nullopt, std::nullopt, std::nullopt, SuccessValue::Failed, sessionLoadFailureFromThunder({ }));
             else {
                 auto responseData = responseMessage->extractData();
-                StringView response(responseData.span());
+                StringView response(byteCast<Latin1Character>(responseData.span()));
                 GST_DEBUG("Error message: %s", response.utf8().data());
                 callback(std::nullopt, std::nullopt, std::nullopt, SuccessValue::Failed, sessionLoadFailureFromThunder(response));
             }

--- a/Source/WebCore/platform/gstreamer/GStreamerElementHarness.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerElementHarness.cpp
@@ -683,7 +683,7 @@ String MermaidBuilder::describeCaps(const GRefPtr<GstCaps>& caps)
 
 std::span<const uint8_t> MermaidBuilder::span() const
 {
-    return m_stringBuilder.span<uint8_t>();
+    return byteCast<uint8_t>(m_stringBuilder.span8());
 }
 #endif
 

--- a/Source/WebCore/platform/image-decoders/png/PNGImageDecoder.cpp
+++ b/Source/WebCore/platform/image-decoders/png/PNGImageDecoder.cpp
@@ -83,7 +83,7 @@ static void PNGAPI decodingWarning(png_structp png, png_const_charp warningMsg)
     // Mozilla did this, so we will too.
     // Convert a tRNS warning to be an error (see
     // http://bugzilla.mozilla.org/show_bug.cgi?id=251381 )
-    if (spanHasPrefix(unsafeSpan(warningMsg), "Missing PLTE before tRNS"_span))
+    if (spanHasPrefix(unsafeSpan(byteCast<char>(warningMsg)), "Missing PLTE before tRNS"_span))
         png_error(png, warningMsg);
 }
 
@@ -565,7 +565,7 @@ void PNGImageDecoder::decode(bool onlySize, unsigned haltAtFrame, bool allDataRe
 
 void PNGImageDecoder::readChunks(png_unknown_chunkp chunk)
 {
-    if (chunk->size == 8 && spanHasPrefix(unsafeSpan(chunk->name), "acTL"_span)) {
+    if (chunk->size == 8 && spanHasPrefix(byteCast<char>(std::span { chunk->name }), "acTL"_span)) {
         if (m_hasInfo || m_isAnimated)
             return;
 
@@ -585,7 +585,7 @@ void PNGImageDecoder::readChunks(png_unknown_chunkp chunk)
             return;
 
         m_frameBufferCache.resize(m_frameCount);
-    } else if (chunk->size == 26 && spanHasPrefix(unsafeSpan(chunk->name), "fcTL"_span)) {
+    } else if (chunk->size == 26 && spanHasPrefix(byteCast<char>(std::span { chunk->name }), "fcTL"_span)) {
         if (m_hasInfo && !m_isAnimated)
             return;
 
@@ -652,7 +652,7 @@ void PNGImageDecoder::readChunks(png_unknown_chunkp chunk)
             fallbackNotAnimated();
             return;
         }
-    } else if (chunk->size >= 4 && spanHasPrefix(unsafeSpan(chunk->name), "fdAT"_span)) {
+    } else if (chunk->size >= 4 && spanHasPrefix(byteCast<char>(std::span { chunk->name }), "fdAT"_span)) {
         if (!m_frameInfo || !m_isAnimated)
             return;
 

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateMock.cpp
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateMock.cpp
@@ -98,9 +98,8 @@ void MediaRecorderPrivateMock::fetchData(FetchDataCallback&& completionHandler)
     RefPtr<FragmentedSharedBuffer> buffer;
     {
         Locker locker { m_bufferLock };
-        Vector<uint8_t> value(m_buffer.span<uint8_t>());
+        buffer = SharedBuffer::create(byteCast<uint8_t>(m_buffer.span<Latin1Character>()));
         m_buffer.clear();
-        buffer = SharedBuffer::create(WTFMove(value));
     }
 
     // Delay calling the completion handler a bit to mimick real writer behavior.

--- a/Source/WebCore/platform/network/curl/OpenSSLHelper.cpp
+++ b/Source/WebCore/platform/network/curl/OpenSSLHelper.cpp
@@ -135,7 +135,7 @@ public:
         if (length < 0)
             return String();
 
-        return String({ data, static_cast<size_t>(length) });
+        return String({ byteCast<Latin1Character>(data), static_cast<size_t>(length) });
     }
 
     std::unique_ptr<X509, deleter<X509>> readX509()
@@ -191,7 +191,7 @@ static String toString(const ASN1_STRING* name)
     if (length <= 0)
         return String();
 
-    String result({ data, static_cast<size_t>(length) });
+    String result({ byteCast<Latin1Character>(data), static_cast<size_t>(length) });
     OPENSSL_free(data);
     return result;
 }

--- a/Source/WebCore/platform/network/soup/CertificateInfoSoup.cpp
+++ b/Source/WebCore/platform/network/soup/CertificateInfoSoup.cpp
@@ -118,7 +118,7 @@ std::optional<CertificateSummary> CertificateInfo::summary() const
     if (subjectName)
         summaryInfo.subject = String::fromUTF8(subjectName.get());
     for (auto dnsName : span<GBytes*>(dnsNames))
-        summaryInfo.dnsNames.append(String(span(dnsName)));
+        summaryInfo.dnsNames.append(String(byteCast<Latin1Character>(span(dnsName))));
     for (auto address : span<GInetAddress*>(ipAddresses)) {
         GUniquePtr<char> ipAddress(g_inet_address_to_string(address));
         summaryInfo.ipAddresses.append(String::fromUTF8(ipAddress.get()));

--- a/Source/WebCore/platform/text/SegmentedString.h
+++ b/Source/WebCore/platform/text/SegmentedString.h
@@ -183,7 +183,7 @@ inline unsigned SegmentedString::Substring::numberOfCharactersConsumed() const
 ALWAYS_INLINE char16_t SegmentedString::Substring::currentCharacter() const
 {
     ASSERT(length());
-    return is8Bit ? s.currentCharacter8.front() : s.currentCharacter16.front();
+    return is8Bit ? char16_t { s.currentCharacter8.front() } : s.currentCharacter16.front();
 }
 
 ALWAYS_INLINE char16_t SegmentedString::Substring::currentCharacterPreIncrement()

--- a/Source/WebCore/testing/MockCDMFactory.cpp
+++ b/Source/WebCore/testing/MockCDMFactory.cpp
@@ -231,7 +231,7 @@ RefPtr<SharedBuffer> MockCDM::sanitizeResponse(const SharedBuffer& response) con
     if (!charactersAreAllASCII(contiguousResponse->span()))
         return nullptr;
 
-    for (auto word : StringView(contiguousResponse->span()).split(' ')) {
+    for (auto word : StringView(byteCast<Latin1Character>(contiguousResponse->span())).split(' ')) {
         if (word == "valid-response"_s)
             return contiguousResponse;
     }
@@ -287,7 +287,7 @@ void MockCDMInstance::initializeWithConfiguration(const MediaKeySystemConfigurat
 void MockCDMInstance::setServerCertificate(Ref<SharedBuffer>&& certificate, SuccessCallback&& callback)
 {
     Ref contiguousData = certificate->makeContiguous();
-    callback(equalLettersIgnoringASCIICase(StringView { contiguousData->span() }, "valid"_s) ? CDMInstanceSuccessValue::Succeeded : CDMInstanceSuccessValue::Failed);
+    callback(equalLettersIgnoringASCIICase(StringView { byteCast<Latin1Character>(contiguousData->span()) }, "valid"_s) ? CDMInstanceSuccessValue::Succeeded : CDMInstanceSuccessValue::Failed);
 }
 
 void MockCDMInstance::setStorageDirectory(const String&)
@@ -345,7 +345,7 @@ void MockCDMInstanceSession::updateLicense(const String& sessionID, LicenseType,
         return;
     }
 
-    Vector<String> responseVector = String(response->makeContiguous()->span()).split(' ');
+    Vector<String> responseVector = String(byteCast<Latin1Character>(response->makeContiguous()->span())).split(' ');
 
     if (responseVector.contains(String("invalid-format"_s))) {
         callback(false, std::nullopt, std::nullopt, std::nullopt, SuccessValue::Failed);

--- a/Source/WebGPU/WebGPU/Pipeline.mm
+++ b/Source/WebGPU/WebGPU/Pipeline.mm
@@ -343,7 +343,7 @@ static void printToFileForPsoRepro()
     }
 
     outputURL = [outputURL URLByAppendingPathComponent:@"psoRepro.mm"];
-    if (FileSystem::overwriteEntireFile(outputURL.path, psoReproStringBuilder().span<uint8_t>()))
+    if (FileSystem::overwriteEntireFile(outputURL.path, byteCast<uint8_t>(psoReproStringBuilder().span<Latin1Character>())))
         WTFLogAlways("Sucessfully saved repro to %@", outputURL); // NOLINT
     else
         WTFLogAlways("Error saving repro to %@ - %@", outputURL, error); // NOLINT

--- a/Source/WebKit/NetworkProcess/cache/NetworkCache.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCache.cpp
@@ -670,8 +670,8 @@ void Cache::dumpContentsToFile()
     if (!fileHandle)
         return;
 
-    constexpr auto prologue = "{\n\"entries\": [\n"_s;
-    fileHandle.write(prologue.span8());
+    constexpr auto prologue = "{\n\"entries\": [\n"_span;
+    fileHandle.write(byteCast<uint8_t>(prologue));
 
     struct Totals {
         unsigned count { 0 };

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp
@@ -128,7 +128,7 @@ static std::optional<uint64_t> readSizeFile(const String& sizeDirectoryPath)
     if (!buffer)
         return std::nullopt;
 
-    return parseInteger<uint64_t>(buffer->span());
+    return parseInteger<uint64_t>(byteCast<Latin1Character>(buffer->span()));
 }
 
 static bool writeSizeFile(const String& sizeDirectoryPath, uint64_t size)

--- a/Source/WebKit/Platform/IPC/DaemonCoders.h
+++ b/Source/WebKit/Platform/IPC/DaemonCoders.h
@@ -146,7 +146,7 @@ template<> struct Coder<WTF::String> {
         encoder << string.length() << is8Bit;
 
         if (is8Bit)
-            encoder.encodeFixedLengthData(string.span8());
+            encoder.encodeFixedLengthData(byteCast<uint8_t>(string.span8()));
         else
             encoder.encodeFixedLengthData(asBytes(string.span16()));
     }

--- a/Source/WebKit/Shared/API/c/cf/WKStringCF.mm
+++ b/Source/WebKit/Shared/API/c/cf/WKStringCF.mm
@@ -61,7 +61,7 @@ CFStringRef WKStringCopyCFString(CFAllocatorRef allocatorRef, WKStringRef string
     // expects to be called on the thread running WebCore.
     if (string.is8Bit()) {
         auto characters = string.span8();
-        return CFStringCreateWithBytes(allocatorRef, characters.data(), characters.size(), kCFStringEncodingISOLatin1, true);
+        return CFStringCreateWithBytes(allocatorRef, byteCast<UInt8>(characters.data()), characters.size(), kCFStringEncodingISOLatin1, true);
     }
     auto characters = string.span16();
     return CFStringCreateWithCharacters(allocatorRef, reinterpret_cast<const UniChar*>(characters.data()), characters.size());

--- a/Source/WebKit/Shared/Cocoa/SandboxExtensionCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/SandboxExtensionCocoa.mm
@@ -45,7 +45,7 @@ std::unique_ptr<SandboxExtensionImpl> SandboxExtensionImpl::create(const char* p
 }
 
 SandboxExtensionImpl::SandboxExtensionImpl(std::span<const uint8_t> serializedFormat)
-    : m_token { serializedFormat }
+    : m_token { byteCast<Latin1Character>(serializedFormat) }
 {
     ASSERT(!serializedFormat.empty());
 }

--- a/Source/WebKit/UIProcess/API/APIContentRuleListStore.cpp
+++ b/Source/WebKit/UIProcess/API/APIContentRuleListStore.cpp
@@ -515,7 +515,7 @@ static WTF::String getContentRuleListSourceFromMappedFile(const MappedData& mapp
     size_t length = sourceSizeBytes - sizeof(bool);
 
     if (is8Bit)
-        return dataSpan.subspan(start, length);
+        return byteCast<Latin1Character>(dataSpan.subspan(start, length));
 
     if (length % sizeof(char16_t)) {
         ASSERT_NOT_REACHED();

--- a/Source/WebKit/UIProcess/API/C/WKPage.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPage.cpp
@@ -280,8 +280,8 @@ static String encodingOf(const String& string)
 static std::span<const uint8_t> dataFrom(const String& string)
 {
     if (string.isNull() || !string.is8Bit())
-        return asBytes(string.span16());
-    return string.span8();
+        return asBytes(string.span<char16_t>());
+    return asBytes(string.span<Latin1Character>());
 }
 
 static Ref<WebCore::DataSegment> dataReferenceFrom(const String& string)

--- a/Source/WebKit/UIProcess/Cocoa/WebPasteboardProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPasteboardProxyCocoa.mm
@@ -737,7 +737,7 @@ void WebPasteboardProxy::testIPCSharedMemory(IPC::Connection& connection, const 
         return;
     }
 
-    completionHandler(sharedMemoryBuffer->size(), sharedMemoryBuffer->span());
+    completionHandler(sharedMemoryBuffer->size(), byteCast<Latin1Character>(sharedMemoryBuffer->span()));
 }
 #endif
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionDeclarativeNetRequestSQLiteStore.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionDeclarativeNetRequestSQLiteStore.cpp
@@ -247,8 +247,7 @@ Ref<JSON::Array> WebExtensionDeclarativeNetRequestSQLiteStore::getKeysAndValuesF
         if (!rule)
             continue;
 
-        auto ruleObject = JSON::Value::optionalParseJSON(StringView(rule->span()));
-
+        auto ruleObject = JSON::Value::optionalParseJSON(byteCast<Latin1Character>(rule->span()));
         if (ruleObject)
             results->pushValue(ruleObject->get());
 

--- a/Source/WebKit/UIProcess/Inspector/glib/RemoteInspectorClient.cpp
+++ b/Source/WebKit/UIProcess/Inspector/glib/RemoteInspectorClient.cpp
@@ -214,7 +214,7 @@ void RemoteInspectorClient::setBackendCommands(const char* backendCommands)
         return;
     }
 
-    m_backendCommandsURL = makeString("data:text/javascript;base64,"_s, base64Encoded(unsafeSpan8(backendCommands)));
+    m_backendCommandsURL = makeString("data:text/javascript;base64,"_s, base64Encoded(byteCast<std::byte>(unsafeSpan(backendCommands))));
 }
 
 void RemoteInspectorClient::connectionDidClose()

--- a/Source/WebKit/UIProcess/Inspector/mac/RemoteWebInspectorUIProxyMac.mm
+++ b/Source/WebKit/UIProcess/Inspector/mac/RemoteWebInspectorUIProxyMac.mm
@@ -188,7 +188,7 @@ void RemoteWebInspectorUIProxy::platformSave(Vector<InspectorFrontendClient::Sav
 void RemoteWebInspectorUIProxy::platformLoad(const String& path, CompletionHandler<void(const String&)>&& completionHandler)
 {
     if (auto contents = FileSystem::readEntireFile(path))
-        completionHandler(String::adopt(WTFMove(*contents)));
+        completionHandler(String { byteCast<Latin1Character>(contents->span()) });
     else
         completionHandler(nullString());
 }

--- a/Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm
+++ b/Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm
@@ -715,7 +715,7 @@ void WebInspectorUIProxy::platformSave(Vector<InspectorFrontendClient::SaveData>
 void WebInspectorUIProxy::platformLoad(const String& path, CompletionHandler<void(const String&)>&& completionHandler)
 {
     if (auto contents = FileSystem::readEntireFile(path))
-        completionHandler(String::adopt(WTFMove(*contents)));
+        completionHandler(String { byteCast<Latin1Character>(contents->span()) });
     else
         completionHandler(nullString());
 }

--- a/Source/WebKit/UIProcess/wpe/WebPasteboardProxyWPE.cpp
+++ b/Source/WebKit/UIProcess/wpe/WebPasteboardProxyWPE.cpp
@@ -304,7 +304,7 @@ void WebPasteboardProxy::readURLFromPasteboard(IPC::Connection& connection, uint
         auto* clipboard = wpe_display_get_clipboard(wpe_display_get_primary());
         if (GRefPtr<GBytes> bytes = adoptGRef(wpe_clipboard_read_bytes(clipboard, "text/uri-list"))) {
             auto buffer = SharedBuffer::create(bytes.get());
-            completionHandler(String(buffer->span()), { });
+            completionHandler(String(byteCast<Latin1Character>(buffer->span())), { });
             return;
         }
     }

--- a/Source/WebKit/WebProcess/Network/webrtc/RTCDataChannelRemoteManager.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/RTCDataChannelRemoteManager.cpp
@@ -124,7 +124,7 @@ void RTCDataChannelRemoteManager::sendData(WebCore::RTCDataChannelIdentifier sou
         if (isRaw)
             source->sendRawData(data);
         else
-            source->sendStringData(CString(data));
+            source->sendStringData(CString(byteCast<Latin1Character>(data)));
     }
 }
 

--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -891,7 +891,7 @@ static void registerLogClient(bool isDebugLoggingEnabled, std::unique_ptr<LogCli
                 logString = logString.first(logStringMaxSize);
                 logString.back() = 0;
             }
-            logClient()->log(logChannel, logCategory, logString, type);
+            logClient()->log(byteCast<uint8_t>(logChannel), byteCast<uint8_t>(logCategory), byteCast<uint8_t>(logString), type);
             free(messageString);
         }
     }).get());

--- a/Tools/TestWebKitAPI/Tests/WTF/Base64.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/Base64.cpp
@@ -36,13 +36,13 @@ TEST(Base64, Encode)
 {
     static constexpr OptionSet<Base64EncodeOption> options;
 
-    EXPECT_ENCODE("", ""_span8);
-    EXPECT_ENCODE("Zg==", "f"_span8);
-    EXPECT_ENCODE("Zm8=", "fo"_span8);
-    EXPECT_ENCODE("Zm9v", "foo"_span8);
-    EXPECT_ENCODE("Zm9vYg==", "foob"_span8);
-    EXPECT_ENCODE("Zm9vYmE=", "fooba"_span8);
-    EXPECT_ENCODE("Zm9vYmFy", "foobar"_span8);
+    EXPECT_ENCODE("", byteCast<uint8_t>(""_span));
+    EXPECT_ENCODE("Zg==", byteCast<uint8_t>("f"_span));
+    EXPECT_ENCODE("Zm8=", byteCast<uint8_t>("fo"_span));
+    EXPECT_ENCODE("Zm9v", byteCast<uint8_t>("foo"_span));
+    EXPECT_ENCODE("Zm9vYg==", byteCast<uint8_t>("foob"_span));
+    EXPECT_ENCODE("Zm9vYmE=", byteCast<uint8_t>("fooba"_span));
+    EXPECT_ENCODE("Zm9vYmFy", byteCast<uint8_t>("foobar"_span));
 
     EXPECT_ENCODE("AA==", Vector<uint8_t>({ 0 }));
     EXPECT_ENCODE("AQ==", Vector<uint8_t>({ 1 }));
@@ -58,13 +58,13 @@ TEST(Base64, EncodeOmitPadding)
 {
     static constexpr OptionSet<Base64EncodeOption> options = { Base64EncodeOption::OmitPadding };
 
-    EXPECT_ENCODE("", ""_span8);
-    EXPECT_ENCODE("Zg", "f"_span8);
-    EXPECT_ENCODE("Zm8", "fo"_span8);
-    EXPECT_ENCODE("Zm9v", "foo"_span8);
-    EXPECT_ENCODE("Zm9vYg", "foob"_span8);
-    EXPECT_ENCODE("Zm9vYmE", "fooba"_span8);
-    EXPECT_ENCODE("Zm9vYmFy", "foobar"_span8);
+    EXPECT_ENCODE("", byteCast<uint8_t>(""_span));
+    EXPECT_ENCODE("Zg", byteCast<uint8_t>("f"_span));
+    EXPECT_ENCODE("Zm8", byteCast<uint8_t>("fo"_span));
+    EXPECT_ENCODE("Zm9v", byteCast<uint8_t>("foo"_span));
+    EXPECT_ENCODE("Zm9vYg", byteCast<uint8_t>("foob"_span));
+    EXPECT_ENCODE("Zm9vYmE", byteCast<uint8_t>("fooba"_span));
+    EXPECT_ENCODE("Zm9vYmFy", byteCast<uint8_t>("foobar"_span));
 
     EXPECT_ENCODE("AA", Vector<uint8_t>({ 0 }));
     EXPECT_ENCODE("AQ", Vector<uint8_t>({ 1 }));
@@ -80,13 +80,13 @@ TEST(Base64, EncodeURL)
 {
     static constexpr OptionSet<Base64EncodeOption> options = { Base64EncodeOption::URL };
 
-    EXPECT_ENCODE("", ""_span8);
-    EXPECT_ENCODE("Zg==", "f"_span8);
-    EXPECT_ENCODE("Zm8=", "fo"_span8);
-    EXPECT_ENCODE("Zm9v", "foo"_span8);
-    EXPECT_ENCODE("Zm9vYg==", "foob"_span8);
-    EXPECT_ENCODE("Zm9vYmE=", "fooba"_span8);
-    EXPECT_ENCODE("Zm9vYmFy", "foobar"_span8);
+    EXPECT_ENCODE("", byteCast<uint8_t>(""_span));
+    EXPECT_ENCODE("Zg==", byteCast<uint8_t>("f"_span));
+    EXPECT_ENCODE("Zm8=", byteCast<uint8_t>("fo"_span));
+    EXPECT_ENCODE("Zm9v", byteCast<uint8_t>("foo"_span));
+    EXPECT_ENCODE("Zm9vYg==", byteCast<uint8_t>("foob"_span));
+    EXPECT_ENCODE("Zm9vYmE=", byteCast<uint8_t>("fooba"_span));
+    EXPECT_ENCODE("Zm9vYmFy", byteCast<uint8_t>("foobar"_span));
 
     EXPECT_ENCODE("AA==", Vector<uint8_t>({ 0 }));
     EXPECT_ENCODE("AQ==", Vector<uint8_t>({ 1 }));
@@ -102,13 +102,13 @@ TEST(Base64, EncodeURLOmitPadding)
 {
     static constexpr OptionSet<Base64EncodeOption> options = { Base64EncodeOption::URL, Base64EncodeOption::OmitPadding };
 
-    EXPECT_ENCODE("", ""_span8);
-    EXPECT_ENCODE("Zg", "f"_span8);
-    EXPECT_ENCODE("Zm8", "fo"_span8);
-    EXPECT_ENCODE("Zm9v", "foo"_span8);
-    EXPECT_ENCODE("Zm9vYg", "foob"_span8);
-    EXPECT_ENCODE("Zm9vYmE", "fooba"_span8);
-    EXPECT_ENCODE("Zm9vYmFy", "foobar"_span8);
+    EXPECT_ENCODE("", byteCast<uint8_t>(""_span));
+    EXPECT_ENCODE("Zg", byteCast<uint8_t>("f"_span));
+    EXPECT_ENCODE("Zm8", byteCast<uint8_t>("fo"_span));
+    EXPECT_ENCODE("Zm9v", byteCast<uint8_t>("foo"_span));
+    EXPECT_ENCODE("Zm9vYg", byteCast<uint8_t>("foob"_span));
+    EXPECT_ENCODE("Zm9vYmE", byteCast<uint8_t>("fooba"_span));
+    EXPECT_ENCODE("Zm9vYmFy", byteCast<uint8_t>("foobar"_span));
 
     EXPECT_ENCODE("AA", Vector<uint8_t>({ 0 }));
     EXPECT_ENCODE("AQ", Vector<uint8_t>({ 1 }));

--- a/Tools/TestWebKitAPI/Tests/WTF/StringImpl.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StringImpl.cpp
@@ -753,12 +753,12 @@ TEST(WTF, StaticPrivateSymbolImpl)
 
 TEST(WTF, ExternalStringImplCreate8bit)
 {
-    constexpr Latin1Character buffer[] = "hello";
+    constexpr char buffer[] = "hello";
     constexpr size_t bufferStringLength = sizeof(buffer) - 1;
     bool freeFunctionCalled = false;
 
     {
-        auto external = ExternalStringImpl::create({ buffer, bufferStringLength }, [&freeFunctionCalled](ExternalStringImpl* externalStringImpl, void* buffer, unsigned bufferSize) mutable {
+        auto external = ExternalStringImpl::create({ byteCast<Latin1Character>(&buffer[0]), bufferStringLength }, [&freeFunctionCalled](ExternalStringImpl* externalStringImpl, void* buffer, unsigned bufferSize) mutable {
             freeFunctionCalled = true;
         });
 
@@ -767,7 +767,7 @@ TEST(WTF, ExternalStringImplCreate8bit)
         ASSERT_FALSE(external->isSymbol());
         ASSERT_FALSE(external->isAtom());
         ASSERT_EQ(external->length(), bufferStringLength);
-        ASSERT_EQ(external->span8().data(), buffer);
+        ASSERT_EQ(byteCast<char>(external->span8().data()), buffer);
     }
 
     ASSERT_TRUE(freeFunctionCalled);
@@ -804,12 +804,12 @@ TEST(WTF, StringImplNotExternal)
 
 TEST(WTF, ExternalStringAtom)
 {
-    constexpr Latin1Character buffer[] = "hello";
+    constexpr char buffer[] = "hello";
     constexpr size_t bufferStringLength = sizeof(buffer) - 1;
     bool freeFunctionCalled = false;
 
     {
-        auto external = ExternalStringImpl::create({ buffer, bufferStringLength }, [&freeFunctionCalled](ExternalStringImpl* externalStringImpl, void* buffer, unsigned bufferSize) mutable {
+        auto external = ExternalStringImpl::create(byteCast<Latin1Character>(std::span { buffer, bufferStringLength }), [&freeFunctionCalled](ExternalStringImpl* externalStringImpl, void* buffer, unsigned bufferSize) mutable {
             freeFunctionCalled = true;
         });    
 
@@ -818,7 +818,7 @@ TEST(WTF, ExternalStringAtom)
         ASSERT_FALSE(external->isSymbol());
         ASSERT_TRUE(external->is8Bit());
         ASSERT_EQ(external->length(), bufferStringLength);
-        ASSERT_EQ(external->span8().data(), buffer);
+        ASSERT_EQ(byteCast<char>(external->span8().data()), buffer);
 
         auto result = AtomStringImpl::lookUp(external.ptr());
         ASSERT_FALSE(result);

--- a/Tools/TestWebKitAPI/Tests/WTF/StringView.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StringView.cpp
@@ -394,10 +394,10 @@ TEST(WTF, StringViewEqualIgnoringASCIICaseWithEmpty)
 
 TEST(WTF, StringViewEqualIgnoringASCIICaseWithLatin1Characters)
 {
-    RefPtr<StringImpl> a = StringImpl::create(std::span { reinterpret_cast<const Latin1Character*>("aBcéeFG"), 7 });
-    RefPtr<StringImpl> b = StringImpl::create(std::span { reinterpret_cast<const Latin1Character*>("ABCÉEFG"), 7 });
-    RefPtr<StringImpl> c = StringImpl::create(std::span { reinterpret_cast<const Latin1Character*>("ABCéEFG"), 7 });
-    RefPtr<StringImpl> d = StringImpl::create(std::span { reinterpret_cast<const Latin1Character*>("abcéefg"), 7 });
+    RefPtr<StringImpl> a = StringImpl::create(byteCast<Latin1Character>(std::span { "aBcéeFG", 7 }));
+    RefPtr<StringImpl> b = StringImpl::create(byteCast<Latin1Character>(std::span { "ABCÉEFG", 7 }));
+    RefPtr<StringImpl> c = StringImpl::create(byteCast<Latin1Character>(std::span { "ABCéEFG", 7 }));
+    RefPtr<StringImpl> d = StringImpl::create(byteCast<Latin1Character>(std::span { "abcéefg", 7 }));
     StringView stringViewA(*a.get());
     StringView stringViewB(*b.get());
     StringView stringViewC(*c.get());

--- a/Tools/TestWebKitAPI/Tests/WTF/cocoa/URLExtras.mm
+++ b/Tools/TestWebKitAPI/Tests/WTF/cocoa/URLExtras.mm
@@ -52,7 +52,7 @@ static const char* dataAsString(NSData *data)
     if ([data length] > buffer.size() - 1)
         return "ERROR";
     auto dataSpan = span(data);
-    if (contains(dataSpan, 0))
+    if (contains(dataSpan, '\0'))
         return "ERROR";
     memcpySpan(std::span { buffer }, dataSpan);
     buffer[[data length]] = '\0';

--- a/Tools/TestWebKitAPI/Tests/WebCore/PushMessageCrypto.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/PushMessageCrypto.cpp
@@ -30,11 +30,19 @@
 #include <wtf/text/Base64.h>
 
 namespace TestWebKitAPI {
+
 using namespace WebCore::PushCrypto;
 
-static Vector<uint8_t> mustBase64URLDecode(const String& encoded)
+static Vector<uint8_t> mustBase64URLDecode(ASCIILiteral encoded)
 {
     return base64URLDecode(encoded).value();
+}
+
+static StringView stringView(const std::optional<Vector<uint8_t>>& vector)
+{
+    if (!vector)
+        return ""_s;
+    return StringView { byteCast<Latin1Character>(vector->span()) };
 }
 
 static ClientKeys makeAES128GCMClientKeys(void)
@@ -59,8 +67,7 @@ TEST(PushMessageCrypto, AES128GCMPayloadWithMinimalPadding)
     auto result = decryptAES128GCMPayload(clientKeys, payload);
     ASSERT_TRUE(result.has_value());
 
-    auto actual = String::adopt(WTFMove(*result));
-    ASSERT_EQ("When I grow up, I want to be a watermelon"_s, actual);
+    EXPECT_EQ("When I grow up, I want to be a watermelon"_s, stringView(result));
 }
 
 TEST(PushMessageCrypto, AES128GCMPayloadWithPadding)
@@ -71,8 +78,7 @@ TEST(PushMessageCrypto, AES128GCMPayloadWithPadding)
     auto result = decryptAES128GCMPayload(clientKeys, payload);
     ASSERT_TRUE(result.has_value());
 
-    auto actual = String::adopt(WTFMove(*result));
-    ASSERT_EQ("foobar"_s, actual);
+    EXPECT_EQ("foobar"_s, stringView(result));
 }
 
 TEST(PushMessageCrypto, AES128GCMPayloadWithIncorrectPadding)
@@ -118,8 +124,7 @@ TEST(PushMessageCrypto, AESGCMPayloadWithMinimalPadding)
     auto result = decryptAESGCMPayload(clientKeys, serverPublicKey, salt, payload);
     ASSERT_TRUE(result.has_value());
 
-    auto actual = String::adopt(WTFMove(*result));
-    ASSERT_EQ("I am the walrus"_s, actual);
+    EXPECT_EQ("I am the walrus"_s, stringView(result));
 }
 
 TEST(PushMessageCrypto, AESGCMPayloadWithPadding)
@@ -132,8 +137,7 @@ TEST(PushMessageCrypto, AESGCMPayloadWithPadding)
     auto result = decryptAESGCMPayload(clientKeys, serverPublicKey, salt, payload);
     ASSERT_TRUE(result.has_value());
 
-    auto actual = String::adopt(WTFMove(*result));
-    ASSERT_EQ("foobar"_s, actual);
+    EXPECT_EQ("foobar"_s, stringView(result));
 }
 
 TEST(PushMessageCrypto, AESGCMPayloadWithIncorrectPadding)

--- a/Tools/TestWebKitAPI/Tests/WebCore/SharedBuffer.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/SharedBuffer.cpp
@@ -52,7 +52,7 @@ TEST_F(FragmentedSharedBufferTest, createWithContentsOfExistingFile)
     auto buffer = SharedBuffer::createWithContentsOfFile(tempFilePath());
     ASSERT_NOT_NULL(buffer);
     EXPECT_TRUE(buffer->size() == strlen(FragmentedSharedBufferTest::testData()));
-    EXPECT_TRUE(String::fromLatin1(FragmentedSharedBufferTest::testData()) == String(buffer->makeContiguous()->span()));
+    EXPECT_TRUE(String::fromLatin1(FragmentedSharedBufferTest::testData()) == String(byteCast<Latin1Character>(buffer->makeContiguous()->span())));
 }
 
 TEST_F(FragmentedSharedBufferTest, createWithContentsOfExistingEmptyFile)
@@ -369,12 +369,12 @@ TEST_F(FragmentedSharedBufferTest, read)
     auto check = [](FragmentedSharedBuffer& sharedBuffer) {
         Vector<uint8_t> data = sharedBuffer.read(4, 3);
         EXPECT_EQ(data.size(), 3u);
-        EXPECT_EQ(StringView(data.subspan(0, 3)), " is"_s);
+        EXPECT_EQ(" is"_s, StringView(byteCast<Latin1Character>(data.subspan(0, 3))));
 
         data = sharedBuffer.read(4, 1000);
         EXPECT_EQ(data.size(), 18u);
 
-        EXPECT_EQ(StringView(data.subspan(0, 18)), " is a simple test."_s);
+        EXPECT_EQ(" is a simple test."_s, StringView(byteCast<Latin1Character>(data.subspan(0, 18))));
     };
     auto sharedBuffer = SharedBuffer::create(simpleText);
     check(sharedBuffer);
@@ -502,8 +502,8 @@ TEST_F(SharedBufferChunkReaderTest, includeSeparator)
     check(builder.take());
 
     for (size_t i = 0; i < 256; ++i) {
-        Latin1Character c = i;
-        builder.append(std::span<const uint8_t> { &c, 1 });
+        const uint8_t byte = i;
+        builder.append(std::span { &byte, 1 });
     }
     check(builder.take());
 }
@@ -522,12 +522,12 @@ TEST_F(SharedBufferChunkReaderTest, peekData)
         size_t read = chunkReader.peek(data, 3);
         EXPECT_EQ(read, 3u);
 
-        EXPECT_EQ(String(data.span().first(3)), " is"_s);
+        EXPECT_EQ(" is"_s, StringView(byteCast<Latin1Character>(data.span().first(3))));
 
         read = chunkReader.peek(data, 1000);
         EXPECT_EQ(read, 18u);
 
-        EXPECT_EQ(String(data.span().first(18)), " is a simple test."_s);
+        EXPECT_EQ(" is a simple test."_s, StringView(byteCast<Latin1Character>(data.span().first(18))));
 
         // Ensure the cursor has not changed.
         chunk = chunkReader.nextChunkAsUTF8StringWithLatin1Fallback();

--- a/Tools/TestWebKitAPI/Tests/WebCore/SharedBufferTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/SharedBufferTest.cpp
@@ -39,7 +39,7 @@ void FragmentedSharedBufferTest::SetUp()
     // create temp file
     auto result = FileSystem::openTemporaryFile("tempTestFile"_s);
     m_tempFilePath = result.first;
-    result.second.write(testData().span8());
+    result.second.write(byteCast<uint8_t>(testData().span()));
     result.second = { };
 
     m_tempEmptyFilePath = FileSystem::createTemporaryFile("tempEmptyTestFile"_s);

--- a/Tools/TestWebKitAPI/Tests/WebCore/curl/CurlMultipartHandleTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/curl/CurlMultipartHandleTests.cpp
@@ -150,7 +150,7 @@ TEST(CurlMultipartHandleTests, SimpleMessage)
     auto curlResponse = createCurlResponse();
     auto handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
 
-    handle->didReceiveMessage(data);
+    handle->didReceiveMessage(byteCast<uint8_t>(data));
     EXPECT_EQ(client.headers().size(), 1);
     EXPECT_TRUE(client.headers().at(0) == "Content-type: text/plain\r\n"_s);
     client.clear();
@@ -181,7 +181,7 @@ TEST(CurlMultipartHandleTests, NoHeader)
     auto curlResponse = createCurlResponse();
     auto handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
 
-    handle->didReceiveMessage(data);
+    handle->didReceiveMessage(byteCast<uint8_t>(data));
     EXPECT_EQ(client.headers().size(), 0);
 
     handle->completeHeaderProcessing();
@@ -203,7 +203,7 @@ TEST(CurlMultipartHandleTests, NoBody)
     auto curlResponse = createCurlResponse();
     auto handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
 
-    handle->didReceiveMessage(data);
+    handle->didReceiveMessage(byteCast<uint8_t>(data));
     EXPECT_EQ(client.headers().size(), 1);
     EXPECT_TRUE(client.headers().at(0) == "Content-type: text/plain\r\n"_s);
     client.clear();
@@ -236,7 +236,7 @@ TEST(CurlMultipartHandleTests, TransportPadding)
     auto curlResponse = createCurlResponse();
     auto handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
 
-    handle->didReceiveMessage(data);
+    handle->didReceiveMessage(byteCast<uint8_t>(data));
     EXPECT_EQ(client.headers().size(), 1);
     EXPECT_TRUE(client.headers().at(0) == "Content-type: text/plain\r\n"_s);
     client.clear();
@@ -268,7 +268,7 @@ TEST(CurlMultipartHandleTests, NoEndOfBoundary)
     auto curlResponse = createCurlResponse();
     auto handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
 
-    handle->didReceiveMessage(data);
+    handle->didReceiveMessage(byteCast<uint8_t>(data));
     EXPECT_EQ(client.headers().size(), 1);
     EXPECT_TRUE(client.headers().at(0) == "Content-type: text/plain\r\n"_s);
     client.clear();
@@ -302,7 +302,7 @@ TEST(CurlMultipartHandleTests, NoEndOfBoundaryAfterCompleted)
     auto curlResponse = createCurlResponse();
     auto handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
 
-    handle->didReceiveMessage(data);
+    handle->didReceiveMessage(byteCast<uint8_t>(data));
     EXPECT_EQ(client.headers().size(), 1);
     EXPECT_TRUE(client.headers().at(0) == "Content-type: text/plain\r\n"_s);
 
@@ -336,7 +336,7 @@ TEST(CurlMultipartHandleTests, NoCloseDelimiter)
     auto curlResponse = createCurlResponse();
     auto handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
 
-    handle->didReceiveMessage(data);
+    handle->didReceiveMessage(byteCast<uint8_t>(data));
     EXPECT_EQ(client.headers().size(), 1);
     EXPECT_TRUE(client.headers().at(0) == "Content-type: text/plain\r\n"_s);
     client.clear();
@@ -371,7 +371,7 @@ TEST(CurlMultipartHandleTests, NoCloseDelimiterAfterCompleted)
     auto curlResponse = createCurlResponse();
     auto handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
 
-    handle->didReceiveMessage(data);
+    handle->didReceiveMessage(byteCast<uint8_t>(data));
     EXPECT_EQ(client.headers().size(), 1);
     EXPECT_TRUE(client.headers().at(0) == "Content-type: text/plain\r\n"_s);
 
@@ -405,7 +405,7 @@ TEST(CurlMultipartHandleTests, CloseDelimiter)
     auto curlResponse = createCurlResponse();
     auto handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
 
-    handle->didReceiveMessage(data);
+    handle->didReceiveMessage(byteCast<uint8_t>(data));
     EXPECT_EQ(client.headers().size(), 1);
     EXPECT_TRUE(client.headers().at(0) == "Content-type: text/plain\r\n"_s);
     client.clear();
@@ -438,7 +438,7 @@ TEST(CurlMultipartHandleTests, CloseDelimiterAfterCompleted)
     auto curlResponse = createCurlResponse();
     auto handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
 
-    handle->didReceiveMessage(data);
+    handle->didReceiveMessage(byteCast<uint8_t>(data));
     EXPECT_EQ(client.headers().size(), 1);
     EXPECT_TRUE(client.headers().at(0) == "Content-type: text/plain\r\n"_s);
 
@@ -473,10 +473,10 @@ TEST(CurlMultipartHandleTests, DivideFirstDelimiter)
     auto curlResponse = createCurlResponse();
     auto handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
 
-    handle->didReceiveMessage(data);
+    handle->didReceiveMessage(byteCast<uint8_t>(data));
     EXPECT_EQ(client.headers().size(), 0);
 
-    handle->didReceiveMessage(nextData);
+    handle->didReceiveMessage(byteCast<uint8_t>(nextData));
     EXPECT_EQ(client.headers().size(), 1);
     EXPECT_TRUE(client.headers().at(0) == "Content-type: text/plain\r\n"_s);
     client.clear();
@@ -510,7 +510,7 @@ TEST(CurlMultipartHandleTests, DivideSecondDelimiter)
     auto curlResponse = createCurlResponse();
     auto handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
 
-    handle->didReceiveMessage(data);
+    handle->didReceiveMessage(byteCast<uint8_t>(data));
     EXPECT_EQ(client.headers().size(), 1);
     EXPECT_TRUE(client.headers().at(0) == "Content-type: text/plain\r\n"_s);
     client.clear();
@@ -518,7 +518,7 @@ TEST(CurlMultipartHandleTests, DivideSecondDelimiter)
     handle->completeHeaderProcessing();
     EXPECT_EQ(client.headers().size(), 0);
 
-    handle->didReceiveMessage(nextData);
+    handle->didReceiveMessage(byteCast<uint8_t>(nextData));
     EXPECT_TRUE(spanHasPrefix(client.data().span(), "ABCDEF"_span));
     EXPECT_EQ(client.headers().size(), 1);
     EXPECT_TRUE(client.headers().at(0) == "Content-type: text/html\r\n"_s);
@@ -547,7 +547,7 @@ TEST(CurlMultipartHandleTests, DivideLastDelimiter)
     auto curlResponse = createCurlResponse();
     auto handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
 
-    handle->didReceiveMessage(data);
+    handle->didReceiveMessage(byteCast<uint8_t>(data));
     EXPECT_EQ(client.headers().size(), 1);
     EXPECT_TRUE(client.headers().at(0) == "Content-type: text/plain\r\n"_s);
     client.clear();
@@ -563,7 +563,7 @@ TEST(CurlMultipartHandleTests, DivideLastDelimiter)
     EXPECT_TRUE(spanHasPrefix(client.data().span(), "<h"_span));
     EXPECT_TRUE(!client.complete());
 
-    handle->didReceiveMessage(nextData);
+    handle->didReceiveMessage(byteCast<uint8_t>(nextData));
     EXPECT_TRUE(spanHasPrefix(client.data().span(), "<html></html>"_span));
 
     handle->didCompleteMessage();
@@ -585,7 +585,7 @@ TEST(CurlMultipartHandleTests, DivideCloseDelimiter)
     auto curlResponse = createCurlResponse();
     auto handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
 
-    handle->didReceiveMessage(data);
+    handle->didReceiveMessage(byteCast<uint8_t>(data));
     EXPECT_EQ(client.headers().size(), 1);
     EXPECT_TRUE(client.headers().at(0) == "Content-type: text/plain\r\n"_s);
     client.clear();
@@ -601,7 +601,7 @@ TEST(CurlMultipartHandleTests, DivideCloseDelimiter)
     EXPECT_TRUE(spanHasPrefix(client.data().span(), "<h"_span));
     EXPECT_TRUE(!client.complete());
 
-    handle->didReceiveMessage(nextData);
+    handle->didReceiveMessage(byteCast<uint8_t>(nextData));
     EXPECT_TRUE(spanHasPrefix(client.data().span(), "<html></html>"_span));
 
     handle->didCompleteMessage();
@@ -624,7 +624,7 @@ TEST(CurlMultipartHandleTests, DivideTransportPadding)
     auto curlResponse = createCurlResponse();
     auto handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
 
-    handle->didReceiveMessage(data);
+    handle->didReceiveMessage(byteCast<uint8_t>(data));
     EXPECT_EQ(client.headers().size(), 1);
     EXPECT_TRUE(client.headers().at(0) == "Content-type: text/plain\r\n"_s);
     client.clear();
@@ -633,7 +633,7 @@ TEST(CurlMultipartHandleTests, DivideTransportPadding)
     EXPECT_EQ(client.headers().size(), 0);
     EXPECT_TRUE(spanHasPrefix(client.data().span(), "ABCDEF"_span));
 
-    handle->didReceiveMessage(nextData);
+    handle->didReceiveMessage(byteCast<uint8_t>(nextData));
     EXPECT_EQ(client.headers().size(), 1);
     EXPECT_TRUE(client.headers().at(0) == "Content-type: text/html\r\n"_s);
     client.clear();
@@ -661,7 +661,7 @@ TEST(CurlMultipartHandleTests, DivideHeader)
     auto curlResponse = createCurlResponse();
     auto handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
 
-    handle->didReceiveMessage(data);
+    handle->didReceiveMessage(byteCast<uint8_t>(data));
     EXPECT_EQ(client.headers().size(), 1);
     EXPECT_TRUE(client.headers().at(0) == "Content-type: text/plain\r\n"_s);
     client.clear();
@@ -670,7 +670,7 @@ TEST(CurlMultipartHandleTests, DivideHeader)
     EXPECT_TRUE(spanHasPrefix(client.data().span(), "ABCDEF"_span));
     EXPECT_EQ(client.headers().size(), 0);
 
-    handle->didReceiveMessage(nextData);
+    handle->didReceiveMessage(byteCast<uint8_t>(nextData));
     EXPECT_EQ(client.headers().size(), 1);
     EXPECT_TRUE(client.headers().at(0) == "Content-type: text/html\r\n"_s);
     client.clear();
@@ -700,7 +700,7 @@ TEST(CurlMultipartHandleTests, DivideBody)
     auto curlResponse = createCurlResponse();
     auto handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
 
-    handle->didReceiveMessage(data);
+    handle->didReceiveMessage(byteCast<uint8_t>(data));
     EXPECT_EQ(client.headers().size(), 1);
     EXPECT_TRUE(client.headers().at(0) == "Content-type: text/plain\r\n"_s);
     client.clear();
@@ -708,7 +708,7 @@ TEST(CurlMultipartHandleTests, DivideBody)
     handle->completeHeaderProcessing();
     EXPECT_EQ(client.data().size(), 0);
 
-    handle->didReceiveMessage(secondData);
+    handle->didReceiveMessage(byteCast<uint8_t>(secondData));
     EXPECT_TRUE(spanHasPrefix(client.data().span(), "ABCDEF"_span));
     EXPECT_EQ(client.headers().size(), 1);
     EXPECT_TRUE(client.headers().at(0) == "Content-type: text/html\r\n"_s);
@@ -717,7 +717,7 @@ TEST(CurlMultipartHandleTests, DivideBody)
     handle->completeHeaderProcessing();
     EXPECT_EQ(client.data().size(), 0);
 
-    handle->didReceiveMessage(lastData);
+    handle->didReceiveMessage(byteCast<uint8_t>(lastData));
     EXPECT_TRUE(spanHasPrefix(client.data().span(), "<html></html>"_span));
     EXPECT_TRUE(!client.complete());
 
@@ -741,17 +741,17 @@ TEST(CurlMultipartHandleTests, CompleteWhileHeaderProcessing)
     auto curlResponse = createCurlResponse();
     auto handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
 
-    handle->didReceiveMessage(data);
+    handle->didReceiveMessage(byteCast<uint8_t>(data));
     EXPECT_EQ(client.headers().size(), 1);
     EXPECT_TRUE(client.headers().at(0) == "Content-type: text/plain\r\n"_s);
     EXPECT_EQ(client.data().size(), 0);
     client.clear();
 
-    handle->didReceiveMessage(secondData);
+    handle->didReceiveMessage(byteCast<uint8_t>(secondData));
     EXPECT_EQ(client.headers().size(), 0);
     EXPECT_EQ(client.data().size(), 0);
 
-    handle->didReceiveMessage(lastData);
+    handle->didReceiveMessage(byteCast<uint8_t>(lastData));
     EXPECT_EQ(client.headers().size(), 0);
     EXPECT_EQ(client.data().size(), 0);
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBPersistence.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBPersistence.mm
@@ -72,7 +72,7 @@ static RetainPtr<NSString> selectedFilePath;
     EXPECT_FALSE(parameters.allowsDirectories);
     constexpr auto TestFileData = "This is test file"_s;
     auto [path, handle] = FileSystem::openTemporaryFile("IndexedDBPersistence"_s);
-    handle.write(TestFileData.span8());
+    handle.write(byteCast<uint8_t>(TestFileData.span()));
     handle = { };
     selectedFilePath = path.createNSString();
     completionHandler(@[ [NSURL fileURLWithPath:selectedFilePath.get()] ]);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
@@ -1207,7 +1207,7 @@ public:
             @"userInfo": apsUserInfo
         };
 
-        String message { span([NSJSONSerialization dataWithJSONObject:obj options:0 error:nullptr]) };
+        String message { byteCast<Latin1Character>(span([NSJSONSerialization dataWithJSONObject:obj options:0 error:nullptr])) };
 
         auto utilityConnection = createAndConfigureConnectionToService("org.webkit.webpushtestdaemon.service");
         auto sender = WebPushXPCConnectionMessageSender { utilityConnection.get() };


### PR DESCRIPTION
#### 6c4e9451b882330c414ce98e7043e8d880bca137
<pre>
Add casts that will be needed once Latin1Character is a distinct type
<a href="https://rdar.apple.com/161524685">rdar://161524685</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=299706">https://bugs.webkit.org/show_bug.cgi?id=299706</a>

Reviewed by Geoffrey Garen.

* Source/JavaScriptCore/API/JSScript.mm:
(+[JSScript scriptOfType:memoryMappedFromASCIIFile:withSourceURL:andBytecodeCache:inVirtualMachine:error:]):
Cast to Latin1Character.

* Source/JavaScriptCore/API/JSStringRefCF.cpp:
(JSStringCreateWithCFString): Cast to UInt8.
(JSStringCopyCFString): Ditto.

* Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorSocket.cpp:
(Inspector::RemoteInspector::backendCommands const): Eliminate use of String::adopt.
It doesn&apos;t really work for vectors any more, and likely we should remove it to avoid
making a promise we can&apos;t keep. It doesn&apos;t work with byteCast, which is why we need
to do this here now.

* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototype.cpp:
(JSC::uint8ArrayPrototypeToHex): Cast to uint8_t.

* Source/JavaScriptCore/runtime/LiteralParser.cpp:
(JSC::reviverMode&gt;::Lexer::lexString): Reduce mixing char with Latin1Character a bit.

* Source/WTF/wtf/URLParser.cpp:
(WTF::URLParser::appendNumberToASCIIBuffer): Cast to char.

* Source/WTF/wtf/cf/CFURLExtras.cpp:
(WTF::bytesAsString): Cast to UInt8.
(WTF::isSameOrigin): Cast to Latin1Character.

* Source/WTF/wtf/cf/URLCF.cpp:
(WTF::URL::createCFURL): Cast to UInt8.

* Source/WTF/wtf/cocoa/NSURLExtras.mm:
(WTF::userVisibleString): Cast to Latin1Character.
* Source/WTF/wtf/persistence/PersistentCoders.cpp:
(WTF::Persistence::Coder&lt;String&gt;::encodeForPersistence): Use asBytes.

* Source/WTF/wtf/text/StringBuilder.h:
(WTF::StringBuilder::operator[] const): Cast so the conditional operator
does not mix types.

* Source/WTF/wtf/text/WTFString.cpp:
(WTF::String::String): Cast to Latin1Character.
(WTF::String::ascii const): Cast so the conditional operator does not mix types.

* Source/WTF/wtf/text/cf/StringCF.cpp:
(WTF::String::String): Cast to UInt8.
* Source/WTF/wtf/text/cf/StringImplCF.cpp:
(WTF::StringImpl::createCFString): Ditto.
* Source/WTF/wtf/text/cf/StringViewCF.cpp:
(WTF::StringView::createCFString const): Ditto.
(WTF::StringView::createCFStringWithoutCopying const): Ditto.

* Source/WebCore/Modules/encryptedmedia/InitDataRegistry.cpp:
(WebCore::extractKeyIDsKeyids): Cast to Latin1Character to pass to parseJSON and remove
the unnecessary copy into a temporary String.

* Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp:
(WebCore::PeerConnectionBackend::handleLogMessage): Cast to uint8_t.
* Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformerCocoa.cpp:
(WebCore::RTCRtpSFrameTransformer::computeSaltKey): Ditto.
(WebCore::createBaseSFrameKey): Ditto.
(WebCore::RTCRtpSFrameTransformer::computeAuthenticationKey): Ditto.
(WebCore::RTCRtpSFrameTransformer::computeEncryptionKey): Ditto.
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerDtlsTransportBackend.cpp:
(WebCore::GStreamerDtlsTransportBackendObserver::stateChanged): Ditto.
* Source/WebCore/Modules/push-api/PushMessageCrypto.cpp:
(WebCore::PushCrypto::decryptAES128GCMPayload): Ditto.
(WebCore::PushCrypto::decryptAESGCMPayload): Ditto.

* Source/WebCore/Modules/websockets/WebSocketHandshake.cpp:
(WebCore::trimInputSample): Cast to Latin1Character.
(WebCore::WebSocketHandshake::readStatusLine): Ditto.

* Source/WebCore/bindings/js/ScriptBufferSourceProvider.h: Cast to Latin1Character.
* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::CloneDeserializer::readString): Ditto.

* Source/WebCore/contentextensions/DFABytecodeInterpreter.cpp:
(WebCore::ContentExtensions::DFABytecodeInterpreter::interpretJumpTable):
Cast so the conditional operator does not mix types.
(WebCore::ContentExtensions::DFABytecodeInterpreter::interpret): Ditto.

* Source/WebCore/crypto/SubtleCrypto.cpp:
(WebCore::SubtleCrypto::unwrapKey): Cast to Latin1Character to pass to JSONParse and remove
the unnecessary copy into a temporary String.

* Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm:
(WebCore::replaceRichContentWithAttachments): Cast to Latin1Character.
* Source/WebCore/fileapi/FileReaderLoader.cpp:
(WebCore::FileReaderLoader::stringResult): Ditto.
* Source/WebCore/html/FTPDirectoryDocument.cpp:
(WebCore::FTPDirectoryDocumentParser::loadDocumentTemplate): Ditto.

* Source/WebCore/html/parser/HTMLEntityParser.cpp:
(WebCore::StringParsingBufferSource::currentCharacter const):
Cast so the conditional operator does not mix types.
* Source/WebCore/html/track/VTTScanner.h:
(WebCore::VTTScanner::currentChar const): Ditto.

* Source/WebCore/html/track/WebVTTParser.cpp:
(WebCore::WebVTTParser::fileFinished): Cast to uint8_t.

* Source/WebCore/loader/FTPDirectoryParser.cpp:
(WebCore::parseOneFTPLine): Cast to Latin1Character.

* Source/WebCore/loader/FormSubmission.cpp:
(WebCore::appendMailtoPostFormDataToURL): Cast to Latin1Character.
(WebCore::FormSubmission::create): Ditto.

* Source/WebCore/loader/TextResourceDecoder.cpp:
(WebCore::findXMLEncoding): Cast to uint8_t.
(WebCore::TextResourceDecoder::checkForCSSCharset): Cast to uint8_t and Latin1Character.
(WebCore::TextResourceDecoder::checkForHeadCharset): Ditto.

* Source/WebCore/loader/cache/CachedScript.cpp:
(WebCore::CachedScript::script): Cast to Latin1Character.
(WebCore::CachedScript::codeBlockHashConcurrently): Ditto.

* Source/WebCore/platform/encryptedmedia/CDMUtilities.cpp:
(WebCore::CDMUtilities::parseJSONObject): Cast to Latin1Character to pass to parseJSON
and remove the unnecessary copy into a temporary String.
* Source/WebCore/platform/graphics/avfoundation/CDMFairPlayStreaming.cpp:
(WebCore::extractSinfData): Ditto.
(WebCore::CDMPrivateFairPlayStreaming::extractKeyIDsMpts): Ditto.

* Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm:
(WebCore::parseJSONValue): Cast to Latin1Character.
* Source/WebCore/platform/graphics/freetype/FontCacheFreeType.cpp:
(WebCore::fontNameMapName): Ditto.

* Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.cpp:
(WebCore::ParsedResponseMessage::ParsedResponseMessage): Cast to Latin1Character.
(WebCore::CDMInstanceSessionThunder::loadSession): Ditto.

* Source/WebCore/platform/gstreamer/GStreamerElementHarness.cpp:
(WebCore::MermaidBuilder::span const): Cast to uint8_t.

* Source/WebCore/platform/image-decoders/png/PNGImageDecoder.cpp:
(WebCore::decodingWarning): Cast to char.
(WebCore::PNGImageDecoder::readChunks): Ditto.

* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateMock.cpp:
(WebCore::MediaRecorderPrivateMock::fetchData): Cast to uint8_t.

* Source/WebCore/platform/network/curl/OpenSSLHelper.cpp:
(OpenSSL::BIO::getDataAsString const): Cast to Latin1Character.
(OpenSSL::toString): Ditto.
* Source/WebCore/platform/network/soup/CertificateInfoSoup.cpp:
(WebCore::CertificateInfo::summary const): Ditto.

* Source/WebCore/platform/text/SegmentedString.h:
(WebCore::SegmentedString::Substring::currentCharacter const):
Cast so the conditional operator does not mix types.

* Source/WebCore/testing/MockCDMFactory.cpp:
(WebCore::MockCDM::sanitizeResponse const): Cast to Latin1Character.
(WebCore::MockCDMInstance::setServerCertificate): Ditto.
(WebCore::MockCDMInstanceSession::updateLicense): Ditto.

* Source/WebGPU/WebGPU/Pipeline.mm:
(WebKit::printToFileForPsoRepro): Cast to uint8_t.
* Source/WebKit/NetworkProcess/cache/NetworkCache.cpp:
(WebKit::NetworkCache::Cache::dumpContentsToFile): Ditto.

* Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp:
(WebKit::readSizeFile): Cast to Latin1Character.

* Source/WebKit/Platform/IPC/DaemonCoders.h:
(WebKit::Daemon::Coder&lt;WTF::String&gt;::encode): Cast to uint8_t.

* Source/WebKit/Shared/API/c/cf/WKStringCF.mm:
(WKStringCopyCFString): Cast to UInt8.

* Source/WebKit/Shared/Cocoa/SandboxExtensionCocoa.mm:
(WebKit::SandboxExtensionImpl::SandboxExtensionImpl): Cast to Latin1Character.

* Source/WebKit/UIProcess/API/APIContentRuleListStore.cpp:
(API::getContentRuleListSourceFromMappedFile): Cast to Latin1Character.

* Source/WebKit/UIProcess/API/C/WKPage.cpp:
(dataFrom): Cast to uint8_t.

* Source/WebKit/UIProcess/Cocoa/WebPasteboardProxyCocoa.mm:
(WebKit::WebPasteboardProxy::testIPCSharedMemory): Cast to Latin1Character.
* Source/WebKit/UIProcess/Extensions/WebExtensionDeclarativeNetRequestSQLiteStore.cpp:
(WebKit::WebExtensionDeclarativeNetRequestSQLiteStore::getKeysAndValuesFromRowIterator):
Ditto.

* Source/WebKit/UIProcess/Inspector/glib/RemoteInspectorClient.cpp:
(WebKit::RemoteInspectorClient::setBackendCommands): Cast to std::byte.

* Source/WebKit/UIProcess/Inspector/mac/RemoteWebInspectorUIProxyMac.mm:
(WebKit::RemoteWebInspectorUIProxy::platformLoad): Cast to Latin1Character.
* Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm:
(WebKit::WebInspectorUIProxy::platformLoad): Ditto.
* Source/WebKit/UIProcess/wpe/WebPasteboardProxyWPE.cpp:
(WebKit::WebPasteboardProxy::readURLFromPasteboard): Ditto.
* Source/WebKit/WebProcess/Network/webrtc/RTCDataChannelRemoteManager.cpp:
(WebKit::RTCDataChannelRemoteManager::sendData): Ditto.

* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:
(WebKit::registerLogClient): Cast to uint8_t.

* Tools/TestWebKitAPI/Tests/WTF/Base64.cpp:
(TestWebKitAPI::TEST(Base64, Encode)): Cast to uint8_t.
(TestWebKitAPI::TEST(Base64, EncodeOmitPadding)): Ditto.
(TestWebKitAPI::TEST(Base64, EncodeURL)): Ditto.
(TestWebKitAPI::TEST(Base64, EncodeURLOmitPadding)): Ditto.
* Tools/TestWebKitAPI/Tests/WTF/FileSystem.cpp:
(TestWebKitAPI::createTestFile): Ditto.
(TestWebKitAPI::TEST_F(FileSystemTest, openExistingFileTruncate)): Ditto.
(TestWebKitAPI::TEST_F(FileSystemTest, openExistingFileReadWrite)): Ditto.
(TestWebKitAPI::TEST_F(FileSystemTest, deleteEmptyDirectoryContainingDSStoreFile)): Ditto.
(TestWebKitAPI::TEST_F(FileSystemTest, deleteEmptyDirectoryOnNonEmptyDirectory)): Ditto.
(TestWebKitAPI::TEST_F(FileSystemTest, moveDirectory)): Ditto.
(TestWebKitAPI::runGetFileModificationTimeTest): Ditto.
(TestWebKitAPI::TEST_F(FileSystemTest, readEntireFile)): Ditto.

* Tools/TestWebKitAPI/Tests/WTF/StringImpl.cpp:
(TestWebKitAPI::TEST(WTF, ExternalStringImplCreate8bit)): Use char and cast to Latin1Character.
(TestWebKitAPI::TEST(WTF, ExternalStringAtom)): Ditto.

* Tools/TestWebKitAPI/Tests/WTF/StringView.cpp:
(TestWebKitAPI::TEST(WTF, StringViewEqualIgnoringASCIICaseWithLatin1Characters)):
Use byteCast instead of reinterpret_cast.

* Tools/TestWebKitAPI/Tests/WTF/cocoa/URLExtras.mm:
(TestWebKitAPI::dataAsString): Pass a character instead of an int.

* Tools/TestWebKitAPI/Tests/WebCore/PushMessageCrypto.cpp:
(TestWebKitAPI::mustBase64URLDecode): Use ASCIILiteral.
(TestWebKitAPI::stringView): Added.
(TestWebKitAPI::TEST(PushMessageCrypto, AES128GCMPayloadWithMinimalPadding)): Use stringView.
(TestWebKitAPI::TEST(PushMessageCrypto, AES128GCMPayloadWithPadding)): Ditto.
(TestWebKitAPI::TEST(PushMessageCrypto, AESGCMPayloadWithMinimalPadding)): Ditto.
(TestWebKitAPI::TEST(PushMessageCrypto, AESGCMPayloadWithPadding)): Ditto.

* Tools/TestWebKitAPI/Tests/WebCore/SharedBuffer.cpp:
(TestWebKitAPI::TEST_F(FragmentedSharedBufferTest, createWithContentsOfExistingFile)):
Cast to Latin1Character.
(TestWebKitAPI::TEST_F(FragmentedSharedBufferTest, read)): Ditto.
(TestWebKitAPI::TEST_F(SharedBufferChunkReaderTest, includeSeparator)): Use uint8_t.
(TestWebKitAPI::TEST_F(SharedBufferChunkReaderTest, peekData)): Cast to Latin1Character.

* Tools/TestWebKitAPI/Tests/WebCore/SharedBufferTest.cpp:
(TestWebKitAPI::FragmentedSharedBufferTest::SetUp): Cast to uint8_t.
* Tools/TestWebKitAPI/Tests/WebCore/curl/CurlMultipartHandleTests.cpp:
(TestWebKitAPI::Curl::TEST(CurlMultipartHandleTests, SimpleMessage)): Ditto.
(TestWebKitAPI::Curl::TEST(CurlMultipartHandleTests, NoHeader)): Ditto.
(TestWebKitAPI::Curl::TEST(CurlMultipartHandleTests, NoBody)): Ditto.
(TestWebKitAPI::Curl::TEST(CurlMultipartHandleTests, TransportPadding)): Ditto.
(TestWebKitAPI::Curl::TEST(CurlMultipartHandleTests, NoEndOfBoundary)): Ditto.
(TestWebKitAPI::Curl::TEST(CurlMultipartHandleTests, NoEndOfBoundaryAfterCompleted)): Ditto.
(TestWebKitAPI::Curl::TEST(CurlMultipartHandleTests, NoCloseDelimiter)): Ditto.
(TestWebKitAPI::Curl::TEST(CurlMultipartHandleTests, NoCloseDelimiterAfterCompleted)): Ditto.
(TestWebKitAPI::Curl::TEST(CurlMultipartHandleTests, CloseDelimiter)): Ditto.
(TestWebKitAPI::Curl::TEST(CurlMultipartHandleTests, CloseDelimiterAfterCompleted)): Ditto.
(TestWebKitAPI::Curl::TEST(CurlMultipartHandleTests, DivideFirstDelimiter)): Ditto.
(TestWebKitAPI::Curl::TEST(CurlMultipartHandleTests, DivideSecondDelimiter)): Ditto.
(TestWebKitAPI::Curl::TEST(CurlMultipartHandleTests, DivideLastDelimiter)): Ditto.
(TestWebKitAPI::Curl::TEST(CurlMultipartHandleTests, DivideCloseDelimiter)): Ditto.
(TestWebKitAPI::Curl::TEST(CurlMultipartHandleTests, DivideTransportPadding)): Ditto.
(TestWebKitAPI::Curl::TEST(CurlMultipartHandleTests, DivideHeader)): Ditto.
(TestWebKitAPI::Curl::TEST(CurlMultipartHandleTests, DivideBody)): Ditto.
(TestWebKitAPI::Curl::TEST(CurlMultipartHandleTests, CompleteWhileHeaderProcessing)): Ditto.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBPersistence.mm:
(-[IndexedDBOpenPanelUIDelegate webView:runOpenPanelWithParameters:initiatedByFrame:completionHandler:]): Ditto.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm:
(TestWebKitAPI::WebPushDTestWebView::injectPushMessage): Cast to Latin1Character.

Canonical link: <a href="https://commits.webkit.org/301031@main">https://commits.webkit.org/301031@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/738d4ea534b93d5793381d7cc7e9edfb26ac2238

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123431 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43146 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33842 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130149 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/75564 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2fe92782-61b0-4c23-b008-ac9b81d6d558) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/125308 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43869 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51740 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93822 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62270 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2e830089-ce2b-4960-a52e-9e1c7640c19c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126384 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34954 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110429 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74449 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/98ef8eeb-f0be-4fb4-87fe-d1f8fa948e3a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33923 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28587 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73665 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/115590 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104668 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28813 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132869 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/121963 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50381 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38346 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102314 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50757 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106652 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102166 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26259 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47524 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25750 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/47186 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50236 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/55997 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/152317 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49708 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/38947 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53057 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51385 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->