### PR TITLE
[OpenXR][GTK][WPE] TestWebCore.GraphicsContextGLTextureMapperTest/AnyContextAttributeTest.WebXRBlitTest/* fail

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp
+++ b/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp
@@ -495,6 +495,18 @@ void GraphicsContextGLTextureMapperANGLE::enableFoveation(GCGLuint)
 void GraphicsContextGLTextureMapperANGLE::disableFoveation()
 {
 }
+
+bool GraphicsContextGLTextureMapperANGLE::enableRequiredWebXRExtensions()
+{
+    if (!makeContextCurrent())
+        return false;
+
+    return enableExtension("GL_ANGLE_framebuffer_multisample"_s)
+        && enableExtension("GL_ANGLE_framebuffer_blit"_s)
+        && enableExtension("GL_EXT_discard_framebuffer"_s)
+        && enableExtension("GL_OES_EGL_image"_s)
+        && enableExtension("GL_OES_rgb8_rgba8"_s);
+}
 #endif
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.h
+++ b/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.h
@@ -65,6 +65,8 @@ public:
     bool addFoveation(IntSize, IntSize, IntSize, std::span<const GCGLfloat>, std::span<const GCGLfloat>, std::span<const GCGLfloat>) final;
     void enableFoveation(GCGLuint) final;
     void disableFoveation() final;
+
+    bool enableRequiredWebXRExtensions() override;
 #endif
 
 protected:

--- a/Tools/TestWebKitAPI/Tests/WebCore/glib/GraphicsContextGLTextureMapper.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/glib/GraphicsContextGLTextureMapper.cpp
@@ -393,7 +393,7 @@ TEST_P(AnyContextAttributeTest, WebXRBlitTest)
         PlatformGLObject color = gl->createRenderbuffer();
         ASSERT_NE(color, 0u);
         gl->bindRenderbuffer(GL::RENDERBUFFER, color);
-        gl->renderbufferStorageMultisampleANGLE(GL::RENDERBUFFER, 0, GL::BGRA_EXT, 2, 2);
+        gl->renderbufferStorageMultisampleANGLE(GL::RENDERBUFFER, 0, GL::RGBA8, 2, 2);
         gl->framebufferRenderbuffer(GL::DRAW_FRAMEBUFFER, GL::COLOR_ATTACHMENT0, GL::RENDERBUFFER, color);
     }
     {

--- a/Tools/TestWebKitAPI/glib/TestExpectations.json
+++ b/Tools/TestWebKitAPI/glib/TestExpectations.json
@@ -282,30 +282,6 @@
             },
             "ImageBufferTests/AnyTwoImageBufferOptionsTest.PutPixelBufferAffectsDrawOutput/1byteobject011byteobject01": {
                 "expected": {"all": {"status": ["SKIP"], "bug":"webkit.org/b/286456"}}
-            },
-            "GraphicsContextGLTextureMapperTest/AnyContextAttributeTest.WebXRBlitTest/truetruetrue": {
-                "expected": {"all": {"status": ["FAIL"], "bug":"webkit.org/b/299730"}}
-            },
-            "GraphicsContextGLTextureMapperTest/AnyContextAttributeTest.WebXRBlitTest/truetruefalse": {
-                "expected": {"all": {"status": ["FAIL"], "bug":"webkit.org/b/299730"}}
-            },
-            "GraphicsContextGLTextureMapperTest/AnyContextAttributeTest.WebXRBlitTest/truefalsetrue": {
-                "expected": {"all": {"status": ["FAIL"], "bug":"webkit.org/b/299730"}}
-            },
-            "GraphicsContextGLTextureMapperTest/AnyContextAttributeTest.WebXRBlitTest/truefalsefalse": {
-                "expected": {"all": {"status": ["FAIL"], "bug":"webkit.org/b/299730"}}
-            },
-            "GraphicsContextGLTextureMapperTest/AnyContextAttributeTest.WebXRBlitTest/falsetruetrue": {
-                "expected": {"all": {"status": ["FAIL"], "bug":"webkit.org/b/299730"}}
-            },
-            "GraphicsContextGLTextureMapperTest/AnyContextAttributeTest.WebXRBlitTest/falsetruefalse": {
-                "expected": {"all": {"status": ["FAIL"], "bug":"webkit.org/b/299730"}}
-            },
-            "GraphicsContextGLTextureMapperTest/AnyContextAttributeTest.WebXRBlitTest/falsefalsetrue": {
-                "expected": {"all": {"status": ["FAIL"], "bug":"webkit.org/b/299730"}}
-            },
-            "GraphicsContextGLTextureMapperTest/AnyContextAttributeTest.WebXRBlitTest/falsefalsefalse": {
-                "expected": {"all": {"status": ["FAIL"], "bug":"webkit.org/b/299730"}}
             }
         }
     },


### PR DESCRIPTION
#### 994571cc50755b9608be0e26c94921dd3d190558
<pre>
[OpenXR][GTK][WPE] TestWebCore.GraphicsContextGLTextureMapperTest/AnyContextAttributeTest.WebXRBlitTest/* fail
<a href="https://bugs.webkit.org/show_bug.cgi?id=299730">https://bugs.webkit.org/show_bug.cgi?id=299730</a>

Reviewed by Sergio Villar Senin.

An API test for WebXR was failing due to missing required OpenGL
features for WebXR. Enabled the required features. BGRA_EXT doesn&apos;t
seem to be supported. Replaced it with RGBA8.

Test: Tools/TestWebKitAPI/Tests/WebCore/glib/GraphicsContextGLTextureMapper.cpp

* Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp:
(WebCore::GraphicsContextGLTextureMapperANGLE::enableRequiredWebXRExtensions):
* Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.h:
* Tools/TestWebKitAPI/Tests/WebCore/glib/GraphicsContextGLTextureMapper.cpp:
(TestWebKitAPI::TEST_P):
* Tools/TestWebKitAPI/glib/TestExpectations.json:

Canonical link: <a href="https://commits.webkit.org/301194@main">https://commits.webkit.org/301194@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/17c5b2baa8de4b35ff2c7b0f4f97bec524f96f79

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124564 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44237 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34970 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131399 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76519 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/126441 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44944 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52811 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94920 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62843 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127518 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35827 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111391 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75331 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34764 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29545 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74881 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105581 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29777 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134067 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51420 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39241 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103231 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51828 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107613 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103013 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48378 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26639 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48356 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19608 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51291 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57084 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50696 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54052 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52380 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->