### PR TITLE
Address some Safer CPP warnings in Source/JavaScriptCore/inspector

### DIFF
--- a/Source/JavaScriptCore/SaferCPPExpectations/RetainPtrCtorAdoptCheckerExpectations
+++ b/Source/JavaScriptCore/SaferCPPExpectations/RetainPtrCtorAdoptCheckerExpectations
@@ -4,4 +4,3 @@ API/JSVirtualMachine.mm
 API/ObjCCallbackFunction.mm
 API/tests/Regress141275.mm
 API/tests/testapi.c
-inspector/remote/cocoa/RemoteConnectionToTargetCocoa.mm

--- a/Source/JavaScriptCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/JavaScriptCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -86,9 +86,7 @@ inspector/agents/InspectorConsoleAgent.cpp
 inspector/agents/InspectorDebuggerAgent.cpp
 inspector/agents/InspectorHeapAgent.cpp
 inspector/agents/InspectorScriptProfilerAgent.cpp
-inspector/agents/InspectorTargetAgent.cpp
 inspector/agents/JSGlobalObjectRuntimeAgent.cpp
-inspector/remote/cocoa/RemoteInspectorCocoa.mm
 jit/BaselineJITPlan.cpp
 jit/ExecutableAllocator.cpp
 jit/GCAwareJITStubRoutine.cpp

--- a/Source/JavaScriptCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/JavaScriptCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -61,14 +61,10 @@ heap/ConservativeRoots.cpp
 heap/HeapHelperPool.cpp
 heap/JITStubRoutineSet.cpp
 inspector/AsyncStackTrace.cpp
-inspector/InspectorBackendDispatcher.cpp
 inspector/JSJavaScriptCallFrame.cpp
 inspector/ScriptCallStackFactory.cpp
 inspector/agents/InspectorDebuggerAgent.cpp
 inspector/agents/InspectorScriptProfilerAgent.cpp
-inspector/remote/RemoteInspector.cpp
-inspector/remote/cocoa/RemoteConnectionToTargetCocoa.mm
-inspector/remote/cocoa/RemoteInspectorCocoa.mm
 interpreter/CallFrame.cpp
 interpreter/Interpreter.cpp
 interpreter/StackVisitor.cpp

--- a/Source/JavaScriptCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
+++ b/Source/JavaScriptCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
@@ -3,8 +3,4 @@ API/JSValue.mm
 API/JSVirtualMachine.mm
 API/JSWrapperMap.mm
 API/tests/Regress141275.mm
-inspector/JSGlobalObjectDebugger.cpp
-inspector/remote/RemoteInspectionTarget.cpp
-inspector/remote/cocoa/RemoteConnectionToTargetCocoa.mm
-inspector/remote/cocoa/RemoteInspectorCocoa.mm
 runtime/JSDateMath.cpp

--- a/Source/JavaScriptCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
+++ b/Source/JavaScriptCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
@@ -5,6 +5,3 @@ API/JSWrapperMap.mm
 API/ObjCCallbackFunction.mm
 API/ObjcRuntimeExtras.h
 API/tests/testapi.c
-inspector/remote/cocoa/RemoteConnectionToTargetCocoa.mm
-inspector/remote/cocoa/RemoteInspectorCocoa.mm
-inspector/remote/cocoa/RemoteInspectorXPCConnection.mm

--- a/Source/JavaScriptCore/inspector/InspectorBackendDispatcher.cpp
+++ b/Source/JavaScriptCore/inspector/InspectorBackendDispatcher.cpp
@@ -173,7 +173,7 @@ void BackendDispatcher::dispatch(const String& message)
         }
 
         String domain = domainAndMethod[0];
-        SupplementalBackendDispatcher* domainDispatcher = m_dispatchers.get(domain);
+        RefPtr domainDispatcher = m_dispatchers.get(domain);
         if (!domainDispatcher) {
             reportProtocolError(MethodNotFound, makeString('\'', domain, "' domain was not found"_s));
             sendPendingErrors();

--- a/Source/JavaScriptCore/inspector/JSGlobalObjectDebugger.cpp
+++ b/Source/JavaScriptCore/inspector/JSGlobalObjectDebugger.cpp
@@ -67,12 +67,12 @@ void JSGlobalObjectDebugger::runEventLoopWhilePaused()
     JSC::JSLock::DropAllLocks dropAllLocks(&m_globalObject.vm());
 
     while (!m_doneProcessingDebuggerEvents) {
-        if (RunLoop::cycle(JSGlobalObjectDebugger::runLoopMode()) == RunLoop::CycleResult::Stop)
+        if (RunLoop::cycle(JSGlobalObjectDebugger::runLoopModeSingleton()) == RunLoop::CycleResult::Stop)
             break;
     }
 }
 
-RunLoopMode JSGlobalObjectDebugger::runLoopMode()
+RunLoopMode JSGlobalObjectDebugger::runLoopModeSingleton()
 {
 #if USE(CF) && !PLATFORM(WATCHOS)
     // Run the RunLoop in a custom run loop mode to prevent default observers

--- a/Source/JavaScriptCore/inspector/JSGlobalObjectDebugger.h
+++ b/Source/JavaScriptCore/inspector/JSGlobalObjectDebugger.h
@@ -40,7 +40,7 @@ public:
 
     JSC::JSGlobalObject& globalObject() const { return m_globalObject; }
 
-    static RunLoopMode runLoopMode();
+    static RunLoopMode runLoopModeSingleton();
 
 private:
     // JSC::Debugger

--- a/Source/JavaScriptCore/inspector/agents/InspectorTargetAgent.cpp
+++ b/Source/JavaScriptCore/inspector/agents/InspectorTargetAgent.cpp
@@ -166,7 +166,7 @@ void InspectorTargetAgent::didCommitProvisionalTarget(const String& oldTargetID,
 
 FrontendChannel::ConnectionType InspectorTargetAgent::connectionType() const
 {
-    return m_router.hasLocalFrontend() ? Inspector::FrontendChannel::ConnectionType::Local : Inspector::FrontendChannel::ConnectionType::Remote;
+    return Ref { m_router }->hasLocalFrontend() ? Inspector::FrontendChannel::ConnectionType::Local : Inspector::FrontendChannel::ConnectionType::Remote;
 }
 
 void InspectorTargetAgent::connectToTargets()

--- a/Source/JavaScriptCore/inspector/remote/RemoteConnectionToTarget.h
+++ b/Source/JavaScriptCore/inspector/remote/RemoteConnectionToTarget.h
@@ -70,6 +70,7 @@ public:
     std::optional<TargetID> targetIdentifier() const WTF_REQUIRES_LOCK(m_targetMutex);
 #if PLATFORM(COCOA)
     NSString *connectionIdentifier() const;
+    RetainPtr<NSString> protectedConnectionIdentifier() const;
     NSString *destination() const;
 
     Lock& queueMutex() { return m_queueMutex; }

--- a/Source/JavaScriptCore/inspector/remote/RemoteInspectionTarget.cpp
+++ b/Source/JavaScriptCore/inspector/remote/RemoteInspectionTarget.cpp
@@ -106,7 +106,7 @@ void RemoteInspectionTarget::pauseWaitingForAutomaticInspection()
 
     m_isPausedWaitingForAutomaticInspection = true;
     while (m_isPausedWaitingForAutomaticInspection) {
-        if (RunLoop::cycle(JSGlobalObjectDebugger::runLoopMode()) == RunLoop::CycleResult::Stop)
+        if (RunLoop::cycle(JSGlobalObjectDebugger::runLoopModeSingleton()) == RunLoop::CycleResult::Stop)
             break;
     }
 }

--- a/Source/JavaScriptCore/inspector/remote/RemoteInspector.cpp
+++ b/Source/JavaScriptCore/inspector/remote/RemoteInspector.cpp
@@ -224,11 +224,8 @@ TargetListing RemoteInspector::listingForTarget(const RemoteControllableTarget& 
 
 void RemoteInspector::updateTargetListing(TargetID targetIdentifier)
 {
-    auto target = m_targetMap.get(targetIdentifier);
-    if (!target)
-        return;
-
-    updateTargetListing(*target);
+    if (RefPtr target = m_targetMap.get(targetIdentifier))
+        updateTargetListing(*target);
 }
 
 void RemoteInspector::updateTargetListing(const RemoteControllableTarget& target)

--- a/Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorXPCConnection.h
+++ b/Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorXPCConnection.h
@@ -56,7 +56,7 @@ public:
     void sendMessage(NSString *messageName, NSDictionary *userInfo);
 
 private:
-    NSDictionary *deserializeMessage(xpc_object_t);
+    RetainPtr<NSDictionary> deserializeMessage(xpc_object_t);
     void handleEvent(xpc_object_t);
     void closeOnQueue();
 


### PR DESCRIPTION
#### d1acf19d9b2f7054c55c0df9644306eaf51f803e
<pre>
Address some Safer CPP warnings in Source/JavaScriptCore/inspector
<a href="https://bugs.webkit.org/show_bug.cgi?id=299925">https://bugs.webkit.org/show_bug.cgi?id=299925</a>

Reviewed by Devin Rousso.

* Source/JavaScriptCore/SaferCPPExpectations/RetainPtrCtorAdoptCheckerExpectations:
* Source/JavaScriptCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/JavaScriptCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/JavaScriptCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations:
* Source/JavaScriptCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations:
* Source/JavaScriptCore/inspector/InspectorBackendDispatcher.cpp:
(Inspector::BackendDispatcher::dispatch):
* Source/JavaScriptCore/inspector/JSGlobalObjectDebugger.cpp:
(Inspector::JSGlobalObjectDebugger::runEventLoopWhilePaused):
(Inspector::JSGlobalObjectDebugger::runLoopModeSingleton):
(Inspector::JSGlobalObjectDebugger::runLoopMode): Deleted.
* Source/JavaScriptCore/inspector/JSGlobalObjectDebugger.h:
* Source/JavaScriptCore/inspector/agents/InspectorTargetAgent.cpp:
(Inspector::InspectorTargetAgent::connectionType const):
* Source/JavaScriptCore/inspector/remote/RemoteConnectionToTarget.h:
* Source/JavaScriptCore/inspector/remote/RemoteInspectionTarget.cpp:
(Inspector::RemoteInspectionTarget::pauseWaitingForAutomaticInspection):
* Source/JavaScriptCore/inspector/remote/RemoteInspector.cpp:
(Inspector::RemoteInspector::updateTargetListing):
* Source/JavaScriptCore/inspector/remote/cocoa/RemoteConnectionToTargetCocoa.mm:
(Inspector::rwiRunLoopSource):
(Inspector::RemoteTargetHandleRunSourceGlobal):
(Inspector::RemoteTargetQueueTaskOnGlobalQueue):
(Inspector::RemoteTargetInitializeGlobalQueue):
(Inspector::RemoteConnectionToTarget::protectedConnectionIdentifier const):
(Inspector::RemoteConnectionToTarget::setup):
(Inspector::RemoteConnectionToTarget::setupRunLoop):
(Inspector::RemoteConnectionToTarget::teardownRunLoop):
* Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorCocoa.mm:
(Inspector::RemoteInspector::sendAutomaticInspectionCandidateMessage):
(Inspector::RemoteInspector::sendMessageToRemote):
(Inspector::RemoteInspector::stopInternal):
(Inspector::RemoteInspector::setupXPCConnectionIfNeeded):
(Inspector::identifierForPID):
(Inspector::RemoteInspector::listingForInspectionTarget const):
(Inspector::RemoteInspector::listingForAutomationTarget const):
(Inspector::RemoteInspector::pushListingsNow):
(Inspector::RemoteInspector::receivedSetupMessage):
(Inspector::RemoteInspector::receivedDataMessage):
(Inspector::RemoteInspector::receivedDidCloseMessage):
(Inspector::RemoteInspector::receivedIndicateMessage):
(Inspector::RemoteInspector::receivedProxyApplicationSetupMessage):
(Inspector::RemoteInspector::receivedConnectionDiedMessage):
* Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorXPCConnection.h:
* Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorXPCConnection.mm:
(Inspector::RemoteInspectorXPCConnection::deserializeMessage):
(Inspector::RemoteInspectorXPCConnection::handleEvent):

Canonical link: <a href="https://commits.webkit.org/300808@main">https://commits.webkit.org/300808@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e813335b2bb360c5cb10f2d7ee3a2dfe868b1ce

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123923 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43638 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34335 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130713 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76074 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7e1344de-f885-4591-939c-32521fbf4536) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44362 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52232 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94259 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/62540 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4b1b3436-232a-4255-9225-ce958be8a6d2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126877 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35344 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110855 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74859 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ae578924-0250-4b45-97c2-ec8f57bb7ea1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34296 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29016 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74186 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/116082 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105073 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29239 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133406 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/122455 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50876 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38746 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102725 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51250 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107075 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102551 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26087 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47895 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26147 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/47729 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50729 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56493 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/153551 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50203 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39029 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53549 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51877 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->