### PR TITLE
Conditional writes are incorrectly handled in Array allocation sinking

### DIFF
--- a/JSTests/stress/array-allocation-sink-conditional-write-osr.js
+++ b/JSTests/stress/array-allocation-sink-conditional-write-osr.js
@@ -1,0 +1,86 @@
+function test(write, escape) {
+    let arr = new Array(4);
+
+    arr[1] = 1.1;
+
+    if (escape) {
+        return arr;
+    }
+
+    if (write) {
+        arr[0] = 2;
+    }
+
+}
+noInline(test);
+
+function test2(write, escape) {
+    let arr = new Array(4);
+
+    arr[1] = 1;
+
+    if (escape) {
+        return arr;
+    }
+
+    if (write) {
+        arr[0] = 2;
+    }
+}
+noInline(test2);
+
+function test3(write, escape) {
+    let arr = new Array(4);
+
+    arr[1] = {};
+
+    if (escape) {
+        return arr;
+    }
+
+    if (write) {
+        arr[0] = 2;
+    }
+}
+noInline(test3);
+
+function test4(overwrite, escape) {
+    let arr = new Array(4);
+    if (escape) {
+        return arr;
+    }
+    arr[0] = 1.1;
+    if (overwrite) {
+        arr[0] = 3.14;
+    }
+}
+noInline(test4);
+
+// JIT warmup loop
+for(let i = 0; i < testLoopCount; i++) {
+    test(true, false);
+    test(false, false);
+    test2(true, false);
+    test2(false, false);
+    test3(true, false);
+    test3(false, false);
+    test4(true, false);
+    test4(false, false);
+}
+
+function check(functor) {
+    let noWrite = functor(true, true);
+    if (0 in noWrite)
+        throw new Error(noWrite);
+}
+
+check(test);
+check(test2);
+check(test3);
+
+if (0 in test4(true, true))
+    throw new Error();
+
+if (0 in test4(false, true))
+    throw new Error();
+

--- a/JSTests/stress/array-sink-materialize-conditional-write-argument-value.js
+++ b/JSTests/stress/array-sink-materialize-conditional-write-argument-value.js
@@ -1,0 +1,112 @@
+function test1(write, escape, value) {
+    let arr = new Array(4);
+
+    arr[1] = 1;
+
+    if (write) {
+        arr[0] = value + 3;
+    }
+
+    if (escape) {
+        return arr;
+    }
+}
+noInline(test1);
+
+function test2(write, escape, value) {
+    let arr = new Array(4);
+
+    arr[1] = 1.1;
+
+    if (write) {
+        arr[0] = value + 3;
+    }
+
+    if (escape) {
+        return arr;
+    }
+}
+noInline(test2);
+
+function test3(write, escape, value) {
+    let arr = new Array(4);
+
+    arr[1] = {};
+
+    if (write) {
+        arr[0] = value + 3;
+    }
+
+    if (escape) {
+        return arr;
+    }
+}
+noInline(test3);
+
+function test4(write, escape, value) {
+    let arr = new Array(4);
+
+    arr[1] = {};
+
+    if (write) {
+        arr[0] = {
+            value: value + 3,
+            valueOf() { return this.value; },
+        };
+    }
+
+    if (escape) {
+        return arr;
+    }
+}
+noInline(test4);
+
+function test5(write, escape, value) {
+    let arr = new Array(4);
+
+    arr[1] = {};
+
+    if (write) {
+        arr[0] = {
+            value: value + 3,
+            valueOf() { return this.value; },
+            // Add a reference cycle.
+            arr,
+        };
+    }
+
+    if (escape) {
+        return arr;
+    }
+}
+noInline(test5);
+
+// JIT warmup loop
+for(let i = 0; i < testLoopCount; i++) {
+    test1(true, false, 3);
+    test1(false, true, 3);
+    test2(true, false, 3);
+    test2(false, true, 3);
+    test3(true, false, 3);
+    test3(false, true, 3);
+    test4(true, false, 3);
+    test4(false, true, 3);
+    test5(true, false, 3);
+    test5(false, true, 3);
+}
+
+function check(functor, value) {
+    let write = functor(true, true, value);
+    if (write[0] != value + 3)
+        throw new Error(write);
+
+    let noWrite = functor(false, true, value);
+    if (0 in noWrite)
+        throw new Error(write);
+}
+
+check(test1, 3);
+check(test2, 3);
+check(test3, 3);
+check(test4, 3);
+check(test5, 3);

--- a/JSTests/stress/array-sink-materialize-conditional-write.js
+++ b/JSTests/stress/array-sink-materialize-conditional-write.js
@@ -1,0 +1,89 @@
+function test(write, escape) {
+    let arr = new Array(4);
+
+    arr[1] = 1.1;
+
+    if (write) {
+        arr[0] = 2;
+    }
+
+    if (escape) {
+        return arr;
+    }
+}
+noInline(test);
+
+function test2(write, escape) {
+    let arr = new Array(4);
+
+    arr[1] = 1;
+
+    if (write) {
+        arr[0] = 2;
+    }
+
+    if (escape) {
+        return arr;
+    }
+}
+noInline(test2);
+
+function test3(write, escape) {
+    let arr = new Array(4);
+
+    arr[1] = {};
+
+    if (write) {
+        arr[0] = 2;
+    }
+
+    if (escape) {
+        return arr;
+    }
+}
+noInline(test3);
+
+function test4(overwrite, escape) {
+    let arr = new Array(4);
+    arr[0] = 1.1;
+    if (overwrite) {
+        arr[0] = 3.14;
+    }
+    if (escape) {
+        return arr;
+    }
+}
+noInline(test4);
+
+// JIT warmup loop
+for(let i = 0; i < testLoopCount; i++) {
+    test(true, false);
+    test(false, true);
+    test2(true, false);
+    test2(false, true);
+    test3(true, false);
+    test3(false, true);
+    test4(true, false);
+    test4(false, true);
+}
+
+function check(functor) {
+    let write = functor(true, true);
+    if (write[0] !== 2)
+        throw new Error(write);
+
+    let noWrite = functor(false, true);
+    if (0 in noWrite)
+        throw new Error(noWrite);
+}
+
+check(test);
+check(test2);
+check(test3);
+
+if (test4(true, true)[0] !== 3.14)
+    throw new Error();
+
+if (test4(false, true)[0] !== 1.1)
+    throw new Error();
+

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -3723,7 +3723,8 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
     case MaterializeNewArrayWithButterfly: {
         SpeculatedType validTypes = [&]() {
             switch (node->indexingType()) {
-            case ALL_INT32_INDEXING_TYPES: return SpecInt32Only;
+            // We can get JSValue() (aka SpecEmpty) when the property hasn't been initialized yet and is still a hole.
+            case ALL_INT32_INDEXING_TYPES: return SpecInt32Only | SpecEmpty;
             case ALL_DOUBLE_INDEXING_TYPES: return SpecBytecodeNumber;
             case ALL_CONTIGUOUS_INDEXING_TYPES: return SpecBytecodeTop;
             default: break;
@@ -3731,7 +3732,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
             RELEASE_ASSERT_NOT_REACHED();
         }();
         for (unsigned i = 2; i < node->numChildren(); ++i)
-            RELEASE_ASSERT(isSubtypeSpeculation(forNode(m_graph.varArgChild(node, i)).m_type, validTypes));
+            DFG_ASSERT(m_graph, node, isSubtypeSpeculation(forNode(m_graph.varArgChild(node, i)).m_type, validTypes));
 
         [[fallthrough]];
     }

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -1964,34 +1964,41 @@ private:
     void compileUpsilon()
     {
         LValue upsilonValue = nullptr;
+        Node* phi = m_node->phi();
         switch (m_node->child1().useKind()) {
         case DoubleRepUse:
             upsilonValue = lowDouble(m_node->child1());
+            ASSERT(phi->result() == NodeResultDouble);
             break;
         case Int32Use:
         case KnownInt32Use:
             upsilonValue = lowInt32(m_node->child1());
+            ASSERT(phi->result() == NodeResultInt32);
             break;
         case Int52RepUse:
             upsilonValue = lowInt52(m_node->child1());
+            ASSERT(phi->result() == NodeResultInt52);
             break;
         case BooleanUse:
         case KnownBooleanUse:
             upsilonValue = lowBoolean(m_node->child1());
+            ASSERT(phi->result() == NodeResultBoolean);
             break;
         case CellUse:
         case KnownCellUse:
             upsilonValue = lowCell(m_node->child1());
+            ASSERT(phi->result() == NodeResultJS);
             break;
         case UntypedUse:
             upsilonValue = lowJSValue(m_node->child1());
+            ASSERT(phi->result() == NodeResultJS);
             break;
         default:
             DFG_CRASH(m_graph, m_node, "Bad use kind");
             break;
         }
         ValueFromBlock upsilon = m_out.anchor(upsilonValue);
-        LValue phiNode = m_phis.get(m_node->phi());
+        LValue phiNode = m_phis.get(phi);
         m_out.addIncomingToPhi(phiNode, upsilon);
     }
 


### PR DESCRIPTION
#### 934b1e28a87a1a9dbd5011751c819d56f6229734
<pre>
Conditional writes are incorrectly handled in Array allocation sinking
<a href="https://bugs.webkit.org/show_bug.cgi?id=299956">https://bugs.webkit.org/show_bug.cgi?id=299956</a>
<a href="https://rdar.apple.com/161681941">rdar://161681941</a>

Reviewed by Yusuke Suzuki and Yijia Huang.

The current bottom value in ObjectAllocationSinking is incorrect for arrays.
Unlike with objects, which track conditional stores by passing the active
structure through SSA, arrays can&apos;t do this. Instead we should set default value
to the appropriate hole value for the given IndexingShape. To make this work
I had to fix some Phi/Upsilon ResultFormat bugs since they previously assumed
everything would be a JSValue.

Also, add ASSERT to FTL lowering that the Phi/Upsilon formats match. I spent 1/2 a day
trying to understand why I was getting zero, when the issue was those values disagreed
and I was getting the default zero value.

Tests: JSTests/stress/array-allocation-sink-conditional-write-osr.js
       JSTests/stress/array-sink-materialize-conditional-write-argument-value.js
       JSTests/stress/array-sink-materialize-conditional-write.js

Canonical link: <a href="https://commits.webkit.org/300888@main">https://commits.webkit.org/300888@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ceb383a9b4da2ab9950990cc194ec5a061a88f57

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124057 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43767 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34469 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130885 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76199 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4bcfcc67-3753-438f-9521-06700b831716) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44496 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52363 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94373 "23 flakes 26 failures") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62615 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/33818b4d-c78c-421b-886c-49351cb0b0fd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127011 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35456 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110976 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74969 "Found 1 new API test failure: TestWTF:WTF_Condition.OneProducerOneConsumerOneSlotTimeout (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ebea0d94-6c13-4119-96fd-57bf61a8474f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34404 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29142 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74368 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/116211 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105190 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29359 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133557 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/122589 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51004 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38856 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102840 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51380 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107195 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102654 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26144 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48002 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26254 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/47882 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50859 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56626 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/153683 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50328 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39061 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53674 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52002 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->