### PR TITLE
Move m_isPrinting from testRunner.h to the UI Process

### DIFF
--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp
@@ -576,6 +576,13 @@ bool InjectedBundle::shouldProcessWorkQueue() const
     return booleanValue(adoptWK(result).get());
 }
 
+bool InjectedBundle::isPrinting() const
+{
+    WKTypeRef result = nullptr;
+    WKBundlePagePostSynchronousMessageForTesting(page()->page(), toWK("GetIsPrinting").get(), nullptr, &result);
+    return booleanValue(result);
+}
+
 void InjectedBundle::processWorkQueue()
 {
     postPageMessage("ProcessWorkQueue");

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.h
@@ -126,6 +126,8 @@ public:
 
     bool isAllowedHost(WKStringRef);
 
+    bool isPrinting() const;
+
     unsigned imageCountInGeneralPasteboard() const;
 
     void setAllowsAnySSLCertificate(bool);

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp
@@ -666,7 +666,7 @@ void InjectedBundlePage::dump()
 
     switch (testRunner->whatToDump()) {
     case WhatToDump::RenderTree: {
-        if (testRunner->isPrinting())
+        if (injectedBundle.isPrinting())
             stringBuilder.append(adoptWK(WKBundlePageCopyRenderTreeExternalRepresentationForPrinting(m_page)).get());
         else
             stringBuilder.append(adoptWK(WKBundlePageCopyRenderTreeExternalRepresentation(m_page, testRunner->renderTreeDumpOptions())).get());
@@ -699,14 +699,14 @@ void InjectedBundlePage::dump()
         injectedBundle.dumpBackForwardListsForAllPages(stringBuilder);
 
     if (injectedBundle.shouldDumpPixels() && testRunner->shouldDumpPixels()) {
-        bool shouldCreateSnapshot = testRunner->isPrinting();
+        bool shouldCreateSnapshot = injectedBundle.isPrinting();
         if (shouldCreateSnapshot) {
             WKSnapshotOptions options = kWKSnapshotOptionsShareable;
             ALLOW_DEPRECATED_DECLARATIONS_BEGIN
             WKRect snapshotRect = WKBundleFrameGetVisibleContentBounds(WKBundlePageGetMainFrame(m_page));
             ALLOW_DEPRECATED_DECLARATIONS_END
 
-            if (testRunner->isPrinting())
+            if (injectedBundle.isPrinting())
                 options |= kWKSnapshotOptionsPrinting;
             else {
                 options |= kWKSnapshotOptionsInViewCoordinates;
@@ -718,7 +718,7 @@ void InjectedBundlePage::dump()
         } else
             injectedBundle.setPixelResultIsPending(true);
 
-        if (WKBundlePageIsTrackingRepaints(m_page) && !testRunner->isPrinting())
+        if (WKBundlePageIsTrackingRepaints(m_page) && !injectedBundle.isPrinting())
             injectedBundle.setRepaintRects(adoptWK(WKBundlePageCopyTrackedRepaintRects(m_page)).get());
     }
 

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
@@ -1430,6 +1430,11 @@ void TestRunner::dumpPrivateClickMeasurement()
     postSynchronousPageMessage("DumpPrivateClickMeasurement");
 }
 
+void TestRunner::setPrinting() const
+{
+    postSynchronousMessage("SetPrinting");
+}
+
 void TestRunner::clearMemoryCache()
 {
     postSynchronousPageMessage("ClearMemoryCache");

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
@@ -203,8 +203,7 @@ public:
 
     // Printing
     bool isPageBoxVisible(JSContextRef, int pageIndex);
-    bool isPrinting() { return m_isPrinting; }
-    void setPrinting() { m_isPrinting = true; }
+    void setPrinting() const;
 
     void setValueForUser(JSContextRef, JSValueRef element, JSStringRef value);
 
@@ -521,7 +520,6 @@ private:
     bool m_testRepaint { false };
     bool m_testRepaintSweepHorizontally { false };
     bool m_displayOnLoadFinish { false };
-    bool m_isPrinting { false };
     bool m_willSendRequestReturnsNull { false };
     bool m_willSendRequestReturnsNullOnRedirect { false };
     bool m_shouldStopProvisionalFrameLoads { false };

--- a/Tools/WebKitTestRunner/TestInvocation.cpp
+++ b/Tools/WebKitTestRunner/TestInvocation.cpp
@@ -610,6 +610,14 @@ WKRetainPtr<WKTypeRef> TestInvocation::didReceiveSynchronousMessageFromInjectedB
         return nullptr;
     }
 
+    if (WKStringIsEqualToUTF8CString(messageName, "SetPrinting")) {
+        setPrinting();
+        return nullptr;
+    }
+
+    if (WKStringIsEqualToUTF8CString(messageName, "GetIsPrinting"))
+        return adoptWK(WKBooleanCreate(isPrinting()));
+
     if (WKStringIsEqualToUTF8CString(messageName, "SetViewSize")) {
         auto messageBodyDictionary = dictionaryValue(messageBody);
         auto width = doubleValue(messageBodyDictionary, "width");

--- a/Tools/WebKitTestRunner/TestInvocation.h
+++ b/Tools/WebKitTestRunner/TestInvocation.h
@@ -87,6 +87,8 @@ public:
     void runUISideScript(WKStringRef, unsigned callbackID);
 
     void dontForceRepaint() { m_forceRepaint = false; }
+    bool isPrinting() const { return m_isPrinting; }
+    void setPrinting() { m_isPrinting = true; }
 
 private:
     TestInvocation(WKURLRef, const TestOptions&);
@@ -155,6 +157,7 @@ private:
     bool m_shouldDumpPrivateClickMeasurement { false };
     bool m_shouldDumpBackForwardListsForAllWindows { false };
     bool m_shouldDumpAllFrameScrollPositions { false };
+    bool m_isPrinting { false };
     WhatToDump m_whatToDump { WhatToDump::RenderTree };
 
     StringBuilder m_textOutput;


### PR DESCRIPTION
#### 0a5ed9bc53745db410f486b096266128a0fcd667
<pre>
Move m_isPrinting from testRunner.h to the UI Process
<a href="https://bugs.webkit.org/show_bug.cgi?id=299884">https://bugs.webkit.org/show_bug.cgi?id=299884</a>
<a href="https://rdar.apple.com/161668803">rdar://161668803</a>

Reviewed by Alex Christensen.

m_isPrinting was in the WebContent process in TestRunner.h, which fails
in site isolation. This fixes that by moving it to the UI process in
TestInvocation.h.

* Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp:
(WTR::InjectedBundle::isPrinting const):
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.h:
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp:
(WTR::InjectedBundlePage::dump):
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp:
(WTR::TestRunner::setPrinting const):
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.h:
(WTR::TestRunner::isPrinting): Deleted.
(WTR::TestRunner::setPrinting): Deleted.
* Tools/WebKitTestRunner/TestInvocation.cpp:
(WTR::TestInvocation::didReceiveSynchronousMessageFromInjectedBundle):
* Tools/WebKitTestRunner/TestInvocation.h:

Canonical link: <a href="https://commits.webkit.org/300842@main">https://commits.webkit.org/300842@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ebd536fb5ff5974b1af62b30c127db29ea076754

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123927 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43642 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34339 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130717 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76078 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/125804 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44366 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52236 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94260 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62544 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126881 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35348 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110857 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74860 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34300 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29018 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74190 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105077 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29241 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133410 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50880 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38750 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102727 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51254 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107077 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102619 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26108 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47899 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26149 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/47733 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50733 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50207 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53553 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51881 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->