### PR TITLE
[WPE][WebDriver] Support taking the screenshots from the UIProcess

### DIFF
--- a/Source/WebKit/Shared/WebBackForwardListItem.h
+++ b/Source/WebKit/Shared/WebBackForwardListItem.h
@@ -74,7 +74,7 @@ public:
     bool itemIsInSameDocument(const WebBackForwardListItem&) const;
     bool itemIsClone(const WebBackForwardListItem&);
 
-#if PLATFORM(COCOA) || PLATFORM(GTK)
+#if PLATFORM(COCOA) || PLATFORM(GTK) || (PLATFORM(WPE) && USE(SKIA))
     ViewSnapshot* snapshot() const { return m_snapshot.get(); }
     void setSnapshot(RefPtr<ViewSnapshot>&& snapshot) { m_snapshot = WTFMove(snapshot); }
 #endif
@@ -121,7 +121,7 @@ private:
     WebCore::ProcessIdentifier m_lastProcessIdentifier;
     RefPtr<WebBackForwardCacheEntry> m_backForwardCacheEntry;
     const RefPtr<BrowsingContextGroup> m_browsingContextGroup;
-#if PLATFORM(COCOA) || PLATFORM(GTK)
+#if PLATFORM(COCOA) || PLATFORM(GTK) || (PLATFORM(WPE) && USE(SKIA))
     RefPtr<ViewSnapshot> m_snapshot;
 #endif
     bool m_isRemoteFrameNavigation { false };

--- a/Source/WebKit/SourcesWPE.txt
+++ b/Source/WebKit/SourcesWPE.txt
@@ -108,6 +108,7 @@ Shared/wpe/WebKeyboardEventWPE.cpp
 
 UIProcess/DefaultUndoController.cpp
 UIProcess/LegacySessionStateCodingNone.cpp
+UIProcess/ViewSnapshotStore.cpp
 UIProcess/WebGrammarDetail.cpp
 UIProcess/WebMemoryPressureHandler.cpp @no-unify
 UIProcess/WebViewportAttributes.cpp
@@ -268,6 +269,8 @@ UIProcess/WebsiteData/glib/WebsiteDataStoreGLib.cpp
 UIProcess/WebsiteData/soup/WebsiteDataStoreSoup.cpp
 
 UIProcess/linux/MemoryPressureMonitor.cpp
+
+UIProcess/skia/ViewSnapshotSkia.cpp
 
 UIProcess/soup/WebProcessPoolSoup.cpp
 

--- a/Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp
@@ -32,6 +32,7 @@
 #include "NativeWebTouchEvent.h"
 #include "NativeWebWheelEvent.h"
 #include "TouchGestureController.h"
+#include "ViewSnapshotStore.h"
 #include "WPEWebViewLegacy.h"
 #include "WPEWebViewPlatform.h"
 #include "WebColorPicker.h"
@@ -563,5 +564,22 @@ void PageClientImpl::callAfterNextPresentationUpdate(CompletionHandler<void()>&&
 {
     m_view.callAfterNextPresentationUpdate(WTFMove(callback));
 }
+
+#if USE(SKIA)
+RefPtr<ViewSnapshot> PageClientImpl::takeViewSnapshot(std::optional<WebCore::IntRect>&& clipRect)
+{
+#if ENABLE(WPE_PLATFORM)
+    if (m_view.wpeView()) {
+        auto snapshot = static_cast<WKWPE::ViewPlatform&>(m_view).takeViewSnapshot(WTFMove(clipRect));
+        // FIXME Forward the Expected in https://webkit.org/b/300271
+        if (snapshot)
+            return WTFMove(snapshot.value());
+    }
+#else
+    UNUSED_PARAM(clipRect)
+#endif
+    return nullptr;
+}
+#endif
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/API/wpe/PageClientImpl.h
+++ b/Source/WebKit/UIProcess/API/wpe/PageClientImpl.h
@@ -188,6 +188,10 @@ private:
 
     WebKitWebResourceLoadManager* webResourceLoadManager() override;
 
+#if USE(SKIA)
+    RefPtr<ViewSnapshot> takeViewSnapshot(std::optional<WebCore::IntRect>&&) override;
+#endif
+
     WKWPE::View& m_view;
     DefaultUndoController m_undoController;
 #if ENABLE(FULLSCREEN_API)

--- a/Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.cpp
@@ -48,10 +48,10 @@
 #endif
 
 #if USE(SKIA)
+#include "ViewSnapshotStore.h"
+
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
-IGNORE_CLANG_WARNINGS_BEGIN("cast-align")
 #include <skia/core/SkPixmap.h>
-IGNORE_CLANG_WARNINGS_END
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 #endif
 
@@ -663,6 +663,13 @@ void ViewPlatform::callAfterNextPresentationUpdate(CompletionHandler<void()>&& c
         }), this);
     }
 }
+
+#if USE(SKIA)
+Expected<Ref<ViewSnapshot>, String> ViewPlatform::takeViewSnapshot(std::optional<WebCore::IntRect>&& clipRect)
+{
+    return m_backingStore->takeSnapshot(WTFMove(clipRect));
+}
+#endif
 
 } // namespace WKWPE
 

--- a/Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.h
+++ b/Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.h
@@ -37,6 +37,7 @@
 
 namespace WebKit {
 class AcceleratedBackingStore;
+class ViewSnapshot;
 class WebPlatformTouchPoint;
 }
 
@@ -60,6 +61,10 @@ public:
 
 #if ENABLE(GAMEPAD)
     static WebKit::WebPageProxy* platformWebPageProxyForGamepadInput();
+#endif
+
+#if USE(SKIA)
+    Expected<Ref<WebKit::ViewSnapshot>, String> takeViewSnapshot(std::optional<WebCore::IntRect>&&);
 #endif
 
     void updateAcceleratedSurface(uint64_t);

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
@@ -2597,7 +2597,7 @@ void WebAutomationSession::takeScreenshot(const Inspector::Protocol::Automation:
     bool scrollIntoViewIfNeeded = optionalScrollIntoViewIfNeeded ? *optionalScrollIntoViewIfNeeded : false;
     bool clipToViewport = optionalClipToViewport ? *optionalClipToViewport : false;
 
-#if PLATFORM(COCOA) || !PLATFORM(GTK)
+#if PLATFORM(COCOA) || (!PLATFORM(GTK) && !(PLATFORM(WPE) && USE(SKIA)))
     auto ipcCompletionHandler = [] (CommandCallback<String>&& callback) mutable {
         return CompletionHandler<void(std::optional<ShareableBitmap::Handle>&&, String&&)> { [callback = WTFMove(callback)] (std::optional<ShareableBitmap::Handle>&& imageDataHandle, String&& errorType) mutable {
             if (!errorType.isEmpty())
@@ -2623,7 +2623,7 @@ void WebAutomationSession::takeScreenshot(const Inspector::Protocol::Automation:
     if (!nodeHandle.isEmpty())
         return page->sendWithAsyncReplyToProcessContainingFrameWithoutDestinationIdentifier(frameID, Messages::WebAutomationSessionProxy::TakeScreenshot(page->webPageIDInMainFrameProcess(), frameID, nodeHandle, scrollIntoViewIfNeeded, clipToViewport), ipcCompletionHandler(WTFMove(callback)));
 #endif
-#if PLATFORM(GTK) || PLATFORM(COCOA)
+#if PLATFORM(GTK) || PLATFORM(COCOA) || (PLATFORM(WPE) && USE(SKIA))
     Function<void(WebPageProxy&, std::optional<WebCore::IntRect>&&, CommandCallback<String>&&)> takeViewSnapshot = [](WebPageProxy& page, std::optional<WebCore::IntRect>&& rect, CommandCallback<String>&& callback) {
         page.callAfterNextPresentationUpdate([page = Ref { page }, rect = WTFMove(rect), callback = WTFMove(callback)] () mutable {
             RefPtr snapshot = page->takeViewSnapshot(WTFMove(rect), ForceSoftwareCapturingViewportSnapshot::Yes);

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -387,7 +387,7 @@ public:
     virtual void selectionDidChange() = 0;
 #endif
 
-#if PLATFORM(COCOA) || PLATFORM(GTK)
+#if PLATFORM(COCOA) || PLATFORM(GTK) || (PLATFORM(WPE) && USE(SKIA))
     virtual RefPtr<ViewSnapshot> takeViewSnapshot(std::optional<WebCore::IntRect>&&) = 0;
 #endif
 

--- a/Source/WebKit/UIProcess/ViewSnapshotStore.cpp
+++ b/Source/WebKit/UIProcess/ViewSnapshotStore.cpp
@@ -39,6 +39,8 @@ static const size_t maximumSnapshotCacheSize = 400 * (1024 * 1024);
 namespace WebKit {
 using namespace WebCore;
 
+#if !(PLATFORM(WPE) && USE(CAIRO))
+
 ViewSnapshotStore::ViewSnapshotStore()
 {
 }
@@ -123,6 +125,8 @@ void ViewSnapshotStore::discardSnapshotImagesForOrigin(const WebCore::SecurityOr
             viewSnapshot->clearImage();
     }
 }
+
+#endif // !(PLATFORM(WPE) && USE(CAIRO))
 
 ViewSnapshot::~ViewSnapshot()
 {

--- a/Source/WebKit/UIProcess/ViewSnapshotStore.h
+++ b/Source/WebKit/UIProcess/ViewSnapshotStore.h
@@ -46,6 +46,11 @@
 #endif
 #endif
 
+#if PLATFORM(WPE) && USE(SKIA)
+#include <skia/core/SkImage.h>
+#include <wtf/Expected.h>
+#endif
+
 namespace WebKit {
 
 class WebBackForwardListItem;
@@ -64,6 +69,9 @@ public:
 #else
     static Ref<ViewSnapshot> create(RefPtr<cairo_surface_t>&&);
 #endif
+#endif
+#if PLATFORM(WPE) && USE(SKIA)
+    static Ref<ViewSnapshot> create(sk_sp<SkImage>&&);
 #endif
 
     ~ViewSnapshot();
@@ -117,6 +125,13 @@ public:
     WebCore::IntSize size() const;
 #endif
 
+#if PLATFORM(WPE) && USE(SKIA)
+    SkImage* image() const { return m_image.get(); }
+
+    size_t estimatedImageSizeInBytes() const;
+    WebCore::IntSize size() const;
+#endif
+
 private:
 #if HAVE(IOSURFACE)
     explicit ViewSnapshot(std::unique_ptr<WebCore::IOSurface>);
@@ -136,6 +151,12 @@ private:
 #endif
 #endif
 
+#if PLATFORM(WPE) && USE(SKIA)
+    explicit ViewSnapshot(sk_sp<SkImage>&&);
+
+    sk_sp<SkImage> m_image;
+#endif
+
     uint64_t m_renderTreeSize;
     float m_deviceScaleFactor;
     WebCore::Color m_backgroundColor;
@@ -143,6 +164,8 @@ private:
     WebCore::FloatBoxExtent m_computedObscuredInset;
     WebCore::SecurityOriginData m_origin;
 };
+
+#if !(PLATFORM(WPE) && USE(CAIRO))
 
 class ViewSnapshotStore {
     WTF_MAKE_NONCOPYABLE(ViewSnapshotStore);
@@ -171,5 +194,7 @@ private:
     ListHashSet<WeakRef<ViewSnapshot>> m_snapshotsWithImages;
     bool m_disableSnapshotVolatility { false };
 };
+
+#endif // !(PLATFORM(WPE) && USE(CAIRO))
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -344,7 +344,7 @@
 #include <WebCore/UTIUtilities.h>
 #endif
 
-#if PLATFORM(COCOA) || PLATFORM(GTK)
+#if PLATFORM(COCOA) || PLATFORM(GTK) || (PLATFORM(WPE) && USE(SKIA))
 #include "ViewSnapshotStore.h"
 #endif
 
@@ -13688,7 +13688,7 @@ void WebPageProxy::setEditableElementIsFocused(bool editableElementIsFocused)
 
 #endif // PLATFORM(MAC)
 
-#if PLATFORM(COCOA) || PLATFORM(GTK)
+#if PLATFORM(COCOA) || PLATFORM(GTK) || (PLATFORM(WPE) && USE(SKIA))
 
 RefPtr<ViewSnapshot> WebPageProxy::takeViewSnapshot(std::optional<WebCore::IntRect>&& clipRect)
 {
@@ -13710,7 +13710,7 @@ RefPtr<ViewSnapshot> WebPageProxy::takeViewSnapshot(std::optional<WebCore::IntRe
 #endif
 }
 
-#endif // PLATFORM(COCOA) || PLATFORM(GTK)
+#endif // PLATFORM(COCOA) || PLATFORM(GTK) || (PLATFORM(WPE) && USE(SKIA))
 
 #if PLATFORM(GTK) || PLATFORM(WPE)
 

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1977,7 +1977,8 @@ public:
     void suppressNextAutomaticNavigationSnapshot() { m_shouldSuppressNextAutomaticNavigationSnapshot = true; }
     void recordNavigationSnapshot(WebBackForwardListItem&);
 
-#if PLATFORM(COCOA) || PLATFORM(GTK)
+#if PLATFORM(COCOA) || PLATFORM(GTK) || (PLATFORM(WPE && USE(SKIA)))
+    // TODO Replace RefPtr with Expected for error reporting https://webkit.org/b/300271
     RefPtr<ViewSnapshot> takeViewSnapshot(std::optional<WebCore::IntRect>&&);
     RefPtr<ViewSnapshot> takeViewSnapshot(std::optional<WebCore::IntRect>&&, ForceSoftwareCapturingViewportSnapshot);
 #endif

--- a/Source/WebKit/UIProcess/skia/ViewSnapshotSkia.cpp
+++ b/Source/WebKit/UIProcess/skia/ViewSnapshotSkia.cpp
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2025 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,dd
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ViewSnapshotStore.h"
+
+#if USE(SKIA)
+
+namespace WebKit {
+using namespace WebCore;
+
+Ref<ViewSnapshot> ViewSnapshot::create(sk_sp<SkImage>&& image)
+{
+    return adoptRef(*new ViewSnapshot(WTFMove(image)));
+}
+
+ViewSnapshot::ViewSnapshot(sk_sp<SkImage>&& image)
+    : m_image(WTFMove(image))
+{
+    if (hasImage())
+        ViewSnapshotStore::singleton().didAddImageToSnapshot(*this);
+}
+
+bool ViewSnapshot::hasImage() const
+{
+    return !!m_image;
+}
+
+void ViewSnapshot::clearImage()
+{
+    if (!hasImage())
+        return;
+
+    ViewSnapshotStore::singleton().willRemoveImageFromSnapshot(*this);
+
+    m_image = nullptr;
+}
+
+size_t ViewSnapshot::estimatedImageSizeInBytes() const
+{
+    if (!m_image)
+        return 0;
+
+    return m_image->imageInfo().computeMinByteSize();
+}
+
+WebCore::IntSize ViewSnapshot::size() const
+{
+    if (!m_image)
+        return { };
+
+    return { m_image->width(), m_image->height() };
+}
+
+} // namespace WebKit
+
+#endif // USE(SKIA)
+

--- a/Source/WebKit/UIProcess/wpe/AcceleratedBackingStore.cpp
+++ b/Source/WebKit/UIProcess/wpe/AcceleratedBackingStore.cpp
@@ -29,6 +29,7 @@
 #if ENABLE(WPE_PLATFORM)
 #include "AcceleratedBackingStoreMessages.h"
 #include "AcceleratedSurfaceMessages.h"
+#include "ViewSnapshotStore.h"
 #include "WebPageProxy.h"
 #include "WebProcessProxy.h"
 #include <WebCore/ShareableBitmap.h>
@@ -38,6 +39,17 @@
 
 #if USE(LIBDRM)
 #include <drm_fourcc.h>
+#endif
+
+#if USE(SKIA)
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
+#include <skia/core/SkColorSpace.h>
+#include <skia/core/SkPixmap.h>
+#include <skia/core/SkStream.h>
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // Skia port
+#include <skia/encode/SkPngEncoder.h>
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 #endif
 
 namespace WebKit {
@@ -154,6 +166,76 @@ void AcceleratedBackingStore::frame(uint64_t bufferID, Rects&& damageRects, WTF:
     } else
         m_fenceMonitor.addFileDescriptor(WTFMove(renderingFenceFD));
 }
+
+#if USE(SKIA)
+static Expected<SkImageInfo, String> getImageInfoFromBuffer(const  GRefPtr<WPEBuffer>& buffer)
+{
+    auto width = wpe_buffer_get_width(buffer.get());
+    auto height = wpe_buffer_get_height(buffer.get());
+
+    if (WPE_IS_BUFFER_DMA_BUF(buffer.get())) {
+        auto* dmaBuffer = WPE_BUFFER_DMA_BUF(buffer.get());
+        SkAlphaType alphaType = kPremul_SkAlphaType;
+        if (wpe_buffer_dma_buf_get_format(dmaBuffer) == DRM_FORMAT_XRGB8888)
+            alphaType = kOpaque_SkAlphaType;
+        return SkImageInfo::Make(width, height, kBGRA_8888_SkColorType, alphaType, SkColorSpace::MakeSRGB());
+    }
+
+    if (WPE_IS_BUFFER_SHM(buffer.get())) {
+        SkAlphaType alphaType = kPremul_SkAlphaType;
+        return SkImageInfo::Make(width, height, kBGRA_8888_SkColorType, alphaType, SkColorSpace::MakeSRGB());
+    }
+    return makeUnexpected("Failed to extract snapshot pixel information"_s);
+}
+
+static Expected<Ref<ViewSnapshot>, String> saveBufferSnapshot(const GRefPtr<WPEBuffer>& buffer, std::optional<WebCore::IntRect>&& clipRect)
+{
+    GUniqueOutPtr<GError> error;
+    GBytes* pixels = wpe_buffer_import_to_pixels(buffer.get(), &error.outPtr());
+
+    if (!pixels) {
+        g_warning("Failed to read current WPEBuffer for snapshot: %s", error->message);
+        return makeUnexpected("Failed to read current WPEBuffer for snapshot"_s);
+    }
+
+    gsize pixelsDataSize;
+    const auto* pixelsData = g_bytes_get_data(pixels, &pixelsDataSize);
+    GRefPtr<GBytes> bytes = adoptGRef(g_bytes_new(pixelsData, pixelsDataSize));
+
+    auto info = getImageInfoFromBuffer(buffer);
+    if (!info)
+        return makeUnexpected(info.error());
+
+    SkPixmap pixmap(info.value(), g_bytes_get_data(bytes.get(), nullptr), info->minRowBytes());
+
+    if (clipRect) {
+        SkIRect clippedRect = SkIRect::MakeXYWH(clipRect->x(), clipRect->y(), clipRect->width(), clipRect->height());
+        SkImageInfo clippedInfo = info->makeWH(clipRect->width(), clipRect->height());
+        SkPixmap clippedPixmap(info.value(), nullptr, clippedInfo.minRowBytes());
+        if (!pixmap.extractSubset(&clippedPixmap, clippedRect))
+            return makeUnexpected("Failed to extract clipped snapshot"_s);
+        pixmap = clippedPixmap;
+    }
+
+    auto image = SkImages::RasterFromPixmap(pixmap, [](const void*, void* context) {
+        g_bytes_unref(static_cast<GBytes*>(context));
+    }, bytes.leakRef());
+
+    if (!image)
+        return makeUnexpected("Failed to create snapshot image"_s);
+
+    return { ViewSnapshot::create(WTFMove(image)) };
+}
+
+Expected<Ref<ViewSnapshot>, String> AcceleratedBackingStore::takeSnapshot(std::optional<WebCore::IntRect>&& clipRect)
+{
+    if (!m_committedBuffer && !m_pendingBuffer) [[unlikely]]
+        return makeUnexpected("No buffer to create snapshot from"_s);
+
+    return saveBufferSnapshot(m_committedBuffer ? m_committedBuffer : m_pendingBuffer, WTFMove(clipRect));
+}
+
+#endif
 
 void AcceleratedBackingStore::renderPendingBuffer()
 {

--- a/Source/WebKit/UIProcess/wpe/AcceleratedBackingStore.h
+++ b/Source/WebKit/UIProcess/wpe/AcceleratedBackingStore.h
@@ -50,6 +50,7 @@ class UnixFileDescriptor;
 
 namespace WebKit {
 
+class ViewSnapshot;
 class WebPageProxy;
 class WebProcessProxy;
 
@@ -66,6 +67,10 @@ public:
     void deref() const final { RefCounted::deref(); }
 
     void updateSurfaceID(uint64_t);
+
+#if USE(SKIA)
+    Expected<Ref<ViewSnapshot>, String> takeSnapshot(std::optional<WebCore::IntRect>&&);
+#endif
 
     RendererBufferDescription bufferDescription() const;
 

--- a/WebDriverTests/TestExpectations.json
+++ b/WebDriverTests/TestExpectations.json
@@ -1950,28 +1950,37 @@
         "subtests": {
             "test_frame_element": {
                 "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/226134"}}
+            },
+            "test_source_origin[cross_origin]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/205994"}}
             }
         }
     },
 
     "imported/w3c/webdriver/tests/classic/take_element_screenshot/screenshot.py": {
         "subtests": {
-            "test_no_top_browsing_context": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/212950"}}
+            "test_no_such_element_with_shadow_root": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             },
-            "test_no_browsing_context": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/212950"}}
+            "test_no_such_element_from_other_window_handle[open]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+            },
+            "test_no_such_element_from_other_window_handle[closed]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+            },
+            "test_no_such_element_from_other_frame[open]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
+            },
+            "test_no_such_element_from_other_frame[closed]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230612"}}
             }
         }
     },
 
-    "imported/w3c/webdriver/tests/classic/take_screenshot/screenshot.py": {
+    "imported/w3c/webdriver/tests/classic/take_screenshot/iframe.py": {
         "subtests": {
-            "test_no_top_browsing_context": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/212950"}}
-            },
-            "test_no_browsing_context": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/212950"}}
+            "test_source_origin[cross_origin]": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/205994"}}
             }
         }
     },


### PR DESCRIPTION
#### 50c1d97fdef710ce465805de08a4d2d6c3c788f4
<pre>
[WPE][WebDriver] Support taking the screenshots from the UIProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=299732">https://bugs.webkit.org/show_bug.cgi?id=299732</a>

Reviewed by Carlos Garcia Campos.

Currently, WPE&apos;s implentation of taking screenshots rely on asking the
root `RenderLayer` on the WebProcess to paint its content. While it
worked fine for most elements, this approach could lead to differences
from the final composited frame that we send back to the UIProcess,
especially for some kinds of accelerated content, like animated 3D CSS
filters.

On top of that, the recent ANGLE bump in 295416@main included a stricter
check on ReadPixels that affected taking screenshots of WebGL scenes on
WebGL 1.0 environments, as the GraphicsContextGLAngle used it to read
the WebGL scenes contents for this code path.

To address these issues, this commits adds support for taking
screenshots on the UIProcess, by reading the last buffer committed to
the system.

* Source/WebKit/Shared/WebBackForwardListItem.h:
* Source/WebKit/SourcesWPE.txt:
* Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp:
(WebKit::PageClientImpl::takeViewSnapshot):
* Source/WebKit/UIProcess/API/wpe/PageClientImpl.h:
* Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.cpp:
(WKWPE::ViewPlatform::takeViewSnapshot):
* Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.h:
* Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp:
(WebKit::WebAutomationSession::takeScreenshot):
* Source/WebKit/UIProcess/Automation/skia/WebAutomationSessionSkia.cpp:
(WebKit::base64EncodedPNGData):
(WebKit::WebAutomationSession::platformGetBase64EncodedPNGData):
* Source/WebKit/UIProcess/PageClient.h:
* Source/WebKit/UIProcess/ViewSnapshotStore.cpp:
* Source/WebKit/UIProcess/ViewSnapshotStore.h:
(WebKit::ViewSnapshot::image const):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/skia/ViewSnapshotSkia.cpp: Copied from Source/WebKit/UIProcess/Automation/skia/WebAutomationSessionSkia.cpp.
(WebKit::ViewSnapshot::create):
(WebKit::ViewSnapshot::ViewSnapshot):
(WebKit::ViewSnapshot::hasImage const):
(WebKit::ViewSnapshot::clearImage):
(WebKit::ViewSnapshot::estimatedImageSizeInBytes const):
(WebKit::ViewSnapshot::size const):
* Source/WebKit/UIProcess/wpe/AcceleratedBackingStore.cpp:
(WebKit::getImageInfoFromBuffer):
(WebKit::saveBufferSnapshot):
(WebKit::AcceleratedBackingStore::takeSnapshot):
* Source/WebKit/UIProcess/wpe/AcceleratedBackingStore.h:
* WebDriverTests/TestExpectations.json:

Canonical link: <a href="https://commits.webkit.org/301948@main">https://commits.webkit.org/301948@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/965e9ff66aada9b922e56a505e0beb663fdbd960

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126748 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/46390 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/37359 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/133705 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78381 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47020 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54927 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96451 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64496 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129696 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37622 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/113365 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76975 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36503 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77098 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107441 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31848 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136282 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/53426 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41112 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104964 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53920 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109725 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104667 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26841 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50164 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28500 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50879 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/53354 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/59152 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52613 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55951 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/54362 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->