### PR TITLE
[run-gtk-test run-wpe-tests] Recognize Google tests value-parameterized tests

### DIFF
--- a/Tools/TestWebKitAPI/glib/TestExpectations.json
+++ b/Tools/TestWebKitAPI/glib/TestExpectations.json
@@ -245,10 +245,67 @@
                 "expected": {"gtk": {"status": ["FAIL", "PASS"], "bug":"webkit.org/b/284628"}}
             },
             "ImageBufferTests.ImageBufferSubTypeCreateCreatesSubtypes": {
-                "expected": {"all": {"status": ["CRASH"], "bug":"webkit.org/b/286456"}}
+                "expected": {"all": {"status": ["SKIP"], "bug":"webkit.org/b/286456"}}
             },
             "ImageBufferTests.ImageBufferSubPixelDrawing": {
-                "expected": {"all": {"status": ["CRASH"], "bug":"webkit.org/b/286456"}}
+                "expected": {"all": {"status": ["SKIP"], "bug":"webkit.org/b/286456"}}
+            },
+            "ImageBufferTests/AnyScaleTest.SinkIntoNativeImageWorks/051byteobject01": {
+                "expected": {"all": {"status": ["SKIP"], "bug":"webkit.org/b/286456"}}
+            },
+            "ImageBufferTests/AnyScaleTest.SinkIntoNativeImageWorks/11byteobject01": {
+                "expected": {"all": {"status": ["SKIP"], "bug":"webkit.org/b/286456"}}
+            },
+            "ImageBufferTests/AnyScaleTest.SinkIntoNativeImageWorks/21byteobject01": {
+                "expected": {"all": {"status": ["SKIP"], "bug":"webkit.org/b/286456"}}
+            },
+            "ImageBufferTests/AnyScaleTest.SinkIntoNativeImageWorks/51byteobject01": {
+                "expected": {"all": {"status": ["SKIP"], "bug":"webkit.org/b/286456"}}
+            },
+            "ImageBufferTests/AnyScaleTest.GetPixelBufferDimensionsContainScale/051byteobject01": {
+                "expected": {"all": {"status": ["SKIP"], "bug":"webkit.org/b/286456"}}
+            },
+            "ImageBufferTests/AnyScaleTest.GetPixelBufferDimensionsContainScale/11byteobject01": {
+                "expected": {"all": {"status": ["SKIP"], "bug":"webkit.org/b/286456"}}
+            },
+            "ImageBufferTests/AnyScaleTest.GetPixelBufferDimensionsContainScale/21byteobject01": {
+                "expected": {"all": {"status": ["SKIP"], "bug":"webkit.org/b/286456"}}
+            },
+            "ImageBufferTests/AnyScaleTest.GetPixelBufferDimensionsContainScale/51byteobject01": {
+                "expected": {"all": {"status": ["SKIP"], "bug":"webkit.org/b/286456"}}
+            },
+            "ImageBufferTests/AnyTwoImageBufferOptionsTest.PutPixelBufferAffectsDrawOutput/1byteobject001byteobject01": {
+                "expected": {"all": {"status": ["SKIP"], "bug":"webkit.org/b/286456"}}
+            },
+            "ImageBufferTests/AnyTwoImageBufferOptionsTest.PutPixelBufferAffectsDrawOutput/1byteobject011byteobject00": {
+                "expected": {"all": {"status": ["SKIP"], "bug":"webkit.org/b/286456"}}
+            },
+            "ImageBufferTests/AnyTwoImageBufferOptionsTest.PutPixelBufferAffectsDrawOutput/1byteobject011byteobject01": {
+                "expected": {"all": {"status": ["SKIP"], "bug":"webkit.org/b/286456"}}
+            },
+            "GraphicsContextGLTextureMapperTest/AnyContextAttributeTest.WebXRBlitTest/truetruetrue": {
+                "expected": {"all": {"status": ["FAIL"], "bug":"webkit.org/b/299730"}}
+            },
+            "GraphicsContextGLTextureMapperTest/AnyContextAttributeTest.WebXRBlitTest/truetruefalse": {
+                "expected": {"all": {"status": ["FAIL"], "bug":"webkit.org/b/299730"}}
+            },
+            "GraphicsContextGLTextureMapperTest/AnyContextAttributeTest.WebXRBlitTest/truefalsetrue": {
+                "expected": {"all": {"status": ["FAIL"], "bug":"webkit.org/b/299730"}}
+            },
+            "GraphicsContextGLTextureMapperTest/AnyContextAttributeTest.WebXRBlitTest/truefalsefalse": {
+                "expected": {"all": {"status": ["FAIL"], "bug":"webkit.org/b/299730"}}
+            },
+            "GraphicsContextGLTextureMapperTest/AnyContextAttributeTest.WebXRBlitTest/falsetruetrue": {
+                "expected": {"all": {"status": ["FAIL"], "bug":"webkit.org/b/299730"}}
+            },
+            "GraphicsContextGLTextureMapperTest/AnyContextAttributeTest.WebXRBlitTest/falsetruefalse": {
+                "expected": {"all": {"status": ["FAIL"], "bug":"webkit.org/b/299730"}}
+            },
+            "GraphicsContextGLTextureMapperTest/AnyContextAttributeTest.WebXRBlitTest/falsefalsetrue": {
+                "expected": {"all": {"status": ["FAIL"], "bug":"webkit.org/b/299730"}}
+            },
+            "GraphicsContextGLTextureMapperTest/AnyContextAttributeTest.WebXRBlitTest/falsefalsefalse": {
+                "expected": {"all": {"status": ["FAIL"], "bug":"webkit.org/b/299730"}}
             }
         }
     },

--- a/Tools/glib/api_test_runner.py
+++ b/Tools/glib/api_test_runner.py
@@ -251,6 +251,7 @@ class TestRunner(object):
                 prefix = line
                 continue
             else:
+                line = line.partition('#')[0]
                 test_name = prefix + line.strip()
                 if not test_name in skipped_test_cases:
                     tests.append(test_name)


### PR DESCRIPTION
#### 8ae5bcb28bc51321acc990f400a75618668ec674
<pre>
[run-gtk-test run-wpe-tests] Recognize Google tests value-parameterized tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=299729">https://bugs.webkit.org/show_bug.cgi?id=299729</a>

Reviewed by Sergio Villar Senin.

run-gtk-test and run-wpe-test scripts didn&apos;t run value-parameterized
tests of Google tests because it didn&apos;t recognize them. Those scripts
collects test names with --gtest_list_tests. It lists up all test
names like the following.

&gt; GStreamerTest.
&gt;   gstStructureGetters
&gt;   gstStructureJSONSerializing
&gt;   (...)
&gt; ImageBufferTests/AnyScaleTest.
&gt;   SinkIntoNativeImageWorks/051byteobject00  # GetParam() = (0.5, 1-byte object &lt;00&gt;)
&gt;   SinkIntoNativeImageWorks/051byteobject01  # GetParam() = (0.5, 1-byte object &lt;01&gt;)

Due to the trailing `#` part, the scripts failed to recognize the
value-parameterized tests. Truncate the `#` and the following part.
Marked new failing tests.

* Tools/TestWebKitAPI/glib/TestExpectations.json:
* Tools/glib/api_test_runner.py:
(TestRunner._get_tests_from_google_test_suite):

Canonical link: <a href="https://commits.webkit.org/300745@main">https://commits.webkit.org/300745@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1f6b18c905574b97a495d4e338be9361052f0ea4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123531 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43246 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33942 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130256 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/75673 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/125408 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43969 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51840 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93915 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62338 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126484 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35029 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110515 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74530 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34000 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28676 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73772 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104746 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28897 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132979 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50482 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38431 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102409 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50857 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106736 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102246 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47598 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25833 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/47290 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19468 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50336 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49810 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53157 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51485 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->