### PR TITLE
[Style] Split style and platform transform operation representations

### DIFF
--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -244,6 +244,7 @@ set(WebCore_PRIVATE_INCLUDE_DIRECTORIES
     "${WEBCORE_DIR}/style/values/text"
     "${WEBCORE_DIR}/style/values/text-decoration"
     "${WEBCORE_DIR}/style/values/transforms"
+    "${WEBCORE_DIR}/style/values/transforms/functions"
     "${WEBCORE_DIR}/style/values/transitions"
     "${WEBCORE_DIR}/style/values/ui"
     "${WEBCORE_DIR}/style/values/view-transitions"

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -3442,6 +3442,17 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     style/values/text-decoration/StyleTextShadow.h
     style/values/text-decoration/StyleTextUnderlineOffset.h
 
+    style/values/transforms/functions/StyleTransformFunctionWrapper.h
+    style/values/transforms/functions/StyleMatrix3DTransformFunction.h
+    style/values/transforms/functions/StyleMatrixTransformFunction.h
+    style/values/transforms/functions/StylePerspectiveTransformFunction.h
+    style/values/transforms/functions/StyleRotateTransformFunction.h
+    style/values/transforms/functions/StyleScaleTransformFunction.h
+    style/values/transforms/functions/StyleSkewTransformFunction.h
+    style/values/transforms/functions/StyleTransformFunctionBase.h
+    style/values/transforms/functions/StyleTransformFunctionWrapper.h
+    style/values/transforms/functions/StyleTranslateTransformFunction.h
+
     style/values/transforms/StylePerspective.h
     style/values/transforms/StylePerspectiveOrigin.h
     style/values/transforms/StyleRotate.h
@@ -3449,7 +3460,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     style/values/transforms/StyleTransform.h
     style/values/transforms/StyleTransformFunction.h
     style/values/transforms/StyleTransformList.h
-    style/values/transforms/StyleTransformOperationWrapper.h
     style/values/transforms/StyleTransformOrigin.h
     style/values/transforms/StyleTranslate.h
 

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -3308,6 +3308,14 @@ style/values/text/StyleLetterSpacing.cpp
 style/values/text/StyleTabSize.cpp
 style/values/text/StyleTextIndent.cpp
 style/values/text/StyleWordSpacing.cpp
+style/values/transforms/functions/StyleMatrix3DTransformFunction.cpp
+style/values/transforms/functions/StyleMatrixTransformFunction.cpp
+style/values/transforms/functions/StylePerspectiveTransformFunction.cpp
+style/values/transforms/functions/StyleRotateTransformFunction.cpp
+style/values/transforms/functions/StyleScaleTransformFunction.cpp
+style/values/transforms/functions/StyleSkewTransformFunction.cpp
+style/values/transforms/functions/StyleTransformFunctionBase.cpp
+style/values/transforms/functions/StyleTranslateTransformFunction.cpp
 style/values/transforms/StylePerspective.cpp
 style/values/transforms/StyleRotate.cpp
 style/values/transforms/StyleScale.cpp

--- a/Source/WebCore/animation/BlendingKeyframes.cpp
+++ b/Source/WebCore/animation/BlendingKeyframes.cpp
@@ -363,26 +363,15 @@ void BlendingKeyframes::analyzeKeyframe(const BlendingKeyframe& keyframe)
             return;
 
         if (keyframe.animatesProperty(CSSPropertyTransform)) {
-            for (auto& function : style->transform()) {
-                if (RefPtr translate = dynamicDowncast<TranslateTransformOperation>(function.platform())) {
-                    if (translate->x().isPercent())
-                        m_hasWidthDependentTransform = true;
-                    if (translate->y().isPercent())
-                        m_hasHeightDependentTransform = true;
-                }
-            }
+            auto [isWidthDependent, isHeightDependent] = style->transform().computeSizeDependencies();
+            m_hasWidthDependentTransform = isWidthDependent;
+            m_hasHeightDependentTransform = isHeightDependent;
         }
 
         if (keyframe.animatesProperty(CSSPropertyTranslate)) {
-            WTF::switchOn(style->translate(),
-                [&](const CSS::Keyword::None&) { },
-                [&](const Style::Translate::Operation& operation) {
-                    if (operation->x().isPercent())
-                        m_hasWidthDependentTransform = true;
-                    if (operation->y().isPercent())
-                        m_hasHeightDependentTransform = true;
-                }
-            );
+            auto [isWidthDependent, isHeightDependent] = style->translate().computeSizeDependencies();
+            m_hasWidthDependentTransform = isWidthDependent;
+            m_hasHeightDependentTransform = isHeightDependent;
         }
     };
 

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -1356,7 +1356,7 @@ void KeyframeEffect::checkForMatchingTransformFunctionLists()
         return;
     }
 
-    TransformOperationsSharedPrimitivesPrefix prefix;
+    TransformOperationsSharedPrimitivesPrefix<Style::TransformFunctionType> prefix;
     for (const auto& keyframe : m_blendingKeyframes)
         prefix.update(keyframe.style()->transform());
 
@@ -2533,7 +2533,7 @@ bool KeyframeEffect::computeTransformedExtentViaTransformList(const FloatRect& r
     FloatRect floatBounds = bounds;
     FloatPoint transformOrigin;
 
-    bool applyTransformOrigin = style.transform().hasTransformOfType<TransformOperation::Type::Rotate>() || style.transform().affectedByTransformOrigin();
+    bool applyTransformOrigin = style.transform().hasTransformOfType<Style::TransformFunctionType::Rotate>() || style.transform().affectedByTransformOrigin();
     if (applyTransformOrigin) {
         transformOrigin = style.computeTransformOrigin(rendererBox).xy();
         // Ignore transformOriginZ because we'll bail if we encounter any 3D transforms.
@@ -2541,7 +2541,7 @@ bool KeyframeEffect::computeTransformedExtentViaTransformList(const FloatRect& r
     }
 
     for (const auto& operation : style.transform()) {
-        if (operation->type() == TransformOperation::Type::Rotate) {
+        if (operation->type() == Style::TransformFunctionType::Rotate) {
             // For now, just treat this as a full rotation. This could take angle into account to reduce inflation.
             floatBounds = boundsOfRotatingRect(floatBounds);
         } else {
@@ -2550,7 +2550,7 @@ bool KeyframeEffect::computeTransformedExtentViaTransformList(const FloatRect& r
             if (!transform.isAffine())
                 return false;
 
-            if (operation->type() == TransformOperation::Type::Matrix || operation->type() == TransformOperation::Type::Matrix3D) {
+            if (operation->type() == Style::TransformFunctionType::Matrix || operation->type() == Style::TransformFunctionType::Matrix3D) {
                 TransformationMatrix::Decomposed2Type toDecomp;
                 // Any rotation prevents us from using a simple start/end rect union.
                 if (!transform.decompose2(toDecomp) || toDecomp.angle)

--- a/Source/WebCore/css/DOMMatrixReadOnly.cpp
+++ b/Source/WebCore/css/DOMMatrixReadOnly.cpp
@@ -238,10 +238,13 @@ ExceptionOr<DOMMatrixReadOnly::AbstractMatrix> DOMMatrixReadOnly::parseStringInt
     if (transform->isNone())
         return AbstractMatrix { };
 
+    auto [isWidthDependent, isHeightDependent] = transform->computeSizeDependencies();
+    if (isWidthDependent || isHeightDependent)
+        return Exception { ExceptionCode::SyntaxError };
+
     AbstractMatrix matrix;
     for (auto& function : *transform) {
-        if (function->apply(matrix.matrix, { 0, 0 }))
-            return Exception { ExceptionCode::SyntaxError };
+        function->apply(matrix.matrix, { 0, 0 });
         if (function->is3DOperation())
             matrix.is2D = false;
     }

--- a/Source/WebCore/css/values/CSSValueAggregates.h
+++ b/Source/WebCore/css/values/CSSValueAggregates.h
@@ -228,6 +228,10 @@ template<CSSValueID C, typename T> struct FunctionNotation {
     bool operator==(const FunctionNotation<C, T>&) const = default;
 };
 
+// Deduction guide for getter/setters that return values and take r-value references.
+template<typename Keyword, typename T>
+FunctionNotation(Keyword, T) -> FunctionNotation<Keyword::value, T>;
+
 template<CSSValueID C, typename T> bool operator==(const UniqueRef<FunctionNotation<C, T>>& a, const UniqueRef<FunctionNotation<C, T>>& b)
 {
     return arePointingToEqualData(a, b);

--- a/Source/WebCore/platform/animation/AcceleratedEffect.cpp
+++ b/Source/WebCore/platform/animation/AcceleratedEffect.cpp
@@ -299,14 +299,14 @@ AcceleratedEffect::AcceleratedEffect(const AcceleratedEffect& source, OptionSet<
     }
 }
 
-static void blend(AcceleratedEffectProperty property, AcceleratedEffectValues& output, const AcceleratedEffectValues& from, const AcceleratedEffectValues& to, BlendingContext& blendingContext, const FloatRect& bounds)
+static void blend(AcceleratedEffectProperty property, AcceleratedEffectValues& output, const AcceleratedEffectValues& from, const AcceleratedEffectValues& to, BlendingContext& blendingContext)
 {
     switch (property) {
     case AcceleratedEffectProperty::Opacity:
         output.opacity = blend(from.opacity, to.opacity, blendingContext);
         break;
     case AcceleratedEffectProperty::Transform:
-        output.transform = blend(from.transform, to.transform, blendingContext, LayoutSize { bounds.size() });
+        output.transform = blend(from.transform, to.transform, blendingContext);
         break;
     case AcceleratedEffectProperty::Translate:
         if (auto& toTranslate = to.translate)
@@ -352,7 +352,7 @@ static void blend(AcceleratedEffectProperty property, AcceleratedEffectValues& o
     }
 }
 
-void AcceleratedEffect::apply(WebAnimationTime currentTime, AcceleratedEffectValues& values, const FloatRect& bounds)
+void AcceleratedEffect::apply(WebAnimationTime currentTime, AcceleratedEffectValues& values)
 {
     auto localTime = [&]() -> WebAnimationTime {
         ASSERT(m_holdTime || m_startTime);
@@ -383,7 +383,7 @@ void AcceleratedEffect::apply(WebAnimationTime currentTime, AcceleratedEffectVal
     if (m_animationType == WebAnimationType::CSSTransition) {
         ASSERT(m_animatedProperties.hasExactlyOneBitSet());
         BlendingContext context { progress, false, m_compositeOperation };
-        blend(*m_animatedProperties.begin(), values, m_keyframes.first().values(), m_keyframes.last().values(), context, bounds);
+        blend(*m_animatedProperties.begin(), values, m_keyframes.first().values(), m_keyframes.last().values(), context);
         return;
     }
 
@@ -403,9 +403,9 @@ void AcceleratedEffect::apply(WebAnimationTime currentTime, AcceleratedEffectVal
             auto& acceleratedKeyframe = downcast<AcceleratedEffect::Keyframe>(keyframe);
             BlendingContext context { 1, false, compositeOperation };
             if (acceleratedKeyframe.offset() == startKeyframe->offset())
-                blend(animatedProperty, startKeyframeValues, propertySpecificKeyframeWithZeroOffset.values(), acceleratedKeyframe.values(), context, bounds);
+                blend(animatedProperty, startKeyframeValues, propertySpecificKeyframeWithZeroOffset.values(), acceleratedKeyframe.values(), context);
             else
-                blend(animatedProperty, endKeyframeValues, propertySpecificKeyframeWithZeroOffset.values(), acceleratedKeyframe.values(), context, bounds);
+                blend(animatedProperty, endKeyframeValues, propertySpecificKeyframeWithZeroOffset.values(), acceleratedKeyframe.values(), context);
         };
 
         KeyframeInterpolation::AccumulationCallback accumulateProperty = [&](const KeyframeInterpolation::Keyframe&) {
@@ -415,7 +415,7 @@ void AcceleratedEffect::apply(WebAnimationTime currentTime, AcceleratedEffectVal
         KeyframeInterpolation::InterpolationCallback interpolateProperty = [&](double intervalProgress, double, IterationCompositeOperation) {
             // FIXME: handle currentIteration and iterationCompositeOperation.
             BlendingContext context { intervalProgress };
-            blend(animatedProperty, values, startKeyframeValues, endKeyframeValues, context, bounds);
+            blend(animatedProperty, values, startKeyframeValues, endKeyframeValues, context);
         };
 
         KeyframeInterpolation::RequiresInterpolationForAccumulativeIterationCallback requiresInterpolationForAccumulativeIterationCallback = [&]() {

--- a/Source/WebCore/platform/animation/AcceleratedEffect.h
+++ b/Source/WebCore/platform/animation/AcceleratedEffect.h
@@ -81,7 +81,7 @@ public:
     WEBCORE_EXPORT Ref<AcceleratedEffect> clone() const;
     WEBCORE_EXPORT Ref<AcceleratedEffect> copyWithProperties(OptionSet<AcceleratedEffectProperty>&) const;
 
-    WEBCORE_EXPORT void apply(WebAnimationTime, AcceleratedEffectValues&, const FloatRect&);
+    WEBCORE_EXPORT void apply(WebAnimationTime, AcceleratedEffectValues&);
 
     // Encoding and decoding support
     AnimationEffectTiming timing() const { return m_timing; }

--- a/Source/WebCore/platform/animation/AcceleratedEffectValues.cpp
+++ b/Source/WebCore/platform/animation/AcceleratedEffectValues.cpp
@@ -106,13 +106,6 @@ static LengthPoint resolveCalculateValuesFor(const LengthPoint& lengthPoint, Int
     };
 }
 
-template<typename T> static RefPtr<TransformOperation> resolveCalculateValuesForTransformOperation(const T& operation, const IntSize& borderBoxSize)
-{
-    if (!operation)
-        return nullptr;
-    return operation->selfOrCopyWithResolvedCalculatedValues(borderBoxSize);
-}
-
 AcceleratedEffectValues::AcceleratedEffectValues(const RenderStyle& style, const IntRect& borderBoxRect, const RenderLayerModelObject* renderer)
 {
     opacity = style.opacity().value.value;
@@ -123,10 +116,10 @@ AcceleratedEffectValues::AcceleratedEffectValues(const RenderStyle& style, const
         transformOperationData = TransformOperationData(renderer->transformReferenceBoxRect(style), renderer);
 
     transformBox = style.transformBox();
-    transform = style.transform().resolvedCalculatedValues(borderBoxSize);
-    translate = resolveCalculateValuesForTransformOperation(Style::toPlatform(style.translate()), borderBoxSize);
-    scale = resolveCalculateValuesForTransformOperation(Style::toPlatform(style.scale()), borderBoxSize);
-    rotate = resolveCalculateValuesForTransformOperation(Style::toPlatform(style.rotate()), borderBoxSize);
+    transform = Style::toPlatform(style.transform(), borderBoxSize);
+    translate = Style::toPlatform(style.translate(), borderBoxSize);
+    scale = Style::toPlatform(style.scale(), borderBoxSize);
+    rotate = Style::toPlatform(style.rotate(), borderBoxSize);
     transformOrigin = resolveCalculateValuesFor(Style::toPlatform(style.transformOrigin().xy()), borderBoxSize);
     offsetPath = Style::toPlatform(style.offsetPath());
     offsetPosition = resolveCalculateValuesFor(Style::toPlatform(style.offsetPosition()), borderBoxSize);
@@ -158,15 +151,15 @@ TransformationMatrix AcceleratedEffectValues::computedTransformationMatrix(const
 
     // 3. Translate by the computed X, Y, and Z values of translate.
     if (translate)
-        translate->apply(matrix, boundingBox.size());
+        translate->apply(matrix);
 
     // 4. Rotate by the computed <angle> about the specified axis of rotate.
     if (rotate)
-        rotate->apply(matrix, boundingBox.size());
+        rotate->apply(matrix);
 
     // 5. Scale by the computed X, Y, and Z values of scale.
     if (scale)
-        scale->apply(matrix, boundingBox.size());
+        scale->apply(matrix);
 
     // 6. Translate and rotate by the transform specified by offset.
     if (transformOperationData && offsetPath) {
@@ -175,7 +168,7 @@ TransformationMatrix AcceleratedEffectValues::computedTransformationMatrix(const
     }
 
     // 7. Multiply by each of the transform functions in transform from left to right.
-    transform.apply(matrix, boundingBox.size());
+    transform.apply(matrix);
 
     // 8. Translate by the negated computed X, Y and Z values of transform-origin.
     // (not needed, the GraphicsLayer handles that)

--- a/Source/WebCore/platform/graphics/GraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.h
@@ -551,7 +551,7 @@ public:
     static String animationNameForTransition(AnimatedProperty);
 
     // Return true if the animation is handled by the compositing system.
-    virtual bool addAnimation(const KeyframeValueList&, const FloatSize& /*boxSize*/, const GraphicsLayerAnimation*, const String& /*animationName*/, double /*timeOffset*/)  { return false; }
+    virtual bool addAnimation(const KeyframeValueList&, const GraphicsLayerAnimation*, const String& /*animationName*/, double /*timeOffset*/)  { return false; }
     virtual void pauseAnimation(const String& /*animationName*/, double /*timeOffset*/) { }
     virtual void removeAnimation(const String& /*animationName*/, std::optional<AnimatedProperty>) { }
     virtual void transformRelatedPropertyDidChange() { }

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
@@ -162,7 +162,7 @@ public:
     WEBCORE_EXPORT void suspendAnimations(MonotonicTime) override;
     WEBCORE_EXPORT void resumeAnimations() override;
 
-    WEBCORE_EXPORT bool addAnimation(const KeyframeValueList&, const FloatSize& boxSize, const GraphicsLayerAnimation*, const String& animationName, double timeOffset) override;
+    WEBCORE_EXPORT bool addAnimation(const KeyframeValueList&, const GraphicsLayerAnimation*, const String& animationName, double timeOffset) override;
     WEBCORE_EXPORT void pauseAnimation(const String& animationName, double timeOffset) override;
     WEBCORE_EXPORT void removeAnimation(const String& animationName, std::optional<AnimatedProperty>) override;
     WEBCORE_EXPORT void transformRelatedPropertyDidChange() override;
@@ -344,7 +344,7 @@ private:
     static void clearClones(LayerMap&);
 
     bool createAnimationFromKeyframes(const KeyframeValueList&, const GraphicsLayerAnimation*, const String& animationName, Seconds timeOffset, bool keyframesShouldUseAnimationWideTimingFunction);
-    bool createTransformAnimationsFromKeyframes(const KeyframeValueList&, const GraphicsLayerAnimation*, const String& animationName, Seconds timeOffset, const FloatSize& boxSize, bool keyframesShouldUseAnimationWideTimingFunction);
+    bool createTransformAnimationsFromKeyframes(const KeyframeValueList&, const GraphicsLayerAnimation*, const String& animationName, Seconds timeOffset, bool keyframesShouldUseAnimationWideTimingFunction);
     bool createFilterAnimationsFromKeyframes(const KeyframeValueList&, const GraphicsLayerAnimation*, const String& animationName, Seconds timeOffset, bool keyframesShouldUseAnimationWideTimingFunction);
 
     // Return autoreleased animation (use RetainPtr?)
@@ -358,8 +358,8 @@ private:
     bool setAnimationEndpoints(const KeyframeValueList&, const GraphicsLayerAnimation*, PlatformCAAnimation*);
     bool setAnimationKeyframes(const KeyframeValueList&, const GraphicsLayerAnimation*, PlatformCAAnimation*, bool keyframesShouldUseAnimationWideTimingFunction);
 
-    bool setTransformAnimationEndpoints(const KeyframeValueList&, const GraphicsLayerAnimation*, PlatformCAAnimation*, int functionIndex, TransformOperation::Type, bool isMatrixAnimation, const FloatSize& boxSize);
-    bool setTransformAnimationKeyframes(const KeyframeValueList&, const GraphicsLayerAnimation*, PlatformCAAnimation*, int functionIndex, TransformOperation::Type, bool isMatrixAnimation, const FloatSize& boxSize, bool keyframesShouldUseAnimationWideTimingFunction);
+    bool setTransformAnimationEndpoints(const KeyframeValueList&, const GraphicsLayerAnimation*, PlatformCAAnimation*, int functionIndex, TransformOperation::Type, bool isMatrixAnimation);
+    bool setTransformAnimationKeyframes(const KeyframeValueList&, const GraphicsLayerAnimation*, PlatformCAAnimation*, int functionIndex, TransformOperation::Type, bool isMatrixAnimation, bool keyframesShouldUseAnimationWideTimingFunction);
     
     bool setFilterAnimationEndpoints(const KeyframeValueList&, const GraphicsLayerAnimation*, PlatformCAAnimation*, int functionIndex);
     bool setFilterAnimationKeyframes(const KeyframeValueList&, const GraphicsLayerAnimation*, PlatformCAAnimation*, int functionIndex, FilterOperation::Type, bool keyframesShouldUseAnimationWideTimingFunction);
@@ -615,7 +615,7 @@ private:
         moveOrCopyAnimations(Copy, fromLayer, toLayer);
     }
 
-    bool appendToUncommittedAnimations(const KeyframeValueList&, const TransformOperation::Type, const GraphicsLayerAnimation*, const String& animationName, const FloatSize& boxSize, unsigned animationIndex, Seconds timeOffset, bool isMatrixAnimation, bool keyframesShouldUseAnimationWideTimingFunction);
+    bool appendToUncommittedAnimations(const KeyframeValueList&, const TransformOperation::Type, const GraphicsLayerAnimation*, const String& animationName, unsigned animationIndex, Seconds timeOffset, bool isMatrixAnimation, bool keyframesShouldUseAnimationWideTimingFunction);
     bool appendToUncommittedAnimations(const KeyframeValueList&, const FilterOperation&, const GraphicsLayerAnimation*, const String& animationName, int animationIndex, Seconds timeOffset, bool keyframesShouldUseAnimationWideTimingFunction);
 
     enum LayerChange : uint64_t {

--- a/Source/WebCore/platform/graphics/texmap/GraphicsLayerTextureMapper.cpp
+++ b/Source/WebCore/platform/graphics/texmap/GraphicsLayerTextureMapper.cpp
@@ -603,7 +603,7 @@ bool GraphicsLayerTextureMapper::filtersCanBeComposited(const FilterOperations& 
     return !filters.hasReferenceFilter();
 }
 
-bool GraphicsLayerTextureMapper::addAnimation(const KeyframeValueList& valueList, const FloatSize& boxSize, const GraphicsLayerAnimation* anim, const String& keyframesName, double timeOffset)
+bool GraphicsLayerTextureMapper::addAnimation(const KeyframeValueList& valueList, const GraphicsLayerAnimation* anim, const String& keyframesName, double timeOffset)
 {
     ASSERT(!keyframesName.isEmpty());
 
@@ -625,7 +625,7 @@ bool GraphicsLayerTextureMapper::addAnimation(const KeyframeValueList& valueList
     }
 
     const MonotonicTime currentTime = MonotonicTime::now();
-    m_animations.add(TextureMapperAnimation(keyframesName, valueList, boxSize, *anim, currentTime - Seconds(timeOffset), 0_s, TextureMapperAnimation::State::Playing));
+    m_animations.add(TextureMapperAnimation(keyframesName, valueList, *anim, currentTime - Seconds(timeOffset), 0_s, TextureMapperAnimation::State::Playing));
     // m_animationStartTime is the time of the first real frame of animation, now or delayed by a negative offset.
     if (Seconds(timeOffset) > 0_s)
         m_animationStartTime = currentTime;

--- a/Source/WebCore/platform/graphics/texmap/GraphicsLayerTextureMapper.h
+++ b/Source/WebCore/platform/graphics/texmap/GraphicsLayerTextureMapper.h
@@ -72,7 +72,7 @@ public:
     void setContentsClippingRect(const FloatRoundedRect&) override;
     void setContentsRectClipsDescendants(bool) override;
 
-    bool addAnimation(const KeyframeValueList&, const FloatSize&, const GraphicsLayerAnimation*, const String&, double) override;
+    bool addAnimation(const KeyframeValueList&, const GraphicsLayerAnimation*, const String&, double) override;
     void pauseAnimation(const String&, double) override;
     void removeAnimation(const String&, std::optional<AnimatedProperty>) override;
 

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperAnimation.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperAnimation.h
@@ -37,7 +37,7 @@ public:
     };
 
     TextureMapperAnimation() = default;
-    TextureMapperAnimation(const String&, const KeyframeValueList&, const FloatSize&, const GraphicsLayerAnimation&, MonotonicTime, Seconds, State);
+    TextureMapperAnimation(const String&, const KeyframeValueList&, const GraphicsLayerAnimation&, MonotonicTime, Seconds, State);
     ~TextureMapperAnimation() = default;
 
     WEBCORE_EXPORT TextureMapperAnimation(const TextureMapperAnimation&);
@@ -62,7 +62,6 @@ private:
 
     String m_name;
     KeyframeValueList m_keyframes { AnimatedProperty::Invalid };
-    FloatSize m_boxSize;
     RefPtr<TimingFunction> m_timingFunction;
     double m_iterationCount { 0 };
     double m_duration { 0 };

--- a/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.cpp
@@ -587,7 +587,7 @@ void GraphicsLayerCoordinated::setBackdropFiltersRect(const FloatRoundedRect& ba
     noteLayerPropertyChanged(Change::BackdropRect, ScheduleFlush::Yes);
 }
 
-bool GraphicsLayerCoordinated::addAnimation(const KeyframeValueList& valueList, const FloatSize& boxSize, const GraphicsLayerAnimation* animation, const String& animationName, double timeOffset)
+bool GraphicsLayerCoordinated::addAnimation(const KeyframeValueList& valueList, const GraphicsLayerAnimation* animation, const String& animationName, double timeOffset)
 {
     ASSERT(!animationName.isEmpty());
     ASSERT(animation);
@@ -624,7 +624,7 @@ bool GraphicsLayerCoordinated::addAnimation(const KeyframeValueList& valueList, 
         return false;
     }
 
-    m_animations.add(TextureMapperAnimation(animationName, valueList, boxSize, *animation, MonotonicTime::now() - Seconds(timeOffset), 0_s, TextureMapperAnimation::State::Playing));
+    m_animations.add(TextureMapperAnimation(animationName, valueList, *animation, MonotonicTime::now() - Seconds(timeOffset), 0_s, TextureMapperAnimation::State::Playing));
     noteLayerPropertyChanged(Change::Animations, ScheduleFlush::Yes);
     return true;
 }

--- a/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.h
@@ -108,7 +108,7 @@ private:
     bool setBackdropFilters(const FilterOperations&) override;
     void setBackdropFiltersRect(const FloatRoundedRect&) override;
 
-    bool addAnimation(const KeyframeValueList&, const FloatSize&, const GraphicsLayerAnimation*, const String&, double) override;
+    bool addAnimation(const KeyframeValueList&, const GraphicsLayerAnimation*, const String&, double) override;
     void removeAnimation(const String&, std::optional<AnimatedProperty>) override;
     void pauseAnimation(const String& animationName, double timeOffset) override;
     void suspendAnimations(MonotonicTime) override;

--- a/Source/WebCore/platform/graphics/transforms/IdentityTransformOperation.h
+++ b/Source/WebCore/platform/graphics/transforms/IdentityTransformOperation.h
@@ -41,16 +41,13 @@ public:
     }
 
 private:
-    bool isIdentity() const override { return true; }
-
     bool operator==(const TransformOperation& o) const override
     {
         return isSameType(o);
     }
 
-    bool apply(TransformationMatrix&, const FloatSize&) const override
+    void apply(TransformationMatrix&) const override
     {
-        return false;
     }
 
     Ref<TransformOperation> blend(const TransformOperation*, const BlendingContext&, bool = false) const override

--- a/Source/WebCore/platform/graphics/transforms/Matrix3DTransformOperation.cpp
+++ b/Source/WebCore/platform/graphics/transforms/Matrix3DTransformOperation.cpp
@@ -60,22 +60,16 @@ Ref<TransformOperation> Matrix3DTransformOperation::blend(const TransformOperati
         return const_cast<Matrix3DTransformOperation&>(*this);
 
     // Convert the TransformOperations into matrices
-    FloatSize size;
     TransformationMatrix fromT;
     TransformationMatrix toT;
     if (from)
-        from->apply(fromT, size);
+        from->apply(fromT);
 
-    apply(toT, size);
+    apply(toT);
 
     if (blendToIdentity)
         return createOperation(fromT, toT, context);
     return createOperation(toT, fromT, context);
-}
-
-bool Matrix3DTransformOperation::isRepresentableIn2D() const
-{
-    return m_matrix.isAffine();
 }
 
 void Matrix3DTransformOperation::dump(TextStream& ts) const

--- a/Source/WebCore/platform/graphics/transforms/Matrix3DTransformOperation.h
+++ b/Source/WebCore/platform/graphics/transforms/Matrix3DTransformOperation.h
@@ -43,19 +43,13 @@ public:
 
     TransformationMatrix matrix() const {return m_matrix; }
 
-private:    
-    bool isIdentity() const override { return m_matrix.isIdentity(); }
-    bool isAffectedByTransformOrigin() const final { return !isIdentity(); }
-
-    bool isRepresentableIn2D() const final;
-
+private:
     bool operator==(const Matrix3DTransformOperation& other) const { return operator==(static_cast<const TransformOperation&>(other)); }
     bool operator==(const TransformOperation&) const override;
 
-    bool apply(TransformationMatrix& transform, const FloatSize&) const override
+    void apply(TransformationMatrix& transform) const override
     {
         transform.multiply(m_matrix);
-        return false;
     }
 
     Ref<TransformOperation> blend(const TransformOperation* from, const BlendingContext&, bool blendToIdentity = false) const override;

--- a/Source/WebCore/platform/graphics/transforms/MatrixTransformOperation.h
+++ b/Source/WebCore/platform/graphics/transforms/MatrixTransformOperation.h
@@ -54,17 +54,13 @@ public:
     TransformationMatrix matrix() const { return TransformationMatrix(m_a, m_b, m_c, m_d, m_e, m_f); }
 
 private:
-    bool isIdentity() const override { return m_a == 1 && m_b == 0 && m_c == 0 && m_d == 1 && m_e == 0 && m_f == 0; }
-    bool isAffectedByTransformOrigin() const override { return !isIdentity(); }
-
     bool operator==(const MatrixTransformOperation& other) const { return operator==(static_cast<const TransformOperation&>(other)); }
     bool operator==(const TransformOperation&) const override;
 
-    bool apply(TransformationMatrix& transform, const FloatSize&) const override
+    void apply(TransformationMatrix& transform) const override
     {
         TransformationMatrix matrix(m_a, m_b, m_c, m_d, m_e, m_f);
         transform.multiply(matrix);
-        return false;
     }
 
     Ref<TransformOperation> blend(const TransformOperation* from, const BlendingContext&, bool blendToIdentity = false) const override;

--- a/Source/WebCore/platform/graphics/transforms/PerspectiveTransformOperation.h
+++ b/Source/WebCore/platform/graphics/transforms/PerspectiveTransformOperation.h
@@ -45,9 +45,7 @@ public:
     std::optional<float> perspective() const { return m_p; }
 
 private:
-    bool isIdentity() const override { return !m_p; }
-    bool isAffectedByTransformOrigin() const override { return !isIdentity(); }
-    bool isRepresentableIn2D() const final { return false; }
+    bool isIdentity() const { return !m_p; }
 
     bool operator==(const PerspectiveTransformOperation& other) const { return operator==(static_cast<const TransformOperation&>(other)); }
     bool operator==(const TransformOperation&) const override;
@@ -64,11 +62,10 @@ private:
         return std::max(1.0f, *m_p);
     }
 
-    bool apply(TransformationMatrix& transform, const FloatSize&) const override
+    void apply(TransformationMatrix& transform) const override
     {
         if (auto value = floatValue())
             transform.applyPerspective(*value);
-        return false;
     }
 
     Ref<TransformOperation> blend(const TransformOperation* from, const BlendingContext&, bool blendToIdentity = false) const override;

--- a/Source/WebCore/platform/graphics/transforms/RotateTransformOperation.h
+++ b/Source/WebCore/platform/graphics/transforms/RotateTransformOperation.h
@@ -57,30 +57,21 @@ public:
 
     Ref<TransformOperation> blend(const TransformOperation* from, const BlendingContext&, bool blendToIdentity = false) const final;
 
-    bool isIdentity() const final { return !m_angle; }
-
-    bool isRepresentableIn2D() const final { return (!m_x && !m_y) || !m_angle; }
-
-    bool isAffectedByTransformOrigin() const final { return !isIdentity(); }
-
-    bool apply(TransformationMatrix& transform, const FloatSize& /*borderBoxSize*/) const final
+    void apply(TransformationMatrix& transform) const final
     {
         if (type() == TransformOperation::Type::Rotate)
             transform.rotate(m_angle);
         else
             transform.rotate3d(m_x, m_y, m_z, m_angle);
-        return false;
     }
 
-    bool applyUnrounded(TransformationMatrix& transform, const FloatSize& /*borderBoxSize*/) const final
+    void applyUnrounded(TransformationMatrix& transform) const final
     {
         if (type() == TransformOperation::Type::Rotate)
             transform.rotate(m_angle, TransformationMatrix::RotationSnapping::None);
         else
             transform.rotate3d(m_x, m_y, m_z, m_angle, TransformationMatrix::RotationSnapping::None);
-        return false;
     }
-
 
     void dump(WTF::TextStream&) const final;
 

--- a/Source/WebCore/platform/graphics/transforms/ScaleTransformOperation.h
+++ b/Source/WebCore/platform/graphics/transforms/ScaleTransformOperation.h
@@ -56,16 +56,9 @@ public:
 
     Ref<TransformOperation> blend(const TransformOperation* from, const BlendingContext&, bool blendToIdentity = false) const final;
 
-    bool isIdentity() const final { return m_x == 1 &&  m_y == 1 &&  m_z == 1; }
-
-    bool isRepresentableIn2D() const final { return m_z == 1; }
-
-    bool isAffectedByTransformOrigin() const final { return !isIdentity(); }
-
-    bool apply(TransformationMatrix& transform, const FloatSize&) const final
+    void apply(TransformationMatrix& transform) const final
     {
         transform.scale3d(m_x, m_y, m_z);
-        return false;
     }
 
     void dump(WTF::TextStream&) const final;

--- a/Source/WebCore/platform/graphics/transforms/SkewTransformOperation.h
+++ b/Source/WebCore/platform/graphics/transforms/SkewTransformOperation.h
@@ -44,16 +44,12 @@ public:
     double angleY() const { return m_angleY; }
 
 private:
-    bool isIdentity() const override { return m_angleX == 0 && m_angleY == 0; }
-    bool isAffectedByTransformOrigin() const override { return !isIdentity(); }
-
     bool operator==(const SkewTransformOperation& other) const { return operator==(static_cast<const TransformOperation&>(other)); }
     bool operator==(const TransformOperation&) const override;
 
-    bool apply(TransformationMatrix& transform, const FloatSize&) const override
+    void apply(TransformationMatrix& transform) const override
     {
         transform.skew(m_angleX, m_angleY);
-        return false;
     }
 
     Ref<TransformOperation> blend(const TransformOperation* from, const BlendingContext&, bool blendToIdentity = false) const override;

--- a/Source/WebCore/platform/graphics/transforms/TransformOperation.h
+++ b/Source/WebCore/platform/graphics/transforms/TransformOperation.h
@@ -72,17 +72,13 @@ public:
     virtual ~TransformOperation() = default;
 
     virtual Ref<TransformOperation> clone() const = 0;
-    virtual Ref<TransformOperation> selfOrCopyWithResolvedCalculatedValues(const FloatSize&) const { return const_cast<TransformOperation&>(*this); }
 
     virtual bool operator==(const TransformOperation&) const = 0;
 
-    virtual bool isIdentity() const = 0;
-
-    // Return true if the borderBoxSize was used in the computation, false otherwise.
-    virtual bool apply(TransformationMatrix&, const FloatSize& borderBoxSize) const = 0;
-    virtual bool applyUnrounded(TransformationMatrix& transform, const FloatSize& borderBoxSize) const
+    virtual void apply(TransformationMatrix&) const = 0;
+    virtual void applyUnrounded(TransformationMatrix& transform) const
     {
-        return apply(transform, borderBoxSize);
+        apply(transform);
     }
 
     virtual Ref<TransformOperation> blend(const TransformOperation* from, const BlendingContext&, bool blendToIdentity = false) const = 0;
@@ -93,24 +89,6 @@ public:
     virtual Type primitiveType() const { return m_type; }
     std::optional<Type> sharedPrimitiveType(Type other) const;
     std::optional<Type> sharedPrimitiveType(const TransformOperation* other) const;
-
-    virtual bool isAffectedByTransformOrigin() const { return false; }
-    
-    bool is3DOperation() const
-    {
-        Type opType = type();
-        return opType == Type::ScaleZ
-            || opType == Type::Scale3D
-            || opType == Type::TranslateZ
-            || opType == Type::Translate3D
-            || opType == Type::RotateX
-            || opType == Type::RotateY
-            || opType == Type::Rotate3D
-            || opType == Type::Matrix3D
-            || opType == Type::Perspective;
-    }
-    
-    virtual bool isRepresentableIn2D() const { return true; }
 
     static bool isRotateTransformOperationType(Type type)
     {
@@ -145,7 +123,7 @@ public:
             || type == Type::Translate
             || type == Type::Translate3D;
     }
-    
+
     virtual void dump(WTF::TextStream&) const = 0;
 
 private:

--- a/Source/WebCore/platform/graphics/transforms/TransformOperations.cpp
+++ b/Source/WebCore/platform/graphics/transforms/TransformOperations.cpp
@@ -55,34 +55,34 @@ TransformOperations TransformOperations::clone() const
     return TransformOperations { m_operations.map([](const auto& op) { return op->clone(); }) };
 }
 
-void TransformOperations::apply(TransformationMatrix& matrix, const FloatSize& size, unsigned start) const
+void TransformOperations::apply(TransformationMatrix& matrix, unsigned start) const
 {
     for (unsigned i = start; i < m_operations.size(); ++i)
-        m_operations[i]->apply(matrix, size);
+        m_operations[i]->apply(matrix);
 }
 
-bool TransformOperations::isInvertible(const LayoutSize& size) const
+bool TransformOperations::isInvertible() const
 {
     TransformationMatrix transform;
-    apply(transform, size);
+    apply(transform);
     return transform.isInvertible();
 }
 
-bool TransformOperations::containsNonInvertibleMatrix(const LayoutSize& boxSize) const
+bool TransformOperations::containsNonInvertibleMatrix() const
 {
-    return (hasTransformOfType<TransformOperation::Type::Matrix>() || hasTransformOfType<TransformOperation::Type::Matrix3D>()) && !isInvertible(boxSize);
+    return (hasTransformOfType<TransformOperation::Type::Matrix>() || hasTransformOfType<TransformOperation::Type::Matrix3D>()) && !isInvertible();
 }
 
-TransformOperations blend(const TransformOperations& from, const TransformOperations& to, const BlendingContext& context, const LayoutSize& boxSize)
+TransformOperations blend(const TransformOperations& from, const TransformOperations& to, const BlendingContext& context)
 {
-    bool shouldFallBackToDiscreteInterpolation = from.containsNonInvertibleMatrix(boxSize) || to.containsNonInvertibleMatrix(boxSize);
+    bool shouldFallBackToDiscreteInterpolation = from.containsNonInvertibleMatrix() || to.containsNonInvertibleMatrix();
 
     auto createBlendedMatrixOperationFromOperationsSuffix = [&](unsigned start) -> Ref<TransformOperation> {
         TransformationMatrix fromTransform;
-        from.apply(fromTransform, boxSize, start);
+        from.apply(fromTransform, start);
 
         TransformationMatrix toTransform;
-        to.apply(toTransform, boxSize, start);
+        to.apply(toTransform, start);
 
         auto progress = context.progress;
         auto compositeOperation = context.compositeOperation;

--- a/Source/WebCore/platform/graphics/transforms/TransformOperations.h
+++ b/Source/WebCore/platform/graphics/transforms/TransformOperations.h
@@ -64,13 +64,13 @@ public:
     const Ref<TransformOperation>& first() const LIFETIME_BOUND { return m_operations.first(); }
     const Ref<TransformOperation>& last() const LIFETIME_BOUND { return m_operations.last(); }
 
-    void apply(TransformationMatrix&, const FloatSize&, unsigned start = 0) const;
+    void apply(TransformationMatrix&, unsigned start = 0) const;
 
     template<TransformOperation::Type operationType>
     bool hasTransformOfType() const;
 
-    bool isInvertible(const LayoutSize&) const;
-    bool containsNonInvertibleMatrix(const LayoutSize&) const;
+    bool isInvertible() const;
+    bool containsNonInvertibleMatrix() const;
 
 private:
     friend struct IPC::ArgumentCoder<TransformOperations, void>;
@@ -85,7 +85,7 @@ bool TransformOperations::hasTransformOfType() const
     return std::ranges::any_of(m_operations, [](auto& op) { return op->type() == operationType; });
 }
 
-TransformOperations blend(const TransformOperations& from, const TransformOperations& to, const BlendingContext&, const LayoutSize&);
+TransformOperations blend(const TransformOperations& from, const TransformOperations& to, const BlendingContext&);
 
 WTF::TextStream& operator<<(WTF::TextStream&, const TransformOperations&);
 

--- a/Source/WebCore/platform/graphics/transforms/TransformOperationsSharedPrimitivesPrefix.h
+++ b/Source/WebCore/platform/graphics/transforms/TransformOperationsSharedPrimitivesPrefix.h
@@ -38,19 +38,20 @@ class TransformOperations;
 // the keyframes of an animation. After `update()` is called with the transform function range
 // of every keyframe, `primitives()` will return the prefix of primitives that are shared
 // by all keyframes passed to `update()`.
-class TransformOperationsSharedPrimitivesPrefix final {
+template<typename PrimitiveType> class TransformOperationsSharedPrimitivesPrefix final {
 public:
     void update(const auto&);
 
     bool hadIncompatibleTransformFunctions() { return m_indexOfFirstMismatch.has_value(); }
-    const Vector<TransformOperation::Type>& primitives() const { return m_primitives; }
+    const Vector<PrimitiveType>& primitives() const { return m_primitives; }
 
 private:
     std::optional<size_t> m_indexOfFirstMismatch;
-    Vector<TransformOperation::Type> m_primitives;
+    Vector<PrimitiveType> m_primitives;
 };
 
-void TransformOperationsSharedPrimitivesPrefix::update(const auto& operations)
+template<typename PrimitiveType>
+void TransformOperationsSharedPrimitivesPrefix<PrimitiveType>::update(const auto& operations)
 {
     size_t maxIteration = operations.size();
     if (m_indexOfFirstMismatch.has_value())

--- a/Source/WebCore/platform/graphics/transforms/TranslateTransformOperation.h
+++ b/Source/WebCore/platform/graphics/transforms/TranslateTransformOperation.h
@@ -24,8 +24,6 @@
 
 #pragma once
 
-#include <WebCore/Length.h>
-#include <WebCore/LengthFunctions.h>
 #include <WebCore/TransformOperation.h>
 #include <wtf/Ref.h>
 
@@ -35,58 +33,42 @@ struct BlendingContext;
 
 class TranslateTransformOperation final : public TransformOperation {
 public:
-    static Ref<TranslateTransformOperation> create(const Length& tx, const Length& ty, TransformOperation::Type type)
+    static Ref<TranslateTransformOperation> create(float tx, float ty, TransformOperation::Type type)
     {
-        return adoptRef(*new TranslateTransformOperation(tx, ty, Length(0, LengthType::Fixed), type));
+        return adoptRef(*new TranslateTransformOperation(tx, ty, 0, type));
     }
 
-    WEBCORE_EXPORT static Ref<TranslateTransformOperation> create(const Length&, const Length&, const Length&, TransformOperation::Type);
+    WEBCORE_EXPORT static Ref<TranslateTransformOperation> create(float, float, float, TransformOperation::Type);
 
     Ref<TransformOperation> clone() const override
     {
         return adoptRef(*new TranslateTransformOperation(m_x, m_y, m_z, type()));
     }
 
-    Ref<TransformOperation> selfOrCopyWithResolvedCalculatedValues(const FloatSize&) const override;
+    float x() const { return m_x; }
+    float y() const { return m_y; }
+    float z() const { return m_z; }
 
-    float xAsFloat(const FloatSize& borderBoxSize) const { return floatValueForLength(m_x, borderBoxSize.width(), 1.0f /* FIXME FIND ZOOM */); }
-    float yAsFloat(const FloatSize& borderBoxSize) const { return floatValueForLength(m_y, borderBoxSize.height(), 1.0f /* FIXME FIND ZOOM */); }
-    float zAsFloat() const { return floatValueForLength(m_z, 1, 1.0f /* FIXME FIND ZOOM */); }
+    TransformOperation::Type primitiveType() const final { return !m_z ? Type::Translate : Type::Translate3D; }
 
-    Length x() const { return m_x; }
-    Length y() const { return m_y; }
-    Length z() const { return m_z; }
-
-    void setX(Length newX) { m_x = newX; }
-    void setY(Length newY) { m_y = newY; }
-    void setZ(Length newZ) { m_z = newZ; }
-
-    TransformOperation::Type primitiveType() const final { return isRepresentableIn2D() ? Type::Translate : Type::Translate3D; }
-
-    bool apply(TransformationMatrix& transform, const FloatSize& borderBoxSize) const final
+    void apply(TransformationMatrix& transform) const final
     {
-        transform.translate3d(xAsFloat(borderBoxSize), yAsFloat(borderBoxSize), zAsFloat());
-        return m_x.isPercent() || m_y.isPercent();
+        transform.translate3d(m_x, m_y, m_z);
     }
-
-    bool isIdentity() const final { return !floatValueForLength(m_x, 1, 1.0f /* FIXME FIND ZOOM */) && !floatValueForLength(m_y, 1, 1.0f /* FIXME FIND ZOOM */) && !floatValueForLength(m_z, 1, 1.0f /* FIXME FIND ZOOM */); }
 
     bool operator==(const TranslateTransformOperation& other) const { return operator==(static_cast<const TransformOperation&>(other)); }
     bool operator==(const TransformOperation&) const final;
 
     Ref<TransformOperation> blend(const TransformOperation* from, const BlendingContext&, bool blendToIdentity = false) const final;
 
-    bool isRepresentableIn2D() const final { return m_z.isZero(); }
-
 private:
-
     void dump(WTF::TextStream&) const final;
 
-    TranslateTransformOperation(const Length&, const Length&, const Length&, TransformOperation::Type);
+    TranslateTransformOperation(float, float, float, TransformOperation::Type);
 
-    Length m_x;
-    Length m_y;
-    Length m_z;
+    float m_x;
+    float m_y;
+    float m_z;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/TextAutoSizing.cpp
+++ b/Source/WebCore/rendering/TextAutoSizing.cpp
@@ -32,6 +32,7 @@
 #include "Document.h"
 #include "DocumentInlines.h"
 #include "FontCascade.h"
+#include "LengthFunctions.h"
 #include "Logging.h"
 #include "RenderBlock.h"
 #include "RenderListMarker.h"

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -35,6 +35,7 @@
 #include "FontSelector.h"
 #include "InlineIteratorTextBox.h"
 #include "InlineTextBoxStyle.h"
+#include "LengthFunctions.h"
 #include "Logging.h"
 #include "MotionPath.h"
 #include "Pagination.h"
@@ -54,6 +55,7 @@
 #include "StyleLengthWrapper+Platform.h"
 #include "StylePrimitiveNumericTypes+Evaluation.h"
 #include "StyleResolver.h"
+#include "StyleScaleTransformFunction.h"
 #include "StyleSelfAlignmentData.h"
 #include "StyleTreeResolver.h"
 #include "TransformOperationData.h"
@@ -2365,7 +2367,7 @@ void RenderStyle::setPageScaleTransform(float scale)
     if (scale == 1)
         return;
 
-    setTransform(Style::Transform { Style::TransformFunction { ScaleTransformOperation::create(scale, scale, TransformOperation::Type::Scale) } });
+    setTransform(Style::Transform { Style::TransformFunction { Style::ScaleTransformFunction::create(scale, scale, Style::TransformFunctionType::Scale) } });
     setTransformOriginX(0_css_px);
     setTransformOriginY(0_css_px);
 }

--- a/Source/WebCore/style/StyleExtractorCustom.h
+++ b/Source/WebCore/style/StyleExtractorCustom.h
@@ -35,6 +35,7 @@
 #include "CSSGridIntegerRepeatValue.h"
 #include "CSSGridLineNamesValue.h"
 #include "CSSPropertyNames.h"
+#include "LengthFunctions.h"
 #include "RenderElementStyleInlines.h"
 #include "StyleExtractorConverter.h"
 #include "StyleExtractorSerializer.h"

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+CSSValueCreation.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+CSSValueCreation.h
@@ -53,5 +53,23 @@ template<Calc StyleType> struct CSSValueCreation<StyleType> {
     }
 };
 
+template<auto nR, auto pR, typename V> struct CSSValueCreation<NumberOrPercentage<nR, pR, V>> {
+    using StyleType = NumberOrPercentage<nR, pR, V>;
+
+    Ref<CSSValue> operator()(CSSValuePool& pool, const RenderStyle& style, const StyleType& value)
+    {
+        return CSS::createCSSValue(pool, toCSS(value, style));
+    }
+};
+
+template<auto nR, auto pR, typename V> struct CSSValueCreation<NumberOrPercentageResolvedToNumber<nR, pR, V>> {
+    using StyleType = NumberOrPercentageResolvedToNumber<nR, pR, V>;
+
+    Ref<CSSValue> operator()(CSSValuePool& pool, const RenderStyle& style, const StyleType& value)
+    {
+        return CSS::createCSSValue(pool, toCSS(value, style));
+    }
+};
+
 } // namespace Style
 } // namespace WebCore

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.h
@@ -438,11 +438,8 @@ template<auto nR, auto pR, typename V> struct ToStyle<CSS::NumberOrPercentageRes
     template<typename... Rest> auto operator()(const From& value, Rest&&... rest) -> To
     {
         return WTF::switchOn(value,
-            [&](const typename From::Number& number) -> To {
-                return { toStyle(number, std::forward<Rest>(rest)...) };
-            },
-            [&](const typename From::Percentage& percentage) -> To {
-                return { toStyle(percentage, std::forward<Rest>(rest)...).value / 100.0 };
+            [&](const auto& numberOrPercentage) -> To {
+                return { toStyle(numberOrPercentage, std::forward<Rest>(rest)...) };
             }
         );
     }

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Serialization.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Serialization.h
@@ -57,5 +57,25 @@ template<Calc StyleType> struct Serialize<StyleType> {
     }
 };
 
+template<auto nR, auto pR, typename V> struct Serialize<NumberOrPercentage<nR, pR, V>> {
+    using StyleType = NumberOrPercentage<nR, pR, V>;
+
+    void operator()(StringBuilder& builder, const CSS::SerializationContext& context, const RenderStyle& style, const StyleType& value)
+    {
+        // FIXME: Do this more efficiently without creating and destroying a CSS::UnevaluatedCalc object.
+        CSS::serializationForCSS(builder, context, toCSS(value, style));
+    }
+};
+
+template<auto nR, auto pR, typename V> struct Serialize<NumberOrPercentageResolvedToNumber<nR, pR, V>> {
+    using StyleType = NumberOrPercentageResolvedToNumber<nR, pR, V>;
+
+    void operator()(StringBuilder& builder, const CSS::SerializationContext& context, const RenderStyle& style, const StyleType& value)
+    {
+        // FIXME: Do this more efficiently without creating and destroying a CSS::UnevaluatedCalc object.
+        CSS::serializationForCSS(builder, context, toCSS(value, style));
+    }
+};
+
 } // namespace Style
 } // namespace WebCore

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes.h
@@ -88,11 +88,6 @@ template<CSS::Range nR = CSS::All, CSS::Range pR = nR, typename V = double> stru
 
     Number value { 0 };
 
-    constexpr NumberOrPercentageResolvedToNumber(typename Number::ResolvedValueType value)
-        : value { value }
-    {
-    }
-
     constexpr NumberOrPercentageResolvedToNumber(Number number)
         : value { number }
     {
@@ -100,6 +95,21 @@ template<CSS::Range nR = CSS::All, CSS::Range pR = nR, typename V = double> stru
 
     constexpr NumberOrPercentageResolvedToNumber(Percentage percentage)
         : value { percentage.value / 100.0 }
+    {
+    }
+
+    constexpr NumberOrPercentageResolvedToNumber(typename Number::ResolvedValueType value)
+        : NumberOrPercentageResolvedToNumber { Number { value } }
+    {
+    }
+
+    constexpr NumberOrPercentageResolvedToNumber(CSS::ValueLiteral<CSS::NumberUnit::Number> literal)
+        : NumberOrPercentageResolvedToNumber { Number { literal } }
+    {
+    }
+
+    constexpr NumberOrPercentageResolvedToNumber(CSS::ValueLiteral<CSS::PercentageUnit::Percentage> literal)
+        : NumberOrPercentageResolvedToNumber { Percentage { literal } }
     {
     }
 

--- a/Source/WebCore/style/values/transforms/StyleTransform.cpp
+++ b/Source/WebCore/style/values/transforms/StyleTransform.cpp
@@ -36,11 +36,6 @@
 namespace WebCore {
 namespace Style {
 
-WebCore::TransformOperations Transform::resolvedCalculatedValues(const FloatSize& size) const
-{
-    return m_value.resolvedCalculatedValues(size);
-}
-
 // MARK: - Conversion
 
 auto CSSValueConversion<Transform>::operator()(BuilderState& state, const CSSValue& value) -> Transform
@@ -90,10 +85,10 @@ auto Blending<Transform>::blend(const Transform& from, const Transform& to, cons
 
 // MARK: - Platform
 
-auto ToPlatform<Transform>::operator()(const Transform& value) -> TransformOperations
+auto ToPlatform<Transform>::operator()(const Transform& value, const FloatSize& size) -> TransformOperations
 {
-    return TransformOperations { WTF::map(value, [](auto& transformFunction) {
-        return Style::toPlatform(transformFunction);
+    return TransformOperations { WTF::map(value, [&](auto& transformFunction) {
+        return Style::toPlatform(transformFunction, size);
     }) };
 }
 

--- a/Source/WebCore/style/values/transforms/StyleTransform.h
+++ b/Source/WebCore/style/values/transforms/StyleTransform.h
@@ -44,9 +44,7 @@ struct Transform : ListOrNone<TransformList> {
     Transform(std::initializer_list<TransformFunction>);
     Transform(TransformFunction&&);
 
-    WebCore::TransformOperations resolvedCalculatedValues(const FloatSize&) const;
-
-    template<TransformOperation::Type operationType>
+    template<TransformFunctionType operationType>
     bool hasTransformOfType() const;
 
     void apply(TransformationMatrix&, const FloatSize&, unsigned start = 0) const;
@@ -57,6 +55,8 @@ struct Transform : ListOrNone<TransformList> {
     bool isRepresentableIn2D() const;
     bool affectedByTransformOrigin() const;
     bool containsNonInvertibleMatrix(const LayoutSize&) const;
+
+    TransformFunctionSizeDependencies computeSizeDependencies() const;
 };
 
 inline Transform::Transform(std::initializer_list<TransformFunction> transformFunctions)
@@ -69,7 +69,7 @@ inline Transform::Transform(TransformFunction&& transformFunction)
 {
 }
 
-template<TransformOperation::Type operationType>
+template<TransformFunctionType operationType>
 bool Transform::hasTransformOfType() const
 {
     return m_value.hasTransformOfType<operationType>();
@@ -100,6 +100,11 @@ inline bool Transform::containsNonInvertibleMatrix(const LayoutSize& size) const
     return m_value.containsNonInvertibleMatrix(size);
 }
 
+inline TransformFunctionSizeDependencies Transform::computeSizeDependencies() const
+{
+    return m_value.computeSizeDependencies();
+}
+
 // MARK: - Conversion
 
 template<> struct CSSValueConversion<Transform> { auto operator()(BuilderState&, const CSSValue&) -> Transform; };
@@ -115,7 +120,7 @@ template<> struct Blending<Transform> {
 
 // MARK: - Platform
 
-template<> struct ToPlatform<Transform> { auto operator()(const Transform&) -> TransformOperations; };
+template<> struct ToPlatform<Transform> { auto operator()(const Transform&, const FloatSize&) -> TransformOperations; };
 
 } // namespace Style
 } // namespace WebCore

--- a/Source/WebCore/style/values/transforms/StyleTransformFunction.h
+++ b/Source/WebCore/style/values/transforms/StyleTransformFunction.h
@@ -30,7 +30,8 @@
 
 #pragma once
 
-#include <WebCore/StyleTransformOperationWrapper.h>
+#include <WebCore/StyleTransformFunctionBase.h>
+#include <WebCore/StyleTransformFunctionWrapper.h>
 #include <WebCore/StyleValueTypes.h>
 #include <WebCore/TransformOperation.h>
 
@@ -39,8 +40,8 @@ namespace Style {
 
 // Any <transform-function>.
 // https://www.w3.org/TR/css-transforms-1/#typedef-transform-function
-struct TransformFunction : TransformOperationWrapper<TransformOperation> {
-    using TransformOperationWrapper<TransformOperation>::TransformOperationWrapper;
+struct TransformFunction : TransformFunctionWrapper<TransformFunctionBase> {
+    using TransformFunctionWrapper<TransformFunctionBase>::TransformFunctionWrapper;
 };
 
 // MARK: - Conversion
@@ -60,7 +61,7 @@ template<> struct Blending<TransformFunction> {
 
 // MARK: - Platform
 
-template<> struct ToPlatform<TransformFunction> { auto operator()(const TransformFunction&) -> Ref<TransformOperation>; };
+template<> struct ToPlatform<TransformFunction> { auto operator()(const TransformFunction&, const FloatSize&) -> Ref<TransformOperation>; };
 
 // MARK: - Logging
 

--- a/Source/WebCore/style/values/transforms/StyleTransformList.h
+++ b/Source/WebCore/style/values/transforms/StyleTransformList.h
@@ -31,7 +31,6 @@ namespace WebCore {
 
 class FloatSize;
 class LayoutSize;
-class TransformOperations;
 class TransformationMatrix;
 
 namespace Style {
@@ -68,9 +67,7 @@ struct TransformList {
 
     bool operator==(const TransformList&) const = default;
 
-    WebCore::TransformOperations resolvedCalculatedValues(const FloatSize&) const;
-
-    template<TransformOperation::Type>
+    template<TransformFunctionType>
     bool hasTransformOfType() const;
 
     void apply(TransformationMatrix&, const FloatSize&, unsigned start = 0) const;
@@ -82,6 +79,8 @@ struct TransformList {
     bool affectedByTransformOrigin() const;
     bool containsNonInvertibleMatrix(const LayoutSize&) const;
 
+    TransformFunctionSizeDependencies computeSizeDependencies() const;
+
 private:
     friend struct Blending<TransformList>;
     friend struct Transform;
@@ -91,7 +90,7 @@ private:
     Container m_value;
 };
 
-template<TransformOperation::Type operationType>
+template<TransformFunctionType operationType>
 bool TransformList::hasTransformOfType() const
 {
     return std::ranges::any_of(m_value, [](auto& op) { return op->type() == operationType; });

--- a/Source/WebCore/style/values/transforms/functions/StyleMatrix3DTransformFunction.cpp
+++ b/Source/WebCore/style/values/transforms/functions/StyleMatrix3DTransformFunction.cpp
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2009 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ */
+
+#include "config.h"
+#include "StyleMatrix3DTransformFunction.h"
+
+#include "AnimationUtilities.h"
+#include "Matrix3DTransformOperation.h"
+#include "StylePrimitiveNumericTypes+Logging.h"
+#include <algorithm>
+
+namespace WebCore {
+namespace Style {
+
+Matrix3DTransformFunction::Matrix3DTransformFunction(const TransformationMatrix& matrix)
+    : TransformFunctionBase(TransformFunctionBase::Type::Matrix3D)
+    , m_matrix(matrix)
+{
+}
+
+Ref<const Matrix3DTransformFunction> Matrix3DTransformFunction::create(const TransformationMatrix& matrix)
+{
+    return adoptRef(*new Matrix3DTransformFunction(matrix));
+}
+
+Ref<const TransformFunctionBase> Matrix3DTransformFunction::clone() const
+{
+    return adoptRef(*new Matrix3DTransformFunction(m_matrix));
+}
+
+Ref<TransformOperation> Matrix3DTransformFunction::toPlatform(const FloatSize&) const
+{
+    return Matrix3DTransformOperation::create(m_matrix);
+}
+
+bool Matrix3DTransformFunction::operator==(const TransformFunctionBase& other) const
+{
+    if (!isSameType(other))
+        return false;
+
+    auto& otherMatrix3D = downcast<Matrix3DTransformFunction>(other);
+    return m_matrix == otherMatrix3D.m_matrix;
+}
+
+void Matrix3DTransformFunction::apply(TransformationMatrix& transform, const FloatSize&) const
+{
+    transform.multiply(m_matrix);
+}
+
+Ref<const TransformFunctionBase> Matrix3DTransformFunction::blend(const TransformFunctionBase* from, const BlendingContext& context, bool blendToIdentity) const
+{
+    auto createOperation = [](TransformationMatrix& to, TransformationMatrix& from, const BlendingContext& context) {
+        to.blend(from, context.progress, context.compositeOperation);
+        return Matrix3DTransformFunction::create(to);
+    };
+
+    if (!sharedPrimitiveType(from))
+        return *this;
+
+    // Convert the TransformFunctions into matrices
+    TransformationMatrix toT = matrix();
+    TransformationMatrix fromT;
+    if (from)
+        fromT = downcast<Matrix3DTransformFunction>(*from).matrix();
+
+    if (blendToIdentity)
+        return createOperation(fromT, toT, context);
+    return createOperation(toT, fromT, context);
+}
+
+void Matrix3DTransformFunction::dump(TextStream& ts) const
+{
+    ts << type() << '(' << m_matrix << ')';
+}
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/transforms/functions/StyleMatrix3DTransformFunction.h
+++ b/Source/WebCore/style/values/transforms/functions/StyleMatrix3DTransformFunction.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2009 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ */
+
+#pragma once
+
+#include <WebCore/StylePrimitiveNumericTypes.h>
+#include <WebCore/StyleTransformFunctionBase.h>
+#include <WebCore/TransformationMatrix.h>
+
+namespace WebCore {
+namespace Style {
+
+// matrix3d() = matrix3d( <number>#{16} )
+// https://drafts.csswg.org/css-transforms-2/#funcdef-matrix3d
+
+class Matrix3DTransformFunction final : public TransformFunctionBase {
+public:
+    static Ref<const Matrix3DTransformFunction> create(const TransformationMatrix&);
+
+    Ref<const TransformFunctionBase> clone() const override;
+    Ref<TransformOperation> toPlatform(const FloatSize&) const override;
+
+    TransformationMatrix matrix() const { return m_matrix; }
+
+    bool isIdentity() const override { return m_matrix.isIdentity(); }
+    bool isAffectedByTransformOrigin() const override { return !isIdentity(); }
+    bool isRepresentableIn2D() const override { return m_matrix.isAffine(); }
+
+    bool operator==(const Matrix3DTransformFunction& other) const { return operator==(static_cast<const TransformFunctionBase&>(other)); }
+    bool operator==(const TransformFunctionBase&) const override;
+
+    void apply(TransformationMatrix&, const FloatSize& borderBoxSize) const override;
+
+    Ref<const TransformFunctionBase> blend(const TransformFunctionBase* from, const BlendingContext&, bool blendToIdentity = false) const override;
+
+    void dump(WTF::TextStream&) const override;
+
+private:
+    Matrix3DTransformFunction(const TransformationMatrix&);
+
+    TransformationMatrix m_matrix;
+};
+
+} // namespace Style
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_STYLE_TRANSFORM_FUNCTION(WebCore::Style::Matrix3DTransformFunction, WebCore::Style::TransformFunctionBase::Type::Matrix3D ==)

--- a/Source/WebCore/style/values/transforms/functions/StyleMatrixTransformFunction.cpp
+++ b/Source/WebCore/style/values/transforms/functions/StyleMatrixTransformFunction.cpp
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 1999 Antti Koivisto (koivisto@kde.org)
+ * Copyright (C) 2004, 2005, 2006, 2007, 2008 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ *
+ */
+
+#include "config.h"
+#include "StyleMatrixTransformFunction.h"
+
+#include "AnimationUtilities.h"
+#include "MatrixTransformOperation.h"
+#include "StylePrimitiveNumericTypes+Logging.h"
+#include <algorithm>
+
+namespace WebCore {
+namespace Style {
+
+MatrixTransformFunction::MatrixTransformFunction(Number<> a, Number<> b, Number<> c, Number<> d, Number<> e, Number<> f)
+    : TransformFunctionBase(TransformFunctionBase::Type::Matrix)
+    , m_a(a)
+    , m_b(b)
+    , m_c(c)
+    , m_d(d)
+    , m_e(e)
+    , m_f(f)
+{
+}
+
+MatrixTransformFunction::MatrixTransformFunction(const TransformationMatrix& matrix)
+    : MatrixTransformFunction(matrix.a(), matrix.b(), matrix.c(), matrix.d(), matrix.e(), matrix.f())
+{
+}
+
+Ref<const MatrixTransformFunction> MatrixTransformFunction::createIdentity()
+{
+    return adoptRef(*new MatrixTransformFunction(1, 0, 0, 1, 0, 0));
+}
+
+Ref<const MatrixTransformFunction> MatrixTransformFunction::create(Number<> a, Number<> b, Number<> c, Number<> d, Number<> e, Number<> f)
+{
+    return adoptRef(*new MatrixTransformFunction(a, b, c, d, e, f));
+}
+
+Ref<const MatrixTransformFunction> MatrixTransformFunction::create(const TransformationMatrix& matrix)
+{
+    return adoptRef(*new MatrixTransformFunction(matrix));
+}
+
+Ref<const TransformFunctionBase> MatrixTransformFunction::clone() const
+{
+    return adoptRef(*new MatrixTransformFunction(m_a, m_b, m_c, m_d, m_e, m_f));
+}
+
+Ref<TransformOperation> MatrixTransformFunction::toPlatform(const FloatSize&) const
+{
+    return MatrixTransformOperation::create(m_a.value, m_b.value, m_c.value, m_d.value, m_e.value, m_f.value);
+}
+
+bool MatrixTransformFunction::operator==(const TransformFunctionBase& other) const
+{
+    if (!isSameType(other))
+        return false;
+
+    auto& otherMatrix = downcast<MatrixTransformFunction>(other);
+    return m_a == otherMatrix.m_a
+        && m_b == otherMatrix.m_b
+        && m_c == otherMatrix.m_c
+        && m_d == otherMatrix.m_d
+        && m_e == otherMatrix.m_e
+        && m_f == otherMatrix.m_f;
+}
+
+void MatrixTransformFunction::apply(TransformationMatrix& transform, const FloatSize&) const
+{
+    transform.multiply(matrix());
+}
+
+Ref<const TransformFunctionBase> MatrixTransformFunction::blend(const TransformFunctionBase* from, const BlendingContext& context, bool blendToIdentity) const
+{
+    auto createOperation = [] (TransformationMatrix& to, TransformationMatrix& from, const BlendingContext& context) {
+        to.blend(from, context.progress, context.compositeOperation);
+        return MatrixTransformFunction::create(to);
+    };
+
+    if (!sharedPrimitiveType(from))
+        return *this;
+
+    // convert the TransformFunctions into matrices
+    TransformationMatrix toT = matrix();
+    TransformationMatrix fromT;
+    if (from)
+        fromT = downcast<MatrixTransformFunction>(*from).matrix();
+
+    if (blendToIdentity)
+        return createOperation(fromT, toT, context);
+    return createOperation(toT, fromT, context);
+}
+
+void MatrixTransformFunction::dump(TextStream& ts) const
+{
+    ts << '('
+       << m_a << ", "_s
+       << m_b << ", "_s
+       << m_c << ", "_s
+       << m_d << ", "_s
+       << m_e << ", "_s
+       << m_f << ')';
+}
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/transforms/functions/StyleMatrixTransformFunction.h
+++ b/Source/WebCore/style/values/transforms/functions/StyleMatrixTransformFunction.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2000 Lars Knoll (knoll@kde.org)
+ *           (C) 2000 Antti Koivisto (koivisto@kde.org)
+ *           (C) 2000 Dirk Mueller (mueller@kde.org)
+ * Copyright (C) 2003, 2005-2008, 2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2006 Graham Dennis (graham.dennis@gmail.com)
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ *
+ */
+
+#pragma once
+
+#include <WebCore/StylePrimitiveNumericTypes.h>
+#include <WebCore/StyleTransformFunctionBase.h>
+
+namespace WebCore {
+namespace Style {
+
+// matrix() = matrix( <number>#{6} )
+// https://drafts.csswg.org/css-transforms/#funcdef-transform-matrix
+
+class MatrixTransformFunction final : public TransformFunctionBase {
+public:
+    static Ref<const MatrixTransformFunction> createIdentity();
+    static Ref<const MatrixTransformFunction> create(Number<>, Number<>, Number<>, Number<>, Number<>, Number<>);
+    static Ref<const MatrixTransformFunction> create(const TransformationMatrix&);
+
+    Ref<const TransformFunctionBase> clone() const override;
+    Ref<TransformOperation> toPlatform(const FloatSize&) const override;
+
+    TransformationMatrix matrix() const { return TransformationMatrix(m_a.value, m_b.value, m_c.value, m_d.value, m_e.value, m_f.value); }
+
+    bool isIdentity() const override { return m_a == 1 && m_b == 0 && m_c == 0 && m_d == 1 && m_e == 0 && m_f == 0; }
+    bool isAffectedByTransformOrigin() const override { return !isIdentity(); }
+
+    bool operator==(const MatrixTransformFunction& other) const { return operator==(static_cast<const TransformFunctionBase&>(other)); }
+    bool operator==(const TransformFunctionBase&) const override;
+
+    void apply(TransformationMatrix&, const FloatSize& borderBoxSize) const override;
+
+    Ref<const TransformFunctionBase> blend(const TransformFunctionBase* from, const BlendingContext&, bool blendToIdentity = false) const override;
+
+    void dump(WTF::TextStream&) const override;
+
+private:
+    MatrixTransformFunction(Number<>, Number<>, Number<>, Number<>, Number<>, Number<>);
+    MatrixTransformFunction(const TransformationMatrix&);
+
+    Number<> m_a;
+    Number<> m_b;
+    Number<> m_c;
+    Number<> m_d;
+    Number<> m_e;
+    Number<> m_f;
+};
+
+} // namespace Style
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_STYLE_TRANSFORM_FUNCTION(WebCore::Style::MatrixTransformFunction, WebCore::Style::TransformFunctionBase::Type::Matrix ==)

--- a/Source/WebCore/style/values/transforms/functions/StylePerspectiveTransformFunction.cpp
+++ b/Source/WebCore/style/values/transforms/functions/StylePerspectiveTransformFunction.cpp
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C) 2009 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ */
+
+#include "config.h"
+#include "StylePerspectiveTransformFunction.h"
+
+#include "AnimationUtilities.h"
+#include "PerspectiveTransformOperation.h"
+#include "StylePrimitiveNumericTypes+Evaluation.h"
+#include "StylePrimitiveNumericTypes+Logging.h"
+#include <wtf/MathExtras.h>
+
+namespace WebCore {
+namespace Style {
+
+PerspectiveTransformFunction::PerspectiveTransformFunction(Perspective p)
+    : TransformFunctionBase(TransformFunctionBase::Type::Perspective)
+    , m_p(p)
+{
+}
+
+Ref<const PerspectiveTransformFunction> PerspectiveTransformFunction::create(Perspective p)
+{
+    return adoptRef(*new PerspectiveTransformFunction(p));
+}
+
+Ref<const TransformFunctionBase> PerspectiveTransformFunction::clone() const
+{
+    return adoptRef(*new PerspectiveTransformFunction(m_p));
+}
+
+Ref<TransformOperation> PerspectiveTransformFunction::toPlatform(const FloatSize&) const
+{
+    return WTF::switchOn(m_p,
+        [](const CSS::Keyword::None&) -> Ref<TransformOperation> {
+            return PerspectiveTransformOperation::create(std::nullopt);
+        },
+        [](const Perspective::Length& value) -> Ref<TransformOperation> {
+            return PerspectiveTransformOperation::create(evaluate<float>(value, ZoomNeeded { }));
+        }
+    );
+}
+
+bool PerspectiveTransformFunction::operator==(const TransformFunctionBase& other) const
+{
+    if (!isSameType(other))
+        return false;
+    auto& otherPerspective = downcast<PerspectiveTransformFunction>(other);
+    return m_p == otherPerspective.m_p;
+}
+
+void PerspectiveTransformFunction::apply(TransformationMatrix& transform, const FloatSize&) const
+{
+    if (auto value = m_p.tryValue())
+        transform.applyPerspective(std::max(1.0f, evaluate<float>(*value, ZoomNeeded { })));
+}
+
+std::optional<float> PerspectiveTransformFunction::unresolvedFloatValue() const
+{
+    return WTF::switchOn(m_p,
+        [](const CSS::Keyword::None&) -> std::optional<float> {
+            return std::nullopt;
+        },
+        [](const Perspective::Length& value) -> std::optional<float> {
+            // From https://drafts.csswg.org/css-transforms-2/#perspective-property:
+            // "As very small <length> values can produce bizarre rendering results and stress the numerical accuracy of
+            // transform calculations, values less than 1px must be treated as 1px for rendering purposes. (This clamping
+            // does not affect the underlying value, so perspective: 0; in a stylesheet will still serialize back as 0.)"
+            return std::max(1.0f, value.unresolvedValue());
+        }
+    );
+}
+
+Ref<const TransformFunctionBase> PerspectiveTransformFunction::blend(const TransformFunctionBase* from, const BlendingContext& context, bool blendToIdentity) const
+{
+    if (!sharedPrimitiveType(from))
+        return *this;
+
+    // https://drafts.csswg.org/css-transforms-2/#interpolation-of-transform-functions
+    // says that we should run matrix decomposition and then run the rules for
+    // interpolation of matrices, but we know what those rules are going to
+    // yield, so just do that directly.
+    auto getInverse = [](const auto& operation) {
+        if (auto value = operation->unresolvedFloatValue())
+            return 1.0 / *value;
+        return 0.0;
+    };
+
+    double ourInverse = getInverse(this);
+    double fromPInverse, toPInverse;
+    if (blendToIdentity) {
+        fromPInverse = ourInverse;
+        toPInverse = 0.0;
+    } else {
+        fromPInverse = from ? getInverse(downcast<PerspectiveTransformFunction>(from)) : 0.0;
+        toPInverse = ourInverse;
+    }
+
+    double pInverse = WebCore::blend(fromPInverse, toPInverse, context);
+    if (pInverse > 0.0 && std::isnormal(pInverse))
+        return PerspectiveTransformFunction::create(Perspective::Length { static_cast<float>(1.0 / pInverse) });
+    return PerspectiveTransformFunction::create(CSS::Keyword::None { });
+}
+
+void PerspectiveTransformFunction::dump(TextStream& ts) const
+{
+    ts << type() << '(' << m_p << ')';
+}
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/transforms/functions/StylePerspectiveTransformFunction.h
+++ b/Source/WebCore/style/values/transforms/functions/StylePerspectiveTransformFunction.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2009 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ */
+
+#pragma once
+
+#include <WebCore/StylePerspective.h>
+#include <WebCore/StylePrimitiveNumericTypes.h>
+#include <WebCore/StyleTransformFunctionBase.h>
+
+namespace WebCore {
+namespace Style {
+
+// perspective() = perspective( [ <length [0,∞]> | none ] )
+// https://drafts.csswg.org/css-transforms-2/#funcdef-perspective
+
+class PerspectiveTransformFunction final : public TransformFunctionBase {
+public:
+    static Ref<const PerspectiveTransformFunction> create(Perspective);
+
+    Ref<const TransformFunctionBase> clone() const override;
+    Ref<TransformOperation> toPlatform(const FloatSize&) const override;
+
+    Perspective perspective() const { return m_p; }
+
+    bool isIdentity() const override { return m_p.isNone(); }
+    bool isAffectedByTransformOrigin() const override { return !isIdentity(); }
+    bool isRepresentableIn2D() const override { return false; }
+
+    bool operator==(const PerspectiveTransformFunction& other) const { return operator==(static_cast<const TransformFunctionBase&>(other)); }
+    bool operator==(const TransformFunctionBase&) const override;
+
+    void apply(TransformationMatrix&, const FloatSize& borderBoxSize) const override;
+
+    Ref<const TransformFunctionBase> blend(const TransformFunctionBase* from, const BlendingContext&, bool blendToIdentity = false) const override;
+
+    void dump(WTF::TextStream&) const override;
+
+private:
+    PerspectiveTransformFunction(Perspective);
+
+    std::optional<float> unresolvedFloatValue() const;
+
+    Perspective m_p;
+};
+
+} // namespace Style
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_STYLE_TRANSFORM_FUNCTION(WebCore::Style::PerspectiveTransformFunction, WebCore::Style::TransformFunctionBase::Type::Perspective ==)

--- a/Source/WebCore/style/values/transforms/functions/StyleRotateTransformFunction.cpp
+++ b/Source/WebCore/style/values/transforms/functions/StyleRotateTransformFunction.cpp
@@ -1,0 +1,171 @@
+/*
+ * Copyright (C) 1999 Antti Koivisto (koivisto@kde.org)
+ * Copyright (C) 2004, 2005, 2006, 2007, 2008 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ *
+ */
+
+#include "config.h"
+#include "StyleRotateTransformFunction.h"
+
+#include "AnimationUtilities.h"
+#include "RotateTransformOperation.h"
+#include "StylePrimitiveNumericTypes+Blending.h"
+#include "StylePrimitiveNumericTypes+Logging.h"
+#include <algorithm>
+#include <wtf/MathExtras.h>
+
+namespace WebCore {
+namespace Style {
+
+RotateTransformFunction::RotateTransformFunction(Number<> x, Number<> y, Number<> z, Angle<> angle, TransformFunctionBase::Type type)
+    : TransformFunctionBase(type)
+    , m_x(x)
+    , m_y(y)
+    , m_z(z)
+    , m_angle(angle)
+{
+    RELEASE_ASSERT(isRotateTransformFunctionType(type));
+}
+
+Ref<const RotateTransformFunction> RotateTransformFunction::create(Angle<> angle, TransformFunctionBase::Type type)
+{
+    return adoptRef(*new RotateTransformFunction(0, 0, 1, angle, type));
+}
+
+Ref<const RotateTransformFunction> RotateTransformFunction::create(Number<> x, Number<> y, Number<> z, Angle<> angle, TransformFunctionBase::Type type)
+{
+    return adoptRef(*new RotateTransformFunction(x, y, z, angle, type));
+}
+
+Ref<const TransformFunctionBase> RotateTransformFunction::clone() const
+{
+    return adoptRef(*new RotateTransformFunction(m_x, m_y, m_z, m_angle, type()));
+}
+
+Ref<TransformOperation> RotateTransformFunction::toPlatform(const FloatSize&) const
+{
+    return RotateTransformOperation::create(m_x.value, m_y.value, m_z.value, m_angle.value, Style::toPlatform(type()));
+}
+
+bool RotateTransformFunction::operator==(const TransformFunctionBase& other) const
+{
+    if (!isSameType(other))
+        return false;
+
+    auto& otherRotate = downcast<RotateTransformFunction>(other);
+    return m_angle == otherRotate.m_angle && m_x == otherRotate.m_x && m_y == otherRotate.m_y && m_z == otherRotate.m_z;
+}
+
+void RotateTransformFunction::apply(TransformationMatrix& transform, const FloatSize&) const
+{
+    if (type() == TransformFunctionBase::Type::Rotate)
+        transform.rotate(m_angle.value);
+    else
+        transform.rotate3d(m_x.value, m_y.value, m_z.value, m_angle.value);
+}
+
+Ref<const TransformFunctionBase> RotateTransformFunction::blend(const TransformFunctionBase* from, const BlendingContext& context, bool blendToIdentity) const
+{
+    if (blendToIdentity) {
+        if (context.compositeOperation == CompositeOperation::Accumulate)
+            return RotateTransformFunction::create(m_x, m_y, m_z, m_angle, type());
+        return RotateTransformFunction::create(m_x, m_y, m_z, m_angle.value - m_angle.value * context.progress, type());
+    }
+    auto outputType = sharedPrimitiveType(from);
+    if (!outputType)
+        return *this;
+
+    auto* fromOp = downcast<RotateTransformFunction>(from);
+    auto* toOp = this;
+
+    // Interpolation of primitives and derived transform functions
+    //
+    // https://drafts.csswg.org/css-transforms-2/#interpolation-of-transform-functions
+    //
+    // For interpolations with the primitive rotate3d(), the direction vectors of the transform functions get
+    // normalized first. If the normalized vectors are not equal and both rotation angles are non-zero the transform
+    // functions get converted into 4x4 matrices first and interpolated as defined in section Interpolation of Matrices
+    // afterwards. Otherwise the rotation angle gets interpolated numerically and the rotation vector of the non-zero
+    // angle is used or (0, 0, 1) if both angles are zero.
+
+    auto normalizedVector = [](const RotateTransformFunction& op) -> FloatPoint3D {
+        if (auto length = std::hypot(op.m_x.value, op.m_y.value, op.m_z.value))
+            return { static_cast<float>(op.m_x.value / length), static_cast<float>(op.m_y.value / length), static_cast<float>(op.m_z.value / length) };
+        return { };
+    };
+
+    auto fromAngle = fromOp ? fromOp->m_angle : Angle<> { 0 };
+    auto toAngle = toOp->m_angle;
+    auto fromNormalizedVector = fromOp ? normalizedVector(*fromOp) : FloatPoint3D(0, 0, 1);
+    auto toNormalizedVector = normalizedVector(*toOp);
+    if (fromAngle.isZero() || toAngle.isZero() || fromNormalizedVector == toNormalizedVector) {
+        auto vector = (fromAngle.isZero() && !toAngle.isZero()) ? toNormalizedVector : fromNormalizedVector;
+        return RotateTransformFunction::create(vector.x(), vector.y(), vector.z(), Style::blend(fromAngle, toAngle, context), *outputType);
+    }
+
+    // Create the 2 rotation matrices
+    TransformationMatrix fromT;
+    TransformationMatrix toT;
+    fromT.rotate3d((fromOp ? fromOp->m_x.value : 0),
+        (fromOp ? fromOp->m_y.value : 0),
+        (fromOp ? fromOp->m_z.value : 1),
+        (fromOp ? fromOp->m_angle.value : 0));
+
+    toT.rotate3d((toOp ? toOp->m_x.value : 0),
+        (toOp ? toOp->m_y.value : 0),
+        (toOp ? toOp->m_z.value : 1),
+        (toOp ? toOp->m_angle.value : 0));
+
+    // Blend them
+    toT.blend(fromT, context.progress, context.compositeOperation);
+
+    // Extract the result as a quaternion
+    TransformationMatrix::Decomposed4Type decomposed;
+    if (!toT.decompose4(decomposed)) {
+        RefPtr usedOperation = context.progress > 0.5 ? this : fromOp;
+        return RotateTransformFunction::create(usedOperation->x(), usedOperation->y(), usedOperation->z(), usedOperation->angle(), TransformFunctionBase::Type::Rotate3D);
+    }
+
+    // Convert that to Axis/Angle form
+    double x = decomposed.quaternion.x;
+    double y = decomposed.quaternion.y;
+    double z = decomposed.quaternion.z;
+    double length = std::hypot(x, y, z);
+    double angle = 0;
+
+    if (length > 0.00001) {
+        x /= length;
+        y /= length;
+        z /= length;
+        angle = rad2deg(acos(decomposed.quaternion.w) * 2);
+    } else {
+        x = 0;
+        y = 0;
+        z = 1;
+    }
+    return RotateTransformFunction::create(x, y, z, angle, Type::Rotate3D);
+}
+
+void RotateTransformFunction::dump(TextStream& ts) const
+{
+    ts << type() << '(' << m_x << ", "_s << m_y << ", "_s << m_z << ", "_s << m_angle << ')';
+}
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/transforms/functions/StyleRotateTransformFunction.h
+++ b/Source/WebCore/style/values/transforms/functions/StyleRotateTransformFunction.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2000 Lars Knoll (knoll@kde.org)
+ *           (C) 2000 Antti Koivisto (koivisto@kde.org)
+ *           (C) 2000 Dirk Mueller (mueller@kde.org)
+ * Copyright (C) 2003, 2005-2008, 2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2006 Graham Dennis (graham.dennis@gmail.com)
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ *
+ */
+
+#pragma once
+
+#include <WebCore/StylePrimitiveNumericTypes.h>
+#include <WebCore/StyleTransformFunctionBase.h>
+
+namespace WebCore {
+namespace Style {
+
+// rotate() = rotate( [ <angle> | <zero> ] )
+// https://drafts.csswg.org/css-transforms/#funcdef-transform-rotate
+// rotate3d() = rotate3d( <number> , <number> , <number> , [ <angle> | <zero> ] )
+// https://drafts.csswg.org/css-transforms-2/#funcdef-rotate3d
+// rotateX() = rotateX( [ <angle> | <zero> ] )
+// https://drafts.csswg.org/css-transforms-2/#funcdef-rotatex
+// rotateY() = rotateY( [ <angle> | <zero> ] )
+// https://drafts.csswg.org/css-transforms-2/#funcdef-rotatey
+// rotateZ() = rotateZ( [ <angle> | <zero> ] )
+// https://drafts.csswg.org/css-transforms-2/#funcdef-rotatez
+
+class RotateTransformFunction final : public TransformFunctionBase {
+public:
+    static Ref<const RotateTransformFunction> create(Angle<>, TransformFunctionBase::Type);
+    static Ref<const RotateTransformFunction> create(Number<>, Number<>, Number<>, Angle<>, TransformFunctionBase::Type);
+
+    Ref<const TransformFunctionBase> clone() const override;
+    Ref<TransformOperation> toPlatform(const FloatSize&) const override;
+
+    Number<> x() const { return m_x; }
+    Number<> y() const { return m_y; }
+    Number<> z() const { return m_z; }
+    Angle<> angle() const { return m_angle; }
+
+    TransformFunctionBase::Type primitiveType() const override { return type() == Type::Rotate ? Type::Rotate : Type::Rotate3D; }
+
+    bool operator==(const RotateTransformFunction& other) const { return operator==(static_cast<const TransformFunctionBase&>(other)); }
+    bool operator==(const TransformFunctionBase&) const override;
+
+    bool isIdentity() const override { return m_angle.isZero(); }
+    bool isRepresentableIn2D() const override { return (m_x.isZero() && m_y.isZero()) || m_angle.isZero(); }
+    bool isAffectedByTransformOrigin() const override { return !isIdentity(); }
+
+    void apply(TransformationMatrix&, const FloatSize& borderBoxSize) const override;
+
+    Ref<const TransformFunctionBase> blend(const TransformFunctionBase* from, const BlendingContext&, bool blendToIdentity = false) const override;
+
+    void dump(WTF::TextStream&) const override;
+
+private:
+    RotateTransformFunction(Number<>, Number<>, Number<>, Angle<>, TransformFunctionBase::Type);
+
+    Number<> m_x;
+    Number<> m_y;
+    Number<> m_z;
+    Angle<> m_angle;
+};
+
+} // namespace Style
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_STYLE_TRANSFORM_FUNCTION(WebCore::Style::RotateTransformFunction, WebCore::Style::TransformFunctionBase::isRotateTransformFunctionType)

--- a/Source/WebCore/style/values/transforms/functions/StyleScaleTransformFunction.cpp
+++ b/Source/WebCore/style/values/transforms/functions/StyleScaleTransformFunction.cpp
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 1999 Antti Koivisto (koivisto@kde.org)
+ * Copyright (C) 2004, 2005, 2006, 2007, 2008 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ *
+ */
+
+#include "config.h"
+#include "StyleScaleTransformFunction.h"
+
+#include "AnimationUtilities.h"
+#include "ScaleTransformOperation.h"
+#include "StylePrimitiveNumericTypes+Blending.h"
+#include "StylePrimitiveNumericTypes+Logging.h"
+
+namespace WebCore {
+namespace Style {
+
+ScaleTransformFunction::ScaleTransformFunction(NumberOrPercentageResolvedToNumber<> x, NumberOrPercentageResolvedToNumber<> y, NumberOrPercentageResolvedToNumber<> z, TransformFunctionBase::Type type)
+    : TransformFunctionBase(type)
+    , m_x(x)
+    , m_y(y)
+    , m_z(z)
+{
+    RELEASE_ASSERT(isScaleTransformFunctionType(type));
+}
+
+Ref<const ScaleTransformFunction> ScaleTransformFunction::create(NumberOrPercentageResolvedToNumber<> x, NumberOrPercentageResolvedToNumber<> y, TransformFunctionBase::Type type)
+{
+    return adoptRef(*new ScaleTransformFunction(x, y, NumberOrPercentageResolvedToNumber<> { 1 }, type));
+}
+
+Ref<const ScaleTransformFunction> ScaleTransformFunction::create(NumberOrPercentageResolvedToNumber<> x, NumberOrPercentageResolvedToNumber<> y, NumberOrPercentageResolvedToNumber<> z, TransformFunctionBase::Type type)
+{
+    return adoptRef(*new ScaleTransformFunction(x, y, z, type));
+}
+
+Ref<const TransformFunctionBase> ScaleTransformFunction::clone() const
+{
+    return adoptRef(*new ScaleTransformFunction(m_x, m_y, m_z, type()));
+}
+
+Ref<TransformOperation> ScaleTransformFunction::toPlatform(const FloatSize&) const
+{
+    return ScaleTransformOperation::create(m_x.value.value, m_y.value.value, m_z.value.value, Style::toPlatform(type()));
+}
+
+bool ScaleTransformFunction::operator==(const TransformFunctionBase& other) const
+{
+    if (!isSameType(other))
+        return false;
+
+    auto& otherScale = downcast<ScaleTransformFunction>(other);
+    return m_x == otherScale.m_x && m_y == otherScale.m_y && m_z == otherScale.m_z;
+}
+
+void ScaleTransformFunction::apply(TransformationMatrix& transform, const FloatSize&) const
+{
+    transform.scale3d(m_x.value.value, m_y.value.value, m_z.value.value);
+}
+
+static NumberOrPercentageResolvedToNumber<> blendScaleComponent(NumberOrPercentageResolvedToNumber<> from, NumberOrPercentageResolvedToNumber<> to, const BlendingContext& context)
+{
+    switch (context.compositeOperation) {
+    case CompositeOperation::Replace:
+        return Style::blend(from, to, context);
+    case CompositeOperation::Add:
+        ASSERT(context.progress == 1.0);
+        return NumberOrPercentageResolvedToNumber<> { from.value.value * to.value.value };
+    case CompositeOperation::Accumulate:
+        ASSERT(context.progress == 1.0);
+        return NumberOrPercentageResolvedToNumber<> { from.value.value + to.value.value - 1 };
+    }
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
+Ref<const TransformFunctionBase> ScaleTransformFunction::blend(const TransformFunctionBase* from, const BlendingContext& context, bool blendToIdentity) const
+{
+    if (blendToIdentity)
+        return ScaleTransformFunction::create(blendScaleComponent(m_x, 1.0, context), blendScaleComponent(m_y, 1.0, context), blendScaleComponent(m_z, 1.0, context), type());
+
+    auto outputType = sharedPrimitiveType(from);
+    if (!outputType)
+        return *this;
+
+    auto* fromOp = downcast<ScaleTransformFunction>(from);
+    auto fromX = fromOp ? fromOp->m_x : NumberOrPercentageResolvedToNumber<> { 1.0 };
+    auto fromY = fromOp ? fromOp->m_y : NumberOrPercentageResolvedToNumber<> { 1.0 };
+    auto fromZ = fromOp ? fromOp->m_z : NumberOrPercentageResolvedToNumber<> { 1.0 };
+    return ScaleTransformFunction::create(blendScaleComponent(fromX, m_x, context), blendScaleComponent(fromY, m_y, context), blendScaleComponent(fromZ, m_z, context), *outputType);
+}
+
+void ScaleTransformFunction::dump(TextStream& ts) const
+{
+    ts << type() << '(' << m_x << ", "_s << m_y << ", "_s << m_z << ')';
+}
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/transforms/functions/StyleScaleTransformFunction.h
+++ b/Source/WebCore/style/values/transforms/functions/StyleScaleTransformFunction.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2000 Lars Knoll (knoll@kde.org)
+ *           (C) 2000 Antti Koivisto (koivisto@kde.org)
+ *           (C) 2000 Dirk Mueller (mueller@kde.org)
+ * Copyright (C) 2003, 2005-2008, 2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2006 Graham Dennis (graham.dennis@gmail.com)
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ *
+ */
+
+#pragma once
+
+#include <WebCore/StylePrimitiveNumericTypes.h>
+#include <WebCore/StyleTransformFunctionBase.h>
+
+namespace WebCore {
+namespace Style {
+
+// scale() = scale( [ <number> | <percentage> ]#{1,2} )
+// https://drafts.csswg.org/css-transforms-2/#funcdef-scale
+// scaleX() = scaleX( [ <number> | <percentage> ] )
+// https://drafts.csswg.org/css-transforms-2/#funcdef-scalex
+// scaleY() = scaleY( [ <number> | <percentage> ] )
+// https://drafts.csswg.org/css-transforms-2/#funcdef-scaley
+// scale3d() = scale3d( [ <number> | <percentage> ]#{3} )
+// https://drafts.csswg.org/css-transforms-2/#funcdef-scale3d
+
+class ScaleTransformFunction final : public TransformFunctionBase {
+public:
+    static Ref<const ScaleTransformFunction> create(NumberOrPercentageResolvedToNumber<>, NumberOrPercentageResolvedToNumber<>, TransformFunctionBase::Type);
+    static Ref<const ScaleTransformFunction> create(NumberOrPercentageResolvedToNumber<>, NumberOrPercentageResolvedToNumber<>, NumberOrPercentageResolvedToNumber<>, TransformFunctionBase::Type);
+
+    Ref<const TransformFunctionBase> clone() const override;
+    Ref<TransformOperation> toPlatform(const FloatSize&) const override;
+
+    TransformFunctionBase::Type primitiveType() const override { return (type() == Type::ScaleZ || type() == Type::Scale3D) ? Type::Scale3D : Type::Scale; }
+
+    NumberOrPercentageResolvedToNumber<> x() const { return m_x; }
+    NumberOrPercentageResolvedToNumber<> y() const { return m_y; }
+    NumberOrPercentageResolvedToNumber<> z() const { return m_z; }
+
+    bool isIdentity() const override { return m_x == 1 &&  m_y == 1 &&  m_z == 1; }
+    bool isRepresentableIn2D() const override { return m_z == 1; }
+    bool isAffectedByTransformOrigin() const override { return !isIdentity(); }
+
+    bool operator==(const ScaleTransformFunction& other) const { return operator==(static_cast<const TransformFunctionBase&>(other)); }
+    bool operator==(const TransformFunctionBase&) const override;
+
+    void apply(TransformationMatrix&, const FloatSize& borderBoxSize) const override;
+
+    Ref<const TransformFunctionBase> blend(const TransformFunctionBase* from, const BlendingContext&, bool blendToIdentity = false) const override;
+
+    void dump(WTF::TextStream&) const override;
+
+private:
+    ScaleTransformFunction(NumberOrPercentageResolvedToNumber<>, NumberOrPercentageResolvedToNumber<>, NumberOrPercentageResolvedToNumber<>, TransformFunctionBase::Type);
+
+    NumberOrPercentageResolvedToNumber<> m_x;
+    NumberOrPercentageResolvedToNumber<> m_y;
+    NumberOrPercentageResolvedToNumber<> m_z;
+};
+
+} // namespace Style
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_STYLE_TRANSFORM_FUNCTION(WebCore::Style::ScaleTransformFunction, WebCore::Style::TransformFunctionBase::isScaleTransformFunctionType)

--- a/Source/WebCore/style/values/transforms/functions/StyleSkewTransformFunction.cpp
+++ b/Source/WebCore/style/values/transforms/functions/StyleSkewTransformFunction.cpp
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 1999 Antti Koivisto (koivisto@kde.org)
+ * Copyright (C) 2004, 2005, 2006, 2007, 2008 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ *
+ */
+
+#include "config.h"
+#include "StyleSkewTransformFunction.h"
+
+#include "AnimationUtilities.h"
+#include "SkewTransformOperation.h"
+#include "StylePrimitiveNumericTypes+Blending.h"
+#include "StylePrimitiveNumericTypes+Logging.h"
+
+namespace WebCore {
+namespace Style {
+
+SkewTransformFunction::SkewTransformFunction(Angle<> angleX, Angle<> angleY, TransformFunctionBase::Type type)
+    : TransformFunctionBase(type)
+    , m_angleX(angleX)
+    , m_angleY(angleY)
+{
+    RELEASE_ASSERT(isSkewTransformFunctionType(type));
+}
+
+Ref<const SkewTransformFunction> SkewTransformFunction::create(Angle<> angleX, Angle<> angleY, TransformFunctionBase::Type type)
+{
+    return adoptRef(*new SkewTransformFunction(angleX, angleY, type));
+}
+
+Ref<const TransformFunctionBase> SkewTransformFunction::clone() const
+{
+    return adoptRef(*new SkewTransformFunction(m_angleX, m_angleY, type()));
+}
+
+Ref<TransformOperation> SkewTransformFunction::toPlatform(const FloatSize&) const
+{
+    return SkewTransformOperation::create(m_angleX.value, m_angleY.value, Style::toPlatform(type()));
+}
+
+bool SkewTransformFunction::operator==(const TransformFunctionBase& other) const
+{
+    if (!isSameType(other))
+        return false;
+
+    auto& otherSkew = downcast<SkewTransformFunction>(other);
+    return m_angleX == otherSkew.m_angleX && m_angleY == otherSkew.m_angleY;
+}
+
+void SkewTransformFunction::apply(TransformationMatrix& transform, const FloatSize&) const
+{
+    transform.skew(m_angleX.value, m_angleY.value);
+}
+
+Ref<const TransformFunctionBase> SkewTransformFunction::blend(const TransformFunctionBase* from, const BlendingContext& context, bool blendToIdentity) const
+{
+    if (blendToIdentity)
+        return SkewTransformFunction::create(Style::blend(m_angleX, Angle<> { 0.0 }, context), Style::blend(m_angleY, Angle<> { 0.0 }, context), type());
+
+    auto outputType = sharedPrimitiveType(from);
+    if (!outputType)
+        return *this;
+
+    auto* fromOp = downcast<SkewTransformFunction>(from);
+    auto fromAngleX = fromOp ? fromOp->m_angleX : Angle<> { 0 };
+    auto fromAngleY = fromOp ? fromOp->m_angleY : Angle<> { 0 };
+    return SkewTransformFunction::create(Style::blend(fromAngleX, m_angleX, context), Style::blend(fromAngleY, m_angleY, context), *outputType);
+}
+
+void SkewTransformFunction::dump(TextStream& ts) const
+{
+    ts << type() << '(' << m_angleX << ", "_s << m_angleY << ')';
+}
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/transforms/functions/StyleSkewTransformFunction.h
+++ b/Source/WebCore/style/values/transforms/functions/StyleSkewTransformFunction.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2000 Lars Knoll (knoll@kde.org)
+ *           (C) 2000 Antti Koivisto (koivisto@kde.org)
+ *           (C) 2000 Dirk Mueller (mueller@kde.org)
+ * Copyright (C) 2003, 2005-2008, 2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2006 Graham Dennis (graham.dennis@gmail.com)
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ *
+ */
+
+#pragma once
+
+#include <WebCore/StylePrimitiveNumericTypes.h>
+#include <WebCore/StyleTransformFunctionBase.h>
+
+namespace WebCore {
+namespace Style {
+
+// skew() = skew( [ <angle> | <zero> ] , [ <angle> | <zero> ]? )
+// https://drafts.csswg.org/css-transforms/#funcdef-transform-skew
+// skewX() = skewX( [ <angle> | <zero> ] )
+// https://drafts.csswg.org/css-transforms/#funcdef-transform-skew
+// skewY() = skewY( [ <angle> | <zero> ] )
+// https://drafts.csswg.org/css-transforms/#funcdef-transform-skewy
+
+class SkewTransformFunction final : public TransformFunctionBase {
+public:
+    static Ref<const SkewTransformFunction> create(Angle<>, Angle<>, TransformFunctionBase::Type);
+
+    Ref<const TransformFunctionBase> clone() const override;
+    Ref<TransformOperation> toPlatform(const FloatSize&) const override;
+
+    Angle<> angleX() const { return m_angleX; }
+    Angle<> angleY() const { return m_angleY; }
+
+    bool isIdentity() const override { return m_angleX.isZero() && m_angleY.isZero(); }
+    bool isAffectedByTransformOrigin() const override { return !isIdentity(); }
+
+    bool operator==(const SkewTransformFunction& other) const { return operator==(static_cast<const TransformFunctionBase&>(other)); }
+    bool operator==(const TransformFunctionBase&) const override;
+
+    void apply(TransformationMatrix&, const FloatSize& borderBoxSize) const override;
+
+    Ref<const TransformFunctionBase> blend(const TransformFunctionBase* from, const BlendingContext&, bool blendToIdentity = false) const override;
+
+    void dump(WTF::TextStream&) const override;
+
+private:
+    SkewTransformFunction(Angle<>, Angle<>, TransformFunctionBase::Type);
+
+    Angle<> m_angleX;
+    Angle<> m_angleY;
+};
+
+} // namespace Style
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_STYLE_TRANSFORM_FUNCTION(WebCore::Style::SkewTransformFunction, WebCore::Style::TransformFunctionBase::isSkewTransformFunctionType)

--- a/Source/WebCore/style/values/transforms/functions/StyleTransformFunctionBase.cpp
+++ b/Source/WebCore/style/values/transforms/functions/StyleTransformFunctionBase.cpp
@@ -1,0 +1,132 @@
+/*
+ * Copyright (C) 2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ */
+
+#include "config.h"
+#include "StyleTransformFunctionBase.h"
+
+#include <wtf/text/TextStream.h>
+
+namespace WebCore {
+namespace Style {
+
+TextStream& operator<<(TextStream& ts, TransformFunctionBase::Type type)
+{
+    switch (type) {
+    case TransformFunctionBase::Type::ScaleX: ts << "scaleX"_s; break;
+    case TransformFunctionBase::Type::ScaleY: ts << "scaleY"_s; break;
+    case TransformFunctionBase::Type::Scale: ts << "scale"_s; break;
+    case TransformFunctionBase::Type::TranslateX: ts << "translateX"_s; break;
+    case TransformFunctionBase::Type::TranslateY: ts << "translateY"_s; break;
+    case TransformFunctionBase::Type::Translate: ts << "translate"_s; break;
+    case TransformFunctionBase::Type::Rotate: ts << "rotate"_s; break;
+    case TransformFunctionBase::Type::SkewX: ts << "skewX"_s; break;
+    case TransformFunctionBase::Type::SkewY: ts << "skewY"_s; break;
+    case TransformFunctionBase::Type::Skew: ts << "skew"_s; break;
+    case TransformFunctionBase::Type::Matrix: ts << "matrix"_s; break;
+    case TransformFunctionBase::Type::ScaleZ: ts << "scaleX"_s; break;
+    case TransformFunctionBase::Type::Scale3D: ts << "scale3d"_s; break;
+    case TransformFunctionBase::Type::TranslateZ: ts << "translateZ"_s; break;
+    case TransformFunctionBase::Type::Translate3D: ts << "translate3d"_s; break;
+    case TransformFunctionBase::Type::RotateX: ts << "rotateX"_s; break;
+    case TransformFunctionBase::Type::RotateY: ts << "rotateY"_s; break;
+    case TransformFunctionBase::Type::RotateZ: ts << "rotateZ"_s; break;
+    case TransformFunctionBase::Type::Rotate3D: ts << "rotate3d"_s; break;
+    case TransformFunctionBase::Type::Matrix3D: ts << "matrix3d"_s; break;
+    case TransformFunctionBase::Type::Perspective: ts << "perspective"_s; break;
+    }
+    return ts;
+}
+
+TextStream& operator<<(TextStream& ts, const TransformFunctionBase& operation)
+{
+    operation.dump(ts);
+    return ts;
+}
+
+std::optional<TransformFunctionBase::Type> TransformFunctionBase::sharedPrimitiveType(Type other) const
+{
+    // https://drafts.csswg.org/css-transforms-2/#interpolation-of-transform-functions
+    // "If both transform functions share a primitive in the two-dimensional space, both transform
+    // functions get converted to the two-dimensional primitive. If one or both transform functions
+    // are three-dimensional transform functions, the common three-dimensional primitive is used."
+    auto type = primitiveType();
+    if (type == other)
+        return type;
+    static constexpr std::array sharedPrimitives {
+        std::array { Type::Rotate, Type::Rotate3D },
+        std::array { Type::Scale, Type::Scale3D },
+        std::array { Type::Translate, Type::Translate3D }
+    };
+    for (auto typePair : sharedPrimitives) {
+        if ((type == typePair[0] || type == typePair[1]) && (other == typePair[0] || other == typePair[1]))
+            return typePair[1];
+    }
+    return std::nullopt;
+}
+
+std::optional<TransformFunctionBase::Type> TransformFunctionBase::sharedPrimitiveType(const TransformFunctionBase* other) const
+{
+    // Blending with a null operation is always supported via blending with identity.
+    if (!other)
+        return type();
+
+    // In case we have the same type, make sure to preserve it.
+    if (other->type() == type())
+        return type();
+
+    return sharedPrimitiveType(other->primitiveType());
+}
+
+auto ToPlatform<TransformFunctionType>::operator()(TransformFunctionType type) -> TransformOperationType
+{
+    switch (type) {
+    case TransformFunctionType::ScaleX:         return TransformOperationType::ScaleX;
+    case TransformFunctionType::ScaleY:         return TransformOperationType::ScaleY;
+    case TransformFunctionType::Scale:          return TransformOperationType::Scale;
+    case TransformFunctionType::TranslateX:     return TransformOperationType::TranslateX;
+    case TransformFunctionType::TranslateY:     return TransformOperationType::TranslateY;
+    case TransformFunctionType::Translate:      return TransformOperationType::Translate;
+    case TransformFunctionType::RotateX:        return TransformOperationType::RotateX;
+    case TransformFunctionType::RotateY:        return TransformOperationType::RotateY;
+    case TransformFunctionType::Rotate:         return TransformOperationType::Rotate;
+    case TransformFunctionType::SkewX:          return TransformOperationType::SkewX;
+    case TransformFunctionType::SkewY:          return TransformOperationType::SkewY;
+    case TransformFunctionType::Skew:           return TransformOperationType::Skew;
+    case TransformFunctionType::Matrix:         return TransformOperationType::Matrix;
+    case TransformFunctionType::ScaleZ:         return TransformOperationType::ScaleZ;
+    case TransformFunctionType::Scale3D:        return TransformOperationType::Scale3D;
+    case TransformFunctionType::TranslateZ:     return TransformOperationType::TranslateZ;
+    case TransformFunctionType::Translate3D:    return TransformOperationType::Translate3D;
+    case TransformFunctionType::RotateZ:        return TransformOperationType::RotateZ;
+    case TransformFunctionType::Rotate3D:       return TransformOperationType::Rotate3D;
+    case TransformFunctionType::Matrix3D:       return TransformOperationType::Matrix3D;
+    case TransformFunctionType::Perspective:    return TransformOperationType::Perspective;
+    }
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/transforms/functions/StyleTransformFunctionBase.h
+++ b/Source/WebCore/style/values/transforms/functions/StyleTransformFunctionBase.h
@@ -1,0 +1,172 @@
+/*
+ * Copyright (C) 2000 Lars Knoll (knoll@kde.org)
+ *           (C) 2000 Antti Koivisto (koivisto@kde.org)
+ *           (C) 2000 Dirk Mueller (mueller@kde.org)
+ * Copyright (C) 2003, 2005-2008, 2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2006 Graham Dennis (graham.dennis@gmail.com)
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ *
+ */
+
+#pragma once
+
+#include <WebCore/FloatSize.h>
+#include <WebCore/StyleValueTypes.h>
+#include <WebCore/TransformOperation.h>
+#include <WebCore/TransformationMatrix.h>
+#include <wtf/Forward.h>
+#include <wtf/RefCounted.h>
+#include <wtf/TypeCasts.h>
+
+namespace WebCore {
+
+struct BlendingContext;
+
+namespace Style {
+
+enum class TransformFunctionType : uint8_t {
+    ScaleX,
+    ScaleY,
+    Scale,
+    TranslateX,
+    TranslateY,
+    Translate,
+    RotateX,
+    RotateY,
+    Rotate,
+    SkewX,
+    SkewY,
+    Skew,
+    Matrix,
+    ScaleZ,
+    Scale3D,
+    TranslateZ,
+    Translate3D,
+    RotateZ,
+    Rotate3D,
+    Matrix3D,
+    Perspective,
+};
+
+struct TransformFunctionSizeDependencies {
+    bool isWidthDependent = false;
+    bool isHeightDependent = false;
+};
+
+class TransformFunctionBase : public RefCounted<TransformFunctionBase> {
+public:
+    using Type = TransformFunctionType;
+
+    TransformFunctionBase(Type type)
+        : m_type(type)
+    {
+    }
+
+    virtual ~TransformFunctionBase() = default;
+
+    virtual Ref<const TransformFunctionBase> clone() const = 0;
+
+    virtual Ref<TransformOperation> toPlatform(const FloatSize& borderBoxSize) const = 0;
+
+    virtual bool operator==(const TransformFunctionBase&) const = 0;
+
+    virtual void apply(TransformationMatrix&, const FloatSize& borderBoxSize) const = 0;
+
+    virtual Ref<const TransformFunctionBase> blend(const TransformFunctionBase* from, const BlendingContext&, bool blendToIdentity = false) const = 0;
+
+    Type type() const { return m_type; }
+    bool isSameType(const TransformFunctionBase& other) const { return type() == other.type(); }
+
+    virtual Type primitiveType() const { return m_type; }
+    std::optional<Type> sharedPrimitiveType(Type other) const;
+    std::optional<Type> sharedPrimitiveType(const TransformFunctionBase* other) const;
+
+    virtual bool isIdentity() const = 0;
+    virtual bool isAffectedByTransformOrigin() const { return false; }
+    virtual bool isRepresentableIn2D() const { return true; }
+
+    virtual TransformFunctionSizeDependencies computeSizeDependencies() const { return { }; }
+
+    bool is3DOperation() const
+    {
+        Type opType = type();
+        return opType == Type::ScaleZ
+            || opType == Type::Scale3D
+            || opType == Type::TranslateZ
+            || opType == Type::Translate3D
+            || opType == Type::RotateX
+            || opType == Type::RotateY
+            || opType == Type::Rotate3D
+            || opType == Type::Matrix3D
+            || opType == Type::Perspective;
+    }
+
+    static bool isRotateTransformFunctionType(Type type)
+    {
+        return type == Type::RotateX
+            || type == Type::RotateY
+            || type == Type::RotateZ
+            || type == Type::Rotate
+            || type == Type::Rotate3D;
+    }
+
+    static bool isScaleTransformFunctionType(Type type)
+    {
+        return type == Type::ScaleX
+            || type == Type::ScaleY
+            || type == Type::ScaleZ
+            || type == Type::Scale
+            || type == Type::Scale3D;
+    }
+
+    static bool isSkewTransformFunctionType(Type type)
+    {
+        return type == Type::SkewX
+            || type == Type::SkewY
+            || type == Type::Skew;
+    }
+
+    static bool isTranslateTransformFunctionType(Type type)
+    {
+        return type == Type::TranslateX
+            || type == Type::TranslateY
+            || type == Type::TranslateZ
+            || type == Type::Translate
+            || type == Type::Translate3D;
+    }
+
+    virtual void dump(WTF::TextStream&) const = 0;
+
+private:
+    Type m_type;
+};
+
+WTF::TextStream& operator<<(WTF::TextStream&, TransformFunctionBase::Type);
+WTF::TextStream& operator<<(WTF::TextStream&, const TransformFunctionBase&);
+
+// MARK: - Platform
+
+template<> struct ToPlatform<TransformFunctionType> { auto operator()(TransformFunctionType) -> TransformOperationType; };
+
+} // namespace Style
+} // namespace WebCore
+
+#define SPECIALIZE_TYPE_TRAITS_STYLE_TRANSFORM_FUNCTION(ToValueTypeName, predicate) \
+SPECIALIZE_TYPE_TRAITS_BEGIN(ToValueTypeName) \
+    static bool isType(const WebCore::Style::TransformFunctionBase& operation) { return predicate(operation.type()); } \
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/style/values/transforms/functions/StyleTransformFunctionWrapper.h
+++ b/Source/WebCore/style/values/transforms/functions/StyleTransformFunctionWrapper.h
@@ -24,23 +24,24 @@
 
 #pragma once
 
+#include <wtf/PointerComparison.h>
 #include <wtf/Ref.h>
 
 namespace WebCore {
 namespace Style {
 
-template<typename PlatformOperation> struct TransformOperationWrapper {
-    TransformOperationWrapper(Ref<PlatformOperation> value) : value { WTFMove(value) } { }
+template<typename Function> struct TransformFunctionWrapper {
+    TransformFunctionWrapper(Ref<const Function> value) : value { WTFMove(value) } { }
 
-    const PlatformOperation& platform() const { return value.get(); }
-    const PlatformOperation* operator->() const { return value.ptr(); }
+    const Function& function() const { return value.get(); }
+    const Function* operator->() const { return value.ptr(); }
 
-    bool operator==(const TransformOperationWrapper& other) const
+    bool operator==(const TransformFunctionWrapper& other) const
     {
-        return value.ptr() == other.value.ptr() || value.get() == other.value.get();
+        return arePointingToEqualData(value, other.value);
     }
 
-    Ref<PlatformOperation> value;
+    Ref<const Function> value;
 };
 
 } // namespace Style

--- a/Source/WebCore/style/values/transforms/functions/StyleTranslateTransformFunction.cpp
+++ b/Source/WebCore/style/values/transforms/functions/StyleTranslateTransformFunction.cpp
@@ -1,0 +1,132 @@
+/*
+ * Copyright (C) 1999 Antti Koivisto (koivisto@kde.org)
+ * Copyright (C) 2004, 2005, 2006, 2007, 2008 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ *
+ */
+
+#include "config.h"
+#include "StyleTranslateTransformFunction.h"
+
+#include "AnimationUtilities.h"
+#include "StyleLengthWrapper+Blending.h"
+#include "StylePrimitiveNumericTypes+Blending.h"
+#include "StylePrimitiveNumericTypes+Evaluation.h"
+#include "StylePrimitiveNumericTypes+Logging.h"
+#include "TranslateTransformOperation.h"
+
+namespace WebCore {
+namespace Style {
+
+using namespace CSS::Literals;
+
+TranslateTransformFunction::TranslateTransformFunction(const LengthPercentage& x, const LengthPercentage& y, const Length& z, TransformFunctionBase::Type type)
+    : TransformFunctionBase(type)
+    , m_x(x)
+    , m_y(y)
+    , m_z(z)
+{
+    RELEASE_ASSERT(isTranslateTransformFunctionType(type));
+}
+
+Ref<const TranslateTransformFunction> TranslateTransformFunction::create(const LengthPercentage& x, const LengthPercentage& y, TransformFunctionBase::Type type)
+{
+    return adoptRef(*new TranslateTransformFunction(x, y, 0_css_px, type));
+}
+
+Ref<const TranslateTransformFunction> TranslateTransformFunction::create(const LengthPercentage& x, const LengthPercentage& y, const Length& z, TransformFunctionBase::Type type)
+{
+    return adoptRef(*new TranslateTransformFunction(x, y, z, type));
+}
+
+Ref<const TransformFunctionBase> TranslateTransformFunction::clone() const
+{
+    return adoptRef(*new TranslateTransformFunction(m_x, m_y, m_z, type()));
+}
+
+Ref<TransformOperation> TranslateTransformFunction::toPlatform(const FloatSize& borderBoxSize) const
+{
+    return TranslateTransformOperation::create(
+        evaluate<float>(m_x, borderBoxSize.width(), ZoomNeeded { }),
+        evaluate<float>(m_y, borderBoxSize.height(), ZoomNeeded { }),
+        evaluate<float>(m_z, ZoomNeeded { }),
+        Style::toPlatform(type())
+    );
+}
+
+TransformFunctionSizeDependencies TranslateTransformFunction::computeSizeDependencies() const
+{
+    return {
+        .isWidthDependent = m_x.isPercent(),
+        .isHeightDependent = m_y.isPercent(),
+    };
+}
+
+bool TranslateTransformFunction::operator==(const TransformFunctionBase& other) const
+{
+    if (!isSameType(other))
+        return false;
+
+    auto& otherTranslate = downcast<TranslateTransformFunction>(other);
+    return m_x == otherTranslate.m_x && m_y == otherTranslate.m_y && m_z == otherTranslate.m_z;
+}
+
+void TranslateTransformFunction::apply(TransformationMatrix& transform, const FloatSize& borderBoxSize) const
+{
+    transform.translate3d(
+        evaluate<float>(m_x, borderBoxSize.width(), ZoomNeeded { }),
+        evaluate<float>(m_y, borderBoxSize.height(), ZoomNeeded { }),
+        evaluate<float>(m_z, ZoomNeeded { })
+    );
+}
+
+Ref<const TransformFunctionBase> TranslateTransformFunction::blend(const TransformFunctionBase* from, const BlendingContext& context, bool blendToIdentity) const
+{
+    if (blendToIdentity) {
+        return TranslateTransformFunction::create(
+            Style::blend(m_x, LengthPercentage { 0_css_px }, context),
+            Style::blend(m_y, LengthPercentage { 0_css_px }, context),
+            Style::blend(m_z, Length { 0_css_px }, context),
+            type()
+        );
+    }
+
+    auto outputType = sharedPrimitiveType(from);
+    if (!outputType)
+        return *this;
+
+    RefPtr fromOp = downcast<TranslateTransformFunction>(from);
+    auto fromX = fromOp ? fromOp->m_x : LengthPercentage { 0_css_px };
+    auto fromY = fromOp ? fromOp->m_y : LengthPercentage { 0_css_px };
+    auto fromZ = fromOp ? fromOp->m_z : Length { 0_css_px };
+
+    return TranslateTransformFunction::create(
+        Style::blend(fromX, x(), context),
+        Style::blend(fromY, y(), context),
+        Style::blend(fromZ, z(), context),
+        *outputType
+    );
+}
+
+void TranslateTransformFunction::dump(TextStream& ts) const
+{
+    ts << type() << '(' << m_x << ", "_s << m_y << ", "_s << m_z << ')';
+}
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/transforms/functions/StyleTranslateTransformFunction.h
+++ b/Source/WebCore/style/values/transforms/functions/StyleTranslateTransformFunction.h
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2000 Lars Knoll (knoll@kde.org)
+ *           (C) 2000 Antti Koivisto (koivisto@kde.org)
+ *           (C) 2000 Dirk Mueller (mueller@kde.org)
+ * Copyright (C) 2003, 2005-2008, 2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2006 Graham Dennis (graham.dennis@gmail.com)
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ *
+ */
+
+#pragma once
+
+#include <WebCore/StyleLengthWrapper.h>
+#include <WebCore/StylePrimitiveNumericTypes.h>
+#include <WebCore/StyleTransformFunctionBase.h>
+
+namespace WebCore {
+namespace Style {
+
+// translate() = translate( <length-percentage> , <length-percentage>? )
+// https://drafts.csswg.org/css-transforms/#funcdef-transform-translate
+// translate3d() = translate3d( <length-percentage> , <length-percentage> , <length> )
+// https://drafts.csswg.org/css-transforms-2/#funcdef-translate3d
+// translateX() = translateX( <length-percentage> )
+// https://drafts.csswg.org/css-transforms/#funcdef-transform-translatex
+// translateY() = translateY( <length-percentage> )
+// https://drafts.csswg.org/css-transforms/#funcdef-transform-translatey
+// translateZ() = translateZ( <length> )
+// https://drafts.csswg.org/css-transforms-2/#funcdef-translatez
+
+struct TranslateLengthPercentage : LengthWrapperBase<LengthPercentage<>> {
+    using Base::Base;
+};
+
+class TranslateTransformFunction final : public TransformFunctionBase {
+public:
+    using LengthPercentage = Style::TranslateLengthPercentage;
+    using Length = Style::Length<>;
+
+    static Ref<const TranslateTransformFunction> create(const LengthPercentage&, const LengthPercentage&, TransformFunctionBase::Type);
+    static Ref<const TranslateTransformFunction> create(const LengthPercentage&, const LengthPercentage&, const Length&, TransformFunctionBase::Type);
+
+    Ref<const TransformFunctionBase> clone() const override;
+    Ref<TransformOperation> toPlatform(const FloatSize&) const override;
+
+    TransformFunctionBase::Type primitiveType() const override { return isRepresentableIn2D() ? Type::Translate : Type::Translate3D; }
+
+    const LengthPercentage& x() const { return m_x; }
+    const LengthPercentage& y() const { return m_y; }
+    Length z() const { return m_z; }
+
+    bool isIdentity() const override { return m_x.isZero() && m_y.isZero() && m_z.isZero(); }
+    bool isRepresentableIn2D() const override { return m_z.isZero(); }
+
+    TransformFunctionSizeDependencies computeSizeDependencies() const override;
+
+    bool operator==(const TranslateTransformFunction& other) const { return operator==(static_cast<const TransformFunctionBase&>(other)); }
+    bool operator==(const TransformFunctionBase&) const override;
+
+    void apply(TransformationMatrix&, const FloatSize& borderBoxSize) const override;
+
+    Ref<const TransformFunctionBase> blend(const TransformFunctionBase* from, const BlendingContext&, bool blendToIdentity = false) const override;
+
+    void dump(WTF::TextStream&) const override;
+
+private:
+    TranslateTransformFunction(const LengthPercentage&, const LengthPercentage&, const Length&, TransformFunctionBase::Type);
+
+    LengthPercentage m_x;
+    LengthPercentage m_y;
+    Length m_z;
+};
+
+} // namespace Style
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_STYLE_TRANSFORM_FUNCTION(WebCore::Style::TranslateTransformFunction, WebCore::Style::TransformFunctionBase::isTranslateTransformFunctionType)
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::TranslateLengthPercentage)

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2974,9 +2974,9 @@ header: <WebCore/KeyboardScroll.h>
 }
 
 [RefCounted] class WebCore::TranslateTransformOperation {
-    WebCore::Length x();
-    WebCore::Length y();
-    WebCore::Length z();
+    float x();
+    float y();
+    float z();
     [Validator='WebCore::TransformOperation::isTranslateTransformOperationType(*type)'] WebCore::TransformOperationType type();
 }
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAcceleratedEffectStack.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAcceleratedEffectStack.mm
@@ -199,7 +199,7 @@ WebCore::AcceleratedEffectValues RemoteAcceleratedEffectStack::computeValues(Mon
     auto values = m_baseValues;
     auto currentTime = now.secondsSinceEpoch() - m_acceleratedTimelineTimeOrigin;
     for (auto& effect : m_backdropLayerEffects.isEmpty() ? m_primaryLayerEffects : m_backdropLayerEffects)
-        effect->apply(currentTime, values, m_bounds);
+        effect->apply(currentTime, values);
     return values;
 }
 

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorBackendClient.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorBackendClient.cpp
@@ -219,7 +219,7 @@ void WebInspectorBackendClient::showPaintRect(const FloatRect& rect)
     Ref opacityAnimation = GraphicsLayerAnimation::create();
     opacityAnimation->setDuration(0.25);
 
-    paintLayer->addAnimation(fadeKeyframes, FloatSize(), opacityAnimation.ptr(), "opacity"_s, 0);
+    paintLayer->addAnimation(fadeKeyframes, opacityAnimation.ptr(), "opacity"_s, 0);
 
     Ref rawLayer = paintLayer.get();
     m_paintRectLayers.add(WTFMove(paintLayer));

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorClient.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorClient.cpp
@@ -219,7 +219,7 @@ void WebInspectorBackendClient::showPaintRect(const FloatRect& rect)
     Ref opacityAnimation = Animation::create();
     opacityAnimation->setDuration(0.25);
 
-    paintLayer->addAnimation(fadeKeyframes, FloatSize(), opacityAnimation.ptr(), "opacity"_s, 0);
+    paintLayer->addAnimation(fadeKeyframes, opacityAnimation.ptr(), "opacity"_s, 0);
     
     Ref rawLayer = paintLayer.get();
     m_paintRectLayers.add(WTFMove(paintLayer));

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.mm
@@ -487,12 +487,9 @@ void PDFDiscretePresentationController::startTransitionAnimation(PageTransitionS
     auto transitionDuration = defaultTransitionDuration;
 
     auto transformAnimationValueForTranslation = [](double keyTime, FloatSize offset) {
-        auto xLength = Length(offset.width(), LengthType::Fixed);
-        auto yLength = Length(offset.height(), LengthType::Fixed);
-
         Vector<Ref<TransformOperation>> operations;
         operations.reserveInitialCapacity(1);
-        operations.append(TranslateTransformOperation::create(xLength, yLength, Length(0, LengthType::Fixed), TransformOperationType::Translate));
+        operations.append(TranslateTransformOperation::create(offset.width(), offset.height(), 0, TransformOperationType::Translate));
 
         return makeUnique<TransformAnimationValue>(keyTime, TransformOperations { WTFMove(operations) }, nullptr);
     };
@@ -541,16 +538,16 @@ void PDFDiscretePresentationController::startTransitionAnimation(PageTransitionS
         moveAnimation->setDuration(transitionDuration.seconds());
         moveAnimation->setTimingFunction(WTFMove(moveTimingFunction));
         Ref animatingRowContainerLayer = *animatingRow.containerLayer;
-        animatingRowContainerLayer->addAnimation(moveFrames, { }, moveAnimation.ptr(), "move"_s, 0);
+        animatingRowContainerLayer->addAnimation(moveFrames, moveAnimation.ptr(), "move"_s, 0);
 
         auto fadeKeyframes = createOpacityKeyframesForAnimation(direction, layerEndOpacities[topLayerIndex]);
         Ref fadeAnimation = GraphicsLayerAnimation::create();
         fadeAnimation->setDuration(transitionDuration.seconds());
         fadeAnimation->setTimingFunction(WTFMove(fadeTimingFunction));
-        animatingRowContainerLayer->addAnimation(fadeKeyframes, { }, fadeAnimation.ptr(), "fade"_s, 0);
+        animatingRowContainerLayer->addAnimation(fadeKeyframes, fadeAnimation.ptr(), "fade"_s, 0);
 
         auto stationaryLayerFadeKeyframes = createOpacityKeyframesForAnimation(direction, layerEndOpacities[bottomLayerIndex]);
-        stationaryRow.protectedContainerLayer()->addAnimation(stationaryLayerFadeKeyframes, { }, fadeAnimation.ptr(), "fade"_s, 0);
+        stationaryRow.protectedContainerLayer()->addAnimation(stationaryLayerFadeKeyframes, fadeAnimation.ptr(), "fade"_s, 0);
 
         return transitionDuration;
     };
@@ -589,7 +586,7 @@ void PDFDiscretePresentationController::startTransitionAnimation(PageTransitionS
 
     case TransitionDirection::NextHorizontal:
     case TransitionDirection::NextVertical: {
-        // Top page animates up, fading out. Botom page fades in.
+        // Top page animates up, fading out. Bottom page fades in.
         auto additionalVisibleRowIndex = additionalVisibleRowIndexForDirection(*m_transitionDirection);
         if (!additionalVisibleRowIndex)
             return;


### PR DESCRIPTION
#### f87b14ad446e9c8acc2768e313611ac359a6ed33
<pre>
[Style] Split style and platform transform operation representations
<a href="https://bugs.webkit.org/show_bug.cgi?id=299814">https://bugs.webkit.org/show_bug.cgi?id=299814</a>

Reviewed by Antti Koivisto.

In order to remove another remaining use of WebCore::Length, this change
adds a style specific parallel set of types for representing transform
operations to the WebCore::TransformOperation ones.

The new types, deriving from Style::TransformFunction, use Style primitive
numerics for the underlying data, allowing us to replace the WebCore::Length
with Style::LengthPercentage&lt;&gt; in Style::TranslateTransformFunction.

In the pre-existing WebCore::TranslateTransformOperation, WebCore::Length
is replaced by direct usage of float (it might make sense to change this
to double at some point, but for now, float is used to maintain the same
bit accuracy as Length).

When going from the style types to the platform types, via Style::toPlatform,
a FloatSize must be passed in so that Style::LengthPercentage&lt;&gt; in
Style::TranslateTransformFunction can be resolved down to float.

The platform transform types are only used for platform layer animation
needs (both GraphicsLayer and threaded), so going forward, any capabilities
they don&apos;t need can stripped from them. For GraphicsLayer, it may make sense
to remove use of WebCore::TransformOperation entirely, instead having the
ability to go straight from Style::TransformFunction to platform animation
types, be it PlatformCAAnimation or TextureMapperAnimation.

This introduces a bit of duplication of logic for the blending that is not
ideal, so a followup change will aim to add a generic implementation of
the blending algorithms that can be shared.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/animation/BlendingKeyframes.cpp:
* Source/WebCore/animation/KeyframeEffect.cpp:
* Source/WebCore/css/values/CSSValueAggregates.h:
* Source/WebCore/platform/animation/AcceleratedEffect.cpp:
* Source/WebCore/platform/animation/AcceleratedEffect.h:
* Source/WebCore/platform/animation/AcceleratedEffectValues.cpp:
* Source/WebCore/platform/graphics/GraphicsLayer.h:
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h:
* Source/WebCore/platform/graphics/texmap/GraphicsLayerTextureMapper.cpp:
* Source/WebCore/platform/graphics/texmap/GraphicsLayerTextureMapper.h:
* Source/WebCore/platform/graphics/texmap/TextureMapperAnimation.cpp:
* Source/WebCore/platform/graphics/texmap/TextureMapperAnimation.h:
* Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.cpp:
* Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.h:
* Source/WebCore/platform/graphics/transforms/IdentityTransformOperation.h:
* Source/WebCore/platform/graphics/transforms/Matrix3DTransformOperation.cpp:
* Source/WebCore/platform/graphics/transforms/Matrix3DTransformOperation.h:
* Source/WebCore/platform/graphics/transforms/MatrixTransformOperation.h:
* Source/WebCore/platform/graphics/transforms/PerspectiveTransformOperation.h:
* Source/WebCore/platform/graphics/transforms/RotateTransformOperation.h:
* Source/WebCore/platform/graphics/transforms/ScaleTransformOperation.h:
* Source/WebCore/platform/graphics/transforms/SkewTransformOperation.h:
* Source/WebCore/platform/graphics/transforms/TransformOperation.h:
* Source/WebCore/platform/graphics/transforms/TransformOperations.cpp:
* Source/WebCore/platform/graphics/transforms/TransformOperations.h:
* Source/WebCore/platform/graphics/transforms/TransformOperationsSharedPrimitivesPrefix.h:
* Source/WebCore/platform/graphics/transforms/TranslateTransformOperation.cpp:
* Source/WebCore/platform/graphics/transforms/TranslateTransformOperation.h:
* Source/WebCore/rendering/RenderLayer.cpp:
* Source/WebCore/rendering/RenderLayerBacking.cpp:
* Source/WebCore/rendering/TextAutoSizing.cpp:
* Source/WebCore/rendering/style/RenderStyle.cpp:
* Source/WebCore/style/StyleExtractorCustom.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+CSSValueConversion.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+CSSValueCreation.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Serialization.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes.h:
* Source/WebCore/style/values/transforms/StyleRotate.cpp:
* Source/WebCore/style/values/transforms/StyleRotate.h:
* Source/WebCore/style/values/transforms/StyleScale.cpp:
* Source/WebCore/style/values/transforms/StyleScale.h:
* Source/WebCore/style/values/transforms/StyleTransform.cpp:
* Source/WebCore/style/values/transforms/StyleTransform.h:
* Source/WebCore/style/values/transforms/StyleTransformFunction.cpp:
* Source/WebCore/style/values/transforms/StyleTransformFunction.h:
* Source/WebCore/style/values/transforms/StyleTransformList.cpp:
* Source/WebCore/style/values/transforms/StyleTransformList.h:
* Source/WebCore/style/values/transforms/StyleTranslate.cpp:
* Source/WebCore/style/values/transforms/StyleTranslate.h:
* Source/WebCore/style/values/transforms/functions/StyleMatrix3DTransformFunction.cpp: Added.
* Source/WebCore/style/values/transforms/functions/StyleMatrix3DTransformFunction.h: Added.
* Source/WebCore/style/values/transforms/functions/StyleMatrixTransformFunction.cpp: Added.
* Source/WebCore/style/values/transforms/functions/StyleMatrixTransformFunction.h: Added.
* Source/WebCore/style/values/transforms/functions/StylePerspectiveTransformFunction.cpp: Added.
* Source/WebCore/style/values/transforms/functions/StylePerspectiveTransformFunction.h: Added.
* Source/WebCore/style/values/transforms/functions/StyleRotateTransformFunction.cpp: Added.
* Source/WebCore/style/values/transforms/functions/StyleRotateTransformFunction.h: Added.
* Source/WebCore/style/values/transforms/functions/StyleScaleTransformFunction.cpp: Added.
* Source/WebCore/style/values/transforms/functions/StyleScaleTransformFunction.h: Added.
* Source/WebCore/style/values/transforms/functions/StyleSkewTransformFunction.cpp: Added.
* Source/WebCore/style/values/transforms/functions/StyleSkewTransformFunction.h: Added.
* Source/WebCore/style/values/transforms/functions/StyleTransformFunctionBase.cpp: Added.
* Source/WebCore/style/values/transforms/functions/StyleTransformFunctionBase.h: Added.
* Source/WebCore/style/values/transforms/functions/StyleTransformFunctionWrapper.h: Renamed from Source/WebCore/style/values/transforms/StyleTransformOperationWrapper.h.
* Source/WebCore/style/values/transforms/functions/StyleTranslateTransformFunction.cpp: Added.
* Source/WebCore/style/values/transforms/functions/StyleTranslateTransformFunction.h: Added.
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteAcceleratedEffectStack.mm:
* Source/WebKit/WebProcess/Inspector/WebInspectorBackendClient.cpp:
* Source/WebKit/WebProcess/Inspector/WebInspectorClient.cpp:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.mm:

Canonical link: <a href="https://commits.webkit.org/300845@main">https://commits.webkit.org/300845@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/353d970ed61a85e684b8b1e2ded6f2d06c0b3eae

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124040 "18 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43754 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34452 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130868 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/76190 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/125917 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44479 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52348 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94364 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/76190 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126994 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35444 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110964 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74951 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34391 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/29130 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74351 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105176 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29347 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133539 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50992 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38843 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102827 "9 flakes 57 failures") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51366 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107183 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102641 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26110 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47993 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26245 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/47868 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50845 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56610 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/50318 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53664 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51992 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->