### PR TITLE
AX: It's impossible to select a date in the date picker from <input type="date"> using the keyboard

### DIFF
--- a/LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/no-blur-when-opening-picker-expected.txt
+++ b/LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/no-blur-when-opening-picker-expected.txt
@@ -1,0 +1,19 @@
+Tests that no blur is fired when the date picker is opened, and that the focused element remains after opening the picker.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS document.activeElement.id === 'date-input' is true
+PASS showingPicker is true
+PASS document.activeElement.id === 'date-input' is true
+PASS blurEventCount is 0
+PASS showingPicker is false
+PASS showingPicker is true
+PASS document.activeElement.id === 'date-input' is true
+PASS blurEventCount is 0
+PASS document.activeElement.id === 'text-input' is true
+PASS blurEventCount is 1
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/no-blur-when-opening-picker.html
+++ b/LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/no-blur-when-opening-picker.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/common.js"></script>
+<script src="../../../../resources/js-test.js"></script>
+<script src="../../../../resources/ui-helper.js"></script>
+</head>
+<body>
+
+<input id="date-input" type="datetime-local" value="2020-09-16T10:45"/>
+<input id="text-input" type="text" />
+
+<script>
+window.jsTestIsAsync = true;
+
+let blurEventCount = 0;
+
+function clickOnDayField() {
+    const shadowRoot = internals.shadowRoot(document.getElementById("date-input"));
+    const monthField = getElementByPseudoId(shadowRoot, "-webkit-datetime-edit-day-field");
+    const rect = monthField.getBoundingClientRect();
+    eventSender.mouseMoveTo(rect.left + rect.width / 2, rect.top + rect.height / 2);
+    eventSender.mouseDown();
+    eventSender.mouseUp();
+}
+
+addEventListener("load", async () => {
+    description("Tests that no blur is fired when the date picker is opened, and that the focused element remains after opening the picker.");
+
+    // Track blur events
+    document.addEventListener("blur", () => blurEventCount++, true);
+
+    await UIHelper.ensurePresentationUpdate();
+    // Tab to focus the first subfield of the date input.
+    UIHelper.keyDown("\t", ["altKey"]);
+    shouldBeTrue("document.activeElement.id === 'date-input'");
+
+    // Press space to open the picker.
+    UIHelper.keyDown(" ");
+    await UIHelper.ensurePresentationUpdate();
+    showingPicker = await UIHelper.isShowingDateTimePicker();
+    shouldBeTrue("showingPicker");
+
+    shouldBeTrue("document.activeElement.id === 'date-input'");
+    shouldBe("blurEventCount", "0");
+
+    // Escape should close the picker and return focus to the subfield we were on before opening the picker (the month field).
+    UIHelper.keyDown("escape");
+    await UIHelper.ensurePresentationUpdate();
+    showingPicker = await UIHelper.isShowingDateTimePicker();
+    shouldBeFalse("showingPicker");
+
+    clickOnDayField();
+    await UIHelper.ensurePresentationUpdate();
+    showingPicker = await UIHelper.isShowingDateTimePicker();
+    shouldBeTrue("showingPicker");
+    // Clicking to activate the picker should also not cause a blur.
+    shouldBeTrue("document.activeElement.id === 'date-input'");
+    shouldBe("blurEventCount", "0");
+
+    // Move focus to the text input.
+    for (let i = 0; i < 5; i++)
+        UIHelper.keyDown("\t", ["altKey"]);
+    shouldBeTrue("document.activeElement.id === 'text-input'");
+    shouldBe("blurEventCount", "1");
+
+    finishJSTest();
+});
+</script>
+</body>
+</html>
+

--- a/LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/picker-keyboard-accessibility-expected.txt
+++ b/LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/picker-keyboard-accessibility-expected.txt
@@ -1,0 +1,15 @@
+Tests that focus is properly managed when alternating between activating the picker with the keyboard and with a mouse click.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS showingPicker is true
+PASS input.value is "2020-09-17T10:45"
+PASS input.value is "2020-08-17T10:45"
+PASS input.value is "2020-08-16T10:45"
+PASS showingPicker is false
+PASS input.value is "2019-08-16T10:45"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/picker-keyboard-accessibility.html
+++ b/LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/picker-keyboard-accessibility.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/common.js"></script>
+<script src="../../../../resources/js-test.js"></script>
+<script src="../../../../resources/ui-helper.js"></script>
+</head>
+<body>
+
+<input id="input" type="datetime-local" value="2020-09-16T10:45"/>
+
+<script>
+window.jsTestIsAsync = true;
+
+function clickOnMonthField() {
+    const shadowRoot = internals.shadowRoot(input);
+    const monthField = getElementByPseudoId(shadowRoot, "-webkit-datetime-edit-month-field");
+    const rect = monthField.getBoundingClientRect();
+    eventSender.mouseMoveTo(rect.left + rect.width / 2, rect.top + rect.height / 2);
+    eventSender.mouseDown();
+    eventSender.mouseUp();
+}
+
+addEventListener("load", async () => {
+    description("Tests that focus is properly managed when alternating between activating the picker with the keyboard and with a mouse click.");
+
+    await UIHelper.ensurePresentationUpdate();
+    // Tab to focus the second subfield of the date input.
+    UIHelper.keyDown("\t", ["altKey"]);
+    UIHelper.keyDown("\t", ["altKey"]);
+    // Press space to open the picker.
+    UIHelper.keyDown(" ");
+    await UIHelper.ensurePresentationUpdate();
+    showingPicker = await UIHelper.isShowingDateTimePicker();
+    shouldBeTrue("showingPicker");
+
+    // Move to the 17th day of the month via the keyboard.
+    UIHelper.keyDown("rightArrow");
+    // Accept the day using space so the <input> is updated.
+    UIHelper.keyDown(" ");
+    shouldBeEqualToString("input.value", "2020-09-17T10:45")
+
+    clickOnMonthField();
+    // Now that we've focused on a date subfield, keypresses should go to that rather than the picker.
+    UIHelper.keyDown("downArrow");
+    shouldBeEqualToString("input.value", "2020-08-17T10:45")
+    // The picker should still be showing though.
+    showingPicker = await UIHelper.isShowingDateTimePicker();
+
+    // Pressing space while focused on a date subfield should move focus back into the picker.
+    UIHelper.keyDown(" ");
+    // Move focus to the 16th day inside the picker.
+    UIHelper.keyDown("leftArrow");
+    // Accept that value.
+    UIHelper.keyDown(" ");
+    shouldBeEqualToString("input.value", "2020-08-16T10:45")
+
+    // Escape should close the picker and return focus to the subfield we were on before opening the picker (the month field).
+    UIHelper.keyDown("escape");
+    await UIHelper.ensurePresentationUpdate();
+    showingPicker = await UIHelper.isShowingDateTimePicker();
+    shouldBeFalse("showingPicker");
+
+    // Move to the year field and update the value.
+    UIHelper.keyDown("\t", ["altKey"]);
+    UIHelper.keyDown("\t", ["altKey"]);
+    UIHelper.keyDown("downArrow");
+    shouldBeEqualToString("input.value", "2019-08-16T10:45")
+
+    finishJSTest();
+});
+</script>
+</body>
+</html>
+

--- a/LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/space-does-not-scroll-page-expected.txt
+++ b/LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/space-does-not-scroll-page-expected.txt
@@ -1,0 +1,12 @@
+Tests that the page is not scrolled when pressing space to activate the date picker.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS showingPicker is true
+PASS window.scrollY === 0 is true
+PASS window.scrollX === 0 is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/space-does-not-scroll-page.html
+++ b/LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/space-does-not-scroll-page.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/common.js"></script>
+<script src="../../../../resources/js-test.js"></script>
+<script src="../../../../resources/ui-helper.js"></script>
+</head>
+<body style="height: 3000px; overflow: scroll;">
+
+<input id="input" type="datetime-local" value="2020-09-16T10:45"/>
+
+<script>
+window.jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description("Tests that the page is not scrolled when pressing space to activate the date picker.");
+
+    await UIHelper.ensurePresentationUpdate();
+    // Tab to focus the first subfield of the date input.
+    UIHelper.keyDown("\t", ["altKey"]);
+    // Press space to open the picker.
+    UIHelper.keyDown(" ");
+
+    await UIHelper.ensurePresentationUpdate();
+    showingPicker = await UIHelper.isShowingDateTimePicker();
+    shouldBeTrue("showingPicker");
+
+    // Pressing the space key should not have scrolled the page.
+    shouldBeTrue("window.scrollY === 0");
+    shouldBeTrue("window.scrollX === 0");
+
+    finishJSTest();
+});
+</script>
+</body>
+</html>
+

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -503,6 +503,13 @@ public:
     virtual bool isFocusable() const;
     virtual bool isKeyboardFocusable(const FocusEventData&) const;
     virtual bool isMouseFocusable() const;
+    // True for elements that transferred focus to a non-web-content picker upon activation.
+    // An example of this is the DateTimeFieldElement (which is what the day / month /
+    // year subfields are rendered as in an <input type="date">). Activating these
+    // elements opens an external date picker on some platforms (e.g. a NSDatePicker inside
+    // a wrapping NSWindow on macOS).
+    virtual bool transferredFocusToPicker() const { return false; }
+    virtual void didSuppressBlurDueToPickerFocusTransfer() { }
 
     virtual bool shouldUseInputMethod();
 

--- a/Source/WebCore/dom/FocusEvent.cpp
+++ b/Source/WebCore/dom/FocusEvent.cpp
@@ -58,4 +58,17 @@ FocusEvent::FocusEvent(const AtomString& type, const Init& initializer)
 
 FocusEvent::~FocusEvent() = default;
 
+String FocusEvent::debugDescription() const
+{
+    String focusTargetDescription = "null"_s;
+    if (RefPtr node = dynamicDowncast<Node>(m_relatedTarget))
+        focusTargetDescription = node->debugDescription();
+    else if (m_relatedTarget) {
+        TextStream stream;
+        stream << "EventTarget "_s << m_relatedTarget.get();
+        focusTargetDescription = stream.release();
+    }
+    return makeString(UIEvent::debugDescription(), ", focus target: "_s, focusTargetDescription);
+}
+
 } // namespace WebCore

--- a/Source/WebCore/dom/FocusEvent.h
+++ b/Source/WebCore/dom/FocusEvent.h
@@ -58,6 +58,7 @@ public:
     }
 
     EventTarget* relatedTarget() const final { return m_relatedTarget.get(); }
+    String debugDescription() const final;
 
 private:
     FocusEvent();

--- a/Source/WebCore/html/BaseDateAndTimeInputType.h
+++ b/Source/WebCore/html/BaseDateAndTimeInputType.h
@@ -137,8 +137,11 @@ private:
     // DateTimeEditElementEditControlOwner functions:
     void didBlurFromControl() final;
     void didChangeValueFromControl() final;
+    void didReceiveSpaceKeyFromControl() final;
     bool isEditControlOwnerDisabled() const final;
     bool isEditControlOwnerReadOnly() const final;
+    bool didEditControlOwnerTransferFocusToPicker() final { return m_didTransferFocusToPicker; }
+    void didSuppressBlurDueToPickerFocusTransfer() final { m_didTransferFocusToPicker = false; }
     AtomString localeIdentifier() const final;
 
     // DateTimeChooserClient functions:
@@ -154,6 +157,9 @@ private:
 
     RefPtr<DateTimeChooser> m_dateTimeChooser;
     RefPtr<DateTimeEditElement> m_dateTimeEditElement;
+
+    bool m_didTransferFocusToPicker { false };
+    bool m_pickerWasActivatedByKeyboard { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/shadow/DateTimeEditElement.h
+++ b/Source/WebCore/html/shadow/DateTimeEditElement.h
@@ -49,9 +49,12 @@ public:
     virtual ~DateTimeEditElementEditControlOwner();
     virtual void didBlurFromControl() = 0;
     virtual void didChangeValueFromControl() = 0;
+    virtual void didReceiveSpaceKeyFromControl() = 0;
     virtual String formatDateTimeFieldsState(const DateTimeFieldsState&) const = 0;
     virtual bool isEditControlOwnerDisabled() const = 0;
     virtual bool isEditControlOwnerReadOnly() const = 0;
+    virtual bool didEditControlOwnerTransferFocusToPicker() = 0;
+    virtual void didSuppressBlurDueToPickerFocusTransfer() = 0;
     virtual AtomString localeIdentifier() const = 0;
 };
 
@@ -104,6 +107,8 @@ private:
     void layout(const LayoutParameters&);
     DateTimeFieldsState valueAsDateTimeFieldsState(DateTimePlaceholderIfNoValue = DateTimePlaceholderIfNoValue::No) const;
 
+    void defaultEventHandler(Event&) final;
+
     bool focusOnNextFocusableField(size_t startIndex);
 
     // DateTimeFieldElementFieldOwner functions:
@@ -114,6 +119,8 @@ private:
     bool isFieldOwnerDisabled() const final;
     bool isFieldOwnerReadOnly() const final;
     bool isFieldOwnerHorizontal() const final;
+    bool didFieldOwnerTransferFocusToPicker() final;
+    void didSuppressBlurDueToPickerFocusTransfer() final;
     AtomString localeIdentifier() const final;
     const GregorianDateTime& placeholderDate() const final;
 

--- a/Source/WebCore/html/shadow/DateTimeFieldElement.cpp
+++ b/Source/WebCore/html/shadow/DateTimeFieldElement.cpp
@@ -210,4 +210,15 @@ bool DateTimeFieldElement::supportsFocus() const
     return true;
 }
 
+bool DateTimeFieldElement::transferredFocusToPicker() const
+{
+    return m_fieldOwner && m_fieldOwner->didFieldOwnerTransferFocusToPicker();
+}
+
+void DateTimeFieldElement::didSuppressBlurDueToPickerFocusTransfer()
+{
+    if (m_fieldOwner)
+        m_fieldOwner->didSuppressBlurDueToPickerFocusTransfer();
+}
+
 } // namespace WebCore

--- a/Source/WebCore/html/shadow/DateTimeFieldElement.h
+++ b/Source/WebCore/html/shadow/DateTimeFieldElement.h
@@ -61,6 +61,8 @@ public:
     virtual bool isFieldOwnerDisabled() const = 0;
     virtual bool isFieldOwnerReadOnly() const = 0;
     virtual bool isFieldOwnerHorizontal() const = 0;
+    virtual bool didFieldOwnerTransferFocusToPicker() = 0;
+    virtual void didSuppressBlurDueToPickerFocusTransfer() = 0;
     virtual AtomString localeIdentifier() const = 0;
     virtual const GregorianDateTime& placeholderDate() const = 0;
 };
@@ -101,6 +103,9 @@ private:
     std::optional<Style::UnadjustedStyle> resolveCustomStyle(const Style::ResolutionContext&, const RenderStyle*) final;
 
     bool supportsFocus() const override;
+
+    bool transferredFocusToPicker() const final;
+    void didSuppressBlurDueToPickerFocusTransfer() final;
 
     void defaultKeyboardEventHandler(KeyboardEvent&);
     bool isFieldOwnerDisabled() const;

--- a/Source/WebCore/page/FocusController.cpp
+++ b/Source/WebCore/page/FocusController.cpp
@@ -413,8 +413,18 @@ static inline void dispatchEventsOnWindowAndFocusedElement(Document* document, b
             return;
     }
 
-    if (!focused && document->focusedElement())
+    if (!focused && document->focusedElement()) {
+        if (document->focusedElement()->transferredFocusToPicker()) {
+            // The webpage lost focus because the focused element transferred focus to
+            // a non-web-content picker when it was activated. We don't want to post any
+            // web-exposed events (e.g. blur) in these cases, so return.
+            document->focusedElement()->didSuppressBlurDueToPickerFocusTransfer();
+            return;
+        }
+
         document->focusedElement()->dispatchBlurEvent(nullptr);
+    }
+
     document->dispatchWindowEvent(Event::create(focused ? eventNames().focusEvent : eventNames().blurEvent, Event::CanBubble::No, Event::IsCancelable::No));
     if (focused && document->focusedElement())
         document->focusedElement()->dispatchFocusEvent(nullptr, { });

--- a/Source/WebCore/platform/DateTimeChooserParameters.h
+++ b/Source/WebCore/platform/DateTimeChooserParameters.h
@@ -50,6 +50,7 @@ struct DateTimeChooserParameters {
     bool useDarkAppearance { false };
     bool hasSecondField { false };
     bool hasMillisecondField { false };
+    bool wasActivatedByKeyboard { false };
 };
 
 } // namespace WebCore

--- a/Source/WebKit/Platform/spi/mac/AppKitSPI.h
+++ b/Source/WebKit/Platform/spi/mac/AppKitSPI.h
@@ -89,6 +89,8 @@ static const NSWindowStyleMask NSWindowStyleMaskAlertWindow = (NSWindowStyleMask
 - (BOOL)registerScrollViewSeparatorTrackingAdapter:(NSObject<NSScrollViewSeparatorTrackingAdapter> *)adapter;
 - (void)unregisterScrollViewSeparatorTrackingAdapter:(NSObject<NSScrollViewSeparatorTrackingAdapter> *)adapter;
 
+- (void)_setSharesParentFirstResponder:(BOOL)sharesParentFirstResponder;
+
 @end
 
 @class LPLinkMetadata;

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2357,6 +2357,7 @@ struct WebCore::DateTimeChooserParameters {
     bool useDarkAppearance;
     bool hasSecondField;
     bool hasMillisecondField;
+    bool wasActivatedByKeyboard;
 }
 
 header: <WebCore/ScreenProperties.h>

--- a/Source/WebKit/UIProcess/mac/WebDateTimePickerMac.h
+++ b/Source/WebKit/UIProcess/mac/WebDateTimePickerMac.h
@@ -43,11 +43,11 @@ public:
     ~WebDateTimePickerMac();
 
     void didChooseDate(StringView);
+    void endPicker() final;
 
 private:
     WebDateTimePickerMac(WebPageProxy&, NSView *);
 
-    void endPicker() final;
     void showDateTimePicker(WebCore::DateTimeChooserParameters&&) final;
 
     WeakObjCPtr<NSView> m_view;


### PR DESCRIPTION
#### 110ae1a60592b7cdf1460fdce01c54aae21a8794
<pre>
AX: It&apos;s impossible to select a date in the date picker from &lt;input type=&quot;date&quot;&gt; using the keyboard
<a href="https://rdar.apple.com/161759633">rdar://161759633</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=299979">https://bugs.webkit.org/show_bug.cgi?id=299979</a>

Reviewed by Aditya Keerthi.

Prior to this commit, the NSDatePicker created by date inputs was entirely inaccessible to keyboard and assistive
technology users. The primary reason for this is that the NSDatePicker was not given first respondership, and thus
didn&apos;t receive any key events. This commit implements mechanisms that allowing managing keyboard focus state between
the date picker, and the backing date input. The interactity model for date inputs and their associated pickers are
as follows:

  - Pressing Space while focused on a date subfield (e.g. day, month, year field) moves focus into the picker.

  - Pressing Escape while focus is in the picker moves focus back to the previously focused subfield.

  - Clicking on a subfield with the mouse leaves focus on that subfield so you can increment / decrement using the
    arrow keys (matching shipping behavior and platform date pickers).

All of the above behavior is captured in a new layout test: picker-keyboard-accessibility.html

It&apos;s also important that the movement of keyboard focus into the picker does not cause any new web-exposed events to
be fired (e.g. blur). Shipping Safari, nor any other browser fire any blur or focus change events when opening the picker.
FocusController::dispatchEventsOnWindowAndFocusedElement is updated with this commit to avoid that, and new
test no-blur-when-opening-picker.html verifies we behave correctly on this front.

Finally, this commit also fixes an existing bug where pressing the space key to open the date picker scrolls the page
resulting in the picker appearing and immediately disappearing as a result of the scroll. New test space-does-not-scroll-page.html
verifies we behave correctly.

Tests: fast/forms/datetimelocal/datetimelocal-editable-components/no-blur-when-opening-picker.html
       fast/forms/datetimelocal/datetimelocal-editable-components/picker-keyboard-accessibility.html
       fast/forms/datetimelocal/datetimelocal-editable-components/space-does-not-scroll-page.html

* LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/no-blur-when-opening-picker-expected.txt: Added.
* LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/no-blur-when-opening-picker.html: Added.
* LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/picker-keyboard-accessibility-expected.txt: Added.
* LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/picker-keyboard-accessibility.html: Added.
* LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/space-does-not-scroll-page-expected.txt: Added.
* LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/space-does-not-scroll-page.html: Added.
* Source/WebCore/dom/Element.h:
(WebCore::Element::transferredFocusToPicker const):
(WebCore::Element::didSuppressBlurDueToPickerFocusTransfer):
* Source/WebCore/dom/FocusEvent.cpp:
(WebCore::FocusEvent::debugDescription const):
* Source/WebCore/dom/FocusEvent.h:
* Source/WebCore/html/BaseDateAndTimeInputType.cpp:
(WebCore::BaseDateAndTimeInputType::handleDOMActivateEvent):
(WebCore::BaseDateAndTimeInputType::didReceiveSpaceKeyFromControl):
(WebCore::BaseDateAndTimeInputType::setupDateTimeChooserParameters):
(WebCore::BaseDateAndTimeInputType::closeDateTimeChooser):
* Source/WebCore/html/BaseDateAndTimeInputType.h:
* Source/WebCore/html/InputType.cpp:
(WebCore::InputType::dispatchSimulatedClickIfActive):
(WebCore::InputType::dispatchSimulatedClickIfActive const): Deleted.
* Source/WebCore/html/InputType.h:
* Source/WebCore/html/shadow/DateTimeEditElement.cpp:
(WebCore::DateTimeEditElement::defaultEventHandler):
(WebCore::DateTimeEditElement::didFieldOwnerTransferFocusToPicker):
(WebCore::DateTimeEditElement::didSuppressBlurDueToPickerFocusTransfer):
* Source/WebCore/html/shadow/DateTimeEditElement.h:
* Source/WebCore/html/shadow/DateTimeFieldElement.cpp:
(WebCore::DateTimeFieldElement::transferredFocusToPicker const):
(WebCore::DateTimeFieldElement::didSuppressBlurDueToPickerFocusTransfer):
* Source/WebCore/html/shadow/DateTimeFieldElement.h:
* Source/WebCore/page/FocusController.cpp:
(WebCore::dispatchEventsOnWindowAndFocusedElement):
* Source/WebCore/platform/DateTimeChooserParameters.h:
* Source/WebKit/Platform/spi/mac/AppKitSPI.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/mac/WebDateTimePickerMac.h:
* Source/WebKit/UIProcess/mac/WebDateTimePickerMac.mm:
(-[WKDateTimePicker initWithParams:inView:]):
(-[WKDateTimePicker showPicker:]):
(-[WKDateTimePicker updatePicker:]):
(-[WKDateTimePicker invalidate]):
(-[WKDateTimePicker handleEscapeKey]):
(-[WKDateTimePicker didChooseDate:]):
(-[WKDateTimePicker wasActivatedByKeyboard]):
(-[WKEscapeHandlingDatePicker setDateTimePicker:]):
(-[WKEscapeHandlingDatePicker dateTimePicker]):
(-[WKEscapeHandlingDatePicker keyDown:]):
(-[WKEscapeHandlingDatePicker acceptsFirstResponder]):

Canonical link: <a href="https://commits.webkit.org/301432@main">https://commits.webkit.org/301432@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/062ccd3afa1c496e4de348c944e8f60009c49ced

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125950 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45610 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36380 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132816 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77806 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/774a201f-257c-44c5-9f09-272ec57504ee) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127821 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46293 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54167 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95955 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64050 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a600b3ef-aedd-41b0-bc1c-c74762d2a7f5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128898 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37026 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112639 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76444 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/14721bdf-9c33-4f67-9b47-9bcb73362b30) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35934 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30824 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76286 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106808 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31037 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135502 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52732 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40462 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104430 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53181 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108850 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104150 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26525 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49525 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27853 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50110 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52626 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58441 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51970 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55318 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53667 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->