### PR TITLE
[GFC] Add some initial logic for computing used margins

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
@@ -45,6 +45,11 @@ struct UsedTrackSizes {
     TrackSizes rowSizes;
 };
 
+struct UsedMargins {
+    LayoutUnit marginStart;
+    LayoutUnit marginEnd;
+};
+
 GridLayout::GridLayout(const GridFormattingContext& gridFormattingContext)
     : m_gridFormattingContext(gridFormattingContext)
 {
@@ -106,6 +111,11 @@ void GridLayout::layout(GridFormattingContext::GridLayoutConstraints, const Unpl
 
     UNUSED_VARIABLE(usedColumnSizes);
     UNUSED_VARIABLE(usedRowSizes);
+
+    // https://drafts.csswg.org/css-grid-1/#alignment
+    auto usedInlineMargins = computeInlineMargins(placedGridItems);
+    auto usedBlockMargins = computeBlockMargins(placedGridItems);
+
 }
 
 TrackSizingFunctionsList GridLayout::trackSizingFunctions(size_t implicitGridTracksCount, const Vector<Style::GridTrackSize> gridTemplateTrackSizes)
@@ -177,6 +187,58 @@ UsedTrackSizes GridLayout::performGridSizingAlgorithm(const PlacedGridItems& pla
     UNUSED_VARIABLE(resolveGridRowSizesIfAnyMinContentContributionChanged);
 
     return { columnSizes, rowSizes };
+}
+
+// https://drafts.csswg.org/css-grid-1/#auto-margins
+Vector<UsedMargins> GridLayout::computeInlineMargins(const PlacedGridItems& placedGridItems)
+{
+    return placedGridItems.map([](const PlacedGridItem& placedGridItem) {
+        auto& inlineAxisSizes = placedGridItem.inlineAxisSizes();
+
+        auto marginStart = [&] -> LayoutUnit {
+            if (auto fixedMarginStart = inlineAxisSizes.marginStart.tryFixed())
+                return LayoutUnit { fixedMarginStart->resolveZoom(Style::ZoomNeeded { }) };
+
+            ASSERT_NOT_IMPLEMENTED_YET();
+            return { };
+        };
+
+        auto marginEnd = [&] -> LayoutUnit {
+            if (auto fixedMarginEnd = inlineAxisSizes.marginEnd.tryFixed())
+                return LayoutUnit { fixedMarginEnd->resolveZoom(Style::ZoomNeeded { }) };
+
+            ASSERT_NOT_IMPLEMENTED_YET();
+            return { };
+        };
+
+        return UsedMargins { marginStart(), marginEnd() };
+    });
+}
+
+// https://drafts.csswg.org/css-grid-1/#auto-margins
+Vector<UsedMargins> GridLayout::computeBlockMargins(const PlacedGridItems& placedGridItems)
+{
+    return placedGridItems.map([](const PlacedGridItem& placedGridItem) {
+        auto& blockAxisSizes = placedGridItem.blockAxisSizes();
+
+        auto marginStart = [&] -> LayoutUnit {
+            if (auto fixedMarginStart = blockAxisSizes.marginStart.tryFixed())
+                return LayoutUnit { fixedMarginStart->resolveZoom(Style::ZoomNeeded { }) };
+
+            ASSERT_NOT_IMPLEMENTED_YET();
+            return { };
+        };
+
+        auto marginEnd = [&] -> LayoutUnit {
+            if (auto fixedMarginEnd = blockAxisSizes.marginEnd.tryFixed())
+                return LayoutUnit { fixedMarginEnd->resolveZoom(Style::ZoomNeeded { }) };
+
+            ASSERT_NOT_IMPLEMENTED_YET();
+            return { };
+        };
+
+        return UsedMargins { marginStart(), marginEnd() };
+    });
 }
 
 const ElementBox& GridLayout::gridContainer() const

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayout.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayout.h
@@ -56,6 +56,7 @@ struct GridAutoFlowOptions {
 };
 
 struct UsedTrackSizes;
+struct UsedMargins;
 
 class GridLayout {
 public:
@@ -70,6 +71,10 @@ private:
     static TrackSizingFunctionsList trackSizingFunctions(size_t implicitGridTracksCount, const Vector<Style::GridTrackSize> gridTemplateTrackSizes);
 
     static UsedTrackSizes performGridSizingAlgorithm(const PlacedGridItems&, const TrackSizingFunctionsList& columnTrackSizingFunctionsList, const TrackSizingFunctionsList& rowTrackSizingFunctionsList);
+
+
+    static Vector<UsedMargins> computeInlineMargins(const PlacedGridItems&);
+    static Vector<UsedMargins> computeBlockMargins(const PlacedGridItems&);
 
     const GridFormattingContext& formattingContext() const { return m_gridFormattingContext.get(); }
 


### PR DESCRIPTION
#### 2ab24cabab0f4416a63e8f47065cfa0f76ceebee
<pre>
[GFC] Add some initial logic for computing used margins
<a href="https://bugs.webkit.org/show_bug.cgi?id=299983">https://bugs.webkit.org/show_bug.cgi?id=299983</a>
<a href="https://rdar.apple.com/161769719">rdar://161769719</a>

Reviewed by Alan Baradlay.

We will need to know the used margins of each grid item for
alignment/positioning after they have been sized so we should have some
logic that goes through and computes the margins for them. In the
simplest case we will just be grabbing fixed values off style and in the
slightly more complicated case we will have to do some match to compute
the used value with respect to the grid area. Here we add the overall
logic that will be used and implement the simplest case of fixed values.

* Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp:
(WebCore::Layout::GridLayout::computeInlineMargins):
(WebCore::Layout::GridLayout::computeBlockMargins):
Introduce the two dedicated functions for computing the inline and block
direction margins. Currently the function signature just requires the
PlacedGridItems since we are grabbing the fixed values from style. In
the future we may need to pass in the column/row sizes to handle
percentages and auto but we will do that when we get there.

Canonical link: <a href="https://commits.webkit.org/300904@main">https://commits.webkit.org/300904@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/224d2d7e63275d1ccc88ac30e8229bd078c337ea

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124083 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43786 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34494 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130912 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76212 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/125960 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44520 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52385 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94391 "1 flakes 15 failures") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62624 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/135fc494-e323-4d3d-b381-e59291415acf) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127037 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35472 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110992 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74983 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a03ac80d-5a98-4db0-b642-696a5fb8e479) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34420 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29156 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-position/multicol/vlr-rtl-rtl-in-multicols.html imported/w3c/web-platform-tests/media-source/mediasource-seek-during-pending-seek.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74396 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105209 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29375 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133584 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51024 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38877 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102857 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51401 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107211 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102668 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26159 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48027 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26268 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/47902 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50879 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56650 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50341 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53689 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52015 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->