### PR TITLE
Align mathml.css UA stylesheet with MathML Core

### DIFF
--- a/Source/WebCore/css/mathml.css
+++ b/Source/WebCore/css/mathml.css
@@ -94,40 +94,22 @@ math[display="inline" i] {
     math-style: compact;
 }
 
-ms, mtext, mi, mn, mo, annotation, mtd {
-    white-space: nowrap !important;
-}
-
-/* Fractions */
-mfrac {
-    padding-inline: 1px;
-}
-
-mfrac > * {
-    math-style: compact;
-}
-
-msub > * + *, msup > * + *, msubsup > * + *, mmultiscripts > * + *, munder > * + *, mover > * + *, munderover > * + * {
-    font-size: 0.71em;
-    math-style: compact;
-}
-
-mroot > *:last-child {
-    font-size: 0.5041em; /* This 0.71^2 since the scriptlevel is incremented by 2 in the index. */
-    math-style: compact;
+/* <mrow>-like elements */
+merror {
+    border: 1px solid red;
+    background-color: lightYellow;
 }
 
 mphantom {
     visibility: hidden;
 }
 
-/* This is a special style for erroneous markup. */
-/* https://w3c.github.io/mathml-core/#error-message-merror */
-merror {
-    border: 1px solid red;
-    background-color: lightYellow;
+/* Token elements */
+ms, mtext, mi, mn, mo, annotation, mtd {
+    white-space: nowrap !important;
 }
 
+/* Tables */
 mtable {
     display: inline-table;
     text-align: center;
@@ -195,7 +177,34 @@ mtable[columnlines="dashed"] > mtr > mtd + mtd {
     border-left: dashed thin;
 }
 
+/* Fractions */
+mfrac {
+    padding-inline: 1px;
+}
+
+mfrac > * {
+    math-style: compact;
+}
+
+mfrac > :nth-child(2) {
+    math-shift: compact;
+}
+
 /* Other rules for scriptlevel, displaystyle and math-shift */
+mroot > *:last-child {
+    font-size: 0.5041em; /* This 0.71^2 since the scriptlevel is incremented by 2 in the index. */
+    math-style: compact;
+}
+
+mroot, msqrt {
+    math-shift: compact;
+}
+
+msub > * + *, msup > * + *, msubsup > * + *, mmultiscripts > * + *, munder > * + *, mover > * + *, munderover > * + * {
+    font-size: 0.71em;
+    math-style: compact;
+}
+
 munder[accentunder="true" i] > :nth-child(2),
 mover[accent="true" i] > :nth-child(2),
 munderover[accentunder="true" i] > :nth-child(2),
@@ -203,9 +212,6 @@ munderover[accent="true" i] > :nth-child(3) {
   font-size: inherit;
 }
 
-mfrac > :nth-child(2),
-mroot,
-msqrt,
 msub > :nth-child(2),
 msubsup > :nth-child(2),
 mmultiscripts > :nth-child(even),


### PR DESCRIPTION
#### 2e0da77802ed289903b41918216b343ad379e20d
<pre>
Align mathml.css UA stylesheet with MathML Core
<a href="https://bugs.webkit.org/show_bug.cgi?id=299719">https://bugs.webkit.org/show_bug.cgi?id=299719</a>

Reviewed by Frédéric Wang.

Change ordering and formatting of the mathml stylesheet to more closely
match the one defined in the spec:
<a href="https://w3c.github.io/mathml-core/#user-agent-stylesheet">https://w3c.github.io/mathml-core/#user-agent-stylesheet</a>
There is no behaviour change.

* Source/WebCore/css/mathml.css:
(merror):
(ms, mtext, mi, mn, mo, annotation, mtd):
(mfrac):
(mfrac &gt; *):
(mfrac &gt; :nth-child(2)):
(mroot &gt; *:last-child):
(mroot, msqrt):
(msub &gt; * + *, msup &gt; * + *, msubsup &gt; * + *, mmultiscripts &gt; * + *, munder &gt; * + *, mover &gt; * + *, munderover &gt; * + *):
(mfrac &gt; :nth-child(2),): Deleted.

Canonical link: <a href="https://commits.webkit.org/300688@main">https://commits.webkit.org/300688@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4b6686828f064795ad01c1e5ad71bf33241d88df

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123490 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43205 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33901 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130208 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/75630 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/125367 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43928 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51799 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93870 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62314 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126443 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35002 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110481 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74502 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33972 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28640 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73725 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104717 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28865 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132927 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50441 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38402 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102364 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50816 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106704 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102215 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25987 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47573 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25801 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/47249 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50295 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56056 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49769 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53116 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51444 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->