### PR TITLE
[GFC] Definite position checking and span sizing.

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp
@@ -70,38 +70,30 @@ UnplacedGridItems GridFormattingContext::constructUnplacedGridItems() const
         auto gridItemRowStart = gridItemStyle->gridItemRowStart();
         auto gridItemRowEnd = gridItemStyle->gridItemRowEnd();
 
+        UnplacedGridItem unplacedGridItem {
+            gridItem.layoutBox,
+            gridItemColumnStart,
+            gridItemColumnEnd,
+            gridItemRowStart,
+            gridItemRowEnd
+        };
+
         // Check if this item is fully explicitly positioned
         bool fullyExplicitlyPositionedItem = gridItemColumnStart.isExplicit()
             && gridItemColumnEnd.isExplicit()
             && gridItemRowStart.isExplicit()
             && gridItemRowEnd.isExplicit();
 
-        bool definiteRowPositioned = gridItemRowStart.isExplicit() || gridItemRowEnd.isExplicit();
-
+        // FIXME: support definite row/column positioning
+        // We should place items with definite row or column positions
+        // but currently we only support fully explicitly positioned items.
+        // See: https://www.w3.org/TR/css-grid-1/#auto-placement-algo
         if (fullyExplicitlyPositionedItem) {
-            unplacedGridItems.nonAutoPositionedItems.constructAndAppend(
-                gridItem.layoutBox,
-                gridItemColumnStart,
-                gridItemColumnEnd,
-                gridItemRowStart,
-                gridItemRowEnd
-            );
-        } else if (definiteRowPositioned) {
-            unplacedGridItems.definiteRowPositionedItems.constructAndAppend(
-                gridItem.layoutBox,
-                gridItemColumnStart,
-                gridItemColumnEnd,
-                gridItemRowStart,
-                gridItemRowEnd
-            );
+            unplacedGridItems.nonAutoPositionedItems.append(unplacedGridItem);
+        } else if (unplacedGridItem.hasDefiniteRowPosition()) {
+            unplacedGridItems.definiteRowPositionedItems.append(unplacedGridItem);
         } else {
-            unplacedGridItems.autoPositionedItems.constructAndAppend(
-                gridItem.layoutBox,
-                gridItemColumnStart,
-                gridItemColumnEnd,
-                gridItemRowStart,
-                gridItemRowEnd
-            );
+            unplacedGridItems.autoPositionedItems.append(unplacedGridItem);
         }
     }
     return unplacedGridItems;

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayout.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayout.h
@@ -40,6 +40,21 @@ namespace Layout {
 
 class ImplicitGrid;
 
+enum class PackingStrategy : bool {
+    Sparse,
+    Dense
+};
+
+enum class GridAutoFlowDirection : bool {
+    Row,
+    Column
+};
+
+struct GridAutoFlowOptions {
+    PackingStrategy strategy;
+    GridAutoFlowDirection direction;
+};
+
 struct UsedTrackSizes;
 
 class GridLayout {
@@ -50,8 +65,8 @@ public:
 
 private:
 
-    static auto placeGridItems(const UnplacedGridItems&, const Vector<Style::GridTrackSize>& gridTemplateColumnsTrackSizes,
-        const Vector<Style::GridTrackSize>& gridTemplateRowsTrackSizes);
+    auto placeGridItems(const UnplacedGridItems&, const Vector<Style::GridTrackSize>& gridTemplateColumnsTrackSizes,
+        const Vector<Style::GridTrackSize>& gridTemplateRowsTrackSizes, GridAutoFlowOptions);
     static TrackSizingFunctionsList trackSizingFunctions(size_t implicitGridTracksCount, const Vector<Style::GridTrackSize> gridTemplateTrackSizes);
 
     static UsedTrackSizes performGridSizingAlgorithm(const PlacedGridItems&, const TrackSizingFunctionsList& columnTrackSizingFunctionsList, const TrackSizingFunctionsList& rowTrackSizingFunctionsList);

--- a/Source/WebCore/layout/formattingContexts/grid/ImplicitGrid.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/ImplicitGrid.cpp
@@ -27,6 +27,7 @@
 #include "ImplicitGrid.h"
 
 #include "GridAreaLines.h"
+#include "GridLayout.h"
 #include "PlacedGridItem.h"
 #include "UnplacedGridItem.h"
 #include <wtf/Range.h>
@@ -118,6 +119,20 @@ GridAreas ImplicitGrid::gridAreas() const
         }
     }
     return gridAreas;
+}
+
+void ImplicitGrid::insertDefiniteRowItem(const UnplacedGridItem& unplacedGridItem, GridAutoFlowOptions autoFlowOptions)
+{
+    // FIXME: Implement placement for items with definite row positions and auto column positions
+    // This should handle dense/sparse packing based on grid-auto-flow CSS property
+    // See: https://www.w3.org/TR/css-grid-1/#auto-placement-algo
+    auto columnSpan = unplacedGridItem.columnSpanSize();
+    UNUSED_VARIABLE(columnSpan);
+
+    auto rowStartAndEnd = unplacedGridItem.definiteRowStartEnd();
+    UNUSED_VARIABLE(rowStartAndEnd);
+
+    UNUSED_PARAM(autoFlowOptions);
 }
 
 } // namespace Layout

--- a/Source/WebCore/layout/formattingContexts/grid/ImplicitGrid.h
+++ b/Source/WebCore/layout/formattingContexts/grid/ImplicitGrid.h
@@ -30,7 +30,11 @@
 #include <wtf/Vector.h>
 
 namespace WebCore {
+
 namespace Layout {
+
+enum class GridLayoutAlgorithm : uint8_t;
+struct GridAutoFlowOptions;
 
 // https://drafts.csswg.org/css-grid-1/#implicit-grids
 class ImplicitGrid {
@@ -41,6 +45,7 @@ public:
     size_t columnsCount() const { return rowsCount() ? m_gridMatrix[0].size() : 0; }
 
     void insertUnplacedGridItem(const UnplacedGridItem&);
+    void insertDefiniteRowItem(const UnplacedGridItem&, GridAutoFlowOptions);
 
     GridAreas gridAreas() const;
 
@@ -49,4 +54,5 @@ private:
 };
 
 } // namespace Layout
+
 } // namespace WebCore

--- a/Source/WebCore/layout/formattingContexts/grid/UnplacedGridItem.h
+++ b/Source/WebCore/layout/formattingContexts/grid/UnplacedGridItem.h
@@ -53,6 +53,12 @@ public:
     int explicitRowStart() const;
     int explicitRowEnd() const;
 
+    bool hasDefiniteRowPosition() const;
+    bool hasDefiniteColumnPosition() const;
+    bool hasAutoColumnPosition() const;
+    size_t columnSpanSize() const;
+    std::pair<int, int> definiteRowStartEnd() const;
+
 private:
     CheckedRef<const ElementBox> m_layoutBox;
 
@@ -97,4 +103,3 @@ template<> struct DefaultHash<WebCore::Layout::UnplacedGridItem> {
 };
 
 }
-


### PR DESCRIPTION
#### 679366a61a1d9d96ba355d5252de6df0c2280bf4
<pre>
[GFC] Definite position checking and span sizing.
<a href="https://bugs.webkit.org/show_bug.cgi?id=299390">https://bugs.webkit.org/show_bug.cgi?id=299390</a>
&lt;<a href="https://rdar.apple.com/161194270">rdar://161194270</a>&gt;

Reviewed by Sammy Gill.

This change introduces the following changes in preperation for
placing items with a definite row position in step 2 of:

  <a href="https://www.w3.org/TR/css-grid-1/#auto-placement-algo">https://www.w3.org/TR/css-grid-1/#auto-placement-algo</a>

1. hasDefiniteRowPosition to determine eligability for placement in step 2
of the grid auto placement algorithm.

2. an initial stub implementation of insertDefiniteRowItem with dense/sparse
styling information.

3.UnplacedGridItem::columnSpanSize() to compute the column size of an
UnplacedGridItem without explicit column start and end.

4. UnplacedGridItem::definiteRowStartEnd() to compute the start/end for
UnplacedGridItem without explicit row start and end.

Combined changes:
* Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp:
(WebCore::Layout::GridFormattingContext::constructUnplacedGridItems const):
* Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp:
(WebCore::Layout::GridLayout::placeGridItems):
* Source/WebCore/layout/formattingContexts/grid/GridLayout.h:
* Source/WebCore/layout/formattingContexts/grid/ImplicitGrid.cpp:
(WebCore::Layout::ImplicitGrid::insertDefiniteRowItem):
* Source/WebCore/layout/formattingContexts/grid/ImplicitGrid.h:
* Source/WebCore/layout/formattingContexts/grid/UnplacedGridItem.cpp:
(WebCore::Layout::UnplacedGridItem::hasDefinitePosition const):
(WebCore::Layout::UnplacedGridItem::hasDefiniteRowPosition const):
(WebCore::Layout::UnplacedGridItem::hasAutoColumnPosition const):
(WebCore::Layout::UnplacedGridItem::columnSpanSize const):
(WebCore::Layout::UnplacedGridItem::hasDefiniteColumnPosition const):
* Source/WebCore/layout/formattingContexts/grid/UnplacedGridItem.h:

Canonical link: <a href="https://commits.webkit.org/300893@main">https://commits.webkit.org/300893@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/041d438a1d244e60c1754139fd17e2258f2aaecb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124080 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43783 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34491 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130909 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76210 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e72d35a8-a64a-4f9f-b973-b4c58e825bbb) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/125957 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44517 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52382 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94387 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62622 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ee5c0a50-fd07-48c3-bf28-c1963225fa89) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127034 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35468 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110988 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74979 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a67820a5-1565-4112-829d-78558a2d4f74) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34416 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29152 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74393 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105204 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29371 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133581 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51021 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38872 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102853 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51398 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107207 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102664 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26152 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48020 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26264 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48026 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50876 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56647 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50339 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53686 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52013 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->