### PR TITLE
[Site Isolation] Reduce the number of launched WebContent process in testing

### DIFF
--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -2299,9 +2299,9 @@ std::tuple<Ref<WebProcessProxy>, RefPtr<SuspendedPageProxy>, ASCIILiteral> WebPr
     if (sourceURL.protocolIsAbout()) {
         if (sourceProcess->site() && sourceProcess->site()->domain().matches(targetURL))
             return { WTFMove(sourceProcess), nullptr, "Navigation is treated as same-site"_s };
-        // With site isolation enabled, this condition is not enough to indicate the web process can be reused;
-        // we may also need to consider whether the process is used or in use by other sites.
-        if (!siteIsolationEnabled && !sourceProcess->hasCommittedAnyMeaningfulProvisionalLoads())
+        // When the source process hasn't committed any meaningful provisional loads, we can reuse it.
+        // No other page should be using this process, since processes used to load about:blank, etc, are not added to the process cache.
+        if (!sourceProcess->hasCommittedAnyMeaningfulProvisionalLoads())
             return { WTFMove(sourceProcess), nullptr, "Navigation is treated as same-site"_s };
     }
 


### PR DESCRIPTION
#### 46c16d747ca9dcc2444f9df2a73aca5fbf23c7f4
<pre>
[Site Isolation] Reduce the number of launched WebContent process in testing
<a href="https://bugs.webkit.org/show_bug.cgi?id=299766">https://bugs.webkit.org/show_bug.cgi?id=299766</a>
<a href="https://rdar.apple.com/161570096">rdar://161570096</a>

Reviewed by NOBODY (OOPS!).

When running layout tests in Site Isolation mode, we are not reusing the process used to load about:blank by WebKitTestRunner.
We should be able to reuse this process, since a process only used to load about:blank is not added to the process cache, so
there should not be another page using this process.

This change reduces the number of WebContent processes launched in layout test in Site Isolation mode with 1 per test, and
brings the total number down to 3 from 4. This is the lowest possible number, as long as we are not utilizing the process
cache in layout tests.

* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::processForNavigationInternal):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/46c16d747ca9dcc2444f9df2a73aca5fbf23c7f4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123553 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43268 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33964 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130280 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/75695 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/84956b12-798e-4624-a204-1e0c1495d2b3) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43991 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51862 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93926 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62349 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/568a6cec-117e-40cf-82cc-1e89e770e0a7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126506 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35043 "Found 2 new test failures: http/tests/site-isolation/frame-access-after-window-open.html http/tests/site-isolation/window-open-with-name-cross-site.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110529 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74546 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/186e2b4e-0424-45f6-927a-7358c2b3e734) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34015 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73796 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104760 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28910 "Found 2 new test failures: http/tests/site-isolation/frame-access-after-window-open.html http/tests/site-isolation/window-open-with-name-cross-site.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133004 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50504 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38450 "Found 14 new test failures: http/tests/site-isolation/draw-after-cross-origin-navigation.html http/tests/site-isolation/edge-sampling-commit-root-frame-load.html http/tests/site-isolation/frame-access-after-window-open.html http/tests/site-isolation/frame-index.html http/tests/site-isolation/history/add-iframe-while-changing-document-title.html http/tests/site-isolation/history/navigate-same-site-iframe-into-new-process-and-go-back.html http/tests/site-isolation/iframe-and-window-open.html http/tests/site-isolation/load-event-after-transition.html http/tests/site-isolation/permissions-policy-nested.html http/tests/site-isolation/unload-grandchild-fetch.html ... (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102421 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50879 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106749 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102263 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47611 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25846 "Found 2 new test failures: http/tests/site-isolation/frame-access-after-window-open.html http/tests/site-isolation/window-open-with-name-cross-site.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/47314 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50358 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56119 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49832 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53179 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51507 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->