### PR TITLE
Add pipeTo support for readable byte streams

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/streams/piping/abort.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/piping/abort.any-expected.txt
@@ -31,5 +31,5 @@ PASS abort should do nothing after the readable is closed
 PASS abort should do nothing after the readable is errored
 PASS abort should do nothing after the readable is errored, even with pending writes
 PASS abort should do nothing after the writable is errored
-FAIL pipeTo on a teed readable byte stream should only be aborted when both branches are aborted assert_true: pipeTo should not resolve yet expected true got false
+PASS pipeTo on a teed readable byte stream should only be aborted when both branches are aborted
 

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/piping/abort.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/piping/abort.any.serviceworker-expected.txt
@@ -31,5 +31,5 @@ PASS abort should do nothing after the readable is closed
 PASS abort should do nothing after the readable is errored
 PASS abort should do nothing after the readable is errored, even with pending writes
 PASS abort should do nothing after the writable is errored
-FAIL pipeTo on a teed readable byte stream should only be aborted when both branches are aborted assert_true: pipeTo should not resolve yet expected true got false
+PASS pipeTo on a teed readable byte stream should only be aborted when both branches are aborted
 

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/piping/abort.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/piping/abort.any.sharedworker-expected.txt
@@ -31,5 +31,5 @@ PASS abort should do nothing after the readable is closed
 PASS abort should do nothing after the readable is errored
 PASS abort should do nothing after the readable is errored, even with pending writes
 PASS abort should do nothing after the writable is errored
-FAIL pipeTo on a teed readable byte stream should only be aborted when both branches are aborted assert_true: pipeTo should not resolve yet expected true got false
+PASS pipeTo on a teed readable byte stream should only be aborted when both branches are aborted
 

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/piping/abort.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/piping/abort.any.worker-expected.txt
@@ -31,5 +31,5 @@ PASS abort should do nothing after the readable is closed
 PASS abort should do nothing after the readable is errored
 PASS abort should do nothing after the readable is errored, even with pending writes
 PASS abort should do nothing after the writable is errored
-FAIL pipeTo on a teed readable byte stream should only be aborted when both branches are aborted assert_true: pipeTo should not resolve yet expected true got false
+PASS pipeTo on a teed readable byte stream should only be aborted when both branches are aborted
 

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -730,6 +730,7 @@ set(WebCore_NON_SVG_IDL_FILES
     Modules/streams/ReadableStreamSink.idl
     Modules/streams/ReadableStreamSource.idl
     Modules/streams/ReadableStreamType.idl
+    Modules/streams/StreamPipeOptions.idl
     Modules/streams/TransformStream.idl
     Modules/streams/TransformStreamDefaultController.idl
     Modules/streams/UnderlyingSource.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -893,6 +893,7 @@ $(PROJECT_DIR)/Modules/streams/ReadableStreamSink.idl
 $(PROJECT_DIR)/Modules/streams/ReadableStreamSource.idl
 $(PROJECT_DIR)/Modules/streams/ReadableStreamType.idl
 $(PROJECT_DIR)/Modules/streams/StreamInternals.js
+$(PROJECT_DIR)/Modules/streams/StreamPipeOptions.idl
 $(PROJECT_DIR)/Modules/streams/TransformStream.idl
 $(PROJECT_DIR)/Modules/streams/TransformStreamDefaultController.idl
 $(PROJECT_DIR)/Modules/streams/TransformStreamDefaultController.js

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -3020,6 +3020,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSStorageManager+FileSystem.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSStorageManager+FileSystem.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSStorageManager.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSStorageManager.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSStreamPipeOptions.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSStreamPipeOptions.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSStringCallback.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSStringCallback.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSStructuredSerializeOptions.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -645,6 +645,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/Modules/streams/ReadableStreamSink.idl \
     $(WebCore)/Modules/streams/ReadableStreamSource.idl \
     $(WebCore)/Modules/streams/ReadableStreamType.idl \
+    $(WebCore)/Modules/streams/StreamPipeOptions.idl \
     $(WebCore)/Modules/streams/TransformStream.idl \
     $(WebCore)/Modules/streams/TransformStreamDefaultController.idl \
     $(WebCore)/Modules/streams/UnderlyingSource.idl \

--- a/Source/WebCore/Modules/streams/ReadableByteStreamController.h
+++ b/Source/WebCore/Modules/streams/ReadableByteStreamController.h
@@ -28,8 +28,8 @@
 #include "ExceptionOr.h"
 #include "JSValueInWrappedObject.h"
 #include "ReadableStreamReadRequest.h"
-#include <wtf/RefCounted.h>
 #include <wtf/Deque.h>
+#include <wtf/RefCounted.h>
 #include <wtf/WeakPtr.h>
 
 namespace JSC {

--- a/Source/WebCore/Modules/streams/StreamPipeOptions.h
+++ b/Source/WebCore/Modules/streams/StreamPipeOptions.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "AbortSignal.h"
+
+namespace WebCore {
+
+struct StreamPipeOptions {
+    bool preventClose { false };
+    bool preventAbort { false };
+    bool preventCancel { false };
+    RefPtr<AbortSignal> signal;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/Modules/streams/StreamPipeOptions.idl
+++ b/Source/WebCore/Modules/streams/StreamPipeOptions.idl
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+dictionary StreamPipeOptions {
+  boolean preventClose = false;
+  boolean preventAbort = false;
+  boolean preventCancel = false;
+  AbortSignal signal;
+};

--- a/Source/WebCore/Modules/streams/StreamPipeToUtilities.cpp
+++ b/Source/WebCore/Modules/streams/StreamPipeToUtilities.cpp
@@ -1,0 +1,643 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "StreamPipeToUtilities.h"
+
+#include "ContextDestructionObserverInlines.h"
+#include "EventLoop.h"
+#include "InternalReadableStream.h"
+#include "InternalWritableStream.h"
+#include "InternalWritableStreamWriter.h"
+#include "JSDOMPromise.h"
+#include "JSDOMPromiseDeferred.h"
+#include "ReadableStream.h"
+#include "ReadableStreamDefaultReader.h"
+#include "ScriptExecutionContextInlines.h"
+#include "StreamPipeOptions.h"
+#include "WritableStream.h"
+
+namespace WebCore {
+
+class PipeToDefaultReadRequest;
+class StreamPipeToState : public RefCountedAndCanMakeWeakPtr<StreamPipeToState>, public ContextDestructionObserver {
+public:
+    static Ref<StreamPipeToState> create(JSDOMGlobalObject& globalObject, Ref<ReadableStream>&& source, Ref<WritableStream>&& destination, Ref<ReadableStreamDefaultReader>&& reader, Ref<InternalWritableStreamWriter>&& writer, StreamPipeOptions&& options, RefPtr<DeferredPromise>&& promise)
+    {
+        Ref state = adoptRef(*new StreamPipeToState(globalObject.protectedScriptExecutionContext().get(), WTFMove(source), WTFMove(destination), WTFMove(reader), WTFMove(writer), WTFMove(options), WTFMove(promise)));
+
+        state->handleSignal();
+
+        state->errorsMustBePropagatedForward(globalObject);
+        state->errorsMustBePropagatedBackward();
+        state->closingMustBePropagatedForward();
+        state->closingMustBePropagatedBackward();
+
+        state->loop();
+        return state;
+    }
+    ~StreamPipeToState();
+
+    void doWrite(JSC::JSValue);
+    JSDOMGlobalObject* globalObject();
+
+private:
+    StreamPipeToState(ScriptExecutionContext*, Ref<ReadableStream>&&, Ref<WritableStream>&&, Ref<ReadableStreamDefaultReader>&&, Ref<InternalWritableStreamWriter>&&, StreamPipeOptions&&, RefPtr<DeferredPromise>&&);
+
+    void loop();
+    void doRead();
+
+    void handleSignal();
+
+    void errorsMustBePropagatedForward(JSDOMGlobalObject&);
+    void errorsMustBePropagatedBackward();
+    void closingMustBePropagatedForward();
+    void closingMustBePropagatedBackward();
+
+    using Action = Function<RefPtr<DOMPromise>()>;
+    using GetError = Function<JSC::JSValue(JSDOMGlobalObject&)>&&;
+    void shutdownWithAction(Action&&, GetError&& = { });
+    void shutdown(GetError&& = { });
+    void finalize(GetError&&);
+
+    RefPtr<DOMPromise> waitForPendingReadAndWrite(Action&&);
+
+    const Ref<ReadableStream> m_source;
+    const Ref<WritableStream> m_destination;
+    const Ref<ReadableStreamDefaultReader> m_reader;
+    const Ref<InternalWritableStreamWriter> m_writer;
+    const StreamPipeOptions m_options;
+    const RefPtr<DeferredPromise> m_promise;
+
+    bool m_shuttingDown { false };
+    RefPtr<PipeToDefaultReadRequest> m_pendingReadRequest;
+    RefPtr<DOMPromise> m_pendingWritePromise;
+};
+
+class PipeToDefaultReadRequest : public ReadableStreamReadRequest {
+public:
+    static Ref<PipeToDefaultReadRequest> create(Ref<StreamPipeToState>&& state) { return adoptRef(*new PipeToDefaultReadRequest(WTFMove(state))); }
+    ~PipeToDefaultReadRequest() = default;
+
+    void whenSettled(Function<void()>&& callback)
+    {
+        if (!m_isPending) {
+            callback();
+            return;
+        }
+
+        if (m_whenSettledCallback) {
+            auto oldCallback = std::exchange(m_whenSettledCallback, { });
+            m_whenSettledCallback = [oldCallback = WTFMove(oldCallback), newCallback = WTFMove(callback)] {
+                oldCallback();
+                newCallback();
+            };
+            return;
+        }
+
+        m_whenSettledCallback = WTFMove(callback);
+    }
+
+private:
+    explicit PipeToDefaultReadRequest(Ref<StreamPipeToState>&& state)
+        : m_state(WTFMove(state))
+    {
+    }
+
+    void runChunkSteps(JSC::JSValue value) final
+    {
+        m_state->doWrite(value);
+        settle();
+    }
+
+    void runCloseSteps() final
+    {
+        settle();
+    }
+
+    void runErrorSteps(JSC::JSValue) final
+    {
+        settle();
+    }
+
+    void runErrorSteps(Exception&&) final
+    {
+        settle();
+    }
+
+    JSDOMGlobalObject* globalObject() final
+    {
+        return m_state->globalObject();
+    }
+
+    void settle()
+    {
+        m_isPending = false;
+        if (m_whenSettledCallback)
+            m_whenSettledCallback();
+    }
+
+    const Ref<StreamPipeToState> m_state;
+    bool m_isPending { true };
+    Function<void()> m_whenSettledCallback;
+};
+
+// https://streams.spec.whatwg.org/#readable-stream-pipe-to
+void readableStreamPipeTo(JSDOMGlobalObject& globalObject, Ref<ReadableStream>&& source, Ref<WritableStream>&& destination, Ref<ReadableStreamDefaultReader>&& reader, Ref<InternalWritableStreamWriter>&& writer, StreamPipeOptions&& options, RefPtr<DeferredPromise>&& promise)
+{
+    StreamPipeToState::create(globalObject, WTFMove(source), WTFMove(destination), WTFMove(reader), WTFMove(writer), WTFMove(options), WTFMove(promise));
+}
+
+static RefPtr<DOMPromise> cancelReadableStream(JSDOMGlobalObject& globalObject, ReadableStream& stream, JSC::JSValue reason)
+{
+    RefPtr internalReadableStream = stream.internalReadableStream();
+    if (!internalReadableStream) {
+        auto [promise, deferred] = createPromiseAndWrapper(globalObject);
+        stream.cancel(globalObject, reason, WTFMove(deferred));
+        return RefPtr { WTFMove(promise) };
+    }
+
+    auto value = internalReadableStream->cancel(globalObject, reason, InternalReadableStream::Use::Private);
+    auto* promise = jsCast<JSC::JSPromise*>(value);
+    if (!promise)
+        return nullptr;
+
+    return DOMPromise::create(globalObject, *promise);
+}
+
+StreamPipeToState::StreamPipeToState(ScriptExecutionContext* context, Ref<ReadableStream>&& source, Ref<WritableStream>&& destination, Ref<ReadableStreamDefaultReader>&& reader, Ref<InternalWritableStreamWriter>&& writer, StreamPipeOptions&& options, RefPtr<DeferredPromise>&& promise)
+    : ContextDestructionObserver(context)
+    , m_source(WTFMove(source))
+    , m_destination(WTFMove(destination))
+    , m_reader(WTFMove(reader))
+    , m_writer(WTFMove(writer))
+    , m_options(WTFMove(options))
+    , m_promise(WTFMove(promise))
+{
+}
+
+StreamPipeToState::~StreamPipeToState() = default;
+
+JSDOMGlobalObject* StreamPipeToState::globalObject()
+{
+    RefPtr context = scriptExecutionContext();
+    return context ? JSC::jsCast<JSDOMGlobalObject*>(context->globalObject()) : nullptr;
+}
+
+void StreamPipeToState::handleSignal()
+{
+    RefPtr signal = m_options.signal;
+    if (!signal)
+        return;
+
+    auto algorithmSteps = [weakThis = WeakPtr { *this }, signal = m_options.signal]() mutable {
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis)
+            return;
+
+        protectedThis->shutdownWithAction([protectedThis, signal] -> RefPtr<DOMPromise> {
+            RefPtr promiseDestination = [&] -> RefPtr<DOMPromise> {
+                bool shouldAbortDestination = !protectedThis->m_options.preventAbort && protectedThis->m_destination->state() == WritableStream::State::Writable;
+                if (!shouldAbortDestination)
+                    return nullptr;
+
+                Ref internalWritableStream = protectedThis->m_destination->internalWritableStream();
+                auto* globalObject = protectedThis->globalObject();
+                if (!globalObject)
+                    return nullptr;
+
+                auto value = internalWritableStream->abort(*globalObject, signal->reason().getValue());
+                auto* promise = jsCast<JSC::JSPromise*>(value);
+                if (!promise)
+                    return nullptr;
+
+                return DOMPromise::create(*globalObject, *promise);
+            }();
+
+            RefPtr promiseSource = [&] -> RefPtr<DOMPromise> {
+                bool shouldAbortSource = !protectedThis->m_options.preventCancel && protectedThis->m_source->state() == ReadableStream::State::Readable;
+                if (!shouldAbortSource)
+                    return nullptr;
+
+                Ref internalWritableStream = protectedThis->m_destination->internalWritableStream();
+                auto* globalObject = protectedThis->globalObject();
+                if (!globalObject)
+                    return nullptr;
+
+                return cancelReadableStream(*globalObject, protectedThis->m_source, signal->reason().getValue());
+            }();
+
+            if (!promiseSource && !promiseDestination)
+                return nullptr;
+
+            auto* globalObject = protectedThis->globalObject();
+            if (!globalObject)
+                return nullptr;
+
+            auto [result, deferred] = createPromiseAndWrapper(*globalObject);
+            if (promiseDestination) {
+                promiseDestination->whenSettled([promiseDestination, promiseSource, deferred] {
+                    if (promiseDestination->status() == DOMPromise::Status::Rejected) {
+                        deferred->rejectWithCallback([&](auto&) {
+                            return promiseDestination->result();
+                        }, RejectAsHandled::Yes);
+                        return;
+                    }
+                    if (promiseSource && promiseSource->status() != DOMPromise::Status::Fulfilled)
+                        return;
+                    deferred->resolve();
+                });
+            }
+            if (promiseSource) {
+                promiseSource->whenSettled([promiseDestination, promiseSource, deferred] {
+                    if (promiseSource->status() == DOMPromise::Status::Rejected) {
+                        deferred->rejectWithCallback([&](auto&) {
+                            return promiseSource->result();
+                        }, RejectAsHandled::Yes);
+                        return;
+                    }
+                    if (promiseDestination && promiseDestination->status() != DOMPromise::Status::Fulfilled)
+                        return;
+                    deferred->resolve();
+                });
+            }
+
+            return RefPtr { WTFMove(result) };
+        }, [signal](auto&) { return signal->reason().getValue(); });
+    };
+
+    if (m_options.signal->aborted()) {
+        algorithmSteps();
+        return;
+    }
+
+    signal->addAlgorithm([algorithmSteps = WTFMove(algorithmSteps)](auto&&) mutable {
+        algorithmSteps();
+    });
+}
+
+void StreamPipeToState::loop()
+{
+    if (!m_shuttingDown)
+        doRead();
+}
+
+void StreamPipeToState::doRead()
+{
+    ASSERT(!m_shuttingDown);
+
+    m_writer->whenReady([protectedThis = Ref { *this }] {
+        auto* globalObject = protectedThis->globalObject();
+        if (protectedThis->m_shuttingDown || !globalObject)
+            return;
+
+        protectedThis->m_pendingReadRequest = PipeToDefaultReadRequest::create(protectedThis.get());
+        protectedThis->m_reader->read(*globalObject, *protectedThis->m_pendingReadRequest);
+    });
+}
+
+void StreamPipeToState::doWrite(JSC::JSValue value)
+{
+    auto* globalObject = this->globalObject();
+    if (!globalObject)
+        return;
+
+    m_pendingReadRequest = nullptr;
+    m_pendingWritePromise = writableStreamDefaultWriterWrite(m_writer, value);
+    RefPtr { m_pendingWritePromise }->markAsHandled();
+
+    loop();
+}
+
+void StreamPipeToState::errorsMustBePropagatedForward(JSDOMGlobalObject& globalObject)
+{
+    auto propagateErrorSteps = [weakThis = WeakPtr { *this }](auto&& error) {
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis)
+            return;
+        if (!protectedThis->m_options.preventAbort) {
+            protectedThis->shutdownWithAction([protectedThis, error] -> RefPtr<DOMPromise> {
+                auto* globalObject = protectedThis->globalObject();
+                if (!globalObject)
+                    return nullptr;
+
+                Ref internalWritableStream = protectedThis->m_destination->internalWritableStream();
+                auto value = internalWritableStream->abort(*globalObject, error.get());
+                auto* promise = jsCast<JSC::JSPromise*>(value);
+                if (!promise) {
+                    auto [result, deferred] = createPromiseAndWrapper(*globalObject);
+                    deferred->resolve();
+                    return RefPtr { WTFMove(result) };
+                }
+                return DOMPromise::create(*globalObject, *promise);
+            }, [error](auto&) { return error.get(); });
+            return;
+        }
+        protectedThis->shutdown([error](auto&) { return error.get(); });
+    };
+
+    if (m_source->state() == ReadableStream::State::Errored) {
+        // FIXME: Check whether ok to take a strong.
+        propagateErrorSteps(JSC::Strong<JSC::Unknown> { Ref { m_destination->internalWritableStream().globalObject()->vm() }, m_source->storedError(globalObject) });
+        return;
+    }
+
+    m_reader->onClosedPromiseRejection([propagateErrorSteps = WTFMove(propagateErrorSteps)](auto& globalObject, auto&& error) mutable {
+        // FIXME: Check whether ok to take a strong.
+        propagateErrorSteps(JSC::Strong<JSC::Unknown> { Ref { globalObject.vm() }, error });
+    });
+}
+
+void StreamPipeToState::errorsMustBePropagatedBackward()
+{
+    auto propagateErrorSteps = [weakThis = WeakPtr { *this }](auto&& error) {
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis)
+            return;
+        if (!protectedThis->m_options.preventCancel) {
+            protectedThis->shutdownWithAction([protectedThis, error] -> RefPtr<DOMPromise> {
+                RefPtr internalReadableStream = protectedThis->m_source->internalReadableStream();
+                if (!internalReadableStream)
+                    return nullptr;
+
+                auto* globalObject = internalReadableStream->globalObject();
+                if (!globalObject)
+                    return nullptr;
+
+                auto getError2 = [error](auto&) {
+                    return error.get();
+                };
+
+                auto [result, deferred] = createPromiseAndWrapper(*globalObject);
+                auto cancelPromise = cancelReadableStream(*globalObject, protectedThis->m_source, error.get());
+                if (!cancelPromise)
+                    deferred->rejectWithCallback(WTFMove(getError2), RejectAsHandled::Yes);
+                else {
+                    cancelPromise->whenSettled([deferred = WTFMove(deferred), cancelPromise, getError2 = WTFMove(getError2)]() mutable {
+                        if (cancelPromise->status() == DOMPromise::Status::Rejected) {
+                            deferred->rejectWithCallback([&](auto&) {
+                                return cancelPromise->result();
+                            }, RejectAsHandled::Yes);
+                            return;
+                        }
+                        deferred->rejectWithCallback(WTFMove(getError2), RejectAsHandled::Yes);
+                    });
+                }
+                return RefPtr { WTFMove(result) };
+            }, [error](auto&) { return error.get(); });
+            return;
+        }
+        protectedThis->shutdown([error](auto&) { return error.get(); });
+    };
+
+    if (m_destination->state() == WritableStream::State::Errored) {
+        // FIXME: Check whether ok to take a strong.
+        auto errorOrException = Ref { m_destination->internalWritableStream() }->storedError();
+        if (errorOrException.hasException())
+            return;
+
+        propagateErrorSteps(JSC::Strong<JSC::Unknown> { Ref { m_destination->internalWritableStream().globalObject()->vm() }, errorOrException.releaseReturnValue() });
+        return;
+    }
+
+    m_writer->onClosedPromiseRejection([propagateErrorSteps = WTFMove(propagateErrorSteps)](auto& globalObject, auto&& error) mutable {
+        // FIXME: Check whether ok to take a strong.
+        propagateErrorSteps(JSC::Strong<JSC::Unknown> { Ref { globalObject.vm() }, error });
+    });
+}
+
+void StreamPipeToState::closingMustBePropagatedForward()
+{
+    auto propagateClosedSteps = [weakThis = WeakPtr { *this }]() {
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis)
+            return;
+        if (!protectedThis->m_options.preventClose) {
+            protectedThis->shutdownWithAction([protectedThis] -> RefPtr<DOMPromise> {
+                return writableStreamDefaultWriterCloseWithErrorPropagation(protectedThis->m_writer);
+            });
+            return;
+        }
+        protectedThis->shutdown();
+    };
+
+    if (m_source->state() == ReadableStream::State::Closed) {
+        propagateClosedSteps();
+        return;
+    }
+
+    m_reader->onClosedPromiseResolution([propagateClosedSteps = WTFMove(propagateClosedSteps)]() mutable {
+        propagateClosedSteps();
+    });
+}
+
+void StreamPipeToState::closingMustBePropagatedBackward()
+{
+    if (!Ref { m_destination->internalWritableStream() }->closeQueuedOrInFlight() && m_destination->state() != WritableStream::State::Closed)
+        return;
+
+    // FIXME: Assert that no chunks have been read or written.
+
+    auto getError = [](auto& globalObject) {
+        return createDOMException(globalObject, Exception { ExceptionCode::TypeError, "closing is propagated backward"_s });
+    };
+
+    if (!m_options.preventCancel) {
+        shutdownWithAction([protectedThis = Ref { *this }, getError = WTFMove(getError)]() mutable -> RefPtr<DOMPromise> {
+            RefPtr internalReadableStream = protectedThis->m_source->internalReadableStream();
+            if (!internalReadableStream)
+                return nullptr;
+
+            auto* globalObject = protectedThis->globalObject();
+            if (!globalObject)
+                return nullptr;
+
+            Ref vm = globalObject->vm();
+            // FIXME: Check whether ok to take a strong.
+            JSC::Strong<JSC::Unknown> error { vm, getError(*globalObject) };
+            auto value = internalReadableStream->cancel(*globalObject, error.get(), InternalReadableStream::Use::Private);
+
+            auto getError2 = [error = WTFMove(error)](auto&) {
+                return error.get();
+            };
+
+            auto [result, deferred] = createPromiseAndWrapper(*globalObject);
+            auto* promise = jsCast<JSC::JSPromise*>(value);
+            if (!promise)
+                deferred->rejectWithCallback(WTFMove(getError2), RejectAsHandled::Yes);
+            else {
+                Ref cancelPromise = DOMPromise::create(*globalObject, *promise);
+                cancelPromise->whenSettled([deferred = WTFMove(deferred), cancelPromise, getError2 = WTFMove(getError2)]() mutable {
+                    if (cancelPromise->status() == DOMPromise::Status::Rejected) {
+                        deferred->rejectWithCallback([&](auto&) {
+                            return cancelPromise->result();
+                        }, RejectAsHandled::Yes);
+                        return;
+                    }
+                    deferred->rejectWithCallback(WTFMove(getError2), RejectAsHandled::Yes);
+                });
+            }
+            return RefPtr { WTFMove(result) };
+        });
+        return;
+    }
+
+    shutdown(WTFMove(getError));
+}
+
+RefPtr<DOMPromise> StreamPipeToState::waitForPendingReadAndWrite(Action&& action)
+{
+    auto* globalObject = this->globalObject();
+    if (!globalObject)
+        return { };
+
+    RefPtr<DOMPromise> finalizePromise;
+    if (m_destination->state() == WritableStream::State::Writable && !Ref { m_destination->internalWritableStream() }->closeQueuedOrInFlight()) {
+        if (m_pendingReadRequest || m_pendingWritePromise) {
+            auto handlePendingWritePromise = [this, protectedThis = Ref { *this }, action = WTFMove(action)](auto&& deferred) mutable {
+                auto waitForAction = [action = WTFMove(action)](auto&& deferred) {
+                    RefPtr promise = action();
+                    if (!promise) {
+                        deferred->resolve();
+                        return;
+                    }
+                    promise->whenSettled([deferred = WTFMove(deferred), promise] {
+                        switch (promise->status()) {
+                        case DOMPromise::Status::Rejected:
+                            deferred->rejectWithCallback([&](auto&) { return promise->result(); }, RejectAsHandled::Yes);
+                            return;
+                        case DOMPromise::Status::Fulfilled:
+                            deferred->resolve();
+                            return;
+                        case DOMPromise::Status::Pending:
+                            ASSERT_NOT_REACHED();
+                            return;
+                        }
+                    });
+                };
+
+                if (!m_pendingWritePromise) {
+                    waitForAction(WTFMove(deferred));
+                    return;
+                }
+
+                auto* globalObject = protectedThis->globalObject();
+                if (!globalObject) {
+                    waitForAction(WTFMove(deferred));
+                    return;
+                }
+
+                m_pendingWritePromise->whenSettled([waitForAction = WTFMove(waitForAction), pendingWritePromise = m_pendingWritePromise, deferred = WTFMove(deferred)]() mutable {
+                    ASSERT(pendingWritePromise->status() != DOMPromise::Status::Pending);
+                    waitForAction(WTFMove(deferred));
+                });
+            };
+
+            auto [promise, deferred] = createPromiseAndWrapper(*globalObject);
+            if (RefPtr readRequest = m_pendingReadRequest) {
+                readRequest->whenSettled([handlePendingWritePromise = WTFMove(handlePendingWritePromise), deferred = WTFMove(deferred)]() mutable {
+                    handlePendingWritePromise(WTFMove(deferred));
+                });
+            } else
+                handlePendingWritePromise(WTFMove(deferred));
+
+            finalizePromise = WTFMove(promise);
+        }
+    }
+
+    if (!finalizePromise)
+        finalizePromise = action();
+
+    return finalizePromise;
+}
+
+void StreamPipeToState::shutdownWithAction(Action&& action, GetError&& getError)
+{
+    if (m_shuttingDown)
+        return;
+    m_shuttingDown = true;
+
+    RefPtr finalizePromise = waitForPendingReadAndWrite(WTFMove(action));
+    if (!finalizePromise) {
+        finalize(WTFMove(getError));
+        return;
+    }
+
+    finalizePromise->whenSettled([protectedThis = Ref { *this }, finalizePromise, getError = WTFMove(getError)]() mutable {
+        switch (finalizePromise->status()) {
+        case DOMPromise::Status::Fulfilled:
+            protectedThis->finalize(WTFMove(getError));
+            return;
+        case DOMPromise::Status::Rejected:
+            protectedThis->finalize([&](auto&) {
+                return finalizePromise->result();
+            });
+            return;
+        case DOMPromise::Status::Pending:
+            ASSERT_NOT_REACHED();
+            break;
+        }
+    });
+}
+
+void StreamPipeToState::shutdown(GetError&& getError)
+{
+    if (m_shuttingDown)
+        return;
+    m_shuttingDown = true;
+
+    RefPtr finalizePromise = waitForPendingReadAndWrite([] { return nullptr; });
+    if (!finalizePromise) {
+        finalize(WTFMove(getError));
+        return;
+    }
+
+    finalizePromise->whenSettled([protectedThis = Ref { *this }, finalizePromise, getError = WTFMove(getError)]() mutable {
+        ASSERT(finalizePromise->status() != DOMPromise::Status::Pending);
+        protectedThis->finalize(WTFMove(getError));
+    });
+}
+
+void StreamPipeToState::finalize(GetError&& getError)
+{
+    auto* globalObject = this->globalObject();
+    if (!globalObject)
+        return;
+
+    writableStreamDefaultWriterRelease(m_writer);
+    m_reader->releaseLock(*globalObject);
+
+    if (!m_promise)
+        return;
+
+    if (getError) {
+        m_promise->rejectWithCallback(WTFMove(getError), RejectAsHandled::No);
+        return;
+    }
+
+    m_promise->resolve();
+}
+
+}

--- a/Source/WebCore/Modules/streams/StreamPipeToUtilities.h
+++ b/Source/WebCore/Modules/streams/StreamPipeToUtilities.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace WebCore {
+
+class DeferredPromise;
+class JSDOMGlobalObject;
+class ReadableStream;
+class WritableStream;
+class ReadableStreamDefaultReader;
+class InternalWritableStreamWriter;
+
+struct StreamPipeOptions;
+
+void readableStreamPipeTo(JSDOMGlobalObject&, Ref<ReadableStream>&&, Ref<WritableStream>&&, Ref<ReadableStreamDefaultReader>&&, Ref<InternalWritableStreamWriter>&&, StreamPipeOptions&&, RefPtr<DeferredPromise>&&);
+}

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -384,6 +384,7 @@ Modules/streams/ReadableStreamDefaultReader.cpp
 Modules/streams/ReadableStreamReadRequest.cpp
 Modules/streams/ReadableStreamSink.cpp
 Modules/streams/ReadableStreamSource.cpp
+Modules/streams/StreamPipeToUtilities.cpp @no-unify
 Modules/streams/StreamTeeUtilities.cpp
 Modules/streams/TransformStream.cpp
 Modules/streams/WritableStream.cpp
@@ -4888,6 +4889,7 @@ JSStereoPannerOptions.cpp
 JSStorage.cpp
 JSStorageEvent.cpp
 JSStorageManager.cpp
+JSStreamPipeOptions.cpp
 JSStringCallback.cpp
 JSStructuredSerializeOptions.cpp
 JSStyleMedia.cpp

--- a/Source/WebCore/bindings/js/InternalReadableStream.cpp
+++ b/Source/WebCore/bindings/js/InternalReadableStream.cpp
@@ -145,7 +145,8 @@ InternalReadableStream::State InternalReadableStream::state() const
         return State::Closed;
     if (state == 4)
         return State::Readable;
-    ASSERT(state == 2);
+
+    ASSERT(state == 3);
     return State::Errored;
 }
 


### PR DESCRIPTION
#### a1b79c5541d9549f0c200870202cd8a64af7a301
<pre>
Add pipeTo support for readable byte streams
<a href="https://bugs.webkit.org/show_bug.cgi?id=299438#">https://bugs.webkit.org/show_bug.cgi?id=299438#</a>
<a href="https://rdar.apple.com/problem/161244992">rdar://problem/161244992</a>

Reviewed by Chris Dumez.

We implement the pipeTo algorithm in C++ using a default reader.
This is the same algorithm as for regular streams so it might replace the JS built-in implementation in a follow-up for regular streams.

The implementation is done via PipeToState which stores the necessary state values needed for pipeTo.
It notably keeps a reference to the source and destination to propagate the errors backward and forward.
It also keeps reference to the reader and writer used for pipeTo.

The implementation follows closely the specification so the pipeTo operations are all done in the thread where live the streams.

Covered by rebased tests.

Canonical link: <a href="https://commits.webkit.org/301030@main">https://commits.webkit.org/301030@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/73be3e274a70a3d81d8d95368b5d4e26fae2332e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124741 "7 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44413 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35148 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131587 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76660 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2b52369b-6002-4813-8fa8-218919bb545e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/126618 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45117 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52983 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94909 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62966 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7930097e-954c-40a0-ad05-0ba8de600c42) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127695 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35987 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111561 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75478 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e67e6bd7-a923-406e-b5fe-4eeb50989139) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34918 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29715 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75063 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105744 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29946 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134252 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51589 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39400 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103386 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52002 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107781 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103157 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26258 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48525 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26803 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48586 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51462 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57260 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50856 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54211 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52550 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->