### PR TITLE
Only one enforced CSP violation is reported for 'require-trusted-types-for'

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/should-sink-type-mismatch-violation-be-blocked-by-csp-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/should-sink-type-mismatch-violation-be-blocked-by-csp-001-expected.txt
@@ -1,9 +1,9 @@
 
-FAIL Multiple enforce require-trusted-types-for directives. assert_equals: expected 5 but got 1
+PASS Multiple enforce require-trusted-types-for directives.
 PASS Multiple report-only require-trusted-types-for directives.
-FAIL One violated report-only require-trusted-types-for directive followed by multiple enforce directives assert_equals: expected 5 but got 1
-FAIL One violated enforce require-trusted-types-for directive followed by multiple report-only directives assert_equals: expected 5 but got 1
-FAIL Mixing enforce and report-only require-trusted-types-for directives. assert_equals: expected 6 but got 1
+PASS One violated report-only require-trusted-types-for directive followed by multiple enforce directives
+PASS One violated enforce require-trusted-types-for directive followed by multiple report-only directives
+PASS Mixing enforce and report-only require-trusted-types-for directives.
 PASS directive "require-trusted-types-for 'invalid'%09'script'" (required-ascii-whitespace)
 PASS directive "require-trusted-types-for 'invalid'%0A%20'script'" (required-ascii-whitespace)
 PASS directive "require-trusted-types-for 'invalid'%0C'script'" (required-ascii-whitespace)

--- a/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
@@ -823,8 +823,8 @@ bool ContentSecurityPolicy::requireTrustedTypesForSinkGroup(const String& sinkGr
 // https://w3c.github.io/trusted-types/dist/spec/#should-block-sink-type-mismatch
 bool ContentSecurityPolicy::allowMissingTrustedTypesForSinkGroup(const String& stringContext, const String& sink, const String& sinkGroup, StringView source) const
 {
-    return std::ranges::all_of(m_policies, [&](auto& policy) {
-        bool isAllowed = true;
+    auto isAllowed = true;
+    for (auto& policy : m_policies) {
         if (policy->requiresTrustedTypesForScript() && sinkGroup == "script"_s) {
             if (!policy->isReportOnly())
                 isAllowed = false;
@@ -848,11 +848,10 @@ bool ContentSecurityPolicy::allowMissingTrustedTypesForSinkGroup(const String& s
                 }
             }
             String violationSample = makeString(sink, '|', sample.left(40));
-            // FIXME: Remove SUPPRESS_UNCOUNTED_LAMBDA_CAPTURE once <rdar://160402332> is fixed.
-            SUPPRESS_UNCOUNTED_LAMBDA_CAPTURE reportViolation("require-trusted-types-for"_s, *policy, "trusted-types-sink"_s, consoleMessage, nullString(), violationSample, TextPosition(OrdinalNumber::beforeFirst(), OrdinalNumber()), nullptr);
+            reportViolation("require-trusted-types-for"_s, *policy, "trusted-types-sink"_s, consoleMessage, nullString(), violationSample, TextPosition(OrdinalNumber::beforeFirst(), OrdinalNumber()), nullptr);
         }
-        return isAllowed;
-    });
+    }
+    return isAllowed;
 }
 
 static bool shouldReportProtocolOnly(const URL& url)


### PR DESCRIPTION
#### aadd704e6d7a3743c5610e1225759d5ece3fc094
<pre>
Only one enforced CSP violation is reported for &apos;require-trusted-types-for&apos;
<a href="https://bugs.webkit.org/show_bug.cgi?id=299889">https://bugs.webkit.org/show_bug.cgi?id=299889</a>

Reviewed by Anne van Kesteren.

Currently, only one CSP violation report is fired no matter how many enforced CSP policies require trusted types.

This is fixed by ensuring we don&apos;t early return when processing CSP policies for this directive.

* LayoutTests/imported/w3c/web-platform-tests/trusted-types/should-sink-type-mismatch-violation-be-blocked-by-csp-001-expected.txt:
* Source/WebCore/page/csp/ContentSecurityPolicy.cpp:
(WebCore::ContentSecurityPolicy::allowMissingTrustedTypesForSinkGroup const):

Canonical link: <a href="https://commits.webkit.org/300832@main">https://commits.webkit.org/300832@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0b706f5665a278664675fef2b3da09e3040961c0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123974 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43689 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34386 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130793 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76126 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/125851 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44413 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52283 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94302 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62565 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126928 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35388 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110903 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74900 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34336 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29066 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74284 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105119 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29287 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133468 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50927 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38793 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102763 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51301 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107123 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102585 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26102 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47936 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26192 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/47785 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50780 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56544 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50254 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53600 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51928 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->