### PR TITLE
[GTK] Deploy more smart pointers in GTK (part 2)

### DIFF
--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
@@ -358,7 +358,11 @@ struct _WebKitWebViewBasePrivate {
     std::unique_ptr<DropTarget> dropTarget;
 #endif
 
-    GtkGesture* touchGestureGroup;
+    GRefPtr<GtkGesture> touchGestureGroup;
+    GRefPtr<GtkGesture> viewMultiPressGesture;
+    GRefPtr<GtkGesture> viewLongPressGesture;
+    GRefPtr<GtkGesture> viewDragGesture;
+    GRefPtr<GtkGesture> viewSwipeGesture;
     RefPtr<ViewGestureController> viewGestureController;
     bool isBackForwardNavigationGestureEnabled { false };
 
@@ -2367,8 +2371,8 @@ static void webkitWebViewBaseConstructed(GObject* object)
     gesture = gtk_gesture_click_new();
     gtk_widget_add_controller(viewWidget, GTK_EVENT_CONTROLLER(gesture));
 #else
-    auto* gesture = gtk_gesture_multi_press_new(viewWidget);
-    g_object_set_data_full(G_OBJECT(viewWidget), "wk-view-multi-press-gesture", gesture, g_object_unref);
+    priv->ViewMultiPressGesture = adoptRef(gtk_gesture_multi_press_new(viewWidget));
+    gesture = priv->ViewMultiPressGesture.get();
 #endif
     gtk_gesture_single_set_touch_only(GTK_GESTURE_SINGLE(gesture), TRUE);
     g_signal_connect_object(gesture, "pressed", G_CALLBACK(webkitWebViewBaseTouchPress), viewWidget, G_CONNECT_SWAPPED);
@@ -2377,23 +2381,22 @@ static void webkitWebViewBaseConstructed(GObject* object)
     // Touch gestures
 #if USE(GTK4)
     priv->touchGestureGroup = gtk_gesture_zoom_new();
-    gtk_widget_add_controller(viewWidget, GTK_EVENT_CONTROLLER(priv->touchGestureGroup));
+    gtk_widget_add_controller(viewWidget, GTK_EVENT_CONTROLLER(priv->touchGestureGroup.get()));
 #else
     priv->touchGestureGroup = gtk_gesture_zoom_new(viewWidget);
-    g_object_set_data_full(G_OBJECT(viewWidget), "wk-view-zoom-gesture", priv->touchGestureGroup, g_object_unref);
 #endif
-    g_signal_connect_object(priv->touchGestureGroup, "begin", G_CALLBACK(webkitWebViewBaseZoomBegin), viewWidget, G_CONNECT_SWAPPED);
-    g_signal_connect_object(priv->touchGestureGroup, "scale-changed", G_CALLBACK(webkitWebViewBaseZoomChanged), viewWidget, G_CONNECT_SWAPPED);
-    g_signal_connect_object(priv->touchGestureGroup, "end", G_CALLBACK(webkitWebViewBaseZoomEnd), viewWidget, G_CONNECT_SWAPPED);
+    g_signal_connect_object(priv->touchGestureGroup.get(), "begin", G_CALLBACK(webkitWebViewBaseZoomBegin), viewWidget, G_CONNECT_SWAPPED);
+    g_signal_connect_object(priv->touchGestureGroup.get(), "scale-changed", G_CALLBACK(webkitWebViewBaseZoomChanged), viewWidget, G_CONNECT_SWAPPED);
+    g_signal_connect_object(priv->touchGestureGroup.get(), "end", G_CALLBACK(webkitWebViewBaseZoomEnd), viewWidget, G_CONNECT_SWAPPED);
 
 #if USE(GTK4)
     gesture = gtk_gesture_long_press_new();
     gtk_widget_add_controller(viewWidget, GTK_EVENT_CONTROLLER(gesture));
 #else
-    gesture = gtk_gesture_long_press_new(viewWidget);
-    g_object_set_data_full(G_OBJECT(viewWidget), "wk-view-long-press-gesture", gesture, g_object_unref);
+    priv->viewLongPressGesture = gtk_gesture_long_press_new(viewWidget);
+    gesture = priv->viewLongPressGesture.get();
 #endif
-    gtk_gesture_group(gesture, priv->touchGestureGroup);
+    gtk_gesture_group(gesture, priv->touchGestureGroup.get());
     gtk_gesture_single_set_touch_only(GTK_GESTURE_SINGLE(gesture), TRUE);
     g_signal_connect_object(gesture, "pressed", G_CALLBACK(webkitWebViewBaseTouchLongPress), viewWidget, G_CONNECT_SWAPPED);
 
@@ -2401,10 +2404,10 @@ static void webkitWebViewBaseConstructed(GObject* object)
     gesture = gtk_gesture_drag_new();
     gtk_widget_add_controller(viewWidget, GTK_EVENT_CONTROLLER(gesture));
 #else
-    gesture = gtk_gesture_drag_new(viewWidget);
-    g_object_set_data_full(G_OBJECT(viewWidget), "wk-view-drag-gesture", gesture, g_object_unref);
+    priv->viewDragGesture = gtk_gesture_drag_new(viewWidget);
+    gesture = priv->viewDragGesture.get();
 #endif
-    gtk_gesture_group(gesture, priv->touchGestureGroup);
+    gtk_gesture_group(gesture, priv->touchGestureGroup.get());
     gtk_gesture_single_set_touch_only(GTK_GESTURE_SINGLE(gesture), TRUE);
     g_signal_connect_object(gesture, "drag-begin", G_CALLBACK(webkitWebViewBaseTouchDragBegin), viewWidget, G_CONNECT_SWAPPED);
     g_signal_connect_object(gesture, "drag-update", G_CALLBACK(webkitWebViewBaseTouchDragUpdate), viewWidget, G_CONNECT_SWAPPED);
@@ -2415,10 +2418,10 @@ static void webkitWebViewBaseConstructed(GObject* object)
     gesture = gtk_gesture_swipe_new();
     gtk_widget_add_controller(viewWidget, GTK_EVENT_CONTROLLER(gesture));
 #else
-    gesture = gtk_gesture_swipe_new(viewWidget);
-    g_object_set_data_full(G_OBJECT(viewWidget), "wk-view-swipe-gesture", gesture, g_object_unref);
+    priv->viewSwipeGesture = gtk_gesture_swipe_new(viewWidget);
+    gesture = priv->viewSwipeGesture.get();
 #endif
-    gtk_gesture_group(gesture, priv->touchGestureGroup);
+    gtk_gesture_group(gesture, priv->touchGestureGroup.get());
     gtk_gesture_single_set_touch_only(GTK_GESTURE_SINGLE(gesture), TRUE);
     g_signal_connect_object(gesture, "swipe", G_CALLBACK(webkitWebViewBaseTouchSwipe), viewWidget, G_CONNECT_SWAPPED);
 
@@ -3424,7 +3427,7 @@ void webkitWebViewBasePageGrabbedTouch(WebKitWebViewBase* webViewBase)
 {
     WebKitWebViewBasePrivate* priv = webViewBase->priv;
     priv->pageGrabbedTouch = true;
-    gtk_gesture_set_state(priv->touchGestureGroup, GTK_EVENT_SEQUENCE_DENIED);
+    gtk_gesture_set_state(priv->touchGestureGroup.get(), GTK_EVENT_SEQUENCE_DENIED);
 }
 
 void webkitWebViewBaseSetShouldNotifyFocusEvents(WebKitWebViewBase* webViewBase, bool shouldNotifyFocusEvents)


### PR DESCRIPTION
#### 162c8fa6a0f29eb1371d8e28372cde24e48045dd
<pre>
[GTK] Deploy more smart pointers in GTK (part 2)
<a href="https://bugs.webkit.org/show_bug.cgi?id=299862">https://bugs.webkit.org/show_bug.cgi?id=299862</a>

Reviewed by NOBODY (OOPS!).

Deploy more smart pointers in Gtk files

No new tests (OOPS!).
* Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp:
(webkitWebViewBaseConstructed):
(webkitWebViewBasePageGrabbedTouch):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/162c8fa6a0f29eb1371d8e28372cde24e48045dd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125541 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45203 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35950 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132399 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77429 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45890 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53764 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95610 "") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/63508 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128489 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36674 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112266 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76127 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35570 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75872 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106446 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30666 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135073 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52343 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40102 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104089 "Failure limit exceed. At least found 9 new test failures: compositing/backface-visibility/backface-visibility-hierarchical-transform.html compositing/color-matching/image-color-matching.html compositing/overflow/overflow-clip-with-accelerated-scrolling-ancestor.html compositing/text-on-large-layer.html css3/color-filters/color-filter-column-rule.html css3/filters/blur-filter-page-scroll-parents.html css3/filters/effect-invert-square.html css3/images/cross-fade-invalidation.html editing/style/designmode.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52783 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108482 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103825 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49187 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27498 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49529 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52232 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58028 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51586 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54939 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53281 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->