### PR TITLE
[GFC] Start storing some computed size properties on PlacedGridItem

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp
@@ -117,9 +117,27 @@ PlacedGridItems GridFormattingContext::constructPlacedGridItems(const GridAreas&
 {
     PlacedGridItems placedGridItems;
     placedGridItems.reserveInitialCapacity(gridAreas.size());
-    for (auto [ unplacedGridItem, gridAreaLines ] : gridAreas)
-        placedGridItems.constructAndAppend(unplacedGridItem, gridAreaLines);
+    for (auto [ unplacedGridItem, gridAreaLines ] : gridAreas) {
 
+        CheckedRef gridItemStyle = unplacedGridItem.m_layoutBox->style();
+        PlacedGridItem::ComputedSizes inlineAxisSizes {
+            gridItemStyle->width(),
+            gridItemStyle->minWidth(),
+            gridItemStyle->maxWidth(),
+            gridItemStyle->marginLeft(),
+            gridItemStyle->marginRight()
+        };
+
+        PlacedGridItem::ComputedSizes blockAxisSizes {
+            gridItemStyle->height(),
+            gridItemStyle->minHeight(),
+            gridItemStyle->maxHeight(),
+            gridItemStyle->marginTop(),
+            gridItemStyle->marginBottom()
+        };
+
+        placedGridItems.constructAndAppend(unplacedGridItem, gridAreaLines, inlineAxisSizes, blockAxisSizes);
+    }
     return placedGridItems;
 }
 

--- a/Source/WebCore/layout/formattingContexts/grid/PlacedGridItem.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/PlacedGridItem.cpp
@@ -32,8 +32,11 @@
 namespace WebCore {
 namespace Layout {
 
-PlacedGridItem::PlacedGridItem(const UnplacedGridItem& unplacedGridItem, GridAreaLines gridAreaLines)
+PlacedGridItem::PlacedGridItem(const UnplacedGridItem& unplacedGridItem, GridAreaLines gridAreaLines,
+    ComputedSizes inlineAxisSizes, ComputedSizes blockAxisSizes)
     : m_layoutBox(unplacedGridItem.m_layoutBox)
+    , m_inlineAxisSizes(inlineAxisSizes)
+    , m_blockAxisSizes(blockAxisSizes)
     , m_gridAreaLines(gridAreaLines)
 {
 }

--- a/Source/WebCore/layout/formattingContexts/grid/PlacedGridItem.h
+++ b/Source/WebCore/layout/formattingContexts/grid/PlacedGridItem.h
@@ -36,8 +36,19 @@ class UnplacedGridItem;
 
 class PlacedGridItem {
 public:
+    struct ComputedSizes {
+        Style::PreferredSize preferredSize;
+        Style::MinimumSize minimumSize;
+        Style::MaximumSize maximumSize;
 
-    PlacedGridItem(const UnplacedGridItem&, GridAreaLines);
+        Style::MarginEdge marginStart;
+        Style::MarginEdge marginEnd;
+    };
+
+    PlacedGridItem(const UnplacedGridItem&, GridAreaLines, ComputedSizes inlineAxisSizes, ComputedSizes blockAxisSizes);
+
+    const ComputedSizes& inlineAxisSizes() const { return m_inlineAxisSizes; }
+    const ComputedSizes& blockAxisSizes() const { return m_blockAxisSizes; }
 
     size_t columnStartLine() const { return m_gridAreaLines.columnStartLine; }
     size_t columnEndLine() const { return m_gridAreaLines.columnEndLine; }
@@ -46,6 +57,9 @@ public:
 
 private:
     const CheckedRef<const ElementBox> m_layoutBox;
+
+    const ComputedSizes m_inlineAxisSizes;
+    const ComputedSizes m_blockAxisSizes;
 
     GridAreaLines m_gridAreaLines;
 };

--- a/Source/WebCore/layout/formattingContexts/grid/UnplacedGridItem.h
+++ b/Source/WebCore/layout/formattingContexts/grid/UnplacedGridItem.h
@@ -60,6 +60,7 @@ private:
     std::pair<Style::GridPosition, Style::GridPosition> m_columnPosition;
     std::pair<Style::GridPosition, Style::GridPosition> m_rowPosition;
 
+    friend class GridFormattingContext;
     friend class PlacedGridItem;
     friend void add(Hasher&, const WebCore::Layout::UnplacedGridItem&);
 };


### PR DESCRIPTION
#### b5aed713d34f3b97363d919d03883e2812dae21e
<pre>
[GFC] Start storing some computed size properties on PlacedGridItem
<a href="https://bugs.webkit.org/show_bug.cgi?id=299812">https://bugs.webkit.org/show_bug.cgi?id=299812</a>
<a href="https://rdar.apple.com/161584151">rdar://161584151</a>

Reviewed by Alan Baradlay.

We will need access to various bits of a grid item&apos;s computed style
during layout. For example, the preferred sizes are properties that can
significantly impact the sizing of a grid item and influence the rest of the
grid layout. One option is to put the pieces of information that we need
on PlacedGridItem so that they can be accessed during layout, which is
what this patch aims to do.

We do this as we construct the PlacedGridItem from its unplaced counterpart
inside of GridFormattingContext. We need to do this here since
GridFormattingContext will have enough information to map the various
properties to the inline and block dimensions as appropriate. Here we
just assume horizontal-tb with non-orthogonal content for
simplicity.

In this patch I add the preferred sizes, min/max sizes, along with
margins as part of ComputedSizes. I leave out border and padding for now
since those are just additional sizes which get resolved to their used
value as part of updating the formatting context geometries before
layout. If we need access to those values we may want to consider
accessing them in a slightly different way since they are slightly
different from these ComputedSizes.

Canonical link: <a href="https://commits.webkit.org/300734@main">https://commits.webkit.org/300734@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/568d00f926b3f9aa2e0c71c5db9729169977ea96

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123621 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43336 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34032 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130389 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/75766 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/981b5623-98f5-47ed-835e-85e3e46eb46b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/125498 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44059 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51930 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94000 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62390 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126574 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35100 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110594 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74601 "Found 2 new API test failures: TestWTF:WTF_Condition.OneProducerOneConsumerOneSlotTimeout, TestWTF:WTF_Condition.OneProducerOneConsumerOneSlot (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4657709b-524b-4cef-82c6-cd2bb0786d31) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34066 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28753 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73868 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104821 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28976 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133083 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50572 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38504 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102470 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50947 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106815 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102311 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26025 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47665 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25906 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/47384 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50426 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56188 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49900 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53247 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51575 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->