### PR TITLE
[WebXR][OpenXR] Content not shown when asking for canvas without alpha layer

### DIFF
--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRLayer.cpp
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRLayer.cpp
@@ -222,7 +222,7 @@ void OpenXRLayer::setGBMDevice(RefPtr<WebCore::GBMDevice> gbmDevice)
 
 std::optional<PlatformXR::FrameData::ExternalTexture> OpenXRLayer::exportOpenXRTextureGBM(WebCore::GLDisplay& display, PlatformGLObject openxrTexture)
 {
-    WebCore::FourCC preferredDMABufFormat = m_swapchain->format() == GL_RGBA8 ? DRM_FORMAT_ARGB8888 : DRM_FORMAT_XRGB8888;
+    WebCore::FourCC preferredDMABufFormat = m_swapchain->hasAlpha() == OpenXRSwapchain::HasAlpha::Yes ? DRM_FORMAT_ARGB8888 : DRM_FORMAT_XRGB8888;
     WebCore::GLDisplay::BufferFormat format;
     const auto& supportedFormats = display.bufferFormats();
     for (const auto& supportedFormat : supportedFormats) {

--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRSwapchain.cpp
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRSwapchain.cpp
@@ -28,7 +28,7 @@ namespace WebKit {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(OpenXRSwapchain);
 
-std::unique_ptr<OpenXRSwapchain> OpenXRSwapchain::create(XrSession session, const XrSwapchainCreateInfo& info)
+std::unique_ptr<OpenXRSwapchain> OpenXRSwapchain::create(XrSession session, const XrSwapchainCreateInfo& info, HasAlpha hasAlpha)
 {
     ASSERT(session != XR_NULL_HANDLE);
     ASSERT(info.faceCount == 1);
@@ -58,13 +58,14 @@ std::unique_ptr<OpenXRSwapchain> OpenXRSwapchain::create(XrSession session, cons
     // Get images from an XrSwapchain
     CHECK_XRCMD(xrEnumerateSwapchainImages(swapchain, imageCount, &imageCount, imageHeaders[0]));
 
-    return std::unique_ptr<OpenXRSwapchain>(new OpenXRSwapchain(swapchain, info, WTFMove(imageBuffers)));
+    return std::unique_ptr<OpenXRSwapchain>(new OpenXRSwapchain(swapchain, info, WTFMove(imageBuffers), hasAlpha));
 }
 
-OpenXRSwapchain::OpenXRSwapchain(XrSwapchain swapchain, const XrSwapchainCreateInfo& info, Vector<XrSwapchainImageOpenGLESKHR>&& imageBuffers)
+OpenXRSwapchain::OpenXRSwapchain(XrSwapchain swapchain, const XrSwapchainCreateInfo& info, Vector<XrSwapchainImageOpenGLESKHR>&& imageBuffers, HasAlpha hasAlpha)
     : m_swapchain(swapchain)
     , m_createInfo(info)
     , m_imageBuffers(WTFMove(imageBuffers))
+    , m_hasAlpha(hasAlpha)
 {
 }
 

--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRSwapchain.h
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRSwapchain.h
@@ -50,7 +50,8 @@ class OpenXRSwapchain {
     WTF_MAKE_TZONE_ALLOCATED(OpenXRSwapchain);
     WTF_MAKE_NONCOPYABLE(OpenXRSwapchain);
 public:
-    static std::unique_ptr<OpenXRSwapchain> create(XrSession, const XrSwapchainCreateInfo&);
+    enum class HasAlpha { No, Yes };
+    static std::unique_ptr<OpenXRSwapchain> create(XrSession, const XrSwapchainCreateInfo&, HasAlpha);
     ~OpenXRSwapchain();
 
     std::optional<PlatformGLObject> acquireImage();
@@ -61,14 +62,16 @@ public:
     WebCore::IntSize size() const { return WebCore::IntSize(width(), height()); }
     int64_t format() const { return m_createInfo.format; }
     PlatformGLObject acquiredTexture() const { return m_acquiredTexture; }
+    HasAlpha hasAlpha() const { return m_hasAlpha; }
 
 private:
-    OpenXRSwapchain(XrSwapchain, const XrSwapchainCreateInfo&, Vector<XrSwapchainImageOpenGLESKHR>&&);
+    OpenXRSwapchain(XrSwapchain, const XrSwapchainCreateInfo&, Vector<XrSwapchainImageOpenGLESKHR>&&, HasAlpha);
 
     XrSwapchain m_swapchain;
     XrSwapchainCreateInfo m_createInfo;
     Vector<XrSwapchainImageOpenGLESKHR> m_imageBuffers;
     PlatformGLObject m_acquiredTexture { 0 };
+    HasAlpha m_hasAlpha;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.cpp
+++ b/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.cpp
@@ -166,7 +166,9 @@ bool OpenXRCoordinator::collectSwapchainFormatsIfNeeded()
 
 std::unique_ptr<OpenXRSwapchain> OpenXRCoordinator::createSwapchain(uint32_t width, uint32_t height, bool alpha) const
 {
-    auto preferredFormat = alpha ? GL_RGBA8 : GL_RGB8;
+    // Even if alpha is false we always ask for the RGBA8 format, as the DRM_FORMAT_RGB8 is not supported by ANGLE.
+    // In this case we ignore the alpha channel by using DRM_FORMAT_XRGB8888 when exporting the texture.
+    auto preferredFormat = GL_RGBA8;
     auto format = m_supportedSwapchainFormats.contains(preferredFormat) ? preferredFormat : m_supportedSwapchainFormats.first();
     auto sampleCount = m_viewConfigurationViews.isEmpty() ? 1 : m_viewConfigurationViews.first().recommendedSwapchainSampleCount;
 
@@ -180,7 +182,7 @@ std::unique_ptr<OpenXRSwapchain> OpenXRCoordinator::createSwapchain(uint32_t wid
     info.sampleCount = sampleCount;
     info.usageFlags = XR_SWAPCHAIN_USAGE_SAMPLED_BIT | XR_SWAPCHAIN_USAGE_COLOR_ATTACHMENT_BIT;
 
-    return OpenXRSwapchain::create(m_session, info);
+    return OpenXRSwapchain::create(m_session, info, alpha ? OpenXRSwapchain::HasAlpha::Yes : OpenXRSwapchain::HasAlpha::No);
 }
 
 void OpenXRCoordinator::createLayerProjection(uint32_t width, uint32_t height, bool alpha)


### PR DESCRIPTION
#### 60a2c8c774dc80e2ef5b695f8eb365084c43ba0a
<pre>
[WebXR][OpenXR] Content not shown when asking for canvas without alpha layer
<a href="https://bugs.webkit.org/show_bug.cgi?id=299737">https://bugs.webkit.org/show_bug.cgi?id=299737</a>

Reviewed by Dan Glastonbury.

Content was not rendered on screen because we were trying to
blit buffers with different pixel formats in case an alpha channel
was not requested. We were creating and OpenXR texture with GL_RGB
but WebGL&apos;s opaque framebuffer unconditionally uses GL_RGBA.

It is not possible to make the opaque framebuffer to use
RGB instead because it has always to import a texture with an
alpha channel because ANGLE does not support creating an
external texture from a framebuffer with RGB format
(see Source/ThirdParty/ANGLE/src/common/linux/dma_buf_utils.cpp).

So the only solution is to make OpenXR always create swapchains
with alpha channel and then when exporting the texture just
ignore it (by using DRM_FORMAT_XRGBA8888). This way WebGL
and OpenXR will use the same format and blitting will work.

* Source/WebKit/UIProcess/XR/openxr/OpenXRLayer.cpp:
(WebKit::OpenXRLayer::exportOpenXRTextureGBM):
* Source/WebKit/UIProcess/XR/openxr/OpenXRSwapchain.cpp:
(WebKit::OpenXRSwapchain::create):
(WebKit::OpenXRSwapchain::OpenXRSwapchain):
* Source/WebKit/UIProcess/XR/openxr/OpenXRSwapchain.h:
(WebKit::OpenXRSwapchain::hasAlpha const):
* Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.cpp:
(WebKit::OpenXRCoordinator::createSwapchain const):

Canonical link: <a href="https://commits.webkit.org/300872@main">https://commits.webkit.org/300872@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4cf4ae1423ba9d3e833d905745c90784a15aa3d9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123561 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43276 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33972 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130289 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/75703 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43999 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51870 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93931 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62355 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126514 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35048 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110537 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74550 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34019 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73804 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104765 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28919 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133014 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50512 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38454 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102427 "7 flakes 57 failures") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50887 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106758 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102269 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26130 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47618 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25853 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/47323 "Failed to compile WebKit") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50366 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56127 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49840 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53187 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51515 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->