### PR TITLE
[Style] Replace isZero/isNegative/isPositive functions inherited from WebCore::Length

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -623,11 +623,13 @@ rendering/style/StyleMultiImage.cpp
 rendering/style/StylePaintImage.cpp
 rendering/svg/RenderSVGBlock.cpp
 rendering/svg/RenderSVGContainer.cpp
+rendering/svg/RenderSVGEllipse.cpp
 rendering/svg/RenderSVGImage.cpp
 rendering/svg/RenderSVGInline.cpp
 rendering/svg/RenderSVGInlineText.cpp
 rendering/svg/RenderSVGModelObject.cpp
 rendering/svg/RenderSVGPath.cpp
+rendering/svg/RenderSVGRect.cpp
 rendering/svg/RenderSVGResourceClipper.cpp
 rendering/svg/RenderSVGResourceFilterInlines.h
 rendering/svg/RenderSVGResourceFilterPrimitive.cpp
@@ -654,10 +656,12 @@ rendering/svg/SVGTextMetrics.cpp
 rendering/svg/SVGTextQuery.cpp
 rendering/svg/SVGVisitedRendererTracking.h
 rendering/svg/legacy/LegacyRenderSVGContainer.cpp
+rendering/svg/legacy/LegacyRenderSVGEllipse.cpp
 rendering/svg/legacy/LegacyRenderSVGForeignObject.cpp
 rendering/svg/legacy/LegacyRenderSVGImage.cpp
 rendering/svg/legacy/LegacyRenderSVGModelObject.cpp
 rendering/svg/legacy/LegacyRenderSVGPath.cpp
+rendering/svg/legacy/LegacyRenderSVGRect.cpp
 rendering/svg/legacy/LegacyRenderSVGResourceClipper.cpp
 rendering/svg/legacy/LegacyRenderSVGResourceContainer.cpp
 rendering/svg/legacy/LegacyRenderSVGResourceFilter.cpp

--- a/Source/WebCore/css/values/CSSValueConcepts.h
+++ b/Source/WebCore/css/values/CSSValueConcepts.h
@@ -74,9 +74,19 @@ template<typename T> concept HasIsZero = requires(T t) {
     { t.isZero() } -> std::convertible_to<bool>;
 };
 
+// The `HasIsKnownZero` concept can be used to filter to types that have an `isKnownZero` member function.
+template<typename T> concept HasIsKnownZero = requires(T t) {
+    { t.isKnownZero() } -> std::convertible_to<bool>;
+};
+
 // The `HasIsEmpty` concept can be used to filter to types that have an `isEmpty` member function.
 template<typename T> concept HasIsEmpty = requires(T t) {
     { t.isEmpty() } -> std::convertible_to<bool>;
+};
+
+// The `HasIsKnownEmpty` concept can be used to filter to types that have an `isKnownEmpty` member function.
+template<typename T> concept HasIsKnownEmpty = requires(T t) {
+    { t.isKnownEmpty() } -> std::convertible_to<bool>;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/layout/formattingContexts/FormattingGeometry.cpp
+++ b/Source/WebCore/layout/formattingContexts/FormattingGeometry.cpp
@@ -177,7 +177,7 @@ std::optional<LayoutUnit> FormattingGeometry::computedWidth(const Box& layoutBox
     if (auto computedWidth = computedWidthValue<WidthType::Normal>(layoutBox, containingBlockWidth)) {
         auto& style = layoutBox.style();
         // Non-quantitative values such as auto and min-content are not influenced by the box-sizing property.
-        if (style.boxSizing() == BoxSizing::ContentBox || style.width().isIntrinsicOrLegacyIntrinsicOrAuto())
+        if (style.boxSizing() == BoxSizing::ContentBox || !style.width().isSpecified())
             return computedWidth;
         auto& boxGeometry = formattingContext().geometryForBox(layoutBox);
         return *computedWidth - boxGeometry.horizontalBorderAndPadding();

--- a/Source/WebCore/rendering/GridLayoutFunctions.cpp
+++ b/Source/WebCore/rendering/GridLayoutFunctions.cpp
@@ -51,10 +51,10 @@ static inline bool marginEndIsAuto(const RenderBox& gridItem, Style::GridTrackSi
 
 static bool gridItemHasMargin(const RenderBox& gridItem, Style::GridTrackSizingDirection direction)
 {
-    // Length::IsZero returns true for 'auto' margins, which is aligned with the purpose of this function.
+    // `isPossiblyZero` returns true for 'auto' margins, which is aligned with the purpose of this function.
     if (direction == Style::GridTrackSizingDirection::Columns)
-        return !gridItem.style().marginStart().isZero() || !gridItem.style().marginEnd().isZero();
-    return !gridItem.style().marginBefore().isZero() || !gridItem.style().marginAfter().isZero();
+        return !gridItem.style().marginStart().isPossiblyZero() || !gridItem.style().marginEnd().isPossiblyZero();
+    return !gridItem.style().marginBefore().isPossiblyZero() || !gridItem.style().marginAfter().isPossiblyZero();
 }
 
 LayoutUnit computeMarginLogicalSizeForGridItem(const RenderGrid& grid, Style::GridTrackSizingDirection direction, const RenderBox& gridItem)

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -3836,7 +3836,7 @@ static bool hasSimpleStaticPositionForInlineLevelOutOfFlowChildrenByStyle(const 
 {
     if (rootStyle.textAlign() != TextAlignMode::Start)
         return false;
-    if (!rootStyle.textIndent().length.isZero())
+    if (!rootStyle.textIndent().length.isKnownZero())
         return false;
     return true;
 }

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -4429,7 +4429,7 @@ void RenderBox::computePositionedLogicalWidth(LogicalExtentComputedValues& compu
 
     // Clamp by min-width.
     auto usedMinWidth = LayoutUnit::min();
-    if (auto& logicalMinWidth = styleToUse.logicalMinWidth(); !logicalMinWidth.isZero() || logicalMinWidth.isIntrinsic())
+    if (auto& logicalMinWidth = styleToUse.logicalMinWidth(); !logicalMinWidth.isKnownZero() || logicalMinWidth.isIntrinsic())
         usedMinWidth = computePositionedLogicalWidthUsing(logicalMinWidth, inlineConstraints);
     if (transferredMinSize > usedMinWidth)
         usedMinWidth = computePositionedLogicalWidthUsing(Style::MinimumSize { Style::MinimumSize::Fixed { transferredMinSize } }, inlineConstraints);
@@ -4561,7 +4561,7 @@ void RenderBox::computePositionedLogicalHeight(LogicalExtentComputedValues& comp
     }
 
     // Clamp by min height.
-    if (auto& logicalMinHeight = styleToUse.logicalMinHeight(); logicalMinHeight.isAuto() || !logicalMinHeight.isZero() || logicalMinHeight.isIntrinsic()) {
+    if (auto& logicalMinHeight = styleToUse.logicalMinHeight(); logicalMinHeight.isAuto() || !logicalMinHeight.isKnownZero() || logicalMinHeight.isIntrinsic()) {
         auto usedMinHeight = computePositionedLogicalHeightUsing(logicalMinHeight, computedHeight, blockConstraints);
         if (usedHeight < usedMinHeight)
             usedHeight = usedMinHeight;
@@ -5076,9 +5076,9 @@ bool RenderBox::hasUnsplittableScrollingOverflow() const
     // Note this is just a heuristic, and it's still possible to have overflow under these
     // conditions, but it should work out to be good enough for common cases. Paginating overflow
     // with scrollbars present is not the end of the world and is what we used to do in the old model anyway.
-    return !style().logicalHeight().isIntrinsicOrLegacyIntrinsicOrAuto()
-        || (!style().logicalMaxHeight().isIntrinsicOrLegacyIntrinsicOrAuto() && !style().logicalMaxHeight().isNone() && (!style().logicalMaxHeight().isPercentOrCalculated() || percentageLogicalHeightIsResolvable()))
-        || (!style().logicalMinHeight().isIntrinsicOrLegacyIntrinsicOrAuto() && style().logicalMinHeight().isPositive() && (!style().logicalMinHeight().isPercentOrCalculated() || percentageLogicalHeightIsResolvable()));
+    return style().logicalHeight().isSpecified()
+        || (style().logicalMaxHeight().isSpecified() && (!style().logicalMaxHeight().isPercentOrCalculated() || percentageLogicalHeightIsResolvable()))
+        || (style().logicalMinHeight().isSpecified() && style().logicalMinHeight().isPossiblyPositive() && (!style().logicalMinHeight().isPercentOrCalculated() || percentageLogicalHeightIsResolvable()));
 }
 
 bool RenderBox::isUnsplittableForPagination() const

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -1354,7 +1354,7 @@ template<typename FillLayers> static bool mustRepaintFillLayers(const RenderElem
     if (!image || !image->canRender(&renderer, renderer.style().usedZoom()))
         return false;
 
-    if (!layer.xPosition().isZero() || !layer.yPosition().isZero())
+    if (!layer.xPosition().isKnownZero() || !layer.yPosition().isKnownZero())
         return true;
 
     return WTF::switchOn(layer.size(),

--- a/Source/WebCore/rendering/RenderImage.cpp
+++ b/Source/WebCore/rendering/RenderImage.cpp
@@ -803,7 +803,7 @@ bool RenderImage::foregroundIsKnownToBeOpaqueInRect(const LayoutRect& localRect,
     if (backgroundClip == FillBox::BorderBox && style().hasBorder() && !borderObscuresBackground())
         return false;
     // Background shows in padding area.
-    if ((backgroundClip == FillBox::BorderBox || backgroundClip == FillBox::PaddingBox) && style().hasPadding())
+    if ((backgroundClip == FillBox::BorderBox || backgroundClip == FillBox::PaddingBox) && !Style::isKnownZero(style().paddingBox()))
         return false;
     // Object-fit may leave parts of the content box empty.
     if (auto objectFit = style().objectFit(); objectFit != ObjectFit::Fill && objectFit != ObjectFit::Cover)

--- a/Source/WebCore/rendering/RenderMarquee.cpp
+++ b/Source/WebCore/rendering/RenderMarquee.cpp
@@ -119,7 +119,8 @@ MarqueeDirection RenderMarquee::direction() const
 
     // Now we have the real direction.  Next we check to see if the increment is negative.
     // If so, then we reverse the direction.
-    if (auto& increment = m_layer->renderer().style().marqueeIncrement(); increment.isNegative())
+    // FIXME: This will fail for `increment` that uses `calc()`, though this can currently never happen due to the property being internal
+    if (auto& increment = m_layer->renderer().style().marqueeIncrement(); increment.isKnownNegative())
         result = reverseDirection(result);
     
     return result;
@@ -176,7 +177,7 @@ int RenderMarquee::computePosition(MarqueeDirection dir, bool stopAtContentEdge)
 
 void RenderMarquee::start()
 {
-    if (m_timer.isActive() || m_layer->renderer().style().marqueeIncrement().isZero())
+    if (m_timer.isActive() || m_layer->renderer().style().marqueeIncrement().isKnownZero())
         return;
 
     CheckedPtr scrollableArea = m_layer->scrollableArea();

--- a/Source/WebCore/rendering/RenderTable.cpp
+++ b/Source/WebCore/rendering/RenderTable.cpp
@@ -304,7 +304,7 @@ void RenderTable::updateLogicalWidth()
     auto& styleLogicalWidth = style().logicalWidth();
     if (auto overridingLogicalWidth = this->overridingBorderBoxLogicalWidth())
         setLogicalWidth(*overridingLogicalWidth);
-    else if ((styleLogicalWidth.isSpecified() && styleLogicalWidth.isPositive()) || styleLogicalWidth.isIntrinsic())
+    else if ((styleLogicalWidth.isSpecified() && styleLogicalWidth.isPossiblyPositive()) || styleLogicalWidth.isIntrinsic())
         setLogicalWidth(convertStyleLogicalWidthToComputedWidth(styleLogicalWidth, containerWidthInInlineDirection));
     else {
         // Subtract out any fixed margins from our available width for auto width tables.
@@ -331,7 +331,7 @@ void RenderTable::updateLogicalWidth()
 
     // Ensure we aren't bigger than our max-width style.
     auto& styleMaxLogicalWidth = style().logicalMaxWidth();
-    if ((styleMaxLogicalWidth.isSpecified() && !styleMaxLogicalWidth.isNegative()) || styleMaxLogicalWidth.isIntrinsic()) {
+    if (styleMaxLogicalWidth.isSpecified() || styleMaxLogicalWidth.isIntrinsic()) {
         LayoutUnit computedMaxLogicalWidth = convertStyleLogicalWidthToComputedWidth(styleMaxLogicalWidth, availableLogicalWidth);
         setLogicalWidth(std::min(logicalWidth(), computedMaxLogicalWidth));
     }
@@ -341,7 +341,7 @@ void RenderTable::updateLogicalWidth()
 
     // Ensure we aren't smaller than our min-width style.
     auto& styleMinLogicalWidth = style().logicalMinWidth();
-    if ((styleMinLogicalWidth.isSpecified() && !styleMinLogicalWidth.isNegative()) || styleMinLogicalWidth.isIntrinsic()) {
+    if (styleMinLogicalWidth.isSpecified() || styleMinLogicalWidth.isIntrinsic()) {
         LayoutUnit computedMinLogicalWidth = convertStyleLogicalWidthToComputedWidth(styleMinLogicalWidth, availableLogicalWidth);
         setLogicalWidth(std::max(logicalWidth(), computedMinLogicalWidth));
     }
@@ -376,7 +376,7 @@ template<typename SizeType> LayoutUnit RenderTable::convertStyleLogicalWidthToCo
     // HTML tables' width styles already include borders and padding, but CSS tables' width styles do not.
     LayoutUnit borders;
     bool isCSSTable = !is<HTMLTableElement>(element());
-    if (isCSSTable && styleLogicalWidth.isSpecified() && styleLogicalWidth.isPositive() && style().boxSizing() == BoxSizing::ContentBox)
+    if (isCSSTable && styleLogicalWidth.isSpecified() && styleLogicalWidth.isPossiblyPositive() && style().boxSizing() == BoxSizing::ContentBox)
         borders = borderStart() + borderEnd() + (collapseBorders() ? 0_lu : paddingStart() + paddingEnd());
 
     return Style::evaluateMinimum<LayoutUnit>(styleLogicalWidth, availableWidth, Style::ZoomNeeded { }) + borders;
@@ -561,7 +561,7 @@ void RenderTable::layout()
         LayoutUnit computedLogicalHeight;
 
         auto& logicalHeightLength = style().logicalHeight();
-        if (logicalHeightLength.isIntrinsic() || (logicalHeightLength.isSpecified() && logicalHeightLength.isPositive()))
+        if (logicalHeightLength.isIntrinsic() || (logicalHeightLength.isSpecified() && logicalHeightLength.isPossiblyPositive()))
             computedLogicalHeight = convertStyleLogicalHeightToComputedHeight(logicalHeightLength);
 
         if (auto overridingLogicalHeight = this->overridingBorderBoxLogicalHeight())
@@ -569,8 +569,7 @@ void RenderTable::layout()
 
         if (!shouldIgnoreLogicalMinMaxHeightSizes()) {
             auto& logicalMaxHeightLength = style().logicalMaxHeight();
-            if (logicalMaxHeightLength.isFillAvailable() || (logicalMaxHeightLength.isSpecified() && !logicalMaxHeightLength.isNegative()
-                && !logicalMaxHeightLength.isMinContent() && !logicalMaxHeightLength.isMaxContent() && !logicalMaxHeightLength.isFitContent())) {
+            if (logicalMaxHeightLength.isFillAvailable() || logicalMaxHeightLength.isSpecified()) {
                 LayoutUnit computedMaxLogicalHeight = convertStyleLogicalHeightToComputedHeight(logicalMaxHeightLength);
                 computedLogicalHeight = std::min(computedLogicalHeight, computedMaxLogicalHeight);
             }
@@ -578,7 +577,7 @@ void RenderTable::layout()
             auto logicalMinHeightLength = style().logicalMinHeight();
             if (logicalMinHeightLength.isMinContent() || logicalMinHeightLength.isMaxContent() || logicalMinHeightLength.isFitContent())
                 logicalMinHeightLength = CSS::Keyword::Auto { };
-            if (logicalMinHeightLength.isIntrinsic() || (logicalMinHeightLength.isSpecified() && !logicalMinHeightLength.isNegative())) {
+            if (logicalMinHeightLength.isIntrinsic() || logicalMinHeightLength.isSpecified()) {
                 LayoutUnit computedMinLogicalHeight = convertStyleLogicalHeightToComputedHeight(logicalMinHeightLength);
                 computedLogicalHeight = std::max(computedLogicalHeight, computedMinLogicalHeight);
             }

--- a/Source/WebCore/rendering/RenderTableSection.cpp
+++ b/Source/WebCore/rendering/RenderTableSection.cpp
@@ -77,7 +77,7 @@ static inline void updateLogicalHeightForCell(RenderTableSection::RowStruct& row
         return;
 
     auto& logicalHeight = !cell->isOrthogonal() ? cell->style().logicalHeight() : cell->style().logicalWidth();
-    if (logicalHeight.isPositive()) {
+    if (logicalHeight.isPossiblyPositive()) {
         if (auto percentageLogicalHeight = logicalHeight.tryPercentage()) {
             if (auto percentageRowLogicalHeight = row.logicalHeight.tryPercentage(); !percentageRowLogicalHeight || percentageRowLogicalHeight->value < percentageLogicalHeight->value)
                 row.logicalHeight = logicalHeight;

--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
@@ -2437,7 +2437,7 @@ bool RenderThemeCocoa::adjustButtonStyleForVectorBasedControls(RenderStyle& styl
     constexpr auto controlBaseHeight = 20.0f;
     constexpr auto controlBaseFontSize = 11.0f;
 
-    if (style.logicalWidth().isIntrinsicOrLegacyIntrinsicOrAuto() || style.logicalHeight().isAuto()) {
+    if (!style.logicalWidth().isSpecified() || style.logicalHeight().isAuto()) {
         auto minimumHeight = controlBaseHeight / controlBaseFontSize * style.fontDescription().computedSize();
         if (auto fixedValue = style.logicalMinHeight().tryFixed())
             minimumHeight = std::max(minimumHeight, fixedValue->resolveZoom(Style::ZoomNeeded { }));

--- a/Source/WebCore/rendering/style/BorderData.cpp
+++ b/Source/WebCore/rendering/style/BorderData.cpp
@@ -79,13 +79,13 @@ void BorderData::dump(TextStream& ts, DumpStyleValues behavior) const
 
     ts.dumpProperty("image"_s, image());
 
-    if (behavior == DumpStyleValues::All || !Style::isZero(topLeftRadius()))
+    if (behavior == DumpStyleValues::All || !Style::isKnownZero(topLeftRadius()))
         ts.dumpProperty("top-left"_s, topLeftRadius());
-    if (behavior == DumpStyleValues::All || !Style::isZero(topRightRadius()))
+    if (behavior == DumpStyleValues::All || !Style::isKnownZero(topRightRadius()))
         ts.dumpProperty("top-right"_s, topRightRadius());
-    if (behavior == DumpStyleValues::All || !Style::isZero(bottomLeftRadius()))
+    if (behavior == DumpStyleValues::All || !Style::isKnownZero(bottomLeftRadius()))
         ts.dumpProperty("bottom-left"_s, bottomLeftRadius());
-    if (behavior == DumpStyleValues::All || !Style::isZero(bottomRightRadius()))
+    if (behavior == DumpStyleValues::All || !Style::isKnownZero(bottomRightRadius()))
         ts.dumpProperty("bottom-right"_s, bottomRightRadius());
 }
 

--- a/Source/WebCore/rendering/style/BorderData.h
+++ b/Source/WebCore/rendering/style/BorderData.h
@@ -58,7 +58,7 @@ public:
 
     bool hasBorderRadius() const
     {
-        return m_radii.anyOf([](auto& corner) { return !Style::isEmpty(corner); });
+        return m_radii.anyOf([](auto& corner) { return !Style::isKnownEmpty(corner); });
     }
 
     template<BoxSide side>

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -3487,7 +3487,7 @@ bool RenderStyle::hasPositiveStrokeWidth() const
 {
     if (!hasExplicitlySetStrokeWidth())
         return textStrokeWidth().isPositive();
-    return strokeWidth().isPositive();
+    return strokeWidth().isPossiblyPositive();
 }
 
 Color RenderStyle::computedStrokeColor() const

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -532,13 +532,10 @@ public:
     void setColumnStylesFromPaginationMode(PaginationMode);
 
     inline bool isFloating() const;
-    inline bool hasMargin() const;
     inline bool hasBorder() const;
     inline bool hasBorderImage() const;
     inline bool hasVisibleBorderDecoration() const;
     inline bool hasVisibleBorder() const;
-    inline bool hasPadding() const;
-    inline bool hasInset() const;
 
     inline bool hasBackgroundImage() const;
 
@@ -1741,7 +1738,6 @@ public:
     
     inline const Style::StrokeWidth& strokeWidth() const;
     inline void setStrokeWidth(Style::StrokeWidth&&);
-    inline bool hasVisibleStroke() const;
     static inline Style::StrokeWidth initialStrokeWidth();
 
     float computedStrokeWidth(const IntSize& viewportSize) const;

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -290,15 +290,12 @@ inline bool RenderStyle::hasExplicitlySetStrokeColor() const { return m_rareInhe
 inline bool RenderStyle::hasFilter() const { return !filter().isNone(); }
 inline bool RenderStyle::hasInFlowPosition() const { return position() == PositionType::Relative || position() == PositionType::Sticky; }
 inline bool RenderStyle::hasIsolation() const { return isolation() != Isolation::Auto; }
-inline bool RenderStyle::hasMargin() const { return !Style::isZero(marginBox()); }
 inline bool RenderStyle::hasMask() const { return maskLayers().hasImage() || maskBorder().hasSource(); }
-inline bool RenderStyle::hasInset() const { return !Style::isZero(insetBox()); }
 inline bool RenderStyle::hasOffsetPath() const { return !WTF::holdsAlternative<CSS::Keyword::None>(m_nonInheritedData->rareData->offsetPath); }
 inline bool RenderStyle::hasOpacity() const { return !opacity().isOpaque(); }
 inline bool RenderStyle::hasOutOfFlowPosition() const { return position() == PositionType::Absolute || position() == PositionType::Fixed; }
 inline bool RenderStyle::hasOutline() const { return outlineStyle() != OutlineStyle::None && outlineWidth().isPositive(); }
 inline bool RenderStyle::hasOutlineInVisualOverflow() const { return hasOutline() && outlineSize() > 0; }
-inline bool RenderStyle::hasPadding() const { return !Style::isZero(paddingBox()); }
 inline bool RenderStyle::hasPerspective() const { return !perspective().isNone(); }
 inline bool RenderStyle::hasPositionedMask() const { return maskLayers().hasImage(); }
 inline bool RenderStyle::hasPseudoStyle(PseudoId pseudo) const { return m_nonInheritedFlags.hasPseudoStyle(pseudo); }
@@ -917,7 +914,6 @@ inline bool RenderStyle::insideSubmitButton() const { return m_rareInheritedData
 
 inline const Style::StrokeWidth& RenderStyle::strokeWidth() const { return m_rareInheritedData->strokeWidth; }
 inline bool RenderStyle::hasExplicitlySetStrokeWidth() const { return m_rareInheritedData->hasSetStrokeWidth; }
-inline bool RenderStyle::hasVisibleStroke() const { return hasStroke() && !strokeWidth().isZero(); }
 inline bool RenderStyle::hasStroke() const { return !stroke().isNone(); }
 inline bool RenderStyle::hasFill() const { return !fill().isNone(); }
 inline bool RenderStyle::hasMarkers() const { return !markerStart().isNone() || !markerMid().isNone() || !markerEnd().isNone(); }

--- a/Source/WebCore/rendering/svg/RenderSVGEllipse.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGEllipse.cpp
@@ -117,7 +117,7 @@ void RenderSVGEllipse::fillShape(GraphicsContext& context) const
 
 void RenderSVGEllipse::strokeShape(GraphicsContext& context) const
 {
-    if (!style().hasVisibleStroke())
+    if (!style().hasStroke() || !style().strokeWidth().isPossiblyPositive())
         return;
     if (hasPath()) {
         RenderSVGShape::strokeShape(context);

--- a/Source/WebCore/rendering/svg/RenderSVGPath.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGPath.cpp
@@ -97,7 +97,7 @@ static void useStrokeStyleToFill(GraphicsContext& context)
 
 void RenderSVGPath::strokeShape(GraphicsContext& context) const
 {
-    if (!style().hasVisibleStroke())
+    if (!style().hasStroke() || !style().strokeWidth().isPossiblyPositive())
         return;
 
     // This happens only if the layout was never been called for this element.

--- a/Source/WebCore/rendering/svg/RenderSVGRect.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGRect.cpp
@@ -158,7 +158,7 @@ bool RenderSVGRect::definitelyHasSimpleStroke() const
 
 void RenderSVGRect::strokeShape(GraphicsContext& context) const
 {
-    if (!style().hasVisibleStroke())
+    if (!style().hasStroke() || !style().strokeWidth().isPossiblyPositive())
         return;
 
     if (hasPath()) {

--- a/Source/WebCore/rendering/svg/RenderSVGShape.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGShape.cpp
@@ -189,7 +189,7 @@ void RenderSVGShape::fillShape(const RenderStyle& style, GraphicsContext& contex
 
 void RenderSVGShape::strokeShape(const RenderStyle& style, GraphicsContext& context)
 {
-    if (!style.hasVisibleStroke())
+    if (!style.hasStroke() || !style.strokeWidth().isPossiblyPositive())
         return;
 
     GraphicsContextStateSaver stateSaver(context, false);

--- a/Source/WebCore/rendering/svg/SVGTextBoxPainter.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextBoxPainter.cpp
@@ -191,7 +191,7 @@ void SVGTextBoxPainter<TextBoxPath>::paint()
     auto& style = parentRenderer.style();
 
     bool hasFill = style.hasFill();
-    bool hasVisibleStroke = style.hasVisibleStroke();
+    bool hasVisibleStroke = style.hasStroke() && style.strokeWidth().isPossiblyPositive();
 
     const RenderStyle* selectionStyle = &style;
     if (hasSelection && shouldPaintSelectionHighlight) {
@@ -200,7 +200,7 @@ void SVGTextBoxPainter<TextBoxPath>::paint()
             if (!hasFill)
                 hasFill = selectionStyle->hasFill();
             if (!hasVisibleStroke)
-                hasVisibleStroke = selectionStyle->hasVisibleStroke();
+                hasVisibleStroke = selectionStyle->hasStroke() && selectionStyle->strokeWidth().isPossiblyPositive();
         } else
             selectionStyle = &style;
     }
@@ -461,7 +461,7 @@ void SVGTextBoxPainter<TextBoxPath>::paintDecoration(Style::TextDecorationLine d
             }
             break;
         case PaintType::Stroke:
-            if (decorationStyle.hasVisibleStroke()) {
+            if (decorationStyle.hasStroke() && decorationStyle.strokeWidth().isPossiblyPositive()) {
                 m_paintingResourceMode = RenderSVGResourceMode::ApplyToStroke;
                 paintDecorationWithStyle(decoration, fragment, *decorationRenderer);
             }

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGEllipse.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGEllipse.cpp
@@ -117,7 +117,7 @@ void LegacyRenderSVGEllipse::fillShape(GraphicsContext& context) const
 
 void LegacyRenderSVGEllipse::strokeShape(GraphicsContext& context) const
 {
-    if (!style().hasVisibleStroke())
+    if (!style().hasStroke() || !style().strokeWidth().isPossiblyPositive())
         return;
     if (hasPath()) {
         LegacyRenderSVGShape::strokeShape(context);

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.cpp
@@ -115,7 +115,7 @@ static void useStrokeStyleToFill(GraphicsContext& context)
 
 void LegacyRenderSVGPath::strokeShape(GraphicsContext& context) const
 {
-    if (!style().hasVisibleStroke())
+    if (!style().hasStroke() || !style().strokeWidth().isPossiblyPositive())
         return;
 
     // This happens only if the layout was never been called for this element.

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRect.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRect.cpp
@@ -121,7 +121,7 @@ void LegacyRenderSVGRect::fillShape(GraphicsContext& context) const
 
 void LegacyRenderSVGRect::strokeShape(GraphicsContext& context) const
 {
-    if (!style().hasVisibleStroke())
+    if (!style().hasStroke() || !style().strokeWidth().isPossiblyPositive())
         return;
 
     if (hasPath()) {

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp
@@ -235,7 +235,7 @@ void LegacyRenderSVGShape::strokeShapeInternal(const RenderStyle& style, Graphic
 
 void LegacyRenderSVGShape::strokeShape(const RenderStyle& style, GraphicsContext& context)
 {
-    if (!style.hasVisibleStroke())
+    if (!style.hasStroke() || !style.strokeWidth().isPossiblyPositive())
         return;
 
     GraphicsContextStateSaver stateSaver(context, false);

--- a/Source/WebCore/style/StyleExtractorCustom.h
+++ b/Source/WebCore/style/StyleExtractorCustom.h
@@ -254,7 +254,7 @@ template<> struct PropertyExtractorAdaptor<CSSPropertyLetterSpacing> {
         // https://www.w3.org/TR/css-text-4/#letter-spacing-property
 
         auto& spacing = state.style.computedLetterSpacing();
-        if (spacing.isFixed() && spacing.isZero())
+        if (auto fixedSpacing = spacing.tryFixed(); fixedSpacing && fixedSpacing->isZero())
             return functor(CSS::Keyword::Normal { });
         return functor(spacing);
     }

--- a/Source/WebCore/style/values/fill-stroke/StyleStrokeWidth.h
+++ b/Source/WebCore/style/values/fill-stroke/StyleStrokeWidth.h
@@ -48,8 +48,7 @@ struct StrokeWidth {
     StrokeWidth(CSS::ValueLiteral<CSS::LengthUnit::Px> literal) : value { literal } { }
     StrokeWidth(CSS::ValueLiteral<CSS::PercentageUnit::Percentage> literal) : value { literal } { }
 
-    bool isZero() const { return value.isZero(); }
-    bool isPositive() const { return value.isPositive(); }
+    bool isPossiblyPositive() const { return value.isPossiblyPositive(); }
 
     template<typename... F> decltype(auto) switchOn(F&&... f) const
     {

--- a/Source/WebCore/style/values/primitives/StyleLengthWrapper.h
+++ b/Source/WebCore/style/values/primitives/StyleLengthWrapper.h
@@ -94,9 +94,19 @@ template<typename Numeric, CSS::PrimitiveKeyword... Ks> struct LengthWrapperBase
     ALWAYS_INLINE bool isPercentOrCalculated() const { return isPercent() || isCalculated(); }
     ALWAYS_INLINE bool isSpecified() const { return isFixed() || isPercent() || isCalculated(); }
 
-    ALWAYS_INLINE bool isZero() const { return m_value.isZero(); }
-    ALWAYS_INLINE bool isPositive() const { return m_value.isPositive(); }
-    ALWAYS_INLINE bool isNegative() const { return m_value.isNegative(); }
+    // `isKnownZero` returns whether the value can be guaranteed to be `0`. Keywords and calc() return `false`.
+    ALWAYS_INLINE bool isKnownZero() const requires (Fixed::range.min <= 0 && Fixed::range.max >= 0) { return m_value.isKnownZero(evaluationKind()); }
+    // `isKnownPositive` returns whether the value can be guaranteed to be more than `0`. Keywords and calc() return `false`.
+    ALWAYS_INLINE bool isKnownPositive() const requires (Fixed::range.max > 0) { return m_value.isKnownPositive(evaluationKind()); }
+    // `isKnownNegative` returns whether the value can be guaranteed to be less than `0`. Keywords and calc() return `false`.
+    ALWAYS_INLINE bool isKnownNegative() const requires (Fixed::range.min < 0) { return m_value.isKnownNegative(evaluationKind()); }
+
+    // `isPossiblyZero` returns whether the value can possibly be `0`. Keywords and calc() return `true`.
+    ALWAYS_INLINE bool isPossiblyZero() const requires (Fixed::range.min <= 0 && Fixed::range.max >= 0) { return m_value.isPossiblyZero(evaluationKind()); }
+    // `isPossiblyPositive` returns whether the value can possibly be more than `0`. Keywords and calc() return `true.
+    ALWAYS_INLINE bool isPossiblyPositive() const requires (Fixed::range.max > 0) { return m_value.isPossiblyPositive(evaluationKind()); }
+    // `isPossiblyNegative` returns whether the value can possibly be less than `0`. Keywords and calc() return `true.
+    ALWAYS_INLINE bool isPossiblyNegative() const requires (Fixed::range.min < 0) { return m_value.isPossiblyNegative(evaluationKind()); }
 
     std::optional<Fixed> tryFixed() const { return isFixed() ? std::make_optional(Fixed { m_value.value() }) : std::nullopt; }
     std::optional<Percentage> tryPercentage() const { return isPercent() ? std::make_optional(Percentage { m_value.value() }) : std::nullopt; }

--- a/Source/WebCore/style/values/primitives/StyleLengthWrapperData.h
+++ b/Source/WebCore/style/values/primitives/StyleLengthWrapperData.h
@@ -81,9 +81,13 @@ struct LengthWrapperData {
     WEBCORE_EXPORT LengthWrapperData(IPCData&&);
     WEBCORE_EXPORT IPCData ipcData() const;
 
-    bool isZero() const;
-    bool isPositive() const;
-    bool isNegative() const;
+    bool isKnownZero(LengthWrapperDataEvaluationKind) const;
+    bool isKnownPositive(LengthWrapperDataEvaluationKind) const;
+    bool isKnownNegative(LengthWrapperDataEvaluationKind) const;
+
+    bool isPossiblyZero(LengthWrapperDataEvaluationKind) const;
+    bool isPossiblyPositive(LengthWrapperDataEvaluationKind) const;
+    bool isPossiblyNegative(LengthWrapperDataEvaluationKind) const;
 
     template<typename ReturnType, typename MaximumType>
     ReturnType minimumValueForLengthWrapperDataWithLazyMaximum(LengthWrapperDataEvaluationKind, NOESCAPE const Invocable<MaximumType()> auto& lazyMaximumValueFunctor, ZoomNeeded) const;
@@ -230,25 +234,46 @@ inline bool LengthWrapperData::operator==(const LengthWrapperData& other) const
     return value() == other.value();
 }
 
-inline bool LengthWrapperData::isPositive() const
+inline bool LengthWrapperData::isKnownZero(LengthWrapperDataEvaluationKind evaluationKind) const
 {
-    if (m_kind == LengthWrapperDataKind::Calculation)
-        return true;
-    return m_floatValue > 0;
+    if (evaluationKind == LengthWrapperDataEvaluationKind::Fixed || evaluationKind == LengthWrapperDataEvaluationKind::Percentage)
+        return !m_floatValue;
+    return false;
 }
 
-inline bool LengthWrapperData::isNegative() const
+inline bool LengthWrapperData::isKnownPositive(LengthWrapperDataEvaluationKind evaluationKind) const
 {
-    if (m_kind == LengthWrapperDataKind::Calculation)
-        return false;
-    return m_floatValue < 0;
+    if (evaluationKind == LengthWrapperDataEvaluationKind::Fixed || evaluationKind == LengthWrapperDataEvaluationKind::Percentage)
+        return m_floatValue > 0;
+    return false;
 }
 
-inline bool LengthWrapperData::isZero() const
+inline bool LengthWrapperData::isKnownNegative(LengthWrapperDataEvaluationKind evaluationKind) const
 {
-    if (m_kind == LengthWrapperDataKind::Calculation)
-        return false;
-    return !m_floatValue;
+    if (evaluationKind == LengthWrapperDataEvaluationKind::Fixed || evaluationKind == LengthWrapperDataEvaluationKind::Percentage)
+        return m_floatValue < 0;
+    return false;
+}
+
+inline bool LengthWrapperData::isPossiblyZero(LengthWrapperDataEvaluationKind evaluationKind) const
+{
+    if (evaluationKind == LengthWrapperDataEvaluationKind::Fixed || evaluationKind == LengthWrapperDataEvaluationKind::Percentage)
+        return !m_floatValue;
+    return true;
+}
+
+inline bool LengthWrapperData::isPossiblyPositive(LengthWrapperDataEvaluationKind evaluationKind) const
+{
+    if (evaluationKind == LengthWrapperDataEvaluationKind::Fixed || evaluationKind == LengthWrapperDataEvaluationKind::Percentage)
+        return m_floatValue > 0;
+    return true;
+}
+
+inline bool LengthWrapperData::isPossiblyNegative(LengthWrapperDataEvaluationKind evaluationKind) const
+{
+    if (evaluationKind == LengthWrapperDataEvaluationKind::Fixed || evaluationKind == LengthWrapperDataEvaluationKind::Percentage)
+        return m_floatValue < 0;
+    return true;
 }
 
 template<typename ReturnType, typename MaximumType>

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumeric.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumeric.h
@@ -69,11 +69,14 @@ template<CSS::Numeric CSSType> struct PrimitiveNumeric {
     {
     }
 
-    constexpr bool isZero() const { return !value; }
-    constexpr bool isPositive() const { return value > 0; }
-    constexpr bool isPositiveOrZero() const { return value >= 0; }
-    constexpr bool isNegative() const { return value < 0; }
-    constexpr bool isNegativeOrZero() const { return value <= 0; }
+    constexpr bool isZero() const requires (range.min <= 0 && range.max >= 0) { return !value; }
+    constexpr bool isKnownZero() const requires (range.min <= 0 && range.max >= 0) { return isZero(); }
+    constexpr bool isPositive() const requires (range.max > 0) { return value > 0; }
+    constexpr bool isKnownPositive() const requires (range.max > 0) { return isPositive(); }
+    constexpr bool isPositiveOrZero() const requires (range.max >= 0) { return value >= 0; }
+    constexpr bool isNegative() const requires (range.min < 0) { return value < 0; }
+    constexpr bool isKnownNegative() const requires (range.min < 0) { return isNegative(); }
+    constexpr bool isNegativeOrZero() const requires (range.min <= 0) { return value <= 0; }
 
     constexpr bool operator==(const PrimitiveNumeric&) const = default;
     constexpr bool operator==(ResolvedValueType other) const { return value == other; }
@@ -147,11 +150,14 @@ template<CSS::Range R, typename V> struct PrimitiveNumeric<CSS::Length<R, V>> {
 
     constexpr auto unresolvedValue() const { return value; }
 
-    constexpr bool isZero() const { return !value; }
-    constexpr bool isPositive() const { return value > 0; }
-    constexpr bool isPositiveOrZero() const { return value >= 0; }
-    constexpr bool isNegative() const { return value < 0; }
-    constexpr bool isNegativeOrZero() const { return value <= 0; }
+    constexpr bool isZero() const requires (range.min <= 0 && range.max >= 0) { return !value; }
+    constexpr bool isKnownZero() const requires (range.min <= 0 && range.max >= 0) { return isZero(); }
+    constexpr bool isPositive() const requires (range.max > 0) { return value > 0; }
+    constexpr bool isKnownPositive() const requires (range.max > 0) { return isPositive(); }
+    constexpr bool isPositiveOrZero() const requires (range.max >= 0) { return value >= 0; }
+    constexpr bool isNegative() const requires (range.min < 0) { return value < 0; }
+    constexpr bool isKnownNegative() const requires (range.min < 0) { return isNegative(); }
+    constexpr bool isNegativeOrZero() const requires (range.min <= 0) { return value <= 0; }
 
     constexpr bool operator==(const PrimitiveNumeric&) const = default;
 
@@ -267,7 +273,7 @@ template<CSS::DimensionPercentageNumeric CSSType> struct PrimitiveNumeric<CSSTyp
         return WTF::switchOn(m_value, std::forward<F>(functors)...);
     }
 
-    constexpr bool isZero() const
+    constexpr bool isKnownZero() const requires (range.min <= 0 && range.max >= 0)
     {
         return WTF::switchOn(m_value,
             []<HasIsZero T>(const T& alternative) { return alternative.isZero(); },

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Blending.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Blending.h
@@ -105,8 +105,8 @@ template<auto R, typename V> struct Blending<LengthPercentage<R, V>> {
             if (context.compositeOperation != CompositeOperation::Replace)
                 return Calc { Calculation::add(copyCalculation(from), copyCalculation(to)) };
 
-            bool fromIsZero = from.isZero();
-            bool toIsZero = to.isZero();
+            bool fromIsZero = from.isKnownZero();
+            bool toIsZero = to.isKnownZero();
 
             // 0% to 0px -> calc(0px + 0%) to calc(0px + 0%) -> 0px
             // 0px to 0% -> calc(0px + 0%) to calc(0px + 0%) -> 0px

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Evaluation.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Evaluation.h
@@ -355,8 +355,8 @@ template<auto aR, auto bR, typename V> auto reflectSum(const LengthPercentage<aR
     using PercentageA = typename LengthPercentage<aR, V>::Percentage;
     using PercentageB = typename LengthPercentage<bR, V>::Percentage;
 
-    bool aIsZero = a.isZero();
-    bool bIsZero = b.isZero();
+    bool aIsZero = a.isKnownZero();
+    bool bIsZero = b.isKnownZero();
 
     // If both `a` and `b` are 0, turn this into a calc expression: `calc(100% - (0 + 0))` aka `100%`.
     if (aIsZero && bIsZero)

--- a/Source/WebCore/style/values/svg/StyleSVGStrokeDasharray.h
+++ b/Source/WebCore/style/values/svg/StyleSVGStrokeDasharray.h
@@ -44,9 +44,6 @@ struct SVGStrokeDasharrayValue {
     SVGStrokeDasharrayValue(CSS::ValueLiteral<CSS::LengthUnit::Px> literal) : value { literal } { }
     SVGStrokeDasharrayValue(CSS::ValueLiteral<CSS::PercentageUnit::Percentage> literal) : value { literal } { }
 
-    bool isZero() const { return value.isZero(); }
-    bool isPositive() const { return value.isPositive(); }
-
     template<typename... F> decltype(auto) switchOn(F&&... f) const
     {
         return WTF::switchOn(value, std::forward<F>(f)...);

--- a/Source/WebCore/style/values/svg/StyleSVGStrokeDashoffset.h
+++ b/Source/WebCore/style/values/svg/StyleSVGStrokeDashoffset.h
@@ -46,9 +46,6 @@ struct SVGStrokeDashoffset {
     SVGStrokeDashoffset(CSS::ValueLiteral<CSS::LengthUnit::Px> literal) : value { literal } { }
     SVGStrokeDashoffset(CSS::ValueLiteral<CSS::PercentageUnit::Percentage> literal) : value { literal } { }
 
-    bool isZero() const { return value.isZero(); }
-    bool isPositive() const { return value.isPositive(); }
-
     template<typename... F> decltype(auto) switchOn(F&&... f) const
     {
         return WTF::switchOn(value, std::forward<F>(f)...);

--- a/Source/WebCore/style/values/transforms/StyleTransformFunction.cpp
+++ b/Source/WebCore/style/values/transforms/StyleTransformFunction.cpp
@@ -534,14 +534,14 @@ auto CSSValueConversion<TransformFunction>::operator()(BuilderState& state, cons
 auto CSSValueCreation<TransformFunction>::operator()(CSSValuePool& pool, const RenderStyle& style, const TransformFunction& value) -> Ref<CSSValue>
 {
     auto translateLength = [&](const auto& length) -> Ref<CSSValue> {
-        if (length.isZero())
+        if (length.isKnownZero())
             return createCSSValue(pool, style, Length<> { 0_css_px });
         else
             return createCSSValue(pool, style, length);
     };
 
     auto includeLength = [](const auto& length) -> bool {
-        return !length.isZero() || length.isPercent();
+        return !length.isKnownZero() || length.isPercent();
     };
 
     auto& function = value.function();
@@ -644,14 +644,14 @@ auto CSSValueCreation<TransformFunction>::operator()(CSSValuePool& pool, const R
 void Serialize<TransformFunction>::operator()(StringBuilder& builder, const CSS::SerializationContext& context, const RenderStyle& style, const TransformFunction& value)
 {
     auto translateLength = [&](const auto& length) {
-        if (length.isZero())
+        if (length.isKnownZero())
             serializationForCSS(builder, context, style, Length<> { 0_css_px });
         else
             serializationForCSS(builder, context, style, length);
     };
 
     auto includeLength = [](const auto& length) -> bool {
-        return !length.isZero() || length.isPercent();
+        return !length.isKnownZero() || length.isPercent();
     };
 
     auto& function = value.function();

--- a/Source/WebCore/style/values/transforms/StyleTranslate.h
+++ b/Source/WebCore/style/values/transforms/StyleTranslate.h
@@ -77,7 +77,7 @@ template<typename... F> decltype(auto) Translate::Function::switchOn(F&&... f) c
     Ref protectedValue = value;
     if (!protectedValue->z().isZero())
         return visitor(SpaceSeparatedTuple { protectedValue->x(), protectedValue->y(), protectedValue->z() });
-    if (!protectedValue->y().isZero() || protectedValue->y().isPercent())
+    if (!protectedValue->y().isKnownZero() || protectedValue->y().isPercent())
         return visitor(SpaceSeparatedTuple { protectedValue->x(), protectedValue->y() });
     return visitor(SpaceSeparatedTuple { protectedValue->x() });
 }

--- a/Source/WebCore/style/values/transforms/functions/StyleTranslateTransformFunction.h
+++ b/Source/WebCore/style/values/transforms/functions/StyleTranslateTransformFunction.h
@@ -64,7 +64,7 @@ public:
     const LengthPercentage& y() const { return m_y; }
     Length z() const { return m_z; }
 
-    bool isIdentity() const override { return m_x.isZero() && m_y.isZero() && m_z.isZero(); }
+    bool isIdentity() const override { return m_x.isKnownZero() && m_y.isKnownZero() && m_z.isZero(); }
     bool isRepresentableIn2D() const override { return m_z.isZero(); }
 
     TransformFunctionSizeDependencies computeSizeDependencies() const override;


### PR DESCRIPTION
#### 33b130ec17ce2cc298ac28ac3a693e14a271d863
<pre>
[Style] Replace isZero/isNegative/isPositive functions inherited from WebCore::Length
<a href="https://bugs.webkit.org/show_bug.cgi?id=299972">https://bugs.webkit.org/show_bug.cgi?id=299972</a>

Reviewed by Darin Adler.

`Style::LengthPercentage&lt;&gt;` and `Style::LengthWrapperBase&lt;&gt;` inherited (to help
things continue to work without too much churn) the isZero/isNegative/isPositive
functions from `WebCore::Length` and along with them their quirky behavior with
calc and keywords.

For a type that includes a Length, Percentage, Calc, and Keywords, the
functions have the following behavior:

- isZero:
    Length        !value
    Percentage    !value
    Calc          false
    Keyword       true (due to keywords having a value equal to 0)

- isPositive:
    Length        value &gt; 0
    Percentage    value &gt; 0
    Calc          true
    Keyword       false (due to keywords having a value equal to 0)

- isNegative:
    Length        value &lt; 0
    Percentage    value &lt; 0
    Calc          false
    Keyword       false (due to keywords having a value equal to 0)

This change replaces these functions with a set that hopefully have
more clear semantics:

The &quot;known&quot; value functions, `isKnownZero`, `isKnownPositive` and
`isKnownNegative`, will perform their comparison for Length and
Percentage values, but will return `false` for anything else (e.g. calc
or keywords).

The &quot;possibly&quot; value functions, `isPossiblyZero`, `isPossiblyPositive` and
`isPossiblyNegative`, will perform their comparison for Length and
Percentage values, but will return `true` for anything else (e.g. calc
or keywords).

In addition, the functions are constrained only to types where the types
numeric range makes the comparison meaningful. This means that a type
like `LengthPercentage&lt;CSS::Nonnegative&gt;`, the `isKnownNegative` and
`isPossiblyNegative` functions will unavailable and produce a compile
error if used. This allowed the removal of a number of useless calls.

* Source/WebCore/css/values/CSSValueConcepts.h:
* Source/WebCore/layout/formattingContexts/FormattingGeometry.cpp:
* Source/WebCore/layout/formattingContexts/block/BlockMarginCollapse.cpp:
* Source/WebCore/rendering/AutoTableLayout.cpp:
* Source/WebCore/rendering/GridLayoutFunctions.cpp:
* Source/WebCore/rendering/RenderBlock.cpp:
* Source/WebCore/rendering/RenderBlockFlow.cpp:
* Source/WebCore/rendering/RenderBox.cpp:
* Source/WebCore/rendering/RenderElement.cpp:
* Source/WebCore/rendering/RenderImage.cpp:
* Source/WebCore/rendering/RenderMarquee.cpp:
* Source/WebCore/rendering/RenderTable.cpp:
* Source/WebCore/rendering/RenderTableSection.cpp:
* Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm:
* Source/WebCore/rendering/style/BorderData.cpp:
* Source/WebCore/rendering/style/BorderData.h:
* Source/WebCore/rendering/style/RenderStyle.cpp:
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
* Source/WebCore/style/StyleExtractorCustom.h:
* Source/WebCore/style/values/StyleValueTypes.h:
* Source/WebCore/style/values/backgrounds/StyleBackgroundSize.h:
* Source/WebCore/style/values/backgrounds/StyleFillLayers.h:
* Source/WebCore/style/values/box/StyleMargin.h:
* Source/WebCore/style/values/fill-stroke/StyleStrokeWidth.cpp:
* Source/WebCore/style/values/fill-stroke/StyleStrokeWidth.h:
* Source/WebCore/style/values/primitives/StyleLengthWrapper+Blending.h:
* Source/WebCore/style/values/primitives/StyleLengthWrapper.h:
* Source/WebCore/style/values/primitives/StyleLengthWrapperData.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumeric.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Blending.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Evaluation.h:
* Source/WebCore/style/values/svg/StyleSVGStrokeDasharray.h:
* Source/WebCore/style/values/svg/StyleSVGStrokeDashoffset.h:

Canonical link: <a href="https://commits.webkit.org/300911@main">https://commits.webkit.org/300911@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c2c6504d2c856b05b99965fc3e8d15bddf1fcb37

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124279 "11 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43965 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34689 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131115 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/76349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/126156 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44708 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52567 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/94543 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/76349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127233 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35633 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111168 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75130 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/34577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29327 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74596 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105377 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29550 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133786 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51191 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39031 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/103019 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51583 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107386 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102816 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26164 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48178 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/26432 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/48131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51054 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56836 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/50492 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53848 "Failed to checkout and rebase branch from PR 51635") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/52167 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->