### PR TITLE
[Liquid Glass] [iOS] Make it possible to KVO the `isHidden` property on `webView.scrollView.topEdgeEffect`

### DIFF
--- a/Source/WebKit/UIProcess/ios/WKUIScrollEdgeEffect.h
+++ b/Source/WebKit/UIProcess/ios/WKUIScrollEdgeEffect.h
@@ -37,6 +37,7 @@
 
 - (instancetype)initWithScrollView:(WKScrollView *)scrollView scrollEdgeEffect:(UIScrollEdgeEffect *)effect boxSide:(WebCore::BoxSide)side;
 
+@property (nonatomic, getter=isHidden) BOOL hidden;
 @property (nonatomic, getter=isInternallyHidden) BOOL internallyHidden;
 @property (nonatomic) BOOL usesHardStyle;
 

--- a/Source/WebKit/UIProcess/ios/WKUIScrollEdgeEffect.mm
+++ b/Source/WebKit/UIProcess/ios/WKUIScrollEdgeEffect.mm
@@ -86,6 +86,11 @@ enum class HiddenScrollEdgeEffectSource : uint8_t {
     return _hiddenSources.contains(WebKit::HiddenScrollEdgeEffectSource::Internal);
 }
 
+- (BOOL)isHidden
+{
+    return _effect.hidden;
+}
+
 - (void)setHidden:(BOOL)hidden
 {
     [self _setHidden:hidden fromSource:WebKit::HiddenScrollEdgeEffectSource::Client];
@@ -103,7 +108,12 @@ enum class HiddenScrollEdgeEffectSource : uint8_t {
     if (oldVisible == newVisible)
         return;
 
+    RetainPtr isHiddenKeyName = NSStringFromSelector(@selector(isHidden));
+    [self willChangeValueForKey:isHiddenKeyName.get()];
+
     _effect.hidden = !newVisible;
+
+    [self didChangeValueForKey:isHiddenKeyName.get()];
 }
 
 - (void)setStyle:(UIScrollEdgeEffectStyle *)style


### PR DESCRIPTION
#### c536d0bbed8a18568c19a4ee4354c3ebd5a86799
<pre>
[Liquid Glass] [iOS] Make it possible to KVO the `isHidden` property on `webView.scrollView.topEdgeEffect`
<a href="https://bugs.webkit.org/show_bug.cgi?id=299954">https://bugs.webkit.org/show_bug.cgi?id=299954</a>
<a href="https://rdar.apple.com/161734906">rdar://161734906</a>

Reviewed by Aditya Keerthi.

Make it possible to add KVO on `WKScrollView`&apos;s scroll edge effects, to observe the `isHidden`
property. This allows clients (namely, Safari) to observe when top or bottom soft scroll pockets are
being suppressed due to the presence of a fixed or sticky element near the edges of the viewport.

Test: Tools/TestWebKitAPI/Tests/ios/WKScrollViewTests.mm

* Source/WebKit/UIProcess/ios/WKUIScrollEdgeEffect.h:
* Source/WebKit/UIProcess/ios/WKUIScrollEdgeEffect.mm:
(-[WKUIScrollEdgeEffect isHidden]):
(-[WKUIScrollEdgeEffect _setHidden:fromSource:]):

Add a `isHidden` property that wraps the real `UIScrollEdgeEffect`&apos;s `isHidden` property; whenever
this changes, call `(will|did)ChangeValueForKey:`.

* Tools/TestWebKitAPI/Tests/ios/WKScrollViewTests.mm:
(-[ScrollEdgeEffectIsHiddenObserver initWithScrollEdgeEffect:callback:]):
(-[ScrollEdgeEffectIsHiddenObserver dealloc]):
(-[ScrollEdgeEffectIsHiddenObserver observeValueForKeyPath:ofObject:change:context:]):

Add a helper object to observe changes to `-[UIScrollEdgeEffect isHidden]`.

(TestWebKitAPI::TEST(WKScrollViewTests, TopScrollEdgeEffectIsHiddenKVO)):

Canonical link: <a href="https://commits.webkit.org/300833@main">https://commits.webkit.org/300833@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e350176e67bb2ed57afa28c362998b1ecb7a1207

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123997 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43712 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34409 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130822 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76150 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/079fcdbc-a1a9-4c8f-acd9-f332cbf19d20) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/125874 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44436 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52306 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/94324 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8945f375-0322-4f9b-8b9c-de7f1ab62d8d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126951 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35410 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110923 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74921 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7ade90f3-3fc8-493a-96d1-136b35d8f066) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34360 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29088 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74302 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105141 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29307 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133495 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50950 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38810 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102789 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51324 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107143 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102607 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26103 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47961 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26211 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/47824 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50803 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56567 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50277 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53623 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51951 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->