### PR TITLE
WTF modulemap to cplusplus20

### DIFF
--- a/Source/WTF/Configurations/modulemap.toml
+++ b/Source/WTF/Configurations/modulemap.toml
@@ -6,7 +6,7 @@ textual-headers = ['spi/mac/MetadataSPI.h']
 
 # Nearly all of WTF depends upon C++ and thus goes in this submodule.
 [module.Cpp]
-requirements = ['cplusplus11']
+requirements = ['cplusplus20']
 
 # The following WTF headers can be used in C contexts as well as C++
 # so we put them in a separate submodule. We'll call it Platform
@@ -23,12 +23,12 @@ headers = ['Assertions.h',
 # AutodrainedPool must never be parsed in an objective-C
 # context.
 [module.AutodrainedPool]
-requirements = ['cplusplus11', '!objc']
+requirements = ['cplusplus20', '!objc']
 headers = ['AutodrainedPool.h']
 
 # Works only on some platforms.
 [module.MetadataSPI]
-requirements = ['cplusplus11']
+requirements = ['cplusplus20']
 headers = ['spi/mac/MetadataSPI.h']
 
 # Swiftc cannot currently parse various bits of WTF so we have to
@@ -37,7 +37,7 @@ headers = ['spi/mac/MetadataSPI.h']
 # Swift cannot understand a std::optional in here, rdar://152718041.
 [module.TextBreakIterator]
 headers = ['text/TextBreakIterator.h']
-requirements = ['cplusplus11']
+requirements = ['cplusplus20']
 
 # Due to conflict between wtf::Task and Swift.Task.
 # FIXME: resolve this using a typealias in Foundation+Extras.swift,
@@ -45,4 +45,4 @@ requirements = ['cplusplus11']
 # which for some reason doesn't seem to work for Task.
 [module.CoroutineUtilities]
 headers = ['CoroutineUtilities.h']
-requirements = ['cplusplus11']
+requirements = ['cplusplus20']


### PR DESCRIPTION
#### 631138c7c05b0d7446226a48b196094d6a9880f9
<pre>
WTF modulemap to cplusplus20
<a href="https://bugs.webkit.org/show_bug.cgi?id=299938">https://bugs.webkit.org/show_bug.cgi?id=299938</a>
<a href="https://rdar.apple.com/161712111">rdar://161712111</a>

Reviewed by Richard Robinson.

Switches the WTF modulemap to cplusplus20.

Canonical link: <a href="https://commits.webkit.org/300945@main">https://commits.webkit.org/300945@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/778cad26358b77a4d92cabf0257b3c03ac7b1d9b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124389 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44069 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34799 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131228 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/76421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2b2a40d0-a733-46b1-9eff-1d45827602fa) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44815 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52668 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94623 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/76421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c12e4a83-396d-4c78-a3d7-65e42acfa2b0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127343 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35719 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111253 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75209 "Found 1 new API test failure: WPE/TestWebKitWebContext:/webkit/WebKitWebContext/no-web-process-leak (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/158c0409-eaed-4b1d-abb4-b09eb2ad3d82) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34653 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29414 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74705 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/116520 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105465 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29635 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133893 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/122917 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51287 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39116 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103102 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51686 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107471 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102897 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26198 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48263 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26511 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48220 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51154 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56948 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/154014 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50578 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39133 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53937 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52252 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->