### PR TITLE
Clang 21 complains about implicit casting between char32_t and char16_t throughout the codebase

### DIFF
--- a/Source/JavaScriptCore/parser/Lexer.cpp
+++ b/Source/JavaScriptCore/parser/Lexer.cpp
@@ -36,6 +36,9 @@
 #include <wtf/HexNumber.h>
 #include <wtf/dtoa.h>
 #include <wtf/text/MakeString.h>
+#include <wtf/text/icu/UnicodeExtras.h>
+#include <wtf/unicode/CharacterCasts.h>
+#include <wtf/unicode/UTF8Conversion.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
@@ -712,7 +715,8 @@ ParsedUnicodeEscapeValue Lexer<CharacterType>::parseUnicodeEscape()
     shift();
     shift();
     shift();
-    return result;
+    // FIXME: What to do if the escape sequence corresponds to a surrogate?
+    return deprecatedBrokenCastUTF16CodeUnitToUTF32IgnoringSurrogates(result);
 }
 
 template <typename T>
@@ -828,7 +832,7 @@ ALWAYS_INLINE char32_t Lexer<char16_t>::currentCodePoint() const
 {
     ASSERT_WITH_MESSAGE(!isIdentStart(errorCodePoint), "error values shouldn't appear as a valid identifier start code point");
     if (!U16_IS_SURROGATE(m_current))
-        return m_current;
+        return castNonSurrogateUTF16CodeUnitToUTF32(m_current);
 
     char16_t trail = peek(1);
     if (!U16_IS_LEAD(m_current) || !U16_IS_SURROGATE_TRAIL(trail)) [[unlikely]]
@@ -2028,9 +2032,9 @@ start:
     }
 
     if constexpr (!std::is_same_v<T, Latin1Character>) {
+        static_assert(std::is_same_v<T, char16_t>);
         if (!isLatin1(m_current)) [[unlikely]] {
-            char32_t codePoint;
-            U16_GET(m_code, 0, 0, m_codeEnd - m_code, codePoint);
+            char32_t codePoint = u16Get(unsafeMakeSpan(m_code, m_codeEnd - m_code), 0);
             if (isNonLatin1IdentStart(codePoint)) {
                 // We are hijacking white space characters for non-latin1 identifier start in the following dispatch since we will never see
                 // these characters in the switch because of `skipWhitespace()` call.
@@ -2801,9 +2805,8 @@ start:
     case  32 /*  32 = Space              CharacterWhiteSpace */:
     case 160 /* 160 = Zs category (nbsp) CharacterWhiteSpace */: {
         if constexpr (ASSERT_ENABLED) {
-            char32_t codePoint;
-            U16_GET(m_code, 0, 0, m_codeEnd - m_code, codePoint);
-            ASSERT(isIdentStart(codePoint));
+            char32_t codePoint = u16Get(unsafeMakeSpan(m_code, m_codeEnd - m_code), 0);
+            ASSERT_UNUSED(isIdentStart(codePoint), codePoint);
         }
         [[fallthrough]];
     }
@@ -2839,10 +2842,12 @@ start:
         if (isLatin1(next)) [[likely]]
             isValidPrivateName = typesOfLatin1Characters[static_cast<Latin1Character>(next)] == CharacterLatin1IdentifierStart || next == '\\';
         else {
-            ASSERT(m_code + 1 < m_codeEnd);
-            char32_t codePoint;
-            U16_GET(m_code + 1, 0, 0, m_codeEnd - (m_code + 1), codePoint);
-            isValidPrivateName = isNonLatin1IdentStart(codePoint);
+            if constexpr (std::is_same_v<T, char16_t>) {
+                ASSERT(m_code + 1 < m_codeEnd);
+                char32_t codePoint = u16Get(unsafeMakeSpan(m_code + 1, m_codeEnd - (m_code + 1)), 0);
+                isValidPrivateName = isNonLatin1IdentStart(codePoint);
+            } else
+                isValidPrivateName = false;
         }
 
         if (isValidPrivateName) {

--- a/Source/JavaScriptCore/runtime/IntlCollator.cpp
+++ b/Source/JavaScriptCore/runtime/IntlCollator.cpp
@@ -492,8 +492,8 @@ void IntlCollator::checkICULocaleInvariants(const LocaleSet& locales)
             Vector<char16_t, 32> buffer;
             for (int32_t index = 0, count = uset_getItemCount(&set); index < count; ++index) {
                 // start and end are inclusive.
-                UChar32 start = 0;
-                UChar32 end = 0;
+                char32_t start = 0;
+                char32_t end = 0;
                 auto status = callBufferProducingFunction(uset_getItem, &set, index, &start, &end, buffer);
                 ASSERT(U_SUCCESS(status));
                 if (buffer.isEmpty()) {

--- a/Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp
@@ -50,6 +50,8 @@
 #include <wtf/text/ASCIIFastPath.h>
 #include <wtf/text/ParsingUtilities.h>
 #include <wtf/text/StringBuilder.h>
+#include <wtf/text/icu/UnicodeExtras.h>
+#include <wtf/unicode/CharacterCasts.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
@@ -95,7 +97,7 @@ static JSValue encode(JSGlobalObject* globalObject, const WTF::BitSet<256>& doNo
         // 4-d-ii-1. Let V be the code unit value of C.
         char32_t codePoint;
         if (!U16_IS_LEAD(character))
-            codePoint = character;
+            codePoint = castNonSurrogateUTF16CodeUnitToUTF32(character);
         else {
             // 4-d-iii. Else,
             // 4-d-iii-1. Increase k by 1.
@@ -181,10 +183,9 @@ static JSValue decode(JSGlobalObject* globalObject, std::span<const CharType> ch
                         }
                     }
                     if (charLen != 0) {
-                        char32_t character;
-                        int32_t offset = 0;
-                        U8_NEXT(sequence, offset, sequenceLen, character);
-                        if (character == static_cast<char32_t>(U_SENTINEL))
+                        size_t offset = 0;
+                        char32_t character = u8Next(sequence, offset);
+                        if (character == static_cast<char32_t>(U_SENTINEL)) // FIXME XXX: this is broken, char32_t is an unsigned type
                             charLen = 0;
                         else if (!U_IS_BMP(character)) {
                             // Convert to surrogate pair.

--- a/Source/JavaScriptCore/runtime/ParseInt.h
+++ b/Source/JavaScriptCore/runtime/ParseInt.h
@@ -28,6 +28,7 @@
 #include <JavaScriptCore/JSCJSValue.h>
 #include <JavaScriptCore/Lexer.h>
 #include <wtf/dtoa.h>
+#include <wtf/unicode/CharacterCasts.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
@@ -101,7 +102,15 @@ ALWAYS_INLINE static bool isStrWhiteSpace(CharacterType c)
     // https://tc39.github.io/ecma262/#sec-tonumber-applied-to-the-string-type
     if constexpr (sizeof(c) == 1)
         return Lexer<Latin1Character>::isWhiteSpace(c) || Lexer<Latin1Character>::isLineTerminator(c);
-    return Lexer<char16_t>::isWhiteSpace(c) || Lexer<char16_t>::isLineTerminator(c);
+    if (!U_IS_BMP(c))
+        return false;
+
+    char16_t c16;
+    if constexpr (std::is_same_v<CharacterType, char16_t>)
+        c16 = c;
+    else if constexpr (std::is_same_v<CharacterType, char32_t>)
+        c16 = castBMPUTF32CodeUnitToUTF16(c);
+    return Lexer<char16_t>::isWhiteSpace(c16) || Lexer<char16_t>::isLineTerminator(c16);
 }
 
 inline static std::optional<double> parseIntDouble(double n)

--- a/Source/JavaScriptCore/runtime/RegExpConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/RegExpConstructor.cpp
@@ -29,6 +29,7 @@
 #include "RegExpGlobalDataInlines.h"
 #include "RegExpPrototype.h"
 #include "YarrFlags.h"
+#include <wtf/text/icu/UnicodeExtras.h>
 
 namespace JSC {
 
@@ -116,21 +117,20 @@ JSC_DEFINE_HOST_FUNCTION(regExpConstructorEscape, (JSGlobalObject* globalObject,
     StringBuilder builder(OverflowPolicy::RecordOverflow);
     builder.reserveCapacity(string->length());
 
-    for (unsigned i = 0; i < string->length() && !builder.hasOverflowed();) {
+    for (size_t i = 0; i < string->length() && !builder.hasOverflowed();) {
         char32_t codePoint;
         if (string->is8Bit())
             codePoint = string->span8()[i++];
-        else {
-            auto characters = string->span16();
-            U16_NEXT(characters, i, string->length(), codePoint);
-        }
+        else
+            codePoint = u16Next(string->span16(), i);
 
         if (builder.isEmpty() && isASCIIAlphanumeric(codePoint)) {
             builder.append('\\', 'x', toStringWithRadix(codePoint, 16));
             continue;
         }
 
-        if (StringView("^$\\.*+?()[]{}|/"_s).contains(codePoint)) {
+        // FIXME: This could match spuriously. We need a StringView::contains(char32_t).
+        if (StringView("^$\\.*+?()[]{}|/"_s).contains(deprecatedBrokenCastUTF32CodeUnitToUTF16IgnoringSurrogates(codePoint))) {
             builder.append('\\', codePoint);
             continue;
         }
@@ -155,7 +155,8 @@ JSC_DEFINE_HOST_FUNCTION(regExpConstructorEscape, (JSGlobalObject* globalObject,
             break;
         }
 
-        if (StringView(",-=<>#&!%:;@~'`\""_s).contains(codePoint) || isStrWhiteSpace(codePoint) || U16_IS_SURROGATE(codePoint)) {
+        // FIXME: This could match spuriously. We need a StringView::contains(char32_t).
+        if (StringView(",-=<>#&!%:;@~'`\""_s).contains(deprecatedBrokenCastUTF32CodeUnitToUTF16IgnoringSurrogates(codePoint)) || isStrWhiteSpace(codePoint) || !U_IS_BMP(codePoint)) {
             if (isLatin1(codePoint))
                 builder.append('\\', 'x', pad('0', 2, toStringWithRadix(codePoint, 16)));
             else if (U_IS_BMP(codePoint))

--- a/Source/JavaScriptCore/runtime/StringPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/StringPrototype.cpp
@@ -48,6 +48,7 @@
 #include <wtf/ASCIICType.h>
 #include <wtf/text/StringBuilder.h>
 #include <wtf/text/StringView.h>
+#include <wtf/text/icu/UnicodeExtras.h>
 #include <wtf/unicode/icu/ICUHelpers.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
@@ -448,10 +449,7 @@ static inline char32_t codePointAt(const String& string, unsigned position, unsi
     RELEASE_ASSERT(position < length);
     if (string.is8Bit())
         return string.span8()[position];
-    char32_t character;
-    auto characters = string.span16();
-    U16_NEXT(characters, position, length, character);
-    return character;
+    return u16Get(string.span16(), position);
 }
 
 JSC_DEFINE_HOST_FUNCTION(stringProtoFuncCodePointAt, (JSGlobalObject* globalObject, CallFrame* callFrame))

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyBuiltin.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyBuiltin.cpp
@@ -35,6 +35,7 @@
 #include "JSWebAssemblyRuntimeError.h"
 #include <wtf/Vector.h>
 #include <wtf/text/MakeString.h>
+#include <wtf/text/icu/UnicodeExtras.h>
 
 /*
     Implementation Overview
@@ -666,13 +667,8 @@ DEFINE_BUILTIN_IMPLEMENTATION_I32(jsstring, codePointAt, JSGlobalObject* globalO
     int32_t result;
     if (view->is8Bit())
         result = view->span8()[index];
-    else {
-        char32_t character;
-        auto characters = view->span16();
-        unsigned i = static_cast<unsigned>(index);
-        U16_NEXT(characters, i, length, character);
-        result = static_cast<int32_t>(character);
-    }
+    else
+        result = static_cast<int32_t>(u16Get(view->span16(), static_cast<unsigned>(index)));
     RELEASE_AND_RETURN(scope, toUCPUStrictInt32(result));
 }
 

--- a/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
+++ b/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
@@ -40,6 +40,7 @@
 #include <wtf/StackCheck.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/WTFString.h>
+#include <wtf/unicode/CharacterCasts.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
@@ -279,6 +280,8 @@ public:
             , length(input.size())
             , decodeSurrogatePairs(decodeSurrogatePairs)
         {
+            if constexpr (std::is_same_v<CharType, char16_t>)
+                ASSERT(decodeSurrogatePairs);
         }
 
         void next()
@@ -296,7 +299,7 @@ public:
         {
             ASSERT(pos < length);
             if (pos < length)
-                return input[pos];
+                return brokenCastToUTF32(input[pos]);
             return errorCodePoint;
         }
 
@@ -313,7 +316,7 @@ public:
                 return U16_GET_SUPPLEMENTARY(result, input[p + 1]);
             } else if (decodeSurrogatePairs && p > 0 && U16_IS_TRAIL(result) && U16_IS_LEAD(input[p - 1]))
                 return errorCodePoint;
-            return result;
+            return brokenCastToUTF32(result);
         }
 
         char32_t readCheckedDontAdvance(unsigned negativePositionOffest)
@@ -327,7 +330,7 @@ public:
                     return errorCodePoint;
                 return U16_GET_SUPPLEMENTARY(result, input[p + 1]);
             }
-            return result;
+            return brokenCastToUTF32(result);
         }
 
         // readForCharacterDump() is only for use by the DUMP_CURR_CHAR macro.
@@ -343,7 +346,7 @@ public:
                     return errorCodePoint;
                 return U16_GET_SUPPLEMENTARY(result, input[p + 1]);
             }
-            return result;
+            return brokenCastToUTF32(result);
         }
         
         char32_t tryReadBackward(unsigned negativePositionOffest)
@@ -357,7 +360,7 @@ public:
                 rewind(1);
                 return U16_GET_SUPPLEMENTARY(input[p - 1], result);
             }
-            return result;
+            return brokenCastToUTF32(result);
         }
 
         char32_t readSurrogatePairChecked(unsigned negativePositionOffset)
@@ -384,7 +387,7 @@ public:
                 if (U16_IS_TRAIL(result) && U16_IS_LEAD(input[from + 1]))
                     return errorCodePoint;
             }
-            return result;
+            return brokenCastToUTF32(result);
         }
 
         char32_t prev()
@@ -478,6 +481,24 @@ public:
         }
 
     private:
+        char32_t brokenCastToUTF32(CharType c)
+        {
+            if constexpr (std::is_same_v<CharType, char16_t>)
+                // FIXME: Should use castNonSurrogateUTF16CodeUnitToUTF32 here, but can't because
+                // although YarrInterpreter is surrogate-aware, it only processes *correct*
+                // surrogates and does not handle invalid UTF-16. E.g. if YarrInterpreter were to
+                // ignore an unpaired surrogate, or a trail surrogate before a lead surrogate, then
+                // castNonSurrogateUTF16CodeUnitToUTF32 would assert.
+                return deprecatedBrokenCastUTF16CodeUnitToUTF32IgnoringSurrogates(c);
+            else if constexpr (std::is_same_v<CharType, Latin1Character>)
+                // FIXME: This is broken for non-ASCII characters (0x80..0xff).
+                return deprecatedBrokenCastLatin1CharacterToUTF32WithoutConvertingToUnicode(c);
+            else if constexpr (sizeof (CharType) == 1)
+                return castSingleByteCodeUnitToUTF32(c);
+            else
+                static_assert(false); // Should not be reached.
+        }
+
         const CharType* input;
         unsigned pos;
         unsigned length;

--- a/Source/JavaScriptCore/yarr/YarrParser.h
+++ b/Source/JavaScriptCore/yarr/YarrParser.h
@@ -34,6 +34,7 @@
 #include <wtf/HashSet.h>
 #include <wtf/text/StringBuilder.h>
 #include <wtf/text/WTFString.h>
+#include <wtf/unicode/CharacterCasts.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
@@ -56,8 +57,8 @@ template <class T> concept YarrSyntaxCheckable = requires (T& checker, Vector<Ve
     { checker.atomBuiltInCharacterClass(BuiltInCharacterClassID { }, bool { }) } -> std::same_as<void>;
     { checker.atomCharacterClassBegin(bool { }) } -> std::same_as<void>;
     { checker.atomCharacterClassBegin() } -> std::same_as<void>;
-    { checker.atomCharacterClassAtom(char16_t { }) } -> std::same_as<void>;
-    { checker.atomCharacterClassRange(char16_t { }, char16_t { }) } -> std::same_as<void>;
+    { checker.atomCharacterClassAtom(char32_t { }) } -> std::same_as<void>;
+    { checker.atomCharacterClassRange(char32_t { }, char32_t { }) } -> std::same_as<void>;
     { checker.atomPatternCharacter(char32_t { }, bool { }) } -> std::same_as<void>;
     { checker.atomCharacterClassBuiltIn(BuiltInCharacterClassID { }, bool { }) } -> std::same_as<void>;
     { checker.atomClassStringDisjunction(disjunctionStrings) } -> std::same_as<void>;
@@ -1940,10 +1941,27 @@ private:
         return m_size - m_index;
     }
 
+    char32_t brokenCastToUTF32(CharType c)
+    {
+        if constexpr (std::is_same_v<CharType, char16_t>)
+            // FIXME: Should use castNonSurrogateUTF16CodeUnitToUTF32 here, but can't because
+            // YarrParser is not surrogate-aware. It also needs to be able to handle invalid UTF-16.
+            // E.g. if YarrParser were to ignore an unpaired surrogate, or a trail surrogate
+            // before a lead surrogate, then castNonSurrogateUTF16CodeUnitToUTF32 would assert.
+            return deprecatedBrokenCastUTF16CodeUnitToUTF32IgnoringSurrogates(c);
+        else if constexpr (std::is_same_v<CharType, Latin1Character>)
+            // FIXME: This is broken for non-ASCII characters (0x80..0xff).
+            return deprecatedBrokenCastLatin1CharacterToUTF32WithoutConvertingToUnicode(c);
+        else if constexpr (sizeof (CharType) == 1)
+            return castSingleByteCodeUnitToUTF32(c);
+        else
+            static_assert(false); // Should not be reached.
+    }
+
     char32_t peek()
     {
         ASSERT(m_index < m_size);
-        return m_data[m_index];
+        return brokenCastToUTF32(m_data[m_index]);
     }
 
     bool peekIsDigit()
@@ -2044,7 +2062,7 @@ private:
     char32_t consume()
     {
         ASSERT(m_index < m_size);
-        return m_data[m_index++];
+        return brokenCastToUTF32(m_data[m_index++]);
     }
 
     unsigned consumeDigit()

--- a/Source/JavaScriptCore/yarr/YarrPattern.cpp
+++ b/Source/JavaScriptCore/yarr/YarrPattern.cpp
@@ -286,7 +286,7 @@ public:
                 // Nothing to do - no canonical equivalents.
                 break;
             case CanonicalizeSet: {
-                char16_t ch;
+                char32_t ch;
                 for (auto* set = canonicalCharacterSetInfo(info->value, m_canonicalMode); (ch = *set); ++set)
                     addSorted(ch);
                 break;

--- a/Source/JavaScriptCore/yarr/YarrSyntaxChecker.cpp
+++ b/Source/JavaScriptCore/yarr/YarrSyntaxChecker.cpp
@@ -40,8 +40,8 @@ public:
     void atomPatternCharacter(char32_t, bool) { }
     void atomBuiltInCharacterClass(BuiltInCharacterClassID, bool) { }
     void atomCharacterClassBegin(bool = false) { }
-    void atomCharacterClassAtom(char16_t) { }
-    void atomCharacterClassRange(char16_t, char16_t) { }
+    void atomCharacterClassAtom(char32_t) { }
+    void atomCharacterClassRange(char32_t, char32_t) { }
     void atomCharacterClassBuiltIn(BuiltInCharacterClassID, bool) { }
     void atomClassStringDisjunction(Vector<Vector<char32_t>>&) { }
     void atomCharacterClassSetOp(CharacterClassSetOp) { }

--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -672,6 +672,7 @@
 		DDF307ED27C086DF006A526F /* StringConcatenateCF.h in Headers */ = {isa = PBXBuildFile; fileRef = 93D0017B264DBACF00BCF109 /* StringConcatenateCF.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DDF307EE27C086DF006A526F /* TextStream.h in Headers */ = {isa = PBXBuildFile; fileRef = A3E4DD921F3A803400DED0B4 /* TextStream.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DDF307EF27C086EA006A526F /* ICUHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 52B228C12458DC8200753D91 /* ICUHelpers.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		DDF307F027C086EA006A526E /* CharacterCasts.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A47349151A825B004123FE /* CharacterCasts.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DDF307F027C086EA006A526F /* CharacterNames.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A47349151A825B004123FF /* CharacterNames.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DDF307F127C086EA006A526F /* BinarySemaphore.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A4733B151A825B004123FF /* BinarySemaphore.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DDF307F227C086EA006A526F /* Signals.h in Headers */ = {isa = PBXBuildFile; fileRef = 5311BD571EA7E1A100525281 /* Signals.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1635,6 +1636,7 @@
 		A8A4733B151A825B004123FF /* BinarySemaphore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BinarySemaphore.h; sourceTree = "<group>"; };
 		A8A4733E151A825B004123FF /* ThreadSafeRefCounted.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ThreadSafeRefCounted.h; sourceTree = "<group>"; };
 		A8A4733F151A825B004123FF /* ThreadSpecific.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ThreadSpecific.h; sourceTree = "<group>"; };
+		A8A47349151A825B004123FE /* CharacterCasts.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CharacterCasts.h; sourceTree = "<group>"; };
 		A8A47349151A825B004123FF /* CharacterNames.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CharacterNames.h; sourceTree = "<group>"; };
 		A8A4734A151A825B004123FF /* Collator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Collator.h; sourceTree = "<group>"; };
 		A8A4734B151A825B004123FF /* CollatorDefault.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CollatorDefault.cpp; sourceTree = "<group>"; };
@@ -2935,6 +2937,7 @@
 			isa = PBXGroup;
 			children = (
 				A8A4734F151A825B004123FF /* icu */,
+				A8A47349151A825B004123FE /* CharacterCasts.h */,
 				A8A47349151A825B004123FF /* CharacterNames.h */,
 				A8A4734A151A825B004123FF /* Collator.h */,
 				A8A4734B151A825B004123FF /* CollatorDefault.cpp */,
@@ -3458,6 +3461,7 @@
 				DDF306D827C08654006A526F /* CFStringSPI.h in Headers */,
 				DDF3071327C086CC006A526F /* CFURLExtras.h in Headers */,
 				DDF306DF27C08654006A526F /* CFXPCBridgeSPI.h in Headers */,
+				DDF307F027C086EA006A526E /* CharacterCasts.h in Headers */,
 				DDF307F027C086EA006A526F /* CharacterNames.h in Headers */,
 				E336BD2F2BAB8A0400E8471C /* CharacterProperties.h in Headers */,
 				DD3DC86627A4BF8E007E5B61 /* CheckedArithmetic.h in Headers */,

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -509,6 +509,7 @@ set(WTF_PUBLIC_HEADERS
     threads/BinarySemaphore.h
     threads/Signals.h
 
+    unicode/CharacterCasts.h
     unicode/CharacterNames.h
     unicode/Collator.h
     unicode/UTF8Conversion.h

--- a/Source/WTF/wtf/URLHelpers.cpp
+++ b/Source/WTF/wtf/URLHelpers.cpp
@@ -38,6 +38,7 @@
 #include <wtf/StdLibExtras.h>
 #include <wtf/text/ParsingUtilities.h>
 #include <wtf/text/WTFString.h>
+#include <wtf/text/icu/UnicodeExtras.h>
 
 namespace WTF {
 namespace URLHelpers {
@@ -171,10 +172,13 @@ bool isLookalikeSequence(const std::optional<char32_t>& previousCodePoint, char3
         return false;
 
     auto isLookalikePair = [] (char16_t first, char16_t second) {
-        return isLookalikeCharacterOfScriptType<ScriptType>(first) && !(isOfScriptType<ScriptType>(second) || isASCIIDigitOrValidHostCharacter(second));
+        return isLookalikeCharacterOfScriptType<ScriptType>(static_cast<char32_t>(first)) && !(isOfScriptType<ScriptType>(static_cast<char32_t>(second)) || isASCIIDigitOrValidHostCharacter(second));
     };
-    return isLookalikePair(codePoint, *previousCodePoint)
-        || isLookalikePair(*previousCodePoint, codePoint);
+
+    auto truncatedPreviousCodePoint = static_cast<char16_t>(*previousCodePoint);
+    auto truncatedCodePoint = static_cast<char16_t>(codePoint);
+    return isLookalikePair(truncatedCodePoint, truncatedPreviousCodePoint)
+        || isLookalikePair(truncatedPreviousCodePoint, truncatedCodePoint);
 }
 
 template <>
@@ -408,8 +412,7 @@ static bool allCharactersInAllowedIDNScriptList(std::span<const char16_t> buffer
     size_t i = 0;
     std::optional<char32_t> previousCodePoint;
     while (i < buffer.size()) {
-        char32_t c;
-        U16_NEXT(buffer, i, buffer.size(), c);
+        char32_t c = u16Next(buffer, i);
         UErrorCode error = U_ZERO_ERROR;
         UScriptCode script = uscript_getScript(c, &error);
         if (error != U_ZERO_ERROR) {

--- a/Source/WTF/wtf/URLParser.cpp
+++ b/Source/WTF/wtf/URLParser.cpp
@@ -341,7 +341,9 @@ template<typename CharacterType>
 ALWAYS_INLINE bool URLParser::isForbiddenHostCodePoint(CharacterType character)
 {
     ASSERT(!m_urlIsSpecial);
-    return WTF::isForbiddenHostCodePoint(character);
+    if (character > 0x7F)
+        return false;
+    return WTF::isForbiddenHostCodePoint(static_cast<char16_t>(character));
 }
 
 template<typename CharacterType>
@@ -798,7 +800,7 @@ void URLParser::copyASCIIStringUntil(const String& string, size_t length)
     else {
         for (auto character : string.span16().first(length)) {
             ASSERT_WITH_SECURITY_IMPLICATION(isASCII(character));
-            appendToASCIIBuffer(character);
+            appendToASCIIBuffer(static_cast<char32_t>(character));
         }
     }
 }
@@ -2693,7 +2695,7 @@ bool URLParser::subdomainStartsWithXNDashDash(CodePointIterator<CharacterType> i
     } state { State::AtSubdomainBegin };
 
     for (; !iterator.atEnd(); advance<CharacterType, ReportSyntaxViolation::No>(iterator)) {
-        CharacterType c = *iterator;
+        auto c = static_cast<CharacterType>(*iterator);
 
         // These characters indicate the end of the host.
         if (c == ':' || c == '/' || c == '?' || c == '#')

--- a/Source/WTF/wtf/text/CodePointIterator.h
+++ b/Source/WTF/wtf/text/CodePointIterator.h
@@ -29,6 +29,7 @@
 #include <wtf/Assertions.h>
 #include <wtf/text/Latin1Character.h>
 #include <wtf/text/ParsingUtilities.h>
+#include <wtf/text/icu/UnicodeExtras.h>
 
 namespace WTF {
 
@@ -96,9 +97,7 @@ template<>
 ALWAYS_INLINE char32_t CodePointIterator<char16_t>::operator*() const
 {
     ASSERT(!atEnd());
-    char32_t c;
-    U16_GET(m_data, 0, 0, m_data.size(), c);
-    return c;
+    return u16Get(m_data, 0);
 }
 
 template<>

--- a/Source/WTF/wtf/text/StringConcatenate.h
+++ b/Source/WTF/wtf/text/StringConcatenate.h
@@ -109,7 +109,7 @@ public:
     void writeTo(std::span<char16_t> destination) const
     {
         if (U_IS_BMP(m_character)) {
-            destination[0] = m_character;
+            destination[0] = static_cast<char16_t>(m_character);
             return;
         }
         destination[0] = U16_LEAD(m_character);

--- a/Source/WTF/wtf/text/StringImpl.cpp
+++ b/Source/WTF/wtf/text/StringImpl.cpp
@@ -370,7 +370,7 @@ char32_t StringImpl::characterStartingAt(unsigned i)
         return span8()[i];
     auto span = span16();
     if (U16_IS_SINGLE(span[i]))
-        return span[i];
+        return static_cast<char32_t>(span[i]);
     if (i + 1 < m_length && U16_IS_LEAD(span[i]) && U16_IS_TRAIL(span[i + 1]))
         return U16_GET_SUPPLEMENTARY(span[i], span[i + 1]);
     return 0;

--- a/Source/WTF/wtf/text/StringView.h
+++ b/Source/WTF/wtf/text/StringView.h
@@ -35,6 +35,7 @@
 #include <wtf/text/Latin1Character.h>
 #include <wtf/text/StringCommon.h>
 #include <wtf/text/UTF8ConversionError.h>
+#include <wtf/text/icu/UnicodeExtras.h>
 
 #if ASSERT_ENABLED
 #define CHECK_STRINGVIEW_LIFETIME 1
@@ -1018,10 +1019,8 @@ inline char32_t StringView::CodePoints::Iterator::operator*() const
     ASSERT(m_current < m_end);
     if (m_is8Bit)
         return *static_cast<const Latin1Character*>(m_current);
-    char32_t codePoint;
     size_t length = static_cast<const char16_t*>(m_end) - static_cast<const char16_t*>(m_current);
-    U16_GET(static_cast<const char16_t*>(m_current), 0, 0, length, codePoint);
-    return codePoint;
+    return u16Get(unsafeMakeSpan(static_cast<const char16_t*>(m_current), length), 0);
 }
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 

--- a/Source/WTF/wtf/text/icu/UnicodeExtras.cpp
+++ b/Source/WTF/wtf/text/icu/UnicodeExtras.cpp
@@ -23,6 +23,9 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// Most of the code in this file is based on ICU.
+// SPDX-License-Identifier: Unicode-3.0
+
 #include "config.h"
 #include "UnicodeExtras.h"
 
@@ -35,6 +38,79 @@ std::span<const UCharsetMatch*> ucsdet_detectAll_span(UCharsetDetector* detector
     int32_t matchesCount = 0;
     auto* matches = ucsdet_detectAll(detector, &matchesCount, status);
     return unsafeMakeSpan(matches, std::max(matchesCount, 0));
+}
+
+static constexpr std::array<char, 16> U8_LEAD3_T1_BITS_SAFE { '\x20', '\x30', '\x30', '\x30', '\x30', '\x30', '\x30', '\x30', '\x30', '\x30', '\x30', '\x30', '\x30', '\x10', '\x30', '\x30' };
+static constexpr std::array<char, 16> U8_LEAD4_T1_BITS_SAFE { '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x1E', '\x0F' , '\x0F', '\x0F', '\x00', '\x00', '\x00', '\x00' };
+
+#define U8_INTERNAL_NEXT_OR_SUB_SAFE(s, i, length, c, sub) { \
+    (c)=(uint8_t)(s)[(i)++]; \
+    if(!U8_IS_SINGLE(c)) { \
+        uint8_t __t = 0; \
+        if((i)!=(length) && \
+            /* fetch/validate/assemble all but last trail byte */ \
+            ((c)>=0xe0 ? \
+                ((c)<0xf0 ?  /* U+0800..U+FFFF except surrogates */ \
+                    U8_LEAD3_T1_BITS_SAFE[(c)&=0xf]&(1<<((__t=(s)[i])>>5)) && \
+                    (__t&=0x3f, 1) \
+                :  /* U+10000..U+10FFFF */ \
+                    ((c)-=0xf0)<=4 && \
+                    U8_LEAD4_T1_BITS_SAFE[(__t=(s)[i])>>4]&(1<<(c)) && \
+                    ((c)=((c)<<6)|(__t&0x3f), ++(i)!=(length)) && \
+                    (__t=(s)[i]-0x80)<=0x3f) && \
+                /* valid second-to-last trail byte */ \
+                ((c)=((c)<<6)|__t, ++(i)!=(length)) \
+            :  /* U+0080..U+07FF */ \
+                (c)>=0xc2 && ((c)&=0x1f, 1)) && \
+            /* last trail byte */ \
+            (__t=(s)[i]-0x80)<=0x3f && \
+            ((c)=((c)<<6)|__t, ++(i), 1)) { \
+        } else { \
+            (c)=(sub);  /* ill-formed*/ \
+        } \
+    } \
+}
+
+char32_t u8Next(std::span<const char8_t> string, size_t& offset)
+{
+    char32_t c;
+    U8_INTERNAL_NEXT_OR_SUB_SAFE(string, offset, string.size(), c, U_SENTINEL);
+    return c;
+}
+
+char32_t u8NextOrFFFD(std::span<const char8_t> string, size_t& offset)
+{
+    char32_t c;
+    U8_INTERNAL_NEXT_OR_SUB_SAFE(string, offset, string.size(), c, 0xfffd);
+    return c;
+}
+
+char32_t u16Get(std::span<const char16_t> string, size_t offset)
+{
+    UChar32 result;
+    U16_GET(string, 0, offset, string.size(), result);
+    return static_cast<char32_t>(result);
+}
+
+char32_t u16Next(std::span<const char16_t> string, size_t& offset)
+{
+    UChar32 result;
+    U16_NEXT(string, offset, string.size(), result);
+    return static_cast<char32_t>(result);
+}
+
+char32_t u16NextOrFFFD(std::span<const char16_t> string, size_t& offset)
+{
+    UChar32 result;
+    U16_NEXT_OR_FFFD(string, offset, string.size(), result);
+    return static_cast<char32_t>(result);
+}
+
+char32_t u16Prev(std::span<const char16_t> string, size_t& offset)
+{
+    UChar32 result;
+    U16_PREV(string, 0, offset, result);
+    return static_cast<char32_t>(result);
 }
 
 } // namespace WTF

--- a/Source/WTF/wtf/text/icu/UnicodeExtras.h
+++ b/Source/WTF/wtf/text/icu/UnicodeExtras.h
@@ -28,45 +28,32 @@
 #include <array>
 #include <span>
 #include <unicode/ucsdet.h>
+#include <unicode/utf16.h>
+#include <unicode/utf8.h>
 
 namespace WTF {
 
 WTF_EXPORT_PRIVATE std::span<const UCharsetMatch*> ucsdet_detectAll_span(UCharsetDetector*, UErrorCode* status);
 
-static constexpr std::array<char, 16> U8_LEAD3_T1_BITS_SAFE { '\x20', '\x30', '\x30', '\x30', '\x30', '\x30', '\x30', '\x30', '\x30', '\x30', '\x30', '\x30', '\x30', '\x10', '\x30', '\x30' };
-static constexpr std::array<char, 16> U8_LEAD4_T1_BITS_SAFE { '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x1E', '\x0F' , '\x0F', '\x0F', '\x00', '\x00', '\x00', '\x00' };
-
-#define U8_INTERNAL_NEXT_OR_SUB_SAFE(s, i, length, c, sub) { \
-    (c)=(uint8_t)(s)[(i)++]; \
-    if(!U8_IS_SINGLE(c)) { \
-        uint8_t __t = 0; \
-        if((i)!=(length) && \
-            /* fetch/validate/assemble all but last trail byte */ \
-            ((c)>=0xe0 ? \
-                ((c)<0xf0 ?  /* U+0800..U+FFFF except surrogates */ \
-                    U8_LEAD3_T1_BITS_SAFE[(c)&=0xf]&(1<<((__t=(s)[i])>>5)) && \
-                    (__t&=0x3f, 1) \
-                :  /* U+10000..U+10FFFF */ \
-                    ((c)-=0xf0)<=4 && \
-                    U8_LEAD4_T1_BITS_SAFE[(__t=(s)[i])>>4]&(1<<(c)) && \
-                    ((c)=((c)<<6)|(__t&0x3f), ++(i)!=(length)) && \
-                    (__t=(s)[i]-0x80)<=0x3f) && \
-                /* valid second-to-last trail byte */ \
-                ((c)=((c)<<6)|__t, ++(i)!=(length)) \
-            :  /* U+0080..U+07FF */ \
-                (c)>=0xc2 && ((c)&=0x1f, 1)) && \
-            /* last trail byte */ \
-            (__t=(s)[i]-0x80)<=0x3f && \
-            ((c)=((c)<<6)|__t, ++(i), 1)) { \
-        } else { \
-            (c)=(sub);  /* ill-formed*/ \
-        } \
-    } \
-}
-
-#define U8_NEXT_SPAN(s, i, c) U8_INTERNAL_NEXT_OR_SUB_SAFE(s, i, std::size(s), c, U_SENTINEL)
-#define U8_NEXT_OR_FFFD_SPAN(s, i, c) U8_INTERNAL_NEXT_OR_SUB_SAFE(s, i, std::size(s), c, 0xfffd)
+// This is like U8_NEXT().
+WTF_EXPORT_PRIVATE char32_t u8Next(std::span<const char8_t> string, size_t& offset);
+// This is like U8_NEXT_OR_FFFD().
+WTF_EXPORT_PRIVATE char32_t u8NextOrFFFD(std::span<const char8_t> string, size_t& offset);
+// This is like U16_GET(). Use a subspan if you need to specify a start offset.
+WTF_EXPORT_PRIVATE char32_t u16Get(std::span<const char16_t> string, size_t offset);
+// This is like U16_NEXT().
+WTF_EXPORT_PRIVATE char32_t u16Next(std::span<const char16_t> string, size_t& offset);
+// This is like U16_NEXT_OR_FFFD().
+WTF_EXPORT_PRIVATE char32_t u16NextOrFFFD(std::span<const char16_t> string, size_t& offset);
+// This is like U16_PREV().
+WTF_EXPORT_PRIVATE char32_t u16Prev(std::span<const char16_t> string, size_t& offset);
 
 } // namespace WTF
 
 using WTF::ucsdet_detectAll_span;
+using WTF::u8Next;
+using WTF::u8NextOrFFFD;
+using WTF::u16Get;
+using WTF::u16Next;
+using WTF::u16NextOrFFFD;
+using WTF::u16Prev;

--- a/Source/WTF/wtf/unicode/CharacterCasts.h
+++ b/Source/WTF/wtf/unicode/CharacterCasts.h
@@ -1,0 +1,88 @@
+/*
+ * Copyright Red Hat
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <unicode/utf16.h>
+
+namespace WTF::Unicode {
+
+// This only works if you're certain the input is in the Basic Multilingual Plane. If you need to
+// handle arbitrary values, use U16_LEAD() and U16_TRAIL() instead.
+inline constexpr char16_t castBMPUTF32CodeUnitToUTF16(char32_t c)
+{
+    ASSERT_UNDER_CONSTEXPR_CONTEXT(U_IS_BMP(c));
+    return static_cast<char16_t>(c);
+}
+
+// FIXME: Code using this is probably broken. Remove it.
+inline constexpr char16_t deprecatedBrokenCastUTF32CodeUnitToUTF16IgnoringSurrogates(char32_t c)
+{
+    return static_cast<char16_t>(c);
+}
+
+// This only works if you're certain the input is not a surrogate. Be careful, because you're
+// responsible for handling even *invalid* surrogates before calling this function, including
+// unpaired surrogates or surrogate trail before the lead.
+//
+// To handle arbitrary values, which may be surrogates, use U16_GET_SUPPLEMENTARY(), or use
+// u16Get from UnicodeExtras.h, or use SurrogatePairAwareTextIterator.
+inline constexpr char32_t castNonSurrogateUTF16CodeUnitToUTF32(char16_t c)
+{
+    ASSERT_UNDER_CONSTEXPR_CONTEXT(!U16_IS_SURROGATE(c));
+    return static_cast<char32_t>(c);
+}
+
+// FIXME: Code using this is probably broken. Remove it.
+inline constexpr char32_t deprecatedBrokenCastUTF16CodeUnitToUTF32IgnoringSurrogates(char16_t c)
+{
+    return static_cast<char32_t>(c);
+}
+
+// This only works if the input is ASCII (not Latin-1).
+template <typename CharType>
+constexpr char32_t castSingleByteCodeUnitToUTF32(CharType c)
+{
+    static_assert(sizeof(CharType) == 1);
+    static_assert(!std::is_same_v<CharType, Latin1Character>);
+
+    ASSERT_UNDER_CONSTEXPR_CONTEXT(U8_IS_SINGLE(c));
+    return static_cast<char32_t>(c);
+}
+
+// FIXME: Code using this is probably broken for non-ASCII Latin-1 characters (0x80..0xff). Remove it.
+constexpr char32_t deprecatedBrokenCastLatin1CharacterToUTF32WithoutConvertingToUnicode(Latin1Character c)
+{
+    return static_cast<char32_t>(c);
+}
+
+} // namespace WTF::Unicode
+
+using WTF::Unicode::castBMPUTF32CodeUnitToUTF16;
+using WTF::Unicode::deprecatedBrokenCastUTF32CodeUnitToUTF16IgnoringSurrogates;
+using WTF::Unicode::castNonSurrogateUTF16CodeUnitToUTF32;
+using WTF::Unicode::deprecatedBrokenCastUTF16CodeUnitToUTF32IgnoringSurrogates;
+using WTF::Unicode::castSingleByteCodeUnitToUTF32;
+using WTF::Unicode::deprecatedBrokenCastLatin1CharacterToUTF32WithoutConvertingToUnicode;

--- a/Source/WTF/wtf/unicode/UTF8Conversion.cpp
+++ b/Source/WTF/wtf/unicode/UTF8Conversion.cpp
@@ -27,7 +27,11 @@
 #include "config.h"
 #include <wtf/unicode/UTF8Conversion.h>
 
+#include <array>
+#include <span>
 #include <unicode/uchar.h>
+#include <unicode/utf16.h>
+#include <unicode/utf8.h>
 #include <wtf/ASCIICType.h>
 #include <wtf/text/StringHasherInlines.h>
 #include <wtf/text/icu/UnicodeExtras.h>
@@ -49,30 +53,25 @@ template<> char32_t next<Replacement::None, Latin1Character>(std::span<const Lat
 
 template<> char32_t next<Replacement::None, char8_t>(std::span<const char8_t> characters, size_t& offset)
 {
-    char32_t character;
-    U8_NEXT_SPAN(characters, offset, character);
+    char32_t character = u8Next(characters, offset);
     return U_IS_SURROGATE(character) ? sentinelCodePoint : character;
 }
 
 template<> char32_t next<Replacement::ReplaceInvalidSequences, char8_t>(std::span<const char8_t> characters, size_t& offset)
 {
-    char32_t character;
-    U8_NEXT_OR_FFFD_SPAN(characters, offset, character);
+    char32_t character = u8NextOrFFFD(characters, offset);
     return character;
 }
 
 template<> char32_t next<Replacement::None, char16_t>(std::span<const char16_t> characters, size_t& offset)
 {
-    char32_t character;
-    U16_NEXT(characters, offset, characters.size(), character);
+    char32_t character = u16Next(characters, offset);
     return U_IS_SURROGATE(character) ? sentinelCodePoint : character;
 }
 
 template<> char32_t next<Replacement::ReplaceInvalidSequences, char16_t>(std::span<const char16_t> characters, size_t& offset)
 {
-    char32_t character;
-    U16_NEXT_OR_FFFD(characters, offset, characters.size(), character);
-    return character;
+    return u16NextOrFFFD(characters, offset);
 }
 
 template<> bool append<Replacement::None, char8_t>(std::span<char8_t> characters, size_t& offset, char32_t character)
@@ -177,7 +176,7 @@ UTF16LengthWithHash computeUTF16LengthWithHash(std::span<const char8_t> source)
         if (character == sentinelCodePoint)
             return { };
         if (U_IS_BMP(character)) {
-            hasher.addCharacter(character);
+            hasher.addCharacter(static_cast<char16_t>(character));
             ++lengthUTF16;
         } else {
             hasher.addCharacter(U16_LEAD(character));

--- a/Source/WebCore/Modules/url-pattern/URLPatternParser.cpp
+++ b/Source/WebCore/Modules/url-pattern/URLPatternParser.cpp
@@ -463,8 +463,9 @@ String generatePatternString(const Vector<Part>& partList, const URLPatternStrin
         }
 
         if (!needsGrouping && part.prefix.isEmpty() && previousPart && previousPart->type == PartType::FixedText) {
+            // FIXME: This cast to char16_t is probably not correct.
             if (options.prefixCodepoint.length() == 1
-                && options.prefixCodepoint.startsWith(*StringView(previousPart->value).codePoints().codePointAt(previousPart->value.length() - 1)))
+                && options.prefixCodepoint.startsWith(static_cast<char16_t>(*StringView(previousPart->value).codePoints().codePointAt(previousPart->value.length() - 1))))
                 needsGrouping = true;
         }
 
@@ -535,7 +536,7 @@ String escapePatternString(StringView input)
 }
 
 // https://urlpattern.spec.whatwg.org/#is-a-valid-name-code-point
-bool isValidNameCodepoint(char16_t codepoint, URLPatternUtilities::IsFirst first)
+bool isValidNameCodepoint(char32_t codepoint, URLPatternUtilities::IsFirst first)
 {
     if (first == URLPatternUtilities::IsFirst::Yes)
         return u_hasBinaryProperty(codepoint, UCHAR_ID_START) || codepoint == '_' || codepoint == '$';

--- a/Source/WebCore/Modules/url-pattern/URLPatternParser.h
+++ b/Source/WebCore/Modules/url-pattern/URLPatternParser.h
@@ -97,7 +97,7 @@ ASCIILiteral convertModifierToString(Modifier);
 std::pair<String, Vector<String>> generateRegexAndNameList(const Vector<Part>& partList, const URLPatternStringOptions&);
 String generatePatternString(const Vector<Part>& partList, const URLPatternStringOptions&);
 String escapePatternString(StringView input);
-bool isValidNameCodepoint(char16_t codepoint, URLPatternUtilities::IsFirst);
+bool isValidNameCodepoint(char32_t codepoint, URLPatternUtilities::IsFirst);
 
 
 } // namespace URLPatternUtilities

--- a/Source/WebCore/Modules/url-pattern/URLPatternTokenizer.cpp
+++ b/Source/WebCore/Modules/url-pattern/URLPatternTokenizer.cpp
@@ -46,7 +46,7 @@ bool Token::isNull() const
 // https://urlpattern.spec.whatwg.org/#get-the-next-code-point
 void Tokenizer::getNextCodePoint()
 {
-    m_codepoint = m_input[m_nextIndex++];
+    m_codepoint = static_cast<char32_t>(m_input[m_nextIndex++]);
 
     if (m_input.is8Bit() || !U16_IS_LEAD(m_codepoint) || m_nextIndex >= m_input.length())
         return;

--- a/Source/WebCore/PAL/pal/text/EncodingTables.h
+++ b/Source/WebCore/PAL/pal/text/EncodingTables.h
@@ -55,6 +55,8 @@ template<typename CollectionType, typename KeyType> static auto findInSortedPair
 inline void checkEncodingTableInvariants() { }
 #endif
 
+IGNORE_CLANG_WARNINGS_BEGIN("character-conversion")
+
 struct CompareFirst {
     template<typename TypeA, typename TypeB> bool operator()(const TypeA& a, const TypeB& b)
     {
@@ -131,5 +133,7 @@ template<typename CollectionType, typename KeyType> static auto findInSortedPair
     }
     return std::ranges::equal_range(collection, makeFirstAdapter(key), CompareFirst { });
 }
+
+IGNORE_CLANG_WARNINGS_END // "character-conversion"
 
 }

--- a/Source/WebCore/PAL/pal/text/TextCodecCJK.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecCJK.cpp
@@ -300,7 +300,7 @@ static Vector<uint8_t> eucJPEncode(StringView string, Function<void(char32_t, Ve
         if (codePoint == 0x2212)
             codePoint = 0xFF0D;
 
-        auto pointer = findFirstInSortedPairs(jis0208EncodeIndex(), codePoint);
+        auto pointer = findFirstInSortedPairs(jis0208EncodeIndex(), static_cast<char16_t>(codePoint));
         if (!pointer) {
             unencodableHandler(codePoint, result);
             continue;
@@ -670,7 +670,7 @@ static Vector<uint8_t> shiftJISEncode(StringView string, Function<void(char32_t,
         if (codePoint == 0x2212)
             codePoint = 0xFF0D;
 
-        auto range = findInSortedPairs(jis0208EncodeIndex(), codePoint);
+        auto range = findInSortedPairs(jis0208EncodeIndex(), static_cast<char16_t>(codePoint));
         if (range.empty()) {
             unencodableHandler(codePoint, result);
             continue;
@@ -724,7 +724,7 @@ static Vector<uint8_t> eucKREncode(StringView string, Function<void(char32_t, Ve
             continue;
         }
 
-        auto pointer = findFirstInSortedPairs(eucKREncodingIndex(), codePoint);
+        auto pointer = findFirstInSortedPairs(eucKREncodingIndex(), static_cast<char16_t>(codePoint));
         if (!pointer) {
             unencodableHandler(codePoint, result);
             continue;
@@ -1036,7 +1036,7 @@ static Vector<uint8_t> gbEncodeShared(StringView string, Function<void(char32_t,
             result.append(0x80);
             continue;
         }
-        if (auto encoded = gb18030AsymmetricEncode(codePoint)) {
+        if (auto encoded = gb18030AsymmetricEncode(static_cast<char16_t>(codePoint))) {
             result.append(*encoded >> 8);
             result.append(*encoded);
             continue;

--- a/Source/WebCore/PAL/pal/text/TextCodecLatin1.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecLatin1.cpp
@@ -210,7 +210,7 @@ static Vector<uint8_t> encodeComplexWindowsLatin1(StringView string, Unencodable
         if (b != character || (character & 0xE0) == 0x80) {
             // Look for a way to encode this with Windows Latin-1.
             for (b = 0x80; b < 0xA0; ++b) {
-                if (latin1ConversionTable[b] == character)
+                if (static_cast<char32_t>(latin1ConversionTable[b]) == character)
                     goto gotByte;
             }
             // No way to encode this character with Windows Latin-1.

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -136,6 +136,7 @@
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/AtomString.h>
 #include <wtf/text/MakeString.h>
+#include <wtf/text/icu/UnicodeExtras.h>
 
 #if PLATFORM(COCOA)
 #include <wtf/spi/darwin/OSVariantSPI.h>
@@ -4125,15 +4126,10 @@ static char32_t characterForCharacterOffset(const CharacterOffset& characterOffs
     if (characterOffset.isNull() || !characterOffset.node->isTextNode())
         return 0;
 
-    char32_t ch = 0;
-    unsigned offset = characterOffset.startIndex + characterOffset.offset;
-    if (offset < characterOffset.node->textContent().length()) {
-        // FIXME: Remove IGNORE_CLANG_WARNINGS macros once one of <rdar://problem/58615489&58615391> is fixed.
-        IGNORE_CLANG_WARNINGS_BEGIN("conditional-uninitialized")
-        U16_NEXT(characterOffset.node->textContent(), offset, characterOffset.node->textContent().length(), ch);
-        IGNORE_CLANG_WARNINGS_END
-    }
-    return ch;
+    size_t offset = characterOffset.startIndex + characterOffset.offset;
+    if (offset < characterOffset.node->textContent().length())
+        return u16Next(characterOffset.node->textContent().span16(), offset);
+    return 0;
 }
 
 char32_t AXObjectCache::characterAfter(const CharacterOffset& characterOffset)

--- a/Source/WebCore/accessibility/AccessibilityMathMLElement.cpp
+++ b/Source/WebCore/accessibility/AccessibilityMathMLElement.cpp
@@ -95,8 +95,8 @@ void AccessibilityMathMLElement::addChildren()
 String AccessibilityMathMLElement::textUnderElement(TextUnderElementMode mode) const
 {
     if (m_isAnonymousOperator && !mode.isHidden()) {
-        char16_t operatorChar = downcast<RenderMathMLOperator>(*m_renderer).textContent();
-        return operatorChar ? String(span(operatorChar)) : String();
+        auto operatorCharacter = downcast<RenderMathMLOperator>(*m_renderer).textContent();
+        return operatorCharacter ? makeString(operatorCharacter) : String { };
     }
 
     return AccessibilityRenderObject::textUnderElement(mode);

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp
@@ -40,6 +40,7 @@
 #include "VisibleUnits.h"
 #include <gio/gio.h>
 #include <wtf/Assertions.h>
+#include <wtf/unicode/CharacterCasts.h>
 #include <wtf/unicode/CharacterNames.h>
 
 namespace WebCore {
@@ -404,7 +405,8 @@ IntPoint AccessibilityObjectAtspi::boundaryOffset(unsigned utf16Offset, TextGran
         if (!utf16Offset && m_hasListMarkerAtStart)
             return { 0, 1 };
 
-        startPosition = isStartOfWord(offsetPosition) && deprecatedIsEditingWhitespace(offsetPosition.characterBefore()) ? offsetPosition : startOfWord(offsetPosition, WordSide::LeftWordIfOnBoundary);
+        char32_t characterBefore = offsetPosition.characterBefore();
+        startPosition = isStartOfWord(offsetPosition) && U_IS_BMP(characterBefore) && deprecatedIsEditingWhitespace(castBMPUTF32CodeUnitToUTF16(characterBefore)) ? offsetPosition : startOfWord(offsetPosition, WordSide::LeftWordIfOnBoundary);
         endPostion = nextWordPosition(startPosition);
         auto positionAfterSpacingAndFollowingWord = nextWordPosition(endPostion);
         if (positionAfterSpacingAndFollowingWord != endPostion) {

--- a/Source/WebCore/contentextensions/URLFilterParser.cpp
+++ b/Source/WebCore/contentextensions/URLFilterParser.cpp
@@ -33,6 +33,7 @@
 #include <JavaScriptCore/YarrParser.h>
 #include <wtf/Deque.h>
 #include <wtf/text/CString.h>
+#include <wtf/unicode/CharacterCasts.h>
 
 namespace WebCore {
 
@@ -76,7 +77,7 @@ public:
         return m_parseStatus;
     }
 
-    void atomPatternCharacter(char16_t character, bool)
+    void atomPatternCharacter(char32_t character, bool)
     {
         if (hasError())
             return;
@@ -179,7 +180,7 @@ public:
         m_floatingTerm = Term(Term::CharacterSetTerm, inverted);
     }
 
-    void atomCharacterClassAtom(char16_t character)
+    void atomCharacterClassAtom(char32_t character)
     {
         if (hasError())
             return;
@@ -189,10 +190,10 @@ public:
             return;
         }
 
-        m_floatingTerm.addCharacter(character, m_patternIsCaseSensitive);
+        m_floatingTerm.addCharacter(castBMPUTF32CodeUnitToUTF16(character), m_patternIsCaseSensitive);
     }
 
-    void atomCharacterClassRange(char16_t a, char16_t b)
+    void atomCharacterClassRange(char32_t a, char32_t b)
     {
         if (hasError())
             return;
@@ -203,7 +204,7 @@ public:
         ASSERT(isASCII(b));
 
         for (unsigned i = a; i <= b; ++i)
-            m_floatingTerm.addCharacter(static_cast<char16_t>(i), m_patternIsCaseSensitive);
+            m_floatingTerm.addCharacter(i, m_patternIsCaseSensitive);
     }
 
     void atomClassStringDisjunction(Vector<Vector<char32_t>>)

--- a/Source/WebCore/css/CSSFontFaceSet.cpp
+++ b/Source/WebCore/css/CSSFontFaceSet.cpp
@@ -40,6 +40,8 @@
 #include "StylePrimitiveNumericTypes+Conversions.h"
 #include "StyleProperties.h"
 #include <ranges>
+#include <wtf/text/icu/UnicodeExtras.h>
+#include <wtf/unicode/CharacterCasts.h>
 
 namespace WebCore {
 
@@ -390,10 +392,11 @@ static CodePointsMap codePointsFromString(StringView stringView)
         ASSERT(cluster.length() > 0);
         char32_t character = 0;
         if (cluster.is8Bit())
-            character = cluster[0];
+            // FIXME: This is broken for non-ASCII characters (0x80..0xff).
+            character = deprecatedBrokenCastLatin1CharacterToUTF32WithoutConvertingToUnicode(cluster[0]);
         else {
             auto characters = cluster.span16();
-            U16_GET(characters, 0, 0, characters.size(), character);
+            character = u16Get(characters, 0);
         }
         result.add(character);
     }

--- a/Source/WebCore/css/CSSMarkup.cpp
+++ b/Source/WebCore/css/CSSMarkup.cpp
@@ -82,7 +82,7 @@ void serializeIdentifier(const String& identifier, StringBuilder& appendTo, bool
         char32_t c = identifier.characterStartingAt(index);
         if (!c) {
             // Check for lone surrogate which characterStartingAt does not return.
-            c = identifier[index];
+            c = static_cast<char32_t>(identifier[index]);
         }
 
         index += U16_LENGTH(c);

--- a/Source/WebCore/css/parser/CSSTokenizer.cpp
+++ b/Source/WebCore/css/parser/CSSTokenizer.cpp
@@ -37,6 +37,7 @@
 #include <wtf/NeverDestroyed.h>
 #include <wtf/text/StringBuilder.h>
 #include <wtf/text/StringToIntegerConversion.h>
+#include <wtf/unicode/CharacterCasts.h>
 #include <wtf/unicode/CharacterNames.h>
 
 namespace WebCore {
@@ -816,7 +817,7 @@ char32_t CSSTokenizer::consumeEscape()
             consumedHexDigits++;
         };
         consumeSingleWhitespaceIfNext();
-        auto codePoint = parseInteger<uint32_t>(hexChars, 16).value();
+        char32_t codePoint = parseInteger<char32_t>(hexChars, 16).value();
         if (!codePoint || U_IS_SURROGATE(codePoint) || codePoint > UCHAR_MAX_VALUE)
             return replacementCharacter;
         return codePoint;
@@ -824,7 +825,11 @@ char32_t CSSTokenizer::consumeEscape()
 
     if (cc == kEndOfFileMarker)
         return replacementCharacter;
-    return cc;
+    // FIXME: The CSS spec says we should have removed all surrogates during preprocessing, but
+    // the spec operates on UTF-32 code points, whereas we operate on UTF-16. So
+    // CSSTokenizer::preprocessString removes only *unpaired* surrogates, and therefore, this
+    // character could be a surrogate.
+    return deprecatedBrokenCastUTF32CodeUnitToUTF16IgnoringSurrogates(cc);
 }
 
 bool CSSTokenizer::nextTwoCharsAreValidEscape()

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -377,6 +377,7 @@
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringBuffer.h>
 #include <wtf/text/TextStream.h>
+#include <wtf/text/icu/UnicodeExtras.h>
 
 #if ENABLE(APP_HIGHLIGHTS)
 #include "AppHighlightStorage.h"
@@ -7410,8 +7411,7 @@ static bool isValidNameNonASCII(std::span<const char16_t> characters)
 {
     for (size_t i = 0; i < characters.size();) {
         bool first = !i;
-        char32_t c;
-        U16_NEXT(characters, i, characters.size(), c); // Increments i.
+        char32_t c = u16Next(characters, i); // Increments i.
         if (first ? !isValidNameStart(c) : !isValidNamePart(c))
             return false;
     }
@@ -7488,9 +7488,8 @@ ExceptionOr<std::pair<AtomString, AtomString>> Document::parseQualifiedName(cons
     if (isValidLocalName) [[likely]]
         return std::pair<AtomString, AtomString> { { }, { qualifiedName } };
 
-    for (unsigned i = 0; i < length; ) {
-        char32_t c;
-        U16_NEXT(qualifiedName, i, length, c);
+    for (size_t i = 0; i < length; ) {
+        char32_t c = u16Next(qualifiedName.span16(), i);
         if (c == ':') {
             if (sawColon)
                 return Exception { ExceptionCode::InvalidCharacterError, makeString("Unexpected colon in qualified name '"_s, qualifiedName, '\'') };

--- a/Source/WebCore/dom/Position.cpp
+++ b/Source/WebCore/dom/Position.cpp
@@ -65,6 +65,7 @@
 #include <wtf/text/CString.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/TextStream.h>
+#include <wtf/unicode/CharacterCasts.h>
 #include <wtf/unicode/CharacterNames.h>
 
 #if ENABLE(TREE_DEBUGGING)
@@ -1140,7 +1141,8 @@ Position Position::trailingWhitespacePosition(Affinity, bool considerNonCollapsi
         return { };
     
     VisiblePosition v(*this);
-    char16_t c = v.characterAfter();
+    // FIXME: Probably need to use U16_GET_SUPPLEMENTARY() here.
+    char16_t c = deprecatedBrokenCastUTF32CodeUnitToUTF16IgnoringSurrogates(v.characterAfter());
     // The space must not be in another paragraph and it must be editable.
     if (!isEndOfParagraph(v) && v.next(CannotCrossEditingBoundary).isNotNull())
         if (considerNonCollapsibleWhitespace ? (isASCIIWhitespace(c) || c == noBreakSpace) : deprecatedIsCollapsibleWhitespace(c))

--- a/Source/WebCore/editing/CompositeEditCommand.cpp
+++ b/Source/WebCore/editing/CompositeEditCommand.cpp
@@ -82,6 +82,7 @@
 #include "WrapContentsInDummySpanCommand.h"
 #include "markup.h"
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/unicode/CharacterCasts.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebCore {
@@ -1016,7 +1017,9 @@ void CompositeEditCommand::prepareWhitespaceAtPositionForSplit(Position& positio
 
 void CompositeEditCommand::replaceCollapsibleWhitespaceWithNonBreakingSpaceIfNeeded(const VisiblePosition& visiblePosition)
 {
-    if (!deprecatedIsCollapsibleWhitespace(visiblePosition.characterAfter()))
+    // FIXME: Change deprecatedIsCollapsibleWhitespace into a CharacterType template,
+    // or find a better whitespace function to use.
+    if (!deprecatedIsCollapsibleWhitespace(deprecatedBrokenCastUTF32CodeUnitToUTF16IgnoringSurrogates(visiblePosition.characterAfter())))
         return;
     
     Position pos = visiblePosition.deepEquivalent().downstream();

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -151,6 +151,7 @@
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/ParsingUtilities.h>
+#include <wtf/unicode/CharacterCasts.h>
 #include <wtf/unicode/CharacterNames.h>
 
 #if PLATFORM(MAC)
@@ -1440,7 +1441,9 @@ bool Editor::insertTextWithoutSendingTextEvent(const String& text, bool selectIn
 
     // FIXME: Should pass false to updateMarkersForWordsAffectedByEditing() to not remove markers if
     // a leading or trailing no-break space is being inserted. See <https://webkit.org/b/212098>.
-    bool isStartOfNewWord = deprecatedIsSpaceOrNewline(selection.visibleStart().characterBefore());
+    // FIXME: Change deprecatedIsCollapsibleWhitespace into a CharacterType template,
+    // or find a better whitespace function to use.
+    bool isStartOfNewWord = deprecatedIsSpaceOrNewline(deprecatedBrokenCastUTF32CodeUnitToUTF16IgnoringSurrogates(selection.visibleStart().characterBefore()));
     updateMarkersForWordsAffectedByEditing(deprecatedIsSpaceOrNewline(text[0]) || isStartOfNewWord);
 
     bool shouldConsiderApplyingAutocorrection = false;

--- a/Source/WebCore/editing/TextIterator.cpp
+++ b/Source/WebCore/editing/TextIterator.cpp
@@ -78,6 +78,7 @@
 #include <wtf/text/ParsingUtilities.h>
 #include <wtf/text/StringBuilder.h>
 #include <wtf/text/TextBreakIterator.h>
+#include <wtf/text/icu/UnicodeExtras.h>
 #include <wtf/unicode/CharacterNames.h>
 #include <wtf/unicode/icu/ICUHelpers.h>
 
@@ -2077,8 +2078,7 @@ inline SearchBuffer::SearchBuffer(const String& target, FindOptions options)
     m_overlap = m_buffer.capacity() / 4;
 
     if (m_options.contains(FindOption::AtWordStarts) && targetLength) {
-        char32_t targetFirstCharacter;
-        U16_GET(m_target, 0, 0u, targetLength, targetFirstCharacter);
+        char32_t targetFirstCharacter = u16Get(m_target.span16(), 0);
         // Characters in the separator category never really occur at the beginning of a word,
         // so if the target begins with such a character, we just ignore the AtWordStart option.
         if (isSeparator(targetFirstCharacter)) {
@@ -2270,15 +2270,13 @@ inline bool SearchBuffer::isWordStartMatch(size_t start, size_t length) const
     if (!start)
         return true;
 
-    int size = m_buffer.size();
-    int offset = start;
-    char32_t firstCharacter;
+    size_t size = m_buffer.size();
+    size_t offset = start;
     auto buffer = m_buffer.span();
-    U16_GET(buffer, 0, offset, size, firstCharacter);
+    char32_t firstCharacter = u16Get(buffer, offset);
 
     if (m_options.contains(FindOption::TreatMedialCapitalAsWordStart)) {
-        char32_t previousCharacter;
-        U16_PREV(buffer, 0, offset, previousCharacter);
+        char32_t previousCharacter = u16Prev(buffer, offset);
 
         if (isSeparator(firstCharacter)) {
             // The start of a separator run is a word start (".org" in "webkit.org").
@@ -2294,7 +2292,7 @@ inline bool SearchBuffer::isWordStartMatch(size_t start, size_t length) const
             U16_FWD_1(buffer, offset, size);
             char32_t nextCharacter = 0;
             if (offset < size)
-                U16_GET(buffer, 0, offset, size, nextCharacter);
+                nextCharacter = u16Get(buffer, offset);
             if (!isASCIIUpper(nextCharacter) && !isASCIIDigit(nextCharacter) && !isSeparator(nextCharacter))
                 return true;
         } else if (isASCIIDigit(firstCharacter)) {

--- a/Source/WebCore/editing/VisiblePosition.cpp
+++ b/Source/WebCore/editing/VisiblePosition.cpp
@@ -53,6 +53,7 @@
 #include <wtf/text/CString.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/TextStream.h>
+#include <wtf/text/icu/UnicodeExtras.h>
 
 namespace WebCore {
 
@@ -623,15 +624,13 @@ char32_t VisiblePosition::characterAfter() const
     case Position::PositionIsOffsetInAnchor:
         break;
     }
-    unsigned offset = static_cast<unsigned>(pos.offsetInContainerNode());
+    size_t offset = pos.offsetInContainerNode();
     RefPtr textNode = pos.containerText();
     unsigned length = textNode->length();
     if (offset >= length)
         return 0;
 
-    char32_t ch;
-    U16_NEXT(textNode->data(), offset, length, ch);
-    return ch;
+    return u16Next(textNode->data().span16(), offset);
 }
 
 InlineBoxAndOffset VisiblePosition::inlineBoxAndOffset() const

--- a/Source/WebCore/editing/VisibleUnits.cpp
+++ b/Source/WebCore/editing/VisibleUnits.cpp
@@ -1868,7 +1868,8 @@ void charactersAroundPosition(const VisiblePosition& position, char32_t& oneAfte
         for (int i = characterString.length() - 1, index = 0; i >= 0 && index < maxCharacters; --i) {
             if (!index && nextPosition.isNull())
                 index++;
-            characters[index++] = characterString[i];
+            //
+            characters[index++] = static_cast<char32_t>(characterString[i]);
         }
     }
     oneAfter = characters[0];

--- a/Source/WebCore/html/parser/HTMLEntityParser.cpp
+++ b/Source/WebCore/html/parser/HTMLEntityParser.cpp
@@ -74,7 +74,7 @@ static constexpr DecodedHTMLEntity makeEntity(char32_t character)
         return { replacementCharacter };
     if ((character & ~0x1F) != 0x80) {
         if (U_IS_BMP(character)) {
-            char16_t codeUnit = character;
+            auto codeUnit = static_cast<char16_t>(character);
             return { codeUnit };
         }
         return { U16_LEAD(character), U16_TRAIL(character) };

--- a/Source/WebCore/html/parser/HTMLParserIdioms.cpp
+++ b/Source/WebCore/html/parser/HTMLParserIdioms.cpp
@@ -275,7 +275,8 @@ static inline bool isHTMLSpaceOrDelimiter(CharacterType character)
     return isASCIIWhitespace(character) || character == ',' || character == ';';
 }
 
-static inline bool isNumberStart(char16_t character)
+template<typename CharacterType>
+static inline bool isNumberStart(CharacterType character)
 {
     return isASCIIDigit(character) || character == '.' || character == '-';
 }

--- a/Source/WebCore/layout/formattingContexts/inline/InlineContentBreaker.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineContentBreaker.cpp
@@ -357,7 +357,7 @@ static inline std::optional<size_t> lastValidBreakingPosition(const InlineConten
             U16_SET_CP_START(text, left, index);
             // We should never find surrogates/segments across inline items.
             ASSERT(index >= inlineTextItem.start());
-            if (canBreakBefore(text[index], lineBreak))
+            if (canBreakBefore(static_cast<char32_t>(text[index]), lineBreak))
                 return index == inlineTextItem.start() ? std::nullopt : std::make_optional(index);
         }
         return { };
@@ -366,7 +366,7 @@ static inline std::optional<size_t> lastValidBreakingPosition(const InlineConten
     if (auto nextTextRunCandidateIndex = nextTextRunIndex(runs, textRunIndex)) {
         auto& nextInlineTextItem = downcast<InlineTextItem>(runs[*nextTextRunCandidateIndex].inlineItem);
         auto canBreakAtRunBoundary = nextInlineTextItem.isWhitespace() ? nextInlineTextItem.style().whiteSpaceCollapse() != WhiteSpaceCollapse::BreakSpaces :
-            canBreakBefore(nextInlineTextItem.inlineTextBox().content()[nextInlineTextItem.start()], lineBreak);
+            canBreakBefore(static_cast<char32_t>(nextInlineTextItem.inlineTextBox().content()[nextInlineTextItem.start()]), lineBreak);
         if (canBreakAtRunBoundary)
             return inlineTextItem.end();
         return lastValidBreakingPositionInsideTextRun();
@@ -395,14 +395,14 @@ static std::optional<TextUtil::WordBreakLeft> midWordBreak(const InlineContentBr
     // Find out if the candidate position for arbitrary breaking is valid. We can't always break between any characters.
     auto lineBreak = textRun.style.lineBreak();
     auto text = inlineTextItem.inlineTextBox().content();
-    if (canBreakBefore(text[inlineTextItem.start() + wordBreak.length], lineBreak))
+    if (canBreakBefore(static_cast<char32_t>(text[inlineTextItem.start() + wordBreak.length]), lineBreak))
         return wordBreak;
 
     const auto left = inlineTextItem.start();
     auto right = left + wordBreak.length;
     for (; right > left; --right) {
         U16_SET_CP_START(text, left, right);
-        if (canBreakBefore(text[right], lineBreak))
+        if (canBreakBefore(static_cast<char32_t>(text[right]), lineBreak))
             break;
     }
     if (left == right)
@@ -514,7 +514,7 @@ std::optional<InlineContentBreaker::PartialRun> InlineContentBreaker::tryBreakin
                     if (auto wordBreak = midWordBreak(candidateRun, candidateTextRun.logicalLeft, availableWidth))
                         return PartialRun { wordBreak->length, wordBreak->logicalWidth };
                 }
-                if (canBreakBefore(inlineTextItem.inlineTextBox().content()[inlineTextItem.start()], style.lineBreak()))
+                if (canBreakBefore(static_cast<char32_t>(inlineTextItem.inlineTextBox().content()[inlineTextItem.start()]), style.lineBreak()))
                     return PartialRun { };
                 else {
                     // Since this is an overflowing content and we are allowed to break at arbitrary position, we really ought to find a breaking position.
@@ -529,7 +529,7 @@ std::optional<InlineContentBreaker::PartialRun> InlineContentBreaker::tryBreakin
                         U16_SET_CP_START(text, left, right);
                         while (right < inlineTextItem.end()) {
                             U16_FWD_1(text, right, inlineTextItem.length());
-                            if (canBreakBefore(text[right], style.lineBreak())) {
+                            if (canBreakBefore(static_cast<char32_t>(text[right]), style.lineBreak())) {
                                 if (right == inlineTextItem.end())
                                     return { };
                                 return TextUtil::WordBreakLeft { right - left, TextUtil::width(inlineTextItem, style.fontCascade(), left, right, candidateTextRun.logicalLeft) };

--- a/Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp
@@ -38,6 +38,7 @@
 #include "platform/text/TextSpacing.h"
 #include <wtf/Scope.h>
 #include <wtf/text/TextBreakIterator.h>
+#include <wtf/text/icu/UnicodeExtras.h>
 #include <wtf/unicode/CharacterNames.h>
 
 namespace WebCore {
@@ -178,7 +179,7 @@ void InlineItemsBuilder::computeInlineBoxBoundaryTextSpacings(const InlineItemLi
         size_t boundaryIndex = inlineBoxStartIndexesOnInlineItemsList[inlineBoxStartOnBoundaryIndex];
         const RenderStyle& boundaryOwnerStyle = inlineItemList[boundaryIndex].layoutBox().parent().style();
         auto boundaryTextAutospace = boundaryOwnerStyle.textAutospace();
-        if (!boundaryTextAutospace.isNoAutospace() && boundaryTextAutospace.shouldApplySpacing(inlineTextBox.content().characterAt(start), lastCharacterFromPreviousRun))
+        if (!boundaryTextAutospace.isNoAutospace() && boundaryTextAutospace.shouldApplySpacing(static_cast<char32_t>(inlineTextBox.content().characterAt(start)), lastCharacterFromPreviousRun))
             spacings.add(boundaryIndex, TextAutospace::textAutospaceSize(boundaryOwnerStyle.fontCascade().primaryFont()));
 
         lastCharacterFromPreviousRun = TextUtil::lastBaseCharacterFromText(content);
@@ -350,13 +351,11 @@ static void replaceNonPreservedNewLineAndTabCharactersAndAppend(const InlineText
     auto needsUnicodeHandling = !textContent.is8Bit();
     size_t nonReplacedContentStartPosition = 0;
     for (size_t position = 0; position < contentLength;) {
-        // Note that because of proper code point boundary handling (see U16_NEXT), position is incremented in an unconventional way here.
+        // Note that because of proper code point boundary handling (see u16Next), position is incremented in an unconventional way here.
         auto startPosition = position;
         auto isNewLineOrTabCharacter = [&] {
             if (needsUnicodeHandling) {
-                char32_t character;
-                auto characters = textContent.span16();
-                U16_NEXT(characters, position, contentLength, character);
+                char32_t character = u16Next(textContent.span16(), position);
                 return character == newlineCharacter || character == tabCharacter;
             }
             auto isNewLineOrTab = textContent[position] == newlineCharacter || textContent[position] == tabCharacter;
@@ -742,7 +741,7 @@ static void handleTextSpacing(TextSpacing::SpacingState& spacingState, Trimmable
     auto autospace = inlineTextItem.style().textAutospace();
     if (!autospace.isNoAutospace()) {
         // We need to store information about spacing added between inline text items since it needs to be trimmed during line breaking if the consecutive items are placed on different lines
-        auto characterClass = TextSpacing::characterClass(inlineTextItem.content().characterAt(0));
+        auto characterClass = TextSpacing::characterClass(static_cast<char32_t>(inlineTextItem.content().characterAt(0)));
         if (autospace.shouldApplySpacing(spacingState.lastCharacterClassFromPreviousRun, characterClass))
             trimmableTextSpacings.add(inlineItemIndex, TextAutospace::textAutospaceSize(inlineTextItem.style().fontCascade().primaryFont()));
 
@@ -1075,3 +1074,4 @@ void InlineItemsBuilder::populateBreakingPositionCache(const InlineItemList& inl
 
 }
 }
+

--- a/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
@@ -45,6 +45,7 @@
 #include <wtf/text/CharacterProperties.h>
 #include <wtf/text/ParsingUtilities.h>
 #include <wtf/text/TextBreakIterator.h>
+#include <wtf/text/icu/UnicodeExtras.h>
 
 namespace WebCore {
 namespace Layout {
@@ -565,7 +566,7 @@ bool TextUtil::containsStrongDirectionalityText(StringView text)
         }
 
         for (auto character : span) {
-            if (mayBeBidiRTL(character))
+            if (mayBeBidiRTL(static_cast<char32_t>(character)))
                 return true;
         }
         return false;
@@ -588,10 +589,9 @@ size_t TextUtil::firstUserPerceivedCharacterLength(const InlineTextBox& inlineTe
     if (textContent.is8Bit())
         return 1;
     if (inlineTextBox.canUseSimpleFontCodePath()) {
-        char32_t character;
         size_t endOfCodePoint = startPosition;
-        auto characters = textContent.span16();
-        U16_NEXT(characters, endOfCodePoint, textContent.length(), character);
+        auto characters = textContent.span16().subspan(0, textContent.length());
+        u16Next(characters, endOfCodePoint);
         ASSERT(endOfCodePoint > startPosition);
         return endOfCodePoint - startPosition;
     }
@@ -691,7 +691,7 @@ template<typename CharacterType>
 static bool canUseSimplifiedTextMeasuringForCharacters(std::span<const CharacterType> characters, const FontCascade& fontCascade, const Font& primaryFont, bool whitespaceIsCollapsed)
 {
     for (auto character : characters) {
-        if (!fontCascade.canUseSimplifiedTextMeasuring(character, AutoVariant, whitespaceIsCollapsed, primaryFont))
+        if (!fontCascade.canUseSimplifiedTextMeasuring(static_cast<char32_t>(character), AutoVariant, whitespaceIsCollapsed, primaryFont))
             return false;
     }
     return true;
@@ -741,7 +741,7 @@ char32_t TextUtil::lastBaseCharacterFromText(StringView string)
         return 0;
 
     for (size_t characterIndex = string.length(); characterIndex > 0; --characterIndex) {
-        auto character = string.characterAt(characterIndex - 1);
+        auto character = static_cast<char32_t>(string.characterAt(characterIndex - 1));
         if (!isCombiningMark(character))
             return character;
     }

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentBuilder.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentBuilder.cpp
@@ -66,7 +66,7 @@ static std::tuple<float, float> glyphOverflowInInlineDirection(size_t firstTextB
         }
         auto character = isLeading ? textContent[0] : textContent[textContent.length() - 1];
         auto& fontCascade = textBox.style().fontCascade();
-        auto glyphData = fontCascade.glyphDataForCharacter(character, !isLeftToRightDirection);
+        auto glyphData = fontCascade.glyphDataForCharacter(static_cast<char32_t>(character), !isLeftToRightDirection);
         return (glyphData.font ? *glyphData.font : fontCascade.primaryFont().get()).boundsForGlyph(glyphData.glyph);
     };
 

--- a/Source/WebCore/layout/layouttree/LayoutTreeBuilder.cpp
+++ b/Source/WebCore/layout/layouttree/LayoutTreeBuilder.cpp
@@ -83,7 +83,7 @@ static BoxType& appendChild(ElementBox& parent, std::unique_ptr<BoxType> newChil
 
 static std::optional<LayoutSize> accumulatedOffsetForInFlowPositionedContinuation(const RenderBox& block)
 {
-    // FIXE: This is a workaround of the continuation logic when the relatively positioned parent inline box
+    // FIXME: This is a workaround of the continuation logic when the relatively positioned parent inline box
     // becomes a sibling box of this block and only reachable through the continuation link which we don't have here.
     if (!block.isAnonymous() || !block.isInFlowPositioned() || !block.isContinuation())
         return { };
@@ -95,7 +95,7 @@ static bool canUseSimplifiedTextMeasuringForCharacters(std::span<const Character
 {
     Ref primaryFont = fontCascade.primaryFont();
     for (auto character : characters) {
-        if (!fontCascade.canUseSimplifiedTextMeasuring(character, AutoVariant, whitespaceIsCollapsed, primaryFont))
+        if (!fontCascade.canUseSimplifiedTextMeasuring(static_cast<char32_t>(character), AutoVariant, whitespaceIsCollapsed, primaryFont))
             return false;
     }
     return true;

--- a/Source/WebCore/platform/graphics/ComplexTextController.cpp
+++ b/Source/WebCore/platform/graphics/ComplexTextController.cpp
@@ -39,6 +39,7 @@
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/CharacterProperties.h>
 #include <wtf/text/TextBreakIterator.h>
+#include <wtf/text/icu/UnicodeExtras.h>
 #include <wtf/unicode/CharacterNames.h>
 
 #if PLATFORM(IOS_FAMILY)
@@ -69,7 +70,7 @@ public:
     {
         m_controller->advance(from, 0, GlyphIterationStyle::ByWholeGlyphs, fallbackFonts);
         float beforeWidth = m_controller->runWidthSoFar();
-        if (m_fontCascade.wordSpacing() && from && FontCascade::treatAsSpace(m_run[from]))
+        if (m_fontCascade.wordSpacing() && from && FontCascade::treatAsSpace(static_cast<char32_t>(m_run[from])))
             beforeWidth += m_fontCascade.wordSpacing();
         m_controller->advance(from + len, 0, GlyphIterationStyle::ByWholeGlyphs, fallbackFonts);
         float afterWidth = m_controller->runWidthSoFar();
@@ -325,16 +326,14 @@ void ComplexTextController::advanceByCombiningCharacterSequence(const CachedText
     ASSERT(remainingCharacters);
 
     std::array<char16_t, 2> buffer;
-    unsigned bufferLength = 1;
     buffer[0] = m_run.get()[currentIndex];
     buffer[1] = 0;
     if (remainingCharacters >= 2) {
         buffer[1] = m_run.get()[currentIndex + 1];
-        bufferLength = 2;
     }
 
-    unsigned i = 0;
-    U16_NEXT(buffer, i, bufferLength, baseCharacter);
+    size_t i = 0;
+    baseCharacter = u16Next(buffer, i);
     if (U_IS_SURROGATE(baseCharacter)) {
         currentIndex += i;
         return;
@@ -406,7 +405,7 @@ void ComplexTextController::collectComplexTextRuns()
     if (shouldSynthesizeSmallCaps(dontSynthesizeSmallCaps, nextFont.get(), baseCharacter, capitalizedBase, fontVariantCaps, engageAllSmallCapsProcessing)) {
         synthesizedFont = nextFont->noSynthesizableFeaturesFont();
         smallSynthesizedFont = synthesizedFont->smallCapsFont(m_fontCascade->fontDescription());
-        char32_t characterToWrite = capitalizedBase ? capitalizedBase.value() : baseOfString[0];
+        char32_t characterToWrite = capitalizedBase ? capitalizedBase.value() : static_cast<char32_t>(baseOfString[0]);
         unsigned characterIndex = 0;
         U16_APPEND_UNSAFE(m_smallCapsBuffer, characterIndex, characterToWrite);
         for (unsigned i = characterIndex; i < currentIndex; ++i)
@@ -441,7 +440,7 @@ void ComplexTextController::collectComplexTextRuns()
         nextFont = m_fontCascade->fontForCombiningCharacterSequence(baseOfString.subspan(previousIndex, currentIndex - previousIndex));
 
         if (shouldProcessTextSpacingTrim && nextFont && !nextFont->isSystemFontFallbackPlaceholder()) {
-            TextSpacing::CharactersData charactersData = { .currentCharacter = baseCharacter, .currentCharacterClass = TextSpacing::characterClass(baseCharacter) };
+            TextSpacing::CharactersData charactersData = { .currentCharacter = static_cast<char32_t>(baseCharacter), .currentCharacterClass = TextSpacing::characterClass(baseCharacter) };
             halfWidthFont = TextSpacing::getHalfWidthFontIfNeeded(*nextFont, m_fontCascade->textSpacingTrim(), charactersData);
             nextFont = halfWidthFont ? halfWidthFont : nextFont;
         }
@@ -739,7 +738,7 @@ void ComplexTextController::adjustGlyphsAndAdvances()
                 if (characterIndex > previousCharacterIndex)
                     isMonotonic = false;
             }
-            char16_t character = charactersSpan[characterIndex];
+            auto character = static_cast<char32_t>(charactersSpan[characterIndex]);
 
             bool treatAsSpace = FontCascade::treatAsSpace(character);
             CGGlyph glyph = glyphs[glyphIndex];
@@ -863,9 +862,7 @@ void ComplexTextController::adjustGlyphsAndAdvances()
             m_totalAdvance += advance;
 
             if (m_forTextEmphasis) {
-                char32_t ch32 = character;
-                if (U16_IS_SURROGATE(character))
-                    U16_GET(charactersSpan, 0, characterIndex, complexTextRun.stringLength(), ch32);
+                char32_t ch32 = u16Get(charactersSpan, characterIndex);
                 // FIXME: Combining marks should receive a text emphasis mark if they are combine with a space.
                 if (!FontCascade::canReceiveTextEmphasis(ch32) || (U_GET_GC_MASK(character) & U_GC_M_MASK)) {
                     glyph = deletedGlyph;
@@ -916,11 +913,10 @@ ComplexTextController::ComplexTextRun::ComplexTextRun(const Font& font, std::spa
 {
     auto runLengthInCodeUnits = m_indexEnd - m_indexBegin;
     m_coreTextIndices.reserveInitialCapacity(runLengthInCodeUnits);
-    unsigned r = m_indexBegin;
+    size_t r = m_indexBegin;
     while (r < m_indexEnd) {
         auto currentIndex = r;
-        char32_t character;
-        U16_NEXT(m_characters, r, stringLength(), character);
+        char32_t character = u16Next(m_characters, r);
         // https://drafts.csswg.org/css-text-3/#white-space-processing
         // "Unsupported Default_ignorable characters must be ignored for text rendering."
         if (!FontCascade::isCharacterWhoseGlyphsShouldBeDeletedForTextRendering(character))

--- a/Source/WebCore/platform/graphics/ComposedCharacterClusterTextIterator.h
+++ b/Source/WebCore/platform/graphics/ComposedCharacterClusterTextIterator.h
@@ -27,6 +27,7 @@
 
 #include <unicode/utf16.h>
 #include <wtf/text/TextBreakIterator.h>
+#include <wtf/text/icu/UnicodeExtras.h>
 
 namespace WebCore {
 
@@ -47,10 +48,10 @@ public:
         if (m_currentIndex >= m_lastIndex)
             return false;
 
-        auto relativeIndex = m_currentIndex - m_originalIndex;
+        size_t relativeIndex = m_currentIndex - m_originalIndex;
         if (auto result = m_iterator.following(relativeIndex)) {
             clusterLength = result.value() - relativeIndex;
-            U16_NEXT(m_characters, relativeIndex, result.value(), character);
+            character = u16Next(m_characters.subspan(0, result.value()), relativeIndex);
             return true;
         }
         

--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -45,6 +45,8 @@
 #include <wtf/text/AtomStringHash.h>
 #include <wtf/text/StringBuilder.h>
 #include <wtf/text/TextStream.h>
+#include <wtf/text/icu/UnicodeExtras.h>
+#include <wtf/unicode/CharacterCasts.h>
 
 namespace WebCore {
 
@@ -348,7 +350,7 @@ NEVER_INLINE float FontCascade::widthForSimpleTextSlow(StringView text, TextDire
 
     auto addGlyphsFromText = [&](GlyphBuffer& glyphBuffer, const Font& font, auto characters) {
         for (size_t i = 0; i < characters.size(); ++i) {
-            auto glyph = font.glyphForCharacter(characters[i]);
+            auto glyph = font.glyphForCharacter(static_cast<char32_t>(characters[i]));
             glyphBuffer.add(glyph, font, font.widthForGlyph(glyph), i);
         }
     };
@@ -1176,7 +1178,7 @@ std::pair<unsigned, bool> FontCascade::expansionOpportunityCountInternal(std::sp
     }
     if (direction == TextDirection::LTR) {
         for (size_t i = 0; i < characters.size(); ++i) {
-            char32_t character = characters[i];
+            auto character = static_cast<char32_t>(characters[i]);
             if (treatAsSpace(character)) {
                 ++count;
                 isAfterExpansion = true;
@@ -1197,7 +1199,7 @@ std::pair<unsigned, bool> FontCascade::expansionOpportunityCountInternal(std::sp
         }
     } else {
         for (size_t i = characters.size(); i > 0; --i) {
-            char32_t character = characters[i - 1];
+            auto character = static_cast<char32_t>(characters[i - 1]);
             if (treatAsSpace(character)) {
                 ++count;
                 isAfterExpansion = true;
@@ -1246,11 +1248,11 @@ bool FontCascade::leftExpansionOpportunity(StringView stringView, TextDirection 
 
     char32_t initialCharacter;
     if (direction == TextDirection::LTR) {
-        initialCharacter = stringView[0];
+        initialCharacter = static_cast<char32_t>(stringView[0]);
         if (U16_IS_LEAD(initialCharacter) && stringView.length() > 1 && U16_IS_TRAIL(stringView[1]))
             initialCharacter = U16_GET_SUPPLEMENTARY(initialCharacter, stringView[1]);
     } else {
-        initialCharacter = stringView[stringView.length() - 1];
+        initialCharacter = static_cast<char32_t>(stringView[stringView.length() - 1]);
         if (U16_IS_TRAIL(initialCharacter) && stringView.length() > 1 && U16_IS_LEAD(stringView[stringView.length() - 2]))
             initialCharacter = U16_GET_SUPPLEMENTARY(stringView[stringView.length() - 2], initialCharacter);
     }
@@ -1265,11 +1267,11 @@ bool FontCascade::rightExpansionOpportunity(StringView stringView, TextDirection
 
     char32_t finalCharacter;
     if (direction == TextDirection::LTR) {
-        finalCharacter = stringView[stringView.length() - 1];
+        finalCharacter = static_cast<char32_t>(stringView[stringView.length() - 1]);
         if (U16_IS_TRAIL(finalCharacter) && stringView.length() > 1 && U16_IS_LEAD(stringView[stringView.length() - 2]))
             finalCharacter = U16_GET_SUPPLEMENTARY(stringView[stringView.length() - 2], finalCharacter);
     } else {
-        finalCharacter = stringView[0];
+        finalCharacter = static_cast<char32_t>(stringView[0]);
         if (U16_IS_LEAD(finalCharacter) && stringView.length() > 1 && U16_IS_TRAIL(stringView[1]))
             finalCharacter = U16_GET_SUPPLEMENTARY(finalCharacter, stringView[1]);
     }
@@ -1346,8 +1348,7 @@ static GlyphUnderlineType computeUnderlineType(const TextRun& textRun, const Gly
     if (textRun.is8Bit())
         baseCharacter = textRun.span8()[offsetInString.value()];
     else {
-        auto characters = textRun.span16();
-        U16_GET(characters, 0, static_cast<unsigned>(offsetInString.value()), characters.size(), baseCharacter);
+        baseCharacter = u16Get(textRun.span16(), offsetInString.value());
     }
     // u_getIntPropertyValue with UCHAR_IDEOGRAPHIC doesn't return true for Japanese or Korean codepoints.
     // Instead, we can use the "Unicode allocation block" for the character.
@@ -1395,10 +1396,10 @@ std::optional<GlyphData> FontCascade::getEmphasisMarkGlyphData(const AtomString&
     if (!mark.is8Bit()) {
         size_t i = 0;
         auto span = mark.span16();
-        U16_NEXT(span, i, span.size(), character);
-        ASSERT(U16_IS_SINGLE(character)); // The CSS parser replaces unpaired surrogates with the object replacement character.
+        character = u16Next(span, i);
+        ASSERT_UNUSED(U16_IS_SINGLE(character), character); // The CSS parser replaces unpaired surrogates with the object replacement character.
     } else
-        character = mark[0];
+        character = castNonSurrogateUTF16CodeUnitToUTF32(mark[0]);
 
     std::optional<GlyphData> glyphData(glyphDataForCharacter(character, false, EmphasisMarkVariant));
     return glyphData.value().isValid() ? glyphData : std::nullopt;

--- a/Source/WebCore/platform/graphics/FontCascade.h
+++ b/Source/WebCore/platform/graphics/FontCascade.h
@@ -323,10 +323,10 @@ public:
 
     static inline char16_t normalizeSpaces(char16_t character)
     {
-        if (treatAsSpace(character))
+        if (treatAsSpace(static_cast<char32_t>(character)))
             return space;
 
-        if (treatAsZeroWidthSpace(character))
+        if (treatAsZeroWidthSpace(static_cast<char32_t>(character)))
             return zeroWidthSpace;
 
         return character;

--- a/Source/WebCore/platform/graphics/SurrogatePairAwareTextIterator.h
+++ b/Source/WebCore/platform/graphics/SurrogatePairAwareTextIterator.h
@@ -20,8 +20,8 @@
 
 #pragma once
 
-#include <unicode/utf16.h>
 #include <wtf/text/WTFString.h>
+#include <wtf/text/icu/UnicodeExtras.h>
 
 namespace WebCore {
 
@@ -44,9 +44,11 @@ public:
             return false;
 
         auto relativeIndex = m_currentIndex - m_originalIndex;
-        clusterLength = 0;
-        auto spanAtRelativeIndex = m_characters.subspan(relativeIndex);
-        U16_NEXT(spanAtRelativeIndex, clusterLength, m_endIndex - m_currentIndex, character);
+        auto spanAtRelativeIndex = m_characters.subspan(relativeIndex, m_endIndex - m_currentIndex);
+        size_t offset = 0;
+        character = u16Next(spanAtRelativeIndex, offset);
+        ASSERT(offset == 1 || offset == 2);
+        clusterLength = offset;
         return true;
     }
 

--- a/Source/WebCore/platform/graphics/WidthCache.h
+++ b/Source/WebCore/platform/graphics/WidthCache.h
@@ -207,7 +207,7 @@ private:
             return true;
         const auto& text = textRun.textAsString();
         for (unsigned index = 0; index < text.length(); ++index) {
-            if (TextSpacing::isIdeograph(text.characterAt(index))) {
+            if (TextSpacing::isIdeograph(static_cast<char32_t>(text.characterAt(index)))) {
                 m_hasSeenIdeograph = true;
                 clear();
                 return true;

--- a/Source/WebCore/platform/graphics/WidthIterator.cpp
+++ b/Source/WebCore/platform/graphics/WidthIterator.cpp
@@ -395,7 +395,7 @@ inline void WidthIterator::advanceInternal(TextIterator& textIterator, GlyphBuff
     RefPtr<Font> halfWidthFont;
     auto shouldProcessTextSpacingTrim = !fontDescription.textSpacingTrim().isSpaceAll();
     if (shouldProcessTextSpacingTrim) {
-        TextSpacing::CharactersData charactersData = { .currentCharacter = character, .currentCharacterClass = TextSpacing::characterClass(character) };
+        TextSpacing::CharactersData charactersData = { .currentCharacter = static_cast<char32_t>(character), .currentCharacterClass = TextSpacing::characterClass(character) };
         halfWidthFont = TextSpacing::getHalfWidthFontIfNeeded(*glyphData.protectedFont(), fontDescription.textSpacingTrim(), charactersData);
         glyphData.font = halfWidthFont ? halfWidthFont.get() : glyphData.font;
     }
@@ -431,7 +431,7 @@ inline void WidthIterator::advanceInternal(TextIterator& textIterator, GlyphBuff
         auto glyphData = m_fontCascade->glyphDataForCharacter(character, false, FontVariant::NormalVariant);
 
         if (shouldProcessTextSpacingTrim) {
-            TextSpacing::CharactersData charactersData = { .currentCharacter = character, .currentCharacterClass = TextSpacing::characterClass(character) };
+            TextSpacing::CharactersData charactersData = { .currentCharacter = static_cast<char32_t>(character), .currentCharacterClass = TextSpacing::characterClass(character) };
             halfWidthFont = TextSpacing::getHalfWidthFontIfNeeded(*glyphData.protectedFont(), fontDescription.textSpacingTrim(), charactersData);
             glyphData.font = halfWidthFont ? halfWidthFont.get() : glyphData.font;
         }
@@ -449,7 +449,7 @@ inline void WidthIterator::advanceInternal(TextIterator& textIterator, GlyphBuff
             characterToWrite = u_charMirror(characterToWrite);
 
         Glyph glyph = glyphData.glyph;
-        if (glyphData.font.get() != advanceInternalState.nextRangeFont || character != characterToWrite)
+        if (glyphData.font.get() != advanceInternalState.nextRangeFont || static_cast<char32_t>(character) != characterToWrite)
             glyph = Ref { *advanceInternalState.nextRangeFont }->glyphForCharacter(characterToWrite);
 
         if (!glyph && !characterMustDrawSomething) {
@@ -514,7 +514,7 @@ auto WidthIterator::calculateAdditionalWidth(GlyphBuffer& glyphBuffer, GlyphBuff
     }
 
     if (hasExtraSpacing()) {
-        bool treatAsSpace = FontCascade::treatAsSpace(character);
+        bool treatAsSpace = FontCascade::treatAsSpace(static_cast<char32_t>(character));
 
         // This is a heuristic to determine if the character is non-visible. Non-visible characters don't get letter-spacing.
         float baseWidth = 0;
@@ -539,7 +539,7 @@ auto WidthIterator::calculateAdditionalWidth(GlyphBuffer& glyphBuffer, GlyphBuff
             bool forbidLeftExpansion = isLeftmostCharacter && m_run->expansionBehavior().left == ExpansionBehavior::Behavior::Forbid;
             bool forbidRightExpansion = isRightmostCharacter && m_run->expansionBehavior().right == ExpansionBehavior::Behavior::Forbid;
 
-            bool isIdeograph = FontCascade::canExpandAroundIdeographsInComplexText() && FontCascade::isCJKIdeographOrSymbol(character);
+            bool isIdeograph = FontCascade::canExpandAroundIdeographsInComplexText() && FontCascade::isCJKIdeographOrSymbol(static_cast<char32_t>(character));
 
             if (treatAsSpace || isIdeograph || forceLeftExpansion || forceRightExpansion) {
                 auto [expandLeft, expandRight] = expansionLocation(isIdeograph, treatAsSpace, ltr(), m_isAfterExpansion, forbidLeftExpansion, forbidRightExpansion, forceLeftExpansion, forceRightExpansion);
@@ -644,7 +644,7 @@ void WidthIterator::applyExtraSpacingAfterShaping(GlyphBuffer& glyphBuffer, unsi
         auto textAutospaceSpacing = 0.f;
         auto characterClass = TextSpacing::CharacterClass::Undefined;
         if (!textAutospace.isNoAutospace()) {
-            characterClass = TextSpacing::characterClass(m_run.get()[i]);
+            characterClass = TextSpacing::characterClass(static_cast<char32_t>(m_run.get()[i]));
             if (textAutospace.shouldApplySpacing(characterClass, previousCharacterClass)) {
                 textAutospaceSpacing = TextAutospace::textAutospaceSize(glyphBuffer.protectedFontAt(glyphIndexRange->leadingGlyphIndex));
                 glyphBuffer.expandAdvanceToLogicalRight(glyphIndexRange->leadingGlyphIndex, textAutospaceSpacing);
@@ -769,7 +769,7 @@ void WidthIterator::applyCSSVisibilityRules(GlyphBuffer& glyphBuffer, unsigned g
         auto stringOffset = glyphBuffer.checkedStringOffsetAt(i, m_run->length());
         if (!stringOffset)
             continue;
-        auto characterResponsibleForThisGlyph = m_run.get()[stringOffset.value()];
+        auto characterResponsibleForThisGlyph = static_cast<char32_t>(m_run.get()[stringOffset.value()]);
 
         switch (characterResponsibleForThisGlyph) {
         case newlineCharacter:

--- a/Source/WebCore/platform/graphics/coretext/ComplexTextControllerCoreText.mm
+++ b/Source/WebCore/platform/graphics/coretext/ComplexTextControllerCoreText.mm
@@ -32,6 +32,7 @@
 #import <pal/spi/cf/CoreTextSPI.h>
 #import <wtf/SoftLinking.h>
 #import <wtf/WeakPtr.h>
+#import <wtf/text/icu/UnicodeExtras.h>
 
 namespace WebCore {
 
@@ -191,7 +192,7 @@ void ComplexTextController::collectComplexTextRunsForCharacters(std::span<const 
         // FIXME: This code path does not support small caps.
         isSystemFallback = true;
 
-        U16_GET(characters, 0, 0, characters.size(), baseCharacter);
+        baseCharacter = u16Get(characters, 0);
         effectiveFont = m_fontCascade->fallbackRangesAt(0).fontForCharacter(baseCharacter);
         if (!effectiveFont)
             effectiveFont = &m_fontCascade->fallbackRangesAt(0).fontForFirstRange();

--- a/Source/WebCore/platform/graphics/freetype/GlyphPageTreeNodeFreeType.cpp
+++ b/Source/WebCore/platform/graphics/freetype/GlyphPageTreeNodeFreeType.cpp
@@ -38,6 +38,7 @@
 #include <cairo.h>
 #include <fontconfig/fcfreetype.h>
 #include <wtf/text/CharacterProperties.h>
+#include <wtf/text/icu/UnicodeExtras.h>
 
 namespace WebCore {
 
@@ -61,12 +62,11 @@ bool GlyphPage::fill(std::span<const char16_t> buffer)
         };
 
     bool haveGlyphs = false;
-    unsigned bufferOffset = 0;
-    for (unsigned i = 0; i < GlyphPage::size; i++) {
+    size_t bufferOffset = 0;
+    for (size_t i = 0; i < GlyphPage::size; i++) {
         if (bufferOffset == buffer.size())
             break;
-        char32_t character;
-        U16_NEXT(buffer, bufferOffset, buffer.size(), character);
+        char32_t character = u16Next(buffer, bufferOffset);
 
         Glyph glyph = FcFreeTypeCharIndex(face, FontCascade::treatAsSpace(character) ? space : character);
         // If the font doesn't support a Default_Ignorable character, replace it with zero with space.

--- a/Source/WebCore/platform/network/RFC8941.cpp
+++ b/Source/WebCore/platform/network/RFC8941.cpp
@@ -35,12 +35,14 @@
 
 namespace RFC8941 {
 
-template<typename CharacterType> constexpr bool isEndOfToken(CharacterType character)
+template<typename CharacterType> static constexpr bool isEndOfToken(CharacterType character)
 {
-    return !RFC7230::isTokenCharacter(character) && character != ':' && character != '/';
+    // FIXME: This cast to char16_t is incorrect. We should probably change
+    // RFC8941 to use CharacterType templates.
+    return !RFC7230::isTokenCharacter(static_cast<char16_t>(character)) && character != ':' && character != '/';
 }
 
-template<typename CharacterType> constexpr bool isEndOfKey(CharacterType character)
+template<typename CharacterType> static constexpr bool isEndOfKey(CharacterType character)
 {
     return !isASCIILower(character) && !isASCIIDigit(character) && character != '_' && character != '-' && character != '.' && character != '*';
 }

--- a/Source/WebCore/platform/text/TextBoundaries.cpp
+++ b/Source/WebCore/platform/text/TextBoundaries.cpp
@@ -30,16 +30,16 @@
 #include <unicode/ubrk.h>
 #include <wtf/text/StringImpl.h>
 #include <wtf/text/TextBreakIterator.h>
+#include <wtf/text/icu/UnicodeExtras.h>
 
 namespace WebCore {
 
 unsigned endOfFirstWordBoundaryContext(StringView text)
 {
     unsigned length = text.length();
-    for (unsigned i = 0; i < length; ) {
+    for (size_t i = 0; i < length; ) {
         unsigned first = i;
-        char32_t ch;
-        U16_NEXT(text, i, length, ch);
+        char32_t ch = u16Next(text.span16(), i);
         if (!requiresContextForWordBoundary(ch))
             return first;
     }
@@ -49,10 +49,9 @@ unsigned endOfFirstWordBoundaryContext(StringView text)
 unsigned startOfLastWordBoundaryContext(StringView text)
 {
     unsigned length = text.length();
-    for (unsigned i = length; i > 0; ) {
+    for (size_t i = length; i > 0; ) {
         unsigned last = i;
-        char32_t ch;
-        U16_PREV(text, 0, i, ch);
+        char32_t ch = u16Prev(text.span16(), i);
         if (!requiresContextForWordBoundary(ch))
             return last;
     }

--- a/Source/WebCore/platform/text/hyphen/HyphenationLibHyphen.cpp
+++ b/Source/WebCore/platform/text/hyphen/HyphenationLibHyphen.cpp
@@ -41,6 +41,7 @@
 #include <wtf/text/AtomStringHash.h>
 #include <wtf/text/CString.h>
 #include <wtf/text/StringView.h>
+#include <wtf/text/icu/UnicodeExtras.h>
 
 #if PLATFORM(GTK)
 #include <wtf/glib/GUniquePtr.h>
@@ -236,16 +237,15 @@ public:
 
 namespace WebCore {
 
-static void countLeadingSpaces(const CString& utf8String, int32_t& pointerOffset, int32_t& characterOffset)
+static void countLeadingSpaces(const CString& utf8String, size_t& pointerOffset, size_t& characterOffset)
 {
     pointerOffset = 0;
     characterOffset = 0;
     const char* stringData = utf8String.data();
-    char32_t character = 0;
-    while (static_cast<unsigned>(pointerOffset) < utf8String.length()) {
-        int32_t nextPointerOffset = pointerOffset;
-        U8_NEXT(stringData, nextPointerOffset, static_cast<int32_t>(utf8String.length()), character);
-        if (character == static_cast<char32_t>(U_SENTINEL) || !u_isUWhiteSpace(character))
+    while (pointerOffset < utf8String.length()) {
+        size_t nextPointerOffset = pointerOffset;
+        char32_t character = u8Next(stringData, nextPointerOffset);
+        if (character == static_cast<char32_t>(U_SENTINEL) || !u_isUWhiteSpace(character)) // FIXME XXX: This is broken, char32_t is an unsigned type.
             return;
 
         pointerOffset = nextPointerOffset;
@@ -264,8 +264,8 @@ size_t lastHyphenLocation(StringView string, size_t beforeIndex, const AtomStrin
     // WebCore often passes strings like " wordtohyphenate" to the platform layer. Since
     // libhyphen isn't advanced enough to deal with leading spaces (presumably CoreFoundation
     // can), we should find the appropriate indexes into the string to skip them.
-    int32_t leadingSpaceBytes;
-    int32_t leadingSpaceCharacters;
+    size_t leadingSpaceBytes;
+    size_t leadingSpaceCharacters;
     countLeadingSpaces(utf8StringCopy, leadingSpaceBytes, leadingSpaceCharacters);
 
     // The libhyphen documentation specifies that this array should be 5 bytes longer than

--- a/Source/WebCore/platform/text/mac/TextBoundaries.mm
+++ b/Source/WebCore/platform/text/mac/TextBoundaries.mm
@@ -36,6 +36,7 @@
 #import <wtf/text/StringView.h>
 #import <wtf/text/TextBreakIterator.h>
 #import <wtf/text/TextBreakIteratorInternalICU.h>
+#import <wtf/text/icu/UnicodeExtras.h>
 #import <wtf/unicode/CharacterNames.h>
 
 namespace WebCore {
@@ -88,9 +89,8 @@ static void findSimpleWordBoundary(StringView text, int position, int* start, in
 
     unsigned startPos = position;
     while (startPos > 0) {
-        int i = startPos;
-        char32_t characterBeforeStartPos;
-        U16_PREV(text, 0, i, characterBeforeStartPos);
+        size_t i = startPos;
+        char32_t characterBeforeStartPos = u16Prev(text, i);
         if (isWordDelimitingCharacter(characterBeforeStartPos)) {
             ASSERT(i >= 0);
             if (!i)
@@ -99,26 +99,24 @@ static void findSimpleWordBoundary(StringView text, int position, int* start, in
             if (!isAmbiguousBoundaryCharacter(characterBeforeStartPos))
                 break;
 
-            char32_t characterBeforeBeforeStartPos;
-            U16_PREV(text, 0, i, characterBeforeBeforeStartPos);
+            char32_t characterBeforeBeforeStartPos = u16Prev(text, i);
             if (isWordDelimitingCharacter(characterBeforeBeforeStartPos))
                 break;
         }
         U16_BACK_1(text, 0, startPos);
     }
     
-    unsigned endPos = position;
+    size_t endPos = position;
     while (endPos < text.length()) {
-        char32_t character;
-        U16_GET(text, 0, endPos, text.length(), character);
+        char32_t character = u16Get(text, endPos);
         if (isWordDelimitingCharacter(character)) {
-            unsigned i = endPos;
+            size_t i = endPos;
             U16_FWD_1(text, i, text.length());
             ASSERT(i <= text.length());
             if (i == text.length())
                 break;
             char32_t characterAfterEndPos;
-            U16_NEXT(text, i, text.length(), characterAfterEndPos);
+            characterAfterEndPos = u16Next(text, i);
             if (!isAmbiguousBoundaryCharacter(character))
                 break;
             if (isWordDelimitingCharacter(characterAfterEndPos))
@@ -130,8 +128,7 @@ static void findSimpleWordBoundary(StringView text, int position, int* start, in
     // The text may consist of all delimiter characters (e.g. "++++++++" or a series of emoji), and returning an empty range
     // makes no sense (and doesn't match findComplexWordBoundary() behavior).
     if (startPos == endPos && endPos < text.length()) {
-        char32_t character;
-        U16_GET(text, 0, endPos, text.length(), character);
+        char32_t character = u16Get(text, endPos);
         if (isSymbolCharacter(character))
             U16_FWD_1(text, endPos, text.length());
     }
@@ -192,9 +189,8 @@ void findWordBoundary(StringView text, int position, int* start, int* end)
     // For complex text (Thai, Japanese, Chinese), visible_units will pass the text in as a 
     // single contiguous run of characters, providing as much context as is possible.
     // We only need one character to determine if the text is complex.
-    char32_t ch;
-    unsigned i = position;
-    U16_NEXT(text, i, text.length(), ch);
+    size_t i = position;
+    char32_t ch = u16Next(text, i);
     bool isComplex = requiresContextForWordBoundary(ch);
 
     // FIXME: This check improves our word boundary behavior, but doesn't actually go far enough.
@@ -202,7 +198,7 @@ void findWordBoundary(StringView text, int position, int* start, int* end)
     if (!isComplex) {
         // Check again for complex text, at the start of the run.
         i = 0;
-        U16_NEXT(text, i, text.length(), ch);
+        ch = u16Next(text, i);
         isComplex = requiresContextForWordBoundary(ch);
     }
 

--- a/Source/WebCore/rendering/LegacyInlineIterator.h
+++ b/Source/WebCore/rendering/LegacyInlineIterator.h
@@ -30,6 +30,7 @@
 #include "RenderText.h"
 #include "UnicodeBidi.h"
 #include <wtf/StdLibExtras.h>
+#include <wtf/text/icu/UnicodeExtras.h>
 
 namespace WebCore {
 
@@ -281,9 +282,10 @@ inline void LegacyInlineIterator::incrementByCodePointInTextNode()
         ++m_pos;
         return;
     }
-    char32_t character;
-    auto characters = text.span16();
-    U16_NEXT(characters, m_pos, text.length(), character);
+    size_t pos = m_pos;
+    u16Next(text.span16(), pos);
+    ASSERT(pos < UINT_MAX);
+    m_pos = pos;
 }
 
 inline void LegacyInlineIterator::setOffset(unsigned position)

--- a/Source/WebCore/rendering/mathml/MathOperator.cpp
+++ b/Source/WebCore/rendering/mathml/MathOperator.cpp
@@ -428,10 +428,10 @@ void MathOperator::calculateStretchyData(const RenderStyle& style, bool calculat
             return;
 
         // We convert the list of Unicode characters into a list of glyph data.
-        assemblyData.topOrRightCodePoint = stretchyCharacter->topChar;
-        assemblyData.extensionCodePoint = stretchyCharacter->extensionChar;
-        assemblyData.bottomOrLeftCodePoint = stretchyCharacter->bottomChar;
-        assemblyData.middleCodePoint = stretchyCharacter->middleChar;
+        assemblyData.topOrRightCodePoint = static_cast<char32_t>(stretchyCharacter->topChar);
+        assemblyData.extensionCodePoint = static_cast<char32_t>(stretchyCharacter->extensionChar);
+        assemblyData.bottomOrLeftCodePoint = static_cast<char32_t>(stretchyCharacter->bottomChar);
+        assemblyData.middleCodePoint = static_cast<char32_t>(stretchyCharacter->middleChar);
     }
 
     auto topOrRight = glyphDataForCodePointOrFallbackGlyph(style, assemblyData.topOrRightCodePoint, assemblyData.topOrRightFallbackGlyph);

--- a/Source/WebCore/rendering/mathml/MathVariant.cpp
+++ b/Source/WebCore/rendering/mathml/MathVariant.cpp
@@ -207,27 +207,27 @@ char32_t mathVariantMapCodePoint(char32_t codePoint, MathVariant mathvariant)
     };
     static constexpr SortedArrayMap latinExceptionMapTable = { latinExceptionMapTableEntries };
 
-    constexpr char16_t greekUpperTheta = 0x03F4;
-    constexpr char16_t holeGreekUpperTheta = 0x03A2;
-    constexpr char16_t nabla = 0x2207;
-    constexpr char16_t partialDifferential = 0x2202;
-    constexpr char16_t greekUpperAlpha = 0x0391;
-    constexpr char16_t greekUpperOmega = 0x03A9;
-    constexpr char16_t greekLowerAlpha = 0x03B1;
-    constexpr char16_t greekLowerOmega = 0x03C9;
-    constexpr char16_t greekLunateEpsilonSymbol = 0x03F5;
-    constexpr char16_t greekThetaSymbol = 0x03D1;
-    constexpr char16_t greekKappaSymbol = 0x03F0;
-    constexpr char16_t greekPhiSymbol = 0x03D5;
-    constexpr char16_t greekRhoSymbol = 0x03F1;
-    constexpr char16_t greekPiSymbol = 0x03D6;
-    constexpr char16_t greekLetterDigamma = 0x03DC;
+    constexpr char32_t greekUpperTheta = 0x03F4;
+    constexpr char32_t holeGreekUpperTheta = 0x03A2;
+    constexpr char32_t nabla = 0x2207;
+    constexpr char32_t partialDifferential = 0x2202;
+    constexpr char32_t greekUpperAlpha = 0x0391;
+    constexpr char32_t greekUpperOmega = 0x03A9;
+    constexpr char32_t greekLowerAlpha = 0x03B1;
+    constexpr char32_t greekLowerOmega = 0x03C9;
+    constexpr char32_t greekLunateEpsilonSymbol = 0x03F5;
+    constexpr char32_t greekThetaSymbol = 0x03D1;
+    constexpr char32_t greekKappaSymbol = 0x03F0;
+    constexpr char32_t greekPhiSymbol = 0x03D5;
+    constexpr char32_t greekRhoSymbol = 0x03F1;
+    constexpr char32_t greekPiSymbol = 0x03D6;
+    constexpr char32_t greekLetterDigamma = 0x03DC;
     constexpr char32_t greekSmallLetterDigamma = 0x03DD;
     constexpr char32_t mathBoldCapitalDigamma = 0x1D7CA;
     constexpr char32_t mathBoldSmallDigamma = 0x1D7CB;
 
-    constexpr char16_t latinSmallLetterDotlessI = 0x0131;
-    constexpr char16_t latinSmallLetterDotlessJ = 0x0237;
+    constexpr char32_t latinSmallLetterDotlessI = 0x0131;
+    constexpr char32_t latinSmallLetterDotlessJ = 0x0237;
 
     constexpr char32_t mathItalicSmallDotlessI = 0x1D6A4;
     constexpr char32_t mathItalicSmallDotlessJ = 0x1D6A5;

--- a/Source/WebCore/rendering/svg/SVGTextLayoutEngineSpacing.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextLayoutEngineSpacing.cpp
@@ -38,7 +38,7 @@ float SVGTextLayoutEngineSpacing::calculateCSSSpacing(char16_t currentCharacter)
 {
     float spacing = m_font->letterSpacing();
 
-    if (m_font->wordSpacing() && FontCascade::treatAsSpace(currentCharacter) && !FontCascade::treatAsSpace(m_lastCharacter))
+    if (m_font->wordSpacing() && FontCascade::treatAsSpace(static_cast<char32_t>(currentCharacter)) && !FontCascade::treatAsSpace(static_cast<char32_t>(m_lastCharacter)))
         spacing += m_font->wordSpacing();
 
     m_lastCharacter = currentCharacter;

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderFirstLetter.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderFirstLetter.cpp
@@ -106,7 +106,8 @@ static inline bool isPunctuationForFirstLetter(char32_t c)
 
 static inline bool shouldSkipForFirstLetter(char32_t c)
 {
-    return deprecatedIsSpaceOrNewline(c) || c == noBreakSpace || isPunctuationForFirstLetter(c);
+    // FIXME: This cast to char16_t is probably not correct.
+    return deprecatedIsSpaceOrNewline(static_cast<char16_t>(c)) || c == noBreakSpace || isPunctuationForFirstLetter(c);
 }
 
 static bool supportsFirstLetter(RenderBlock& block)

--- a/Source/cmake/WebKitCompilerFlags.cmake
+++ b/Source/cmake/WebKitCompilerFlags.cmake
@@ -250,9 +250,6 @@ if (COMPILER_IS_GCC_OR_CLANG)
 
     WEBKIT_PREPEND_GLOBAL_COMPILER_FLAGS(-Werror=undefined-inline
                                          -Werror=undefined-internal)
-
-    # FIXME: https://bugs.webkit.org/show_bug.cgi?id=299689
-    WEBKIT_PREPEND_GLOBAL_COMPILER_FLAGS(-Wno-character-conversion)
 endif ()
 
 if (COMPILER_IS_GCC_OR_CLANG AND NOT MSVC)

--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(TESTWEBKITAPI_DIR "${TOOLS_DIR}/TestWebKitAPI")
 set(TestWebKitAPI_DISABLED_WARNINGS
+    -Wno-character-conversion
     -Wno-dangling-else
     -Wno-sign-compare
     -Wno-undef


### PR DESCRIPTION
#### 6a5e969cf2e9ca600e2af4915f692fe3b3492bb7
<pre>
Clang 21 complains about implicit casting between char32_t and char16_t throughout the codebase
<a href="https://bugs.webkit.org/show_bug.cgi?id=299689">https://bugs.webkit.org/show_bug.cgi?id=299689</a>

Reviewed by NOBODY (OOPS!).

This pull request is a WIP draft. It is incomplete and not ready for review.

This prepares WebKit&apos;s cross-platform code for Clang 21&apos;s
-Wcharacter-conversion. In practice, this warning is emitted whenever we
implicitly convert from char32_t to char16_t, or vice-versa. In general,
the solution is to add a cast.

Casting to char16_t to char32_t is safe if you&apos;re certain that none of
the code units are surrogates, so let&apos;s add a cast that asserts this is
true.

Converting from char32_t to char16_t is safe if you&apos;re certain that the
character is in the Basic Multilingual Plane, so let&apos;s add a cast that
asserts this is true.

Since char32_t is not compatible with ICU&apos;s UChar32, and we want to use
char32_t to represent UTF-32, I&apos;ve added variants of various ICU
conversion macros that return char32_t instead of UChar32. They also
receive inputs as spans, use char8_t instead of UChar8, and notably
avoid triggering -Wunsafe-buffer-usage.

In a few cases, I change behavior where the original code looks wrong
and seems easy to fix, e.g. isStrWhiteSpace in ParseInt.h, or
URLParser::isForbiddenHostCodePoint.

EncodingTables.h uses templates throughout the file and I&apos;m not sure how
to fix it, so I decided not to worry about it and just suppressed the
warning. I made the same decision for all of TestWebKitAPI to avoid
requiring changes to GoogleTest.

Lastly, I have added a deprecated/broken cast for use in cases that look
suspicious, where I suspect that the assertion might be hit. These will
require follow-up investigation.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6a5e969cf2e9ca600e2af4915f692fe3b3492bb7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132126 "37 style errors") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/4619 "Hash 6a5e969c for PR 51527 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43148 "Hash 6a5e969c for PR 51527 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/139641 "Hash 6a5e969c for PR 51527 does not build (failure)") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84043 "Hash 6a5e969c for PR 51527 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/133996 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/4567 "Hash 6a5e969c for PR 51527 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4380 "Hash 6a5e969c for PR 51527 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/139641 "Hash 6a5e969c for PR 51527 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/84043 "Hash 6a5e969c for PR 51527 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135072 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/4567 "Hash 6a5e969c for PR 51527 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/138/builds/43148 "Hash 6a5e969c for PR 51527 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/139641 "Hash 6a5e969c for PR 51527 does not build (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/4567 "Hash 6a5e969c for PR 51527 does not build (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/138/builds/43148 "Hash 6a5e969c for PR 51527 does not build (failure)") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/82860 "Hash 6a5e969c for PR 51527 does not build (failure)") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/124189 "Hash 6a5e969c for PR 51527 does not build (failure)") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/4567 "Hash 6a5e969c for PR 51527 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/138/builds/43148 "Hash 6a5e969c for PR 51527 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142287 "Hash 6a5e969c for PR 51527 does not build (failure)") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/130633 "Hash 6a5e969c for PR 51527 does not build (failure)") | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4288 "Hash 6a5e969c for PR 51527 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/138/builds/43148 "Hash 6a5e969c for PR 51527 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/142287 "Hash 6a5e969c for PR 51527 does not build (failure)") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4369 "Hash 6a5e969c for PR 51527 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/4380 "Hash 6a5e969c for PR 51527 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/142287 "Hash 6a5e969c for PR 51527 does not build (failure)") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/138/builds/43148 "Hash 6a5e969c for PR 51527 does not build (failure)") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/57534 "Hash 6a5e969c for PR 51527 does not build (failure)") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/4342 "Hash 6a5e969c for PR 51527 does not build (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/138/builds/43148 "Hash 6a5e969c for PR 51527 does not build (failure)") | [❌ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/163600 "Hash 6a5e969c for PR 51527 does not build (failure)") | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4173 "Hash 6a5e969c for PR 51527 does not build (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/67788 "Failed to build and analyze WebKit") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/163600 "Hash 6a5e969c for PR 51527 does not build (failure)") | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/4433 "Hash 6a5e969c for PR 51527 does not build (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/4301 "Hash 6a5e969c for PR 51527 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->