### PR TITLE
Trusted Types attribute processing order is wrong

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/set-attributes-mutations-in-callback.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/set-attributes-mutations-in-callback.tentative-expected.txt
@@ -13,34 +13,34 @@ PASS Element.setAttributeNS works for elementNS=http://www.w3.org/1999/xhtml, el
 PASS Element.setAttributeNS works for elementNS=http://www.w3.org/1999/xhtml, element=SCRIPT, attrName=src (delete other attribute before)
 PASS Element.setAttributeNS works for elementNS=http://www.w3.org/2000/svg, element=script, attrName=href (delete other attribute before)
 PASS Element.setAttributeNS works for elementNS=http://www.w3.org/2000/svg, element=script, attrNS=http://www.w3.org/1999/xlink, attrName=href (delete other attribute before)
-FAIL Element.setAttributeNode works for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrName=onclick (delete other attribute before) assert_equals: expected Node object of unknown type but got Node object of unknown type
-FAIL Element.setAttributeNode works for elementNS=http://www.w3.org/2000/svg, element=g, attrName=ondblclick (delete other attribute before) assert_equals: expected Node object of unknown type but got Node object of unknown type
-FAIL Element.setAttributeNode works for elementNS=http://www.w3.org/1998/Math/MathML, element=mrow, attrName=onmousedown (delete other attribute before) assert_equals: expected Node object of unknown type but got Node object of unknown type
-FAIL Element.setAttributeNode works for elementNS=http://www.w3.org/1999/xhtml, element=IFRAME, attrName=srcdoc (delete other attribute before) assert_equals: expected Node object of unknown type but got Node object of unknown type
-FAIL Element.setAttributeNode works for elementNS=http://www.w3.org/1999/xhtml, element=SCRIPT, attrName=src (delete other attribute before) assert_equals: expected Node object of unknown type but got Node object of unknown type
-FAIL Element.setAttributeNode works for elementNS=http://www.w3.org/2000/svg, element=script, attrName=href (delete other attribute before) assert_equals: expected Node object of unknown type but got Node object of unknown type
-FAIL Element.setAttributeNode works for elementNS=http://www.w3.org/2000/svg, element=script, attrNS=http://www.w3.org/1999/xlink, attrName=href (delete other attribute before) assert_equals: expected Node object of unknown type but got Node object of unknown type
-FAIL Element.setAttributeNodeNS works for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrName=onclick (delete other attribute before) assert_equals: expected Node object of unknown type but got Node object of unknown type
-FAIL Element.setAttributeNodeNS works for elementNS=http://www.w3.org/2000/svg, element=g, attrName=ondblclick (delete other attribute before) assert_equals: expected Node object of unknown type but got Node object of unknown type
-FAIL Element.setAttributeNodeNS works for elementNS=http://www.w3.org/1998/Math/MathML, element=mrow, attrName=onmousedown (delete other attribute before) assert_equals: expected Node object of unknown type but got Node object of unknown type
-FAIL Element.setAttributeNodeNS works for elementNS=http://www.w3.org/1999/xhtml, element=IFRAME, attrName=srcdoc (delete other attribute before) assert_equals: expected Node object of unknown type but got Node object of unknown type
-FAIL Element.setAttributeNodeNS works for elementNS=http://www.w3.org/1999/xhtml, element=SCRIPT, attrName=src (delete other attribute before) assert_equals: expected Node object of unknown type but got Node object of unknown type
-FAIL Element.setAttributeNodeNS works for elementNS=http://www.w3.org/2000/svg, element=script, attrName=href (delete other attribute before) assert_equals: expected Node object of unknown type but got Node object of unknown type
-FAIL Element.setAttributeNodeNS works for elementNS=http://www.w3.org/2000/svg, element=script, attrNS=http://www.w3.org/1999/xlink, attrName=href (delete other attribute before) assert_equals: expected Node object of unknown type but got Node object of unknown type
-FAIL NamedNodeMap.setNamedItem works for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrName=onclick (delete other attribute before) assert_equals: expected Node object of unknown type but got Node object of unknown type
-FAIL NamedNodeMap.setNamedItem works for elementNS=http://www.w3.org/2000/svg, element=g, attrName=ondblclick (delete other attribute before) assert_equals: expected Node object of unknown type but got Node object of unknown type
-FAIL NamedNodeMap.setNamedItem works for elementNS=http://www.w3.org/1998/Math/MathML, element=mrow, attrName=onmousedown (delete other attribute before) assert_equals: expected Node object of unknown type but got Node object of unknown type
-FAIL NamedNodeMap.setNamedItem works for elementNS=http://www.w3.org/1999/xhtml, element=IFRAME, attrName=srcdoc (delete other attribute before) assert_equals: expected Node object of unknown type but got Node object of unknown type
-FAIL NamedNodeMap.setNamedItem works for elementNS=http://www.w3.org/1999/xhtml, element=SCRIPT, attrName=src (delete other attribute before) assert_equals: expected Node object of unknown type but got Node object of unknown type
-FAIL NamedNodeMap.setNamedItem works for elementNS=http://www.w3.org/2000/svg, element=script, attrName=href (delete other attribute before) assert_equals: expected Node object of unknown type but got Node object of unknown type
-FAIL NamedNodeMap.setNamedItem works for elementNS=http://www.w3.org/2000/svg, element=script, attrNS=http://www.w3.org/1999/xlink, attrName=href (delete other attribute before) assert_equals: expected Node object of unknown type but got Node object of unknown type
-FAIL NamedNodeMap.setNamedItemNS works for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrName=onclick (delete other attribute before) assert_equals: expected Node object of unknown type but got Node object of unknown type
-FAIL NamedNodeMap.setNamedItemNS works for elementNS=http://www.w3.org/2000/svg, element=g, attrName=ondblclick (delete other attribute before) assert_equals: expected Node object of unknown type but got Node object of unknown type
-FAIL NamedNodeMap.setNamedItemNS works for elementNS=http://www.w3.org/1998/Math/MathML, element=mrow, attrName=onmousedown (delete other attribute before) assert_equals: expected Node object of unknown type but got Node object of unknown type
-FAIL NamedNodeMap.setNamedItemNS works for elementNS=http://www.w3.org/1999/xhtml, element=IFRAME, attrName=srcdoc (delete other attribute before) assert_equals: expected Node object of unknown type but got Node object of unknown type
-FAIL NamedNodeMap.setNamedItemNS works for elementNS=http://www.w3.org/1999/xhtml, element=SCRIPT, attrName=src (delete other attribute before) assert_equals: expected Node object of unknown type but got Node object of unknown type
-FAIL NamedNodeMap.setNamedItemNS works for elementNS=http://www.w3.org/2000/svg, element=script, attrName=href (delete other attribute before) assert_equals: expected Node object of unknown type but got Node object of unknown type
-FAIL NamedNodeMap.setNamedItemNS works for elementNS=http://www.w3.org/2000/svg, element=script, attrNS=http://www.w3.org/1999/xlink, attrName=href (delete other attribute before) assert_equals: expected Node object of unknown type but got Node object of unknown type
+PASS Element.setAttributeNode works for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrName=onclick (delete other attribute before)
+PASS Element.setAttributeNode works for elementNS=http://www.w3.org/2000/svg, element=g, attrName=ondblclick (delete other attribute before)
+PASS Element.setAttributeNode works for elementNS=http://www.w3.org/1998/Math/MathML, element=mrow, attrName=onmousedown (delete other attribute before)
+PASS Element.setAttributeNode works for elementNS=http://www.w3.org/1999/xhtml, element=IFRAME, attrName=srcdoc (delete other attribute before)
+PASS Element.setAttributeNode works for elementNS=http://www.w3.org/1999/xhtml, element=SCRIPT, attrName=src (delete other attribute before)
+PASS Element.setAttributeNode works for elementNS=http://www.w3.org/2000/svg, element=script, attrName=href (delete other attribute before)
+PASS Element.setAttributeNode works for elementNS=http://www.w3.org/2000/svg, element=script, attrNS=http://www.w3.org/1999/xlink, attrName=href (delete other attribute before)
+PASS Element.setAttributeNodeNS works for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrName=onclick (delete other attribute before)
+PASS Element.setAttributeNodeNS works for elementNS=http://www.w3.org/2000/svg, element=g, attrName=ondblclick (delete other attribute before)
+PASS Element.setAttributeNodeNS works for elementNS=http://www.w3.org/1998/Math/MathML, element=mrow, attrName=onmousedown (delete other attribute before)
+PASS Element.setAttributeNodeNS works for elementNS=http://www.w3.org/1999/xhtml, element=IFRAME, attrName=srcdoc (delete other attribute before)
+PASS Element.setAttributeNodeNS works for elementNS=http://www.w3.org/1999/xhtml, element=SCRIPT, attrName=src (delete other attribute before)
+PASS Element.setAttributeNodeNS works for elementNS=http://www.w3.org/2000/svg, element=script, attrName=href (delete other attribute before)
+PASS Element.setAttributeNodeNS works for elementNS=http://www.w3.org/2000/svg, element=script, attrNS=http://www.w3.org/1999/xlink, attrName=href (delete other attribute before)
+PASS NamedNodeMap.setNamedItem works for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrName=onclick (delete other attribute before)
+PASS NamedNodeMap.setNamedItem works for elementNS=http://www.w3.org/2000/svg, element=g, attrName=ondblclick (delete other attribute before)
+PASS NamedNodeMap.setNamedItem works for elementNS=http://www.w3.org/1998/Math/MathML, element=mrow, attrName=onmousedown (delete other attribute before)
+PASS NamedNodeMap.setNamedItem works for elementNS=http://www.w3.org/1999/xhtml, element=IFRAME, attrName=srcdoc (delete other attribute before)
+PASS NamedNodeMap.setNamedItem works for elementNS=http://www.w3.org/1999/xhtml, element=SCRIPT, attrName=src (delete other attribute before)
+PASS NamedNodeMap.setNamedItem works for elementNS=http://www.w3.org/2000/svg, element=script, attrName=href (delete other attribute before)
+PASS NamedNodeMap.setNamedItem works for elementNS=http://www.w3.org/2000/svg, element=script, attrNS=http://www.w3.org/1999/xlink, attrName=href (delete other attribute before)
+PASS NamedNodeMap.setNamedItemNS works for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrName=onclick (delete other attribute before)
+PASS NamedNodeMap.setNamedItemNS works for elementNS=http://www.w3.org/2000/svg, element=g, attrName=ondblclick (delete other attribute before)
+PASS NamedNodeMap.setNamedItemNS works for elementNS=http://www.w3.org/1998/Math/MathML, element=mrow, attrName=onmousedown (delete other attribute before)
+PASS NamedNodeMap.setNamedItemNS works for elementNS=http://www.w3.org/1999/xhtml, element=IFRAME, attrName=srcdoc (delete other attribute before)
+PASS NamedNodeMap.setNamedItemNS works for elementNS=http://www.w3.org/1999/xhtml, element=SCRIPT, attrName=src (delete other attribute before)
+PASS NamedNodeMap.setNamedItemNS works for elementNS=http://www.w3.org/2000/svg, element=script, attrName=href (delete other attribute before)
+PASS NamedNodeMap.setNamedItemNS works for elementNS=http://www.w3.org/2000/svg, element=script, attrNS=http://www.w3.org/1999/xlink, attrName=href (delete other attribute before)
 PASS Attr.value works for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrName=onclick (delete other attribute before)
 PASS Attr.value works for elementNS=http://www.w3.org/2000/svg, element=g, attrName=ondblclick (delete other attribute before)
 PASS Attr.value works for elementNS=http://www.w3.org/1998/Math/MathML, element=mrow, attrName=onmousedown (delete other attribute before)
@@ -103,27 +103,27 @@ PASS NamedNodeMap.setNamedItemNS works for elementNS=http://www.w3.org/1999/xhtm
 PASS NamedNodeMap.setNamedItemNS works for elementNS=http://www.w3.org/1999/xhtml, element=SCRIPT, attrName=src (delete attribute)
 PASS NamedNodeMap.setNamedItemNS works for elementNS=http://www.w3.org/2000/svg, element=script, attrName=href (delete attribute)
 PASS NamedNodeMap.setNamedItemNS works for elementNS=http://www.w3.org/2000/svg, element=script, attrNS=http://www.w3.org/1999/xlink, attrName=href (delete attribute)
-FAIL Attr.value works for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrName=onclick (delete attribute) assert_equals: expected 2 but got 3
-FAIL Attr.value works for elementNS=http://www.w3.org/2000/svg, element=g, attrName=ondblclick (delete attribute) assert_equals: expected 2 but got 3
-FAIL Attr.value works for elementNS=http://www.w3.org/1998/Math/MathML, element=mrow, attrName=onmousedown (delete attribute) assert_equals: expected 2 but got 3
-FAIL Attr.value works for elementNS=http://www.w3.org/1999/xhtml, element=IFRAME, attrName=srcdoc (delete attribute) assert_equals: expected 2 but got 3
-FAIL Attr.value works for elementNS=http://www.w3.org/1999/xhtml, element=SCRIPT, attrName=src (delete attribute) assert_equals: expected 2 but got 3
-FAIL Attr.value works for elementNS=http://www.w3.org/2000/svg, element=script, attrName=href (delete attribute) assert_equals: expected 2 but got 3
-FAIL Attr.value works for elementNS=http://www.w3.org/2000/svg, element=script, attrNS=http://www.w3.org/1999/xlink, attrName=href (delete attribute) assert_equals: expected 2 but got 3
-FAIL Node.nodeValue works for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrName=onclick (delete attribute) assert_equals: expected 2 but got 3
-FAIL Node.nodeValue works for elementNS=http://www.w3.org/2000/svg, element=g, attrName=ondblclick (delete attribute) assert_equals: expected 2 but got 3
-FAIL Node.nodeValue works for elementNS=http://www.w3.org/1998/Math/MathML, element=mrow, attrName=onmousedown (delete attribute) assert_equals: expected 2 but got 3
-FAIL Node.nodeValue works for elementNS=http://www.w3.org/1999/xhtml, element=IFRAME, attrName=srcdoc (delete attribute) assert_equals: expected 2 but got 3
-FAIL Node.nodeValue works for elementNS=http://www.w3.org/1999/xhtml, element=SCRIPT, attrName=src (delete attribute) assert_equals: expected 2 but got 3
-FAIL Node.nodeValue works for elementNS=http://www.w3.org/2000/svg, element=script, attrName=href (delete attribute) assert_equals: expected 2 but got 3
-FAIL Node.nodeValue works for elementNS=http://www.w3.org/2000/svg, element=script, attrNS=http://www.w3.org/1999/xlink, attrName=href (delete attribute) assert_equals: expected 2 but got 3
-FAIL Node.textContent works for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrName=onclick (delete attribute) assert_equals: expected 2 but got 3
-FAIL Node.textContent works for elementNS=http://www.w3.org/2000/svg, element=g, attrName=ondblclick (delete attribute) assert_equals: expected 2 but got 3
-FAIL Node.textContent works for elementNS=http://www.w3.org/1998/Math/MathML, element=mrow, attrName=onmousedown (delete attribute) assert_equals: expected 2 but got 3
-FAIL Node.textContent works for elementNS=http://www.w3.org/1999/xhtml, element=IFRAME, attrName=srcdoc (delete attribute) assert_equals: expected 2 but got 3
-FAIL Node.textContent works for elementNS=http://www.w3.org/1999/xhtml, element=SCRIPT, attrName=src (delete attribute) assert_equals: expected 2 but got 3
-FAIL Node.textContent works for elementNS=http://www.w3.org/2000/svg, element=script, attrName=href (delete attribute) assert_equals: expected 2 but got 3
-FAIL Node.textContent works for elementNS=http://www.w3.org/2000/svg, element=script, attrNS=http://www.w3.org/1999/xlink, attrName=href (delete attribute) assert_equals: expected 2 but got 3
+PASS Attr.value works for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrName=onclick (delete attribute)
+PASS Attr.value works for elementNS=http://www.w3.org/2000/svg, element=g, attrName=ondblclick (delete attribute)
+PASS Attr.value works for elementNS=http://www.w3.org/1998/Math/MathML, element=mrow, attrName=onmousedown (delete attribute)
+PASS Attr.value works for elementNS=http://www.w3.org/1999/xhtml, element=IFRAME, attrName=srcdoc (delete attribute)
+PASS Attr.value works for elementNS=http://www.w3.org/1999/xhtml, element=SCRIPT, attrName=src (delete attribute)
+PASS Attr.value works for elementNS=http://www.w3.org/2000/svg, element=script, attrName=href (delete attribute)
+PASS Attr.value works for elementNS=http://www.w3.org/2000/svg, element=script, attrNS=http://www.w3.org/1999/xlink, attrName=href (delete attribute)
+PASS Node.nodeValue works for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrName=onclick (delete attribute)
+PASS Node.nodeValue works for elementNS=http://www.w3.org/2000/svg, element=g, attrName=ondblclick (delete attribute)
+PASS Node.nodeValue works for elementNS=http://www.w3.org/1998/Math/MathML, element=mrow, attrName=onmousedown (delete attribute)
+PASS Node.nodeValue works for elementNS=http://www.w3.org/1999/xhtml, element=IFRAME, attrName=srcdoc (delete attribute)
+PASS Node.nodeValue works for elementNS=http://www.w3.org/1999/xhtml, element=SCRIPT, attrName=src (delete attribute)
+PASS Node.nodeValue works for elementNS=http://www.w3.org/2000/svg, element=script, attrName=href (delete attribute)
+PASS Node.nodeValue works for elementNS=http://www.w3.org/2000/svg, element=script, attrNS=http://www.w3.org/1999/xlink, attrName=href (delete attribute)
+PASS Node.textContent works for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrName=onclick (delete attribute)
+PASS Node.textContent works for elementNS=http://www.w3.org/2000/svg, element=g, attrName=ondblclick (delete attribute)
+PASS Node.textContent works for elementNS=http://www.w3.org/1998/Math/MathML, element=mrow, attrName=onmousedown (delete attribute)
+PASS Node.textContent works for elementNS=http://www.w3.org/1999/xhtml, element=IFRAME, attrName=srcdoc (delete attribute)
+PASS Node.textContent works for elementNS=http://www.w3.org/1999/xhtml, element=SCRIPT, attrName=src (delete attribute)
+PASS Node.textContent works for elementNS=http://www.w3.org/2000/svg, element=script, attrName=href (delete attribute)
+PASS Node.textContent works for elementNS=http://www.w3.org/2000/svg, element=script, attrNS=http://www.w3.org/1999/xlink, attrName=href (delete attribute)
 PASS Element.setAttribute works for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrName=onclick (modify attribute)
 PASS Element.setAttribute works for elementNS=http://www.w3.org/2000/svg, element=g, attrName=ondblclick (modify attribute)
 PASS Element.setAttribute works for elementNS=http://www.w3.org/1998/Math/MathML, element=mrow, attrName=onmousedown (modify attribute)
@@ -137,34 +137,34 @@ PASS Element.setAttributeNS works for elementNS=http://www.w3.org/1999/xhtml, el
 PASS Element.setAttributeNS works for elementNS=http://www.w3.org/1999/xhtml, element=SCRIPT, attrName=src (modify attribute)
 PASS Element.setAttributeNS works for elementNS=http://www.w3.org/2000/svg, element=script, attrName=href (modify attribute)
 PASS Element.setAttributeNS works for elementNS=http://www.w3.org/2000/svg, element=script, attrNS=http://www.w3.org/1999/xlink, attrName=href (modify attribute)
-FAIL Element.setAttributeNode works for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrName=onclick (modify attribute) assert_equals: expected Node object of unknown type but got Node object of unknown type
-FAIL Element.setAttributeNode works for elementNS=http://www.w3.org/2000/svg, element=g, attrName=ondblclick (modify attribute) assert_equals: expected Node object of unknown type but got Node object of unknown type
-FAIL Element.setAttributeNode works for elementNS=http://www.w3.org/1998/Math/MathML, element=mrow, attrName=onmousedown (modify attribute) assert_equals: expected Node object of unknown type but got Node object of unknown type
-FAIL Element.setAttributeNode works for elementNS=http://www.w3.org/1999/xhtml, element=IFRAME, attrName=srcdoc (modify attribute) assert_equals: expected Node object of unknown type but got Node object of unknown type
-FAIL Element.setAttributeNode works for elementNS=http://www.w3.org/1999/xhtml, element=SCRIPT, attrName=src (modify attribute) assert_equals: expected Node object of unknown type but got Node object of unknown type
-FAIL Element.setAttributeNode works for elementNS=http://www.w3.org/2000/svg, element=script, attrName=href (modify attribute) assert_equals: expected Node object of unknown type but got Node object of unknown type
-FAIL Element.setAttributeNode works for elementNS=http://www.w3.org/2000/svg, element=script, attrNS=http://www.w3.org/1999/xlink, attrName=href (modify attribute) assert_equals: expected Node object of unknown type but got Node object of unknown type
-FAIL Element.setAttributeNodeNS works for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrName=onclick (modify attribute) assert_equals: expected Node object of unknown type but got Node object of unknown type
-FAIL Element.setAttributeNodeNS works for elementNS=http://www.w3.org/2000/svg, element=g, attrName=ondblclick (modify attribute) assert_equals: expected Node object of unknown type but got Node object of unknown type
-FAIL Element.setAttributeNodeNS works for elementNS=http://www.w3.org/1998/Math/MathML, element=mrow, attrName=onmousedown (modify attribute) assert_equals: expected Node object of unknown type but got Node object of unknown type
-FAIL Element.setAttributeNodeNS works for elementNS=http://www.w3.org/1999/xhtml, element=IFRAME, attrName=srcdoc (modify attribute) assert_equals: expected Node object of unknown type but got Node object of unknown type
-FAIL Element.setAttributeNodeNS works for elementNS=http://www.w3.org/1999/xhtml, element=SCRIPT, attrName=src (modify attribute) assert_equals: expected Node object of unknown type but got Node object of unknown type
-FAIL Element.setAttributeNodeNS works for elementNS=http://www.w3.org/2000/svg, element=script, attrName=href (modify attribute) assert_equals: expected Node object of unknown type but got Node object of unknown type
-FAIL Element.setAttributeNodeNS works for elementNS=http://www.w3.org/2000/svg, element=script, attrNS=http://www.w3.org/1999/xlink, attrName=href (modify attribute) assert_equals: expected Node object of unknown type but got Node object of unknown type
-FAIL NamedNodeMap.setNamedItem works for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrName=onclick (modify attribute) assert_equals: expected Node object of unknown type but got Node object of unknown type
-FAIL NamedNodeMap.setNamedItem works for elementNS=http://www.w3.org/2000/svg, element=g, attrName=ondblclick (modify attribute) assert_equals: expected Node object of unknown type but got Node object of unknown type
-FAIL NamedNodeMap.setNamedItem works for elementNS=http://www.w3.org/1998/Math/MathML, element=mrow, attrName=onmousedown (modify attribute) assert_equals: expected Node object of unknown type but got Node object of unknown type
-FAIL NamedNodeMap.setNamedItem works for elementNS=http://www.w3.org/1999/xhtml, element=IFRAME, attrName=srcdoc (modify attribute) assert_equals: expected Node object of unknown type but got Node object of unknown type
-FAIL NamedNodeMap.setNamedItem works for elementNS=http://www.w3.org/1999/xhtml, element=SCRIPT, attrName=src (modify attribute) assert_equals: expected Node object of unknown type but got Node object of unknown type
-FAIL NamedNodeMap.setNamedItem works for elementNS=http://www.w3.org/2000/svg, element=script, attrName=href (modify attribute) assert_equals: expected Node object of unknown type but got Node object of unknown type
-FAIL NamedNodeMap.setNamedItem works for elementNS=http://www.w3.org/2000/svg, element=script, attrNS=http://www.w3.org/1999/xlink, attrName=href (modify attribute) assert_equals: expected Node object of unknown type but got Node object of unknown type
-FAIL NamedNodeMap.setNamedItemNS works for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrName=onclick (modify attribute) assert_equals: expected Node object of unknown type but got Node object of unknown type
-FAIL NamedNodeMap.setNamedItemNS works for elementNS=http://www.w3.org/2000/svg, element=g, attrName=ondblclick (modify attribute) assert_equals: expected Node object of unknown type but got Node object of unknown type
-FAIL NamedNodeMap.setNamedItemNS works for elementNS=http://www.w3.org/1998/Math/MathML, element=mrow, attrName=onmousedown (modify attribute) assert_equals: expected Node object of unknown type but got Node object of unknown type
-FAIL NamedNodeMap.setNamedItemNS works for elementNS=http://www.w3.org/1999/xhtml, element=IFRAME, attrName=srcdoc (modify attribute) assert_equals: expected Node object of unknown type but got Node object of unknown type
-FAIL NamedNodeMap.setNamedItemNS works for elementNS=http://www.w3.org/1999/xhtml, element=SCRIPT, attrName=src (modify attribute) assert_equals: expected Node object of unknown type but got Node object of unknown type
-FAIL NamedNodeMap.setNamedItemNS works for elementNS=http://www.w3.org/2000/svg, element=script, attrName=href (modify attribute) assert_equals: expected Node object of unknown type but got Node object of unknown type
-FAIL NamedNodeMap.setNamedItemNS works for elementNS=http://www.w3.org/2000/svg, element=script, attrNS=http://www.w3.org/1999/xlink, attrName=href (modify attribute) assert_equals: expected Node object of unknown type but got Node object of unknown type
+PASS Element.setAttributeNode works for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrName=onclick (modify attribute)
+PASS Element.setAttributeNode works for elementNS=http://www.w3.org/2000/svg, element=g, attrName=ondblclick (modify attribute)
+PASS Element.setAttributeNode works for elementNS=http://www.w3.org/1998/Math/MathML, element=mrow, attrName=onmousedown (modify attribute)
+PASS Element.setAttributeNode works for elementNS=http://www.w3.org/1999/xhtml, element=IFRAME, attrName=srcdoc (modify attribute)
+PASS Element.setAttributeNode works for elementNS=http://www.w3.org/1999/xhtml, element=SCRIPT, attrName=src (modify attribute)
+PASS Element.setAttributeNode works for elementNS=http://www.w3.org/2000/svg, element=script, attrName=href (modify attribute)
+PASS Element.setAttributeNode works for elementNS=http://www.w3.org/2000/svg, element=script, attrNS=http://www.w3.org/1999/xlink, attrName=href (modify attribute)
+PASS Element.setAttributeNodeNS works for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrName=onclick (modify attribute)
+PASS Element.setAttributeNodeNS works for elementNS=http://www.w3.org/2000/svg, element=g, attrName=ondblclick (modify attribute)
+PASS Element.setAttributeNodeNS works for elementNS=http://www.w3.org/1998/Math/MathML, element=mrow, attrName=onmousedown (modify attribute)
+PASS Element.setAttributeNodeNS works for elementNS=http://www.w3.org/1999/xhtml, element=IFRAME, attrName=srcdoc (modify attribute)
+PASS Element.setAttributeNodeNS works for elementNS=http://www.w3.org/1999/xhtml, element=SCRIPT, attrName=src (modify attribute)
+PASS Element.setAttributeNodeNS works for elementNS=http://www.w3.org/2000/svg, element=script, attrName=href (modify attribute)
+PASS Element.setAttributeNodeNS works for elementNS=http://www.w3.org/2000/svg, element=script, attrNS=http://www.w3.org/1999/xlink, attrName=href (modify attribute)
+PASS NamedNodeMap.setNamedItem works for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrName=onclick (modify attribute)
+PASS NamedNodeMap.setNamedItem works for elementNS=http://www.w3.org/2000/svg, element=g, attrName=ondblclick (modify attribute)
+PASS NamedNodeMap.setNamedItem works for elementNS=http://www.w3.org/1998/Math/MathML, element=mrow, attrName=onmousedown (modify attribute)
+PASS NamedNodeMap.setNamedItem works for elementNS=http://www.w3.org/1999/xhtml, element=IFRAME, attrName=srcdoc (modify attribute)
+PASS NamedNodeMap.setNamedItem works for elementNS=http://www.w3.org/1999/xhtml, element=SCRIPT, attrName=src (modify attribute)
+PASS NamedNodeMap.setNamedItem works for elementNS=http://www.w3.org/2000/svg, element=script, attrName=href (modify attribute)
+PASS NamedNodeMap.setNamedItem works for elementNS=http://www.w3.org/2000/svg, element=script, attrNS=http://www.w3.org/1999/xlink, attrName=href (modify attribute)
+PASS NamedNodeMap.setNamedItemNS works for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrName=onclick (modify attribute)
+PASS NamedNodeMap.setNamedItemNS works for elementNS=http://www.w3.org/2000/svg, element=g, attrName=ondblclick (modify attribute)
+PASS NamedNodeMap.setNamedItemNS works for elementNS=http://www.w3.org/1998/Math/MathML, element=mrow, attrName=onmousedown (modify attribute)
+PASS NamedNodeMap.setNamedItemNS works for elementNS=http://www.w3.org/1999/xhtml, element=IFRAME, attrName=srcdoc (modify attribute)
+PASS NamedNodeMap.setNamedItemNS works for elementNS=http://www.w3.org/1999/xhtml, element=SCRIPT, attrName=src (modify attribute)
+PASS NamedNodeMap.setNamedItemNS works for elementNS=http://www.w3.org/2000/svg, element=script, attrName=href (modify attribute)
+PASS NamedNodeMap.setNamedItemNS works for elementNS=http://www.w3.org/2000/svg, element=script, attrNS=http://www.w3.org/1999/xlink, attrName=href (modify attribute)
 PASS Attr.value works for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrName=onclick (modify attribute)
 PASS Attr.value works for elementNS=http://www.w3.org/2000/svg, element=g, attrName=ondblclick (modify attribute)
 PASS Attr.value works for elementNS=http://www.w3.org/1998/Math/MathML, element=mrow, attrName=onmousedown (modify attribute)
@@ -227,25 +227,25 @@ PASS NamedNodeMap.setNamedItemNS works for elementNS=http://www.w3.org/1999/xhtm
 PASS NamedNodeMap.setNamedItemNS works for elementNS=http://www.w3.org/1999/xhtml, element=SCRIPT, attrName=src (move attribute node to another element)
 PASS NamedNodeMap.setNamedItemNS works for elementNS=http://www.w3.org/2000/svg, element=script, attrName=href (move attribute node to another element)
 PASS NamedNodeMap.setNamedItemNS works for elementNS=http://www.w3.org/2000/svg, element=script, attrNS=http://www.w3.org/1999/xlink, attrName=href (move attribute node to another element)
-FAIL Attr.value works for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrName=onclick (move attribute node to another element) assert_equals: expected 0 but got 1
-FAIL Attr.value works for elementNS=http://www.w3.org/2000/svg, element=g, attrName=ondblclick (move attribute node to another element) assert_equals: expected 0 but got 1
-FAIL Attr.value works for elementNS=http://www.w3.org/1998/Math/MathML, element=mrow, attrName=onmousedown (move attribute node to another element) assert_equals: expected 0 but got 1
-FAIL Attr.value works for elementNS=http://www.w3.org/1999/xhtml, element=IFRAME, attrName=srcdoc (move attribute node to another element) assert_equals: expected 0 but got 1
-FAIL Attr.value works for elementNS=http://www.w3.org/1999/xhtml, element=SCRIPT, attrName=src (move attribute node to another element) assert_equals: expected 0 but got 1
-FAIL Attr.value works for elementNS=http://www.w3.org/2000/svg, element=script, attrName=href (move attribute node to another element) assert_equals: expected 0 but got 1
-FAIL Attr.value works for elementNS=http://www.w3.org/2000/svg, element=script, attrNS=http://www.w3.org/1999/xlink, attrName=href (move attribute node to another element) assert_equals: expected 0 but got 1
-FAIL Node.nodeValue works for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrName=onclick (move attribute node to another element) assert_equals: expected 0 but got 1
-FAIL Node.nodeValue works for elementNS=http://www.w3.org/2000/svg, element=g, attrName=ondblclick (move attribute node to another element) assert_equals: expected 0 but got 1
-FAIL Node.nodeValue works for elementNS=http://www.w3.org/1998/Math/MathML, element=mrow, attrName=onmousedown (move attribute node to another element) assert_equals: expected 0 but got 1
-FAIL Node.nodeValue works for elementNS=http://www.w3.org/1999/xhtml, element=IFRAME, attrName=srcdoc (move attribute node to another element) assert_equals: expected 0 but got 1
-FAIL Node.nodeValue works for elementNS=http://www.w3.org/1999/xhtml, element=SCRIPT, attrName=src (move attribute node to another element) assert_equals: expected 0 but got 1
-FAIL Node.nodeValue works for elementNS=http://www.w3.org/2000/svg, element=script, attrName=href (move attribute node to another element) assert_equals: expected 0 but got 1
-FAIL Node.nodeValue works for elementNS=http://www.w3.org/2000/svg, element=script, attrNS=http://www.w3.org/1999/xlink, attrName=href (move attribute node to another element) assert_equals: expected 0 but got 1
-FAIL Node.textContent works for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrName=onclick (move attribute node to another element) assert_equals: expected 0 but got 1
-FAIL Node.textContent works for elementNS=http://www.w3.org/2000/svg, element=g, attrName=ondblclick (move attribute node to another element) assert_equals: expected 0 but got 1
-FAIL Node.textContent works for elementNS=http://www.w3.org/1998/Math/MathML, element=mrow, attrName=onmousedown (move attribute node to another element) assert_equals: expected 0 but got 1
-FAIL Node.textContent works for elementNS=http://www.w3.org/1999/xhtml, element=IFRAME, attrName=srcdoc (move attribute node to another element) assert_equals: expected 0 but got 1
-FAIL Node.textContent works for elementNS=http://www.w3.org/1999/xhtml, element=SCRIPT, attrName=src (move attribute node to another element) assert_equals: expected 0 but got 1
-FAIL Node.textContent works for elementNS=http://www.w3.org/2000/svg, element=script, attrName=href (move attribute node to another element) assert_equals: expected 0 but got 1
-FAIL Node.textContent works for elementNS=http://www.w3.org/2000/svg, element=script, attrNS=http://www.w3.org/1999/xlink, attrName=href (move attribute node to another element) assert_equals: expected 0 but got 1
+PASS Attr.value works for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrName=onclick (move attribute node to another element)
+PASS Attr.value works for elementNS=http://www.w3.org/2000/svg, element=g, attrName=ondblclick (move attribute node to another element)
+PASS Attr.value works for elementNS=http://www.w3.org/1998/Math/MathML, element=mrow, attrName=onmousedown (move attribute node to another element)
+PASS Attr.value works for elementNS=http://www.w3.org/1999/xhtml, element=IFRAME, attrName=srcdoc (move attribute node to another element)
+PASS Attr.value works for elementNS=http://www.w3.org/1999/xhtml, element=SCRIPT, attrName=src (move attribute node to another element)
+PASS Attr.value works for elementNS=http://www.w3.org/2000/svg, element=script, attrName=href (move attribute node to another element)
+PASS Attr.value works for elementNS=http://www.w3.org/2000/svg, element=script, attrNS=http://www.w3.org/1999/xlink, attrName=href (move attribute node to another element)
+PASS Node.nodeValue works for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrName=onclick (move attribute node to another element)
+PASS Node.nodeValue works for elementNS=http://www.w3.org/2000/svg, element=g, attrName=ondblclick (move attribute node to another element)
+PASS Node.nodeValue works for elementNS=http://www.w3.org/1998/Math/MathML, element=mrow, attrName=onmousedown (move attribute node to another element)
+PASS Node.nodeValue works for elementNS=http://www.w3.org/1999/xhtml, element=IFRAME, attrName=srcdoc (move attribute node to another element)
+PASS Node.nodeValue works for elementNS=http://www.w3.org/1999/xhtml, element=SCRIPT, attrName=src (move attribute node to another element)
+PASS Node.nodeValue works for elementNS=http://www.w3.org/2000/svg, element=script, attrName=href (move attribute node to another element)
+PASS Node.nodeValue works for elementNS=http://www.w3.org/2000/svg, element=script, attrNS=http://www.w3.org/1999/xlink, attrName=href (move attribute node to another element)
+PASS Node.textContent works for elementNS=http://www.w3.org/1999/xhtml, element=DIV, attrName=onclick (move attribute node to another element)
+PASS Node.textContent works for elementNS=http://www.w3.org/2000/svg, element=g, attrName=ondblclick (move attribute node to another element)
+PASS Node.textContent works for elementNS=http://www.w3.org/1998/Math/MathML, element=mrow, attrName=onmousedown (move attribute node to another element)
+PASS Node.textContent works for elementNS=http://www.w3.org/1999/xhtml, element=IFRAME, attrName=srcdoc (move attribute node to another element)
+PASS Node.textContent works for elementNS=http://www.w3.org/1999/xhtml, element=SCRIPT, attrName=src (move attribute node to another element)
+PASS Node.textContent works for elementNS=http://www.w3.org/2000/svg, element=script, attrName=href (move attribute node to another element)
+PASS Node.textContent works for elementNS=http://www.w3.org/2000/svg, element=script, attrNS=http://www.w3.org/1999/xlink, attrName=href (move attribute node to another element)
 

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -190,7 +190,7 @@ public:
     AtomString getAttributeForBindings(const QualifiedName&, ResolveURLs = ResolveURLs::NoExcludingURLsForPrivacy) const;
     template<typename... QualifiedNames>
     inline const AtomString& getAttribute(const QualifiedName&, const QualifiedNames&...) const;
-    WEBCORE_EXPORT ExceptionOr<void> setAttribute(const QualifiedName&, const AtomString& value, bool enforceTrustedTypes = false);
+    WEBCORE_EXPORT void setAttribute(const QualifiedName&, const AtomString& value);
     void setAttributeWithoutOverwriting(const QualifiedName&, const AtomString& value);
     WEBCORE_EXPORT void setAttributeWithoutSynchronization(const QualifiedName&, const AtomString& value);
     void setSynchronizedLazyAttribute(const QualifiedName&, const AtomString& value);

--- a/Source/WebCore/dom/TrustedType.h
+++ b/Source/WebCore/dom/TrustedType.h
@@ -45,6 +45,8 @@ class ScriptExecutionContext;
 class QualifiedName;
 template<typename> class ExceptionOr;
 
+using TrustedTypeOrString = Variant<RefPtr<TrustedHTML>, RefPtr<TrustedScript>, RefPtr<TrustedScriptURL>, AtomString>;
+
 enum class TrustedType : int8_t {
     TrustedHTML,
     TrustedScript,
@@ -77,5 +79,7 @@ WEBCORE_EXPORT AttributeTypeAndSink trustedTypeForAttribute(const String& elemen
 ExceptionOr<bool> canCompile(ScriptExecutionContext&, JSC::CompilationType, String codeString, const JSC::ArgList& args);
 
 bool isEventHandlerAttribute(const QualifiedName& attributeName);
+
+ExceptionOr<AtomString> trustedTypesCompliantAttributeValue(ScriptExecutionContext&, const String& attributeType, const TrustedTypeOrString& value, const String& sink);
 
 } // namespace WebCore


### PR DESCRIPTION
#### 8c427733d7f7dc0afe679a321936c2ea670f918d
<pre>
Trusted Types attribute processing order is wrong
<a href="https://bugs.webkit.org/show_bug.cgi?id=299898">https://bugs.webkit.org/show_bug.cgi?id=299898</a>

Reviewed by Darin Adler.

This patch moves the trusted types value processing earlier in some of the DOM attribute setting algorithms.

This ensures that script execution caused by the default policy can&apos;t break expectations in the code.

* LayoutTests/imported/w3c/web-platform-tests/trusted-types/set-attributes-mutations-in-callback.tentative-expected.txt:
* Source/WebCore/dom/Attr.cpp:
(WebCore::Attr::setValue):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::setAttribute):
(WebCore::Element::setAttributeNode):
(WebCore::Element::setAttributeNodeNS):
(WebCore::Element::setAttributeNS):
(WebCore::trustedTypesCompliantAttributeValue): Deleted.
* Source/WebCore/dom/Element.h:
* Source/WebCore/dom/TrustedType.cpp:
(WebCore::trustedTypesCompliantAttributeValue):
* Source/WebCore/dom/TrustedType.h:

Canonical link: <a href="https://commits.webkit.org/302272@main">https://commits.webkit.org/302272@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dec679cab362f57227ead4b66731269e0402fc3f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128521 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/789 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39352 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135913 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79954 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130393 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/733 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/662 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97839 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65758 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131469 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/539 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115151 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78451 "Found 1 new API test failure: WPE/TestWebsiteData:/webkit/WebKitWebsiteData/itp (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/486 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33258 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79196 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108909 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33741 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138362 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/625 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/592 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106376 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/669 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111491 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106190 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27058 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/525 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30030 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52963 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/682 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/63882 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/564 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/625 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/636 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->