### PR TITLE
Add typed array constructor support for byte streams

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/general.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/general.any-expected.txt
@@ -39,8 +39,8 @@ PASS ReadableStream with byte source: Respond to multiple pull() by separate enq
 PASS ReadableStream with byte source: read(view), then respond()
 PASS ReadableStream with byte source: read(view), then respondWithNewView() with a transferred ArrayBuffer
 PASS ReadableStream with byte source: read(view), then respond() with too big value
-FAIL ReadableStream with byte source: respond(3) to read(view) with 2 element Uint16Array enqueues the 1 byte remainder assert_equals: byteLength expected 2 but got 1
-FAIL ReadableStream with byte source: respond(3) to read(view) with 2 element Uint16Array fulfills second read(view) with the 1 byte remainder assert_equals: byteLength expected 2 but got 1
+PASS ReadableStream with byte source: respond(3) to read(view) with 2 element Uint16Array enqueues the 1 byte remainder
+PASS ReadableStream with byte source: respond(3) to read(view) with 2 element Uint16Array fulfills second read(view) with the 1 byte remainder
 PASS ReadableStream with byte source: enqueue(), getReader(), then read(view)
 PASS ReadableStream with byte source: enqueue(), getReader(), then cancel() (mode = not BYOB)
 PASS ReadableStream with byte source: enqueue(), getReader(), then cancel() (mode = BYOB)
@@ -50,12 +50,8 @@ PASS ReadableStream with byte source: enqueue(), getReader(), then read(view) wh
 PASS ReadableStream with byte source: Multiple enqueue(), getReader(), then read(view)
 PASS ReadableStream with byte source: enqueue(), getReader(), then read(view) with a bigger view
 PASS ReadableStream with byte source: enqueue(), getReader(), then read(view) with smaller views
-FAIL ReadableStream with byte source: enqueue() 1 byte, getReader(), then read(view) with Uint16Array assert_equals: expected 2 but got 1
-FAIL ReadableStream with byte source: enqueue() 3 byte, getReader(), then read(view) with 2-element Uint16Array assert_equals: constructor expected function "function Uint16Array() {
-    [native code]
-}" but got function "function Uint8Array() {
-    [native code]
-}"
+PASS ReadableStream with byte source: enqueue() 1 byte, getReader(), then read(view) with Uint16Array
+PASS ReadableStream with byte source: enqueue() 3 byte, getReader(), then read(view) with 2-element Uint16Array
 FAIL ReadableStream with byte source: read(view) with Uint16Array on close()-d stream with 1 byte enqueue()-d must fail promise_rejects_js: read(view) must fail function "function() { throw e; }" threw object "close is requested" ("") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
@@ -63,8 +59,8 @@ PASS ReadableStream with byte source: A stream must be errored if close()-d befo
 PASS ReadableStream with byte source: Throw if close()-ed more than once
 PASS ReadableStream with byte source: Throw on enqueue() after close()
 PASS ReadableStream with byte source: read(view), then respond() and close() in pull()
-FAIL ReadableStream with byte source: read(view) with Uint32Array, then fill it by multiple respond() calls assert_equals: result.value.byteLength expected 4 but got 1
-FAIL ReadableStream with byte source: read(view) with Uint32Array, then fill it by multiple enqueue() calls assert_equals: result.value.byteLength expected 4 but got 1
+PASS ReadableStream with byte source: read(view) with Uint32Array, then fill it by multiple respond() calls
+PASS ReadableStream with byte source: read(view) with Uint32Array, then fill it by multiple enqueue() calls
 PASS ReadableStream with byte source: read() twice, then enqueue() twice
 PASS ReadableStream with byte source: Multiple read(view), close() and respond()
 PASS ReadableStream with byte source: Multiple read(view), big enqueue()
@@ -98,7 +94,7 @@ PASS ReadableStream with byte source: respondWithNewView() with a transferred no
 PASS ReadableStream with byte source: respondWithNewView() with a transferred zero-length view (in the closed state)
 PASS ReadableStream with byte source: enqueue() discards auto-allocated BYOB request
 PASS ReadableStream with byte source: releaseLock() with pending read(view), read(view) on second reader, respond()
-FAIL ReadableStream with byte source: releaseLock() with pending read(view), read(view) on second reader with 1 element Uint16Array, respond(1) assert_equals: second result.value.byteLength expected 2 but got 1
+PASS ReadableStream with byte source: releaseLock() with pending read(view), read(view) on second reader with 1 element Uint16Array, respond(1)
 PASS ReadableStream with byte source: releaseLock() with pending read(view), read(view) on second reader with 2 element Uint8Array, respond(3)
 PASS ReadableStream with byte source: releaseLock() with pending read(view), read(view) on second reader, respondWithNewView()
 PASS ReadableStream with byte source: releaseLock() with pending read(view), read(view) on second reader, enqueue()
@@ -107,7 +103,7 @@ PASS ReadableStream with byte source: autoAllocateChunkSize, releaseLock() with 
 PASS ReadableStream with byte source: autoAllocateChunkSize, releaseLock() with pending read(), read() on second reader, enqueue()
 PASS ReadableStream with byte source: autoAllocateChunkSize, releaseLock() with pending read(), read(view) on second reader, respond()
 PASS ReadableStream with byte source: autoAllocateChunkSize, releaseLock() with pending read(), read(view) on second reader, enqueue()
-FAIL ReadableStream with byte source: read(view) with 1 element Uint16Array, respond(1), releaseLock(), read(view) on second reader with 1 element Uint16Array, respond(1) assert_equals: second result.value.byteLength expected 2 but got 1
+PASS ReadableStream with byte source: read(view) with 1 element Uint16Array, respond(1), releaseLock(), read(view) on second reader with 1 element Uint16Array, respond(1)
 PASS ReadableStream with byte source: read(view) with 1 element Uint16Array, respond(1), releaseLock(), read() on second reader, enqueue()
 PASS ReadableStream with byte source: autoAllocateChunkSize, read(), respondWithNewView()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/general.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/general.any.serviceworker-expected.txt
@@ -39,8 +39,8 @@ PASS ReadableStream with byte source: Respond to multiple pull() by separate enq
 PASS ReadableStream with byte source: read(view), then respond()
 PASS ReadableStream with byte source: read(view), then respondWithNewView() with a transferred ArrayBuffer
 PASS ReadableStream with byte source: read(view), then respond() with too big value
-FAIL ReadableStream with byte source: respond(3) to read(view) with 2 element Uint16Array enqueues the 1 byte remainder assert_equals: byteLength expected 2 but got 1
-FAIL ReadableStream with byte source: respond(3) to read(view) with 2 element Uint16Array fulfills second read(view) with the 1 byte remainder assert_equals: byteLength expected 2 but got 1
+PASS ReadableStream with byte source: respond(3) to read(view) with 2 element Uint16Array enqueues the 1 byte remainder
+PASS ReadableStream with byte source: respond(3) to read(view) with 2 element Uint16Array fulfills second read(view) with the 1 byte remainder
 PASS ReadableStream with byte source: enqueue(), getReader(), then read(view)
 PASS ReadableStream with byte source: enqueue(), getReader(), then cancel() (mode = not BYOB)
 PASS ReadableStream with byte source: enqueue(), getReader(), then cancel() (mode = BYOB)
@@ -50,12 +50,8 @@ PASS ReadableStream with byte source: enqueue(), getReader(), then read(view) wh
 PASS ReadableStream with byte source: Multiple enqueue(), getReader(), then read(view)
 PASS ReadableStream with byte source: enqueue(), getReader(), then read(view) with a bigger view
 PASS ReadableStream with byte source: enqueue(), getReader(), then read(view) with smaller views
-FAIL ReadableStream with byte source: enqueue() 1 byte, getReader(), then read(view) with Uint16Array assert_equals: expected 2 but got 1
-FAIL ReadableStream with byte source: enqueue() 3 byte, getReader(), then read(view) with 2-element Uint16Array assert_equals: constructor expected function "function Uint16Array() {
-    [native code]
-}" but got function "function Uint8Array() {
-    [native code]
-}"
+PASS ReadableStream with byte source: enqueue() 1 byte, getReader(), then read(view) with Uint16Array
+PASS ReadableStream with byte source: enqueue() 3 byte, getReader(), then read(view) with 2-element Uint16Array
 FAIL ReadableStream with byte source: read(view) with Uint16Array on close()-d stream with 1 byte enqueue()-d must fail promise_rejects_js: read(view) must fail function "function() { throw e; }" threw object "close is requested" ("") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
@@ -63,8 +59,8 @@ PASS ReadableStream with byte source: A stream must be errored if close()-d befo
 PASS ReadableStream with byte source: Throw if close()-ed more than once
 PASS ReadableStream with byte source: Throw on enqueue() after close()
 PASS ReadableStream with byte source: read(view), then respond() and close() in pull()
-FAIL ReadableStream with byte source: read(view) with Uint32Array, then fill it by multiple respond() calls assert_equals: result.value.byteLength expected 4 but got 1
-FAIL ReadableStream with byte source: read(view) with Uint32Array, then fill it by multiple enqueue() calls assert_equals: result.value.byteLength expected 4 but got 1
+PASS ReadableStream with byte source: read(view) with Uint32Array, then fill it by multiple respond() calls
+PASS ReadableStream with byte source: read(view) with Uint32Array, then fill it by multiple enqueue() calls
 PASS ReadableStream with byte source: read() twice, then enqueue() twice
 PASS ReadableStream with byte source: Multiple read(view), close() and respond()
 PASS ReadableStream with byte source: Multiple read(view), big enqueue()
@@ -98,7 +94,7 @@ PASS ReadableStream with byte source: respondWithNewView() with a transferred no
 PASS ReadableStream with byte source: respondWithNewView() with a transferred zero-length view (in the closed state)
 PASS ReadableStream with byte source: enqueue() discards auto-allocated BYOB request
 PASS ReadableStream with byte source: releaseLock() with pending read(view), read(view) on second reader, respond()
-FAIL ReadableStream with byte source: releaseLock() with pending read(view), read(view) on second reader with 1 element Uint16Array, respond(1) assert_equals: second result.value.byteLength expected 2 but got 1
+PASS ReadableStream with byte source: releaseLock() with pending read(view), read(view) on second reader with 1 element Uint16Array, respond(1)
 PASS ReadableStream with byte source: releaseLock() with pending read(view), read(view) on second reader with 2 element Uint8Array, respond(3)
 PASS ReadableStream with byte source: releaseLock() with pending read(view), read(view) on second reader, respondWithNewView()
 PASS ReadableStream with byte source: releaseLock() with pending read(view), read(view) on second reader, enqueue()
@@ -107,7 +103,7 @@ PASS ReadableStream with byte source: autoAllocateChunkSize, releaseLock() with 
 PASS ReadableStream with byte source: autoAllocateChunkSize, releaseLock() with pending read(), read() on second reader, enqueue()
 PASS ReadableStream with byte source: autoAllocateChunkSize, releaseLock() with pending read(), read(view) on second reader, respond()
 PASS ReadableStream with byte source: autoAllocateChunkSize, releaseLock() with pending read(), read(view) on second reader, enqueue()
-FAIL ReadableStream with byte source: read(view) with 1 element Uint16Array, respond(1), releaseLock(), read(view) on second reader with 1 element Uint16Array, respond(1) assert_equals: second result.value.byteLength expected 2 but got 1
+PASS ReadableStream with byte source: read(view) with 1 element Uint16Array, respond(1), releaseLock(), read(view) on second reader with 1 element Uint16Array, respond(1)
 PASS ReadableStream with byte source: read(view) with 1 element Uint16Array, respond(1), releaseLock(), read() on second reader, enqueue()
 PASS ReadableStream with byte source: autoAllocateChunkSize, read(), respondWithNewView()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/general.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/general.any.sharedworker-expected.txt
@@ -39,8 +39,8 @@ PASS ReadableStream with byte source: Respond to multiple pull() by separate enq
 PASS ReadableStream with byte source: read(view), then respond()
 PASS ReadableStream with byte source: read(view), then respondWithNewView() with a transferred ArrayBuffer
 PASS ReadableStream with byte source: read(view), then respond() with too big value
-FAIL ReadableStream with byte source: respond(3) to read(view) with 2 element Uint16Array enqueues the 1 byte remainder assert_equals: byteLength expected 2 but got 1
-FAIL ReadableStream with byte source: respond(3) to read(view) with 2 element Uint16Array fulfills second read(view) with the 1 byte remainder assert_equals: byteLength expected 2 but got 1
+PASS ReadableStream with byte source: respond(3) to read(view) with 2 element Uint16Array enqueues the 1 byte remainder
+PASS ReadableStream with byte source: respond(3) to read(view) with 2 element Uint16Array fulfills second read(view) with the 1 byte remainder
 PASS ReadableStream with byte source: enqueue(), getReader(), then read(view)
 PASS ReadableStream with byte source: enqueue(), getReader(), then cancel() (mode = not BYOB)
 PASS ReadableStream with byte source: enqueue(), getReader(), then cancel() (mode = BYOB)
@@ -50,12 +50,8 @@ PASS ReadableStream with byte source: enqueue(), getReader(), then read(view) wh
 PASS ReadableStream with byte source: Multiple enqueue(), getReader(), then read(view)
 PASS ReadableStream with byte source: enqueue(), getReader(), then read(view) with a bigger view
 PASS ReadableStream with byte source: enqueue(), getReader(), then read(view) with smaller views
-FAIL ReadableStream with byte source: enqueue() 1 byte, getReader(), then read(view) with Uint16Array assert_equals: expected 2 but got 1
-FAIL ReadableStream with byte source: enqueue() 3 byte, getReader(), then read(view) with 2-element Uint16Array assert_equals: constructor expected function "function Uint16Array() {
-    [native code]
-}" but got function "function Uint8Array() {
-    [native code]
-}"
+PASS ReadableStream with byte source: enqueue() 1 byte, getReader(), then read(view) with Uint16Array
+PASS ReadableStream with byte source: enqueue() 3 byte, getReader(), then read(view) with 2-element Uint16Array
 FAIL ReadableStream with byte source: read(view) with Uint16Array on close()-d stream with 1 byte enqueue()-d must fail promise_rejects_js: read(view) must fail function "function() { throw e; }" threw object "close is requested" ("") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
@@ -63,8 +59,8 @@ PASS ReadableStream with byte source: A stream must be errored if close()-d befo
 PASS ReadableStream with byte source: Throw if close()-ed more than once
 PASS ReadableStream with byte source: Throw on enqueue() after close()
 PASS ReadableStream with byte source: read(view), then respond() and close() in pull()
-FAIL ReadableStream with byte source: read(view) with Uint32Array, then fill it by multiple respond() calls assert_equals: result.value.byteLength expected 4 but got 1
-FAIL ReadableStream with byte source: read(view) with Uint32Array, then fill it by multiple enqueue() calls assert_equals: result.value.byteLength expected 4 but got 1
+PASS ReadableStream with byte source: read(view) with Uint32Array, then fill it by multiple respond() calls
+PASS ReadableStream with byte source: read(view) with Uint32Array, then fill it by multiple enqueue() calls
 PASS ReadableStream with byte source: read() twice, then enqueue() twice
 PASS ReadableStream with byte source: Multiple read(view), close() and respond()
 PASS ReadableStream with byte source: Multiple read(view), big enqueue()
@@ -98,7 +94,7 @@ PASS ReadableStream with byte source: respondWithNewView() with a transferred no
 PASS ReadableStream with byte source: respondWithNewView() with a transferred zero-length view (in the closed state)
 PASS ReadableStream with byte source: enqueue() discards auto-allocated BYOB request
 PASS ReadableStream with byte source: releaseLock() with pending read(view), read(view) on second reader, respond()
-FAIL ReadableStream with byte source: releaseLock() with pending read(view), read(view) on second reader with 1 element Uint16Array, respond(1) assert_equals: second result.value.byteLength expected 2 but got 1
+PASS ReadableStream with byte source: releaseLock() with pending read(view), read(view) on second reader with 1 element Uint16Array, respond(1)
 PASS ReadableStream with byte source: releaseLock() with pending read(view), read(view) on second reader with 2 element Uint8Array, respond(3)
 PASS ReadableStream with byte source: releaseLock() with pending read(view), read(view) on second reader, respondWithNewView()
 PASS ReadableStream with byte source: releaseLock() with pending read(view), read(view) on second reader, enqueue()
@@ -107,7 +103,7 @@ PASS ReadableStream with byte source: autoAllocateChunkSize, releaseLock() with 
 PASS ReadableStream with byte source: autoAllocateChunkSize, releaseLock() with pending read(), read() on second reader, enqueue()
 PASS ReadableStream with byte source: autoAllocateChunkSize, releaseLock() with pending read(), read(view) on second reader, respond()
 PASS ReadableStream with byte source: autoAllocateChunkSize, releaseLock() with pending read(), read(view) on second reader, enqueue()
-FAIL ReadableStream with byte source: read(view) with 1 element Uint16Array, respond(1), releaseLock(), read(view) on second reader with 1 element Uint16Array, respond(1) assert_equals: second result.value.byteLength expected 2 but got 1
+PASS ReadableStream with byte source: read(view) with 1 element Uint16Array, respond(1), releaseLock(), read(view) on second reader with 1 element Uint16Array, respond(1)
 PASS ReadableStream with byte source: read(view) with 1 element Uint16Array, respond(1), releaseLock(), read() on second reader, enqueue()
 PASS ReadableStream with byte source: autoAllocateChunkSize, read(), respondWithNewView()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/general.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/general.any.worker-expected.txt
@@ -39,8 +39,8 @@ PASS ReadableStream with byte source: Respond to multiple pull() by separate enq
 PASS ReadableStream with byte source: read(view), then respond()
 PASS ReadableStream with byte source: read(view), then respondWithNewView() with a transferred ArrayBuffer
 PASS ReadableStream with byte source: read(view), then respond() with too big value
-FAIL ReadableStream with byte source: respond(3) to read(view) with 2 element Uint16Array enqueues the 1 byte remainder assert_equals: byteLength expected 2 but got 1
-FAIL ReadableStream with byte source: respond(3) to read(view) with 2 element Uint16Array fulfills second read(view) with the 1 byte remainder assert_equals: byteLength expected 2 but got 1
+PASS ReadableStream with byte source: respond(3) to read(view) with 2 element Uint16Array enqueues the 1 byte remainder
+PASS ReadableStream with byte source: respond(3) to read(view) with 2 element Uint16Array fulfills second read(view) with the 1 byte remainder
 PASS ReadableStream with byte source: enqueue(), getReader(), then read(view)
 PASS ReadableStream with byte source: enqueue(), getReader(), then cancel() (mode = not BYOB)
 PASS ReadableStream with byte source: enqueue(), getReader(), then cancel() (mode = BYOB)
@@ -50,12 +50,8 @@ PASS ReadableStream with byte source: enqueue(), getReader(), then read(view) wh
 PASS ReadableStream with byte source: Multiple enqueue(), getReader(), then read(view)
 PASS ReadableStream with byte source: enqueue(), getReader(), then read(view) with a bigger view
 PASS ReadableStream with byte source: enqueue(), getReader(), then read(view) with smaller views
-FAIL ReadableStream with byte source: enqueue() 1 byte, getReader(), then read(view) with Uint16Array assert_equals: expected 2 but got 1
-FAIL ReadableStream with byte source: enqueue() 3 byte, getReader(), then read(view) with 2-element Uint16Array assert_equals: constructor expected function "function Uint16Array() {
-    [native code]
-}" but got function "function Uint8Array() {
-    [native code]
-}"
+PASS ReadableStream with byte source: enqueue() 1 byte, getReader(), then read(view) with Uint16Array
+PASS ReadableStream with byte source: enqueue() 3 byte, getReader(), then read(view) with 2-element Uint16Array
 FAIL ReadableStream with byte source: read(view) with Uint16Array on close()-d stream with 1 byte enqueue()-d must fail promise_rejects_js: read(view) must fail function "function() { throw e; }" threw object "close is requested" ("") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
@@ -63,8 +59,8 @@ PASS ReadableStream with byte source: A stream must be errored if close()-d befo
 PASS ReadableStream with byte source: Throw if close()-ed more than once
 PASS ReadableStream with byte source: Throw on enqueue() after close()
 PASS ReadableStream with byte source: read(view), then respond() and close() in pull()
-FAIL ReadableStream with byte source: read(view) with Uint32Array, then fill it by multiple respond() calls assert_equals: result.value.byteLength expected 4 but got 1
-FAIL ReadableStream with byte source: read(view) with Uint32Array, then fill it by multiple enqueue() calls assert_equals: result.value.byteLength expected 4 but got 1
+PASS ReadableStream with byte source: read(view) with Uint32Array, then fill it by multiple respond() calls
+PASS ReadableStream with byte source: read(view) with Uint32Array, then fill it by multiple enqueue() calls
 PASS ReadableStream with byte source: read() twice, then enqueue() twice
 PASS ReadableStream with byte source: Multiple read(view), close() and respond()
 PASS ReadableStream with byte source: Multiple read(view), big enqueue()
@@ -98,7 +94,7 @@ PASS ReadableStream with byte source: respondWithNewView() with a transferred no
 PASS ReadableStream with byte source: respondWithNewView() with a transferred zero-length view (in the closed state)
 PASS ReadableStream with byte source: enqueue() discards auto-allocated BYOB request
 PASS ReadableStream with byte source: releaseLock() with pending read(view), read(view) on second reader, respond()
-FAIL ReadableStream with byte source: releaseLock() with pending read(view), read(view) on second reader with 1 element Uint16Array, respond(1) assert_equals: second result.value.byteLength expected 2 but got 1
+PASS ReadableStream with byte source: releaseLock() with pending read(view), read(view) on second reader with 1 element Uint16Array, respond(1)
 PASS ReadableStream with byte source: releaseLock() with pending read(view), read(view) on second reader with 2 element Uint8Array, respond(3)
 PASS ReadableStream with byte source: releaseLock() with pending read(view), read(view) on second reader, respondWithNewView()
 PASS ReadableStream with byte source: releaseLock() with pending read(view), read(view) on second reader, enqueue()
@@ -107,7 +103,7 @@ PASS ReadableStream with byte source: autoAllocateChunkSize, releaseLock() with 
 PASS ReadableStream with byte source: autoAllocateChunkSize, releaseLock() with pending read(), read() on second reader, enqueue()
 PASS ReadableStream with byte source: autoAllocateChunkSize, releaseLock() with pending read(), read(view) on second reader, respond()
 PASS ReadableStream with byte source: autoAllocateChunkSize, releaseLock() with pending read(), read(view) on second reader, enqueue()
-FAIL ReadableStream with byte source: read(view) with 1 element Uint16Array, respond(1), releaseLock(), read(view) on second reader with 1 element Uint16Array, respond(1) assert_equals: second result.value.byteLength expected 2 but got 1
+PASS ReadableStream with byte source: read(view) with 1 element Uint16Array, respond(1), releaseLock(), read(view) on second reader with 1 element Uint16Array, respond(1)
 PASS ReadableStream with byte source: read(view) with 1 element Uint16Array, respond(1), releaseLock(), read() on second reader, enqueue()
 PASS ReadableStream with byte source: autoAllocateChunkSize, read(), respondWithNewView()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/patched-global.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/patched-global.any-expected.txt
@@ -1,7 +1,3 @@
 
-FAIL Patched then() sees byobRequest after filling all pending pull-into descriptors assert_equals: result2.value constructor expected function "function BigUint64Array() {
-    [native code]
-}" but got function "function Uint8Array() {
-    [native code]
-}"
+PASS Patched then() sees byobRequest after filling all pending pull-into descriptors
 

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/patched-global.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/patched-global.any.serviceworker-expected.txt
@@ -1,7 +1,3 @@
 
-FAIL Patched then() sees byobRequest after filling all pending pull-into descriptors assert_equals: result2.value constructor expected function "function BigUint64Array() {
-    [native code]
-}" but got function "function Uint8Array() {
-    [native code]
-}"
+PASS Patched then() sees byobRequest after filling all pending pull-into descriptors
 

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/patched-global.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/patched-global.any.sharedworker-expected.txt
@@ -1,7 +1,3 @@
 
-FAIL Patched then() sees byobRequest after filling all pending pull-into descriptors assert_equals: result2.value constructor expected function "function BigUint64Array() {
-    [native code]
-}" but got function "function Uint8Array() {
-    [native code]
-}"
+PASS Patched then() sees byobRequest after filling all pending pull-into descriptors
 

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/patched-global.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/patched-global.any.worker-expected.txt
@@ -1,7 +1,3 @@
 
-FAIL Patched then() sees byobRequest after filling all pending pull-into descriptors assert_equals: result2.value constructor expected function "function BigUint64Array() {
-    [native code]
-}" but got function "function Uint8Array() {
-    [native code]
-}"
+PASS Patched then() sees byobRequest after filling all pending pull-into descriptors
 

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/read-min.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/read-min.any-expected.txt
@@ -5,11 +5,7 @@ PASS ReadableStream with byte source: read({ min }) rejects if min is larger tha
 PASS ReadableStream with byte source: read({ min }) rejects if min is larger than view's length (Uint16Array)
 PASS ReadableStream with byte source: read({ min }) rejects if min is larger than view's length (DataView)
 PASS ReadableStream with byte source: read({ min }), then read()
-FAIL ReadableStream with byte source: read({ min }) with a DataView assert_equals: result.value must be a DataView expected function "function DataView() {
-    [native code]
-}" but got function "function Uint8Array() {
-    [native code]
-}"
+PASS ReadableStream with byte source: read({ min }) with a DataView
 PASS ReadableStream with byte source: enqueue(), then read({ min })
 PASS ReadableStream with byte source: read({ min: 3 }) on a 3-byte Uint8Array, then multiple enqueue() up to 3 bytes
 PASS ReadableStream with byte source: read({ min: 3 }) on a 5-byte Uint8Array, then multiple enqueue() up to 3 bytes

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/read-min.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/read-min.any.serviceworker-expected.txt
@@ -5,11 +5,7 @@ PASS ReadableStream with byte source: read({ min }) rejects if min is larger tha
 PASS ReadableStream with byte source: read({ min }) rejects if min is larger than view's length (Uint16Array)
 PASS ReadableStream with byte source: read({ min }) rejects if min is larger than view's length (DataView)
 PASS ReadableStream with byte source: read({ min }), then read()
-FAIL ReadableStream with byte source: read({ min }) with a DataView assert_equals: result.value must be a DataView expected function "function DataView() {
-    [native code]
-}" but got function "function Uint8Array() {
-    [native code]
-}"
+PASS ReadableStream with byte source: read({ min }) with a DataView
 PASS ReadableStream with byte source: enqueue(), then read({ min })
 PASS ReadableStream with byte source: read({ min: 3 }) on a 3-byte Uint8Array, then multiple enqueue() up to 3 bytes
 PASS ReadableStream with byte source: read({ min: 3 }) on a 5-byte Uint8Array, then multiple enqueue() up to 3 bytes

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/read-min.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/read-min.any.sharedworker-expected.txt
@@ -5,11 +5,7 @@ PASS ReadableStream with byte source: read({ min }) rejects if min is larger tha
 PASS ReadableStream with byte source: read({ min }) rejects if min is larger than view's length (Uint16Array)
 PASS ReadableStream with byte source: read({ min }) rejects if min is larger than view's length (DataView)
 PASS ReadableStream with byte source: read({ min }), then read()
-FAIL ReadableStream with byte source: read({ min }) with a DataView assert_equals: result.value must be a DataView expected function "function DataView() {
-    [native code]
-}" but got function "function Uint8Array() {
-    [native code]
-}"
+PASS ReadableStream with byte source: read({ min }) with a DataView
 PASS ReadableStream with byte source: enqueue(), then read({ min })
 PASS ReadableStream with byte source: read({ min: 3 }) on a 3-byte Uint8Array, then multiple enqueue() up to 3 bytes
 PASS ReadableStream with byte source: read({ min: 3 }) on a 5-byte Uint8Array, then multiple enqueue() up to 3 bytes

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/read-min.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/read-min.any.worker-expected.txt
@@ -5,11 +5,7 @@ PASS ReadableStream with byte source: read({ min }) rejects if min is larger tha
 PASS ReadableStream with byte source: read({ min }) rejects if min is larger than view's length (Uint16Array)
 PASS ReadableStream with byte source: read({ min }) rejects if min is larger than view's length (DataView)
 PASS ReadableStream with byte source: read({ min }), then read()
-FAIL ReadableStream with byte source: read({ min }) with a DataView assert_equals: result.value must be a DataView expected function "function DataView() {
-    [native code]
-}" but got function "function Uint8Array() {
-    [native code]
-}"
+PASS ReadableStream with byte source: read({ min }) with a DataView
 PASS ReadableStream with byte source: enqueue(), then read({ min })
 PASS ReadableStream with byte source: read({ min: 3 }) on a 3-byte Uint8Array, then multiple enqueue() up to 3 bytes
 PASS ReadableStream with byte source: read({ min: 3 }) on a 5-byte Uint8Array, then multiple enqueue() up to 3 bytes


### PR DESCRIPTION
#### b751cdb55418162aa8c478fd0a98f5843fc42c67
<pre>
Add typed array constructor support for byte streams
<a href="https://rdar.apple.com/161669716">rdar://161669716</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=299887">https://bugs.webkit.org/show_bug.cgi?id=299887</a>

Reviewed by Chris Dumez.

As per spec, we use the input view type where needed.
Covered by rebased tests.

Canonical link: <a href="https://commits.webkit.org/300803@main">https://commits.webkit.org/300803@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/525f63306a0ebed08fd3d13d59f8badf0ce69b20

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123840 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43555 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34252 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130622 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/75990 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bdbf739c-310b-4be6-b280-9b116bc2376c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/125717 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44279 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52149 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94185 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62501 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cc41ceb7-536a-414c-84ef-7176d4e6b05f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126793 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35277 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110781 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74784 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/44a25395-1662-4815-b64f-5ab6333a0fd9) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34233 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/repeated-imports.any.sharedworker.html (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28942 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74102 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105004 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29165 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133317 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50793 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38679 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102654 "11 flakes 57 failures") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51167 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107001 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102483 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26078 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47826 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26080 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/47642 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50646 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56410 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50120 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53466 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51794 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->