### PR TITLE
When closed without enough data, ReadableByteStreamController should throw with a TypeError

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/general.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/general.any-expected.txt
@@ -48,9 +48,7 @@ PASS ReadableStream with byte source: enqueue(), getReader(), then read(view) wi
 PASS ReadableStream with byte source: enqueue(), getReader(), then read(view) with smaller views
 PASS ReadableStream with byte source: enqueue() 1 byte, getReader(), then read(view) with Uint16Array
 PASS ReadableStream with byte source: enqueue() 3 byte, getReader(), then read(view) with 2-element Uint16Array
-FAIL ReadableStream with byte source: read(view) with Uint16Array on close()-d stream with 1 byte enqueue()-d must fail promise_rejects_js: read(view) must fail function "function() { throw e; }" threw object "close is requested" ("") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
+PASS ReadableStream with byte source: read(view) with Uint16Array on close()-d stream with 1 byte enqueue()-d must fail
 PASS ReadableStream with byte source: A stream must be errored if close()-d before fulfilling read(view) with Uint16Array
 PASS ReadableStream with byte source: Throw if close()-ed more than once
 PASS ReadableStream with byte source: Throw on enqueue() after close()

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/general.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/general.any.serviceworker-expected.txt
@@ -48,9 +48,7 @@ PASS ReadableStream with byte source: enqueue(), getReader(), then read(view) wi
 PASS ReadableStream with byte source: enqueue(), getReader(), then read(view) with smaller views
 PASS ReadableStream with byte source: enqueue() 1 byte, getReader(), then read(view) with Uint16Array
 PASS ReadableStream with byte source: enqueue() 3 byte, getReader(), then read(view) with 2-element Uint16Array
-FAIL ReadableStream with byte source: read(view) with Uint16Array on close()-d stream with 1 byte enqueue()-d must fail promise_rejects_js: read(view) must fail function "function() { throw e; }" threw object "close is requested" ("") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
+PASS ReadableStream with byte source: read(view) with Uint16Array on close()-d stream with 1 byte enqueue()-d must fail
 PASS ReadableStream with byte source: A stream must be errored if close()-d before fulfilling read(view) with Uint16Array
 PASS ReadableStream with byte source: Throw if close()-ed more than once
 PASS ReadableStream with byte source: Throw on enqueue() after close()

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/general.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/general.any.sharedworker-expected.txt
@@ -48,9 +48,7 @@ PASS ReadableStream with byte source: enqueue(), getReader(), then read(view) wi
 PASS ReadableStream with byte source: enqueue(), getReader(), then read(view) with smaller views
 PASS ReadableStream with byte source: enqueue() 1 byte, getReader(), then read(view) with Uint16Array
 PASS ReadableStream with byte source: enqueue() 3 byte, getReader(), then read(view) with 2-element Uint16Array
-FAIL ReadableStream with byte source: read(view) with Uint16Array on close()-d stream with 1 byte enqueue()-d must fail promise_rejects_js: read(view) must fail function "function() { throw e; }" threw object "close is requested" ("") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
+PASS ReadableStream with byte source: read(view) with Uint16Array on close()-d stream with 1 byte enqueue()-d must fail
 PASS ReadableStream with byte source: A stream must be errored if close()-d before fulfilling read(view) with Uint16Array
 PASS ReadableStream with byte source: Throw if close()-ed more than once
 PASS ReadableStream with byte source: Throw on enqueue() after close()

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/general.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/general.any.worker-expected.txt
@@ -48,9 +48,7 @@ PASS ReadableStream with byte source: enqueue(), getReader(), then read(view) wi
 PASS ReadableStream with byte source: enqueue(), getReader(), then read(view) with smaller views
 PASS ReadableStream with byte source: enqueue() 1 byte, getReader(), then read(view) with Uint16Array
 PASS ReadableStream with byte source: enqueue() 3 byte, getReader(), then read(view) with 2-element Uint16Array
-FAIL ReadableStream with byte source: read(view) with Uint16Array on close()-d stream with 1 byte enqueue()-d must fail promise_rejects_js: read(view) must fail function "function() { throw e; }" threw object "close is requested" ("") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
+PASS ReadableStream with byte source: read(view) with Uint16Array on close()-d stream with 1 byte enqueue()-d must fail
 PASS ReadableStream with byte source: A stream must be errored if close()-d before fulfilling read(view) with Uint16Array
 PASS ReadableStream with byte source: Throw if close()-ed more than once
 PASS ReadableStream with byte source: Throw on enqueue() after close()

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/read-min.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/read-min.any-expected.txt
@@ -20,9 +20,7 @@ PASS ReadableStream with byte source: read({ min }), then error()
 PASS ReadableStream with byte source: getReader(), read({ min }), then cancel()
 PASS ReadableStream with byte source: cancel() with partially filled pending read({ min }) request
 PASS ReadableStream with byte source: enqueue(), then read({ min }) with smaller views
-FAIL ReadableStream with byte source: 3 byte enqueue(), then close(), then read({ min }) with 2-element Uint16Array must fail promise_rejects_js: read() must fail function "function() { throw e; }" threw object "close is requested" ("") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
+PASS ReadableStream with byte source: 3 byte enqueue(), then close(), then read({ min }) with 2-element Uint16Array must fail
 PASS ReadableStream with byte source: read({ min }) with 2-element Uint16Array, then 3 byte enqueue(), then close() must fail
 FAIL ReadableStream with byte source: tee() with read({ min }) from branch1 and read() from branch2 promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/read-min.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/read-min.any.serviceworker-expected.txt
@@ -20,9 +20,7 @@ PASS ReadableStream with byte source: read({ min }), then error()
 PASS ReadableStream with byte source: getReader(), read({ min }), then cancel()
 PASS ReadableStream with byte source: cancel() with partially filled pending read({ min }) request
 PASS ReadableStream with byte source: enqueue(), then read({ min }) with smaller views
-FAIL ReadableStream with byte source: 3 byte enqueue(), then close(), then read({ min }) with 2-element Uint16Array must fail promise_rejects_js: read() must fail function "function() { throw e; }" threw object "close is requested" ("") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
+PASS ReadableStream with byte source: 3 byte enqueue(), then close(), then read({ min }) with 2-element Uint16Array must fail
 PASS ReadableStream with byte source: read({ min }) with 2-element Uint16Array, then 3 byte enqueue(), then close() must fail
 FAIL ReadableStream with byte source: tee() with read({ min }) from branch1 and read() from branch2 promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/read-min.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/read-min.any.sharedworker-expected.txt
@@ -20,9 +20,7 @@ PASS ReadableStream with byte source: read({ min }), then error()
 PASS ReadableStream with byte source: getReader(), read({ min }), then cancel()
 PASS ReadableStream with byte source: cancel() with partially filled pending read({ min }) request
 PASS ReadableStream with byte source: enqueue(), then read({ min }) with smaller views
-FAIL ReadableStream with byte source: 3 byte enqueue(), then close(), then read({ min }) with 2-element Uint16Array must fail promise_rejects_js: read() must fail function "function() { throw e; }" threw object "close is requested" ("") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
+PASS ReadableStream with byte source: 3 byte enqueue(), then close(), then read({ min }) with 2-element Uint16Array must fail
 PASS ReadableStream with byte source: read({ min }) with 2-element Uint16Array, then 3 byte enqueue(), then close() must fail
 FAIL ReadableStream with byte source: tee() with read({ min }) from branch1 and read() from branch2 promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/read-min.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/read-min.any.worker-expected.txt
@@ -20,9 +20,7 @@ PASS ReadableStream with byte source: read({ min }), then error()
 PASS ReadableStream with byte source: getReader(), read({ min }), then cancel()
 PASS ReadableStream with byte source: cancel() with partially filled pending read({ min }) request
 PASS ReadableStream with byte source: enqueue(), then read({ min }) with smaller views
-FAIL ReadableStream with byte source: 3 byte enqueue(), then close(), then read({ min }) with 2-element Uint16Array must fail promise_rejects_js: read() must fail function "function() { throw e; }" threw object "close is requested" ("") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
+PASS ReadableStream with byte source: 3 byte enqueue(), then close(), then read({ min }) with 2-element Uint16Array must fail
 PASS ReadableStream with byte source: read({ min }) with 2-element Uint16Array, then 3 byte enqueue(), then close() must fail
 FAIL ReadableStream with byte source: tee() with read({ min }) from branch1 and read() from branch2 promise_test: Unhandled rejection with value: object "NotSupportedError: Teeing byte streams is not yet supported"
 

--- a/Source/WebCore/Modules/streams/ReadableByteStreamController.cpp
+++ b/Source/WebCore/Modules/streams/ReadableByteStreamController.cpp
@@ -673,7 +673,7 @@ void ReadableByteStreamController::pullInto(JSDOMGlobalObject& globalObject, JSC
             return;
         }
         if (m_closeRequested) {
-            JSC::JSValue e = toJS(&globalObject, &globalObject, DOMException::create(ExceptionCode::TypeError, "close is requested"_s));
+            JSC::JSValue e = JSC::createTypeError(&globalObject, "close is requested"_s);
             error(globalObject, e);
             readIntoRequest->reject<IDLAny>(e);
             return;


### PR DESCRIPTION
#### 257b3fca30fefc6183fe3692312ffa85b340eca7
<pre>
When closed without enough data, ReadableByteStreamController should throw with a TypeError
<a href="https://rdar.apple.com/161670046">rdar://161670046</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=299891">https://bugs.webkit.org/show_bug.cgi?id=299891</a>

Reviewed by Chris Dumez.

Update code to directly create the expected TypeError JS object.
Covered by rebased tests.

Canonical link: <a href="https://commits.webkit.org/300813@main">https://commits.webkit.org/300813@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f4d102182885301b9c73100ac3db9727e3ce1fca

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123948 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43663 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34360 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130739 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/76100 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c40ab33c-8066-450d-b93e-7bd1efa22208) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/125825 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44387 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52257 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/94279 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/76100 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/655455f5-49cf-4545-a08c-d57ec1822173) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126902 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35364 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110875 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74880 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c47394b9-b7bc-4b24-a369-4571216bc3e3) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/34312 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29037 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74211 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105094 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29259 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133431 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50901 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38768 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102745 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51275 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107095 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102569 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26090 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47915 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26166 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/47754 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50754 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56518 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50228 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53574 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51902 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->