### PR TITLE
Trusted Types incorrectly handles null or undefined policy values

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/policy-without-return-value.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/policy-without-return-value.sub-expected.txt
@@ -1,5 +1,6 @@
 
-PASS createHTML with a policy that returns undefined
-PASS createScript with a policy that returns undefined
-FAIL createScriptURL with a policy that returns undefined assert_equals: expected "http://web-platform.test:8800/trusted-types/policy-without-return-value.sub.html" but got ""
+PASS createHTML with a policy that returns undefined DOMParser
+PASS createHTML with a policy that returns undefined iframe.srcdoc
+PASS createScript with a policy that returns undefined <div onload>
+PASS createScriptURL with a policy that returns undefined script.src
 

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/policy-without-return-value.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/policy-without-return-value.sub.html
@@ -22,17 +22,28 @@ test(t => {
   const doc = new DOMParser().parseFromString(
     policy.createHTML("bla"), "text/html");
   assert_equals(doc.body.textContent, "");
-}, "createHTML with a policy that returns undefined");
+}, "createHTML with a policy that returns undefined DOMParser");
+
+test(t => {
+  const policy = trustedTypes.createPolicy("emptyCreateHTML", {
+    "createHTML": _ => {},
+  });
+
+  const iframe = document.createElement("iframe");
+  iframe.srcdoc = policy.createHTML("bla");
+  assert_equals(iframe.srcdoc, "");
+  assert_true(iframe.hasAttribute('srcdoc'), "srcdoc attribute exists");
+}, "createHTML with a policy that returns undefined iframe.srcdoc");
 
 test(t => {
   const policy = trustedTypes.createPolicy("emptyCreateScript", {
     "createScript": _ => {},
   });
 
-  const script = document.createElement("script");
-  script.textContent = policy.createScript("bla");
-  assert_equals(script.textContent, "");
-}, "createScript with a policy that returns undefined");
+  const div = document.createElement("div");
+  div.setAttribute('onload', policy.createScript("bla"));
+  assert_true(div.hasAttribute("onload"), "onload attribute exists");
+}, "createScript with a policy that returns undefined <div onload>");
 
 test(t => {
   const policy = trustedTypes.createPolicy("emptyCreateScriptURL", {
@@ -42,6 +53,7 @@ test(t => {
   const script = document.createElement("script");
   script.src = policy.createScriptURL("bla");
   assert_equals(script.src, document.location.href);
-}, "createScriptURL with a policy that returns undefined");
+  assert_true(script.hasAttribute("src"), "src attribute exists");
+}, "createScriptURL with a policy that returns undefined script.src");
 </script>
 </body>

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/trusted-types/policy-without-return-value.sub-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/trusted-types/policy-without-return-value.sub-expected.txt
@@ -1,5 +1,0 @@
-
-PASS createHTML with a policy that returns undefined
-PASS createScript with a policy that returns undefined
-FAIL createScriptURL with a policy that returns undefined assert_equals: expected "http://web-platform.test:8800/trusted-types/policy-without-return-value.sub.html" but got ""
-

--- a/Source/WebCore/dom/TrustedTypePolicy.cpp
+++ b/Source/WebCore/dom/TrustedTypePolicy.cpp
@@ -59,7 +59,11 @@ ExceptionOr<Ref<TrustedHTML>> TrustedTypePolicy::createHTML(const String& input,
     if (policyValue.hasException())
         return policyValue.releaseException();
 
-    return TrustedHTML::create(policyValue.releaseReturnValue());
+    auto dataString = policyValue.releaseReturnValue();
+    if (dataString.isNull())
+        dataString = emptyString();
+
+    return TrustedHTML::create(dataString);
 }
 
 ExceptionOr<Ref<TrustedScript>> TrustedTypePolicy::createScript(const String& input, FixedVector<JSC::Strong<JSC::Unknown>>&& arguments)
@@ -69,7 +73,11 @@ ExceptionOr<Ref<TrustedScript>> TrustedTypePolicy::createScript(const String& in
     if (policyValue.hasException())
         return policyValue.releaseException();
 
-    return TrustedScript::create(policyValue.releaseReturnValue());
+    auto dataString = policyValue.releaseReturnValue();
+    if (dataString.isNull())
+        dataString = emptyString();
+
+    return TrustedScript::create(dataString);
 }
 
 ExceptionOr<Ref<TrustedScriptURL>> TrustedTypePolicy::createScriptURL(const String& input, FixedVector<JSC::Strong<JSC::Unknown>>&& arguments)
@@ -79,7 +87,11 @@ ExceptionOr<Ref<TrustedScriptURL>> TrustedTypePolicy::createScriptURL(const Stri
     if (policyValue.hasException())
         return policyValue.releaseException();
 
-    return TrustedScriptURL::create(policyValue.releaseReturnValue());
+    auto dataString = policyValue.releaseReturnValue();
+    if (dataString.isNull())
+        dataString = emptyString();
+
+    return TrustedScriptURL::create(dataString);
 }
 
 // https://w3c.github.io/trusted-types/dist/spec/#get-trusted-type-policy-value-algorithm


### PR DESCRIPTION
#### f1a37fa5d05b1511ee773111a901032c7d25fb3b
<pre>
Trusted Types incorrectly handles null or undefined policy values
<a href="https://bugs.webkit.org/show_bug.cgi?id=299958">https://bugs.webkit.org/show_bug.cgi?id=299958</a>

Reviewed by Ryosuke Niwa.

We previously only handled this case for processing default policies,
this means that some policy values are left as null strings when they should be
empty strings.

We fix this by converting to an empty string within the Trusted Type creation steps.

<a href="https://w3c.github.io/trusted-types/dist/spec/#create-a-trusted-type-algorithm">https://w3c.github.io/trusted-types/dist/spec/#create-a-trusted-type-algorithm</a> - step 4

* LayoutTests/imported/w3c/web-platform-tests/trusted-types/policy-without-return-value.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/policy-without-return-value.sub.html:
* Source/WebCore/dom/TrustedTypePolicy.cpp:
(WebCore::TrustedTypePolicy::createHTML):
(WebCore::TrustedTypePolicy::createScript):
(WebCore::TrustedTypePolicy::createScriptURL):
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/trusted-types/policy-without-return-value.sub-expected.txt: Removed.

Canonical link: <a href="https://commits.webkit.org/300892@main">https://commits.webkit.org/300892@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dccf6bd94652241a8cfe12265e1370539c66a381

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124205 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43898 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34615 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131035 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76297 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/126082 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44639 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52498 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94483 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/62684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127159 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35572 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111097 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75071 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34517 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29259 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74520 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105314 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29480 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133710 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51128 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38969 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102958 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51514 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107315 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102760 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26150 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48117 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26365 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48032 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50989 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56764 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50436 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53788 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52111 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->