### PR TITLE
Add IPC signposts

### DIFF
--- a/Source/WTF/wtf/PlatformEnableCocoa.h
+++ b/Source/WTF/wtf/PlatformEnableCocoa.h
@@ -1133,3 +1133,8 @@
 #if !defined(ENABLE_NETWORK_CACHE_SIGNPOSTS)
 #define ENABLE_NETWORK_CACHE_SIGNPOSTS 1
 #endif
+
+// <os/signpost.h> doesn't work from Swift since some of its macros are guarded by #ifndef __swift__.
+#if !defined(ENABLE_CORE_IPC_SIGNPOSTS) && !defined(__swift__)
+#define ENABLE_CORE_IPC_SIGNPOSTS 1
+#endif

--- a/Source/WebKit/Platform/IPC/Connection.h
+++ b/Source/WebKit/Platform/IPC/Connection.h
@@ -544,7 +544,8 @@ public:
     void markCurrentlyDispatchedMessageAsInvalid();
 
 #if ENABLE(CORE_IPC_SIGNPOSTS)
-    static void* generateSignpostIdentifier();
+    static bool signpostsEnabled();
+    static void forceEnableSignposts();
 #endif
 
     static bool shouldCrashOnMessageCheckFailure();

--- a/Source/WebKit/Shared/AuxiliaryProcess.cpp
+++ b/Source/WebKit/Shared/AuxiliaryProcess.cpp
@@ -27,10 +27,12 @@
 #include "AuxiliaryProcess.h"
 
 #include "AuxiliaryProcessCreationParameters.h"
+#include "Connection.h"
 #include "ContentWorldShared.h"
 #include "LogInitialization.h"
 #include "Logging.h"
 #include "SandboxInitializationParameters.h"
+#include "StreamClientConnection.h"
 #include "WebPageProxyIdentifier.h"
 #include <WebCore/LogInitialization.h>
 #include <pal/SessionID.h>
@@ -255,6 +257,12 @@ void AuxiliaryProcess::applyProcessCreationParameters(AuxiliaryProcessCreationPa
 #endif
 #if PLATFORM(COCOA)
     SecureCoding::applyProcessCreationParameters(WTFMove(parameters));
+#endif
+#if ENABLE(CORE_IPC_SIGNPOSTS)
+    if (parameters.shouldEnableIPCSignposts)
+        IPC::Connection::forceEnableSignposts();
+    if (parameters.shouldEnableStreamingIPCSignposts)
+        IPC::StreamClientConnection::forceEnableSignposts();
 #endif
 }
 

--- a/Source/WebKit/Shared/AuxiliaryProcessCreationParameters.h
+++ b/Source/WebKit/Shared/AuxiliaryProcessCreationParameters.h
@@ -36,6 +36,11 @@ struct AuxiliaryProcessCreationParameters {
     String webCoreLoggingChannels;
     String webKitLoggingChannels;
     std::unique_ptr<HashSet<String>> classNamesExemptFromSecureCodingCrash;
+
+#if ENABLE(CORE_IPC_SIGNPOSTS)
+    bool shouldEnableIPCSignposts { false };
+    bool shouldEnableStreamingIPCSignposts { false };
+#endif
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/AuxiliaryProcessCreationParameters.serialization.in
+++ b/Source/WebKit/Shared/AuxiliaryProcessCreationParameters.serialization.in
@@ -25,4 +25,9 @@ struct WebKit::AuxiliaryProcessCreationParameters {
     String webCoreLoggingChannels;
     String webKitLoggingChannels;
     std::unique_ptr<HashSet<String>> classNamesExemptFromSecureCodingCrash;
+
+#if ENABLE(CORE_IPC_SIGNPOSTS)
+    bool shouldEnableIPCSignposts;
+    bool shouldEnableStreamingIPCSignposts;
+#endif
 };

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -110,6 +110,7 @@ class Attachment;
 
 namespace WebCore {
 struct AppHighlight;
+struct ExceptionData;
 struct ExceptionDetails;
 struct TextAnimationData;
 enum class BoxSide : uint8_t;
@@ -121,6 +122,7 @@ enum class TextSuggestionState : uint8_t;
 
 #if HAVE(DIGITAL_CREDENTIALS_UI)
 struct DigitalCredentialsRequestData;
+struct DigitalCredentialsResponseData;
 struct MobileDocumentRequest;
 struct OpenID4VPRequest;
 #endif

--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
@@ -28,9 +28,11 @@
 
 #include "AuxiliaryProcessCreationParameters.h"
 #include "AuxiliaryProcessMessages.h"
+#include "Connection.h"
 #include "Logging.h"
 #include "MessageNames.h"
 #include "OverrideLanguages.h"
+#include "StreamClientConnection.h"
 #include "UIProcessLogInitialization.h"
 #include "WebPageProxy.h"
 #include "WebPageProxyIdentifier.h"
@@ -560,6 +562,11 @@ AuxiliaryProcessCreationParameters AuxiliaryProcessProxy::auxiliaryProcessParame
     auto* exemptClassNames = SecureCoding::classNamesExemptFromSecureCodingCrash();
     if (exemptClassNames)
         parameters.classNamesExemptFromSecureCodingCrash = WTF::makeUnique<HashSet<String>>(*exemptClassNames);
+#endif
+
+#if ENABLE(CORE_IPC_SIGNPOSTS)
+    parameters.shouldEnableIPCSignposts = IPC::Connection::signpostsEnabled();
+    parameters.shouldEnableStreamingIPCSignposts = IPC::StreamClientConnection::signpostsEnabled();
 #endif
 
     return parameters;

--- a/Source/WebKit/UIProcess/WebsiteData/Cocoa/ScreenTimeWebsiteDataSupport.mm
+++ b/Source/WebKit/UIProcess/WebsiteData/Cocoa/ScreenTimeWebsiteDataSupport.mm
@@ -30,6 +30,7 @@
 
 #import "WebsiteDataStoreConfiguration.h"
 #import <wtf/BlockPtr.h>
+#import <wtf/CompletionHandler.h>
 #import <wtf/HashSet.h>
 #import <wtf/URL.h>
 #import <wtf/URLHash.h>


### PR DESCRIPTION
#### 6cbe39143180c7529ab73b181ed57c4d7f013d07
<pre>
Add IPC signposts
<a href="https://rdar.apple.com/161685428">rdar://161685428</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=299903">https://bugs.webkit.org/show_bug.cgi?id=299903</a>

Reviewed by Per Arne Vollan.

This enables the CORE_IPC_SIGNPOSTS compile time feature I added a couple of years ago, since adding
IPC to traces makes them significantly more useful for debugging weird timing issues.

Since IPC signposts can be pretty spammy, we gate emitting IPC signposts behind a user default which
defaults to off. Users can enable IPC signposts via these prefs:

 - WebKitDebugIPCSignposts: enables signposts from IPC::Connection
 - WebKitDebugStreamingIPCSignposts: enables signposts from IPC::StreamClientConnection

In the default case where signposts are off, the various IPC send paths contain one extra
in-framework function call to check whether signposts are enabled, so we don&apos;t expect this to affect
perf unless the IPC signpost preference is enabled.

* Source/WTF/wtf/PlatformEnable.h:
* Source/WebKit/Platform/IPC/Connection.cpp:
(IPC::Connection::forceEnableSignposts):
(IPC::Connection::signpostsEnabled):
(IPC::generateSignpostIdentifier):
(IPC::Connection::sendMessage):
(IPC::Connection::sendMessageWithAsyncReply):
(IPC::Connection::waitForMessage):
(IPC::Connection::sendSyncMessage):
(IPC::Connection::generateSignpostIdentifier): Deleted.
* Source/WebKit/Platform/IPC/Connection.h:
* Source/WebKit/Platform/IPC/StreamClientConnection.cpp:
(IPC::StreamClientConnection::forceEnableSignposts):
(IPC::StreamClientConnection::signpostsEnabled):
(IPC::StreamClientConnection::generateSignpostIdentifier):
(IPC::StreamClientConnection::emitSendSignpost):
* Source/WebKit/Platform/IPC/StreamClientConnection.h:
(IPC::StreamClientConnection::send):
(IPC::StreamClientConnection::sendWithAsyncReply):
(IPC::StreamClientConnection::sendSync):
* Source/WebKit/Shared/AuxiliaryProcess.cpp:
(WebKit::AuxiliaryProcess::applyProcessCreationParameters):
* Source/WebKit/Shared/AuxiliaryProcessCreationParameters.h:
* Source/WebKit/Shared/AuxiliaryProcessCreationParameters.serialization.in:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp:
(WebKit::AuxiliaryProcessProxy::auxiliaryProcessParameters):

* Source/WebKit/UIProcess/WebsiteData/Cocoa/ScreenTimeWebsiteDataSupport.mm:

Canonical link: <a href="https://commits.webkit.org/300901@main">https://commits.webkit.org/300901@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/245754b394f5d5cb61f9fa980c298676424989a6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124235 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43925 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34645 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131069 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76319 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/46bc3206-9ee6-4156-9988-f32193e3b8cb) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44667 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52526 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94501 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62698 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ca31ba95-c9a2-4251-a629-2de0345f1c0d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127189 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35594 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111134 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75089 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a954f43d-386d-4383-b5c0-558c186a94bf) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34540 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29291 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74550 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/116382 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105337 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29513 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133741 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/122766 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51154 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38995 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102980 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51542 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107348 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102775 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26157 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48142 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26396 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48062 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51016 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56794 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/153860 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50460 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39102 "Found 5 new JSC binary failures: testair, testapi, testb3, testdfg, testmasm, Found 8 new JSC stress test failures: wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.default-wasm, wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.wasm-bbq, wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.wasm-bbq-no-consts, wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.wasm-collect-continuously, wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.wasm-eager, wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.wasm-eager-jettison, wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.wasm-no-cjit, wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.wasm-slow-memory (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53814 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52136 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->