### PR TITLE
Suppress some Safer CPP false positives in the UIProcess

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/RetainPtrCtorAdoptCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/RetainPtrCtorAdoptCheckerExpectations
@@ -10,7 +10,6 @@ Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
 UIProcess/API/Cocoa/NSAttributedString.mm
 UIProcess/API/Cocoa/WKBackForwardListItem.mm
 UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm
-UIProcess/Cocoa/ModelElementControllerCocoa.mm
 UIProcess/Cocoa/PageClientImplCocoa.mm
 UIProcess/mac/WebViewImpl.mm
 webpushd/_WKMockUserNotificationCenter.mm

--- a/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
@@ -74,9 +74,7 @@ UIProcess/Cocoa/UIDelegate.mm
 UIProcess/Cocoa/WKContactPicker.mm
 UIProcess/Cocoa/WKShareSheet.mm
 UIProcess/Cocoa/WKStorageAccessAlert.mm
-UIProcess/Cocoa/WebPageProxyCocoa.mm
 UIProcess/Cocoa/_WKWarningView.mm
-UIProcess/Gamepad/mac/UIGamepadProviderMac.mm
 UIProcess/Inspector/Cocoa/InspectorExtensionDelegate.mm
 UIProcess/Inspector/mac/WKInspectorViewController.mm
 UIProcess/Inspector/mac/WKInspectorWKWebView.mm

--- a/Source/WebKit/UIProcess/Cocoa/ModelElementControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/ModelElementControllerCocoa.mm
@@ -320,7 +320,8 @@ void ModelElementController::modelElementSizeDidChange(const String& uuid, WebCo
                 return;
             }
 
-            auto fenceSendRight = MachSendRight::adopt([strongFenceHandle copyPort]);
+            // FIXME: This is a safer cpp false positive.
+            SUPPRESS_RETAINPTR_CTOR_ADOPT auto fenceSendRight = MachSendRight::adopt([strongFenceHandle copyPort]);
             [strongFenceHandle invalidate];
             handler(WTFMove(fenceSendRight));
         });

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -373,7 +373,8 @@ void WebPageProxy::platformRegisterAttachment(Ref<API::Attachment>&& attachment,
     if (!pageClient)
         return;
 
-    RetainPtr fileWrapper = adoptNS([pageClient->allocFileWrapperInstance() initRegularFileWithContents:bufferCopy.unsafeBuffer()->createNSData().get()]);
+    // FIXME: This is a safer cpp false positive.
+    SUPPRESS_RETAINPTR_CTOR_ADOPT RetainPtr fileWrapper = adoptNS([pageClient->allocFileWrapperInstance() initRegularFileWithContents:bufferCopy.unsafeBuffer()->createNSData().get()]);
     [fileWrapper setPreferredFilename:preferredFileName.createNSString().get()];
     attachment->setFileWrapper(fileWrapper.get());
 }
@@ -387,7 +388,8 @@ void WebPageProxy::platformRegisterAttachment(Ref<API::Attachment>&& attachment,
     if (!pageClient)
         return;
 
-    RetainPtr fileWrapper = adoptNS([pageClient->allocFileWrapperInstance() initWithURL:adoptNS([[NSURL alloc] initFileURLWithPath:filePath.createNSString().get()]).get() options:0 error:nil]);
+    // FIXME: This is a safer cpp false positive.
+    SUPPRESS_RETAINPTR_CTOR_ADOPT RetainPtr fileWrapper = adoptNS([pageClient->allocFileWrapperInstance() initWithURL:adoptNS([[NSURL alloc] initFileURLWithPath:filePath.createNSString().get()]).get() options:0 error:nil]);
     attachment->setFileWrapper(fileWrapper.get());
 }
 

--- a/Source/WebKit/UIProcess/Gamepad/mac/UIGamepadProviderMac.mm
+++ b/Source/WebKit/UIProcess/Gamepad/mac/UIGamepadProviderMac.mm
@@ -39,13 +39,14 @@ namespace WebKit {
 WebPageProxy* UIGamepadProvider::platformWebPageProxyForGamepadInput()
 {
     ASSERT(hasProcessPrivilege(ProcessPrivilege::CanCommunicateWithWindowServer));
-    auto responder = [[NSApp keyWindow] firstResponder];
+    // This is a safer cpp false positive (<rdar://problem/161068288>).
+    SUPPRESS_UNRETAINED_ARG RetainPtr responder = [[NSApp keyWindow] firstResponder];
 
-    if (RetainPtr view = dynamic_objc_cast<WKWebView>(responder))
+    if (RetainPtr view = dynamic_objc_cast<WKWebView>(responder.get()))
         return view->_page.get();
 
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    if (RetainPtr view = dynamic_objc_cast<WKView>(responder))
+    if (RetainPtr view = dynamic_objc_cast<WKView>(responder.get()))
         return toImpl(view.get().pageRef);
 ALLOW_DEPRECATED_DECLARATIONS_END
 


### PR DESCRIPTION
#### 68ded6a55ff9efad424c2286ee3afd78ee55a246
<pre>
Suppress some Safer CPP false positives in the UIProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=299850">https://bugs.webkit.org/show_bug.cgi?id=299850</a>

Reviewed by Geoffrey Garen.

* Source/WebKit/SaferCPPExpectations/RetainPtrCtorAdoptCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations:
* Source/WebKit/UIProcess/Cocoa/ModelElementControllerCocoa.mm:
(WebKit::ModelElementController::modelElementSizeDidChange):
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::platformRegisterAttachment):
* Source/WebKit/UIProcess/Gamepad/mac/UIGamepadProviderMac.mm:
(WebKit::UIGamepadProvider::platformWebPageProxyForGamepadInput):

Canonical link: <a href="https://commits.webkit.org/300800@main">https://commits.webkit.org/300800@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9624c22e1cf2e5eb6a7c3ffcc049bfa2e1ba883a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123919 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43634 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34331 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130709 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/76070 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/956a570a-b66e-4367-be89-0f10da874c65) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44358 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52228 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/94253 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/76070 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0c25552f-522d-4557-90e0-56b443be561a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126873 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35340 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110851 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/74854 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1d92b7e6-2533-4007-ae3f-b95758c42ffd) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/34291 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74182 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105069 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29235 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133402 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50872 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/38743 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/102721 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51246 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107071 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/102548 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26073 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47892 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/26143 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/47725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50725 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56489 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50199 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53545 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51873 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->