### PR TITLE
[libpas] Implement primary support for MTE

### DIFF
--- a/Source/WTF/wtf/WTFConfig.cpp
+++ b/Source/WTF/wtf/WTFConfig.cpp
@@ -26,6 +26,9 @@
 #include "config.h"
 #include <wtf/WTFConfig.h>
 
+#include <cstdio>
+
+#include <wtf/FastMalloc.h>
 #include <wtf/Gigacage.h>
 #include <wtf/Lock.h>
 #include <wtf/MathExtras.h>
@@ -37,7 +40,14 @@
 #include <mach-o/getsect.h>
 #include <mach-o/ldsyms.h>
 #include <mach/vm_param.h>
+#include "unistd.h"
 #endif
+
+#if defined(__has_include)
+#if __has_include(<libproc.h>)
+#include <libproc.h>
+#endif // __has_include(<libproc.h>)
+#endif // defined(__has_include)
 
 #if PLATFORM(COCOA)
 #include <wtf/spi/cocoa/MachVMSPI.h>
@@ -48,6 +58,9 @@
 
 #if USE(APPLE_INTERNAL_SDK)
 #include <WebKitAdditions/WTFConfigAdditions.h>
+#endif
+#if !USE(SYSTEM_MALLOC)
+#include "bmalloc/pas_mte_config.h"
 #endif
 
 #include <mutex>
@@ -72,7 +85,7 @@ alignas(WTF::ConfigAlignment) WTF_CONFIG_SECTION Slot g_config[WTF::ConfigSizeTo
 } // namespace WebConfig
 
 #if !USE(SYSTEM_MALLOC)
-static_assert(Gigacage::startSlotOfGigacageConfig == WebConfig::reservedSlotsForExecutableAllocator + WebConfig::additionalReservedSlots);
+static_assert(Gigacage::startSlotOfGigacageConfig == WebConfig::NumberOfReservedConfigBytes);
 #endif
 
 namespace WTF {
@@ -154,8 +167,11 @@ void Config::initialize()
     g_wtfConfig.highestAccessibleAddress = static_cast<uintptr_t>((1ULL << OS_CONSTANT(EFFECTIVE_ADDRESS_WIDTH)) - 1);
     SignalHandlers::initialize();
 
-    uint8_t* reservedConfigBytes = reinterpret_cast_ptr<uint8_t*>(WebConfig::g_config + WebConfig::reservedSlotsForExecutableAllocator);
+    [[maybe_unused]] uint8_t* reservedConfigBytes = reinterpret_cast_ptr<uint8_t*>(WebConfig::g_config);
 
+#if USE(LIBPAS)
+    pas_mte_ensure_initialized();
+#endif // USE(LIBPAS)
     const char* useAllocationProfilingRaw = getenv("JSC_useAllocationProfiling");
     if (useAllocationProfilingRaw) {
         auto useAllocationProfiling = unsafeSpan(useAllocationProfilingRaw);
@@ -177,7 +193,6 @@ void Config::initialize()
             }
         }
     }
-
 }
 
 void Config::finalize()

--- a/Source/WTF/wtf/WTFConfig.h
+++ b/Source/WTF/wtf/WTFConfig.h
@@ -39,8 +39,8 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 #if USE(SYSTEM_MALLOC)
 namespace Gigacage {
-// The first 4 slots are reserved for the use of the ExecutableAllocator and additionalReservedSlots.
-constexpr size_t reservedSlotsForGigacageConfig = 4;
+// The first 6 slots are reserved for use by system allocators
+constexpr size_t reservedSlotsForGigacageConfig = 6;
 constexpr size_t reservedBytesForGigacageConfig = reservedSlotsForGigacageConfig * sizeof(uint64_t);
 }
 #else
@@ -53,15 +53,21 @@ using Slot = uint64_t;
 extern "C" WTF_EXPORT_PRIVATE Slot g_config[];
 
 constexpr size_t reservedSlotsForExecutableAllocator = 2;
-constexpr size_t additionalReservedSlots = 2;
+constexpr size_t reservedSlotsForMTEConfiguration = 2;
+constexpr size_t reservedSlotsForAllocationProfiling = 2;
 
 enum ReservedConfigByteOffset {
+    ReservedByteForExecutableAllocator0 = 0,
+    ReservedByteForExecutableAllocator1,
+    // The MTE offsets must be kept in sync with pas_mte_config.h
+    ReservedByteForMTEEnablement,
+    ReservedByteForMTEExtendedConfiguration,
     ReservedByteForAllocationProfiling,
     ReservedByteForAllocationProfilingMode,
     NumberOfReservedConfigBytes
 };
 
-static_assert(NumberOfReservedConfigBytes <= sizeof(Slot) * additionalReservedSlots);
+static_assert(NumberOfReservedConfigBytes <= sizeof(Slot) * (reservedSlotsForExecutableAllocator + reservedSlotsForMTEConfiguration + reservedSlotsForAllocationProfiling));
 
 } // namespace WebConfig
 

--- a/Source/bmalloc/CMakeLists.txt
+++ b/Source/bmalloc/CMakeLists.txt
@@ -151,6 +151,8 @@ set(bmalloc_C_SOURCES
     libpas/src/libpas/pas_medium_megapage_cache.c
     libpas/src/libpas/pas_megapage_cache.c
     libpas/src/libpas/pas_monotonic_time.c
+    libpas/src/libpas/pas_mte.c
+    libpas/src/libpas/pas_mte_config.c
     libpas/src/libpas/pas_page_base.c
     libpas/src/libpas/pas_page_base_config.c
     libpas/src/libpas/pas_page_header_table.c
@@ -551,6 +553,8 @@ set(bmalloc_PUBLIC_HEADERS
     libpas/src/libpas/pas_min_heap.h
     libpas/src/libpas/pas_mmap_capability.h
     libpas/src/libpas/pas_monotonic_time.h
+    libpas/src/libpas/pas_mte.h
+    libpas/src/libpas/pas_mte_config.h
     libpas/src/libpas/pas_mutation_count.h
     libpas/src/libpas/pas_object_kind.h
     libpas/src/libpas/pas_page_base_and_kind.h

--- a/Source/bmalloc/bmalloc.xcodeproj/project.pbxproj
+++ b/Source/bmalloc/bmalloc.xcodeproj/project.pbxproj
@@ -606,6 +606,10 @@
 		DD4BEDE229CBA49700398E35 /* minalign32_heap.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F18F84125C3467700721C2A /* minalign32_heap.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD4BEDE329CBA49700398E35 /* pas_compact_expendable_memory.c in Sources */ = {isa = PBXBuildFile; fileRef = 2C48133C27406A3E006CAB55 /* pas_compact_expendable_memory.c */; };
 		DD4BEDE429CBA49700398E35 /* pas_status_reporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FC40A1B2451498400876DA0 /* pas_status_reporter.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		0100000C37BABA0A0A999999 /* pas_mte.c in Sources */ = {isa = PBXBuildFile; fileRef = 0100000A37BABA0A0A999999 /* pas_mte.c */; };
+		0100000D37BABA0A0A999999 /* pas_mte.h in Headers */ = {isa = PBXBuildFile; fileRef = 0100000B37BABA0A0A999999 /* pas_mte.h */; settings = {ATTRIBUTES = (Private, ); };};
+		0100000C37BABA0A0A993999 /* pas_mte_config.c in Sources */ = {isa = PBXBuildFile; fileRef = 0100000A37BABA0A0A993999 /* pas_mte_config.c */; };
+		0100000D37BABA0A0A993999 /* pas_mte_config.h in Headers */ = {isa = PBXBuildFile; fileRef = 0100000B37BABA0A0A993999 /* pas_mte_config.h */; settings = {ATTRIBUTES = (Private, ); };};
 		0100000D37BABA0A0A991999 /* pas_zero_memory.h in Headers */ = {isa = PBXBuildFile; fileRef = 0100000B37BABA0A0A991999 /* pas_zero_memory.h */; settings = {ATTRIBUTES = (Private, ); };};
 		DD4BEDE529CBA49700398E35 /* pagesize64k_heap_config.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F18F83F25C3467700721C2A /* pagesize64k_heap_config.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD4BEDE629CBA49700398E35 /* iso_heap.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FC409292451494300876DA0 /* iso_heap.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1351,6 +1355,10 @@
 		2C48133B27406A3E006CAB55 /* pas_large_expendable_memory.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pas_large_expendable_memory.c; path = libpas/src/libpas/pas_large_expendable_memory.c; sourceTree = "<group>"; };
 		2C48133C27406A3E006CAB55 /* pas_compact_expendable_memory.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pas_compact_expendable_memory.c; path = libpas/src/libpas/pas_compact_expendable_memory.c; sourceTree = "<group>"; };
 		2C48133D27406A3E006CAB55 /* pas_compact_expendable_memory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pas_compact_expendable_memory.h; path = libpas/src/libpas/pas_compact_expendable_memory.h; sourceTree = "<group>"; };
+		0100000A37BABA0A0A999999 /* pas_mte.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pas_mte.c; path = libpas/src/libpas/pas_mte.c; sourceTree = "<group>"; };
+		0100000B37BABA0A0A999999 /* pas_mte.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pas_mte.h; path = libpas/src/libpas/pas_mte.h; sourceTree = "<group>"; };
+		0100000A37BABA0A0A993999 /* pas_mte_config.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pas_mte_config.c; path = libpas/src/libpas/pas_mte_config.c; sourceTree = "<group>"; };
+		0100000B37BABA0A0A993999 /* pas_mte_config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pas_mte_config.h; path = libpas/src/libpas/pas_mte_config.h; sourceTree = "<group>"; };
 		0100000B37BABA0A0A991999 /* pas_zero_memory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pas_zero_memory.h; path = libpas/src/libpas/pas_zero_memory.h; sourceTree = "<group>"; };
 		2C48133E27406A3E006CAB55 /* pas_expendable_memory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pas_expendable_memory.h; path = libpas/src/libpas/pas_expendable_memory.h; sourceTree = "<group>"; };
 		2C48133F27406A3E006CAB55 /* pas_large_expendable_memory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pas_large_expendable_memory.h; path = libpas/src/libpas/pas_large_expendable_memory.h; sourceTree = "<group>"; };
@@ -1870,6 +1878,10 @@
 				2C09D8BE2797C6EA005AA15C /* pas_mmap_capability.h */,
 				0FC40A8F2451498C00876DA0 /* pas_monotonic_time.c */,
 				0FC40A712451498A00876DA0 /* pas_monotonic_time.h */,
+				0100000A37BABA0A0A999999 /* pas_mte.c */,
+				0100000B37BABA0A0A999999 /* pas_mte.h */,
+				0100000A37BABA0A0A993999 /* pas_mte_config.c */,
+				0100000B37BABA0A0A993999 /* pas_mte_config.h */,
 				0FC40AD22451499100876DA0 /* pas_mutation_count.h */,
 				0F87004E25AF8A19000E1ABF /* pas_object_kind.h */,
 				0F87005225AF8A1A000E1ABF /* pas_page_base.c */,
@@ -2610,6 +2622,8 @@
 				DD4BECFF29CBA49700398E35 /* pas_min_heap.h in Headers */,
 				DD4BEC7329CBA49700398E35 /* pas_mmap_capability.h in Headers */,
 				DD4BED3A29CBA49700398E35 /* pas_monotonic_time.h in Headers */,
+				0100000D37BABA0A0A999999 /* pas_mte.h in Headers */,
+				0100000D37BABA0A0A993999 /* pas_mte_config.h in Headers */,
 				DD4BEC5F29CBA49700398E35 /* pas_mutation_count.h in Headers */,
 				DD4BED4729CBA49700398E35 /* pas_object_kind.h in Headers */,
 				DD4BEDFB29CBA49700398E35 /* pas_page_base.h in Headers */,
@@ -3030,6 +3044,8 @@
 				DD4BEC2729CBA49700398E35 /* pas_medium_megapage_cache.c in Sources */,
 				DD4BED2829CBA49700398E35 /* pas_megapage_cache.c in Sources */,
 				DD4BECBC29CBA49700398E35 /* pas_monotonic_time.c in Sources */,
+				0100000C37BABA0A0A999999 /* pas_mte.c in Sources */,
+				0100000C37BABA0A0A993999 /* pas_mte_config.c in Sources */,
 				DD4BEC4D29CBA49700398E35 /* pas_page_base.c in Sources */,
 				DD4BECDE29CBA49700398E35 /* pas_page_base_config.c in Sources */,
 				DD4BEDA029CBA49700398E35 /* pas_page_header_table.c in Sources */,

--- a/Source/bmalloc/bmalloc/BPlatform.h
+++ b/Source/bmalloc/bmalloc/BPlatform.h
@@ -33,6 +33,12 @@
 #include <TargetConditionals.h>
 #endif
 
+#if defined(__has_include)
+#if __has_include(<WebKitAdditions/pas_mte_additions.h>)
+#include <WebKitAdditions/pas_mte_additions.h>
+#endif // __has_include(<WebKitAdditions/pas_mte_additions.h>)
+#endif // defined(__has_include)
+
 #ifndef BASSERT_ENABLED
 #ifdef NDEBUG
 #define BASSERT_ENABLED 0
@@ -344,6 +350,17 @@
 #define BENABLE_MALLOC_HEAP_BREAKDOWN 0
 #endif
 
+#if BPLATFORM(COCOA)
+/* Should be aligned with the definition in WTF/wtf/PlatformUse.h */
+#if defined __has_include && __has_include(<CoreFoundation/CFPriv.h>)
+#define BUSE_APPLE_INTERNAL_SDK 1
+#else
+#define BUSE_APPLE_INTERNAL_SDK 0
+#endif
+#else // BPLATFORM(COCOA)
+#define BUSE_APPLE_INTERNAL_SDK 0
+#endif // !BPLATFORM(COCOA)
+
 /* This is used for debugging when hacking on how bmalloc calculates its physical footprint. */
 #define ENABLE_PHYSICAL_PAGE_MAP 0
 
@@ -367,6 +384,14 @@
 #define BUSE_LIBPAS 0
 #endif
 #endif
+
+#if BUSE_LIBPAS
+#ifndef BENABLE_MTE
+#define BENABLE_MTE (BUSE(APPLE_INTERNAL_SDK) && BPLATFORM(IOS_FAMILY) && BCPU(ARM64E))
+#endif // !defined(BENABLE_MTE)
+#else // !BUSE_LIBPAS
+#define BENABLE_MTE 0
+#endif // BUSE_LIBPAS
 
 #if !defined(BUSE_PRECOMPUTED_CONSTANTS_VMPAGE4K)
 #define BUSE_PRECOMPUTED_CONSTANTS_VMPAGE4K 1

--- a/Source/bmalloc/bmalloc/GigacageConfig.h
+++ b/Source/bmalloc/bmalloc/GigacageConfig.h
@@ -98,8 +98,8 @@ struct Config {
     size_t allocSizes[static_cast<size_t>(NumberOfKinds)];
 };
 
-// The first 4 slots are reserved for the use of the ExecutableAllocator.
-constexpr size_t startSlotOfGigacageConfig = 4;
+// The first 6 slots are reserved for use by system allocators
+constexpr size_t startSlotOfGigacageConfig = 6;
 constexpr size_t startOffsetOfGigacageConfig = startSlotOfGigacageConfig * sizeof(WebConfig::Slot);
 
 constexpr size_t reservedSlotsForGigacageConfig = 16;

--- a/Source/bmalloc/bmalloc/SystemHeap.cpp
+++ b/Source/bmalloc/bmalloc/SystemHeap.cpp
@@ -33,6 +33,7 @@
 #include <thread>
 
 #if BENABLE(LIBPAS)
+#include "pas_mte.h"
 #include "pas_system_heap.h"
 #endif
 
@@ -273,6 +274,7 @@ void* pas_system_heap_malloc(size_t size)
 {
     auto systemHeap = SystemHeap::getExisting();
     PAS_PROFILE(SYSTEM_HEAP_ALLOCATION, systemHeap, size, 0, pas_non_compact_allocation_mode);
+    PAS_MTE_HANDLE(SYSTEM_HEAP_ALLOCATION, systemHeap, size, 0, pas_non_compact_allocation_mode);
     return systemHeap->malloc(size, FailureAction::ReturnNull);
 }
 
@@ -280,6 +282,7 @@ void* pas_system_heap_memalign(size_t alignment, size_t size)
 {
     auto systemHeap = SystemHeap::getExisting();
     PAS_PROFILE(SYSTEM_HEAP_ALLOCATION, systemHeap, size, alignment, pas_non_compact_allocation_mode);
+    PAS_MTE_HANDLE(SYSTEM_HEAP_ALLOCATION, systemHeap, size, alignment, pas_non_compact_allocation_mode);
     return systemHeap->memalign(alignment, size, FailureAction::ReturnNull);
 }
 
@@ -287,6 +290,7 @@ void* pas_system_heap_realloc(void* ptr, size_t size)
 {
     auto systemHeap = SystemHeap::getExisting();
     PAS_PROFILE(SYSTEM_HEAP_REALLOCATION, systemHeap, ptr, size, pas_non_compact_allocation_mode);
+    PAS_MTE_HANDLE(SYSTEM_HEAP_REALLOCATION, systemHeap, ptr, size, pas_non_compact_allocation_mode);
     return systemHeap->realloc(ptr, size, FailureAction::ReturnNull);
 }
 
@@ -294,6 +298,7 @@ void* pas_system_heap_malloc_compact(size_t size)
 {
     auto systemHeap = SystemHeap::getExisting();
     PAS_PROFILE(SYSTEM_HEAP_ALLOCATION, systemHeap, size, 0, pas_always_compact_allocation_mode);
+    PAS_MTE_HANDLE(SYSTEM_HEAP_ALLOCATION, systemHeap, size, 0, pas_always_compact_allocation_mode);
     return systemHeap->malloc(size, FailureAction::ReturnNull);
 }
 
@@ -301,6 +306,7 @@ void* pas_system_heap_memalign_compact(size_t alignment, size_t size)
 {
     auto systemHeap = SystemHeap::getExisting();
     PAS_PROFILE(SYSTEM_HEAP_ALLOCATION, systemHeap, size, alignment, pas_always_compact_allocation_mode);
+    PAS_MTE_HANDLE(SYSTEM_HEAP_ALLOCATION, systemHeap, size, alignment, pas_always_compact_allocation_mode);
     return systemHeap->memalign(alignment, size, FailureAction::ReturnNull);
 }
 
@@ -308,6 +314,7 @@ void* pas_system_heap_realloc_compact(void* ptr, size_t size)
 {
     auto systemHeap = SystemHeap::getExisting();
     PAS_PROFILE(SYSTEM_HEAP_REALLOCATION, systemHeap, ptr, size, pas_always_compact_allocation_mode);
+    PAS_MTE_HANDLE(SYSTEM_HEAP_REALLOCATION, systemHeap, ptr, size, pas_always_compact_allocation_mode);
     return systemHeap->realloc(ptr, size, FailureAction::ReturnNull);
 }
 

--- a/Source/bmalloc/bmalloc/VMAllocate.h
+++ b/Source/bmalloc/bmalloc/VMAllocate.h
@@ -265,6 +265,10 @@ inline void vmRevokePermissions(void* p, size_t vmSize)
     mprotect(p, vmSize, PROT_NONE);
 }
 
+#if BENABLE(MTE) && BOS(DARWIN)
+bool tryVmZeroAndPurgeMTECase(void* p, size_t vmSize, VMTag usage);
+#endif // BENABLE(MTE) && BOS(DARWIN)
+
 inline void vmZeroAndPurge(void* p, size_t vmSize, VMTag usage)
 {
     vmValidate(p, vmSize);
@@ -278,6 +282,10 @@ inline void vmZeroAndPurge(void* p, size_t vmSize, VMTag usage)
     }
 #endif
     BPROFILE_ZERO_FILL_PAGE(p, vmSize, flags, tag);
+#if BENABLE(MTE) && BOS(DARWIN)
+    if (tryVmZeroAndPurgeMTECase(p, vmSize, usage))
+        return;
+#endif // BENABLE(MTE) && BOS(DARWIN)
     // MAP_ANON guarantees the memory is zeroed. This will also cause
     // page faults on accesses to this range following this call.
     void* result = mmap(p, vmSize, PROT_READ | PROT_WRITE, flags, tag, 0);

--- a/Source/bmalloc/libpas/libpas.xcodeproj/project.pbxproj
+++ b/Source/bmalloc/libpas/libpas.xcodeproj/project.pbxproj
@@ -360,6 +360,11 @@
 		0FC4EC3B234A91E300B710A3 /* pas_status_reporter.c in Sources */ = {isa = PBXBuildFile; fileRef = 0FC4EC32234A91E200B710A3 /* pas_status_reporter.c */; };
 		0FC4EC3C234A91E300B710A3 /* pas_string_stream.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FC4EC33234A91E200B710A3 /* pas_string_stream.h */; };
 		0FC4EC3D234A91E300B710A3 /* pas_status_reporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FC4EC34234A91E200B710A3 /* pas_status_reporter.h */; };
+		0F99999C26AAAA0000212121 /* pas_mte.c in Sources */ = {isa = PBXBuildFile; fileRef = 0F99999A26AAAA0000212121 /* pas_mte.c */; };
+		0F99999D26AAAA0000212121 /* pas_mte.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F99999B26AAAA0000212121 /* pas_mte.h */; };
+		0F99999C26AAAA0000213121 /* pas_mte_config.c in Sources */ = {isa = PBXBuildFile; fileRef = 0F99999A26AAAA0000213121 /* pas_mte_config.c */; };
+		0F99999D26AAAA0000213121 /* pas_mte_config.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F99999B26AAAA0000213121 /* pas_mte_config.h */; };
+		0F99999D26AAAA0000111111 /* pas_mte.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F99999B26AAAA0000111111 /* pas_zero_memory.h */; };
 		0FC4EC3E234A91E300B710A3 /* pas_compute_summary_object_callbacks.c in Sources */ = {isa = PBXBuildFile; fileRef = 0FC4EC35234A91E300B710A3 /* pas_compute_summary_object_callbacks.c */; };
 		0FC4EC3F234A91E300B710A3 /* pas_fd_stream.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FC4EC36234A91E300B710A3 /* pas_fd_stream.h */; };
 		0FC4EC792351707B00B710A3 /* pas_segregated_page_emptiness_kind.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FC4EC782351707B00B710A3 /* pas_segregated_page_emptiness_kind.h */; };
@@ -1072,6 +1077,10 @@
 		0FC4EC32234A91E200B710A3 /* pas_status_reporter.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pas_status_reporter.c; sourceTree = "<group>"; };
 		0FC4EC33234A91E200B710A3 /* pas_string_stream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pas_string_stream.h; sourceTree = "<group>"; };
 		0FC4EC34234A91E200B710A3 /* pas_status_reporter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pas_status_reporter.h; sourceTree = "<group>"; };
+		0F99999A26AAAA0000212121 /* pas_mte.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pas_mte.c; sourceTree = "<group>"; };
+		0F99999B26AAAA0000212121 /* pas_mte.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pas_mte.h; sourceTree = "<group>"; };
+		0F99999A26AAAA0000213121 /* pas_mte_config.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pas_mte_config.c; sourceTree = "<group>"; };
+		0F99999B26AAAA0000213121 /* pas_mte_config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pas_mte_config.h; sourceTree = "<group>"; };
 		0F99999B26AAAA0000111111 /* pas_zero_memory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pas_zero_memory.h; sourceTree = "<group>"; };
 		0FC4EC35234A91E300B710A3 /* pas_compute_summary_object_callbacks.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pas_compute_summary_object_callbacks.c; sourceTree = "<group>"; };
 		0FC4EC36234A91E300B710A3 /* pas_fd_stream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pas_fd_stream.h; sourceTree = "<group>"; };
@@ -1789,6 +1798,10 @@
 				2C47314F277A540F00B62C49 /* pas_mmap_capability.h */,
 				0FD48B1023A9ABB10026C46D /* pas_monotonic_time.c */,
 				0FD48AFD23A9ABB00026C46D /* pas_monotonic_time.h */,
+				0F99999A26AAAA0000212121 /* pas_mte.c */,
+				0F99999B26AAAA0000212121 /* pas_mte.h */,
+				0F99999A26AAAA0000213121 /* pas_mte_config.c */,
+				0F99999B26AAAA0000213121 /* pas_mte_config.h */,
 				0F09226922B07C21007D5D3A /* pas_mutation_count.h */,
 				0F9A1D4A255F2CD700C8D11B /* pas_object_kind.h */,
 				0F9A1CBA2559961400C8D11B /* pas_page_base.c */,
@@ -2302,6 +2315,8 @@
 				0FD22CFC22CAF16400B21841 /* pas_min_heap.h in Headers */,
 				2C473152277A540F00B62C49 /* pas_mmap_capability.h in Headers */,
 				0FD48B3823A9ABB30026C46D /* pas_monotonic_time.h in Headers */,
+				0F99999D26AAAA0000212121 /* pas_mte.h in Headers */,
+				0F99999D26AAAA0000213121 /* pas_mte_config.h in Headers */,
 				0F09226A22B07C21007D5D3A /* pas_mutation_count.h in Headers */,
 				0F9A1D4C255F2CD700C8D11B /* pas_object_kind.h in Headers */,
 				0F9A1D052559961700C8D11B /* pas_page_base.h in Headers */,
@@ -2829,6 +2844,8 @@
 				0F037AF325AEA91A0079B582 /* pas_medium_megapage_cache.c in Sources */,
 				0FE7EDC822960142004F4166 /* pas_megapage_cache.c in Sources */,
 				0FD48B4B23A9ABB30026C46D /* pas_monotonic_time.c in Sources */,
+				0F99999C26AAAA0000212121 /* pas_mte.c in Sources */,
+				0F99999C26AAAA0000213121 /* pas_mte_config.c in Sources */,
 				0F9A1D062559961700C8D11B /* pas_page_base.c in Sources */,
 				2C34000227581687005565CB /* pas_page_base_config.c in Sources */,
 				0F9A1CF22559961700C8D11B /* pas_page_header_table.c in Sources */,

--- a/Source/bmalloc/libpas/src/libpas/jit_heap_config.h
+++ b/Source/bmalloc/libpas/src/libpas/jit_heap_config.h
@@ -131,6 +131,7 @@ PAS_HEAP_CONFIG_SPECIALIZATION_DECLARATIONS(jit_heap_config);
         .base = { \
             .is_enabled = true, \
             .allow_profiling = false, \
+            .allow_mte_tagging = false, \
             .heap_config_ptr = &jit_heap_config, \
             .page_config_ptr = &jit_heap_config.variant_lowercase ## _bitfit_config.base, \
             .page_config_kind = pas_page_config_kind_bitfit, \
@@ -166,6 +167,7 @@ PAS_HEAP_CONFIG_SPECIALIZATION_DECLARATIONS(jit_heap_config);
             .base = { \
                 .is_enabled = true, \
                 .allow_profiling = false, \
+                .allow_mte_tagging = false, \
                 .heap_config_ptr = &jit_heap_config, \
                 .page_config_ptr = &jit_heap_config.small_segregated_config.base, \
                 .page_config_kind = pas_page_config_kind_segregated, \

--- a/Source/bmalloc/libpas/src/libpas/pas_allocation_result.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_allocation_result.h
@@ -28,6 +28,7 @@
 
 #include <errno.h>
 #include "pas_internal_config.h"
+#include "pas_mte.h"
 #include "pas_utils.h"
 #include "pas_zero_memory.h"
 #include "pas_zero_mode.h"
@@ -96,6 +97,7 @@ pas_allocation_result_zero(pas_allocation_result result,
 
     PAS_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     PAS_PROFILE(ZERO_ALLOCATION_RESULT, result.begin);
+    PAS_MTE_HANDLE(ZERO_ALLOCATION_RESULT, result.begin);
     PAS_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     void* memory = (void*)result.begin;

--- a/Source/bmalloc/libpas/src/libpas/pas_bitfit_page_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_bitfit_page_inlines.h
@@ -31,6 +31,7 @@
 #include "pas_bitfit_view.h"
 #include "pas_commit_span.h"
 #include "pas_heap_config.h"
+#include "pas_mte.h"
 #include "pas_page_base_inlines.h"
 #include "pas_page_sharing_pool.h"
 #include "pas_thread.h"
@@ -247,6 +248,7 @@ static PAS_ALWAYS_INLINE pas_bitfit_allocation_result pas_bitfit_page_finish_all
     pas_bitfit_page_testing_verify(page);
 
     PAS_PROFILE(BITFIT_ALLOCATION, &page_config, begin, size, allocation_mode);
+    PAS_MTE_HANDLE(BITFIT_ALLOCATION, &page_config, begin, size, allocation_mode);
 
     return pas_bitfit_allocation_result_create_success(begin);
 }
@@ -900,6 +902,7 @@ static PAS_ALWAYS_INLINE uintptr_t pas_bitfit_page_deallocate_with_page_impl(
     } }
 
     PAS_PROFILE(BITFIT_PAGE_DEALLOCATION, page_config, begin, original_object_size);
+    PAS_MTE_HANDLE(BITFIT_PAGE_DEALLOCATION, page_config, begin, original_object_size);
 
     return num_bits;
 }

--- a/Source/bmalloc/libpas/src/libpas/pas_config.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_config.h
@@ -30,6 +30,14 @@
 
 #include "stdbool.h"
 
+#if defined(PAS_BMALLOC) && PAS_BMALLOC
+#if defined(__has_include)
+#if __has_include(<WebKitAdditions/pas_mte_additions.h>)
+#include <WebKitAdditions/pas_mte_additions.h>
+#endif // __has_include(<WebKitAdditions/pas_mte_additions.h>) && !PAS_ENABLE_TESTING
+#endif // defined(__has_include)
+#endif // defined(PAS_BMALLOC) && PAS_BMALLOC
+
 #define PAS_LOG_NONE (0)
 #define PAS_LOG_HEAP_INFRASTRUCTURE (1 << 0)
 #define PAS_LOG_BOOTSTRAP_HEAPS (1 << 1)
@@ -64,6 +72,10 @@
 #define PAS_ARM32 __PAS_ARM32
 
 #define PAS_ARM __PAS_ARM
+
+#ifndef PAS_ENABLE_MTE
+#define PAS_ENABLE_MTE (PAS_USE_APPLE_INTERNAL_SDK && PAS_PLATFORM(IOS_FAMILY) && __PAS_ARM64E)
+#endif
 
 #define PAS_RISCV __PAS_RISCV
 

--- a/Source/bmalloc/libpas/src/libpas/pas_create_basic_heap_page_caches_with_reserved_memory.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_create_basic_heap_page_caches_with_reserved_memory.c
@@ -34,6 +34,7 @@
 #include "pas_immortal_heap.h"
 #include "pas_large_heap_physical_page_sharing_cache.h"
 #include "pas_megapage_cache.h"
+#include "pas_mte.h"
 #include "pas_reserved_memory_provider.h"
 #include "pas_segregated_shared_page_directory.h"
 
@@ -79,6 +80,7 @@ static pas_allocation_result allocate_from_megapages(
     heap_config = pas_heap_config_kind_get_config(heap->config_kind);
 
     PAS_PROFILE(MEGAPAGES_ALLOCATION, heap, size, alignment.alignment, heap_config, cache_size);
+    PAS_MTE_HANDLE(MEGAPAGES_ALLOCATION, heap, size, alignment.alignment, heap_config);
 
     return pas_large_heap_try_allocate_and_forget(
         &heap->megapage_large_heap, size, alignment.alignment, pas_non_compact_allocation_mode,

--- a/Source/bmalloc/libpas/src/libpas/pas_fast_megapage_table.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_fast_megapage_table.c
@@ -24,6 +24,7 @@
  */
 
 #include "pas_config.h"
+#include "pas_zero_memory.h"
 
 #if LIBPAS_ENABLED
 #include "pas_zero_memory.h"

--- a/Source/bmalloc/libpas/src/libpas/pas_fast_megapage_table.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_fast_megapage_table.h
@@ -133,6 +133,7 @@ static inline pas_fast_megapage_kind pas_fast_megapage_table_get(
     uintptr_t begin)
 {
     PAS_PROFILE(MEGAPAGE_GET, begin);
+    PAS_MTE_HANDLE(MEGAPAGE_GET, begin);
     return pas_fast_megapage_table_get_by_index(table, begin >> PAS_FAST_MEGAPAGE_SHIFT);
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_get_allocation_size.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_get_allocation_size.h
@@ -30,6 +30,7 @@
 #include "pas_heap_config.h"
 #include "pas_heap_lock.h"
 #include "pas_large_map.h"
+#include "pas_mte.h"
 #include "pas_segregated_page_inlines.h"
 #include "pas_segregated_size_directory.h"
 
@@ -124,6 +125,7 @@ static PAS_ALWAYS_INLINE size_t pas_get_allocation_size(void* ptr,
         
         if (!pas_large_map_entry_is_empty(entry)) {
             PAS_PROFILE(LARGE_MAP_FOUND_ENTRY, &config, entry.begin, entry.end);
+            PAS_MTE_HANDLE(LARGE_MAP_FOUND_ENTRY, &config, entry.begin, entry.end);
             PAS_ASSERT(entry.begin == begin);
             PAS_ASSERT(entry.end > begin);
             

--- a/Source/bmalloc/libpas/src/libpas/pas_get_heap.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_get_heap.h
@@ -31,6 +31,7 @@
 #include "pas_heap.h"
 #include "pas_heap_config.h"
 #include "pas_large_map.h"
+#include "pas_mte.h"
 #include "pas_segregated_page_inlines.h"
 #include "pas_segregated_size_directory.h"
 
@@ -110,6 +111,7 @@ static PAS_ALWAYS_INLINE pas_heap* pas_get_heap(void* ptr,
         
         PAS_ASSERT(!pas_large_map_entry_is_empty(entry));
         PAS_PROFILE(LARGE_MAP_FOUND_ENTRY, &config, entry.begin, entry.end);
+        PAS_MTE_HANDLE(LARGE_MAP_FOUND_ENTRY, &config, entry.begin, entry.end);
         PAS_ASSERT(entry.begin == begin);
         PAS_ASSERT(entry.end > begin);
         

--- a/Source/bmalloc/libpas/src/libpas/pas_heap_config_utils.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_heap_config_utils.h
@@ -104,6 +104,7 @@ typedef struct {
         .base = { \
             .is_enabled = true, \
             .allow_profiling = PAS_SHOULD_PROFILE_BASIC_HEAP_PAGE(pas_page_config_size_category_small), \
+            .allow_mte_tagging = PAS_SHOULD_MTE_TAG_BASIC_HEAP_PAGE(pas_page_config_size_category_small), \
             .heap_config_ptr = &name ## _heap_config, \
             .page_config_ptr = &name ## _heap_config.small_segregated_config.base, \
             .page_config_kind = pas_page_config_kind_segregated, \
@@ -174,6 +175,7 @@ typedef struct {
             .is_enabled = \
                 ((pas_basic_heap_config_arguments){__VA_ARGS__}).use_medium_segregated, \
             .allow_profiling = PAS_SHOULD_PROFILE_BASIC_HEAP_PAGE(pas_page_config_size_category_medium), \
+            .allow_mte_tagging = PAS_SHOULD_MTE_TAG_BASIC_HEAP_PAGE(pas_page_config_size_category_medium), \
             .heap_config_ptr = &name ## _heap_config, \
             .page_config_ptr = &name ## _heap_config.medium_segregated_config.base, \
             .page_config_kind = pas_page_config_kind_segregated, \
@@ -230,6 +232,7 @@ typedef struct {
             .is_enabled = \
                 ((pas_basic_heap_config_arguments){__VA_ARGS__}).use_small_bitfit, \
             .allow_profiling = PAS_SHOULD_PROFILE_BASIC_HEAP_PAGE(pas_page_config_size_category_small), \
+            .allow_mte_tagging = PAS_SHOULD_MTE_TAG_BASIC_HEAP_PAGE(pas_page_config_size_category_small), \
             .heap_config_ptr = &name ## _heap_config, \
             .page_config_ptr = &name ## _heap_config.small_bitfit_config.base, \
             .page_config_kind = pas_page_config_kind_bitfit, \
@@ -273,6 +276,7 @@ typedef struct {
             .is_enabled = \
                 ((pas_basic_heap_config_arguments){__VA_ARGS__}).use_medium_bitfit, \
             .allow_profiling = PAS_SHOULD_PROFILE_BASIC_HEAP_PAGE(pas_page_config_size_category_medium), \
+            .allow_mte_tagging = PAS_SHOULD_MTE_TAG_BASIC_HEAP_PAGE(pas_page_config_size_category_medium), \
             .heap_config_ptr = &name ## _heap_config, \
             .page_config_ptr = &name ## _heap_config.medium_bitfit_config.base, \
             .page_config_kind = pas_page_config_kind_bitfit, \
@@ -306,6 +310,7 @@ typedef struct {
             .is_enabled = \
                 ((pas_basic_heap_config_arguments){__VA_ARGS__}).use_marge_bitfit, \
             .allow_profiling = PAS_SHOULD_PROFILE_BASIC_HEAP_PAGE(pas_page_config_size_category_marge), \
+            .allow_mte_tagging = PAS_SHOULD_MTE_TAG_BASIC_HEAP_PAGE(pas_page_config_size_category_marge), \
             .heap_config_ptr = &name ## _heap_config, \
             .page_config_ptr = &name ## _heap_config.marge_bitfit_config.base, \
             .page_config_kind = pas_page_config_kind_bitfit, \

--- a/Source/bmalloc/libpas/src/libpas/pas_heap_config_utils_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_heap_config_utils_inlines.h
@@ -31,6 +31,7 @@
 #include "pas_heap_config_utils.h"
 #include "pas_large_heap_physical_page_sharing_cache.h"
 #include "pas_medium_megapage_cache.h"
+#include "pas_mte.h"
 #include "pas_segregated_page_config_utils_inlines.h"
 
 PAS_BEGIN_EXTERN_C;
@@ -164,11 +165,13 @@ typedef struct {
             megapage_cache = &page_caches->small_other_megapage_cache; \
             megapage_kind = pas_small_other_fast_megapage_kind; \
             PAS_PROFILE(SMALL_SHARED_SEGREGATED_PAGE_ALLOCATION, heap, megapage_cache); \
+            PAS_MTE_HANDLE(SMALL_SHARED_SEGREGATED_PAGE_ALLOCATION, heap, megapage_cache); \
             break; \
         case pas_segregated_page_exclusive_role: \
             megapage_cache = &page_caches->small_exclusive_segregated_megapage_cache; \
             megapage_kind = pas_small_exclusive_segregated_fast_megapage_kind; \
             PAS_PROFILE(SMALL_EXCLUSIVE_SEGREGATED_PAGE_ALLOCATION, heap, megapage_cache); \
+            PAS_MTE_HANDLE(SMALL_EXCLUSIVE_SEGREGATED_PAGE_ALLOCATION, heap, megapage_cache); \
             break; \
         } \
         \
@@ -202,6 +205,7 @@ typedef struct {
         megapage_cache = &page_caches->small_other_megapage_cache; \
         \
         PAS_PROFILE(SMALL_BITFIT_PAGE_ALLOCATION, heap, megapage_cache); \
+        PAS_MTE_HANDLE(SMALL_BITFIT_PAGE_ALLOCATION, heap, megapage_cache); \
         allocation = pas_fast_megapage_cache_try_allocate( \
             megapage_cache, \
             &name ## _megapage_table, \
@@ -235,6 +239,7 @@ typedef struct {
         megapage_cache = &page_caches->medium_megapage_cache; \
         \
         PAS_PROFILE(MEDIUM_SEGREGATED_PAGE_ALLOCATION, heap, megapage_cache); \
+        PAS_MTE_HANDLE(MEDIUM_SEGREGATED_PAGE_ALLOCATION, heap, megapage_cache); \
         allocation = pas_medium_megapage_cache_try_allocate( \
             megapage_cache, \
             page_config.base.page_config_ptr, \
@@ -263,6 +268,7 @@ typedef struct {
         megapage_cache = &page_caches->medium_megapage_cache; \
         \
         PAS_PROFILE(MEDIUM_BITFIT_PAGE_ALLOCATION, heap, megapage_cache); \
+        PAS_MTE_HANDLE(MEDIUM_BITFIT_PAGE_ALLOCATION, heap, megapage_cache); \
         allocation = pas_medium_megapage_cache_try_allocate( \
             megapage_cache, \
             page_config.base.page_config_ptr, \
@@ -291,6 +297,7 @@ typedef struct {
         megapage_cache = &page_caches->medium_megapage_cache; \
         \
         PAS_PROFILE(MARGE_BITFIT_PAGE_ALLOCATION, heap, megapage_cache); \
+        PAS_MTE_HANDLE(MARGE_BITFIT_PAGE_ALLOCATION, heap, megapage_cache); \
         allocation = pas_medium_megapage_cache_try_allocate( \
             megapage_cache, \
             page_config.base.page_config_ptr, \

--- a/Source/bmalloc/libpas/src/libpas/pas_heap_ref.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_heap_ref.c
@@ -43,6 +43,7 @@ pas_heap* pas_ensure_heap_slow(pas_heap_ref* heap_ref,
 
     PAS_ASSERT(heap_ref_kind != pas_fake_heap_ref_kind);
     PAS_PROFILE(ENSURE_HEAP_SLOW, heap, heap_ref, heap_ref_kind, config, runtime_config);
+    PAS_MTE_HANDLE(ENSURE_HEAP_SLOW, heap, heap_ref, heap_ref_kind, config, runtime_config);
 
     pas_heap_lock_lock();
     heap = heap_ref->heap;

--- a/Source/bmalloc/libpas/src/libpas/pas_immortal_heap.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_immortal_heap.c
@@ -32,6 +32,7 @@
 #include "pas_allocation_callbacks.h"
 #include "pas_compact_heap_reservation.h"
 #include "pas_heap_lock.h"
+#include "pas_mte.h"
 
 uintptr_t pas_immortal_heap_current;
 uintptr_t pas_immortal_heap_end;

--- a/Source/bmalloc/libpas/src/libpas/pas_large_free_heap_helpers.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_large_free_heap_helpers.c
@@ -35,6 +35,7 @@
 #include "pas_large_sharing_pool.h"
 #include "pas_page_malloc.h"
 #include "pas_page_sharing_pool.h"
+#include "pas_zero_memory.h"
 
 bool pas_large_utility_free_heap_talks_to_large_sharing_pool = true;
 

--- a/Source/bmalloc/libpas/src/libpas/pas_large_heap.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_large_heap.c
@@ -37,6 +37,7 @@
 #include "pas_large_free_heap_config.h"
 #include "pas_large_sharing_pool.h"
 #include "pas_large_map.h"
+#include "pas_mte.h"
 #include "pas_page_malloc.h"
 #include "pas_probabilistic_guard_malloc_allocator.h"
 #include <stdio.h>
@@ -209,6 +210,7 @@ bool pas_large_heap_try_deallocate(uintptr_t begin,
     }
 
     PAS_PROFILE(LARGE_MAP_TOOK_ENTRY, heap_config, map_entry.begin, map_entry.end);
+    PAS_MTE_HANDLE(LARGE_MAP_TOOK_ENTRY, heap_config, map_entry.begin, map_entry.end);
     PAS_ASSERT(pas_heap_config_kind_get_config(
                    pas_heap_for_large_heap(map_entry.heap)->config_kind)
                == heap_config);
@@ -252,6 +254,7 @@ bool pas_large_heap_try_shrink(uintptr_t begin,
         return false;
 
     PAS_PROFILE(LARGE_MAP_TOOK_ENTRY, heap_config, map_entry.begin, map_entry.end);
+    PAS_MTE_HANDLE(LARGE_MAP_TOOK_ENTRY, heap_config, map_entry.begin, map_entry.end);
     heap = map_entry.heap;
     type = pas_heap_for_large_heap(heap)->type;
 

--- a/Source/bmalloc/libpas/src/libpas/pas_large_map.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_large_map.c
@@ -31,6 +31,7 @@
 
 #include "pas_large_heap.h"
 #include "pas_large_utility_free_heap.h"
+#include "pas_mte.h"
 
 pas_large_map_hashtable pas_large_map_hashtable_instance = PAS_HASHTABLE_INITIALIZER;
 pas_large_map_hashtable_in_flux_stash pas_large_map_hashtable_instance_in_flux_stash;
@@ -43,6 +44,7 @@ pas_tiny_large_map_second_level_hashtable_in_flux_stash pas_tiny_large_map_secon
 pas_large_map_entry pas_large_map_find(uintptr_t begin)
 {
     PAS_PROFILE(LARGE_MAP_FIND, begin);
+    PAS_MTE_HANDLE(LARGE_MAP_FIND, begin);
 
     uintptr_t tiny_base;
     pas_first_level_tiny_large_map_entry* first_level_tiny_entry;
@@ -79,6 +81,7 @@ void pas_large_map_add(pas_large_map_entry entry)
     pas_heap_lock_assert_held();
 
     PAS_PROFILE(LARGE_MAP_ADD, entry.begin, entry.end);
+    PAS_MTE_HANDLE(LARGE_MAP_ADD, entry.begin, entry.end);
 
     if (verbose)
         pas_log("large map adding %p...%p, heap = %p.\n", (void*)entry.begin, (void*)entry.end, entry.heap);
@@ -157,6 +160,7 @@ pas_large_map_entry pas_large_map_take(uintptr_t begin)
     pas_small_large_map_entry small_entry;
 
     PAS_PROFILE(LARGE_MAP_TAKE, begin);
+    PAS_MTE_HANDLE(LARGE_MAP_TAKE, begin);
 
     pas_heap_lock_assert_held();
 

--- a/Source/bmalloc/libpas/src/libpas/pas_large_sharing_pool.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_large_sharing_pool.c
@@ -36,6 +36,7 @@
 #include "pas_heap_lock.h"
 #include "pas_large_free_heap_deferred_commit_log.h"
 #include "pas_log.h"
+#include "pas_mte.h"
 #include "pas_page_malloc.h"
 #include "pas_page_sharing_pool.h"
 #include "pas_physical_memory_transaction.h"
@@ -1031,6 +1032,7 @@ void pas_large_sharing_pool_boot_free(
     uint64_t epoch;
 
     PAS_PROFILE(LARGE_SHARING_POOL_BOOT_FREE, range.begin, range.end);
+    PAS_MTE_HANDLE(LARGE_SHARING_POOL_BOOT_FREE, range.begin, range.end);
 
     if (!pas_large_sharing_pool_enabled)
         return;
@@ -1046,6 +1048,7 @@ void pas_large_sharing_pool_free(pas_range range,
     uint64_t epoch;
 
     PAS_PROFILE(LARGE_SHARING_POOL_FREE, range.begin, range.end);
+    PAS_MTE_HANDLE(LARGE_SHARING_POOL_FREE, range.begin, range.end);
 
     if (!pas_large_sharing_pool_enabled)
         return;
@@ -1064,6 +1067,7 @@ bool pas_large_sharing_pool_allocate_and_commit(
     static const bool verbose = false;
 
     PAS_PROFILE(LARGE_SHARING_POOL_ALLOCATE_AND_COMMIT, range.begin, range.end);
+    PAS_MTE_HANDLE(LARGE_SHARING_POOL_ALLOCATE_AND_COMMIT, range.begin, range.end);
     
     pas_large_free_heap_deferred_commit_log commit_log;
     uint64_t epoch;
@@ -1212,6 +1216,7 @@ pas_large_sharing_pool_compute_summary(
     pas_heap_summary result;
 
     PAS_PROFILE(LARGE_SHARING_POOL_COMPUTE_SUMMARY, range.begin, range.end);
+    PAS_MTE_HANDLE(LARGE_SHARING_POOL_COMPUTE_SUMMARY, range.begin, range.end);
 
     pas_zero_memory(&result, sizeof(result));
     

--- a/Source/bmalloc/libpas/src/libpas/pas_local_allocator.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_local_allocator.h
@@ -57,6 +57,7 @@ struct pas_local_allocator {
     bool current_word_is_valid : 1; /* This is just used by enumeration. */
     bool is_small : 1; /* Marks that this local allocator is used to allocate small objects. */
     bool is_profiled; /* Marks that allocations coming out of this local allocator should be profiled. */
+    bool is_mte_tagged; /* Marks that allocations coming out of this local allocator are MTE-tagged. */
 
     /* This has to have a pointer to our index within the view. We can get to the view using
        page_ish. Maybe worth reconsidering that, but then again maybe it's good enough. 
@@ -96,6 +97,7 @@ struct pas_local_allocator {
         .current_word_is_valid = false, \
         .is_small = 0, \
         .is_profiled = 0, \
+        .is_mte_tagged = 0, \
         .current_word = 0, \
         .config_kind = pas_local_allocator_config_kind_null \
     })

--- a/Source/bmalloc/libpas/src/libpas/pas_local_allocator_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_local_allocator_inlines.h
@@ -34,6 +34,7 @@
 #include "pas_epoch.h"
 #include "pas_full_alloc_bits_inlines.h"
 #include "pas_malloc_stack_logging.h"
+#include "pas_mte.h"
 #include "pas_scavenger.h"
 #include "pas_segregated_exclusive_view_inlines.h"
 #include "pas_segregated_size_directory_inlines.h"
@@ -120,6 +121,7 @@ static inline void pas_local_allocator_set_up_bump(pas_local_allocator* allocato
     allocator->end_offset = 0;
     allocator->current_word = 0;
     PAS_PROFILE(SET_UP_LOCAL_ALLOCATOR, page_config, segregated_heap, allocator);
+    PAS_MTE_HANDLE(SET_UP_LOCAL_ALLOCATOR, page_config, segregated_heap, allocator);
     pas_compiler_fence();
     allocator->page_ish = page_boundary;
 }
@@ -241,6 +243,7 @@ static PAS_ALWAYS_INLINE void pas_local_allocator_scan_bits_to_set_up_free_bits(
             PAS_BITVECTOR_BIT_INDEX64(current_offset),
             page_config.base);
     PAS_PROFILE(SET_UP_LOCAL_ALLOCATOR, page_config, directory->heap, allocator);
+    PAS_MTE_HANDLE(SET_UP_LOCAL_ALLOCATOR, page_config, directory->heap, allocator);
 
     pas_compiler_fence();
 
@@ -600,6 +603,7 @@ pas_local_allocator_set_up_primordial_bump(
     }
 
     PAS_PROFILE(POPULATE_PRIMORDIAL_PARTIAL_VIEW, page_config, page, view, bump_result, allocation_mode);
+    PAS_MTE_HANDLE(POPULATE_PRIMORDIAL_PARTIAL_VIEW, page_config, page, view, bump_result, allocation_mode);
 
     switch (mode) {
     case pas_local_allocator_primordial_bump_return_first_allocation:
@@ -707,6 +711,7 @@ pas_local_allocator_start_allocating_in_primordial_partial_view(
         
         allocator->page_ish = (uintptr_t)pas_segregated_page_boundary(page, page_config);
         PAS_PROFILE(SET_UP_LOCAL_ALLOCATOR, page_config, heap, allocator);
+        PAS_MTE_HANDLE(SET_UP_LOCAL_ALLOCATOR, page_config, heap, allocator);
 
         pas_zero_memory(allocator->bits, pas_segregated_page_config_num_alloc_bytes(page_config));
 
@@ -912,6 +917,7 @@ pas_local_allocator_try_allocate_in_primordial_partial_view(
 
     if (result.did_succeed) {
         PAS_PROFILE(PRIMORDIAL_BUMP_ALLOCATION, &page_config, result.begin, allocator->object_size, allocation_mode);
+        PAS_MTE_HANDLE(PRIMORDIAL_BUMP_ALLOCATION, &page_config, result.begin, allocator->object_size, allocation_mode);
     }
 
     pas_lock_switch(&held_lock, NULL);
@@ -1511,6 +1517,7 @@ pas_local_allocator_try_allocate_with_free_bits(
     }
 
     PAS_PROFILE(LOCAL_FREEBITS_ALLOCATION, &page_config, result, allocator, allocation_mode);
+    PAS_MTE_HANDLE(LOCAL_FREEBITS_ALLOCATION, &page_config, result, allocator, allocation_mode);
     
     return pas_allocation_result_create_success(result);
 }
@@ -1556,6 +1563,7 @@ pas_local_allocator_try_allocate_inline_cases(pas_local_allocator* allocator,
             pas_log("Returning bump allocation %p.\n", (void*)result);
 
         PAS_PROFILE(LOCAL_BUMP_ALLOCATION, config, allocator, result, object_size, allocation_mode);
+        PAS_MTE_HANDLE(LOCAL_BUMP_ALLOCATION, config, allocator, result, object_size, allocation_mode);
 
         return pas_allocation_result_create_success(result);
     }

--- a/Source/bmalloc/libpas/src/libpas/pas_megapage_cache.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_megapage_cache.c
@@ -32,6 +32,7 @@
 #include "pas_bootstrap_free_heap.h"
 #include "pas_internal_config.h"
 #include "pas_large_free_heap_config.h"
+#include "pas_mte.h"
 #include "pas_payload_reservation_page_list.h"
 #include "pas_zero_memory.h"
 #include <stdio.h>
@@ -121,6 +122,7 @@ static pas_aligned_allocation_result megapage_cache_allocate_aligned(size_t size
     
     begin = (uintptr_t)base_before_exclusion;
     PAS_PROFILE(MEGAPAGE_SET, begin);
+    PAS_MTE_HANDLE(MEGAPAGE_SET, begin);
 
     end = begin + new_size;
 

--- a/Source/bmalloc/libpas/src/libpas/pas_mte.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_mte.h
@@ -1,0 +1,953 @@
+/*
+ * Copyright (c) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ */
+
+#ifndef PAS_MTE_H
+#define PAS_MTE_H
+
+#include "pas_mte_config.h"
+
+#if PAS_OS(DARWIN)
+#include <dispatch/dispatch.h>
+#if PAS_USE_APPLE_INTERNAL_SDK
+#include <mach/mach_init.h>
+#include <mach/mach_vm.h>
+#include <mach/vm_page_size.h>
+#include <mach/vm_statistics.h>
+#endif // PAS_USE_APPLE_INTERNAL_SDK
+#endif // PAS_OS(DARWIN)
+#include "stdint.h"
+#include "stdio.h"
+#include "stdlib.h"
+#if !PAS_OS(WINDOWS)
+#include "unistd.h"
+#endif
+
+#if PAS_ENABLE_MTE
+
+PAS_IGNORE_WARNINGS_BEGIN("unsafe-buffer-usage")
+
+#define PAS_MTE_TAG_MASK 0x0f00000000000000ull
+#define PAS_MTE_CANONICAL_MASK ((0x1ull << 48) - 1)
+
+#if __has_include(<malloc_private.h>)
+#include <malloc_private.h>
+#endif
+
+/*
+ * This must be kept in sync with the value of PAS_SMALL_PAGE_DEFAULT_SHIFT
+ * from OpenSource's pas_internal_config.h -- we cannot use it directly as
+ * pas_utils.h is too high up in the include hierarchy.
+ */
+#define PAS_MTE_SMALL_PAGE_DEFAULT_SHIFT (14)
+#define PAS_MTE_SMALL_PAGE_NO_MASK (0x0000ffffffffffffull & ~((1 << PAS_MTE_SMALL_PAGE_DEFAULT_SHIFT) - 1))
+#define PAS_MTE_SMALL_PAGE_NO(ptr) (((uintptr_t)ptr) & PAS_MTE_SMALL_PAGE_NO_MASK)
+
+#define PAS_MTE_GET_TAG(ptr) do { \
+        asm volatile( \
+            ".arch_extension memtag\n\t" \
+            "ldg %0, [%0]" \
+            : "+r"(ptr) \
+            : \
+            : \
+        ); \
+    } while (0)
+#define PAS_MTE_SET_TAG(ptr) do { \
+        asm volatile( \
+            ".arch_extension memtag\n\t" \
+            "stg %0, [%0]" \
+            : \
+            : "r"(ptr) \
+            : \
+        ); \
+    } while (0)
+#define PAS_MTE_SET_TAG_PAIR(ptr) do { \
+        asm volatile( \
+            ".arch_extension memtag\n\t" \
+            "st2g %0, [%0]" \
+            : \
+            : "r"(ptr) \
+            : \
+        ); \
+    } while (0)
+#define PAS_MTE_SET_TAG_WITH_OFFSET(ptr, offset) do { \
+        asm volatile( \
+            ".arch_extension memtag\n\t" \
+            "stg %0, [%0, #" #offset "]" \
+            : \
+            : "r"(ptr) \
+            : \
+        ); \
+    } while (0)
+#define PAS_MTE_SET_TAG_PAIR_WITH_OFFSET(ptr, offset) do { \
+        asm volatile( \
+            ".arch_extension memtag\n\t" \
+            "st2g %0, [%0, #" #offset "]" \
+            : \
+            : "r"(ptr) \
+            : \
+        ); \
+    } while (0)
+#define PAS_MTE_SET_TAG_POSTINDEX(ptr) do { \
+        asm volatile( \
+            ".arch_extension memtag\n\t" \
+            "stg %0, [%0], #16" \
+            : "+r"(ptr) \
+            : \
+            : \
+        ); \
+    } while (0)
+#define PAS_MTE_SET_TAG_PAIR_POSTINDEX(ptr) do { \
+        asm volatile( \
+            ".arch_extension memtag\n\t" \
+            "st2g %0, [%0], #32" \
+            : "+r"(ptr) \
+            : \
+            : \
+        ); \
+    } while (0)
+#define PAS_MTE_CREATE_RANDOM_TAG(ptr, mask) do { \
+        if (PAS_MTE_FEATURE_ENABLED(PAS_MTE_FEATURE_ZERO_TAG_ALL)) { \
+            ptr &= (uintptr_t)~PAS_MTE_TAG_MASK; \
+            break; \
+        } \
+        asm volatile( \
+            ".arch_extension memtag\n\t" \
+            "irg %0, %0, %1" \
+            : "+r"(ptr) \
+            : "r"((uintptr_t)(mask)) \
+            : \
+        ); \
+    } while (0)
+#define PAS_MTE_CHECK_TAG_AND_SET_TCO(ptr) do { \
+        /* We're only checking one tag-granule, so it's not perfect, \
+         * but it does mean that a potential attacker would at least \
+         * need to know the tag for some of their target range. */ \
+        asm volatile( \
+            ".arch_extension memtag\n\t" \
+            "ldr xzr, [%0]\n\t" \
+            "msr tco, #1" \
+            : \
+            : "r"(ptr) \
+            : "memory" \
+        ); \
+    } while (0)
+#define PAS_MTE_SET_TCO_UNCHECKED do { \
+        asm volatile( \
+            ".arch_extension memtag\n\t" \
+            "msr tco, #1" \
+            : \
+            : \
+            : "memory" \
+        ); \
+    } while (0)
+#define PAS_MTE_CLEAR_TCO do { \
+        asm volatile( \
+            ".arch_extension memtag\n\t" \
+            "msr tco, #0" \
+            : \
+            : \
+            : "memory" \
+        ); \
+    } while (0)
+
+/*
+ * DC GVA writes tags for a contiguous range of addresses in bulk. The size of this
+ * range, and whether or not DC GVA is enabled in hardware, is controlled by the
+ * DCZID_EL0 register. Technically, if we wanted to be maximally robust, we would
+ * query this register to detect if DC GVA is enabled and if so, how much memory it
+ * can tag at once. In practice, DC GVA should always be enabled on PAS_MTE-compatible
+ * Apple hardware, with a size of 64 bytes. Because tagging code is so critical to
+ * PAS_MTE performance, we assume both of these things are true, saving us the cost of
+ * needing to remember enablement and granule size dynamically.
+ *
+ * In addition, DC GVA requires at least 16-byte alignment, and really ideally
+ * 64-byte alignment as far as I am aware. Our usage of this instruction should be
+ * careful to respect 64-byte alignment.
+ */
+#define DC_GVA_GRANULE_SIZE 64
+#define PAS_MTE_SET_TAGS_USING_DC_GVA(ptr) do { \
+        asm volatile( \
+            ".arch_extension memtag\n\t" \
+            "dc gva, %0" \
+            : \
+            : "r"(ptr) \
+            : "memory" \
+        ); \
+    } while (0)
+
+// We call an allocator of taggable objects "homogeneous" if all taggable
+// objects allocated by the allocator are the same size, e.g. like is the
+// case with any slab allocator.
+enum pas_mte_allocator_homogeneity {
+  pas_mte_homogeneous_allocator,
+  pas_mte_nonhomogeneous_allocator,
+};
+
+enum pas_mte_tag_constraint {
+  pas_mte_any_nonzero_tag = 0x0001,
+  pas_mte_odd_tag = 0x5555,
+  pas_mte_nonzero_even_tag = 0xaaab,
+};
+
+PAS_IGNORE_WARNINGS_BEGIN("implicit-fallthrough")
+
+inline __attribute__((always_inline)) void pas_mte_tag_st2g_loop(uint8_t* begin, size_t size)
+{
+    uint8_t* end = begin + size;
+    if (PAS_MTE_FEATURE_ENABLED(PAS_MTE_FEATURE_LOG_ON_TAG))
+        printf("[MTE]\t    Tagging initial 16 bytes %p to %p\n", begin, begin + 16);
+    PAS_MTE_SET_TAG(begin);
+
+    // Ensure begin is a multiple of 32 bytes from the end.
+    begin += size % 32;
+
+    if (PAS_MTE_FEATURE_ENABLED(PAS_MTE_FEATURE_LOG_ON_TAG) && begin < end)
+        printf("[MTE]\t    Doing ST2G loop from %p to %p\n", begin, end);
+    while (begin < end)
+        PAS_MTE_SET_TAG_PAIR_POSTINDEX(begin);
+}
+
+inline __attribute__((always_inline)) void pas_mte_tag_st2g_switching(uint8_t* begin, size_t size)
+{
+    uint8_t* end = begin + size;
+    if (PAS_MTE_FEATURE_ENABLED(PAS_MTE_FEATURE_LOG_ON_TAG))
+        printf("[MTE]\t    Tagging initial 16 bytes %p to %p\n", begin, begin + 16);
+    PAS_MTE_SET_TAG(begin);
+
+    // Ensure begin is a multiple of 32 bytes from the end.
+    begin += size % 32;
+
+    if (PAS_MTE_FEATURE_ENABLED(PAS_MTE_FEATURE_LOG_ON_TAG))
+        printf("[MTE]\t    Doing ST2G loop from %p to %p\n", begin, end);
+    while (begin < end) {
+        uintptr_t num_granules_to_st2g = (uintptr_t)(end - begin) / (uintptr_t)32 & 15;
+        if (!num_granules_to_st2g)
+            num_granules_to_st2g = 16;
+        if (PAS_MTE_FEATURE_ENABLED(PAS_MTE_FEATURE_LOG_ON_TAG)) {
+            size_t tagged_size = num_granules_to_st2g * 32;
+            printf("[MTE]\t        Tagging %zu bytes from %p to %p\n", tagged_size, begin, begin + tagged_size);
+        }
+        switch (num_granules_to_st2g) {
+        case 16: PAS_MTE_SET_TAG_PAIR_WITH_OFFSET(begin, 480);
+        case 15: PAS_MTE_SET_TAG_PAIR_WITH_OFFSET(begin, 448);
+        case 14: PAS_MTE_SET_TAG_PAIR_WITH_OFFSET(begin, 416);
+        case 13: PAS_MTE_SET_TAG_PAIR_WITH_OFFSET(begin, 384);
+        case 12: PAS_MTE_SET_TAG_PAIR_WITH_OFFSET(begin, 352);
+        case 11: PAS_MTE_SET_TAG_PAIR_WITH_OFFSET(begin, 320);
+        case 10: PAS_MTE_SET_TAG_PAIR_WITH_OFFSET(begin, 288);
+        case 9: PAS_MTE_SET_TAG_PAIR_WITH_OFFSET(begin, 256);
+        case 8: PAS_MTE_SET_TAG_PAIR_WITH_OFFSET(begin, 224);
+        case 7: PAS_MTE_SET_TAG_PAIR_WITH_OFFSET(begin, 192);
+        case 6: PAS_MTE_SET_TAG_PAIR_WITH_OFFSET(begin, 160);
+        case 5: PAS_MTE_SET_TAG_PAIR_WITH_OFFSET(begin, 128);
+        case 4: PAS_MTE_SET_TAG_PAIR_WITH_OFFSET(begin, 96);
+        case 3: PAS_MTE_SET_TAG_PAIR_WITH_OFFSET(begin, 64);
+        case 2: PAS_MTE_SET_TAG_PAIR_WITH_OFFSET(begin, 32);
+        case 1: PAS_MTE_SET_TAG_PAIR(begin); break;
+        default: __builtin_unreachable();
+        }
+        begin += num_granules_to_st2g * 32;
+    }
+}
+
+inline __attribute__((always_inline)) void pas_mte_tag_dc_gva_loop(uint8_t* begin, size_t size)
+{
+    /* Get the small-object case out of the way. */
+    if (size <= 48) {
+        if (PAS_MTE_FEATURE_ENABLED(PAS_MTE_FEATURE_LOG_ON_TAG))
+            printf("[MTE]\t    Tagging small object with size %zu from %p to %p\n", size, begin, begin + size);
+        PAS_MTE_SET_TAG(begin);
+        if (size <= 16)
+            return;
+        PAS_MTE_SET_TAG_PAIR(begin);
+        if (size > 32)
+            PAS_MTE_SET_TAG_WITH_OFFSET(begin, 32);
+        return;
+    }
+
+    /* Now that we know the size is at least 64 bytes, we can use DC GVA. */
+    /* First, we handle the first 64 bytes, which may not be aligned to 64 bytes. */
+    if (PAS_MTE_FEATURE_ENABLED(PAS_MTE_FEATURE_LOG_ON_TAG))
+        printf("[MTE]\t    Tagging initial 64 bytes from %p to %p\n", begin, begin + 64);
+    PAS_MTE_SET_TAG_PAIR(begin);
+    PAS_MTE_SET_TAG_PAIR_WITH_OFFSET(begin, 32);
+
+    uint8_t* end = begin + size;
+
+    if (size > 128) {
+        /* Next, we align our begin and end, in preparation for doing a DC GVA loop. */
+        begin = (uint8_t*)((uintptr_t)begin + DC_GVA_GRANULE_SIZE - 1 & (intptr_t)-DC_GVA_GRANULE_SIZE);
+        uint8_t* end_aligned = (uint8_t*)((uintptr_t)end & (intptr_t)-DC_GVA_GRANULE_SIZE);
+
+        if (PAS_MTE_FEATURE_ENABLED(PAS_MTE_FEATURE_LOG_ON_TAG))
+            printf("[MTE]\t    Doing aligned DC GVA loop from %p to %p\n", begin, end_aligned);
+        while (begin < end_aligned) {
+            PAS_MTE_SET_TAGS_USING_DC_GVA(begin);
+            begin += DC_GVA_GRANULE_SIZE;
+        }
+    }
+
+    /* Handle the last 64 bytes, covering the unaligned remainder we may have */
+    /* missed in our DC GVA loop. */
+    if (PAS_MTE_FEATURE_ENABLED(PAS_MTE_FEATURE_LOG_ON_TAG))
+        printf("[MTE]\t    Tagging final 64 bytes from %p to %p\n", end - 64, end);
+    PAS_MTE_SET_TAG_PAIR_WITH_OFFSET(end, -64);
+    PAS_MTE_SET_TAG_PAIR_WITH_OFFSET(end, -32);
+}
+
+inline __attribute__((always_inline)) void pas_mte_tag_dc_gva_known_medium(uint8_t* begin, size_t size)
+{
+    uint8_t* end = begin + size;
+    while (begin < end) {
+        PAS_MTE_SET_TAGS_USING_DC_GVA(begin);
+        PAS_MTE_SET_TAGS_USING_DC_GVA(begin + DC_GVA_GRANULE_SIZE);
+        PAS_MTE_SET_TAGS_USING_DC_GVA(begin + DC_GVA_GRANULE_SIZE * 2);
+        PAS_MTE_SET_TAGS_USING_DC_GVA(begin + DC_GVA_GRANULE_SIZE * 3);
+        PAS_MTE_SET_TAGS_USING_DC_GVA(begin + DC_GVA_GRANULE_SIZE * 4);
+        PAS_MTE_SET_TAGS_USING_DC_GVA(begin + DC_GVA_GRANULE_SIZE * 5);
+        PAS_MTE_SET_TAGS_USING_DC_GVA(begin + DC_GVA_GRANULE_SIZE * 6);
+        PAS_MTE_SET_TAGS_USING_DC_GVA(begin + DC_GVA_GRANULE_SIZE * 7);
+        begin += DC_GVA_GRANULE_SIZE * 8;
+    }
+}
+
+inline __attribute__((always_inline)) void pas_mte_tag_dc_gva_switching(uint8_t* begin, size_t size)
+{
+    /* Get the small-object case out of the way. */
+    if (size <= 48) {
+        if (PAS_MTE_FEATURE_ENABLED(PAS_MTE_FEATURE_LOG_ON_TAG))
+            printf("[MTE]\t    Tagging small object with size %zu from %p to %p\n", size, begin, begin + size);
+        PAS_MTE_SET_TAG(begin);
+        if (size <= 16)
+            return;
+        PAS_MTE_SET_TAG_PAIR(begin);
+        if (size > 32)
+            PAS_MTE_SET_TAG_WITH_OFFSET(begin, 32);
+        return;
+    }
+
+    /* Now that we know the size is at least 64 bytes, we can use DC GVA. */
+    /* First, we handle the first 64 bytes, which may not be aligned to 64 bytes. */
+    if (PAS_MTE_FEATURE_ENABLED(PAS_MTE_FEATURE_LOG_ON_TAG))
+        printf("[MTE]\t    Tagging initial 64 bytes from %p to %p\n", begin, begin + 64);
+    PAS_MTE_SET_TAG_PAIR(begin);
+    PAS_MTE_SET_TAG_PAIR_WITH_OFFSET(begin, 32);
+
+    uint8_t* end = begin + size;
+
+    if (size > 128) {
+        /* Next, we align our begin and end, in preparation for doing a DC GVA loop. */
+        begin = (uint8_t*)((uintptr_t)begin + 63 & (intptr_t)-64);
+        uint8_t* end_aligned = (uint8_t*)((uintptr_t)end & (intptr_t)-64);
+
+        if (PAS_MTE_FEATURE_ENABLED(PAS_MTE_FEATURE_LOG_ON_TAG))
+            printf("[MTE]\t    Doing aligned DC GVA loop from %p to %p\n", begin, end_aligned);
+        while (begin < end_aligned) {
+            uintptr_t num_granules_to_gva = (uintptr_t)(end_aligned - begin) / (uintptr_t)DC_GVA_GRANULE_SIZE % 16;
+            if (!num_granules_to_gva)
+                num_granules_to_gva = 16;
+            if (PAS_MTE_FEATURE_ENABLED(PAS_MTE_FEATURE_LOG_ON_TAG)) {
+                size_t tagged_size = num_granules_to_gva * DC_GVA_GRANULE_SIZE;
+                printf("[MTE]\t        Tagging %zu bytes from %p to %p\n", tagged_size, begin, begin + tagged_size);
+            }
+            switch (num_granules_to_gva) {
+            case 16: PAS_MTE_SET_TAGS_USING_DC_GVA(begin + DC_GVA_GRANULE_SIZE * 15);
+            case 15: PAS_MTE_SET_TAGS_USING_DC_GVA(begin + DC_GVA_GRANULE_SIZE * 14);
+            case 14: PAS_MTE_SET_TAGS_USING_DC_GVA(begin + DC_GVA_GRANULE_SIZE * 13);
+            case 13: PAS_MTE_SET_TAGS_USING_DC_GVA(begin + DC_GVA_GRANULE_SIZE * 12);
+            case 12: PAS_MTE_SET_TAGS_USING_DC_GVA(begin + DC_GVA_GRANULE_SIZE * 11);
+            case 11: PAS_MTE_SET_TAGS_USING_DC_GVA(begin + DC_GVA_GRANULE_SIZE * 10);
+            case 10: PAS_MTE_SET_TAGS_USING_DC_GVA(begin + DC_GVA_GRANULE_SIZE * 9);
+            case 9: PAS_MTE_SET_TAGS_USING_DC_GVA(begin + DC_GVA_GRANULE_SIZE * 8);
+            case 8: PAS_MTE_SET_TAGS_USING_DC_GVA(begin + DC_GVA_GRANULE_SIZE * 7);
+            case 7: PAS_MTE_SET_TAGS_USING_DC_GVA(begin + DC_GVA_GRANULE_SIZE * 6);
+            case 6: PAS_MTE_SET_TAGS_USING_DC_GVA(begin + DC_GVA_GRANULE_SIZE * 5);
+            case 5: PAS_MTE_SET_TAGS_USING_DC_GVA(begin + DC_GVA_GRANULE_SIZE * 4);
+            case 4: PAS_MTE_SET_TAGS_USING_DC_GVA(begin + DC_GVA_GRANULE_SIZE * 3);
+            case 3: PAS_MTE_SET_TAGS_USING_DC_GVA(begin + DC_GVA_GRANULE_SIZE * 2);
+            case 2: PAS_MTE_SET_TAGS_USING_DC_GVA(begin + DC_GVA_GRANULE_SIZE);
+            case 1: PAS_MTE_SET_TAGS_USING_DC_GVA(begin); break;
+            default: __builtin_unreachable();
+            }
+            begin += num_granules_to_gva * DC_GVA_GRANULE_SIZE;
+        }
+    }
+
+    /* Handle the last 64 bytes, covering the unaligned remainder we may have */
+    /* missed in our DC GVA loop. */
+    if (PAS_MTE_FEATURE_ENABLED(PAS_MTE_FEATURE_LOG_ON_TAG))
+        printf("[MTE]\t    Tagging final 64 bytes from %p to %p\n", end - 64, end);
+    PAS_MTE_SET_TAG_PAIR_WITH_OFFSET(end, -64);
+    PAS_MTE_SET_TAG_PAIR_WITH_OFFSET(end, -32);
+}
+
+PAS_IGNORE_WARNINGS_END
+
+#define ASSERT_PRIOR_TAG_IS_DISJOINT(ptr) do { \
+        uint8_t* prev_ptr = (uint8_t*)((uintptr_t)ptr - 16); \
+        uint8_t* curr_ptr = (uint8_t*)ptr; \
+        if (PAS_MTE_SMALL_PAGE_NO(prev_ptr) == PAS_MTE_SMALL_PAGE_NO(curr_ptr)) { \
+            PAS_MTE_GET_TAG(prev_ptr); \
+            PAS_MTE_GET_TAG(curr_ptr); \
+            uintptr_t prev_tag = (uintptr_t)prev_ptr & PAS_MTE_TAG_MASK; \
+            uintptr_t curr_tag = (uintptr_t)curr_ptr & PAS_MTE_TAG_MASK; \
+            if (prev_tag == curr_tag && !curr_tag) \
+                printf("[MTE]\tAdjacent tag collision between %p and %p: crashing\n", prev_ptr, curr_ptr); \
+            PAS_MTE_ASSERT(prev_tag != curr_tag || !curr_tag); \
+        } \
+    } while (0)
+
+#define TAG_REGION_FROM_POINTER(ptr, size, is_known_medium) do { \
+        uint8_t* pas_mte_begin = (uint8_t*)(ptr); \
+        size_t pas_mte_size = (size_t)(size); \
+        if (PAS_MTE_FEATURE_ENABLED(PAS_MTE_FEATURE_LOG_ON_TAG)) { \
+            void* purified_begin = pas_mte_begin; \
+            PAS_MTE_GET_TAG(purified_begin); \
+            printf("[MTE]\tTagging %zu bytes from %p to %p (old tag is %p)\n", pas_mte_size, pas_mte_begin, pas_mte_begin + pas_mte_size, purified_begin); \
+        } \
+        if (is_known_medium) \
+            pas_mte_tag_dc_gva_known_medium(pas_mte_begin, pas_mte_size); \
+        else \
+            pas_mte_tag_st2g_loop(pas_mte_begin, pas_mte_size); \
+    } while (0)
+
+// Purify is used to reload the correct tag for a pointer from tag
+// memory. We generally use this when we add to or round down a pointer,
+// and need to modify memory at that new address, such as page headers.
+
+#define PAS_MTE_PURIFY(a) do { \
+        if (PAS_USE_MTE) { \
+            if (PAS_MTE_FEATURE_ENABLED(PAS_MTE_FEATURE_LOG_ON_PURIFY)) \
+                printf("[MTE]\tPurified %p", (void*)(a)); \
+            PAS_MTE_GET_TAG(a); \
+            if (PAS_MTE_FEATURE_ENABLED(PAS_MTE_FEATURE_LOG_ON_PURIFY)) \
+                printf(" to %p\n", (void*)(a)); \
+        } \
+    } while (0)
+
+// Clear is used to canonicalize (zero out) the tag bits of a pointer.
+// We generally use this when we want to treat the address itself as
+// an integer or key, and don't intend to load from it directly.
+// We don't check for PAS_MTE enablement in these cases, since on non-PAS_MTE
+// hardware, the tag should be zero anyway, and masking off the bits
+// should be faster than branching on g_config.
+
+#define PAS_MTE_CLEAR(a) do { \
+        a &= ~PAS_MTE_TAG_MASK; \
+    } while (0)
+
+#define PAS_MTE_CLEAR_PAIR(a, b) do { \
+        a &= ~PAS_MTE_TAG_MASK; \
+        b &= ~PAS_MTE_TAG_MASK; \
+    } while (0)
+
+// Tagging is what actually applies an PAS_MTE tag to an allocation. If the
+// pas_allocation_mode passed to this macro is compact, we zero the upper
+// bits of the pointer and tag the object with a zero tag. Otherwise, we
+// randomly choose a nonzero tag. It's assumed that this macro will be
+// invoked with a size that's a multiple of 16, and it's really important
+// that the size passed be the allocation size of the object, not the
+// actual size.
+#define PAS_MTE_TAG_REGION(ptr, size, mode, is_allocator_homogeneous, is_known_medium) do { \
+        if (PAS_MTE_SHOULD_STORE_TAG) { \
+            if (mode != pas_non_compact_allocation_mode) \
+                ptr &= ~PAS_MTE_TAG_MASK; \
+            else { \
+                if (PAS_MTE_FEATURE_ENABLED(PAS_MTE_FEATURE_ADJACENT_TAG_EXCLUSION) && is_allocator_homogeneous == pas_mte_homogeneous_allocator) { \
+                    if ((((uintptr_t)ptr & PAS_MTE_CANONICAL_MASK) / size) & 0x1) \
+                        PAS_MTE_CREATE_RANDOM_TAG(ptr, pas_mte_odd_tag); \
+                    else \
+                        PAS_MTE_CREATE_RANDOM_TAG(ptr, pas_mte_nonzero_even_tag); \
+                } else \
+                    PAS_MTE_CREATE_RANDOM_TAG(ptr, pas_mte_any_nonzero_tag); \
+            } \
+            if (mode != pas_always_compact_allocation_mode) { \
+                TAG_REGION_FROM_POINTER(ptr, size, is_known_medium); \
+                if (PAS_MTE_FEATURE_ENABLED(PAS_MTE_FEATURE_ADJACENT_TAG_EXCLUSION) \
+                    && PAS_MTE_FEATURE_ENABLED(PAS_MTE_FEATURE_ASSERT_ADJACENT_TAGS_ARE_DISJOINT) \
+                    && is_allocator_homogeneous == pas_mte_homogeneous_allocator) { \
+                    ASSERT_PRIOR_TAG_IS_DISJOINT(ptr); \
+                    ASSERT_PRIOR_TAG_IS_DISJOINT(ptr + size); \
+                } \
+            } \
+        } \
+    } while (0)
+
+#define PAS_MTE_TAG_REGION_FROM_INITIAL_ALLOCATION(ptr, size, mode, is_allocator_homogeneous, is_known_medium) do { \
+        PAS_MTE_TAG_REGION(ptr, size, mode, is_allocator_homogeneous, is_known_medium); \
+        if (PAS_MTE_FEATURE_ENABLED(PAS_MTE_FEATURE_LOG_ON_TAG)) { \
+            uint8_t* pas_mte_begin = (uint8_t*)(ptr); \
+            size_t pas_mte_size = (size_t)size; \
+            printf("[MTE]\tFirst time tagging region: alloc-tagging %zu bytes from %p to %p\n", pas_mte_size, pas_mte_begin, pas_mte_begin + pas_mte_size); \
+        } \
+    } while (0)
+
+// We leave the majority of the view to be tagged as individual segregated
+// allocations are slab-allocated from within it. All we need to do here is
+// zero-tag the trailing-buffer which the shared view shared-allocator leaves
+// at the end of the new partial view.
+#define PAS_MTE_TAG_BUMP_ALLOCATION_FOR_PARTIAL_VIEW(page_config, page, view, bump, mode) do { \
+        if (mode != pas_always_compact_allocation_mode) { \
+            uintptr_t page_boundary = (uintptr_t)pas_page_base_boundary(&page->base, page_config.base); \
+            uintptr_t ptr = page_boundary + (bump.new_bump - 16); \
+            TAG_REGION_FROM_POINTER(ptr, 16, PAS_MTE_IS_KNOWN_MEDIUM_PAGE(&page_config)); \
+            if (PAS_MTE_FEATURE_ENABLED(PAS_MTE_FEATURE_LOG_ON_TAG)) { \
+                uintptr_t bump_base = page_boundary + bump.old_bump; \
+                printf("[MTE]\tTagging 16 bytes from %p for trailing-buffer of partial view %p, bump starting at %p\n", (void*)ptr, view, (void*)bump_base); \
+            } \
+        } \
+    } while (0)
+
+#define PAS_MTE_TAG_REGION_FROM_OTHER_ALLOCATION(ptr, size, mode, is_allocator_homogeneous, is_known_medium) do { \
+        if (!PAS_MTE_FEATURE_ENABLED(PAS_MTE_FEATURE_RETAG_ON_FREE)) { \
+            PAS_MTE_TAG_REGION(ptr, size, mode, is_allocator_homogeneous, is_known_medium); \
+            break; \
+        } \
+        uint8_t* pas_mte_begin = (uint8_t*)(ptr); \
+        size_t pas_mte_size = (size_t)size; \
+        if (mode == pas_non_compact_allocation_mode) { \
+            /* assume: size >= 16 && ptr % 16 == 0 */ \
+            if (PAS_MTE_FEATURE_ENABLED(PAS_MTE_FEATURE_LOG_ON_TAG)) \
+                printf("[MTE]\tSkipping alloc-tagging %zu bytes from %p to %p\n", pas_mte_size, pas_mte_begin, pas_mte_begin + pas_mte_size); \
+            PAS_MTE_PURIFY(ptr); \
+        } else { \
+            PAS_MTE_TAG_REGION(ptr, size, mode, is_allocator_homogeneous, is_known_medium); \
+        } \
+    } while (0)
+#define PAS_MTE_TAG_REGION_FROM_DEALLOCATION(page_config, ptr, size, is_allocator_homogeneous) do { \
+        if (!PAS_MTE_FEATURE_ENABLED(PAS_MTE_FEATURE_RETAG_ON_FREE)) \
+            break; \
+        PAS_MTE_TAG_REGION(ptr, size, pas_non_compact_allocation_mode, is_allocator_homogeneous, PAS_MTE_IS_KNOWN_MEDIUM_PAGE(&page_config)); \
+    } while (0)
+
+// When zeroing out memory we need to be careful to not clear its tagged status.
+// Neither memset nor mach_vm_behavior_set will do so, but re-mapping the page
+// with mmap or mach_vm_map will do so unless we force it to use PAS_VM_MTE.
+// This has the side effect of making *non*-PAS_MTE pages into tagged memory, but
+// the only side effect of that should be a small hit to performance -- which
+// will have to suffice until we can start using mach_vm_behavior_set.
+
+#if PAS_OS(DARWIN)
+
+// We can't check whether PAS_ASSERT is defined since this header is included early
+// on within pas_utils.h, where PAS_ASSERT is defined. So if RELEASE_BASSERT
+// isn't available we just use PAS_ASSERT and let the compiler error if it's not
+// around.
+#if defined(RELEASE_BASSERT)
+#define PAS_MTE_ASSERT(x) RELEASE_BASSERT(x)
+#else
+#define PAS_MTE_ASSERT(x) PAS_ASSERT(x)
+#endif
+
+#define PAS_MTE_ZERO_FILL_PAGE(ptr, size, flags, tag) do { \
+        (void)flags; \
+        if (PAS_USE_MTE) { \
+            const vm_inherit_t childProcessInheritance = VM_INHERIT_DEFAULT; \
+            const bool copy = false; \
+            /* FIXME: use mach_vm_behavior_set instead rdar://160813532 */ \
+            kern_return_t vm_map_result = mach_vm_map(mach_task_self(), \
+                (mach_vm_address_t*)&ptr, \
+                (size), \
+                0, \
+                VM_FLAGS_FIXED | VM_FLAGS_OVERWRITE | PAS_VM_MTE | (tag), MEMORY_OBJECT_NULL, \
+                0, \
+                copy, \
+                VM_PROT_DEFAULT, \
+                VM_PROT_ALL, \
+                childProcessInheritance); \
+            if (vm_map_result != KERN_SUCCESS) \
+                errno = 0; \
+            PAS_MTE_ASSERT(vm_map_result == KERN_SUCCESS); \
+            /* Early exit from caller function since we've done the zero-fill ourselves */ \
+            return; \
+        } \
+    } while (false) \
+
+#else
+#define PAS_MTE_ZERO_FILL_PAGE(ptr, size, flags, tag) do { \
+          (void)ptr; \
+          (void)size; \
+          (void)flags; \
+          (void)tag; \
+      } while (false)
+#endif // PAS_OS(DARWIN)
+
+// This is no longer needed as the pointer is already tagged in preparation for
+// being returned to the caller of the allocation function.
+#define PAS_MTE_HANDLE_ZERO_ALLOCATION_RESULT(a) do { (void)a; } while (false)
+
+// Used to zero an existing page allocation without clearing the tagged-memory
+// bit in its page-table entries.
+#define PAS_MTE_HANDLE_ZERO_FILL_PAGE(ptr, size, flags, tag) PAS_MTE_ZERO_FILL_PAGE(ptr, size, flags, tag)
+
+// Used to allow us to toggle TCO before setting large chunks of
+// memory to 0.
+#define PAS_MTE_HANDLE_ZERO_MEMORY(ptr, size) do { \
+        if (PAS_USE_MTE) { \
+            PAS_MTE_CHECK_TAG_AND_SET_TCO(ptr); \
+            memset((void*)ptr, 0, size); \
+            PAS_MTE_CLEAR_TCO; \
+            /* Early exit from caller function since \
+             * we've done the zero-fill ourselves */ \
+            return; \
+        } \
+    } while (false)
+
+// Used to clear the tag before we look up the address in the megapage table when reallocating.
+#define PAS_MTE_HANDLE_REALLOCATE(a) PAS_MTE_CLEAR(a)
+
+// Used to restore the correct tag when reallocating something to a new address before copying it.
+#define PAS_MTE_HANDLE_TRY_REALLOCATE_AND_COPY(ptr, old_ptr, size) do { \
+        if (PAS_USE_MTE) { \
+            PAS_MTE_CHECK_TAG_AND_SET_TCO(ptr); \
+            memcpy((void*)ptr, old_ptr, size); \
+            PAS_MTE_CLEAR_TCO; \
+            if (verbose) { \
+                pas_log("\t...done copying size %zu from %p to %p\n", size, old_ptr, (void*)ptr); \
+            } \
+            /* Early exit from caller function since \
+             * we've done the copy ourselves */ \
+            return result; \
+        } \
+    } while (false)
+
+// Used to clear the tag from a pointer into a page, since the page header should
+// be zero-tagged.
+#define PAS_MTE_HANDLE_PAGE_BASE_FROM_BOUNDARY(a) PAS_MTE_CLEAR(a)
+
+// Used to clear pointer tag bits before looking it up in the page header table.
+#define PAS_MTE_HANDLE_PAGE_HEADER_TABLE_GET(a) PAS_MTE_CLEAR(a)
+
+// Used to clear pointer tag bits before adding it to the page header table.
+#define PAS_MTE_HANDLE_PAGE_HEADER_TABLE_ADD(a) PAS_MTE_CLEAR(a)
+
+// Used to clear key tag bits before looking up a pointer in the large map.
+#define PAS_MTE_HANDLE_LARGE_MAP_FIND(a) PAS_MTE_CLEAR(a)
+
+// Used to clear key tag bits before inserting a pointer range into the large map.
+#define PAS_MTE_HANDLE_LARGE_MAP_ADD(a, b) PAS_MTE_CLEAR(a)
+
+// Used to clear key tag bits before taking a pointer from the large map.
+#define PAS_MTE_HANDLE_LARGE_MAP_TAKE(a) PAS_MTE_CLEAR(a)
+
+// Used to restore the correct tag of a large map entry key after looking it up.
+// Takes a pas_heap_config*
+#define PAS_MTE_HANDLE_LARGE_MAP_FOUND_ENTRY(config, a, b) PAS_MTE_PURIFY(a)
+
+// Used to restore the correct tag of a large map entry key after taking it from the map.
+// Takes a pas_heap_config*
+#define PAS_MTE_HANDLE_LARGE_MAP_TOOK_ENTRY(config, a, b) PAS_MTE_PURIFY(a)
+
+// Used to clear pointer tag bits before taking a pointer from the large map.
+// Takes a pas_heap_config*
+#define PAS_MTE_HANDLE_PGM_ALLOCATE(config, a) PAS_MTE_CLEAR(a)
+
+// Used to clear pointer tag bits before taking a pointer from the large map.
+#define PAS_MTE_HANDLE_PGM_DEALLOCATE(a) PAS_MTE_CLEAR(a)
+
+// Used to clear pointer tag bits before putting a pointer to the megapage table.
+#define PAS_MTE_HANDLE_MEGAPAGE_SET(a) PAS_MTE_CLEAR(a)
+
+// Used to clear pointer tag bits before getting a pointer from the megapage table.
+#define PAS_MTE_HANDLE_MEGAPAGE_GET(a) PAS_MTE_CLEAR(a)
+
+// Used to clear pointer tag bits freeing a range in the large sharing pool.
+#define PAS_MTE_HANDLE_LARGE_SHARING_POOL_BOOT_FREE(a, b) PAS_MTE_CLEAR_PAIR(a, b)
+
+// Used to clear pointer tag bits freeing a range in the large sharing pool.
+#define PAS_MTE_HANDLE_LARGE_SHARING_POOL_FREE(a, b) PAS_MTE_CLEAR_PAIR(a, b)
+
+// Used to clear pointer tag bits allocating a range in the large sharing pool.
+#define PAS_MTE_HANDLE_LARGE_SHARING_POOL_ALLOCATE_AND_COMMIT(a, b) PAS_MTE_CLEAR_PAIR(a, b)
+
+// Used to clear pointer tag bits when summarizing a range in the large sharing pool.
+#define PAS_MTE_HANDLE_LARGE_SHARING_POOL_COMPUTE_SUMMARY(a, b) PAS_MTE_CLEAR_PAIR(a, b)
+
+// Use these to configure the tagging policy for different sizes. Currently we only
+// tag small and medium allocations, in both segregated and bitfit pages. Medium
+// allocations should be additionally guarded at runtime by PAS_MTE_MEDIUM_TAGGING_ENABLED.
+#define PAS_MTE_ALLOW_TAG_SMALL 1
+#define PAS_MTE_ALLOW_TAG_MEDIUM 1
+
+#if PAS_MTE_ALLOW_TAG_SMALL && PAS_MTE_ALLOW_TAG_MEDIUM
+#define PAS_MTE_SHOULD_TAG_ALLOCATOR(allocator) (allocator)->is_mte_tagged
+#define PAS_MTE_DECIDE_PAGE_CONFIG_TAGGEDNESS(size_category) \
+    (size_category == pas_page_config_size_category_small || size_category == pas_page_config_size_category_medium)
+// TODO: once we drop support for runtime-differentiating medium tagging, we can
+// drop the second half of this statement
+#define PAS_MTE_SHOULD_TAG_PAGE(page_config) ((page_config)->base.allow_mte_tagging && \
+                                          (PAS_MTE_MEDIUM_TAGGING_ENABLED || (page_config)->base.page_config_size_category != pas_page_config_size_category_medium))
+#define PAS_MTE_IS_KNOWN_MEDIUM_BUMP(allocator) !(allocator)->is_small
+#define PAS_MTE_IS_KNOWN_MEDIUM_PAGE(page_config) (page_config)->base.page_config_size_category == pas_page_config_size_category_medium
+#define PAS_MTE_SHOULD_TAG_SEGREGATED_HEAP(segregated_heap) (segregated_heap->parent_heap && segregated_heap->parent_heap->is_non_compact_heap)
+#elif PAS_MTE_ALLOW_TAG_SMALL
+#define PAS_MTE_DECIDE_PAGE_CONFIG_TAGGEDNESS(size_category) (size_category == pas_page_config_size_category_small)
+#define PAS_MTE_SHOULD_TAG_ALLOCATOR(allocator) (allocator)->is_mte_tagged
+#define PAS_MTE_SHOULD_TAG_PAGE(page_config) ((page_config)->base.allow_mte_tagging)
+#define PAS_MTE_IS_KNOWN_MEDIUM_BUMP(allocator) 0
+#define PAS_MTE_IS_KNOWN_MEDIUM_PAGE(page_config) 0
+#else
+#define PAS_MTE_DECIDE_PAGE_CONFIG_TAGGEDNESS(size_category) (false)
+
+#define PAS_MTE_SHOULD_TAG_ALLOCATOR(allocator) 0
+#define PAS_MTE_SHOULD_TAG_PAGE(page_config) 0
+#define PAS_MTE_IS_KNOWN_MEDIUM_BUMP(allocator) 0
+#define PAS_MTE_IS_KNOWN_MEDIUM_PAGE(page_config) 0
+#endif
+
+#define PAS_SHOULD_MTE_TAG_BASIC_HEAP_PAGE(size_category) PAS_MTE_DECIDE_PAGE_CONFIG_TAGGEDNESS(size_category)
+
+struct __pas_heap;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+extern struct __pas_heap bmalloc_common_primitive_heap;
+#ifdef __cplusplus
+}
+#endif
+
+// It's possible for users to allocate memory from a pas_heap prior to ever
+// inducing libpas to go down the pas_page_malloc path -- e.g. if they only use
+// the system allocator, or heaps which use memory allocated by the user.
+// However, all such allocations have to go down the pas-heap initialization
+// path -- so we can intercept here to catch those cases.
+// This is not sufficient on its own, however, as it's theoretically possible
+// for libpas to allocate PAS_MTE memory on its own, e.g. via the utility heap.
+// N.b.: `heap` is empty (nullptr) at the time when this macro is used, so we
+// cannot actually make use of it. We take it as a parameter as a bandaid over
+// a spurious unused-variable warning that clang sometimes throws otherwise:
+// see rdar://157158045
+#define PAS_MTE_HANDLE_ENSURE_HEAP_SLOW(heap, heap_ref, heap_ref_kind, heap_config, runtime_config) do { \
+        (void)heap; \
+        (void)heap_ref; \
+        (void)heap_ref_kind; \
+        (void)heap_config; \
+        (void)runtime_config; \
+        pas_mte_ensure_initialized(); \
+    } while (false)
+
+// Used to set up whether a local allocator should tag its allocations.
+#define PAS_MTE_HANDLE_SET_UP_LOCAL_ALLOCATOR(page_config, segregated_heap, allocator) do { \
+        if (PAS_USE_MTE && PAS_MTE_SHOULD_TAG_SEGREGATED_HEAP(segregated_heap)) { \
+            allocator->is_mte_tagged = PAS_MTE_SHOULD_TAG_PAGE(&page_config); \
+            allocator->is_small = (page_config).base.page_config_size_category == pas_page_config_size_category_small; \
+        } else \
+            allocator->is_mte_tagged = false; \
+    } while (false)
+
+// Used to tag bump allocations from a local allocator.
+#define PAS_MTE_HANDLE_LOCAL_BUMP_ALLOCATION(heap_config, allocator, ptr, size, mode) do { \
+        if (PAS_MTE_SHOULD_TAG_ALLOCATOR(allocator)) \
+            PAS_MTE_TAG_REGION_FROM_INITIAL_ALLOCATION(ptr, size, mode, pas_mte_homogeneous_allocator, PAS_MTE_IS_KNOWN_MEDIUM_BUMP(allocator)); \
+    } while (false)
+
+// Used to tag free-bit scanning allocations from a local allocator.
+#define PAS_MTE_HANDLE_LOCAL_FREEBITS_ALLOCATION(page_config, ptr, allocator, mode) do { \
+        if (PAS_MTE_SHOULD_TAG_ALLOCATOR(allocator)) \
+            PAS_MTE_TAG_REGION_FROM_OTHER_ALLOCATION(ptr, allocator->object_size, mode, pas_mte_homogeneous_allocator, PAS_MTE_IS_KNOWN_MEDIUM_PAGE(page_config)); \
+    } while (false)
+
+// Used to tag bitfit allocations.
+#define PAS_MTE_HANDLE_BITFIT_ALLOCATION(page_config, ptr, size, mode) do { \
+        if (PAS_USE_MTE && PAS_MTE_SHOULD_TAG_PAGE(page_config)) \
+            PAS_MTE_TAG_REGION_FROM_OTHER_ALLOCATION(ptr, size, mode, pas_mte_nonhomogeneous_allocator, PAS_MTE_IS_KNOWN_MEDIUM_PAGE(page_config)); \
+    } while (false)
+
+// Logic for tagging system heap (aka system malloc) allocations. These are used
+// in production in some services/daemons to avoid using up memory for both
+// libpas and system malloc metadata, but since the system malloc also supports
+// PAS_MTE and some of these services have PAS_MTE enabled, we need to ensure
+// allocations we expect to be zero-tagged under PAS_MTE are zero-tagged in this
+// mode too.
+//
+// At the time of writing, malloc_zone_malloc_with_options_np with
+// MALLOC_NP_OPTION_CANONICAL_TAG is the preferred means of doing this. Since
+// we don't have an equivalent for realloc yet, we do our own malloc + copy +
+// free sequence instead.
+
+// Allowed argument values (as dictated by malloc_zone_malloc_with_options_np):
+//  - alignment: 0 for unaligned, or a power of 2 >= sizeof(void*).
+//  - size: any if alignment == 0, a multiple of the alignment otherwise.
+
+inline __attribute__((always_inline)) void* pas_mte_system_heap_malloc_zero_tagged(malloc_zone_t* zone, size_t alignment, size_t size)
+{
+PAS_IGNORE_WARNINGS_BEGIN("deprecated-declarations")
+    return malloc_zone_malloc_with_options_np(zone, alignment, size, MALLOC_NP_OPTION_CANONICAL_TAG);
+PAS_IGNORE_WARNINGS_END
+}
+
+inline __attribute__((always_inline)) void* pas_mte_system_heap_zeroed_malloc_zero_tagged(malloc_zone_t* zone, size_t alignment, size_t size)
+{
+PAS_IGNORE_WARNINGS_BEGIN("deprecated-declarations")
+    return malloc_zone_malloc_with_options_np(zone, alignment, size, (malloc_options_np_t)(MALLOC_NP_OPTION_CANONICAL_TAG | MALLOC_NP_OPTION_CLEAR));
+PAS_IGNORE_WARNINGS_END
+}
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+void* pas_mte_system_heap_realloc_zero_tagged(malloc_zone_t* zone, void* ptr, size_t size);
+#ifdef __cplusplus
+}
+#endif
+
+#define PAS_MTE_HANDLE_SYSTEM_HEAP_ALLOCATION(systemHeap, size, alignment, mode) do { \
+        if ((mode) != pas_non_compact_allocation_mode) \
+            return pas_mte_system_heap_malloc_zero_tagged(systemHeap->zone(), (alignment), (size)); \
+    } while (false)
+
+#define PAS_MTE_HANDLE_SYSTEM_HEAP_REALLOCATION(systemHeap, ptr, size, mode) do { \
+        if (mode != pas_non_compact_allocation_mode) \
+            return pas_mte_system_heap_realloc_zero_tagged(systemHeap->zone(), (ptr), (size)); \
+    } while (false)
+
+// Used to tag bump allocations in the primordial heap.
+// Non-homogeneous because this comes from a partial view, meaning other
+// allocators can use the same page.
+// Takes a pas_segregated_page_config*
+#define PAS_MTE_HANDLE_PRIMORDIAL_BUMP_ALLOCATION(page_config, ptr, size, mode) do { \
+        /* Even though this is a bump allocation, because we have the page_config */ \
+        /* handy, we use the page instead of the allocator for purposes of checking */ \
+        /* if this allocation should be tagged. */ \
+        if (PAS_USE_MTE && PAS_MTE_SHOULD_TAG_PAGE(page_config)) \
+            PAS_MTE_TAG_REGION_FROM_OTHER_ALLOCATION(ptr, size, mode, pas_mte_homogeneous_allocator, PAS_MTE_IS_KNOWN_MEDIUM_PAGE(page_config)); \
+    } while (false)
+
+// Used to bail from allocating megapages from the megapage large heap if PAS_MTE is disabled.
+// The non-MTE default is to use the megapage large heap for any non-compact megapage
+// allocation, which is what we want in an PAS_MTE world, but splitting up the page sources incurs
+// a modest but significant performance/memory overhead when PAS_MTE is disabled. This is part of
+// the inevitable overhead of enabling PAS_MTE, but we don't want to burden non-PAS_MTE hardware with
+// this cost, so we inject this early return.
+#define PAS_MTE_HANDLE_MEGAPAGES_ALLOCATION(heap, size, alignment, heap_config) do { \
+        if (!PAS_USE_MTE) { \
+            return pas_large_heap_try_allocate_and_forget( \
+                &heap->large_heap, size, alignment, pas_non_compact_allocation_mode, \
+                heap_config, transaction); \
+        } \
+    } while (false)
+
+// Used to tag the trailing-buffer bytes of a partial view when it is first
+// committed and becomes ready for use as an allocator.
+#define PAS_MTE_HANDLE_POPULATE_PRIMORDIAL_PARTIAL_VIEW(page_config, page, view, bump_result, mode) do { \
+        if (PAS_USE_MTE) { \
+            if (PAS_MTE_SHOULD_TAG_PAGE(&page_config)) \
+                PAS_MTE_TAG_BUMP_ALLOCATION_FOR_PARTIAL_VIEW(page_config, page, view, bump_result, mode); \
+        } \
+    } while (false)
+
+// Used to redirect small megapage allocations when PAS_MTE is not enabled to the respective untagged megapage cache.
+#define PAS_MTE_HANDLE_SMALL_SHARED_SEGREGATED_PAGE_ALLOCATION(heap, megapage_cache) do { \
+        if (!PAS_USE_MTE || !heap->parent_heap->is_non_compact_heap) \
+            megapage_cache = &page_caches->small_compact_other_megapage_cache; \
+    } while (false)
+#define PAS_MTE_HANDLE_SMALL_EXCLUSIVE_SEGREGATED_PAGE_ALLOCATION(heap, megapage_cache) do { \
+        if (!PAS_USE_MTE || !heap->parent_heap->is_non_compact_heap) \
+            megapage_cache = &page_caches->small_compact_exclusive_segregated_megapage_cache; \
+    } while (false)
+#define PAS_MTE_HANDLE_SMALL_BITFIT_PAGE_ALLOCATION(heap, megapage_cache) do { \
+        if (!PAS_USE_MTE || !heap->parent_heap->is_non_compact_heap) \
+            megapage_cache = &page_caches->small_compact_other_megapage_cache; \
+    } while (false)
+
+// Used to redirect medium megapage allocations when medium object tagging is not enabled to the respective untagged megapage cache.
+#define PAS_MTE_HANDLE_MEDIUM_SEGREGATED_PAGE_ALLOCATION(heap, megapage_cache) do { \
+        if (!PAS_MTE_MEDIUM_TAGGING_ENABLED || !heap->parent_heap->is_non_compact_heap) \
+            megapage_cache = &page_caches->medium_compact_megapage_cache; \
+    } while (false)
+#define PAS_MTE_HANDLE_MEDIUM_BITFIT_PAGE_ALLOCATION(heap, megapage_cache) do { \
+        if (!PAS_MTE_MEDIUM_TAGGING_ENABLED || !heap->parent_heap->is_non_compact_heap) \
+            megapage_cache = &page_caches->medium_compact_megapage_cache; \
+    } while (false)
+
+// Used to tacitly redirect all marge megapage allocations to the untagged megapage cache.
+#define PAS_MTE_HANDLE_MARGE_BITFIT_PAGE_ALLOCATION(heap, megapage_cache) do { \
+        megapage_cache = &page_caches->medium_compact_megapage_cache; \
+    } while (false)
+
+// Used to tag the memory left behind by objects freed from bitfit heaps.
+#define PAS_MTE_HANDLE_BITFIT_PAGE_DEALLOCATION(page_config, ptr, size) do { \
+        (void)page_config; \
+        (void)ptr; \
+        (void)size; \
+        if (PAS_USE_MTE) { \
+            if (PAS_MTE_SHOULD_TAG_PAGE(&page_config)) \
+                PAS_MTE_TAG_REGION_FROM_DEALLOCATION(page_config, ptr, size, pas_mte_nonhomogeneous_allocator); \
+        } \
+    } while (false)
+
+// Used to tag the memory left behind by objects freed from segregated heaps.
+#define PAS_MTE_HANDLE_SEGREGATED_PAGE_DEALLOCATION(page_config, ptr, size) do { \
+        (void)page_config; \
+        (void)ptr; \
+        (void)size; \
+        if (PAS_USE_MTE) { \
+            if (PAS_MTE_SHOULD_TAG_PAGE(&page_config)) \
+                PAS_MTE_TAG_REGION_FROM_DEALLOCATION(page_config, ptr, size, pas_mte_homogeneous_allocator); \
+        } \
+    } while (false)
+
+#define PAS_MTE_HANDLE_SCAVENGER_THREAD_MAIN(data) do { \
+        pas_mte_ensure_initialized(); \
+    } while (false)
+
+#if PAS_OS(DARWIN)
+#define PAS_MTE_HANDLE_PAGE_ALLOCATION(size, is_small, tag) do { \
+        pas_mte_ensure_initialized(); \
+        if (PAS_USE_MTE && (is_small)) { \
+            const vm_inherit_t childProcessInheritance = VM_INHERIT_DEFAULT; \
+            const bool copy = false; \
+            const vm_prot_t protections = VM_PROT_WRITE | VM_PROT_READ; \
+            kern_return_t vm_map_result = mach_vm_map(mach_task_self(), (mach_vm_address_t*)&mmap_result, (size), pas_page_malloc_alignment() - 1, VM_FLAGS_ANYWHERE | PAS_VM_MTE | (tag), MEMORY_OBJECT_NULL, 0, copy, protections, protections, childProcessInheritance); \
+            if (vm_map_result != KERN_SUCCESS) { \
+                errno = 0; \
+                if (PAS_MTE_FEATURE_ENABLED(PAS_MTE_FEATURE_LOG_PAGE_ALLOC)) \
+                    printf("[MTE]\tFailed to map %zu bytes with VM_FLAGS_MTE.\n", (size_t)(size)); \
+                return NULL; \
+            } \
+            if (PAS_MTE_FEATURE_ENABLED(PAS_MTE_FEATURE_LOG_PAGE_ALLOC)) \
+                printf("[MTE]\tMapped %zu bytes from %p to %p with VM_FLAGS_MTE.\n", (size_t)(size), (void*)(mmap_result), (uint8_t*)(mmap_result) + (size)); \
+            return mmap_result; \
+        } \
+    } while (false)
+#else // PAS_OS(DARWIN) -> !PAS_OS(DARWIN)
+#define PAS_MTE_HANDLE_PAGE_ALLOCATION(a, b) do { \
+        (void)(a); \
+        (void)(b); \
+    } while (false)
+#endif // !PAS_OS(DARWIN)
+
+#define PAS_MTE_HANDLE(kind, ...) \
+    PAS_MTE_HANDLE_ ## kind(__VA_ARGS__)
+
+PAS_IGNORE_WARNINGS_END
+
+#else // !PAS_ENABLE_MTE
+#define PAS_MTE_HANDLE(kind, ...) PAS_UNUSED_V(__VA_ARGS__)
+#define PAS_SHOULD_MTE_TAG_BASIC_HEAP_PAGE(size_category) (false)
+#endif // PAS_ENABLE_MTE
+
+#endif // PAS_MTE_H

--- a/Source/bmalloc/libpas/src/libpas/pas_mte_config.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_mte_config.c
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ */
+
+#include "pas_mte_config.h"
+
+#include "stdlib.h"
+#if PAS_OS(DARWIN)
+#include <sys/sysctl.h>
+#endif
+#if !PAS_OS(WINDOWS)
+#include "unistd.h"
+#endif
+
+#include "pas_mte.h"
+#include "pas_utils.h"
+#include "pas_heap.h"
+#include "pas_zero_memory.h"
+
+#if PAS_ENABLE_MTE
+
+extern pas_heap bmalloc_common_primitive_heap;
+
+static int is_env_false(const char* var)
+{
+    const char* value = getenv(var);
+    if (!value)
+        return 0;
+    return !strcasecmp(value, "false") || !strcasecmp(value, "no") || !strcasecmp(value, "0");
+}
+
+static int is_env_true(const char* var)
+{
+    const char* value = getenv(var);
+    if (!value)
+        return 0;
+    return !strcasecmp(value, "true") || !strcasecmp(value, "yes") || !strcasecmp(value, "1");
+}
+
+static bool get_value_if_available(unsigned* valuePtr, const char* var)
+{
+    const char* varStr = getenv(var);
+    if (varStr) {
+        unsigned value = 0;
+        if (sscanf(varStr, "%u", &value) == 1) {
+            *valuePtr = value;
+            return true; // Found.
+        }
+    }
+    return false; // Not found.
+}
+
+static void pas_mte_do_initialization(void)
+{
+    uint8_t* enabled_byte = &PAS_MTE_CONFIG_BYTE(PAS_MTE_ENABLE_FLAG);
+    uint8_t* mode_byte = &PAS_MTE_CONFIG_BYTE(PAS_MTE_MODE_BITS);
+    uint8_t* medium_byte = &PAS_MTE_CONFIG_BYTE(PAS_MTE_MEDIUM_TAGGING_ENABLE_FLAG);
+    uint8_t* lockdown_mode_byte = &PAS_MTE_CONFIG_BYTE(PAS_MTE_LOCKDOWN_MODE_FLAG);
+    uint8_t* is_wcp_byte = &PAS_MTE_CONFIG_BYTE(PAS_MTE_IS_WCP_FLAG);
+
+    struct proc_bsdinfo info;
+    int rc = proc_pidinfo(getpid(), PROC_PIDTBSDINFO, 0, &info, sizeof(info));
+    if (rc == sizeof(info) && info.pbi_flags & PAS_MTE_PROC_FLAG_SEC_ENABLED)
+        *enabled_byte = 1;
+
+    if (is_env_true("JSC_useAllocationProfiling") || is_env_true("MTE_overrideEnablementForJavaScriptCore")) {
+        PAS_ASSERT(!(is_env_false("JSC_useAllocationProfiling") || is_env_false("MTE_overrideEnablementForJavaScriptCore")));
+        *enabled_byte = 1;
+    }
+    if (is_env_false("JSC_useAllocationProfiling") || is_env_false("MTE_overrideEnablementForJavaScriptCore"))
+        *enabled_byte = 0;
+
+    if (!*enabled_byte)
+        return;
+
+    unsigned mode = 0;
+    if (get_value_if_available(&mode, "JSC_allocationProfilingMode"))
+        *mode_byte = (uint8_t)(mode & 0xFF);
+
+    const char* name = info.pbi_name[0] ? info.pbi_name : info.pbi_comm;
+    bool isWebContentProcess = !strncmp(name, "com.apple.WebKit.WebContent", 27) || !strncmp(name, "jsc", 3);
+    *is_wcp_byte = isWebContentProcess;
+
+    unsigned taggingRate = 100;
+    if (isWebContentProcess) {
+        const uint8_t defaultWebContentTaggingRate = 33;
+        taggingRate = defaultWebContentTaggingRate;
+
+        // Debug option to override the WCP tagging rate.
+        get_value_if_available(&taggingRate, "MTE_taggingRateForWebContent");
+    }
+
+    // Debug option to unconditionally override the tagging rate.
+    get_value_if_available(&taggingRate, "MTE_taggingRate");
+
+    PAS_MTE_CONFIG_BYTE(PAS_MTE_TAGGING_RATE) = taggingRate;
+
+    if (isWebContentProcess) {
+        *medium_byte = 0;
+#if !PAS_USE_MTE_IN_WEBCONTENT
+        // Disable tagging in libpas by default in WebContent process
+        *enabled_byte = 0;
+#endif
+        uint64_t ldmState = 0;
+        size_t sysCtlLen = sizeof(ldmState);
+        if (sysctlbyname("security.mac.lockdown_mode_state", &ldmState, &sysCtlLen, NULL, 0) >= 0 && ldmState == 1) {
+            *enabled_byte = 1;
+            *medium_byte = 1;
+            *lockdown_mode_byte = 1;
+        } else {
+            *lockdown_mode_byte = 0;
+
+            // FIXME: rdar://159974195
+            bmalloc_common_primitive_heap.is_non_compact_heap = false;
+        }
+
+#ifndef NDEBUG
+        if (is_env_true("MTE_disableForWebContent")) {
+            PAS_ASSERT(!is_env_true("MTE_overrideEnablementForWebContent"));
+            *enabled_byte = 0;
+            *medium_byte = 0;
+        }
+#endif
+        if (is_env_true("MTE_overrideEnablementForWebContent")) {
+            *enabled_byte = 1;
+            *medium_byte = 1;
+        } else if (is_env_false("MTE_overrideEnablementForWebContent")) {
+            *enabled_byte = 0;
+            *medium_byte = 0;
+        }
+    } else
+        *medium_byte = 1; // Tag libpas medium objects in privileged processes.
+}
+
+static bool pas_mte_is_enabled(void)
+{
+    const uint8_t* enabledByte = ((const uint8_t*)(g_config + 2));
+    struct proc_bsdinfo info;
+    int rc = proc_pidinfo(getpid(), PROC_PIDTBSDINFO, 0, &info, sizeof(info));
+    return (rc == sizeof(info) && (info.pbi_flags & PAS_MTE_PROC_FLAG_SEC_ENABLED) && !!*enabledByte);
+}
+
+#else // !PAS_ENABLE_MTE
+
+static PAS_UNUSED void pas_mte_do_initialization(void) { }
+
+static PAS_UNUSED bool pas_mte_is_enabled(void)
+{
+    return false;
+}
+
+#endif // PAS_ENABLE_MTE
+
+#if PAS_OS(DARWIN)
+static void pas_mte_do_and_check_initialization(void* context)
+{
+    (void)context;
+    pas_mte_do_initialization();
+    const char* crashIfMTENotEnabled = getenv("MTE_crashIfNotEnabled");
+    if (crashIfMTENotEnabled) {
+        if (!strcasecmp(crashIfMTENotEnabled, "true")
+            || !strcasecmp(crashIfMTENotEnabled, "yes")
+            || !strcasecmp(crashIfMTENotEnabled, "1")) {
+            PAS_ASSERT(pas_mte_is_enabled() && "MTE is not enabled, crashing");
+        }
+    }
+}
+
+void pas_mte_ensure_initialized(void)
+{
+    static dispatch_once_t pred;
+    dispatch_once_f(&pred, NULL, pas_mte_do_and_check_initialization);
+}
+#else // !PAS_OS(DARWIN)
+#if PAS_ENABLE_MTE
+#error "pas_mte_ensure_initialized does not support non-Darwin systems"
+#endif
+void pas_mte_ensure_initialized(void) { }
+#endif // PAS_OS(DARWIN)

--- a/Source/bmalloc/libpas/src/libpas/pas_mte_config.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_mte_config.h
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ */
+
+#ifndef PAS_MTE_CONFIG_H
+#define PAS_MTE_CONFIG_H
+
+#include "pas_platform.h"
+#include "pas_config.h"
+#if defined(PAS_BMALLOC)
+#include "BPlatform.h"
+#endif
+
+#if defined(__has_include)
+#if __has_include(<WebKitAdditions/pas_mte_additions.h>)
+#include <WebKitAdditions/pas_mte_additions.h>
+#endif // __has_include(<WebKitAdditions/pas_mte_additions.h>)
+#if __has_include(<libproc.h>)
+#include <libproc.h>
+#endif // __has_include(<libproc.h>)
+#endif // defined(__has_include)
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __APPLE__
+#include <Availability.h>
+#include <AvailabilityMacros.h>
+#include <TargetConditionals.h>
+#endif
+#if PAS_OS(DARWIN)
+#include <dispatch/dispatch.h>
+#if PAS_USE_APPLE_INTERNAL_SDK
+#include <mach/mach_init.h>
+#include <mach/mach_vm.h>
+#include <mach/vm_page_size.h>
+#include <mach/vm_statistics.h>
+#endif // PAS_USE_APPLE_INTERNAL_SDK
+#endif // PAS_OS(DARWIN)
+
+#if PAS_ENABLE_MTE
+
+typedef uint64_t Slot;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+extern Slot g_config[];
+#ifdef __cplusplus
+}
+#endif
+
+#define PAS_MTE_ENABLE_FLAG 0
+#define PAS_MTE_MODE_BITS 1
+#define PAS_MTE_TAGGING_RATE 2
+#define PAS_MTE_MEDIUM_TAGGING_ENABLE_FLAG 3
+#define PAS_MTE_LOCKDOWN_MODE_FLAG 4
+#define PAS_MTE_IS_WCP_FLAG 5
+
+// Must be kept in sync with the offsets in WTFConfig.h:ReservedConfigByteOffset
+#define PAS_MTE_CONFIG_RESERVED_BYTE_OFFSET 2
+#define PAS_MTE_CONFIG_BYTE(byte) (((uint8_t*)(g_config + PAS_MTE_CONFIG_RESERVED_BYTE_OFFSET))[byte])
+
+#define PAS_USE_MTE (PAS_MTE_CONFIG_BYTE(PAS_MTE_ENABLE_FLAG))
+#ifndef PAS_USE_MTE_IN_WEBCONTENT
+#define PAS_USE_MTE_IN_WEBCONTENT 1
+#endif
+
+#define PAS_MTE_CONFIG_FIELD(byte, bit) (((PAS_MTE_CONFIG_BYTE(byte)) & (1UL << (bit))) ? 1 : 0)
+#define PAS_MTE_MEDIUM_TAGGING_ENABLED (PAS_MTE_CONFIG_BYTE(PAS_MTE_MEDIUM_TAGGING_ENABLE_FLAG))
+#define PAS_MTE_IS_LOCKDOWN_MODE (PAS_MTE_CONFIG_BYTE(PAS_MTE_LOCKDOWN_MODE_FLAG))
+#define PAS_MTE_IS_IN_WCP (PAS_MTE_CONFIG_BYTE(PAS_MTE_IS_WCP_FLAG))
+
+#define PAS_VM_MTE 0x2000
+#define PAS_MTE_PROC_FLAG_SEC_ENABLED 0x4000000
+
+#define PAS_MTE_SHOULD_STORE_TAG 1
+
+#ifndef PAS_USE_COMPACT_ONLY_HEAP
+/*
+ * The reason we make TZone compact-only heaps reliant on runtime PAS_MTE
+ * enablement, and not the general compact-only heap, is that lumping all
+ * non-compact objects into the same heap is a security regression for TZone,
+ * but not a security regression for the general bmalloc heap where we already
+ * expect all allocations to come out of the same singular intrinsic heap.
+ * By avoiding checking PAS_USE_MTE, we save an additional check in the malloc
+ * fast path for ordinary allocations, while the corresponding check for TZone
+ * heaps only occurs during heap selection - it's not as significant.
+ */
+#define PAS_USE_COMPACT_ONLY_HEAP 1
+#define PAS_USE_COMPACT_ONLY_TZONE_HEAP PAS_USE_MTE
+#endif
+
+#define PAS_MTE_FEATURE_RETAG_ON_FREE 0
+#define PAS_MTE_FEATURE_LOG_ON_TAG 1
+#define PAS_MTE_FEATURE_LOG_ON_PURIFY 2
+#define PAS_MTE_FEATURE_LOG_PAGE_ALLOC 3
+#define PAS_MTE_FEATURE_ZERO_TAG_ALL 4
+#define PAS_MTE_FEATURE_ADJACENT_TAG_EXCLUSION 5
+#define PAS_MTE_FEATURE_ASSERT_ADJACENT_TAGS_ARE_DISJOINT 6
+
+#define PAS_MTE_FEATURE_FORCED(feature) (0)
+#define PAS_MTE_FEATURE_PRIVILEGED_FORCED(feature) (feature == PAS_MTE_FEATURE_ADJACENT_TAG_EXCLUSION)
+#define PAS_MTE_FEATURE_WCP_FORCED(feature) (0)
+#define PAS_MTE_FEATURE_DEBUG_FORCED(feature) (feature == PAS_MTE_FEATURE_ASSERT_ADJACENT_TAGS_ARE_DISJOINT)
+
+#define PAS_MTE_FEATURE_FORCED_IN_RELEASE_BUILD(feature) \
+    (PAS_MTE_FEATURE_FORCED(feature) || \
+     (PAS_MTE_FEATURE_PRIVILEGED_FORCED(feature) && !PAS_MTE_IS_IN_WCP) || \
+     (PAS_MTE_FEATURE_WCP_FORCED(feature) && PAS_MTE_IS_IN_WCP))
+
+#define PAS_MTE_FEATURE_FORCED_IN_DEBUG_BUILD(feature) \
+    (PAS_MTE_FEATURE_FORCED_IN_RELEASE_BUILD(feature) || \
+     PAS_MTE_FEATURE_DEBUG_FORCED(feature) || \
+     PAS_MTE_CONFIG_FIELD(PAS_MTE_MODE_BITS, feature))
+
+#ifndef NDEBUG
+#define PAS_MTE_FEATURE_ENABLED(feature) (PAS_USE_MTE && PAS_MTE_FEATURE_FORCED_IN_DEBUG_BUILD(feature))
+#else
+#define PAS_MTE_FEATURE_ENABLED(feature) (PAS_USE_MTE && PAS_MTE_FEATURE_FORCED_IN_RELEASE_BUILD(feature))
+#endif
+
+#else // !PAS_ENABLE_MTE
+#define PAS_USE_MTE (0)
+#define PAS_USE_MTE_IN_WEBCONTENT (0)
+#define PAS_MTE_FEATURE_ENABLED(feature) (0)
+#endif // PAS_ENABLE_MTE
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+void pas_mte_ensure_initialized(void);
+#ifdef __cplusplus
+}
+#endif
+
+#if defined(PAS_BMALLOC) && BENABLE(LIBPAS)
+#if BENABLE_MTE != PAS_ENABLE_MTE
+#error "cannot enable MTE in libpas without enabling it in bmalloc, or vice versa"
+#endif
+
+#define BMALLOC_VM_MTE PAS_VM_MTE
+#define BMALLOC_USE_MTE PAS_USE_MTE
+
+#endif // defined(PAS_BMALLOC) && BENABLE(LIBPAS)
+
+#endif // PAS_MTE_CONFIG_H

--- a/Source/bmalloc/libpas/src/libpas/pas_page_base_config.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_page_base_config.h
@@ -68,6 +68,9 @@ struct pas_page_base_config {
     /* whether profiling macros should ignore pages of this kind */
     bool allow_profiling;
 
+    /* Whether this page can be allocated with backing MTE tag memory. */
+    bool allow_mte_tagging;
+
     /* This points to the owning heap config. Currently there is always an owning heap config. */
     const pas_heap_config* heap_config_ptr;
     

--- a/Source/bmalloc/libpas/src/libpas/pas_page_base_config_utils.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_page_base_config_utils.h
@@ -28,6 +28,7 @@
 
 #include "pas_config.h"
 #include "pas_internal_config.h"
+#include "pas_mte.h"
 #include "pas_page_base_config.h"
 #include "pas_page_header_placement_mode.h"
 #include "pas_page_header_table.h"
@@ -69,16 +70,21 @@ typedef struct {
         case pas_page_header_at_head_of_page: { \
             uintptr_t ptr = (uintptr_t)boundary; \
             PAS_PROFILE(PAGE_BASE_FROM_BOUNDARY, ptr); \
+            PAS_MTE_HANDLE(PAGE_BASE_FROM_BOUNDARY, ptr); \
             return (pas_page_base*)ptr; \
         } \
         \
         case pas_page_header_in_table: { \
             uintptr_t page_base = (uintptr_t)boundary; \
             PAS_PROFILE(PAGE_BASE_FROM_BOUNDARY, page_base); \
+            PAS_MTE_HANDLE(PAGE_BASE_FROM_BOUNDARY, page_base); \
             page_base = (uintptr_t)pas_page_header_table_get_for_boundary( \
                 arguments.header_table, config.page_size, (pas_page_base*)page_base); \
             PAS_TESTING_ASSERT(page_base); \
             PAS_PROFILE(PAGE_BASE_FROM_TABLE, page_base); \
+            /* Does not need to be MTE-tagged since page-bases should always */ \
+            /* be zero-tagged, and the page header table should already have */ \
+            /* cleared the pointer it gave us. */ \
             return (pas_page_base*)page_base; \
         } } \
         \

--- a/Source/bmalloc/libpas/src/libpas/pas_page_header_table.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_page_header_table.c
@@ -43,6 +43,7 @@ pas_page_base* pas_page_header_table_add(pas_page_header_table* table,
 
     uintptr_t boundary_int = (uintptr_t)boundary;
     PAS_PROFILE(PAGE_HEADER_TABLE_ADD, boundary_int);
+    PAS_MTE_HANDLE(PAGE_HEADER_TABLE_ADD, boundary_int);
     boundary = (void*)boundary_int;
 
     if (verbose)

--- a/Source/bmalloc/libpas/src/libpas/pas_page_header_table.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_page_header_table.h
@@ -27,6 +27,7 @@
 #define PAS_PAGE_HEADER_TABLE_H
 
 #include "pas_lock_free_read_ptr_ptr_hashtable.h"
+#include "pas_mte.h"
 
 PAS_BEGIN_EXTERN_C;
 
@@ -96,6 +97,7 @@ pas_page_header_table_get_for_boundary(pas_page_header_table* table,
                        == begin);
 
     PAS_PROFILE(PAGE_HEADER_TABLE_GET, begin);
+    PAS_MTE_HANDLE(PAGE_HEADER_TABLE_GET, begin);
     boundary = (void*)begin;
     return (pas_page_base*)pas_lock_free_read_ptr_ptr_hashtable_find(
         &table->hashtable, pas_page_header_table_hash, (void*)page_size, boundary);

--- a/Source/bmalloc/libpas/src/libpas/pas_page_malloc.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_page_malloc.c
@@ -44,6 +44,7 @@
 
 #include "pas_internal_config.h"
 #include "pas_log.h"
+#include "pas_mte.h"
 #include "pas_utils.h"
 #include "pas_zero_memory.h"
 
@@ -146,12 +147,14 @@ pas_page_malloc_try_map_pages(size_t size, bool may_contain_small_or_medium)
 {
 #if PAS_OS(WINDOWS)
     PAS_PROFILE(PAGE_ALLOCATION, size, may_contain_small_or_medium, PAS_VM_TAG);
+    PAS_MTE_HANDLE(PAGE_ALLOCATION, size, may_contain_small_or_medium, PAS_VM_TAG);
 
     return virtual_alloc_with_retry(NULL, size, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
 #else
     void* mmap_result = NULL;
 
     PAS_PROFILE(PAGE_ALLOCATION, size, may_contain_small_or_medium, PAS_VM_TAG);
+    PAS_MTE_HANDLE(PAGE_ALLOCATION, size, may_contain_small_or_medium, PAS_VM_TAG);
 
     mmap_result = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON | PAS_NORESERVE, PAS_VM_TAG, 0);
     if (mmap_result == MAP_FAILED) {
@@ -308,6 +311,7 @@ void pas_page_malloc_zero_fill(void* base, size_t size)
 #endif /* PAS_USE_MADV_ZERO */
 
     PAS_PROFILE(ZERO_FILL_PAGE, base, size, flags, tag);
+    PAS_MTE_HANDLE(ZERO_FILL_PAGE, base, size, flags, tag);
     result_ptr = mmap(base, size, PROT_READ | PROT_WRITE, flags, tag, 0);
     PAS_ASSERT(result_ptr == base);
 #endif /* PAS_OS(WINDOWS) */

--- a/Source/bmalloc/libpas/src/libpas/pas_platform.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_platform.h
@@ -203,6 +203,17 @@
 #error "Unsupported compiler for libpas"
 #endif
 
+#if PAS_PLATFORM(COCOA)
+/* Should be aligned with the definition in WTF/wtf/PlatformUse.h */
+#if defined __has_include && __has_include(<CoreFoundation/CFPriv.h>)
+#define PAS_USE_APPLE_INTERNAL_SDK 1
+#else
+#define PAS_USE_APPLE_INTERNAL_SDK 0
+#endif
+#else // !PAS_PLATFORM(COCOA)
+#define PAS_USE_APPLE_INTERNAL_SDK 0
+#endif // PAS_PLATFORM(COCOA)
+
 /* PAS_ALLOW_UNSAFE_BUFFER_USAGE */
 
 #if PAS_COMPILER(CLANG)

--- a/Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.c
@@ -32,6 +32,7 @@
 
 #include "pas_heap.h"
 #include "pas_large_utility_free_heap.h"
+#include "pas_mte.h"
 #include "pas_random.h"
 #include "pas_utility_heap.h"
 #include <stdbool.h>
@@ -211,6 +212,7 @@ pas_allocation_result pas_probabilistic_guard_malloc_allocate(pas_large_heap* la
 #endif
 
     PAS_PROFILE(PGM_ALLOCATE, heap_config, key);
+    PAS_MTE_HANDLE(PGM_ALLOCATE, heap_config, key);
 
     /* create struct to hold hash map value */
     pas_pgm_storage* value = pas_utility_heap_try_allocate(sizeof(pas_pgm_storage), "pas_pgm_hash_map_VALUE");
@@ -260,6 +262,7 @@ void pas_probabilistic_guard_malloc_deallocate(void* mem)
 
     uintptr_t key = (uintptr_t)mem;
     PAS_PROFILE(PGM_DEALLOCATE, key);
+    PAS_MTE_HANDLE(PGM_DEALLOCATE, key);
 
     pas_ptr_hash_map_entry* entry = pas_ptr_hash_map_find(&pas_pgm_hash_map, (void*)key);
     if (!entry || !entry->value)

--- a/Source/bmalloc/libpas/src/libpas/pas_root.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_root.c
@@ -24,6 +24,7 @@
  */
 
 #include "pas_config.h"
+
 #if LIBPAS_ENABLED
 #include "pas_zero_memory.h"
 #include "pas_root.h"

--- a/Source/bmalloc/libpas/src/libpas/pas_scavenger.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_scavenger.c
@@ -38,6 +38,7 @@
 #include "pas_immortal_heap.h"
 #include "pas_large_expendable_memory.h"
 #include "pas_lock.h"
+#include "pas_mte.h"
 #include "pas_page_sharing_pool.h"
 #include "pas_status_reporter.h"
 #include "pas_thread_local_cache.h"
@@ -214,6 +215,7 @@ static void* scavenger_thread_main(void* arg)
 #endif
 
     PAS_PROFILE(SCAVENGER_THREAD_MAIN, data);
+    PAS_MTE_HANDLE(SCAVENGER_THREAD_MAIN, data);
 
     for (;;) {
         pas_page_sharing_pool_scavenge_result scavenge_result;

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_page_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_page_inlines.h
@@ -28,6 +28,7 @@
 
 #include "pas_config.h"
 #include "pas_log.h"
+#include "pas_mte.h"
 #include "pas_page_base_inlines.h"
 #include "pas_segregated_deallocation_mode.h"
 #include "pas_segregated_exclusive_view_inlines.h"
@@ -465,6 +466,7 @@ pas_segregated_page_deallocate_with_page(pas_segregated_page* page,
     }
 
     PAS_PROFILE(SEGREGATED_PAGE_DEALLOCATION, page_config, begin, object_size);
+    PAS_MTE_HANDLE(SEGREGATED_PAGE_DEALLOCATION, page_config, begin, object_size);
 
     if (page_config.base.page_size > page_config.base.granule_size) {
         /* This is the partial decommit case. It's intended for medium pages. It requires doing

--- a/Source/bmalloc/libpas/src/libpas/pas_small_medium_bootstrap_heap_page_provider.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_small_medium_bootstrap_heap_page_provider.c
@@ -30,6 +30,7 @@
 #include "pas_small_medium_bootstrap_heap_page_provider.h"
 
 #include "pas_bootstrap_free_heap.h"
+#include "pas_mte.h"
 #include "pas_small_medium_bootstrap_free_heap.h"
 
 pas_allocation_result pas_small_medium_bootstrap_heap_page_provider(

--- a/Source/bmalloc/libpas/src/libpas/pas_thread_local_cache.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_thread_local_cache.h
@@ -38,6 +38,7 @@
 #include "pas_malloc_stack_logging.h"
 #include "pas_segregated_page_config_kind_and_role.h"
 #include "pas_utils.h"
+#include "pas_zero_memory.h"
 
 #include "pas_thread.h"
 

--- a/Source/bmalloc/libpas/src/libpas/pas_try_reallocate.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_try_reallocate.h
@@ -30,6 +30,7 @@
 #include "pas_deallocate.h"
 #include "pas_large_map.h"
 #include "pas_malloc_stack_logging.h"
+#include "pas_mte.h"
 #include "pas_reallocate_free_mode.h"
 #include "pas_reallocate_heap_teleport_rule.h"
 #include "pas_try_allocate.h"
@@ -102,6 +103,7 @@ pas_try_allocate_for_reallocate_and_copy(
         if (verbose)
             pas_log("copying size %zu from %p to %p\n", copy_size, old_ptr, (void*)result.begin);
         PAS_PROFILE(TRY_REALLOCATE_AND_COPY, result.begin, old_ptr, copy_size);
+        PAS_MTE_HANDLE(TRY_REALLOCATE_AND_COPY, result.begin, old_ptr, copy_size);
         memcpy((void*)result.begin, old_ptr, copy_size);
         if (verbose)
             pas_log("\t...done copying size %zu from %p to %p\n", copy_size, old_ptr, (void*)result.begin);
@@ -353,6 +355,7 @@ pas_try_reallocate(void* old_ptr,
         }
 
         PAS_PROFILE(LARGE_MAP_FOUND_ENTRY, &config, entry.begin, entry.end);
+        PAS_MTE_HANDLE(LARGE_MAP_FOUND_ENTRY, &config, entry.begin, entry.end);
         PAS_ASSERT(entry.begin == begin);
         PAS_ASSERT(entry.end > begin);
         PAS_ASSERT(entry.heap);

--- a/Source/bmalloc/libpas/src/libpas/pas_utility_heap_config.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_utility_heap_config.h
@@ -94,6 +94,7 @@ PAS_API void pas_utility_heap_config_dump_shared_page_directory_arg(
             .base = { \
                 .is_enabled = true, \
                 .allow_profiling = true, \
+                .allow_mte_tagging = true, \
                 .heap_config_ptr = &pas_utility_heap_config, \
                 .page_config_ptr = &pas_utility_heap_config.small_segregated_config.base, \
                 .page_config_kind = pas_page_config_kind_segregated, \

--- a/Source/bmalloc/libpas/src/libpas/pas_utils.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_utils.h
@@ -58,6 +58,10 @@ PAS_IGNORE_CLANG_WARNINGS_BEGIN("qualifier-requires-header")
 #define PAS_END_EXTERN_C __PAS_END_EXTERN_C
 
 #if defined(PAS_BMALLOC) && PAS_BMALLOC
+#include "pas_mte_config.h"
+#endif // defined(PAS_BMALLOC) && PAS_BMALLOC
+
+#if defined(PAS_BMALLOC) && PAS_BMALLOC
 #if defined(__has_include)
 #if __has_include(<WebKitAdditions/pas_utils_additions.h>) && !PAS_ENABLE_TESTING
 #include <WebKitAdditions/pas_utils_additions.h>

--- a/Source/bmalloc/libpas/src/libpas/pas_zero_memory.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_zero_memory.h
@@ -26,6 +26,7 @@
 #ifndef PAS_ZERO_MEMORY_H
 #define PAS_ZERO_MEMORY_H
 
+#include "pas_mte.h"
 #include "pas_utils.h"
 #include <stdint.h>
 
@@ -35,6 +36,7 @@ static PAS_ALWAYS_INLINE void pas_zero_memory(void* memory, size_t size)
 {
     PAS_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     PAS_PROFILE(ZERO_MEMORY, memory, size);
+    PAS_MTE_HANDLE(ZERO_MEMORY, memory, size);
     memset(memory, 0, size);
     PAS_ALLOW_UNSAFE_BUFFER_USAGE_END
 }

--- a/Tools/Scripts/webkitpy/style/checker.py
+++ b/Tools/Scripts/webkitpy/style/checker.py
@@ -373,10 +373,17 @@ _PATH_RULES_SPECIFIER = [
     ([
       # Source/bmalloc/libpas/src/ is first-party code, but largely operates
       # as an separate codebase, with a few different style rules.
+      # It also does not have access to any of WTF's safe-cpp wrappers,
+      # e.g. memsetSpan.
       os.path.join('Source', 'bmalloc', 'libpas', 'src')],
      ["-readability/naming/underscores",
+      "-readability/parameter_name",
       "-whitespace/declaration",
-      "-whitespace/indent"]),
+      "-whitespace/indent",
+      "-safercpp/printf",
+      "-safercpp/memset",
+      "-safercpp/memcpy",
+      "-safercpp/strncmp",]),
 
     ([
       # There is no way to avoid the symbols __jit_debug_register_code


### PR DESCRIPTION
#### f3dd2851bfd6fc0f9b1f16a4943b0f81ac9ac7b6
<pre>
[libpas] Implement primary support for MTE
<a href="https://bugs.webkit.org/show_bug.cgi?id=299488">https://bugs.webkit.org/show_bug.cgi?id=299488</a>
<a href="https://rdar.apple.com/161273712">rdar://161273712</a>

Reviewed by Daniel Liu.

As announced on September 9th, the SoCs used in the next generation of
iPhones will include support for ARM&apos;S Memory Tagging Extension
functionality. As part of Apple&apos;s MIE (Memory Integrity Enforcement)
feature, libpas should thus implement support for MTE and related
memory-safety functionality to ensure that WebKit is up to par with the
new memory safety standards set by the rest of the system.

In particular, this patch ensures that when possible we allocate memory
with backing MTE tag pages and tag allocations made within them prior to
returning allocation memory to the caller. Not all memory can be tagged
this way: in particular, objects &gt;= 32K and objects which may be
referenced via compact pointers cannot be MTE tagged. There are other
exceptions as well, depending on process/object-type/platform.
It also implements a variety of hardening strategies to further
strengthen the feature and prevent certain well-known kinds of attacks.

Trying this again, since the previous attempt caused build breakages
in certain configurations.

Canonical link: <a href="https://commits.webkit.org/300960@main">https://commits.webkit.org/300960@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ec076f6aff6c7d0d8cdf8c846b38945897e2a7a1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124336 "8 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44018 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34746 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131175 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76388 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e5fdaaad-4a6b-4a89-bc32-fdd201b8b2d6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/126213 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44763 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52616 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94581 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62747 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/905ce85f-b443-4d80-92a6-de0305540149) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127290 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35675 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111212 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75168 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/614ad52f-bf16-49b8-acd1-682590fd19e2) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/123692 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34614 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29372 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74652 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/116468 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105420 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29595 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133842 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/122864 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51237 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39074 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103060 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51634 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107431 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102856 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26206 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48219 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26471 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48172 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51103 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56888 "Built successfully") | [❌ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/153961 "Hash ec076f6a for PR 51633 does not build (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50536 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/153961 "Hash ec076f6a for PR 51633 does not build (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53892 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52211 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->