### PR TITLE
Address more Safer CPP warnings in WebKit/WebProcess

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -48,6 +48,5 @@ WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm
 WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.mm
 WebProcess/WebPage/mac/WebPageMac.mm
 WebProcess/cocoa/PlaybackSessionManager.mm
-WebProcess/cocoa/UserMediaCaptureManager.cpp
 WebProcess/cocoa/VideoPresentationManager.mm
 WebProcess/cocoa/WebProcessCocoa.mm

--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -114,8 +114,6 @@ WebProcess/WebPage/mac/TiledCoreAnimationScrollingCoordinator.mm
 WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.mm
 WebProcess/WebPage/mac/WKAccessibilityWebPageObjectMac.mm
 WebProcess/cocoa/PlaybackSessionManager.mm
-WebProcess/cocoa/RemoteCaptureSampleManager.cpp
 WebProcess/cocoa/TextTrackRepresentationCocoa.mm
-WebProcess/cocoa/UserMediaCaptureManager.cpp
 WebProcess/cocoa/VideoPresentationManager.mm
 WebProcess/cocoa/WebProcessCocoa.mm

--- a/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
@@ -95,7 +95,6 @@ UIProcess/mac/WebDateTimePickerMac.mm
 UIProcess/mac/WebPopupMenuProxyMac.mm
 UIProcess/mac/WebViewImpl.mm
 WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxyProcessor.cpp
-WebProcess/GPU/webrtc/SharedVideoFrame.cpp
 WebProcess/InjectedBundle/API/Cocoa/WKWebProcessBundleParameters.mm
 WebProcess/InjectedBundle/API/mac/WKDOMInternals.mm
 WebProcess/InjectedBundle/API/mac/WKWebProcessPlugIn.mm

--- a/Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.h
@@ -117,6 +117,7 @@ public:
 
 private:
     CVPixelBufferPoolRef pixelBufferPool(const WebCore::SharedVideoFrameInfo&);
+    RetainPtr<CVPixelBufferPoolRef> protectedPixelBufferPool(const WebCore::SharedVideoFrameInfo&);
     RetainPtr<CVPixelBufferRef> readBufferFromSharedMemory();
 
     const RefPtr<RemoteVideoFrameObjectHeap> m_objectHeap;

--- a/Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.cpp
+++ b/Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.cpp
@@ -64,7 +64,7 @@ UserMediaCaptureManager::~UserMediaCaptureManager()
     RealtimeMediaSourceCenter::singleton().unsetDisplayCaptureFactory(m_displayFactory);
     RealtimeMediaSourceCenter::singleton().unsetVideoCaptureFactory(m_videoFactory);
     m_process->removeMessageReceiver(Messages::UserMediaCaptureManager::messageReceiverName());
-    m_remoteCaptureSampleManager.stopListeningForIPC();
+    protectedRemoteCaptureSampleManager()->stopListeningForIPC();
 }
 
 void UserMediaCaptureManager::ref() const
@@ -236,7 +236,7 @@ CaptureSourceOrError UserMediaCaptureManager::VideoFactory::createVideoCaptureSo
         return CaptureSourceOrError { "Video capture in GPUProcess is not implemented"_s };
 #endif
     if (m_shouldCaptureInGPUProcess)
-        m_manager->m_remoteCaptureSampleManager.setVideoFrameObjectHeapProxy(&WebProcess::singleton().ensureGPUProcessConnection().videoFrameObjectHeapProxy());
+        m_manager->protectedRemoteCaptureSampleManager()->setVideoFrameObjectHeapProxy(&WebProcess::singleton().ensureProtectedGPUProcessConnection()->videoFrameObjectHeapProxy());
 
     return RemoteRealtimeVideoSource::create(device, constraints, WTFMove(hashSalts), m_manager, m_shouldCaptureInGPUProcess, pageIdentifier);
 }
@@ -248,8 +248,8 @@ CaptureSourceOrError UserMediaCaptureManager::DisplayFactory::createDisplayCaptu
         return CaptureSourceOrError { "Display capture in GPUProcess is not implemented"_s };
 #endif
     if (m_shouldCaptureInGPUProcess) {
-        Ref videoFrameObjectHeapProxy = WebProcess::singleton().ensureGPUProcessConnection().videoFrameObjectHeapProxy();
-        m_manager->m_remoteCaptureSampleManager.setVideoFrameObjectHeapProxy(WTFMove(videoFrameObjectHeapProxy));
+        Ref videoFrameObjectHeapProxy = WebProcess::singleton().ensureProtectedGPUProcessConnection()->videoFrameObjectHeapProxy();
+        m_manager->protectedRemoteCaptureSampleManager()->setVideoFrameObjectHeapProxy(WTFMove(videoFrameObjectHeapProxy));
     }
 
     return RemoteRealtimeVideoSource::create(device, constraints, WTFMove(hashSalts), m_manager, m_shouldCaptureInGPUProcess, pageIdentifier);


### PR DESCRIPTION
#### 1770311fd05a624e36cf4c145e87c71aa1d6f60e
<pre>
Address more Safer CPP warnings in WebKit/WebProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=299848">https://bugs.webkit.org/show_bug.cgi?id=299848</a>

Reviewed by Darin Adler.

* Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations:
* Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.cpp:
(WebKit::SharedVideoFrameWriter::writeBuffer):
(WebKit::SharedVideoFrameReader::readBufferFromSharedMemory):
(WebKit::SharedVideoFrameReader::readBuffer):
(WebKit::SharedVideoFrameReader::protectedPixelBufferPool):
* Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.h:
* Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.cpp:
(WebKit::RemoteCaptureSampleManager::stopListeningForIPC):
(WebKit::RemoteCaptureSampleManager::setConnection):
(WebKit::RemoteCaptureSampleManager::videoFrameAvailable):
(WebKit::RemoteCaptureSampleManager::videoFrameAvailableCV):
(WebKit::RemoteCaptureSampleManager::RemoteAudio::stopThread):
* Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.cpp:
(WebKit::UserMediaCaptureManager::~UserMediaCaptureManager):
(WebKit::UserMediaCaptureManager::VideoFactory::createVideoCaptureSource):
(WebKit::UserMediaCaptureManager::DisplayFactory::createDisplayCaptureSource):

Canonical link: <a href="https://commits.webkit.org/300780@main">https://commits.webkit.org/300780@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/32a802560bff4843a2efbb8a5fd57bc345e13672

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123700 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43415 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34111 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130474 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/75846 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6ad0c208-7218-40ce-8fb5-a263923e9331) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44138 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52009 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94062 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62426 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1d95a1d2-73c5-4989-947d-812a20aaf8ed) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126653 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35158 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110659 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74666 "Found 1 new API test failure: TestWTF:WTF_Condition.OneProducerOneConsumerOneSlotTimeout (failure)") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ef39be98-86a3-4f60-b50d-6ef5f34364ab) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34118 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73955 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104879 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29042 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133164 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50651 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38561 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102533 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51026 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106881 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102372 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26054 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47717 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25966 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/47478 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50505 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56267 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49980 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53326 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51654 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->