### PR TITLE
[iOS] <select> element menu may dismiss early

### DIFF
--- a/LayoutTests/fast/forms/ios/select-change-focus-to-another-select-expected.txt
+++ b/LayoutTests/fast/forms/ios/select-change-focus-to-another-select-expected.txt
@@ -1,0 +1,10 @@
+This test verifies that focusing one select and then focusing another does not dismiss the second select's menu.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS areArraysEqual(items, ["D", "E", "F"]) is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/ios/select-change-focus-to-another-select.html
+++ b/LayoutTests/fast/forms/ios/select-change-focus-to-another-select.html
@@ -1,0 +1,46 @@
+<html>
+    <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+        <script src="../../../resources/js-test.js"></script>
+        <script src="../../../resources/ui-helper.js"></script>
+        <style>
+
+        select {
+            margin-top: 100px;
+        }
+
+        </style>
+    </head>
+<body>
+<select id="select1">
+    <option>A</option>
+    <option>B</option>
+    <option>C</option>
+</select>
+<select id="select2">
+    <option>D</option>
+    <option>E</option>
+    <option>F</option>
+</select>
+</body>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description("This test verifies that focusing one select and then focusing another does not dismiss the second select's menu.");
+
+    await UIHelper.activateElement(select1);
+    await UIHelper.waitForContextMenuToShow();
+
+    await UIHelper.tapAt(20, 20);
+    await UIHelper.activateElement(select2);
+
+    await UIHelper.delayFor(1000);
+
+    items = await UIHelper.selectMenuItems();
+    shouldBeTrue("areArraysEqual(items, " + '["D", "E", "F"]' + ")");
+
+    finishJSTest();
+});
+</script>
+</html>

--- a/Source/WebKit/UIProcess/ios/forms/WKFormSelectPicker.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFormSelectPicker.mm
@@ -698,11 +698,13 @@ static constexpr auto removeLineLimitForChildrenMenuOption = static_cast<UIMenuO
 - (void)contextMenuInteraction:(UIContextMenuInteraction *)interaction willEndForConfiguration:(UIContextMenuConfiguration *)configuration animator:(id <UIContextMenuInteractionAnimating>)animator
 {
     _isAnimatingContextMenuDismissal = YES;
-    [animator addCompletion:[weakSelf = WeakObjCPtr<WKSelectPicker>(self)] {
+    [animator addCompletion:[weakSelf = WeakObjCPtr<WKSelectPicker>(self), elementContext = _view.focusedElementInformation.elementContext] {
         auto strongSelf = weakSelf.get();
         if (strongSelf) {
-            [strongSelf->_view accessoryDone];
-            [strongSelf->_view.webView _didDismissContextMenu];
+            RetainPtr view = strongSelf->_view;
+            if (elementContext.isSameElement([view focusedElementInformation].elementContext))
+                [view accessoryDone];
+            [[view webView] _didDismissContextMenu];
             strongSelf->_isAnimatingContextMenuDismissal = NO;
         }
     }];


### PR DESCRIPTION
#### 02f7a612039f3c91d767af54ee0212db38436c19
<pre>
[iOS] &lt;select&gt; element menu may dismiss early
<a href="https://bugs.webkit.org/show_bug.cgi?id=299822">https://bugs.webkit.org/show_bug.cgi?id=299822</a>
<a href="https://rdar.apple.com/147261775">rdar://147261775</a>

Reviewed by Wenson Hsieh and Abrar Rahman Protyasha.

When presenting a context menu after dismissing another one, the first menu&apos;s
dismissal animation may complete while the second menu is being presented. This
scenario is not accounted for in `WKSelectPicker`, which calls
`-[WKContentView accessoryDone]` whenever a dismissal animation is completed.
Consequently, the completion of the dismissal of the first menu can trigger the
dismissal of the second menu.

Fix by only calling `accessoryDone` after dismissal if the focused element is
still the same. If the focused element changes for any other reason, the menu
would already be dismissed.

* LayoutTests/fast/forms/ios/select-change-focus-to-another-select-expected.txt: Added.
* LayoutTests/fast/forms/ios/select-change-focus-to-another-select.html: Added.
* Source/WebKit/UIProcess/ios/forms/WKFormSelectPicker.mm:
(-[WKSelectPicker contextMenuInteraction:willEndForConfiguration:animator:]):

Canonical link: <a href="https://commits.webkit.org/300720@main">https://commits.webkit.org/300720@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9fb7731ad1c4151d9e9952fe5b27f9e67625ddb1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123619 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43334 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34030 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130387 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/75764 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3e22ccd5-1004-4f65-91df-e28dfc15fd19) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44057 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51928 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93998 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/62387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/479ddb6c-525c-494d-b042-68920948ce5f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126572 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35098 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110591 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74599 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/69a8c600-fa20-4cd1-bd45-92180594c2cb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34064 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28750 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73866 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104819 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28973 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133081 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50570 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38500 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102469 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50945 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106812 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102310 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47663 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25903 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/47381 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19460 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50424 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56186 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49898 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53245 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51573 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->