### PR TITLE
vp9HardwareDecoderAvailable() is non-functional when called in the content process.

### DIFF
--- a/Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.h
+++ b/Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.h
@@ -47,6 +47,7 @@ WEBCORE_EXPORT void registerWebKitVP9Decoder();
 WEBCORE_EXPORT void registerSupplementalVP9Decoder();
 bool isVP9DecoderAvailable();
 WEBCORE_EXPORT bool vp9HardwareDecoderAvailable();
+WEBCORE_EXPORT bool vp9HardwareDecoderAvailableInProcess();
 bool isVP8DecoderAvailable();
 bool isVPCodecConfigurationRecordSupported(const VPCodecConfigurationRecord&);
 std::optional<MediaCapabilitiesInfo> validateVPParameters(const VPCodecConfigurationRecord&, const VideoConfiguration&);
@@ -71,31 +72,35 @@ struct VP8FrameHeader {
 std::optional<VP8FrameHeader> parseVP8FrameHeader(std::span<const uint8_t>);
 Ref<VideoInfo> createVideoInfoFromVP8Header(const VP8FrameHeader&, const webm::Video&);
 
-class WEBCORE_EXPORT VP9TestingOverrides {
+class VP9TestingOverrides {
 public:
-    static VP9TestingOverrides& singleton();
+    static WEBCORE_EXPORT VP9TestingOverrides& singleton();
 
-    void setHardwareDecoderDisabled(std::optional<bool>&&);
+    WEBCORE_EXPORT void setHardwareDecoderDisabled(std::optional<bool>&&);
     std::optional<bool> hardwareDecoderDisabled() const { return m_hardwareDecoderDisabled; }
     
-    void setVP9DecoderDisabled(std::optional<bool>&&);
+    WEBCORE_EXPORT void setVP9HardwareDecoderEnabledOverride(std::optional<bool>&&);
+    std::optional<bool> vp9HardwareDecoderEnabledOverride() const { return m_vp9HardwareDecoderEnabledOverride; }
+
+    WEBCORE_EXPORT void setVP9DecoderDisabled(std::optional<bool>&&);
     std::optional<bool> vp9DecoderDisabled() const { return m_vp9DecoderDisabled; }
 
-    void setVP9ScreenSizeAndScale(std::optional<ScreenDataOverrides>&&);
+    WEBCORE_EXPORT void setVP9ScreenSizeAndScale(std::optional<ScreenDataOverrides>&&);
     std::optional<ScreenDataOverrides> vp9ScreenSizeAndScale() const { return m_screenSizeAndScale; }
 
-    void setConfigurationChangedCallback(std::function<void(bool)>&&);
-    void resetOverridesToDefaultValues();
+    WEBCORE_EXPORT void setConfigurationChangedCallback(std::function<void(bool)>&&);
+    WEBCORE_EXPORT void resetOverridesToDefaultValues();
 
-    void setSWVPDecodersAlwaysEnabled(bool);
+    WEBCORE_EXPORT void setSWVPDecodersAlwaysEnabled(bool);
     bool swVPDecodersAlwaysEnabled() const { return m_swVPDecodersAlwaysEnabled; }
 
-    void setShouldEnableVP9Decoder(bool);
-    bool shouldEnableVP9Decoder() const;
+    WEBCORE_EXPORT void setShouldEnableVP9Decoder(bool);
+    WEBCORE_EXPORT bool shouldEnableVP9Decoder() const;
 
 private:
     std::optional<bool> m_hardwareDecoderDisabled;
     std::optional<bool> m_vp9DecoderDisabled;
+    std::optional<bool> m_vp9HardwareDecoderEnabledOverride;
     std::optional<ScreenDataOverrides> m_screenSizeAndScale;
     Function<void(bool)> m_configurationChangedCallback;
     bool m_vp9DecoderEnabled { false };

--- a/Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.mm
@@ -64,6 +64,13 @@ void VP9TestingOverrides::setHardwareDecoderDisabled(std::optional<bool>&& disab
         m_configurationChangedCallback(false);
 }
 
+void VP9TestingOverrides::setVP9HardwareDecoderEnabledOverride(std::optional<bool>&& disabled)
+{
+    m_vp9HardwareDecoderEnabledOverride = WTFMove(disabled);
+    if (m_configurationChangedCallback)
+        m_configurationChangedCallback(false);
+}
+
 void VP9TestingOverrides::setVP9DecoderDisabled(std::optional<bool>&& disabled)
 {
     m_vp9DecoderDisabled = WTFMove(disabled);
@@ -182,6 +189,17 @@ bool isVP8DecoderAvailable()
 }
 
 bool vp9HardwareDecoderAvailable()
+{
+    if (auto disabledForTesting = VP9TestingOverrides::singleton().hardwareDecoderDisabled())
+        return !*disabledForTesting;
+
+    if (auto vp9HardwareDecoderOverride = VP9TestingOverrides::singleton().vp9HardwareDecoderEnabledOverride())
+        return *vp9HardwareDecoderOverride;
+
+    return canLoad_VideoToolbox_VTIsHardwareDecodeSupported() && VTIsHardwareDecodeSupported(kCMVideoCodecType_VP9);
+}
+
+bool vp9HardwareDecoderAvailableInProcess()
 {
     if (auto disabledForTesting = VP9TestingOverrides::singleton().hardwareDecoderDisabled())
         return !*disabledForTesting;

--- a/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm
+++ b/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm
@@ -418,7 +418,7 @@ void VideoMediaSampleRenderer::enqueueSample(const MediaSample& sample, const Me
         // Only use a decompression session for vp8 or vp9 when software decoded.
         CMVideoFormatDescriptionRef videoFormatDescription = PAL::CMSampleBufferGetFormatDescription(cmSampleBuffer.get());
         auto fourCC = PAL::CMFormatDescriptionGetMediaSubType(videoFormatDescription);
-        needsDecompressionSession = fourCC == 'vp08' || (fourCC == 'vp09' && !vp9HardwareDecoderAvailable());
+        needsDecompressionSession = fourCC == 'vp08' || (fourCC == 'vp09' && !vp9HardwareDecoderAvailableInProcess());
         m_currentCodec = fourCC;
     }
 #endif

--- a/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProviderCocoa.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProviderCocoa.cpp
@@ -69,7 +69,7 @@ std::unique_ptr<webrtc::VideoDecoderFactory> LibWebRTCProviderCocoa::createDecod
         return nullptr;
 
     auto vp9Support = isSupportingVP9Profile2() ? webrtc::WebKitVP9::Profile0And2 : isSupportingVP9Profile0() ? webrtc::WebKitVP9::Profile0 : webrtc::WebKitVP9::Off;
-    return webrtc::createWebKitDecoderFactory(isSupportingH265() ? webrtc::WebKitH265::On : webrtc::WebKitH265::Off, vp9Support, vp9HardwareDecoderAvailable() ? webrtc::WebKitVP9VTB::On : webrtc::WebKitVP9VTB::Off, isSupportingAV1() ? webrtc::WebKitAv1::On : webrtc::WebKitAv1::Off);
+    return webrtc::createWebKitDecoderFactory(isSupportingH265() ? webrtc::WebKitH265::On : webrtc::WebKitH265::Off, vp9Support, vp9HardwareDecoderAvailableInProcess() ? webrtc::WebKitVP9VTB::On : webrtc::WebKitVP9VTB::Off, isSupportingAV1() ? webrtc::WebKitAv1::On : webrtc::WebKitAv1::Off);
 }
 
 std::unique_ptr<webrtc::VideoEncoderFactory> LibWebRTCProviderCocoa::createEncoderFactory()

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
@@ -358,7 +358,7 @@ GPUConnectionToWebProcess::GPUConnectionToWebProcess(GPUProcess& gpuProcess, Web
     if (parameters.hasVP9HardwareDecoder)
         hasVP9HardwareDecoder = *parameters.hasVP9HardwareDecoder;
     else {
-        hasVP9HardwareDecoder = WebCore::vp9HardwareDecoderAvailable();
+        hasVP9HardwareDecoder = WebCore::vp9HardwareDecoderAvailableInProcess();
         gpuProcess.send(Messages::GPUProcessProxy::SetHasVP9HardwareDecoder(hasVP9HardwareDecoder));
     }
 #endif

--- a/Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp
+++ b/Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp
@@ -327,6 +327,9 @@ void GPUProcessConnection::didInitialize(std::optional<GPUProcessConnectionInfo>
     WebProcess::singleton().protectedLibWebRTCCodecs()->setHasAV1HardwareDecoder(info->hasAV1HardwareDecoder);
 #endif
 #endif
+#if PLATFORM(COCOA) && ENABLE(VP9)
+    VP9TestingOverrides::singleton().setVP9HardwareDecoderEnabledOverride(info->hasVP9HardwareDecoder);
+#endif
 }
 
 bool GPUProcessConnection::waitForDidInitialize()


### PR DESCRIPTION
#### 0bdf4bc8a0482a603ae2b4dfcd0b6b35459870c5
<pre>
vp9HardwareDecoderAvailable() is non-functional when called in the content process.
<a href="https://bugs.webkit.org/show_bug.cgi?id=299710">https://bugs.webkit.org/show_bug.cgi?id=299710</a>
<a href="https://rdar.apple.com/161534911">rdar://161534911</a>

Reviewed by Youenn Fablet.

We re-use the VP9TestingOverrides structure to be able to store if we
the VP9 HW decoder is available. When the value of GPUProcessConnectionInfo::hasVP9HardwareDecoder
is retrieved, we set it to VP9TestingOverrides.

This allows to enable the SourceBufferParserWebM to work in the content process.

* Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.h:
* Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.mm:
(WebCore::VP9TestingOverrides::setVP9HardwareDecoderEnabledOverride):
(WebCore::vp9HardwareDecoderAvailable):
* Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp:
(WebKit::GPUProcessConnection::didInitialize):

Canonical link: <a href="https://commits.webkit.org/300722@main">https://commits.webkit.org/300722@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/322d5b8b88d8b9562911dfb7bcff6646ad8757bc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123631 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43346 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34042 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130399 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/75776 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a7a55ed7-46d9-437b-a7e3-7588854b6805) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/125508 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44069 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51940 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94007 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/62396 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f0c48800-cf3a-4fa4-b118-d1fc592c2942) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126584 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35110 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110599 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74609 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d3b86700-6e5f-47e7-bf4b-26c061e563ec) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34074 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28758 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73878 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104831 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28981 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133094 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50582 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38510 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102477 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50957 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106820 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102318 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26007 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47675 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25910 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/47394 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50436 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56198 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49910 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53257 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51585 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->