### PR TITLE
_WKImmediateActionType is incorrectly defined multiple times

### DIFF
--- a/Source/WebKit/Shared/API/c/WKImmediateActionTypes.h
+++ b/Source/WebKit/Shared/API/c/WKImmediateActionTypes.h
@@ -41,10 +41,6 @@ enum {
     kWKImmediateActionTelLink
 };
 
-#ifndef _WKImmediateActionType 
-#define _WKImmediateActionType uint32_t
-#endif
-
 #ifdef __cplusplus
 }
 #endif

--- a/Source/WebKit/WebKit2Prefix.h
+++ b/Source/WebKit/WebKit2Prefix.h
@@ -32,8 +32,6 @@
 
 #if PLATFORM(COCOA)
 
-#define _WKImmediateActionType _WKImmediateActionType
-
 #include <CoreFoundation/CoreFoundation.h>
 #include <CoreGraphics/CoreGraphics.h>
 


### PR DESCRIPTION
#### 8769b161599834607f43dd16f983805992502d0c
<pre>
_WKImmediateActionType is incorrectly defined multiple times
<a href="https://bugs.webkit.org/show_bug.cgi?id=299817">https://bugs.webkit.org/show_bug.cgi?id=299817</a>
<a href="https://rdar.apple.com/161590500">rdar://161590500</a>

Reviewed by Abrar Rahman Protyasha.

This enum was being defined in three places, which causes issues if they are not defined in a particular order.

Fix by removing two of the three definitions, since they aren&apos;t even used anyways.

* Source/WebKit/Shared/API/c/WKImmediateActionTypes.h:
* Source/WebKit/WebKit2Prefix.h:

Canonical link: <a href="https://commits.webkit.org/300717@main">https://commits.webkit.org/300717@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/679fadb3c222efb276bda397f2404163035a3319

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123608 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43323 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34019 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130376 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/75752 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/09badb90-5b17-46ce-a3cb-f4fd4d9c75f1) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44046 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51917 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93992 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/75752 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/dddadb9e-3c8c-4c4f-b918-0df3c5b4795b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126561 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35089 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/110582 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74591 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8ef8804c-7916-47f7-bf2e-2b06f2208ddf) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34055 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73855 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104809 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28964 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133069 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50559 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38492 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/102465 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50934 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106803 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102307 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26003 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47656 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25894 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/47370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50413 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56175 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49887 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53234 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51562 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->