### PR TITLE
Controls clipped in Video Viewer when video is narrower than fullscreen controls

### DIFF
--- a/Source/WebCore/Modules/modern-media-controls/controls/layout-traits.js
+++ b/Source/WebCore/Modules/modern-media-controls/controls/layout-traits.js
@@ -28,12 +28,17 @@ class LayoutTraits
 
     constructor(mode)
     {
-        this.mode = mode
+        this._mode = mode
+    }
+    
+    get mode()
+    {
+        return this._mode;
     }
 
     get isFullscreen()
     {
-        return this.mode == LayoutTraits.Mode.Fullscreen;
+        return this._mode == LayoutTraits.Mode.Fullscreen || this._mode == LayoutTraits.Mode.NarrowViewer;
     }
 
     mediaControlsClass()
@@ -106,7 +111,8 @@ class LayoutTraits
 
 LayoutTraits.Mode = {
     Inline     : 0,
-    Fullscreen : 1
+    Fullscreen : 1,
+    NarrowViewer : 2
 };
 
 // LayoutTraits subclasses should "register" themselves by adding themselves to this map.

--- a/Source/WebCore/Modules/modern-media-controls/controls/macos-inline-media-controls.js
+++ b/Source/WebCore/Modules/modern-media-controls/controls/macos-inline-media-controls.js
@@ -30,7 +30,10 @@ class MacOSInlineMediaControls extends InlineMediaControls
 
     constructor(options = {})
     {
-        options.layoutTraits = new MacOSLayoutTraits(LayoutTraits.Mode.Inline);
+        if (options.mode === undefined)
+            options.layoutTraits = new MacOSLayoutTraits(LayoutTraits.Mode.Inline);
+        else
+            options.layoutTraits = new MacOSLayoutTraits(options.mode);
 
         super(options);
 
@@ -54,6 +57,12 @@ class MacOSInlineMediaControls extends InlineMediaControls
         this.muteButton.element.addEventListener("mouseenter", this);
         this.muteButton.element.addEventListener("mouseleave", this);
         this._volumeSliderContainer.element.addEventListener("mouseleave", this);
+        
+        if (this.layoutTraits.mode == LayoutTraits.Mode.NarrowViewer) {
+            this.element.classList.add("narrowviewer");
+            this.fullscreenButton.isFullscreen = true;
+        }
+        
     }
 
     // Protected

--- a/Source/WebCore/Modules/modern-media-controls/controls/macos-layout-traits.js
+++ b/Source/WebCore/Modules/modern-media-controls/controls/macos-layout-traits.js
@@ -27,7 +27,7 @@ class MacOSLayoutTraits extends LayoutTraits
 {
     mediaControlsClass()
     {
-        if (this.isFullscreen)
+        if (this._mode === LayoutTraits.Mode.Fullscreen)
             return MacOSFullscreenMediaControls;
         return MacOSInlineMediaControls;
     }
@@ -89,8 +89,10 @@ class MacOSLayoutTraits extends LayoutTraits
 
     toString()
     {
-        const mode = this.isFullscreen ? "Fullscreen" : "Inline";
-        return `[MacOSLayoutTraits ${mode}]`;
+        if (this._mode === LayoutTraits.Mode.Fullscreen)
+            return `[MacOSLayoutTraits Fullscreen]`;
+        return `[MacOSLayoutTraits Inline]`;
+        
     }
 }
 

--- a/Source/WebCore/Modules/modern-media-controls/media/media-controller.js
+++ b/Source/WebCore/Modules/modern-media-controls/media/media-controller.js
@@ -24,6 +24,7 @@
  */
 
 const maxNonLiveDuration = 604800; // 604800 seconds == 1 week
+const MaximumNarrowViewerControlsBarWidth = 468;
 
 class MediaController
 {
@@ -159,7 +160,13 @@ class MediaController
 
     get layoutTraits()
     {
-        let mode = this.isFullscreen ? LayoutTraits.Mode.Fullscreen : LayoutTraits.Mode.Inline;
+        let mode = LayoutTraits.Mode.Inline;
+        if (this.isFullscreen) {
+            if (this.host && this.host.inWindowFullscreen && this.media.offsetWidth < MaximumNarrowViewerControlsBarWidth)
+                mode = LayoutTraits.Mode.NarrowViewer;
+            else
+                mode = LayoutTraits.Mode.Fullscreen;
+        }
     
         if (this.host) {
             let LayoutTraitsClass = window.layoutTraitsClasses[this.host.layoutTraitsClassName];
@@ -393,7 +400,7 @@ class MediaController
         if (previousControls)
             previousControls.disable();
 
-        this.controls = new ControlsClass;
+        this.controls = new ControlsClass({ mode: layoutTraits.mode });
         this.controls.delegate = this;
 
         if (this.controls.autoHideController && this.shadowRoot.host && this.shadowRoot.host.dataset.autoHideDelay)

--- a/Source/WebCore/Modules/modern-media-controls/media/start-support.js
+++ b/Source/WebCore/Modules/modern-media-controls/media/start-support.js
@@ -77,6 +77,9 @@ class StartSupport extends MediaControllerSupport
     {
         const media = this.mediaController.media;
         const host = this.mediaController.host;
+        
+        if (host && host.inWindowFullscreen)
+            return false;
 
         if (host && host.shouldForceControlsDisplay)
             return true;

--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
@@ -347,7 +347,7 @@ static const String& glassMaterialMediaControlsStyleSheet()
         "        --primary-glyph-color: white;"
         "        --secondary-glyph-color: white;"
         "    }"
-        "    .media-controls.inline.mac:not(.audio) {"
+        "    .media-controls.inline.mac:not(.audio, .narrowviewer) {"
         "        background-color: rgba(0, 0, 0, 0.4);"
         "    }"
         "    .media-controls.inline.mac:not(.audio):is(:empty, .faded) {"


### PR DESCRIPTION
#### 0b56a8bbac19f4b614a32f71c44f687bdaba7bee
<pre>
Controls clipped in Video Viewer when video is narrower than fullscreen controls
<a href="https://bugs.webkit.org/show_bug.cgi?id=299895">https://bugs.webkit.org/show_bug.cgi?id=299895</a>
<a href="https://rdar.apple.com/147323739">rdar://147323739</a>

Reviewed by Andy Estes.

While in viewer mode, the video can potentially be narrower than the fullscreen controls.
In this case, the controls are cut off. This patch makes it so when the video is too narrow
to fit the fullscreen controls, we instead show the inline controls. This patch creates a
new MacOSLayoutTraits mode called NarrowViewer. This mode&apos;s controls class is MacOSInlineControls.
When we are in this mode, MacOSInlineControls tells the fullscreen button that we are in
fullscreen. Additionally MacOSInlineControls adds a class &quot;narrowviewer&quot; to the controls
element&apos;s class list so that in css we only put a background tint on the inline controls
if the controls do not have this class.

* Source/WebCore/Modules/modern-media-controls/controls/layout-traits.js:
(LayoutTraits):
(LayoutTraits.prototype.get mode):
(LayoutTraits.prototype.get isFullscreen):
* Source/WebCore/Modules/modern-media-controls/controls/macos-inline-media-controls.js:
(MacOSInlineMediaControls.):
* Source/WebCore/Modules/modern-media-controls/controls/macos-layout-traits.js:
(MacOSLayoutTraits.prototype.mediaControlsClass):
(MacOSLayoutTraits.prototype.toString):
(MacOSLayoutTraits):
* Source/WebCore/Modules/modern-media-controls/media/media-controller.js:
(MediaController.prototype.get layoutTraits):
(MediaController.prototype._updateControlsIfNeeded):
* Source/WebCore/Modules/modern-media-controls/media/start-support.js:
(StartSupport.prototype._shouldShowStartButton):
(StartSupport):
* Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm:
(WebCore::glassMaterialMediaControlsStyleSheet):

Canonical link: <a href="https://commits.webkit.org/301153@main">https://commits.webkit.org/301153@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a62fed3b7a2771e9d7685f107cea98acfd1f00e2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125117 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44784 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35523 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131965 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/76988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/126994 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/45475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53347 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/95242 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/76988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128071 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/45475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/111886 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/75784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/45475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/30049 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75445 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/45475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/30279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134645 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/51927 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/39718 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/103712 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52361 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/108107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/103483 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/48832 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/27120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/48980 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19593 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51819 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/57603 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/51186 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/54542 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/52876 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->