### PR TITLE
Address forward declaration Safer CPP warnings in worker code

### DIFF
--- a/Source/WebCore/Modules/cookie-store/CookieStore.cpp
+++ b/Source/WebCore/Modules/cookie-store/CookieStore.cpp
@@ -115,7 +115,7 @@ void CookieStore::MainThreadBridge::ensureOnMainThread(Function<void(ScriptExecu
         return;
     }
 
-    downcast<WorkerGlobalScope>(*context).protectedThread()->checkedWorkerLoaderProxy()->postTaskToLoader(WTFMove(task));
+    downcast<WorkerGlobalScope>(*context).thread()->checkedWorkerLoaderProxy()->postTaskToLoader(WTFMove(task));
 }
 
 void CookieStore::MainThreadBridge::ensureOnContextThread(Function<void(CookieStore&)>&& task)

--- a/Source/WebCore/Modules/permissions/Permissions.cpp
+++ b/Source/WebCore/Modules/permissions/Permissions.cpp
@@ -242,7 +242,7 @@ void Permissions::query(JSC::Strong<JSC::JSObject> permissionDescriptorValue, DO
         });
     };
 
-    if (CheckedPtr workerLoaderProxy = workerGlobalScope->thread().workerLoaderProxy())
+    if (CheckedPtr workerLoaderProxy = workerGlobalScope->thread()->workerLoaderProxy())
         workerLoaderProxy->postTaskToLoader(WTFMove(completionHandler));
 }
 

--- a/Source/WebCore/Modules/storage/WorkerStorageConnection.cpp
+++ b/Source/WebCore/Modules/storage/WorkerStorageConnection.cpp
@@ -66,7 +66,7 @@ void WorkerStorageConnection::getPersisted(ClientOrigin&& origin, StorageConnect
     RefPtr scope = m_scope.get();
     ASSERT(scope);
 
-    auto* workerLoaderProxy = scope->thread().workerLoaderProxy();
+    auto* workerLoaderProxy = scope->thread()->workerLoaderProxy();
     if (!workerLoaderProxy)
         return completionHandler(false);
 
@@ -101,7 +101,7 @@ void WorkerStorageConnection::getEstimate(ClientOrigin&& origin, StorageConnecti
     RefPtr scope = m_scope.get();
     ASSERT(scope);
 
-    auto* workerLoaderProxy = scope->thread().workerLoaderProxy();
+    auto* workerLoaderProxy = scope->thread()->workerLoaderProxy();
     if (!workerLoaderProxy)
         return completionHandler(Exception { ExceptionCode::InvalidStateError });
 
@@ -136,7 +136,7 @@ void WorkerStorageConnection::fileSystemGetDirectory(ClientOrigin&& origin, Stor
     RefPtr scope = m_scope.get();
     ASSERT(scope);
 
-    auto* workerLoaderProxy = scope->thread().workerLoaderProxy();
+    auto* workerLoaderProxy = scope->thread()->workerLoaderProxy();
     if (!workerLoaderProxy)
         return completionHandler(Exception { ExceptionCode::InvalidStateError });
     

--- a/Source/WebCore/Modules/webaudio/AudioWorkletGlobalScope.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletGlobalScope.cpp
@@ -123,7 +123,7 @@ ExceptionOr<void> AudioWorkletGlobalScope::registerProcessor(String&& name, Ref<
     if (!addResult.isNewEntry)
         return Exception { ExceptionCode::NotSupportedError, "A processor was already registered with this name"_s };
 
-    auto* messagingProxy = thread().messagingProxy();
+    auto* messagingProxy = thread()->messagingProxy();
     if (!messagingProxy)
         return Exception { ExceptionCode::InvalidStateError };
 
@@ -188,9 +188,9 @@ std::unique_ptr<AudioWorkletProcessorConstructionData> AudioWorkletGlobalScope::
     return std::exchange(m_pendingProcessorConstructionData, nullptr);
 }
 
-AudioWorkletThread& AudioWorkletGlobalScope::thread() const
+Ref<AudioWorkletThread> AudioWorkletGlobalScope::thread() const
 {
-    return *static_cast<AudioWorkletThread*>(workerOrWorkletThread());
+    return downcast<AudioWorkletThread>(workerOrWorkletThread()).releaseNonNull();
 }
 
 void AudioWorkletGlobalScope::handlePreRenderTasks()

--- a/Source/WebCore/Modules/webaudio/AudioWorkletGlobalScope.h
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletGlobalScope.h
@@ -65,7 +65,7 @@ public:
 
     double currentTime() const { return m_sampleRate > 0.0 ? m_currentFrame / static_cast<double>(m_sampleRate) : 0.0; }
 
-    AudioWorkletThread& thread() const;
+    Ref<AudioWorkletThread> thread() const;
     void prepareForDestruction() final;
 
     std::unique_ptr<AudioWorkletProcessorConstructionData> takePendingProcessorConstructionData();

--- a/Source/WebCore/Modules/webaudio/AudioWorkletThread.h
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletThread.h
@@ -37,7 +37,7 @@ namespace WebCore {
 class AudioWorkletGlobalScope;
 class AudioWorkletMessagingProxy;
 
-class AudioWorkletThread : public WorkerOrWorkletThread {
+class AudioWorkletThread final : public WorkerOrWorkletThread {
 public:
     static Ref<AudioWorkletThread> create(AudioWorkletMessagingProxy& messagingProxy, WorkletParameters&& parameters)
     {
@@ -57,6 +57,7 @@ public:
 
 private:
     AudioWorkletThread(AudioWorkletMessagingProxy&, WorkletParameters&&);
+    bool isAudioWorkletThread() const final { return true; }
 
     // WorkerOrWorkletThread.
     Ref<Thread> createThread() final;
@@ -67,5 +68,9 @@ private:
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::AudioWorkletThread)
+    static bool isType(const WebCore::WorkerOrWorkletThread& thread) { return thread.isAudioWorkletThread(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // ENABLE(WEB_AUDIO)

--- a/Source/WebCore/Modules/websockets/ThreadableWebSocketChannel.cpp
+++ b/Source/WebCore/Modules/websockets/ThreadableWebSocketChannel.cpp
@@ -61,8 +61,8 @@ RefPtr<ThreadableWebSocketChannel> ThreadableWebSocketChannel::create(Document& 
 RefPtr<ThreadableWebSocketChannel> ThreadableWebSocketChannel::create(ScriptExecutionContext& context, WebSocketChannelClient& client, SocketProvider& provider)
 {
     if (RefPtr workerGlobalScope = dynamicDowncast<WorkerGlobalScope>(context)) {
-        WorkerRunLoop& runLoop = workerGlobalScope->thread().runLoop();
-        return WorkerThreadableWebSocketChannel::create(*workerGlobalScope, client, makeString("webSocketChannelMode"_s, runLoop.createUniqueId()), provider);
+        auto identifier = workerGlobalScope->thread()->runLoop().createUniqueId();
+        return WorkerThreadableWebSocketChannel::create(*workerGlobalScope, client, makeString("webSocketChannelMode"_s, identifier), provider);
     }
 
     return create(downcast<Document>(context), client, provider);

--- a/Source/WebCore/Modules/websockets/WebSocket.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocket.cpp
@@ -339,7 +339,7 @@ ExceptionOr<void> WebSocket::connect(const String& url, const Vector<String>& pr
     };
     if (is<Document>(context))
         reportRegistrableDomain(context.get());
-    else if (auto* workerLoaderProxy = downcast<WorkerGlobalScope>(context)->thread().workerLoaderProxy())
+    else if (auto* workerLoaderProxy = downcast<WorkerGlobalScope>(context)->thread()->workerLoaderProxy())
         workerLoaderProxy->postTaskToLoader(WTFMove(reportRegistrableDomain));
 
     m_pendingActivity = makePendingActivity(*this);

--- a/Source/WebCore/Modules/websockets/WorkerThreadableWebSocketChannel.cpp
+++ b/Source/WebCore/Modules/websockets/WorkerThreadableWebSocketChannel.cpp
@@ -350,7 +350,7 @@ void WorkerThreadableWebSocketChannel::Peer::didUpgradeURL()
 WorkerThreadableWebSocketChannel::Bridge::Bridge(Ref<ThreadableWebSocketChannelClientWrapper>&& workerClientWrapper, Ref<WorkerGlobalScope>&& workerGlobalScope, const String& taskMode, Ref<SocketProvider>&& socketProvider)
     : m_workerClientWrapper(WTFMove(workerClientWrapper))
     , m_workerGlobalScope(WTFMove(workerGlobalScope))
-    , m_loaderProxy(*m_workerGlobalScope->thread().workerLoaderProxy())
+    , m_loaderProxy(*m_workerGlobalScope->thread()->workerLoaderProxy())
     , m_taskMode(taskMode)
     , m_socketProvider(WTFMove(socketProvider))
 {

--- a/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
@@ -106,11 +106,5 @@ rendering/svg/SVGRenderingContext.h
 style/StyleExtractorState.h
 style/StyleScope.h
 testing/Internals.cpp
-workers/DedicatedWorkerThread.cpp
-workers/Worker.h
-workers/WorkerOrWorkletGlobalScope.h
-workers/WorkerThread.h
-workers/shared/SharedWorkerGlobalScope.h
-workers/shared/context/SharedWorkerThread.h
 xml/XSLStyleSheetLibxslt.cpp
 xml/parser/XMLDocumentParserLibxml2.cpp

--- a/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -29,7 +29,6 @@ Modules/push-api/ServiceWorkerRegistrationPushAPI.cpp
 Modules/screen-wake-lock/NavigatorScreenWakeLock.cpp
 Modules/speech/LocalDOMWindowSpeechSynthesis.cpp
 Modules/speech/SpeechSynthesis.cpp
-Modules/webaudio/AudioWorkletGlobalScope.cpp
 Modules/webaudio/WaveShaperProcessor.cpp
 Modules/webdriver/NavigatorWebDriver.cpp
 SVGNames.cpp

--- a/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
@@ -81,6 +81,5 @@ style/StyleScopeRuleSets.h
 style/Styleable.h
 svg/properties/SVGPropertyOwnerRegistry.h
 workers/WorkerMessagingProxy.h
-workers/WorkerOrWorkletGlobalScope.h
 xml/XPathGrammar.cpp
 xml/XPathGrammar.h

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -515,7 +515,6 @@ inspector/NetworkResourcesData.cpp
 inspector/PageDebugger.cpp
 inspector/WebInjectedScriptManager.cpp
 inspector/WorkerDebugger.cpp
-inspector/WorkerToPageFrontendChannel.h
 inspector/agents/InspectorAnimationAgent.cpp
 inspector/agents/InspectorCPUProfilerAgent.cpp
 inspector/agents/InspectorCSSAgent.cpp
@@ -537,7 +536,6 @@ inspector/agents/page/PageDebuggerAgent.cpp
 inspector/agents/page/PageNetworkAgent.cpp
 inspector/agents/page/PageRuntimeAgent.cpp
 inspector/agents/worker/ServiceWorkerAgent.cpp
-inspector/agents/worker/WorkerNetworkAgent.cpp
 inspector/agents/worker/WorkerRuntimeAgent.cpp
 layout/integration/inline/LayoutIntegrationInlineContentBuilder.cpp
 layout/integration/inline/LayoutIntegrationLineLayout.cpp
@@ -552,7 +550,6 @@ loader/NavigationScheduler.cpp
 loader/PolicyChecker.cpp
 loader/ResourceLoadNotifier.cpp
 loader/ResourceLoader.cpp
-loader/WorkerThreadableLoader.cpp
 loader/archive/cf/LegacyWebArchive.cpp
 loader/cache/CachedImage.cpp
 loader/cache/CachedImage.h
@@ -1007,7 +1004,6 @@ workers/DedicatedWorkerGlobalScope.cpp
 workers/Worker.cpp
 workers/WorkerAnimationController.cpp
 workers/WorkerGlobalScope.cpp
-workers/WorkerInspectorProxy.cpp
 workers/WorkerMessagingProxy.cpp
 workers/shared/SharedWorker.cpp
 worklets/PaintWorkletGlobalScope.cpp

--- a/Source/WebCore/bindings/js/JSWorkerGlobalScopeBase.cpp
+++ b/Source/WebCore/bindings/js/JSWorkerGlobalScopeBase.cpp
@@ -136,7 +136,7 @@ bool JSWorkerGlobalScopeBase::shouldInterruptScriptBeforeTimeout(const JSGlobalO
 RuntimeFlags JSWorkerGlobalScopeBase::javaScriptRuntimeFlags(const JSGlobalObject* object)
 {
     const JSWorkerGlobalScopeBase *thisObject = jsCast<const JSWorkerGlobalScopeBase*>(object);
-    return thisObject->m_wrapped->thread().runtimeFlags();
+    return thisObject->m_wrapped->thread()->runtimeFlags();
 }
 
 JSC::ScriptExecutionStatus JSWorkerGlobalScopeBase::scriptExecutionStatus(JSC::JSGlobalObject* globalObject, JSC::JSObject* owner)

--- a/Source/WebCore/bindings/js/ScheduledAction.cpp
+++ b/Source/WebCore/bindings/js/ScheduledAction.cpp
@@ -151,7 +151,7 @@ void ScheduledAction::execute(Document& document)
 void ScheduledAction::execute(WorkerGlobalScope& workerGlobalScope)
 {
     // In a Worker, the execution should always happen on a worker thread.
-    ASSERT(workerGlobalScope.thread().thread() == &Thread::currentSingleton());
+    ASSERT(workerGlobalScope.thread()->thread() == &Thread::currentSingleton());
 
     auto* scriptController = workerGlobalScope.script();
 

--- a/Source/WebCore/dom/BroadcastChannel.cpp
+++ b/Source/WebCore/dom/BroadcastChannel.cpp
@@ -118,7 +118,7 @@ void BroadcastChannel::MainThreadBridge::ensureOnMainThread(Function<void(Page*)
         return;
     }
 
-    CheckedPtr workerLoaderProxy = downcast<WorkerGlobalScope>(*context).thread().workerLoaderProxy();
+    CheckedPtr workerLoaderProxy = downcast<WorkerGlobalScope>(*context).thread()->workerLoaderProxy();
     if (!workerLoaderProxy)
         return;
 

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -4895,6 +4895,11 @@ IDBClient::IDBConnectionProxy* Document::idbConnectionProxy()
     return m_idbConnectionProxy.get();
 }
 
+RefPtr<IDBClient::IDBConnectionProxy> Document::protectedIDBConnectionProxy()
+{
+    return idbConnectionProxy();
+}
+
 StorageConnection* Document::storageConnection()
 {
     return page() ? &page()->storageConnection() : nullptr;

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -882,6 +882,7 @@ public:
     bool requiresTrustedTypes() const { return m_requiresTrustedTypes && !shouldBypassMainWorldContentSecurityPolicy(); }
 
     IDBClient::IDBConnectionProxy* idbConnectionProxy() final;
+    RefPtr<IDBClient::IDBConnectionProxy> protectedIDBConnectionProxy();
     StorageConnection* storageConnection();
     SocketProvider* socketProvider() final;
     RefPtr<SocketProvider> protectedSocketProvider();

--- a/Source/WebCore/dom/messageports/WorkerMessagePortChannelProvider.cpp
+++ b/Source/WebCore/dom/messageports/WorkerMessagePortChannelProvider.cpp
@@ -112,7 +112,7 @@ void WorkerMessagePortChannelProvider::takeAllMessagesForPort(const MessagePortI
     uint64_t callbackIdentifier = ++m_lastCallbackIdentifier;
     m_takeAllMessagesCallbacks.add(callbackIdentifier, WTFMove(callback));
 
-    callOnMainThread([weakThis = WeakPtr { *this }, workerThread = RefPtr { m_scope->workerOrWorkletThread() }, callbackIdentifier, identifier]() mutable {
+    callOnMainThread([weakThis = WeakPtr { *this }, workerThread = Ref { m_scope.get() }->workerOrWorkletThread(), callbackIdentifier, identifier]() mutable {
         MessagePortChannelProvider::singleton().takeAllMessagesForPort(identifier, [weakThis = WTFMove(weakThis), workerThread = WTFMove(workerThread), callbackIdentifier](Vector<MessageWithMessagePorts>&& messages, Function<void()>&& completionHandler) mutable {
             workerThread->runLoop().postTaskForMode([weakThis = WTFMove(weakThis), callbackIdentifier, messages = WTFMove(messages), completionHandler = MainThreadCompletionHandler(WTFMove(completionHandler))](auto&) mutable {
                 CheckedPtr checkedThis = weakThis.get();

--- a/Source/WebCore/inspector/WorkerInspectorController.cpp
+++ b/Source/WebCore/inspector/WorkerInspectorController.cpp
@@ -114,7 +114,7 @@ void WorkerInspectorController::frontendInitialized()
     }
 
     if (m_isAutomaticInspection && is<ServiceWorkerGlobalScope>(m_globalScope)) {
-        auto serviceWorkerIdentifier = Ref { downcast<ServiceWorkerGlobalScope>(m_globalScope.get()) }->thread().identifier();
+        auto serviceWorkerIdentifier = Ref { downcast<ServiceWorkerGlobalScope>(m_globalScope.get()) }->thread()->identifier();
         SWContextManager::singleton().stopRunningDebuggerTasksOnServiceWorker(serviceWorkerIdentifier);
     }
 #endif

--- a/Source/WebCore/inspector/WorkerToPageFrontendChannel.h
+++ b/Source/WebCore/inspector/WorkerToPageFrontendChannel.h
@@ -51,7 +51,7 @@ private:
             workerDebuggerProxy->postMessageToDebugger(message);
     }
 
-    CheckedPtr<WorkerOrWorkletGlobalScope> m_globalScope;
+    const CheckedPtr<WorkerOrWorkletGlobalScope> m_globalScope;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/inspector/agents/worker/WorkerNetworkAgent.cpp
+++ b/Source/WebCore/inspector/agents/worker/WorkerNetworkAgent.cpp
@@ -65,7 +65,7 @@ Vector<WebSocket*> WorkerNetworkAgent::activeWebSockets()
 
 void WorkerNetworkAgent::setResourceCachingDisabledInternal(bool disabled)
 {
-    if (auto* workerDebuggerProxy = m_globalScope->workerOrWorkletThread()->workerDebuggerProxy())
+    if (auto* workerDebuggerProxy = Ref { m_globalScope.get() }->workerOrWorkletThread()->workerDebuggerProxy())
         workerDebuggerProxy->setResourceCachingDisabledByWebInspector(disabled);
 }
 

--- a/Source/WebCore/loader/WorkerThreadableLoader.cpp
+++ b/Source/WebCore/loader/WorkerThreadableLoader.cpp
@@ -160,9 +160,9 @@ WorkerThreadableLoader::MainThreadBridge::MainThreadBridge(ThreadableLoaderClien
 
     if (RefPtr serviceWorkerGlobalScope = dynamicDowncast<ServiceWorkerGlobalScope>(globalScope)) {
         InspectorInstrumentation::willSendRequest(*serviceWorkerGlobalScope, m_workerRequestIdentifier, request);
-        optionsCopy->options.workerIdentifier = serviceWorkerGlobalScope->thread().identifier();
+        optionsCopy->options.workerIdentifier = serviceWorkerGlobalScope->thread()->identifier();
     } else if (RefPtr sharedWorkerGlobalScope = dynamicDowncast<SharedWorkerGlobalScope>(globalScope))
-        optionsCopy->options.workerIdentifier = sharedWorkerGlobalScope->thread().identifier();
+        optionsCopy->options.workerIdentifier = sharedWorkerGlobalScope->thread()->identifier();
 
     if (!m_loaderProxy)
         return;

--- a/Source/WebCore/loader/cache/MemoryCache.cpp
+++ b/Source/WebCore/loader/cache/MemoryCache.cpp
@@ -691,7 +691,7 @@ void MemoryCache::adjustSize(bool live, long long delta)
 void MemoryCache::removeRequestFromSessionCaches(ScriptExecutionContext& context, const ResourceRequest& request)
 {
     if (auto* globalScope = dynamicDowncast<WorkerGlobalScope>(context)) {
-        auto* workerLoaderProxy = globalScope->thread().workerLoaderProxy();
+        auto* workerLoaderProxy = globalScope->thread()->workerLoaderProxy();
         if (!workerLoaderProxy)
             return;
         workerLoaderProxy->postTaskToLoader([request = request.isolatedCopy()] (ScriptExecutionContext& context) {

--- a/Source/WebCore/page/WorkerNavigator.cpp
+++ b/Source/WebCore/page/WorkerNavigator.cpp
@@ -103,7 +103,7 @@ void WorkerNavigator::setAppBadge(std::optional<unsigned long long> badge, Ref<D
         return;
     }
 
-    if (auto* workerBadgeProxy = scope->thread().workerBadgeProxy())
+    if (auto* workerBadgeProxy = scope->thread()->workerBadgeProxy())
         workerBadgeProxy->setAppBadge(badge);
     promise->resolve();
 }

--- a/Source/WebCore/workers/DedicatedWorkerGlobalScope.cpp
+++ b/Source/WebCore/workers/DedicatedWorkerGlobalScope.cpp
@@ -104,14 +104,14 @@ ExceptionOr<void> DedicatedWorkerGlobalScope::postMessage(JSC::JSGlobalObject& s
     if (channels.hasException())
         return channels.releaseException();
 
-    if (CheckedPtr workerObjectProxy = thread().workerObjectProxy())
+    if (CheckedPtr workerObjectProxy = thread()->workerObjectProxy())
         workerObjectProxy->postMessageToWorkerObject({ message.releaseReturnValue(), channels.releaseReturnValue() });
     return { };
 }
 
-DedicatedWorkerThread& DedicatedWorkerGlobalScope::thread()
+Ref<DedicatedWorkerThread> DedicatedWorkerGlobalScope::thread()
 {
-    return static_cast<DedicatedWorkerThread&>(Base::thread());
+    return downcast<DedicatedWorkerThread>(Base::thread());
 }
 
 #if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)

--- a/Source/WebCore/workers/DedicatedWorkerGlobalScope.h
+++ b/Source/WebCore/workers/DedicatedWorkerGlobalScope.h
@@ -73,7 +73,7 @@ public:
 
     ExceptionOr<void> postMessage(JSC::JSGlobalObject&, JSC::JSValue message, StructuredSerializeOptions&&);
 
-    DedicatedWorkerThread& thread();
+    Ref<DedicatedWorkerThread> thread();
 
 #if ENABLE(NOTIFICATIONS)
     NotificationClient* notificationClient() final;

--- a/Source/WebCore/workers/DedicatedWorkerThread.cpp
+++ b/Source/WebCore/workers/DedicatedWorkerThread.cpp
@@ -33,8 +33,10 @@
 #include "DedicatedWorkerThread.h"
 
 #include "DedicatedWorkerGlobalScope.h"
+#include "IDBConnectionProxy.h"
 #include "SecurityOrigin.h"
 #include "ServiceWorker.h"
+#include "SocketProvider.h"
 #include "WorkerObjectProxy.h"
 
 namespace WebCore {

--- a/Source/WebCore/workers/DedicatedWorkerThread.h
+++ b/Source/WebCore/workers/DedicatedWorkerThread.h
@@ -40,7 +40,7 @@ class ContentSecurityPolicyResponseHeaders;
 class ScriptBuffer;
 class WorkerObjectProxy;
 
-class DedicatedWorkerThread : public WorkerThread {
+class DedicatedWorkerThread final : public WorkerThread {
 public:
     template<typename... Args> static Ref<DedicatedWorkerThread> create(Args&&... args)
     {
@@ -58,6 +58,7 @@ protected:
 
 private:
     DedicatedWorkerThread(const WorkerParameters&, const ScriptBuffer& sourceCode, WorkerLoaderProxy&, WorkerDebuggerProxy&, WorkerObjectProxy&, WorkerBadgeProxy&, WorkerThreadStartMode, const SecurityOrigin& topOrigin, IDBClient::IDBConnectionProxy*, SocketProvider*, JSC::RuntimeFlags);
+    bool isDedicatedWorkerThread() const final { return true; }
 
     ASCIILiteral threadName() const final { return "WebCore: Worker"_s; }
 
@@ -65,3 +66,7 @@ private:
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::DedicatedWorkerThread)
+    static bool isType(const WebCore::WorkerOrWorkletThread& thread) { return thread.isDedicatedWorkerThread(); }
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/workers/Worker.h
+++ b/Source/WebCore/workers/Worker.h
@@ -32,6 +32,7 @@
 #include "EventTargetInterfaces.h"
 #include "FetchRequestCredentials.h"
 #include "MessagePort.h"
+#include "WorkerGlobalScopeProxy.h"
 #include "WorkerOptions.h"
 #include "WorkerScriptLoaderClient.h"
 #include "WorkerType.h"
@@ -52,7 +53,6 @@ class RTCRtpScriptTransform;
 class RTCRtpScriptTransformer;
 class ScriptExecutionContext;
 class TrustedScriptURL;
-class WorkerGlobalScopeProxy;
 class WorkerScriptLoader;
 
 struct StructuredSerializeOptions;

--- a/Source/WebCore/workers/WorkerGlobalScope.h
+++ b/Source/WebCore/workers/WorkerGlobalScope.h
@@ -114,8 +114,7 @@ public:
     WorkerSWClientConnection& swClientConnection();
     void updateServiceWorkerClientData() final;
 
-    WorkerThread& thread() const;
-    Ref<WorkerThread> protectedThread() const;
+    Ref<WorkerThread> thread() const;
 
     using ScriptExecutionContext::hasPendingActivity;
 

--- a/Source/WebCore/workers/WorkerInspectorProxy.cpp
+++ b/Source/WebCore/workers/WorkerInspectorProxy.cpp
@@ -176,7 +176,7 @@ void WorkerInspectorProxy::workerTerminated()
 void WorkerInspectorProxy::resumeWorkerIfPaused()
 {
     m_workerThread->runLoop().postDebuggerTask([] (ScriptExecutionContext& context) {
-        downcast<WorkerGlobalScope>(context).thread().stopRunningDebuggerTasks();
+        downcast<WorkerGlobalScope>(context).thread()->stopRunningDebuggerTasks();
     });
 }
 
@@ -206,7 +206,7 @@ void WorkerInspectorProxy::disconnectFromWorkerInspectorController()
 
         // In case the worker is paused running debugger tasks, ensure we break out of
         // the pause since this will be the last debugger task we send to the worker.
-        downcast<WorkerGlobalScope>(context).thread().stopRunningDebuggerTasks();
+        downcast<WorkerGlobalScope>(context).thread()->stopRunningDebuggerTasks();
     });
 }
 

--- a/Source/WebCore/workers/WorkerNotificationClient.cpp
+++ b/Source/WebCore/workers/WorkerNotificationClient.cpp
@@ -111,7 +111,7 @@ auto WorkerNotificationClient::checkPermission(ScriptExecutionContext*) -> Permi
 
 void WorkerNotificationClient::postToMainThread(Function<void(NotificationClient*, ScriptExecutionContext& context)>&& task)
 {
-    Ref { m_workerScope.get() }->thread().workerLoaderProxy()->postTaskToLoader([task = WTFMove(task)](auto& context) mutable {
+    Ref { m_workerScope.get() }->thread()->workerLoaderProxy()->postTaskToLoader([task = WTFMove(task)](auto& context) mutable {
         task(context.notificationClient(), context);
     });
 }

--- a/Source/WebCore/workers/WorkerOrWorkletGlobalScope.cpp
+++ b/Source/WebCore/workers/WorkerOrWorkletGlobalScope.cpp
@@ -153,4 +153,9 @@ OptionSet<NoiseInjectionPolicy> WorkerOrWorkletGlobalScope::noiseInjectionPolici
     return policies;
 }
 
+RefPtr<WorkerOrWorkletThread> WorkerOrWorkletGlobalScope::workerOrWorkletThread() const
+{
+    return m_thread.get();
+}
+
 } // namespace WebCore

--- a/Source/WebCore/workers/WorkerOrWorkletGlobalScope.h
+++ b/Source/WebCore/workers/WorkerOrWorkletGlobalScope.h
@@ -53,7 +53,7 @@ public:
     USING_CAN_MAKE_WEAKPTR(ScriptExecutionContext);
 
     bool isClosing() const { return m_isClosing; }
-    WorkerOrWorkletThread* workerOrWorkletThread() const { return m_thread; }
+    RefPtr<WorkerOrWorkletThread> workerOrWorkletThread() const;
 
     WorkerOrWorkletScriptController* script() const { return m_script.get(); }
     void clearScript();
@@ -70,7 +70,7 @@ public:
     void postTask(Task&&) final; // Executes the task on context's thread asynchronously.
     std::optional<PAL::SessionID> sessionID() const final { return m_sessionID; }
 
-    // Defined specifcially for WorkerOrWorkletGlobalScope for cooperation with
+    // Defined specifically for WorkerOrWorkletGlobalScope for cooperation with
     // WorkerEventLoop and WorkerRunLoop, not part of ScriptExecutionContext.
     void postTaskForMode(Task&&, const String&);
 
@@ -113,7 +113,7 @@ private:
 
     std::unique_ptr<WorkerOrWorkletScriptController> m_script;
     const UniqueRef<ScriptModuleLoader> m_moduleLoader;
-    WorkerOrWorkletThread* m_thread;
+    ThreadSafeWeakPtr<WorkerOrWorkletThread> m_thread;
     const RefPtr<WorkerEventLoop> m_eventLoop;
     const std::unique_ptr<EventLoopTaskGroup> m_defaultTaskGroup;
     const UniqueRef<WorkerInspectorController> m_inspectorController;

--- a/Source/WebCore/workers/WorkerOrWorkletThread.h
+++ b/Source/WebCore/workers/WorkerOrWorkletThread.h
@@ -83,6 +83,12 @@ public:
     void addChildThread(WorkerOrWorkletThread&);
     void removeChildThread(WorkerOrWorkletThread&);
 
+    virtual bool isWorkerThread() const { return false; }
+    virtual bool isDedicatedWorkerThread() const { return false; }
+    virtual bool isServiceWorkerThread() const { return false; }
+    virtual bool isSharedWorkerThread() const { return false; }
+    virtual bool isAudioWorkletThread() const { return false; }
+
 protected:
     explicit WorkerOrWorkletThread(const String& inspectorIdentifier, WorkerThreadMode = WorkerThreadMode::CreateNewThread);
     void workerOrWorkletThread();

--- a/Source/WebCore/workers/WorkerThread.h
+++ b/Source/WebCore/workers/WorkerThread.h
@@ -106,11 +106,6 @@ public:
     // Number of active worker threads.
     WEBCORE_EXPORT static unsigned workerThreadCount();
 
-#if ENABLE(NOTIFICATIONS)
-    NotificationClient* getNotificationClient() { return m_notificationClient; }
-    void setNotificationClient(NotificationClient* client) { m_notificationClient = client; }
-#endif
-    
     JSC::RuntimeFlags runtimeFlags() const { return m_runtimeFlags; }
     bool isInStaticScriptEvaluation() const { return m_isInStaticScriptEvaluation; }
 
@@ -133,6 +128,7 @@ private:
     virtual ASCIILiteral threadName() const = 0;
 
     virtual void finishedEvaluatingScript() { }
+    bool isWorkerThread() const final { return true; }
 
     // WorkerOrWorkletThread.
     Ref<Thread> createThread() final;
@@ -148,13 +144,13 @@ private:
 
     std::unique_ptr<WorkerThreadStartupData> m_startupData;
 
-#if ENABLE(NOTIFICATIONS)
-    NotificationClient* m_notificationClient { nullptr };
-#endif
-
     const RefPtr<IDBClient::IDBConnectionProxy> m_idbConnectionProxy;
     const RefPtr<SocketProvider> m_socketProvider;
     bool m_isInStaticScriptEvaluation { false };
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::WorkerThread)
+    static bool isType(const WebCore::WorkerOrWorkletThread& thread) { return thread.isWorkerThread(); }
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/workers/service/ServiceWorker.cpp
+++ b/Source/WebCore/workers/service/ServiceWorker.cpp
@@ -129,7 +129,7 @@ ExceptionOr<void> ServiceWorker::postMessage(JSC::JSGlobalObject& globalObject, 
     // FIXME: Maybe we could use a ScriptExecutionContextIdentifier for service workers too.
     ServiceWorkerOrClientIdentifier sourceIdentifier = [&]() -> ServiceWorkerOrClientIdentifier {
         if (RefPtr serviceWorker = dynamicDowncast<ServiceWorkerGlobalScope>(context))
-            return serviceWorker->thread().identifier();
+            return serviceWorker->thread()->identifier();
         return context->identifier();
     }();
 

--- a/Source/WebCore/workers/service/ServiceWorkerClient.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerClient.cpp
@@ -91,7 +91,7 @@ ExceptionOr<void> ServiceWorkerClient::postMessage(JSC::JSGlobalObject& globalOb
 
     MessageWithMessagePorts message = { messageData.releaseReturnValue(), portsOrException.releaseReturnValue() };
     Ref context = downcast<ServiceWorkerGlobalScope>(*scriptExecutionContext());
-    auto sourceIdentifier = context->thread().identifier();
+    auto sourceIdentifier = context->thread()->identifier();
     callOnMainThread([message = WTFMove(message), destinationIdentifier = identifier(), sourceIdentifier, sourceOrigin = context->origin().isolatedCopy()] {
         if (RefPtr connection = SWContextManager::singleton().connection())
             connection->postMessageToServiceWorkerClient(destinationIdentifier, message, sourceIdentifier, sourceOrigin);

--- a/Source/WebCore/workers/service/ServiceWorkerClients.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerClients.cpp
@@ -52,7 +52,7 @@ static inline void didFinishGetRequest(ServiceWorkerGlobalScope& scope, Deferred
 
 void ServiceWorkerClients::get(ScriptExecutionContext& context, const String& id, Ref<DeferredPromise>&& promise)
 {
-    auto serviceWorkerIdentifier = downcast<ServiceWorkerGlobalScope>(context).thread().identifier();
+    auto serviceWorkerIdentifier = downcast<ServiceWorkerGlobalScope>(context).thread()->identifier();
 
     callOnMainThread([promiseIdentifier = addPendingPromise(WTFMove(promise)), serviceWorkerIdentifier, id = id.isolatedCopy()] () {
         Ref connection = *SWContextManager::singleton().connection();
@@ -79,7 +79,7 @@ static inline void matchAllCompleted(ServiceWorkerGlobalScope& scope, DeferredPr
 
 void ServiceWorkerClients::matchAll(ScriptExecutionContext& context, const ClientQueryOptions& options, Ref<DeferredPromise>&& promise)
 {
-    auto serviceWorkerIdentifier = downcast<ServiceWorkerGlobalScope>(context).thread().identifier();
+    auto serviceWorkerIdentifier = downcast<ServiceWorkerGlobalScope>(context).thread()->identifier();
 
     callOnMainThread([promiseIdentifier = addPendingPromise(WTFMove(promise)), serviceWorkerIdentifier, options] () mutable {
         Ref connection = *SWContextManager::singleton().connection();
@@ -112,7 +112,7 @@ void ServiceWorkerClients::openWindow(ScriptExecutionContext& context, const Str
         return;
     }
 
-    auto serviceWorkerIdentifier = downcast<ServiceWorkerGlobalScope>(context).thread().identifier();
+    auto serviceWorkerIdentifier = downcast<ServiceWorkerGlobalScope>(context).thread()->identifier();
     callOnMainThread([promiseIdentifier = addPendingPromise(WTFMove(promise)), serviceWorkerIdentifier, url = url.isolatedCopy()] () mutable {
         Ref connection = *SWContextManager::singleton().connection();
         connection->openWindow(serviceWorkerIdentifier, url, [promiseIdentifier, serviceWorkerIdentifier]<typename Result> (Result&& result) mutable {
@@ -147,7 +147,7 @@ void ServiceWorkerClients::openWindow(ScriptExecutionContext& context, const Str
 
 void ServiceWorkerClients::claim(ScriptExecutionContext& context, Ref<DeferredPromise>&& promise)
 {
-    auto serviceWorkerIdentifier = downcast<ServiceWorkerGlobalScope>(context).thread().identifier();
+    auto serviceWorkerIdentifier = downcast<ServiceWorkerGlobalScope>(context).thread()->identifier();
 
     callOnMainThread([promiseIdentifier = addPendingPromise(WTFMove(promise)), serviceWorkerIdentifier] () mutable {
         Ref connection = *SWContextManager::singleton().connection();

--- a/Source/WebCore/workers/service/ServiceWorkerContainer.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerContainer.cpp
@@ -742,7 +742,7 @@ ServiceWorkerOrClientIdentifier ServiceWorkerContainer::contextIdentifier()
     ASSERT(m_creationThread.ptr() == &Thread::currentSingleton());
     ASSERT(scriptExecutionContext());
     if (RefPtr serviceWorkerGlobal = dynamicDowncast<ServiceWorkerGlobalScope>(*scriptExecutionContext()))
-        return serviceWorkerGlobal->thread().identifier();
+        return serviceWorkerGlobal->thread()->identifier();
     return scriptExecutionContext()->identifier();
 }
 

--- a/Source/WebCore/workers/service/ServiceWorkerGlobalScope.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerGlobalScope.cpp
@@ -143,7 +143,7 @@ Page* ServiceWorkerGlobalScope::serviceWorkerPage()
 
 void ServiceWorkerGlobalScope::skipWaiting(Ref<DeferredPromise>&& promise)
 {
-    RELEASE_LOG(ServiceWorker, "ServiceWorkerGlobalScope::skipWaiting for worker %" PRIu64, thread().identifier().toUInt64());
+    RELEASE_LOG(ServiceWorker, "ServiceWorkerGlobalScope::skipWaiting for worker %" PRIu64, thread()->identifier().toUInt64());
 
     uint64_t requestIdentifier = ++m_lastRequestIdentifier;
     m_pendingSkipWaitingPromises.add(requestIdentifier, WTFMove(promise));
@@ -169,9 +169,9 @@ enum EventTargetInterfaceType ServiceWorkerGlobalScope::eventTargetInterface() c
     return EventTargetInterfaceType::ServiceWorkerGlobalScope;
 }
 
-ServiceWorkerThread& ServiceWorkerGlobalScope::thread()
+Ref<ServiceWorkerThread> ServiceWorkerGlobalScope::thread()
 {
-    return static_cast<ServiceWorkerThread&>(WorkerGlobalScope::thread());
+    return downcast<ServiceWorkerThread>(WorkerGlobalScope::thread());
 }
 
 void ServiceWorkerGlobalScope::prepareForDestruction()
@@ -212,7 +212,7 @@ void ServiceWorkerGlobalScope::updateExtendedEventsSet(ExtendableEvent* newEvent
     if (hasPendingEvents == hadPendingEvents)
         return;
 
-    callOnMainThread([threadIdentifier = thread().identifier(), hasPendingEvents] {
+    callOnMainThread([threadIdentifier = thread()->identifier(), hasPendingEvents] {
         if (RefPtr connection = SWContextManager::singleton().connection())
             connection->setServiceWorkerHasPendingEvents(threadIdentifier, hasPendingEvents);
     });
@@ -226,7 +226,7 @@ const ServiceWorkerContextData::ImportedScript* ServiceWorkerGlobalScope::script
 
 void ServiceWorkerGlobalScope::setScriptResource(const URL& url, ServiceWorkerContextData::ImportedScript&& script)
 {
-    callOnMainThread([threadIdentifier = thread().identifier(), url = url.isolatedCopy(), script = script.isolatedCopy()] {
+    callOnMainThread([threadIdentifier = thread()->identifier(), url = url.isolatedCopy(), script = script.isolatedCopy()] {
         if (RefPtr connection = SWContextManager::singleton().connection())
             connection->setScriptResource(threadIdentifier, url, script);
     });
@@ -266,7 +266,7 @@ bool ServiceWorkerGlobalScope::didFirePushEventRecently() const
 void ServiceWorkerGlobalScope::addConsoleMessage(MessageSource source, MessageLevel level, const String& message, unsigned long requestIdentifier)
 {
     if (m_consoleMessageReportingEnabled) {
-        callOnMainThread([threadIdentifier = thread().identifier(), source, level, message = message.isolatedCopy(), requestIdentifier] {
+        callOnMainThread([threadIdentifier = thread()->identifier(), source, level, message = message.isolatedCopy(), requestIdentifier] {
             if (RefPtr connection = SWContextManager::singleton().connection())
                 connection->reportConsoleMessage(threadIdentifier, source, level, message, requestIdentifier);
         });

--- a/Source/WebCore/workers/service/ServiceWorkerGlobalScope.h
+++ b/Source/WebCore/workers/service/ServiceWorkerGlobalScope.h
@@ -74,7 +74,7 @@ public:
 
     enum EventTargetInterfaceType eventTargetInterface() const final;
 
-    ServiceWorkerThread& thread();
+    Ref<ServiceWorkerThread> thread();
 
     void updateExtendedEventsSet(ExtendableEvent* newEvent = nullptr);
 

--- a/Source/WebCore/workers/service/ServiceWorkerWindowClient.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerWindowClient.cpp
@@ -51,7 +51,7 @@ void ServiceWorkerWindowClient::focus(ScriptExecutionContext& context, Ref<Defer
     }
 
     auto promiseIdentifier = serviceWorkerContext.clients().addPendingPromise(WTFMove(promise));
-    callOnMainThread([clientIdentifier = identifier(), promiseIdentifier, serviceWorkerIdentifier = serviceWorkerContext.thread().identifier()]() mutable {
+    callOnMainThread([clientIdentifier = identifier(), promiseIdentifier, serviceWorkerIdentifier = serviceWorkerContext.thread()->identifier()]() mutable {
         SWContextManager::singleton().protectedConnection()->focus(clientIdentifier, [promiseIdentifier, serviceWorkerIdentifier](auto result) mutable {
             SWContextManager::singleton().postTaskToServiceWorker(serviceWorkerIdentifier, [promiseIdentifier, result = crossThreadCopy(WTFMove(result))](auto& serviceWorkerContext) mutable {
                 auto promise = serviceWorkerContext.clients().takePendingPromise(promiseIdentifier);
@@ -87,7 +87,7 @@ void ServiceWorkerWindowClient::navigate(ScriptExecutionContext& context, const 
     // We implement step 4 (checking of client's active service worker) in network process as we cannot do it synchronously.
     auto& serviceWorkerContext = downcast<ServiceWorkerGlobalScope>(context);
     auto promiseIdentifier = serviceWorkerContext.clients().addPendingPromise(WTFMove(promise));
-    callOnMainThread([clientIdentifier = identifier(), promiseIdentifier, serviceWorkerIdentifier = serviceWorkerContext.thread().identifier(), url = WTFMove(url).isolatedCopy()]() mutable {
+    callOnMainThread([clientIdentifier = identifier(), promiseIdentifier, serviceWorkerIdentifier = serviceWorkerContext.thread()->identifier(), url = WTFMove(url).isolatedCopy()]() mutable {
         SWContextManager::singleton().protectedConnection()->navigate(clientIdentifier, serviceWorkerIdentifier, url, [promiseIdentifier, serviceWorkerIdentifier](auto result) mutable {
             SWContextManager::singleton().postTaskToServiceWorker(serviceWorkerIdentifier, [promiseIdentifier, result = crossThreadCopy(WTFMove(result))](auto& serviceWorkerContext) mutable {
                 auto promise = serviceWorkerContext.clients().takePendingPromise(promiseIdentifier);

--- a/Source/WebCore/workers/service/context/ServiceWorkerFetch.cpp
+++ b/Source/WebCore/workers/service/context/ServiceWorkerFetch.cpp
@@ -169,7 +169,7 @@ void dispatchFetchEvent(Ref<Client>&& client, ServiceWorkerGlobalScope& globalSc
     bool isNavigation = options.mode == FetchOptions::Mode::Navigate;
 
     ASSERT(globalScope.registration().active());
-    ASSERT(globalScope.registration().active()->identifier() == globalScope.thread().identifier());
+    ASSERT(globalScope.registration().active()->identifier() == globalScope.thread()->identifier());
     // FIXME: we should use the same path for registration changes as for fetch events.
     ASSERT(globalScope.registration().active()->state() == ServiceWorkerState::Activated || globalScope.registration().active()->state() == ServiceWorkerState::Activating);
 

--- a/Source/WebCore/workers/service/context/ServiceWorkerInspectorProxy.cpp
+++ b/Source/WebCore/workers/service/context/ServiceWorkerInspectorProxy.cpp
@@ -84,7 +84,7 @@ void ServiceWorkerInspectorProxy::disconnectFromWorker(FrontendChannel& channel)
 
         // In case the worker is paused running debugger tasks, ensure we break out of
         // the pause since this will be the last debugger task we send to the worker.
-        downcast<WorkerGlobalScope>(context).protectedThread()->stopRunningDebuggerTasks();
+        downcast<WorkerGlobalScope>(context).thread()->stopRunningDebuggerTasks();
     });
 }
 

--- a/Source/WebCore/workers/service/context/ServiceWorkerThread.cpp
+++ b/Source/WebCore/workers/service/context/ServiceWorkerThread.cpp
@@ -239,7 +239,7 @@ void ServiceWorkerThread::queueTaskToFireInstallEvent()
 {
     Ref serviceWorkerGlobalScope = downcast<ServiceWorkerGlobalScope>(*globalScope());
     serviceWorkerGlobalScope->checkedEventLoop()->queueTask(TaskSource::DOMManipulation, [weakThis = ThreadSafeWeakPtr { *this }, serviceWorkerGlobalScope]() mutable {
-        RELEASE_LOG(ServiceWorker, "ServiceWorkerThread::queueTaskToFireInstallEvent firing event for worker %" PRIu64, serviceWorkerGlobalScope->thread().identifier().toUInt64());
+        RELEASE_LOG(ServiceWorker, "ServiceWorkerThread::queueTaskToFireInstallEvent firing event for worker %" PRIu64, serviceWorkerGlobalScope->thread()->identifier().toUInt64());
 
         Ref installEvent = serviceWorkerGlobalScope->settingsValues().serviceWorkerInstallEventEnabled ? Ref<ExtendableEvent> { InstallEvent::create(eventNames().installEvent, { }, ExtendableEvent::IsTrusted::Yes) } : ExtendableEvent::create(eventNames().installEvent, { }, ExtendableEvent::IsTrusted::Yes);
         serviceWorkerGlobalScope->dispatchEvent(installEvent);
@@ -266,7 +266,7 @@ void ServiceWorkerThread::queueTaskToFireActivateEvent()
 {
     Ref serviceWorkerGlobalScope = downcast<ServiceWorkerGlobalScope>(*globalScope());
     serviceWorkerGlobalScope->checkedEventLoop()->queueTask(TaskSource::DOMManipulation, [weakThis = ThreadSafeWeakPtr { *this }, serviceWorkerGlobalScope]() mutable {
-        RELEASE_LOG(ServiceWorker, "ServiceWorkerThread::queueTaskToFireActivateEvent firing event for worker %" PRIu64, serviceWorkerGlobalScope->thread().identifier().toUInt64());
+        RELEASE_LOG(ServiceWorker, "ServiceWorkerThread::queueTaskToFireActivateEvent firing event for worker %" PRIu64, serviceWorkerGlobalScope->thread()->identifier().toUInt64());
 
         auto activateEvent = ExtendableEvent::create(eventNames().activateEvent, { }, ExtendableEvent::IsTrusted::Yes);
         serviceWorkerGlobalScope->dispatchEvent(activateEvent);
@@ -296,7 +296,7 @@ void ServiceWorkerThread::queueTaskToFirePushEvent(std::optional<Vector<uint8_t>
 
     Ref serviceWorkerGlobalScope = downcast<ServiceWorkerGlobalScope>(*globalScope());
     serviceWorkerGlobalScope->checkedEventLoop()->queueTask(TaskSource::DOMManipulation, [serviceWorkerGlobalScope, data = WTFMove(data), callback = WTFMove(callback)]() mutable {
-        RELEASE_LOG(ServiceWorker, "ServiceWorkerThread::queueTaskToFirePushEvent firing event for worker %" PRIu64, serviceWorkerGlobalScope->thread().identifier().toUInt64());
+        RELEASE_LOG(ServiceWorker, "ServiceWorkerThread::queueTaskToFirePushEvent firing event for worker %" PRIu64, serviceWorkerGlobalScope->thread()->identifier().toUInt64());
 
         serviceWorkerGlobalScope->setHasPendingSilentPushEvent(true);
 
@@ -331,7 +331,7 @@ void ServiceWorkerThread::queueTaskToFireDeclarativePushEvent(NotificationPayloa
     Ref serviceWorkerGlobalScope = downcast<ServiceWorkerGlobalScope>(*globalScope());
     auto scopeURL = serviceWorkerGlobalScope->registration().data().scopeURL;
     serviceWorkerGlobalScope->checkedEventLoop()->queueTask(TaskSource::DOMManipulation, [weakThis = ThreadSafeWeakPtr { *this }, serviceWorkerGlobalScope = Ref { serviceWorkerGlobalScope }, proposedPayload = WTFMove(proposedPayload), callback = WTFMove(callback), scopeURL]() mutable {
-        RELEASE_LOG(ServiceWorker, "ServiceWorkerThread::queueTaskToFireDeclarativePushEvent firing push event for worker %" PRIu64, serviceWorkerGlobalScope->thread().identifier().toUInt64());
+        RELEASE_LOG(ServiceWorker, "ServiceWorkerThread::queueTaskToFireDeclarativePushEvent firing push event for worker %" PRIu64, serviceWorkerGlobalScope->thread()->identifier().toUInt64());
 
         auto notification = Notification::create(serviceWorkerGlobalScope.get(), scopeURL, proposedPayload);
         Ref declarativePushEvent = PushEvent::create(eventNames().pushEvent, { }, notification.get(), proposedPayload.appBadge, ExtendableEvent::IsTrusted::Yes);
@@ -376,7 +376,7 @@ void ServiceWorkerThread::queueTaskToFirePushSubscriptionChangeEvent(std::option
 {
     Ref serviceWorkerGlobalScope = downcast<ServiceWorkerGlobalScope>(*globalScope());
     serviceWorkerGlobalScope->checkedEventLoop()->queueTask(TaskSource::DOMManipulation, [weakThis = ThreadSafeWeakPtr { *this }, serviceWorkerGlobalScope, newSubscriptionData = WTFMove(newSubscriptionData), oldSubscriptionData = WTFMove(oldSubscriptionData)]() mutable {
-        RELEASE_LOG(ServiceWorker, "ServiceWorkerThread::queueTaskToFirePushSubscriptionChangeEvent firing event for worker %" PRIu64, serviceWorkerGlobalScope->thread().identifier().toUInt64());
+        RELEASE_LOG(ServiceWorker, "ServiceWorkerThread::queueTaskToFirePushSubscriptionChangeEvent firing event for worker %" PRIu64, serviceWorkerGlobalScope->thread()->identifier().toUInt64());
 
         RefPtr<PushSubscription> newSubscription;
         RefPtr<PushSubscription> oldSubscription;
@@ -405,7 +405,7 @@ void ServiceWorkerThread::queueTaskToFireNotificationEvent(NotificationData&& da
 {
     Ref serviceWorkerGlobalScope = downcast<ServiceWorkerGlobalScope>(*globalScope());
     serviceWorkerGlobalScope->checkedEventLoop()->queueTask(TaskSource::DOMManipulation, [serviceWorkerGlobalScope, data = WTFMove(data), eventType, callback = WTFMove(callback)]() mutable {
-        RELEASE_LOG(ServiceWorker, "ServiceWorkerThread::queueTaskToFireNotificationEvent firing event for worker %" PRIu64, serviceWorkerGlobalScope->thread().identifier().toUInt64());
+        RELEASE_LOG(ServiceWorker, "ServiceWorkerThread::queueTaskToFireNotificationEvent firing event for worker %" PRIu64, serviceWorkerGlobalScope->thread()->identifier().toUInt64());
 
         auto notification = Notification::create(serviceWorkerGlobalScope.get(), WTFMove(data));
         AtomString eventName;
@@ -443,7 +443,7 @@ void ServiceWorkerThread::queueTaskToFireBackgroundFetchEvent(BackgroundFetchInf
 {
     Ref serviceWorkerGlobalScope = downcast<ServiceWorkerGlobalScope>(*globalScope());
     serviceWorkerGlobalScope->checkedEventLoop()->queueTask(TaskSource::DOMManipulation, [weakThis = ThreadSafeWeakPtr { *this }, serviceWorkerGlobalScope, info = crossThreadCopy(WTFMove(info)), callback = WTFMove(callback)]() mutable {
-        RELEASE_LOG(ServiceWorker, "ServiceWorkerThread::queueTaskToFireBackgroundFetchEvent firing event for worker %" PRIu64, serviceWorkerGlobalScope->thread().identifier().toUInt64());
+        RELEASE_LOG(ServiceWorker, "ServiceWorkerThread::queueTaskToFireBackgroundFetchEvent firing event for worker %" PRIu64, serviceWorkerGlobalScope->thread()->identifier().toUInt64());
 
         Ref manager = ServiceWorkerRegistrationBackgroundFetchAPI::backgroundFetch(serviceWorkerGlobalScope->registration());
         BackgroundFetchEventInit eventInit { { }, manager->backgroundFetchRegistrationInstance(serviceWorkerGlobalScope, WTFMove(info)) };
@@ -481,7 +481,7 @@ void ServiceWorkerThread::queueTaskToFireBackgroundFetchClickEvent(BackgroundFet
 {
     Ref serviceWorkerGlobalScope = downcast<ServiceWorkerGlobalScope>(*globalScope());
     serviceWorkerGlobalScope->checkedEventLoop()->queueTask(TaskSource::DOMManipulation, [serviceWorkerGlobalScope, info = crossThreadCopy(WTFMove(info)), callback = WTFMove(callback)]() mutable {
-        RELEASE_LOG(ServiceWorker, "ServiceWorkerThread::queueTaskToFireBackgroundFetchClickEvent firing event for worker %" PRIu64, serviceWorkerGlobalScope->thread().identifier().toUInt64());
+        RELEASE_LOG(ServiceWorker, "ServiceWorkerThread::queueTaskToFireBackgroundFetchClickEvent firing event for worker %" PRIu64, serviceWorkerGlobalScope->thread()->identifier().toUInt64());
 
         Ref manager = ServiceWorkerRegistrationBackgroundFetchAPI::backgroundFetch(serviceWorkerGlobalScope->registration());
         BackgroundFetchEventInit eventInit { { }, manager->backgroundFetchRegistrationInstance(serviceWorkerGlobalScope, WTFMove(info)) };

--- a/Source/WebCore/workers/service/context/ServiceWorkerThread.h
+++ b/Source/WebCore/workers/service/context/ServiceWorkerThread.h
@@ -53,7 +53,7 @@ struct NotificationPayload;
 
 enum class AdvancedPrivacyProtections : uint16_t;
 
-class ServiceWorkerThread : public WorkerThread {
+class ServiceWorkerThread final : public WorkerThread {
 public:
     static Ref<ServiceWorkerThread> create(ServiceWorkerContextData&&, ServiceWorkerData&&, String&& userAgent, WorkerThreadMode, const SettingsValues&, WorkerLoaderProxy&, WorkerDebuggerProxy&, WorkerBadgeProxy&, IDBClient::IDBConnectionProxy*, SocketProvider*, std::unique_ptr<NotificationClient>&&, PAL::SessionID, std::optional<uint64_t>, OptionSet<AdvancedPrivacyProtections>);
     virtual ~ServiceWorkerThread();
@@ -102,6 +102,7 @@ private:
 
     ASCIILiteral threadName() const final { return "WebCore: ServiceWorker"_s; }
     void finishedEvaluatingScript() final;
+    bool isServiceWorkerThread() const final { return true; }
 
     void finishedFiringInstallEvent(bool hasRejectedAnyPromise);
     void finishedFiringActivateEvent();
@@ -137,3 +138,7 @@ private:
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::ServiceWorkerThread)
+    static bool isType(const WebCore::WorkerOrWorkletThread& thread) { return thread.isServiceWorkerThread(); }
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/workers/shared/SharedWorkerGlobalScope.h
+++ b/Source/WebCore/workers/shared/SharedWorkerGlobalScope.h
@@ -39,17 +39,12 @@ class SharedWorkerGlobalScope final : public WorkerGlobalScope {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(SharedWorkerGlobalScope);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SharedWorkerGlobalScope);
 public:
-    template<typename... Args> static Ref<SharedWorkerGlobalScope> create(Args&&... args)
-    {
-        auto scope = adoptRef(*new SharedWorkerGlobalScope(std::forward<Args>(args)...));
-        scope->addToContextsMap();
-        return scope;
-    }
+    static Ref<SharedWorkerGlobalScope> create(const String& name, const WorkerParameters&, Ref<SecurityOrigin>&&, SharedWorkerThread&, Ref<SecurityOrigin>&& topOrigin, IDBClient::IDBConnectionProxy*, SocketProvider*, std::unique_ptr<WorkerClient>&&);
     ~SharedWorkerGlobalScope();
 
     Type type() const final { return Type::SharedWorker; }
     const String& name() const { return m_name; }
-    SharedWorkerThread& thread();
+    Ref<SharedWorkerThread> thread();
 
     void postConnectEvent(TransferredMessagePort&&, const String& sourceOrigin);
 

--- a/Source/WebCore/workers/shared/context/SharedWorkerThread.cpp
+++ b/Source/WebCore/workers/shared/context/SharedWorkerThread.cpp
@@ -26,12 +26,19 @@
 #include "config.h"
 #include "SharedWorkerThread.h"
 
+#include "IDBConnectionProxy.h"
 #include "Logging.h"
 #include "ServiceWorker.h"
 #include "SharedWorkerGlobalScope.h"
+#include "SocketProvider.h"
 #include "WorkerObjectProxy.h"
 
 namespace WebCore {
+
+Ref<SharedWorkerThread> SharedWorkerThread::create(SharedWorkerIdentifier identifier, const WorkerParameters& parameters, const ScriptBuffer& sourceCode, WorkerLoaderProxy& loaderProxy, WorkerDebuggerProxy& debuggerProxy, WorkerObjectProxy& objectProxy, WorkerBadgeProxy& badgeProxy, WorkerThreadStartMode startMode, const SecurityOrigin& topOrigin, IDBClient::IDBConnectionProxy* connectionProxy, SocketProvider* socketProvider, JSC::RuntimeFlags runtimeFlags)
+{
+    return adoptRef(*new SharedWorkerThread(identifier, parameters, sourceCode, loaderProxy, debuggerProxy, objectProxy, badgeProxy, startMode, topOrigin, connectionProxy, socketProvider, runtimeFlags));
+}
 
 SharedWorkerThread::SharedWorkerThread(SharedWorkerIdentifier identifier, const WorkerParameters& parameters, const ScriptBuffer& sourceCode, WorkerLoaderProxy& loaderProxy, WorkerDebuggerProxy& debuggerProxy, WorkerObjectProxy& objectProxy, WorkerBadgeProxy& badgeProxy, WorkerThreadStartMode startMode, const SecurityOrigin& topOrigin, IDBClient::IDBConnectionProxy* connectionProxy, SocketProvider* socketProvider, JSC::RuntimeFlags runtimeFlags)
     : WorkerThread(parameters, sourceCode, loaderProxy, debuggerProxy, objectProxy, badgeProxy, startMode, topOrigin, connectionProxy, socketProvider, runtimeFlags)

--- a/Source/WebCore/workers/shared/context/SharedWorkerThread.h
+++ b/Source/WebCore/workers/shared/context/SharedWorkerThread.h
@@ -32,9 +32,9 @@ namespace WebCore {
 
 class WorkerObjectProxy;
 
-class SharedWorkerThread : public WorkerThread {
+class SharedWorkerThread final : public WorkerThread {
 public:
-    template<typename... Args> static Ref<SharedWorkerThread> create(Args&&... args) { return adoptRef(*new SharedWorkerThread(std::forward<Args>(args)...)); }
+    static Ref<SharedWorkerThread> create(SharedWorkerIdentifier, const WorkerParameters&, const ScriptBuffer& sourceCode, WorkerLoaderProxy&, WorkerDebuggerProxy&, WorkerObjectProxy&, WorkerBadgeProxy&, WorkerThreadStartMode, const SecurityOrigin& topOrigin, IDBClient::IDBConnectionProxy*, SocketProvider*, JSC::RuntimeFlags);
 
     SharedWorkerIdentifier identifier() const { return m_identifier; }
 
@@ -43,9 +43,14 @@ private:
 
     Ref<WorkerGlobalScope> createWorkerGlobalScope(const WorkerParameters&, Ref<SecurityOrigin>&&, Ref<SecurityOrigin>&& topOrigin) final;
     ASCIILiteral threadName() const final { return "WebCore: SharedWorker"_s; }
+    bool isSharedWorkerThread() const final { return true; }
 
     SharedWorkerIdentifier m_identifier;
     String m_name;
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::SharedWorkerThread)
+    static bool isType(const WebCore::WorkerOrWorkletThread& thread) { return thread.isSharedWorkerThread(); }
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.cpp
+++ b/Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.cpp
@@ -35,6 +35,7 @@
 #include "EventLoop.h"
 #include "EventNames.h"
 #include "FrameLoader.h"
+#include "IDBConnectionProxy.h"
 #include "LoaderStrategy.h"
 #include "LocalFrame.h"
 #include "MessageEvent.h"
@@ -46,6 +47,7 @@
 #include "SharedWorkerContextManager.h"
 #include "SharedWorkerGlobalScope.h"
 #include "SharedWorkerThread.h"
+#include "SocketProvider.h"
 #include "WebRTCProvider.h"
 #include "WorkerClient.h"
 #include "WorkerFetchResult.h"
@@ -103,7 +105,7 @@ SharedWorkerThreadProxy::SharedWorkerThreadProxy(Ref<Page>&& page, SharedWorkerI
     : m_page(WTFMove(page))
     , m_document(*m_page->localTopDocument())
     , m_contextIdentifier(*initializationData.clientIdentifier)
-    , m_workerThread(SharedWorkerThread::create(sharedWorkerIdentifier, generateWorkerParameters(workerFetchResult, WTFMove(workerOptions), WTFMove(initializationData), m_document), WTFMove(workerFetchResult.script), *this, *this, *this, *this, WorkerThreadStartMode::Normal, clientOrigin.topOrigin.securityOrigin(), m_document->idbConnectionProxy(), m_document->socketProvider(), JSC::RuntimeFlags::createAllEnabled()))
+    , m_workerThread(SharedWorkerThread::create(sharedWorkerIdentifier, generateWorkerParameters(workerFetchResult, WTFMove(workerOptions), WTFMove(initializationData), m_document), WTFMove(workerFetchResult.script), *this, *this, *this, *this, WorkerThreadStartMode::Normal, clientOrigin.topOrigin.securityOrigin(), m_document->protectedIDBConnectionProxy().get(), m_document->protectedSocketProvider().get(), JSC::RuntimeFlags::createAllEnabled()))
     , m_cacheStorageProvider(cacheStorageProvider)
     , m_clientOrigin(clientOrigin)
 {


### PR DESCRIPTION
#### 6e9cf96cb12faab5e43b662535211e9536d06533
<pre>
Address forward declaration Safer CPP warnings in worker code
<a href="https://bugs.webkit.org/show_bug.cgi?id=299941">https://bugs.webkit.org/show_bug.cgi?id=299941</a>

Reviewed by Darin Adler.

* Source/WebCore/Modules/cookie-store/CookieStore.cpp:
(WebCore::CookieStore::MainThreadBridge::ensureOnMainThread):
* Source/WebCore/Modules/permissions/Permissions.cpp:
(WebCore::Permissions::query):
* Source/WebCore/Modules/storage/WorkerStorageConnection.cpp:
(WebCore::WorkerStorageConnection::getPersisted):
(WebCore::WorkerStorageConnection::getEstimate):
(WebCore::WorkerStorageConnection::fileSystemGetDirectory):
* Source/WebCore/Modules/webaudio/AudioWorkletGlobalScope.cpp:
(WebCore::AudioWorkletGlobalScope::registerProcessor):
(WebCore::AudioWorkletGlobalScope::thread const):
* Source/WebCore/Modules/webaudio/AudioWorkletGlobalScope.h:
* Source/WebCore/Modules/webaudio/AudioWorkletThread.h:
(isType):
(WebCore::AudioWorkletThread::create): Deleted.
(WebCore::AudioWorkletThread::messagingProxy): Deleted.
* Source/WebCore/Modules/websockets/ThreadableWebSocketChannel.cpp:
(WebCore::ThreadableWebSocketChannel::create):
* Source/WebCore/Modules/websockets/WebSocket.cpp:
(WebCore::WebSocket::connect):
* Source/WebCore/Modules/websockets/WorkerThreadableWebSocketChannel.cpp:
(WebCore::WorkerThreadableWebSocketChannel::Bridge::Bridge):
* Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/bindings/js/JSWorkerGlobalScopeBase.cpp:
(WebCore::JSWorkerGlobalScopeBase::javaScriptRuntimeFlags):
* Source/WebCore/bindings/js/ScheduledAction.cpp:
(WebCore::ScheduledAction::execute):
* Source/WebCore/dom/BroadcastChannel.cpp:
(WebCore::BroadcastChannel::MainThreadBridge::ensureOnMainThread):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::protectedIDBConnectionProxy):
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/messageports/WorkerMessagePortChannelProvider.cpp:
(WebCore::WorkerMessagePortChannelProvider::takeAllMessagesForPort):
* Source/WebCore/inspector/WorkerInspectorController.cpp:
(WebCore::WorkerInspectorController::frontendInitialized):
* Source/WebCore/inspector/WorkerToPageFrontendChannel.h:
* Source/WebCore/inspector/agents/worker/WorkerNetworkAgent.cpp:
(WebCore::WorkerNetworkAgent::setResourceCachingDisabledInternal):
* Source/WebCore/loader/WorkerThreadableLoader.cpp:
(WebCore::m_contextIdentifier):
* Source/WebCore/loader/cache/MemoryCache.cpp:
(WebCore::MemoryCache::removeRequestFromSessionCaches):
* Source/WebCore/page/WorkerNavigator.cpp:
(WebCore::WorkerNavigator::setAppBadge):
* Source/WebCore/workers/DedicatedWorkerGlobalScope.cpp:
(WebCore::DedicatedWorkerGlobalScope::postMessage):
(WebCore::DedicatedWorkerGlobalScope::thread):
* Source/WebCore/workers/DedicatedWorkerGlobalScope.h:
* Source/WebCore/workers/DedicatedWorkerThread.cpp:
* Source/WebCore/workers/DedicatedWorkerThread.h:
(isType):
(WebCore::DedicatedWorkerThread::create): Deleted.
(WebCore::DedicatedWorkerThread::workerObjectProxy const): Deleted.
(WebCore::DedicatedWorkerThread::start): Deleted.
* Source/WebCore/workers/Worker.h:
* Source/WebCore/workers/WorkerGlobalScope.cpp:
(WebCore::WorkerGlobalScope::~WorkerGlobalScope):
(WebCore::WorkerGlobalScope::close):
(WebCore::WorkerGlobalScope::logExceptionToConsole):
(WebCore::WorkerGlobalScope::serializeAndWrapCryptoKey):
(WebCore::WorkerGlobalScope::unwrapCryptoKey):
(WebCore::WorkerGlobalScope::thread const):
(WebCore::WorkerGlobalScope::reportErrorToWorkerObject):
(WebCore::WorkerGlobalScope::protectedThread const): Deleted.
* Source/WebCore/workers/WorkerGlobalScope.h:
* Source/WebCore/workers/WorkerInspectorProxy.cpp:
(WebCore::WorkerInspectorProxy::resumeWorkerIfPaused):
(WebCore::WorkerInspectorProxy::disconnectFromWorkerInspectorController):
* Source/WebCore/workers/WorkerMessagingProxy.cpp:
(WebCore::loaderContextIdentifierFromContext):
(WebCore::WorkerMessagingProxy::WorkerMessagingProxy):
(WebCore::WorkerMessagingProxy::~WorkerMessagingProxy):
(WebCore::WorkerMessagingProxy::startWorkerGlobalScope):
(WebCore::WorkerMessagingProxy::workerGlobalScopeDestroyedInternal):
* Source/WebCore/workers/WorkerNotificationClient.cpp:
(WebCore::WorkerNotificationClient::postToMainThread):
* Source/WebCore/workers/WorkerOrWorkletGlobalScope.cpp:
(WebCore::WorkerOrWorkletGlobalScope::workerOrWorkletThread const):
* Source/WebCore/workers/WorkerOrWorkletGlobalScope.h:
(WebCore::WorkerOrWorkletGlobalScope::workerOrWorkletThread const): Deleted.
* Source/WebCore/workers/WorkerOrWorkletThread.h:
(WebCore::WorkerOrWorkletThread::isWorkerThread const):
(WebCore::WorkerOrWorkletThread::isDedicatedWorkerThread const):
(WebCore::WorkerOrWorkletThread::isServiceWorkerThread const):
(WebCore::WorkerOrWorkletThread::isSharedWorkerThread const):
(WebCore::WorkerOrWorkletThread::isAudioWorkletThread const):
* Source/WebCore/workers/WorkerThread.h:
(isType):
(WebCore::WorkerThread::getNotificationClient): Deleted.
(WebCore::WorkerThread::setNotificationClient): Deleted.
* Source/WebCore/workers/service/ServiceWorker.cpp:
(WebCore::ServiceWorker::postMessage):
* Source/WebCore/workers/service/ServiceWorkerClient.cpp:
(WebCore::ServiceWorkerClient::postMessage):
* Source/WebCore/workers/service/ServiceWorkerClients.cpp:
(WebCore::ServiceWorkerClients::get):
(WebCore::ServiceWorkerClients::matchAll):
(WebCore::ServiceWorkerClients::openWindow):
(WebCore::ServiceWorkerClients::claim):
* Source/WebCore/workers/service/ServiceWorkerContainer.cpp:
(WebCore::ServiceWorkerContainer::contextIdentifier):
* Source/WebCore/workers/service/ServiceWorkerGlobalScope.cpp:
(WebCore::ServiceWorkerGlobalScope::skipWaiting):
(WebCore::ServiceWorkerGlobalScope::thread):
(WebCore::ServiceWorkerGlobalScope::updateExtendedEventsSet):
(WebCore::ServiceWorkerGlobalScope::setScriptResource):
(WebCore::ServiceWorkerGlobalScope::addConsoleMessage):
* Source/WebCore/workers/service/ServiceWorkerGlobalScope.h:
* Source/WebCore/workers/service/ServiceWorkerWindowClient.cpp:
(WebCore::ServiceWorkerWindowClient::focus):
(WebCore::ServiceWorkerWindowClient::navigate):
* Source/WebCore/workers/service/context/ServiceWorkerFetch.cpp:
(WebCore::ServiceWorkerFetch::dispatchFetchEvent):
* Source/WebCore/workers/service/context/ServiceWorkerInspectorProxy.cpp:
(WebCore::ServiceWorkerInspectorProxy::disconnectFromWorker):
* Source/WebCore/workers/service/context/ServiceWorkerThread.cpp:
(WebCore::ServiceWorkerThread::queueTaskToFireInstallEvent):
(WebCore::ServiceWorkerThread::queueTaskToFireActivateEvent):
(WebCore::ServiceWorkerThread::queueTaskToFirePushEvent):
(WebCore::ServiceWorkerThread::queueTaskToFireDeclarativePushEvent):
(WebCore::ServiceWorkerThread::queueTaskToFirePushSubscriptionChangeEvent):
(WebCore::ServiceWorkerThread::queueTaskToFireNotificationEvent):
(WebCore::ServiceWorkerThread::queueTaskToFireBackgroundFetchEvent):
(WebCore::ServiceWorkerThread::queueTaskToFireBackgroundFetchClickEvent):
* Source/WebCore/workers/service/context/ServiceWorkerThread.h:
(isType):
(WebCore::ServiceWorkerThread::identifier const): Deleted.
(WebCore::ServiceWorkerThread::jobDataIdentifier const): Deleted.
(WebCore::ServiceWorkerThread::doesHandleFetch const): Deleted.
(WebCore::ServiceWorkerThread::stopFetchEventMonitoring): Deleted.
(WebCore::ServiceWorkerThread::stopFunctionalEventMonitoring): Deleted.
(WebCore::ServiceWorkerThread::stopNotificationPayloadFunctionalEventMonitoring): Deleted.
* Source/WebCore/workers/shared/SharedWorkerGlobalScope.cpp:
(WebCore::SharedWorkerGlobalScope::create):
(WebCore::SharedWorkerGlobalScope::thread):
* Source/WebCore/workers/shared/SharedWorkerGlobalScope.h:
* Source/WebCore/workers/shared/context/SharedWorkerThread.cpp:
(WebCore::SharedWorkerThread::create):
* Source/WebCore/workers/shared/context/SharedWorkerThread.h:
(isType):
(WebCore::SharedWorkerThread::create): Deleted.
(WebCore::SharedWorkerThread::identifier const): Deleted.
* Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.cpp:
(WebCore::SharedWorkerThreadProxy::SharedWorkerThreadProxy):

Canonical link: <a href="https://commits.webkit.org/300878@main">https://commits.webkit.org/300878@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c31cec43f5cb4b450f74c4be19968c7a0030d74

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124189 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43882 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34599 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131017 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/76281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0d8e3b39-245d-4ab6-bc3b-92273d4c7268) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/126066 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44623 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52482 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/94469 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/76281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cf323750-b9c7-4a35-8549-dfb4a02fb44c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127143 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35560 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/111086 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75060 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b31d95bc-5e36-4405-b89a-596b8cba16d2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34505 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29248 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74503 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105301 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29469 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133698 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51112 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38957 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/102949 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51498 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107304 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/102751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26135 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48105 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26354 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48010 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50973 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56748 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50420 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53772 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52096 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->