### PR TITLE
Add align-self/justify-self dialog behavior to enable UA style for popovers

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/align-dialog-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/align-dialog-001-expected.txt
@@ -1,0 +1,10 @@
+
+PASS e.style['align-self'] = "dialog" should set the property value
+PASS e.style['align-items'] = "dialog" should set the property value
+PASS e.style['justify-self'] = "dialog" should set the property value
+PASS e.style['justify-items'] = "dialog" should set the property value
+PASS Property align-self value 'dialog'
+PASS Property align-items value 'dialog'
+PASS Property justify-self value 'dialog'
+PASS Property justify-items value 'dialog'
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/align-dialog-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/align-dialog-001.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<title>Tests the dialog keyword is parsed and computed as specified</title>
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#conditional-centering">
+<link rel="author" href="mailto:tabatkins@google.com">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+<script src="/css/support/computed-testcommon.js"></script>
+
+<div id="container">
+  <div id="target"></div>
+</div>
+
+<script>
+test_valid_value('align-self', 'dialog');
+test_valid_value('align-items', 'dialog');
+test_valid_value('justify-self', 'dialog');
+test_valid_value('justify-items', 'dialog');
+
+test_computed_value('align-self', 'dialog');
+test_computed_value('align-items', 'dialog');
+test_computed_value('justify-self', 'dialog');
+test_computed_value('justify-items', 'dialog');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/align-dialog-002-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/align-dialog-002-expected.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<title>Tests the dialog keyword is parsed and computed as specified</title>
+<link rel="author" href="mailto:tabatkins@google.com">
+
+<style>
+.container {
+  position: relative;
+  width: 100px;
+  height: 100px;
+  border: 1px solid;
+  margin: 1em;
+  anchor-scope: all;
+}
+.anchor {
+  border: solid blue 15px;
+  width: 0;
+  margin: 25px;
+  anchor-name: --foo;
+}
+.abspos {
+  position: absolute;
+  position-anchor: --foo;
+  border: solid orange 10px;
+  inset: 0;
+}
+</style>
+
+/* Should be centered, no position-area */
+<div class="container">
+  <div class="anchor"></div>
+  <div class="abspos" style="place-self: center"></div>
+</div>
+
+/* Centered in an offset box */
+<div class="container">
+  <div class="anchor"></div>
+  <div class="abspos" style="place-self: center; left: anchor(left); top: anchor(top)"></div>
+</div>
+
+/* Anchor-centered on the left side. */
+<div class="container">
+  <div class="anchor"></div>
+  <div class="abspos" style="place-self: normal; position-area: left span-all"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/align-dialog-002-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/align-dialog-002-ref.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<title>Tests the dialog keyword is parsed and computed as specified</title>
+<link rel="author" href="mailto:tabatkins@google.com">
+
+<style>
+.container {
+  position: relative;
+  width: 100px;
+  height: 100px;
+  border: 1px solid;
+  margin: 1em;
+  anchor-scope: all;
+}
+.anchor {
+  border: solid blue 15px;
+  width: 0;
+  margin: 25px;
+  anchor-name: --foo;
+}
+.abspos {
+  position: absolute;
+  position-anchor: --foo;
+  border: solid orange 10px;
+  inset: 0;
+}
+</style>
+
+/* Should be centered, no position-area */
+<div class="container">
+  <div class="anchor"></div>
+  <div class="abspos" style="place-self: center"></div>
+</div>
+
+/* Centered in an offset box */
+<div class="container">
+  <div class="anchor"></div>
+  <div class="abspos" style="place-self: center; left: anchor(left); top: anchor(top)"></div>
+</div>
+
+/* Anchor-centered on the left side. */
+<div class="container">
+  <div class="anchor"></div>
+  <div class="abspos" style="place-self: normal; position-area: left span-all"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/align-dialog-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/align-dialog-002.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<title>Tests the dialog keyword is parsed and computed as specified</title>
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#conditional-centering">
+<link rel="match" href="align-dialog-002-ref.html">
+<link rel="author" href="mailto:tabatkins@google.com">
+<link rel="author" title="Elika J. Etemad" href="http://fantasai.inkedblade.net/contact">
+
+<style>
+.container {
+  position: relative;
+  width: 100px;
+  height: 100px;
+  border: 1px solid;
+  margin: 1em;
+  anchor-scope: all;
+}
+.anchor {
+  border: solid blue 15px;
+  width: 0;
+  margin: 25px;
+  anchor-name: --foo;
+}
+.abspos {
+  position: absolute;
+  position-anchor: --foo;
+  border: solid orange 10px;
+  place-self: dialog;
+  inset: 0;
+}
+</style>
+
+/* Should be centered, no position-area */
+<div class="container">
+  <div class="anchor"></div>
+  <div class="abspos"></div>
+</div>
+
+/* Centered in an offset box */
+<div class="container">
+  <div class="anchor"></div>
+  <div class="abspos" style="left: anchor(left); top: anchor(top)"></div>
+</div>
+
+/* Anchor-centered on the left side. */
+<div class="container">
+  <div class="anchor"></div>
+  <div class="abspos" style="position-area: left span-all"></div>
+</div>

--- a/Source/WebCore/css/CSSPrimitiveValueMappings.h
+++ b/Source/WebCore/css/CSSPrimitiveValueMappings.h
@@ -2202,7 +2202,7 @@ template<> constexpr CSSBoxType fromCSSValueID(CSSValueID valueID)
 #define TYPE ItemPosition
 #define FOR_EACH(CASE) CASE(Legacy) CASE(Auto) CASE(Normal) CASE(Stretch) CASE(Baseline) \
     CASE(LastBaseline) CASE(Center) CASE(Start) CASE(End) CASE(SelfStart) CASE(SelfEnd) \
-    CASE(FlexStart) CASE(FlexEnd) CASE(Left) CASE(Right) CASE(AnchorCenter)
+    CASE(FlexStart) CASE(FlexEnd) CASE(Left) CASE(Right) CASE(AnchorCenter) CASE(Dialog)
 DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
 #undef TYPE
 #undef FOR_EACH

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -9521,7 +9521,8 @@
                 "start",
                 "end",
                 "self-start",
-                "self-end"
+                "self-end",
+                "dialog"
             ],
             "codegen-properties": {
                 "aliases": [
@@ -13759,7 +13760,7 @@
             }
         },
         "<self-position>": {
-            "grammar": "center | start | end | self-start | self-end | flex-start | flex-end | anchor-center",
+            "grammar": "center | start | end | self-start | self-end | flex-start | flex-end | anchor-center | dialog",
             "specification": {
                 "category": "css-align",
                 "url": "https://www.w3.org/TR/css-align-3/#typedef-self-position"

--- a/Source/WebCore/css/CSSValueKeywords.in
+++ b/Source/WebCore/css/CSSValueKeywords.in
@@ -724,6 +724,7 @@ space-evenly
 first-baseline
 last-baseline
 // stretch
+dialog
 
 // justify-content
 // start

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Align.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Align.cpp
@@ -83,7 +83,7 @@ enum class AdditionalSelfPositionKeywords {
 
 static bool isSelfPositionKeyword(CSSValueID id, OptionSet<AdditionalSelfPositionKeywords> additionalKeywords)
 {
-    bool matches = identMatches<CSSValueStart, CSSValueEnd, CSSValueCenter, CSSValueSelfStart, CSSValueSelfEnd, CSSValueFlexStart, CSSValueFlexEnd>(id);
+    bool matches = identMatches<CSSValueStart, CSSValueEnd, CSSValueCenter, CSSValueSelfStart, CSSValueSelfEnd, CSSValueFlexStart, CSSValueFlexEnd, CSSValueDialog>(id);
 
     if (additionalKeywords.contains(AdditionalSelfPositionKeywords::LeftRight))
         matches |= isLeftOrRightKeyword(id);

--- a/Source/WebCore/rendering/PositionedLayoutConstraints.cpp
+++ b/Source/WebCore/rendering/PositionedLayoutConstraints.cpp
@@ -474,19 +474,21 @@ ItemPosition PositionedLayoutConstraints::resolveAlignmentValue() const
 {
     auto alignmentPosition = [&] {
         auto itemPosition = m_alignment.position();
-        if (m_useStaticPosition) {
+        if (ItemPosition::Auto == itemPosition) {
+
+            if (m_useStaticPosition) {
 #if ASSERT_ENABLED
-            ASSERT(m_isEligibleForStaticRangeAlignment);
+                ASSERT(m_isEligibleForStaticRangeAlignment);
 #endif
-            auto* parentStyle = m_renderer->parentStyle();
-            return m_style.resolvedAlignSelf(parentStyle, ItemPosition::Start).position();
-        }
-        if (ItemPosition::Auto == itemPosition)
+                auto* parentStyle = m_renderer->parentStyle();
+                return m_style.resolvedAlignSelf(parentStyle, ItemPosition::Start).position();
+            }
             return ItemPosition::Normal;
+        }
         return itemPosition;
     }();
 
-    if (m_style.positionArea() && ItemPosition::Normal == alignmentPosition)
+    if (m_style.positionArea() && (ItemPosition::Normal == alignmentPosition || ItemPosition::Dialog == alignmentPosition))
         alignmentPosition = m_style.positionArea()->defaultAlignmentForAxis(m_physicalAxis, m_containingWritingMode, m_writingMode);
 
     if (!m_defaultAnchorBox && alignmentPosition == ItemPosition::AnchorCenter)

--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -2071,6 +2071,7 @@ static LayoutUnit alignmentOffset(LayoutUnit availableFreeSpace, ItemPosition po
         return availableFreeSpace;
     case ItemPosition::Center:
     case ItemPosition::AnchorCenter:
+    case ItemPosition::Dialog:
         return availableFreeSpace / 2;
     case ItemPosition::Baseline:
     case ItemPosition::LastBaseline: 

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -2041,6 +2041,7 @@ GridAxisPosition RenderGrid::columnAxisPositionForGridItem(const RenderBox& grid
         return GridAxisPosition::GridAxisStart;
     case ItemPosition::Center:
     case ItemPosition::AnchorCenter:
+    case ItemPosition::Dialog:
         return GridAxisPosition::GridAxisCenter;
     case ItemPosition::FlexStart: // Only used in flex layout, otherwise equivalent to 'start'.
         // Aligns the alignment subject to be flush with the alignment container's 'start' edge (block-start) in the column axis.
@@ -2099,6 +2100,7 @@ GridAxisPosition RenderGrid::rowAxisPositionForGridItem(const RenderBox& gridIte
         return writingMode().isBidiLTR() ? GridAxisPosition::GridAxisEnd : GridAxisPosition::GridAxisStart;
     case ItemPosition::Center:
     case ItemPosition::AnchorCenter:
+    case ItemPosition::Dialog:
         return GridAxisPosition::GridAxisCenter;
     case ItemPosition::FlexStart: // Only used in flex layout, otherwise equivalent to 'start'.
         // Aligns the alignment subject to be flush with the alignment container's 'start' edge (inline-start) in the row axis.

--- a/Source/WebCore/rendering/style/RenderStyleConstants.cpp
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.cpp
@@ -731,6 +731,7 @@ TextStream& operator<<(TextStream& ts, ItemPosition position)
     case ItemPosition::Left: ts << "left"_s; break;
     case ItemPosition::Right: ts << "right"_s; break;
     case ItemPosition::AnchorCenter: ts << "anchor-center"_s; break;
+    case ItemPosition::Dialog: ts << "dialog"_s; break;
     }
     return ts;
 }

--- a/Source/WebCore/rendering/style/RenderStyleConstants.h
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.h
@@ -481,6 +481,7 @@ enum class ItemPosition : uint8_t {
     Left,
     Right,
     AnchorCenter,
+    Dialog
 };
 
 enum class OverflowAlignment : uint8_t {

--- a/Source/WebCore/rendering/style/StyleSelfAlignmentData.cpp
+++ b/Source/WebCore/rendering/style/StyleSelfAlignmentData.cpp
@@ -47,6 +47,7 @@ LayoutUnit StyleSelfAlignmentData::adjustmentFromStartEdge(LayoutUnit extraSpace
 
     case ItemPosition::Center:
     case ItemPosition::AnchorCenter:
+    case ItemPosition::Dialog:
         return extraSpace / 2;
 
     case ItemPosition::End:

--- a/Source/WebCore/rendering/style/StyleSelfAlignmentData.h
+++ b/Source/WebCore/rendering/style/StyleSelfAlignmentData.h
@@ -67,7 +67,7 @@ public:
     friend bool operator==(const StyleSelfAlignmentData&, const StyleSelfAlignmentData&) = default;
 
 private:
-    PREFERRED_TYPE(ItemPosition) uint8_t m_position : 4 { 0 };
+    PREFERRED_TYPE(ItemPosition) uint8_t m_position : 5 { 0 };
     PREFERRED_TYPE(ItemPositionType) uint8_t m_positionType: 1 { 0 }; // Whether or not alignment uses the 'legacy' keyword.
     PREFERRED_TYPE(OverflowAlignment) uint8_t m_overflow : 2 { 0 };
 };

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -571,6 +571,7 @@ inline ItemPosition oppositeItemPosition(ItemPosition position)
     case ItemPosition::LastBaseline:
     case ItemPosition::Center:
     case ItemPosition::AnchorCenter:
+    case ItemPosition::Dialog:
         return position;
 
     case ItemPosition::Start:


### PR DESCRIPTION
#### d7f2e52c03a8d52f3421e876b5157280f5369c7b
<pre>
Add align-self/justify-self dialog behavior to enable UA style for popovers
<a href="https://bugs.webkit.org/show_bug.cgi?id=299995">https://bugs.webkit.org/show_bug.cgi?id=299995</a>
<a href="https://rdar.apple.com/161779751">rdar://161779751</a>

Reviewed by Tim Nguyen.

Adds new &apos;dialog&apos; value to the self alignment position values, maps it to
be equivalent to &apos;center&apos; in most cases, and gives it special behavior
for &apos;position-area&apos; values other than &apos;none&apos;. See
  <a href="https://github.com/w3c/csswg-drafts/issues/10258">https://github.com/w3c/csswg-drafts/issues/10258</a>
  <a href="https://drafts.csswg.org/css-anchor-position-1/#conditional-centering">https://drafts.csswg.org/css-anchor-position-1/#conditional-centering</a>

Tests: imported/w3c/web-platform-tests/css/css-anchor-position/align-dialog-001.html
       imported/w3c/web-platform-tests/css/css-anchor-position/align-dialog-002-ref.html
       imported/w3c/web-platform-tests/css/css-anchor-position/align-dialog-002.html
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/align-dialog-001-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/align-dialog-001.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/align-dialog-002-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/align-dialog-002-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/align-dialog-002.html: Added.

Import WPT tests.

* Source/WebCore/css/CSSPrimitiveValueMappings.h:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/CSSValueKeywords.in:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Align.cpp:
(WebCore::CSSPropertyParserHelpers::isSelfPositionKeyword):

Implement parsing for &apos;dialog&apos;.

* Source/WebCore/rendering/PositionedLayoutConstraints.cpp:
(WebCore::PositionedLayoutConstraints::resolveAlignmentValue const):
* Source/WebCore/rendering/RenderFlexibleBox.cpp:
(WebCore::alignmentOffset):
* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::columnAxisPositionForGridItem const):
(WebCore::RenderGrid::rowAxisPositionForGridItem const):

Update layout code to handle ItemPosition::Dialog.

* Source/WebCore/rendering/style/RenderStyleConstants.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/rendering/style/RenderStyleConstants.h:
* Source/WebCore/rendering/style/StyleSelfAlignmentData.cpp:
(WebCore::StyleSelfAlignmentData::adjustmentFromStartEdge):
* Source/WebCore/rendering/style/StyleSelfAlignmentData.h:
* Source/WebCore/style/StyleBuilderConverter.h:
(WebCore::Style::oppositeItemPosition):

Update style system to handle ItemPosition::Dialog.

Canonical link: <a href="https://commits.webkit.org/300865@main">https://commits.webkit.org/300865@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c818c02b6700674bb5086a353ee1b428552bb19

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124120 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43814 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34530 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130948 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76236 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b2ae7fb1-d076-492d-8279-ab18a8eb22dc) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/125997 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44555 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52415 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94416 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/62638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3e8a97e2-ee9c-4acc-a2d8-cb9f31b04bc0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127074 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35505 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111029 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75008 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c57e87e1-8353-45c7-a044-5b45d22a31c6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34453 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29192 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74436 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105244 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29412 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133622 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51052 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38901 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102886 "Found 1 new test failure: imported/blink/fast/pagination/viewport-y-horizontal-bt-rtl.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51431 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107248 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102694 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26125 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48052 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26298 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/47931 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50908 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56680 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50368 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53716 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52042 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->