### PR TITLE
Address safer cpp warnings in PrivateClickMeasurementDatabase.cpp

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -1,5 +1,4 @@
 NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp
-NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDatabase.cpp
 Platform/IPC/ArgumentCoders.h
 Platform/cocoa/_WKWebViewTextInputNotifications.mm
 Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm


### PR DESCRIPTION
#### ccac5c735ff6fd61cd21515b089bb0aa914ca6da
<pre>
Address safer cpp warnings in PrivateClickMeasurementDatabase.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=300008">https://bugs.webkit.org/show_bug.cgi?id=300008</a>

Reviewed by Darin Adler.

* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDatabase.cpp:
(WebKit::PCM::Database::insertPrivateClickMeasurement):
(WebKit::PCM::Database::markAllUnattributedPrivateClickMeasurementAsExpiredForTesting):
(WebKit::PCM::Database::findPrivateClickMeasurement):
(WebKit::PCM::Database::removeUnattributed):
(WebKit::PCM::Database::allAttributedPrivateClickMeasurement):
(WebKit::PCM::Database::privateClickMeasurementToStringForTesting const):
(WebKit::PCM::Database::markAttributedPrivateClickMeasurementsAsExpiredForTesting):
(WebKit::PCM::Database::clearPrivateClickMeasurement):
(WebKit::PCM::Database::clearExpiredPrivateClickMeasurement):
(WebKit::PCM::Database::clearSentAttribution):
(WebKit::PCM::Database::markReportAsSentToDestination):
(WebKit::PCM::Database::markReportAsSentToSource):
(WebKit::PCM::Database::earliestTimesToSend):
(WebKit::PCM::Database::domainID):
(WebKit::PCM::Database::getDomainStringFromDomainID const):
(WebKit::PCM::Database::ensureDomainID):
* Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:

Canonical link: <a href="https://commits.webkit.org/300874@main">https://commits.webkit.org/300874@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7736d59b1548a2d61d535660b38c24dc4583d4e7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124174 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43867 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34584 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131001 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76266 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b7345197-d35b-46ac-82a8-30d3ab61f1dd) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44608 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52467 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94456 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/62660 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2cfdd6a7-95cc-41a2-87e2-f2558fc62ac1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127128 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35546 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111072 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75047 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/58fa7701-5da3-4b59-9069-1b90a1f6f704) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34490 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74487 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105287 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29455 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133675 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51097 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38941 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102926 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51483 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107290 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102734 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26136 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48092 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26340 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/47986 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50958 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56733 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50405 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53757 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52081 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->