### PR TITLE
Implement WebTransport CSP check during initialization

### DIFF
--- a/Source/WebCore/Modules/webtransport/WebTransport.h
+++ b/Source/WebCore/Modules/webtransport/WebTransport.h
@@ -94,6 +94,7 @@ private:
 
     void initializeOverHTTP(SocketProvider&, ScriptExecutionContext&, URL&&, bool dedicated, bool http3Only, WebTransportCongestionControl, Vector<WebTransportHash>&&);
     void cleanup(Ref<DOMException>&&, std::optional<WebTransportCloseInfo>&&);
+    void cleanupWithSessionError();
 
     // ActiveDOMObject.
     bool virtualHasPendingActivity() const final;

--- a/Source/WebCore/Modules/webtransport/WebTransportError.cpp
+++ b/Source/WebCore/Modules/webtransport/WebTransportError.cpp
@@ -34,7 +34,7 @@ Ref<WebTransportError> WebTransportError::create(String&& message, WebTransportE
 }
 
 WebTransportError::WebTransportError(String&& message, WebTransportErrorOptions&& options)
-    : DOMException(0, "WebTransportError"_s, WTFMove(message))
+    : DOMException(0, "WebTransportError"_s, WTFMove(message), DOMException::Type::WebTransportError)
     , m_options(WTFMove(options))
 {
 }

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -680,6 +680,7 @@ bindings/js/JSDOMConvertDate.cpp
 bindings/js/JSDOMConvertNumbers.cpp
 bindings/js/JSDOMConvertStrings.cpp
 bindings/js/JSDOMConvertWebGL.cpp
+bindings/js/JSDOMExceptionCustom.cpp
 bindings/js/JSDOMExceptionHandling.cpp
 bindings/js/JSDOMGlobalObject.cpp
 bindings/js/JSDOMGuardedObject.cpp

--- a/Source/WebCore/bindings/js/JSDOMExceptionCustom.cpp
+++ b/Source/WebCore/bindings/js/JSDOMExceptionCustom.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "JSDOMException.h"
+
+#include "JSDOMBinding.h"
+#include "JSWebTransportError.h"
+
+namespace WebCore {
+
+JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, DOMException& exception)
+{
+    return wrap(lexicalGlobalObject, globalObject, exception);
+}
+
+JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject* globalObject, Ref<DOMException>&& exception)
+{
+    if (exception->type() == DOMException::Type::WebTransportError)
+        return createWrapper<WebTransportError>(globalObject, WTFMove(exception));
+
+    return createWrapper<DOMException>(globalObject, WTFMove(exception));
+}
+
+}

--- a/Source/WebCore/dom/DOMException.cpp
+++ b/Source/WebCore/dom/DOMException.cpp
@@ -107,8 +107,9 @@ Ref<DOMException> DOMException::create(const Exception& exception)
     return adoptRef(*new DOMException(description.legacyCode, description.name, exception.message().isEmpty() ? description.message : exception.message()));
 }
 
-DOMException::DOMException(LegacyCode legacyCode, const String& name, const String& message)
-    : m_legacyCode(legacyCode)
+DOMException::DOMException(LegacyCode legacyCode, const String& name, const String& message, Type type)
+    : m_type(type)
+    , m_legacyCode(legacyCode)
     , m_name(name)
     , m_message(message)
 {

--- a/Source/WebCore/dom/DOMException.h
+++ b/Source/WebCore/dom/DOMException.h
@@ -62,13 +62,17 @@ public:
     static ASCIILiteral name(ExceptionCode ec) { return description(ec).name; }
     static ASCIILiteral message(ExceptionCode ec) { return description(ec).message; }
 
+    enum class Type : bool { Default, WebTransportError };
+    Type type() const { return m_type; }
+
 protected:
-    DOMException(LegacyCode, const String& name, const String& message);
+    DOMException(LegacyCode, const String& name, const String& message, Type = Type::Default);
 
 private:
-    LegacyCode m_legacyCode;
-    String m_name;
-    String m_message;
+    const Type m_type;
+    const LegacyCode m_legacyCode;
+    const String m_name;
+    const String m_message;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/DOMException.idl
+++ b/Source/WebCore/dom/DOMException.idl
@@ -27,6 +27,7 @@
  */
 
 [
+    CustomToJSObject,
     DoNotCheckConstants,
     Exposed=(Window,Worker),
     Exception


### PR DESCRIPTION
#### 747ac91cfae91994e62d499648fb029f2f179704
<pre>
Implement WebTransport CSP check during initialization
<a href="https://bugs.webkit.org/show_bug.cgi?id=299992">https://bugs.webkit.org/show_bug.cgi?id=299992</a>
<a href="https://rdar.apple.com/141593282">rdar://141593282</a>

Reviewed by Matthew Finkel.

The test is very similar to csp-pass.https.window.js and csp-fail.https.window.js
from WPT, but it works with our current test infrastructure.
In order to get it to completely pass, I needed to make sure JS saw the correct
type of DOMException when rejecting the promises.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/WebTransport.mm
* Source/WebCore/Modules/webtransport/WebTransport.cpp:
(WebCore::WebTransport::initializeOverHTTP):
(WebCore::WebTransport::cleanupWithSessionError):
(WebCore::WebTransport::close):
(WebCore::WebTransport::cleanup):
* Source/WebCore/Modules/webtransport/WebTransport.h:
* Source/WebCore/Modules/webtransport/WebTransportError.cpp:
(WebCore::WebTransportError::WebTransportError):
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/JSDOMExceptionCustom.cpp: Copied from Source/WebCore/Modules/webtransport/WebTransportError.cpp.
(WebCore::toJS):
(WebCore::toJSNewlyCreated):
* Source/WebCore/dom/DOMException.cpp:
(WebCore::DOMException::DOMException):
* Source/WebCore/dom/DOMException.h:
(WebCore::DOMException::type const):
* Source/WebCore/dom/DOMException.idl:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebTransport.mm:
(TestWebKitAPI::TEST(WebTransport, CSP)):

Canonical link: <a href="https://commits.webkit.org/300858@main">https://commits.webkit.org/300858@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dd5fd6ac858601d7fab02728c58476daed4ef962

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124111 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/43808 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34521 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130944 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/76232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9f9d716f-980c-4de7-bc73-f7adbb1aa7c7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/125988 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44547 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52409 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/94413 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/76232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/99b0d9cd-5ca4-419f-9683-b441a9696b11) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127065 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/35500 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111019 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75005 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/453d3686-6351-466d-8b2f-b009f8806285) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/34448 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29183 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74424 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/105239 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29402 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133614 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/51046 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/38895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/102879 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51425 "Build is in progress. Recent messages:") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107238 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102686 "Passed tests") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/26292 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/47925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19502 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/50902 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56674 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/50363 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/53711 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/52037 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->