### PR TITLE
[Navigation API] dispose-after-bfcache.html and entries-after-bfcache.html fail on WPT

### DIFF
--- a/LayoutTests/http/tests/navigation-api/different-origin-entries-removed-after-bfcache-expected.txt
+++ b/LayoutTests/http/tests/navigation-api/different-origin-entries-removed-after-bfcache-expected.txt
@@ -1,0 +1,12 @@
+This tests that when page A is restored from the bfcache after a different origin page B is visited, navigation.entries contains only the entry for page A.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Visting Page 1 for the first time, navigating to page-that-goes-back
+Visiting Page 1 for the second time
+PASS window.navigation.entries().length is 1
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/navigation-api/different-origin-entries-removed-after-bfcache.html
+++ b/LayoutTests/http/tests/navigation-api/different-origin-entries-removed-after-bfcache.html
@@ -1,0 +1,27 @@
+<script src="/js-test-resources/js-test.js"></script>
+
+<script>
+description("This tests that when page A is restored from the bfcache after a different origin page B is visited, navigation.entries contains only the entry for page A.");
+jsTestIsAsync = true;
+
+window.addEventListener('pageshow', function() {
+    if (!sessionStorage.getItem('hasVisited')) {
+        debug('Visting Page 1 for the first time, navigating to page-that-goes-back');
+        sessionStorage.setItem('hasVisited', 'true');
+
+        setTimeout(() => {
+            window.location.href = 'http://localhost:8000/navigation-api/resources/page-that-goes-back.html';
+        }, 0);
+    } else {
+        sessionStorage.removeItem('hasVisited');
+
+        window.navigation.addEventListener('navigate', function() {
+            debug('Visiting Page 1 for the second time');
+            shouldBeEqualToNumber("window.navigation.entries().length", 1);
+            finishJSTest();
+        });
+    }
+});
+</script>
+
+

--- a/LayoutTests/http/tests/navigation-api/resources/page-that-goes-back.html
+++ b/LayoutTests/http/tests/navigation-api/resources/page-that-goes-back.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <script src="/js-test-resources/js-test.js"></script>
+    </head>
+<body>
+    <script>
+        window.addEventListener('load', function() {
+            debug('page-that-goes-back loaded, going back using history.back()');
+            setTimeout(() => {
+                history.back();
+            }, 0);
+        });
+    </script>
+</body>
+</html>

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -1451,6 +1451,8 @@ imported/w3c/web-platform-tests/xhr/xhr-timeout-longtask.any.html
 
 webkit.org/b/187230 editing/mac/pasteboard/can-copy-url-without-title.html [ Skip ]
 
+# The Navigation API is not supported on WK1
+http/tests/navigation-api/ [ Skip ]
 webkit.org/b/270055 imported/w3c/web-platform-tests/navigation-api/ [ Skip ]
 webkit.org/b/270055 http/wpt/navigation-api/ [ Skip ]
 

--- a/Source/WebCore/history/BackForwardController.cpp
+++ b/Source/WebCore/history/BackForwardController.cpp
@@ -175,21 +175,9 @@ RefPtr<HistoryItem> BackForwardController::itemAtIndex(int i, std::optional<Fram
     return m_client->itemAtIndex(i, frameID.value_or(m_page->mainFrame().frameID()));
 }
 
-Vector<Ref<HistoryItem>> BackForwardController::allItems()
+Vector<Ref<HistoryItem>> BackForwardController::allItems(std::optional<FrameIdentifier> frameID)
 {
-    return m_client->allItems(m_page->mainFrame().frameID());
-}
-
-Vector<Ref<HistoryItem>> BackForwardController::reachableItemsForFrame(FrameIdentifier frameID)
-{
-    // Returns only the frame items that correspond to the currently reachable session history.
-    // This is different from itemsForFrame() which returns all frame items across the frame's lifetime.
-    Vector<Ref<HistoryItem>> reachableFrameItems;
-    for (auto& item : allItems()) {
-        if (RefPtr childItem = item->childItemWithFrameID(frameID))
-            reachableFrameItems.append(childItem.releaseNonNull());
-    }
-    return reachableFrameItems;
+    return m_client->allItems(frameID.value_or(m_page->mainFrame().frameID()));
 }
 
 void BackForwardController::close()

--- a/Source/WebCore/history/BackForwardController.h
+++ b/Source/WebCore/history/BackForwardController.h
@@ -65,17 +65,15 @@ public:
     WEBCORE_EXPORT unsigned backCount() const;
     WEBCORE_EXPORT unsigned forwardCount() const;
 
-    WEBCORE_EXPORT RefPtr<HistoryItem> itemAtIndex(int, std::optional<FrameIdentifier> = std::nullopt);
     bool containsItem(const HistoryItem&) const;
-
-    void close();
 
     WEBCORE_EXPORT RefPtr<HistoryItem> backItem(std::optional<FrameIdentifier> = std::nullopt);
     WEBCORE_EXPORT RefPtr<HistoryItem> currentItem(std::optional<FrameIdentifier> = std::nullopt);
     WEBCORE_EXPORT RefPtr<HistoryItem> forwardItem(std::optional<FrameIdentifier> = std::nullopt);
+    WEBCORE_EXPORT RefPtr<HistoryItem> itemAtIndex(int, std::optional<FrameIdentifier> = std::nullopt);
+    Vector<Ref<HistoryItem>> allItems(std::optional<FrameIdentifier> = std::nullopt);
 
-    Vector<Ref<HistoryItem>> allItems();
-    Vector<Ref<HistoryItem>> reachableItemsForFrame(FrameIdentifier);
+    void close();
 
 private:
     Ref<Page> protectedPage() const;

--- a/Source/WebCore/history/CachedPage.h
+++ b/Source/WebCore/history/CachedPage.h
@@ -33,6 +33,7 @@
 
 namespace WebCore {
 
+class BackForwardController;
 class Document;
 class DocumentLoader;
 class Page;
@@ -66,6 +67,8 @@ public:
     void markForContentsSizeChanged() { m_needsUpdateContentsSize = true; }
 
 private:
+    void restoreNavigationAPIHistoryItems(LocalFrame&, BackForwardController*);
+
     WeakRef<Page> m_page;
     MonotonicTime m_expirationTime;
     std::unique_ptr<CachedFrame> m_cachedMainFrame;

--- a/Source/WebCore/page/Navigation.h
+++ b/Source/WebCore/page/Navigation.h
@@ -185,6 +185,8 @@ public:
 
     void updateNavigationEntry(Ref<HistoryItem>&&, ShouldCopyStateObjectFromCurrentEntry);
 
+    static Vector<Ref<HistoryItem>> filterHistoryItemsForNavigationAPI(Vector<Ref<HistoryItem>>&&, HistoryItem&);
+
 private:
     explicit Navigation(LocalDOMWindow&);
 


### PR DESCRIPTION
#### 855821352f744e79f32c3246ba82010994d965a3
<pre>
[Navigation API] dispose-after-bfcache.html and entries-after-bfcache.html fail on WPT
<a href="https://bugs.webkit.org/show_bug.cgi?id=299918">https://bugs.webkit.org/show_bug.cgi?id=299918</a>
<a href="https://rdar.apple.com/161694156">rdar://161694156</a>

Reviewed by Chris Dumez.

When a restoring a Page from the bfcache, we must also restore the Navigation
object&apos;s list of HistoryItems.

This happens in CachedPage::restore. For each frame, we get all of its HistoryItems
from the UIProcess and send them to Navigation::updateForReactivation. But the
Navigation API&apos;s list can only contain sequential items of the same origin as the
current item.

For example, consider this UI Process b/f list:

1. foo.com
2. bar.com
3. foo.com
4. bar.com
5. bar.com#1  &lt;-- currentItem
6. bar.com#2
7. foo.com
8. bar.com

The Navigation object&apos;s list must be: { 4, 5, 6 } in that order and nothing more.

This means that once we get the b/f list from the UI Process, we must filter it
before giving it Navigation::updateForReactivation.

BackForwardController::reachableItemsForFrame claimed to have this logic, but it&apos;s
logic was wrong. It was not filtering out non-same-origin entries, but rather
getting *all* of the items across a frame&apos;s lifetime.

To fix this, we remove BackForwardController::reachableItemsForFrame and replace it
with Navigation::filterHistoryItemsForNavigationAPI (since this filtering is specific
to the Navigation API). We also refactor the Navigation API restoring code in
CachedPage::restore to be cleaner.

This change will make dispose-after-bfcache.html and entries-after-bfcache.html
pass on WPT. I have manually verified this. They already pass locally. They were
failing on WPT because when the test is run on WPT, an extra item is present in
the b/f list initially, This item wasn&apos;t getting filtered out and was causing the
test to fail. This item is not present when the test is run locally, and so the
test is passing. To simulate this difference, we add a new test:

LayoutTests/http/tests/navigation-api/different-origin-entries-removed-after-bfcache.html

* LayoutTests/http/tests/navigation-api/different-origin-entries-removed-after-bfcache-expected.txt: Added.
* LayoutTests/http/tests/navigation-api/different-origin-entries-removed-after-bfcache.html: Added.
* LayoutTests/http/tests/navigation-api/resources/page-that-goes-back.html: Added.
* LayoutTests/platform/mac-wk1/TestExpectations:
* Source/WebCore/history/BackForwardController.cpp:
(WebCore::BackForwardController::allItems):
(WebCore::BackForwardController::reachableItemsForFrame): Deleted.
* Source/WebCore/history/BackForwardController.h:
* Source/WebCore/history/CachedPage.cpp:
(WebCore::CachedPage::restore):
(WebCore::CachedPage::restoreNavigationAPIHistoryItems):

For each frame, obtain send the filtered list to the Navigation object.

* Source/WebCore/history/CachedPage.h:
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::filterHistoryItemsForNavigationAPI):

Filter the list in the way described above.

* Source/WebCore/page/Navigation.h:

Canonical link: <a href="https://commits.webkit.org/301283@main">https://commits.webkit.org/301283@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/989170ac613b5fd3337058aaf7e84865a687ff45

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125453 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45120 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35861 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132311 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77341 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0e0ac848-4f08-49eb-8346-42c8f55a1486) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127329 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45807 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53682 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95533 "Failed to checkout and rebase branch from PR 51604") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/66cd52c5-74be-44bc-a193-a3b09231af5b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128406 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36604 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112191 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76059 "Found 1 new API test failure: WPE/TestWebKitWebContext:/webkit/WebKitWebContext/no-web-process-leak (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/299fa140-c021-4b1c-b7ec-d9237a71baee) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35504 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30364 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75787 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106375 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30591 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134991 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52255 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40033 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104009 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52694 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108407 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103757 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49124 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27422 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49419 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19652 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52153 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57937 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51504 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54860 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53199 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->