### PR TITLE
[GStreamer][WebRTC] End-point shouldn't generate SDP offer with empty media msid attribute

### DIFF
--- a/LayoutTests/webrtc/createOfferAnswer-expected.txt
+++ b/LayoutTests/webrtc/createOfferAnswer-expected.txt
@@ -1,4 +1,5 @@
 
 PASS Ensuring that offer is a RTCSessionDescriptionInit
 PASS Ensuring that answer is a RTCSessionDescriptionInit
+PASS SDP offer for recvonly transceiver should not contain a msid attribute
 

--- a/LayoutTests/webrtc/createOfferAnswer.html
+++ b/LayoutTests/webrtc/createOfferAnswer.html
@@ -34,6 +34,22 @@ promise_test((test) => {
     });
 }, "Ensuring that answer is a RTCSessionDescriptionInit");
 
+promise_test((test) => {
+    var pc3 = new RTCPeerConnection();
+    pc3.addTransceiver("video", {"direction": "recvonly"});
+
+    return pc3.createOffer().then((offer) => {
+        var lines = offer.sdp.split(/\r?\n/g);
+        var msidLine = "";
+        for (var i = 0; i < lines.length; i++) {
+            if (lines[i].match("a=msid:")) {
+                msidLine = lines[i];
+                break;
+            }
+        }
+        assert_true(msidLine === "");
+    });
+}, "SDP offer for recvonly transceiver should not contain a msid attribute");
         </script>
     </body>
 </html>

--- a/Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp
@@ -253,7 +253,7 @@ void PeerConnectionBackend::createOfferSucceeded(String&& sdp)
     ASSERT(isMainThread());
 
 #if !RELEASE_LOG_DISABLED
-    logger().toObservers(LogWebRTC, WTFLogLevel::Always, LOGIDENTIFIER, "to:\n", sdp);
+    logger().toObservers(LogWebRTC, WTFLogLevel::Always, LOGIDENTIFIER, "SDP offer created:\n", sdp);
     RELEASE_LOG_FORWARDABLE(WebRTC, PEERCONNECTIONBACKEND_CREATEOFFERSUCCEEDED, logIdentifier(), sdp.utf8());
 #endif
 
@@ -289,7 +289,7 @@ void PeerConnectionBackend::createAnswerSucceeded(String&& sdp)
     ASSERT(isMainThread());
 
 #if !RELEASE_LOG_DISABLED
-    logger().toObservers(LogWebRTC, WTFLogLevel::Always, LOGIDENTIFIER, "to:\n", sdp);
+    logger().toObservers(LogWebRTC, WTFLogLevel::Always, LOGIDENTIFIER, "SDP answer created:\n", sdp);
     RELEASE_LOG_FORWARDABLE(WebRTC, PEERCONNECTIONBACKEND_CREATEANSWERSUCCEEDED, logIdentifier(), sdp.utf8());
 #endif
 


### PR DESCRIPTION
#### ab8caf13a6f05e29b440bb567e9d89e20dac8735
<pre>
[GStreamer][WebRTC] End-point shouldn&apos;t generate SDP offer with empty media msid attribute
<a href="https://bugs.webkit.org/show_bug.cgi?id=299734">https://bugs.webkit.org/show_bug.cgi?id=299734</a>

Reviewed by Xabier Rodriguez-Calvar.

Until this patch the SDP offer media corresponding to recvonly transceivers contained an empty msid
attribute. That attribute, if present should not be empty. Now covered by a layout test as well.

Driving by, minor logging improvements in PeerConnectionBackend.

* LayoutTests/webrtc/createOfferAnswer-expected.txt:
* LayoutTests/webrtc/createOfferAnswer.html:
* Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp:
(WebCore::PeerConnectionBackend::createOfferSucceeded):
(WebCore::PeerConnectionBackend::createAnswerSucceeded):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp:
(WebCore::GStreamerMediaEndpoint::createTransceiverBackends):

Canonical link: <a href="https://commits.webkit.org/300741@main">https://commits.webkit.org/300741@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bf0ae056942f5fd3f577c608768b1f490d4757b2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123554 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43269 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33965 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130281 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/75696 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/125431 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43992 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51863 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93927 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62350 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126507 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35046 "Found 1 new test failure: media/media-video-fullrange.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110527 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74547 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28685 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73797 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104763 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28909 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133005 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50505 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38449 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102422 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50880 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106748 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102264 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26028 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47613 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25845 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/47315 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50359 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56120 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49833 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53180 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51508 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->