### PR TITLE
REGRESSION(300277@main): [macOS Debug] 2x in fast/selectors/style-invalidation-hover-change are flaky failure

### DIFF
--- a/LayoutTests/fast/selectors/style-invalidation-hover-change-descendants.html
+++ b/LayoutTests/fast/selectors/style-invalidation-hover-change-descendants.html
@@ -45,6 +45,7 @@
         <div class="target child">
         </div>
     </div>
+    <div id="console"></div>
 </div>
 
 <script>

--- a/LayoutTests/fast/selectors/style-invalidation-hover-change-siblings.html
+++ b/LayoutTests/fast/selectors/style-invalidation-hover-change-siblings.html
@@ -48,6 +48,7 @@
         <div class="target child">
         </div>
     </div>
+    <div id="console"></div>
 </div>
 
 <script>

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2519,7 +2519,3 @@ webkit.org/b/280234 imported/w3c/web-platform-tests/html/dom/idlharness.https.ht
 webkit.org/b/299131 [ Release ] inspector/unit-tests/target-manager.html [ Pass Crash ]
 
 webkit.org/b/299322 imported/w3c/web-platform-tests/uievents/mouse/mouse_boundary_events_after_reappending_last_over_target.tentative.html [ Pass Failure ]
-
-# webkit.org/b/299553 REGRESSION(300277@main): [macOS Debug] 2x in fast/selectors/style-invalidation-hover-change are flaky failure
-[ Debug ] fast/selectors/style-invalidation-hover-change-siblings.html [ Pass Failure ]
-[ Debug ] fast/selectors/style-invalidation-hover-change-descendants.html [ Pass Failure ]


### PR DESCRIPTION
#### 195e2f818f9a6d3ca7609a030b49c5b90a64e9ea
<pre>
REGRESSION(300277@main): [macOS Debug] 2x in fast/selectors/style-invalidation-hover-change are flaky failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=299553">https://bugs.webkit.org/show_bug.cgi?id=299553</a>
<a href="https://rdar.apple.com/161356964">rdar://161356964</a>

Reviewed by Abrar Rahman Protyasha and Aditya Keerthi.

In 300277@main, we introduced hover state updates when a layout update results in
the element underneath the mouse changing. Both failing tests work by moving
the mouse into a specific element, and then checking style changes to see if the
hover state updated correctly. However, the output of these tests is positioned
above the elements, causing the tested elements to shift downwards each time a
PASS or FAIL message is printed. This causes the mouse underneath the element to
change. This did not cause a test failure before 300277@main because we simply
did not update the hover state correctly after layout changes.

After 300277@main, the test was flakey rather than simply failing due to a
race condition. If the style was checked before the layout change updated
the hover state, the test would pass, and if it checked afterwards, it would
fail due to the element under the mouse changing.

To fix this, simply add the console ourselves to the end of the page rather
than allowing the imported script to add it to the beginning of the page.

* LayoutTests/fast/selectors/style-invalidation-hover-change-descendants.html:
* LayoutTests/fast/selectors/style-invalidation-hover-change-siblings.html:
* LayoutTests/platform/mac/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/300733@main">https://commits.webkit.org/300733@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6e4ccba9f68c9698a35cf138fb485dc7c8bb96f8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123618 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43333 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34029 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130386 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/75763 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/127feabd-87ae-4569-8772-3a4fbe802f5b) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44056 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51927 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93997 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62386 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3930e7c0-aa87-4e10-91a0-5a4813a7fbef) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126571 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35094 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110585 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74598 "Found 1 new API test failure: WPE/TestWebsiteData:/webkit/WebKitWebsiteData/itp (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/859cbb7a-e4c1-4f60-b531-e55328e0932e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34060 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28744 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73865 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104815 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28967 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133080 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50569 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38502 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102468 "Failed to checkout and rebase branch from PR 51523") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50944 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106806 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102309 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26024 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47662 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25897 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/47383 "Hash 6e4ccba9 for PR 51523 does not build (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50423 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49897 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53244 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51572 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->