### PR TITLE
[GTK] Deploy more smart pointers in GTK

### DIFF
--- a/Source/WebKit/UIProcess/API/gtk/WebKitAuthenticationDialog.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitAuthenticationDialog.cpp
@@ -57,7 +57,7 @@ static void webkitAuthenticationDialogDestroy(WebKitAuthenticationDialog* authDi
 
 static void okButtonClicked(GtkButton*, WebKitAuthenticationDialog* authDialog)
 {
-    WebKitAuthenticationDialogPrivate* priv = authDialog->priv;
+    GRefPtr<WebKitAuthenticationDialogPrivate> priv = authDialog->priv;
     const char* username = gtk_entry_get_text(GTK_ENTRY(priv->loginEntry));
     const char* password = gtk_entry_get_text(GTK_ENTRY(priv->passwordEntry));
 #if USE(GTK4)
@@ -139,7 +139,7 @@ static void webkitAuthenticationDialogInitialize(WebKitAuthenticationDialog* aut
     gtk_widget_show(button);
 #endif
 
-    WebKitAuthenticationDialogPrivate* priv = authDialog->priv;
+    GRefPtr<WebKitAuthenticationDialogPrivate> priv = authDialog->priv;
     button = gtk_button_new_with_mnemonic(_("_Authenticate"));
     priv->defaultButton = button;
     g_signal_connect(button, "clicked", G_CALLBACK(okButtonClicked), authDialog);
@@ -282,7 +282,7 @@ static void webkitAuthenticationDialogUnmap(GtkWidget* widget)
 
 static void webkitAuthenticationDialogMap(GtkWidget* widget)
 {
-    WebKitAuthenticationDialogPrivate* priv = WEBKIT_AUTHENTICATION_DIALOG(widget)->priv;
+    GRefPtr<WebKitAuthenticationDialogPrivate> priv = WEBKIT_AUTHENTICATION_DIALOG(widget)->priv;
     gtk_widget_grab_focus(priv->loginEntry);
     auto* toplevel = gtk_widget_get_toplevel(widget);
     if (WebCore::widgetIsOnscreenToplevelWindow(toplevel))
@@ -293,7 +293,7 @@ static void webkitAuthenticationDialogMap(GtkWidget* widget)
 
 static void webkitAuthenticationDialogDispose(GObject* object)
 {
-    WebKitAuthenticationDialogPrivate* priv = WEBKIT_AUTHENTICATION_DIALOG(object)->priv;
+    GRefPtr<WebKitAuthenticationDialogPrivate> priv = WEBKIT_AUTHENTICATION_DIALOG(object)->priv;
     if (priv->authenticationCancelledID) {
         g_signal_handler_disconnect(priv->request.get(), priv->authenticationCancelledID);
         priv->authenticationCancelledID = 0;

--- a/Source/WebKit/UIProcess/API/gtk/WebKitAuthenticationDialog.h
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitAuthenticationDialog.h
@@ -21,7 +21,9 @@
 
 #include "WebKitAuthenticationRequest.h"
 #include "WebKitWebViewDialog.h"
+#include <wtf/glib/GRefPtr.h>
 #include <gtk/gtk.h>
+
 
 enum CredentialStorageMode {
     AllowPersistentStorage, // The user is asked whether to store credential information.
@@ -45,7 +47,7 @@ struct _WebKitAuthenticationDialog {
     WebKitWebViewDialog parent;
 
     /*< private >*/
-    WebKitAuthenticationDialogPrivate* priv;
+    GRefPtr<WebKitAuthenticationDialogPrivate> priv;
 };
 
 struct _WebKitAuthenticationDialogClass {

--- a/Source/WebKit/UIProcess/API/gtk/WebKitColorChooserRequest.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitColorChooserRequest.cpp
@@ -70,7 +70,7 @@ enum {
 };
 
 struct _WebKitColorChooserRequestPrivate {
-    WebKitColorChooser* colorChooser;
+    GRefPtr<WebKitColorChooser> colorChooser;
     GdkRGBA rgba;
     bool handled;
 };

--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebInspector.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebInspector.cpp
@@ -286,7 +286,7 @@ class WebKitInspectorClient final : public WebInspectorUIProxyClient {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(WebKitInspectorClient);
 public:
     explicit WebKitInspectorClient(WebKitWebInspector* inspector)
-        : m_inspector(inspector)
+        : m_inspector(adoptGRef(inspector))
     {
     }
 
@@ -294,19 +294,19 @@ private:
     bool openWindow(WebInspectorUIProxy&) override
     {
         gboolean returnValue;
-        g_signal_emit(m_inspector, signals[OPEN_WINDOW], 0, &returnValue);
+        g_signal_emit(m_inspector.get(), signals[OPEN_WINDOW], 0, &returnValue);
         return returnValue;
     }
 
     void didClose(WebInspectorUIProxy&) override
     {
-        g_signal_emit(m_inspector, signals[CLOSED], 0);
+        g_signal_emit(m_inspector.get(), signals[CLOSED], 0);
     }
 
     bool bringToFront(WebInspectorUIProxy&) override
     {
         gboolean returnValue;
-        g_signal_emit(m_inspector, signals[BRING_TO_FRONT], 0, &returnValue);
+        g_signal_emit(m_inspector.get(), signals[BRING_TO_FRONT], 0, &returnValue);
         return returnValue;
     }
 
@@ -316,20 +316,20 @@ private:
         if (uri == m_inspector->priv->inspectedURI)
             return;
         m_inspector->priv->inspectedURI = uri;
-        g_object_notify_by_pspec(G_OBJECT(m_inspector), sObjProperties[PROP_INSPECTED_URI]);
+        g_object_notify_by_pspec(G_OBJECT(m_inspector.get()), sObjProperties[PROP_INSPECTED_URI]);
     }
 
     bool attach(WebInspectorUIProxy&) override
     {
         gboolean returnValue;
-        g_signal_emit(m_inspector, signals[ATTACH], 0, &returnValue);
+        g_signal_emit(m_inspector.get(), signals[ATTACH], 0, &returnValue);
         return returnValue;
     }
 
     bool detach(WebInspectorUIProxy&) override
     {
         gboolean returnValue;
-        g_signal_emit(m_inspector, signals[DETACH], 0, &returnValue);
+        g_signal_emit(m_inspector.get(), signals[DETACH], 0, &returnValue);
         return returnValue;
     }
 
@@ -338,7 +338,7 @@ private:
         if (m_inspector->priv->attachedHeight == height)
             return;
         m_inspector->priv->attachedHeight = height;
-        g_object_notify_by_pspec(G_OBJECT(m_inspector), sObjProperties[PROP_ATTACHED_HEIGHT]);
+        g_object_notify_by_pspec(G_OBJECT(m_inspector.get()), sObjProperties[PROP_ATTACHED_HEIGHT]);
     }
 
     void didChangeAttachedWidth(WebInspectorUIProxy&, unsigned width) override
@@ -350,10 +350,10 @@ private:
         if (m_inspector->priv->canAttach == available)
             return;
         m_inspector->priv->canAttach = available;
-        g_object_notify_by_pspec(G_OBJECT(m_inspector), sObjProperties[PROP_CAN_ATTACH]);
+        g_object_notify_by_pspec(G_OBJECT(m_inspector.get()), sObjProperties[PROP_CAN_ATTACH]);
     }
 
-    WebKitWebInspector* m_inspector;
+    GRefPtr<WebKitWebInspector> m_inspector;
 };
 
 WebKitWebInspector* webkitWebInspectorCreate(WebInspectorUIProxy* webInspector)


### PR DESCRIPTION
#### 4bdf12d3e957703778d692abbf5987d06b6b2442
<pre>
[GTK] Deploy more smart pointers in GTK
<a href="https://bugs.webkit.org/show_bug.cgi?id=299856">https://bugs.webkit.org/show_bug.cgi?id=299856</a>

Reviewed by NOBODY (OOPS!).

Deploy more smart pointers in GTK

* Source/WebKit/UIProcess/API/gtk/WebKitAuthenticationDialog.cpp:
(okButtonClicked):
(webkitAuthenticationDialogInitialize):
(webkitAuthenticationDialogMap):
(webkitAuthenticationDialogDispose):
* Source/WebKit/UIProcess/API/gtk/WebKitAuthenticationDialog.h:
* Source/WebKit/UIProcess/API/gtk/WebKitColorChooserRequest.cpp:
* Source/WebKit/UIProcess/API/gtk/WebKitWebInspector.cpp:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4bdf12d3e957703778d692abbf5987d06b6b2442

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123710 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43425 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34121 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130485 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/75856 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44148 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52019 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94071 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62433 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126663 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35166 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110668 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74676 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34126 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73967 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104889 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29051 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133174 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50661 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38569 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102544 "39 flakes 69 failures") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51036 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106890 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102381 "Found 4 new API test failures: WebKitGTK/TestInspector:/webkit/WebKitWebInspector/default, WebKitGTK/TestUIClient:/webkit/WebKitWebView/color-chooser-request, WebKitGTK/TestInspector:/webkit/WebKitWebInspector/manual-attach-detach, WebKitGTK/TestInspector:/webkit/WebKitWebInspector/custom-container-destroyed (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47726 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25974 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/47575 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50515 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56277 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49990 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53336 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51664 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->