### PR TITLE
Address Safer CPP warnings in ViewGestureControllerMac.mm and WebPageProxyMac.mm

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations
@@ -29,5 +29,4 @@ UIProcess/mac/WKImmediateActionController.h
 UIProcess/mac/WKPrintingView.h
 UIProcess/mac/WKTextFinderClient.mm
 UIProcess/mac/WebDataListSuggestionsDropdownMac.mm
-UIProcess/mac/WebPageProxyMac.mm
 UIProcess/mac/WebViewImpl.mm

--- a/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
@@ -85,7 +85,6 @@ UIProcess/mac/DisplayCaptureSessionManager.mm
 UIProcess/mac/PageClientImplMac.mm
 UIProcess/mac/SecItemShimProxy.cpp
 UIProcess/mac/TiledCoreAnimationDrawingAreaProxy.mm
-UIProcess/mac/ViewGestureControllerMac.mm
 UIProcess/mac/WKFullScreenWindowController.mm
 UIProcess/mac/WKImmediateActionController.mm
 UIProcess/mac/WKPrintingView.mm
@@ -94,7 +93,6 @@ UIProcess/mac/WKTextAnimationManagerMac.mm
 UIProcess/mac/WebContextMenuProxyMac.mm
 UIProcess/mac/WebDataListSuggestionsDropdownMac.mm
 UIProcess/mac/WebDateTimePickerMac.mm
-UIProcess/mac/WebPageProxyMac.mm
 UIProcess/mac/WebPopupMenuProxyMac.mm
 UIProcess/mac/WebViewImpl.mm
 WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxyProcessor.cpp

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -521,6 +521,7 @@ public:
     virtual bool useFormSemanticContext() const = 0;
     
     virtual NSView *viewForPresentingRevealPopover() const = 0;
+    RetainPtr<NSView> protectedViewForPresentingRevealPopover() const;
 
     virtual void showPlatformContextMenu(NSMenu *, WebCore::IntPoint) = 0;
 

--- a/Source/WebKit/UIProcess/ViewSnapshotStore.h
+++ b/Source/WebKit/UIProcess/ViewSnapshotStore.h
@@ -73,6 +73,7 @@ public:
 
 #if HAVE(IOSURFACE)
     id asLayerContents();
+    RetainPtr<id> asProtectedLayerContents();
     RetainPtr<CGImageRef> asImageForTesting();
 #endif
 

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
@@ -1173,6 +1173,11 @@ void PageClientImpl::didChangeLocalInspectorAttachment()
 #endif
 }
 
+RetainPtr<NSView> PageClient::protectedViewForPresentingRevealPopover() const
+{
+    return viewForPresentingRevealPopover();
+}
+
 } // namespace WebKit
 
 #endif // PLATFORM(MAC)

--- a/Source/WebKit/UIProcess/mac/ViewGestureControllerMac.mm
+++ b/Source/WebKit/UIProcess/mac/ViewGestureControllerMac.mm
@@ -385,12 +385,12 @@ void ViewGestureController::applyDebuggingPropertiesToSwipeViews()
 {
     RetainPtr filter = [CAFilter filterWithType:kCAFilterColorInvert];
     [m_swipeLayer setFilters:@[ filter.get() ]];
-    [m_swipeLayer setBackgroundColor:[NSColor blueColor].CGColor];
-    [m_swipeLayer setBorderColor:[NSColor yellowColor].CGColor];
+    [m_swipeLayer setBackgroundColor:RetainPtr { [NSColor blueColor].CGColor }.get()];
+    [m_swipeLayer setBorderColor:RetainPtr { [NSColor yellowColor].CGColor }.get()];
     [m_swipeLayer setBorderWidth:4];
 
-    [m_swipeSnapshotLayer setBackgroundColor:[NSColor greenColor].CGColor];
-    [m_swipeSnapshotLayer setBorderColor:[NSColor redColor].CGColor];
+    [m_swipeSnapshotLayer setBackgroundColor:RetainPtr { [NSColor greenColor].CGColor }.get()];
+    [m_swipeSnapshotLayer setBorderColor:RetainPtr { [NSColor redColor].CGColor }.get()];
     [m_swipeSnapshotLayer setBorderWidth:2];
 }
 
@@ -440,7 +440,7 @@ void ViewGestureController::beginSwipeGesture(WebBackForwardListItem* targetItem
     RetainPtr backgroundColor = CGColorGetConstantColor(kCGColorWhite);
     if (RefPtr snapshot = targetItem->snapshot()) {
         if (shouldUseSnapshotForSize(*snapshot, swipeArea.size(), obscuredContentInsets))
-            [m_swipeSnapshotLayer setContents:snapshot->asLayerContents()];
+            [m_swipeSnapshotLayer setContents:snapshot->asProtectedLayerContents().get()];
 
         Color coreColor = snapshot->backgroundColor();
         if (coreColor.isValid())
@@ -488,7 +488,7 @@ void ViewGestureController::beginSwipeGesture(WebBackForwardListItem* targetItem
         FloatRect dimmingRect(FloatPoint(), page->viewSize());
         m_swipeDimmingLayer = adoptNS([[CALayer alloc] init]);
         [m_swipeDimmingLayer setName:@"Gesture Swipe Dimming Layer"];
-        [m_swipeDimmingLayer setBackgroundColor:[NSColor blackColor].CGColor];
+        [m_swipeDimmingLayer setBackgroundColor:RetainPtr { [NSColor blackColor].CGColor }.get()];
         [m_swipeDimmingLayer setOpacity:swipeOverlayDimmingOpacity];
         [m_swipeDimmingLayer setAnchorPoint:CGPointZero];
         [m_swipeDimmingLayer setFrame:dimmingRect];

--- a/Source/WebKit/UIProcess/mac/ViewSnapshotStoreMac.mm
+++ b/Source/WebKit/UIProcess/mac/ViewSnapshotStoreMac.mm
@@ -98,6 +98,11 @@ id ViewSnapshot::asLayerContents()
     return m_surface->asLayerContents();
 }
 
+RetainPtr<id> ViewSnapshot::asProtectedLayerContents()
+{
+    return asLayerContents();
+}
+
 RetainPtr<CGImageRef> ViewSnapshot::asImageForTesting()
 {
     if (!m_surface)


### PR DESCRIPTION
#### e776570a7e73c621e524262d647e3be7556ff983
<pre>
Address Safer CPP warnings in ViewGestureControllerMac.mm and WebPageProxyMac.mm
<a href="https://bugs.webkit.org/show_bug.cgi?id=299840">https://bugs.webkit.org/show_bug.cgi?id=299840</a>

Reviewed by Ryosuke Niwa.

* Source/WebKit/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations:
* Source/WebKit/UIProcess/PageClient.h:
* Source/WebKit/UIProcess/ViewSnapshotStore.h:
* Source/WebKit/UIProcess/mac/PageClientImplMac.mm:
(WebKit::PageClient::protectedViewForPresentingRevealPopover const):
* Source/WebKit/UIProcess/mac/ViewGestureControllerMac.mm:
(WebKit::ViewGestureController::applyDebuggingPropertiesToSwipeViews):
(WebKit::ViewGestureController::beginSwipeGesture):
* Source/WebKit/UIProcess/mac/ViewSnapshotStoreMac.mm:
(WebKit::ViewSnapshot::asProtectedLayerContents):
* Source/WebKit/UIProcess/mac/WebPageProxyMac.mm:
(-[WKPDFMenuTarget selectedMenuItem]):
(WebKit::WebPageProxy::getIsSpeaking):
(WebKit::WebPageProxy::speak):
(WebKit::WebPageProxy::stopSpeaking):
(WebKit::WebPageProxy::didPerformDictionaryLookup):
(WebKit::temporaryPDFDirectoryPath):
(WebKit::WebPageProxy::showTelephoneNumberMenu):
(WebKit::WebPageProxy::platformUnderPageBackgroundColor const):

Canonical link: <a href="https://commits.webkit.org/300743@main">https://commits.webkit.org/300743@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6dbc749ab0cf5133d1bfa60eacc18a18750b77d1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123701 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43416 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34112 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130475 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/75847 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ef53e203-0fc3-4da3-8c64-43bb4ee63447) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44139 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52010 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94064 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/75847 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/be4b5ae0-c52f-4a35-a340-37d96477a953) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126654 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35159 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110661 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74668 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/82a7e55a-7053-46ec-be4c-1d601aee94dc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34119 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73956 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104880 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29044 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133165 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50652 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38562 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102534 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51027 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106883 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102373 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26030 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47718 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25968 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/47479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50506 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56268 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49981 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53327 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51655 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->