### PR TITLE
REGRESSION (iOS 26): MediaRecorder produces corrupted video/audio files, resulting in some loss of content

### DIFF
--- a/LayoutTests/http/wpt/mediarecorder/record-96KHz-long-mp4-expected.txt
+++ b/LayoutTests/http/wpt/mediarecorder/record-96KHz-long-mp4-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Recording a long audio, will not yield a truncated file
+

--- a/LayoutTests/http/wpt/mediarecorder/record-96KHz-long-mp4.html
+++ b/LayoutTests/http/wpt/mediarecorder/record-96KHz-long-mp4.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta name="timeout" content="long">
+    <meta charset="utf-8">
+    <title>Test writing long mp4 doesn't truncate</title>
+    <script src="../../resources/testharness.js"></script>
+    <script src="../../resources/testharnessreport.js"></script>
+    <script>
+
+    function waitFor(duration)
+    {
+        return new Promise((resolve) => setTimeout(resolve, duration));
+    }
+
+    function deviceFromLabel(devices, label)
+    {
+        for (let device of devices) {
+            if (device.label === label)
+                return device;
+        }
+    }
+
+    promise_test(async (test) => {
+        const duration = 22; // recording duration in seconds
+
+        let stream = await navigator.mediaDevices.getUserMedia({ audio:true, video:false })
+        const devices = await navigator.mediaDevices.enumerateDevices();
+        assert_true(devices.length > 2, "after getting permission, more than 1 camera and 1 microphone are exposed");
+        devices.forEach((device) => {
+            assert_not_equals(device.deviceId.length == 0 , "device.deviceId is empty before permission to capture");
+        });
+        stream.getAudioTracks()[0].stop();
+
+        const mic96KHz = deviceFromLabel(devices, "Mock audio device 3");
+        stream = await navigator.mediaDevices.getUserMedia({ audio: { deviceId:mic96KHz.deviceId, sampleRate:96000 } })
+        test.add_cleanup(() => stream.getTracks().forEach(t => t.stop()));
+
+        const recorder = new MediaRecorder(stream, { mimeType : "video/mp4" });
+
+        const dataPromise = new Promise(resolve => recorder.ondataavailable = (e) => resolve(e.data));
+        const startPromise = new Promise(resolve => recorder.onstart = resolve);
+        recorder.start();
+        await startPromise;
+
+        await waitFor(duration * 1000);
+        recorder.stop();
+        const blob = await dataPromise;
+
+        const url = URL.createObjectURL(blob);
+        const video = document.createElement("video");
+        video.src = url;
+        await new Promise((resolve) => video.addEventListener("loadedmetadata", resolve, { once: true }));
+        assert_greater_than(video.duration, duration - 1);
+        URL.revokeObjectURL(url);
+    }, "Recording a long audio, will not yield a truncated file");
+    </script>
+</head>
+<body>
+</body>
+</html>

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -1635,3 +1635,5 @@ imported/w3c/web-platform-tests/css/css-view-transitions/navigation/skip-outboun
 webkit.org/b/298727 css3/text-decoration/text-decoration-line-grammar-error-1.html [ Skip ]
 webkit.org/b/298727 css3/text-decoration/text-decoration-line-grammar-error-2.html [ Skip ]
 webkit.org/b/298727 css3/text-decoration/text-decoration-line-grammar-error-3.html [ Skip ]
+
+webkit.org/b/299944 http/wpt/mediarecorder/record-96KHz-long-mp4.html [ Skip ]

--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -1344,3 +1344,5 @@ webkit.org/b/298727 css3/text-decoration/text-decoration-line-spelling-error-3.h
 webkit.org/b/298727 css3/text-decoration/text-decoration-line-grammar-error-1.html [ Skip ]
 webkit.org/b/298727 css3/text-decoration/text-decoration-line-grammar-error-2.html [ Skip ]
 webkit.org/b/298727 css3/text-decoration/text-decoration-line-grammar-error-3.html [ Skip ]
+
+webkit.org/b/299944 http/wpt/mediarecorder/record-96KHz-long-mp4.html [ Skip ]

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateWriter.cpp
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateWriter.cpp
@@ -95,11 +95,7 @@ Ref<GenericPromise> MediaRecorderPrivateWriter::close()
 {
     ASSERT(m_lastEndTime.isValid(), "writeFrames must have been called once");
 
-    if (!m_pendingFrames.isEmpty())
-        writeFrames({ }, m_lastEndTime); // Attempt one last time to write the frames we do have.
-
-    m_pendingFrames.clear();
-    return close(m_lastEndTime);
+    return close(std::exchange(m_pendingFrames, { }), m_lastEndTime);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateWriter.h
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateWriter.h
@@ -68,14 +68,14 @@ public:
     virtual bool allTracksAdded() = 0;
     enum class Result : uint8_t { Success, Failure, NotReady };
     using WriterPromise = NativePromise<void, Result>;
-    WEBCORE_EXPORT virtual Ref<WriterPromise> writeFrames(Deque<UniqueRef<MediaSamplesBlock>>&&, const MediaTime&);
-    WEBCORE_EXPORT virtual Ref<GenericPromise> close();
+    WEBCORE_EXPORT Ref<WriterPromise> writeFrames(Deque<UniqueRef<MediaSamplesBlock>>&&, const MediaTime&);
+    WEBCORE_EXPORT Ref<GenericPromise> close();
     virtual bool shouldApplyVideoRotation() const { return false; }
 
 private:
     virtual Result writeFrame(const MediaSamplesBlock&) = 0;
     virtual void forceNewSegment(const MediaTime&) = 0;
-    virtual Ref<GenericPromise> close(const MediaTime&) = 0;
+    virtual Ref<GenericPromise> close(Deque<UniqueRef<MediaSamplesBlock>>&&, const MediaTime&) = 0;
     Deque<UniqueRef<MediaSamplesBlock>> m_pendingFrames;
     MediaTime m_lastEndTime { MediaTime::invalidTime() };
 };

--- a/Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterAVFObjC.h
+++ b/Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterAVFObjC.h
@@ -51,7 +51,7 @@ private:
     bool allTracksAdded() final;
     Result writeFrame(const MediaSamplesBlock&) final;
     void forceNewSegment(const WTF::MediaTime&) final;
-    Ref<GenericPromise> close(const WTF::MediaTime&) final;
+    Ref<GenericPromise> close(Deque<UniqueRef<MediaSamplesBlock>>&&, const WTF::MediaTime&) final;
 
     RetainPtr<AVAssetWriterInput> m_audioAssetWriterInput;
     RetainPtr<AVAssetWriterInput> m_videoAssetWriterInput;
@@ -64,6 +64,7 @@ private:
     RetainPtr<CMFormatDescriptionRef> m_videoDescription;
     const RetainPtr<WebAVAssetWriterDelegate> m_delegate;
     const RetainPtr<AVAssetWriter> m_writer;
+    const Ref<WorkQueue> m_waitingQueue;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterWebM.cpp
+++ b/Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterWebM.cpp
@@ -190,8 +190,12 @@ void MediaRecorderPrivateWriterWebM::forceNewSegment(const MediaTime&)
     m_delegate->forceNewClusterOnNextFrame();
 }
 
-Ref<GenericPromise> MediaRecorderPrivateWriterWebM::close(const MediaTime&)
+Ref<GenericPromise> MediaRecorderPrivateWriterWebM::close(Deque<UniqueRef<MediaSamplesBlock>>&& samples, const MediaTime&)
 {
+    auto result = Result::Success;
+    while (!samples.isEmpty() && result == Result::Success)
+        result = writeFrame(samples.takeFirst().get());
+
     m_delegate->finalize();
     return GenericPromise::createAndResolve();
 }

--- a/Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterWebM.h
+++ b/Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterWebM.h
@@ -48,7 +48,7 @@ private:
     bool allTracksAdded() final { return true; }
     Result writeFrame(const MediaSamplesBlock&) final;
     void forceNewSegment(const WTF::MediaTime&) final;
-    Ref<GenericPromise> close(const WTF::MediaTime&) final;
+    Ref<GenericPromise> close(Deque<UniqueRef<MediaSamplesBlock>>&&, const WTF::MediaTime&) final;
     bool shouldApplyVideoRotation() const final { return true; }
 
     const UniqueRef<MediaRecorderPrivateWriterWebMDelegate> m_delegate;


### PR DESCRIPTION
#### 812a4cd88295f97f134a61e9f7a3621530188f4c
<pre>
REGRESSION (iOS 26): MediaRecorder produces corrupted video/audio files, resulting in some loss of content
<a href="https://bugs.webkit.org/show_bug.cgi?id=299164">https://bugs.webkit.org/show_bug.cgi?id=299164</a>
<a href="https://rdar.apple.com/160982017">rdar://160982017</a>

Reviewed by Youenn Fablet.

In typical usage, a MediaRecorder is configured to generate segments of a finite size.
However, in the provided reproduction steps, no size are provided and the
audio recordings will be as long as the duration between the recording starting
and the recording being stopped.
When writing the last segment, if the AVAssetWriterInput reported not to be
ready for more data, we would abort in the expectation that another fetchData
would be called that would flush the remaining samples. However, this last fetchData
will never occur.

The MediaRecorderPrivateWriterAVFObjC made the incorrect assumptions that
the AVAssetWriterInput would always be accepting more content as we only feed
it compressed, interleaved sample. This assumption turned out to be false.

When closing the recording, we now pass to the writer all the pending samples
and write them asynchronously using the appropriate AVAssetWriterInput&apos;s APIs
that ensure writes are delayed until ready.
We now call AVAssetWriterInput as per its documentation suggests

Added test.

* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateWriter.cpp:
(WebCore::MediaRecorderPrivateWriter::close):
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateWriter.h:
* Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterAVFObjC.h:
* Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterAVFObjC.mm:
(WebCore::MediaRecorderPrivateWriterAVFObjC::MediaRecorderPrivateWriterAVFObjC):
(WebCore::MediaRecorderPrivateWriterAVFObjC::writeFrame):
(WebCore::MediaRecorderPrivateWriterAVFObjC::close):
* Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterWebM.cpp:
(WebCore::MediaRecorderPrivateWriterWebM::close):
* Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterWebM.h:

Canonical link: <a href="https://commits.webkit.org/300824@main">https://commits.webkit.org/300824@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3308e752e1b3966056d0ee9a6fe4a40d2d8c116b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123980 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43695 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34392 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130799 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76132 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d05723ac-2369-492b-b81c-c43ad43d7ad2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/125857 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44419 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52289 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/94304 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/62568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/336444fa-5604-406a-9bd2-5cf1bc81dc52) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126934 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35389 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110900 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74902 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4aee1ef2-28d9-44a5-b8ad-a5d3152b7b69) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34337 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29063 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74282 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105120 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29284 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/133473 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50933 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38798 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/133473 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51307 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107120 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/133473 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26097 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47942 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/47793 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50786 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56550 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50260 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53606 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51934 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->