### PR TITLE
REGRESSION (273213@main): ImageBitmap fails to report memory cost

### DIFF
--- a/LayoutTests/fast/images/imagebitmap-memory-expected.html
+++ b/LayoutTests/fast/images/imagebitmap-memory-expected.html
@@ -1,0 +1,8 @@
+<body style="margin: 0px;">
+<canvas id="c" width="2017" height="3333" style="image-rendering: pixelated"></canvas>
+<script>
+let ctx = c.getContext("2d");
+ctx.fillStyle = "lime";
+ctx.fillRect(8, 9, 200, 200);
+</script>
+</body>

--- a/LayoutTests/fast/images/imagebitmap-memory.html
+++ b/LayoutTests/fast/images/imagebitmap-memory.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ runSingly=true ] -->
+<html>
+<body style="margin: 0px;">
+<canvas id="c" width="2017" height="3333" style="image-rendering: pixelated"></canvas>
+<script>
+// Creates a lot of ImageBitmaps in order to test that GC collects them
+// before memory runs out. Tests that ImageBitmaps report their sizes to
+// GC, so that GC is run when many of the images are alive.
+function heapSize()
+{
+    if (window.internals)
+        return internals.memoryInfo().usedJSHeapSize;
+    return 0;
+}
+
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+async function runTest() {
+    $vm?.gc();
+    const rounds = 200;
+    const heapSizeBefore = heapSize();
+    let ctx = c.getContext("2d");
+    let imageBitmap;
+    for (let i = 0; i < rounds; ++i) {
+        ctx.fillStyle = (i % 2 == 1) ? "lime" : "red";
+        ctx.fillRect(8, 9, 200, 200);
+        imageBitmap = await createImageBitmap(c);
+    }
+    ctx.clearRect(0, 0, c.width, c.height);
+
+    let succeeded = true;
+    if (window.internals) {
+        let heapUsed = heapSize() - heapSizeBefore;
+        if (heapUsed > 0 && heapUsed < 400000000) {
+            // If heapSize() can be used to detect effect of ImageBitmap, and GC was able to free memory
+            // during the loop, the ImageBitmap memory cost reporting is likely to be ok.
+            // The backing store takes 26mb, so test tests that at GC leaves at most 14 uncollected at the
+            // time of the check. Note, we don't want to force GC, as we test that GC decides to run by 
+            // itself.
+            succeeded = true;
+        } else {
+            succeeded = false;
+            $vm?.print(`heap used: ${heapUsed}`);
+        }
+    }
+    if (succeeded)
+        ctx.drawImage(imageBitmap, 0, 0); // Verify the bitmaps work.
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+
+window.onload = runTest;
+</script>
+</body>
+</html>

--- a/Source/WebCore/html/ImageBitmap.h
+++ b/Source/WebCore/html/ImageBitmap.h
@@ -172,10 +172,9 @@ private:
     static void createCompletionHandler(ScriptExecutionContext&, RefPtr<ImageData>&, ImageBitmapOptions&&, std::optional<IntRect>, ImageBitmapCompletionHandler&&);
     static void createCompletionHandler(ScriptExecutionContext&, RefPtr<CSSStyleImageValue>&, ImageBitmapOptions&&, std::optional<IntRect>, ImageBitmapCompletionHandler&&);
     static void createFromBuffer(ScriptExecutionContext&, Ref<ArrayBuffer>&&, String mimeType, long long expectedContentLength, const URL&, ImageBitmapOptions&&, std::optional<IntRect>, ImageBitmapCompletionHandler&&);
-    void updateMemoryCost();
 
     RefPtr<ImageBuffer> m_bitmap;
-    std::atomic<size_t> m_memoryCost { 0 };
+    std::atomic<size_t> m_memoryCost { 0 }; // Atomic, accessed from arbitrary thread by GC.
     const bool m_originClean : 1 { false };
     const bool m_premultiplyAlpha : 1 { false };
     const bool m_forciblyPremultiplyAlpha : 1 { false };


### PR DESCRIPTION
#### 6d1a61fa69dfe8e0a4b64ef6d629681068f37dd1
<pre>
REGRESSION (273213@main): ImageBitmap fails to report memory cost
<a href="https://bugs.webkit.org/show_bug.cgi?id=295618">https://bugs.webkit.org/show_bug.cgi?id=295618</a>
<a href="https://rdar.apple.com/155563791">rdar://155563791</a>

Reviewed by Matt Woodrow.

GC would not be triggered when many or large ImageBitmaps were
allocated.

Update ImageBitmap::m_memoryCost when creating the instance. This will
be used by bindings ReportExtraMemoryCost feature to report
the extra memory cost to the JS heap when the binding object is created
and visited.

Test: fast/images/imagebitmap-memory.html
* LayoutTests/fast/images/imagebitmap-memory-expected.html: Added.
* LayoutTests/fast/images/imagebitmap-memory.html: Added.
* Source/WebCore/html/ImageBitmap.cpp:
(WebCore::ImageBitmap::detach):
(WebCore::ImageBitmap::ImageBitmap):
(WebCore::ImageBitmap::~ImageBitmap):
(WebCore::ImageBitmap::takeImageBuffer):
(WebCore::ImageBitmap::memoryCost const):
(WebCore::ImageBitmap::updateMemoryCost): Deleted.
* Source/WebCore/html/ImageBitmap.h:

Canonical link: <a href="https://commits.webkit.org/300870@main">https://commits.webkit.org/300870@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/445765d8ea942682ef5f299d780b4a55c6f30f26

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124176 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43869 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34586 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131003 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/76268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/db64b0e6-a9b5-4f6f-a4a6-ea568b149305) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/126053 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44610 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52469 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/94458 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/76268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/09a6d3c7-842f-448b-b44e-0af12fd18782) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127130 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35548 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111074 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75049 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/627c7a36-553c-48ba-9297-6e005a267302) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/34492 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29236 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74489 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105289 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/29457 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133683 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51099 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38945 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/102932 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51485 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107292 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/102738 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26128 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48093 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26342 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/47988 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50960 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56735 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50407 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53759 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52083 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->