### PR TITLE
Address Safer CPP warnings in

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
@@ -86,7 +86,6 @@ UIProcess/mac/DisplayCaptureSessionManager.mm
 UIProcess/mac/PageClientImplMac.mm
 UIProcess/mac/SecItemShimProxy.cpp
 UIProcess/mac/TiledCoreAnimationDrawingAreaProxy.mm
-UIProcess/mac/ViewGestureControllerMac.mm
 UIProcess/mac/WKFullScreenWindowController.mm
 UIProcess/mac/WKImmediateActionController.mm
 UIProcess/mac/WKPrintingView.mm

--- a/Source/WebKit/UIProcess/ViewSnapshotStore.h
+++ b/Source/WebKit/UIProcess/ViewSnapshotStore.h
@@ -73,6 +73,7 @@ public:
 
 #if HAVE(IOSURFACE)
     id asLayerContents();
+    RetainPtr<id> asProtectedLayerContents();
     RetainPtr<CGImageRef> asImageForTesting();
 #endif
 

--- a/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
+++ b/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
@@ -562,7 +562,7 @@ String WebsiteDataStore::tempDirectoryFileSystemRepresentation(const String& dir
     static NeverDestroyed<RetainPtr<NSURL>> tempURL;
     
     dispatch_once(&onceToken, ^{
-        RetainPtr url = [NSURL fileURLWithPath:NSTemporaryDirectory() isDirectory:YES];
+        RetainPtr url = [NSURL fileURLWithPath:RetainPtr { NSTemporaryDirectory() }.get() isDirectory:YES];
         if (!url)
             RELEASE_ASSERT_NOT_REACHED();
         
@@ -802,9 +802,23 @@ static HashSet<WebCore::RegistrableDomain>& managedDomains()
     return managedDomains;
 }
 
-NSString *kManagedSitesIdentifier = @"com.apple.mail-shared";
-NSString *kCrossSiteTrackingPreventionRelaxedDomainsKey = @"CrossSiteTrackingPreventionRelaxedDomains";
-NSString *kCrossSiteTrackingPreventionRelaxedAppsKey = @"CrossSiteTrackingPreventionRelaxedApps";
+static NSString *managedSitesIdentifierSingleton()
+{
+    static NSString *identifier = @"com.apple.mail-shared";
+    return identifier;
+}
+
+static NSString *crossSiteTrackingPreventionRelaxedDomainsKeySingleton()
+{
+    static NSString *key = @"CrossSiteTrackingPreventionRelaxedDomains";
+    return key;
+}
+
+static NSString *crossSiteTrackingPreventionRelaxedAppsKeySingleton()
+{
+    static NSString *key = @"CrossSiteTrackingPreventionRelaxedApps";
+    return key;
+}
 
 void WebsiteDataStore::initializeManagedDomains(ForceReinitialization forceReinitialization)
 {
@@ -823,9 +837,9 @@ void WebsiteDataStore::initializeManagedDomains(ForceReinitialization forceReini
         bool isSafari = false;
 #if PLATFORM(MAC)
         isSafari = WTF::MacApplication::isSafari();
-        RetainPtr managedSitesPrefs = adoptNS([[NSDictionary alloc] initWithContentsOfFile:[adoptNS([[NSString alloc] initWithFormat:@"/Library/Managed Preferences/%@/%@.plist", NSUserName(), kManagedSitesIdentifier]) stringByStandardizingPath]]);
-        crossSiteTrackingPreventionRelaxedDomains = [managedSitesPrefs objectForKey:kCrossSiteTrackingPreventionRelaxedDomainsKey];
-        crossSiteTrackingPreventionRelaxedApps = [managedSitesPrefs objectForKey:kCrossSiteTrackingPreventionRelaxedAppsKey];
+        RetainPtr managedSitesPrefs = adoptNS([[NSDictionary alloc] initWithContentsOfFile:[adoptNS([[NSString alloc] initWithFormat:@"/Library/Managed Preferences/%@/%@.plist", RetainPtr { NSUserName() }.get(), managedSitesIdentifierSingleton()]) stringByStandardizingPath]]);
+        crossSiteTrackingPreventionRelaxedDomains = [managedSitesPrefs objectForKey:crossSiteTrackingPreventionRelaxedDomainsKeySingleton()];
+        crossSiteTrackingPreventionRelaxedApps = [managedSitesPrefs objectForKey:crossSiteTrackingPreventionRelaxedAppsKeySingleton()];
 #elif !PLATFORM(MACCATALYST)
         isSafari = WTF::IOSApplication::isMobileSafari();
         if ([PAL::getMCProfileConnectionClassSingleton() instancesRespondToSelector:@selector(crossSiteTrackingPreventionRelaxedDomains)])
@@ -926,7 +940,7 @@ void WebsiteDataStore::reinitializeManagedDomains()
 
 bool WebsiteDataStore::networkProcessHasEntitlementForTesting(const String& entitlement)
 {
-    return WTF::hasEntitlement(networkProcess().connection().xpcConnection(), entitlement);
+    return WTF::hasEntitlement(networkProcess().connection().protectedXPCConnection().get(), entitlement);
 }
 
 std::optional<double> WebsiteDataStore::defaultOriginQuotaRatio()

--- a/Source/WebKit/UIProcess/mac/ViewGestureControllerMac.mm
+++ b/Source/WebKit/UIProcess/mac/ViewGestureControllerMac.mm
@@ -385,12 +385,12 @@ void ViewGestureController::applyDebuggingPropertiesToSwipeViews()
 {
     RetainPtr filter = [CAFilter filterWithType:kCAFilterColorInvert];
     [m_swipeLayer setFilters:@[ filter.get() ]];
-    [m_swipeLayer setBackgroundColor:[NSColor blueColor].CGColor];
-    [m_swipeLayer setBorderColor:[NSColor yellowColor].CGColor];
+    [m_swipeLayer setBackgroundColor:RetainPtr { [NSColor blueColor].CGColor }.get()];
+    [m_swipeLayer setBorderColor:RetainPtr { [NSColor yellowColor].CGColor }.get()];
     [m_swipeLayer setBorderWidth:4];
 
-    [m_swipeSnapshotLayer setBackgroundColor:[NSColor greenColor].CGColor];
-    [m_swipeSnapshotLayer setBorderColor:[NSColor redColor].CGColor];
+    [m_swipeSnapshotLayer setBackgroundColor:RetainPtr { [NSColor greenColor].CGColor }.get()];
+    [m_swipeSnapshotLayer setBorderColor:RetainPtr { [NSColor redColor].CGColor }.get()];
     [m_swipeSnapshotLayer setBorderWidth:2];
 }
 
@@ -440,7 +440,7 @@ void ViewGestureController::beginSwipeGesture(WebBackForwardListItem* targetItem
     RetainPtr backgroundColor = CGColorGetConstantColor(kCGColorWhite);
     if (RefPtr snapshot = targetItem->snapshot()) {
         if (shouldUseSnapshotForSize(*snapshot, swipeArea.size(), obscuredContentInsets))
-            [m_swipeSnapshotLayer setContents:snapshot->asLayerContents()];
+            [m_swipeSnapshotLayer setContents:snapshot->asProtectedLayerContents().get()];
 
         Color coreColor = snapshot->backgroundColor();
         if (coreColor.isValid())
@@ -488,7 +488,7 @@ void ViewGestureController::beginSwipeGesture(WebBackForwardListItem* targetItem
         FloatRect dimmingRect(FloatPoint(), page->viewSize());
         m_swipeDimmingLayer = adoptNS([[CALayer alloc] init]);
         [m_swipeDimmingLayer setName:@"Gesture Swipe Dimming Layer"];
-        [m_swipeDimmingLayer setBackgroundColor:[NSColor blackColor].CGColor];
+        [m_swipeDimmingLayer setBackgroundColor:RetainPtr { [NSColor blackColor].CGColor }.get()];
         [m_swipeDimmingLayer setOpacity:swipeOverlayDimmingOpacity];
         [m_swipeDimmingLayer setAnchorPoint:CGPointZero];
         [m_swipeDimmingLayer setFrame:dimmingRect];

--- a/Source/WebKit/UIProcess/mac/ViewSnapshotStoreMac.mm
+++ b/Source/WebKit/UIProcess/mac/ViewSnapshotStoreMac.mm
@@ -98,6 +98,11 @@ id ViewSnapshot::asLayerContents()
     return m_surface->asLayerContents();
 }
 
+RetainPtr<id> ViewSnapshot::asProtectedLayerContents()
+{
+    return asLayerContents();
+}
+
 RetainPtr<CGImageRef> ViewSnapshot::asImageForTesting()
 {
     if (!m_surface)


### PR DESCRIPTION
#### 1b3b933ffb3df93ad337d745e0834c283376a507
<pre>
Address Safer CPP warnings in ViewGestureControllerMac.mm
<a href="https://bugs.webkit.org/show_bug.cgi?id=299840">https://bugs.webkit.org/show_bug.cgi?id=299840</a>

Reviewed by NOBODY (OOPS!).

* Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations:
* Source/WebKit/UIProcess/ViewSnapshotStore.h:
* Source/WebKit/UIProcess/mac/ViewGestureControllerMac.mm:
(WebKit::ViewGestureController::applyDebuggingPropertiesToSwipeViews):
(WebKit::ViewGestureController::beginSwipeGesture):
* Source/WebKit/UIProcess/mac/ViewSnapshotStoreMac.mm:
(WebKit::ViewSnapshot::asProtectedLayerContents):
</pre>
----------------------------------------------------------------------
#### a7eacb6312715a10446b94845355e6e8e1247b54
<pre>
Address Safer CPP warnings in WebsiteDataStoreCocoa.mm
<a href="https://bugs.webkit.org/show_bug.cgi?id=299839">https://bugs.webkit.org/show_bug.cgi?id=299839</a>

Reviewed by NOBODY (OOPS!).

* Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm:
(WebKit::WebsiteDataStore::tempDirectoryFileSystemRepresentation):
(WebKit::managedSitesIdentifierSingleton):
(WebKit::crossSiteTrackingPreventionRelaxedDomainsKeySingleton):
(WebKit::crossSiteTrackingPreventionRelaxedAppsKeySingleton):
(WebKit::WebsiteDataStore::initializeManagedDomains):
(WebKit::WebsiteDataStore::networkProcessHasEntitlementForTesting):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1b3b933ffb3df93ad337d745e0834c283376a507

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123682 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43397 "Hash 1b3b933f for PR 51538 does not build (failure)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34093 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130456 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/75827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/48d9f95c-5088-43fb-848b-7c65f9d9485a) 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44120 "Hash 1b3b933f for PR 51538 does not build (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51991 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/94046 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/75827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/769a02ac-f0b0-4118-b049-8b52466824b1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126635 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/130/builds/44120 "Hash 1b3b933f for PR 51538 does not build (failure)") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/110644 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/74649 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c97febdd-0b45-42a0-aabc-5f08e428a008) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/130/builds/44120 "Hash 1b3b933f for PR 51538 does not build (failure)") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73935 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/130/builds/44120 "Hash 1b3b933f for PR 51538 does not build (failure)") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/29027 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133146 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/50633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/38552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/102520 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/51008 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/106866 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/102360 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/25952 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/47453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/50487 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56249 "Found 1 new failure in UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm and found 1 fixed file: UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/49962 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/53308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/51636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->