### PR TITLE
pip and exit buttons in video full screen on IOS is not liquid glass

### DIFF
--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
@@ -151,7 +151,7 @@ private:
     WeakObjCPtr<id<WKFullScreenViewControllerDelegate>> _delegate;
     RetainPtr<UILongPressGestureRecognizer> _touchGestureRecognizer;
     RetainPtr<UIView> _animatingView;
-    RetainPtr<UIStackView> _stackView;
+    RetainPtr<UIView> _stackView;
 #if ENABLE(FULLSCREEN_DISMISSAL_GESTURES)
     RetainPtr<UIStackView> _banner;
     RetainPtr<_WKInsetLabel> _bannerLabel;
@@ -186,6 +186,10 @@ private:
     };
     OptionSet<ButtonState> _buttonState;
     BOOL _viewDidAppear;
+#endif
+#if HAVE(UI_GLASS_EFFECT)
+    RetainPtr<UIVisualEffectView> _glassEffectView;
+    RetainPtr<UIStackView> _buttonStackView;
 #endif
 }
 
@@ -519,7 +523,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     }
 
     if (_environmentPickerButtonViewController == environmentPickerButtonViewController) {
-        ASSERT(!environmentPickerButtonViewController || [[_stackView arrangedSubviews] containsObject:environmentPickerButtonViewController.view]);
+        ASSERT(!environmentPickerButtonViewController || [self _stackViewContainsView:environmentPickerButtonViewController.view]);
         return;
     }
 
@@ -528,7 +532,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         return;
 
     [self addChildViewController:environmentPickerButtonViewController];
-    [_stackView insertArrangedSubview:environmentPickerButtonViewController.view atIndex:1];
+    [self _insertArrangedSubviewInStackView:environmentPickerButtonViewController.view atIndex:1];
     [environmentPickerButtonViewController didMoveToParentViewController:self];
     _environmentPickerButtonViewController = environmentPickerButtonViewController;
     _buttonState.add(EnvironmentPicker);
@@ -542,7 +546,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     UIView *environmentPickerButtonView = [_environmentPickerButtonViewController view];
 
     [_environmentPickerButtonViewController willMoveToParentViewController:nil];
-    [_stackView removeArrangedSubview:environmentPickerButtonView];
+    [self _removeArrangedSubviewFromStackView:environmentPickerButtonView];
     [environmentPickerButtonView removeFromSuperview];
     [self removeChildViewController:_environmentPickerButtonViewController.get()];
 
@@ -795,14 +799,45 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         [_centeredStackView setSpacing:24.0];
 #endif
 
-        _stackView = adoptNS([[UIStackView alloc] init]);
-        [_stackView addArrangedSubview:_cancelButton.get()];
-        [_stackView addArrangedSubview:_pipButton.get()];
+        RetainPtr stackView = adoptNS([[UIStackView alloc] init]);
+        [stackView addArrangedSubview:_cancelButton.get()];
+        [stackView addArrangedSubview:_pipButton.get()];
 #if PLATFORM(VISION)
-        [_stackView addArrangedSubview:_moreActionsButton.get()];
+        [stackView addArrangedSubview:_moreActionsButton.get()];
 #endif
-        [_stackView setSpacing:24.0];
+        [stackView setSpacing:24.0];
+        _stackView = stackView.get();
     } else {
+#if HAVE(UI_GLASS_EFFECT)
+        static constexpr CGFloat buttonSpacing = 24.0;
+        static constexpr CGFloat padding = 16.0;
+        static constexpr CGFloat cornerRadius = 24.0;
+
+        _buttonStackView = adoptNS([[UIStackView alloc] init]);
+        [_buttonStackView setSpacing:buttonSpacing];
+        [_buttonStackView addArrangedSubview:_cancelButton.get()];
+        [_buttonStackView addArrangedSubview:_pipButton.get()];
+        [_buttonStackView setTranslatesAutoresizingMaskIntoConstraints:NO];
+
+        RetainPtr glassEffect = adoptNS([[UIGlassEffect alloc] init]);
+
+        _glassEffectView = adoptNS([[UIVisualEffectView alloc] initWithEffect:glassEffect.get()]);
+        [_glassEffectView setClipsToBounds:YES];
+
+        [[_glassEffectView contentView] addSubview:_buttonStackView.get()];
+
+        [NSLayoutConstraint activateConstraints:@[
+            [[_buttonStackView centerXAnchor] constraintEqualToAnchor:[[_glassEffectView contentView] centerXAnchor]],
+            [[_buttonStackView centerYAnchor] constraintEqualToAnchor:[[_glassEffectView contentView] centerYAnchor]],
+            [[_buttonStackView leadingAnchor] constraintGreaterThanOrEqualToAnchor:[[_glassEffectView contentView] leadingAnchor] constant:padding],
+            [[_buttonStackView trailingAnchor] constraintLessThanOrEqualToAnchor:[[_glassEffectView contentView] trailingAnchor] constant:-padding],
+            [[_buttonStackView topAnchor] constraintGreaterThanOrEqualToAnchor:[[_glassEffectView contentView] topAnchor] constant:padding],
+            [[_buttonStackView bottomAnchor] constraintLessThanOrEqualToAnchor:[[_glassEffectView contentView] bottomAnchor] constant:-padding]
+        ]];
+
+        [[_glassEffectView layer] setCornerRadius:cornerRadius];
+        _stackView = _glassEffectView.get();
+#else
         RetainPtr<WKFullscreenStackView> stackView = adoptNS([[WKFullscreenStackView alloc] init]);
 #if PLATFORM(APPLETV)
         [stackView addArrangedSubview:_cancelButton.get()];
@@ -811,6 +846,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         [stackView addArrangedSubview:_pipButton.get() applyingMaterialStyle:AVBackgroundViewMaterialStylePrimary tintEffectStyle:AVBackgroundViewTintEffectStyleSecondary];
 #endif
         _stackView = WTFMove(stackView);
+#endif
     }
 
     [_stackView setTranslatesAutoresizingMaskIntoConstraints:NO];
@@ -936,6 +972,15 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     [self._webView setFrame:[_animatingView bounds]];
 #if ENABLE(FULLSCREEN_DISMISSAL_GESTURES)
     [_bannerLabel setPreferredMaxLayoutWidth:self.view.bounds.size.width];
+#endif
+
+#if HAVE(UI_GLASS_EFFECT)
+    if (self._webView._page && !self._webView._page->preferences().alternateFullScreenControlDesignEnabled()) {
+        if (_glassEffectView) {
+            CGFloat cornerRadius = [_glassEffectView bounds].size.height / 2;
+            [[_glassEffectView layer] setCornerRadius:cornerRadius];
+        }
+    }
 #endif
 }
 
@@ -1167,6 +1212,37 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     [button setAdjustsImageWhenHighlighted:NO];
 ALLOW_DEPRECATED_DECLARATIONS_END
     [button setTintColor:[UIColor whiteColor]];
+}
+
+- (UIStackView *)_actualStackView
+{
+#if HAVE(UI_GLASS_EFFECT)
+    if (_buttonStackView)
+        return _buttonStackView.get();
+#endif
+    if (RetainPtr stackView = dynamic_objc_cast<UIStackView>(_stackView))
+        return stackView.autorelease();
+    return nil;
+}
+
+- (BOOL)_stackViewContainsView:(UIView *)view
+{
+    RetainPtr stackView = [self _actualStackView];
+    return stackView && [[stackView arrangedSubviews] containsObject:view];
+}
+
+- (void)_insertArrangedSubviewInStackView:(UIView *)view atIndex:(NSUInteger)index
+{
+    RetainPtr stackView = [self _actualStackView];
+    if (stackView)
+        [stackView insertArrangedSubview:view atIndex:index];
+}
+
+- (void)_removeArrangedSubviewFromStackView:(UIView *)view
+{
+    RetainPtr stackView = [self _actualStackView];
+    if (stackView)
+        [stackView removeArrangedSubview:view];
 }
 
 - (void)wkExtrinsicButtonWillDisplayMenu:(WKExtrinsicButton *)button


### PR DESCRIPTION
#### 1a25cbb80d8f6d188ba695af375e58e5186f3709
<pre>
pip and exit buttons in video full screen on IOS is not liquid glass
<a href="https://bugs.webkit.org/show_bug.cgi?id=299986">https://bugs.webkit.org/show_bug.cgi?id=299986</a>
<a href="https://rdar.apple.com/161771527">rdar://161771527</a>

Reviewed by NOBODY (OOPS!).

Apply UIGlassEffect to the container of the pip and exit button.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1a25cbb80d8f6d188ba695af375e58e5186f3709

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126201 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45859 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36673 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132985 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77983 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c85bd28f-afb3-42e2-b8f7-324987413f33) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46528 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54407 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/96089 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64200 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/290f7753-87d1-4a5f-8059-9652966f736e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129149 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37223 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112893 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76572 "Found 1 new API test failure: WPE/TestWebsiteData:/webkit/WebKitWebsiteData/itp (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/30970238-b2a7-4816-873e-50996ea91da7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36123 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76459 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/107005 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31301 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135688 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52955 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40673 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104591 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53417 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/109116 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104295 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49734 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/28067 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/50339 "The change is no longer eligible for processing.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52855 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58688 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52173 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55519 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53888 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->