### PR TITLE
[css-anchor-position-1] Rework re-generating position option when applying it changes scroll container size

### DIFF
--- a/Source/WebCore/rendering/style/PositionTryFallback.h
+++ b/Source/WebCore/rendering/style/PositionTryFallback.h
@@ -48,7 +48,7 @@ struct PositionTryFallback {
     Vector<Tactic> tactics { };
 
     // A position-area fallback is mutually exclusive with the rest.
-    const RefPtr<const StyleProperties> positionAreaProperties { };
+    RefPtr<const StyleProperties> positionAreaProperties { };
 
     ~PositionTryFallback();
     friend bool operator==(const PositionTryFallback&, const PositionTryFallback&);

--- a/Source/WebCore/style/StyleExtractorConverter.h
+++ b/Source/WebCore/style/StyleExtractorConverter.h
@@ -438,8 +438,8 @@ inline Ref<CSSValue> ExtractorConverter::convertPositionTryFallbacks(ExtractorSt
 
     CSSValueListBuilder list;
     for (auto& fallback : fallbacks) {
-        if (fallback.positionAreaProperties) {
-            auto areaValue = fallback.positionAreaProperties->getPropertyCSSValue(CSSPropertyPositionArea);
+        if (RefPtr positionAreaProperties = fallback.positionAreaProperties) {
+            auto areaValue = positionAreaProperties->getPropertyCSSValue(CSSPropertyPositionArea);
             if (areaValue)
                 list.append(*areaValue);
             continue;

--- a/Source/WebCore/style/StyleExtractorSerializer.h
+++ b/Source/WebCore/style/StyleExtractorSerializer.h
@@ -471,8 +471,8 @@ inline void ExtractorSerializer::serializePositionTryFallbacks(ExtractorState& s
 
     CSSValueListBuilder list;
     for (auto& fallback : fallbacks) {
-        if (fallback.positionAreaProperties) {
-            auto areaValue = fallback.positionAreaProperties->getPropertyCSSValue(CSSPropertyPositionArea);
+        if (RefPtr positionAreaProperties = fallback.positionAreaProperties) {
+            auto areaValue = positionAreaProperties->getPropertyCSSValue(CSSPropertyPositionArea);
             if (areaValue)
                 list.append(*areaValue);
             continue;


### PR DESCRIPTION
#### bd1c5258d78a050aee737c0a5e7cf93d7c0ec3ee
<pre>
[css-anchor-position-1] Rework re-generating position option when applying it changes scroll container size
<a href="https://rdar.apple.com/161599518">rdar://161599518</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=299825">https://bugs.webkit.org/show_bug.cgi?id=299825</a>

Reviewed by Antti Koivisto.

300465@main implements re-generating position option style when applying it changes
the scroll container size. It does this by simply deleting the entire PositionOption
object. TreeResolver::generatePositionOptionsIfNeeded will then re-generate the
PositionOption, and because we save the last successful (also the last tried)
position option at style resolution time, TreeResolver::sortPositionOptionsIfNeeded
will adjust the re-generated PositionOption to continue trying from the position
option that caused re-generation.

However, the spec dictates that the last successful position option is remembered
when ResizeObserver events are delivered. To prepare for this behavior, this
patch re-work 300465@main to not rely on last successful position option
being remembered at style resolution time.

* Source/WebCore/rendering/style/PositionTryFallback.cpp:
(WebCore::Style::operator==):
(WebCore::Style::operator&lt;&lt;):
    - Explicitly ref-count PositionTryFallback::positionAreaProperties before using
      it, since it&apos;s now non-const

* Source/WebCore/rendering/style/PositionTryFallback.h:
    - Make PositionTryFallback::positionAreaProperties non-const so PositionTryFallback
      can be copied around.

* Source/WebCore/style/StyleExtractorConverter.h:
(WebCore::Style::ExtractorConverter::convertPositionTryFallbacks):
* Source/WebCore/style/StyleExtractorSerializer.h:
(WebCore::Style::ExtractorSerializer::serializePositionTryFallbacks):
    - Explicitly ref-count PositionTryFallback::positionAreaProperties before using it.

* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::styleForStyleable):
    - Pass resolutionContext to TreeResolver::tryChoosePositionOption

(WebCore::Style::TreeResolver::resolvePseudoElement):
    - Pass resolutionContext to TreeResolver::tryChoosePositionOption

(WebCore::Style::TreeResolver::generatePositionOptionsIfNeeded):
    - Save the original resolved style in PositionOptions.
    - For each generated PositionOption, save the used option.

(WebCore::Style::TreeResolver::tryChoosePositionOption):
    - When the scroll container size changes, re-generate a new style on the fly
      to replace the existing style.
    - Add a ResolutionContext argument. TreeResolver::generatePositionOption requires
      the ResolutionContext to generate a style.

* Source/WebCore/style/StyleTreeResolver.h:
    - PositionOption: additionally store (1) the option used to generate the style,
      and (2) the scroll container size when the PositionOption is generated.
    - PositionOptions: (1) store the original ResolvedStyle, so it can be used for
      style re-generation (2) remove the saved scroll container size - this size is
      now tracked for each PositionOption.

Canonical link: <a href="https://commits.webkit.org/300805@main">https://commits.webkit.org/300805@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/22781314eb44e8a37d5e76aa648a819819ec3098

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123882 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43597 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34294 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130669 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76033 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2faddd33-9179-48f7-aa75-a338f380c875) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/125759 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44321 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52191 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94221 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62522 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d999a6f1-e0ca-4526-b5aa-0d1093166542) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126835 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35311 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110822 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74821 "Found 1 new API test failure: TestWTF:WTF_Condition.OneProducerOneConsumerOneSlotTimeout (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/dc1679e5-4037-4440-9fe6-603d95d7d4c3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34264 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28983 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74145 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105038 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29206 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133362 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50835 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38715 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102691 "47 flakes 73 failures") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51209 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107042 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102519 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26083 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47860 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26117 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/47684 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50688 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56452 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50162 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53508 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51836 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->