### PR TITLE
TrustedTypes verifies event handlers on incorrect element namespaces

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-getAttributeType-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-getAttributeType-expected.txt
@@ -34,11 +34,11 @@ PASS getAttributeType(
           "href",
           "http://www.w3.org/2000/svg",
           "http://www.w3.org/1999/xlink") == "TrustedScriptURL"
-FAIL getAttributeType(
+PASS getAttributeType(
           "foo",
           "onmouseup",
           "https://example.com/namespace",
-          "null") == "null" assert_equals: expected (object) null but got (string) "TrustedScript"
+          "null") == "null"
 PASS getAttributeType(
           "DIV",
           "onclick",

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/set-attributes-require-trusted-types-default-policy-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/set-attributes-require-trusted-types-default-policy-expected.txt
@@ -5,7 +5,7 @@ PASS Element.setAttribute applies default policy for elementNS=http://www.w3.org
 PASS Element.setAttribute applies default policy for elementNS=http://www.w3.org/1999/xhtml, element=IFRAME, attrName=srcdoc
 PASS Element.setAttribute applies default policy for elementNS=http://www.w3.org/1999/xhtml, element=SCRIPT, attrName=src
 PASS Element.setAttribute applies default policy for elementNS=http://www.w3.org/2000/svg, element=script, attrName=href
-FAIL Element.setAttribute does not apply default policy for elementNS=https://example.com/namespace, element=foo, attrName=onmouseup assert_equals: expected (undefined) undefined but got (string) "Element onmouseup"
+PASS Element.setAttribute does not apply default policy for elementNS=https://example.com/namespace, element=foo, attrName=onmouseup
 PASS Element.setAttribute does not apply default policy for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrName=ondoesnotexist
 PASS Element.setAttribute does not apply default policy for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrName=data-onclick
 PASS Element.setAttribute does not apply default policy for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrName=srcdoc
@@ -24,7 +24,7 @@ PASS Element.setAttributeNS applies default policy for elementNS=http://www.w3.o
 PASS Element.setAttributeNS applies default policy for elementNS=http://www.w3.org/1999/xhtml, element=SCRIPT, attrName=src
 PASS Element.setAttributeNS applies default policy for elementNS=http://www.w3.org/2000/svg, element=script, attrName=href
 PASS Element.setAttributeNS applies default policy for elementNS=http://www.w3.org/2000/svg, element=script, attrNS=http://www.w3.org/1999/xlink, attrName=href
-FAIL Element.setAttributeNS does not apply default policy for elementNS=https://example.com/namespace, element=foo, attrName=onmouseup assert_equals: expected (undefined) undefined but got (string) "Element onmouseup"
+PASS Element.setAttributeNS does not apply default policy for elementNS=https://example.com/namespace, element=foo, attrName=onmouseup
 PASS Element.setAttributeNS does not apply default policy for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrNS=https://example.com/namespace, attrName=onclick
 PASS Element.setAttributeNS does not apply default policy for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrName=ondoesnotexist
 PASS Element.setAttributeNS does not apply default policy for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrName=data-onclick
@@ -47,7 +47,7 @@ PASS Element.setAttributeNode applies default policy for elementNS=http://www.w3
 PASS Element.setAttributeNode applies default policy for elementNS=http://www.w3.org/1999/xhtml, element=SCRIPT, attrName=src
 PASS Element.setAttributeNode applies default policy for elementNS=http://www.w3.org/2000/svg, element=script, attrName=href
 PASS Element.setAttributeNode applies default policy for elementNS=http://www.w3.org/2000/svg, element=script, attrNS=http://www.w3.org/1999/xlink, attrName=href
-FAIL Element.setAttributeNode does not apply default policy for elementNS=https://example.com/namespace, element=foo, attrName=onmouseup assert_equals: expected (undefined) undefined but got (string) "Element onmouseup"
+PASS Element.setAttributeNode does not apply default policy for elementNS=https://example.com/namespace, element=foo, attrName=onmouseup
 PASS Element.setAttributeNode does not apply default policy for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrNS=https://example.com/namespace, attrName=onclick
 PASS Element.setAttributeNode does not apply default policy for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrName=ondoesnotexist
 PASS Element.setAttributeNode does not apply default policy for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrName=data-onclick
@@ -70,7 +70,7 @@ PASS Element.setAttributeNodeNS applies default policy for elementNS=http://www.
 PASS Element.setAttributeNodeNS applies default policy for elementNS=http://www.w3.org/1999/xhtml, element=SCRIPT, attrName=src
 PASS Element.setAttributeNodeNS applies default policy for elementNS=http://www.w3.org/2000/svg, element=script, attrName=href
 PASS Element.setAttributeNodeNS applies default policy for elementNS=http://www.w3.org/2000/svg, element=script, attrNS=http://www.w3.org/1999/xlink, attrName=href
-FAIL Element.setAttributeNodeNS does not apply default policy for elementNS=https://example.com/namespace, element=foo, attrName=onmouseup assert_equals: expected (undefined) undefined but got (string) "Element onmouseup"
+PASS Element.setAttributeNodeNS does not apply default policy for elementNS=https://example.com/namespace, element=foo, attrName=onmouseup
 PASS Element.setAttributeNodeNS does not apply default policy for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrNS=https://example.com/namespace, attrName=onclick
 PASS Element.setAttributeNodeNS does not apply default policy for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrName=ondoesnotexist
 PASS Element.setAttributeNodeNS does not apply default policy for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrName=data-onclick
@@ -93,7 +93,7 @@ PASS NamedNodeMap.setNamedItem applies default policy for elementNS=http://www.w
 PASS NamedNodeMap.setNamedItem applies default policy for elementNS=http://www.w3.org/1999/xhtml, element=SCRIPT, attrName=src
 PASS NamedNodeMap.setNamedItem applies default policy for elementNS=http://www.w3.org/2000/svg, element=script, attrName=href
 PASS NamedNodeMap.setNamedItem applies default policy for elementNS=http://www.w3.org/2000/svg, element=script, attrNS=http://www.w3.org/1999/xlink, attrName=href
-FAIL NamedNodeMap.setNamedItem does not apply default policy for elementNS=https://example.com/namespace, element=foo, attrName=onmouseup assert_equals: expected (undefined) undefined but got (string) "Element onmouseup"
+PASS NamedNodeMap.setNamedItem does not apply default policy for elementNS=https://example.com/namespace, element=foo, attrName=onmouseup
 PASS NamedNodeMap.setNamedItem does not apply default policy for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrNS=https://example.com/namespace, attrName=onclick
 PASS NamedNodeMap.setNamedItem does not apply default policy for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrName=ondoesnotexist
 PASS NamedNodeMap.setNamedItem does not apply default policy for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrName=data-onclick
@@ -116,7 +116,7 @@ PASS NamedNodeMap.setNamedItemNS applies default policy for elementNS=http://www
 PASS NamedNodeMap.setNamedItemNS applies default policy for elementNS=http://www.w3.org/1999/xhtml, element=SCRIPT, attrName=src
 PASS NamedNodeMap.setNamedItemNS applies default policy for elementNS=http://www.w3.org/2000/svg, element=script, attrName=href
 PASS NamedNodeMap.setNamedItemNS applies default policy for elementNS=http://www.w3.org/2000/svg, element=script, attrNS=http://www.w3.org/1999/xlink, attrName=href
-FAIL NamedNodeMap.setNamedItemNS does not apply default policy for elementNS=https://example.com/namespace, element=foo, attrName=onmouseup assert_equals: expected (undefined) undefined but got (string) "Element onmouseup"
+PASS NamedNodeMap.setNamedItemNS does not apply default policy for elementNS=https://example.com/namespace, element=foo, attrName=onmouseup
 PASS NamedNodeMap.setNamedItemNS does not apply default policy for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrNS=https://example.com/namespace, attrName=onclick
 PASS NamedNodeMap.setNamedItemNS does not apply default policy for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrName=ondoesnotexist
 PASS NamedNodeMap.setNamedItemNS does not apply default policy for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrName=data-onclick
@@ -139,7 +139,7 @@ PASS Attr.value applies default policy for elementNS=http://www.w3.org/1999/xhtm
 PASS Attr.value applies default policy for elementNS=http://www.w3.org/1999/xhtml, element=SCRIPT, attrName=src
 PASS Attr.value applies default policy for elementNS=http://www.w3.org/2000/svg, element=script, attrName=href
 PASS Attr.value applies default policy for elementNS=http://www.w3.org/2000/svg, element=script, attrNS=http://www.w3.org/1999/xlink, attrName=href
-FAIL Attr.value does not apply default policy for elementNS=https://example.com/namespace, element=foo, attrName=onmouseup assert_equals: expected "unsafe_input" but got ""
+PASS Attr.value does not apply default policy for elementNS=https://example.com/namespace, element=foo, attrName=onmouseup
 PASS Attr.value does not apply default policy for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrNS=https://example.com/namespace, attrName=onclick
 PASS Attr.value does not apply default policy for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrName=ondoesnotexist
 PASS Attr.value does not apply default policy for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrName=data-onclick
@@ -162,7 +162,7 @@ PASS Node.nodeValue applies default policy for elementNS=http://www.w3.org/1999/
 PASS Node.nodeValue applies default policy for elementNS=http://www.w3.org/1999/xhtml, element=SCRIPT, attrName=src
 PASS Node.nodeValue applies default policy for elementNS=http://www.w3.org/2000/svg, element=script, attrName=href
 PASS Node.nodeValue applies default policy for elementNS=http://www.w3.org/2000/svg, element=script, attrNS=http://www.w3.org/1999/xlink, attrName=href
-FAIL Node.nodeValue does not apply default policy for elementNS=https://example.com/namespace, element=foo, attrName=onmouseup assert_equals: expected "unsafe_input" but got ""
+PASS Node.nodeValue does not apply default policy for elementNS=https://example.com/namespace, element=foo, attrName=onmouseup
 PASS Node.nodeValue does not apply default policy for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrNS=https://example.com/namespace, attrName=onclick
 PASS Node.nodeValue does not apply default policy for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrName=ondoesnotexist
 PASS Node.nodeValue does not apply default policy for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrName=data-onclick
@@ -185,7 +185,7 @@ PASS Node.textContent applies default policy for elementNS=http://www.w3.org/199
 PASS Node.textContent applies default policy for elementNS=http://www.w3.org/1999/xhtml, element=SCRIPT, attrName=src
 PASS Node.textContent applies default policy for elementNS=http://www.w3.org/2000/svg, element=script, attrName=href
 PASS Node.textContent applies default policy for elementNS=http://www.w3.org/2000/svg, element=script, attrNS=http://www.w3.org/1999/xlink, attrName=href
-FAIL Node.textContent does not apply default policy for elementNS=https://example.com/namespace, element=foo, attrName=onmouseup assert_equals: expected "unsafe_input" but got ""
+PASS Node.textContent does not apply default policy for elementNS=https://example.com/namespace, element=foo, attrName=onmouseup
 PASS Node.textContent does not apply default policy for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrNS=https://example.com/namespace, attrName=onclick
 PASS Node.textContent does not apply default policy for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrName=ondoesnotexist
 PASS Node.textContent does not apply default policy for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrName=data-onclick

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/set-attributes-require-trusted-types-no-default-policy-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/set-attributes-require-trusted-types-no-default-policy-expected.txt
@@ -5,7 +5,7 @@ PASS Element.setAttribute throws for elementNS=http://www.w3.org/1998/Math/MathM
 PASS Element.setAttribute throws for elementNS=http://www.w3.org/1999/xhtml, element=IFRAME,  attrName=srcdoc with a plain string
 PASS Element.setAttribute throws for elementNS=http://www.w3.org/1999/xhtml, element=SCRIPT,  attrName=src with a plain string
 PASS Element.setAttribute throws for elementNS=http://www.w3.org/2000/svg, element=script,  attrName=href with a plain string
-FAIL Element.setAttribute works for elementNS=https://example.com/namespace, element=foo,  attrName=onmouseup with a plain string This assignment requires a TrustedScript
+PASS Element.setAttribute works for elementNS=https://example.com/namespace, element=foo,  attrName=onmouseup with a plain string
 PASS Element.setAttribute works for elementNS=http://www.w3.org/1999/xhtml, element=DIV,  attrName=ondoesnotexist with a plain string
 PASS Element.setAttribute works for elementNS=http://www.w3.org/1999/xhtml, element=DIV,  attrName=data-onclick with a plain string
 PASS Element.setAttribute works for elementNS=http://www.w3.org/1999/xhtml, element=DIV,  attrName=srcdoc with a plain string
@@ -24,7 +24,7 @@ PASS Element.setAttributeNS throws for elementNS=http://www.w3.org/1999/xhtml, e
 PASS Element.setAttributeNS throws for elementNS=http://www.w3.org/1999/xhtml, element=SCRIPT,  attrName=src with a plain string
 PASS Element.setAttributeNS throws for elementNS=http://www.w3.org/2000/svg, element=script,  attrName=href with a plain string
 PASS Element.setAttributeNS throws for elementNS=http://www.w3.org/2000/svg, element=script, attrNS=http://www.w3.org/1999/xlink,  attrName=href with a plain string
-FAIL Element.setAttributeNS works for elementNS=https://example.com/namespace, element=foo,  attrName=onmouseup with a plain string This assignment requires a TrustedScript
+PASS Element.setAttributeNS works for elementNS=https://example.com/namespace, element=foo,  attrName=onmouseup with a plain string
 PASS Element.setAttributeNS works for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrNS=https://example.com/namespace,  attrName=onclick with a plain string
 PASS Element.setAttributeNS works for elementNS=http://www.w3.org/1999/xhtml, element=DIV,  attrName=ondoesnotexist with a plain string
 PASS Element.setAttributeNS works for elementNS=http://www.w3.org/1999/xhtml, element=DIV,  attrName=data-onclick with a plain string
@@ -47,7 +47,7 @@ PASS Element.setAttributeNode throws for elementNS=http://www.w3.org/1999/xhtml,
 PASS Element.setAttributeNode throws for elementNS=http://www.w3.org/1999/xhtml, element=SCRIPT,  attrName=src with a plain string
 PASS Element.setAttributeNode throws for elementNS=http://www.w3.org/2000/svg, element=script,  attrName=href with a plain string
 PASS Element.setAttributeNode throws for elementNS=http://www.w3.org/2000/svg, element=script, attrNS=http://www.w3.org/1999/xlink,  attrName=href with a plain string
-FAIL Element.setAttributeNode works for elementNS=https://example.com/namespace, element=foo,  attrName=onmouseup with a plain string This assignment requires a TrustedScript
+PASS Element.setAttributeNode works for elementNS=https://example.com/namespace, element=foo,  attrName=onmouseup with a plain string
 PASS Element.setAttributeNode works for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrNS=https://example.com/namespace,  attrName=onclick with a plain string
 PASS Element.setAttributeNode works for elementNS=http://www.w3.org/1999/xhtml, element=DIV,  attrName=ondoesnotexist with a plain string
 PASS Element.setAttributeNode works for elementNS=http://www.w3.org/1999/xhtml, element=DIV,  attrName=data-onclick with a plain string
@@ -70,7 +70,7 @@ PASS Element.setAttributeNodeNS throws for elementNS=http://www.w3.org/1999/xhtm
 PASS Element.setAttributeNodeNS throws for elementNS=http://www.w3.org/1999/xhtml, element=SCRIPT,  attrName=src with a plain string
 PASS Element.setAttributeNodeNS throws for elementNS=http://www.w3.org/2000/svg, element=script,  attrName=href with a plain string
 PASS Element.setAttributeNodeNS throws for elementNS=http://www.w3.org/2000/svg, element=script, attrNS=http://www.w3.org/1999/xlink,  attrName=href with a plain string
-FAIL Element.setAttributeNodeNS works for elementNS=https://example.com/namespace, element=foo,  attrName=onmouseup with a plain string This assignment requires a TrustedScript
+PASS Element.setAttributeNodeNS works for elementNS=https://example.com/namespace, element=foo,  attrName=onmouseup with a plain string
 PASS Element.setAttributeNodeNS works for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrNS=https://example.com/namespace,  attrName=onclick with a plain string
 PASS Element.setAttributeNodeNS works for elementNS=http://www.w3.org/1999/xhtml, element=DIV,  attrName=ondoesnotexist with a plain string
 PASS Element.setAttributeNodeNS works for elementNS=http://www.w3.org/1999/xhtml, element=DIV,  attrName=data-onclick with a plain string
@@ -93,7 +93,7 @@ PASS NamedNodeMap.setNamedItem throws for elementNS=http://www.w3.org/1999/xhtml
 PASS NamedNodeMap.setNamedItem throws for elementNS=http://www.w3.org/1999/xhtml, element=SCRIPT,  attrName=src with a plain string
 PASS NamedNodeMap.setNamedItem throws for elementNS=http://www.w3.org/2000/svg, element=script,  attrName=href with a plain string
 PASS NamedNodeMap.setNamedItem throws for elementNS=http://www.w3.org/2000/svg, element=script, attrNS=http://www.w3.org/1999/xlink,  attrName=href with a plain string
-FAIL NamedNodeMap.setNamedItem works for elementNS=https://example.com/namespace, element=foo,  attrName=onmouseup with a plain string This assignment requires a TrustedScript
+PASS NamedNodeMap.setNamedItem works for elementNS=https://example.com/namespace, element=foo,  attrName=onmouseup with a plain string
 PASS NamedNodeMap.setNamedItem works for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrNS=https://example.com/namespace,  attrName=onclick with a plain string
 PASS NamedNodeMap.setNamedItem works for elementNS=http://www.w3.org/1999/xhtml, element=DIV,  attrName=ondoesnotexist with a plain string
 PASS NamedNodeMap.setNamedItem works for elementNS=http://www.w3.org/1999/xhtml, element=DIV,  attrName=data-onclick with a plain string
@@ -116,7 +116,7 @@ PASS NamedNodeMap.setNamedItemNS throws for elementNS=http://www.w3.org/1999/xht
 PASS NamedNodeMap.setNamedItemNS throws for elementNS=http://www.w3.org/1999/xhtml, element=SCRIPT,  attrName=src with a plain string
 PASS NamedNodeMap.setNamedItemNS throws for elementNS=http://www.w3.org/2000/svg, element=script,  attrName=href with a plain string
 PASS NamedNodeMap.setNamedItemNS throws for elementNS=http://www.w3.org/2000/svg, element=script, attrNS=http://www.w3.org/1999/xlink,  attrName=href with a plain string
-FAIL NamedNodeMap.setNamedItemNS works for elementNS=https://example.com/namespace, element=foo,  attrName=onmouseup with a plain string This assignment requires a TrustedScript
+PASS NamedNodeMap.setNamedItemNS works for elementNS=https://example.com/namespace, element=foo,  attrName=onmouseup with a plain string
 PASS NamedNodeMap.setNamedItemNS works for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrNS=https://example.com/namespace,  attrName=onclick with a plain string
 PASS NamedNodeMap.setNamedItemNS works for elementNS=http://www.w3.org/1999/xhtml, element=DIV,  attrName=ondoesnotexist with a plain string
 PASS NamedNodeMap.setNamedItemNS works for elementNS=http://www.w3.org/1999/xhtml, element=DIV,  attrName=data-onclick with a plain string
@@ -139,7 +139,7 @@ PASS Attr.value throws for elementNS=http://www.w3.org/1999/xhtml, element=IFRAM
 PASS Attr.value throws for elementNS=http://www.w3.org/1999/xhtml, element=SCRIPT,  attrName=src with a plain string
 PASS Attr.value throws for elementNS=http://www.w3.org/2000/svg, element=script,  attrName=href with a plain string
 PASS Attr.value throws for elementNS=http://www.w3.org/2000/svg, element=script, attrNS=http://www.w3.org/1999/xlink,  attrName=href with a plain string
-FAIL Attr.value works for elementNS=https://example.com/namespace, element=foo,  attrName=onmouseup with a plain string This assignment requires a TrustedScript
+PASS Attr.value works for elementNS=https://example.com/namespace, element=foo,  attrName=onmouseup with a plain string
 PASS Attr.value works for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrNS=https://example.com/namespace,  attrName=onclick with a plain string
 PASS Attr.value works for elementNS=http://www.w3.org/1999/xhtml, element=DIV,  attrName=ondoesnotexist with a plain string
 PASS Attr.value works for elementNS=http://www.w3.org/1999/xhtml, element=DIV,  attrName=data-onclick with a plain string
@@ -162,7 +162,7 @@ PASS Node.nodeValue throws for elementNS=http://www.w3.org/1999/xhtml, element=I
 PASS Node.nodeValue throws for elementNS=http://www.w3.org/1999/xhtml, element=SCRIPT,  attrName=src with a plain string
 PASS Node.nodeValue throws for elementNS=http://www.w3.org/2000/svg, element=script,  attrName=href with a plain string
 PASS Node.nodeValue throws for elementNS=http://www.w3.org/2000/svg, element=script, attrNS=http://www.w3.org/1999/xlink,  attrName=href with a plain string
-FAIL Node.nodeValue works for elementNS=https://example.com/namespace, element=foo,  attrName=onmouseup with a plain string This assignment requires a TrustedScript
+PASS Node.nodeValue works for elementNS=https://example.com/namespace, element=foo,  attrName=onmouseup with a plain string
 PASS Node.nodeValue works for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrNS=https://example.com/namespace,  attrName=onclick with a plain string
 PASS Node.nodeValue works for elementNS=http://www.w3.org/1999/xhtml, element=DIV,  attrName=ondoesnotexist with a plain string
 PASS Node.nodeValue works for elementNS=http://www.w3.org/1999/xhtml, element=DIV,  attrName=data-onclick with a plain string
@@ -185,7 +185,7 @@ PASS Node.textContent throws for elementNS=http://www.w3.org/1999/xhtml, element
 PASS Node.textContent throws for elementNS=http://www.w3.org/1999/xhtml, element=SCRIPT,  attrName=src with a plain string
 PASS Node.textContent throws for elementNS=http://www.w3.org/2000/svg, element=script,  attrName=href with a plain string
 PASS Node.textContent throws for elementNS=http://www.w3.org/2000/svg, element=script, attrNS=http://www.w3.org/1999/xlink,  attrName=href with a plain string
-FAIL Node.textContent works for elementNS=https://example.com/namespace, element=foo,  attrName=onmouseup with a plain string This assignment requires a TrustedScript
+PASS Node.textContent works for elementNS=https://example.com/namespace, element=foo,  attrName=onmouseup with a plain string
 PASS Node.textContent works for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrNS=https://example.com/namespace,  attrName=onclick with a plain string
 PASS Node.textContent works for elementNS=http://www.w3.org/1999/xhtml, element=DIV,  attrName=ondoesnotexist with a plain string
 PASS Node.textContent works for elementNS=http://www.w3.org/1999/xhtml, element=DIV,  attrName=data-onclick with a plain string

--- a/Source/WebCore/dom/TrustedType.cpp
+++ b/Source/WebCore/dom/TrustedType.cpp
@@ -33,6 +33,7 @@
 #include "JSDOMExceptionHandling.h"
 #include "JSTrustedScript.h"
 #include "LocalDOMWindow.h"
+#include "MathMLNames.h"
 #include "SVGNames.h"
 #include "TrustedTypePolicy.h"
 #include "TrustedTypePolicyFactory.h"
@@ -246,7 +247,7 @@ AttributeTypeAndSink trustedTypeForAttribute(const String& elementName, const St
     QualifiedName element(nullAtom(), AtomString(localName), elementNS);
     QualifiedName attribute(nullAtom(), AtomString(attributeName), attributeNS);
 
-    if (attributeNS.isNull() && !attributeName.isNull()) {
+    if (attributeNS.isNull() && !attributeName.isNull() && (elementNS == HTMLNames::xhtmlNamespaceURI || elementNS == SVGNames::svgNamespaceURI || elementNS == MathMLNames::mathmlNamespaceURI)) {
         if (isEventHandlerAttribute(attribute)) {
             returnValues.sink = makeString("Element "_s, attributeName);
             returnValues.attributeType = trustedTypeToString(TrustedType::TrustedScript);


### PR DESCRIPTION
#### 6d2f6fa0e5515d4ede14d8ad5c1a40c5ac62a5cc
<pre>
TrustedTypes verifies event handlers on incorrect element namespaces
<a href="https://bugs.webkit.org/show_bug.cgi?id=289907">https://bugs.webkit.org/show_bug.cgi?id=289907</a>

Reviewed by Tim Nguyen.

The specification has been updated to only check event handler attributes for elements within the XHTML, SVG, and MathML namespaces.

This patch checks the element&apos;s namespace matches that list.

* LayoutTests/imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-getAttributeType-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/set-attributes-require-trusted-types-default-policy-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/set-attributes-require-trusted-types-no-default-policy-expected.txt:
* Source/WebCore/dom/TrustedType.cpp:
(WebCore::trustedTypeForAttribute):

Canonical link: <a href="https://commits.webkit.org/300783@main">https://commits.webkit.org/300783@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d4861cb6a03b325f0e5923f3f6c8b80f6de2a795

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123826 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43541 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34238 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130608 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/75976 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/125703 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44265 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52135 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94171 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/62492 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126779 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35270 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110775 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74800 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34225 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28936 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74088 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104997 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29159 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133301 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50779 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38668 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102642 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51153 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106995 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102472 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26057 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47817 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26075 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/47628 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50632 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56396 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50106 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53452 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51780 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->