### PR TITLE
Add tee support for readable byte streams

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/streams/piping/abort.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/piping/abort.any-expected.txt
@@ -31,5 +31,5 @@ PASS abort should do nothing after the readable is closed
 PASS abort should do nothing after the readable is errored
 PASS abort should do nothing after the readable is errored, even with pending writes
 PASS abort should do nothing after the writable is errored
-FAIL pipeTo on a teed readable byte stream should only be aborted when both branches are aborted promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
+FAIL pipeTo on a teed readable byte stream should only be aborted when both branches are aborted assert_true: pipeTo should not resolve yet expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/piping/abort.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/piping/abort.any.serviceworker-expected.txt
@@ -31,5 +31,5 @@ PASS abort should do nothing after the readable is closed
 PASS abort should do nothing after the readable is errored
 PASS abort should do nothing after the readable is errored, even with pending writes
 PASS abort should do nothing after the writable is errored
-FAIL pipeTo on a teed readable byte stream should only be aborted when both branches are aborted promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
+FAIL pipeTo on a teed readable byte stream should only be aborted when both branches are aborted assert_true: pipeTo should not resolve yet expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/piping/abort.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/piping/abort.any.sharedworker-expected.txt
@@ -31,5 +31,5 @@ PASS abort should do nothing after the readable is closed
 PASS abort should do nothing after the readable is errored
 PASS abort should do nothing after the readable is errored, even with pending writes
 PASS abort should do nothing after the writable is errored
-FAIL pipeTo on a teed readable byte stream should only be aborted when both branches are aborted promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
+FAIL pipeTo on a teed readable byte stream should only be aborted when both branches are aborted assert_true: pipeTo should not resolve yet expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/piping/abort.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/piping/abort.any.worker-expected.txt
@@ -31,5 +31,5 @@ PASS abort should do nothing after the readable is closed
 PASS abort should do nothing after the readable is errored
 PASS abort should do nothing after the readable is errored, even with pending writes
 PASS abort should do nothing after the writable is errored
-FAIL pipeTo on a teed readable byte stream should only be aborted when both branches are aborted promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
+FAIL pipeTo on a teed readable byte stream should only be aborted when both branches are aborted assert_true: pipeTo should not resolve yet expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/read-min.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/read-min.any-expected.txt
@@ -22,5 +22,5 @@ PASS ReadableStream with byte source: cancel() with partially filled pending rea
 PASS ReadableStream with byte source: enqueue(), then read({ min }) with smaller views
 PASS ReadableStream with byte source: 3 byte enqueue(), then close(), then read({ min }) with 2-element Uint16Array must fail
 PASS ReadableStream with byte source: read({ min }) with 2-element Uint16Array, then 3 byte enqueue(), then close() must fail
-FAIL ReadableStream with byte source: tee() with read({ min }) from branch1 and read() from branch2 promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
+PASS ReadableStream with byte source: tee() with read({ min }) from branch1 and read() from branch2
 

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/read-min.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/read-min.any.serviceworker-expected.txt
@@ -22,5 +22,5 @@ PASS ReadableStream with byte source: cancel() with partially filled pending rea
 PASS ReadableStream with byte source: enqueue(), then read({ min }) with smaller views
 PASS ReadableStream with byte source: 3 byte enqueue(), then close(), then read({ min }) with 2-element Uint16Array must fail
 PASS ReadableStream with byte source: read({ min }) with 2-element Uint16Array, then 3 byte enqueue(), then close() must fail
-FAIL ReadableStream with byte source: tee() with read({ min }) from branch1 and read() from branch2 promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
+PASS ReadableStream with byte source: tee() with read({ min }) from branch1 and read() from branch2
 

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/read-min.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/read-min.any.sharedworker-expected.txt
@@ -22,5 +22,5 @@ PASS ReadableStream with byte source: cancel() with partially filled pending rea
 PASS ReadableStream with byte source: enqueue(), then read({ min }) with smaller views
 PASS ReadableStream with byte source: 3 byte enqueue(), then close(), then read({ min }) with 2-element Uint16Array must fail
 PASS ReadableStream with byte source: read({ min }) with 2-element Uint16Array, then 3 byte enqueue(), then close() must fail
-FAIL ReadableStream with byte source: tee() with read({ min }) from branch1 and read() from branch2 promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
+PASS ReadableStream with byte source: tee() with read({ min }) from branch1 and read() from branch2
 

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/read-min.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/read-min.any.worker-expected.txt
@@ -22,5 +22,5 @@ PASS ReadableStream with byte source: cancel() with partially filled pending rea
 PASS ReadableStream with byte source: enqueue(), then read({ min }) with smaller views
 PASS ReadableStream with byte source: 3 byte enqueue(), then close(), then read({ min }) with 2-element Uint16Array must fail
 PASS ReadableStream with byte source: read({ min }) with 2-element Uint16Array, then 3 byte enqueue(), then close() must fail
-FAIL ReadableStream with byte source: tee() with read({ min }) from branch1 and read() from branch2 promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
+PASS ReadableStream with byte source: tee() with read({ min }) from branch1 and read() from branch2
 

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/tee.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/tee.any-expected.txt
@@ -1,41 +1,43 @@
 
-FAIL ReadableStream teeing with byte source: rs.tee() returns an array of two ReadableStreams Teeing byte streams is not yet supported
-FAIL ReadableStream teeing with byte source: should be able to read one branch to the end without affecting the other promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: chunks should be cloned for each branch promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: chunks for BYOB requests from branch 1 should be cloned to branch 2 promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: errors in the source should propagate to both branches promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: canceling branch1 should not impact branch2 promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: canceling branch2 should not impact branch1 promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
+Harness Error (FAIL), message = Unhandled rejection: Type error
+
+PASS ReadableStream teeing with byte source: rs.tee() returns an array of two ReadableStreams
+PASS ReadableStream teeing with byte source: should be able to read one branch to the end without affecting the other
+PASS ReadableStream teeing with byte source: chunks should be cloned for each branch
+PASS ReadableStream teeing with byte source: chunks for BYOB requests from branch 1 should be cloned to branch 2
+PASS ReadableStream teeing with byte source: errors in the source should propagate to both branches
+PASS ReadableStream teeing with byte source: canceling branch1 should not impact branch2
+PASS ReadableStream teeing with byte source: canceling branch2 should not impact branch1
 PASS Running templatedRSTeeCancel with ReadableStream teeing with byte source
-FAIL ReadableStream teeing with byte source: canceling both branches should aggregate the cancel reasons into an array promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: canceling both branches in reverse order should aggregate the cancel reasons into an array promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: failing to cancel the original stream should cause cancel() to reject on branches promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: erroring a teed stream should properly handle canceled branches promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: closing the original should close the branches promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: erroring the original should immediately error the branches promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: erroring the original should error pending reads from default reader promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: erroring the original should error pending reads from BYOB reader promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: canceling branch1 should finish when branch2 reads until end of stream promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: canceling branch1 should finish when original stream errors promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: should not pull any chunks if no branches are reading promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: should only pull enough to fill the emptiest queue promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: should not pull when original is already errored promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: stops pulling when original stream errors while branch 1 is reading promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: stops pulling when original stream errors while branch 2 is reading promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: stops pulling when original stream errors while both branches are reading promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: canceling both branches in sequence with delay promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: failing to cancel when canceling both branches in sequence with delay promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: read from branch1 and branch2, cancel branch1, cancel branch2 promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: read from branch1 and branch2, cancel branch2, cancel branch1 promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: read from branch1 and branch2, cancel branch2, enqueue to branch1 promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: read from branch1 and branch2, cancel branch1, respond to branch2 promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: pull with BYOB reader, then pull with default reader promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: pull with default reader, then pull with BYOB reader promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: read from branch2, then read from branch1 promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: read from branch1 with default reader, then close while branch2 has pending BYOB read promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: read from branch2 with default reader, then close while branch1 has pending BYOB read promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: close when both branches have pending BYOB reads promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: enqueue() and close() while both branches are pulling promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: respond() and close() while both branches are pulling promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: reading an array with a byte offset should clone correctly promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
+PASS ReadableStream teeing with byte source: canceling both branches should aggregate the cancel reasons into an array
+PASS ReadableStream teeing with byte source: canceling both branches in reverse order should aggregate the cancel reasons into an array
+PASS ReadableStream teeing with byte source: failing to cancel the original stream should cause cancel() to reject on branches
+PASS ReadableStream teeing with byte source: erroring a teed stream should properly handle canceled branches
+PASS ReadableStream teeing with byte source: closing the original should close the branches
+PASS ReadableStream teeing with byte source: erroring the original should immediately error the branches
+PASS ReadableStream teeing with byte source: erroring the original should error pending reads from default reader
+PASS ReadableStream teeing with byte source: erroring the original should error pending reads from BYOB reader
+PASS ReadableStream teeing with byte source: canceling branch1 should finish when branch2 reads until end of stream
+PASS ReadableStream teeing with byte source: canceling branch1 should finish when original stream errors
+PASS ReadableStream teeing with byte source: should not pull any chunks if no branches are reading
+PASS ReadableStream teeing with byte source: should only pull enough to fill the emptiest queue
+PASS ReadableStream teeing with byte source: should not pull when original is already errored
+PASS ReadableStream teeing with byte source: stops pulling when original stream errors while branch 1 is reading
+PASS ReadableStream teeing with byte source: stops pulling when original stream errors while branch 2 is reading
+PASS ReadableStream teeing with byte source: stops pulling when original stream errors while both branches are reading
+PASS ReadableStream teeing with byte source: canceling both branches in sequence with delay
+PASS ReadableStream teeing with byte source: failing to cancel when canceling both branches in sequence with delay
+PASS ReadableStream teeing with byte source: read from branch1 and branch2, cancel branch1, cancel branch2
+PASS ReadableStream teeing with byte source: read from branch1 and branch2, cancel branch2, cancel branch1
+PASS ReadableStream teeing with byte source: read from branch1 and branch2, cancel branch2, enqueue to branch1
+PASS ReadableStream teeing with byte source: read from branch1 and branch2, cancel branch1, respond to branch2
+PASS ReadableStream teeing with byte source: pull with BYOB reader, then pull with default reader
+PASS ReadableStream teeing with byte source: pull with default reader, then pull with BYOB reader
+PASS ReadableStream teeing with byte source: read from branch2, then read from branch1
+PASS ReadableStream teeing with byte source: read from branch1 with default reader, then close while branch2 has pending BYOB read
+PASS ReadableStream teeing with byte source: read from branch2 with default reader, then close while branch1 has pending BYOB read
+PASS ReadableStream teeing with byte source: close when both branches have pending BYOB reads
+PASS ReadableStream teeing with byte source: enqueue() and close() while both branches are pulling
+PASS ReadableStream teeing with byte source: respond() and close() while both branches are pulling
+PASS ReadableStream teeing with byte source: reading an array with a byte offset should clone correctly
 

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/tee.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/tee.any.serviceworker-expected.txt
@@ -1,41 +1,43 @@
 
-FAIL ReadableStream teeing with byte source: rs.tee() returns an array of two ReadableStreams Teeing byte streams is not yet supported
-FAIL ReadableStream teeing with byte source: should be able to read one branch to the end without affecting the other promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: chunks should be cloned for each branch promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: chunks for BYOB requests from branch 1 should be cloned to branch 2 promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: errors in the source should propagate to both branches promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: canceling branch1 should not impact branch2 promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: canceling branch2 should not impact branch1 promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
+Harness Error (FAIL), message = Unhandled rejection: Type error
+
+PASS ReadableStream teeing with byte source: rs.tee() returns an array of two ReadableStreams
+PASS ReadableStream teeing with byte source: should be able to read one branch to the end without affecting the other
+PASS ReadableStream teeing with byte source: chunks should be cloned for each branch
+PASS ReadableStream teeing with byte source: chunks for BYOB requests from branch 1 should be cloned to branch 2
+PASS ReadableStream teeing with byte source: errors in the source should propagate to both branches
+PASS ReadableStream teeing with byte source: canceling branch1 should not impact branch2
+PASS ReadableStream teeing with byte source: canceling branch2 should not impact branch1
 PASS Running templatedRSTeeCancel with ReadableStream teeing with byte source
-FAIL ReadableStream teeing with byte source: canceling both branches should aggregate the cancel reasons into an array promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: canceling both branches in reverse order should aggregate the cancel reasons into an array promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: failing to cancel the original stream should cause cancel() to reject on branches promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: erroring a teed stream should properly handle canceled branches promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: closing the original should close the branches promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: erroring the original should immediately error the branches promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: erroring the original should error pending reads from default reader promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: erroring the original should error pending reads from BYOB reader promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: canceling branch1 should finish when branch2 reads until end of stream promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: canceling branch1 should finish when original stream errors promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: should not pull any chunks if no branches are reading promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: should only pull enough to fill the emptiest queue promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: should not pull when original is already errored promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: stops pulling when original stream errors while branch 1 is reading promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: stops pulling when original stream errors while branch 2 is reading promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: stops pulling when original stream errors while both branches are reading promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: canceling both branches in sequence with delay promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: failing to cancel when canceling both branches in sequence with delay promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: read from branch1 and branch2, cancel branch1, cancel branch2 promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: read from branch1 and branch2, cancel branch2, cancel branch1 promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: read from branch1 and branch2, cancel branch2, enqueue to branch1 promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: read from branch1 and branch2, cancel branch1, respond to branch2 promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: pull with BYOB reader, then pull with default reader promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: pull with default reader, then pull with BYOB reader promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: read from branch2, then read from branch1 promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: read from branch1 with default reader, then close while branch2 has pending BYOB read promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: read from branch2 with default reader, then close while branch1 has pending BYOB read promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: close when both branches have pending BYOB reads promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: enqueue() and close() while both branches are pulling promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: respond() and close() while both branches are pulling promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: reading an array with a byte offset should clone correctly promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
+PASS ReadableStream teeing with byte source: canceling both branches should aggregate the cancel reasons into an array
+PASS ReadableStream teeing with byte source: canceling both branches in reverse order should aggregate the cancel reasons into an array
+PASS ReadableStream teeing with byte source: failing to cancel the original stream should cause cancel() to reject on branches
+PASS ReadableStream teeing with byte source: erroring a teed stream should properly handle canceled branches
+PASS ReadableStream teeing with byte source: closing the original should close the branches
+PASS ReadableStream teeing with byte source: erroring the original should immediately error the branches
+PASS ReadableStream teeing with byte source: erroring the original should error pending reads from default reader
+PASS ReadableStream teeing with byte source: erroring the original should error pending reads from BYOB reader
+PASS ReadableStream teeing with byte source: canceling branch1 should finish when branch2 reads until end of stream
+PASS ReadableStream teeing with byte source: canceling branch1 should finish when original stream errors
+PASS ReadableStream teeing with byte source: should not pull any chunks if no branches are reading
+PASS ReadableStream teeing with byte source: should only pull enough to fill the emptiest queue
+PASS ReadableStream teeing with byte source: should not pull when original is already errored
+PASS ReadableStream teeing with byte source: stops pulling when original stream errors while branch 1 is reading
+PASS ReadableStream teeing with byte source: stops pulling when original stream errors while branch 2 is reading
+PASS ReadableStream teeing with byte source: stops pulling when original stream errors while both branches are reading
+PASS ReadableStream teeing with byte source: canceling both branches in sequence with delay
+PASS ReadableStream teeing with byte source: failing to cancel when canceling both branches in sequence with delay
+PASS ReadableStream teeing with byte source: read from branch1 and branch2, cancel branch1, cancel branch2
+PASS ReadableStream teeing with byte source: read from branch1 and branch2, cancel branch2, cancel branch1
+PASS ReadableStream teeing with byte source: read from branch1 and branch2, cancel branch2, enqueue to branch1
+PASS ReadableStream teeing with byte source: read from branch1 and branch2, cancel branch1, respond to branch2
+PASS ReadableStream teeing with byte source: pull with BYOB reader, then pull with default reader
+PASS ReadableStream teeing with byte source: pull with default reader, then pull with BYOB reader
+PASS ReadableStream teeing with byte source: read from branch2, then read from branch1
+PASS ReadableStream teeing with byte source: read from branch1 with default reader, then close while branch2 has pending BYOB read
+PASS ReadableStream teeing with byte source: read from branch2 with default reader, then close while branch1 has pending BYOB read
+PASS ReadableStream teeing with byte source: close when both branches have pending BYOB reads
+PASS ReadableStream teeing with byte source: enqueue() and close() while both branches are pulling
+PASS ReadableStream teeing with byte source: respond() and close() while both branches are pulling
+PASS ReadableStream teeing with byte source: reading an array with a byte offset should clone correctly
 

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/tee.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/tee.any.sharedworker-expected.txt
@@ -1,41 +1,43 @@
 
-FAIL ReadableStream teeing with byte source: rs.tee() returns an array of two ReadableStreams Teeing byte streams is not yet supported
-FAIL ReadableStream teeing with byte source: should be able to read one branch to the end without affecting the other promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: chunks should be cloned for each branch promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: chunks for BYOB requests from branch 1 should be cloned to branch 2 promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: errors in the source should propagate to both branches promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: canceling branch1 should not impact branch2 promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: canceling branch2 should not impact branch1 promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
+Harness Error (FAIL), message = Unhandled rejection: Type error
+
+PASS ReadableStream teeing with byte source: rs.tee() returns an array of two ReadableStreams
+PASS ReadableStream teeing with byte source: should be able to read one branch to the end without affecting the other
+PASS ReadableStream teeing with byte source: chunks should be cloned for each branch
+PASS ReadableStream teeing with byte source: chunks for BYOB requests from branch 1 should be cloned to branch 2
+PASS ReadableStream teeing with byte source: errors in the source should propagate to both branches
+PASS ReadableStream teeing with byte source: canceling branch1 should not impact branch2
+PASS ReadableStream teeing with byte source: canceling branch2 should not impact branch1
 PASS Running templatedRSTeeCancel with ReadableStream teeing with byte source
-FAIL ReadableStream teeing with byte source: canceling both branches should aggregate the cancel reasons into an array promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: canceling both branches in reverse order should aggregate the cancel reasons into an array promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: failing to cancel the original stream should cause cancel() to reject on branches promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: erroring a teed stream should properly handle canceled branches promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: closing the original should close the branches promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: erroring the original should immediately error the branches promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: erroring the original should error pending reads from default reader promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: erroring the original should error pending reads from BYOB reader promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: canceling branch1 should finish when branch2 reads until end of stream promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: canceling branch1 should finish when original stream errors promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: should not pull any chunks if no branches are reading promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: should only pull enough to fill the emptiest queue promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: should not pull when original is already errored promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: stops pulling when original stream errors while branch 1 is reading promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: stops pulling when original stream errors while branch 2 is reading promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: stops pulling when original stream errors while both branches are reading promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: canceling both branches in sequence with delay promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: failing to cancel when canceling both branches in sequence with delay promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: read from branch1 and branch2, cancel branch1, cancel branch2 promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: read from branch1 and branch2, cancel branch2, cancel branch1 promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: read from branch1 and branch2, cancel branch2, enqueue to branch1 promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: read from branch1 and branch2, cancel branch1, respond to branch2 promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: pull with BYOB reader, then pull with default reader promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: pull with default reader, then pull with BYOB reader promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: read from branch2, then read from branch1 promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: read from branch1 with default reader, then close while branch2 has pending BYOB read promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: read from branch2 with default reader, then close while branch1 has pending BYOB read promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: close when both branches have pending BYOB reads promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: enqueue() and close() while both branches are pulling promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: respond() and close() while both branches are pulling promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: reading an array with a byte offset should clone correctly promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
+PASS ReadableStream teeing with byte source: canceling both branches should aggregate the cancel reasons into an array
+PASS ReadableStream teeing with byte source: canceling both branches in reverse order should aggregate the cancel reasons into an array
+PASS ReadableStream teeing with byte source: failing to cancel the original stream should cause cancel() to reject on branches
+PASS ReadableStream teeing with byte source: erroring a teed stream should properly handle canceled branches
+PASS ReadableStream teeing with byte source: closing the original should close the branches
+PASS ReadableStream teeing with byte source: erroring the original should immediately error the branches
+PASS ReadableStream teeing with byte source: erroring the original should error pending reads from default reader
+PASS ReadableStream teeing with byte source: erroring the original should error pending reads from BYOB reader
+PASS ReadableStream teeing with byte source: canceling branch1 should finish when branch2 reads until end of stream
+PASS ReadableStream teeing with byte source: canceling branch1 should finish when original stream errors
+PASS ReadableStream teeing with byte source: should not pull any chunks if no branches are reading
+PASS ReadableStream teeing with byte source: should only pull enough to fill the emptiest queue
+PASS ReadableStream teeing with byte source: should not pull when original is already errored
+PASS ReadableStream teeing with byte source: stops pulling when original stream errors while branch 1 is reading
+PASS ReadableStream teeing with byte source: stops pulling when original stream errors while branch 2 is reading
+PASS ReadableStream teeing with byte source: stops pulling when original stream errors while both branches are reading
+PASS ReadableStream teeing with byte source: canceling both branches in sequence with delay
+PASS ReadableStream teeing with byte source: failing to cancel when canceling both branches in sequence with delay
+PASS ReadableStream teeing with byte source: read from branch1 and branch2, cancel branch1, cancel branch2
+PASS ReadableStream teeing with byte source: read from branch1 and branch2, cancel branch2, cancel branch1
+PASS ReadableStream teeing with byte source: read from branch1 and branch2, cancel branch2, enqueue to branch1
+PASS ReadableStream teeing with byte source: read from branch1 and branch2, cancel branch1, respond to branch2
+PASS ReadableStream teeing with byte source: pull with BYOB reader, then pull with default reader
+PASS ReadableStream teeing with byte source: pull with default reader, then pull with BYOB reader
+PASS ReadableStream teeing with byte source: read from branch2, then read from branch1
+PASS ReadableStream teeing with byte source: read from branch1 with default reader, then close while branch2 has pending BYOB read
+PASS ReadableStream teeing with byte source: read from branch2 with default reader, then close while branch1 has pending BYOB read
+PASS ReadableStream teeing with byte source: close when both branches have pending BYOB reads
+PASS ReadableStream teeing with byte source: enqueue() and close() while both branches are pulling
+PASS ReadableStream teeing with byte source: respond() and close() while both branches are pulling
+PASS ReadableStream teeing with byte source: reading an array with a byte offset should clone correctly
 

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/tee.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/tee.any.worker-expected.txt
@@ -1,41 +1,43 @@
 
-FAIL ReadableStream teeing with byte source: rs.tee() returns an array of two ReadableStreams Teeing byte streams is not yet supported
-FAIL ReadableStream teeing with byte source: should be able to read one branch to the end without affecting the other promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: chunks should be cloned for each branch promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: chunks for BYOB requests from branch 1 should be cloned to branch 2 promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: errors in the source should propagate to both branches promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: canceling branch1 should not impact branch2 promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: canceling branch2 should not impact branch1 promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
+Harness Error (FAIL), message = Unhandled rejection: Type error
+
+PASS ReadableStream teeing with byte source: rs.tee() returns an array of two ReadableStreams
+PASS ReadableStream teeing with byte source: should be able to read one branch to the end without affecting the other
+PASS ReadableStream teeing with byte source: chunks should be cloned for each branch
+PASS ReadableStream teeing with byte source: chunks for BYOB requests from branch 1 should be cloned to branch 2
+PASS ReadableStream teeing with byte source: errors in the source should propagate to both branches
+PASS ReadableStream teeing with byte source: canceling branch1 should not impact branch2
+PASS ReadableStream teeing with byte source: canceling branch2 should not impact branch1
 PASS Running templatedRSTeeCancel with ReadableStream teeing with byte source
-FAIL ReadableStream teeing with byte source: canceling both branches should aggregate the cancel reasons into an array promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: canceling both branches in reverse order should aggregate the cancel reasons into an array promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: failing to cancel the original stream should cause cancel() to reject on branches promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: erroring a teed stream should properly handle canceled branches promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: closing the original should close the branches promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: erroring the original should immediately error the branches promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: erroring the original should error pending reads from default reader promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: erroring the original should error pending reads from BYOB reader promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: canceling branch1 should finish when branch2 reads until end of stream promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: canceling branch1 should finish when original stream errors promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: should not pull any chunks if no branches are reading promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: should only pull enough to fill the emptiest queue promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: should not pull when original is already errored promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: stops pulling when original stream errors while branch 1 is reading promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: stops pulling when original stream errors while branch 2 is reading promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: stops pulling when original stream errors while both branches are reading promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: canceling both branches in sequence with delay promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: failing to cancel when canceling both branches in sequence with delay promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: read from branch1 and branch2, cancel branch1, cancel branch2 promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: read from branch1 and branch2, cancel branch2, cancel branch1 promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: read from branch1 and branch2, cancel branch2, enqueue to branch1 promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: read from branch1 and branch2, cancel branch1, respond to branch2 promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: pull with BYOB reader, then pull with default reader promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: pull with default reader, then pull with BYOB reader promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: read from branch2, then read from branch1 promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: read from branch1 with default reader, then close while branch2 has pending BYOB read promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: read from branch2 with default reader, then close while branch1 has pending BYOB read promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: close when both branches have pending BYOB reads promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: enqueue() and close() while both branches are pulling promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: respond() and close() while both branches are pulling promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
-FAIL ReadableStream teeing with byte source: reading an array with a byte offset should clone correctly promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
+PASS ReadableStream teeing with byte source: canceling both branches should aggregate the cancel reasons into an array
+PASS ReadableStream teeing with byte source: canceling both branches in reverse order should aggregate the cancel reasons into an array
+PASS ReadableStream teeing with byte source: failing to cancel the original stream should cause cancel() to reject on branches
+PASS ReadableStream teeing with byte source: erroring a teed stream should properly handle canceled branches
+PASS ReadableStream teeing with byte source: closing the original should close the branches
+PASS ReadableStream teeing with byte source: erroring the original should immediately error the branches
+PASS ReadableStream teeing with byte source: erroring the original should error pending reads from default reader
+PASS ReadableStream teeing with byte source: erroring the original should error pending reads from BYOB reader
+PASS ReadableStream teeing with byte source: canceling branch1 should finish when branch2 reads until end of stream
+PASS ReadableStream teeing with byte source: canceling branch1 should finish when original stream errors
+PASS ReadableStream teeing with byte source: should not pull any chunks if no branches are reading
+PASS ReadableStream teeing with byte source: should only pull enough to fill the emptiest queue
+PASS ReadableStream teeing with byte source: should not pull when original is already errored
+PASS ReadableStream teeing with byte source: stops pulling when original stream errors while branch 1 is reading
+PASS ReadableStream teeing with byte source: stops pulling when original stream errors while branch 2 is reading
+PASS ReadableStream teeing with byte source: stops pulling when original stream errors while both branches are reading
+PASS ReadableStream teeing with byte source: canceling both branches in sequence with delay
+PASS ReadableStream teeing with byte source: failing to cancel when canceling both branches in sequence with delay
+PASS ReadableStream teeing with byte source: read from branch1 and branch2, cancel branch1, cancel branch2
+PASS ReadableStream teeing with byte source: read from branch1 and branch2, cancel branch2, cancel branch1
+PASS ReadableStream teeing with byte source: read from branch1 and branch2, cancel branch2, enqueue to branch1
+PASS ReadableStream teeing with byte source: read from branch1 and branch2, cancel branch1, respond to branch2
+PASS ReadableStream teeing with byte source: pull with BYOB reader, then pull with default reader
+PASS ReadableStream teeing with byte source: pull with default reader, then pull with BYOB reader
+PASS ReadableStream teeing with byte source: read from branch2, then read from branch1
+PASS ReadableStream teeing with byte source: read from branch1 with default reader, then close while branch2 has pending BYOB read
+PASS ReadableStream teeing with byte source: read from branch2 with default reader, then close while branch1 has pending BYOB read
+PASS ReadableStream teeing with byte source: close when both branches have pending BYOB reads
+PASS ReadableStream teeing with byte source: enqueue() and close() while both branches are pulling
+PASS ReadableStream teeing with byte source: respond() and close() while both branches are pulling
+PASS ReadableStream teeing with byte source: reading an array with a byte offset should clone correctly
 

--- a/Source/WebCore/Modules/fetch/FetchBody.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBody.cpp
@@ -328,7 +328,7 @@ FetchBody::TakenData FetchBody::take()
     return nullptr;
 }
 
-FetchBody FetchBody::clone()
+FetchBody FetchBody::clone(JSDOMGlobalObject& globalObject)
 {
     FetchBody clone(m_consumer.clone());
 
@@ -345,7 +345,7 @@ FetchBody FetchBody::clone()
     else if (isURLSearchParams())
         clone.m_data = protectedURLSearchParamsBody();
     else if (RefPtr readableStream = m_readableStream) {
-        auto clones = readableStream->tee(true);
+        auto clones = readableStream->tee(globalObject, true);
         ASSERT(!clones.hasException());
         if (!clones.hasException()) {
             auto pair = clones.releaseReturnValue();

--- a/Source/WebCore/Modules/fetch/FetchBody.h
+++ b/Source/WebCore/Modules/fetch/FetchBody.h
@@ -85,7 +85,7 @@ public:
     void cleanConsumer() { m_consumer.clean(); }
     bool hasConsumerPendingActivity() const { return m_consumer.hasPendingActivity(); }
 
-    FetchBody clone();
+    FetchBody clone(JSDOMGlobalObject&);
 
     bool hasReadableStream() const { return !!m_readableStream; }
     const ReadableStream* readableStream() const { return m_readableStream.get(); }

--- a/Source/WebCore/Modules/fetch/FetchBodyOwner.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBodyOwner.cpp
@@ -163,12 +163,12 @@ void FetchBodyOwner::bytes(Ref<DeferredPromise>&& promise)
     m_body->bytes(*this, WTFMove(promise));
 }
 
-void FetchBodyOwner::cloneBody(FetchBodyOwner& owner)
+void FetchBodyOwner::cloneBody(JSDOMGlobalObject& globalObject, FetchBodyOwner& owner)
 {
     m_loadingError = owner.m_loadingError;
     if (owner.isBodyNull())
         return;
-    m_body = owner.m_body->clone();
+    m_body = owner.m_body->clone(globalObject);
 }
 
 ExceptionOr<void> FetchBodyOwner::extractBody(FetchBody::Init&& value)

--- a/Source/WebCore/Modules/fetch/FetchBodyOwner.h
+++ b/Source/WebCore/Modules/fetch/FetchBodyOwner.h
@@ -90,7 +90,7 @@ protected:
     const FetchBody& body() const { return *m_body; }
     bool isBodyNull() const { return !m_body; }
     bool isBodyNullOrOpaque() const { return !m_body || m_isBodyOpaque; }
-    void cloneBody(FetchBodyOwner&);
+    void cloneBody(JSDOMGlobalObject&, FetchBodyOwner&);
 
     ExceptionOr<void> extractBody(FetchBody::Init&&);
     void consumeOnceLoadingFinished(FetchBodyConsumer::Type, Ref<DeferredPromise>&&);

--- a/Source/WebCore/Modules/fetch/FetchRequest.cpp
+++ b/Source/WebCore/Modules/fetch/FetchRequest.cpp
@@ -387,7 +387,7 @@ ResourceRequest FetchRequest::resourceRequest() const
     return request;
 }
 
-ExceptionOr<Ref<FetchRequest>> FetchRequest::clone()
+ExceptionOr<Ref<FetchRequest>> FetchRequest::clone(JSDOMGlobalObject& globalObject)
 {
     if (isDisturbedOrLocked())
         return Exception { ExceptionCode::TypeError, "Body is disturbed or locked"_s };
@@ -396,7 +396,7 @@ ExceptionOr<Ref<FetchRequest>> FetchRequest::clone()
         return Exception { ExceptionCode::InvalidStateError, "Cannot clone FetchRequest without a valid script execution context"_s };
     auto clone = adoptRef(*new FetchRequest(*context, std::nullopt, FetchHeaders::create(m_headers.get()), ResourceRequest { m_request }, FetchOptions { m_options }, String { m_referrer }));
     clone->suspendIfNeeded();
-    clone->cloneBody(*this);
+    clone->cloneBody(globalObject, *this);
     clone->setNavigationPreloadIdentifier(m_navigationPreloadIdentifier);
     clone->m_enableContentExtensionsCheck = m_enableContentExtensionsCheck;
     if (RefPtr document = dynamicDowncast<Document>(*context); document && document->settings().localNetworkAccessEnabled())

--- a/Source/WebCore/Modules/fetch/FetchRequest.h
+++ b/Source/WebCore/Modules/fetch/FetchRequest.h
@@ -77,7 +77,7 @@ public:
 
     const String& integrity() const { return m_options.integrity; }
 
-    ExceptionOr<Ref<FetchRequest>> clone();
+    ExceptionOr<Ref<FetchRequest>> clone(JSDOMGlobalObject&);
 
     const FetchOptions& fetchOptions() const { return m_options; }
     const ResourceRequest& internalRequest() const { return m_request; }

--- a/Source/WebCore/Modules/fetch/FetchRequest.idl
+++ b/Source/WebCore/Modules/fetch/FetchRequest.idl
@@ -57,7 +57,7 @@ typedef (FetchRequest or USVString) RequestInfo;
     readonly attribute AbortSignal signal;
     [EnabledBySetting=LocalNetworkAccessEnabled] readonly attribute IPAddressSpace targetAddressSpace;
 
-    [NewObject] FetchRequest clone();
+    [CallWith=CurrentGlobalObject, NewObject] FetchRequest clone();
 };
 
 FetchRequest includes FetchBody;

--- a/Source/WebCore/Modules/fetch/FetchResponse.cpp
+++ b/Source/WebCore/Modules/fetch/FetchResponse.cpp
@@ -196,7 +196,7 @@ FetchResponse::FetchResponse(ScriptExecutionContext* context, std::optional<Fetc
 {
 }
 
-ExceptionOr<Ref<FetchResponse>> FetchResponse::clone()
+ExceptionOr<Ref<FetchResponse>> FetchResponse::clone(JSDOMGlobalObject& globalObject)
 {
     if (isDisturbedOrLocked())
         return Exception { ExceptionCode::TypeError, "Body is disturbed or locked"_s };
@@ -219,7 +219,7 @@ ExceptionOr<Ref<FetchResponse>> FetchResponse::clone()
 
     Ref headers = FetchHeaders::create(this->headers());
     auto clone = FetchResponse::create(context.get(), std::nullopt, WTFMove(headers), ResourceResponse { m_internalResponse });
-    clone->cloneBody(*this);
+    clone->cloneBody(globalObject, *this);
     clone->m_opaqueLoadIdentifier = m_opaqueLoadIdentifier;
     clone->m_bodySizeWithPadding = m_bodySizeWithPadding;
     return clone;

--- a/Source/WebCore/Modules/fetch/FetchResponse.h
+++ b/Source/WebCore/Modules/fetch/FetchResponse.h
@@ -88,7 +88,7 @@ public:
 
     const FetchHeaders& headers() const { return m_headers; }
     FetchHeaders& headers() { return m_headers; }
-    ExceptionOr<Ref<FetchResponse>> clone();
+    ExceptionOr<Ref<FetchResponse>> clone(JSDOMGlobalObject&);
 
     void consumeBodyAsStream() final;
     void feedStream() final;

--- a/Source/WebCore/Modules/fetch/FetchResponse.idl
+++ b/Source/WebCore/Modules/fetch/FetchResponse.idl
@@ -58,7 +58,7 @@ dictionary FetchResponseInit {
     readonly attribute ByteString statusText;
     [SameObject] readonly attribute FetchHeaders headers;
 
-    [NewObject] FetchResponse clone();
+    [CallWith=CurrentGlobalObject, NewObject] FetchResponse clone();
 };
 
 FetchResponse includes FetchBody;

--- a/Source/WebCore/Modules/streams/ReadableByteStreamController.h
+++ b/Source/WebCore/Modules/streams/ReadableByteStreamController.h
@@ -94,13 +94,14 @@ public:
     JSValueInWrappedObject& underlyingSourceConcurrently() { return m_underlyingSource; }
     JSValueInWrappedObject& storedErrorConcurrently() { return m_storedError; }
 
+    using PullAlgorithm = Function<Ref<DOMPromise>(JSDOMGlobalObject&, ReadableByteStreamController&)>;
+    using CancelAlgorithm = Function<Ref<DOMPromise>(JSDOMGlobalObject&, ReadableByteStreamController&, std::optional<JSC::JSValue>&&)>;
+
 private:
     friend ReadableStream;
     ReadableByteStreamController(ReadableStream&, JSC::JSValue, RefPtr<UnderlyingSourcePullCallback>&&, RefPtr<UnderlyingSourceCancelCallback>&&, double highWaterMark, size_t autoAllocateChunkSize);
 
     using Callback = Function<void(JSDOMGlobalObject&, std::optional<JSC::JSValue>&&)>;
-    using PullAlgorithm = Function<Ref<DOMPromise>(JSDOMGlobalObject&, ReadableByteStreamController&)>;
-    using CancelAlgorithm = Function<Ref<DOMPromise>(JSDOMGlobalObject&, ReadableByteStreamController&, std::optional<JSC::JSValue>&&)>;
     ReadableByteStreamController(ReadableStream&, PullAlgorithm&&, CancelAlgorithm&&, double highWaterMark, size_t autoAllocateChunkSize);
 
     enum ReaderType : uint8_t { None, Default, Byob };

--- a/Source/WebCore/Modules/streams/ReadableStream.h
+++ b/Source/WebCore/Modules/streams/ReadableStream.h
@@ -71,7 +71,7 @@ public:
 
     void cancel(JSDOMGlobalObject&, JSC::JSValue, Ref<DeferredPromise>&&);
     ExceptionOr<ReadableStreamReader> getReader(JSDOMGlobalObject&, const GetReaderOptions&);
-    ExceptionOr<Vector<Ref<ReadableStream>>> tee(bool shouldClone = false);
+    ExceptionOr<Vector<Ref<ReadableStream>>> tee(JSDOMGlobalObject&, bool shouldClone = false);
 
     using State = InternalReadableStream::State;
     State state() const;
@@ -116,6 +116,8 @@ public:
 
     void visitAdditionalChildren(JSC::AbstractSlotVisitor&);
 
+    static Ref<ReadableStream> createReadableByteStream(JSDOMGlobalObject&, ReadableByteStreamController::PullAlgorithm&&, ReadableByteStreamController::CancelAlgorithm&&);
+
 protected:
     static ExceptionOr<Ref<ReadableStream>> createFromJSValues(JSC::JSGlobalObject&, JSC::JSValue, JSC::JSValue);
     static ExceptionOr<Ref<InternalReadableStream>> createInternalReadableStream(JSDOMGlobalObject&, Ref<ReadableStreamSource>&&);
@@ -124,9 +126,6 @@ protected:
 private:
     ExceptionOr<void> setupReadableByteStreamControllerFromUnderlyingSource(JSDOMGlobalObject&, JSC::JSValue, UnderlyingSource&&, double);
     void setupReadableByteStreamController(JSDOMGlobalObject&, ReadableByteStreamController::PullAlgorithm&&, ReadableByteStreamController::CancelAlgorithm&&, double);
-    ExceptionOr<Vector<Ref<ReadableStream>>> byteStreamTee(JSDOMGlobalObject&);
-
-    static Ref<ReadableStream> createReadableByteStream(JSDOMGlobalObject&, ReadableByteStreamController::PullAlgorithm&&, ReadableByteStreamController::CancelAlgorithm&&);
 
     bool m_disturbed { false };
     WeakPtr<ReadableStreamDefaultReader> m_defaultReader;

--- a/Source/WebCore/Modules/streams/ReadableStream.idl
+++ b/Source/WebCore/Modules/streams/ReadableStream.idl
@@ -54,7 +54,7 @@ typedef (ReadableStreamDefaultReader or ReadableStreamBYOBReader) ReadableStream
     [CallWith=CurrentGlobalObject] ReadableStreamReader getReader(optional ReadableStreamGetReaderOptions options = { });
     [Custom, ReturnsOwnPromise] Promise<undefined> pipeTo(WritableStream destination, optional StreamPipeOptions options = {});
     [Custom] ReadableStream pipeThrough(ReadableWritablePair transform, optional StreamPipeOptions options = {});
-    sequence<ReadableStream> tee();
+    [CallWith=CurrentGlobalObject] sequence<ReadableStream> tee();
 
     [ImplementedAs=isLocked] readonly attribute boolean locked;
 };

--- a/Source/WebCore/Modules/streams/StreamTeeUtilities.cpp
+++ b/Source/WebCore/Modules/streams/StreamTeeUtilities.cpp
@@ -1,0 +1,556 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#include "config.h"
+#include "StreamTeeUtilities.h"
+
+#include "JSDOMPromise.h"
+#include "JSDOMPromiseDeferred.h"
+#include "JSReadableStreamReadResult.h"
+#include "ReadableByteStreamController.h"
+#include "ReadableStream.h"
+#include "ReadableStreamBYOBReader.h"
+#include "ReadableStreamBYOBRequest.h"
+#include "ReadableStreamDefaultReader.h"
+
+namespace WebCore {
+
+class StreamTeeState : public RefCountedAndCanMakeWeakPtr<StreamTeeState> {
+public:
+    template<typename Reader>
+    static Ref<StreamTeeState> create(JSDOMGlobalObject& globalObject, Ref<ReadableStream>&& stream, Ref<Reader>&& reader)
+    {
+        auto [cancelPromise, cancelDeferred] = createPromiseAndWrapper(globalObject);
+        return adoptRef(*new StreamTeeState(WTFMove(stream), WTFMove(reader), WTFMove(cancelDeferred), WTFMove(cancelPromise)));
+    }
+
+    ~StreamTeeState();
+
+    bool isReader(const ReadableStreamDefaultReader* thisReader) const { return m_defaultReader && m_defaultReader.get() == thisReader; }
+    bool isReader(const ReadableStreamBYOBReader* thisReader) const { return m_byobReader && m_byobReader.get() == thisReader; }
+
+    bool reading() const { return m_reading; }
+    void setReading(bool value) { m_reading = value; }
+
+    bool readAgainForBranch1() const { return m_readAgainForBranch1; }
+    void setReadAgainForBranch1(bool value) { m_readAgainForBranch1 = value; }
+
+    bool readAgainForBranch2() const { return m_readAgainForBranch2; }
+    void setReadAgainForBranch2(bool value) { m_readAgainForBranch2 = value; }
+
+    bool canceled1() const { return m_canceled1; }
+    bool canceled2() const { return m_canceled2; }
+    void setCanceled1() { m_canceled1 = true; }
+    void setCanceled2() { m_canceled2 = true; }
+    JSC::Strong<JSC::Unknown> takeReason1() { return std::exchange(m_branch1Reason, { }); }
+    JSC::Strong<JSC::Unknown> takeReason2() { return std::exchange(m_branch2Reason, { }); }
+    void setReason1(JSDOMGlobalObject& globalObject, JSC::JSValue value)
+    {
+        Ref vm = globalObject.vm();
+        m_branch1Reason = { vm, value };
+    }
+    void setReason2(JSDOMGlobalObject& globalObject, JSC::JSValue value)
+    {
+        Ref vm = globalObject.vm();
+        m_branch2Reason = { vm, value };
+    }
+
+    ReadableStream& stream() const { return m_stream; }
+    ReadableStream* branch1() const { return m_branch1.get(); }
+    ReadableStream* branch2() const { return m_branch2.get(); }
+    void setBranch1(ReadableStream& stream) { m_branch1 = &stream; }
+    void setBranch2(ReadableStream& stream) { m_branch2 = &stream; }
+
+    DOMPromise* readPromise() const { return m_readPromise.get(); }
+    void setReadPromise(Ref<DOMPromise>&& promise)
+    {
+        ASSERT(!m_readPromise || m_readPromise->status() != DOMPromise::Status::Pending);
+        m_readPromise = WTFMove(promise);
+    }
+
+    ReadableStreamBYOBReader* byobReader() const { return m_byobReader.get(); }
+    RefPtr<ReadableStreamBYOBReader> takeBYOBReader() { return std::exchange(m_byobReader, { }); }
+    void setReader(Ref<ReadableStreamBYOBReader>&& reader)
+    {
+        ASSERT(!m_defaultReader);
+        ASSERT(!m_byobReader);
+        m_byobReader = WTFMove(reader);
+    }
+
+    ReadableStreamDefaultReader* defaultReader() const { return m_defaultReader.get(); }
+    RefPtr<ReadableStreamDefaultReader> takeDefaultReader() { return std::exchange(m_defaultReader, { }); }
+    void setReader(Ref<ReadableStreamDefaultReader>&& reader)
+    {
+        ASSERT(!m_defaultReader);
+        ASSERT(!m_byobReader);
+        m_defaultReader = WTFMove(reader);
+    }
+
+    DOMPromise& cancelPromise() { return m_cancelPromise; }
+
+    void resolveCancelPromise()
+    {
+        Ref { m_cancelDeferredPromise }->resolve();
+    }
+
+    void rejectCancelPromise(JSC::JSValue value)
+    {
+        Ref { m_cancelDeferredPromise }->rejectWithCallback([&](auto&) {
+            return value;
+        });
+    }
+
+    template<typename Reader>
+    void forwardReadError(Reader& thisReader)
+    {
+        thisReader.onClosedPromiseRejection([weakThis = WeakPtr { *this }, thisReader = WeakPtr { thisReader }](auto& globalObject, auto&& reason) {
+            RefPtr protectedThis = weakThis.get();
+            if (!protectedThis || !protectedThis->isReader(thisReader.get()))
+                return;
+
+            if (RefPtr branch1 = protectedThis->branch1())
+                branch1->controller()->error(globalObject, reason);
+            if (RefPtr branch2 = protectedThis->branch2())
+                branch2->controller()->error(globalObject, reason);
+            if (!protectedThis->canceled1() || !protectedThis->canceled2())
+                protectedThis->resolveCancelPromise();
+        });
+    }
+
+private:
+    StreamTeeState(Ref<ReadableStream>&& stream, Ref<ReadableStreamDefaultReader>&& reader, Ref<DeferredPromise>&& cancelDeferred, Ref<DOMPromise>&& cancelPromise)
+        : m_stream(WTFMove(stream))
+        , m_defaultReader(WTFMove(reader))
+        , m_cancelDeferredPromise(WTFMove(cancelDeferred))
+        , m_cancelPromise(WTFMove(cancelPromise))
+    {
+    }
+
+    StreamTeeState(Ref<ReadableStream>&& stream, Ref<ReadableStreamBYOBReader>&& reader, Ref<DeferredPromise>&& cancelDeferred, Ref<DOMPromise>&& cancelPromise)
+        : m_stream(WTFMove(stream))
+        , m_byobReader(WTFMove(reader))
+        , m_cancelDeferredPromise(WTFMove(cancelDeferred))
+        , m_cancelPromise(WTFMove(cancelPromise))
+    {
+    }
+
+    const Ref<ReadableStream> m_stream;
+    RefPtr<ReadableStreamDefaultReader> m_defaultReader;
+    RefPtr<ReadableStreamBYOBReader> m_byobReader;
+    bool m_reading = false;
+    bool m_readAgainForBranch1 = false;
+    bool m_readAgainForBranch2 = false;
+    bool m_canceled1 = false;
+    bool m_canceled2 = false;
+    Ref<DeferredPromise> m_cancelDeferredPromise;
+    Ref<DOMPromise> m_cancelPromise;
+    RefPtr<ReadableStream> m_branch1;
+    RefPtr<ReadableStream> m_branch2;
+
+    // FIXME: we should probably have m_stream mark m_branch1Reason and m_branch2Reason instead of taking strong.
+    JSC::Strong<JSC::Unknown> m_branch1Reason;
+    JSC::Strong<JSC::Unknown> m_branch2Reason;
+
+    RefPtr<DOMPromise> m_readPromise;
+};
+
+// https://streams.spec.whatwg.org/#abstract-opdef-readablebytestreamtee
+ExceptionOr<Vector<Ref<ReadableStream>>> byteStreamTee(JSDOMGlobalObject& globalObject, ReadableStream& stream)
+{
+    ASSERT(stream.controller());
+
+    auto readerOrException = ReadableStreamDefaultReader::create(globalObject, stream);
+    if (readerOrException.hasException())
+        return readerOrException.releaseException();
+
+    Ref reader = readerOrException.releaseReturnValue();
+    Ref state = StreamTeeState::create(globalObject, stream, reader.copyRef());
+
+    ReadableByteStreamController::PullAlgorithm pull1Algorithm = [state = Ref { state }](auto& globalObject, auto&&) {
+        return pull1Steps(globalObject, state, Ref { *state->branch1() });
+    };
+
+    ReadableByteStreamController::PullAlgorithm pull2Algorithm = [state = Ref { state }](auto& globalObject, auto&&) {
+        return pull2Steps(globalObject, state, Ref { *state->branch2() });
+    };
+
+    ReadableByteStreamController::CancelAlgorithm cancel1Algorithm = [state = Ref { state }](auto& globalObject, auto&&, auto&& reason) {
+        state->setCanceled1();
+        state->setReason1(globalObject, reason.value_or(JSC::jsUndefined()));
+
+        if (state->canceled2()) {
+            // Create the array of reason1 and reason2.
+            JSC::MarkedArgumentBuffer list;
+            list.ensureCapacity(2);
+            list.append(state->takeReason1().get());
+            list.append(state->takeReason2().get());
+            JSC::JSValue reason = JSC::constructArray(&globalObject, static_cast<JSC::ArrayAllocationProfile*>(nullptr), list);
+
+            auto [promise, deferred] = createPromiseAndWrapper(globalObject);
+            state->stream().cancel(globalObject, reason, WTFMove(deferred));
+            promise->whenSettled([state, promise] {
+                if (promise->status() == DOMPromise::Status::Rejected) {
+                    state->rejectCancelPromise(promise->result());
+                    return;
+                }
+                state->resolveCancelPromise();
+            });
+        }
+        return Ref { state->cancelPromise() };
+    };
+
+    ReadableByteStreamController::CancelAlgorithm cancel2Algorithm = [state = Ref { state }](auto& globalObject, auto&&, auto&& reason) {
+        state->setCanceled2();
+        state->setReason2(globalObject, reason.value_or(JSC::jsUndefined()));
+
+        if (state->canceled1()) {
+            // Create the array of reason1 and reason2.
+            JSC::MarkedArgumentBuffer list;
+            list.ensureCapacity(2);
+            list.append(state->takeReason1().get());
+            list.append(state->takeReason2().get());
+            JSC::JSValue reason = JSC::constructArray(&globalObject, static_cast<JSC::ArrayAllocationProfile*>(nullptr), list);
+
+            auto [promise, deferred] = createPromiseAndWrapper(globalObject);
+            state->stream().cancel(globalObject, reason, WTFMove(deferred));
+            promise->whenSettled([state, promise] {
+                if (promise->status() == DOMPromise::Status::Rejected) {
+                    state->rejectCancelPromise(promise->result());
+                    return;
+                }
+                state->resolveCancelPromise();
+            });
+        }
+        return Ref { state->cancelPromise() };
+    };
+
+    Vector<Ref<ReadableStream>> branches;
+    branches.append(ReadableStream::createReadableByteStream(globalObject, WTFMove(pull1Algorithm), WTFMove(cancel1Algorithm)));
+    branches.append(ReadableStream::createReadableByteStream(globalObject, WTFMove(pull2Algorithm), WTFMove(cancel2Algorithm)));
+
+    state->setBranch1(branches[0]);
+    state->setBranch2(branches[1]);
+
+    state->forwardReadError(reader.get());
+
+    return branches;
+}
+
+StreamTeeState::~StreamTeeState() = default;
+
+static ExceptionOr<Ref<JSC::ArrayBufferView>> cloneAsUInt8Array(JSC::ArrayBufferView& o)
+{
+    RefPtr buffer = JSC::ArrayBuffer::tryCreate(o.span());
+    if (!buffer)
+        return Exception { ExceptionCode::OutOfMemoryError };
+
+    Ref<JSC::ArrayBufferView> clone = JSC::Uint8Array::create(WTFMove(buffer), 0, o.byteLength());
+
+    return clone;
+}
+
+static void pullWithBYOBReader(JSDOMGlobalObject&, StreamTeeState&, ReadableStreamBYOBRequest&, bool);
+static void pullWithDefaultReader(JSDOMGlobalObject&, StreamTeeState&);
+
+static Ref<DOMPromise> pull1Steps(JSDOMGlobalObject& globalObject, StreamTeeState& state, ReadableStream& branch1)
+{
+    if (state.reading()) {
+        state.setReadAgainForBranch1(true);
+        auto [promise, deferred] = createPromiseAndWrapper(globalObject);
+        deferred->resolve();
+        return promise;
+    }
+
+    state.setReading(true);
+
+    RefPtr byobRequest = branch1.protectedController()->getByobRequest();
+    if (!byobRequest)
+        pullWithDefaultReader(globalObject, state);
+    else
+        pullWithBYOBReader(globalObject, state, *byobRequest, false);
+
+    auto [promise, deferred] = createPromiseAndWrapper(globalObject);
+    deferred->resolve();
+    return promise;
+}
+
+static Ref<DOMPromise> pull2Steps(JSDOMGlobalObject& globalObject, StreamTeeState& state, ReadableStream& branch2)
+{
+    if (state.reading()) {
+        state.setReadAgainForBranch2(true);
+        auto [promise, deferred] = createPromiseAndWrapper(globalObject);
+        deferred->resolve();
+        return promise;
+    }
+
+    state.setReading(true);
+
+    RefPtr byobRequest = branch2.protectedController()->getByobRequest();
+    if (!byobRequest)
+        pullWithDefaultReader(globalObject, state);
+    else
+        pullWithBYOBReader(globalObject, state, *byobRequest, true);
+
+    auto [promise, deferred] = createPromiseAndWrapper(globalObject);
+    deferred->resolve();
+    return promise;
+}
+
+static void pullWithDefaultReader(JSDOMGlobalObject& globalObject, StreamTeeState& state)
+{
+    if (RefPtr byobReader = state.takeBYOBReader()) {
+        ASSERT(!byobReader->readIntoRequestsSize());
+        byobReader->releaseLock(globalObject);
+
+        auto readerOrException = ReadableStreamDefaultReader::create(globalObject, Ref { state.stream() }.get());
+        if (readerOrException.hasException()) {
+            ASSERT_NOT_REACHED();
+            return;
+        }
+        Ref reader = readerOrException.releaseReturnValue();
+        state.setReader(reader.get());
+        state.forwardReadError(reader.get());
+    }
+
+    RefPtr reader = state.defaultReader();
+
+    auto [promise, deferred] = createPromiseAndWrapper(globalObject);
+    reader->read(globalObject, WTFMove(deferred));
+    promise->whenSettled([state = Ref { state }, weakReader = WeakPtr { *reader }] {
+        RefPtr readPromise = state->readPromise();
+        RefPtr reader = weakReader.get();
+        if (!readPromise || !reader)
+            return;
+
+        switch (readPromise->status()) {
+        case DOMPromise::Status::Fulfilled: {
+            auto& globalObject = *readPromise->globalObject();
+
+            Ref vm = globalObject.vm();
+            auto scope = DECLARE_THROW_SCOPE(vm);
+            auto resultOrException = convertDictionary<ReadableStreamReadResult>(globalObject, readPromise->result());
+            ASSERT(!resultOrException.hasException(scope));
+            if (resultOrException.hasException(scope))
+                return;
+
+            RefPtr branch1 = state->branch1();
+            RefPtr branch2 = state->branch2();
+
+            auto result = resultOrException.releaseReturnValue();
+            if (!result.done) {
+                // chunk steps.
+                state->setReadAgainForBranch1(false);
+                state->setReadAgainForBranch2(false);
+
+                auto chunkResult = convert<IDLArrayBufferView>(globalObject, result.value);
+                if (chunkResult.hasException(scope)) [[unlikely]]
+                    return;
+
+                Ref chunk1 = chunkResult.releaseReturnValue();
+                Ref chunk2 = chunk1;
+
+                if (!state->canceled1() && !state->canceled2()) {
+                    auto resultOrException = cloneAsUInt8Array(chunk1);
+                    if (resultOrException.hasException()) {
+                        if (branch1)
+                            branch1->controller()->error(globalObject, resultOrException.exception());
+                        if (branch2)
+                            branch2->controller()->error(globalObject, resultOrException.exception());
+
+                        state->stream().cancel(resultOrException.releaseException());
+                        return;
+                    }
+                    chunk2 = resultOrException.releaseReturnValue();
+                }
+                if (!state->canceled1() && branch1)
+                    branch1->protectedController()->enqueue(globalObject, chunk1);
+                if (!state->canceled2() && branch2)
+                    branch2->protectedController()->enqueue(globalObject, chunk2);
+
+                state->setReading(false);
+                if (state->readAgainForBranch1() && branch1)
+                    pull1Steps(globalObject, state, *branch1);
+                else if (state->readAgainForBranch2() && branch2)
+                    pull2Steps(globalObject, state, *branch2);
+                return;
+            }
+
+            // close steps.
+            state->setReading(false);
+            if (!state->canceled1() && branch1)
+                branch1->controller()->close(globalObject);
+            if (!state->canceled2() && branch2)
+                branch2->controller()->close(globalObject);
+
+            if (branch1 && branch1->protectedController()->hasPendingPullIntos())
+                branch1->protectedController()->respond(globalObject, 0);
+            if (branch2 && branch2->protectedController()->hasPendingPullIntos())
+                branch2->protectedController()->respond(globalObject, 0);
+
+            if (!state->canceled1() || !state->canceled2())
+                state->resolveCancelPromise();
+            return;
+        }
+        case DOMPromise::Status::Rejected:
+            // error steps.
+            state->setReading(false);
+            return;
+        case DOMPromise::Status::Pending:
+            ASSERT_NOT_REACHED();
+            break;
+        }
+    });
+    state.setReadPromise(WTFMove(promise));
+}
+
+static void pullWithBYOBReader(JSDOMGlobalObject& globalObject, StreamTeeState& state, ReadableStreamBYOBRequest& request, bool forBranch2)
+{
+    if (RefPtr defaultReader = state.takeDefaultReader()) {
+        ASSERT(!defaultReader->getNumReadRequests());
+        defaultReader->releaseLock(globalObject);
+
+        auto readerOrException = ReadableStreamBYOBReader::create(globalObject, Ref { state.stream() }.get());
+        if (readerOrException.hasException()) {
+            ASSERT_NOT_REACHED();
+            return;
+        }
+        Ref reader = readerOrException.releaseReturnValue();
+        state.setReader(reader.get());
+        state.forwardReadError(reader.get());
+    }
+
+    RefPtr reader = state.byobReader();
+    RefPtr byobBranch = forBranch2 ? state.branch2() : state.branch1();
+    RefPtr otherBranch = forBranch2 ? state.branch1() : state.branch2();
+
+    auto [promise, deferred] = createPromiseAndWrapper(globalObject);
+
+    reader->read(globalObject, Ref { *request.view() }, 1, WTFMove(deferred));
+    promise->whenSettled([state = Ref { state }, weakReader = WeakPtr { *reader }, forBranch2] {
+        RefPtr readPromise = state->readPromise();
+        RefPtr reader = weakReader.get();
+        if (!readPromise || !reader)
+            return;
+
+        switch (readPromise->status()) {
+        case DOMPromise::Status::Fulfilled: {
+            auto& globalObject = *readPromise->globalObject();
+            auto resultOrException = convertDictionary<ReadableStreamReadResult>(globalObject, readPromise->result());
+
+            Ref vm = globalObject.vm();
+            auto scope = DECLARE_THROW_SCOPE(vm);
+            ASSERT(!resultOrException.hasException(scope));
+            if (resultOrException.hasException(scope))
+                return;
+
+            RefPtr branch1 = state->branch1();
+            RefPtr branch2 = state->branch2();
+
+            auto result = resultOrException.releaseReturnValue();
+            if (!result.done) {
+                // Chunk steps.
+                auto chunkResult = convert<IDLArrayBufferView>(globalObject, result.value);
+                if (chunkResult.hasException(scope)) [[unlikely]]
+                    return;
+
+                Ref chunk = chunkResult.releaseReturnValue();
+
+                state->setReadAgainForBranch1(false);
+                state->setReadAgainForBranch2(false);
+
+                bool byobCanceled = forBranch2 ? state->canceled2() : state->canceled1();
+                bool otherCanceled = forBranch2 ? state->canceled1() : state->canceled2();
+
+                RefPtr byobBranch = forBranch2 ? branch2 : branch1;
+                RefPtr otherBranch = forBranch2 ? branch1 : branch2;
+                if (!otherCanceled) {
+                    auto resultOrException = cloneAsUInt8Array(chunk);
+                    if (resultOrException.hasException()) {
+                        if (byobBranch)
+                            byobBranch->controller()->error(globalObject, resultOrException.exception());
+                        if (otherBranch)
+                            otherBranch->controller()->error(globalObject, resultOrException.exception());
+
+                        state->stream().cancel(resultOrException.releaseException());
+                        return;
+                    }
+                    Ref clonedChunk = resultOrException.releaseReturnValue();
+                    if (!byobCanceled)
+                        byobBranch->protectedController()->respondWithNewView(globalObject, chunk);
+                    otherBranch->protectedController()->enqueue(globalObject, clonedChunk);
+                } else if (!byobCanceled)
+                    byobBranch->protectedController()->respondWithNewView(globalObject, chunk);
+
+                state->setReading(false);
+                if (state->readAgainForBranch1() && branch1)
+                    pull1Steps(globalObject, state, *branch1);
+                else if (state->readAgainForBranch2() && branch2)
+                    pull2Steps(globalObject, state, *branch2);
+
+                return;
+            }
+
+            // Close steps.
+            state->setReading(false);
+            bool byobCanceled = forBranch2 ? state->canceled2() : state->canceled1();
+            bool otherCanceled = forBranch2 ? state->canceled1() : state->canceled2();
+            if (!byobCanceled && branch1)
+                branch1->controller()->close(globalObject);
+
+            if (!otherCanceled && branch2)
+                branch2->controller()->close(globalObject);
+
+            if (result.value) {
+                auto chunkResult = convert<IDLArrayBufferView>(globalObject, result.value);
+                if (chunkResult.hasException(scope)) [[unlikely]]
+                    return;
+
+                Ref chunk = chunkResult.releaseReturnValue();
+                ASSERT(!chunk->byteLength());
+
+                if (!byobCanceled && branch1)
+                    branch1->protectedController()->respondWithNewView(globalObject, chunk);
+                if (!otherCanceled && branch2 && branch2->controller()->hasPendingPullIntos())
+                    branch2->protectedController()->respond(globalObject, 0);
+            }
+            if (!byobCanceled || !otherCanceled)
+                state->resolveCancelPromise();
+            return;
+        }
+        case DOMPromise::Status::Rejected:
+            // error steps.
+            state->setReading(false);
+            return;
+        case DOMPromise::Status::Pending:
+            ASSERT_NOT_REACHED();
+            break;
+        }
+    });
+    state.setReadPromise(WTFMove(promise));
+}
+
+
+} // namespace WebCore

--- a/Source/WebCore/Modules/streams/StreamTeeUtilities.h
+++ b/Source/WebCore/Modules/streams/StreamTeeUtilities.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ExceptionOr.h"
+#include <wtf/Vector.h>
+
+namespace WebCore {
+
+class JSDOMGlobalObject;
+class ReadableStream;
+
+// https://streams.spec.whatwg.org/#abstract-opdef-readablebytestreamtee
+ExceptionOr<Vector<Ref<ReadableStream>>> byteStreamTee(JSDOMGlobalObject&, ReadableStream&);
+
+} // namespace WebCore

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -383,6 +383,7 @@ Modules/streams/ReadableStreamBYOBRequest.cpp
 Modules/streams/ReadableStreamDefaultReader.cpp
 Modules/streams/ReadableStreamSink.cpp
 Modules/streams/ReadableStreamSource.cpp
+Modules/streams/StreamTeeUtilities.cpp
 Modules/streams/TransformStream.cpp
 Modules/streams/WritableStream.cpp
 Modules/url-pattern/URLPattern.cpp


### PR DESCRIPTION
#### df0241e3ab24bb75fd5513ae0fcda4a71fc36be3
<pre>
Add tee support for readable byte streams
<a href="https://rdar.apple.com/161246220">rdar://161246220</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=299440">https://bugs.webkit.org/show_bug.cgi?id=299440</a>

Reviewed by Chris Dumez.

We add support for teeing byte streams, following <a href="https://streams.spec.whatwg.org/#abstract-opdef-readablebytestreamtee.">https://streams.spec.whatwg.org/#abstract-opdef-readablebytestreamtee.</a>
We introduce a class StreamTeeState which stores the various state values needed by this algorithm.
This tee state is kept alive as long as:
- A tee child stream is alive.
- The tee parent stream is not closed.

The tee state keeps a reference to the parent stream and weak references to the child streams.
We currently store as strong values the cancelled reasons until we can cancel the parent stream.

Covered by rebased tests.

Canonical link: <a href="https://commits.webkit.org/300827@main">https://commits.webkit.org/300827@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eea065150b15031c8f700dfc2a3d988a376be728

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123981 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43696 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34393 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130812 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76133 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ff5dc97e-4b1b-4e68-837c-9062a480e955) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/125858 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44420 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52290 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/94319 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/62569 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/07a7d5a4-eefd-449c-9ded-602a4380596c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126935 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35395 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110906 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/74913 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6b9fb3dc-35c8-4cdb-af1d-3ec879a68fb7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34344 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29069 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74283 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105126 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29290 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133478 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50934 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38797 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/102773 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51308 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107126 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/102594 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26100 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47944 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26194 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/47794 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50787 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56551 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50261 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53607 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51935 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->