### PR TITLE
CALayer should be declared as a system defined type.

### DIFF
--- a/Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj
+++ b/Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj
@@ -65,6 +65,7 @@
 		44B1A8682A7C5BAD00DC80A6 /* Device.h in Headers */ = {isa = PBXBuildFile; fileRef = 44B1A8622A7C334D00DC80A6 /* Device.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		44B1A8692A7C606000DC80A6 /* UserInterfaceIdiom.h in Headers */ = {isa = PBXBuildFile; fileRef = 44B1A8662A7C339300DC80A6 /* UserInterfaceIdiom.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		44E1A8B021FA54EB00C3048E /* LookupSoftLink.mm in Sources */ = {isa = PBXBuildFile; fileRef = 44E1A8AE21FA54DA00C3048E /* LookupSoftLink.mm */; };
+		4631825C2E8A1BCB00E0A31B /* CALayerForward.h in Headers */ = {isa = PBXBuildFile; fileRef = 4631825B2E8A1BCB00E0A31B /* CALayerForward.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		46FF911929196C73006005B5 /* SleepDisablerIOS.mm in Sources */ = {isa = PBXBuildFile; fileRef = 46FF911829196C73006005B5 /* SleepDisablerIOS.mm */; };
 		5157ADFD2B23B9F300C0E095 /* ContactsSoftLink.h in Headers */ = {isa = PBXBuildFile; fileRef = 5157ADFB2B23B9F300C0E095 /* ContactsSoftLink.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		5157ADFE2B23B9F300C0E095 /* ContactsSoftLink.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5157ADFC2B23B9F300C0E095 /* ContactsSoftLink.mm */; };
@@ -627,6 +628,7 @@
 		44E1A8AD21FA54DA00C3048E /* LookupSoftLink.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LookupSoftLink.h; sourceTree = "<group>"; };
 		44E1A8AE21FA54DA00C3048E /* LookupSoftLink.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = LookupSoftLink.mm; sourceTree = "<group>"; };
 		44EEA0FE2747438900594A83 /* NSServicesRolloverButtonCellSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSServicesRolloverButtonCellSPI.h; sourceTree = "<group>"; };
+		4631825B2E8A1BCB00E0A31B /* CALayerForward.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CALayerForward.h; sourceTree = "<group>"; };
 		46FF911829196C73006005B5 /* SleepDisablerIOS.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = SleepDisablerIOS.mm; sourceTree = "<group>"; };
 		4996C0F22717642B002C125D /* TCCSPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TCCSPI.h; sourceTree = "<group>"; };
 		5157ADFB2B23B9F300C0E095 /* ContactsSoftLink.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ContactsSoftLink.h; sourceTree = "<group>"; };
@@ -1115,6 +1117,7 @@
 				41D99CC72C9C45580025844F /* AVFAudioSoftLink.mm */,
 				077E87B0226A460200A2AFF0 /* AVFoundationSoftLink.h */,
 				077E87AF226A460200A2AFF0 /* AVFoundationSoftLink.mm */,
+				4631825B2E8A1BCB00E0A31B /* CALayerForward.h */,
 				5157ADFB2B23B9F300C0E095 /* ContactsSoftLink.h */,
 				5157ADFC2B23B9F300C0E095 /* ContactsSoftLink.mm */,
 				E544F3902CEBD95D007E1413 /* CoreMaterialSoftLink.h */,
@@ -1404,6 +1407,7 @@
 				DD20DDDE27BC90D70093D175 /* AXSpeechManagerSPI.h in Headers */,
 				3CBEEDE928A1861D00221FAE /* BarcodeSupportSPI.h in Headers */,
 				F4F0A5502B634D88001A54E5 /* BrowserEngineKitSPI.h in Headers */,
+				4631825C2E8A1BCB00E0A31B /* CALayerForward.h in Headers */,
 				DD20DE0F27BC90D80093D175 /* CelestialSPI.h in Headers */,
 				DD20DDCA27BC90D70093D175 /* CFNetworkConnectionCacheSPI.h in Headers */,
 				DD20DDCB27BC90D70093D175 /* CFNetworkSPI.h in Headers */,

--- a/Source/WebCore/PAL/pal/cocoa/CALayerForward.h
+++ b/Source/WebCore/PAL/pal/cocoa/CALayerForward.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,43 +25,8 @@
 
 #pragma once
 
-#include <wtf/Platform.h>
-#if ENABLE(ASYNC_SCROLLING) && PLATFORM(MAC)
+DECLARE_SYSTEM_HEADER
 
-#include <WebCore/ScrollingTreeOverflowScrollingNode.h>
+#include <wtf/Compiler.h>
 
-#if PLATFORM(COCOA)
-#include <pal/cocoa/CALayerForward.h>
-#endif
-
-namespace WebCore {
-
-class ScrollingTreeScrollingNodeDelegateMac;
-
-class WEBCORE_EXPORT ScrollingTreeOverflowScrollingNodeMac : public ScrollingTreeOverflowScrollingNode {
-public:
-    static Ref<ScrollingTreeOverflowScrollingNodeMac> create(ScrollingTree&, ScrollingNodeID);
-    virtual ~ScrollingTreeOverflowScrollingNodeMac();
-
-protected:
-    ScrollingTreeOverflowScrollingNodeMac(ScrollingTree&, ScrollingNodeID);
-
-    bool commitStateBeforeChildren(const ScrollingStateNode&) override;
-
-    void currentScrollPositionChanged(ScrollType, ScrollingLayerPositionAction) final;
-    void willDoProgrammaticScroll(const FloatPoint&) final;
-
-    void repositionScrollingLayers() override;
-    void repositionRelatedLayers() override;
-
-    WheelEventHandlingResult handleWheelEvent(const PlatformWheelEvent&, EventTargeting) override;
-
-private:
-    ScrollingTreeScrollingNodeDelegateMac& delegate() const;
-
-    void willBeDestroyed() final;
-};
-
-} // namespace WebKit
-
-#endif // ENABLE(ASYNC_SCROLLING) && PLATFORM(MAC)
+OBJC_CLASS CALayer;

--- a/Source/WebCore/page/scrolling/cocoa/ScrollingTreeFixedNodeCocoa.h
+++ b/Source/WebCore/page/scrolling/cocoa/ScrollingTreeFixedNodeCocoa.h
@@ -31,7 +31,9 @@
 #include <wtf/RetainPtr.h>
 #include <wtf/TZoneMalloc.h>
 
-OBJC_CLASS CALayer;
+#if PLATFORM(COCOA)
+#include <pal/cocoa/CALayerForward.h>
+#endif
 
 namespace WebCore {
 

--- a/Source/WebCore/page/scrolling/mac/ScrollerMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollerMac.h
@@ -33,7 +33,10 @@
 #include <wtf/RecursiveLockAdapter.h>
 #include <wtf/RetainPtr.h>
 
-OBJC_CLASS CALayer;
+#if PLATFORM(COCOA)
+#include <pal/cocoa/CALayerForward.h>
+#endif
+
 OBJC_CLASS NSColor;
 OBJC_CLASS NSScrollerImp;
 OBJC_CLASS WebScrollerImpDelegateMac;

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.h
@@ -35,7 +35,9 @@
 #include <wtf/RetainPtr.h>
 #include <wtf/TZoneMalloc.h>
 
-OBJC_CLASS CALayer;
+#if PLATFORM(COCOA)
+#include <pal/cocoa/CALayerForward.h>
+#endif
 
 namespace WebCore {
 

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreePluginScrollingNodeMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreePluginScrollingNodeMac.h
@@ -30,7 +30,9 @@
 
 #include <WebCore/ScrollingTreePluginScrollingNode.h>
 
-OBJC_CLASS CALayer;
+#if PLATFORM(COCOA)
+#include <pal/cocoa/CALayerForward.h>
+#endif
 
 namespace WebCore {
 

--- a/Source/WebCore/platform/cocoa/VideoFullscreenCaptions.h
+++ b/Source/WebCore/platform/cocoa/VideoFullscreenCaptions.h
@@ -27,7 +27,9 @@
 
 #include <WebCore/PlatformImage.h>
 
-OBJC_CLASS CALayer;
+#if PLATFORM(COCOA)
+#include <pal/cocoa/CALayerForward.h>
+#endif
 
 namespace WebCore {
 

--- a/Source/WebCore/platform/graphics/PlatformLayer.h
+++ b/Source/WebCore/platform/graphics/PlatformLayer.h
@@ -28,8 +28,11 @@
 #pragma once
 
 #include <wtf/Platform.h>
+
 #if PLATFORM(COCOA)
-OBJC_CLASS CALayer;
+
+#include <pal/cocoa/CALayerForward.h>
+
 using PlatformLayer = CALayer;
 #elif USE(COORDINATED_GRAPHICS)
 namespace WebCore {

--- a/Source/WebCore/platform/ios/LegacyTileCache.h
+++ b/Source/WebCore/platform/ios/LegacyTileCache.h
@@ -38,7 +38,10 @@
 #include <wtf/Vector.h>
 #include <wtf/WeakPtr.h>
 
-OBJC_CLASS CALayer;
+#if PLATFORM(COCOA)
+#include <pal/cocoa/CALayerForward.h>
+#endif
+
 OBJC_CLASS LegacyTileCacheTombstone;
 OBJC_CLASS LegacyTileLayer;
 OBJC_CLASS WAKWindow;

--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h
@@ -39,6 +39,7 @@
 #include <WebCore/VideoPresentationLayerProvider.h>
 #include <WebCore/VideoPresentationModel.h>
 #include <objc/objc.h>
+#include <pal/cocoa/CALayerForward.h>
 #include <wtf/Forward.h>
 #include <wtf/Function.h>
 #include <wtf/OptionSet.h>
@@ -52,7 +53,6 @@ OBJC_CLASS UIImage;
 OBJC_CLASS UIViewController;
 OBJC_CLASS UIWindow;
 OBJC_CLASS UIView;
-OBJC_CLASS CALayer;
 OBJC_CLASS NSError;
 OBJC_CLASS WKSPlayableViewControllerHost;
 OBJC_CLASS WebAVPlayerController;

--- a/Source/WebCore/platform/mac/ScrollbarThemeMac.h
+++ b/Source/WebCore/platform/mac/ScrollbarThemeMac.h
@@ -30,7 +30,7 @@
 
 #if PLATFORM(MAC)
 
-OBJC_CLASS CALayer;
+#include <pal/cocoa/CALayerForward.h>
 
 namespace WebCore {
 

--- a/Source/WebKit/Platform/cocoa/LayerHostingContext.h
+++ b/Source/WebKit/Platform/cocoa/LayerHostingContext.h
@@ -36,7 +36,10 @@
 #include <wtf/MachSendRightAnnotated.h>
 #endif
 
-OBJC_CLASS CALayer;
+#if PLATFORM(COCOA)
+#include <pal/cocoa/CALayerForward.h>
+#endif
+
 OBJC_CLASS CAContext;
 
 #if USE(EXTENSIONKIT)

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h
@@ -40,7 +40,10 @@
 #include <wtf/WeakPtr.h>
 #include <wtf/WeakRef.h>
 
-OBJC_CLASS CALayer;
+#if PLATFORM(COCOA)
+#include <pal/cocoa/CALayerForward.h>
+#endif
+
 OBJC_CLASS UIView;
 
 // FIXME: Make PlatformCALayerRemote.cpp Objective-C so we can include WebLayer.h here and share the typedef.

--- a/Source/WebKit/UIProcess/API/APIFindClient.h
+++ b/Source/WebKit/UIProcess/API/APIFindClient.h
@@ -30,7 +30,9 @@
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/WTFString.h>
 
-OBJC_CLASS CALayer;
+#if PLATFORM(COCOA)
+#include <pal/cocoa/CALayerForward.h>
+#endif
 
 namespace WebCore {
 class IntRect;

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -61,6 +61,7 @@
 #include "CocoaWindow.h"
 #include "WKBrowserEngineDefinitions.h"
 #include "WKFoundation.h"
+#include <pal/cocoa/CALayerForward.h>
 
 #if PLATFORM(IOS_FAMILY)
 #include <WebCore/InspectorOverlay.h>
@@ -75,7 +76,6 @@
 #endif
 
 OBJC_CLASS AVPlayerViewController;
-OBJC_CLASS CALayer;
 OBJC_CLASS NSFileWrapper;
 OBJC_CLASS NSMenu;
 OBJC_CLASS NSObject;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h
@@ -38,7 +38,10 @@
 #include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
-OBJC_CLASS CALayer;
+#if PLATFORM(COCOA)
+#include <pal/cocoa/CALayerForward.h>
+#endif
+
 OBJC_CLASS NSString;
 #if PLATFORM(IOS_FAMILY)
 OBJC_CLASS UIView;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/cocoa/RemoteScrollingTreeCocoa.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/cocoa/RemoteScrollingTreeCocoa.h
@@ -33,7 +33,9 @@ enum class EventListenerRegionType : uint32_t;
 class FloatPoint;
 }
 
-OBJC_CLASS CALayer;
+#if PLATFORM(COCOA)
+#include <pal/cocoa/CALayerForward.h>
+#endif
 
 namespace WebKit {
 

--- a/Source/WebKit/UIProcess/ViewGestureController.h
+++ b/Source/WebKit/UIProcess/ViewGestureController.h
@@ -41,6 +41,7 @@
 #include <wtf/WeakPtr.h>
 
 #if PLATFORM(COCOA)
+#include <pal/cocoa/CALayerForward.h>
 #include <wtf/BlockPtr.h>
 #endif
 
@@ -54,7 +55,6 @@
 #endif
 
 #if PLATFORM(COCOA)
-OBJC_CLASS CALayer;
 
 #if PLATFORM(IOS_FAMILY)
 OBJC_CLASS UIGestureRecognizer;

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -39,6 +39,10 @@
 #include <wtf/UniqueRef.h>
 #include <wtf/WeakHashSet.h>
 
+#if PLATFORM(COCOA)
+#include <pal/cocoa/CALayerForward.h>
+#endif
+
 namespace API {
 class Attachment;
 class ContentWorld;
@@ -395,7 +399,6 @@ using UserMediaRequestIdentifier = ObjectIdentifier<UserMediaRequestIdentifierTy
 } // namespace WebCore
 
 OBJC_CLASS AMSUIEngagementTask;
-OBJC_CLASS CALayer;
 OBJC_CLASS NSArray;
 OBJC_CLASS NSData;
 OBJC_CLASS NSDictionary;

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h
@@ -39,7 +39,10 @@
 #include <wtf/URL.h>
 #include <wtf/Vector.h>
 
-OBJC_CLASS CALayer;
+#if PLATFORM(COCOA)
+#include <pal/cocoa/CALayerForward.h>
+#endif
+
 OBJC_CLASS NSArray;
 OBJC_CLASS NSAttributedString;
 OBJC_CLASS NSData;

--- a/Source/WebKit/WebProcess/WebPage/PageBanner.h
+++ b/Source/WebKit/WebProcess/WebPage/PageBanner.h
@@ -30,7 +30,7 @@
 #include <wtf/WeakPtr.h>
 
 #if PLATFORM(MAC)
-OBJC_CLASS CALayer;
+#include <pal/cocoa/CALayerForward.h>
 #include <wtf/RetainPtr.h>
 #endif
 

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemote.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemote.h
@@ -30,11 +30,13 @@
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
 
+#if PLATFORM(COCOA)
+#include <pal/cocoa/CALayerForward.h>
+#endif
+
 namespace WTF {
 class TextStream;
 };
-
-OBJC_CLASS CALayer;
 
 namespace WebKit {
 

--- a/Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.h
+++ b/Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.h
@@ -37,7 +37,9 @@
 #include <wtf/RunLoop.h>
 #include <wtf/TZoneMalloc.h>
 
-OBJC_CLASS CALayer;
+#if PLATFORM(COCOA)
+#include <pal/cocoa/CALayerForward.h>
+#endif
 
 namespace WebCore {
 class LocalFrameView;


### PR DESCRIPTION
#### 327e7ac23d2a5a6adf5862b97b6010e5e36d5158
<pre>
CALayer should be declared as a system defined type.
<a href="https://bugs.webkit.org/show_bug.cgi?id=299655">https://bugs.webkit.org/show_bug.cgi?id=299655</a>
<a href="https://rdar.apple.com/161469530">rdar://161469530</a>

Reviewed by NOBODY (OOPS!).

This is so that safer cpp static analysis properly recognizes CALayer as a
system defined type, thus avoiding false positives.

* Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj:
* Source/WebCore/PAL/pal/cocoa/CALayerForward.h: Copied from Source/WebKit/UIProcess/RemoteLayerTree/cocoa/RemoteScrollingTreeCocoa.h.
* Source/WebCore/page/scrolling/cocoa/ScrollingTreeFixedNodeCocoa.h:
* Source/WebCore/page/scrolling/mac/ScrollerMac.h:
* Source/WebCore/page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.h:
* Source/WebCore/page/scrolling/mac/ScrollingTreeOverflowScrollingNodeMac.h:
* Source/WebCore/page/scrolling/mac/ScrollingTreePluginScrollingNodeMac.h:
* Source/WebCore/platform/cocoa/VideoFullscreenCaptions.h:
* Source/WebCore/platform/graphics/PlatformLayer.h:
* Source/WebCore/platform/ios/LegacyTileCache.h:
* Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h:
* Source/WebCore/platform/mac/ScrollbarThemeMac.h:
* Source/WebKit/Platform/cocoa/LayerHostingContext.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h:
* Source/WebKit/UIProcess/API/APIFindClient.h:
* Source/WebKit/UIProcess/PageClient.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h:
* Source/WebKit/UIProcess/RemoteLayerTree/cocoa/RemoteScrollingTreeCocoa.h:
* Source/WebKit/UIProcess/ViewGestureController.h:
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h:
* Source/WebKit/WebProcess/WebPage/PageBanner.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemote.h:
* Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/327e7ac23d2a5a6adf5862b97b6010e5e36d5158

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123451 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43166 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33862 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130169 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/75588 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/913df365-a246-4f14-938c-bb3407a4e5c5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/125328 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43889 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51760 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93839 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62286 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d19a6be4-51d0-46c4-8f12-8097e73e1425) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126404 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34972 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110448 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74470 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d44b2e94-758f-4c82-85b9-40d54ac08120) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33943 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28606 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73686 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104687 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28831 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132888 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50401 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38366 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102333 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50777 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106670 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102185 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47543 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25768 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/47206 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50256 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56017 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49728 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53077 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51405 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->