### PR TITLE
Images on axton.gallery disappear momentarily when clicking on them

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/reference/svg-filter-filter-units-user-space-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/reference/svg-filter-filter-units-user-space-ref.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        .container {
+            width: 200px;
+            height: 200px;
+            display: inline-block;
+            vertical-align: top;
+            margin-right: 2px;
+            margin-bottom: 4px;
+            background-color: lightgray;
+        }
+
+        .green-box {
+            background-color: red;
+            width: 50px;
+            height: 50px;
+            background-color: green;
+            transform: translate(10px, 10px);
+        }
+
+        svg {
+            background-color: rgb(160, 160, 160);
+        }
+    </style>
+</head>
+<body>
+    <div>
+        <div class="container"></div>
+        <div class="container">
+            <svg width="150" height="150">
+                <rect x="0" y="0" width="75" height="75" fill="green" />
+            </svg>
+        </div>
+        <div class="container">
+            <div class="green-box"></div>
+        </div>
+    </div>
+    <div>
+        <div class="container">
+            <svg width="200" height="200">
+                <rect x="0" y="0" width="100" height="100" fill="green" />
+            </svg>
+        </div>
+        <div class="container">
+            <svg width="150" height="150">
+                <rect x="0" y="0" width="75" height="75" fill="green" />
+            </svg>
+        </div>
+        <div class="container">
+            <div class="green-box"></div>
+        </div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/reference/svg-filter-primitive-units-user-space-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/reference/svg-filter-primitive-units-user-space-ref.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        .container {
+            width: 200px;
+            height: 200px;
+            display: inline-block;
+            vertical-align: top;
+            margin-right: 2px;
+            margin-bottom: 4px;
+            background-color: lightgray;
+        }
+
+        .filtered-box {
+            background-color: green;
+            width: 100px;
+            height: 100px;
+        }
+
+        svg {
+            background-color: rgb(160, 160, 160);
+        }
+    </style>
+</head>
+<body>
+    <div>
+        <div class="container"></div>
+        <div class="container">
+            <svg width="150" height="150">
+                <rect x="0" y="0" width="120" height="120" fill="green" />
+            </svg>
+        </div>
+        <div class="container">
+            <div class="filtered-box"></div>
+        </div>
+    </div>
+    <div>
+        <div class="container">
+            <svg width="200" height="200">
+                <rect x="0" y="0" width="120" height="120" fill="green" />
+            </svg>
+        </div>
+        <div class="container">
+            <svg width="150" height="150">
+                <rect x="0" y="0" width="120" height="120" fill="green" />
+            </svg>
+        </div>
+        <div class="container">
+            <div class="filtered-box"></div>
+        </div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/svg-filter-filter-units-user-space-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/svg-filter-filter-units-user-space-expected.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        .container {
+            width: 200px;
+            height: 200px;
+            display: inline-block;
+            vertical-align: top;
+            margin-right: 2px;
+            margin-bottom: 4px;
+            background-color: lightgray;
+        }
+
+        .green-box {
+            background-color: red;
+            width: 50px;
+            height: 50px;
+            background-color: green;
+            transform: translate(10px, 10px);
+        }
+
+        svg {
+            background-color: rgb(160, 160, 160);
+        }
+    </style>
+</head>
+<body>
+    <div>
+        <div class="container"></div>
+        <div class="container">
+            <svg width="150" height="150">
+                <rect x="0" y="0" width="75" height="75" fill="green" />
+            </svg>
+        </div>
+        <div class="container">
+            <div class="green-box"></div>
+        </div>
+    </div>
+    <div>
+        <div class="container">
+            <svg width="200" height="200">
+                <rect x="0" y="0" width="100" height="100" fill="green" />
+            </svg>
+        </div>
+        <div class="container">
+            <svg width="150" height="150">
+                <rect x="0" y="0" width="75" height="75" fill="green" />
+            </svg>
+        </div>
+        <div class="container">
+            <div class="green-box"></div>
+        </div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/svg-filter-filter-units-user-space.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/svg-filter-filter-units-user-space.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <link rel="author" title="Said Abou-Hallawa" href="mailto:said@apple.com>">
+    <link rel="help" href="https://drafts.fxtf.org/filter-effects/#element-attrdef-filter-primitiveunits">
+    <link rel="help" href="https://drafts.csswg.org/css-transforms-1/#local-coordinate-system">
+    <link rel="match" href="svg-filter-filter-units-user-space-ref.html">
+    <style>
+        .container {
+            width: 200px;
+            height: 200px;
+            display: inline-block;
+            vertical-align: top;
+            margin-right: 2px;
+            margin-bottom: 4px;
+            background-color: lightgray;
+        }
+
+        .filtered-box {
+            background-color: red;
+            width: 100px;
+            height: 100px;
+            transform: translate(10px, 10px);
+        }
+
+        svg {
+            background-color: rgb(160, 160, 160);
+        }
+    </style>
+</head>
+<body>
+    <div>
+        <div class="container">
+            <svg width="0" height="0" style="position: absolute;">
+                <defs>
+                    <filter id="floodFilter-1" filterUnits="userSpaceOnUse" x="0" y="0" width="100%" height="100%">
+                        <feFlood flood-color="green" width="50%" height="50%" />
+                    </filter>
+                </defs>
+            </svg>
+        </div>
+        <div class="container">
+            <svg width="150" height="150">
+                <rect x="10" y="10" width="100" height="100" fill="red" filter="url(#floodFilter-1)" />
+            </svg>
+        </div>
+        <div class="container">
+            <div class="filtered-box" style="filter: url(#floodFilter-1);"></div>
+        </div>
+    </div>
+    <div>
+        <div class="container">
+            <svg width="200" height="200">
+                <defs>
+                    <filter id="floodFilter-2" filterUnits="userSpaceOnUse" x="0" y="0" width="100%" height="100%">
+                        <feFlood flood-color="green" width="50%" height="50%" />
+                    </filter>
+                </defs>
+                <rect x="10" y="10" width="100" height="100" fill="red" filter="url(#floodFilter-2)" />
+            </svg>
+        </div>
+        <div class="container">
+            <svg width="150" height="150">
+                <rect x="10" y="10" width="100" height="100" fill="red" filter="url(#floodFilter-2)" />
+            </svg>
+        </div>
+        <div class="container">
+            <div class="filtered-box" style="filter: url(#floodFilter-2);"></div>
+        </div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/svg-filter-primitive-units-user-space-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/svg-filter-primitive-units-user-space-expected.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        .container {
+            width: 200px;
+            height: 200px;
+            display: inline-block;
+            vertical-align: top;
+            margin-right: 2px;
+            margin-bottom: 4px;
+            background-color: lightgray;
+        }
+
+        .filtered-box {
+            background-color: green;
+            width: 100px;
+            height: 100px;
+        }
+
+        svg {
+            background-color: rgb(160, 160, 160);
+        }
+    </style>
+</head>
+<body>
+    <div>
+        <div class="container"></div>
+        <div class="container">
+            <svg width="150" height="150">
+                <rect x="0" y="0" width="120" height="120" fill="green" />
+            </svg>
+        </div>
+        <div class="container">
+            <div class="filtered-box"></div>
+        </div>
+    </div>
+    <div>
+        <div class="container">
+            <svg width="200" height="200">
+                <rect x="0" y="0" width="120" height="120" fill="green" />
+            </svg>
+        </div>
+        <div class="container">
+            <svg width="150" height="150">
+                <rect x="0" y="0" width="120" height="120" fill="green" />
+            </svg>
+        </div>
+        <div class="container">
+            <div class="filtered-box"></div>
+        </div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/svg-filter-primitive-units-user-space.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/svg-filter-primitive-units-user-space.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="fuzzy" content="maxDifference=0-160; totalPixels=0-723">
+    <link rel="author" title="Said Abou-Hallawa" href="mailto:said@apple.com>">
+    <link rel="help" href="https://drafts.fxtf.org/filter-effects/#element-attrdef-filter-primitiveunits">
+    <link rel="help" href="https://drafts.csswg.org/css-transforms-1/#local-coordinate-system">
+    <link rel="match" href="svg-filter-primitive-units-user-space-ref.html">
+    <style>
+        .container {
+            width: 200px;
+            height: 200px;
+            display: inline-block;
+            vertical-align: top;
+            margin-right: 2px;
+            margin-bottom: 4px;
+            background-color: lightgray;
+        }
+
+        .filtered-box {
+            background-color: red;
+            width: 100px;
+            height: 100px;
+            transform: translate(10px, 10px);
+        }
+
+        svg {
+            background-color: rgb(160, 160, 160);
+        }
+    </style>
+</head>
+<body>
+    <div>
+        <div class="container">
+            <svg width="0" height="0" style="position: absolute;">
+                <defs>
+                    <filter id="floodFilter-1" primitiveUnits="userSpaceOnUse">
+                        <feFlood flood-color="green" width="100%" height="100%" />
+                    </filter>
+                </defs>
+            </svg>
+        </div>
+        <div class="container">
+            <svg width="150" height="150">
+                <rect x="10" y="10" width="100" height="100" fill="red" filter="url(#floodFilter-1)" />
+            </svg>
+        </div>
+        <div class="container">
+            <div class="filtered-box" style="filter: url(#floodFilter-1);"></div>
+        </div>
+    </div>
+    <div>
+        <div class="container">
+            <svg width="200" height="200">
+                <defs>
+                    <filter id="floodFilter-2" primitiveUnits="userSpaceOnUse">
+                        <feFlood flood-color="green" width="100%" height="100%" />
+                    </filter>
+                </defs>
+                <rect x="10" y="10" width="100" height="100" fill="red" filter="url(#floodFilter-2)" />
+            </svg>
+        </div>
+        <div class="container">
+            <svg width="150" height="150">
+                <rect x="10" y="10" width="100" height="100" fill="red" filter="url(#floodFilter-2)" />
+            </svg>
+        </div>
+        <div class="container">
+            <div class="filtered-box" style="filter: url(#floodFilter-2);"></div>
+        </div>
+    </div>
+</body>
+</html>

--- a/Source/WebCore/rendering/CSSFilterRenderer.cpp
+++ b/Source/WebCore/rendering/CSSFilterRenderer.cpp
@@ -235,9 +235,13 @@ static RefPtr<SVGFilterRenderer> createReferenceFilter(CSSFilterRenderer& filter
     if (!filterElement)
         return nullptr;
 
-    auto filterRegion = SVGLengthContext::resolveRectangle<SVGFilterElement>(filterElement.get(), filterElement->filterUnits(), targetBoundingBox);
+    RefPtr contextElement = dynamicDowncast<SVGElement>(renderer.element());
 
-    return SVGFilterRenderer::create(*filterElement, preferredFilterRenderingModes, filter.filterScale(), filterRegion, targetBoundingBox, destinationContext);
+    auto filterRegion = SVGLengthContext::resolveRectangle(contextElement.get(), *filterElement, filterElement->filterUnits(), targetBoundingBox);
+    if (filterRegion.isEmpty())
+        return nullptr;
+
+    return SVGFilterRenderer::create(contextElement.get(), *filterElement, preferredFilterRenderingModes, filter.filterScale(), filterRegion, targetBoundingBox, destinationContext);
 }
 
 RefPtr<FilterFunction> CSSFilterRenderer::buildFilterFunction(RenderElement& renderer, const FilterOperation& operation, OptionSet<FilterRenderingMode> preferredFilterRenderingModes, const FloatRect& targetBoundingBox, const GraphicsContext& destinationContext)

--- a/Source/WebCore/rendering/svg/RenderSVGResourceFilter.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceFilter.cpp
@@ -46,7 +46,14 @@ RenderSVGResourceFilter::~RenderSVGResourceFilter() = default;
 FloatRect RenderSVGResourceFilter::resourceBoundingBox(const RenderObject& object, RepaintRectCalculation)
 {
     Ref filterElement = this->filterElement();
-    return SVGLengthContext::resolveRectangle<SVGFilterElement>(filterElement.ptr(), filterElement->filterUnits(), object.objectBoundingBox());
+
+    CheckedPtr renderer = dynamicDowncast<RenderElement>(object);
+    if (!renderer)
+        return SVGLengthContext::resolveRectangle(filterElement.get(), filterElement->filterUnits(), object.objectBoundingBox());
+
+    RefPtr contextElement = dynamicDowncast<SVGElement>(renderer->element());
+
+    return SVGLengthContext::resolveRectangle(contextElement.get(), filterElement.get(), filterElement->filterUnits(), object.objectBoundingBox());
 }
 
 void RenderSVGResourceFilter::invalidateFilter()

--- a/Source/WebCore/rendering/svg/RenderSVGResourceMasker.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceMasker.cpp
@@ -167,7 +167,7 @@ FloatRect RenderSVGResourceMasker::resourceBoundingBox(const RenderObject& objec
         maskRect = contentTransform.mapRect(maskRect);
     }
 
-    auto maskBoundaries = SVGLengthContext::resolveRectangle<SVGMaskElement>(maskElement.ptr(), maskElement->maskUnits(), targetBoundingBox);
+    auto maskBoundaries = SVGLengthContext::resolveRectangle(maskElement.get(), maskElement->maskUnits(), targetBoundingBox);
     maskRect.intersect(maskBoundaries);
     if (maskRect.isEmpty())
         return targetBoundingBox;

--- a/Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp
@@ -457,9 +457,10 @@ void writeSVGResourceContainer(TextStream& ts, const LegacyRenderSVGResourceCont
         writeNameValuePair(ts, "primitiveUnits"_s, filter.primitiveUnits());
         ts << '\n';
         // Creating a placeholder filter which is passed to the builder.
+        Ref filterElement = filter.filterElement();
         FloatRect dummyRect;
         FloatSize dummyScale(1, 1);
-        auto dummyFilter = SVGFilterRenderer::create(filter.protectedFilterElement(), FilterRenderingMode::Software, dummyScale, dummyRect, dummyRect, NullGraphicsContext());
+        auto dummyFilter = SVGFilterRenderer::create(filterElement.ptr(), filterElement, FilterRenderingMode::Software, dummyScale, dummyRect, dummyRect, NullGraphicsContext());
         if (dummyFilter) {
             TextStream::IndentScope indentScope(ts);
             dummyFilter->externalRepresentation(ts, FilterRepresentation::TestOutput);

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMasker.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMasker.cpp
@@ -184,7 +184,7 @@ FloatRect LegacyRenderSVGResourceMasker::resourceBoundingBox(const RenderObject&
 {
     FloatRect objectBoundingBox = object.objectBoundingBox();
     Ref maskElement = this->maskElement();
-    FloatRect maskBoundaries = SVGLengthContext::resolveRectangle<SVGMaskElement>(maskElement.ptr(), maskElement->maskUnits(), objectBoundingBox);
+    FloatRect maskBoundaries = SVGLengthContext::resolveRectangle(maskElement.get(), maskElement->maskUnits(), objectBoundingBox);
 
     // Resource was not layouted yet. Give back clipping rect of the mask.
     if (selfNeedsLayout())

--- a/Source/WebCore/svg/SVGLengthContext.cpp
+++ b/Source/WebCore/svg/SVGLengthContext.cpp
@@ -50,8 +50,9 @@
 
 namespace WebCore {
 
-SVGLengthContext::SVGLengthContext(const SVGElement* context)
+SVGLengthContext::SVGLengthContext(const SVGElement* context, const std::optional<FloatSize>& viewportSize)
     : m_context(context)
+    , m_viewportSize(!m_context ? viewportSize : std::nullopt)
 {
 }
 
@@ -69,7 +70,7 @@ FloatRect SVGLengthContext::resolveRectangle(const SVGElement* context, SVGUnitT
             convertValueFromPercentageToUserUnits(height.valueAsPercentage(), height.lengthMode(), viewportSize));
     }
 
-    SVGLengthContext lengthContext(context);
+    SVGLengthContext lengthContext(context, viewport.size());
     return FloatRect(x.value(lengthContext), y.value(lengthContext), width.value(lengthContext), height.value(lengthContext));
 }
 
@@ -385,7 +386,7 @@ ExceptionOr<float> SVGLengthContext::convertValueFromEXSToUserUnits(float value)
 std::optional<FloatSize> SVGLengthContext::viewportSize() const
 {
     if (!m_context)
-        return std::nullopt;
+        return m_viewportSize;
 
     if (!m_viewportSize)
         m_viewportSize = computeViewportSize();

--- a/Source/WebCore/svg/SVGLengthContext.h
+++ b/Source/WebCore/svg/SVGLengthContext.h
@@ -45,13 +45,19 @@ struct StrokeWidth;
 
 class SVGLengthContext {
 public:
-    explicit SVGLengthContext(const SVGElement*);
+    explicit SVGLengthContext(const SVGElement*, const std::optional<FloatSize>& viewportSize = std::nullopt);
     ~SVGLengthContext();
 
     template<typename T>
-    static FloatRect resolveRectangle(const T* context, SVGUnitTypes::SVGUnitType type, const FloatRect& viewport)
+    static FloatRect resolveRectangle(const SVGElement* context, T& element, SVGUnitTypes::SVGUnitType type, const FloatRect& viewport)
     {
-        return resolveRectangle(context, type, viewport, context->x(), context->y(), context->width(), context->height());
+        return resolveRectangle(context, type, viewport, element.x(), element.y(), element.width(), element.height());
+    }
+
+    template<typename T>
+    static FloatRect resolveRectangle(const T& element, SVGUnitTypes::SVGUnitType type, const FloatRect& viewport)
+    {
+        return resolveRectangle(&element, element, type, viewport);
     }
 
     static FloatRect resolveRectangle(const SVGElement*, SVGUnitTypes::SVGUnitType, const FloatRect& viewport, const SVGLengthValue& x, const SVGLengthValue& y, const SVGLengthValue& width, const SVGLengthValue& height);

--- a/Source/WebCore/svg/graphics/filters/SVGFilterRenderer.cpp
+++ b/Source/WebCore/svg/graphics/filters/SVGFilterRenderer.cpp
@@ -36,11 +36,11 @@ namespace WebCore {
 
 static constexpr unsigned maxCountChildNodes = 200;
 
-RefPtr<SVGFilterRenderer> SVGFilterRenderer::create(SVGFilterElement& filterElement, OptionSet<FilterRenderingMode> preferredFilterRenderingModes, const FloatSize& filterScale, const FloatRect& filterRegion, const FloatRect& targetBoundingBox, const GraphicsContext& destinationContext, std::optional<RenderingResourceIdentifier> renderingResourceIdentifier)
+RefPtr<SVGFilterRenderer> SVGFilterRenderer::create(SVGElement *contextElement, SVGFilterElement& filterElement, OptionSet<FilterRenderingMode> preferredFilterRenderingModes, const FloatSize& filterScale, const FloatRect& filterRegion, const FloatRect& targetBoundingBox, const GraphicsContext& destinationContext, std::optional<RenderingResourceIdentifier> renderingResourceIdentifier)
 {
     auto filter = adoptRef(*new SVGFilterRenderer(filterScale, filterRegion, targetBoundingBox, filterElement.primitiveUnits(), renderingResourceIdentifier));
 
-    auto result = buildExpression(filterElement, filter, destinationContext);
+    auto result = buildExpression(contextElement, filterElement, filter, destinationContext);
     if (!result)
         return nullptr;
 
@@ -81,7 +81,7 @@ SVGFilterRenderer::SVGFilterRenderer(const FloatRect& targetBoundingBox, SVGUnit
 {
 }
 
-static std::optional<std::tuple<SVGFilterEffectGraph, FilterEffectGeometryMap>> buildFilterEffectGraph(SVGFilterElement& filterElement, const SVGFilterRenderer& filter, const GraphicsContext& destinationContext)
+static std::optional<std::tuple<SVGFilterEffectGraph, FilterEffectGeometryMap>> buildFilterEffectGraph(SVGElement *contextElement, SVGFilterElement& filterElement, const SVGFilterRenderer& filter, const GraphicsContext& destinationContext)
 {
     if (filterElement.countChildNodes() > maxCountChildNodes)
         return std::nullopt;
@@ -105,7 +105,7 @@ static std::optional<std::tuple<SVGFilterEffectGraph, FilterEffectGeometryMap>> 
             return std::nullopt;
 
         if (auto flags = effectElement->effectGeometryFlags()) {
-            auto effectBoundaries = SVGLengthContext::resolveRectangle<SVGFilterPrimitiveStandardAttributes>(effectElement.ptr(), filter.primitiveUnits(), filter.targetBoundingBox());
+            auto effectBoundaries = SVGLengthContext::resolveRectangle(contextElement, effectElement.get(), filter.primitiveUnits(), filter.targetBoundingBox());
             effectGeometryMap.add(*effect, FilterEffectGeometry(effectBoundaries, flags));
         }
 
@@ -119,9 +119,9 @@ static std::optional<std::tuple<SVGFilterEffectGraph, FilterEffectGeometryMap>> 
     return { { WTFMove(graph), WTFMove(effectGeometryMap) } };
 }
 
-std::optional<std::tuple<SVGFilterExpression, FilterEffectVector>> SVGFilterRenderer::buildExpression(SVGFilterElement& filterElement, const SVGFilterRenderer& filter, const GraphicsContext& destinationContext)
+std::optional<std::tuple<SVGFilterExpression, FilterEffectVector>> SVGFilterRenderer::buildExpression(SVGElement *contextElement, SVGFilterElement& filterElement, const SVGFilterRenderer& filter, const GraphicsContext& destinationContext)
 {
-    auto result = buildFilterEffectGraph(filterElement, filter, destinationContext);
+    auto result = buildFilterEffectGraph(contextElement, filterElement, filter, destinationContext);
     if (!result)
         return std::nullopt;
 

--- a/Source/WebCore/svg/graphics/filters/SVGFilterRenderer.h
+++ b/Source/WebCore/svg/graphics/filters/SVGFilterRenderer.h
@@ -33,11 +33,12 @@ namespace WebCore {
 
 class FilterImage;
 class GraphicsContext;
+class SVGElement;
 class SVGFilterElement;
 
 class SVGFilterRenderer final : public Filter {
 public:
-    static RefPtr<SVGFilterRenderer> create(SVGFilterElement&, OptionSet<FilterRenderingMode> preferredFilterRenderingModes, const FloatSize& filterScale, const FloatRect& filterRegion, const FloatRect& targetBoundingBox, const GraphicsContext& destinationContext, std::optional<RenderingResourceIdentifier> = std::nullopt);
+    static RefPtr<SVGFilterRenderer> create(SVGElement* contextElement, SVGFilterElement&, OptionSet<FilterRenderingMode> preferredFilterRenderingModes, const FloatSize& filterScale, const FloatRect& filterRegion, const FloatRect& targetBoundingBox, const GraphicsContext& destinationContext, std::optional<RenderingResourceIdentifier> = std::nullopt);
     WEBCORE_EXPORT static Ref<SVGFilterRenderer> create(const FloatRect& targetBoundingBox, SVGUnitTypes::SVGUnitType primitiveUnits, SVGFilterExpression&&, FilterEffectVector&&, std::optional<RenderingResourceIdentifier>, OptionSet<FilterRenderingMode>, const FloatSize& filterScale, const FloatRect& filterRegion);
 
     static bool isIdentity(SVGFilterElement&);
@@ -67,7 +68,7 @@ private:
     SVGFilterRenderer(const FloatSize& filterScale, const FloatRect& filterRegion, const FloatRect& targetBoundingBox, SVGUnitTypes::SVGUnitType primitiveUnits, std::optional<RenderingResourceIdentifier>);
     SVGFilterRenderer(const FloatRect& targetBoundingBox, SVGUnitTypes::SVGUnitType primitiveUnits, SVGFilterExpression&&, FilterEffectVector&&, std::optional<RenderingResourceIdentifier>, const FloatSize& filterScale, const FloatRect& filterRegion);
 
-    static std::optional<std::tuple<SVGFilterExpression, FilterEffectVector>> buildExpression(SVGFilterElement&, const SVGFilterRenderer&, const GraphicsContext& destinationContext);
+    static std::optional<std::tuple<SVGFilterExpression, FilterEffectVector>> buildExpression(SVGElement* contextElement, SVGFilterElement&, const SVGFilterRenderer&, const GraphicsContext& destinationContext);
     void setExpression(SVGFilterExpression&& expression) { m_expression = WTFMove(expression); }
     void setEffects(FilterEffectVector&& effects) { m_effects = WTFMove(effects); }
 


### PR DESCRIPTION
#### 41e6b037fd006ed630cd9114706ef9a803adbe2a
<pre>
Images on axton.gallery disappear momentarily when clicking on them
<a href="https://bugs.webkit.org/show_bug.cgi?id=298540">https://bugs.webkit.org/show_bug.cgi?id=298540</a>
<a href="https://rdar.apple.com/154363710">rdar://154363710</a>

Reviewed by Simon Fraser.

Currently if primitiveUnits is equal to userSpaceOnUse, primitiveSubRegion is
resolved against the viewport of the &lt;filter&gt; element&apos;s ancestor &lt;svg&gt;. Similarly
if filterUnits is to userSpaceOnUse, the filterRegion is resolved against the 
viewport of the &lt;filter&gt; element&apos;s ancestor &lt;svg&gt;.

The specs state that:

[1] Any length values within the filter definitions represent values in the current
local coordinate system in place at the time when the filter element is referenced.

[2] The local coordinate system is the coordinate system that is currently active
and which is used to define how coordinates and lengths are located and computed,
respectively, on the current canvas.

So the fix is:

1. For an HTML target element, its bounding box should be used to resolve
   primitiveSubRegion and filterRegion.

2. For an SVG target element, the viewport of its a ancestor &lt;svg&gt; should be
   used to resolve primitiveSubRegion and filterRegion.

[1] <a href="https://drafts.fxtf.org/filter-effects/#element-attrdef-filter-primitiveunits">https://drafts.fxtf.org/filter-effects/#element-attrdef-filter-primitiveunits</a>
[2] <a href="https://drafts.csswg.org/css-transforms-1/#local-coordinate-system">https://drafts.csswg.org/css-transforms-1/#local-coordinate-system</a>

Tests: imported/w3c/web-platform-tests/css/filter-effects/svg-filter-filter-units-user-space.html
       imported/w3c/web-platform-tests/css/filter-effects/svg-filter-primitive-units-user-space.html

* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/reference/svg-filter-filter-units-user-space-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/reference/svg-filter-primitive-units-user-space-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/svg-filter-filter-units-user-space-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/svg-filter-filter-units-user-space.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/svg-filter-primitive-units-user-space-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/svg-filter-primitive-units-user-space.html: Added.
* Source/WebCore/rendering/CSSFilterRenderer.cpp:
(WebCore::createReferenceFilter):
* Source/WebCore/rendering/svg/RenderSVGResourceFilter.cpp:
(WebCore::RenderSVGResourceFilter::resourceBoundingBox):
* Source/WebCore/rendering/svg/RenderSVGResourceMasker.cpp:
(WebCore::RenderSVGResourceMasker::resourceBoundingBox):
* Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp:
(WebCore::writeSVGResourceContainer):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilter.cpp:
(WebCore::LegacyRenderSVGResourceFilter::applyResource):
(WebCore::LegacyRenderSVGResourceFilter::resourceBoundingBox):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMasker.cpp:
(WebCore::LegacyRenderSVGResourceMasker::resourceBoundingBox):
* Source/WebCore/svg/SVGLengthContext.cpp:
(WebCore::SVGLengthContext::SVGLengthContext):
(WebCore::SVGLengthContext::resolveRectangle):
(WebCore::SVGLengthContext::viewportSize const):
* Source/WebCore/svg/SVGLengthContext.h:
(WebCore::SVGLengthContext::resolveRectangle):
* Source/WebCore/svg/graphics/filters/SVGFilterRenderer.cpp:
(WebCore::SVGFilterRenderer::create):
(WebCore::buildFilterEffectGraph):
(WebCore::SVGFilterRenderer::buildExpression):
* Source/WebCore/svg/graphics/filters/SVGFilterRenderer.h:

Canonical link: <a href="https://commits.webkit.org/301424@main">https://commits.webkit.org/301424@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/034ae413cf8d184ca892fa06c6e1941e5538568d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125971 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45628 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36399 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/132829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/77820 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/536438e0-eac2-48ff-a73e-7453c1d6ddab) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127842 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46309 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54183 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/132829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/77820 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8a090c49-b019-43e2-ad72-c0c2597ecaa5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128919 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/37042 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/112658 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/132829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8ac02235-a85e-4bf8-8000-f2cdf874b247) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/35950 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/30844 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/76300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/106824 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31058 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/135517 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/52748 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40479 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/135517 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53197 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108872 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/135517 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26516 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49539 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27871 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/50126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52642 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58459 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/51985 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/55333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/53682 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->