### PR TITLE
ReadableStream constructor should rethrow start exceptions

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/general.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/general.any-expected.txt
@@ -1,14 +1,10 @@
 
-Harness Error (FAIL), message = Error
-
 PASS getReader({mode: "byob"}) throws on non-bytes streams
 PASS ReadableStream with byte source can be constructed with no errors
 PASS getReader({mode}) must perform ToString()
 PASS ReadableStream with byte source: Construct and expect start and pull being called
 PASS ReadableStream with byte source: No automatic pull call if start doesn't finish
-FAIL ReadableStream with byte source: start() throws an exception assert_throws_js: start() can throw an exception with type: bytes function "() => new ReadableStream({ start() { throw new Error(); }, type:'bytes' })" threw object "TypeError: start threw" ("TypeError") expected instance of function "function Error() {
-    [native code]
-}" ("Error")
+PASS ReadableStream with byte source: start() throws an exception
 PASS ReadableStream with byte source: Construct with highWaterMark of 0
 PASS ReadableStream with byte source: desiredSize when closed
 PASS ReadableStream with byte source: desiredSize when errored

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/general.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/general.any.serviceworker-expected.txt
@@ -1,14 +1,10 @@
 
-Harness Error (FAIL), message = Error
-
 PASS getReader({mode: "byob"}) throws on non-bytes streams
 PASS ReadableStream with byte source can be constructed with no errors
 PASS getReader({mode}) must perform ToString()
 PASS ReadableStream with byte source: Construct and expect start and pull being called
 PASS ReadableStream with byte source: No automatic pull call if start doesn't finish
-FAIL ReadableStream with byte source: start() throws an exception assert_throws_js: start() can throw an exception with type: bytes function "() => new ReadableStream({ start() { throw new Error(); }, type:'bytes' })" threw object "TypeError: start threw" ("TypeError") expected instance of function "function Error() {
-    [native code]
-}" ("Error")
+PASS ReadableStream with byte source: start() throws an exception
 PASS ReadableStream with byte source: Construct with highWaterMark of 0
 PASS ReadableStream with byte source: desiredSize when closed
 PASS ReadableStream with byte source: desiredSize when errored

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/general.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/general.any.sharedworker-expected.txt
@@ -1,14 +1,10 @@
 
-Harness Error (FAIL), message = Error in remote http://web-platform.test:8800/streams/readable-byte-streams/general.any.js: Error
-
 PASS getReader({mode: "byob"}) throws on non-bytes streams
 PASS ReadableStream with byte source can be constructed with no errors
 PASS getReader({mode}) must perform ToString()
 PASS ReadableStream with byte source: Construct and expect start and pull being called
 PASS ReadableStream with byte source: No automatic pull call if start doesn't finish
-FAIL ReadableStream with byte source: start() throws an exception assert_throws_js: start() can throw an exception with type: bytes function "() => new ReadableStream({ start() { throw new Error(); }, type:'bytes' })" threw object "TypeError: start threw" ("TypeError") expected instance of function "function Error() {
-    [native code]
-}" ("Error")
+PASS ReadableStream with byte source: start() throws an exception
 PASS ReadableStream with byte source: Construct with highWaterMark of 0
 PASS ReadableStream with byte source: desiredSize when closed
 PASS ReadableStream with byte source: desiredSize when errored

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/general.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/general.any.worker-expected.txt
@@ -1,14 +1,10 @@
 
-Harness Error (FAIL), message = Error in remote http://web-platform.test:8800/streams/readable-byte-streams/general.any.js: Error
-
 PASS getReader({mode: "byob"}) throws on non-bytes streams
 PASS ReadableStream with byte source can be constructed with no errors
 PASS getReader({mode}) must perform ToString()
 PASS ReadableStream with byte source: Construct and expect start and pull being called
 PASS ReadableStream with byte source: No automatic pull call if start doesn't finish
-FAIL ReadableStream with byte source: start() throws an exception assert_throws_js: start() can throw an exception with type: bytes function "() => new ReadableStream({ start() { throw new Error(); }, type:'bytes' })" threw object "TypeError: start threw" ("TypeError") expected instance of function "function Error() {
-    [native code]
-}" ("Error")
+PASS ReadableStream with byte source: start() throws an exception
 PASS ReadableStream with byte source: Construct with highWaterMark of 0
 PASS ReadableStream with byte source: desiredSize when closed
 PASS ReadableStream with byte source: desiredSize when errored

--- a/Source/WebCore/Modules/streams/ReadableByteStreamController.cpp
+++ b/Source/WebCore/Modules/streams/ReadableByteStreamController.cpp
@@ -205,10 +205,9 @@ ExceptionOr<void> ReadableByteStreamController::start(JSDOMGlobalObject& globalO
         auto* promise = JSC::JSPromise::resolvedPromise(&globalObject, JSC::jsUndefined());
         startPromise = DOMPromise::create(globalObject, *promise);
     } else {
-        auto startResult = startAlgorithm->invoke(m_underlyingSource.getValue(), *this);
+        auto startResult = startAlgorithm->invokeRethrowingException(m_underlyingSource.getValue(), *this);
         if (startResult.type() != CallbackResultType::Success) {
-            // FIXME: Get exception from start algorithm.
-            return Exception { ExceptionCode::TypeError, "start threw"_s };
+            return Exception { ExceptionCode::ExistingExceptionError };
         }
         Ref vm = globalObject.vm();
         auto scope = DECLARE_THROW_SCOPE(vm);


### PR DESCRIPTION
#### 9e41756dea41a75e9169fd0a4527c7d1e1e62d37
<pre>
ReadableStream constructor should rethrow start exceptions
<a href="https://rdar.apple.com/161669815">rdar://161669815</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=299888">https://bugs.webkit.org/show_bug.cgi?id=299888</a>

Reviewed by Chris Dumez.

Use invokeRethrowingException and ExistingExceptionError to forward the exception triggered by the start method.
Covered by rebased tests.

Canonical link: <a href="https://commits.webkit.org/300804@main">https://commits.webkit.org/300804@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/70ecf8ff67e7586f4d307d385b882037d2a9f014

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123842 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43557 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34254 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130635 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/75993 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/03f6170c-11c2-4598-8199-76f197f19f8d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/125719 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44281 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52151 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94190 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62508 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e87c16a3-3b92-4bfa-a608-b1a0103ed8a2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126795 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35279 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110784 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74788 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/004a9d1b-d89c-4806-8d7e-3e53e24c8973) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34235 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28945 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74117 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105006 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29168 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133319 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50795 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38680 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102656 "Found 1 new test failure: imported/blink/fast/pagination/viewport-y-horizontal-bt-rtl.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51169 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107004 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102485 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26079 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47828 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26083 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/47644 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50648 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56412 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50122 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53468 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51796 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->