### PR TITLE
Unreviewed, reverting 300115@main (28698492e4f8)

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
@@ -52,6 +52,7 @@ platform/cocoa/UserAgentCocoa.mm
 platform/cocoa/WebAVPlayerLayer.mm
 platform/gamepad/mac/HIDGamepadElement.cpp
 platform/graphics/BitmapImageDescriptor.cpp
+platform/graphics/DestinationColorSpace.cpp
 platform/graphics/avfoundation/AVTrackPrivateAVFObjCImpl.mm
 platform/graphics/avfoundation/AudioSourceProviderAVFObjC.mm
 platform/graphics/avfoundation/FormatDescriptionUtilities.cpp

--- a/Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
@@ -31,6 +31,7 @@ platform/cocoa/RemoteCommandListenerCocoa.mm
 platform/cocoa/SearchPopupMenuCocoa.mm
 platform/cocoa/SerializedPlatformDataCueValue.mm
 platform/cocoa/SystemVersion.mm
+platform/graphics/DestinationColorSpace.cpp
 platform/graphics/avfoundation/AVTrackPrivateAVFObjCImpl.mm
 platform/graphics/avfoundation/FormatDescriptionUtilities.cpp
 platform/graphics/avfoundation/InbandTextTrackPrivateAVF.cpp

--- a/Source/WebCore/platform/graphics/DestinationColorSpace.cpp
+++ b/Source/WebCore/platform/graphics/DestinationColorSpace.cpp
@@ -125,7 +125,7 @@ const DestinationColorSpace& DestinationColorSpace::ExtendedRec2020()
 bool operator==(const DestinationColorSpace& a, const DestinationColorSpace& b)
 {
 #if USE(CG)
-    return CGColorSpaceEqualToColorSpace(a.protectedPlatformColorSpace().get(), b.protectedPlatformColorSpace().get());
+    return CGColorSpaceEqualToColorSpace(a.platformColorSpace(), b.platformColorSpace());
 #elif USE(SKIA)
     return SkColorSpace::Equals(a.platformColorSpace().get(), b.platformColorSpace().get());
 #else
@@ -136,17 +136,17 @@ bool operator==(const DestinationColorSpace& a, const DestinationColorSpace& b)
 std::optional<DestinationColorSpace> DestinationColorSpace::asRGB() const
 {
 #if USE(CG)
-    RetainPtr<CGColorSpaceRef> colorSpace = platformColorSpace();
-    if (CGColorSpaceGetModel(colorSpace.get()) == kCGColorSpaceModelIndexed)
-        colorSpace = CGColorSpaceGetBaseColorSpace(colorSpace.get());
+    CGColorSpaceRef colorSpace = platformColorSpace();
+    if (CGColorSpaceGetModel(colorSpace) == kCGColorSpaceModelIndexed)
+        colorSpace = CGColorSpaceGetBaseColorSpace(colorSpace);
 
-    if (CGColorSpaceGetModel(colorSpace.get()) != kCGColorSpaceModelRGB)
+    if (CGColorSpaceGetModel(colorSpace) != kCGColorSpaceModelRGB)
         return std::nullopt;
 
     if (usesExtendedRange())
         return std::nullopt;
 
-    return DestinationColorSpace(colorSpace.get());
+    return DestinationColorSpace(colorSpace);
 
 #elif USE(SKIA)
     // When using skia, we're not using color spaces consisting of custom lookup tables, so we either yield SRGB or nothing.
@@ -164,7 +164,7 @@ std::optional<DestinationColorSpace> DestinationColorSpace::asExtended() const
     if (usesExtendedRange())
         return *this;
 #if USE(CG)
-    if (RetainPtr colorSpace = adoptCF(CGColorSpaceCreateExtended(protectedPlatformColorSpace().get())))
+    if (RetainPtr colorSpace = adoptCF(CGColorSpaceCreateExtended(platformColorSpace())))
         return DestinationColorSpace(WTFMove(colorSpace));
 #endif
     return std::nullopt;
@@ -173,7 +173,7 @@ std::optional<DestinationColorSpace> DestinationColorSpace::asExtended() const
 bool DestinationColorSpace::supportsOutput() const
 {
 #if USE(CG)
-    return CGColorSpaceSupportsOutput(protectedPlatformColorSpace().get());
+    return CGColorSpaceSupportsOutput(platformColorSpace());
 #else
     notImplemented();
     return true;
@@ -183,7 +183,7 @@ bool DestinationColorSpace::supportsOutput() const
 bool DestinationColorSpace::usesExtendedRange() const
 {
 #if USE(CG)
-    return CGColorSpaceUsesExtendedRange(protectedPlatformColorSpace().get());
+    return CGColorSpaceUsesExtendedRange(platformColorSpace());
 #else
     notImplemented();
     return false;
@@ -193,7 +193,7 @@ bool DestinationColorSpace::usesExtendedRange() const
 bool DestinationColorSpace::usesITUR_2100TF() const
 {
 #if USE(CG)
-    return CGColorSpaceUsesITUR_2100TF(protectedPlatformColorSpace().get());
+    return CGColorSpaceUsesITUR_2100TF(platformColorSpace());
 #else
     notImplemented();
     return false;
@@ -219,7 +219,7 @@ TextStream& operator<<(TextStream& ts, const DestinationColorSpace& colorSpace)
         ts << "ExtendedRec2020"_s;
 #endif
 #if USE(CG)
-    else if (auto description = adoptCF(CGColorSpaceCopyICCProfileDescription(colorSpace.protectedPlatformColorSpace().get())))
+    else if (auto description = adoptCF(CGColorSpaceCopyICCProfileDescription(colorSpace.platformColorSpace())))
         ts << String(description.get());
 #endif
 


### PR DESCRIPTION
#### e9aa5f3ee4abb3a80d1bf589d2630633171848dd
<pre>
Unreviewed, reverting 300115@main (28698492e4f8)
<a href="https://bugs.webkit.org/show_bug.cgi?id=299835">https://bugs.webkit.org/show_bug.cgi?id=299835</a>
<a href="https://rdar.apple.com/161607588">rdar://161607588</a>

Unreviewed, revert 300115@main as it seems to have regressed MotionMark

Reverted change:

    Address safer CPP warnings in DestinationColorSpace.cpp
    <a href="https://bugs.webkit.org/show_bug.cgi?id=298923">https://bugs.webkit.org/show_bug.cgi?id=298923</a>
    300115@main (28698492e4f8)

* Source/WebCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations:
* Source/WebCore/platform/graphics/DestinationColorSpace.cpp:
(WebCore::operator==):
(WebCore::DestinationColorSpace::asRGB const):
(WebCore::DestinationColorSpace::asExtended const):
(WebCore::DestinationColorSpace::supportsOutput const):
(WebCore::DestinationColorSpace::usesExtendedRange const):
(WebCore::DestinationColorSpace::usesITUR_2100TF const):
(WebCore::operator&lt;&lt;):

Canonical link: <a href="https://commits.webkit.org/300727@main">https://commits.webkit.org/300727@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c7475c6ab0f4e2039b898ece7736a1213ba63d5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123672 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43387 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34083 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130446 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/75817 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0dac4126-d571-4be4-b36d-d5f8b580186d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/125549 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44110 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51981 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94035 "") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/75817 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/399200e4-33e0-4a20-aea8-367a82a31027) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126625 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/35137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/110636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/74638 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0be21fbf-76d1-4117-990e-13f7fcc1783f) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/34100 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/28795 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73921 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104858 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29018 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133136 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/50623 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/38540 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/102507 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/50998 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106857 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102347 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26014 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/25944 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/47442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/50477 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56239 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/49951 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/53298 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/51626 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->