### PR TITLE
[ safaridriver ] dblclick not being issued

### DIFF
--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
@@ -924,7 +924,7 @@ void WebAutomationSession::documentLoadedForFrame(const WebFrameProxy& frame, st
         }
 
 #if ENABLE(WEBDRIVER_MOUSE_INTERACTIONS)
-        resetClickCount();
+        resetMouseState();
 #endif
     } else {
         if (auto callback = m_pendingEagerNavigationInBrowsingContextCallbacksPerFrame.take(frame.frameID())) {
@@ -1942,24 +1942,38 @@ void WebAutomationSession::viewportInViewCenterPointOfElement(WebPageProxy& page
 #if ENABLE(WEBDRIVER_MOUSE_INTERACTIONS)
 void WebAutomationSession::updateClickCount(MouseButton button, const WebCore::IntPoint& position, Seconds maxTime, int maxDistance)
 {
-    auto now = MonotonicTime::now();
-    if (now - m_lastClickTime < maxTime && button == m_lastClickButton && m_lastClickPosition.distanceSquaredToPoint(position) < maxDistance) {
-        m_clickCount++;
-        m_lastClickTime = now;
+    if (button != MouseButton::Left) {
+        m_lastClickPosition.reset();
+        m_clickCount = 1;
         return;
     }
 
-    m_clickCount = 1;
+    auto now = MonotonicTime::now();
+    if (!m_lastClickPosition || m_lastClickPosition->distanceSquaredToPoint(position) > maxDistance || now - m_lastClickTime > maxTime) {
+        m_lastClickPosition = position;
+        m_lastClickTime = now;
+        m_clickCount = 1;
+        return;
+    }
+
     m_lastClickTime = now;
-    m_lastClickButton = button;
-    m_lastClickPosition = position;
+    ++m_clickCount;
 }
 
-void WebAutomationSession::resetClickCount()
+void WebAutomationSession::updateLastPosition(const WebCore::IntPoint& position, int maxDistance)
+{
+    // Cancel multiple clicks if mouse strays too far:
+    if (m_lastClickPosition && m_lastClickPosition->distanceSquaredToPoint(position) > maxDistance)
+        m_lastClickPosition.reset();
+
+    m_lastPosition = position;
+}
+
+void WebAutomationSession::resetMouseState()
 {
     m_clickCount = 1;
-    m_lastClickButton = MouseButton::None;
-    m_lastClickPosition = { };
+    m_lastPosition.reset();
+    m_lastClickPosition.reset();
 }
 
 void WebAutomationSession::simulateMouseInteraction(WebPageProxy& page, MouseInteraction interaction, MouseButton mouseButton, const WebCore::IntPoint& locationInViewport, const String& pointerType, CompletionHandler<void(std::optional<AutomationCommandError>)>&& completionHandler)

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
@@ -328,7 +328,8 @@ private:
     // Platform-dependent implementations.
 #if ENABLE(WEBDRIVER_MOUSE_INTERACTIONS)
     void updateClickCount(MouseButton, const WebCore::IntPoint&, Seconds maxTime = 1_s, int maxDistance = 0);
-    void resetClickCount();
+    void updateLastPosition(const WebCore::IntPoint&, int maxDistance = 0);
+    void resetMouseState();
     void platformSimulateMouseInteraction(WebPageProxy&, MouseInteraction, MouseButton, const WebCore::IntPoint& locationInViewport, OptionSet<WebEventModifier>, const String& pointerType);
     static OptionSet<WebEventModifier> platformWebModifiersFromRaw(WebPageProxy&, unsigned modifiers);
 #endif
@@ -426,9 +427,9 @@ private:
 #endif
 #if ENABLE(WEBDRIVER_MOUSE_INTERACTIONS)
     MonotonicTime m_lastClickTime;
-    MouseButton m_lastClickButton { MouseButton::None };
     HashMap<MouseButton, bool, WTF::IntHash<MouseButton>, WTF::StrongEnumHashTraits<MouseButton>> m_mouseButtonsCurrentlyDown;
-    WebCore::IntPoint m_lastClickPosition;
+    std::optional<WebCore::IntPoint> m_lastPosition;
+    std::optional<WebCore::IntPoint> m_lastClickPosition;
     unsigned m_clickCount { 1 };
 #endif
 


### PR DESCRIPTION
#### 5e03e11ba5bc99e03b3cc97aa70d3ef8d91877b3
<pre>
[ safaridriver ] dblclick not being issued
<a href="https://bugs.webkit.org/show_bug.cgi?id=299551">https://bugs.webkit.org/show_bug.cgi?id=299551</a>
<a href="https://rdar.apple.com/161399867">rdar://161399867</a>

Reviewed by Abrar Rahman Protyasha and BJ Burg.

Simulated MouseUps and MouseDowns through WebDriver now contain the
correct value for clickCount, triggering the doubleclick detection
downstream. This required a code change to make sure m_clickCount
always has the correct value.

This patch introduces m_lastPosition and updateLastPosition() to
decouple mouse delta calculation and multiple click detection.
Previously, m_lastClickPosition and updateClickCount() were overloaded,
being used to detect multiple clicks on GTK and to calculate mouse
deltas on Mac. On Mac, updateClickCount() had to be called on every
simulated mouse event (instead of only on mousedowns), which would
result in a clobbered m_clickCount.

This patch causes imported/w3c/web-platform-tests/event-timing/dblclick.html
to pass on safaridriver (previously passing only on WKTR). No changes were
observed on imported/w3c/web-platform-tests/pointerevents tests.

Canonical link: <a href="https://commits.webkit.org/300900@main">https://commits.webkit.org/300900@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e8c81542768205199ea387dd7173683e053d4a0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124209 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43902 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34619 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131039 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76300 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44643 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52501 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94484 "23 flakes 25 failures") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62686 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127163 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35574 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111099 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75072 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34519 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74524 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105316 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29482 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133714 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51131 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38971 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102957 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51518 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107317 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102759 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26156 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48119 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26367 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/48037 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50992 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56768 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50439 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53791 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52114 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->