### PR TITLE
Synchronize EventCount's backing map with ScriptWrappable

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1277,6 +1277,9 @@ imported/w3c/web-platform-tests/resource-timing/TAO-match.html [ Pass Failure ]
 imported/w3c/web-platform-tests/resource-timing/iframe-failed-commit.html [ Pass Failure ]
 imported/w3c/web-platform-tests/resource-timing/fetch-cross-origin-redirect.https.html [ Pass Failure ]
 
+# Partially implemented:
+webkit.org/b/214677 imported/w3c/web-platform-tests/event-timing/event-counts-maplike-iterators-always-updated.html [ Pass Failure ]
+
 # No browser passes, test is likely outdated:
 webkit.org/b/214677 imported/w3c/web-platform-tests/event-timing/modal-dialog-interrupt-paint.html [ Skip ]
 webkit.org/b/214677 imported/w3c/web-platform-tests/event-timing/TapToStopFling.html [ Skip ]

--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1277,8 +1277,8 @@ imported/w3c/web-platform-tests/resource-timing/TAO-match.html [ Pass Failure ]
 imported/w3c/web-platform-tests/resource-timing/iframe-failed-commit.html [ Pass Failure ]
 imported/w3c/web-platform-tests/resource-timing/fetch-cross-origin-redirect.https.html [ Pass Failure ]
 
-# Partially implemented:
-webkit.org/b/214677 imported/w3c/web-platform-tests/event-timing/event-counts-maplike-iterators-always-updated.html [ Pass Failure ]
+# Requires the update of all JSWrapper of EventCounts, not just the main world:
+webkit.org/b/214677 imported/w3c/web-platform-tests/event-timing/event-counts-maplike-iterators-iframe-always-updated.html [ Pass Failure ]
 
 # No browser passes, test is likely outdated:
 webkit.org/b/214677 imported/w3c/web-platform-tests/event-timing/modal-dialog-interrupt-paint.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/event-timing/event-counts-maplike-iterators-always-updated-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/event-timing/event-counts-maplike-iterators-always-updated-expected.txt
@@ -1,0 +1,5 @@
+Outside target!
+Click me
+
+FAIL Event Timing eventCount iterators always updated. assert_equals: Iterators must be always up-to-date expected 2 but got 1
+

--- a/LayoutTests/imported/w3c/web-platform-tests/event-timing/event-counts-maplike-iterators-always-updated-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/event-timing/event-counts-maplike-iterators-always-updated-expected.txt
@@ -1,5 +1,5 @@
 Outside target!
 Click me
 
-FAIL Event Timing eventCount iterators always updated. assert_equals: Iterators must be always up-to-date expected 2 but got 1
+PASS Event Timing eventCount iterators always updated.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/event-timing/event-counts-maplike-iterators-always-updated.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/event-timing/event-counts-maplike-iterators-always-updated.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+<meta charset=utf-8 />
+<title>Event Timing eventCount iterators always updated.</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=/resources/testdriver.js></script>
+<script src=/resources/testdriver-actions.js></script>
+<script src=/resources/testdriver-vendor.js></script>
+<script src=resources/event-timing-test-utils.js></script>
+<div>Outside target!</div>
+<div id='target'>Click me</div>
+<script>
+  promise_test(async t => {
+    let entriesIterator1 = performance.eventCounts.entries()
+    const nClicksStart = performance.eventCounts.get('click')
+
+    await clickAndBlockMain('target');
+    await afterNextPaint();
+    let entriesIterator2 = performance.eventCounts.entries()
+    let entriesIterator3 = performance.eventCounts.entries()
+    let clickFound = false
+    entriesIterator1.forEach( pair => {
+      let [key1, value1] = [...pair]
+      let [key2,value2] = [...entriesIterator2.next().value]
+      assert_equals(key1, key2, "Iterators created at different moments must match")
+      assert_equals(value1, value2, "Iterators created at different moments must match")
+      if (key1 == 'click') {
+        assert_equals(value1, nClicksStart + 1)
+        clickFound = true
+      }
+    })
+    assert_true(clickFound, 'click entry should exist')
+
+    await clickAndBlockMain('target')
+    await afterNextPaint()
+    clickFound = false
+    entriesIterator3.forEach( pair => {
+      let [key, value] = [...pair]
+      if (key == 'click') {
+        assert_equals(value, nClicksStart + 2, "Iterators must be always up-to-date")
+        clickFound = true
+      }
+    })
+    assert_true(clickFound, 'click entry should exist')
+  })
+
+</script>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/event-timing/event-counts-maplike-iterators-iframe-always-updated-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/event-timing/event-counts-maplike-iterators-iframe-always-updated-expected.txt
@@ -1,0 +1,5 @@
+Outside target!
+
+
+FAIL Event Timing eventCount iterators always updated. assert_equals: Click inside iframe must be counted expected 1 but got 0
+

--- a/LayoutTests/imported/w3c/web-platform-tests/event-timing/event-counts-maplike-iterators-iframe-always-updated.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/event-timing/event-counts-maplike-iterators-iframe-always-updated.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<meta charset=utf-8 />
+<title>Event Timing eventCount iterators always updated.</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=/resources/testdriver.js></script>
+<script src=/resources/testdriver-actions.js></script>
+<script src=/resources/testdriver-vendor.js></script>
+<script src=resources/event-timing-test-utils.js></script>
+
+<body>
+<div>Outside target!</div>
+<iframe id='same-origin-iframe' srcdoc="
+    <div id='target'>Click me</div>
+">
+</iframe>
+<script>
+  promise_test(async t => {
+    await new Promise( async resolve => {
+      if (document.readyState === 'complete')
+        resolve()
+      else
+        window.addEventListener('load', async (e) => resolve())
+    })
+    const target = document.getElementById('same-origin-iframe').contentDocument.getElementById('target');
+    let entriesIterator = document.getElementById('same-origin-iframe').contentWindow.performance.eventCounts.entries()
+    const nClicksStart = document.getElementById('same-origin-iframe').contentWindow.performance.eventCounts.get('click')
+    await test_driver.click(target);
+    await afterNextPaint();
+    assert_equals(document.getElementById('same-origin-iframe').contentWindow.performance.eventCounts.get('click'), nClicksStart + 1, "Click inside iframe must be counted")
+    entriesIterator.forEach( pair => {
+      let [key1, value1] = [...pair]
+      if (key1 != 'click')
+        return;
+      assert_equals(value1, nClicksStart + 1, "Iterator from inside iframe must always be up-to-date")
+    })
+  })
+</script>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/event-timing/event-counts-maplike-validate-iterators-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/event-timing/event-counts-maplike-validate-iterators-expected.txt
@@ -1,0 +1,3 @@
+
+PASS EventCounts iterators constent with .get() and .size
+

--- a/LayoutTests/imported/w3c/web-platform-tests/event-timing/event-counts-maplike-validate-iterators.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/event-timing/event-counts-maplike-validate-iterators.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<meta charset=utf-8 />
+<title>Event Timing eventCount validate iterators.</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=/resources/testdriver.js></script>
+<script src=/resources/testdriver-actions.js></script>
+<script src=/resources/testdriver-vendor.js></script>
+<script src=resources/event-timing-test-utils.js></script>
+<script>
+  test( () => {
+    keysIterator = performance.eventCounts.keys();
+    valuesIterator = performance.eventCounts.values();
+    entriesIterator = performance.eventCounts.entries();
+    nEntries = 0;
+    performance.eventCounts.forEach( (value, key) => {
+      nEntries++;
+      keyFromIterator = keysIterator.next().value;
+      valueFromIterator = valuesIterator.next().value;
+      entryFromIterator = entriesIterator.next().value;
+      assert_equals(keyFromIterator, key, ".keys() should match .forEach()");
+      assert_equals(valueFromIterator, value, ".values() should match .forEach()");
+      assert_equals(entryFromIterator[0], key, ".entries() should match .forEach()");
+      assert_equals(entryFromIterator[1], value, ".entries() should match .forEach()");
+      assert_equals(performance.eventCounts.get(key), value, "iterators should match .get()");
+    })
+    assert_equals(nEntries, performance.eventCounts.size, "Number of entries in .forEach() should match .size");
+    assert_true(keysIterator.next().done, "Number of entries in .keys() should match .size");
+    assert_true(valuesIterator.next().done, "Number of entries in .values() should match .size");
+    assert_true(entriesIterator.next().done, "Number of entries in .entries() should match .size");
+  }, "EventCounts iterators constent with .get() and .size")
+</script>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/event-timing/idlharness.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/event-timing/idlharness.any-expected.txt
@@ -25,7 +25,7 @@ PASS EventCounts interface object name
 PASS EventCounts interface: existence and properties of interface prototype object
 PASS EventCounts interface: existence and properties of interface prototype object's "constructor" property
 PASS EventCounts interface: existence and properties of interface prototype object's @@unscopables property
-FAIL EventCounts interface: maplike<DOMString, unsigned long long> undefined is not an object (evaluating 'desc.value')
+PASS EventCounts interface: maplike<DOMString, unsigned long long>
 PASS Performance interface: attribute eventCounts
 PASS Performance interface: attribute interactionCount
 PASS Performance interface: performance must inherit property "eventCounts" with the proper type

--- a/LayoutTests/imported/w3c/web-platform-tests/event-timing/idlharness.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/event-timing/idlharness.window-expected.txt
@@ -25,7 +25,7 @@ PASS EventCounts interface object name
 PASS EventCounts interface: existence and properties of interface prototype object
 PASS EventCounts interface: existence and properties of interface prototype object's "constructor" property
 PASS EventCounts interface: existence and properties of interface prototype object's @@unscopables property
-FAIL EventCounts interface: maplike<DOMString, unsigned long long> undefined is not an object (evaluating 'desc.value')
+PASS EventCounts interface: maplike<DOMString, unsigned long long>
 PASS EventCounts must be primary interface of performance.eventCounts
 PASS Stringification of performance.eventCounts
 PASS Performance interface: attribute eventCounts

--- a/Source/WebCore/bindings/js/JSDOMMapLike.h
+++ b/Source/WebCore/bindings/js/JSDOMMapLike.h
@@ -79,21 +79,13 @@ void DOMMapAdapter::set(typename IDLKeyType::ParameterType key, typename IDLValu
     setToBackingMap(m_lexicalGlobalObject, m_backingMap, jsKey, jsValue);
 }
 
-template<typename T>
-concept shouldAlwaysInitializeMapLike = requires {
-    typename T::shouldAlwaysInitializeMapLikeMarker;
-};
-
 template<typename WrapperClass> JSC::JSObject& getAndInitializeBackingMap(JSC::JSGlobalObject& lexicalGlobalObject, WrapperClass& mapLike)
 {
     auto pair = getBackingMap(lexicalGlobalObject, mapLike);
-    if constexpr (!shouldAlwaysInitializeMapLike<typename WrapperClass::DOMWrapped>) {
-        if (!pair.first)
-            return pair.second.get();
+    if (pair.first) {
+        DOMMapAdapter adapter { lexicalGlobalObject, pair.second.get() };
+        mapLike.wrapped().initializeMapLike(adapter);
     }
-
-    DOMMapAdapter adapter { lexicalGlobalObject, pair.second.get() };
-    mapLike.wrapped().initializeMapLike(adapter);
     return pair.second.get();
 }
 

--- a/Source/WebCore/page/EventCounts.cpp
+++ b/Source/WebCore/page/EventCounts.cpp
@@ -43,13 +43,6 @@ void EventCounts::add(EventType type)
     ++m_counts[index];
 }
 
-unsigned EventCounts::get(const String& type) const
-{
-    auto typeInfo = eventNames().typeInfoForEvent(AtomString(type));
-    size_t index = std::ranges::lower_bound(EventNames::timedEvents, typeInfo.type()) - EventNames::timedEvents.begin();
-    return m_counts[index];
-}
-
 void EventCounts::initializeMapLike(DOMMapAdapter& map)
 {
     auto& eventNamesObject = eventNames();

--- a/Source/WebCore/page/EventCounts.cpp
+++ b/Source/WebCore/page/EventCounts.cpp
@@ -28,6 +28,8 @@
 
 #include "IDLTypes.h"
 #include "JSDOMMapLike.h"
+#include "ScriptWrappableInlines.h"
+#include "WebCoreJSClientData.h"
 #include <algorithm>
 
 namespace WebCore {
@@ -49,6 +51,22 @@ void EventCounts::initializeMapLike(DOMMapAdapter& map)
     for (size_t index = 0; index < EventNames::timedEvents.size(); ++index) {
         auto type = EventNames::timedEvents[index];
         map.set<IDLDOMString, IDLUnsignedLongLong>(eventNamesObject.eventNameFromEventType(type), m_counts[index]);
+    }
+}
+
+void EventCounts::reloadCounts()
+{
+    if (auto w = wrapper()) {
+        auto& vm = w->vm();
+        JSC::JSGlobalObject& globalObject(*w->globalObject());
+        JSC::JSObject& object(*w);
+        auto backingMap = object.getDirect(vm, builtinNames(vm).backingMapPrivateName());
+        if (!backingMap)
+            return;
+
+        auto& backingMapObject(*JSC::asObject(backingMap));
+        DOMMapAdapter mapAdapter(globalObject, backingMapObject);
+        initializeMapLike(mapAdapter);
     }
 }
 

--- a/Source/WebCore/page/EventCounts.h
+++ b/Source/WebCore/page/EventCounts.h
@@ -42,11 +42,10 @@ public:
     void deref() { m_performance->deref(); }
 
     void initializeMapLike(DOMMapAdapter&);
-    void add(EventType);
+    // Trait that causes the wrapper's backing map to be initialized again before every access:
+    using shouldAlwaysInitializeMapLikeMarker = void;
 
-    // FIXME: get() and size() should be provided by the maplike interface
-    unsigned get(const String& type) const;
-    unsigned size() const { return m_counts.size(); };
+    void add(EventType);
 
 private:
     WeakRef<Performance, Performance::WeakPtrImplType> m_performance;

--- a/Source/WebCore/page/EventCounts.h
+++ b/Source/WebCore/page/EventCounts.h
@@ -28,13 +28,14 @@
 
 #include "EventNames.h"
 #include "Performance.h"
+#include "ScriptWrappable.h"
 #include <wtf/WeakRef.h>
 
 namespace WebCore {
 
 class DOMMapAdapter;
 
-class EventCounts final {
+class EventCounts final : public ScriptWrappable {
 WTF_DEPRECATED_MAKE_FAST_ALLOCATED(EventCounts);
 public:
     EventCounts(Performance*);
@@ -42,10 +43,11 @@ public:
     void deref() { m_performance->deref(); }
 
     void initializeMapLike(DOMMapAdapter&);
-    // Trait that causes the wrapper's backing map to be initialized again before every access:
-    using shouldAlwaysInitializeMapLikeMarker = void;
+    // Reload the backing maps on the main JSWrapper:
+    void reloadCounts();
 
     void add(EventType);
+    void updateWrapper() const;
 
 private:
     WeakRef<Performance, Performance::WeakPtrImplType> m_performance;

--- a/Source/WebCore/page/EventCounts.idl
+++ b/Source/WebCore/page/EventCounts.idl
@@ -29,9 +29,5 @@
     Exposed=Window,
     EnabledBySetting=EventTimingEnabled
 ] interface EventCounts {
-    // FIXME: EventCounts' methods and operations should
-    // be provided by maplike instead:
-    // readonly maplike<DOMString, unsigned long long>;
-    unsigned long long get(DOMString type);
-    readonly attribute unsigned long long size;
+    readonly maplike<DOMString, unsigned long long>;
 };

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -2709,6 +2709,7 @@ void LocalDOMWindow::dispatchPendingEventTimingEntries()
         candidateEntry.duration = renderingTime - candidateEntry.startTime;
         performance().processEventEntry(candidateEntry);
     }
+    performance().eventCounts()->reloadCounts();
     m_performanceEventTimingCandidates.clear();
 }
 


### PR DESCRIPTION
#### 8b6c6725035be89aef494401e0b27748adbdb11a
<pre>
Synchronize EventCount&apos;s backing map with ScriptWrappable
</pre>
----------------------------------------------------------------------
#### 98f431c183e0cfe2190e1cb2728ae5dceaf4985d
<pre>
Implement EventCounts as maplike
<a href="https://bugs.webkit.org/show_bug.cgi?id=299211">https://bugs.webkit.org/show_bug.cgi?id=299211</a>
<a href="https://rdar.apple.com/160968888">rdar://160968888</a>

Reviewed by NOBODY (OOPS!).

Implements the EventCounts interface as a maplike, which
provides methods such as .forEach(), keys(), etc.

EventCounts cannot use the previous maplike implementation
because it would get out of sync after the backing map is
initialized. To solve this, we use the trait
shouldAlwaysInitializeMapLike to decide if the backing map
should be reloaded on every access through the wrapper. The trait
simply checks for the presence of a marker
(shouldAlwaysInitializeMapLikeMarker).

This implementation isn&apos;t perfect: although the backing map
will be kept up-to-date when accessed through the wrapper,
it won&apos;t be updated if accessed through an iterator generated
from that map. This is documented by the failing test
event-timing/event-counts-maplike-iterators-always-updated.html.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8b6c6725035be89aef494401e0b27748adbdb11a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123886 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43601 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34298 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130673 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76037 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/125763 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44325 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52195 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94225 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62524 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126840 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35313 "Exiting early after 10 failures. 26 tests run. 1 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110824 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74826 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34266 "Found 1 new test failure: imported/w3c/web-platform-tests/event-timing/event-counts-maplike-iterators-always-updated.html (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28985 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74149 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105040 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29208 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133366 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50839 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38718 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102693 "Found 1 new test failure: imported/blink/fast/pagination/viewport-y-horizontal-bt-rtl.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51213 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107044 "Exiting early after 10 failures. 158 tests run. 1 flakes") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102522 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47865 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26118 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/47688 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50692 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56456 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50166 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53512 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51840 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->