### PR TITLE
[Site Isolation] [iOS] Enable http/tests/site-isolation/key-events.html by using UIScriptController.keyDown

### DIFF
--- a/LayoutTests/http/tests/site-isolation/key-events-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/key-events-expected.txt
@@ -1,5 +1,10 @@
+Tests key events on cross-origin iframes in site isolation mode
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS Received key event x
 PASS successfullyParsed is true
 
 TEST COMPLETE
-PASS Received key event x
 

--- a/LayoutTests/http/tests/site-isolation/key-events.html
+++ b/LayoutTests/http/tests/site-isolation/key-events.html
@@ -1,18 +1,24 @@
 <!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
 <script src="/js-test-resources/js-test.js"></script>
+<script src="/js-test-resources/ui-helper.js"></script>
 <script>
-window.addEventListener("message", function (event) {
+description("Tests key events on cross-origin iframes in site isolation mode");
+jsTestIsAsync = true;
+
+window.addEventListener("message", async function (event) {
     testPassed("Received key event " + event.data);
-    testRunner.notifyDone();
+    finishJSTest();
 });
 
-function test() {
+async function test() {
     document.getElementById("iframe").focus();
-    if (window.testRunner) {
-        testRunner.dumpAsText();
-        testRunner.waitUntilDone();
-        eventSender.keyDown("x");
-    }
+    testRunner?.dumpAsText();
+    await UIHelper.setHardwareKeyboardAttached(true);
+    await UIHelper.keyDown("x");
+}
+
+async function onIframeLoad() {
+    await test();
 }
 </script>
-<iframe onload="test()" id="iframe" src="http://localhost:8000/site-isolation/resources/key-event-handler.html"></iframe>
+<iframe onload="onIframeLoad()" id="iframe" src="http://localhost:8000/site-isolation/resources/key-event-handler.html"></iframe>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -4730,9 +4730,6 @@ webkit.org/b/257904 http/tests/site-isolation/draw-after-navigation.html [ Skip 
 webkit.org/b/257904 http/tests/site-isolation/draw-with-size-after-same-origin-navigation.html [ Skip ]
 webkit.org/b/257904 http/tests/site-isolation/page-zoom.html [ Skip ]
 
-# This test can't be enabled on iOS until EventSenderProxy::keyDown() is implemented on iOS.
-http/tests/site-isolation/key-events.html [ Skip ]
-
 # Initial css/compositing test import
 imported/w3c/web-platform-tests/css/compositing/mix-blend-mode/mix-blend-mode-both-parent-and-blended-with-3D-transform.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/compositing/mix-blend-mode/mix-blend-mode-parent-with-text.html [ ImageOnlyFailure ]


### PR DESCRIPTION
#### 9568bb677f63cfc8ccb196db07e50bfe9a7b6bff
<pre>
[Site Isolation] [iOS] Enable http/tests/site-isolation/key-events.html by using UIScriptController.keyDown
<a href="https://bugs.webkit.org/show_bug.cgi?id=299896">https://bugs.webkit.org/show_bug.cgi?id=299896</a>
<a href="https://rdar.apple.com/161674451">rdar://161674451</a>

Reviewed by Richard Robinson.

This test was previously skipped because iOS lacks eventSender.keyDown()
support. However, we can just port the test to using similar primitives
provided by UIScriptController, instead.

* LayoutTests/http/tests/site-isolation/key-events-expected.txt:

Update expected output order.

* LayoutTests/http/tests/site-isolation/key-events.html:
* LayoutTests/platform/ios/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/300782@main">https://commits.webkit.org/300782@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/065e82dd539621aece1b11907826e3337fda56ec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123839 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43554 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34251 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130621 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/75989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/652019ab-be30-4e1a-bd53-ee628a84c232) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44278 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52148 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94182 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/75989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5711c25c-e519-45ea-8014-8447da0009ce) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126792 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35273 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110780 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74781 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d07f25e2-c336-47fe-bf96-496273c06d08) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34228 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28941 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74101 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105000 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29164 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133316 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50792 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38678 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102653 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51166 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107000 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102482 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26053 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47823 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26079 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/47641 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50645 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50119 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53465 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51793 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->