### PR TITLE
REGRESSION(300757@main): TestWebKitAPI.UnifiedPDF.PasswordFormShouldDismissAfterNavigation broke

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -474,6 +474,7 @@ html/canvas/CanvasRenderingContext.cpp
 html/canvas/CanvasRenderingContext2D.cpp
 html/canvas/CanvasRenderingContext2DBase.cpp
 html/canvas/CanvasStyle.cpp
+html/canvas/EXTDisjointTimerQuery.cpp
 html/canvas/GPUCanvasContextCocoa.mm
 html/canvas/ImageBitmapRenderingContext.cpp
 html/canvas/OffscreenCanvasRenderingContext2D.cpp

--- a/Source/WebCore/animation/WebAnimation.cpp
+++ b/Source/WebCore/animation/WebAnimation.cpp
@@ -829,7 +829,7 @@ void WebAnimation::cancel(Silently silently)
         // 2. Reject the current finished promise with a DOMException named "AbortError".
         // 3. Set the [[PromiseIsHandled]] internal slot of the current finished promise to true.
         if (RefPtr context = scriptExecutionContext(); context && !m_finishedPromise->isFulfilled()) {
-            context->eventLoop().queueMicrotask(*context, [finishedPromise = WTFMove(m_finishedPromise)]() mutable {
+            context->eventLoop().queueMicrotask([finishedPromise = WTFMove(m_finishedPromise)]() mutable {
                 finishedPromise->reject(Exception { ExceptionCode::AbortError }, RejectAsHandled::Yes);
             });
         }
@@ -950,7 +950,7 @@ void WebAnimation::resetPendingTasks()
     // 5. Reject animation's current ready promise with a DOMException named "AbortError".
     // 6. Set the [[PromiseIsHandled]] internal slot of animation’s current ready promise to true.
     if (RefPtr context = scriptExecutionContext()) {
-        context->eventLoop().queueMicrotask(*context, [readyPromise = WTFMove(m_readyPromise)]() mutable {
+        context->eventLoop().queueMicrotask([readyPromise = WTFMove(m_readyPromise)]() mutable {
             if (!readyPromise->isFulfilled())
                 readyPromise->reject(Exception { ExceptionCode::AbortError }, RejectAsHandled::Yes);
         });
@@ -1099,7 +1099,7 @@ void WebAnimation::updateFinishedState(DidSeek didSeek, SynchronouslyNotify sync
             // is already a microtask queued to run those steps for animation.
             m_finishNotificationStepsMicrotaskPending = true;
             if (RefPtr context = scriptExecutionContext()) {
-                context->eventLoop().queueMicrotask(*context, [this, protectedThis = Ref { *this }] {
+                context->eventLoop().queueMicrotask([this, protectedThis = Ref { *this }] {
                     if (m_finishNotificationStepsMicrotaskPending) {
                         m_finishNotificationStepsMicrotaskPending = false;
                         finishNotificationSteps();

--- a/Source/WebCore/dom/CustomElementReactionQueue.cpp
+++ b/Source/WebCore/dom/CustomElementReactionQueue.cpp
@@ -389,8 +389,7 @@ void CustomElementReactionQueue::enqueueElementOnAppropriateElementQueue(Element
     ASSERT(element.reactionQueue());
     element.setIsInCustomElementReactionQueue();
     if (!CustomElementReactionStack::s_currentProcessingStack) {
-        Ref document { element.protectedDocument() };
-        document->windowEventLoop().backupElementQueue(document).add(element);
+        element.protectedDocument()->windowEventLoop().backupElementQueue().add(element);
         return;
     }
 

--- a/Source/WebCore/dom/DocumentStorageAccess.cpp
+++ b/Source/WebCore/dom/DocumentStorageAccess.cpp
@@ -258,7 +258,7 @@ void DocumentStorageAccess::requestStorageAccess(Ref<DeferredPromise>&& promise)
 
         Ref document = m_document.get();
         if (shouldPreserveUserGesture) {
-            document->checkedEventLoop()->queueMicrotask(document, [this, weakThis] {
+            document->checkedEventLoop()->queueMicrotask([this, weakThis] {
                 if (weakThis)
                     enableTemporaryTimeUserGesture();
             });
@@ -283,7 +283,7 @@ void DocumentStorageAccess::requestStorageAccess(Ref<DeferredPromise>&& promise)
         }
 
         if (shouldPreserveUserGesture) {
-            document->checkedEventLoop()->queueMicrotask(document, [this, weakThis] {
+            document->checkedEventLoop()->queueMicrotask([this, weakThis] {
                 if (weakThis)
                     consumeTemporaryTimeUserGesture();
             });
@@ -352,8 +352,7 @@ void DocumentStorageAccess::requestStorageAccessQuirk(RegistrableDomain&& reques
         bool shouldPreserveUserGesture = result.wasGranted == StorageAccessWasGranted::Yes || result.promptWasShown == StorageAccessPromptWasShown::No;
 
         if (shouldPreserveUserGesture) {
-            Ref protectedDocument { this->protectedDocument() };
-            protectedDocument->checkedEventLoop()->queueMicrotask(protectedDocument, [this, weakThis] {
+            protectedDocument()->checkedEventLoop()->queueMicrotask([this, weakThis] {
                 if (weakThis)
                     enableTemporaryTimeUserGesture();
             });
@@ -371,8 +370,7 @@ void DocumentStorageAccess::requestStorageAccessQuirk(RegistrableDomain&& reques
         }
 
         if (shouldPreserveUserGesture) {
-            Ref protectedDocument { this->protectedDocument() };
-            protectedDocument->checkedEventLoop()->queueMicrotask(protectedDocument, [this, weakThis] {
+            protectedDocument()->checkedEventLoop()->queueMicrotask([this, weakThis] {
                 if (weakThis)
                     consumeTemporaryTimeUserGesture();
             });

--- a/Source/WebCore/dom/EventLoop.cpp
+++ b/Source/WebCore/dom/EventLoop.cpp
@@ -558,9 +558,9 @@ private:
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(EventLoopFunctionMicrotaskDispatcher);
 
-void EventLoopTaskGroup::queueMicrotask(ScriptExecutionContext& context, EventLoop::TaskFunction&& function)
+void EventLoopTaskGroup::queueMicrotask(EventLoop::TaskFunction&& function)
 {
-    queueMicrotask(JSC::QueuedTask { EventLoopFunctionMicrotaskDispatcher::create(*this, WTFMove(function)), context.globalObject() });
+    queueMicrotask(JSC::QueuedTask { EventLoopFunctionMicrotaskDispatcher::create(*this, WTFMove(function)), nullptr });
 }
 
 void EventLoopTaskGroup::queueMicrotask(JSC::QueuedTask&& task)

--- a/Source/WebCore/dom/EventLoop.h
+++ b/Source/WebCore/dom/EventLoop.h
@@ -205,7 +205,7 @@ public:
     WEBCORE_EXPORT void queueTask(TaskSource, EventLoop::TaskFunction&&);
 
     // https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-microtask
-    WEBCORE_EXPORT void queueMicrotask(ScriptExecutionContext&, EventLoop::TaskFunction&&);
+    WEBCORE_EXPORT void queueMicrotask(EventLoop::TaskFunction&&);
     WEBCORE_EXPORT void queueMicrotask(JSC::QueuedTask&&);
     MicrotaskQueue& microtaskQueue() { return protectedEventLoop()->microtaskQueue(); }
 

--- a/Source/WebCore/dom/MutationObserver.cpp
+++ b/Source/WebCore/dom/MutationObserver.cpp
@@ -153,26 +153,25 @@ void MutationObserver::enqueueMutationRecord(Ref<MutationRecord>&& mutation)
 
     Ref eventLoop = document->windowEventLoop();
     eventLoop->activeMutationObservers().add(this);
-    eventLoop->queueMutationObserverCompoundMicrotask(document);
+    eventLoop->queueMutationObserverCompoundMicrotask();
 }
 
 void MutationObserver::enqueueSlotChangeEvent(HTMLSlotElement& slot)
 {
     ASSERT(isMainThread());
-    Ref document = slot.document();
-    Ref eventLoop = document->windowEventLoop();
+    Ref eventLoop = slot.document().windowEventLoop();
     auto& list = eventLoop->signalSlotList();
     ASSERT(list.findIf([&slot](auto& entry) { return entry.ptr() == &slot; }) == notFound);
     list.append(slot);
 
-    eventLoop->queueMutationObserverCompoundMicrotask(document);
+    eventLoop->queueMutationObserverCompoundMicrotask();
 }
 
 void MutationObserver::setHasTransientRegistration(Document& document)
 {
     Ref eventLoop = document.windowEventLoop();
     eventLoop->activeMutationObservers().add(this);
-    eventLoop->queueMutationObserverCompoundMicrotask(document);
+    eventLoop->queueMutationObserverCompoundMicrotask();
 }
 
 bool MutationObserver::isReachableFromOpaqueRoots(JSC::AbstractSlotVisitor& visitor) const

--- a/Source/WebCore/dom/WindowEventLoop.cpp
+++ b/Source/WebCore/dom/WindowEventLoop.cpp
@@ -241,12 +241,12 @@ void WindowEventLoop::didFireIdleTimer()
     opportunisticallyRunIdleCallbacks();
 }
 
-void WindowEventLoop::queueMutationObserverCompoundMicrotask(ScriptExecutionContext& scriptExecutionContext)
+void WindowEventLoop::queueMutationObserverCompoundMicrotask()
 {
     if (m_mutationObserverCompoundMicrotaskQueuedFlag)
         return;
     m_mutationObserverCompoundMicrotaskQueuedFlag = true;
-    m_perpetualTaskGroupForSimilarOriginWindowAgents.queueMicrotask(scriptExecutionContext, [weakThis = WeakPtr { *this }] {
+    m_perpetualTaskGroupForSimilarOriginWindowAgents.queueMicrotask([weakThis = WeakPtr { *this }] {
         // We can't make a Ref to WindowEventLoop in the lambda capture as that would result in a reference cycle & leak.
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
@@ -263,11 +263,11 @@ void WindowEventLoop::queueMutationObserverCompoundMicrotask(ScriptExecutionCont
     });
 }
 
-CustomElementQueue& WindowEventLoop::backupElementQueue(ScriptExecutionContext& scriptExecutionContext)
+CustomElementQueue& WindowEventLoop::backupElementQueue()
 {
     if (!m_processingBackupElementQueue) {
         m_processingBackupElementQueue = true;
-        m_perpetualTaskGroupForSimilarOriginWindowAgents.queueMicrotask(scriptExecutionContext, [weakThis = WeakPtr { *this }] {
+        m_perpetualTaskGroupForSimilarOriginWindowAgents.queueMicrotask([weakThis = WeakPtr { *this }] {
             // We can't make a Ref to WindowEventLoop in the lambda capture as that would result in a reference cycle & leak.
             RefPtr protectedThis = weakThis.get();
             if (!protectedThis)

--- a/Source/WebCore/dom/WindowEventLoop.h
+++ b/Source/WebCore/dom/WindowEventLoop.h
@@ -48,12 +48,12 @@ public:
 
     virtual ~WindowEventLoop();
 
-    void queueMutationObserverCompoundMicrotask(ScriptExecutionContext&);
+    void queueMutationObserverCompoundMicrotask();
     Vector<GCReachableRef<HTMLSlotElement>>& signalSlotList() { return m_signalSlotList; }
     HashSet<RefPtr<MutationObserver>>& activeMutationObservers() { return m_activeObservers; }
     HashSet<RefPtr<MutationObserver>>& suspendedMutationObservers() { return m_suspendedObservers; }
 
-    CustomElementQueue& backupElementQueue(ScriptExecutionContext&);
+    CustomElementQueue& backupElementQueue();
 
     void scheduleIdlePeriod();
     void opportunisticallyRunIdleCallbacks(std::optional<MonotonicTime> deadline = std::nullopt);

--- a/Source/WebCore/html/canvas/EXTDisjointTimerQuery.cpp
+++ b/Source/WebCore/html/canvas/EXTDisjointTimerQuery.cpp
@@ -159,8 +159,7 @@ void EXTDisjointTimerQuery::endQueryEXT(GCGLenum target)
     context->protectedGraphicsContextGL()->endQueryEXT(target);
 
     // A query's result must not be made available until control has returned to the user agent's main loop.
-    RefPtr protectedScriptExecutionContext { context->protectedScriptExecutionContext() };
-    protectedScriptExecutionContext->eventLoop().queueMicrotask(*protectedScriptExecutionContext, [query = WTFMove(context->m_activeQuery)] {
+    context->scriptExecutionContext()->eventLoop().queueMicrotask([query = WTFMove(context->m_activeQuery)] {
         query->makeResultAvailable();
     });
 }
@@ -191,8 +190,7 @@ void EXTDisjointTimerQuery::queryCounterEXT(WebGLTimerQueryEXT& query, GCGLenum 
     context->protectedGraphicsContextGL()->queryCounterEXT(query.object(), target);
 
     // A query's result must not be made available until control has returned to the user agent's main loop.
-    RefPtr protectedScriptExecutionContext { context->protectedScriptExecutionContext() };
-    protectedScriptExecutionContext->eventLoop().queueMicrotask(*protectedScriptExecutionContext, [&] {
+    context->scriptExecutionContext()->eventLoop().queueMicrotask([&] {
         query.makeResultAvailable();
     });
 }

--- a/Source/WebCore/html/canvas/EXTDisjointTimerQueryWebGL2.cpp
+++ b/Source/WebCore/html/canvas/EXTDisjointTimerQueryWebGL2.cpp
@@ -77,8 +77,7 @@ void EXTDisjointTimerQueryWebGL2::queryCounterEXT(WebGLQuery& query, GCGLenum ta
     context->protectedGraphicsContextGL()->queryCounterEXT(query.object(), target);
 
     // A query's result must not be made available until control has returned to the user agent's main loop.
-    RefPtr protectedScriptExecutionContext { context->protectedScriptExecutionContext() };
-    protectedScriptExecutionContext->checkedEventLoop()->queueMicrotask(*protectedScriptExecutionContext, [&] {
+    context->protectedScriptExecutionContext()->checkedEventLoop()->queueMicrotask([&] {
         query.makeResultAvailable();
     });
 }

--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
@@ -1802,8 +1802,7 @@ void WebGL2RenderingContext::endQuery(GCGLenum target)
     protectedGraphicsContextGL()->endQuery(target);
 
     // A query's result must not be made available until control has returned to the user agent's main loop.
-    RefPtr protectedScriptExecutionContext { this->protectedScriptExecutionContext() };
-    protectedScriptExecutionContext->checkedEventLoop()->queueMicrotask(*protectedScriptExecutionContext, [query = WTFMove(m_activeQueries[*activeQueryKey])] {
+    protectedScriptExecutionContext()->checkedEventLoop()->queueMicrotask([query = WTFMove(m_activeQueries[*activeQueryKey])] {
         query->makeResultAvailable();
     });
 }

--- a/Source/WebCore/inspector/agents/InspectorCanvasAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorCanvasAgent.cpp
@@ -534,8 +534,8 @@ void InspectorCanvasAgent::recordAction(CanvasRenderingContext& canvasRenderingC
 
     // Only enqueue one microtask for all actively recording canvases.
     if (m_recordingCanvasIdentifiers.isEmpty()) {
-        if (RefPtr scriptExecutionContext = inspectorCanvas->scriptExecutionContext()) {
-            scriptExecutionContext->eventLoop().queueMicrotask(*scriptExecutionContext, [weakThis = WeakPtr { *this }] {
+        if (auto* scriptExecutionContext = inspectorCanvas->scriptExecutionContext()) {
+            scriptExecutionContext->eventLoop().queueMicrotask([weakThis = WeakPtr { *this }] {
                 if (!weakThis)
                     return;
 

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -913,7 +913,7 @@ struct AwaitingPromiseData : public RefCounted<AwaitingPromiseData> {
 static void waitForAllPromises(Document& document, const Vector<RefPtr<DOMPromise>>& promises, Function<void()>&& fulfilledCallback, Function<void(JSC::JSValue)>&& rejectionCallback)
 {
     if (promises.isEmpty()) {
-        document.checkedEventLoop()->queueMicrotask(document, WTFMove(fulfilledCallback));
+        document.checkedEventLoop()->queueMicrotask(WTFMove(fulfilledCallback));
         return;
     }
 

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -5696,7 +5696,7 @@ void Internals::queueMicroTask(int testNumber)
 
     ScriptExecutionContext* context = document;
     auto& eventLoop = context->eventLoop();
-    eventLoop.queueMicrotask(*context, [document = Ref { *document }, testNumber]() {
+    eventLoop.queueMicrotask([document = Ref { *document }, testNumber]() {
         document->addConsoleMessage(MessageSource::JS, MessageLevel::Debug, makeString("MicroTask #"_s, testNumber, " has run."_s));
     });
 }
@@ -6165,7 +6165,7 @@ ExceptionOr<void> Internals::queueTaskToQueueMicrotask(Document& document, const
     ScriptExecutionContext& context = document; // This avoids unnecessarily exporting Document::eventLoop.
     context.eventLoop().queueTask(*source, [movedCallback = WTFMove(callback), protectedDocument = Ref { document }]() mutable {
         ScriptExecutionContext& context = protectedDocument.get();
-        context.eventLoop().queueMicrotask(context, [callback = WTFMove(movedCallback)] {
+        context.eventLoop().queueMicrotask([callback = WTFMove(movedCallback)] {
             callback->invoke();
         });
     });

--- a/Source/WebCore/workers/service/ExtendableEvent.cpp
+++ b/Source/WebCore/workers/service/ExtendableEvent.cpp
@@ -73,7 +73,7 @@ void ExtendableEvent::addExtendLifetimePromise(Ref<DOMPromise>&& promise)
         RefPtr context = globalObject.scriptExecutionContext();
         if (!context)
             return;
-        context->checkedEventLoop()->queueMicrotask(*context, [this, protectedThis = WTFMove(protectedThis), settledPromise = WTFMove(settledPromise)]() mutable {
+        context->checkedEventLoop()->queueMicrotask([this, protectedThis = WTFMove(protectedThis), settledPromise = WTFMove(settledPromise)]() mutable {
             --m_pendingPromiseCount;
 
             // FIXME: Let registration be the context object's relevant global object's associated service worker's containing service worker registration.


### PR DESCRIPTION
#### 521db04141edf96fc27b7c770d6320cb6e0bddd4
<pre>
REGRESSION(300757@main): TestWebKitAPI.UnifiedPDF.PasswordFormShouldDismissAfterNavigation broke
<a href="https://bugs.webkit.org/show_bug.cgi?id=299897">https://bugs.webkit.org/show_bug.cgi?id=299897</a>
<a href="https://rdar.apple.com/161677197">rdar://161677197</a>

Reviewed by Yijia Huang.

There are some a bit wrong use of microtasks in WebCore: using
microtasks before setting up Document fully (navigation). And this
causes weird issue that we may end up creating JSGlobalObject before
fully setting up Document. So let&apos;s just revert back to the old way for
a work-around. And re-create VMEntryScope only when necessary.

* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::cancel):
(WebCore::WebAnimation::resetPendingTasks):
(WebCore::WebAnimation::updateFinishedState):
* Source/WebCore/dom/CustomElementReactionQueue.cpp:
(WebCore::CustomElementReactionQueue::enqueueElementOnAppropriateElementQueue):
* Source/WebCore/dom/DocumentStorageAccess.cpp:
(WebCore::DocumentStorageAccess::requestStorageAccess):
(WebCore::DocumentStorageAccess::requestStorageAccessQuirk):
* Source/WebCore/dom/EventLoop.cpp:
(WebCore::EventLoopTaskGroup::queueMicrotask):
* Source/WebCore/dom/EventLoop.h:
* Source/WebCore/dom/Microtasks.cpp:
(WebCore::MicrotaskQueue::performMicrotaskCheckpoint):
* Source/WebCore/dom/MutationObserver.cpp:
(WebCore::MutationObserver::enqueueMutationRecord):
(WebCore::MutationObserver::enqueueSlotChangeEvent):
(WebCore::MutationObserver::setHasTransientRegistration):
* Source/WebCore/dom/WindowEventLoop.cpp:
(WebCore::WindowEventLoop::queueMutationObserverCompoundMicrotask):
(WebCore::WindowEventLoop::backupElementQueue):
* Source/WebCore/dom/WindowEventLoop.h:
* Source/WebCore/html/canvas/EXTDisjointTimerQuery.cpp:
(WebCore::EXTDisjointTimerQuery::endQueryEXT):
(WebCore::EXTDisjointTimerQuery::queryCounterEXT):
* Source/WebCore/html/canvas/EXTDisjointTimerQueryWebGL2.cpp:
(WebCore::EXTDisjointTimerQueryWebGL2::queryCounterEXT):
* Source/WebCore/html/canvas/WebGL2RenderingContext.cpp:
(WebCore::WebGL2RenderingContext::endQuery):
* Source/WebCore/inspector/agents/InspectorCanvasAgent.cpp:
(WebCore::InspectorCanvasAgent::recordAction):
* Source/WebCore/page/Navigation.cpp:
(WebCore::waitForAllPromises):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::queueMicroTask):
(WebCore::Internals::queueTaskToQueueMicrotask):
* Source/WebCore/workers/service/ExtendableEvent.cpp:
(WebCore::ExtendableEvent::addExtendLifetimePromise):

Canonical link: <a href="https://commits.webkit.org/300886@main">https://commits.webkit.org/300886@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/14602aada0e8375d02a29454b2829cff58129629

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124085 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43788 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34496 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130914 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76214 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fc191877-1c25-44b6-8342-ac850a53c54e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/125962 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44522 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52387 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94392 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62623 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/50982a87-ea15-4964-9b5c-aa090af8ebba) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127039 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35480 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110999 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74984 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2e527480-20e9-4369-b40e-69c3ebac7a7b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34428 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29163 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74398 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105218 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29382 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133604 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51026 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38876 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102870 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51403 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107218 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102679 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48026 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26274 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/47904 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19513 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50881 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56652 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50343 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53691 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52017 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->