### PR TITLE
Address safer CPP warnings in WebViewImpl.mm

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/RetainPtrCtorAdoptCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/RetainPtrCtorAdoptCheckerExpectations
@@ -9,5 +9,4 @@ Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
 UIProcess/API/Cocoa/NSAttributedString.mm
 UIProcess/API/Cocoa/WKBackForwardListItem.mm
 UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm
-UIProcess/mac/WebViewImpl.mm
 webpushd/_WKMockUserNotificationCenter.mm

--- a/Source/WebKit/Shared/mac/PasteboardTypes.h
+++ b/Source/WebKit/Shared/mac/PasteboardTypes.h
@@ -37,12 +37,12 @@ public:
     static NSString * const WebURLPboardType;
     static NSString * const WebURLNamePboardType;
     static NSString * const WebDummyPboardType;
-    
-    static NSArray *forEditing();
-    static NSArray *forURL();
-    static NSArray *forImages();
-    static NSArray *forImagesWithArchive();
-    static NSArray *forSelection();
+
+    static NSArray *forEditingSingleton();
+    static NSArray *forURLSingleton();
+    static NSArray *forImagesSingleton();
+    static NSArray *forImagesWithArchiveSingleton();
+    static NSArray *forSelectionSingleton();
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/mac/PasteboardTypes.mm
+++ b/Source/WebKit/Shared/mac/PasteboardTypes.mm
@@ -39,8 +39,8 @@ NSString * const PasteboardTypes::WebURLsWithTitlesPboardType = @"WebURLsWithTit
 NSString * const PasteboardTypes::WebURLPboardType = @"public.url";
 NSString * const PasteboardTypes::WebURLNamePboardType = @"public.url-name";
 NSString * const PasteboardTypes::WebDummyPboardType = @"Apple WebKit dummy pasteboard type";
-    
-NSArray* PasteboardTypes::forEditing()
+
+NSArray* PasteboardTypes::forEditingSingleton()
 {
     static NeverDestroyed<RetainPtr<NSArray>> types = @[
         WebArchivePboardType,
@@ -59,7 +59,7 @@ NSArray* PasteboardTypes::forEditing()
     return types.get().get();
 }
 
-NSArray* PasteboardTypes::forURL()
+NSArray* PasteboardTypes::forURLSingleton()
 {
     static NeverDestroyed<RetainPtr<NSArray>> types = @[
         WebURLsWithTitlesPboardType,
@@ -73,7 +73,7 @@ NSArray* PasteboardTypes::forURL()
     return types.get().get();
 }
 
-NSArray* PasteboardTypes::forImages()
+NSArray* PasteboardTypes::forImagesSingleton()
 {
     static NeverDestroyed<RetainPtr<NSArray>> types = @[
         WebCore::legacyTIFFPasteboardTypeSingleton(),
@@ -86,7 +86,7 @@ NSArray* PasteboardTypes::forImages()
     return types.get().get();
 }
 
-NSArray* PasteboardTypes::forImagesWithArchive()
+NSArray* PasteboardTypes::forImagesWithArchiveSingleton()
 {
     static NeverDestroyed<RetainPtr<NSArray>> types = @[
         WebCore::legacyTIFFPasteboardTypeSingleton(),
@@ -101,7 +101,7 @@ NSArray* PasteboardTypes::forImagesWithArchive()
     return types.get().get();
 }
 
-NSArray* PasteboardTypes::forSelection()
+NSArray* PasteboardTypes::forSelectionSingleton()
 {
     static NeverDestroyed<RetainPtr<NSArray>> types = @[
         WebArchivePboardType,
@@ -113,7 +113,7 @@ NSArray* PasteboardTypes::forSelection()
     ];
     return types.get().get();
 }
-    
+
 } // namespace WebKit
 
 #endif // PLATFORM(MAC)

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -229,10 +229,12 @@ public:
     ~WebViewImpl();
 
     NSWindow *window();
+    RetainPtr<NSWindow> protectedWindow();
 
     WebPageProxy& page() { return m_page.get(); }
 
     WKWebView *view() const { return m_view.getAutoreleased(); }
+    RetainPtr<WKWebView> protectedView() const { return m_view.get(); };
 
     void processWillSwap();
     void processDidExit();
@@ -401,6 +403,7 @@ public:
 #if ENABLE(FULLSCREEN_API)
     bool hasFullScreenWindowController() const;
     WKFullScreenWindowController *fullScreenWindowController();
+    RetainPtr<WKFullScreenWindowController> protectedFullScreenWindowController();
     void closeFullScreenWindowController();
 #endif
     NSView *fullScreenPlaceholderView();
@@ -907,7 +910,7 @@ private:
 #endif
 
 #if ENABLE(IMAGE_ANALYSIS)
-    CocoaImageAnalyzer *ensureImageAnalyzer();
+    CocoaImageAnalyzer* ensureImageAnalyzer();
     int32_t processImageAnalyzerRequest(CocoaImageAnalyzerRequest *, CompletionHandler<void(RetainPtr<CocoaImageAnalysis>&&, NSError *)>&&);
 #endif
 
@@ -1070,8 +1073,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 #endif
 
 #if ENABLE(IMAGE_ANALYSIS)
-    RefPtr<WorkQueue> m_imageAnalyzerQueue;
-    RetainPtr<CocoaImageAnalyzer> m_imageAnalyzer;
+    const RefPtr<WorkQueue> m_imageAnalyzerQueue;
+    const RetainPtr<CocoaImageAnalyzer> m_imageAnalyzer;
 #endif
 
 #if ENABLE(IMAGE_ANALYSIS_ENHANCEMENTS)

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -281,7 +281,8 @@ WTF_DECLARE_CF_TYPE_TRAIT(CGImage);
 
 - (void)_settingsDidChange:(NSNotification *)notification
 {
-    _impl->accessibilitySettingsDidChange();
+    if (CheckedPtr impl = _impl.get())
+        impl->accessibilitySettingsDidChange();
 }
 
 @end
@@ -464,88 +465,88 @@ static void* keyValueObservingContext = &keyValueObservingContext;
 
 - (void)_windowDidOrderOnScreen:(NSNotification *)notification
 {
-    if (_impl)
-        _impl->windowDidOrderOnScreen();
+    if (CheckedPtr impl = _impl.get())
+        impl->windowDidOrderOnScreen();
 }
 
 - (void)_windowDidOrderOffScreen:(NSNotification *)notification
 {
-    if (_impl)
-        _impl->windowDidOrderOffScreen();
+    if (CheckedPtr impl = _impl.get())
+        impl->windowDidOrderOffScreen();
 }
 
 - (void)_windowDidBecomeKey:(NSNotification *)notification
 {
-    if (_impl)
-        _impl->windowDidBecomeKey([notification object]);
+    if (CheckedPtr impl = _impl.get())
+        impl->windowDidBecomeKey([notification object]);
 }
 
 - (void)_windowDidResignKey:(NSNotification *)notification
 {
-    if (_impl)
-        _impl->windowDidResignKey([notification object]);
+    if (CheckedPtr impl = _impl.get())
+        impl->windowDidResignKey([notification object]);
 }
 
 - (void)_windowDidMiniaturize:(NSNotification *)notification
 {
-    if (_impl)
-        _impl->windowDidMiniaturize();
+    if (CheckedPtr impl = _impl.get())
+        impl->windowDidMiniaturize();
 }
 
 - (void)_windowDidDeminiaturize:(NSNotification *)notification
 {
-    if (_impl)
-        _impl->windowDidDeminiaturize();
+    if (CheckedPtr impl = _impl.get())
+        impl->windowDidDeminiaturize();
 }
 
 - (void)_windowDidMove:(NSNotification *)notification
 {
-    if (_impl)
-        _impl->windowDidMove();
+    if (CheckedPtr impl = _impl.get())
+        impl->windowDidMove();
 }
 
 - (void)_windowDidResize:(NSNotification *)notification
 {
-    if (_impl)
-        _impl->windowDidResize();
+    if (CheckedPtr impl = _impl.get())
+        impl->windowDidResize();
 }
 
 - (void)_windowWillBeginSheet:(NSNotification *)notification
 {
-    if (_impl)
-        _impl->windowWillBeginSheet();
+    if (CheckedPtr impl = _impl.get())
+        impl->windowWillBeginSheet();
 }
 
 - (void)_windowDidChangeBackingProperties:(NSNotification *)notification
 {
-    if (!_impl)
-        return;
-    CGFloat oldBackingScaleFactor = [[notification.userInfo objectForKey:NSBackingPropertyOldScaleFactorKey] doubleValue];
-    _impl->windowDidChangeBackingProperties(oldBackingScaleFactor);
+    if (CheckedPtr impl = _impl.get()) {
+        CGFloat oldBackingScaleFactor = [[notification.userInfo objectForKey:NSBackingPropertyOldScaleFactorKey] doubleValue];
+        impl->windowDidChangeBackingProperties(oldBackingScaleFactor);
+    }
 }
 
 - (void)_windowDidChangeScreen:(NSNotification *)notification
 {
-    if (_impl)
-        _impl->windowDidChangeScreen();
+    if (CheckedPtr impl = _impl.get())
+        impl->windowDidChangeScreen();
 }
 
 - (void)_windowDidChangeOcclusionState:(NSNotification *)notification
 {
-    if (_impl)
-        _impl->windowDidChangeOcclusionState();
+    if (CheckedPtr impl = _impl.get())
+        impl->windowDidChangeOcclusionState();
 }
 
 - (void)_windowWillClose:(NSNotification *)notification
 {
-    if (_impl)
-        _impl->windowWillClose();
+    if (CheckedPtr impl = _impl.get())
+        impl->windowWillClose();
 }
 
 - (void)_screenDidChangeColorSpace:(NSNotification *)notification
 {
-    if (_impl)
-        _impl->screenDidChangeColorSpace();
+    if (CheckedPtr impl = _impl.get())
+        impl->screenDidChangeColorSpace();
 }
 
 #if HAVE(SUPPORT_HDR_DISPLAY_APIS)
@@ -569,15 +570,14 @@ static void* keyValueObservingContext = &keyValueObservingContext;
         return;
     }
 
-    if (!_impl)
-        return;
-
-    if ([keyPath isEqualToString:@"visible"] && [NSFontPanel sharedFontPanelExists] && object == [NSFontPanel sharedFontPanel]) {
-        _impl->updateFontManagerIfNeeded();
-        return;
+    if (CheckedPtr impl = _impl.get()) {
+        if ([keyPath isEqualToString:@"visible"] && [NSFontPanel sharedFontPanelExists] && object == [NSFontPanel sharedFontPanel]) {
+            impl->updateFontManagerIfNeeded();
+            return;
+        }
+        if ([keyPath isEqualToString:@"contentLayoutRect"] || [keyPath isEqualToString:@"titlebarAppearsTransparent"])
+            impl->updateContentInsetsIfAutomatic();
     }
-    if ([keyPath isEqualToString:@"contentLayoutRect"] || [keyPath isEqualToString:@"titlebarAppearsTransparent"])
-        _impl->updateContentInsetsIfAutomatic();
 }
 
 #if !ENABLE(REVEAL)
@@ -602,8 +602,8 @@ static void* keyValueObservingContext = &keyValueObservingContext;
 
 - (void)_activeSpaceDidChange:(NSNotification *)notification
 {
-    if (_impl)
-        _impl->activeSpaceDidChange();
+    if (CheckedPtr impl = _impl.get())
+        impl->activeSpaceDidChange();
 }
 
 @end
@@ -740,7 +740,8 @@ static void* keyValueObservingContext = &keyValueObservingContext;
 
 - (void)_web_grantDOMPasteAccess
 {
-    _impl->handleDOMPasteRequestForCategoryWithResult(_category, WebCore::DOMPasteAccessResponse::GrantedForGesture);
+    if (CheckedPtr impl = _impl.get())
+        impl->handleDOMPasteRequestForCategoryWithResult(_category, WebCore::DOMPasteAccessResponse::GrantedForGesture);
 }
 
 @end
@@ -1138,7 +1139,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 - (NSViewController *)textListViewController
 {
     if (!_textListTouchBarViewController)
-        _textListTouchBarViewController = adoptNS([[WKTextListTouchBarViewController alloc] initWithWebViewImpl:_webViewImpl.get()]);
+        _textListTouchBarViewController = adoptNS([[WKTextListTouchBarViewController alloc] initWithWebViewImpl:CheckedPtr { _webViewImpl.get() }.get()]);
     return _textListTouchBarViewController.get();
 }
 
@@ -1187,13 +1188,15 @@ static void* imageOverlayObservationContext = &imageOverlayObservationContext;
 
     _impl = impl;
     _overlayView = impl.imageAnalysisOverlayView();
-    [_overlayView addObserver:self forKeyPath:@"hasActiveTextSelection" options:NSKeyValueObservingOptionOld | NSKeyValueObservingOptionNew context:imageOverlayObservationContext];
+    RetainPtr overlayView = { _overlayView };
+    [overlayView.get() addObserver:self forKeyPath:@"hasActiveTextSelection" options:NSKeyValueObservingOptionOld | NSKeyValueObservingOptionNew context:imageOverlayObservationContext];
     return self;
 }
 
 - (void)dealloc
 {
-    [_overlayView removeObserver:self forKeyPath:@"hasActiveTextSelection"];
+    RetainPtr overlayView = _overlayView;
+    [overlayView removeObserver:self forKeyPath:@"hasActiveTextSelection"];
     [super dealloc];
 }
 
@@ -1204,7 +1207,7 @@ static void* imageOverlayObservationContext = &imageOverlayObservationContext;
 
     BOOL oldHasActiveTextSelection = [change[NSKeyValueChangeOldKey] boolValue];
     BOOL newHasActiveTextSelection = [change[NSKeyValueChangeNewKey] boolValue];
-    RetainPtr webView = _impl ? _impl->view() : nil;
+    RetainPtr webView = _impl ? CheckedPtr { _impl.get() }->view() : nil;
     RetainPtr<NSResponder> currentResponder = webView.get().window.firstResponder;
     if (oldHasActiveTextSelection && !newHasActiveTextSelection) {
         if (self.firstResponderIsInsideImageOverlay) {
@@ -1212,8 +1215,8 @@ static void* imageOverlayObservationContext = &imageOverlayObservationContext;
             [webView.get().window makeFirstResponder:webView.get()];
         }
     } else if (!oldHasActiveTextSelection && newHasActiveTextSelection) {
-        if (_lastOverlayResponderView && currentResponder.get() != _lastOverlayResponderView)
-            [webView.get().window makeFirstResponder:_lastOverlayResponderView];
+        if (RetainPtr lastOverlayResponderView = _lastOverlayResponderView; lastOverlayResponderView && currentResponder.get() != _lastOverlayResponderView)
+            [webView.get().window makeFirstResponder:lastOverlayResponderView.get()];
     }
 }
 
@@ -1222,7 +1225,7 @@ static void* imageOverlayObservationContext = &imageOverlayObservationContext;
     if (!_impl)
         return NO;
 
-    for (RetainPtr view = dynamic_objc_cast<NSView>(_impl->view().window.firstResponder); view; view = view.get().superview) {
+    for (RetainPtr view = dynamic_objc_cast<NSView>(CheckedPtr { _impl.get() }->protectedView().get().window.firstResponder); view; view = view.get().superview) {
         if (view == _overlayView)
             return YES;
     }
@@ -1242,7 +1245,7 @@ static void* imageOverlayObservationContext = &imageOverlayObservationContext;
         return CGRectMake(0, 0, 1, 1);
 
     auto unitInteractionRect = _impl->imageAnalysisInteractionBounds();
-    WebCore::FloatRect unobscuredRect = _impl->view().bounds;
+    WebCore::FloatRect unobscuredRect = CheckedPtr { _impl.get() }->protectedView().get().bounds;
     unitInteractionRect.moveBy(-unobscuredRect.location());
     unitInteractionRect.scale(1 / unobscuredRect.size());
     return unitInteractionRect;
@@ -1296,7 +1299,7 @@ WebViewImpl::WebViewImpl(WKWebView *view, WebProcessPool& processPool, Ref<API::
     static_cast<PageClientImpl&>(m_pageClient.get()).setImpl(*this);
 
     ASSERT(hasProcessPrivilege(ProcessPrivilege::CanCommunicateWithWindowServer));
-    [NSApp registerServicesMenuSendTypes:PasteboardTypes::forSelection() returnTypes:PasteboardTypes::forEditing()];
+    [NSApp registerServicesMenuSendTypes:PasteboardTypes::forSelectionSingleton() returnTypes:PasteboardTypes::forEditingSingleton()];
 
 #if ENABLE(TILED_CA_DRAWING_AREA)
     auto useRemoteLayerTree = [&]() {
@@ -1325,14 +1328,14 @@ WebViewImpl::WebViewImpl(WKWebView *view, WebProcessPool& processPool, Ref<API::
             // A layer hosting view may have already been created and added to the view hierarchy
             // in the process of initializing the WKWebView from an NSCoder.
             m_layerHostingView = layerHostingView.get();
-            [layerHostingView setFrame:[m_view bounds]];
+            [layerHostingView setFrame:[m_view.get() bounds]];
             break;
         }
     }
 
     if (!m_layerHostingView) {
         // Create an NSView that will host our layer tree.
-        m_layerHostingView = adoptNS([[WKFlippedView alloc] initWithFrame:[m_view bounds]]);
+        m_layerHostingView = adoptNS([[WKFlippedView alloc] initWithFrame:[m_view.get() bounds]]);
         [view addSubview:m_layerHostingView.get() positioned:NSWindowBelow relativeTo:nil];
     }
 
@@ -1416,7 +1419,12 @@ WebViewImpl::~WebViewImpl()
 
 NSWindow *WebViewImpl::window()
 {
-    return [m_view window];
+    return [m_view.get() window];
+}
+
+RetainPtr<NSWindow> WebViewImpl::protectedWindow()
+{
+    return window();
 }
 
 void WebViewImpl::handleProcessSwapOrExit()
@@ -1430,7 +1438,7 @@ void WebViewImpl::handleProcessSwapOrExit()
 
     hideDOMPasteMenuWithResult(WebCore::DOMPasteAccessResponse::DeniedForGesture);
 
-    [view() _updateFixedContainerEdges:FixedContainerEdges { }];
+    [m_view.get() _updateFixedContainerEdges:FixedContainerEdges { }];
 }
 
 void WebViewImpl::processWillSwap()
@@ -1468,7 +1476,7 @@ void WebViewImpl::setDrawsBackground(bool drawsBackground)
     m_page->setBackgroundColor(backgroundColor);
 
     // Make sure updateLayer gets called on the web view.
-    [m_view setNeedsDisplay:YES];
+    [m_view.get() setNeedsDisplay:YES];
 }
 
 bool WebViewImpl::drawsBackground() const
@@ -1482,7 +1490,7 @@ void WebViewImpl::setBackgroundColor(NSColor *backgroundColor)
     m_backgroundColor = backgroundColor;
 
     // Make sure updateLayer gets called on the web view.
-    [m_view setNeedsDisplay:YES];
+    [m_view.get() setNeedsDisplay:YES];
 }
 
 NSColor *WebViewImpl::backgroundColor() const
@@ -1521,7 +1529,7 @@ bool WebViewImpl::becomeFirstResponder()
         return true;
     }
 
-    NSSelectionDirection direction = [[m_view window] keyViewSelectionDirection];
+    NSSelectionDirection direction = [[m_view.get() window] keyViewSelectionDirection];
 
     m_inBecomeFirstResponder = true;
 
@@ -1550,10 +1558,11 @@ bool WebViewImpl::resignFirstResponder()
 {
     // Predict the case where we are losing first responder status only to
     // gain it back again. We want resignFirstResponder to do nothing in that case.
-    RetainPtr<id> nextResponder = [[m_view window] _newFirstResponderAfterResigning];
+    // FIXME: This is a safer cpp false-positive.
+    SUPPRESS_RETAINPTR_CTOR_ADOPT RetainPtr<id> nextResponder = [protectedWindow() _newFirstResponderAfterResigning];
 
     // FIXME: This will probably need to change once WKWebView doesn't contain a WKView.
-    if ([nextResponder isKindOfClass:[WKWebView class]] && [m_view superview] == nextResponder.get()) {
+    if ([nextResponder isKindOfClass:[WKWebView class]] && [m_view.get() superview] == nextResponder.get()) {
         m_willBecomeFirstResponderAgain = true;
         return true;
     }
@@ -1609,7 +1618,7 @@ void WebViewImpl::showWarningView(const BrowsingWarning& warning, CompletionHand
 
     m_page->logDiagnosticMessageWithValueDictionary("SafeBrowsing.ShowedWarning"_s, "Safari"_s, showedWarningDictionary, WebCore::ShouldSample::No);
 
-    m_warningView = adoptNS([[_WKWarningView alloc] initWithFrame:[m_view bounds] browsingWarning:warning completionHandler:[weakThis = WeakPtr { *this }, completionHandler = WTFMove(completionHandler)] (auto&& result) mutable {
+    m_warningView = adoptNS([[_WKWarningView alloc] initWithFrame:[m_view.get() bounds] browsingWarning:warning completionHandler:[weakThis = WeakPtr { *this }, completionHandler = WTFMove(completionHandler)] (auto&& result) mutable {
         completionHandler(WTFMove(result));
         if (!weakThis)
             return;
@@ -1646,7 +1655,7 @@ void WebViewImpl::showWarningView(const BrowsingWarning& warning, CompletionHand
         }
         [std::exchange(weakThis->m_warningView, nullptr) removeFromSuperview];
     }]);
-    [m_view addSubview:m_warningView.get()];
+    [m_view.get() addSubview:m_warningView.get()];
 }
 
 void WebViewImpl::clearWarningView()
@@ -1666,7 +1675,7 @@ bool WebViewImpl::isFocused() const
         return true;
     if (m_inResignFirstResponder)
         return false;
-    return [m_view window].firstResponder == m_view.getAutoreleased();
+    return [m_view.get() window].firstResponder == m_view.getAutoreleased();
 }
 
 void WebViewImpl::viewWillStartLiveResize()
@@ -1687,7 +1696,7 @@ void WebViewImpl::createPDFHUD(PDFPluginIdentifier identifier, WebCore::FrameIde
 {
     removePDFHUD(identifier);
     auto hud = adoptNS([[WKPDFHUDView alloc] initWithFrame:rect pluginIdentifier:identifier frameIdentifier:frameID page:m_page.get()]);
-    [m_view addSubview:hud.get()];
+    [m_view.get() addSubview:hud.get()];
     _pdfHUDViews.add(identifier, WTFMove(hud));
 }
 
@@ -1723,7 +1732,7 @@ void WebViewImpl::renewGState()
     suppressContentRelativeChildViews(ContentRelativeChildViewsSuppressionType::TemporarilyRemove);
 
     // Update the view frame.
-    if ([m_view window])
+    if ([m_view.get() window])
         updateWindowAndViewFrames();
 
     updateContentInsetsIfAutomatic();
@@ -1732,7 +1741,7 @@ void WebViewImpl::renewGState()
 void WebViewImpl::setFrameSize(CGSize)
 {
     [m_layoutStrategy didChangeFrameSize];
-    [m_warningView setFrame:[m_view bounds]];
+    [m_warningView setFrame:[m_view.get() bounds]];
 }
 
 void WebViewImpl::disableFrameSizeUpdates()
@@ -1755,7 +1764,7 @@ void WebViewImpl::setFrameAndScrollBy(CGRect frame, CGSize scrollDelta)
     if (!CGSizeEqualToSize(scrollDelta, CGSizeZero))
         m_scrollOffsetAdjustment = scrollDelta;
 
-    [m_view frame] = NSRectFromCGRect(frame);
+    [m_view.get() frame] = NSRectFromCGRect(frame);
 }
 
 void WebViewImpl::updateWindowAndViewFrames()
@@ -1766,7 +1775,7 @@ void WebViewImpl::updateWindowAndViewFrames()
     NSRect scrollViewFrame = this->scrollViewFrame();
     if (!NSEqualRects(m_lastScrollViewFrame, scrollViewFrame)) {
         m_lastScrollViewFrame = scrollViewFrame;
-        [m_view didChangeValueForKey:@"scrollViewFrame"];
+        [m_view.get() didChangeValueForKey:@"scrollViewFrame"];
     }
 
     updateTitlebarAdjacencyState();
@@ -1785,12 +1794,14 @@ void WebViewImpl::updateWindowAndViewFrames()
         NSRect viewFrameInWindowCoordinates = NSZeroRect;
         NSPoint accessibilityPosition = NSZeroPoint;
 
-        if (weakThis->m_needsViewFrameInWindowCoordinates)
-            viewFrameInWindowCoordinates = [weakThis->m_view convertRect:[weakThis->m_view frame] toView:nil];
+        if (weakThis->m_needsViewFrameInWindowCoordinates) {
+            RetainPtr view = weakThis->m_view.get();
+            viewFrameInWindowCoordinates = [view convertRect:[view frame] toView:nil];
+        }
 
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         if (WebCore::AXObjectCache::accessibilityEnabled())
-            accessibilityPosition = [[weakThis->m_view accessibilityAttributeValue:NSAccessibilityPositionAttribute] pointValue];
+            accessibilityPosition = [[weakThis->m_view.get() accessibilityAttributeValue:NSAccessibilityPositionAttribute] pointValue];
 ALLOW_DEPRECATED_DECLARATIONS_END
 
         weakThis->m_page->windowAndViewFramesChanged(viewFrameInWindowCoordinates, accessibilityPosition);
@@ -1845,7 +1856,7 @@ void WebViewImpl::setDrawingAreaSize(CGSize size)
 
 void WebViewImpl::updateLayer()
 {
-    [m_view layer].backgroundColor = drawsBackground() ? [backgroundColor() CGColor] : CGColorGetConstantColor(kCGColorClear);
+    [m_view.get() layer].backgroundColor = RetainPtr { drawsBackground() ? RetainPtr { backgroundColor() }.get().CGColor : CGColorGetConstantColor(kCGColorClear) }.get();
 }
 
 void WebViewImpl::drawRect(CGRect rect)
@@ -1915,7 +1926,7 @@ void WebViewImpl::prepareContentInRect(CGRect rect)
 
 void WebViewImpl::updateViewExposedRect()
 {
-    CGRect exposedRect = NSRectToCGRect([m_view visibleRect]);
+    CGRect exposedRect = NSRectToCGRect([m_view.get() visibleRect]);
 
     if (m_useContentPreparationRectForVisibleRect)
         exposedRect = CGRectUnion(m_contentPreparationRect, exposedRect);
@@ -1981,7 +1992,7 @@ void WebViewImpl::setIntrinsicContentSize(CGSize intrinsicContentSize)
         intrinsicContentSizeAcknowledgingFlexibleWidth.width = NSViewNoIntrinsicMetric;
 
     m_intrinsicContentSize = intrinsicContentSizeAcknowledgingFlexibleWidth;
-    [m_view invalidateIntrinsicContentSize];
+    [m_view.get() invalidateIntrinsicContentSize];
 }
 
 CGSize WebViewImpl::intrinsicContentSize() const
@@ -2067,7 +2078,7 @@ float WebViewImpl::intrinsicDeviceScaleFactor() const
 {
     if (m_targetWindowForMovePreparation)
         return [m_targetWindowForMovePreparation backingScaleFactor];
-    if (RetainPtr window = [m_view window])
+    if (RetainPtr window = [m_view.get() window])
         return window.get().backingScaleFactor;
     return [NSScreen mainScreen].backingScaleFactor;
 }
@@ -2100,7 +2111,7 @@ void WebViewImpl::windowDidOrderOnScreen()
 
 void WebViewImpl::windowDidBecomeKey(NSWindow *keyWindow)
 {
-    if (keyWindow == [m_view window] || keyWindow == [m_view window].attachedSheet) {
+    if (keyWindow == window() || keyWindow == [protectedWindow() attachedSheet]) {
 #if ENABLE(GAMEPAD)
         UIGamepadProvider::singleton().viewBecameActive(m_page.get());
 #endif
@@ -2111,7 +2122,7 @@ void WebViewImpl::windowDidBecomeKey(NSWindow *keyWindow)
 
 void WebViewImpl::windowDidResignKey(NSWindow *formerKeyWindow)
 {
-    if (formerKeyWindow == [m_view window] || formerKeyWindow == [m_view window].attachedSheet) {
+    if (formerKeyWindow == window() || formerKeyWindow == [protectedWindow() attachedSheet]) {
 #if ENABLE(GAMEPAD)
         UIGamepadProvider::singleton().viewBecameInactive(m_page.get());
 #endif
@@ -2160,7 +2171,7 @@ void WebViewImpl::windowDidChangeBackingProperties(CGFloat oldBackingScaleFactor
 
 void WebViewImpl::windowDidChangeScreen()
 {
-    RetainPtr window = m_targetWindowForMovePreparation ? m_targetWindowForMovePreparation.get() : [m_view window];
+    RetainPtr window = m_targetWindowForMovePreparation ? m_targetWindowForMovePreparation.get() : WebViewImpl::window();
     auto displayID = WebCore::displayID(window.get().screen);
     m_page->windowScreenDidChange(displayID);
 }
@@ -2188,7 +2199,7 @@ void WebViewImpl::applicationShouldSuppressHDR(bool suppress)
 
 bool WebViewImpl::mightBeginDragWhileInactive()
 {
-    if ([m_view window].isKeyWindow)
+    if ([m_view.get() window].isKeyWindow)
         return false;
 
     if (m_page->editorState().selectionIsNone || !m_page->editorState().selectionIsRange)
@@ -2221,7 +2232,7 @@ bool WebViewImpl::acceptsFirstMouse(NSEvent *event)
     // the current event prevents that from causing a problem inside WebKit or AppKit code.
     retainPtr(event).autorelease();
 
-    if (![m_view hitTest:event.locationInWindow])
+    if (![m_view.get() hitTest:event.locationInWindow])
         return false;
 
     auto previousEvent = setLastMouseDownEvent(event);
@@ -2240,14 +2251,14 @@ bool WebViewImpl::shouldDelayWindowOrderingForEvent(NSEvent *event)
     // the current event prevents that from causing a problem inside WebKit or AppKit code.
     retainPtr(event).autorelease();
 
-    if (![m_view hitTest:event.locationInWindow])
+    if (![m_view.get() hitTest:event.locationInWindow])
         return false;
 
     if (!page().protectedLegacyMainFrameProcess()->isResponsive())
         return false;
 
     if (page().editorState().hasPostLayoutData()) {
-        auto locationInView = [m_view convertPoint:event.locationInWindow fromView:nil];
+        auto locationInView = [m_view.get() convertPoint:event.locationInWindow fromView:nil];
         if (!page().selectionBoundingRectInRootViewCoordinates().contains(roundedIntPoint(locationInView)))
             return false;
     }
@@ -2260,14 +2271,14 @@ bool WebViewImpl::shouldDelayWindowOrderingForEvent(NSEvent *event)
 
 bool WebViewImpl::windowResizeMouseLocationIsInVisibleScrollerThumb(CGPoint point)
 {
-    NSPoint localPoint = [m_view convertPoint:NSPointFromCGPoint(point) fromView:nil];
+    NSPoint localPoint = [m_view.get() convertPoint:NSPointFromCGPoint(point) fromView:nil];
     NSRect visibleThumbRect = NSRect(m_page->visibleScrollerThumbRect());
-    return NSMouseInRect(localPoint, visibleThumbRect, [m_view isFlipped]);
+    return NSMouseInRect(localPoint, visibleThumbRect, [m_view.get() isFlipped]);
 }
 
 void WebViewImpl::viewWillMoveToWindowImpl(NSWindow *window)
 {
-    RetainPtr currentWindow = [m_view window];
+    RetainPtr currentWindow = WebViewImpl::window();
     if (window == currentWindow.get())
         return;
 
@@ -2295,7 +2306,7 @@ void WebViewImpl::viewWillMoveToWindow(NSWindow *window)
 
 void WebViewImpl::viewDidMoveToWindow()
 {
-    RetainPtr window = m_targetWindowForMovePreparation ? m_targetWindowForMovePreparation.get() : [m_view window];
+    RetainPtr window = m_targetWindowForMovePreparation ? m_targetWindowForMovePreparation.get() : WebViewImpl::window();
 
     LOG(ActivityState, "WebViewImpl %p viewDidMoveToWindow %p", this, window.get());
 
@@ -2313,8 +2324,8 @@ void WebViewImpl::viewDidMoveToWindow()
 
         accessibilityRegisterUIProcessTokens();
 
-        if (m_immediateActionGestureRecognizer && ![[m_view gestureRecognizers] containsObject:m_immediateActionGestureRecognizer.get()] && !m_ignoresNonWheelEvents && m_allowsLinkPreview)
-            [m_view addGestureRecognizer:m_immediateActionGestureRecognizer.get()];
+        if (m_immediateActionGestureRecognizer && ![[m_view.get() gestureRecognizers] containsObject:m_immediateActionGestureRecognizer.get()] && !m_ignoresNonWheelEvents && m_allowsLinkPreview)
+            [m_view.get() addGestureRecognizer:m_immediateActionGestureRecognizer.get()];
     } else {
         OptionSet<WebCore::ActivityState> activityStateChanges { WebCore::ActivityState::WindowIsActive, WebCore::ActivityState::IsVisible };
         if (m_shouldDeferViewInWindowChanges)
@@ -2329,7 +2340,7 @@ void WebViewImpl::viewDidMoveToWindow()
         if (m_immediateActionGestureRecognizer) {
             // Work around <rdar://problem/22646404> by explicitly cancelling the animation.
             cancelImmediateActionAnimation();
-            [m_view removeGestureRecognizer:m_immediateActionGestureRecognizer.get()];
+            [m_view.get() removeGestureRecognizer:m_immediateActionGestureRecognizer.get()];
         }
 
         removeFlagsChangedEventMonitor();
@@ -2341,7 +2352,7 @@ void WebViewImpl::viewDidMoveToWindow()
 
 void WebViewImpl::viewDidChangeBackingProperties()
 {
-    RetainPtr<NSColorSpace> colorSpace = [m_view window].colorSpace;
+    RetainPtr<NSColorSpace> colorSpace = protectedWindow().get().colorSpace;
     if ([colorSpace isEqualTo:m_colorSpace.get()])
         return;
 
@@ -2376,7 +2387,7 @@ void WebViewImpl::pageDidScroll(const IntPoint& scrollPosition)
     if (pageIsScrolledToTop == m_pageIsScrolledToTop)
         return;
 
-    [m_view willChangeValueForKey:@"hasScrolledContentsUnderTitlebar"];
+    [m_view.get() willChangeValueForKey:@"hasScrolledContentsUnderTitlebar"];
 
     m_pageIsScrolledToTop = pageIsScrolledToTop;
 
@@ -2385,7 +2396,7 @@ void WebViewImpl::pageDidScroll(const IntPoint& scrollPosition)
     updatePrefersSolidColorHardPocket();
 #endif
 
-    [m_view didChangeValueForKey:@"hasScrolledContentsUnderTitlebar"];
+    [m_view.get() didChangeValueForKey:@"hasScrolledContentsUnderTitlebar"];
 }
 
 #if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
@@ -2428,10 +2439,10 @@ void WebViewImpl::updateTopScrollPocketCaptureColor()
 NSRect WebViewImpl::scrollViewFrame()
 {
     auto insets = obscuredContentInsets();
-    FloatRect boundsAdjustedByHorizontalInsets = [m_view bounds];
+    FloatRect boundsAdjustedByHorizontalInsets = [m_view.get() bounds];
     boundsAdjustedByHorizontalInsets.shiftXEdgeBy(insets.left());
     boundsAdjustedByHorizontalInsets.shiftMaxXEdgeBy(-insets.right());
-    return [m_view convertRect:boundsAdjustedByHorizontalInsets toView:nil];
+    return [m_view.get() convertRect:boundsAdjustedByHorizontalInsets toView:nil];
 }
 
 bool WebViewImpl::hasScrolledContentsUnderTitlebar()
@@ -2441,14 +2452,14 @@ bool WebViewImpl::hasScrolledContentsUnderTitlebar()
 
 void WebViewImpl::updateTitlebarAdjacencyState()
 {
-    RetainPtr window = [m_view window];
-    bool visible = ![m_view isHiddenOrHasHiddenAncestor];
-    CGFloat topOfWindowContentLayoutRectInSelf = NSMinY([m_view convertRect:[window contentLayoutRect] fromView:nil]);
-    bool topOfWindowContentLayoutRectAdjacent = NSMinY([m_view bounds]) <= topOfWindowContentLayoutRectInSelf;
+    RetainPtr window = WebViewImpl::window();
+    bool visible = ![m_view.get() isHiddenOrHasHiddenAncestor];
+    CGFloat topOfWindowContentLayoutRectInSelf = NSMinY([m_view.get() convertRect:[window contentLayoutRect] fromView:nil]);
+    bool topOfWindowContentLayoutRectAdjacent = NSMinY([m_view.get() bounds]) <= topOfWindowContentLayoutRectInSelf;
 
-    bool shouldRegister = topOfWindowContentLayoutRectAdjacent && visible && [[m_view effectiveAppearance] _usesMetricsAppearance];
+    bool shouldRegister = topOfWindowContentLayoutRectAdjacent && visible && [[m_view.get() effectiveAppearance] _usesMetricsAppearance];
 
-    if (shouldRegister && !m_isRegisteredScrollViewSeparatorTrackingAdapter && [m_view conformsToProtocol:@protocol(NSScrollViewSeparatorTrackingAdapter)]) {
+    if (shouldRegister && !m_isRegisteredScrollViewSeparatorTrackingAdapter && [m_view.get() conformsToProtocol:RetainPtr { @protocol(NSScrollViewSeparatorTrackingAdapter) }.get()]) {
         m_isRegisteredScrollViewSeparatorTrackingAdapter = [window registerScrollViewSeparatorTrackingAdapter:(NSObject<NSScrollViewSeparatorTrackingAdapter> *)m_view.get().get()];
     } else if (!shouldRegister && m_isRegisteredScrollViewSeparatorTrackingAdapter) {
         [window unregisterScrollViewSeparatorTrackingAdapter:(NSObject<NSScrollViewSeparatorTrackingAdapter> *)m_view.get().get()];
@@ -2463,7 +2474,7 @@ void WebViewImpl::scrollToRect(const WebCore::FloatRect& targetRect, const WebCo
 
 RetainPtr<NSView> WebViewImpl::hitTest(CGPoint point)
 {
-    RetainPtr hitView = [m_view _web_superHitTest:NSPointFromCGPoint(point)];
+    RetainPtr hitView = [m_view.get() _web_superHitTest:NSPointFromCGPoint(point)];
     if (hitView && hitView == m_layerHostingView)
         hitView = m_view.get();
 
@@ -2485,8 +2496,8 @@ WebCore::DestinationColorSpace WebViewImpl::colorSpace()
         m_colorSpace = [&] () -> NSColorSpace * {
             if (m_targetWindowForMovePreparation)
                 return [m_targetWindowForMovePreparation colorSpace];
-            
-            if (RetainPtr window = [m_view window])
+
+            if (RetainPtr window = [m_view.get() window])
                 return [window colorSpace];
 
             return nil;
@@ -2608,7 +2619,7 @@ void WebViewImpl::setFontForWebView(NSFont *font, id sender)
 
 void WebViewImpl::updateSecureInputState()
 {
-    if (![[m_view window] isKeyWindow] || !isFocused()) {
+    if (![protectedWindow() isKeyWindow] || !isFocused()) {
         if (m_inSecureInputState) {
             DisableSecureEventInput();
             m_inSecureInputState = false;
@@ -2616,7 +2627,7 @@ void WebViewImpl::updateSecureInputState()
         return;
     }
     // WKView has a single input context for all editable areas (except for plug-ins).
-    RetainPtr context = [m_view _web_superInputContext];
+    RetainPtr context = [m_view.get() _web_superInputContext];
     bool isInPasswordField = m_page->editorState().isInPasswordField;
 
     if (isInPasswordField) {
@@ -2647,12 +2658,12 @@ void WebViewImpl::notifyInputContextAboutDiscardedComposition()
     // <rdar://problem/9359055>: -discardMarkedText can only be called for active contexts.
     // FIXME: We fail to ever notify the input context if something (e.g. a navigation) happens while the window is not key.
     // This is not a problem when the window is key, because we discard marked text on resigning first responder.
-    if (![[m_view window] isKeyWindow] || m_view.getAutoreleased() != [[m_view window] firstResponder])
+    if (![[m_view.get() window] isKeyWindow] || m_view.getAutoreleased() != [[m_view.get() window] firstResponder])
         return;
 
     LOG(TextInput, "-> discardMarkedText");
 
-    [[m_view _web_superInputContext] discardMarkedText]; // Inform the input method that we won't have an inline input area despite having been asked to.
+    [[m_view.get() _web_superInputContext] discardMarkedText]; // Inform the input method that we won't have an inline input area despite having been asked to.
 }
 
 void WebViewImpl::handleAcceptedAlternativeText(const String& acceptedAlternative)
@@ -2692,9 +2703,14 @@ bool WebViewImpl::hasFullScreenWindowController() const
 WKFullScreenWindowController *WebViewImpl::fullScreenWindowController()
 {
     if (!m_fullScreenWindowController)
-        m_fullScreenWindowController = adoptNS([[WKFullScreenWindowController alloc] initWithWindow:fullScreenWindow() webView:m_view.getAutoreleased() page:m_page.get()]);
+        m_fullScreenWindowController = adoptNS([[WKFullScreenWindowController alloc] initWithWindow:RetainPtr { fullScreenWindow() }.get() webView:m_view.getAutoreleased() page:m_page.get()]);
 
     return m_fullScreenWindowController.get();
+}
+
+RetainPtr<WKFullScreenWindowController> WebViewImpl::protectedFullScreenWindowController()
+{
+    return fullScreenWindowController();
 }
 
 void WebViewImpl::closeFullScreenWindowController()
@@ -2785,7 +2801,7 @@ bool WebViewImpl::executeSavedCommandBySelector(SEL selector)
     // The sink does two things: 1) Tells us if the responder went unhandled, and
     // 2) prevents any NSBeep; we don't ever want to beep here.
     RetainPtr<WKResponderChainSink> sink = adoptNS([[WKResponderChainSink alloc] initWithResponderChain:m_view.getAutoreleased()]);
-    [m_view _web_superDoCommandBySelector:selector];
+    [m_view.get() _web_superDoCommandBySelector:selector];
     [sink detach];
     return ![sink didReceiveUnhandledCommand];
 }
@@ -2800,7 +2816,7 @@ void WebViewImpl::registerEditCommand(Ref<WebEditCommandProxy>&& command, UndoOr
     auto actionName = command->label();
     auto commandObjC = adoptNS([[WKEditCommand alloc] initWithWebEditCommandProxy:WTFMove(command)]);
 
-    RetainPtr undoManager = [m_view undoManager];
+    RetainPtr undoManager = [m_view.get() undoManager];
     [undoManager registerUndoWithTarget:m_undoTarget.get() selector:((undoOrRedo == UndoOrRedo::Undo) ? @selector(undoEditing:) : @selector(redoEditing:)) object:commandObjC.get()];
     if (!actionName.isEmpty())
         [undoManager setActionName:actionName.createNSString().get()];
@@ -2808,7 +2824,7 @@ void WebViewImpl::registerEditCommand(Ref<WebEditCommandProxy>&& command, UndoOr
 
 void WebViewImpl::clearAllEditCommands()
 {
-    [[m_view undoManager] removeAllActionsWithTarget:m_undoTarget.get()];
+    [[m_view.get() undoManager] removeAllActionsWithTarget:m_undoTarget.get()];
 }
 
 bool WebViewImpl::writeSelectionToPasteboard(NSPasteboard *pasteboard, NSArray *types)
@@ -2845,19 +2861,19 @@ id WebViewImpl::validRequestorForSendAndReturnTypes(NSString *sendType, NSString
         if (editorState.isInPlugin)
             isValidSendType = [sendType isEqualToString:WebCore::legacyStringPasteboardTypeSingleton()];
         else
-            isValidSendType = [PasteboardTypes::forSelection() containsObject:sendType];
+            isValidSendType = [PasteboardTypes::forSelectionSingleton() containsObject:sendType];
     }
 
     bool isValidReturnType = false;
     if (!returnType)
         isValidReturnType = true;
-    else if ([PasteboardTypes::forEditing() containsObject:returnType] && editorState.isContentEditable) {
+    else if ([PasteboardTypes::forEditingSingleton() containsObject:returnType] && editorState.isContentEditable) {
         // We can insert strings in any editable context.  We can insert other types, like images, only in rich edit contexts.
         isValidReturnType = editorState.isContentRichlyEditable || [returnType isEqualToString:WebCore::legacyStringPasteboardTypeSingleton()];
     }
     if (isValidSendType && isValidReturnType)
         return m_view.getAutoreleased();
-    return [[m_view nextResponder] validRequestorForSendType:sendType returnType:returnType];
+    return [[m_view.get() nextResponder] validRequestorForSendType:sendType returnType:returnType];
 }
 
 void WebViewImpl::centerSelectionInVisibleArea()
@@ -2891,14 +2907,14 @@ void WebViewImpl::selectionDidChange()
     }
 #endif
 
-    RetainPtr window = [m_view window];
+    RetainPtr window = WebViewImpl::window();
     if (window.get().firstResponder == m_view.get().get()) {
         RetainPtr<NSInspectorBar> inspectorBar = window.get().inspectorBar;
         if (inspectorBar.get().visible)
             [inspectorBar _update];
     }
 
-    [m_view _web_editorStateDidChange];
+    [m_view.get() _web_editorStateDidChange];
 }
 
 void WebViewImpl::showShareSheet(WebCore::ShareDataWithParsedURL&& data, WTF::CompletionHandler<void(bool)>&& completionHandler, WKWebView *view)
@@ -3021,6 +3037,11 @@ static NSMenuItem *menuItem(id<NSValidatedUserInterfaceItem> item)
     return (NSMenuItem *)item;
 }
 
+static RetainPtr<NSMenuItem> protectedMenuItem(id<NSValidatedUserInterfaceItem> item)
+{
+    return menuItem(item);
+}
+
 static NSToolbarItem *toolbarItem(id<NSValidatedUserInterfaceItem> item)
 {
     if (![(NSObject *)item isKindOfClass:[NSToolbarItem class]])
@@ -3045,19 +3066,19 @@ bool WebViewImpl::validateUserInterfaceItem(id<NSValidatedUserInterfaceItem> ite
     if (action == @selector(toggleContinuousSpellChecking:)) {
         bool enabled = TextChecker::isContinuousSpellCheckingAllowed();
         bool checked = enabled && TextChecker::state().contains(TextCheckerState::ContinuousSpellCheckingEnabled);
-        [menuItem(item) setState:checked ? NSControlStateValueOn : NSControlStateValueOff];
+        [protectedMenuItem(item) setState:checked ? NSControlStateValueOn : NSControlStateValueOff];
         return enabled;
     }
 
     if (action == @selector(toggleGrammarChecking:)) {
         bool checked = TextChecker::state().contains(TextCheckerState::GrammarCheckingEnabled);
-        [menuItem(item) setState:checked ? NSControlStateValueOn : NSControlStateValueOff];
+        [protectedMenuItem(item) setState:checked ? NSControlStateValueOn : NSControlStateValueOff];
         return true;
     }
 
     if (action == @selector(toggleAutomaticSpellingCorrection:)) {
         bool enable = m_page->editorState().canEnableAutomaticSpellingCorrection;
-        menuItem(item).state = TextChecker::state().contains(TextCheckerState::AutomaticSpellingCorrectionEnabled) && enable ? NSControlStateValueOn : NSControlStateValueOff;
+        protectedMenuItem(item).get().state = TextChecker::state().contains(TextCheckerState::AutomaticSpellingCorrectionEnabled) && enable ? NSControlStateValueOn : NSControlStateValueOff;
         return enable;
     }
 
@@ -3069,31 +3090,31 @@ bool WebViewImpl::validateUserInterfaceItem(id<NSValidatedUserInterfaceItem> ite
 
     if (action == @selector(toggleSmartInsertDelete:)) {
         bool checked = m_page->isSmartInsertDeleteEnabled();
-        [menuItem(item) setState:checked ? NSControlStateValueOn : NSControlStateValueOff];
+        [protectedMenuItem(item) setState:checked ? NSControlStateValueOn : NSControlStateValueOff];
         return m_page->editorState().isContentEditable;
     }
 
     if (action == @selector(toggleAutomaticQuoteSubstitution:)) {
         bool checked = TextChecker::state().contains(TextCheckerState::AutomaticQuoteSubstitutionEnabled);
-        [menuItem(item) setState:checked ? NSControlStateValueOn : NSControlStateValueOff];
+        [protectedMenuItem(item) setState:checked ? NSControlStateValueOn : NSControlStateValueOff];
         return m_page->editorState().isContentEditable;
     }
 
     if (action == @selector(toggleAutomaticDashSubstitution:)) {
         bool checked = TextChecker::state().contains(TextCheckerState::AutomaticDashSubstitutionEnabled);
-        [menuItem(item) setState:checked ? NSControlStateValueOn : NSControlStateValueOff];
+        [protectedMenuItem(item) setState:checked ? NSControlStateValueOn : NSControlStateValueOff];
         return m_page->editorState().isContentEditable;
     }
 
     if (action == @selector(toggleAutomaticLinkDetection:)) {
         bool checked = TextChecker::state().contains(TextCheckerState::AutomaticLinkDetectionEnabled);
-        [menuItem(item) setState:checked ? NSControlStateValueOn : NSControlStateValueOff];
+        [protectedMenuItem(item) setState:checked ? NSControlStateValueOn : NSControlStateValueOff];
         return m_page->editorState().isContentEditable;
     }
 
     if (action == @selector(toggleAutomaticTextReplacement:)) {
         bool checked = TextChecker::state().contains(TextCheckerState::AutomaticTextReplacementEnabled);
-        [menuItem(item) setState:checked ? NSControlStateValueOn : NSControlStateValueOff];
+        [protectedMenuItem(item) setState:checked ? NSControlStateValueOn : NSControlStateValueOff];
         return m_page->editorState().isContentEditable;
     }
 
@@ -3143,9 +3164,11 @@ void WebViewImpl::setUserInterfaceItemState(NSString *commandName, bool enabled,
 {
     ValidationVector items = m_validationMap.take(commandName);
     for (auto& item : items) {
-        [menuItem(item.get()) setState:state];
-        [menuItem(item.get()) setEnabled:enabled];
-        [toolbarItem(item.get()) setEnabled:enabled];
+        RetainPtr protectedMenuItem = menuItem(item.get());
+        RetainPtr protectedToolbarItem = toolbarItem(item.get());
+        [protectedMenuItem setState:state];
+        [protectedMenuItem setEnabled:enabled];
+        [protectedToolbarItem setEnabled:enabled];
         // FIXME <rdar://problem/8803392>: If the item is neither a menu nor toolbar item, it will be left enabled.
     }
 }
@@ -3460,7 +3483,8 @@ void WebViewImpl::handleRequestedCandidates(NSInteger sequenceNumber, NSArray<NS
     WebCore::IntRect offsetSelectionRect = postLayoutData->selectionBoundingRect;
     offsetSelectionRect.move(0, offsetSelectionRect.height());
 
-    [candidateListTouchBarItem() setCandidates:candidates forSelectedRange:selectedRange inString:postLayoutData->paragraphContextForCandidateRequest.createNSString().get() rect:offsetSelectionRect view:m_view.getAutoreleased() completionHandler:nil];
+    RetainPtr candidateList = candidateListTouchBarItem();
+    [candidateList setCandidates:candidates forSelectedRange:selectedRange inString:postLayoutData->paragraphContextForCandidateRequest.createNSString().get() rect:offsetSelectionRect view:m_view.getAutoreleased() completionHandler:nil];
 
 #if HAVE(INLINE_PREDICTIONS)
     if (allowsInlinePredictions())
@@ -3518,7 +3542,7 @@ void WebViewImpl::handleAcceptedCandidate(NSTextCheckingResult *acceptedCandidat
             return;
 
         viewImpl->m_isHandlingAcceptedCandidate = false;
-        [viewImpl->m_view _didHandleAcceptedCandidate];
+        [viewImpl->m_view.get() _didHandleAcceptedCandidate];
     });
 }
 
@@ -3530,7 +3554,7 @@ void WebViewImpl::preferencesDidChange()
         return;
 
     m_needsViewFrameInWindowCoordinates = needsViewFrameInWindowCoordinates;
-    if ([m_view window])
+    if ([m_view.get() window])
         updateWindowAndViewFrames();
 }
 
@@ -3541,7 +3565,7 @@ CALayer* WebViewImpl::textIndicatorInstallationLayer()
 
 void WebViewImpl::dismissContentRelativeChildWindowsWithAnimation(bool animate)
 {
-    [m_view _web_dismissContentRelativeChildWindowsWithAnimation:animate];
+    [m_view.get() _web_dismissContentRelativeChildWindowsWithAnimation:animate];
 }
 
 void WebViewImpl::dismissContentRelativeChildWindowsWithAnimationFromViewOnly(bool animate)
@@ -3549,7 +3573,7 @@ void WebViewImpl::dismissContentRelativeChildWindowsWithAnimationFromViewOnly(bo
     // Calling _clearTextIndicatorWithAnimation here will win out over the animated clear in dismissContentRelativeChildWindowsFromViewOnly.
     // We can't invert these because clients can override (and have overridden) _dismissContentRelativeChildWindows, so it needs to be called.
     // For this same reason, this can't be moved to WebViewImpl without care.
-    [m_view _web_dismissContentRelativeChildWindows];
+    [m_view.get() _web_dismissContentRelativeChildWindows];
 }
 
 void WebViewImpl::dismissContentRelativeChildWindowsFromViewOnly()
@@ -3558,7 +3582,7 @@ void WebViewImpl::dismissContentRelativeChildWindowsFromViewOnly()
     hasActiveImmediateAction = [m_immediateActionController hasActiveImmediateAction];
 
     // FIXME: We don't know which panel we are dismissing, it may not even be in the current page (see <rdar://problem/13875766>).
-    if ([m_view window].isKeyWindow || hasActiveImmediateAction) {
+    if ([m_view.get() window].isKeyWindow || hasActiveImmediateAction) {
         WebCore::DictionaryLookup::hidePopup();
 
         if (PAL::isDataDetectorsFrameworkAvailable())
@@ -3572,14 +3596,14 @@ void WebViewImpl::dismissContentRelativeChildWindowsFromViewOnly()
     m_pageClient->dismissCorrectionPanel(WebCore::ReasonForDismissingAlternativeText::Ignored);
 
 #if HAVE(TRANSLATION_UI_SERVICES) && ENABLE(CONTEXT_MENUS)
-    [std::exchange(m_lastContextMenuTranslationPopover, nil) close];
+    [std::exchange(m_lastContextMenuTranslationPopover, nil).get() close];
 #endif
 }
 
 bool WebViewImpl::hasContentRelativeChildViews() const
 {
 #if ENABLE(WRITING_TOOLS)
-    return [m_view _web_hasActiveIntelligenceTextEffects] || [m_textAnimationTypeManager hasActiveTextAnimationType];
+    return [m_view.get() _web_hasActiveIntelligenceTextEffects] || [m_textAnimationTypeManager hasActiveTextAnimationType];
 #else
     return false;
 #endif
@@ -3616,7 +3640,7 @@ void WebViewImpl::contentRelativeViewsHysteresisTimerFired(PAL::HysteresisState 
 void WebViewImpl::suppressContentRelativeChildViews()
 {
 #if ENABLE(WRITING_TOOLS)
-    [m_view _web_suppressContentRelativeChildViews];
+    [m_view.get() _web_suppressContentRelativeChildViews];
     [m_textAnimationTypeManager suppressTextAnimationType];
 #endif
 }
@@ -3624,7 +3648,7 @@ void WebViewImpl::suppressContentRelativeChildViews()
 void WebViewImpl::restoreContentRelativeChildViews()
 {
 #if ENABLE(WRITING_TOOLS)
-    [m_view _web_restoreContentRelativeChildViews];
+    [m_view.get() _web_restoreContentRelativeChildViews];
     [m_textAnimationTypeManager restoreTextAnimationType];
 #endif
 }
@@ -3640,11 +3664,11 @@ void WebViewImpl::quickLookWithEvent(NSEvent *event)
         return;
 
     if (m_immediateActionGestureRecognizer) {
-        [m_view _web_superQuickLookWithEvent:event];
+        [m_view.get() _web_superQuickLookWithEvent:event];
         return;
     }
 
-    NSPoint locationInViewCoordinates = [m_view convertPoint:[event locationInWindow] fromView:nil];
+    NSPoint locationInViewCoordinates = [m_view.get() convertPoint:[event locationInWindow] fromView:nil];
     m_page->performDictionaryLookupAtLocation(WebCore::FloatPoint(locationInViewCoordinates));
 }
 
@@ -3661,14 +3685,14 @@ void WebViewImpl::setAllowsLinkPreview(bool allowsLinkPreview)
     m_allowsLinkPreview = allowsLinkPreview;
 
     if (!allowsLinkPreview)
-        [m_view removeGestureRecognizer:m_immediateActionGestureRecognizer.get()];
+        [m_view.get() removeGestureRecognizer:m_immediateActionGestureRecognizer.get()];
     else if (RetainPtr immediateActionRecognizer = m_immediateActionGestureRecognizer.get())
-        [m_view addGestureRecognizer:immediateActionRecognizer.get()];
+        [m_view.get() addGestureRecognizer:immediateActionRecognizer.get()];
 }
 
 NSObject *WebViewImpl::immediateActionAnimationControllerForHitTestResult(API::HitTestResult* hitTestResult, uint32_t type, API::Object* userData)
 {
-    return [m_view _web_immediateActionAnimationControllerForHitTestResultInternal:hitTestResult withType:type userData:userData];
+    return [m_view.get() _web_immediateActionAnimationControllerForHitTestResultInternal:hitTestResult withType:type userData:userData];
 }
 
 void WebViewImpl::didPerformImmediateActionHitTest(const WebHitTestResultData& result, bool contentPreventsDefault, API::Object* userData)
@@ -3678,22 +3702,22 @@ void WebViewImpl::didPerformImmediateActionHitTest(const WebHitTestResultData& r
 
 void WebViewImpl::prepareForImmediateActionAnimation()
 {
-    [m_view _web_prepareForImmediateActionAnimation];
+    [m_view.get() _web_prepareForImmediateActionAnimation];
 }
 
 void WebViewImpl::cancelImmediateActionAnimation()
 {
-    [m_view _web_cancelImmediateActionAnimation];
+    [m_view.get() _web_cancelImmediateActionAnimation];
 }
 
 void WebViewImpl::completeImmediateActionAnimation()
 {
-    [m_view _web_completeImmediateActionAnimation];
+    [m_view.get() _web_completeImmediateActionAnimation];
 }
 
 void WebViewImpl::didChangeContentSize(CGSize newSize)
 {
-    [m_view _web_didChangeContentSize:NSSizeFromCGSize(newSize)];
+    [m_view.get() _web_didChangeContentSize:NSSizeFromCGSize(newSize)];
 }
 
 void WebViewImpl::videoControlsManagerDidChange()
@@ -3704,7 +3728,7 @@ void WebViewImpl::videoControlsManagerDidChange()
 
 #if ENABLE(FULLSCREEN_API)
     if (hasFullScreenWindowController())
-        [fullScreenWindowController() videoControlsManagerDidChange];
+        [protectedFullScreenWindowController() videoControlsManagerDidChange];
 #endif
 }
 
@@ -3719,10 +3743,10 @@ void WebViewImpl::setIgnoresNonWheelEvents(bool ignoresNonWheelEvents)
     m_page->setShouldDispatchFakeMouseMoveEvents(!ignoresNonWheelEvents);
 
     if (ignoresNonWheelEvents)
-        [m_view removeGestureRecognizer:m_immediateActionGestureRecognizer.get()];
+        [m_view.get() removeGestureRecognizer:m_immediateActionGestureRecognizer.get()];
     else if (RetainPtr immediateActionRecognizer = m_immediateActionGestureRecognizer.get()) {
         if (m_allowsLinkPreview)
-            [m_view addGestureRecognizer:immediateActionRecognizer.get()];
+            [m_view.get() addGestureRecognizer:immediateActionRecognizer.get()];
     }
 }
 
@@ -3800,7 +3824,7 @@ void WebViewImpl::accessibilityRegisterUIProcessTokens()
     // Initialize remote accessibility when the window connection has been established.
     RetainPtr remoteElementToken = [NSAccessibilityRemoteUIElement remoteTokenForLocalUIElement:m_view.getAutoreleased()];
     m_remoteAccessibilityTokenGeneratedByUIProcess = remoteElementToken.get();
-    RetainPtr remoteWindowToken = [NSAccessibilityRemoteUIElement remoteTokenForLocalUIElement:[m_view window]];
+    RetainPtr remoteWindowToken = [NSAccessibilityRemoteUIElement remoteTokenForLocalUIElement:[m_view.get() window]];
     m_page->registerUIProcessAccessibilityTokens(span(remoteElementToken.get()), span(remoteWindowToken.get()));
 }
 
@@ -3858,7 +3882,7 @@ id WebViewImpl::accessibilityAttributeValue(NSString *attribute, id parameter)
     if ([attribute isEqualToString:NSAccessibilityRoleDescriptionAttribute])
         return NSAccessibilityRoleDescription(NSAccessibilityGroupRole, nil);
     if ([attribute isEqualToString:NSAccessibilityParentAttribute])
-        return NSAccessibilityUnignoredAncestor([m_view superview]);
+        return NSAccessibilityUnignoredAncestor([m_view.get() superview]);
     if ([attribute isEqualToString:NSAccessibilityEnabledAttribute])
         return @YES;
 
@@ -3869,7 +3893,7 @@ id WebViewImpl::accessibilityAttributeValue(NSString *attribute, id parameter)
         }
     }
 
-    return [m_view _web_superAccessibilityAttributeValue:attribute];
+    return [m_view.get() _web_superAccessibilityAttributeValue:attribute];
 }
 
 RetainPtr<NSAccessibilityRemoteUIElement> WebViewImpl::remoteAccessibilityChildIfNotSuspended()
@@ -3881,10 +3905,10 @@ RetainPtr<NSAccessibilityRemoteUIElement> WebViewImpl::remoteAccessibilityChildI
 
 void WebViewImpl::updatePrimaryTrackingAreaOptions(NSTrackingAreaOptions options)
 {
-    auto trackingArea = adoptNS([[NSTrackingArea alloc] initWithRect:[m_view frame] options:options owner:m_mouseTrackingObserver.get() userInfo:nil]);
-    [m_view removeTrackingArea:m_primaryTrackingArea.get()];
+    auto trackingArea = adoptNS([[NSTrackingArea alloc] initWithRect:[m_view.get() frame] options:options owner:m_mouseTrackingObserver.get() userInfo:nil]);
+    [m_view.get() removeTrackingArea:m_primaryTrackingArea.get()];
     m_primaryTrackingArea = trackingArea;
-    [m_view addTrackingArea:trackingArea.get()];
+    [m_view.get() addTrackingArea:trackingArea.get()];
 
 }
 
@@ -3929,7 +3953,7 @@ void WebViewImpl::removeTrackingRect(NSTrackingRectTag tag)
     }
 
     if (tag == m_lastToolTipTag) {
-        [m_view _web_superRemoveTrackingRect:tag];
+        [m_view.get() _web_superRemoveTrackingRect:tag];
         m_lastToolTipTag = 0;
         return;
     }
@@ -3954,7 +3978,7 @@ RetainPtr<id> WebViewImpl::toolTipOwnerForSendingMouseEvents() const
     if (RetainPtr<id> owner = m_trackingRectOwner.get())
         return owner;
 
-    for (NSTrackingArea *trackingArea in view().trackingAreas) {
+    for (NSTrackingArea *trackingArea in protectedView().get().trackingAreas) {
         static Class managerClass;
         static std::once_flag onceFlag;
         std::call_once(onceFlag, [] {
@@ -3975,7 +3999,7 @@ void WebViewImpl::sendToolTipMouseExited()
         location:NSZeroPoint
         modifierFlags:0
         timestamp:0
-        windowNumber:[m_view window].windowNumber
+        windowNumber:protectedWindow().get().windowNumber
         context:nil
         eventNumber:0
         trackingNumber:TRACKING_RECT_TAG
@@ -3990,7 +4014,7 @@ void WebViewImpl::sendToolTipMouseEntered()
         location:NSZeroPoint
         modifierFlags:0
         timestamp:0
-        windowNumber:[m_view window].windowNumber
+        windowNumber:protectedWindow().get().windowNumber
         context:nil
         eventNumber:0
         trackingNumber:TRACKING_RECT_TAG
@@ -4010,9 +4034,9 @@ void WebViewImpl::toolTipChanged(const String& oldToolTip, const String& newTool
 
     if (!newToolTip.isEmpty()) {
         // See radar 3500217 for why we remove all tooltips rather than just the single one we created.
-        [m_view removeAllToolTips];
+        [m_view.get() removeAllToolTips];
         NSRect wideOpenRect = NSMakeRect(-100000, -100000, 200000, 200000);
-        m_lastToolTipTag = [m_view addToolTipRect:wideOpenRect owner:m_view.getAutoreleased() userData:NULL];
+        m_lastToolTipTag = [m_view.get() addToolTipRect:wideOpenRect owner:m_view.getAutoreleased() userData:NULL];
         sendToolTipMouseEntered();
     }
 }
@@ -4117,7 +4141,7 @@ bool WebViewImpl::updateThumbnailViewLayer()
     RetainPtr thumbnailView = m_thumbnailView.get();
     ASSERT(thumbnailView);
 
-    if ([thumbnailView _waitingForSnapshot] && [m_view window]) {
+    if ([thumbnailView _waitingForSnapshot] && window()) {
         reparentLayerTreeInThumbnailView();
         return true;
     }
@@ -4134,7 +4158,7 @@ void WebViewImpl::setInspectorAttachmentView(NSView *newView)
     m_inspectorAttachmentView = newView;
     
     if (RefPtr inspector = m_page->inspector())
-        inspector->attachmentViewDidChange(oldView ? oldView.get() : m_view.getAutoreleased(), newView ? newView : m_view.getAutoreleased());
+        inspector->attachmentViewDidChange(oldView ? oldView.get() : m_view.getAutoreleased(), newView ? RetainPtr { newView }.get() : m_view.getAutoreleased());
 }
 
 RetainPtr<NSView> WebViewImpl::inspectorAttachmentView()
@@ -4163,13 +4187,13 @@ void WebViewImpl::draggedImage(NSImage *, CGPoint endPoint, NSDragOperation oper
 
 void WebViewImpl::sendDragEndToPage(CGPoint endPoint, NSDragOperation dragOperationMask)
 {
-    NSPoint windowImageLoc = [[m_view window] convertPointFromScreen:NSPointFromCGPoint(endPoint)];
+    NSPoint windowImageLoc = [protectedWindow() convertPointFromScreen:NSPointFromCGPoint(endPoint)];
     NSPoint windowMouseLoc = windowImageLoc;
 
     // Prevent queued mouseDragged events from coming after the drag and fake mouseUp event.
     m_ignoresMouseDraggedEvents = true;
 
-    m_page->dragEnded(WebCore::IntPoint(windowMouseLoc), WebCore::IntPoint(WebCore::globalPoint(windowMouseLoc, [m_view window])), coreDragOperationMask(dragOperationMask));
+    m_page->dragEnded(WebCore::IntPoint(windowMouseLoc), WebCore::IntPoint(WebCore::globalPoint(windowMouseLoc, protectedWindow().get())), coreDragOperationMask(dragOperationMask));
 }
 
 static OptionSet<WebCore::DragApplicationFlags> applicationFlagsForDrag(NSView *view, id<NSDraggingInfo> draggingInfo)
@@ -4190,9 +4214,9 @@ static OptionSet<WebCore::DragApplicationFlags> applicationFlagsForDrag(NSView *
 
 NSDragOperation WebViewImpl::draggingEntered(id<NSDraggingInfo> draggingInfo)
 {
-    WebCore::IntPoint client([m_view convertPoint:draggingInfo.draggingLocation fromView:nil]);
-    WebCore::IntPoint global(WebCore::globalPoint(draggingInfo.draggingLocation, [m_view window]));
-    auto dragDestinationActionMask = coreDragDestinationActionMask([m_view _web_dragDestinationActionForDraggingInfo:draggingInfo]);
+    WebCore::IntPoint client([m_view.get() convertPoint:draggingInfo.draggingLocation fromView:nil]);
+    WebCore::IntPoint global(WebCore::globalPoint(draggingInfo.draggingLocation, [m_view.get() window]));
+    auto dragDestinationActionMask = coreDragDestinationActionMask([m_view.get() _web_dragDestinationActionForDraggingInfo:draggingInfo]);
     auto dragOperationMask = coreDragOperationMask(draggingInfo.draggingSourceOperationMask);
     WebCore::DragData dragData(draggingInfo, client, global, dragOperationMask, applicationFlagsForDrag(m_view.getAutoreleased(), draggingInfo), dragDestinationActionMask, m_page->webPageIDInMainFrameProcess());
 
@@ -4228,9 +4252,9 @@ static NSDragOperation kit(std::optional<WebCore::DragOperation> dragOperation)
 
 NSDragOperation WebViewImpl::draggingUpdated(id<NSDraggingInfo> draggingInfo)
 {
-    WebCore::IntPoint client([m_view convertPoint:draggingInfo.draggingLocation fromView:nil]);
-    WebCore::IntPoint global(WebCore::globalPoint(draggingInfo.draggingLocation, [m_view window]));
-    auto dragDestinationActionMask = coreDragDestinationActionMask([m_view _web_dragDestinationActionForDraggingInfo:draggingInfo]);
+    WebCore::IntPoint client([m_view.get() convertPoint:draggingInfo.draggingLocation fromView:nil]);
+    WebCore::IntPoint global(WebCore::globalPoint(draggingInfo.draggingLocation, [m_view.get() window]));
+    auto dragDestinationActionMask = coreDragDestinationActionMask([m_view.get() _web_dragDestinationActionForDraggingInfo:draggingInfo]);
     auto dragOperationMask = coreDragOperationMask(draggingInfo.draggingSourceOperationMask);
     WebCore::DragData dragData(draggingInfo, client, global, dragOperationMask, applicationFlagsForDrag(m_view.getAutoreleased(), draggingInfo), dragDestinationActionMask, m_page->webPageIDInMainFrameProcess());
     m_page->dragUpdated(dragData, draggingInfo.draggingPasteboard.name);
@@ -4254,8 +4278,8 @@ NSDragOperation WebViewImpl::draggingUpdated(id<NSDraggingInfo> draggingInfo)
 
 void WebViewImpl::draggingExited(id<NSDraggingInfo> draggingInfo)
 {
-    WebCore::IntPoint client([m_view convertPoint:draggingInfo.draggingLocation fromView:nil]);
-    WebCore::IntPoint global(WebCore::globalPoint(draggingInfo.draggingLocation, [m_view window]));
+    WebCore::IntPoint client([m_view.get() convertPoint:draggingInfo.draggingLocation fromView:nil]);
+    WebCore::IntPoint global(WebCore::globalPoint(draggingInfo.draggingLocation, [m_view.get() window]));
     WebCore::DragData dragData(draggingInfo, client, global, coreDragOperationMask(draggingInfo.draggingSourceOperationMask), applicationFlagsForDrag(m_view.getAutoreleased(), draggingInfo), WebCore::anyDragDestinationAction(), m_page->webPageIDInMainFrameProcess());
     m_page->dragExited(dragData);
     m_page->resetCurrentDragInformation();
@@ -4301,7 +4325,7 @@ static bool handleLegacyFilesPromisePasteboard(id<NSDraggingInfo> draggingInfo, 
     RetainPtr dropDestination = [NSURL fileURLWithPath:dropDestinationPath.get() isDirectory:YES];
     String pasteboardName = draggingInfo.draggingPasteboard.name;
     Ref protectedPage { page };
-    [draggingInfo enumerateDraggingItemsWithOptions:0 forView:view.autorelease() classes:@[NSFilePromiseReceiver.class] searchOptions:@{ } usingBlock:[&](NSDraggingItem *draggingItem, NSInteger idx, BOOL *stop) {
+    [draggingInfo enumerateDraggingItemsWithOptions:0 forView:view.get() classes:@[NSFilePromiseReceiver.class] searchOptions:@{ } usingBlock:[&](NSDraggingItem *draggingItem, NSInteger idx, BOOL *stop) {
         auto queue = adoptNS([NSOperationQueue new]);
         [draggingItem.item receivePromisedFilesAtDestination:dropDestination.get() options:@{ } operationQueue:queue.get() reader:[protectedPage, fileNames, fileCount, dragData, pasteboardName](NSURL *fileURL, NSError *errorOrNil) {
             if (errorOrNil)
@@ -4364,8 +4388,8 @@ static bool handleLegacyFilesPasteboard(id<NSDraggingInfo> draggingInfo, Box<Web
 
 bool WebViewImpl::performDragOperation(id<NSDraggingInfo> draggingInfo)
 {
-    WebCore::IntPoint client([m_view convertPoint:draggingInfo.draggingLocation fromView:nil]);
-    WebCore::IntPoint global(WebCore::globalPoint(draggingInfo.draggingLocation, [m_view window]));
+    WebCore::IntPoint client([m_view.get() convertPoint:draggingInfo.draggingLocation fromView:nil]);
+    WebCore::IntPoint global(WebCore::globalPoint(draggingInfo.draggingLocation, [m_view.get() window]));
     auto dragData = Box<WebCore::DragData>::create(draggingInfo, client, global, coreDragOperationMask(draggingInfo.draggingSourceOperationMask), applicationFlagsForDrag(m_view.getAutoreleased(), draggingInfo), WebCore::anyDragDestinationAction(), m_page->webPageIDInMainFrameProcess());
 
     RetainPtr<NSArray> types = draggingInfo.draggingPasteboard.types;
@@ -4389,17 +4413,17 @@ NSView *WebViewImpl::hitTestForDragTypes(CGPoint point, NSSet *types)
     // This code is needed to support drag and drop when the drag types cannot be matched.
     // This is the case for elements that do not place content
     // in the drag pasteboard automatically when the drag start (i.e. dragging a DIV element).
-    if ([[m_view superview] mouse:NSPointFromCGPoint(point) inRect:[m_view frame]])
+    if ([[m_view.get() superview] mouse:NSPointFromCGPoint(point) inRect:[m_view.get() frame]])
         return m_view.getAutoreleased();
     return nil;
 }
 
 void WebViewImpl::registerDraggedTypes()
 {
-    auto types = adoptNS([[NSMutableSet alloc] initWithArray:PasteboardTypes::forEditing()]);
-    [types addObjectsFromArray:PasteboardTypes::forURL()];
+    auto types = adoptNS([[NSMutableSet alloc] initWithArray:PasteboardTypes::forEditingSingleton()]);
+    [types addObjectsFromArray:PasteboardTypes::forURLSingleton()];
     [types addObject:PasteboardTypes::WebDummyPboardType];
-    [m_view registerForDraggedTypes:[types allObjects]];
+    [m_view.get() registerForDraggedTypes:[types allObjects]];
 }
 
 NSString *WebViewImpl::fileNameForFilePromiseProvider(NSFilePromiseProvider *provider, NSString *)
@@ -4418,7 +4442,7 @@ static NSError *webKitUnknownError()
 
 void WebViewImpl::didPerformDragOperation(bool handled)
 {
-    [m_view _web_didPerformDragOperation:handled];
+    [m_view.get() _web_didPerformDragOperation:handled];
 }
 
 void WebViewImpl::writeToURLForFilePromiseProvider(NSFilePromiseProvider *provider, NSURL *fileURL, void(^completionHandler)(NSError *))
@@ -4459,7 +4483,7 @@ void WebViewImpl::draggingSessionEnded(NSDraggingSession *, NSPoint endPoint, NS
 
 void WebViewImpl::startWindowDrag()
 {
-    [[m_view window] performWindowDragWithEvent:m_lastMouseDownEvent.get()];
+    [protectedWindow() performWindowDragWithEvent:m_lastMouseDownEvent.get()];
 }
 
 void WebViewImpl::startDrag(const WebCore::DragItem& item, ShareableBitmap::Handle&& dragImageHandle)
@@ -4507,7 +4531,7 @@ void WebViewImpl::startDrag(const WebCore::DragItem& item, ShareableBitmap::Hand
             return;
         }
 
-        [m_view beginDraggingSessionWithItems:@[draggingItem.get()] event:m_lastMouseDownEvent.get() source:(id<NSDraggingSource>)m_view.getAutoreleased()];
+        [m_view.get() beginDraggingSessionWithItems:@[draggingItem.get()] event:m_lastMouseDownEvent.get() source:(id<NSDraggingSource>)m_view.getAutoreleased()];
 
         for (size_t index = 0; index < info.additionalTypesAndData.size(); ++index) {
             auto nsData = Ref { *info.additionalTypesAndData[index].second }->createNSData();
@@ -4521,7 +4545,7 @@ void WebViewImpl::startDrag(const WebCore::DragItem& item, ShareableBitmap::Hand
 
     [pasteboard setString:@"" forType:PasteboardTypes::WebDummyPboardType];
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    [m_view dragImage:dragNSImage.get() at:NSPointFromCGPoint(clientDragLocation) offset:NSZeroSize event:m_lastMouseDownEvent.get() pasteboard:pasteboard.get() source:m_view.getAutoreleased() slideBack:YES];
+    [m_view.get() dragImage:dragNSImage.get() at:NSPointFromCGPoint(clientDragLocation) offset:NSZeroSize event:m_lastMouseDownEvent.get() pasteboard:pasteboard.get() source:m_view.getAutoreleased() slideBack:YES];
 ALLOW_DEPRECATED_DECLARATIONS_END
 }
 
@@ -4559,13 +4583,13 @@ void WebViewImpl::setPromisedDataForImage(WebCore::Image& image, NSString *filen
 
     RetainPtr<NSData> customDataBuffer;
     if (originIdentifier.length) {
-        [types addObject:@(WebCore::PasteboardCustomData::cocoaType().characters())];
+        [types addObject:RetainPtr { @(WebCore::PasteboardCustomData::cocoaType().characters()) }.get()];
         WebCore::PasteboardCustomData customData;
         customData.setOrigin(originIdentifier);
         customDataBuffer = customData.createSharedBuffer()->createNSData();
     }
 
-    [types addObjectsFromArray:archiveBuffer ? PasteboardTypes::forImagesWithArchive() : PasteboardTypes::forImages()];
+    [types addObjectsFromArray:RetainPtr { archiveBuffer ? PasteboardTypes::forImagesWithArchiveSingleton() : PasteboardTypes::forImagesSingleton() }.get()];
 
     [pasteboard clearContents];
     if (m_page->sessionID().isEphemeral())
@@ -4610,7 +4634,7 @@ void WebViewImpl::provideDataForPasteboard(NSPasteboard *pasteboard, NSString *t
 
     // FIXME: Need to support NSRTFDPboardType.
     if ([type isEqual:WebCore::legacyTIFFPasteboardTypeSingleton()])
-        [pasteboard setData:(__bridge NSData *)promisedImage->adapter().tiffRepresentation() forType:WebCore::legacyTIFFPasteboardTypeSingleton()];
+        [pasteboard setData:(__bridge NSData *)RetainPtr { promisedImage->adapter().tiffRepresentation() }.get() forType:WebCore::legacyTIFFPasteboardTypeSingleton()];
 }
 
 static BOOL fileExists(NSString *path)
@@ -4692,7 +4716,7 @@ static NSPasteboardName pasteboardNameForAccessCategory(WebCore::DOMPasteAccessC
     }
 }
 
-static NSPasteboard *pasteboardForAccessCategory(WebCore::DOMPasteAccessCategory pasteAccessCategory)
+static RetainPtr<NSPasteboard> pasteboardForAccessCategory(WebCore::DOMPasteAccessCategory pasteAccessCategory)
 {
     switch (pasteAccessCategory) {
     case WebCore::DOMPasteAccessCategory::General:
@@ -4708,7 +4732,7 @@ void WebViewImpl::requestDOMPasteAccess(WebCore::DOMPasteAccessCategory pasteAcc
     ASSERT(!m_domPasteRequestHandler);
     hideDOMPasteMenuWithResult(WebCore::DOMPasteAccessResponse::DeniedForGesture);
 
-    RetainPtr data = [pasteboardForAccessCategory(pasteAccessCategory) dataForType:@(WebCore::PasteboardCustomData::cocoaType().characters())];
+    RetainPtr data = [pasteboardForAccessCategory(pasteAccessCategory).get() dataForType:RetainPtr { @(WebCore::PasteboardCustomData::cocoaType().characters()) }.get()];
     auto buffer = WebCore::SharedBuffer::create(data.get());
     if (requiresInteraction == WebCore::DOMPasteRequiresInteraction::No && WebCore::PasteboardCustomData::fromSharedBuffer(buffer.get()).origin() == originIdentifier) {
         m_page->grantAccessToCurrentPasteboardData(pasteboardNameForAccessCategory(pasteAccessCategory), [completion = WTFMove(completion)] () mutable {
@@ -4727,7 +4751,7 @@ void WebViewImpl::requestDOMPasteAccess(WebCore::DOMPasteAccessCategory pasteAcc
     auto pasteMenuItem = RetainPtr([m_domPasteMenu insertItemWithTitle:WebCore::contextMenuItemTagPaste().createNSString().get() action:@selector(_web_grantDOMPasteAccess) keyEquivalent:@"" atIndex:0]);
     [pasteMenuItem setTarget:m_domPasteMenuDelegate.get()];
 
-    RetainPtr window = [m_view window];
+    RetainPtr window = [m_view.get() window];
     RetainPtr event = m_page->createSyntheticEventForContextMenu([window convertPointFromScreen:NSEvent.mouseLocation]);
     [NSMenu popUpContextMenu:m_domPasteMenu.get() withEvent:event.get() forView:window.get().contentView];
 }
@@ -4785,7 +4809,7 @@ RefPtr<ViewSnapshot> WebViewImpl::takeViewSnapshot()
 
 RefPtr<ViewSnapshot> WebViewImpl::takeViewSnapshot(ForceSoftwareCapturingViewportSnapshot forceSoftwareCapturing)
 {
-    RetainPtr window = [m_view window];
+    RetainPtr window = WebViewImpl::window();
 
     CGSWindowID windowID = (CGSWindowID)window.get().windowNumber;
     if (!windowID || !window.get().isVisible)
@@ -4808,9 +4832,10 @@ RefPtr<ViewSnapshot> WebViewImpl::takeViewSnapshot(ForceSoftwareCapturingViewpor
     if (!boundsForCustomSwipeViews.isEmpty())
         windowCaptureRect = boundsForCustomSwipeViews;
     else {
-        FloatRect unobscuredBounds = [m_view bounds];
+        RetainPtr view = m_view.get();
+        FloatRect unobscuredBounds = [view bounds];
         unobscuredBounds.contract(m_page->obscuredContentInsets());
-        windowCaptureRect = [m_view convertRect:unobscuredBounds toView:nil];
+        windowCaptureRect = [view convertRect:unobscuredBounds toView:nil];
     }
 
     NSRect windowCaptureScreenRect = [window convertRectToScreen:windowCaptureRect];
@@ -4944,7 +4969,8 @@ void WebViewImpl::setMagnification(double magnification)
     dismissContentRelativeChildWindowsWithAnimation(false);
     suppressContentRelativeChildViews(ContentRelativeChildViewsSuppressionType::TemporarilyRemove);
 
-    WebCore::FloatPoint viewCenter(NSMidX([m_view bounds]), NSMidY([m_view bounds]));
+    RetainPtr view = m_view.get();
+    WebCore::FloatPoint viewCenter(NSMidX([view bounds]), NSMidY([view bounds]));
     m_page->scalePageInViewCoordinates(magnification, roundedIntPoint(viewCenter));
 }
 
@@ -5044,7 +5070,7 @@ void WebViewImpl::swipeWithEvent(NSEvent *event)
         return;
 
     if (!m_allowsBackForwardNavigationGestures) {
-        [m_view _web_superSwipeWithEvent:event];
+        [m_view.get() _web_superSwipeWithEvent:event];
         return;
     }
 
@@ -5053,7 +5079,7 @@ void WebViewImpl::swipeWithEvent(NSEvent *event)
     else if (event.deltaX < 0.0)
         m_page->goForward();
     else
-        [m_view _web_superSwipeWithEvent:event];
+        [m_view.get() _web_superSwipeWithEvent:event];
 }
 
 void WebViewImpl::magnifyWithEvent(NSEvent *event)
@@ -5063,7 +5089,7 @@ void WebViewImpl::magnifyWithEvent(NSEvent *event)
         if (auto webEvent = NativeWebGestureEvent::create(event, m_view.getAutoreleased()))
             m_page->handleGestureEvent(*webEvent);
 #endif
-        [m_view _web_superMagnifyWithEvent:event];
+        [m_view.get() _web_superMagnifyWithEvent:event];
         return;
     }
 
@@ -5073,27 +5099,27 @@ void WebViewImpl::magnifyWithEvent(NSEvent *event)
 
 #if ENABLE(MAC_GESTURE_EVENTS)
     if (gestureController->hasActiveMagnificationGesture()) {
-        gestureController->handleMagnificationGestureEvent(event, [m_view convertPoint:event.locationInWindow fromView:nil]);
+        gestureController->handleMagnificationGestureEvent(event, [m_view.get() convertPoint:event.locationInWindow fromView:nil]);
         return;
     }
 
     if (auto webEvent = NativeWebGestureEvent::create(event, m_view.getAutoreleased()))
         m_page->handleGestureEvent(*webEvent);
 #else
-    gestureController->handleMagnificationGestureEvent(event, [m_view convertPoint:event.locationInWindow fromView:nil]);
+    gestureController->handleMagnificationGestureEvent(event, [m_view.get() convertPoint:event.locationInWindow fromView:nil]);
 #endif
 }
 
 void WebViewImpl::smartMagnifyWithEvent(NSEvent *event)
 {
     if (!m_allowsMagnification) {
-        [m_view _web_superSmartMagnifyWithEvent:event];
+        [m_view.get() _web_superSmartMagnifyWithEvent:event];
         return;
     }
 
     dismissContentRelativeChildWindowsWithAnimation(false);
 
-    ensureProtectedGestureController()->handleSmartMagnificationGesture([m_view convertPoint:event.locationInWindow fromView:nil]);
+    ensureProtectedGestureController()->handleSmartMagnificationGesture([m_view.get() convertPoint:event.locationInWindow fromView:nil]);
 }
 
 RetainPtr<NSEvent> WebViewImpl::setLastMouseDownEvent(NSEvent *event)
@@ -5113,14 +5139,14 @@ void WebViewImpl::rotateWithEvent(NSEvent *event)
 
 void WebViewImpl::gestureEventWasNotHandledByWebCore(NSEvent *event)
 {
-    [m_view _web_gestureEventWasNotHandledByWebCore:event];
+    [m_view.get() _web_gestureEventWasNotHandledByWebCore:event];
 }
 
 void WebViewImpl::gestureEventWasNotHandledByWebCoreFromViewOnly(NSEvent *event)
 {
 #if ENABLE(MAC_GESTURE_EVENTS)
     if (m_allowsMagnification && m_gestureController)
-        m_gestureController->gestureEventWasNotHandledByWebCore(event, [m_view convertPoint:event.locationInWindow fromView:nil]);
+        m_gestureController->gestureEventWasNotHandledByWebCore(event, [m_view.get() convertPoint:event.locationInWindow fromView:nil]);
 #endif
 }
 
@@ -5189,7 +5215,7 @@ Vector<WebCore::KeypressCommand> WebViewImpl::collectKeyboardLayoutCommandsForEv
     if (RetainPtr context = inputContext())
         [context handleEventByKeyboardLayout:event];
     else
-        [m_view interpretKeyEvents:@[event]];
+        [m_view.get() interpretKeyEvents:@[event]];
 
     auto commands = WTFMove(*m_collectedKeypressCommands);
     m_collectedKeypressCommands = std::nullopt;
@@ -5230,7 +5256,8 @@ void WebViewImpl::interpretKeyEvent(NSEvent *event, void(^completionHandler)(BOO
 #endif
 
     LOG(TextInput, "-> handleEventByInputMethod:%p %@", event, event);
-    [inputContext() handleEventByInputMethod:event completionHandler:[weakThis = WeakPtr { *this }, capturedEvent = retainPtr(event), capturedBlock = makeBlockPtr(completionHandler)](BOOL handled) mutable {
+    RetainPtr inputContext { WebViewImpl::inputContext() };
+    [inputContext.get() handleEventByInputMethod:event completionHandler:[weakThis = WeakPtr { *this }, capturedEvent = retainPtr(event), capturedBlock = makeBlockPtr(completionHandler)](BOOL handled) mutable {
         CheckedPtr checkedThis = weakThis.get();
         if (!checkedThis) {
             capturedBlock(NO, { });
@@ -5288,7 +5315,7 @@ void WebViewImpl::doCommandBySelector(SEL selector)
     } else {
         // FIXME: Send the command to Editor synchronously and only send it along the
         // responder chain if it's a selector that does not correspond to an editing command.
-        [m_view _web_superDoCommandBySelector:selector];
+        [m_view.get() _web_superDoCommandBySelector:selector];
     }
 }
 
@@ -5438,8 +5465,9 @@ void WebViewImpl::firstRectForCharacterRange(NSRange range, void(^completionHand
             return;
         }
 
-        NSRect resultRect = [weakThis->m_view convertRect:rect toView:nil];
-        resultRect = [[weakThis->m_view window] convertRectToScreen:resultRect];
+        RetainPtr view = weakThis->m_view.get();
+        NSRect resultRect = [view convertRect:rect toView:nil];
+        resultRect = [[view window] convertRectToScreen:resultRect];
 
         LOG(TextInput, "    -> firstRectForCharacterRange returned (%f, %f, %f, %f)", resultRect.origin.x, resultRect.origin.y, resultRect.size.width, resultRect.size.height);
         completionHandler(resultRect, actualRange);
@@ -5450,10 +5478,10 @@ void WebViewImpl::characterIndexForPoint(NSPoint point, void(^completionHandler)
 {
     LOG(TextInput, "characterIndexForPoint:(%f, %f)", point.x, point.y);
 
-    RetainPtr window = [m_view window];
+    RetainPtr window = [m_view.get() window];
     if (window)
         point = [window convertPointFromScreen:point];
-    point = [m_view convertPoint:point fromView:nil];  // the point is relative to the main frame
+    point = [m_view.get() convertPoint:point fromView:nil]; // the point is relative to the main frame
 
     m_page->characterIndexForPointAsync(WebCore::IntPoint(point), [completionHandler = makeBlockPtr(completionHandler)](uint64_t result) {
         if (result == notFound)
@@ -5469,7 +5497,7 @@ NSTextInputContext *WebViewImpl::inputContext()
     if (!m_page->editorState().isContentEditable)
         return nil;
 
-    return [m_view _web_superInputContext];
+    return [m_view.get() _web_superInputContext];
 }
 
 void WebViewImpl::unmarkText()
@@ -5848,19 +5876,19 @@ bool WebViewImpl::performKeyEquivalent(NSEvent *event)
     // but both get transformed to a cancelOperation: command, executing which passes an Esc key event to -performKeyEquivalent:.
     // Don't interpret this event again, avoiding re-entrancy and infinite loops.
     if ([[event charactersIgnoringModifiers] isEqualToString:@"\e"] && !([event modifierFlags] & NSEventModifierFlagDeviceIndependentFlagsMask))
-        return [m_view _web_superPerformKeyEquivalent:event];
+        return [m_view.get() _web_superPerformKeyEquivalent:event];
 
     if (m_keyDownEventBeingResent) {
         // WebCore has already seen the event, no need for custom processing.
         // Note that we can get multiple events for each event being re-sent. For example, for Cmd+'=' AppKit
         // first performs the original key equivalent, and if that isn't handled, it dispatches a synthetic Cmd+'+'.
-        return [m_view _web_superPerformKeyEquivalent:event];
+        return [m_view.get() _web_superPerformKeyEquivalent:event];
     }
 
     // Pass key combos through WebCore if there is a key binding available for
     // this event. This lets webpages have a crack at intercepting key-modified keypresses.
     // FIXME: Why is the firstResponder check needed?
-    if (m_view.getAutoreleased() == [m_view window].firstResponder) {
+    if (m_view.getAutoreleased() == [m_view.get() window].firstResponder) {
         interpretKeyEvent(event, [weakThis = WeakPtr { *this }, capturedEvent = retainPtr(event)](BOOL handledByInputMethod, const Vector<WebCore::KeypressCommand>& commands) {
             if (weakThis)
                 weakThis->m_page->handleKeyboardEvent(NativeWebKeyboardEvent(capturedEvent.get(), handledByInputMethod, false, commands));
@@ -5868,7 +5896,7 @@ bool WebViewImpl::performKeyEquivalent(NSEvent *event)
         return YES;
     }
 
-    return [m_view _web_superPerformKeyEquivalent:event];
+    return [m_view.get() _web_superPerformKeyEquivalent:event];
 }
 
 void WebViewImpl::keyUp(NSEvent *event)
@@ -5897,7 +5925,7 @@ void WebViewImpl::keyDown(NSEvent *event)
     // there is no range selection).
     // If this is the case we should ignore the key down.
     if (m_keyDownEventBeingResent == event) {
-        [m_view _web_superKeyDown:event];
+        [m_view.get() _web_superKeyDown:event];
         return;
     }
 
@@ -5959,7 +5987,7 @@ void WebViewImpl::nativeMouseEventHandler(NSEvent *event)
         return;
     }
 
-    if (RetainPtr context = [m_view inputContext]) {
+    if (RetainPtr context = [m_view.get() inputContext]) {
         WeakPtr weakThis { *this };
         RetainPtr<NSEvent> retainedEvent = event;
         [context handleEvent:event completionHandler:[weakThis, retainedEvent] (BOOL handled) {
@@ -6008,7 +6036,8 @@ void WebViewImpl::removeFlagsChangedEventMonitor()
     if (!m_flagsChangedEventMonitor)
         return;
 
-    [NSEvent removeMonitor:m_flagsChangedEventMonitor];
+    RetainPtr flagsChangedEventMonitor = m_flagsChangedEventMonitor;
+    [NSEvent removeMonitor:flagsChangedEventMonitor.get()];
     m_flagsChangedEventMonitor = nil;
 }
 
@@ -6102,7 +6131,8 @@ void WebViewImpl::mouseMoved(NSEvent *event)
         [hud mouseMoved:event];
 
     // When a view is first responder, it gets mouse moved events even when the mouse is outside its visible rect.
-    if (m_view.getAutoreleased() == [m_view window].firstResponder && !NSPointInRect([m_view convertPoint:[event locationInWindow] fromView:nil], [m_view visibleRect]))
+    RetainPtr view = m_view.get();
+    if (view == [view window].firstResponder && !NSPointInRect([view convertPoint:[event locationInWindow] fromView:nil], [view visibleRect]))
         return;
 
     mouseMovedInternal(event);
@@ -6219,10 +6249,11 @@ void WebViewImpl::mouseDragged(NSEvent *event)
 
 bool WebViewImpl::windowIsFrontWindowUnderMouse(NSEvent *event)
 {
-    NSRect eventScreenPosition = [[m_view window] convertRectToScreen:NSMakeRect(event.locationInWindow.x, event.locationInWindow.y, 0, 0)];
+    RetainPtr window = WebViewImpl::window();
+    NSRect eventScreenPosition = [window convertRectToScreen:NSMakeRect(event.locationInWindow.x, event.locationInWindow.y, 0, 0)];
     NSInteger eventWindowNumber = [NSWindow windowNumberAtPoint:eventScreenPosition.origin belowWindowWithWindowNumber:0];
 
-    return [m_view window].windowNumber != eventWindowNumber;
+    return window.get().windowNumber != eventWindowNumber;
 }
 
 static WebCore::UserInterfaceLayoutDirection toUserInterfaceLayoutDirection(NSUserInterfaceLayoutDirection direction)
@@ -6240,7 +6271,7 @@ static WebCore::UserInterfaceLayoutDirection toUserInterfaceLayoutDirection(NSUs
 
 WebCore::UserInterfaceLayoutDirection WebViewImpl::userInterfaceLayoutDirection()
 {
-    return toUserInterfaceLayoutDirection([m_view userInterfaceLayoutDirection]);
+    return toUserInterfaceLayoutDirection([m_view.get() userInterfaceLayoutDirection]);
 }
 
 void WebViewImpl::setUserInterfaceLayoutDirection(NSUserInterfaceLayoutDirection direction)
@@ -6273,7 +6304,7 @@ void WebViewImpl::effectiveAppearanceDidChange()
 
 bool WebViewImpl::effectiveAppearanceIsDark()
 {
-    RetainPtr appearance = [[m_view effectiveAppearance] bestMatchFromAppearancesWithNames:@[ NSAppearanceNameAqua, NSAppearanceNameDarkAqua ]];
+    RetainPtr appearance = [[m_view.get() effectiveAppearance] bestMatchFromAppearancesWithNames:@[ NSAppearanceNameAqua, NSAppearanceNameDarkAqua ]];
     return [appearance isEqualToString:NSAppearanceNameDarkAqua];
 }
 
@@ -6284,7 +6315,7 @@ bool WebViewImpl::effectiveUserInterfaceLevelIsElevated()
 
 bool WebViewImpl::useFormSemanticContext() const
 {
-    return [m_view _semanticContext] == NSViewSemanticContextForm;
+    return [m_view.get() _semanticContext] == NSViewSemanticContextForm;
 }
 
 void WebViewImpl::semanticContextDidChange()
@@ -6330,8 +6361,8 @@ void WebViewImpl::updateTouchBar()
             touchBar = [m_mediaTouchBarProvider respondsToSelector:@selector(touchBar)] ? [(id)m_mediaTouchBarProvider.get() touchBar] : [(id)m_mediaTouchBarProvider.get() touchBar];
     } else if ([m_mediaTouchBarProvider playbackControlsController]) {
         if (m_clientWantsMediaPlaybackControlsView) {
-            if ([m_view respondsToSelector:@selector(_web_didRemoveMediaControlsManager)] && m_view.getAutoreleased() == [m_view window].firstResponder)
-                [m_view _web_didRemoveMediaControlsManager];
+            if ([m_view.get() respondsToSelector:@selector(_web_didRemoveMediaControlsManager)] && m_view.getAutoreleased() == protectedWindow().get().firstResponder)
+                [m_view.get() _web_didRemoveMediaControlsManager];
         }
         [m_mediaTouchBarProvider setPlaybackControlsController:nil];
         [m_mediaPlaybackControlsView setPlaybackControlsController:nil];
@@ -6347,9 +6378,9 @@ void WebViewImpl::updateTouchBar()
         return;
 
     m_currentTouchBar = touchBar.get();
-    [m_view willChangeValueForKey:@"touchBar"];
-    [m_view setTouchBar:m_currentTouchBar.get()];
-    [m_view didChangeValueForKey:@"touchBar"];
+    [m_view.get() willChangeValueForKey:@"touchBar"];
+    [m_view.get() setTouchBar:m_currentTouchBar.get()];
+    [m_view.get() didChangeValueForKey:@"touchBar"];
 }
 
 NSCandidateListTouchBarItem *WebViewImpl::candidateListTouchBarItem() const
@@ -6380,7 +6411,7 @@ bool WebViewImpl::useMediaPlaybackControlsView() const
 void WebViewImpl::dismissTextTouchBarPopoverItemWithIdentifier(NSString *identifier)
 {
     NSTouchBarItem *foundItem = nil;
-    for (NSTouchBarItem *item in textTouchBar().items) {
+    for (NSTouchBarItem *item in RetainPtr { textTouchBar() }.get().items) {
         if ([item.identifier isEqualToString:identifier]) {
             foundItem = item;
             break;
@@ -6519,8 +6550,9 @@ void WebViewImpl::updateTextTouchBar()
 
     if ([NSSpellChecker isAutomaticTextCompletionEnabled] && !m_isCustomizingTouchBar) {
         BOOL showCandidatesList = !m_page->editorState().selectionIsRange || m_isHandlingAcceptedCandidate;
-        [candidateListTouchBarItem() updateWithInsertionPointVisibility:showCandidatesList];
-        [m_view _didUpdateCandidateListVisibility:showCandidatesList];
+        RetainPtr candidateListTouchBarItem = WebViewImpl::candidateListTouchBarItem();
+        [candidateListTouchBarItem updateWithInsertionPointVisibility:showCandidatesList];
+        [m_view.get() _didUpdateCandidateListVisibility:showCandidatesList];
     }
 
     if (m_page->editorState().isInPasswordField) {
@@ -6685,8 +6717,8 @@ void WebViewImpl::updateMediaTouchBar()
         return;
     }
 
-    if (m_playbackControlsManager && m_view.getAutoreleased() == [m_view window].firstResponder && [m_view respondsToSelector:@selector(_web_didAddMediaControlsManager:)])
-        [m_view _web_didAddMediaControlsManager:m_mediaPlaybackControlsView.get()];
+    if (m_playbackControlsManager && m_view.getAutoreleased() == protectedWindow().get().firstResponder && [m_view.get() respondsToSelector:@selector(_web_didAddMediaControlsManager:)])
+        [m_view.get() _web_didAddMediaControlsManager:m_mediaPlaybackControlsView.get()];
 #endif
 }
 
@@ -6710,7 +6742,8 @@ bool WebViewImpl::shouldRequestCandidates() const
     if (m_page->editorState().isInPasswordField)
         return false;
 
-    if (candidateListTouchBarItem().candidateListVisible)
+    RetainPtr candidateListTouchBarItem = WebViewImpl::candidateListTouchBarItem();
+    if (candidateListTouchBarItem.get().candidateListVisible)
         return true;
 
 #if HAVE(INLINE_PREDICTIONS)
@@ -6757,7 +6790,7 @@ void WebViewImpl::updateCursorAccessoryPlacement()
 
     auto& postLayoutData = *editorState.postLayoutData;
 
-    RetainPtr context = [m_view _web_superInputContext];
+    RetainPtr context = [m_view.get() _web_superInputContext];
     if (!context)
         return;
 
@@ -6907,11 +6940,11 @@ void WebViewImpl::didFinishPresentation(WKRevealItemPresenter *presenter)
 
 #if ENABLE(IMAGE_ANALYSIS)
 
-CocoaImageAnalyzer *WebViewImpl::ensureImageAnalyzer()
+CocoaImageAnalyzer* WebViewImpl::ensureImageAnalyzer()
 {
     if (!m_imageAnalyzer) {
-        m_imageAnalyzerQueue = WorkQueue::create("WebKit image analyzer queue"_s);
-        m_imageAnalyzer = createImageAnalyzer();
+        lazyInitialize(m_imageAnalyzerQueue, WorkQueue::create("WebKit image analyzer queue"_s));
+        lazyInitialize(m_imageAnalyzer, createImageAnalyzer());
         [m_imageAnalyzer setCallbackQueue:m_imageAnalyzerQueue->dispatchQueue()];
     }
     return m_imageAnalyzer.get();
@@ -7048,7 +7081,7 @@ void WebViewImpl::installImageAnalysisOverlayView(RetainPtr<VKCImageAnalysis>&& 
             return;
 
         if (!checkedThis->m_imageAnalysisOverlayView) {
-            checkedThis->m_imageAnalysisOverlayView = adoptNS([PAL::allocVKCImageAnalysisOverlayViewInstance() initWithFrame:[checkedThis->m_view bounds]]);
+            checkedThis->m_imageAnalysisOverlayView = adoptNS([PAL::allocVKCImageAnalysisOverlayViewInstance() initWithFrame:[checkedThis->m_view.get() bounds]]);
             checkedThis->m_imageAnalysisOverlayViewDelegate = adoptNS([[WKImageAnalysisOverlayViewDelegate alloc] initWithWebViewImpl:*checkedThis.get()]);
             [checkedThis->m_imageAnalysisOverlayView setDelegate:checkedThis->m_imageAnalysisOverlayViewDelegate.get()];
             prepareImageAnalysisForOverlayView(checkedThis->m_imageAnalysisOverlayView.get());
@@ -7057,7 +7090,7 @@ void WebViewImpl::installImageAnalysisOverlayView(RetainPtr<VKCImageAnalysis>&& 
         }
 
         [checkedThis->m_imageAnalysisOverlayView setAnalysis:analysis.get()];
-        [checkedThis->m_view addSubview:checkedThis->m_imageAnalysisOverlayView.get()];
+        [checkedThis->m_view.get() addSubview:checkedThis->m_imageAnalysisOverlayView.get()];
     };
 
     performOrDeferImageAnalysisOverlayViewHierarchyTask(WTFMove(installTask));


### PR DESCRIPTION
#### 110713922f458b43a98b6ba2feefd803e2333650
<pre>
Address safer CPP warnings in WebViewImpl.mm
<a href="https://bugs.webkit.org/show_bug.cgi?id=299872">https://bugs.webkit.org/show_bug.cgi?id=299872</a>

Reviewed by Chris Dumez.

Incidentally also fixed a few warnings in PageClientImplMac.mm, but
that file still has plenty of its own.

Renamed some methods to add a singleton suffix, others were made into
protected variants, added a few protected getters, etc.

* Source/WebKit/SaferCPPExpectations/RetainPtrCtorAdoptCheckerExpectations:
* Source/WebKit/Shared/mac/PasteboardTypes.h:
* Source/WebKit/Shared/mac/PasteboardTypes.mm:
(WebKit::PasteboardTypes::forEditingSingleton):
(WebKit::PasteboardTypes::forURLSingleton):
(WebKit::PasteboardTypes::forImagesSingleton):
(WebKit::PasteboardTypes::forImagesWithArchiveSingleton):
(WebKit::PasteboardTypes::forSelectionSingleton):
(WebKit::PasteboardTypes::forEditing): Deleted.
(WebKit::PasteboardTypes::forURL): Deleted.
(WebKit::PasteboardTypes::forImages): Deleted.
(WebKit::PasteboardTypes::forImagesWithArchive): Deleted.
(WebKit::PasteboardTypes::forSelection): Deleted.
* Source/WebKit/UIProcess/mac/PageClientImplMac.mm:
(WebKit::PageClientImpl::isFullScreen):
(WebKit::PageClientImpl::enterFullScreen):
(WebKit::PageClientImpl::exitFullScreen):
(WebKit::PageClientImpl::beganEnterFullScreen):
(WebKit::PageClientImpl::beganExitFullScreen):
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(-[WKAccessibilitySettingsObserver _settingsDidChange:]):
(-[WKWindowVisibilityObserver _windowDidOrderOnScreen:]):
(-[WKWindowVisibilityObserver _windowDidOrderOffScreen:]):
(-[WKWindowVisibilityObserver _windowDidBecomeKey:]):
(-[WKWindowVisibilityObserver _windowDidResignKey:]):
(-[WKWindowVisibilityObserver _windowDidMiniaturize:]):
(-[WKWindowVisibilityObserver _windowDidDeminiaturize:]):
(-[WKWindowVisibilityObserver _windowDidMove:]):
(-[WKWindowVisibilityObserver _windowDidResize:]):
(-[WKWindowVisibilityObserver _windowWillBeginSheet:]):
(-[WKWindowVisibilityObserver _windowDidChangeBackingProperties:]):
(-[WKWindowVisibilityObserver _windowDidChangeScreen:]):
(-[WKWindowVisibilityObserver _windowDidChangeOcclusionState:]):
(-[WKWindowVisibilityObserver _windowWillClose:]):
(-[WKWindowVisibilityObserver _screenDidChangeColorSpace:]):
(-[WKWindowVisibilityObserver observeValueForKeyPath:ofObject:change:context:]):
(-[WKWindowVisibilityObserver _activeSpaceDidChange:]):
(-[WKDOMPasteMenuDelegate _web_grantDOMPasteAccess]):
(-[WKTextTouchBarItemController textListViewController]):
(-[WKImageAnalysisOverlayViewDelegate initWithWebViewImpl:]):
(-[WKImageAnalysisOverlayViewDelegate dealloc]):
(-[WKImageAnalysisOverlayViewDelegate observeValueForKeyPath:ofObject:change:context:]):
(-[WKImageAnalysisOverlayViewDelegate firstResponderIsInsideImageOverlay]):
(-[WKImageAnalysisOverlayViewDelegate contentsRectForImageAnalysisOverlayView:]):
(WebKit::m_flagsChangedEventMonitorTrackingArea):
(WebKit::WebViewImpl::window):
(WebKit::WebViewImpl::protectedWindow):
(WebKit::WebViewImpl::handleProcessSwapOrExit):
(WebKit::WebViewImpl::setDrawsBackground):
(WebKit::WebViewImpl::setBackgroundColor):
(WebKit::WebViewImpl::becomeFirstResponder):
(WebKit::WebViewImpl::resignFirstResponder):
(WebKit::WebViewImpl::showWarningView):
(WebKit::WebViewImpl::isFocused const):
(WebKit::WebViewImpl::createPDFHUD):
(WebKit::WebViewImpl::renewGState):
(WebKit::WebViewImpl::setFrameSize):
(WebKit::WebViewImpl::setFrameAndScrollBy):
(WebKit::WebViewImpl::updateWindowAndViewFrames):
(WebKit::WebViewImpl::updateLayer):
(WebKit::WebViewImpl::updateViewExposedRect):
(WebKit::WebViewImpl::setIntrinsicContentSize):
(WebKit::WebViewImpl::intrinsicDeviceScaleFactor const):
(WebKit::WebViewImpl::windowDidBecomeKey):
(WebKit::WebViewImpl::windowDidResignKey):
(WebKit::WebViewImpl::windowDidChangeScreen):
(WebKit::WebViewImpl::mightBeginDragWhileInactive):
(WebKit::WebViewImpl::acceptsFirstMouse):
(WebKit::WebViewImpl::shouldDelayWindowOrderingForEvent):
(WebKit::WebViewImpl::windowResizeMouseLocationIsInVisibleScrollerThumb):
(WebKit::WebViewImpl::viewWillMoveToWindowImpl):
(WebKit::WebViewImpl::viewDidMoveToWindow):
(WebKit::WebViewImpl::viewDidChangeBackingProperties):
(WebKit::WebViewImpl::pageDidScroll):
(WebKit::WebViewImpl::scrollViewFrame):
(WebKit::WebViewImpl::updateTitlebarAdjacencyState):
(WebKit::WebViewImpl::hitTest):
(WebKit::WebViewImpl::colorSpace):
(WebKit::WebViewImpl::updateSecureInputState):
(WebKit::WebViewImpl::notifyInputContextAboutDiscardedComposition):
(WebKit::WebViewImpl::fullScreenWindowController):
(WebKit::WebViewImpl::protectedFullScreenWindowController):
(WebKit::WebViewImpl::executeSavedCommandBySelector):
(WebKit::WebViewImpl::registerEditCommand):
(WebKit::WebViewImpl::clearAllEditCommands):
(WebKit::WebViewImpl::validRequestorForSendAndReturnTypes):
(WebKit::WebViewImpl::selectionDidChange):
(WebKit::protectedMenuItem):
(WebKit::WebViewImpl::validateUserInterfaceItem):
(WebKit::WebViewImpl::setUserInterfaceItemState):
(WebKit::WebViewImpl::handleRequestedCandidates):
(WebKit::WebViewImpl::handleAcceptedCandidate):
(WebKit::WebViewImpl::preferencesDidChange):
(WebKit::WebViewImpl::dismissContentRelativeChildWindowsWithAnimation):
(WebKit::WebViewImpl::dismissContentRelativeChildWindowsWithAnimationFromViewOnly):
(WebKit::WebViewImpl::dismissContentRelativeChildWindowsFromViewOnly):
(WebKit::WebViewImpl::hasContentRelativeChildViews const):
(WebKit::WebViewImpl::suppressContentRelativeChildViews):
(WebKit::WebViewImpl::restoreContentRelativeChildViews):
(WebKit::WebViewImpl::quickLookWithEvent):
(WebKit::WebViewImpl::setAllowsLinkPreview):
(WebKit::WebViewImpl::immediateActionAnimationControllerForHitTestResult):
(WebKit::WebViewImpl::prepareForImmediateActionAnimation):
(WebKit::WebViewImpl::cancelImmediateActionAnimation):
(WebKit::WebViewImpl::completeImmediateActionAnimation):
(WebKit::WebViewImpl::didChangeContentSize):
(WebKit::WebViewImpl::videoControlsManagerDidChange):
(WebKit::WebViewImpl::setIgnoresNonWheelEvents):
(WebKit::WebViewImpl::accessibilityRegisterUIProcessTokens):
(WebKit::WebViewImpl::accessibilityAttributeValue):
(WebKit::WebViewImpl::updatePrimaryTrackingAreaOptions):
(WebKit::WebViewImpl::removeTrackingRect):
(WebKit::WebViewImpl::toolTipOwnerForSendingMouseEvents const):
(WebKit::WebViewImpl::sendToolTipMouseExited):
(WebKit::WebViewImpl::sendToolTipMouseEntered):
(WebKit::WebViewImpl::toolTipChanged):
(WebKit::WebViewImpl::updateThumbnailViewLayer):
(WebKit::WebViewImpl::setInspectorAttachmentView):
(WebKit::WebViewImpl::sendDragEndToPage):
(WebKit::WebViewImpl::draggingEntered):
(WebKit::WebViewImpl::draggingUpdated):
(WebKit::WebViewImpl::draggingExited):
(WebKit::handleLegacyFilesPromisePasteboard):
(WebKit::WebViewImpl::performDragOperation):
(WebKit::WebViewImpl::hitTestForDragTypes):
(WebKit::WebViewImpl::registerDraggedTypes):
(WebKit::WebViewImpl::didPerformDragOperation):
(WebKit::WebViewImpl::startWindowDrag):
(WebKit::WebViewImpl::startDrag):
(WebKit::WebViewImpl::setPromisedDataForImage):
(WebKit::WebViewImpl::provideDataForPasteboard):
(WebKit::pasteboardForAccessCategory):
(WebKit::WebViewImpl::requestDOMPasteAccess):
(WebKit::WebViewImpl::takeViewSnapshot):
(WebKit::WebViewImpl::setMagnification):
(WebKit::WebViewImpl::swipeWithEvent):
(WebKit::WebViewImpl::magnifyWithEvent):
(WebKit::WebViewImpl::smartMagnifyWithEvent):
(WebKit::WebViewImpl::gestureEventWasNotHandledByWebCore):
(WebKit::WebViewImpl::gestureEventWasNotHandledByWebCoreFromViewOnly):
(WebKit::WebViewImpl::collectKeyboardLayoutCommandsForEvent):
(WebKit::WebViewImpl::interpretKeyEvent):
(WebKit::WebViewImpl::doCommandBySelector):
(WebKit::WebViewImpl::firstRectForCharacterRange):
(WebKit::WebViewImpl::characterIndexForPoint):
(WebKit::WebViewImpl::inputContext):
(WebKit::WebViewImpl::performKeyEquivalent):
(WebKit::WebViewImpl::keyDown):
(WebKit::WebViewImpl::nativeMouseEventHandler):
(WebKit::WebViewImpl::removeFlagsChangedEventMonitor):
(WebKit::WebViewImpl::mouseMoved):
(WebKit::WebViewImpl::windowIsFrontWindowUnderMouse):
(WebKit::WebViewImpl::userInterfaceLayoutDirection):
(WebKit::WebViewImpl::effectiveAppearanceIsDark):
(WebKit::WebViewImpl::useFormSemanticContext const):
(WebKit::WebViewImpl::updateTouchBar):
(WebKit::WebViewImpl::dismissTextTouchBarPopoverItemWithIdentifier):
(WebKit::WebViewImpl::updateTextTouchBar):
(WebKit::WebViewImpl::updateMediaTouchBar):
(WebKit::WebViewImpl::shouldRequestCandidates const):
(WebKit::WebViewImpl::updateCursorAccessoryPlacement):
(WebKit::WebViewImpl::ensureImageAnalyzer):
(WebKit::WebViewImpl::installImageAnalysisOverlayView):

Canonical link: <a href="https://commits.webkit.org/301130@main">https://commits.webkit.org/301130@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e36d5c5aa83708935e5f8ba937fbf30fcd3599ae

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125023 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44692 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35429 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131872 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76900 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45384 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53258 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95168 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/63142 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127977 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36221 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111810 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75711 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35140 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75354 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105984 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30193 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134548 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51845 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39644 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103639 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52270 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108022 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103413 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26331 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48750 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27040 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48891 "Hash e36d5c5a for PR 51562 does not build (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51730 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57523 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51104 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54461 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52795 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->