### PR TITLE
[css-anchor-position-1] Adjust order of position option to try when a last successful position option is present

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-006-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-006-expected.txt
@@ -2,7 +2,7 @@
 PASS Should use the last (fourth) position option initially
 PASS Should still use the last position option as long as it fits.
 PASS Should use the third position option with enough space below, and not enough above
-FAIL Should use the second position option with enough space right assert_equals: Anchored element should be at the right of anchor expected 650 but got 450
-FAIL Should still use the second position option as long as it fits assert_equals: Anchored element should be at the right of anchor expected 650 but got 450
+PASS Should use the second position option with enough space right
+PASS Should still use the second position option as long as it fits
 PASS Should use the first position option with enough space below and right
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-008-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-008-expected.txt
@@ -1,6 +1,6 @@
 
 PASS Should use the last fallback position initially
 PASS Should use the third fallback position with enough space left
-FAIL Should use the second fallback position with enough space above assert_equals: Anchored element should be at the top of anchor expected 135 but got 335
+PASS Should use the second fallback position with enough space above
 PASS Should use the first fallback position with enough space left and above
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-009-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-009-expected.txt
@@ -1,6 +1,6 @@
 
 PASS Should use the last fallback position initially
 PASS Should use the third fallback position with enough space right
-FAIL Should use the second fallback position with enough space below assert_equals: Anchored element should be at the bottom of anchor expected 450 but got 250
+PASS Should use the second fallback position with enough space below
 PASS Should use the first fallback position with enough space right and below
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-010-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-010-expected.txt
@@ -1,6 +1,6 @@
 
 PASS Should use the last fallback position initially
 PASS Should use the third fallback position with enough space right
-FAIL Should use the second fallback position with enough space above assert_equals: Anchored element should be at the top of anchor expected 135 but got 335
+PASS Should use the second fallback position with enough space above
 PASS Should use the first fallback position with enough space right and above
 


### PR DESCRIPTION
#### 9bbf8f4571f65c6a021e9956e5d55b5f2b7cbd65
<pre>
[css-anchor-position-1] Adjust order of position option to try when a last successful position option is present
<a href="https://rdar.apple.com/161714637">rdar://161714637</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=299940">https://bugs.webkit.org/show_bug.cgi?id=299940</a>

Reviewed by Elika Etemad.

The way we change the position option order to make the last successful position option
the first option to try is wrong. Previously, we took the position option list (after
sorting by position-try-order), and &quot;rotated&quot; it so that the last successful option
is the first option. This means the order goes like this:
1) last successful position option
2) option following the last successful position option in the before-rotated list
3) option following 2)
4) ...

This seems to be wrong, as the order to make WPT tests passes is:
1) last successful position option first
2) original style (not using any options)
3) other options in the sorted position option list, in order, excluding the last successful option

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-006-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-008-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-009-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-010-expected.txt:
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::sortPositionOptionsIfNeeded):

Canonical link: <a href="https://commits.webkit.org/300909@main">https://commits.webkit.org/300909@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1fef4ca7c9346d91a5650f6eced620d650b06d5f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124265 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43951 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34675 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131101 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/76336 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ff23bd08-4b13-4df4-9629-79d317b4ab6f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/126142 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44694 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52553 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94522 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/76336 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/306a16bd-417e-4839-8244-9d0bae52ed4b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127219 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35615 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111152 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75111 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/990fac77-8373-432f-8e7a-cf10ea92f06c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34559 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29311 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74582 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105359 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29533 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133772 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51178 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39017 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103001 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51569 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107368 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102801 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26161 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48160 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26416 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/48111 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51040 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56822 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50479 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53835 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52154 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->