### PR TITLE
[Style] Add strongly-typed zoom factor

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -2691,6 +2691,20 @@ EnumeratingVisibleNetworkInterfacesEnabled:
     WebKit:
       default: true
 
+EvaluationTimeZoomEnabled:
+  category: css
+  type: bool
+  status: unstable
+  humanReadableName: "Evaluation time zoom enabled"
+  humanReadableDescription: "Enables used zoom value to be applied during layout and avoid applying at style-build time"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 EventHandlerDrivenSmoothKeyboardScrollingEnabled:
   type: bool
   status: internal

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -3375,7 +3375,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     style/values/primitives/StyleRatio.h
     style/values/primitives/StyleURL.h
     style/values/primitives/StyleUnevaluatedCalculation.h
-    style/values/primitives/StyleZoomNeededToken.h
+    style/values/primitives/StyleZoomPrimitives.h
 
     style/values/rhythm/StyleBlockStepSize.h
 

--- a/Source/WebCore/layout/formattingContexts/FormattingGeometry.h
+++ b/Source/WebCore/layout/formattingContexts/FormattingGeometry.h
@@ -27,7 +27,7 @@
 
 #include "FormattingContext.h"
 #include <WebCore/LayoutBoxGeometry.h>
-#include <WebCore/StyleZoomNeededToken.h>
+#include <WebCore/StyleZoomPrimitives.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -420,6 +420,16 @@ void RenderStyle::copyContentFrom(const RenderStyle& other)
     m_nonInheritedData.access().miscData.access().content = other.m_nonInheritedData->miscData->content;
 }
 
+void RenderStyle::setEnableEvaluationTimeZoom(bool value)
+{
+    SET_VAR(m_rareInheritedData, enableEvaluationTimeZoom, value);
+}
+
+void RenderStyle::setUseSVGZoomRulesForLength(bool value)
+{
+    SET_NESTED_VAR(m_nonInheritedData, rareData, useSVGZoomRulesForLength, value);
+}
+
 void RenderStyle::copyPseudoElementsFrom(const RenderStyle& other)
 {
     if (!other.m_cachedPseudoStyles)

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -370,6 +370,7 @@ struct WebkitTextStrokeWidth;
 struct Widows;
 struct WordSpacing;
 struct ZIndex;
+struct ZoomFactor;
 
 enum class Change : uint8_t;
 enum class GridTrackSizingDirection : bool;
@@ -766,7 +767,8 @@ public:
 
     inline float zoom() const;
     inline float usedZoom() const;
-    
+    inline Style::ZoomFactor usedZoomForLength() const;
+
     inline TextZoom textZoom() const;
 
     const Length& specifiedLineHeight() const;
@@ -1766,6 +1768,12 @@ public:
     inline void setFill(Style::SVGPaint&&);
     inline void setVisitedLinkFill(Style::SVGPaint&&);
     static inline Style::SVGPaint initialFill();
+
+    inline bool enableEvaluationTimeZoom() const;
+    void setEnableEvaluationTimeZoom(bool);
+
+    inline bool useSVGZoomRulesForLength() const;
+    void setUseSVGZoomRulesForLength(bool);
 
     inline Style::Opacity fillOpacity() const;
     inline void setFillOpacity(Style::Opacity);

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -1364,4 +1364,25 @@ inline bool RenderStyle::fontCascadeEqual(const RenderStyle& other) const
         || m_inheritedData->fontData->fontCascade == other.m_inheritedData->fontData->fontCascade;
 }
 
+inline bool RenderStyle::enableEvaluationTimeZoom() const
+{
+    return m_rareInheritedData->enableEvaluationTimeZoom;
+}
+
+inline bool RenderStyle::useSVGZoomRulesForLength() const
+{
+    return m_nonInheritedData->rareData->useSVGZoomRulesForLength;
+}
+
+inline Style::ZoomFactor RenderStyle::usedZoomForLength() const
+{
+    if (useSVGZoomRulesForLength())
+        return Style::ZoomFactor(1.0f);
+
+    if (enableEvaluationTimeZoom())
+        return Style::ZoomFactor(usedZoom());
+
+    return Style::ZoomFactor(1.0f);
+}
+
 } // namespace WebCore

--- a/Source/WebCore/rendering/style/StyleRareInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleRareInheritedData.cpp
@@ -148,6 +148,7 @@ StyleRareInheritedData::StyleRareInheritedData()
     , autoRevealsWhenFound(false)
     , insideDefaultButton(false)
     , insideSubmitButton(false)
+    , enableEvaluationTimeZoom(false)
 #if HAVE(CORE_MATERIAL)
     , usedAppleVisualEffectForSubtree(static_cast<unsigned>(AppleVisualEffect::None))
 #endif
@@ -252,6 +253,7 @@ inline StyleRareInheritedData::StyleRareInheritedData(const StyleRareInheritedDa
     , autoRevealsWhenFound(o.autoRevealsWhenFound)
     , insideDefaultButton(o.insideDefaultButton)
     , insideSubmitButton(o.insideSubmitButton)
+    , enableEvaluationTimeZoom(o.enableEvaluationTimeZoom)
 #if HAVE(CORE_MATERIAL)
     , usedAppleVisualEffectForSubtree(o.usedAppleVisualEffectForSubtree)
 #endif
@@ -392,7 +394,8 @@ bool StyleRareInheritedData::operator==(const StyleRareInheritedData& o) const
         && customProperties == o.customProperties
         && listStyleImage == o.listStyleImage
         && listStyleType == o.listStyleType
-        && blockEllipsis == o.blockEllipsis;
+        && blockEllipsis == o.blockEllipsis
+        && enableEvaluationTimeZoom == o.enableEvaluationTimeZoom;
 }
 
 bool StyleRareInheritedData::hasColorFilters() const
@@ -549,6 +552,8 @@ void StyleRareInheritedData::dumpDifferences(TextStream& ts, const StyleRareInhe
 
     LOG_IF_DIFFERENT(listStyleType);
     LOG_IF_DIFFERENT(blockEllipsis);
+
+    LOG_IF_DIFFERENT(enableEvaluationTimeZoom);
 }
 #endif
 

--- a/Source/WebCore/rendering/style/StyleRareInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleRareInheritedData.h
@@ -194,6 +194,7 @@ public:
     PREFERRED_TYPE(bool) unsigned autoRevealsWhenFound : 1;
     PREFERRED_TYPE(bool) unsigned insideDefaultButton : 1;
     PREFERRED_TYPE(bool) unsigned insideSubmitButton : 1;
+    PREFERRED_TYPE(bool) unsigned enableEvaluationTimeZoom : 1;
 #if HAVE(CORE_MATERIAL)
     PREFERRED_TYPE(AppleVisualEffect) unsigned usedAppleVisualEffectForSubtree : 4;
 #endif

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp
@@ -141,6 +141,7 @@ StyleRareNonInheritedData::StyleRareNonInheritedData()
     , usesAnchorFunctions(false)
     , anchorFunctionScrollCompensatedAxes(0)
     , isPopoverInvoker(false)
+    , useSVGZoomRulesForLength(false)
 {
 }
 
@@ -247,6 +248,7 @@ inline StyleRareNonInheritedData::StyleRareNonInheritedData(const StyleRareNonIn
     , usesAnchorFunctions(o.usesAnchorFunctions)
     , anchorFunctionScrollCompensatedAxes(o.anchorFunctionScrollCompensatedAxes)
     , isPopoverInvoker(o.isPopoverInvoker)
+    , useSVGZoomRulesForLength(o.useSVGZoomRulesForLength)
 {
 }
 
@@ -359,7 +361,8 @@ bool StyleRareNonInheritedData::operator==(const StyleRareNonInheritedData& o) c
         && scrollbarWidth == o.scrollbarWidth
         && usesAnchorFunctions == o.usesAnchorFunctions
         && anchorFunctionScrollCompensatedAxes == o.anchorFunctionScrollCompensatedAxes
-        && isPopoverInvoker == o.isPopoverInvoker;
+        && isPopoverInvoker == o.isPopoverInvoker
+        && useSVGZoomRulesForLength == o.useSVGZoomRulesForLength;
 }
 
 OptionSet<Containment> StyleRareNonInheritedData::usedContain() const
@@ -532,6 +535,7 @@ void StyleRareNonInheritedData::dumpDifferences(TextStream& ts, const StyleRareN
     LOG_IF_DIFFERENT_WITH_CAST(bool, usesAnchorFunctions);
     LOG_IF_DIFFERENT_WITH_CAST(bool, anchorFunctionScrollCompensatedAxes);
     LOG_IF_DIFFERENT_WITH_CAST(bool, isPopoverInvoker);
+    LOG_IF_DIFFERENT_WITH_CAST(bool, useSVGZoomRulesForLength);
 }
 #endif // !LOG_DISABLED
 

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
@@ -271,6 +271,7 @@ public:
     PREFERRED_TYPE(OptionSet<BoxAxisFlag>) unsigned anchorFunctionScrollCompensatedAxes : 2;
     PREFERRED_TYPE(bool) unsigned usesTreeCountingFunctions : 1;
     PREFERRED_TYPE(bool) unsigned isPopoverInvoker : 1;
+    PREFERRED_TYPE(bool) unsigned useSVGZoomRulesForLength : 1;
 
 private:
     StyleRareNonInheritedData();

--- a/Source/WebCore/style/StyleResolveForDocument.cpp
+++ b/Source/WebCore/style/StyleResolveForDocument.cpp
@@ -108,6 +108,8 @@ RenderStyle resolveForDocument(const Document& document)
     fontCascade.update(WTFMove(fontSelector));
     documentStyle.setFontCascade(WTFMove(fontCascade));
 
+    documentStyle.setEnableEvaluationTimeZoom(document.settings().evaluationTimeZoomEnabled());
+
     return documentStyle;
 }
 

--- a/Source/WebCore/style/StyleResolver.cpp
+++ b/Source/WebCore/style/StyleResolver.cpp
@@ -67,6 +67,7 @@
 #include "SVGDocumentExtensions.h"
 #include "SVGElement.h"
 #include "SVGFontFaceElement.h"
+#include "SVGSVGElement.h"
 #include "Settings.h"
 #include "ShadowRoot.h"
 #include "SharedStringHash.h"
@@ -286,6 +287,10 @@ auto Resolver::initializeStateAndStyle(const Element& element, const ResolutionC
         state.setStyle(defaultStyleForElement(&element));
         state.setParentStyle(RenderStyle::clonePtr(*state.style()));
     }
+
+    // BuilderState::useSVGZoomRulesForLength equivalent
+    if (is<SVGElement>(element) && !(is<SVGSVGElement>(element) && element.parentNode()))
+        state.style()->setUseSVGZoomRulesForLength(true);
 
     if (element.isLink()) {
         auto& style = *state.style();

--- a/Source/WebCore/style/values/primitives/StyleLengthWrapper.h
+++ b/Source/WebCore/style/values/primitives/StyleLengthWrapper.h
@@ -293,12 +293,12 @@ template<LengthWrapperBaseDerived T, typename Result> struct Evaluation<T, Resul
         return value.m_value.template valueForLengthWrapperDataWithLazyMaximum<Result, Result>(value.evaluationKind(), [&] ALWAYS_INLINE_LAMBDA { return maximumValue; }, token);
     }
 
-    auto operator()(const T& value, NOESCAPE const Invocable<Result()> auto& lazyMaximumValueFunctor, float zoom) -> Result
+    auto operator()(const T& value, NOESCAPE const Invocable<Result()> auto& lazyMaximumValueFunctor, ZoomFactor zoom) -> Result
         requires (T::Fixed::range.zoomOptions == CSS::RangeZoomOptions::Unzoomed)
     {
         return value.m_value.template valueForLengthWrapperDataWithLazyMaximum<Result, Result>(value.evaluationKind(), lazyMaximumValueFunctor, zoom);
     }
-    auto operator()(const T& value, Result maximumValue, float zoom) -> Result
+    auto operator()(const T& value, Result maximumValue, ZoomFactor zoom) -> Result
         requires (T::Fixed::range.zoomOptions == CSS::RangeZoomOptions::Unzoomed)
     {
         return value.m_value.template valueForLengthWrapperDataWithLazyMaximum<Result, Result>(value.evaluationKind(), [&] ALWAYS_INLINE_LAMBDA { return maximumValue; }, zoom);
@@ -325,12 +325,12 @@ template<LengthWrapperBaseDerived T, typename Result> struct MinimumEvaluation<T
         return value.m_value.template minimumValueForLengthWrapperDataWithLazyMaximum<LayoutUnit, LayoutUnit>(value.evaluationKind(), [&] ALWAYS_INLINE_LAMBDA { return LayoutUnit(maximumValue); }, token);
     }
 
-    auto operator()(const T& value, NOESCAPE const Invocable<Result()> auto& lazyMaximumValueFunctor, float zoom) -> Result
+    auto operator()(const T& value, NOESCAPE const Invocable<Result()> auto& lazyMaximumValueFunctor, ZoomFactor zoom) -> Result
         requires (T::Fixed::range.zoomOptions == CSS::RangeZoomOptions::Unzoomed)
     {
         return value.m_value.template minimumValueForLengthWrapperDataWithLazyMaximum<LayoutUnit, LayoutUnit>(value.evaluationKind(), lazyMaximumValueFunctor, zoom);
     }
-    auto operator()(const T& value, Result maximumValue, float zoom) -> Result
+    auto operator()(const T& value, Result maximumValue, ZoomFactor zoom) -> Result
         requires (T::Fixed::range.zoomOptions == CSS::RangeZoomOptions::Unzoomed)
     {
         return value.m_value.template minimumValueForLengthWrapperDataWithLazyMaximum<LayoutUnit, LayoutUnit>(value.evaluationKind(), [&] ALWAYS_INLINE_LAMBDA { return LayoutUnit(maximumValue); }, zoom);

--- a/Source/WebCore/style/values/primitives/StyleLengthWrapperData.h
+++ b/Source/WebCore/style/values/primitives/StyleLengthWrapperData.h
@@ -25,7 +25,7 @@
 #pragma once
 
 #include <WebCore/Length.h>
-#include <WebCore/StyleZoomNeededToken.h>
+#include <WebCore/StyleZoomPrimitives.h>
 
 namespace WebCore {
 namespace Style {
@@ -88,12 +88,12 @@ struct LengthWrapperData {
     template<typename ReturnType, typename MaximumType>
     ReturnType minimumValueForLengthWrapperDataWithLazyMaximum(LengthWrapperDataEvaluationKind, NOESCAPE const Invocable<MaximumType()> auto& lazyMaximumValueFunctor, ZoomNeeded) const;
     template<typename ReturnType, typename MaximumType>
-    ReturnType minimumValueForLengthWrapperDataWithLazyMaximum(LengthWrapperDataEvaluationKind, NOESCAPE const Invocable<MaximumType()> auto& lazyMaximumValueFunctor, float zoom) const;
+    ReturnType minimumValueForLengthWrapperDataWithLazyMaximum(LengthWrapperDataEvaluationKind, NOESCAPE const Invocable<MaximumType()> auto& lazyMaximumValueFunctor, ZoomFactor) const;
 
     template<typename ReturnType, typename MaximumType>
     ReturnType valueForLengthWrapperDataWithLazyMaximum(LengthWrapperDataEvaluationKind, NOESCAPE const Invocable<MaximumType()> auto& lazyMaximumValueFunctor, ZoomNeeded) const;
     template<typename ReturnType, typename MaximumType>
-    ReturnType valueForLengthWrapperDataWithLazyMaximum(LengthWrapperDataEvaluationKind, NOESCAPE const Invocable<MaximumType()> auto& lazyMaximumValueFunctor, float zoom) const;
+    ReturnType valueForLengthWrapperDataWithLazyMaximum(LengthWrapperDataEvaluationKind, NOESCAPE const Invocable<MaximumType()> auto& lazyMaximumValueFunctor, ZoomFactor) const;
 
 private:
     WEBCORE_EXPORT float nonNanCalculatedValue(float maxValue) const;
@@ -273,12 +273,12 @@ ReturnType LengthWrapperData::minimumValueForLengthWrapperDataWithLazyMaximum(Le
 }
 
 template<typename ReturnType, typename MaximumType>
-ReturnType LengthWrapperData::minimumValueForLengthWrapperDataWithLazyMaximum(LengthWrapperDataEvaluationKind evaluationKind, NOESCAPE const Invocable<MaximumType()> auto& lazyMaximumValueFunctor, float zoom) const
+ReturnType LengthWrapperData::minimumValueForLengthWrapperDataWithLazyMaximum(LengthWrapperDataEvaluationKind evaluationKind, NOESCAPE const Invocable<MaximumType()> auto& lazyMaximumValueFunctor, ZoomFactor zoom) const
 {
     switch (evaluationKind) {
     case LengthWrapperDataEvaluationKind::Fixed:
         ASSERT(m_kind == LengthWrapperDataKind::Default);
-        return ReturnType(m_floatValue * zoom);
+        return ReturnType(m_floatValue * zoom.value);
     case LengthWrapperDataEvaluationKind::Percentage:
         ASSERT(m_kind == LengthWrapperDataKind::Default);
         return ReturnType(static_cast<float>(lazyMaximumValueFunctor() * m_floatValue / 100.0f));
@@ -315,12 +315,12 @@ ReturnType LengthWrapperData::valueForLengthWrapperDataWithLazyMaximum(LengthWra
 }
 
 template<typename ReturnType, typename MaximumType>
-ReturnType LengthWrapperData::valueForLengthWrapperDataWithLazyMaximum(LengthWrapperDataEvaluationKind evaluationKind, NOESCAPE const Invocable<MaximumType()> auto& lazyMaximumValueFunctor, float zoom) const
+ReturnType LengthWrapperData::valueForLengthWrapperDataWithLazyMaximum(LengthWrapperDataEvaluationKind evaluationKind, NOESCAPE const Invocable<MaximumType()> auto& lazyMaximumValueFunctor, ZoomFactor zoom) const
 {
     switch (evaluationKind) {
     case LengthWrapperDataEvaluationKind::Fixed:
         ASSERT(m_kind == LengthWrapperDataKind::Default);
-        return ReturnType(m_floatValue * zoom);
+        return ReturnType(m_floatValue * zoom.value);
     case LengthWrapperDataEvaluationKind::Percentage:
         ASSERT(m_kind == LengthWrapperDataKind::Default);
         return ReturnType(static_cast<float>(lazyMaximumValueFunctor() * m_floatValue / 100.0f));

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumeric.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumeric.h
@@ -29,7 +29,7 @@
 #include <WebCore/StylePrimitiveNumericConcepts.h>
 #include <WebCore/StyleUnevaluatedCalculation.h>
 #include <WebCore/StyleValueTypes.h>
-#include <WebCore/StyleZoomNeededToken.h>
+#include <WebCore/StyleZoomPrimitives.h>
 #include <algorithm>
 #include <wtf/CompactVariant.h>
 #include <wtf/Forward.h>
@@ -139,10 +139,10 @@ template<CSS::Range R, typename V> struct PrimitiveNumeric<CSS::Length<R, V>> {
         return value;
     }
 
-    constexpr auto resolveZoom(float zoom) const
+    constexpr auto resolveZoom(ZoomFactor zoom) const
         requires (range.zoomOptions == WebCore::CSS::RangeZoomOptions::Unzoomed)
     {
-        return value * zoom;
+        return value * zoom.value;
     }
 
     constexpr auto unresolvedValue() const { return value; }

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+CSSValueConversion.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+CSSValueConversion.h
@@ -27,6 +27,7 @@
 #include "CSSPrimitiveNumericUnits.h"
 #include "CSSPrimitiveValue.h"
 #include "StyleBuilderChecking.h"
+#include "StylePrimitiveNumericTypes+Conversions.h"
 #include "StylePrimitiveNumericTypes.h"
 #include "StyleValueTypes.h"
 
@@ -103,7 +104,12 @@ template<auto R, typename V> struct CSSValueConversion<Length<R, V>> {
                 ? builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f)
                 : builderState.cssToLengthConversionData();
         } else if constexpr (R.zoomOptions == CSS::RangeZoomOptions::Unzoomed) {
-            return builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f);
+            if (shouldUseEvaluationTimeZoom(builderState))
+                return builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f);
+
+            return builderState.useSVGZoomRulesForLength()
+                ? builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f)
+                : builderState.cssToLengthConversionData();
         }
     }
     auto operator()(BuilderState& builderState, const CSSPrimitiveValue& value) -> Length<R, V>
@@ -183,7 +189,12 @@ template<auto R, typename V> struct CSSValueConversion<LengthPercentage<R, V>> {
                 ? builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f)
                 : builderState.cssToLengthConversionData();
         } else if constexpr (LengthPercentage<R, V>::Dimension::range.zoomOptions == CSS::RangeZoomOptions::Unzoomed) {
-            return builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f);
+            if (shouldUseEvaluationTimeZoom(builderState))
+                return builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f);
+
+            return builderState.useSVGZoomRulesForLength()
+                ? builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f)
+                : builderState.cssToLengthConversionData();
         }
     }
     auto operator()(BuilderState& builderState, const CSSPrimitiveValue& value) -> StyleType

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.cpp
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.cpp
@@ -24,6 +24,7 @@
 
 #include "config.h"
 #include "StylePrimitiveNumericTypes+Conversions.h"
+#include "Settings.h"
 
 #include "RenderStyleInlines.h"
 #include "StyleLengthResolution.h"
@@ -63,6 +64,16 @@ float canonicalizeAndClampLength(double value, CSS::LengthUnit unit, const CSSTo
 float adjustForZoom(float value, const RenderStyle& style)
 {
     return adjustFloatForAbsoluteZoom(value, style);
+}
+
+bool shouldUseEvaluationTimeZoom(const RenderStyle& style)
+{
+    return style.enableEvaluationTimeZoom();
+}
+
+bool shouldUseEvaluationTimeZoom(const BuilderState& state)
+{
+    return state.document().settings().evaluationTimeZoomEnabled();
 }
 
 } // namespace Style

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Evaluation.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Evaluation.h
@@ -47,7 +47,7 @@ template<auto R, typename V, typename Result> struct Evaluation<Length<R, V>, Re
     {
         return Result(value.resolveZoom(token));
     }
-    constexpr auto operator()(const Length<R, V>& value, float zoom) -> Result
+    constexpr auto operator()(const Length<R, V>& value, ZoomFactor zoom) -> Result
         requires (R.zoomOptions == CSS::RangeZoomOptions::Unzoomed)
     {
         return Result(value.resolveZoom(zoom));
@@ -58,7 +58,7 @@ template<auto R, typename V, typename Result> struct Evaluation<Length<R, V>, Re
     {
         return Result(value.resolveZoom(token));
     }
-    constexpr auto operator()(const Length<R, V>& value, Result, float zoom) -> Result
+    constexpr auto operator()(const Length<R, V>& value, Result, ZoomFactor zoom) -> Result
         requires (R.zoomOptions == CSS::RangeZoomOptions::Unzoomed)
     {
         return Result(value.resolveZoom(zoom));
@@ -125,7 +125,7 @@ template<auto R, typename V, typename Result> struct Evaluation<LengthPercentage
             }
         );
     }
-    constexpr auto operator()(const LengthPercentage<R, V>& lengthPercentage, Result referenceLength, float zoom) -> Result
+    constexpr auto operator()(const LengthPercentage<R, V>& lengthPercentage, Result referenceLength, ZoomFactor zoom) -> Result
         requires (R.zoomOptions == CSS::RangeZoomOptions::Unzoomed)
     {
         return WTF::switchOn(lengthPercentage,
@@ -161,8 +161,8 @@ template<typename T> struct Evaluation<SpaceSeparatedPoint<T>, FloatPoint> {
             evaluate<float>(value.y(), referenceBox.height(), token)
         };
     }
-    auto operator()(const SpaceSeparatedPoint<T>& value, FloatSize referenceBox, float zoom) -> FloatPoint
-        requires HasThreeParameterEvaluate<T, float, float, float>
+    auto operator()(const SpaceSeparatedPoint<T>& value, FloatSize referenceBox, ZoomFactor zoom) -> FloatPoint
+        requires HasThreeParameterEvaluate<T, float, float, ZoomFactor>
     {
         return {
             evaluate<float>(value.x(), referenceBox.width(), zoom),
@@ -187,8 +187,8 @@ template<typename T> struct Evaluation<SpaceSeparatedPoint<T>, LayoutPoint> {
             evaluate<LayoutUnit>(value.y(), referenceBox.height(), token)
         };
     }
-    auto operator()(const SpaceSeparatedPoint<T>& value, LayoutSize referenceBox, float zoom) -> LayoutPoint
-        requires HasThreeParameterEvaluate<T, LayoutUnit, LayoutUnit, float>
+    auto operator()(const SpaceSeparatedPoint<T>& value, LayoutSize referenceBox, ZoomFactor zoom) -> LayoutPoint
+        requires HasThreeParameterEvaluate<T, LayoutUnit, LayoutUnit, ZoomFactor>
     {
         return {
             evaluate<LayoutUnit>(value.x(), referenceBox.width(), zoom),
@@ -216,7 +216,7 @@ template<typename T> struct Evaluation<SpaceSeparatedSize<T>, FloatSize> {
             evaluate<float>(value.height(), referenceBox.height(), token)
         };
     }
-    auto operator()(const SpaceSeparatedSize<T>& value, FloatSize referenceBox, float zoom) -> FloatSize
+    auto operator()(const SpaceSeparatedSize<T>& value, FloatSize referenceBox, ZoomFactor zoom) -> FloatSize
         requires HasThreeParameterEvaluate<T, float, float, float>
     {
         return {
@@ -242,7 +242,7 @@ template<typename T> struct Evaluation<SpaceSeparatedSize<T>, LayoutSize> {
             evaluate<LayoutUnit>(value.height(), referenceBox.height(), token)
         };
     }
-    auto operator()(const SpaceSeparatedSize<T>& value, LayoutSize referenceBox, float zoom) -> LayoutSize
+    auto operator()(const SpaceSeparatedSize<T>& value, LayoutSize referenceBox, ZoomFactor zoom) -> LayoutSize
         requires HasThreeParameterEvaluate<T, LayoutUnit, LayoutUnit, float>
     {
         return {
@@ -271,8 +271,8 @@ template<typename T> struct Evaluation<MinimallySerializingSpaceSeparatedSize<T>
             evaluate<float>(value.height(), referenceBox.height(), token)
         };
     }
-    auto operator()(const MinimallySerializingSpaceSeparatedSize<T>& value, FloatSize referenceBox, float zoom) -> FloatSize
-        requires HasThreeParameterEvaluate<T, float, float, float>
+    auto operator()(const MinimallySerializingSpaceSeparatedSize<T>& value, FloatSize referenceBox, ZoomFactor zoom) -> FloatSize
+        requires HasThreeParameterEvaluate<T, float, float, ZoomFactor>
     {
         return {
             evaluate<float>(value.width(), referenceBox.width(), zoom),
@@ -297,8 +297,8 @@ template<typename T> struct Evaluation<MinimallySerializingSpaceSeparatedSize<T>
             evaluate<LayoutUnit>(value.height(), referenceBox.height(), token)
         };
     }
-    auto operator()(const MinimallySerializingSpaceSeparatedSize<T>& value, LayoutSize referenceBox, float zoom) -> LayoutSize
-        requires HasThreeParameterEvaluate<T, LayoutUnit, LayoutUnit, float>
+    auto operator()(const MinimallySerializingSpaceSeparatedSize<T>& value, LayoutSize referenceBox, ZoomFactor zoom) -> LayoutSize
+        requires HasThreeParameterEvaluate<T, LayoutUnit, LayoutUnit, ZoomFactor>
     {
         return {
             evaluate<LayoutUnit>(value.width(), referenceBox.width(), zoom),

--- a/Source/WebCore/style/values/primitives/StyleZoomPrimitives.h
+++ b/Source/WebCore/style/values/primitives/StyleZoomPrimitives.h
@@ -30,5 +30,11 @@ namespace Style {
 // Token passed around to indicate that the evaluation will need zoom passed in the future.
 struct ZoomNeeded { };
 
+struct ZoomFactor {
+    float value;
+
+    constexpr explicit ZoomFactor(float v) : value(v) { }
+};
+
 } // namespace Style
 } // namespace WebCore


### PR DESCRIPTION
#### bc3c76dc5216d7c5e47f498a8fb9fd375e60f7f2
<pre>
[Style] Add strongly-typed zoom factor
<a href="https://bugs.webkit.org/show_bug.cgi?id=299980">https://bugs.webkit.org/show_bug.cgi?id=299980</a>
<a href="https://rdar.apple.com/161759785">rdar://161759785</a>

Reviewed by Sam Weinig and Antti Koivisto.

We add a strongly-typed ZoomFactor that is applied during
evaluation-time, i.e., during rendering/layout after style resolution.
This replaces the previous float-based zoom value.

We also introduce a new feature flag, &quot;EvaluationTimeZoom&quot;. When
enabled, it prevents zoom from being applied at style resolution and
ensures it is applied only during evaluation-time (rendering/layout
after styles have been resolved).

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/Headers.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/layout/formattingContexts/FormattingGeometry.h:
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::setEnableEvaluationTimeZoom):
(WebCore::RenderStyle::setUseSVGZoomRulesForLength):
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
(WebCore::RenderStyle::enableEvaluationTimeZoom const):
(WebCore::RenderStyle::useSVGZoomRulesForLength const):
(WebCore::RenderStyle::usedZoomForLength const):
* Source/WebCore/rendering/style/StyleRareInheritedData.cpp:
(WebCore::StyleRareInheritedData::StyleRareInheritedData):
(WebCore::StyleRareInheritedData::operator== const):
(WebCore::StyleRareInheritedData::dumpDifferences const):
* Source/WebCore/rendering/style/StyleRareInheritedData.h:
* Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp:
(WebCore::StyleRareNonInheritedData::StyleRareNonInheritedData):
(WebCore::StyleRareNonInheritedData::operator== const):
(WebCore::StyleRareNonInheritedData::dumpDifferences const):
* Source/WebCore/rendering/style/StyleRareNonInheritedData.h:
* Source/WebCore/style/StyleResolveForDocument.cpp:
(WebCore::Style::resolveForDocument):
* Source/WebCore/style/StyleResolver.cpp:
(WebCore::Style::Resolver::initializeStateAndStyle):
* Source/WebCore/style/values/primitives/StyleLengthWrapper.h:
* Source/WebCore/style/values/primitives/StyleLengthWrapperData.h:
(WebCore::Style::LengthWrapperData::minimumValueForLengthWrapperDataWithLazyMaximum const):
(WebCore::Style::LengthWrapperData::valueForLengthWrapperDataWithLazyMaximum const):
* Source/WebCore/style/values/primitives/StylePrimitiveNumeric.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+CSSValueConversion.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.cpp:
(WebCore::Style::shouldUseEvaluationTimeZoom):
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Evaluation.h:
* Source/WebCore/style/values/primitives/StyleZoomPrimitives.h: Renamed from Source/WebCore/style/values/primitives/StyleZoomNeededToken.h.
(WebCore::Style::ZoomFactor::ZoomFactor):

Canonical link: <a href="https://commits.webkit.org/300868@main">https://commits.webkit.org/300868@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9adeacfb29b977fb8c6a24bdd4368ea474bcb22c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124156 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43849 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34566 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130983 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76254 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/126033 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44590 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52449 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94441 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/62653 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c23b31e0-3963-4b55-b5a1-cd7d41822356) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127110 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35529 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111055 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75032 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34474 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29217 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74469 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/116303 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105271 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29438 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133657 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/122687 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51080 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38926 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102912 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51465 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107273 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102719 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26127 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48075 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26323 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/47960 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50940 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56715 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/153781 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50388 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39082 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53741 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52065 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->