### PR TITLE
[JSC] WASM IPInt SIMD: support exceptions with v128

### DIFF
--- a/JSTests/wasm/stress/exception-containing-v128.js
+++ b/JSTests/wasm/stress/exception-containing-v128.js
@@ -101,10 +101,13 @@ let wat = `
 
 async function test() {
     const instance = await instantiate(wat, {}, { exceptions: true, simd: true });
-    assert.eq(instance.exports.testCatchOwnV128(), 42);
-    assert.eq(instance.exports.testCatchCalleeV128(), 42);
-    assert.eq(instance.exports.testLotsOfInterleavedTypes(), 42);
-    assert.throws(() => instance.exports.testThrowV128ToJS(), WebAssembly.Exception);
+
+    for (let i = 0; i < wasmTestLoopCount; i++) {
+        assert.eq(instance.exports.testCatchOwnV128(), 42);
+        assert.eq(instance.exports.testCatchCalleeV128(), 42);
+        assert.eq(instance.exports.testLotsOfInterleavedTypes(), 42);
+        assert.throws(() => instance.exports.testThrowV128ToJS(), WebAssembly.Exception);
+    }
 }
 
 await assert.asyncTest(test());

--- a/JSTests/wasm/stress/import-exception-tag-with-v128.js
+++ b/JSTests/wasm/stress/import-exception-tag-with-v128.js
@@ -50,9 +50,12 @@ async function test() {
         vvtag: vvtag,
         vitag: vitag
     } }, { exceptions: true, simd: true });
-    assert.eq(instance.exports.testThrowV128(), 42);
-    assert.eq(instance.exports.testThrowV128Pair(), 42);
-    assert.eq(instance.exports.testThrowV128AndI32(), 42);
+
+    for (let i = 0; i < wasmTestLoopCount; i++) {
+        assert.eq(instance.exports.testThrowV128(), 42);
+        assert.eq(instance.exports.testThrowV128Pair(), 42);
+        assert.eq(instance.exports.testThrowV128AndI32(), 42);
+    }
 }
 
 await assert.asyncTest(test());

--- a/JSTests/wasm/stress/simd-instructions-exceptions-cross-tier.js
+++ b/JSTests/wasm/stress/simd-instructions-exceptions-cross-tier.js
@@ -1,0 +1,231 @@
+//@ requireOptions("--useWasmSIMD=1", "--useDollarVM=1", "--useOMGInlining=0")
+//@ skip unless $isSIMDPlatform
+import { instantiate } from "../wabt-wrapper.js";
+import * as assert from "../assert.js";
+
+// Verify exception throwing across tiers, including v128 types
+
+const verbose = false;
+
+let watModule1 = `
+(module
+    (import "m" "isOMG" (func $isOMG (result i32)))
+    (import "m" "logOMG" (func $logOMG (param i32 i32)))
+    (import "shared" "vtag" (tag $vtag (param i32 v128 f64)))
+    (import "other" "coldCallee" (func $coldCallee))
+    (import "other" "hotCallee" (func $hotCallee))
+
+    ;; Test 1: Hot caller (with loop) -> Cold callee (no loop, in different module)
+    (func $hotCaller (export "testHotCallerColdCallee") (result i32)
+        (local $i i32)
+        (local $v128_temp v128)
+        (local $f64_temp f64)
+
+        (loop $inner
+            local.get $i
+            i32.const 1
+            i32.add
+            local.tee $i
+            i32.const 50
+            i32.lt_s
+            br_if $inner
+        )
+
+        ;; Function ID 1 for hotCaller
+        (call $logOMG (i32.const 1) (call $isOMG))
+
+        try (result i32)
+            call $coldCallee
+            i32.const 0
+        catch $vtag
+            ;; Exception parameters are on stack: i32, v128, f64 (top to bottom)
+            ;; Store f64 param in local $f64_temp
+            local.set $f64_temp
+            ;; Store v128 param in local $v128_temp
+            local.set $v128_temp
+            ;; i32 param is now on top of stack
+
+            ;; Calculate: i32 + (v128_lane0*1) + (v128_lane1*10) + (v128_lane2*100) + (v128_lane3*1000) + f64
+            ;; Start with i32 param (already on stack)
+
+            ;; Add v128 lanes with different weights to detect reordering
+            local.get $v128_temp
+            i32x4.extract_lane 0
+            i32.const 1
+            i32.mul
+            i32.add
+
+            local.get $v128_temp
+            i32x4.extract_lane 1
+            i32.const 10
+            i32.mul
+            i32.add
+
+            local.get $v128_temp
+            i32x4.extract_lane 2
+            i32.const 100
+            i32.mul
+            i32.add
+
+            local.get $v128_temp
+            i32x4.extract_lane 3
+            i32.const 1000
+            i32.mul
+            i32.add
+
+            ;; Add f64 as i32
+            local.get $f64_temp
+            f64.trunc
+            i32.trunc_f64_s
+            i32.add
+        end
+    )
+
+    ;; Test 2: Cold caller (no loop) -> Hot callee (with loop, in different module)
+    (func $coldCaller (export "testColdCallerHotCallee") (result i32)
+        (local $v128_temp v128)
+        (local $f64_temp f64)
+        ;; Function ID 3 for coldCaller
+        (call $logOMG (i32.const 3) (call $isOMG))
+
+        try (result i32)
+            call $hotCallee
+            i32.const 0
+        catch $vtag
+            ;; Same weighted combination logic for test 2
+            ;; Store f64 param
+            local.set $f64_temp
+            ;; Store v128 param
+            local.set $v128_temp
+            ;; i32 param is now on stack
+
+            local.get $v128_temp
+            i32x4.extract_lane 0
+            i32.const 1
+            i32.mul
+            i32.add
+
+            local.get $v128_temp
+            i32x4.extract_lane 1
+            i32.const 10
+            i32.mul
+            i32.add
+
+            local.get $v128_temp
+            i32x4.extract_lane 2
+            i32.const 100
+            i32.mul
+            i32.add
+
+            local.get $v128_temp
+            i32x4.extract_lane 3
+            i32.const 1000
+            i32.mul
+            i32.add
+
+            local.get $f64_temp
+            f64.trunc
+            i32.trunc_f64_s
+            i32.add
+        end
+    )
+)
+`;
+
+let watModule2 = `
+(module
+    (import "m" "isOMG" (func $isOMG (result i32)))
+    (import "m" "logOMG" (func $logOMG (param i32 i32)))
+    (import "shared" "vtag" (tag $vtag (param i32 v128 f64)))
+
+    (func $coldCallee (export "coldCallee")
+        ;; Function ID 2 for coldCallee
+        (call $logOMG (i32.const 2) (call $isOMG))
+
+        ;; Throw complex exception: i32=10, v128=[1,2,3,4], f64=5.0
+        i32.const 10
+        v128.const i32x4 1 2 3 4
+        f64.const 5.0
+        throw $vtag
+    )
+
+    (func $hotCallee (export "hotCallee")
+        (local $i i32)
+
+        (loop $inner
+            local.get $i
+            i32.const 1
+            i32.add
+            local.tee $i
+            i32.const 50
+            i32.lt_s
+            br_if $inner
+        )
+
+        ;; Function ID 4 for hotCallee
+        (call $logOMG (i32.const 4) (call $isOMG))
+
+        ;; Throw complex exception: i32=20, v128=[5,6,7,8], f64=9.0
+        i32.const 20
+        v128.const i32x4 5 6 7 8
+        f64.const 9.0
+        throw $vtag
+    )
+)
+`;
+
+async function test() {
+    let omgTracker = {};
+    let currentIteration = 0;
+
+    function logOMG(funcId, isOMG) {
+        if (isOMG && !omgTracker[funcId]) {
+            omgTracker[funcId] = true;
+            if (verbose)
+                print(`Function ${funcId} reached OMG at iteration ${currentIteration}`);
+        }
+    }
+
+    // Create shared exception tag with multiple parameters
+    const sharedTag = new WebAssembly.Tag({ parameters: ['i32', 'v128', 'f64'] });
+
+    // First instantiate module 2 (contains coldCallee and hotCallee)
+    const instance2 = await instantiate(watModule2, {
+        m: {
+            isOMG: $vm.omgTrue,
+            logOMG: logOMG
+        },
+        shared: {
+            vtag: sharedTag
+        }
+    }, { exceptions: true, simd: true });
+
+    // Then instantiate module 1 (contains hotCaller and coldCaller, imports from module 2)
+    const instance1 = await instantiate(watModule1, {
+        m: {
+            isOMG: $vm.omgTrue,
+            logOMG: logOMG
+        },
+        shared: {
+            vtag: sharedTag
+        },
+        other: {
+            coldCallee: instance2.exports.coldCallee,
+            hotCallee: instance2.exports.hotCallee
+        }
+    }, { exceptions: true, simd: true });
+
+    for (let i = 0; i < wasmTestLoopCount; i++) {
+        currentIteration = i;
+
+        // Test 1: Hot caller (module 1) -> Cold callee (module 2)
+        // Expected: 10 + (1*1 + 2*10 + 3*100 + 4*1000) + 5 = 10 + 4321 + 5 = 4336
+        assert.eq(instance1.exports.testHotCallerColdCallee(), 4336);
+
+        // Test 2: Cold caller (module 1) -> Hot callee (module 2)
+        // Expected: 20 + (5*1 + 6*10 + 7*100 + 8*1000) + 9 = 20 + 8765 + 9 = 8794
+        assert.eq(instance1.exports.testColdCallerHotCallee(), 8794);
+    }
+}
+
+await assert.asyncTest(test());

--- a/JSTests/wasm/stress/try-table-simd.js
+++ b/JSTests/wasm/stress/try-table-simd.js
@@ -46,7 +46,7 @@ let wasmBytes = new Uint8Array([
 
 let result = await WebAssembly.instantiate(wasmBytes);
 
-for (let i = 0; i < 1e4; ++i) {
+for (let i = 0; i < wasmTestLoopCount; ++i) {
     assert.eq(result.instance.exports.simple_throw_catch_v128(0), 13);
     assert.eq(result.instance.exports.simple_throw_catch_v128(1), 42);
 }


### PR DESCRIPTION
#### 7043565202db79486162b349b91b3203ee495085
<pre>
[JSC] WASM IPInt SIMD: support exceptions with v128
<a href="https://bugs.webkit.org/show_bug.cgi?id=299988">https://bugs.webkit.org/show_bug.cgi?id=299988</a>
<a href="https://rdar.apple.com/161773437">rdar://161773437</a>

Reviewed by Yusuke Suzuki.

The IPInt slow path exception throwing and catching code
assumed that exception payloads were always 64-bits. With v128,
the payloads are 128-bits, so these paths need to pack (or unpack)
the WASM stack appropriately based on the tag signature.

Test: JSTests/wasm/stress/simd-instructions-exceptions-cross-tier.js
* JSTests/wasm/stress/exception-containing-v128.js:
(async test):
* JSTests/wasm/stress/import-exception-tag-with-v128.js:
(async test):
* JSTests/wasm/stress/simd-instructions-exceptions-cross-tier.js: Added.
(async test.logOMG):
(async test):
* JSTests/wasm/stress/try-table-simd.js:
* Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp:
(JSC::IPInt::copyExceptionStackToPayload):
(JSC::IPInt::copyExceptionPayloadToStack):
(JSC::IPInt::WASM_IPINT_EXTERN_CPP_DECL):

Canonical link: <a href="https://commits.webkit.org/300882@main">https://commits.webkit.org/300882@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8f04a066fd8d86737c304a918d585d5cff7f41d9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124099 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43797 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34509 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130926 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76221 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/871ade5d-2c7e-4a19-9144-1b6d41488838) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44535 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52397 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94397 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62628 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ffd36659-b744-4adc-af8a-8939f4be05fc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127053 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35487 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111010 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74989 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34435 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29174 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74410 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/116246 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105225 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29393 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133601 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/122630 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51035 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38886 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102865 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51413 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107229 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102674 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26141 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48036 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26283 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/47914 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50891 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56662 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/153724 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50352 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39070 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53700 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52026 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->