### PR TITLE
Cancelling a readable locked byte stream should reject

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/templated.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/templated.any-expected.txt
@@ -14,7 +14,7 @@ PASS ReadableStream with byte source (empty) default reader: releasing the lock 
 PASS ReadableStream with byte source (empty) default reader: releasing the lock should cause closed calls to reject with a TypeError
 PASS ReadableStream with byte source (empty) default reader: releasing the lock should cause locked to become false
 PASS ReadableStream with byte source (empty) default reader: canceling via the reader should cause the reader to act closed
-FAIL ReadableStream with byte source (empty) default reader: canceling via the stream should fail assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS ReadableStream with byte source (empty) default reader: canceling via the stream should fail
 PASS Running templatedRSEmptyReader with ReadableStream with byte source (empty) BYOB reader
 PASS ReadableStream with byte source (empty) BYOB reader: instances have the correct methods and properties
 PASS ReadableStream with byte source (empty) BYOB reader: locked should be true
@@ -27,7 +27,7 @@ PASS ReadableStream with byte source (empty) BYOB reader: releasing the lock sho
 PASS ReadableStream with byte source (empty) BYOB reader: releasing the lock should cause closed calls to reject with a TypeError
 PASS ReadableStream with byte source (empty) BYOB reader: releasing the lock should cause locked to become false
 PASS ReadableStream with byte source (empty) BYOB reader: canceling via the reader should cause the reader to act closed
-FAIL ReadableStream with byte source (empty) BYOB reader: canceling via the stream should fail assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS ReadableStream with byte source (empty) BYOB reader: canceling via the stream should fail
 PASS Running templatedRSThrowAfterCloseOrError with ReadableStream with byte source
 PASS ReadableStream with byte source: enqueue() throws after close()
 PASS ReadableStream with byte source: enqueue() throws after enqueue() and close()

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/templated.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/templated.any.serviceworker-expected.txt
@@ -14,7 +14,7 @@ PASS ReadableStream with byte source (empty) default reader: releasing the lock 
 PASS ReadableStream with byte source (empty) default reader: releasing the lock should cause closed calls to reject with a TypeError
 PASS ReadableStream with byte source (empty) default reader: releasing the lock should cause locked to become false
 PASS ReadableStream with byte source (empty) default reader: canceling via the reader should cause the reader to act closed
-FAIL ReadableStream with byte source (empty) default reader: canceling via the stream should fail assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS ReadableStream with byte source (empty) default reader: canceling via the stream should fail
 PASS Running templatedRSEmptyReader with ReadableStream with byte source (empty) BYOB reader
 PASS ReadableStream with byte source (empty) BYOB reader: instances have the correct methods and properties
 PASS ReadableStream with byte source (empty) BYOB reader: locked should be true
@@ -27,7 +27,7 @@ PASS ReadableStream with byte source (empty) BYOB reader: releasing the lock sho
 PASS ReadableStream with byte source (empty) BYOB reader: releasing the lock should cause closed calls to reject with a TypeError
 PASS ReadableStream with byte source (empty) BYOB reader: releasing the lock should cause locked to become false
 PASS ReadableStream with byte source (empty) BYOB reader: canceling via the reader should cause the reader to act closed
-FAIL ReadableStream with byte source (empty) BYOB reader: canceling via the stream should fail assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS ReadableStream with byte source (empty) BYOB reader: canceling via the stream should fail
 PASS Running templatedRSThrowAfterCloseOrError with ReadableStream with byte source
 PASS ReadableStream with byte source: enqueue() throws after close()
 PASS ReadableStream with byte source: enqueue() throws after enqueue() and close()

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/templated.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/templated.any.sharedworker-expected.txt
@@ -14,7 +14,7 @@ PASS ReadableStream with byte source (empty) default reader: releasing the lock 
 PASS ReadableStream with byte source (empty) default reader: releasing the lock should cause closed calls to reject with a TypeError
 PASS ReadableStream with byte source (empty) default reader: releasing the lock should cause locked to become false
 PASS ReadableStream with byte source (empty) default reader: canceling via the reader should cause the reader to act closed
-FAIL ReadableStream with byte source (empty) default reader: canceling via the stream should fail assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS ReadableStream with byte source (empty) default reader: canceling via the stream should fail
 PASS Running templatedRSEmptyReader with ReadableStream with byte source (empty) BYOB reader
 PASS ReadableStream with byte source (empty) BYOB reader: instances have the correct methods and properties
 PASS ReadableStream with byte source (empty) BYOB reader: locked should be true
@@ -27,7 +27,7 @@ PASS ReadableStream with byte source (empty) BYOB reader: releasing the lock sho
 PASS ReadableStream with byte source (empty) BYOB reader: releasing the lock should cause closed calls to reject with a TypeError
 PASS ReadableStream with byte source (empty) BYOB reader: releasing the lock should cause locked to become false
 PASS ReadableStream with byte source (empty) BYOB reader: canceling via the reader should cause the reader to act closed
-FAIL ReadableStream with byte source (empty) BYOB reader: canceling via the stream should fail assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS ReadableStream with byte source (empty) BYOB reader: canceling via the stream should fail
 PASS Running templatedRSThrowAfterCloseOrError with ReadableStream with byte source
 PASS ReadableStream with byte source: enqueue() throws after close()
 PASS ReadableStream with byte source: enqueue() throws after enqueue() and close()

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/templated.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/templated.any.worker-expected.txt
@@ -14,7 +14,7 @@ PASS ReadableStream with byte source (empty) default reader: releasing the lock 
 PASS ReadableStream with byte source (empty) default reader: releasing the lock should cause closed calls to reject with a TypeError
 PASS ReadableStream with byte source (empty) default reader: releasing the lock should cause locked to become false
 PASS ReadableStream with byte source (empty) default reader: canceling via the reader should cause the reader to act closed
-FAIL ReadableStream with byte source (empty) default reader: canceling via the stream should fail assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS ReadableStream with byte source (empty) default reader: canceling via the stream should fail
 PASS Running templatedRSEmptyReader with ReadableStream with byte source (empty) BYOB reader
 PASS ReadableStream with byte source (empty) BYOB reader: instances have the correct methods and properties
 PASS ReadableStream with byte source (empty) BYOB reader: locked should be true
@@ -27,7 +27,7 @@ PASS ReadableStream with byte source (empty) BYOB reader: releasing the lock sho
 PASS ReadableStream with byte source (empty) BYOB reader: releasing the lock should cause closed calls to reject with a TypeError
 PASS ReadableStream with byte source (empty) BYOB reader: releasing the lock should cause locked to become false
 PASS ReadableStream with byte source (empty) BYOB reader: canceling via the reader should cause the reader to act closed
-FAIL ReadableStream with byte source (empty) BYOB reader: canceling via the stream should fail assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS ReadableStream with byte source (empty) BYOB reader: canceling via the stream should fail
 PASS Running templatedRSThrowAfterCloseOrError with ReadableStream with byte source
 PASS ReadableStream with byte source: enqueue() throws after close()
 PASS ReadableStream with byte source: enqueue() throws after enqueue() and close()

--- a/Source/WebCore/Modules/streams/ReadableStream.cpp
+++ b/Source/WebCore/Modules/streams/ReadableStream.cpp
@@ -475,7 +475,13 @@ JSC::JSValue JSReadableStream::cancel(JSC::JSGlobalObject& globalObject, JSC::Ca
     RefPtr internalReadableStream = wrapped().internalReadableStream();
     if (!internalReadableStream) {
         return callPromiseFunction(globalObject, callFrame, [this](auto& globalObject, auto& callFrame, auto&& promise) {
-            protectedWrapped()->cancel(globalObject, callFrame.argument(0), WTFMove(promise));
+            Ref protectedWrapped = this->wrapped();
+            if (protectedWrapped->isLocked()) {
+                promise->reject(Exception { ExceptionCode::TypeError, "ReadableStream is locked"_s });
+                return;
+            }
+
+            protectedWrapped->cancel(globalObject, callFrame.argument(0), WTFMove(promise));
         });
     }
 


### PR DESCRIPTION
#### 11a15d44e81b72584db41e71d30c8ffc39d2a303
<pre>
Cancelling a readable locked byte stream should reject
<a href="https://rdar.apple.com/161669970">rdar://161669970</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=299890">https://bugs.webkit.org/show_bug.cgi?id=299890</a>

Reviewed by Chris Dumez.

Add a missing check in JSReadableStream::cancel to validate that the byte source readable stream is not locked.
Covered by rebased tests.

Canonical link: <a href="https://commits.webkit.org/300812@main">https://commits.webkit.org/300812@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/411455182f5149fa0946a3caaa4e51469fc1e28f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123942 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43657 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34354 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130733 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/76094 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/125819 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44381 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52251 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94273 "Failed to checkout and rebase branch from PR 51588") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/76094 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126896 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35363 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110871 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74874 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/34311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29033 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74205 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105093 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29255 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133425 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50895 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38763 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/102743 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51269 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107091 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102567 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26089 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47909 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26163 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/47748 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50748 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56512 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50222 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53568 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51896 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->