### PR TITLE
Fix audit-spi errors for isSystemVoice on iOS 26.

### DIFF
--- a/Source/WebCore/Configurations/AllowedSPI-legacy.toml
+++ b/Source/WebCore/Configurations/AllowedSPI-legacy.toml
@@ -16,12 +16,15 @@ selectors = [
 ]
 requires = ["ENABLE_MULTI_REPRESENTATION_HEIC"]
 
-# This is SPI, but it's marked as public on 26.x releases due to rdar://148943382.
+# -isSystemVoice is SPI, but it's marked as public on internal builds of 26.x
+# releases due to rdar://148943382.
 [[legacy]]
-selectors = [
-    { name = "isSystemVoice", class = "?" },
-]
+selectors = [{ name = "isSystemVoice", class = "?" }]
 requires = ["!SDKDB_HAS_148943382"]
+
+[[legacy]]
+selectors = [{ name = "isSystemVoice", class = "?" }]
+requires = ["!USE_APPLE_INTERNAL_SDK"]
 
 [[legacy]]
 classes = [


### PR DESCRIPTION
#### 3494c79f8969a8def641d2f94428c4f7c0a733ae
<pre>
Fix audit-spi errors for isSystemVoice on iOS 26.
<a href="https://bugs.webkit.org/show_bug.cgi?id=299985">https://bugs.webkit.org/show_bug.cgi?id=299985</a>
<a href="https://rdar.apple.com/161770465">rdar://161770465</a>

Reviewed by Elliott Williams and Jonathan Bedard.

iOS 26 is failing to build due to a failing audit-spi check for isSystemVoice.
This change addresses that failure.

* Source/WebCore/Configurations/AllowedSPI-legacy.toml: Add isSystemVoice.

Canonical link: <a href="https://commits.webkit.org/300877@main">https://commits.webkit.org/300877@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9fbb4ead3e02d37240f4067ef550e5420eabe7b8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124087 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43789 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34497 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130915 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76215 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b65b80b7-7980-484a-a15b-9186656cd533) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/125964 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44524 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52388 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94390 "1 flakes 15 failures") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62625 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d25f8964-ef54-4c60-8909-0fa07f94ef12) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127041 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35476 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110997 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74982 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f46f345e-f534-42a5-8097-fafb8edc53cd) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34424 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29161 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74399 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105214 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29380 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133587 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51027 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38878 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102856 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51404 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107216 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102667 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26138 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48025 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26272 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/47905 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50882 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56653 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50344 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53692 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52018 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->