### PR TITLE
Fix debug assert in TestWebKitAPI.ProcessSwap.MemoryPressureDuringProcessSwap

### DIFF
--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -1498,9 +1498,11 @@ void WebProcessPool::handleMemoryPressureWarning(Critical)
     m_backForwardCache->clear();
     m_webProcessCache->clear();
 
+    for (WeakPtr maybePrewarmedProcess : copyToVector(m_prewarmedProcesses)) {
+        if (RefPtr prewarmedProcess = maybePrewarmedProcess.get())
+            prewarmedProcess->shutDown();
+    }
 
-    for (RefPtr prewarmedProcess : m_prewarmedProcesses)
-        prewarmedProcess->shutDown();
     ASSERT(m_prewarmedProcesses.isEmptyIgnoringNullReferences());
 
     for (Ref process : m_processes)


### PR DESCRIPTION
#### 3a5023d400978930a513f4ef8f77e9b03b78e49a
<pre>
Fix debug assert in TestWebKitAPI.ProcessSwap.MemoryPressureDuringProcessSwap
<a href="https://bugs.webkit.org/show_bug.cgi?id=299967">https://bugs.webkit.org/show_bug.cgi?id=299967</a>
<a href="https://rdar.apple.com/161749579">rdar://161749579</a>

Reviewed by Per Arne Vollan and Youenn Fablet.

This test started crashing after 300594@main because calling shutDown modifies the hash map during
iteration. Fix with a copyToVector.

* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::handleMemoryPressureWarning):

Canonical link: <a href="https://commits.webkit.org/300884@main">https://commits.webkit.org/300884@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/272e30a854a1838e36bbb146abe2a68bcb465136

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124125 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43818 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34535 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130952 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76238 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cc851451-2f6a-45f5-8efa-ab05b7c4bb65) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44559 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52419 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94429 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62642 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ea851b89-dd0d-4f13-b7bc-9f2255bc4049) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127079 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35504 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111030 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75009 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5c208062-61f8-4a34-927f-18bf29b5fdd8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34452 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74439 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105243 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29413 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133626 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51056 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38905 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102901 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51435 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107249 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102696 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26143 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48050 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26299 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/47935 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50912 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56684 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50370 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53720 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52046 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->