### PR TITLE
Address Safer cpp warnings in ResourceLoadStatisticsStore.cpp

### DIFF
--- a/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp
+++ b/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp
@@ -466,10 +466,10 @@ HashSet<RegistrableDomain> ResourceLoadStatisticsStore::loadWebsitesWithUserInte
     ASSERT(!RunLoop::isMain());
 
     HashSet<RegistrableDomain> results;
-    auto statement = m_database.prepareStatement(domainWithUserInteractionQuery);
-    if (!statement)
+    auto sqlStatement = m_database.prepareStatement(domainWithUserInteractionQuery);
+    if (!sqlStatement)
         return { };
-
+    CheckedRef statement = sqlStatement.value();
     while (statement->step() == SQLITE_ROW)
         results.add(RegistrableDomain::uncheckedCreateFromRegistrableDomainString(statement->columnText(0)));
 
@@ -844,6 +844,7 @@ std::optional<Vector<String>> ResourceLoadStatisticsStore::checkForMissingTables
     if (missingTables.isEmpty())
         return std::nullopt;
 
+
     return missingTables;
 }
 
@@ -855,11 +856,12 @@ bool ResourceLoadStatisticsStore::tableExists(StringView tableName)
         ITP_RELEASE_LOG_DATABASE_ERROR("tableExists: failed to prepare statement");
         return false;
     }
-    if (scopedStatement->bindText(1, tableName) != SQLITE_OK) {
+    CheckedPtr statement = scopedStatement.get();
+    if (statement->bindText(1, tableName) != SQLITE_OK) {
         ITP_RELEASE_LOG_DATABASE_ERROR("tableExists: failed to bind parameter");
         return false;
     }
-    return scopedStatement->step() == SQLITE_ROW;
+    return statement->step() == SQLITE_ROW;
 }
 
 void ResourceLoadStatisticsStore::deleteTable(StringView tableName)
@@ -867,18 +869,23 @@ void ResourceLoadStatisticsStore::deleteTable(StringView tableName)
     ASSERT(tableExists(tableName));
     auto dropTableQuery = m_database.prepareStatementSlow(makeString("DROP TABLE "_s, tableName));
     ASSERT(dropTableQuery);
-    if (!dropTableQuery || dropTableQuery->step() != SQLITE_DONE)
+    if (!dropTableQuery) {
+        ITP_RELEASE_LOG_DATABASE_ERROR("deleteTable: failed to prepare statement");
+        return;
+    }
+    CheckedRef statement = dropTableQuery.value();
+    if (statement->step() != SQLITE_DONE)
         ITP_RELEASE_LOG_DATABASE_ERROR("deleteTable: failed to step statement");
 }
 
 bool ResourceLoadStatisticsStore::missingUniqueIndices()
 {
-    auto statement = m_database.prepareStatement("SELECT COUNT(*) FROM sqlite_master WHERE type = 'index'"_s);
-    if (!statement) {
+    auto sqlStatement = m_database.prepareStatement("SELECT COUNT(*) FROM sqlite_master WHERE type = 'index'"_s);
+    if (!sqlStatement) {
         ITP_RELEASE_LOG_DATABASE_ERROR("missingUniqueIndices: failed to prepare statement");
         return false;
     }
-
+    CheckedRef statement = sqlStatement.value();
     if (statement->step() != SQLITE_ROW) {
         ITP_RELEASE_LOG_DATABASE_ERROR("missingUniqueIndices: failed to step statement");
         return false;
@@ -923,8 +930,9 @@ void ResourceLoadStatisticsStore::migrateDataToPCMDatabaseIfNecessary()
             ITP_RELEASE_LOG_DATABASE_ERROR("migrateDataToPCMDatabaseIfNecessary: failed to prepare unattributedScopedStatement");
             return;
         }
-        while (unattributedScopedStatement->step() == SQLITE_ROW)
-            unattributed.append(buildPrivateClickMeasurementFromDatabase(unattributedScopedStatement.value(), PrivateClickMeasurementAttributionType::Unattributed));
+        CheckedRef statement = unattributedScopedStatement.value();
+        while (statement->step() == SQLITE_ROW)
+            unattributed.append(buildPrivateClickMeasurementFromDatabase(statement.get(), PrivateClickMeasurementAttributionType::Unattributed));
     }
 
     Vector<WebCore::PrivateClickMeasurement> attributed;
@@ -935,8 +943,9 @@ void ResourceLoadStatisticsStore::migrateDataToPCMDatabaseIfNecessary()
             ITP_RELEASE_LOG_DATABASE_ERROR("migrateDataToPCMDatabaseIfNecessary: failed to prepare attributedScopedStatement");
             return;
         }
-        while (attributedScopedStatement->step() == SQLITE_ROW)
-            attributed.append(buildPrivateClickMeasurementFromDatabase(attributedScopedStatement.value(), PrivateClickMeasurementAttributionType::Attributed));
+        CheckedRef statement = attributedScopedStatement.value();
+        while (statement->step() == SQLITE_ROW)
+            attributed.append(buildPrivateClickMeasurementFromDatabase(statement.get(), PrivateClickMeasurementAttributionType::Attributed));
     }
 
     if (!unattributed.isEmpty() || !attributed.isEmpty()) {
@@ -1054,12 +1063,16 @@ bool ResourceLoadStatisticsStore::isEmpty() const
     ASSERT(!RunLoop::isMain());
 
     auto scopedStatement = this->scopedStatement(m_observedDomainCountStatement, observedDomainCountQuery, "isEmpty"_s);
-    if (!scopedStatement
-        || scopedStatement->step() != SQLITE_ROW) {
+    if (!scopedStatement) {
+        ITP_RELEASE_LOG_DATABASE_ERROR("isEmpty: failed to prepare statement");
+        return false;
+    }
+    CheckedPtr statement = scopedStatement.get();
+    if (statement->step() != SQLITE_ROW) {
         ITP_RELEASE_LOG_DATABASE_ERROR("isEmpty: failed to step statement");
         return false;
     }
-    return !scopedStatement->columnInt(0);
+    return !statement->columnInt(0);
 }
 
 bool ResourceLoadStatisticsStore::createUniqueIndices()
@@ -1212,39 +1225,47 @@ bool ResourceLoadStatisticsStore::insertObservedDomain(const ResourceLoadStatist
         return false;
     }
     auto scopedStatement = this->scopedStatement(m_insertObservedDomainStatement, insertObservedDomainQuery, "insertObservedDomain"_s);
-    if (!scopedStatement
-        || scopedStatement->bindText(RegistrableDomainIndex, loadStatistics.registrableDomain.string()) != SQLITE_OK
-        || scopedStatement->bindDouble(LastSeenIndex, loadStatistics.lastSeen.secondsSinceEpoch().value()) != SQLITE_OK
-        || scopedStatement->bindInt(HadUserInteractionIndex, loadStatistics.hadUserInteraction) != SQLITE_OK
-        || scopedStatement->bindDouble(MostRecentUserInteractionTimeIndex, loadStatistics.mostRecentUserInteractionTime.secondsSinceEpoch().value()) != SQLITE_OK
-        || scopedStatement->bindInt(GrandfatheredIndex, loadStatistics.grandfathered) != SQLITE_OK
-        || scopedStatement->bindInt(IsPrevalentIndex, loadStatistics.isPrevalentResource) != SQLITE_OK
-        || scopedStatement->bindInt(IsVeryPrevalentIndex, loadStatistics.isVeryPrevalentResource) != SQLITE_OK
-        || scopedStatement->bindInt(DataRecordsRemovedIndex, loadStatistics.dataRecordsRemoved) != SQLITE_OK
-        || scopedStatement->bindInt(TimesAccessedAsFirstPartyDueToUserInteractionIndex, loadStatistics.timesAccessedAsFirstPartyDueToUserInteraction) != SQLITE_OK
-        || scopedStatement->bindInt(TimesAccessedAsFirstPartyDueToStorageAccessAPIIndex, loadStatistics.timesAccessedAsFirstPartyDueToStorageAccessAPI) != SQLITE_OK
-        || scopedStatement->bindInt(IsScheduledForAllButCookieDataRemovalIndex, loadStatistics.gotLinkDecorationFromPrevalentResource
-        || scopedStatement->bindDouble(MostRecentWebPushInteractionTimeIndex, 0.0)) != SQLITE_OK) {
+    if (!scopedStatement) {
+        ITP_RELEASE_LOG_DATABASE_ERROR("insertObservedDomain: failed to prepare statement");
+        return false;
+    }
+    CheckedPtr statement = scopedStatement.get();
+    if (statement->bindText(RegistrableDomainIndex, loadStatistics.registrableDomain.string()) != SQLITE_OK
+        || statement->bindDouble(LastSeenIndex, loadStatistics.lastSeen.secondsSinceEpoch().value()) != SQLITE_OK
+        || statement->bindInt(HadUserInteractionIndex, loadStatistics.hadUserInteraction) != SQLITE_OK
+        || statement->bindDouble(MostRecentUserInteractionTimeIndex, loadStatistics.mostRecentUserInteractionTime.secondsSinceEpoch().value()) != SQLITE_OK
+        || statement->bindInt(GrandfatheredIndex, loadStatistics.grandfathered) != SQLITE_OK
+        || statement->bindInt(IsPrevalentIndex, loadStatistics.isPrevalentResource) != SQLITE_OK
+        || statement->bindInt(IsVeryPrevalentIndex, loadStatistics.isVeryPrevalentResource) != SQLITE_OK
+        || statement->bindInt(DataRecordsRemovedIndex, loadStatistics.dataRecordsRemoved) != SQLITE_OK
+        || statement->bindInt(TimesAccessedAsFirstPartyDueToUserInteractionIndex, loadStatistics.timesAccessedAsFirstPartyDueToUserInteraction) != SQLITE_OK
+        || statement->bindInt(TimesAccessedAsFirstPartyDueToStorageAccessAPIIndex, loadStatistics.timesAccessedAsFirstPartyDueToStorageAccessAPI) != SQLITE_OK
+        || statement->bindInt(IsScheduledForAllButCookieDataRemovalIndex, loadStatistics.gotLinkDecorationFromPrevalentResource
+        || statement->bindDouble(MostRecentWebPushInteractionTimeIndex, 0.0)) != SQLITE_OK) {
         ITP_RELEASE_LOG_DATABASE_ERROR("insertObservedDomain: failed to bind parameters");
         return false;
     }
 
-    if (scopedStatement->step() != SQLITE_DONE) {
+    if (statement->step() != SQLITE_DONE) {
         ITP_RELEASE_LOG_DATABASE_ERROR("insertObservedDomain: failed to step statement");
         return false;
     }
     return true;
 }
 
-bool ResourceLoadStatisticsStore::relationshipExists(SQLiteStatementAutoResetScope& statement, std::optional<unsigned> firstDomainID, const RegistrableDomain& secondDomain) const
+bool ResourceLoadStatisticsStore::relationshipExists(SQLiteStatementAutoResetScope& sqlStatement, std::optional<unsigned> firstDomainID, const RegistrableDomain& secondDomain) const
 {
     if (!firstDomainID)
         return false;
 
     ASSERT(!RunLoop::isMain());
 
-    if (!statement
-        || statement->bindInt(1, *firstDomainID) != SQLITE_OK
+    if (!sqlStatement) {
+        ITP_RELEASE_LOG_DATABASE_ERROR("relationshipExists: failed to prepare statement");
+        return false;
+    }
+    CheckedPtr statement = sqlStatement.get();
+    if (statement->bindInt(1, *firstDomainID) != SQLITE_OK
         || statement->bindText(2, secondDomain.string()) != SQLITE_OK
         || statement->step() != SQLITE_ROW) {
         ITP_RELEASE_LOG_DATABASE_ERROR("relationshipExists: failed to step statement");
@@ -1258,17 +1279,22 @@ std::optional<unsigned> ResourceLoadStatisticsStore::domainID(const RegistrableD
     ASSERT(!RunLoop::isMain());
 
     auto scopedStatement = this->scopedStatement(m_domainIDFromStringStatement, domainIDFromStringQuery, "domainID"_s);
-    if (!scopedStatement || scopedStatement->bindText(1, domain.string()) != SQLITE_OK) {
+    if (!scopedStatement) {
+        ITP_RELEASE_LOG_DATABASE_ERROR("domainID: failed to prepare statement");
+        return std::nullopt;
+    }
+    CheckedPtr statement = scopedStatement.get();
+    if (statement->bindText(1, domain.string()) != SQLITE_OK) {
         ITP_RELEASE_LOG_DATABASE_ERROR("domainID: failed to bind parameter");
         return std::nullopt;
     }
 
-    if (scopedStatement->step() != SQLITE_ROW) {
+    if (statement->step() != SQLITE_ROW) {
         ITP_RELEASE_LOG_DATABASE_ERROR("domainID: failed to step statement");
         return std::nullopt;
     }
 
-    return scopedStatement->columnInt(0);
+    return statement->columnInt(0);
 }
 
 String ResourceLoadStatisticsStore::ensureAndMakeDomainList(const HashSet<RegistrableDomain>& domainList)
@@ -1284,9 +1310,14 @@ String ResourceLoadStatisticsStore::ensureAndMakeDomainList(const HashSet<Regist
 
 void ResourceLoadStatisticsStore::insertDomainRelationshipList(const String& statement, const HashSet<RegistrableDomain>& domainList, unsigned domainID)
 {
-    auto insertRelationshipStatement = m_database.prepareStatementSlow(makeString(statement, ensureAndMakeDomainList(domainList), " );"_s));
+    auto insertRelationship = m_database.prepareStatementSlow(makeString(statement, ensureAndMakeDomainList(domainList), " );"_s));
 
-    if (!insertRelationshipStatement || insertRelationshipStatement->bindInt(1, domainID) != SQLITE_OK) {
+    if (!insertRelationship) {
+        ITP_RELEASE_LOG_DATABASE_ERROR("insertDomainRelationshipList: failed to prepare statement");
+        return;
+    }
+    CheckedRef insertRelationshipStatement = insertRelationship.value();
+    if (insertRelationshipStatement->bindInt(1, domainID) != SQLITE_OK) {
         ITP_RELEASE_LOG_DATABASE_ERROR("insertDomainRelationshipList: failed to bind first parameter");
         return;
     }
@@ -1371,14 +1402,18 @@ void ResourceLoadStatisticsStore::mergeStatistic(const ResourceLoadStatistics& s
 
     auto transactionScope = beginTransactionIfNecessary();
     auto scopedStatement = this->scopedStatement(m_getResourceDataByDomainNameStatement, getResourceDataByDomainNameQuery, "mergeStatistic"_s);
-    if (!scopedStatement
-        || scopedStatement->bindText(1, statistic.registrableDomain.string()) != SQLITE_OK
-        || scopedStatement->step() != SQLITE_ROW) {
+    if (!scopedStatement) {
+        ITP_RELEASE_LOG_DATABASE_ERROR("mergeStatistic: failed to prepare statement");
+        return;
+    }
+    CheckedPtr statement = scopedStatement.get();
+    if (statement->bindText(1, statistic.registrableDomain.string()) != SQLITE_OK
+        || statement->step() != SQLITE_ROW) {
         ITP_RELEASE_LOG_DATABASE_ERROR("mergeStatistic: failed to step statement");
         return;
     }
 
-    merge(scopedStatement.get(), statistic);
+    merge(statement.get(), statistic);
 }
 
 void ResourceLoadStatisticsStore::mergeStatistics(Vector<ResourceLoadStatistics>&& statistics)
@@ -1428,16 +1463,20 @@ static ASCIILiteral joinSubStatisticsForSorting()
 Vector<ITPThirdPartyDataForSpecificFirstParty> ResourceLoadStatisticsStore::getThirdPartyDataForSpecificFirstPartyDomains(unsigned thirdPartyDomainID, const RegistrableDomain& thirdPartyDomain) const
 {
     auto scopedStatement = this->scopedStatement(m_getAllSubStatisticsStatement, getAllSubStatisticsUnderDomainQuery, "getThirdPartyDataForSpecificFirstPartyDomains"_s);
-    if (!scopedStatement
-        || scopedStatement->bindInt(1, thirdPartyDomainID) != SQLITE_OK
-        || scopedStatement->bindInt(2, thirdPartyDomainID) != SQLITE_OK
-        || scopedStatement->bindInt(3, thirdPartyDomainID) != SQLITE_OK) {
+    if (!scopedStatement) {
+        ITP_RELEASE_LOG_DATABASE_ERROR("getThirdPartyDataForSpecificFirstPartyDomains: failed to prepare statement");
+        return { };
+    }
+    CheckedPtr statement = scopedStatement.get();
+    if (statement->bindInt(1, thirdPartyDomainID) != SQLITE_OK
+        || statement->bindInt(2, thirdPartyDomainID) != SQLITE_OK
+        || statement->bindInt(3, thirdPartyDomainID) != SQLITE_OK) {
         ITP_RELEASE_LOG_DATABASE_ERROR("getThirdPartyDataForSpecificFirstPartyDomains: failed to bind parameters");
         return { };
     }
     Vector<ITPThirdPartyDataForSpecificFirstParty> thirdPartyDataForSpecificFirstPartyDomains;
-    while (scopedStatement->step() == SQLITE_ROW) {
-        RegistrableDomain firstPartyDomain = RegistrableDomain::uncheckedCreateFromRegistrableDomainString(getDomainStringFromDomainID(m_getAllSubStatisticsStatement->columnInt(0)));
+    while (statement->step() == SQLITE_ROW) {
+        RegistrableDomain firstPartyDomain = RegistrableDomain::uncheckedCreateFromRegistrableDomainString(getDomainStringFromDomainID(statement->columnInt(0)));
         thirdPartyDataForSpecificFirstPartyDomains.appendIfNotContains(ITPThirdPartyDataForSpecificFirstParty { firstPartyDomain, hasStorageAccess(firstPartyDomain, thirdPartyDomain), getMostRecentlyUpdatedTimestamp(thirdPartyDomain, firstPartyDomain) });
     }
     return thirdPartyDataForSpecificFirstPartyDomains;
@@ -1455,15 +1494,19 @@ Vector<ITPThirdPartyData> ResourceLoadStatisticsStore::aggregatedThirdPartyData(
     Vector<ITPThirdPartyData> thirdPartyDataList;
     const auto prevalentDomainsBindParameter = thirdPartyCookieBlockingMode() == ThirdPartyCookieBlockingMode::All ? "%"_s : "1"_s;
     auto sortedStatistics = m_database.prepareStatement(joinSubStatisticsForSorting());
-    if (!sortedStatistics
-        || sortedStatistics->bindText(1, prevalentDomainsBindParameter)
-        || sortedStatistics->bindText(2, "%"_s) != SQLITE_OK) {
+    if (!sortedStatistics) {
+        ITP_RELEASE_LOG_DATABASE_ERROR("aggregatedThirdPartyData: failed to prepare statement");
+        return thirdPartyDataList;
+    }
+    CheckedRef statement = sortedStatistics.value();
+    if (statement->bindText(1, prevalentDomainsBindParameter) != SQLITE_OK
+        || statement->bindText(2, "%"_s) != SQLITE_OK) {
         ITP_RELEASE_LOG_DATABASE_ERROR("aggregatedThirdPartyData: failed to bind parameters");
         return thirdPartyDataList;
     }
-    while (sortedStatistics->step() == SQLITE_ROW) {
-        if (hasBeenThirdParty(sortedStatistics->columnInt(1))) {
-            auto thirdPartyDomainID = sortedStatistics->columnInt(0);
+    while (statement->step() == SQLITE_ROW) {
+        if (hasBeenThirdParty(statement->columnInt(1))) {
+            auto thirdPartyDomainID = statement->columnInt(0);
             auto thirdPartyDomain = RegistrableDomain::uncheckedCreateFromRegistrableDomainString(getDomainStringFromDomainID(thirdPartyDomainID));
             thirdPartyDataList.append(ITPThirdPartyData { thirdPartyDomain, getThirdPartyDataForSpecificFirstPartyDomains(thirdPartyDomainID, thirdPartyDomain) });
         }
@@ -1476,7 +1519,12 @@ void ResourceLoadStatisticsStore::incrementRecordsDeletedCountForDomains(HashSet
     ASSERT(!RunLoop::isMain());
 
     auto domainsToUpdateStatement = m_database.prepareStatementSlow(makeString("UPDATE ObservedDomains SET dataRecordsRemoved = dataRecordsRemoved + 1 WHERE registrableDomain IN ("_s, buildList(domains), ')'));
-    if (!domainsToUpdateStatement || domainsToUpdateStatement->step() != SQLITE_DONE)
+    if (!domainsToUpdateStatement) {
+        ITP_RELEASE_LOG_DATABASE_ERROR("incrementRecordsDeletedCountForDomains: failed to prepare statement");
+        return;
+    }
+    CheckedRef statement = domainsToUpdateStatement.value();
+    if (statement->step() != SQLITE_DONE)
         ITP_RELEASE_LOG_DATABASE_ERROR("incrementRecordsDeletedCountForDomains: failed to step statement");
 }
 
@@ -1495,27 +1543,36 @@ unsigned ResourceLoadStatisticsStore::recursivelyFindNonPrevalentDomainsThatRedi
 
     StdSet<unsigned> newlyIdentifiedDomains;
     auto findSubresources = m_database.prepareStatement("SELECT SubresourceUniqueRedirectsFrom.fromDomainID from SubresourceUniqueRedirectsFrom INNER JOIN ObservedDomains ON ObservedDomains.domainID = SubresourceUniqueRedirectsFrom.fromDomainID WHERE subresourceDomainID = ? AND ObservedDomains.isPrevalent = 0"_s);
-    if (!findSubresources || findSubresources->bindInt(1, primaryDomainID) != SQLITE_OK) {
+    if (!findSubresources) {
+        ITP_RELEASE_LOG_DATABASE_ERROR("recursivelyFindNonPrevalentDomainsThatRedirectedToThisDomain: failed to prepare statement for findSubresources");
+        return 0;
+    }
+    CheckedRef findSubresourcesStatement = findSubresources.value();
+    if (findSubresourcesStatement->bindInt(1, primaryDomainID) != SQLITE_OK) {
         ITP_RELEASE_LOG_DATABASE_ERROR("recursivelyFindNonPrevalentDomainsThatRedirectedToThisDomain: failed to bind parameter for findSubresources");
         return 0;
     }
 
-    while (findSubresources->step() == SQLITE_ROW) {
-        int newDomainID = findSubresources->columnInt(0);
+    while (findSubresourcesStatement->step() == SQLITE_ROW) {
+        int newDomainID = findSubresourcesStatement->columnInt(0);
         auto insertResult = nonPrevalentRedirectionSources.insert(newDomainID);
         if (insertResult.second)
             newlyIdentifiedDomains.insert(newDomainID);
     }
 
     auto findTopFrames = m_database.prepareStatement("SELECT TopFrameUniqueRedirectsFrom.fromDomainID from TopFrameUniqueRedirectsFrom INNER JOIN ObservedDomains ON ObservedDomains.domainID = TopFrameUniqueRedirectsFrom.fromDomainID WHERE targetDomainID = ? AND ObservedDomains.isPrevalent = 0"_s);
-    if (!findTopFrames
-        || findTopFrames->bindInt(1, primaryDomainID) != SQLITE_OK) {
+    if (!findTopFrames) {
+        ITP_RELEASE_LOG_DATABASE_ERROR("recursivelyFindNonPrevalentDomainsThatRedirectedToThisDomain: failed to prepare statement for findTopFrames");
+        return 0;
+    }
+    CheckedRef findTopFramesStatement = findTopFrames.value();
+    if (findTopFramesStatement->bindInt(1, primaryDomainID) != SQLITE_OK) {
         ITP_RELEASE_LOG_DATABASE_ERROR("recursivelyFindNonPrevalentDomainsThatRedirectedToThisDomain: failed to bind parameter for findTopFrames");
         return 0;
     }
 
-    while (findTopFrames->step() == SQLITE_ROW) {
-        int newDomainID = findTopFrames->columnInt(0);
+    while (findTopFramesStatement->step() == SQLITE_ROW) {
+        int newDomainID = findTopFramesStatement->columnInt(0);
         auto insertResult = nonPrevalentRedirectionSources.insert(newDomainID);
         if (insertResult.second)
             newlyIdentifiedDomains.insert(newDomainID);
@@ -1537,19 +1594,24 @@ void ResourceLoadStatisticsStore::markAsPrevalentIfHasRedirectedToPrevalent()
     StdSet<unsigned> prevalentDueToRedirect;
     auto subresourceRedirectStatement = m_database.prepareStatement("SELECT DISTINCT SubresourceUniqueRedirectsTo.subresourceDomainID FROM SubresourceUniqueRedirectsTo JOIN ObservedDomains ON ObservedDomains.domainID = SubresourceUniqueRedirectsTo.toDomainID AND ObservedDomains.isPrevalent = 1"_s);
     if (subresourceRedirectStatement) {
-        while (subresourceRedirectStatement->step() == SQLITE_ROW)
-            prevalentDueToRedirect.insert(subresourceRedirectStatement->columnInt(0));
+        CheckedRef statement = subresourceRedirectStatement.value();
+        while (statement->step() == SQLITE_ROW)
+            prevalentDueToRedirect.insert(statement->columnInt(0));
     }
 
     auto topFrameRedirectStatement = m_database.prepareStatement("SELECT DISTINCT TopFrameUniqueRedirectsTo.sourceDomainID FROM TopFrameUniqueRedirectsTo JOIN ObservedDomains ON ObservedDomains.domainID = TopFrameUniqueRedirectsTo.toDomainID AND ObservedDomains.isPrevalent = 1"_s);
     if (topFrameRedirectStatement) {
-        while (topFrameRedirectStatement->step() == SQLITE_ROW)
-            prevalentDueToRedirect.insert(topFrameRedirectStatement->columnInt(0));
+        CheckedRef statement = topFrameRedirectStatement.value();
+        while (statement->step() == SQLITE_ROW)
+            prevalentDueToRedirect.insert(statement->columnInt(0));
     }
 
     auto markPrevalentStatement = m_database.prepareStatementSlow(makeString("UPDATE ObservedDomains SET isPrevalent = 1 WHERE domainID IN ("_s, buildList(prevalentDueToRedirect), ')'));
-    if (!markPrevalentStatement || markPrevalentStatement->step() != SQLITE_DONE)
-        ITP_RELEASE_LOG_DATABASE_ERROR("markAsPrevalentIfHasRedirectedToPrevalent: failed to step statement");
+    if (markPrevalentStatement) {
+        CheckedRef statement = markPrevalentStatement.value();
+        if (statement->step() != SQLITE_DONE)
+            ITP_RELEASE_LOG_DATABASE_ERROR("markAsPrevalentIfHasRedirectedToPrevalent: failed to step statement");
+    }
 }
 
 HashMap<unsigned, ResourceLoadStatisticsStore::NotVeryPrevalentResources> ResourceLoadStatisticsStore::findNotVeryPrevalentResources()
@@ -1559,13 +1621,14 @@ HashMap<unsigned, ResourceLoadStatisticsStore::NotVeryPrevalentResources> Resour
     HashMap<unsigned, NotVeryPrevalentResources> results;
     auto notVeryPrevalentResourcesStatement = m_database.prepareStatement("SELECT domainID, registrableDomain, isPrevalent FROM ObservedDomains WHERE isVeryPrevalent = 0"_s);
     if (notVeryPrevalentResourcesStatement) {
-        while (notVeryPrevalentResourcesStatement->step() == SQLITE_ROW) {
-            unsigned key = static_cast<unsigned>(notVeryPrevalentResourcesStatement->columnInt(0));
+        CheckedRef statement = notVeryPrevalentResourcesStatement.value();
+        while (statement->step() == SQLITE_ROW) {
+            unsigned key = static_cast<unsigned>(statement->columnInt(0));
             ASSERT(key);
             if (!key)
                 continue;
-            NotVeryPrevalentResources value({ RegistrableDomain::uncheckedCreateFromRegistrableDomainString(notVeryPrevalentResourcesStatement->columnText(1))
-                , notVeryPrevalentResourcesStatement->columnInt(2) ? ResourceLoadPrevalence::High : ResourceLoadPrevalence::Low , 0, 0, 0, 0 });
+            NotVeryPrevalentResources value({ RegistrableDomain::uncheckedCreateFromRegistrableDomainString(statement->columnText(1))
+                , statement->columnInt(2) ? ResourceLoadPrevalence::High : ResourceLoadPrevalence::Low , 0, 0, 0, 0 });
             results.add(key, WTFMove(value));
         }
     }
@@ -1574,53 +1637,57 @@ HashMap<unsigned, ResourceLoadStatisticsStore::NotVeryPrevalentResources> Resour
 
     auto subresourceUnderTopFrameDomainsStatement = m_database.prepareStatementSlow(makeString("SELECT subresourceDomainID, COUNT(topFrameDomainID) FROM SubresourceUnderTopFrameDomains WHERE subresourceDomainID IN ("_s, domainIDsOfInterest, ") GROUP BY subresourceDomainID"_s));
     if (subresourceUnderTopFrameDomainsStatement) {
-        while (subresourceUnderTopFrameDomainsStatement->step() == SQLITE_ROW) {
-            unsigned domainID = static_cast<unsigned>(subresourceUnderTopFrameDomainsStatement->columnInt(0));
+        CheckedRef statement = subresourceUnderTopFrameDomainsStatement.value();
+        while (statement->step() == SQLITE_ROW) {
+            unsigned domainID = static_cast<unsigned>(statement->columnInt(0));
             ASSERT(domainID);
             if (!domainID)
                 continue;
             auto result = results.find(domainID);
             if (result != results.end())
-                result->value.subresourceUnderTopFrameDomainsCount = static_cast<unsigned>(subresourceUnderTopFrameDomainsStatement->columnInt(1));
+                result->value.subresourceUnderTopFrameDomainsCount = static_cast<unsigned>(statement->columnInt(1));
         }
     }
 
     auto subresourceUniqueRedirectsToCountStatement = m_database.prepareStatementSlow(makeString("SELECT subresourceDomainID, COUNT(toDomainID) FROM SubresourceUniqueRedirectsTo WHERE subresourceDomainID IN ("_s, domainIDsOfInterest, ") GROUP BY subresourceDomainID"_s));
     if (subresourceUniqueRedirectsToCountStatement) {
-        while (subresourceUniqueRedirectsToCountStatement->step() == SQLITE_ROW) {
-            unsigned domainID = static_cast<unsigned>(subresourceUniqueRedirectsToCountStatement->columnInt(0));
+        CheckedRef statement = subresourceUniqueRedirectsToCountStatement.value();
+        while (statement->step() == SQLITE_ROW) {
+            unsigned domainID = static_cast<unsigned>(statement->columnInt(0));
             ASSERT(domainID);
             if (!domainID)
                 continue;
             auto result = results.find(domainID);
             if (result != results.end())
-                result->value.subresourceUniqueRedirectsToCount = static_cast<unsigned>(subresourceUniqueRedirectsToCountStatement->columnInt(1));
+                result->value.subresourceUniqueRedirectsToCount = static_cast<unsigned>(statement->columnInt(1));
         }
     }
 
     auto subframeUnderTopFrameDomainsCountStatement = m_database.prepareStatementSlow(makeString("SELECT subframeDomainID, COUNT(topFrameDomainID) FROM SubframeUnderTopFrameDomains WHERE subframeDomainID IN ("_s, domainIDsOfInterest, ") GROUP BY subframeDomainID"_s));
     if (subframeUnderTopFrameDomainsCountStatement) {
-        while (subframeUnderTopFrameDomainsCountStatement->step() == SQLITE_ROW) {
-            unsigned domainID = static_cast<unsigned>(subframeUnderTopFrameDomainsCountStatement->columnInt(0));
+        CheckedRef statement = subframeUnderTopFrameDomainsCountStatement.value();
+        while (statement->step() == SQLITE_ROW) {
+            unsigned domainID = static_cast<unsigned>(statement->columnInt(0));
             ASSERT(domainID);
             if (!domainID)
                 continue;
             auto result = results.find(domainID);
             if (result != results.end())
-                result->value.subframeUnderTopFrameDomainsCount = static_cast<unsigned>(subframeUnderTopFrameDomainsCountStatement->columnInt(1));
+                result->value.subframeUnderTopFrameDomainsCount = static_cast<unsigned>(statement->columnInt(1));
         }
     }
 
     auto topFrameUniqueRedirectsToCountStatement = m_database.prepareStatementSlow(makeString("SELECT sourceDomainID, COUNT(toDomainID) FROM TopFrameUniqueRedirectsTo WHERE sourceDomainID IN ("_s, domainIDsOfInterest, ") GROUP BY sourceDomainID"_s));
     if (topFrameUniqueRedirectsToCountStatement) {
-        while (topFrameUniqueRedirectsToCountStatement->step() == SQLITE_ROW) {
-            unsigned domainID = static_cast<unsigned>(topFrameUniqueRedirectsToCountStatement->columnInt(0));
+        CheckedRef statement = topFrameUniqueRedirectsToCountStatement.value();
+        while (statement->step() == SQLITE_ROW) {
+            unsigned domainID = static_cast<unsigned>(statement->columnInt(0));
             ASSERT(domainID);
             if (!domainID)
                 continue;
             auto result = results.find(domainID);
             if (result != results.end())
-                result->value.topFrameUniqueRedirectsToCount = static_cast<unsigned>(topFrameUniqueRedirectsToCountStatement->columnInt(1));
+                result->value.topFrameUniqueRedirectsToCount = static_cast<unsigned>(statement->columnInt(1));
         }
     }
 
@@ -1750,9 +1817,13 @@ void ResourceLoadStatisticsStore::requestStorageAccess(SubFrameDomain&& subFrame
     auto transactionScope = beginTransactionIfNecessary();
 
     auto incrementStorageAccess = m_database.prepareStatement("UPDATE ObservedDomains SET timesAccessedAsFirstPartyDueToStorageAccessAPI = timesAccessedAsFirstPartyDueToStorageAccessAPI + 1 WHERE domainID = ?"_s);
-    if (!incrementStorageAccess
-        || incrementStorageAccess->bindInt(1, *subFrameStatus.second) != SQLITE_OK
-        || incrementStorageAccess->step() != SQLITE_DONE) {
+    if (!incrementStorageAccess) {
+        ITP_RELEASE_LOG_DATABASE_ERROR("requestStorageAccess: failed to prepare statement");
+        return completionHandler(StorageAccessStatus::CannotRequestAccess);
+    }
+    CheckedRef statement = incrementStorageAccess.value();
+    if (statement->bindInt(1, *subFrameStatus.second) != SQLITE_OK
+        || statement->step() != SQLITE_DONE) {
         ITP_RELEASE_LOG_DATABASE_ERROR("requestStorageAccess: failed to step statement");
         return completionHandler(StorageAccessStatus::CannotRequestAccess);
     }
@@ -1813,9 +1884,13 @@ void ResourceLoadStatisticsStore::revokeStorageAccessPermission(const Registrabl
         return;
 
     auto removeStorageAccess = m_database.prepareStatement("DELETE FROM StorageAccessUnderTopFrameDomains WHERE domainID = ?"_s);
-    if (!removeStorageAccess
-        || removeStorageAccess->bindInt(1, *targetResult.second) != SQLITE_OK
-        || removeStorageAccess->step() != SQLITE_DONE) {
+    if (!removeStorageAccess) {
+        ITP_RELEASE_LOG_DATABASE_ERROR("revokeStorageAccessPermission: failed to prepare statement");
+        return;
+    }
+    CheckedRef statement = removeStorageAccess.value();
+    if (statement->bindInt(1, *targetResult.second) != SQLITE_OK
+        || statement->step() != SQLITE_DONE) {
         ITP_RELEASE_LOG_DATABASE_ERROR("revokeStorageAccessPermission: failed to step statement");
     }
 }
@@ -1927,7 +2002,12 @@ void ResourceLoadStatisticsStore::grandfatherDataForDomains(const HashSet<Regist
     }
 
     auto domainsToUpdateStatement = m_database.prepareStatementSlow(makeString("UPDATE ObservedDomains SET grandfathered = 1 WHERE registrableDomain IN ("_s, buildList(domains), ')'));
-    if (!domainsToUpdateStatement || domainsToUpdateStatement->step() != SQLITE_DONE)
+    if (!domainsToUpdateStatement) {
+        ITP_RELEASE_LOG_DATABASE_ERROR("grandfatherDataForDomains: failed to prepare statement");
+        return;
+    }
+    CheckedRef statement = domainsToUpdateStatement.value();
+    if (statement->step() != SQLITE_DONE)
         ITP_RELEASE_LOG_DATABASE_ERROR("grandfatherDataForDomains: failed to step statement");
 }
 
@@ -2057,9 +2137,11 @@ void ResourceLoadStatisticsStore::clearTopFrameUniqueRedirectsToSinceSameSiteStr
         return completionHandler();
 
     auto removeRedirectsToSinceSameSite = m_database.prepareStatement("DELETE FROM TopFrameUniqueRedirectsToSinceSameSiteStrictEnforcement WHERE sourceDomainID = ?"_s);
-    if (!removeRedirectsToSinceSameSite
-        || removeRedirectsToSinceSameSite->bindInt(1, *targetResult.second) != SQLITE_OK
-        || removeRedirectsToSinceSameSite->step() != SQLITE_DONE)
+    if (!removeRedirectsToSinceSameSite)
+        return completionHandler();
+    CheckedRef statement = removeRedirectsToSinceSameSite.value();
+    if (statement->bindInt(1, *targetResult.second) != SQLITE_OK
+        || statement->step() != SQLITE_DONE)
         ITP_RELEASE_LOG_DATABASE_ERROR("clearTopFrameUniqueRedirectsToSinceSameSiteStrictEnforcement: failed to step statement");
 
     completionHandler();
@@ -2070,12 +2152,17 @@ void ResourceLoadStatisticsStore::setUserInteraction(const RegistrableDomain& do
     ASSERT(!RunLoop::isMain());
 
     auto scopedStatement = this->scopedStatement(m_mostRecentUserInteractionStatement, mostRecentUserInteractionQuery, "setUserInteraction"_s);
-    if (!scopedStatement
-        || scopedStatement->bindInt(1, hadUserInteraction) != SQLITE_OK
-        || scopedStatement->bindDouble(2, mostRecentInteraction.secondsSinceEpoch().value()) != SQLITE_OK
-        || scopedStatement->bindText(3, domain.string()) != SQLITE_OK
-        || scopedStatement->step() != SQLITE_DONE)
+    if (!scopedStatement) {
+        ITP_RELEASE_LOG_DATABASE_ERROR("setUserInteraction: failed to prepare statement");
+        return;
+    }
+    CheckedPtr statement = scopedStatement.get();
+    if (statement->bindInt(1, hadUserInteraction) != SQLITE_OK
+        || statement->bindDouble(2, mostRecentInteraction.secondsSinceEpoch().value()) != SQLITE_OK
+        || statement->bindText(3, domain.string()) != SQLITE_OK
+        || statement->step() != SQLITE_DONE) {
         ITP_RELEASE_LOG_DATABASE_ERROR("setUserInteraction: failed to step statement");
+    }
 }
 
 void ResourceLoadStatisticsStore::logUserInteraction(const TopFrameDomain& domain, CompletionHandler<void()>&& completionHandler)
@@ -2119,18 +2206,22 @@ bool ResourceLoadStatisticsStore::hasHadUserInteraction(const RegistrableDomain&
 
     auto transactionScope = beginTransactionIfNecessary();
     auto scopedStatement = this->scopedStatement(m_hadUserInteractionStatement, hadUserInteractionQuery, "hasHadUserInteraction"_s);
-    if (!scopedStatement
-        || scopedStatement->bindText(1, domain.string()) != SQLITE_OK
-        || scopedStatement->step() != SQLITE_ROW) {
+    if (!scopedStatement) {
+        ITP_RELEASE_LOG_DATABASE_ERROR("hasHadUserInteraction: failed to prepare statement");
+        return false;
+    }
+    CheckedPtr statement = scopedStatement.get();
+    if (statement->bindText(1, domain.string()) != SQLITE_OK
+        || statement->step() != SQLITE_ROW) {
         ITP_RELEASE_LOG_DATABASE_ERROR("hasHadUserInteraction: failed to step statement");
         return false;
     }
 
-    bool hadUserInteraction = !!scopedStatement->columnInt(0);
+    bool hadUserInteraction = !!statement->columnInt(0);
     if (!hadUserInteraction)
         return false;
 
-    WallTime mostRecentUserInteractionTime = WallTime::fromRawSeconds(scopedStatement->columnDouble(1));
+    WallTime mostRecentUserInteractionTime = WallTime::fromRawSeconds(statement->columnDouble(1));
 
     if (hasStatisticsExpired(mostRecentUserInteractionTime, operatingDatesWindow)) {
         // Drop privacy sensitive data because we no longer need it.
@@ -2167,19 +2258,27 @@ void ResourceLoadStatisticsStore::setPrevalentResource(const RegistrableDomain& 
         return;
     }
 
-    auto scopedUpdatePrevalentResourceStatement = this->scopedStatement(m_updatePrevalentResourceStatement, updatePrevalentResourceQuery, "setPrevalentResource"_s);
-    if (!scopedUpdatePrevalentResourceStatement
-        || scopedUpdatePrevalentResourceStatement->bindInt(1, 1) != SQLITE_OK
+    auto scopedUpdatePrevalentResource = this->scopedStatement(m_updatePrevalentResourceStatement, updatePrevalentResourceQuery, "setPrevalentResource"_s);
+    if (!scopedUpdatePrevalentResource) {
+        ITP_RELEASE_LOG_DATABASE_ERROR("setPrevalentResource: failed at to prepare scopedUpdatePrevalentResourceStatement");
+        return;
+    }
+    CheckedPtr scopedUpdatePrevalentResourceStatement = scopedUpdatePrevalentResource.get();
+    if (scopedUpdatePrevalentResourceStatement->bindInt(1, 1) != SQLITE_OK
         || scopedUpdatePrevalentResourceStatement->bindText(2, domain.string()) != SQLITE_OK
         || scopedUpdatePrevalentResourceStatement->step() != SQLITE_DONE) {
         ITP_RELEASE_LOG_DATABASE_ERROR("setPrevalentResource: failed at to step scopedUpdatePrevalentResourceStatement");
         return;
     }
 
-    auto scopedUpdateVeryPrevalentResourceStatement = this->scopedStatement(m_updateVeryPrevalentResourceStatement, updateVeryPrevalentResourceQuery, "setPrevalentResource updateVeryPrevalentResource"_s);
     if (newPrevalence == ResourceLoadPrevalence::VeryHigh) {
-        if (!scopedUpdateVeryPrevalentResourceStatement
-            || scopedUpdateVeryPrevalentResourceStatement->bindInt(1, 1) != SQLITE_OK
+        auto scopedUpdateVeryPrevalentResource = this->scopedStatement(m_updateVeryPrevalentResourceStatement, updateVeryPrevalentResourceQuery, "setPrevalentResource updateVeryPrevalentResource"_s);
+        if (!scopedUpdateVeryPrevalentResource) {
+            ITP_RELEASE_LOG_DATABASE_ERROR("setPrevalentResource: failed at to prepare scopedUpdateVeryPrevalentResourceStatement");
+            return;
+        }
+        CheckedPtr scopedUpdateVeryPrevalentResourceStatement = scopedUpdateVeryPrevalentResource.get();
+        if (scopedUpdateVeryPrevalentResourceStatement->bindInt(1, 1) != SQLITE_OK
             || scopedUpdateVeryPrevalentResourceStatement->bindText(2, domain.string()) != SQLITE_OK
             || scopedUpdateVeryPrevalentResourceStatement->step() != SQLITE_DONE) {
             ITP_RELEASE_LOG_DATABASE_ERROR("setPrevalentResource: failed at to step scopedUpdateVeryPrevalentResourceStatement");
@@ -2197,7 +2296,12 @@ void ResourceLoadStatisticsStore::setDomainsAsPrevalent(StdSet<unsigned>&& domai
     ASSERT(!RunLoop::isMain());
 
     auto domainsToUpdateStatement = m_database.prepareStatementSlow(makeString("UPDATE ObservedDomains SET isPrevalent = 1 WHERE domainID IN ("_s, buildList(domains), ')'));
-    if (!domainsToUpdateStatement || domainsToUpdateStatement->step() != SQLITE_DONE)
+    if (!domainsToUpdateStatement) {
+        ITP_RELEASE_LOG_DATABASE_ERROR("setDomainsAsPrevalent: failed to prepare statement");
+        return;
+    }
+    CheckedRef statement = domainsToUpdateStatement.value();
+    if (statement->step() != SQLITE_DONE)
         ITP_RELEASE_LOG_DATABASE_ERROR("setDomainsAsPrevalent: failed to step statement");
 }
 
@@ -2220,8 +2324,9 @@ void ResourceLoadStatisticsStore::dumpResourceLoadStatistics(CompletionHandler<v
         return completionHandler({ });
 
     Vector<String> domains;
-    while (scopedStatement->step() == SQLITE_ROW)
-        domains.append(scopedStatement->columnText(0));
+    CheckedPtr statement = scopedStatement.get();
+    while (statement->step() == SQLITE_ROW)
+        domains.append(statement->columnText(0));
     std::ranges::sort(domains, WTF::codePointCompareLessThan);
 
     StringBuilder result;
@@ -2242,13 +2347,17 @@ int ResourceLoadStatisticsStore::predicateValueForDomain(SQLiteStatementAutoRese
 {
     ASSERT(!RunLoop::isMain());
 
-    if (!predicateStatement
-        || predicateStatement->bindText(1, domain.string()) != SQLITE_OK
-        || predicateStatement->step() != SQLITE_ROW) {
+    if (!predicateStatement) {
+        ITP_RELEASE_LOG_DATABASE_ERROR("predicateValueForDomain: failed to prepare statement");
+        return false;
+    }
+    CheckedPtr statement = predicateStatement.get();
+    if (statement->bindText(1, domain.string()) != SQLITE_OK
+        || statement->step() != SQLITE_ROW) {
         ITP_RELEASE_LOG_DATABASE_ERROR("predicateValueForDomain: failed to step statement");
         return false;
     }
-    return predicateStatement->columnInt(0);
+    return statement->columnInt(0);
 }
 
 bool ResourceLoadStatisticsStore::isPrevalentResource(const RegistrableDomain& domain) const
@@ -2319,10 +2428,15 @@ void ResourceLoadStatisticsStore::clearPrevalentResource(const RegistrableDomain
         return;
 
     auto scopedStatement = this->scopedStatement(m_clearPrevalentResourceStatement, clearPrevalentResourceQuery, "clearPrevalentResource"_s);
-    if (!scopedStatement
-        || scopedStatement->bindText(1, domain.string()) != SQLITE_OK
-        || scopedStatement->step() != SQLITE_DONE)
+    if (!scopedStatement) {
+        ITP_RELEASE_LOG_DATABASE_ERROR("clearPrevalentResource: failed to prepare statement");
+        return;
+    }
+    CheckedPtr statement = scopedStatement.get();
+    if (statement->bindText(1, domain.string()) != SQLITE_OK
+        || statement->step() != SQLITE_DONE) {
         ITP_RELEASE_LOG_DATABASE_ERROR("clearPrevalentResource: failed to step statement");
+    }
 }
 
 void ResourceLoadStatisticsStore::setGrandfathered(const RegistrableDomain& domain, bool value)
@@ -2335,11 +2449,16 @@ void ResourceLoadStatisticsStore::setGrandfathered(const RegistrableDomain& doma
         return;
 
     auto scopedStatement = this->scopedStatement(m_updateGrandfatheredStatement, updateGrandfatheredQuery, "setGrandfathered"_s);
-    if (!scopedStatement
-        || scopedStatement->bindInt(1, value) != SQLITE_OK
-        || scopedStatement->bindText(2, domain.string()) != SQLITE_OK
-        || scopedStatement->step() != SQLITE_DONE)
+    if (!scopedStatement) {
+        ITP_RELEASE_LOG_DATABASE_ERROR("setGrandfathered: failed to prepare statement");
+        return;
+    }
+    CheckedPtr statement = scopedStatement.get();
+    if (statement->bindInt(1, value) != SQLITE_OK
+        || statement->bindText(2, domain.string()) != SQLITE_OK
+        || statement->step() != SQLITE_DONE) {
         ITP_RELEASE_LOG_DATABASE_ERROR("setGrandfathered: failed to step statement");
+    }
 }
 
 void ResourceLoadStatisticsStore::setIsScheduledForAllScriptWrittenStorageRemoval(const RegistrableDomain& domain, DataRemovalFrequency dataRemovalFrequency)
@@ -2351,10 +2470,14 @@ void ResourceLoadStatisticsStore::setIsScheduledForAllScriptWrittenStorageRemova
         return;
 
     auto scopedStatement = this->scopedStatement(m_updateIsScheduledForAllButCookieDataRemovalStatement, updateIsScheduledForAllButCookieDataRemovalQuery, "setIsScheduledForAllScriptWrittenStorageRemoval"_s);
-    if (!scopedStatement
-        || scopedStatement->bindInt(1, static_cast<int>(dataRemovalFrequency)) != SQLITE_OK
-        || scopedStatement->bindText(2, domain.string()) != SQLITE_OK
-        || scopedStatement->step() != SQLITE_DONE) {
+    if (!scopedStatement) {
+        ITP_RELEASE_LOG_DATABASE_ERROR("setIsScheduledForAllScriptWrittenStorageRemoval: failed to prepare statement");
+        return;
+    }
+    CheckedPtr statement = scopedStatement.get();
+    if (statement->bindInt(1, static_cast<int>(dataRemovalFrequency)) != SQLITE_OK
+        || statement->bindText(2, domain.string()) != SQLITE_OK
+        || statement->step() != SQLITE_DONE) {
         ITP_RELEASE_LOG_DATABASE_ERROR("setIsScheduledForAllScriptWrittenStorageRemoval: failed to step statement");
     }
 }
@@ -2370,10 +2493,14 @@ void ResourceLoadStatisticsStore::setMostRecentWebPushInteractionTime(const Regi
         return;
 
     auto scopedStatement = this->scopedStatement(m_updateMostRecentWebPushInteractionTimeStatement, updateMostRecentWebPushInteractionTimeQuery, "setMostRecentWebPushInteractionTime"_s);
-    if (!scopedStatement
-        || scopedStatement->bindDouble(1, time.secondsSinceEpoch().value()) != SQLITE_OK
-        || scopedStatement->bindText(2, domain.string()) != SQLITE_OK
-        || scopedStatement->step() != SQLITE_DONE) {
+    if (!scopedStatement) {
+        ITP_RELEASE_LOG_DATABASE_ERROR("setMostRecentWebPushInteractionTime: failed to prepare statement");
+        return;
+    }
+    CheckedPtr statement = scopedStatement.get();
+    if (statement->bindDouble(1, time.secondsSinceEpoch().value()) != SQLITE_OK
+        || statement->bindText(2, domain.string()) != SQLITE_OK
+        || statement->step() != SQLITE_DONE) {
         ITP_RELEASE_LOG_DATABASE_ERROR("setMostRecentWebPushInteractionTime: failed to step statement");
     }
 }
@@ -2389,22 +2516,26 @@ Seconds ResourceLoadStatisticsStore::getMostRecentlyUpdatedTimestamp(const Regis
         return Seconds { ResourceLoadStatistics::NoExistingTimestamp };
 
     auto scopedStatement = this->scopedStatement(m_getMostRecentlyUpdatedTimestampStatement, getMostRecentlyUpdatedTimestampQuery, "getMostRecentlyUpdatedTimestamp"_s);
-    if (!scopedStatement
-        || scopedStatement->bindInt(1, *subFrameDomainID) != SQLITE_OK
-        || scopedStatement->bindInt(2, *topFrameDomainID) != SQLITE_OK
-        || scopedStatement->bindInt(3, *subFrameDomainID) != SQLITE_OK
-        || scopedStatement->bindInt(4, *topFrameDomainID) != SQLITE_OK
-        || scopedStatement->bindInt(5, *subFrameDomainID) != SQLITE_OK
-        || scopedStatement->bindInt(6, *topFrameDomainID) != SQLITE_OK
-        || scopedStatement->bindInt(7, *subFrameDomainID) != SQLITE_OK
-        || scopedStatement->bindInt(8, *topFrameDomainID) != SQLITE_OK) {
+    if (!scopedStatement) {
+        ITP_RELEASE_LOG_DATABASE_ERROR("getMostRecentlyUpdatedTimestamp: failed to prepare statement");
+        return Seconds { ResourceLoadStatistics::NoExistingTimestamp  };
+    }
+    CheckedPtr statement = scopedStatement.get();
+    if (statement->bindInt(1, *subFrameDomainID) != SQLITE_OK
+        || statement->bindInt(2, *topFrameDomainID) != SQLITE_OK
+        || statement->bindInt(3, *subFrameDomainID) != SQLITE_OK
+        || statement->bindInt(4, *topFrameDomainID) != SQLITE_OK
+        || statement->bindInt(5, *subFrameDomainID) != SQLITE_OK
+        || statement->bindInt(6, *topFrameDomainID) != SQLITE_OK
+        || statement->bindInt(7, *subFrameDomainID) != SQLITE_OK
+        || statement->bindInt(8, *topFrameDomainID) != SQLITE_OK) {
         ITP_RELEASE_LOG_DATABASE_ERROR("getMostRecentlyUpdatedTimestamp: failed to step statement");
         return Seconds { ResourceLoadStatistics::NoExistingTimestamp  };
     }
-    if (scopedStatement->step() != SQLITE_ROW)
+    if (statement->step() != SQLITE_ROW)
         return Seconds { ResourceLoadStatistics::NoExistingTimestamp  };
 
-    return Seconds { scopedStatement->columnDouble(0) };
+    return Seconds { statement->columnDouble(0) };
 }
 
 bool ResourceLoadStatisticsStore::isGrandfathered(const RegistrableDomain& domain) const
@@ -2505,14 +2636,18 @@ std::pair<ResourceLoadStatisticsStore::AddedRecord, std::optional<unsigned>> Res
 
     {
         auto scopedStatement = this->scopedStatement(m_domainIDFromStringStatement, domainIDFromStringQuery, "ensureResourceStatisticsForRegistrableDomain"_s);
-        if (!scopedStatement
-            || scopedStatement->bindText(1, domain.string()) != SQLITE_OK) {
+        if (!scopedStatement) {
+            ITP_RELEASE_LOG_DATABASE_ERROR("ensureResourceStatisticsForRegistrableDomain: reason %" PUBLIC_LOG_STRING ", failed to prepare statement", reason.characters());
+            return { AddedRecord::No, 0 };
+        }
+        CheckedPtr statement = scopedStatement.get();
+        if (statement->bindText(1, domain.string()) != SQLITE_OK) {
             ITP_RELEASE_LOG_DATABASE_ERROR("ensureResourceStatisticsForRegistrableDomain: reason %" PUBLIC_LOG_STRING ", failed to bind parameter", reason.characters());
             return { AddedRecord::No, 0 };
         }
 
-        if (scopedStatement->step() == SQLITE_ROW) {
-            unsigned domainID = scopedStatement->columnInt(0);
+        if (statement->step() == SQLITE_ROW) {
+            unsigned domainID = statement->columnInt(0);
             return { AddedRecord::No, domainID };
         }
     }
@@ -2543,10 +2678,15 @@ void ResourceLoadStatisticsStore::removeDataForDomain(const RegistrableDomain& d
         return;
 
     auto scopedStatement = this->scopedStatement(m_removeAllDataStatement, removeAllDataQuery, "removeDataForDomain"_s);
-    if (!scopedStatement
-        || scopedStatement->bindInt(1, *domainIDToRemove) != SQLITE_OK
-        || scopedStatement->step() != SQLITE_DONE)
+    if (!scopedStatement) {
+        ITP_RELEASE_LOG_DATABASE_ERROR("removeDataForDomain: failed to prepare statement");
+        return;
+    }
+    CheckedPtr statement = scopedStatement.get();
+    if (statement->bindInt(1, *domainIDToRemove) != SQLITE_OK
+        || statement->step() != SQLITE_DONE) {
         ITP_RELEASE_LOG_DATABASE_ERROR("removeDataForDomain: failed to step statement");
+    }
 }
 
 Vector<RegistrableDomain> ResourceLoadStatisticsStore::allDomains() const
@@ -2556,10 +2696,10 @@ Vector<RegistrableDomain> ResourceLoadStatisticsStore::allDomains() const
     auto scopedStatement = this->scopedStatement(m_getAllDomainsStatement, getAllDomainsQuery, "allDomains"_s);
     if (!scopedStatement)
         return { };
-
+    CheckedPtr statement = scopedStatement.get();
     Vector<RegistrableDomain> domains;
-    while (scopedStatement->step() == SQLITE_ROW)
-        domains.append(RegistrableDomain::uncheckedCreateFromRegistrableDomainString(scopedStatement->columnText(0)));
+    while (statement->step() == SQLITE_ROW)
+        domains.append(RegistrableDomain::uncheckedCreateFromRegistrableDomainString(statement->columnText(0)));
     return domains;
 }
 
@@ -2610,8 +2750,13 @@ CookieAccess ResourceLoadStatisticsStore::cookieAccess(const SubResourceDomain& 
 {
     ASSERT(!RunLoop::isMain());
 
-    auto statement = m_database.prepareStatement("SELECT isPrevalent, hadUserInteraction FROM ObservedDomains WHERE registrableDomain = ?"_s);
-    if (!statement || statement->bindText(1, subresourceDomain.string()) != SQLITE_OK) {
+    auto sqlStatement = m_database.prepareStatement("SELECT isPrevalent, hadUserInteraction FROM ObservedDomains WHERE registrableDomain = ?"_s);
+    if (!sqlStatement) {
+        ITP_RELEASE_LOG_DATABASE_ERROR("cookieAccess: failed to prepare parameter");
+        return CookieAccess::CannotRequest;
+    }
+    CheckedRef statement = sqlStatement.value();
+    if (statement->bindText(1, subresourceDomain.string()) != SQLITE_OK) {
         ITP_RELEASE_LOG_DATABASE_ERROR("cookieAccess: failed to bind parameter");
         return CookieAccess::CannotRequest;
     }
@@ -2639,12 +2784,15 @@ StorageAccessPromptWasShown ResourceLoadStatisticsStore::hasUserGrantedStorageAc
 
     auto firstPartyPrimaryDomainID = *result.second;
 
-    auto statement = m_database.prepareStatement("SELECT COUNT(*) FROM StorageAccessUnderTopFrameDomains WHERE domainID = ? AND topLevelDomainID = ?"_s);
-    if (!statement
-        || statement->bindInt(1, requestingDomainID) != SQLITE_OK
-        || statement->bindInt(2, firstPartyPrimaryDomainID) != SQLITE_OK
-        || statement->step() != SQLITE_ROW)
+    auto sqlStatement = m_database.prepareStatement("SELECT COUNT(*) FROM StorageAccessUnderTopFrameDomains WHERE domainID = ? AND topLevelDomainID = ?"_s);
+    if (!sqlStatement)
         return StorageAccessPromptWasShown::No;
+    CheckedRef statement = sqlStatement.value();
+    if (statement->bindInt(1, requestingDomainID) != SQLITE_OK
+        || statement->bindInt(2, firstPartyPrimaryDomainID) != SQLITE_OK
+        || statement->step() != SQLITE_ROW) {
+        return StorageAccessPromptWasShown::No;
+    }
 
     return !!statement->columnInt(0) ? StorageAccessPromptWasShown::Yes : StorageAccessPromptWasShown::No;
 }
@@ -2654,10 +2802,10 @@ Vector<RegistrableDomain> ResourceLoadStatisticsStore::domainsToBlockAndDeleteCo
     ASSERT(!RunLoop::isMain());
 
     Vector<RegistrableDomain> results;
-    auto statement = m_database.prepareStatement("SELECT registrableDomain FROM ObservedDomains WHERE isPrevalent = 1 AND hadUserInteraction = 0"_s);
-    if (!statement)
+    auto sqlStatement = m_database.prepareStatement("SELECT registrableDomain FROM ObservedDomains WHERE isPrevalent = 1 AND hadUserInteraction = 0"_s);
+    if (!sqlStatement)
         return results;
-
+    CheckedRef statement = sqlStatement.value();
     while (statement->step() == SQLITE_ROW)
         results.append(RegistrableDomain::uncheckedCreateFromRegistrableDomainString(statement->columnText(0)));
 
@@ -2669,10 +2817,10 @@ Vector<RegistrableDomain> ResourceLoadStatisticsStore::domainsToBlockButKeepCook
     ASSERT(!RunLoop::isMain());
 
     Vector<RegistrableDomain> results;
-    auto statement = m_database.prepareStatement("SELECT registrableDomain FROM ObservedDomains WHERE isPrevalent = 1 AND hadUserInteraction = 1"_s);
-    if (!statement)
+    auto sqlStatement = m_database.prepareStatement("SELECT registrableDomain FROM ObservedDomains WHERE isPrevalent = 1 AND hadUserInteraction = 1"_s);
+    if (!sqlStatement)
         return results;
-
+    CheckedRef statement = sqlStatement.value();
     while (statement->step() == SQLITE_ROW)
         results.append(RegistrableDomain::uncheckedCreateFromRegistrableDomainString(statement->columnText(0)));
 
@@ -2684,10 +2832,10 @@ Vector<RegistrableDomain> ResourceLoadStatisticsStore::domainsWithUserInteractio
     ASSERT(!RunLoop::isMain());
 
     Vector<RegistrableDomain> results;
-    auto statement = m_database.prepareStatement("SELECT registrableDomain FROM ObservedDomains WHERE hadUserInteraction = 1"_s);
-    if (!statement)
+    auto sqlStatement = m_database.prepareStatement("SELECT registrableDomain FROM ObservedDomains WHERE hadUserInteraction = 1"_s);
+    if (!sqlStatement)
         return results;
-
+    CheckedRef statement = sqlStatement.value();
     while (statement->step() == SQLITE_ROW)
         results.append(RegistrableDomain::uncheckedCreateFromRegistrableDomainString(statement->columnText(0)));
 
@@ -2699,10 +2847,10 @@ HashMap<TopFrameDomain, Vector<SubResourceDomain>> ResourceLoadStatisticsStore::
     ASSERT(!RunLoop::isMain());
 
     HashMap<WebCore::RegistrableDomain, Vector<WebCore::RegistrableDomain>> results;
-    auto statement = m_database.prepareStatement("SELECT subFrameDomain, registrableDomain FROM (SELECT o.registrableDomain as subFrameDomain, s.topLevelDomainID as topLevelDomainID FROM ObservedDomains as o INNER JOIN StorageAccessUnderTopFrameDomains as s WHERE o.domainID = s.domainID) as z INNER JOIN ObservedDomains ON domainID = z.topLevelDomainID;"_s);
-    if (!statement)
+    auto sqlStatement = m_database.prepareStatement("SELECT subFrameDomain, registrableDomain FROM (SELECT o.registrableDomain as subFrameDomain, s.topLevelDomainID as topLevelDomainID FROM ObservedDomains as o INNER JOIN StorageAccessUnderTopFrameDomains as s WHERE o.domainID = s.domainID) as z INNER JOIN ObservedDomains ON domainID = z.topLevelDomainID;"_s);
+    if (!sqlStatement)
         return results;
-
+    CheckedRef statement = sqlStatement.value();
     while (statement->step() == SQLITE_ROW)
         results.add(RegistrableDomain::uncheckedCreateFromRegistrableDomainString(statement->columnText(1)), Vector<SubResourceDomain> { }).iterator->value.append(RegistrableDomain::uncheckedCreateFromRegistrableDomainString(statement->columnText(0)));
 
@@ -2750,10 +2898,10 @@ Vector<ResourceLoadStatisticsStore::DomainData> ResourceLoadStatisticsStore::dom
     ASSERT(!RunLoop::isMain());
 
     Vector<DomainData> results;
-    auto statement = m_database.prepareStatement("SELECT domainID, registrableDomain, mostRecentUserInteractionTime, mostRecentWebPushInteractionTime, hadUserInteraction, grandfathered, isScheduledForAllButCookieDataRemoval, countOfTopFrameRedirects FROM ObservedDomains LEFT JOIN (SELECT sourceDomainID, COUNT(*) as countOfTopFrameRedirects from TopFrameUniqueRedirectsToSinceSameSiteStrictEnforcement GROUP BY sourceDomainID) as z ON z.sourceDomainID = domainID"_s);
-    if (!statement)
+    auto sqlStatement = m_database.prepareStatement("SELECT domainID, registrableDomain, mostRecentUserInteractionTime, mostRecentWebPushInteractionTime, hadUserInteraction, grandfathered, isScheduledForAllButCookieDataRemoval, countOfTopFrameRedirects FROM ObservedDomains LEFT JOIN (SELECT sourceDomainID, COUNT(*) as countOfTopFrameRedirects from TopFrameUniqueRedirectsToSinceSameSiteStrictEnforcement GROUP BY sourceDomainID) as z ON z.sourceDomainID = domainID"_s);
+    if (!sqlStatement)
         return results;
-
+    CheckedRef statement = sqlStatement.value();
     while (statement->step() == SQLITE_ROW) {
         results.append({ static_cast<unsigned>(statement->columnInt(0))
             , RegistrableDomain::uncheckedCreateFromRegistrableDomainString(statement->columnText(1))
@@ -2781,8 +2929,8 @@ void ResourceLoadStatisticsStore::clearGrandfathering(Vector<unsigned>&& domainI
     auto clearGrandfatheringStatement = m_database.prepareStatementSlow(makeString("UPDATE ObservedDomains SET grandfathered = 0 WHERE domainID IN ("_s, listToClear, ')'));
     if (!clearGrandfatheringStatement)
         return;
-
-    if (clearGrandfatheringStatement->step() != SQLITE_DONE)
+    CheckedRef statement = clearGrandfatheringStatement.value();
+    if (statement->step() != SQLITE_DONE)
         ITP_RELEASE_LOG_DATABASE_ERROR("clearGrandfathering: failed to step statement");
 }
 
@@ -2923,8 +3071,9 @@ void ResourceLoadStatisticsStore::pruneStatisticsIfNeeded()
     if (!scopedStatement)
         return;
 
-    if (scopedStatement->step() == SQLITE_ROW)
-        count = scopedStatement->columnInt(0);
+    CheckedPtr statement = scopedStatement.get();
+    if (statement->step() == SQLITE_ROW)
+        count = statement->columnInt(0);
 
     if (count <= parameters().maxStatisticsEntries)
         return;
@@ -2935,19 +3084,29 @@ void ResourceLoadStatisticsStore::pruneStatisticsIfNeeded()
     ASSERT(countLeftToPrune);
 
     auto recordsToPrune = m_database.prepareStatement("SELECT domainID FROM ObservedDomains ORDER BY hadUserInteraction, isPrevalent, lastSeen LIMIT ?"_s);
-    if (!recordsToPrune || recordsToPrune->bindInt(1, countLeftToPrune) != SQLITE_OK) {
+    if (!recordsToPrune) {
+        ITP_RELEASE_LOG_DATABASE_ERROR("pruneStatisticsIfNeeded: failed to prepare statement");
+        return;
+    }
+    CheckedRef recordsToPruneStatement = recordsToPrune.value();
+    if (recordsToPruneStatement->bindInt(1, countLeftToPrune) != SQLITE_OK) {
         ITP_RELEASE_LOG_DATABASE_ERROR("pruneStatisticsIfNeeded: failed to bind parameter");
         return;
     }
 
     Vector<unsigned> entriesToPrune;
-    while (recordsToPrune->step() == SQLITE_ROW)
-        entriesToPrune.append(recordsToPrune->columnInt(0));
+    while (recordsToPruneStatement->step() == SQLITE_ROW)
+        entriesToPrune.append(recordsToPruneStatement->columnInt(0));
 
     auto listToPrune = buildList(entriesToPrune);
 
     auto pruneCommand = m_database.prepareStatementSlow(makeString("DELETE from ObservedDomains WHERE domainID IN ("_s, listToPrune, ')'));
-    if (!pruneCommand || pruneCommand->step() != SQLITE_DONE)
+    if (!pruneCommand) {
+        ITP_RELEASE_LOG_DATABASE_ERROR("pruneStatisticsIfNeeded: failed to prepare statement");
+        return;
+    }
+    CheckedRef pruneStatement = pruneCommand.value();
+    if (pruneStatement->step() != SQLITE_DONE)
         ITP_RELEASE_LOG_DATABASE_ERROR("pruneStatisticsIfNeeded: failed to step statement");
 }
 
@@ -2956,11 +3115,16 @@ void ResourceLoadStatisticsStore::updateLastSeen(const RegistrableDomain& domain
     ASSERT(!RunLoop::isMain());
 
     auto scopedStatement = this->scopedStatement(m_updateLastSeenStatement, updateLastSeenQuery, "updateLastSeen"_s);
-    if (!scopedStatement
-        || scopedStatement->bindDouble(1, lastSeen.secondsSinceEpoch().value()) != SQLITE_OK
-        || scopedStatement->bindText(2, domain.string()) != SQLITE_OK
-        || scopedStatement->step() != SQLITE_DONE)
+    if (!scopedStatement) {
+        ITP_RELEASE_LOG_DATABASE_ERROR("updateLastSeen: failed to prepare statement");
+        return;
+    }
+    CheckedPtr statement = scopedStatement.get();
+    if (statement->bindDouble(1, lastSeen.secondsSinceEpoch().value()) != SQLITE_OK
+        || statement->bindText(2, domain.string()) != SQLITE_OK
+        || statement->step() != SQLITE_DONE) {
         ITP_RELEASE_LOG_DATABASE_ERROR("updateLastSeen: failed to step statement");
+    }
 }
 
 void ResourceLoadStatisticsStore::setLastSeen(const RegistrableDomain& domain, Seconds seconds)
@@ -3010,10 +3174,14 @@ void ResourceLoadStatisticsStore::updateDataRecordsRemoved(const RegistrableDoma
     ASSERT(!RunLoop::isMain());
 
     auto scopedStatement = this->scopedStatement(m_updateDataRecordsRemovedStatement, updateDataRecordsRemovedQuery, "updateDataRecordsRemoved"_s);
-    if (!scopedStatement
-        || scopedStatement->bindInt(1, value) != SQLITE_OK
-        || scopedStatement->bindText(2, domain.string()) != SQLITE_OK
-        || scopedStatement->step() != SQLITE_DONE)
+    if (!scopedStatement) {
+        ITP_RELEASE_LOG_DATABASE_ERROR("updateDataRecordsRemoved: failed to prepare statement");
+        return;
+    }
+    CheckedPtr statement = scopedStatement.get();
+    if (statement->bindInt(1, value) != SQLITE_OK
+        || statement->bindText(2, domain.string()) != SQLITE_OK
+        || statement->step() != SQLITE_DONE)
         ITP_RELEASE_LOG_DATABASE_ERROR("updateDataRecordsRemoved: failed to step statement");
 }
 
@@ -3027,25 +3195,28 @@ bool ResourceLoadStatisticsStore::isCorrectSubStatisticsCount(const RegistrableD
         ITP_RELEASE_LOG_DATABASE_ERROR("isCorrectSubStatisticsCount: failed to prepare statement");
         return false;
     }
+    CheckedRef subFrameUnderTopFrameCountStatement = subFrameUnderTopFrameCount.value();
+    CheckedRef subresourceUnderTopFrameCountStatement = subresourceUnderTopFrameCount.value();
+    CheckedRef subresourceUniqueRedirectsToStatement = subresourceUniqueRedirectsTo.value();
 
-    if (subFrameUnderTopFrameCount->bindInt(1, domainID(subframeDomain).value()) != SQLITE_OK
-        || subFrameUnderTopFrameCount->bindInt(2, domainID(topFrameDomain).value()) != SQLITE_OK
-        || subresourceUnderTopFrameCount->bindInt(1, domainID(subframeDomain).value()) != SQLITE_OK
-        || subresourceUnderTopFrameCount->bindInt(2, domainID(topFrameDomain).value()) != SQLITE_OK
-        || subresourceUniqueRedirectsTo->bindInt(1, domainID(subframeDomain).value()) != SQLITE_OK
-        || subresourceUniqueRedirectsTo->bindInt(2, domainID(topFrameDomain).value()) != SQLITE_OK) {
+    if (subFrameUnderTopFrameCountStatement->bindInt(1, domainID(subframeDomain).value()) != SQLITE_OK
+        || subFrameUnderTopFrameCountStatement->bindInt(2, domainID(topFrameDomain).value()) != SQLITE_OK
+        || subresourceUnderTopFrameCountStatement->bindInt(1, domainID(subframeDomain).value()) != SQLITE_OK
+        || subresourceUnderTopFrameCountStatement->bindInt(2, domainID(topFrameDomain).value()) != SQLITE_OK
+        || subresourceUniqueRedirectsToStatement->bindInt(1, domainID(subframeDomain).value()) != SQLITE_OK
+        || subresourceUniqueRedirectsToStatement->bindInt(2, domainID(topFrameDomain).value()) != SQLITE_OK) {
         ITP_RELEASE_LOG_DATABASE_ERROR("isCorrectSubStatisticsCount: failed to bind parameters");
         return false;
     }
 
-    if (subFrameUnderTopFrameCount->step() != SQLITE_ROW
-        || subresourceUnderTopFrameCount->step() != SQLITE_ROW
-        || subresourceUniqueRedirectsTo->step() != SQLITE_ROW) {
+    if (subFrameUnderTopFrameCountStatement->step() != SQLITE_ROW
+        || subresourceUnderTopFrameCountStatement->step() != SQLITE_ROW
+        || subresourceUniqueRedirectsToStatement->step() != SQLITE_ROW) {
         ITP_RELEASE_LOG_DATABASE_ERROR("isCorrectSubStatisticsCount: failed to step statement");
         return false;
     }
 
-    return (subFrameUnderTopFrameCount->columnInt(0) == 1 && subresourceUnderTopFrameCount->columnInt(0) == 1 && subresourceUniqueRedirectsTo->columnInt(0) == 1);
+    return (subFrameUnderTopFrameCountStatement->columnInt(0) == 1 && subresourceUnderTopFrameCountStatement->columnInt(0) == 1 && subresourceUniqueRedirectsToStatement->columnInt(0) == 1);
 }
 
 static void appendBoolean(StringBuilder& builder, ASCIILiteral label, bool flag)
@@ -3063,14 +3234,18 @@ String ResourceLoadStatisticsStore::getDomainStringFromDomainID(unsigned domainI
     auto result = emptyString();
 
     auto scopedStatement = this->scopedStatement(m_domainStringFromDomainIDStatement, domainStringFromDomainIDQuery, "getDomainStringFromDomainID"_s);
-    if (!scopedStatement
-        || scopedStatement->bindInt(1, domainID) != SQLITE_OK) {
+    if (!scopedStatement) {
+        ITP_RELEASE_LOG_DATABASE_ERROR("getDomainStringFromDomainID: failed to prepare statement");
+        return result;
+    }
+    CheckedPtr statement = scopedStatement.get();
+    if (statement->bindInt(1, domainID) != SQLITE_OK) {
         ITP_RELEASE_LOG_DATABASE_ERROR("getDomainStringFromDomainID: failed to bind parameter");
         return result;
     }
 
-    if (scopedStatement->step() == SQLITE_ROW)
-        result = m_domainStringFromDomainIDStatement->columnText(0);
+    if (statement->step() == SQLITE_ROW)
+        result = statement->columnText(0);
 
     return result;
 }
@@ -3107,22 +3282,26 @@ void ResourceLoadStatisticsStore::appendSubStatisticList(StringBuilder& builder,
         return;
 
     auto data = m_database.prepareStatement(query);
-
-    if (!data || data->bindInt(1, domainID(RegistrableDomain::uncheckedCreateFromHost(domain)).value()) != SQLITE_OK) {
+    if (!data) {
+        ITP_RELEASE_LOG_DATABASE_ERROR("appendSubStatisticList: failed to prepare statement");
+        return;
+    }
+    CheckedRef statement = data.value();
+    if (statement->bindInt(1, domainID(RegistrableDomain::uncheckedCreateFromHost(domain)).value()) != SQLITE_OK) {
         ITP_RELEASE_LOG_DATABASE_ERROR("appendSubStatisticList: failed to bind parameter");
         return;
     }
 
-    if (data->step() != SQLITE_ROW)
+    if (statement->step() != SQLITE_ROW)
         return;
 
     builder.append("    "_s, tableName, ":\n"_s);
 
-    auto result = getDomainStringFromDomainID(data->columnInt(0));
+    auto result = getDomainStringFromDomainID(statement->columnInt(0));
     appendNextEntry(builder, result);
 
-    while (data->step() == SQLITE_ROW) {
-        result = getDomainStringFromDomainID(data->columnInt(0));
+    while (statement->step() == SQLITE_ROW) {
+        result = getDomainStringFromDomainID(statement->columnInt(0));
         appendNextEntry(builder, result);
     }
 }
@@ -3135,9 +3314,13 @@ static bool hasHadRecentUserInteraction(WTF::Seconds interactionTimeSeconds, Wal
 void ResourceLoadStatisticsStore::resourceToString(StringBuilder& builder, const String& domain) const
 {
     auto scopedStatement = this->scopedStatement(m_getResourceDataByDomainNameStatement, getResourceDataByDomainNameQuery, "resourceToString"_s);
-    if (!scopedStatement
-        || scopedStatement->bindText(1, domain) != SQLITE_OK
-        || scopedStatement->step() != SQLITE_ROW) {
+    if (!scopedStatement) {
+        ITP_RELEASE_LOG_DATABASE_ERROR("resourceToString: failed to prepare statement");
+        return;
+    }
+    CheckedPtr statement = scopedStatement.get();
+    if (statement->bindText(1, domain) != SQLITE_OK
+        || statement->step() != SQLITE_ROW) {
         ITP_RELEASE_LOG_DATABASE_ERROR("resourceToString: failed to step statement");
         return;
     }
@@ -3145,15 +3328,15 @@ void ResourceLoadStatisticsStore::resourceToString(StringBuilder& builder, const
     builder.append("Registrable domain: "_s, domain, '\n');
 
     // User interaction
-    appendBoolean(builder, "hadUserInteraction"_s, m_getResourceDataByDomainNameStatement->columnInt(HadUserInteractionIndex));
+    appendBoolean(builder, "hadUserInteraction"_s, statement->columnInt(HadUserInteractionIndex));
     builder.append('\n');
     builder.append("    mostRecentUserInteraction: "_s);
-    if (hasHadRecentUserInteraction(Seconds(m_getResourceDataByDomainNameStatement->columnDouble(MostRecentUserInteractionTimeIndex)), nowTime(m_timeAdvanceForTesting)))
+    if (hasHadRecentUserInteraction(Seconds(statement->columnDouble(MostRecentUserInteractionTimeIndex)), nowTime(m_timeAdvanceForTesting)))
         builder.append("within 24 hours"_s);
     else
         builder.append("-1"_s);
     builder.append('\n');
-    appendBoolean(builder, "grandfathered"_s, m_getResourceDataByDomainNameStatement->columnInt(GrandfatheredIndex));
+    appendBoolean(builder, "grandfathered"_s, statement->columnInt(GrandfatheredIndex));
     builder.append('\n');
 
     // Storage access
@@ -3166,7 +3349,7 @@ void ResourceLoadStatisticsStore::resourceToString(StringBuilder& builder, const
     appendSubStatisticList(builder, "TopFrameLinkDecorationsFrom"_s, domain);
     appendSubStatisticList(builder, "TopFrameLoadedThirdPartyScripts"_s, domain);
 
-    auto dataRemovalFrequencyValue = m_getResourceDataByDomainNameStatement->columnInt(IsScheduledForAllButCookieDataRemovalIndex);
+    auto dataRemovalFrequencyValue = statement->columnInt(IsScheduledForAllButCookieDataRemovalIndex);
     builder.append("    DataRemovalFrequency: "_s, dataRemovalFrequencyToString(toDataRemovalFrequency(dataRemovalFrequencyValue)), '\n');
 
     // Subframe stats
@@ -3178,81 +3361,105 @@ void ResourceLoadStatisticsStore::resourceToString(StringBuilder& builder, const
     appendSubStatisticList(builder, "SubresourceUniqueRedirectsFrom"_s, domain);
 
     // Prevalent Resource
-    appendBoolean(builder, "isPrevalentResource"_s, m_getResourceDataByDomainNameStatement->columnInt(IsPrevalentIndex));
+    appendBoolean(builder, "isPrevalentResource"_s, statement->columnInt(IsPrevalentIndex));
     builder.append('\n');
-    appendBoolean(builder, "isVeryPrevalentResource"_s, m_getResourceDataByDomainNameStatement->columnInt(IsVeryPrevalentIndex));
+    appendBoolean(builder, "isVeryPrevalentResource"_s, statement->columnInt(IsVeryPrevalentIndex));
     builder.append('\n');
-    builder.append("    dataRecordsRemoved: "_s, m_getResourceDataByDomainNameStatement->columnInt(DataRecordsRemovedIndex));
+    builder.append("    dataRecordsRemoved: "_s, statement->columnInt(DataRecordsRemovedIndex));
     builder.append('\n');
 }
 
 bool ResourceLoadStatisticsStore::domainIDExistsInDatabase(int domainID)
 {
-    auto scopedLinkDecorationExistsStatement = this->scopedStatement(m_linkDecorationExistsStatement, linkDecorationExistsQuery, "domainIDExistsInDatabase"_s);
-    auto scopedScriptLoadExistsStatement = this->scopedStatement(m_scriptLoadExistsStatement, scriptLoadExistsQuery, "domainIDExistsInDatabase linkDecorationExistsStatement"_s);
-    auto scopedSubFrameExistsStatement = this->scopedStatement(m_subFrameExistsStatement, subFrameExistsQuery, "domainIDExistsInDatabase subFrameExistsStatement"_s);
-    auto scopedSubResourceExistsStatement = this->scopedStatement(m_subResourceExistsStatement, subResourceExistsQuery, "domainIDExistsInDatabase subResourceExistsStatement"_s);
-    auto scopedUniqueRedirectExistsStatement = this->scopedStatement(m_uniqueRedirectExistsStatement, uniqueRedirectExistsQuery, "domainIDExistsInDatabase uniqueRedirectExistsStatement"_s);
-    auto scopedObservedDomainsExistsStatement = this->scopedStatement(m_observedDomainsExistsStatement, observedDomainsExistsQuery, "domainIDExistsInDatabase observedDomainsExistsStatement"_s);
+    auto scopedLinkDecorationExists = this->scopedStatement(m_linkDecorationExistsStatement, linkDecorationExistsQuery, "domainIDExistsInDatabase"_s);
+    auto scopedScriptLoadExists = this->scopedStatement(m_scriptLoadExistsStatement, scriptLoadExistsQuery, "domainIDExistsInDatabase linkDecorationExistsStatement"_s);
+    auto scopedSubFrameExists = this->scopedStatement(m_subFrameExistsStatement, subFrameExistsQuery, "domainIDExistsInDatabase subFrameExistsStatement"_s);
+    auto scopedSubResourceExists = this->scopedStatement(m_subResourceExistsStatement, subResourceExistsQuery, "domainIDExistsInDatabase subResourceExistsStatement"_s);
+    auto scopedUniqueRedirectExists = this->scopedStatement(m_uniqueRedirectExistsStatement, uniqueRedirectExistsQuery, "domainIDExistsInDatabase uniqueRedirectExistsStatement"_s);
+    auto scopedObservedDomainsExists = this->scopedStatement(m_observedDomainsExistsStatement, observedDomainsExistsQuery, "domainIDExistsInDatabase observedDomainsExistsStatement"_s);
 
-    if (!scopedLinkDecorationExistsStatement
-        || !scopedScriptLoadExistsStatement
-        || !scopedSubFrameExistsStatement
-        || !scopedSubResourceExistsStatement
-        || !scopedUniqueRedirectExistsStatement
-        || !scopedObservedDomainsExistsStatement
-        || m_linkDecorationExistsStatement->bindInt(1, domainID) != SQLITE_OK
-        || m_linkDecorationExistsStatement->bindInt(2, domainID) != SQLITE_OK
-        || m_scriptLoadExistsStatement->bindInt(1, domainID) != SQLITE_OK
-        || m_scriptLoadExistsStatement->bindInt(2, domainID) != SQLITE_OK
-        || m_subFrameExistsStatement->bindInt(1, domainID) != SQLITE_OK
-        || m_subFrameExistsStatement->bindInt(2, domainID) != SQLITE_OK
-        || m_subResourceExistsStatement->bindInt(1, domainID) != SQLITE_OK
-        || m_subResourceExistsStatement->bindInt(2, domainID) != SQLITE_OK
-        || m_uniqueRedirectExistsStatement->bindInt(1, domainID) != SQLITE_OK
-        || m_uniqueRedirectExistsStatement->bindInt(2, domainID) != SQLITE_OK
-        || m_observedDomainsExistsStatement->bindInt(1, domainID) != SQLITE_OK) {
+    if (!scopedLinkDecorationExists
+        || !scopedScriptLoadExists
+        || !scopedSubFrameExists
+        || !scopedSubResourceExists
+        || !scopedUniqueRedirectExists
+        || !scopedObservedDomainsExists) {
+        ITP_RELEASE_LOG_DATABASE_ERROR("domainIDExistsInDatabase: failed to prepare statements");
+        return false;
+    }
+    CheckedPtr scopedLinkDecorationExistsStatement = scopedLinkDecorationExists.get();
+    CheckedPtr scopedScriptLoadExistsStatement = scopedScriptLoadExists.get();
+    CheckedPtr scopedSubFrameExistsStatement = scopedSubFrameExists.get();
+    CheckedPtr scopedSubResourceExistsStatement = scopedSubResourceExists.get();
+    CheckedPtr scopedUniqueRedirectExistsStatement = scopedUniqueRedirectExists.get();
+    CheckedPtr scopedObservedDomainsExistsStatement = scopedObservedDomainsExists.get();
+    if (scopedLinkDecorationExistsStatement->bindInt(1, domainID) != SQLITE_OK
+        || scopedLinkDecorationExistsStatement->bindInt(2, domainID) != SQLITE_OK
+        || scopedScriptLoadExistsStatement->bindInt(1, domainID) != SQLITE_OK
+        || scopedScriptLoadExistsStatement->bindInt(2, domainID) != SQLITE_OK
+        || scopedSubFrameExistsStatement->bindInt(1, domainID) != SQLITE_OK
+        || scopedSubFrameExistsStatement->bindInt(2, domainID) != SQLITE_OK
+        || scopedSubResourceExistsStatement->bindInt(1, domainID) != SQLITE_OK
+        || scopedSubResourceExistsStatement->bindInt(2, domainID) != SQLITE_OK
+        || scopedUniqueRedirectExistsStatement->bindInt(1, domainID) != SQLITE_OK
+        || scopedUniqueRedirectExistsStatement->bindInt(2, domainID) != SQLITE_OK
+        || scopedObservedDomainsExistsStatement->bindInt(1, domainID) != SQLITE_OK) {
         ITP_RELEASE_LOG_DATABASE_ERROR("domainIDExistsInDatabase: failed to bind parameters");
         return false;
     }
 
-    if (m_linkDecorationExistsStatement->step() != SQLITE_ROW
-        || m_scriptLoadExistsStatement->step() != SQLITE_ROW
-        || m_subFrameExistsStatement->step() != SQLITE_ROW
-        || m_subResourceExistsStatement->step() != SQLITE_ROW
-        || m_uniqueRedirectExistsStatement->step() != SQLITE_ROW
-        || m_observedDomainsExistsStatement->step() != SQLITE_ROW) {
+    if (scopedLinkDecorationExistsStatement->step() != SQLITE_ROW
+        || scopedScriptLoadExistsStatement->step() != SQLITE_ROW
+        || scopedSubFrameExistsStatement->step() != SQLITE_ROW
+        || scopedSubResourceExistsStatement->step() != SQLITE_ROW
+        || scopedUniqueRedirectExistsStatement->step() != SQLITE_ROW
+        || scopedObservedDomainsExistsStatement->step() != SQLITE_ROW) {
         ITP_RELEASE_LOG_DATABASE_ERROR("domainIDExistsInDatabase: failed to step statement");
         return false;
     }
 
-    return m_linkDecorationExistsStatement->columnInt(0) || m_scriptLoadExistsStatement->columnInt(0) || m_subFrameExistsStatement->columnInt(0) || m_subResourceExistsStatement->columnInt(0) || m_uniqueRedirectExistsStatement->columnInt(0) || m_observedDomainsExistsStatement->columnInt(0);
+    return scopedLinkDecorationExistsStatement->columnInt(0)
+        || scopedScriptLoadExistsStatement->columnInt(0)
+        || scopedSubFrameExistsStatement->columnInt(0)
+        || scopedSubResourceExistsStatement->columnInt(0)
+        || scopedUniqueRedirectExistsStatement->columnInt(0)
+        || scopedObservedDomainsExistsStatement->columnInt(0);
 }
 
 void ResourceLoadStatisticsStore::updateOperatingDatesParameters()
 {
-    auto countOperatingDatesStatement = m_database.prepareStatement("SELECT COUNT(*) FROM OperatingDates;"_s);
-    auto getMostRecentOperatingDateStatement = m_database.prepareStatement("SELECT * FROM OperatingDates ORDER BY year DESC, month DESC, monthDay DESC LIMIT 1;"_s);
-    auto getOperatingDateWindowStatement = m_database.prepareStatement("SELECT * FROM OperatingDates ORDER BY year DESC, month DESC, monthDay DESC LIMIT 1 OFFSET ?;"_s);
-
-    if (!countOperatingDatesStatement || countOperatingDatesStatement->step() != SQLITE_ROW) {
+    auto countOperatingDates = m_database.prepareStatement("SELECT COUNT(*) FROM OperatingDates;"_s);
+    if (!countOperatingDates) {
+        ITP_RELEASE_LOG_DATABASE_ERROR("updateOperatingDatesParameters: failed to prepare countOperatingDatesStatement");
+        return;
+    }
+    CheckedRef countOperatingDatesStatement = countOperatingDates.value();
+    if (countOperatingDatesStatement->step() != SQLITE_ROW) {
         ITP_RELEASE_LOG_DATABASE_ERROR("updateOperatingDatesParameters: failed to step countOperatingDatesStatement");
         return;
     }
 
     m_operatingDatesSize = countOperatingDatesStatement->columnInt(0);
 
-    if (!getMostRecentOperatingDateStatement || getMostRecentOperatingDateStatement->step() != SQLITE_ROW) {
+    auto getMostRecentOperatingDate = m_database.prepareStatement("SELECT * FROM OperatingDates ORDER BY year DESC, month DESC, monthDay DESC LIMIT 1;"_s);
+    if (!getMostRecentOperatingDate) {
+        ITP_RELEASE_LOG_DATABASE_ERROR("updateOperatingDatesParameters: failed to prepare getMostRecentOperatingDateStatement");
+        return;
+    }
+    CheckedRef getMostRecentOperatingDateStatement = getMostRecentOperatingDate.value();
+    if (getMostRecentOperatingDateStatement->step() != SQLITE_ROW) {
         ITP_RELEASE_LOG_DATABASE_ERROR("updateOperatingDatesParameters: failed to step getMostRecentOperatingDateStatement");
         return;
     }
     m_mostRecentOperatingDate = OperatingDate(getMostRecentOperatingDateStatement->columnInt(0), getMostRecentOperatingDateStatement->columnInt(1), getMostRecentOperatingDateStatement->columnInt(2));
 
-    if (!getOperatingDateWindowStatement) {
+    auto getOperatingDateWindow = m_database.prepareStatement("SELECT * FROM OperatingDates ORDER BY year DESC, month DESC, monthDay DESC LIMIT 1 OFFSET ?;"_s);
+    if (!getOperatingDateWindow) {
         ITP_RELEASE_LOG_DATABASE_ERROR("updateOperatingDatesParameters: failed to prepare getOperatingDateWindowStatement");
         return;
     }
 
+    CheckedRef getOperatingDateWindowStatement = getOperatingDateWindow.value();
     auto updateWindowOperatingDate = [&] (auto& memberOperatingDate, auto window) {
         if (m_operatingDatesSize <= window - 1)
             memberOperatingDate = std::nullopt;
@@ -3287,18 +3494,26 @@ void ResourceLoadStatisticsStore::includeTodayAsOperatingDateIfNecessary()
 
     int rowsToPrune = m_operatingDatesSize - operatingDatesWindowLong + 1;
     if (rowsToPrune > 0) {
-        auto deleteLeastRecentOperatingDateStatement = m_database.prepareStatement("DELETE FROM OperatingDates ORDER BY year, month, monthDay LIMIT ?;"_s);
-        if (!deleteLeastRecentOperatingDateStatement
-            || deleteLeastRecentOperatingDateStatement->bindInt(1, rowsToPrune) != SQLITE_OK
+        auto deleteLeastRecentOperatingDate = m_database.prepareStatement("DELETE FROM OperatingDates ORDER BY year, month, monthDay LIMIT ?;"_s);
+        if (!deleteLeastRecentOperatingDate) {
+            ITP_RELEASE_LOG_DATABASE_ERROR("includeTodayAsOperatingDateIfNecessary: failed to prepare deleteLeastRecentOperatingDateStatement");
+            return;
+        }
+        CheckedRef deleteLeastRecentOperatingDateStatement = deleteLeastRecentOperatingDate.value();
+        if (deleteLeastRecentOperatingDateStatement->bindInt(1, rowsToPrune) != SQLITE_OK
             || deleteLeastRecentOperatingDateStatement->step() != SQLITE_DONE) {
             ITP_RELEASE_LOG_DATABASE_ERROR("includeTodayAsOperatingDateIfNecessary: failed to step deleteLeastRecentOperatingDateStatement");
             return;
         }
     }
 
-    auto insertOperatingDateStatement = m_database.prepareStatement("INSERT OR IGNORE INTO OperatingDates (year, month, monthDay) SELECT ?, ?, ?;"_s);
-    if (!insertOperatingDateStatement
-        || insertOperatingDateStatement->bindInt(1, today.year()) != SQLITE_OK
+    auto insertOperatingDate = m_database.prepareStatement("INSERT OR IGNORE INTO OperatingDates (year, month, monthDay) SELECT ?, ?, ?;"_s);
+    if (!insertOperatingDate) {
+        ITP_RELEASE_LOG_DATABASE_ERROR("includeTodayAsOperatingDateIfNecessary: failed to prepare insertOperatingDateStatement");
+        return;
+    }
+    CheckedRef insertOperatingDateStatement = insertOperatingDate.value();
+    if (insertOperatingDateStatement->bindInt(1, today.year()) != SQLITE_OK
         || insertOperatingDateStatement->bindInt(2, today.month()) != SQLITE_OK
         || insertOperatingDateStatement->bindInt(3, today.monthDay()) != SQLITE_OK
         || insertOperatingDateStatement->step() != SQLITE_DONE) {
@@ -3349,22 +3564,31 @@ void ResourceLoadStatisticsStore::insertExpiredStatisticForTesting(const Registr
         auto dateToInsert = OperatingDate::fromWallTime(WallTime::fromRawSeconds(daysAgoInSeconds));
 
         auto insertOperatingDateStatement = m_database.prepareStatement("INSERT OR IGNORE INTO OperatingDates (year, month, monthDay) SELECT ?, ?, ?;"_s);
-        if (!insertOperatingDateStatement
-            || insertOperatingDateStatement->bindInt(1, dateToInsert.year()) != SQLITE_OK
-            || insertOperatingDateStatement->bindInt(2, dateToInsert.month()) != SQLITE_OK
-            || insertOperatingDateStatement->bindInt(3, dateToInsert.monthDay()) != SQLITE_OK
-            || insertOperatingDateStatement->step() != SQLITE_DONE) {
+        if (!insertOperatingDateStatement) {
+            ITP_RELEASE_LOG_DATABASE_ERROR("insertExpiredStatisticForTesting: failed to prepare insertOperatingDateStatement");
+            return;
+        }
+        CheckedRef statement = insertOperatingDateStatement.value();
+        if (statement->bindInt(1, dateToInsert.year()) != SQLITE_OK
+            || statement->bindInt(2, dateToInsert.month()) != SQLITE_OK
+            || statement->bindInt(3, dateToInsert.monthDay()) != SQLITE_OK
+            || statement->step() != SQLITE_DONE) {
             ITP_RELEASE_LOG_DATABASE_ERROR("insertExpiredStatisticForTesting: failed to step insertOperatingDateStatement");
             return;
         }
-        insertOperatingDateStatement->reset();
+        statement->reset();
     }
 
     updateOperatingDatesParameters();
 
     // Make sure mostRecentUserInteractionTime is the least recent of all entries.
     daysAgoInSeconds -= Seconds::fromHours(24).value();
-    auto scopedInsertObservedDomainStatement = this->scopedStatement(m_insertObservedDomainStatement, insertObservedDomainQuery, "insertExpiredStatisticForTesting"_s);
+    auto scopedInsertObservedDomain = this->scopedStatement(m_insertObservedDomainStatement, insertObservedDomainQuery, "insertExpiredStatisticForTesting"_s);
+    if (!scopedInsertObservedDomain) {
+        ITP_RELEASE_LOG_DATABASE_ERROR("insertExpiredStatisticForTesting: failed to prepare scopedInsertObservedDomainStatement");
+        return;
+    }
+    CheckedPtr scopedInsertObservedDomainStatement = scopedInsertObservedDomain.get();
     if (scopedInsertObservedDomainStatement->bindText(RegistrableDomainIndex, domain.string()) != SQLITE_OK
         || scopedInsertObservedDomainStatement->bindDouble(LastSeenIndex, daysAgoInSeconds) != SQLITE_OK
         || scopedInsertObservedDomainStatement->bindInt(HadUserInteractionIndex, hasUserInteraction) != SQLITE_OK

--- a/Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -1,4 +1,3 @@
-NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp
 NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDatabase.cpp
 Platform/IPC/ArgumentCoders.h
 Platform/cocoa/_WKWebViewTextInputNotifications.mm


### PR DESCRIPTION
#### b15e7898af01dae911786233a78d94067886c4f3
<pre>
Address Safer cpp warnings in ResourceLoadStatisticsStore.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=300007">https://bugs.webkit.org/show_bug.cgi?id=300007</a>

Reviewed by NOBODY (OOPS!).

* Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp:
(WebKit::ResourceLoadStatisticsStore::loadWebsitesWithUserInteraction):
(WebKit::ResourceLoadStatisticsStore::checkForMissingTablesInSchema):
(WebKit::ResourceLoadStatisticsStore::tableExists):
(WebKit::ResourceLoadStatisticsStore::deleteTable):
(WebKit::ResourceLoadStatisticsStore::missingUniqueIndices):
(WebKit::ResourceLoadStatisticsStore::migrateDataToPCMDatabaseIfNecessary):
(WebKit::ResourceLoadStatisticsStore::isEmpty const):
(WebKit::ResourceLoadStatisticsStore::insertObservedDomain):
(WebKit::ResourceLoadStatisticsStore::relationshipExists const):
(WebKit::ResourceLoadStatisticsStore::domainID const):
(WebKit::ResourceLoadStatisticsStore::insertDomainRelationshipList):
(WebKit::ResourceLoadStatisticsStore::mergeStatistic):
(WebKit::ResourceLoadStatisticsStore::getThirdPartyDataForSpecificFirstPartyDomains const):
(WebKit::ResourceLoadStatisticsStore::aggregatedThirdPartyData const):
(WebKit::ResourceLoadStatisticsStore::incrementRecordsDeletedCountForDomains):
(WebKit::ResourceLoadStatisticsStore::recursivelyFindNonPrevalentDomainsThatRedirectedToThisDomain):
(WebKit::ResourceLoadStatisticsStore::markAsPrevalentIfHasRedirectedToPrevalent):
(WebKit::ResourceLoadStatisticsStore::findNotVeryPrevalentResources):
(WebKit::ResourceLoadStatisticsStore::requestStorageAccess):
(WebKit::ResourceLoadStatisticsStore::revokeStorageAccessPermission):
(WebKit::ResourceLoadStatisticsStore::grandfatherDataForDomains):
(WebKit::ResourceLoadStatisticsStore::clearTopFrameUniqueRedirectsToSinceSameSiteStrictEnforcement):
(WebKit::ResourceLoadStatisticsStore::setUserInteraction):
(WebKit::ResourceLoadStatisticsStore::hasHadUserInteraction):
(WebKit::ResourceLoadStatisticsStore::setPrevalentResource):
(WebKit::ResourceLoadStatisticsStore::setDomainsAsPrevalent):
(WebKit::ResourceLoadStatisticsStore::dumpResourceLoadStatistics):
(WebKit::ResourceLoadStatisticsStore::predicateValueForDomain const):
(WebKit::ResourceLoadStatisticsStore::clearPrevalentResource):
(WebKit::ResourceLoadStatisticsStore::setGrandfathered):
(WebKit::ResourceLoadStatisticsStore::setIsScheduledForAllScriptWrittenStorageRemoval):
(WebKit::ResourceLoadStatisticsStore::setMostRecentWebPushInteractionTime):
(WebKit::ResourceLoadStatisticsStore::getMostRecentlyUpdatedTimestamp const):
(WebKit::ResourceLoadStatisticsStore::ensureResourceStatisticsForRegistrableDomain):
(WebKit::ResourceLoadStatisticsStore::removeDataForDomain):
(WebKit::ResourceLoadStatisticsStore::allDomains const):
(WebKit::ResourceLoadStatisticsStore::cookieAccess):
(WebKit::ResourceLoadStatisticsStore::hasUserGrantedStorageAccessThroughPrompt):
(WebKit::ResourceLoadStatisticsStore::domainsToBlockAndDeleteCookiesFor const):
(WebKit::ResourceLoadStatisticsStore::domainsToBlockButKeepCookiesFor const):
(WebKit::ResourceLoadStatisticsStore::domainsWithUserInteractionAsFirstParty const):
(WebKit::ResourceLoadStatisticsStore::domainsWithStorageAccess const):
(WebKit::ResourceLoadStatisticsStore::domains const):
(WebKit::ResourceLoadStatisticsStore::clearGrandfathering):
(WebKit::ResourceLoadStatisticsStore::pruneStatisticsIfNeeded):
(WebKit::ResourceLoadStatisticsStore::updateLastSeen):
(WebKit::ResourceLoadStatisticsStore::updateDataRecordsRemoved):
(WebKit::ResourceLoadStatisticsStore::isCorrectSubStatisticsCount):
(WebKit::ResourceLoadStatisticsStore::getDomainStringFromDomainID const):
(WebKit::ResourceLoadStatisticsStore::appendSubStatisticList const):
(WebKit::ResourceLoadStatisticsStore::resourceToString const):
(WebKit::ResourceLoadStatisticsStore::domainIDExistsInDatabase):
(WebKit::ResourceLoadStatisticsStore::updateOperatingDatesParameters):
(WebKit::ResourceLoadStatisticsStore::includeTodayAsOperatingDateIfNecessary):
(WebKit::ResourceLoadStatisticsStore::insertExpiredStatisticForTesting):
* Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b15e7898af01dae911786233a78d94067886c4f3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124173 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43866 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34583 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131000 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76265 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2de3fba1-0020-4721-8c9d-1069d3bba736) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44607 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52466 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94457 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62661 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3d2b46d3-5ed6-4723-8988-e393f5729c02) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127127 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35544 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111071 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75048 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d870bb7c-42a8-461f-bce6-e17b4ad6adf8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34488 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74486 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105285 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29454 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133674 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51096 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38940 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102927 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51482 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107289 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102735 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48089 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26339 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/47985 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50957 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56732 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50404 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53756 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52080 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->