### PR TITLE
Restore pointer equality of WKScriptMessage.name after 298430@main

### DIFF
--- a/Source/WebKit/UIProcess/API/APIScriptMessage.cpp
+++ b/Source/WebKit/UIProcess/API/APIScriptMessage.cpp
@@ -36,11 +36,11 @@ namespace API {
 ScriptMessage::~ScriptMessage() = default;
 
 #if PLATFORM(COCOA)
-ScriptMessage::ScriptMessage(RetainPtr<id>&& body, WebKit::WebPageProxy& page, Ref<API::FrameInfo>&& frame, const WTF::String& name, Ref<API::ContentWorld>&& world)
+ScriptMessage::ScriptMessage(RetainPtr<id>&& body, WebKit::WebPageProxy& page, Ref<API::FrameInfo>&& frame, RetainPtr<NSString>&& name, Ref<API::ContentWorld>&& world)
     : m_body(WTFMove(body))
+    , m_cocoaName(WTFMove(name))
     , m_page(page)
     , m_frame(WTFMove(frame))
-    , m_name(name)
     , m_world(WTFMove(world)) { }
 #endif
 

--- a/Source/WebKit/UIProcess/API/APIScriptMessage.h
+++ b/Source/WebKit/UIProcess/API/APIScriptMessage.h
@@ -51,6 +51,7 @@ public:
 
 #if PLATFORM(COCOA)
     const RetainPtr<id>& body() const { return m_body; }
+    const RetainPtr<NSString> cocoaName() const { return m_cocoaName; }
 #endif
     API::Object* apiBody() const { return m_apiBody.get(); }
     WebKit::WebPageProxy* page() const;
@@ -61,9 +62,10 @@ public:
 private:
     ScriptMessage(RefPtr<API::Object>&&, WebKit::WebPageProxy&, Ref<API::FrameInfo>&&, const WTF::String&, Ref<API::ContentWorld>&&);
 #if PLATFORM(COCOA)
-    ScriptMessage(RetainPtr<id>&&, WebKit::WebPageProxy&, Ref<API::FrameInfo>&&, const WTF::String&, Ref<API::ContentWorld>&&);
+    ScriptMessage(RetainPtr<id>&&, WebKit::WebPageProxy&, Ref<API::FrameInfo>&&, RetainPtr<NSString>&&, Ref<API::ContentWorld>&&);
 
     const RetainPtr<id> m_body;
+    const RetainPtr<NSString> m_cocoaName;
 #endif
     const RefPtr<API::Object> m_apiBody;
     const WeakPtr<WebKit::WebPageProxy> m_page;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKScriptMessage.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKScriptMessage.mm
@@ -62,7 +62,7 @@
 
 - (NSString *)name
 {
-    return _scriptMessage->name().createNSString().autorelease();
+    return _scriptMessage->cocoaName().get();
 }
 
 - (WKContentWorld *)world

--- a/Source/WebKit/UIProcess/API/Cocoa/WKUserContentController.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKUserContentController.mm
@@ -149,7 +149,7 @@ public:
     void didPostMessage(WebKit::WebPageProxy& page, WebKit::FrameInfoData&& frameInfoData, API::ContentWorld& world, WebKit::JavaScriptEvaluationResult&& jsMessage, CompletionHandler<void(Expected<WebKit::JavaScriptEvaluationResult, String>&&)>&& replyHandler) final
     {
         @autoreleasepool {
-            RetainPtr message = wrapper(API::ScriptMessage::create(jsMessage.toID(), page, API::FrameInfo::create(WTFMove(frameInfoData)), m_name, world));
+            RetainPtr message = wrapper(API::ScriptMessage::create(jsMessage.toID(), page, API::FrameInfo::create(WTFMove(frameInfoData)), RetainPtr { m_name }, world));
 
             if (m_supportsAsyncReply) {
                 __block auto handler = CompletionHandlerWithFinalizer<void(Expected<WebKit::JavaScriptEvaluationResult, String>&&)>(WTFMove(replyHandler), [](auto& function) {
@@ -178,7 +178,7 @@ public:
 private:
     const RetainPtr<WKUserContentController> m_controller;
     const RetainPtr<id> m_handler;
-    const String m_name;
+    const RetainPtr<NSString> m_name;
     const bool m_supportsAsyncReply { false };
 };
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewEvaluateJavaScript.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewEvaluateJavaScript.mm
@@ -96,7 +96,8 @@ TEST(WKWebView, EvaluateJavaScriptErrorCases)
 
     auto handler = adoptNS([TestScriptMessageHandler new]);
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    [[webView configuration].userContentController addScriptMessageHandler:handler.get() name:@"testHandler"];
+    NSString *handlerName = @"testHandler";
+    [[webView configuration].userContentController addScriptMessageHandler:handler.get() name:handlerName];
     NSString *postMessages = @""
         "window.webkit.messageHandlers.testHandler.postMessage(document.body);"
         "window.webkit.messageHandlers.testHandler.postMessage('abc');"
@@ -107,6 +108,8 @@ TEST(WKWebView, EvaluateJavaScriptErrorCases)
     "";
     [webView evaluateJavaScript:postMessages completionHandler:nil];
     RetainPtr firstMessage = [handler waitForMessage];
+    EXPECT_EQ(firstMessage.get().name, handlerName);
+    EXPECT_WK_STREQ(firstMessage.get().name, handlerName);
     EXPECT_WK_STREQ(firstMessage.get().body, "abc");
     EXPECT_EQ(firstMessage.get().body, firstMessage.get().body);
     EXPECT_EQ([handler waitForMessage].body, NSNull.null);


### PR DESCRIPTION
#### c9a7cab829db6b4aa4285ac3eb9dfe1f3edcda18
<pre>
Restore pointer equality of WKScriptMessage.name after 298430@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=299978">https://bugs.webkit.org/show_bug.cgi?id=299978</a>
<a href="https://rdar.apple.com/161210050">rdar://161210050</a>

Reviewed by Basuke Suzuki.

Why compare strings when you can just compare pointers?
298430@main made it so WKScriptMessage.name returns a different NSString pointer
with the same contents.  This restores compatibility by returning the exact same pointer.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewEvaluateJavaScript.mm
* Source/WebKit/UIProcess/API/APIScriptMessage.cpp:
(API::ScriptMessage::ScriptMessage):
* Source/WebKit/UIProcess/API/APIScriptMessage.h:
* Source/WebKit/UIProcess/API/Cocoa/WKScriptMessage.mm:
(-[WKScriptMessage name]):
* Source/WebKit/UIProcess/API/Cocoa/WKUserContentController.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewEvaluateJavaScript.mm:
(TEST(WKWebView, EvaluateJavaScriptErrorCases)):

Canonical link: <a href="https://commits.webkit.org/300847@main">https://commits.webkit.org/300847@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9ac020c406b305b4bc4c4d54dc7b89e28db73ae9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124060 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/43770 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34472 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130888 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/76200 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f9217524-fc2d-4018-a2c6-63cf5604d457) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/125937 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44499 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52366 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94376 "Failed to checkout and rebase branch from PR 51642") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/76200 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d582cd46-546a-4741-833c-20caafe2acda) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127014 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/35463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110977 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74965 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4009821b-c656-4100-bcc5-69807f34d7c0) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/34411 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29143 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74371 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/105199 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29360 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133560 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51007 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38858 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/102839 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51383 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107196 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102653 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48005 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/26255 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/47884 "Failed to checkout and rebase branch from PR 51642") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19498 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50862 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56629 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/50329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/53675 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/52003 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->