### PR TITLE
[OpenXR] Unsupported path errors trying to bind hand interaction profile in desktop

### DIFF
--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRInputSource.cpp
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRInputSource.cpp
@@ -143,7 +143,21 @@ XrResult OpenXRInputSource::suggestBindings(SuggestedBindings& bindings) const
         }
     };
 
+    auto isInteractionPathSupported = [](const ASCIILiteral& path) {
+        if (path == handInteractionProfilePath) {
+#if defined(XR_EXT_hand_interaction)
+            return OpenXRExtensions::singleton().isExtensionSupported(XR_EXT_HAND_INTERACTION_EXTENSION_NAME ""_span);
+#else
+            return false;
+#endif
+        }
+        return true;
+    };
+
     for (const auto& profile : openXRInteractionProfiles) {
+        if (!isInteractionPathSupported(profile.path))
+            continue;
+
         CHECK_XRCMD(createBinding(profile.path, m_gripAction, makeString(m_subactionPathName, s_inputGripPath), bindings));
         CHECK_XRCMD(createBinding(profile.path, m_pointerAction, makeString(m_subactionPathName, s_inputAimPath), bindings));
 


### PR DESCRIPTION
#### 3c67bdc9b9be20540a2f2f69d31fd4474c9b8b08
<pre>
[OpenXR] Unsupported path errors trying to bind hand interaction profile in desktop
<a href="https://bugs.webkit.org/show_bug.cgi?id=299864">https://bugs.webkit.org/show_bug.cgi?id=299864</a>

Reviewed by Carlos Garcia Campos.

Hand interaction profile is normally not supported by desktop runtimes.
That&apos;s why the runtime issues an unsupported path error while trying to bind it.

XR_ERROR_PATH_UNSUPPORTED: xrSuggestInteractionProfileBindings(suggestedBindings-&gt;interactionProfile
== &quot;/interaction_profiles/ext/hand_interaction_ext&quot;) used but XR_EXT_hand_interaction not enabled

The error is harmless but we can get rid of it by not binding unsupported
interaction profiles.

No new tests required as this just prevents an error from the
runtime from being shown. It does not affect functionality
because the unsupported interaction profile was ignored anyway.

* Source/WebKit/UIProcess/XR/openxr/OpenXRInputSource.cpp:
(WebKit::OpenXRInputSource::suggestBindings const):

Canonical link: <a href="https://commits.webkit.org/301129@main">https://commits.webkit.org/301129@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8e513464958a5a841252d7a39c26de10b40827fb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125045 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44713 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35451 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131893 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/76923 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45405 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53279 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/95183 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/76923 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127999 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/36241 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/111830 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75726 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/35156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75375 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106004 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30212 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134570 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51865 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/39660 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/103654 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52291 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108041 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103428 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26328 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48767 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27059 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48914 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51751 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57544 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51124 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54481 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52815 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->