### PR TITLE
ReadableByteStreamController should check for non transferable buffers

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/non-transferable-buffers.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/non-transferable-buffers.any-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL ReadableStream with byte source: read() with a non-transferable buffer assert_unreached: pull() should not be called Reached unreachable code
-FAIL ReadableStream with byte source: fill() with a non-transferable buffer assert_unreached: pull() should not be called Reached unreachable code
-FAIL ReadableStream with byte source: enqueue() with a non-transferable buffer assert_throws_js: function "() => controller.enqueue(view)" did not throw
-FAIL ReadableStream with byte source: respondWithNewView() with a non-transferable buffer assert_unreached: read() should not resolve Reached unreachable code
+PASS ReadableStream with byte source: read() with a non-transferable buffer
+PASS ReadableStream with byte source: fill() with a non-transferable buffer
+PASS ReadableStream with byte source: enqueue() with a non-transferable buffer
+PASS ReadableStream with byte source: respondWithNewView() with a non-transferable buffer
 

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/non-transferable-buffers.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/non-transferable-buffers.any.serviceworker-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL ReadableStream with byte source: read() with a non-transferable buffer assert_unreached: pull() should not be called Reached unreachable code
-FAIL ReadableStream with byte source: fill() with a non-transferable buffer assert_unreached: pull() should not be called Reached unreachable code
-FAIL ReadableStream with byte source: enqueue() with a non-transferable buffer assert_throws_js: function "() => controller.enqueue(view)" did not throw
-FAIL ReadableStream with byte source: respondWithNewView() with a non-transferable buffer assert_unreached: read() should not resolve Reached unreachable code
+PASS ReadableStream with byte source: read() with a non-transferable buffer
+PASS ReadableStream with byte source: fill() with a non-transferable buffer
+PASS ReadableStream with byte source: enqueue() with a non-transferable buffer
+PASS ReadableStream with byte source: respondWithNewView() with a non-transferable buffer
 

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/non-transferable-buffers.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/non-transferable-buffers.any.sharedworker-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL ReadableStream with byte source: read() with a non-transferable buffer assert_unreached: pull() should not be called Reached unreachable code
-FAIL ReadableStream with byte source: fill() with a non-transferable buffer assert_unreached: pull() should not be called Reached unreachable code
-FAIL ReadableStream with byte source: enqueue() with a non-transferable buffer assert_throws_js: function "() => controller.enqueue(view)" did not throw
-FAIL ReadableStream with byte source: respondWithNewView() with a non-transferable buffer assert_unreached: read() should not resolve Reached unreachable code
+PASS ReadableStream with byte source: read() with a non-transferable buffer
+PASS ReadableStream with byte source: fill() with a non-transferable buffer
+PASS ReadableStream with byte source: enqueue() with a non-transferable buffer
+PASS ReadableStream with byte source: respondWithNewView() with a non-transferable buffer
 

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/non-transferable-buffers.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/non-transferable-buffers.any.worker-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL ReadableStream with byte source: read() with a non-transferable buffer assert_unreached: pull() should not be called Reached unreachable code
-FAIL ReadableStream with byte source: fill() with a non-transferable buffer assert_unreached: pull() should not be called Reached unreachable code
-FAIL ReadableStream with byte source: enqueue() with a non-transferable buffer assert_throws_js: function "() => controller.enqueue(view)" did not throw
-FAIL ReadableStream with byte source: respondWithNewView() with a non-transferable buffer assert_unreached: read() should not resolve Reached unreachable code
+PASS ReadableStream with byte source: read() with a non-transferable buffer
+PASS ReadableStream with byte source: fill() with a non-transferable buffer
+PASS ReadableStream with byte source: enqueue() with a non-transferable buffer
+PASS ReadableStream with byte source: respondWithNewView() with a non-transferable buffer
 


### PR DESCRIPTION
#### f1d59834d1c5d02d7a7e035f27cc90ab999a1fbf
<pre>
ReadableByteStreamController should check for non transferable buffers
<a href="https://rdar.apple.com/161670267">rdar://161670267</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=299892">https://bugs.webkit.org/show_bug.cgi?id=299892</a>

Reviewed by Chris Dumez.

We add a check for Wasm backed array buffer in transferArrayBuffer to prevent transferring those buffers.
We do a refactoring to return an exceptino when transferring fails and add handling code at call site.
Covered by rebased tests.

Canonical link: <a href="https://commits.webkit.org/300814@main">https://commits.webkit.org/300814@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7e404e04331f9dc0797167389410951480bb5249

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123945 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43660 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34357 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130736 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/76097 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/91f31f6d-a424-4cb0-a890-61c5ec1efa08) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/125822 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44384 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52254 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94276 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/76097 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126899 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35366 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110876 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74877 "Found 1 new API test failure: TestWTF:WTF_Condition.OneProducerOneConsumerOneSlotTimeout (failure)") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/34314 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29038 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74208 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105096 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29260 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133428 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50898 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/38769 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/102749 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51272 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107096 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/102573 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26091 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47914 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26167 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/47751 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50751 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56515 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50225 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53571 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51899 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->