### PR TITLE
[OpenXR] khrSimpleControllerName and handInteractionProfileName are really paths not names

### DIFF
--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRInputMappings.h
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRInputMappings.h
@@ -120,7 +120,7 @@ struct OpenXRInteractionProfile {
     std::span<const OpenXRAxis> axes;
 };
 
-constexpr ASCIILiteral handInteractionProfileName { "/interaction_profiles/ext/hand_interaction_ext"_s };
+constexpr ASCIILiteral handInteractionProfilePath { "/interaction_profiles/ext/hand_interaction_ext"_s };
 constexpr std::array<OpenXRProfileId, 3> handInteractionProfileIds { "generic-hand-select-grasp", "generic-hand-select", "generic-hand" };
 constexpr std::array<OpenXRButton, 2> handInteractionProfileButtons {
     OpenXRButton { .type = OpenXRButtonType::Trigger, .path = s_pathPinchExt, .flags = OpenXRButtonFlags::Value, .hand = OpenXRHandFlags::Both },
@@ -128,14 +128,14 @@ constexpr std::array<OpenXRButton, 2> handInteractionProfileButtons {
 };
 
 constexpr OpenXRInteractionProfile handInteractionProfile {
-    handInteractionProfileName,
+    handInteractionProfilePath,
     handInteractionProfileIds,
     handInteractionProfileButtons,
     { }
 };
 
 // Default fallback when there isn't a specific controller binding.
-constexpr ASCIILiteral khrSimpleControllerName { "/interaction_profiles/khr/simple_controller"_s };
+constexpr ASCIILiteral khrSimpleControllerPath { "/interaction_profiles/khr/simple_controller"_s };
 constexpr std::array<ASCIILiteral, 1> khrSimpleProfileIds { "generic-button"_s };
 
 constexpr std::array<OpenXRButton, 1> khrSimpleButtons {
@@ -143,7 +143,7 @@ constexpr std::array<OpenXRButton, 1> khrSimpleButtons {
 };
 
 constexpr OpenXRInteractionProfile khrSimpleControllerProfile {
-    khrSimpleControllerName,
+    khrSimpleControllerPath,
     khrSimpleProfileIds,
     khrSimpleButtons,
     { }

--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRInputSource.cpp
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRInputSource.cpp
@@ -306,7 +306,7 @@ XrResult OpenXRInputSource::updateInteractionProfile()
     m_profiles.clear();
     for (auto& profile : openXRInteractionProfiles) {
         if (equalSpans(profile.path.span(), unsafeSpan(buffer))) {
-            m_usingHandInteractionProfile = equalSpans(profile.path.span(), handInteractionProfileName.span());
+            m_usingHandInteractionProfile = equalSpans(profile.path.span(), handInteractionProfilePath.span());
             LOG(XR, "Input source %s using interaction profile %s", m_subactionPathName.utf8().data(), profile.path.span().data());
             for (const auto& id : profile.profileIds)
                 m_profiles.append(String::fromUTF8(id));


### PR DESCRIPTION
#### 7ac2bdf74c88b7d35d067a9143f01a43961ee692
<pre>
[OpenXR] khrSimpleControllerName and handInteractionProfileName are really paths not names
<a href="https://bugs.webkit.org/show_bug.cgi?id=299870">https://bugs.webkit.org/show_bug.cgi?id=299870</a>

Reviewed by Adrian Perez de Castro.

Both store paths in the path tree. They are not names.

No new tests as this is just a trivial rename.

* Source/WebKit/UIProcess/XR/openxr/OpenXRInputMappings.h:
* Source/WebKit/UIProcess/XR/openxr/OpenXRInputSource.cpp:
(WebKit::OpenXRInputSource::updateInteractionProfile):

Canonical link: <a href="https://commits.webkit.org/300806@main">https://commits.webkit.org/300806@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/74c3becc71d6b5f55759161e70f1446ea3d644ad

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123744 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43459 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34155 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130522 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/75893 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44182 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52053 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94109 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62453 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126697 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35199 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110702 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74712 "Found 1 new API test failure: TestWTF:WTF_Condition.OneProducerOneConsumerOneSlot (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34158 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74001 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104922 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29085 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133211 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50695 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38605 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102585 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51070 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106920 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102411 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26082 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47755 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26007 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/47527 "Hash 74c3becc for PR 51558 does not build (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50549 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56316 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50024 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53370 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51698 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->