### PR TITLE
[ Gardening ] REGRESSION(300539@main): [macOS] TestWebKitAPI.PreferredAudioBufferSize.AudioWithWebAudio is timing out

### DIFF
--- a/Tools/Scripts/webkitpy/api_tests/allowlist.txt
+++ b/Tools/Scripts/webkitpy/api_tests/allowlist.txt
@@ -386,7 +386,6 @@ TestWebKitAPI.Path
 TestWebKitAPI.PermissionsAPI
 TestWebKitAPI.PlatformCAAnimation
 TestWebKitAPI.PlatformDynamicRangeLimit
-TestWebKitAPI.PreferredAudioBufferSize
 TestWebKitAPI.PreferredContentMode
 TestWebKitAPI.ProcessInfo
 TestWebKitAPI.ProcessSuspension


### PR DESCRIPTION
#### 50dc1faf8d313535184cd4580ee949c5d8509ed7
<pre>
[ Gardening ] REGRESSION(300539@main): [macOS] TestWebKitAPI.PreferredAudioBufferSize.AudioWithWebAudio is timing out
<a href="https://bugs.webkit.org/show_bug.cgi?id=299834">https://bugs.webkit.org/show_bug.cgi?id=299834</a>
<a href="https://rdar.apple.com/161609209">rdar://161609209</a>

Unreviewed test gardening.

Removing this test suite from the allowlist because it is failing in parallel.

* Tools/Scripts/webkitpy/api_tests/allowlist.txt:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/50dc1faf8d313535184cd4580ee949c5d8509ed7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124023 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43738 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34435 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130850 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76176 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/29182aeb-d9db-4a27-aabb-519047c7372c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/125900 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44462 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52332 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94345 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; Running layout-tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62602 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f509fe81-9cd3-4318-a1b4-a301cfd7e010) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126977 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35431 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110946 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74938 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7ee34218-b7a5-4192-a576-a8cd4f7c12e0) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/123379 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34381 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29111 "Build is in progress. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; Running layout-tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74333 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105163 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29329 "Build is in progress. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-layout-tests-in-stress-mode; Running layout-tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133534 "Built successfully") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50976 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Running apply-patch; Checked out pull request; Running compile-webkit") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38831 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102820 "Passed tests") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51350 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Running apply-patch; Checked out pull request; Running compile-webkit") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107165 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102635 "Passed tests") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26232 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/47851 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50829 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50303 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53649 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51977 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->