### PR TITLE
DNS resolver is not started for all iOS simulators

### DIFF
--- a/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py
+++ b/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py
@@ -546,9 +546,6 @@ def _set_up_derived_options(port, options):
     if options.platform in ["gtk", "wpe"]:
         options.webkit_test_runner = True
 
-    options.local_dns_resolver = port.port_name in ["mac", "ios-simulator", "visionos-simulator"]
-
-
 def run(port, options, args, logging_stream):
     logger = logging.getLogger()
     logger.setLevel(logging.DEBUG if options.debug_rwt_logging else logging.INFO)

--- a/Tools/Scripts/webkitpy/layout_tests/servers/web_platform_test_server.py
+++ b/Tools/Scripts/webkitpy/layout_tests/servers/web_platform_test_server.py
@@ -132,7 +132,24 @@ class WebPlatformTestServer(http_server_base.HttpServerBase):
         self._wsout = None
         self._process = None
         self._dns_server = None
-        if port_obj.supports_localhost_aliases and port_obj.get_option('local_dns_resolver') and not port_obj.get_option('disable_wpt_hostname_aliases'):
+
+        port_has_local_dns_resolver = port_obj.port_name is not None and (port_obj.port_name == "mac" or "simulator" in port_obj.port_name)
+        use_local_dns_resolver = port_obj.supports_localhost_aliases and port_has_local_dns_resolver and not port_obj.get_option('disable_wpt_hostname_aliases')
+
+        if port_obj.supports_localhost_aliases:
+            print("Port supports localhost aliases")
+        else:
+            print("Port does not support localhost aliases")
+        if port_obj.get_option('disable_wpt_hostname_aliases'):
+            print("Port has disabled hostname aliases")
+        else:
+            print("Port has enabled hostname aliases")
+        if use_local_dns_resolver:
+            print("Using local DNS resolver for", port_obj.port_name)
+        else:
+            print("Not Using local DNS resolver for", port_obj.port_name)
+
+        if use_local_dns_resolver:
             logger = DNSLogger(logf=_log.debug)
             self._dns_server = DNSServer(Resolver(
                 allowed_hosts=port_obj.localhost_aliases()), port=8053, address="127.0.0.1", logger=logger)


### PR DESCRIPTION
#### e98c3bbd92a660136e880ba9bb1ea502efa90e10
<pre>
DNS resolver is not started for all iOS simulators
<a href="https://bugs.webkit.org/show_bug.cgi?id=299842">https://bugs.webkit.org/show_bug.cgi?id=299842</a>
<a href="https://rdar.apple.com/161616161">rdar://161616161</a>

Reviewed by Chris Dumez.

The current check using the port name is not correct in all cases. We should enable the resolver
for all port names containing &apos;simulator&apos;.

* Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py:
(_set_up_derived_options):
* Tools/Scripts/webkitpy/layout_tests/servers/web_platform_test_server.py:
(WebPlatformTestServer.__init__):

Canonical link: <a href="https://commits.webkit.org/300748@main">https://commits.webkit.org/300748@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d000c3cb3dc1421127e161d5998da100929c56a3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123747 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43462 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34159 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130525 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/75896 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/37424278-6181-4425-b013-7d801e745778) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/125624 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44186 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52056 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94110 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/62455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d549edef-eb09-4fd9-b4ec-b26362ab3d3a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126700 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35202 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110706 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74713 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/41820e26-e2b6-4aa8-b9be-d9d08d5b5b83) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/123103 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34160 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28865 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74004 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104925 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29089 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133215 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50698 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38608 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102587 "Found 1 new test failure: imported/blink/fast/pagination/viewport-y-horizontal-bt-rtl.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51073 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106925 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102416 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47757 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26011 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/47577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19470 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50553 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50027 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53373 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51701 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->