### PR TITLE
Move m_forceRepaint from testRunner.h to the UI Process

### DIFF
--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.h
@@ -65,7 +65,7 @@ public:
 
     void dumpBackForwardListsForAllPages(StringBuilder&);
 
-    void done(bool forceRepaint);
+    void done();
     void setAudioResult(WKDataRef audioData) { m_audioResult = audioData; }
     void setPixelResult(WKImageRef image) { m_pixelResult = image; m_pixelResultIsPending = false; }
     void setPixelResultIsPending(bool isPending) { m_pixelResultIsPending = isPending; }
@@ -150,6 +150,8 @@ public:
     WKRetainPtr<WKStringRef> lastRemovedBackgroundFetchIdentifier() const;
     WKRetainPtr<WKStringRef> lastUpdatedBackgroundFetchIdentifier() const;
     WKRetainPtr<WKStringRef> backgroundFetchState(WKStringRef);
+
+    bool shouldForceRepaint() const;
 
 private:
     InjectedBundle() = default;

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp
@@ -635,7 +635,7 @@ void InjectedBundlePage::dumpDOMAsWebArchive(WKBundleFrameRef frame, StringBuild
 #endif
 }
 
-void InjectedBundlePage::dump(bool forceRepaint)
+void InjectedBundlePage::dump()
 {
     auto& injectedBundle = InjectedBundle::singleton();
     RefPtr testRunner = injectedBundle.testRunner();
@@ -644,7 +644,7 @@ void InjectedBundlePage::dump(bool forceRepaint)
         return;
     }
 
-    if (forceRepaint) {
+    if (injectedBundle.shouldForceRepaint()) {
         // Force a paint before dumping. This matches DumpRenderTree on Windows. (DumpRenderTree on Mac
         // does this at a slightly different time.) See <http://webkit.org/b/55469> for details.
         WKBundlePageForceRepaint(m_page);
@@ -723,7 +723,7 @@ void InjectedBundlePage::dump(bool forceRepaint)
     }
 
     injectedBundle.outputText(stringBuilder.toString(), InjectedBundle::IsFinalTestOutput::Yes);
-    injectedBundle.done(forceRepaint);
+    injectedBundle.done();
 }
 
 void InjectedBundlePage::didFinishLoadForFrame(WKBundleFrameRef frame)
@@ -1317,7 +1317,7 @@ static void dumpAfterWaitAttributeIsRemoved(WKBundlePageRef page)
     if (!testRunner)
         return;
     if (auto currentPage = bundle.page(); currentPage && currentPage->page() == page)
-        currentPage->dump(testRunner->shouldForceRepaint());
+        currentPage->dump();
 }
 
 void InjectedBundlePage::frameDidChangeLocation(WKBundleFrameRef frame)
@@ -1349,7 +1349,7 @@ void InjectedBundlePage::frameDidChangeLocation(WKBundleFrameRef frame)
 
     auto page = InjectedBundle::singleton().page();
     if (!page) {
-        injectedBundle.done(testRunner->shouldForceRepaint());
+        injectedBundle.done();
         return;
     }
 
@@ -1369,10 +1369,7 @@ void InjectedBundlePage::notifyDone()
 
 void InjectedBundlePage::forceImmediateCompletion()
 {
-    RefPtr testRunner = InjectedBundle::singleton().testRunner();
-    if (!testRunner)
-        return;
-    dump(testRunner->shouldForceRepaint());
+    dump();
 }
 
 } // namespace WTR

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.h
@@ -43,7 +43,7 @@ public:
 
     void notifyDone();
     void forceImmediateCompletion();
-    void dump(bool forceRepaint);
+    void dump();
 
     void resetAfterTest();
 

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
@@ -1410,6 +1410,11 @@ unsigned long TestRunner::serverTrustEvaluationCallbackCallsCount()
     return postSynchronousMessageReturningUInt64("ServerTrustEvaluationCallbackCallsCount");
 }
 
+void TestRunner::dontForceRepaint() const
+{
+    postSynchronousMessage("DontForceRepaint");
+}
+
 void TestRunner::setShouldDismissJavaScriptAlertsAsynchronously(bool shouldDismissAsynchronously)
 {
     postSynchronousMessage("ShouldDismissJavaScriptAlertsAsynchronously", shouldDismissAsynchronously);

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
@@ -173,8 +173,7 @@ public:
     void display();
     void displayOnLoadFinish() { m_displayOnLoadFinish = true; }
     bool shouldDisplayOnLoadFinish() { return m_displayOnLoadFinish; }
-    void dontForceRepaint() { m_forceRepaint = false; }
-    bool shouldForceRepaint() { return m_forceRepaint; }
+    void dontForceRepaint() const;
 
     // UserContent testing.
     void addUserScript(JSStringRef source, bool runAtStart, bool allFrames);
@@ -524,7 +523,6 @@ private:
     bool m_testRepaint { false };
     bool m_testRepaintSweepHorizontally { false };
     bool m_displayOnLoadFinish { false };
-    bool m_forceRepaint { true };
     bool m_isPrinting { false };
     bool m_willSendRequestReturnsNull { false };
     bool m_willSendRequestReturnsNullOnRedirect { false };

--- a/Tools/WebKitTestRunner/TestInvocation.cpp
+++ b/Tools/WebKitTestRunner/TestInvocation.cpp
@@ -381,7 +381,6 @@ void TestInvocation::didReceiveMessageFromInjectedBundle(WKStringRef messageName
         }
         m_repaintRects = static_cast<WKArrayRef>(value(messageBodyDictionary, "RepaintRects"));
         m_audioResult = static_cast<WKDataRef>(value(messageBodyDictionary, "AudioResult"));
-        m_forceRepaint = booleanValue(messageBodyDictionary, "ForceRepaint");
         done();
         return;
     }
@@ -1161,6 +1160,11 @@ WKRetainPtr<WKTypeRef> TestInvocation::didReceiveSynchronousMessageFromInjectedB
         return nullptr;
     }
 
+    if (WKStringIsEqualToUTF8CString(messageName, "DontForceRepaint")) {
+        dontForceRepaint();
+        return nullptr;
+    }
+
     if (WKStringIsEqualToUTF8CString(messageName, "DumpPrivateClickMeasurement")) {
         dumpPrivateClickMeasurement();
         return nullptr;
@@ -1294,6 +1298,9 @@ WKRetainPtr<WKTypeRef> TestInvocation::didReceiveSynchronousMessageFromInjectedB
         TestController::singleton().setHasMouseDeviceForTesting((booleanValue(messageBody)));
         return nullptr;
     }
+
+    if (WKStringIsEqualToUTF8CString(messageName, "ShouldForceRepaint"))
+        return adoptWK(WKBooleanCreate(m_forceRepaint));
 
     ASSERT_NOT_REACHED();
     return nullptr;

--- a/Tools/WebKitTestRunner/TestInvocation.h
+++ b/Tools/WebKitTestRunner/TestInvocation.h
@@ -86,6 +86,8 @@ public:
 
     void runUISideScript(WKStringRef, unsigned callbackID);
 
+    void dontForceRepaint() { m_forceRepaint = false; }
+
 private:
     TestInvocation(WKURLRef, const TestOptions&);
 


### PR DESCRIPTION
#### c511e3a72c902f686220111954dc833635578d2b
<pre>
Move m_forceRepaint from testRunner.h to the UI Process
<a href="https://bugs.webkit.org/show_bug.cgi?id=299894">https://bugs.webkit.org/show_bug.cgi?id=299894</a>
<a href="https://rdar.apple.com/161672393">rdar://161672393</a>

Reviewed by Alex Christensen.

m_forceRepaint was in the WebContent process in TestRunner.h and in
the UI process in TestInvocation.h I cleaned this up by removing the
state from TestRunner.h.

* Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp:
(WTR::InjectedBundle::shouldForceRepaint const):
(WTR::InjectedBundle::didReceiveMessageToPage):
(WTR::InjectedBundle::done):
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.h:
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp:
(WTR::InjectedBundlePage::dump):
(WTR::dumpAfterWaitAttributeIsRemoved):
(WTR::InjectedBundlePage::frameDidChangeLocation):
(WTR::InjectedBundlePage::forceImmediateCompletion):
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.h:
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp:
(WTR::TestRunner::dontForceRepaint const):
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.h:
(WTR::TestRunner::dontForceRepaint): Deleted.
(WTR::TestRunner::shouldForceRepaint): Deleted.
* Tools/WebKitTestRunner/TestInvocation.cpp:
(WTR::TestInvocation::didReceiveMessageFromInjectedBundle):
(WTR::TestInvocation::didReceiveSynchronousMessageFromInjectedBundle):
* Tools/WebKitTestRunner/TestInvocation.h:

Canonical link: <a href="https://commits.webkit.org/300799@main">https://commits.webkit.org/300799@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d2919d185bbb27f72a3e3c849e5df5669dec2842

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123890 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43605 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34302 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130677 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76041 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/125767 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44329 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52199 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94226 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/62526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126844 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35320 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110828 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74828 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34271 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28989 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74153 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105048 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29212 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133370 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50843 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38720 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102698 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51217 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107048 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102525 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26074 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47869 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26120 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/47692 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50696 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50170 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53516 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51844 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->