### PR TITLE
Add caching for whitespace strings in HTMLFastPathParser

### DIFF
--- a/LayoutTests/fast/parser/html-fast-path-whitespace-caching-expected.txt
+++ b/LayoutTests/fast/parser/html-fast-path-whitespace-caching-expected.txt
@@ -1,0 +1,158 @@
+Test that HTMLDocumentParserFastPath correctly caches whitespace (newline + 0-32 spaces) when using innerHTML. This test does not check utilization of the cache. It just verifies that generated text nodes have the correct number of spaces once parsed and constructed into the DOM. There is currently no observable way to detect that the cache has been utilized, or a side effect of using the cache to detect.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Testing case 1: Newline only (0 spaces)
+HTML: "Before\nAfter"
+Created 3 child nodes
+PASS testDiv.childNodes.length is 3
+PASS textNode.nodeType is 3
+Text node content actual vs expected
+"\n"
+"\n"
+PASS Newline only (0 spaces) - Found exact cached whitespace with 0 spaces
+Testing case 2: Newline + 1 space
+HTML: "Before\n After"
+Created 3 child nodes
+PASS testDiv.childNodes.length is 3
+PASS textNode.nodeType is 3
+Text node content actual vs expected
+"\n "
+"\n "
+PASS Newline + 1 space - Found exact cached whitespace with 1 spaces
+Testing case 3: Newline + 4 spaces
+HTML: "Before\n    After"
+Created 3 child nodes
+PASS testDiv.childNodes.length is 3
+PASS textNode.nodeType is 3
+Text node content actual vs expected
+"\n    "
+"\n    "
+PASS Newline + 4 spaces - Found exact cached whitespace with 4 spaces
+Testing case 4: Newline + 8 spaces
+HTML: "Before\n        After"
+Created 3 child nodes
+PASS testDiv.childNodes.length is 3
+PASS textNode.nodeType is 3
+Text node content actual vs expected
+"\n        "
+"\n        "
+PASS Newline + 8 spaces - Found exact cached whitespace with 8 spaces
+Testing case 5: Newline + 16 spaces
+HTML: "Before\n                After"
+Created 3 child nodes
+PASS testDiv.childNodes.length is 3
+PASS textNode.nodeType is 3
+Text node content actual vs expected
+"\n                "
+"\n                "
+PASS Newline + 16 spaces - Found exact cached whitespace with 16 spaces
+Testing case 6: Newline + 16 spaces + content at end
+HTML: "Before\n                heyAfter"
+Created 3 child nodes
+PASS testDiv.childNodes.length is 3
+PASS textNode.nodeType is 3
+Text node content actual vs expected
+"\n                hey"
+"\n                hey"
+PASS Newline + 16 spaces + content at end - Non-cached case parsed successfully
+Testing case 7: Single span with newline + text
+HTML: "Before\nJAfter"
+Created 3 child nodes
+PASS testDiv.childNodes.length is 3
+PASS textNode.nodeType is 3
+Text node content actual vs expected
+"\nJ"
+"\nJ"
+PASS Single span with newline + text - Non-cached case parsed successfully
+Testing case 8: Newline + 32 spaces (max)
+HTML: "Before\n                                After"
+Created 3 child nodes
+PASS testDiv.childNodes.length is 3
+PASS textNode.nodeType is 3
+Text node content actual vs expected
+"\n                                "
+"\n                                "
+PASS Newline + 32 spaces (max) - Found exact cached whitespace with 32 spaces
+Testing case 9: Newline + 33 spaces (over max)
+HTML: "Before\n                                 After"
+Created 3 child nodes
+PASS testDiv.childNodes.length is 3
+PASS textNode.nodeType is 3
+Text node content actual vs expected
+"\n                                 "
+"\n                                 "
+PASS Newline + 33 spaces (over max) - Non-cached case parsed successfully
+Testing case 10: Mixed whitespace (tab+spaces)
+HTML: "Before\n\t  After"
+Created 3 child nodes
+PASS testDiv.childNodes.length is 3
+PASS textNode.nodeType is 3
+Text node content actual vs expected
+"\n\t  "
+"\n\t  "
+PASS Mixed whitespace (tab+spaces) - Non-cached case parsed successfully
+Testing case 11: No leading newline
+HTML: "Before    After"
+Created 3 child nodes
+PASS testDiv.childNodes.length is 3
+PASS textNode.nodeType is 3
+Text node content actual vs expected
+"    "
+"    "
+PASS No leading newline - Non-cached case parsed successfully
+Testing case 12: Text content mixed in
+HTML: "Before\n    text contentAfter"
+Created 3 child nodes
+PASS testDiv.childNodes.length is 3
+PASS textNode.nodeType is 3
+Text node content actual vs expected
+"\n    text content"
+"\n    text content"
+PASS Text content mixed in - Non-cached case parsed successfully
+Testing case 13: Escaped entity in whitespace
+HTML: "Before\n    &After"
+Created 3 child nodes
+PASS testDiv.childNodes.length is 3
+PASS textNode.nodeType is 3
+Text node content actual vs expected
+"\n    &"
+"\n    &"
+PASS Escaped entity in whitespace - Non-cached case parsed successfully
+Testing case 14: Carriage return in whitespace
+HTML: "Before\n\r  After"
+Created 3 child nodes
+PASS testDiv.childNodes.length is 3
+PASS textNode.nodeType is 3
+Text node content actual vs expected
+"\n\n  "
+"\n\n  "
+PASS Carriage return in whitespace - Non-cached case parsed successfully
+Testing case 15: HTML entity only
+HTML: "Before After"
+Created 3 child nodes
+PASS testDiv.childNodes.length is 3
+PASS textNode.nodeType is 3
+Text node content actual vs expected
+" "
+" "
+PASS HTML entity only - Non-cached case parsed successfully
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Before After
+Before After
+Before After
+Before After
+Before After
+Before heyAfter
+Before JAfter
+Before After
+Before After
+Before After
+Before After
+Before text contentAfter
+Before &After
+Before After
+Before After

--- a/LayoutTests/fast/parser/html-fast-path-whitespace-caching.html
+++ b/LayoutTests/fast/parser/html-fast-path-whitespace-caching.html
@@ -1,0 +1,156 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>HTML Fast Path Whitespace Caching Test</title>
+    <script src="../../resources/js-test.js"></script>
+</head>
+<body>
+    <div id="test-results"></div>
+    <div id="container"></div>
+
+    <script>
+        description("Test that HTMLDocumentParserFastPath correctly caches whitespace (newline + 0-32 spaces) when using innerHTML. This test does not check utilization of the cache. It just verifies that generated text nodes have the correct number of spaces once parsed and constructed into the DOM. There is currently no observable way to detect that the cache has been utilized, or a side effect of using the cache to detect.");
+
+        function testWhitespaceCaching() {
+            const results = [];
+            const container = document.getElementById('container');
+
+            // Define test cases with their innerHTML strings
+            const testCases = [
+                {
+                    name: 'Newline only (0 spaces)',
+                    html: '<span>Before</span>\n<span>After</span>',
+                    expectedCachedWhiteSpace: true,
+                    expectedSpaces: 0
+                },
+                {
+                    name: 'Newline + 1 space',
+                    html: '<span>Before</span>\n <span>After</span>',
+                    expectedCachedWhiteSpace: true,
+                    expectedSpaces: 1
+                },
+                {
+                    name: 'Newline + 4 spaces',
+                    html: '<span>Before</span>\n    <span>After</span>',
+                    expectedCachedWhiteSpace: true,
+                    expectedSpaces: 4
+                },
+                {
+                    name: 'Newline + 8 spaces',
+                    html: '<span>Before</span>\n        <span>After</span>',
+                    expectedCachedWhiteSpace: true,
+                    expectedSpaces: 8
+                },
+                {
+                    name: 'Newline + 16 spaces',
+                    html: '<span>Before</span>\n                <span>After</span>',
+                    expectedCachedWhiteSpace: true,
+                    expectedSpaces: 16
+                },
+                {
+                    name: 'Newline + 16 spaces + content at end',
+                    html: '<span>Before</span>\n                hey<span>After</span>',
+                    expectedCachedWhiteSpace: false,
+                    expectedSpaces: 16
+                },
+                {
+                    name: 'Single span with newline + text',
+                    html: '<span>Before</span>\nJ<span>After</span>',
+                    expectedCachedWhiteSpace: false,
+                    expectedSpaces: null
+                },
+                {
+                    name: 'Newline + 32 spaces (max)',
+                    html: '<span>Before</span>\n                                <span>After</span>',
+                    expectedCachedWhiteSpace: true,
+                    expectedSpaces: 32
+                },
+                {
+                    name: 'Newline + 33 spaces (over max)',
+                    html: '<span>Before</span>\n                                 <span>After</span>',
+                    expectedCachedWhiteSpace: false,
+                    expectedSpaces: 33
+                },
+                {
+                    name: 'Mixed whitespace (tab+spaces)',
+                    html: '<span>Before</span>\n\t  <span>After</span>',
+                    expectedCachedWhiteSpace: false,
+                    expectedSpaces: null
+                },
+                {
+                    name: 'No leading newline',
+                    html: '<span>Before</span>    <span>After</span>',
+                    expectedCachedWhiteSpace: false,
+                    expectedSpaces: null
+                },
+                {
+                    name: 'Text content mixed in',
+                    html: '<span>Before</span>\n    text content<span>After</span>',
+                    expectedCachedWhiteSpace: false,
+                    expectedSpaces: null
+                },
+                {
+                    name: 'Escaped entity in whitespace',
+                    html: '<span>Before</span>\n    &amp;<span>After</span>',
+                    expectedCachedWhiteSpace: false,
+                    expectedSpaces: null
+                },
+                {
+                    name: 'Carriage return in whitespace',
+                    html: '<span>Before</span>\n\r  <span>After</span>',
+                    expectedCachedWhiteSpace: false,
+                    expectedSpaces: null
+                },
+                {
+                    name: 'HTML entity only',
+                    html: '<span>Before</span>&nbsp;<span>After</span>',
+                    expectedCachedWhiteSpace: false,
+                    expectedSpaces: null
+                }
+            ];
+
+            testCases.forEach((testCase, index) => {
+                debug(`Testing case ${index + 1}: ${testCase.name}`);
+                debug(`HTML: ${JSON.stringify(testCase.html)}`);
+
+                testDiv = document.createElement('div');
+                testDiv.className = 'test-container';
+                testDiv.id = `test-case-${index}`;
+
+                // Uses fast path parser
+                testDiv.innerHTML = testCase.html;
+                container.appendChild(testDiv);
+
+                // Should always have exactly 3 child nodes: <span>, text, <span>
+                debug(`Created ${testDiv.childNodes.length} child nodes`);
+                shouldBe("testDiv.childNodes.length", "3");
+
+                // The middle node should be our text node
+                textNode = testDiv.childNodes[1];
+                shouldBe("textNode.nodeType", "3");
+
+                const actualWhitespace = textNode.textContent;
+                debug(`Text node content actual vs expected`)
+                debug(`${JSON.stringify(actualWhitespace)}`)
+                if (testCase.expectedCachedWhiteSpace) {
+                    // For cached cases, we expect exactly the newline + spaces pattern
+                    const expectedWhitespace = '\n' + ' '.repeat(testCase.expectedSpaces);
+                    debug(`${JSON.stringify(expectedWhitespace)}`);
+
+                    if (actualWhitespace === expectedWhitespace) {
+                        testPassed(`${testCase.name} - Found exact cached whitespace with ${testCase.expectedSpaces} spaces`);
+                    } else {
+                        testFailed(`${testCase.name} - Expected ${JSON.stringify(expectedWhitespace)}, got ${JSON.stringify(actualWhitespace)}`);
+                    }
+                } else {
+                    // Non cached case
+                    debug(`${JSON.stringify(actualWhitespace)}`);
+                    testPassed(`${testCase.name} - Non-cached case parsed successfully`);
+                }
+            });
+        }
+
+        testWhitespaceCaching();
+    </script>
+</body>
+</html>


### PR DESCRIPTION
#### 4eacd1576afcd0b9f9c083aea8faeef60564dd49
<pre>
Add caching for whitespace strings in HTMLFastPathParser
<a href="https://bugs.webkit.org/show_bug.cgi?id=299919">https://bugs.webkit.org/show_bug.cgi?id=299919</a>
<a href="https://rdar.apple.com/161694563">rdar://161694563</a>

Reviewed by Ryan Reno.

The fast path parser takes up a significant percentage of the work in SP3.
It has high memory demand, mainly due to the allocation of DOM nodes,
but ~14% of the memory demand is spent in the String constructor.
Add a cache of pre allocated Strings that are newline char + some number
of space characters to use while parsing instead of dynamically allocating
the string for the text node.

This cache shows with local testing to improve memory demand of the fast path
parser by 14%.

A/B testing shows this patch is perf neutral to 1-2% improvement in
TODOMVC-JQuery.

This patch was heavily influenced by Blink&apos;s fast path parser which
has the same optomization

Test: fast/parser/html-fast-path-whitespace-caching.html
* LayoutTests/fast/parser/html-fast-path-whitespace-caching-expected.txt: Added.
* LayoutTests/fast/parser/html-fast-path-whitespace-caching.html: Added.
* Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp:
(NewlineThenWhitespaceStringsTable::getCachedWhitespace):
(NewlineThenWhitespaceStringsTable::whitespaceStringCache):
(WebCore::HTMLFastPathParser::ScanTextResult::tryUseWhitespaceCache const):
(WebCore::HTMLFastPathParser::scanText):
(WebCore::HTMLFastPathParser::parseChildren):

Canonical link: <a href="https://commits.webkit.org/301416@main">https://commits.webkit.org/301416@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fddf11c8b356b15832078295530f1daadb111b8a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125634 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45296 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36046 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132495 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77573 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/21f0e825-7306-4b64-953c-4bed6f66ad5f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127505 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45983 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53858 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95705 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64038 "An unexpected error occured. Recent messages:Printed configuration") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/248d69d6-d0e7-4485-8600-96d29a625a63) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128582 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36755 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112349 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76200 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/82c0c919-8b5f-4a5a-923b-446ea545e498) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35655 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30530 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75967 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106533 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30748 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135167 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52429 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40195 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104199 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52875 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108560 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103905 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26512 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49263 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27575 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49648 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52324 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58125 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51672 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55025 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53368 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->