### PR TITLE
[WTF] Make CStringView handle only null termination related methods and add some helpers for spans to StringCommon

### DIFF
--- a/Source/WTF/wtf/text/ASCIILiteral.h
+++ b/Source/WTF/wtf/text/ASCIILiteral.h
@@ -77,6 +77,7 @@ public:
     constexpr size_t length() const { return !m_charactersWithNullTerminator.empty() ? m_charactersWithNullTerminator.size() - 1 : 0; }
     constexpr std::span<const char> span() const { return m_charactersWithNullTerminator.first(length()); }
     std::span<const Latin1Character> span8() const { return byteCast<Latin1Character>(m_charactersWithNullTerminator.first(length())); }
+    std::span<const char8_t> spanChar8() const { return byteCast<char8_t>(m_charactersWithNullTerminator.first(length())); }
     std::span<const char> spanIncludingNullTerminator() const { return m_charactersWithNullTerminator; }
     size_t isEmpty() const { return m_charactersWithNullTerminator.size() <= 1; }
 
@@ -165,6 +166,16 @@ constexpr std::span<const char> operator""_span(const char* characters, size_t n
 constexpr std::span<const Latin1Character> operator""_span8(const char* characters, size_t n)
 {
     auto span = byteCast<Latin1Character>(unsafeMakeSpan(characters, n));
+#if ASSERT_ENABLED
+    for (size_t i = 0, size = span.size(); i < size; ++i)
+        ASSERT_UNDER_CONSTEXPR_CONTEXT(isASCII(span[i]));
+#endif
+    return span;
+}
+
+constexpr std::span<const char8_t> operator""_spanChar8(const char* characters, size_t n)
+{
+    auto span = byteCast<char8_t>(unsafeMakeSpan(characters, n));
 #if ASSERT_ENABLED
     for (size_t i = 0, size = span.size(); i < size; ++i)
         ASSERT_UNDER_CONSTEXPR_CONTEXT(isASCII(span[i]));

--- a/Source/WTF/wtf/text/CString.cpp
+++ b/Source/WTF/wtf/text/CString.cpp
@@ -169,4 +169,30 @@ bool CStringHash::equal(const CString& a, const CString& b)
     return a == b;
 }
 
+enum class ASCIICase { Lower, Upper };
+
+template<ASCIICase type>
+CString convertASCIICase(std::span<const char8_t> input)
+{
+    if (input.empty())
+        return CString(""_s);
+
+    std::span<char> characters;
+    auto result = CString::newUninitialized(input.size(), characters);
+    size_t i = 0;
+    for (auto character : input)
+        characters[i++] = type == ASCIICase::Lower ? toASCIILower(character) : toASCIIUpper(character);
+    return result;
+}
+
+CString convertToASCIILowercase(std::span<const char8_t> string)
+{
+    return convertASCIICase<ASCIICase::Lower>(string);
+}
+
+CString convertToASCIIUppercase(std::span<const char8_t> string)
+{
+    return convertASCIICase<ASCIICase::Upper>(string);
+}
+
 } // namespace WTF

--- a/Source/WTF/wtf/text/CString.h
+++ b/Source/WTF/wtf/text/CString.h
@@ -95,6 +95,7 @@ public:
     size_t length() const;
 
     bool isNull() const { return !m_buffer; }
+    bool isEmpty() const { return isNull() || m_buffer->length() <= 1; }
     bool isSafeToSendToAnotherThread() const;
 
     CStringBuffer* buffer() const LIFETIME_BOUND { return m_buffer.get(); }
@@ -111,6 +112,9 @@ private:
 
 WTF_EXPORT_PRIVATE bool operator==(const CString&, const CString&);
 WTF_EXPORT_PRIVATE bool operator<(const CString&, const CString&);
+
+WTF_EXPORT_PRIVATE CString convertToASCIILowercase(std::span<const char8_t>);
+WTF_EXPORT_PRIVATE CString convertToASCIIUppercase(std::span<const char8_t>);
 
 struct CStringHash {
     static unsigned hash(const CString& string) { return string.hash(); }
@@ -170,3 +174,5 @@ inline const char* safePrintfType(const CString& cstring) { return cstring.data(
 } // namespace WTF
 
 using WTF::CString;
+using WTF::convertToASCIILowercase;
+using WTF::convertToASCIIUppercase;

--- a/Source/WTF/wtf/text/CStringView.cpp
+++ b/Source/WTF/wtf/text/CStringView.cpp
@@ -30,19 +30,12 @@
 #include <wtf/text/CStringView.h>
 
 #include <wtf/PrintStream.h>
-#include <wtf/text/MakeString.h>
-#include <wtf/text/WTFString.h>
 
 namespace WTF {
 
-String CStringView::toString() const
-{
-    return String::fromUTF8(span8());
-}
-
 void CStringView::dump(PrintStream& out) const
 {
-    out.print(span8());
+    out.print(span());
 }
 
 } // namespace WTF

--- a/Source/WTF/wtf/text/ParsingUtilities.h
+++ b/Source/WTF/wtf/text/ParsingUtilities.h
@@ -105,6 +105,24 @@ template<bool characterPredicate(char16_t), typename CharacterType> bool skipExa
     return false;
 }
 
+template<bool characterPredicate(char8_t), typename CharacterType> bool skipExactly(std::span<CharacterType>& buffer) requires(std::is_same_v<std::remove_const_t<CharacterType>, char8_t>)
+{
+    if (!buffer.empty() && characterPredicate(buffer[0])) {
+        skip(buffer, 1);
+        return true;
+    }
+    return false;
+}
+
+template<bool characterPredicate(char), typename CharacterType> bool skipExactly(std::span<CharacterType>& buffer) requires(std::is_same_v<std::remove_const_t<CharacterType>, char>)
+{
+    if (!buffer.empty() && characterPredicate(buffer[0])) {
+        skip(buffer, 1);
+        return true;
+    }
+    return false;
+}
+
 template<typename CharacterType, typename DelimiterType> void skipUntil(StringParsingBuffer<CharacterType>& buffer, DelimiterType delimiter)
 {
     while (buffer.hasCharactersRemaining() && *buffer != delimiter)
@@ -128,6 +146,22 @@ template<bool characterPredicate(Latin1Character), typename CharacterType> void 
 }
 
 template<bool characterPredicate(char16_t), typename CharacterType> void skipUntil(std::span<CharacterType>& data) requires(std::is_same_v<std::remove_const_t<CharacterType>, char16_t>)
+{
+    size_t index = 0;
+    while (index < data.size() && !characterPredicate(data[index]))
+        ++index;
+    skip(data, index);
+}
+
+template<bool characterPredicate(char8_t), typename CharacterType> void skipUntil(std::span<CharacterType>& data) requires(std::is_same_v<std::remove_const_t<CharacterType>, char8_t>)
+{
+    size_t index = 0;
+    while (index < data.size() && !characterPredicate(data[index]))
+        ++index;
+    skip(data, index);
+}
+
+template<bool characterPredicate(char), typename CharacterType> void skipUntil(std::span<CharacterType>& data) requires(std::is_same_v<std::remove_const_t<CharacterType>, char>)
 {
     size_t index = 0;
     while (index < data.size() && !characterPredicate(data[index]))
@@ -170,6 +204,22 @@ template<bool characterPredicate(Latin1Character), typename CharacterType> void 
 }
 
 template<bool characterPredicate(char16_t), typename CharacterType> void skipWhile(std::span<CharacterType>& data) requires(std::is_same_v<std::remove_const_t<CharacterType>, char16_t>)
+{
+    size_t index = 0;
+    while (index < data.size() && characterPredicate(data[index]))
+        ++index;
+    skip(data, index);
+}
+
+template<bool characterPredicate(char8_t), typename CharacterType> void skipWhile(std::span<CharacterType>& data) requires(std::is_same_v<std::remove_const_t<CharacterType>, char8_t>)
+{
+    size_t index = 0;
+    while (index < data.size() && characterPredicate(data[index]))
+        ++index;
+    skip(data, index);
+}
+
+template<bool characterPredicate(char), typename CharacterType> void skipWhile(std::span<CharacterType>& data) requires(std::is_same_v<std::remove_const_t<CharacterType>, char>)
 {
     size_t index = 0;
     while (index < data.size() && characterPredicate(data[index]))
@@ -240,7 +290,7 @@ template<typename CharacterType, std::size_t Extent> constexpr bool skipCharacte
     return true;
 }
 
-// Adapt a char16_t-predicate to an Latin1Character-predicate.
+// Adapt a char16_t-predicate to a Latin1Character-predicate.
 template<bool characterPredicate(char16_t)>
 static inline bool Latin1CharacterPredicateAdapter(Latin1Character c) { return characterPredicate(c); }
 

--- a/Source/WTF/wtf/text/StringToIntegerConversion.h
+++ b/Source/WTF/wtf/text/StringToIntegerConversion.h
@@ -41,6 +41,8 @@ enum class ParseIntegerWhitespacePolicy : bool { Disallow, Allow };
 
 template<typename IntegralType> std::optional<IntegralType> parseInteger(StringView, uint8_t base = 10, ParseIntegerWhitespacePolicy = ParseIntegerWhitespacePolicy::Allow);
 template<typename IntegralType> std::optional<IntegralType> parseIntegerAllowingTrailingJunk(StringView, uint8_t base = 10);
+template<typename IntegralType, typename CharacterType> std::optional<IntegralType> parseInteger(std::span<const CharacterType>, uint8_t base = 10, ParseIntegerWhitespacePolicy = ParseIntegerWhitespacePolicy::Allow);
+template<typename IntegralType, typename CharacterType> std::optional<IntegralType> parseIntegerAllowingTrailingJunk(std::span<const CharacterType>, uint8_t base = 10);
 
 enum class TrailingJunkPolicy : bool { Disallow, Allow };
 
@@ -91,18 +93,32 @@ template<typename IntegralType, typename CharacterType> std::optional<IntegralTy
     return value.value();
 }
 
-template<typename IntegralType> std::optional<IntegralType> parseInteger(StringView string, uint8_t base, ParseIntegerWhitespacePolicy whitespacePolicy)
+template<typename IntegralType, typename CharacterType>
+std::optional<IntegralType> parseInteger(std::span<const CharacterType> data, uint8_t base, ParseIntegerWhitespacePolicy whitespacePolicy)
 {
-    if (string.is8Bit())
-        return parseInteger<IntegralType>(string.span8(), base, TrailingJunkPolicy::Disallow, whitespacePolicy);
-    return parseInteger<IntegralType>(string.span16(), base, TrailingJunkPolicy::Disallow, whitespacePolicy);
+    return parseInteger<IntegralType>(data, base, TrailingJunkPolicy::Disallow, whitespacePolicy);
 }
 
-template<typename IntegralType> std::optional<IntegralType> parseIntegerAllowingTrailingJunk(StringView string, uint8_t base)
+template<typename IntegralType, typename CharacterType>
+std::optional<IntegralType> parseIntegerAllowingTrailingJunk(std::span<const CharacterType> data, uint8_t base)
+{
+    return parseInteger<IntegralType>(data, base, TrailingJunkPolicy::Allow);
+}
+
+template<typename IntegralType>
+std::optional<IntegralType> parseInteger(StringView string, uint8_t base, ParseIntegerWhitespacePolicy whitespacePolicy)
 {
     if (string.is8Bit())
-        return parseInteger<IntegralType>(string.span8(), base, TrailingJunkPolicy::Allow);
-    return parseInteger<IntegralType>(string.span16(), base, TrailingJunkPolicy::Allow);
+        return parseInteger<IntegralType>(string.span8(), base, whitespacePolicy);
+    return parseInteger<IntegralType>(string.span16(), base, whitespacePolicy);
+}
+
+template<typename IntegralType>
+std::optional<IntegralType> parseIntegerAllowingTrailingJunk(StringView string, uint8_t base)
+{
+    if (string.is8Bit())
+        return parseIntegerAllowingTrailingJunk<IntegralType>(string.span8(), base);
+    return parseIntegerAllowingTrailingJunk<IntegralType>(string.span16(), base);
 }
 
 }

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
@@ -1130,7 +1130,7 @@ GRefPtr<GstPad> GStreamerMediaEndpoint::requestPad(const GRefPtr<GstCaps>& allow
         }
         std::optional<int> payloadType;
         if (auto encodingName = gstStructureGetString(structure, "encoding-name"_s))
-            payloadType = payloadTypeForEncodingName(encodingName.toString());
+            payloadType = payloadTypeForEncodingName(encodingName.span());
 
         if (!payloadType) {
             if (availablePayloadType < 128)

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpReceiverBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpReceiverBackend.cpp
@@ -76,7 +76,7 @@ RTCRtpParameters GStreamerRtpReceiverBackend::getParameters()
         auto media = gstStructureGetString(structure, "media"_s);
         auto encodingName = gstStructureGetString(structure, "encoding-name"_s);
         if (!media.isEmpty() && !encodingName.isEmpty())
-            codec.mimeType = makeString(media.toString(), '/', encodingName.toString().convertToASCIILowercase());
+            codec.mimeType = makeString(media.span(), '/', String(encodingName.span()).convertToASCIILowercase());
 
         if (auto clockRate = gstStructureGet<uint64_t>(structure, "clock-rate"_s))
             codec.clockRate = *clockRate;
@@ -85,7 +85,7 @@ RTCRtpParameters GStreamerRtpReceiverBackend::getParameters()
             codec.channels = *channels;
 
         if (auto fmtpLine = gstStructureGetString(structure, "fmtp-line"_s))
-            codec.sdpFmtpLine = fmtpLine.toString();
+            codec.sdpFmtpLine = fmtpLine.span();
 
         parameters.codecs.append(WTFMove(codec));
 
@@ -94,7 +94,7 @@ RTCRtpParameters GStreamerRtpReceiverBackend::getParameters()
             if (!name.startsWith("extmap-"_s))
                 return true;
 
-            auto extensionId = parseInteger<unsigned short>(name.toStringWithoutCopying().substring(7));
+            auto extensionId = parseInteger<unsigned short>(name.substring(7));
             if (!extensionId)
                 return true;
 

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpTransceiverBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpTransceiverBackend.cpp
@@ -160,7 +160,7 @@ ExceptionOr<void> GStreamerRtpTransceiverBackend::setCodecPreferences(const Vect
     if (currentCaps && gst_caps_get_size(currentCaps.get()) > 0) {
         auto structure = gst_caps_get_structure(currentCaps.get(), 0);
         if (auto msIdValue = gstStructureGetString(structure, "a-msid"_s))
-            msid = msIdValue.toString();
+            msid = msIdValue.span();
 
         gstStructureForeach(structure, [&](auto id, const auto& value) -> bool {
             auto key = gstIdToString(id);

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
@@ -381,7 +381,7 @@ bool doCapsHaveType(const GstCaps* caps, ASCIILiteral type)
         GST_WARNING("Failed to get MediaType");
         return false;
     }
-    return mediaType.toString().startsWith(type);
+    return startsWith(mediaType.span(), type);
 }
 
 bool areEncryptedCaps(const GstCaps* caps)

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
@@ -1166,20 +1166,19 @@ void GStreamerRegistryScanner::fillVideoRtpCapabilities(Configuration configurat
             element = gst_element_factory_make("webkitvideoencoder", nullptr);
 
         if (element) {
-            Vector<ASCIILiteral> profiles = {
-                "42e01f"_s,
-                "640c1f"_s,
-                "42001f"_s,
-                "4d001f"_s,
-            };
+            static constexpr std::array<std::pair<ASCIILiteral, unsigned>, 4> profiles = { {
+                { "42e01f"_s, 0x42e01f },
+                { "640c1f"_s, 0x640c1f },
+                { "42001f"_s, 0x42001f },
+                { "4d001f"_s, 0x4d001f },
+            } };
 
-            for (auto& profileLevelId : profiles) {
+            for (auto& [profileLevelId, spsAsInteger] : profiles) {
                 if (WEBKIT_IS_VIDEO_ENCODER(element.get())) {
                     auto codec = makeString("avc1."_s, profileLevelId);
                     if (!videoEncoderSupportsCodec(WEBKIT_VIDEO_ENCODER(element.get()), codec))
                         continue;
                 } else {
-                    auto spsAsInteger = parseInteger<uint64_t>(profileLevelId, 16).value_or(0);
                     std::array<uint8_t, 3> sps;
                     sps[0] = spsAsInteger >> 16;
                     sps[1] = (spsAsInteger >> 8) & 0xff;

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -2271,7 +2271,7 @@ void MediaPlayerPrivateGStreamer::handleMessage(GstMessage* message)
         if (gst_structure_has_name(structure, "http-headers")) {
             GST_DEBUG_OBJECT(pipeline(), "Processing HTTP headers: %" GST_PTR_FORMAT, structure);
             if (auto uri = gstStructureGetString(structure, "uri"_s)) {
-                URL url { uri.toString() };
+                URL url { uri.span() };
 
                 if (url != m_url) {
                     GST_DEBUG_OBJECT(pipeline(), "Ignoring HTTP response headers for non-main URI.");
@@ -2296,7 +2296,7 @@ void MediaPlayerPrivateGStreamer::handleMessage(GstMessage* message)
                     // handle it here, until we remove the webkit+ protocol
                     // prefix from webkitwebsrc.
                     if (auto contentLengthValue = gstStructureGetString(responseHeaders.get(), contentLengthHeaderName)) {
-                        if (auto parsedContentLength = parseInteger<uint64_t>(contentLengthValue.toString()))
+                        if (auto parsedContentLength = parseInteger<uint64_t>(contentLengthValue.span()))
                             contentLength = *parsedContentLength;
                     }
                 } else
@@ -3084,9 +3084,8 @@ bool MediaPlayerPrivateGStreamer::loadNextLocation()
         // Found a candidate. new-location is not always an absolute url
         // though. We need to take the base of the current url and
         // append the value of new-location to it.
-        auto locationString = newLocation.toString();
-        URL baseURL = gst_uri_is_valid(locationString.utf8().data()) ? URL() : m_url;
-        URL newURL = URL(baseURL, WTFMove(locationString));
+        URL baseURL = gst_uri_is_valid(newLocation.utf8()) ? URL() : m_url;
+        URL newURL = URL(baseURL, newLocation.span());
 
         GUniqueOutPtr<gchar> playbinURLStr;
         g_object_get(m_pipeline.get(), "current-uri", &playbinURLStr.outPtr(), nullptr);

--- a/Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.cpp
@@ -270,7 +270,7 @@ static GstFlowReturn transformInPlace(GstBaseTransform* base, GstBuffer* buffer)
 
     bool isCbcs = false;
     if (auto cipherMode = WebCore::gstStructureGetString(protectionMeta->info, "cipher-mode"_s))
-        isCbcs = WTF::equalIgnoringASCIICase(cipherMode.toString(), "cbcs"_s);
+        isCbcs = WTF::equalIgnoringASCIICase(cipherMode.span(), "cbcs"_s);
 
     auto ivSizeFromMeta = WebCore::gstStructureGet<unsigned>(protectionMeta->info, "iv_size"_s);
     if (!ivSizeFromMeta) {

--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
@@ -428,7 +428,7 @@ std::tuple<GRefPtr<GstCaps>, StreamType, FloatSize> AppendPipeline::parseDemuxer
     auto& gstRegistryScanner = GStreamerRegistryScannerMSE::singleton();
     if (doCapsHaveType(demuxerSrcPadCaps, GST_TEXT_CAPS_TYPE_PREFIX) || originalMediaType == "application/x-subtitle-vtt"_s || originalMediaType == "closedcaption/x-cea-608") {
         streamType = StreamType::Text;
-    } else if (!gstRegistryScanner.isCodecSupported(GStreamerRegistryScanner::Configuration::Decoding, originalMediaType.toString())) {
+    } else if (!gstRegistryScanner.isCodecSupported(GStreamerRegistryScanner::Configuration::Decoding, originalMediaType.span())) {
         streamType = StreamType::Invalid;
     } else if (doCapsHaveType(demuxerSrcPadCaps, GST_VIDEO_CAPS_TYPE_PREFIX)) {
         presentationSize = getVideoResolutionFromCaps(demuxerSrcPadCaps).value_or(FloatSize());

--- a/Source/WebCore/platform/gstreamer/GStreamerElementHarness.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerElementHarness.cpp
@@ -659,7 +659,7 @@ String MermaidBuilder::describeCaps(const GRefPtr<GstCaps>& caps)
     for (unsigned i = 0; i < capsSize; i++) {
         auto* features = gst_caps_get_features(caps.get(), i);
         const auto* structure = gst_caps_get_structure(caps.get(), i);
-        builder.append(gstStructureGetName(structure).toString(), "<br/>"_s);
+        builder.append(gstStructureGetName(structure).span(), "<br/>"_s);
         if (features && (gst_caps_features_is_any(features) || !gst_caps_features_is_equal(features, GST_CAPS_FEATURES_MEMORY_SYSTEM_MEMORY))) {
             GUniquePtr<char> serializedFeature(gst_caps_features_to_string(features));
             builder.append('(', unsafeSpan(serializedFeature.get()), ')');

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioRTPPacketizer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioRTPPacketizer.cpp
@@ -43,9 +43,8 @@ RefPtr<GStreamerAudioRTPPacketizer> GStreamerAudioRTPPacketizer::create(RefPtr<U
 
     GST_DEBUG("Creating packetizer for codec: %" GST_PTR_FORMAT " and encoding parameters %" GST_PTR_FORMAT, codecParameters, encodingParameters.get());
     String encoding;
-    auto encodingName = gstStructureGetString(codecParameters, "encoding-name"_s);
-    if (encodingName)
-        encoding = encodingName.toString().convertToASCIILowercase();
+    if (auto encodingName = gstStructureGetString(codecParameters, "encoding-name"_s))
+        encoding = String(encodingName.span()).convertToASCIILowercase();
     else {
         GST_ERROR("encoding-name not found");
         return nullptr;
@@ -93,7 +92,7 @@ RefPtr<GStreamerAudioRTPPacketizer> GStreamerAudioRTPPacketizer::create(RefPtr<U
 
         if (gst_caps_is_any(inputCaps.get())) {
             if (auto encodingParameters = gstStructureGetString(structure.get(), "encoding-params"_s)) {
-                if (auto channels = parseIntegerAllowingTrailingJunk<int>(encodingParameters.toString()))
+                if (auto channels = parseIntegerAllowingTrailingJunk<int>(encodingParameters.span()))
                     inputCaps = adoptGRef(gst_caps_new_simple("audio/x-raw", "channels", G_TYPE_INT, *channels, nullptr));
             }
         }
@@ -121,7 +120,7 @@ RefPtr<GStreamerAudioRTPPacketizer> GStreamerAudioRTPPacketizer::create(RefPtr<U
     g_object_set(payloader.get(), "auto-header-extension", TRUE, "mtu", 1200, nullptr);
 
     if (auto minPTime = gstStructureGetString(structure.get(), "minptime"_s)) {
-        if (auto value = parseIntegerAllowingTrailingJunk<int64_t>(minPTime.toString())) {
+        if (auto value = parseIntegerAllowingTrailingJunk<int64_t>(minPTime.span())) {
             if (gstObjectHasProperty(payloader.get(), "min-ptime"_s))
                 g_object_set(payloader.get(), "min-ptime", *value * GST_MSECOND, nullptr);
             else

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.cpp
@@ -226,13 +226,13 @@ std::optional<GStreamerCaptureDevice> GStreamerCaptureDeviceManager::captureDevi
     auto nodeName = gstStructureGetString(properties.get(), "node.name"_s);
     String identifier;
     if (nodeName.isEmpty())
-        identifier = makeString(deviceName.span(), ", "_s, deviceClass, ", "_s, deviceClassString.toString());
+        identifier = makeString(deviceName.span(), ", "_s, deviceClass, ", "_s, deviceClassString.span());
     else
-        identifier = makeString(nodeName.toString(), ", "_s, deviceClass, ", "_s, deviceClassString.toString());
+        identifier = makeString(nodeName.span(), ", "_s, deviceClass, ", "_s, deviceClassString.span());
 
     bool isMock = false;
     if (auto persistentId = gstStructureGetString(properties.get(), "persistent-id"_s)) {
-        identifier = persistentId.toString();
+        identifier = persistentId.span();
         isMock = true;
     }
 

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerMockDeviceProvider.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerMockDeviceProvider.cpp
@@ -79,10 +79,10 @@ void webkitGstMockDeviceProviderSwitchDefaultDevice(const CaptureDevice& oldDevi
     for (GList* it = devices; it; it = it->next) {
         auto device = GST_DEVICE_CAST(it->data);
         GUniquePtr<GstStructure> properties(gst_device_get_properties(device));
-        auto persistentId = gstStructureGetString(properties.get(), "persistent-id"_s).toString();
-        if (persistentId == oldDevice.persistentId())
+        auto persistentId = gstStructureGetString(properties.get(), "persistent-id"_s);
+        if (equal(oldDevice.persistentId(), persistentId.span()))
             oldGstDevice = device;
-        else if (persistentId == newDevice.persistentId())
+        else if (equal(newDevice.persistentId(), persistentId.span()))
             newGstDevice = device;
         if (oldGstDevice && newGstDevice)
             break;

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerRTPPacketizer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerRTPPacketizer.cpp
@@ -177,7 +177,7 @@ String GStreamerRTPPacketizer::rtpStreamId() const
         return emptyString();
 
     if (auto rid = gstStructureGetString(m_encodingParameters.get(), "rid"_s))
-        return rid.toString();
+        return rid.span();
 
     return emptyString();
 }

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.cpp
@@ -373,10 +373,10 @@ void GStreamerVideoCapturer::reconfigure()
                 selector->maxWidth = *width;
                 selector->maxHeight = *height;
                 selector->maxFrameRate = *frameRate;
-                selector->mimeType = gstStructureGetName(structure).toString();
+                selector->mimeType = gstStructureGetName(structure).span();
                 if (gst_structure_has_name(structure, "video/x-raw")) {
                     if (gst_structure_has_field(structure, "format"))
-                        selector->format = gstStructureGetString(structure, "format"_s).toString();
+                        selector->format = gstStructureGetString(structure, "format"_s).span();
                     else
                         return TRUE;
                 }
@@ -387,10 +387,10 @@ void GStreamerVideoCapturer::reconfigure()
                 selector->maxWidth = *width;
                 selector->maxHeight = *height;
                 selector->maxFrameRate = *frameRate;
-                selector->mimeType = gstStructureGetName(structure).toString();
+                selector->mimeType = gstStructureGetName(structure).span();
                 if (gst_structure_has_name(structure, "video/x-raw")) {
                     if (gst_structure_has_field(structure, "format"))
-                        selector->format = gstStructureGetString(structure, "format"_s).toString();
+                        selector->format = gstStructureGetString(structure, "format"_s).span();
                     else
                         return TRUE;
                 }

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoRTPPacketizer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoRTPPacketizer.cpp
@@ -48,9 +48,8 @@ RefPtr<GStreamerVideoRTPPacketizer> GStreamerVideoRTPPacketizer::create(RefPtr<U
     GUniquePtr<GstStructure> codecParameters(gst_structure_copy(parameters));
     GST_DEBUG("Creating packetizer for codec: %" GST_PTR_FORMAT " and encoding parameters %" GST_PTR_FORMAT, codecParameters.get(), encodingParameters.get());
     String encoding;
-    auto encodingName = gstStructureGetString(codecParameters.get(), "encoding-name"_s);
-    if (encodingName)
-        encoding = encodingName.toString().convertToASCIILowercase();
+    if (auto encodingName = gstStructureGetString(codecParameters.get(), "encoding-name"_s))
+        encoding = String(encodingName.span()).convertToASCIILowercase();
     else {
         GST_ERROR("encoding-name not found");
         return nullptr;
@@ -78,7 +77,7 @@ RefPtr<GStreamerVideoRTPPacketizer> GStreamerVideoRTPPacketizer::create(RefPtr<U
         VPCodecConfigurationRecord record;
         record.codecName = "vp09"_s;
         if (auto vp9Profile = gstStructureGetString(codecParameters.get(), "profile-id"_s)) {
-            if (auto profile = parseInteger<uint8_t>(vp9Profile.toString()))
+            if (auto profile = parseInteger<uint8_t>(vp9Profile.span()))
                 record.profile = *profile;
         }
         codec = createVPCodecParametersString(record);
@@ -88,7 +87,7 @@ RefPtr<GStreamerVideoRTPPacketizer> GStreamerVideoRTPPacketizer::create(RefPtr<U
 
         auto profileLevelID = gstStructureGetString(codecParameters.get(), "profile-level-id"_s);
         if (!profileLevelID.isEmpty()) {
-            codec = makeString("avc1."_s, profileLevelID.toString());
+            codec = makeString("avc1."_s, profileLevelID.span());
             gst_structure_remove_field(codecParameters.get(), "profile-level-id");
         } else {
             auto profileValue = gstStructureGetString(codecParameters.get(), "profile"_s);

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingAudioSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingAudioSourceGStreamer.cpp
@@ -70,7 +70,7 @@ void RealtimeOutgoingAudioSourceGStreamer::setInitialParameters(GUniquePtr<GstSt
 {
     for (const auto& codec : gstStructureGetList<const GstStructure*>(parameters.get(), "codecs"_s)) {
         auto encodingName = gstStructureGetString(codec, "mime-type"_s);
-        if (encodingName.isEmpty() || encodingName.isNull())
+        if (encodingName.isEmpty())
             continue;
 
         if (encodingName != "audio/telephone-event"_s)

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.cpp
@@ -433,7 +433,7 @@ void RealtimeOutgoingMediaSourceGStreamer::setParameters(GUniquePtr<GstStructure
         if (!rid)
             continue;
 
-        auto packetizer = getPacketizerForRid(rid.toString());
+        auto packetizer = getPacketizerForRid(rid.span());
         if (!packetizer)
             continue;
 

--- a/Tools/TestWebKitAPI/Tests/WTF/CStringView.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/CStringView.cpp
@@ -63,29 +63,42 @@ TEST(WTF, CStringViewNullAndEmpty)
     EXPECT_TRUE(string);
 }
 
-TEST(WTF, CStringViewLength)
+TEST(WTF, CStringViewSize)
 {
     CStringView string;
-    EXPECT_EQ(string.length(), static_cast<size_t>(0));
-    EXPECT_EQ(string.span8().size(), static_cast<size_t>(0));
+    EXPECT_EQ(string.lengthInBytes(), 0UZ);
+    EXPECT_EQ(string.span().size(), 0UZ);
+    EXPECT_EQ(string.spanIncludingNullTerminator().size(), 0UZ);
 
     string = CStringView("test"_s);
-    EXPECT_EQ(string.length(), static_cast<size_t>(4));
-    EXPECT_EQ(string.span8().size(), static_cast<size_t>(4));
+    EXPECT_EQ(string.lengthInBytes(), 4UZ);
+    EXPECT_EQ(string.span().size(), 4UZ);
+    EXPECT_EQ(string.spanIncludingNullTerminator().size(), 5UZ);
+
+    string = CStringView::unsafeFromUTF8("water🍉melon");
+    EXPECT_EQ(string.lengthInBytes(), 14UZ);
+    EXPECT_EQ(string.span().size(), 14UZ);
+    EXPECT_EQ(string.spanIncludingNullTerminator().size(), 15UZ);
 }
 
 TEST(WTF, CStringViewFrom)
 {
     const char* stringPtr = "test";
     CStringView string = CStringView::unsafeFromUTF8(stringPtr);
-    EXPECT_EQ(string.length(), static_cast<size_t>(4));
+    EXPECT_EQ(string.lengthInBytes(), 4UZ);
     EXPECT_TRUE(string);
     EXPECT_EQ(string.utf8(), stringPtr);
 
     stringPtr = "";
     string = CStringView::unsafeFromUTF8(stringPtr);
-    EXPECT_EQ(string.length(), static_cast<size_t>(0));
+    EXPECT_EQ(string.lengthInBytes(), 0UZ);
     EXPECT_FALSE(string);
+    EXPECT_EQ(string.utf8(), stringPtr);
+
+    stringPtr = "water🍉melon";
+    string = CStringView::unsafeFromUTF8(stringPtr);
+    EXPECT_EQ(string.lengthInBytes(), 14UZ);
+    EXPECT_TRUE(string);
     EXPECT_EQ(string.utf8(), stringPtr);
 }
 
@@ -101,6 +114,14 @@ TEST(WTF, CStringViewEquality)
     EXPECT_EQ(string, sameString);
     EXPECT_TRUE(string != anotherString);
     EXPECT_EQ(emptyString, nullString);
+
+    char* bareEmptyString = strdup("");
+    char* bareEmptyString2 = strdup("");
+    emptyString = CStringView::unsafeFromUTF8(bareEmptyString);
+    auto emptyString2 = CStringView::unsafeFromUTF8(bareEmptyString2);
+    EXPECT_EQ(emptyString, emptyString2);
+    free(bareEmptyString);
+    free(bareEmptyString2);
 }
 
 } // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/WTF/StringBuilder.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StringBuilder.cpp
@@ -119,6 +119,12 @@ TEST(StringBuilderTest, Append)
         const char16_t resultArray[] = { U16_LEAD(frakturAChar), U16_TRAIL(frakturAChar), U16_LEAD(frakturAChar), U16_TRAIL(frakturAChar) };
         EXPECT_EQ(String({ resultArray, std::size(resultArray) }), builderContent(builder));
     }
+
+    {
+        StringBuilder builder;
+        builder.append(unsafeSpanChar8("Water🍉Melon"));
+        EXPECT_EQ(builder.toString(), unsafeSpanChar8("Water🍉Melon"));
+    }
 }
 
 TEST(StringBuilderTest, AppendIntMin)

--- a/Tools/TestWebKitAPI/Tests/WTF/StringCommon.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StringCommon.cpp
@@ -107,6 +107,114 @@ TEST(WTF_StringCommon, FindIgnoringASCIICaseWithoutLengthIdentical)
     EXPECT_EQ(WTF::findIgnoringASCIICaseWithoutLength("needley", "needle"), 0UL);
 }
 
+TEST(WTF_StringCommon, Equal)
+{
+    EXPECT_TRUE(WTF::equal(unsafeSpanChar8("Water🍉Melon"), unsafeSpanChar8("Water🍉Melon")));
+    EXPECT_FALSE(WTF::equal(unsafeSpanChar8("Water🍉Melon"), unsafeSpanChar8("🍉WaterMelon🍉")));
+    // EXPECT_TRUE(WTF::equal("test"_spanChar8, "test"_span8)); // This should not compile.
+    String string(unsafeSpanChar8("Water🍉Melon"));
+    EXPECT_FALSE(string.is8Bit());
+    EXPECT_TRUE(WTF::equal(string, unsafeSpanChar8("Water🍉Melon")));
+    EXPECT_FALSE(WTF::equal(string, unsafeSpanChar8("🍉WaterMelon🍉")));
+}
+
+TEST(WTF_StringCommon, EqualIgnoringASCIICase)
+{
+    EXPECT_TRUE(WTF::equalIgnoringASCIICase("Test"_spanChar8, "test"_spanChar8));
+    EXPECT_FALSE(WTF::equalIgnoringASCIICase("another test"_spanChar8, "test"_spanChar8));
+    // EXPECT_TRUE(WTF::equalIgnoringASCIICase("test"_spanChar8, "test"_span8)); // This should not compile.
+}
+
+TEST(WTF_StringCommon, StartsWith)
+{
+    EXPECT_TRUE(WTF::startsWith(unsafeSpanChar8("Water🍉Melon"), "Water"_s));
+    EXPECT_FALSE(WTF::startsWith(unsafeSpanChar8("Water🍉Melon"), "water"_s));
+    EXPECT_FALSE(WTF::startsWith(unsafeSpanChar8("🍉WaterMelon🍉"), "Water"_s));
+    EXPECT_TRUE(WTF::startsWith(unsafeSpanChar8("🍉WaterMelon🍉"), unsafeSpanChar8("🍉")));
+    EXPECT_FALSE(WTF::startsWith(unsafeSpanChar8("Water🍉Melon"), unsafeSpanChar8("🍉")));
+    // EXPECT_TRUE(WTF::startsWith("test"_spanChar8, "test"_span8)); // This should not compile.
+}
+
+TEST(WTF_StringCommon, EndsWith)
+{
+    EXPECT_TRUE(WTF::endsWith(unsafeSpanChar8("Water🍉Melon"), "Melon"_s));
+    EXPECT_FALSE(WTF::endsWith(unsafeSpanChar8("Water🍉Melon"), "melon"_s));
+    EXPECT_FALSE(WTF::endsWith(unsafeSpanChar8("🍉WaterMelon🍉"), "Melon"_s));
+    EXPECT_TRUE(WTF::endsWith(unsafeSpanChar8("🍉WaterMelon🍉"), unsafeSpanChar8("🍉")));
+    EXPECT_FALSE(WTF::endsWith(unsafeSpanChar8("Water🍉Melon"), unsafeSpanChar8("🍉")));
+    // EXPECT_TRUE(WTF::endsWith("test"_spanChar8, "test"_span8)); // This should not compile.
+}
+
+TEST(WTF_StringCommon, Find)
+{
+    EXPECT_EQ(WTF::find(unsafeSpanChar8("Water🍉Melon"), "ter"_s), 2UZ);
+    EXPECT_EQ(WTF::find(unsafeSpanChar8("🍉WaterMelon🍉"), "ter"_s), 6UZ);
+    EXPECT_EQ(WTF::find(unsafeSpanChar8("Water🍉Melon"), unsafeSpanChar8("🍉")), 5UZ);
+    EXPECT_EQ(WTF::find(unsafeSpanChar8("🍉WaterMelon🍉"), unsafeSpanChar8("🍉")), 0UZ);
+    // EXPECT_NEQ(WTF::find("test"_spanChar8, "test"_span8), notFound); // This should not compile.
+}
+
+TEST(WTF_StringCommon, ReverseFind)
+{
+    EXPECT_EQ(WTF::reverseFind(unsafeSpanChar8("Water🍉Melon"), "ter"_s), 2UZ);
+    EXPECT_EQ(WTF::reverseFind(unsafeSpanChar8("🍉WaterMelon🍉"), "ter"_s), 6UZ);
+    EXPECT_EQ(WTF::reverseFind(unsafeSpanChar8("Water🍉Melon"), unsafeSpanChar8("🍉")), 5UZ);
+    EXPECT_EQ(WTF::reverseFind(unsafeSpanChar8("🍉WaterMelon🍉"), unsafeSpanChar8("🍉")), 14UZ);
+    // EXPECT_NEQ(WTF::reverseFind("test"_spanChar8, "test"_span8), notFound); // This should not compile.
+}
+
+TEST(WTF_StringCommon, Contains)
+{
+    EXPECT_TRUE(WTF::contains(unsafeSpanChar8("Water🍉Melon"), "Water"_s));
+    EXPECT_TRUE(WTF::contains(unsafeSpanChar8("🍉WaterMelon🍉"), "Water"_s));
+    EXPECT_TRUE(WTF::contains(unsafeSpanChar8("Water🍉Melon"), unsafeSpanChar8("🍉")));
+    EXPECT_TRUE(WTF::contains(unsafeSpanChar8("🍉WaterMelon🍉"), unsafeSpanChar8("🍉")));
+    EXPECT_FALSE(WTF::contains(unsafeSpanChar8("Water🍉Melon"), "pear"_s));
+    EXPECT_FALSE(WTF::contains(unsafeSpanChar8("🍉WaterMelon🍉"), "pear"_s));
+    EXPECT_FALSE(WTF::contains(unsafeSpanChar8("Water🍉Melon"), unsafeSpanChar8("🍈")));
+    EXPECT_FALSE(WTF::contains(unsafeSpanChar8("🍉WaterMelon🍉"), unsafeSpanChar8("🍈")));
+    // EXPECT_TRUE(WTF::contains("test"_spanChar8, "test"_span8)); // This should not compile.
+}
+
+TEST(WTF_StringCommon, StartsWithLettersIgnoringASCIICase)
+{
+    EXPECT_TRUE(WTF::startsWithLettersIgnoringASCIICase(unsafeSpanChar8("Water🍉Melon"), "water"_s));
+    EXPECT_FALSE(WTF::startsWithLettersIgnoringASCIICase(unsafeSpanChar8("🍉WaterMelon🍉"), "water"_s));
+    // EXPECT_TRUE(WTF::startsWithLettersIgnoringASCIICase("test"_spanChar8, "test"_span8)); // This should not compile.
+}
+
+TEST(WTF_StringCommon, EndsWithLettersIgnoringASCIICase)
+{
+    EXPECT_TRUE(WTF::endsWithLettersIgnoringASCIICase(unsafeSpanChar8("Water🍉Melon"), "melon"_s));
+    EXPECT_FALSE(WTF::endsWithLettersIgnoringASCIICase(unsafeSpanChar8("🍉WaterMelon🍉"), "melon"_s));
+    // EXPECT_TRUE(WTF::endsWithLettersIgnoringASCIICase("test"_spanChar8, "test"_span8)); // This should not compile.
+}
+
+TEST(WTF_StringCommon, FindIgnoringASCIICase)
+{
+    EXPECT_EQ(WTF::findIgnoringASCIICase(unsafeSpanChar8("Water🍉Melon"), "water"_s), 0UZ);
+    EXPECT_EQ(WTF::findIgnoringASCIICase(unsafeSpanChar8("🍉WaterMelon🍉"), "water"_s), 4UZ);
+    EXPECT_EQ(WTF::findIgnoringASCIICase(unsafeSpanChar8("Water🍉Melon"), unsafeSpanChar8("🍉")), 5UZ);
+    EXPECT_EQ(WTF::findIgnoringASCIICase(unsafeSpanChar8("🍉WaterMelon🍉"), unsafeSpanChar8("🍉")), 0UZ);
+    // EXPECT_NEQ(WTF::findIgnoringASCIICase("test"_spanChar8, "test"_span8), notFound); // This should not compile.
+}
+
+TEST(WTF_StringCommon, ContainsIgnoringASCIICase)
+{
+    EXPECT_TRUE(WTF::containsIgnoringASCIICase(unsafeSpanChar8("Water🍉Melon"), "melon"_s));
+    EXPECT_TRUE(WTF::containsIgnoringASCIICase(unsafeSpanChar8("🍉WaterMelon🍉"), "melon"_s));
+    EXPECT_TRUE(WTF::containsIgnoringASCIICase(unsafeSpanChar8("Water🍉Melon"), unsafeSpanChar8("🍉")));
+    EXPECT_TRUE(WTF::containsIgnoringASCIICase(unsafeSpanChar8("🍉WaterMelon🍉"), unsafeSpanChar8("🍉")));
+    // EXPECT_TRUE(WTF::containsIgnoringASCIICase("test"_spanChar8, "test"_span8)); // This should not compile.
+}
+
+TEST(WTF_StringCommon, CharactersAreAllASCII)
+{
+    EXPECT_TRUE(WTF::charactersAreAllASCII("Test"_spanChar8));
+    EXPECT_TRUE(WTF::charactersAreAllASCII(std::span<const char8_t>()));
+    EXPECT_FALSE(WTF::charactersAreAllASCII(unsafeSpanChar8("🍉")));
+}
+
 TEST(WTF_StringCommon, CopyElements64To8)
 {
     Vector<uint8_t> destination;


### PR DESCRIPTION
#### 92993a7cca0e741db9ef10138b0d0e20cc2e1048
<pre>
[WTF] Make CStringView handle only null termination related methods and add some helpers for spans to StringCommon
<a href="https://bugs.webkit.org/show_bug.cgi?id=299946">https://bugs.webkit.org/show_bug.cgi?id=299946</a>

Reviewed by Darin Adler.

Improved several comparisons, like starts, ends, contains, find, both case and aware and not. Also some more useful
conversions and parsing. For this, some more tweaks and templating was needed as many string management methods consider
Latin1Character only and CStringView handles char8_t.

Fly-by: fix return value of isEmpty to be bool instead of size_t and renamed length into lengthInBytes.

GStreamer code using CStringView already was adapted to this.

Tests: Tools/TestWebKitAPI/Tests/WTF/CString.cpp
       Tools/TestWebKitAPI/Tests/WTF/CStringView.cpp
       Tools/TestWebKitAPI/Tests/WTF/StringBuilder.cpp
       Tools/TestWebKitAPI/Tests/WTF/StringCommon.cpp
* Source/WTF/wtf/StdLibExtras.h:
(WTF::find):
(WTF::contains):
(WTF::ByteCastTraits&lt;T&gt;::cast):
(WTF::ByteCastTraits&lt;T::cast):
(WTF::byteCast):
* Source/WTF/wtf/text/ASCIILiteral.h:
(WTF::StringLiterals::operator_spanChar8):
* Source/WTF/wtf/text/CString.cpp:
(WTF::convertASCIICase):
(WTF::convertToASCIILowercase):
(WTF::convertToASCIIUppercase):
* Source/WTF/wtf/text/CString.h:
* Source/WTF/wtf/text/CStringView.cpp:
(WTF::CStringView::dump const):
(WTF::CStringView::toString const): Deleted.
* Source/WTF/wtf/text/CStringView.h:
(WTF::operator==):
* Source/WTF/wtf/text/ParsingUtilities.h:
(WTF::requires):
* Source/WTF/wtf/text/StringCommon.h:
(WTF::unsafeSpanChar8):
(WTF::equal):
(WTF::requires):
(WTF::equalIgnoringASCIICase):
(WTF::findIgnoringASCIICase):
(WTF::containsIgnoringASCIICase):
(WTF::find):
(WTF::contains):
(WTF::reverseFind):
(WTF::equalLettersIgnoringASCIICaseWithLength):
(WTF::startsWith):
(WTF::endsWith):
(WTF::endsWithLettersIgnoringASCIICaseCommon):
(WTF::endsWithLettersIgnoringASCIICase):
(WTF::startsWithLettersIgnoringASCIICaseCommon):
(WTF::startsWithLettersIgnoringASCIICase):
* Source/WTF/wtf/text/StringToIntegerConversion.h:
(WTF::parseInteger):
(WTF::parseIntegerAllowingTrailingJunk):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp:
(WebCore::GStreamerMediaEndpoint::requestPad):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpReceiverBackend.cpp:
(WebCore::GStreamerRtpReceiverBackend::getParameters):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpTransceiverBackend.cpp:
(WebCore::GStreamerRtpTransceiverBackend::setCodecPreferences):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerStatsCollector.cpp:
(WebCore::RTCStatsReport::Stats::Stats):
(WebCore::RTCStatsReport::RtpStreamStats::RtpStreamStats):
(WebCore::RTCStatsReport::CodecStats::CodecStats):
(WebCore::RTCStatsReport::RemoteInboundRtpStreamStats::RemoteInboundRtpStreamStats):
(WebCore::RTCStatsReport::RemoteOutboundRtpStreamStats::RemoteOutboundRtpStreamStats):
(WebCore::RTCStatsReport::InboundRtpStreamStats::InboundRtpStreamStats):
(WebCore::RTCStatsReport::OutboundRtpStreamStats::OutboundRtpStreamStats):
(WebCore::RTCStatsReport::TransportStats::TransportStats):
(WebCore::RTCStatsReport::IceCandidateStats::IceCandidateStats):
(WebCore::RTCStatsReport::IceCandidatePairStats::IceCandidatePairStats):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp:
(WebCore::toRTCEncodingParameters):
(WebCore::toRTCCodecParameters):
(WebCore::toRTCRtpSendParameters):
(WebCore::capsFromRtpCapabilities):
(WebCore::capsFromSDPMedia):
(WebCore::extractMidAndRidFromRTPBuffer):
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp:
(WebCore::doCapsHaveType):
* Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp:
(WebCore::GStreamerRegistryScanner::fillVideoRtpCapabilities):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::handleMessage):
(WebCore::MediaPlayerPrivateGStreamer::loadNextLocation):
* Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.cpp:
(transformInPlace):
* Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp:
(WebCore::AppendPipeline::parseDemuxerSrcPadCaps):
* Source/WebCore/platform/gstreamer/GStreamerElementHarness.cpp:
(WebCore::MermaidBuilder::describeCaps):
* Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.cpp:
(annexBStreamFormatCapsFieldValue):
(videoEncoderSetEncoder):
(webkit_video_encoder_class_init):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioRTPPacketizer.cpp:
(WebCore::GStreamerAudioRTPPacketizer::create):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.cpp:
(WebCore::GStreamerCaptureDeviceManager::captureDeviceFromGstDevice):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.cpp:
(WebCore::GStreamerIncomingTrackProcessor::configure):
(WebCore::GStreamerIncomingTrackProcessor::incomingTrackProcessor):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerMockDeviceProvider.cpp:
(webkitGstMockDeviceProviderSwitchDefaultDevice):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerRTPPacketizer.cpp:
(WebCore::GStreamerRTPPacketizer::rtpStreamId const):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.cpp:
(WebCore::GStreamerVideoCapturer::reconfigure):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoRTPPacketizer.cpp:
(WebCore::GStreamerVideoRTPPacketizer::create):
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingAudioSourceGStreamer.cpp:
(WebCore::RealtimeOutgoingAudioSourceGStreamer::setInitialParameters):
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.cpp:
(WebCore::RealtimeOutgoingMediaSourceGStreamer::setParameters):
* Tools/TestWebKitAPI/Tests/WTF/CString.cpp:
(TEST(WTF, CStringNullStringConstructor)):
(TEST(WTF, CStringEmptyEmptyConstructor)):
(TEST(WTF, CStringViewASCIICaseConversions)):
* Tools/TestWebKitAPI/Tests/WTF/CStringView.cpp:
(TestWebKitAPI::TEST(WTF, CStringViewSize)):
(TestWebKitAPI::TEST(WTF, CStringViewFrom)):
(TestWebKitAPI::TEST(WTF, CStringViewEquality)):
(TestWebKitAPI::TEST(WTF, CStringViewLength)): Deleted.
* Tools/TestWebKitAPI/Tests/WTF/StringBuilder.cpp:
(TestWebKitAPI::TEST(StringBuilderTest, Append)):
* Tools/TestWebKitAPI/Tests/WTF/StringCommon.cpp:
(TestWebKitAPI::TEST(WTF_StringCommon, Equal)):
(TestWebKitAPI::TEST(WTF_StringCommon, EqualIgnoringASCIICase)):
(TestWebKitAPI::TEST(WTF_StringCommon, StartsWith)):
(TestWebKitAPI::TEST(WTF_StringCommon, EndsWith)):
(TestWebKitAPI::TEST(WTF_StringCommon, Find)):
(TestWebKitAPI::TEST(WTF_StringCommon, ReverseFind)):
(TestWebKitAPI::TEST(WTF_StringCommon, Contains)):
(TestWebKitAPI::TEST(WTF_StringCommon, StartsWithLettersIgnoringASCIICase)):
(TestWebKitAPI::TEST(WTF_StringCommon, EndsWithLettersIgnoringASCIICase)):
(TestWebKitAPI::TEST(WTF_StringCommon, FindIgnoringASCIICase)):
(TestWebKitAPI::TEST(WTF_StringCommon, ContainsIgnoringASCIICase)):
(TestWebKitAPI::TEST(WTF_StringCommon, CharactersAreAllASCII)):

Canonical link: <a href="https://commits.webkit.org/303011@main">https://commits.webkit.org/303011@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/db41f5762e2b22fea835d90973546c0ddedcea9a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/130836 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/3159 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/41795 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/138264 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/82492 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/132707 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/3140 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/3002 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/99692 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/67508 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/133782 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/2257 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/117153 "Found 1 new API test failure: TestWebKitAPI.SiteIsolation.NavigationAfterWindowOpen (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/80386 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/2179 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/35282 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/81518 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/122852 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/110772 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/35785 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/140741 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/129289 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/2903 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/2615 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/108207 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/2949 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/113485 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/108126 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27527 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/2220 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/31911 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/55933 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/2971 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/66363 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/162306 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/2792 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/40486 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/2992 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/2900 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->