### PR TITLE
[JSC] Introduce JSPromiseReaction object

### DIFF
--- a/JSTests/stress/destructuring-assignment-require-object-coercible-symbol-private.js
+++ b/JSTests/stress/destructuring-assignment-require-object-coercible-symbol-private.js
@@ -22,7 +22,7 @@ function shouldThrow(testFunction, expectedError) {
 
 {
     const destructToPrivateName = $vm.createBuiltin(
-        "(function (value) { var { @context } = value; })",
+        "(function (value) { var { @Number } = value; })",
     );
     shouldThrow(() => {
         destructToPrivateName(null);

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -2084,6 +2084,7 @@
 		E3A38EFD2E754D3B00D53DDD /* B3BulkMemoryValue.h in Headers */ = {isa = PBXBuildFile; fileRef = E3A38EFB2E754D3B00D53DDD /* B3BulkMemoryValue.h */; };
 		E3A421431D6F58930007C617 /* PreciseJumpTargetsInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = E3A421421D6F588F0007C617 /* PreciseJumpTargetsInlines.h */; };
 		E3AC277721FDB4940024452C /* RegExpCachedResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 86F75EFC151C062F007C9BA3 /* RegExpCachedResult.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		E3AEF17D2E890C0C00D493ED /* JSPromiseReaction.h in Headers */ = {isa = PBXBuildFile; fileRef = E3AEF17A2E890C0C00D493ED /* JSPromiseReaction.h */; };
 		E3B2329D2DF7A0CC00ECC447 /* ConcatKeyAtomStringCache.h in Headers */ = {isa = PBXBuildFile; fileRef = E3B2329A2DF7A0BE00ECC447 /* ConcatKeyAtomStringCache.h */; };
 		E3B2329E2DF7A0D300ECC447 /* ConcatKeyAtomStringCacheInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = E3B2329C2DF7A0BE00ECC447 /* ConcatKeyAtomStringCacheInlines.h */; };
 		E3B24859291224540029C08A /* BufferMemoryHandle.h in Headers */ = {isa = PBXBuildFile; fileRef = E3B24857291224530029C08A /* BufferMemoryHandle.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -5923,6 +5924,8 @@
 		E3A38EFB2E754D3B00D53DDD /* B3BulkMemoryValue.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = B3BulkMemoryValue.h; path = b3/B3BulkMemoryValue.h; sourceTree = "<group>"; };
 		E3A38EFC2E754D3B00D53DDD /* B3BulkMemoryValue.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = B3BulkMemoryValue.cpp; path = b3/B3BulkMemoryValue.cpp; sourceTree = "<group>"; };
 		E3A421421D6F588F0007C617 /* PreciseJumpTargetsInlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PreciseJumpTargetsInlines.h; sourceTree = "<group>"; };
+		E3AEF17A2E890C0C00D493ED /* JSPromiseReaction.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = JSPromiseReaction.h; sourceTree = "<group>"; };
+		E3AEF17B2E890C0C00D493ED /* JSPromiseReaction.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = JSPromiseReaction.cpp; sourceTree = "<group>"; };
 		E3B2329A2DF7A0BE00ECC447 /* ConcatKeyAtomStringCache.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ConcatKeyAtomStringCache.h; sourceTree = "<group>"; };
 		E3B2329B2DF7A0BE00ECC447 /* ConcatKeyAtomStringCache.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ConcatKeyAtomStringCache.cpp; sourceTree = "<group>"; };
 		E3B2329C2DF7A0BE00ECC447 /* ConcatKeyAtomStringCacheInlines.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ConcatKeyAtomStringCacheInlines.h; sourceTree = "<group>"; };
@@ -8758,6 +8761,8 @@
 				7C184E2117BEE240007CB63A /* JSPromiseConstructor.h */,
 				7C184E1C17BEE22E007CB63A /* JSPromisePrototype.cpp */,
 				7C184E1D17BEE22E007CB63A /* JSPromisePrototype.h */,
+				E3AEF17B2E890C0C00D493ED /* JSPromiseReaction.cpp */,
+				E3AEF17A2E890C0C00D493ED /* JSPromiseReaction.h */,
 				2A05ABD31961DF2400341750 /* JSPropertyNameEnumerator.cpp */,
 				2A05ABD41961DF2400341750 /* JSPropertyNameEnumerator.h */,
 				276B387A2A71D11700252F4E /* JSPropertyNameEnumeratorInlines.h */,
@@ -11655,6 +11660,7 @@
 				AA785BEE2E77BED70097F688 /* JSPromiseAllContextInlines.h in Headers */,
 				7C184E2317BEE240007CB63A /* JSPromiseConstructor.h in Headers */,
 				7C184E1F17BEE22E007CB63A /* JSPromisePrototype.h in Headers */,
+				E3AEF17D2E890C0C00D493ED /* JSPromiseReaction.h in Headers */,
 				2A05ABD61961DF2400341750 /* JSPropertyNameEnumerator.h in Headers */,
 				276B387D2A71D11800252F4E /* JSPropertyNameEnumeratorInlines.h in Headers */,
 				E39E578329380FC6000D0D3B /* JSRawJSONObject.h in Headers */,
@@ -12277,7 +12283,6 @@
 				527E6CEC2772B9CB005E0782 /* WasmOSREntryPlan.h in Headers */,
 				53F40E8D1D5901F20099A1B6 /* WasmParser.h in Headers */,
 				531374BD1D5CE67600AF7A0B /* WasmPlan.h in Headers */,
-				E37986372E6FA60E008B5EA6 /* WasmProfileCollection.h in Headers */,
 				FFD49E6F2E276CA10083E383 /* WasmQueryHandler.h in Headers */,
 				E3A0531C21342B680022EC14 /* WasmSectionParser.h in Headers */,
 				53F40E851D58F9770099A1B6 /* WasmSections.h in Headers */,

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -940,6 +940,7 @@ runtime/JSPromise.cpp
 runtime/JSPromiseAllContext.cpp
 runtime/JSPromiseConstructor.cpp
 runtime/JSPromisePrototype.cpp
+runtime/JSPromiseReaction.cpp
 runtime/JSPropertyNameEnumerator.cpp
 runtime/JSRawJSONObject.cpp
 runtime/JSRegExpStringIterator.cpp

--- a/Source/JavaScriptCore/builtins/BuiltinNames.h
+++ b/Source/JavaScriptCore/builtins/BuiltinNames.h
@@ -57,7 +57,6 @@ namespace JSC {
     macro(iteratedObject) \
     macro(iteratedString) \
     macro(promise) \
-    macro(promiseOrCapability) \
     macro(Object) \
     macro(Number) \
     macro(Array) \
@@ -78,8 +77,6 @@ namespace JSC {
     macro(homeObject) \
     macro(enqueueJob) \
     macro(hostPromiseRejectionTracker) \
-    macro(onFulfilled) \
-    macro(onRejected) \
     macro(push) \
     macro(repeatCharacter) \
     macro(starDefault) \
@@ -88,7 +85,6 @@ namespace JSC {
     macro(values) \
     macro(set) \
     macro(clear) \
-    macro(context) \
     macro(defer) \
     macro(delete) \
     macro(size) \
@@ -195,7 +191,6 @@ namespace JSC {
     macro(hasOwnPropertyFunction) \
     macro(createPrivateSymbol) \
     macro(entries) \
-    macro(outOfLineReactionCounts) \
     macro(emptyPropertyNameEnumerator) \
     macro(sentinelString) \
     macro(createRemoteFunction) \
@@ -216,6 +211,7 @@ namespace JSC {
     macro(wrapForValidIteratorCreate) \
     macro(asyncFromSyncIteratorCreate) \
     macro(promiseAllContextCreate) \
+    macro(promiseReactionCreate) \
     macro(regExpStringIteratorCreate) \
     macro(iteratorHelperCreate) \
     macro(syncIterator) \

--- a/Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.h
+++ b/Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.h
@@ -63,6 +63,7 @@ enum class LinkTimeConstant : int32_t;
     macro(getProxyInternalField) \
     macro(getWrapForValidIteratorInternalField) \
     macro(getPromiseAllContextInternalField) \
+    macro(getPromiseReactionInternalField) \
     macro(getDisposableStackInternalField) \
     macro(idWithProfile) \
     macro(isAsyncDisposableStack) \
@@ -78,6 +79,7 @@ enum class LinkTimeConstant : int32_t;
     macro(isAsyncGenerator) \
     macro(isPromise) \
     macro(isPromiseAllContext) \
+    macro(isPromiseReaction) \
     macro(isRegExpObject) \
     macro(isMap) \
     macro(isSet) \
@@ -111,6 +113,7 @@ enum class LinkTimeConstant : int32_t;
     macro(putSetIteratorInternalField) \
     macro(putRegExpStringIteratorInternalField) \
     macro(putPromiseAllContextInternalField) \
+    macro(putPromiseReactionInternalField) \
     macro(putDisposableStackInternalField) \
     macro(superSamplerBegin) \
     macro(superSamplerEnd) \
@@ -206,6 +209,11 @@ enum class LinkTimeConstant : int32_t;
     macro(promiseAllContextFieldValues) \
     macro(promiseAllContextFieldRemainingElementsCount) \
     macro(promiseAllContextFieldIndex) \
+    macro(promiseReactionFieldPromise) \
+    macro(promiseReactionFieldOnFulfilled) \
+    macro(promiseReactionFieldOnRejected) \
+    macro(promiseReactionFieldContext) \
+    macro(promiseReactionFieldNext) \
     macro(regExpStringIteratorFieldRegExp) \
     macro(regExpStringIteratorFieldString) \
     macro(regExpStringIteratorFieldGlobal) \

--- a/Source/JavaScriptCore/bytecode/LinkTimeConstant.h
+++ b/Source/JavaScriptCore/bytecode/LinkTimeConstant.h
@@ -148,6 +148,7 @@ class JSGlobalObject;
     v(wrapForValidIteratorCreate, nullptr) \
     v(asyncFromSyncIteratorCreate, nullptr) \
     v(promiseAllContextCreate, nullptr) \
+    v(promiseReactionCreate, nullptr) \
     v(regExpStringIteratorCreate, nullptr) \
     v(iteratorHelperCreate, nullptr) \
     v(ReferenceError, nullptr) \

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
@@ -928,6 +928,7 @@ namespace JSC {
         RegisterID* emitIsJSArray(RegisterID* dst, RegisterID* src) { return emitIsCellWithType(dst, src, ArrayType); }
         RegisterID* emitIsPromise(RegisterID* dst, RegisterID* src) { return emitIsCellWithType(dst, src, JSPromiseType); }
         RegisterID* emitIsPromiseAllContext(RegisterID* dst, RegisterID* src) { return emitIsCellWithType(dst, src, JSPromiseAllContextType); }
+        RegisterID* emitIsPromiseReaction(RegisterID* dst, RegisterID* src) { return emitIsCellWithType(dst, src, JSPromiseReactionType); }
         RegisterID* emitIsProxyObject(RegisterID* dst, RegisterID* src) { return emitIsCellWithType(dst, src, ProxyObjectType); }
         RegisterID* emitIsRegExpObject(RegisterID* dst, RegisterID* src) { return emitIsCellWithType(dst, src, RegExpObjectType); }
         RegisterID* emitIsMap(RegisterID* dst, RegisterID* src) { return emitIsCellWithType(dst, src, JSMapType); }

--- a/Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp
@@ -46,6 +46,7 @@
 #include "JSIteratorHelper.h"
 #include "JSMapIterator.h"
 #include "JSPromiseAllContext.h"
+#include "JSPromiseReaction.h"
 #include "JSRegExpStringIterator.h"
 #include "JSSetIterator.h"
 #include "JSWrapForValidIterator.h"
@@ -1117,6 +1118,9 @@ private:
                 break;
             case JSPromiseAllContextType:
                 target = handleInternalFieldClass<JSPromiseAllContext>(node, writes);
+                break;
+            case JSPromiseReactionType:
+                target = handleInternalFieldClass<JSPromiseReaction>(node, writes);
                 break;
             case JSRegExpStringIteratorType:
                 target = handleInternalFieldClass<JSRegExpStringIterator>(node, writes);

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -68,6 +68,7 @@
 #include "JSMapIterator.h"
 #include "JSPromiseAllContext.h"
 #include "JSPromiseConstructor.h"
+#include "JSPromiseReaction.h"
 #include "JSPropertyNameEnumerator.h"
 #include "JSRegExpStringIterator.h"
 #include "JSSet.h"
@@ -2370,6 +2371,16 @@ JSC_DEFINE_JIT_OPERATION(operationNewPromiseAllContext, JSCell*, (VM* vmPointer,
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     OPERATION_RETURN(scope, JSPromiseAllContext::createWithInitialValues(vm, structure));
+}
+
+JSC_DEFINE_JIT_OPERATION(operationNewPromiseReaction, JSCell*, (VM* vmPointer, Structure* structure))
+{
+    VM& vm = *vmPointer;
+    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    OPERATION_RETURN(scope, JSPromiseReaction::createWithInitialValues(vm, structure));
 }
 
 JSC_DEFINE_JIT_OPERATION(operationNewRegExpStringIterator, JSCell*, (VM* vmPointer, Structure* structure))

--- a/Source/JavaScriptCore/dfg/DFGOperations.h
+++ b/Source/JavaScriptCore/dfg/DFGOperations.h
@@ -177,6 +177,7 @@ JSC_DECLARE_JIT_OPERATION(operationNewIteratorHelper, JSCell*, (VM*, Structure*)
 JSC_DECLARE_JIT_OPERATION(operationNewWrapForValidIterator, JSCell*, (VM*, Structure*));
 JSC_DECLARE_JIT_OPERATION(operationNewAsyncFromSyncIterator, JSCell*, (VM*, Structure*));
 JSC_DECLARE_JIT_OPERATION(operationNewPromiseAllContext, JSCell*, (VM*, Structure*));
+JSC_DECLARE_JIT_OPERATION(operationNewPromiseReaction, JSCell*, (VM*, Structure*));
 JSC_DECLARE_JIT_OPERATION(operationNewRegExpStringIterator, JSCell*, (VM*, Structure*));
 
 JSC_DECLARE_JIT_OPERATION(operationPutByValCellStringStrict, void, (JSGlobalObject*, JSCell*, JSCell* string, EncodedJSValue encodedValue));

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -67,6 +67,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 #include "JSLexicalEnvironment.h"
 #include "JSMapIterator.h"
 #include "JSPromiseAllContext.h"
+#include "JSPromiseReaction.h"
 #include "JSPropertyNameEnumerator.h"
 #include "JSRegExpStringIterator.h"
 #include "JSSetIterator.h"
@@ -15559,6 +15560,9 @@ void SpeculativeJIT::compileNewInternalFieldObject(Node* node)
         break;
     case JSPromiseAllContextType:
         compileNewInternalFieldObjectImpl<JSPromiseAllContext>(node, operationNewPromiseAllContext);
+        break;
+    case JSPromiseReactionType:
+        compileNewInternalFieldObjectImpl<JSPromiseReaction>(node, operationNewPromiseReaction);
         break;
     case JSRegExpStringIteratorType:
         compileNewInternalFieldObjectImpl<JSRegExpStringIterator>(node, operationNewRegExpStringIterator);

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -92,6 +92,7 @@
 #include "JSLexicalEnvironment.h"
 #include "JSMapIterator.h"
 #include "JSPromiseAllContext.h"
+#include "JSPromiseReaction.h"
 #include "JSRegExpStringIterator.h"
 #include "JSSetIterator.h"
 #include "JSWeakMap.h"
@@ -9406,6 +9407,9 @@ IGNORE_CLANG_WARNINGS_END
         case JSPromiseAllContextType:
             compileNewInternalFieldObjectImpl<JSPromiseAllContext>(operationNewPromiseAllContext);
             break;
+        case JSPromiseReactionType:
+            compileNewInternalFieldObjectImpl<JSPromiseReaction>(operationNewPromiseReaction);
+            break;
         case JSRegExpStringIteratorType:
             compileNewInternalFieldObjectImpl<JSRegExpStringIterator>(operationNewRegExpStringIterator);
             break;
@@ -17752,6 +17756,9 @@ IGNORE_CLANG_WARNINGS_END
             break;
         case JSPromiseAllContextType:
             compileMaterializeNewInternalFieldObjectImpl<JSPromiseAllContext>(operationNewPromiseAllContext);
+            break;
+        case JSPromiseReactionType:
+            compileMaterializeNewInternalFieldObjectImpl<JSPromiseReaction>(operationNewPromiseReaction);
             break;
         case JSPromiseType:
             if (m_node->structure()->classInfoForCells() == JSInternalPromise::info())

--- a/Source/JavaScriptCore/ftl/FTLOperations.cpp
+++ b/Source/JavaScriptCore/ftl/FTLOperations.cpp
@@ -48,6 +48,7 @@
 #include "JSLexicalEnvironment.h"
 #include "JSMapIterator.h"
 #include "JSPromiseAllContext.h"
+#include "JSPromiseReaction.h"
 #include "JSRegExpStringIterator.h"
 #include "JSSetIterator.h"
 #include "JSWrapForValidIterator.h"
@@ -189,6 +190,9 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationPopulateObjectInOSR, void, (JSGlobalO
             break;
         case JSPromiseAllContextType:
             materialize(jsCast<JSPromiseAllContext*>(target));
+            break;
+        case JSPromiseReactionType:
+            materialize(jsCast<JSPromiseReaction*>(target));
             break;
         case JSRegExpStringIteratorType:
             materialize(jsCast<JSRegExpStringIterator*>(target));
@@ -488,6 +492,8 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationMaterializeObjectInOSR, HeapCell*, (J
             return create.operator()<JSAsyncFromSyncIterator>();
         case JSPromiseAllContextType:
             return create.operator()<JSPromiseAllContext>();
+        case JSPromiseReactionType:
+            return create.operator()<JSPromiseReaction>();
         case JSRegExpStringIteratorType:
             return create.operator()<JSRegExpStringIterator>();
         case JSPromiseType:

--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -53,6 +53,7 @@
 #include "JSFinalizationRegistry.h"
 #include "JSIterator.h"
 #include "JSPromiseAllContext.h"
+#include "JSPromiseReaction.h"
 #include "JSRawJSONObject.h"
 #include "JSRemoteFunction.h"
 #include "JSVirtualMachineInternal.h"

--- a/Source/JavaScriptCore/heap/Heap.h
+++ b/Source/JavaScriptCore/heap/Heap.h
@@ -298,6 +298,7 @@ class Heap;
     v(withScopeSpace, cellHeapCellType, JSWithScope) \
     v(wrapForValidIteratorSpace, cellHeapCellType, JSWrapForValidIterator) \
     v(promiseAllContextSpace, cellHeapCellType, JSPromiseAllContext) \
+    v(promiseReactionSpace, cellHeapCellType, JSPromiseReaction) \
     v(asyncFromSyncIteratorSpace, cellHeapCellType, JSAsyncFromSyncIterator) \
     v(regExpStringIteratorSpace, cellHeapCellType, JSRegExpStringIterator) \
     v(disposableStackSpace, cellHeapCellType, JSDisposableStack) \

--- a/Source/JavaScriptCore/runtime/Intrinsic.h
+++ b/Source/JavaScriptCore/runtime/Intrinsic.h
@@ -199,6 +199,7 @@ namespace JSC {
     macro(WrapForValidIteratorCreateIntrinsic) \
     macro(AsyncFromSyncIteratorCreateIntrinsic) \
     macro(PromiseAllContextCreateIntrinsic) \
+    macro(PromiseReactionCreateIntrinsic) \
     macro(RegExpStringIteratorCreateIntrinsic) \
     \
     /* Getter intrinsics. */ \

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -202,6 +202,7 @@
 #include "JSWithScope.h"
 #include "JSWrapForValidIteratorInlines.h"
 #include "JSPromiseAllContextInlines.h"
+#include "JSPromiseReaction.h"
 #include "LazyClassStructureInlines.h"
 #include "LazyPropertyInlines.h"
 #include "LinkTimeConstant.h"
@@ -1201,6 +1202,7 @@ void JSGlobalObject::init(VM& vm)
     m_wrapForValidIteratorStructure.set(vm, this, JSWrapForValidIterator::createStructure(vm, this, wrapForValidIteratorPrototype));
 
     m_promiseAllContextStructure.set(vm, this, JSPromiseAllContext::createStructure(vm, this, jsNull()));
+    m_promiseReactionStructure.set(vm, this, JSPromiseReaction::createStructure(vm, this, jsNull()));
 
     auto* asyncFromSyncIteratorPrototype = AsyncFromSyncIteratorPrototype::create(vm, this, AsyncFromSyncIteratorPrototype::createStructure(vm, this, m_iteratorPrototype.get()));
     m_asyncFromSyncIteratorStructure.set(vm, this, JSAsyncFromSyncIterator::createStructure(vm, this, asyncFromSyncIteratorPrototype));
@@ -1607,6 +1609,11 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
     // PromiseAllContext Helpers
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::promiseAllContextCreate)].initLater([](const Initializer<JSCell>& init) {
         init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 4, "promiseAllContextCreate"_s, promiseAllContextPrivateFuncCreate, ImplementationVisibility::Private, PromiseAllContextCreateIntrinsic));
+    });
+
+    // PromiseReaction Helpers
+    m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::promiseReactionCreate)].initLater([](const Initializer<JSCell>& init) {
+        init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 5, "promiseReactionCreate"_s, promiseReactionPrivateFuncCreate, ImplementationVisibility::Private, PromiseReactionCreateIntrinsic));
     });
 
     // RegExpStringIteratorHelpers
@@ -2724,6 +2731,7 @@ void JSGlobalObject::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     visitor.append(thisObject->m_setIteratorStructure);
     visitor.append(thisObject->m_wrapForValidIteratorStructure);
     visitor.append(thisObject->m_promiseAllContextStructure);
+    visitor.append(thisObject->m_promiseReactionStructure);
     visitor.append(thisObject->m_asyncFromSyncIteratorStructure);
     visitor.append(thisObject->m_regExpStringIteratorStructure);
     thisObject->m_iteratorResultObjectStructure.visit(visitor);

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -94,6 +94,7 @@ class JSModuleRecord;
 class JSPromise;
 class JSPromiseConstructor;
 class JSPromisePrototype;
+class JSPromiseReaction;
 class JSTypedArrayViewConstructor;
 class JSTypedArrayViewPrototype;
 class MapIteratorPrototype;
@@ -383,6 +384,7 @@ public:
     WriteBarrierStructureID m_setIteratorStructure;
     WriteBarrierStructureID m_wrapForValidIteratorStructure;
     WriteBarrierStructureID m_promiseAllContextStructure;
+    WriteBarrierStructureID m_promiseReactionStructure;
     WriteBarrierStructureID m_regExpMatchesArrayStructure;
     WriteBarrierStructureID m_regExpMatchesArrayWithIndicesStructure;
     WriteBarrierStructureID m_regExpMatchesIndicesArrayStructure;
@@ -909,6 +911,7 @@ public:
     Structure* setIteratorStructure() const { return m_setIteratorStructure.get(); }
     Structure* wrapForValidIteratorStructure() const { return m_wrapForValidIteratorStructure.get(); }
     Structure* promiseAllContextStructure() const { return m_promiseAllContextStructure.get(); }
+    Structure* promiseReactionStructure() const { return m_promiseReactionStructure.get(); }
     Structure* stringObjectStructure() const { return m_stringObjectStructure.get(); }
     Structure* symbolObjectStructure() const { return m_symbolObjectStructure.get(); }
     Structure* iteratorResultObjectStructure() const { return m_iteratorResultObjectStructure.get(this); }

--- a/Source/JavaScriptCore/runtime/JSPromiseReaction.cpp
+++ b/Source/JavaScriptCore/runtime/JSPromiseReaction.cpp
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "JSPromiseReaction.h"
+
+#include "JSCInlines.h"
+#include "JSInternalFieldObjectImplInlines.h"
+
+namespace JSC {
+
+const ClassInfo JSPromiseReaction::s_info = { "PromiseReaction"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSPromiseReaction) };
+
+JSPromiseReaction* JSPromiseReaction::createWithInitialValues(VM& vm, Structure* structure)
+{
+    auto values = initialValues();
+    JSPromiseReaction* result = new (NotNull, allocateCell<JSPromiseReaction>(vm)) JSPromiseReaction(vm, structure, values[0], values[1], values[2], values[3], values[4]);
+    result->finishCreation(vm);
+    return result;
+}
+
+JSPromiseReaction* JSPromiseReaction::create(VM& vm, Structure* structure, JSValue promise, JSValue onFulfilled, JSValue onRejected, JSValue context, JSValue next)
+{
+    JSPromiseReaction* result = new (NotNull, allocateCell<JSPromiseReaction>(vm)) JSPromiseReaction(vm, structure, promise, onFulfilled, onRejected, context, next);
+    result->finishCreation(vm);
+    return result;
+}
+
+template<typename Visitor>
+void JSPromiseReaction::visitChildrenImpl(JSCell* cell, Visitor& visitor)
+{
+    auto* thisObject = jsCast<JSPromiseReaction*>(cell);
+    ASSERT_GC_OBJECT_INHERITS(thisObject, info());
+    Base::visitChildren(thisObject, visitor);
+}
+
+Structure* JSPromiseReaction::createStructure(VM& vm, JSGlobalObject* globalObject, JSValue prototype)
+{
+    return Structure::create(vm, globalObject, prototype, TypeInfo(JSPromiseReactionType, StructureFlags), info());
+}
+
+DEFINE_VISIT_CHILDREN(JSPromiseReaction);
+
+JSC_DEFINE_HOST_FUNCTION(promiseReactionPrivateFuncCreate, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+
+    JSValue promise = callFrame->uncheckedArgument(0);
+    JSValue onFulfilled = callFrame->uncheckedArgument(1);
+    JSValue onRejected = callFrame->uncheckedArgument(2);
+    JSValue context = callFrame->uncheckedArgument(3);
+    JSValue next = callFrame->uncheckedArgument(4);
+
+    return JSValue::encode(JSPromiseReaction::create(vm, globalObject->promiseReactionStructure(), promise, onFulfilled, onRejected, context, next));
+}
+
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSPromiseReaction.h
+++ b/Source/JavaScriptCore/runtime/JSPromiseReaction.h
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "JSInternalFieldObjectImpl.h"
+
+namespace JSC {
+
+const static uint8_t JSPromiseReactionNumberOfInternalFields = 5;
+
+class JSPromiseReaction final : public JSInternalFieldObjectImpl<JSPromiseReactionNumberOfInternalFields> {
+public:
+    using Base = JSInternalFieldObjectImpl<JSPromiseReactionNumberOfInternalFields>;
+
+    DECLARE_EXPORT_INFO;
+    DECLARE_VISIT_CHILDREN;
+
+    enum class Field : uint8_t {
+        Promise = 0,
+        OnFulfilled,
+        OnRejected,
+        Context,
+        Next,
+    };
+    static_assert(numberOfInternalFields == JSPromiseReactionNumberOfInternalFields);
+
+    static std::array<JSValue, numberOfInternalFields> initialValues()
+    {
+        return { {
+            jsUndefined(),
+            jsUndefined(),
+            jsUndefined(),
+            jsUndefined(),
+            jsUndefined(),
+        } };
+    }
+
+    const WriteBarrier<Unknown>& internalField(Field field) const { return Base::internalField(static_cast<uint32_t>(field)); }
+    WriteBarrier<Unknown>& internalField(Field field) { return Base::internalField(static_cast<uint32_t>(field)); }
+
+    template<typename CellType, SubspaceAccess mode>
+    static GCClient::IsoSubspace* subspaceFor(VM& vm)
+    {
+        return vm.promiseReactionSpace<mode>();
+    }
+
+    static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
+
+    static JSPromiseReaction* createWithInitialValues(VM&, Structure*);
+    static JSPromiseReaction* create(VM&, Structure*, JSValue promise, JSValue onFulfilled, JSValue onRejected, JSValue context, JSValue next);
+
+    JSValue promise() const { return internalField(Field::Promise).get(); }
+    JSValue onFulfilled() const { return internalField(Field::OnFulfilled).get(); }
+    JSValue onRejected() const { return internalField(Field::OnRejected).get(); }
+    JSValue context() const { return internalField(Field::Context).get(); }
+    JSValue next() const { return internalField(Field::Next).get(); }
+
+    void setPromise(VM& vm, JSValue value) { internalField(Field::Promise).set(vm, this, value); }
+    void setOnFulfilled(VM& vm, JSValue value) { internalField(Field::OnFulfilled).set(vm, this, value); }
+    void setOnRejected(VM& vm, JSValue value) { internalField(Field::OnRejected).set(vm, this, value); }
+    void setContext(VM& vm, JSValue value) { internalField(Field::Context).set(vm, this, value); }
+    void setNext(VM& vm, JSValue value) { internalField(Field::Next).set(vm, this, value); }
+
+private:
+    JSPromiseReaction(VM& vm, Structure* structure, JSValue promise, JSValue onFulfilled, JSValue onRejected, JSValue context, JSValue next)
+        : Base(vm, structure)
+    {
+        internalField(Field::Promise).setWithoutWriteBarrier(promise);
+        internalField(Field::OnFulfilled).setWithoutWriteBarrier(onFulfilled);
+        internalField(Field::OnRejected).setWithoutWriteBarrier(onRejected);
+        internalField(Field::Context).setWithoutWriteBarrier(context);
+        internalField(Field::Next).setWithoutWriteBarrier(next);
+    }
+};
+
+STATIC_ASSERT_IS_TRIVIALLY_DESTRUCTIBLE(JSPromiseReaction);
+
+JSC_DECLARE_HOST_FUNCTION(promiseReactionPrivateFuncCreate);
+
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSType.cpp
+++ b/Source/JavaScriptCore/runtime/JSType.cpp
@@ -128,6 +128,7 @@ void printInternal(PrintStream& out, JSC::JSType type)
     CASE(DisposableStackType)
     CASE(AsyncDisposableStackType)
     CASE(JSPromiseAllContextType)
+    CASE(JSPromiseReactionType)
     }
 }
 

--- a/Source/JavaScriptCore/runtime/JSType.h
+++ b/Source/JavaScriptCore/runtime/JSType.h
@@ -132,6 +132,7 @@ namespace JSC {
     macro(JSAsyncFromSyncIteratorType, SpecObjectOther) \
     macro(JSPromiseType, SpecPromiseObject) \
     macro(JSPromiseAllContextType, SpecObjectOther) \
+    macro(JSPromiseReactionType, SpecObjectOther) \
     macro(JSMapType, SpecMapObject) \
     macro(JSSetType, SpecSetObject) \
     macro(JSWeakMapType, SpecWeakMapObject) \


### PR DESCRIPTION
#### a1cb5e087a461a8ff468d49e85897349a175a2dd
<pre>
[JSC] Introduce JSPromiseReaction object
<a href="https://bugs.webkit.org/show_bug.cgi?id=299707">https://bugs.webkit.org/show_bug.cgi?id=299707</a>
<a href="https://rdar.apple.com/161528913">rdar://161528913</a>

Reviewed by Sosuke Suzuki.

This patch introduces JSPromiseReaction object. This is the first step
for cleaning up our Promise implementation mainly focusing on improving
JetStream3/doxbee-promise.

1. We simplify our reaction mechanism. Previously we were using
   array-likes, but in most of cases (1) user do not set multiple
   reactions to the same promise and (2) array tends to allocate more
   memory due to 2x resizing. So let&apos;s just use single-linked list of
   JSPromiseReaction.
2. JSPromiseReaction is internal JSObject, which has fixed slots
   accessible from JS side as well. Also DFG / FTL optimized allocation
   is set up.
3. Change of @pushNewPromiseReaction made @performPromiseThen bytecode
   size increased. And we observed large performance regression in
   JetStream3/doxbee-promise due to this. We annotate @performPromiseThen
   with @alwaysInline not to introduce this performance regression.

* JSTests/stress/destructuring-assignment-require-object-coercible-symbol-private.js:
(throw.new.Error):
* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/Sources.txt:
* Source/JavaScriptCore/builtins/BuiltinNames.h:
* Source/JavaScriptCore/builtins/PromiseOperations.js:
(linkTimeConstant.triggerPromiseReactions):
(linkTimeConstant.promiseResolveThenableJobFast):
(linkTimeConstant.promiseResolveThenableJobWithoutPromiseFast):
(linkTimeConstant.alwaysInline.performPromiseThen):
(linkTimeConstant.pushNewPromiseReaction): Deleted.
(linkTimeConstant.performPromiseThen): Deleted.
* Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.h:
* Source/JavaScriptCore/bytecode/LinkTimeConstant.h:
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h:
(JSC::BytecodeGenerator::emitIsPromiseReaction):
* Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp:
(JSC::promiseReactionInternalFieldIndex):
(JSC::BytecodeIntrinsicNode::emit_intrinsic_getPromiseReactionInternalField):
(JSC::BytecodeIntrinsicNode::emit_intrinsic_putPromiseReactionInternalField):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleIntrinsicCall):
* Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp:
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/dfg/DFGOperations.h:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileNewInternalFieldObject):
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
* Source/JavaScriptCore/ftl/FTLOperations.cpp:
(JSC::FTL::JSC_DEFINE_NOEXCEPT_JIT_OPERATION):
* Source/JavaScriptCore/heap/Heap.cpp:
* Source/JavaScriptCore/heap/Heap.h:
* Source/JavaScriptCore/interpreter/Interpreter.cpp:
(JSC::Interpreter::getAsyncStackTrace):
* Source/JavaScriptCore/runtime/Intrinsic.h:
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::init):
(JSC::JSGlobalObject::visitChildrenImpl):
* Source/JavaScriptCore/runtime/JSGlobalObject.h:
(JSC::JSGlobalObject::promiseReactionStructure const):
* Source/JavaScriptCore/runtime/JSPromiseReaction.cpp: Added.
(JSC::JSPromiseReaction::createWithInitialValues):
(JSC::JSPromiseReaction::create):
(JSC::JSPromiseReaction::visitChildrenImpl):
(JSC::JSPromiseReaction::createStructure):
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/JSPromiseReaction.h: Added.
* Source/JavaScriptCore/runtime/JSType.cpp:
(WTF::printInternal):
* Source/JavaScriptCore/runtime/JSType.h:

Canonical link: <a href="https://commits.webkit.org/300670@main">https://commits.webkit.org/300670@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f31669399a1a0d6dbbb64b3fe86ae784bdf43e19

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123453 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43168 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33864 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130171 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/75590 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/62d16036-4587-4013-b876-b94fc4b51abf) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43891 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51762 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/93840 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/62289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b0490852-37fb-44ee-8439-e8eaf232e41e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126406 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34973 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110451 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74471 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/13f3e83f-b6c6-4a99-940a-c1027ca7114c) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/33944 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28609 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73688 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/115612 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104688 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28834 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132890 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/121985 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50403 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38367 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/102334 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50779 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106673 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102186 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47544 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25771 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/47208 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19439 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50258 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56019 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/152339 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49731 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/38958 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53079 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51407 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->