### PR TITLE
[JSC] Add testwasmdebugger to JSC-only build configurations

### DIFF
--- a/Tools/Scripts/webkitperl/BuildSubproject.pm
+++ b/Tools/Scripts/webkitperl/BuildSubproject.pm
@@ -180,7 +180,7 @@ if (isCMakeBuild()) {
     unless (isAnyWindows()) {
         # By default we build using all of the available CPUs
         $makeArgs .= ($makeArgs ? " " : "") . "-j" . numberOfCPUs() if $makeArgs !~ /-j\s*\d+/;
-        $buildTarget = "jsc testb3 testair testapi testmasm testdfg $makeArgs";
+        $buildTarget = "jsc testb3 testair testapi testmasm testdfg testwasmdebugger $makeArgs";
     } elsif (canUseNinja()) {
         $buildTarget .= "jsc testapi testmasm";
     }

--- a/Tools/Scripts/webkitpy/common/config/ports.py
+++ b/Tools/Scripts/webkitpy/common/config/ports.py
@@ -218,6 +218,7 @@ class JscOnlyPort(DeprecatedPort):
         command.append("--no-testb3")
         command.append("--no-testdfg")
         command.append("--no-testapi")
+        command.append("--no-testwasmdebugger")
         if 'JSCTESTS_OPTIONS' in os.environ:
             command += os.environ['JSCTESTS_OPTIONS'].split()
         return self._append_build_style_flag(command, build_style)

--- a/Tools/Scripts/webkitpy/common/config/ports_unittest.py
+++ b/Tools/Scripts/webkitpy/common/config/ports_unittest.py
@@ -67,4 +67,4 @@ class DeprecatedPortTest(unittest.TestCase):
         self.assertEqual(JscOnlyPort().build_jsc_command(), DeprecatedPort().script_shell_command("build-jsc") + ["--jsc-only"])
         self.assertEqual(JscOnlyPort().build_jsc_command(build_style="release"), DeprecatedPort().script_shell_command("build-jsc") + ["--jsc-only", "--release"])
         self.assertEqual(JscOnlyPort().build_jsc_command(build_style="debug"), DeprecatedPort().script_shell_command("build-jsc") + ["--jsc-only", "--debug"])
-        self.assertEqual(JscOnlyPort().run_javascriptcore_tests_command(build_style="debug"), DeprecatedPort().script_shell_command("run-javascriptcore-tests") + ['--no-fail-fast', '--no-testmasm', '--no-testair', '--no-testb3', '--no-testdfg', '--no-testapi', '--debug'])
+        self.assertEqual(JscOnlyPort().run_javascriptcore_tests_command(build_style="debug"), DeprecatedPort().script_shell_command("run-javascriptcore-tests") + ['--no-fail-fast', '--no-testmasm', '--no-testair', '--no-testb3', '--no-testdfg', '--no-testapi', '--no-testwasmdebugger', '--debug'])


### PR DESCRIPTION
#### f9dad6578607c24da3c66b90d8a9876359a799dc
<pre>
[JSC] Add testwasmdebugger to JSC-only build configurations
<a href="https://bugs.webkit.org/show_bug.cgi?id=299852">https://bugs.webkit.org/show_bug.cgi?id=299852</a>
<a href="https://rdar.apple.com/161623367">rdar://161623367</a>

Reviewed by Yusuke Suzuki.

testwasmdebugger was missing from JSC-only build configurations used by
EWS and testing infrastructure.

Updates:
- BuildSubproject.pm: Include testwasmdebugger in JSC-only CMake builds
- ports.py: Add --no-testwasmdebugger flag to JSC-only test runs
- ports_unittest.py: Update unit test to include new flag

This ensures testwasmdebugger is built and properly excluded from JSC-only
test runs, maintaining consistency with other JSC test binaries (testb3,
testair, testmasm, testdfg, testapi).

Canonical link: <a href="https://commits.webkit.org/300758@main">https://commits.webkit.org/300758@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f78b2bd74c230d3adb99a6337b39ec9bfd97d6dd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123707 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43422 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34118 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130481 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/75853 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d76f53f7-e777-42a6-b178-b558ed6451f1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/125584 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44145 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52016 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94067 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62427 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2ffe5e49-c6bb-4146-8b7d-6122d4b84f79) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126660 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35164 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110665 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74671 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/58767415-9294-427b-9bf8-280d508210a5) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/123063 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34124 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28825 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73963 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104885 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29048 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133171 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50658 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38567 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102542 "12 flakes 55 failures") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51033 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106887 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102379 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47723 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25972 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/47573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19475 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50512 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49987 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53333 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51661 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->