### PR TITLE
Port WebExtensionContext Background and Inspector functions to C++

### DIFF
--- a/Source/WebCore/en.lproj/Localizable.strings
+++ b/Source/WebCore/en.lproj/Localizable.strings
@@ -77,13 +77,13 @@
 "%@ in %%@" = "%@ in %%@";
 
 /* Label for an inspectable Web Extension background page */
-"%@ — Extension Background Page" = "%@ — Extension Background Page";
+"%s — Extension Background Page" = "%s— Extension Background Page";
 
 /* Label for an inspectable Web Extension popup page */
 "%@ — Extension Popup Page" = "%@ — Extension Popup Page";
 
 /* Label for an inspectable Web Extension service worker */
-"%@ — Extension Service Worker" = "%@ — Extension Service Worker";
+"%s — Extension Service Worker" = "%s — Extension Service Worker";
 
 /* Label to describe the number of files selected in a file upload control that allows multiple files */
 "%d files" = "%d files";

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContext.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContext.mm
@@ -156,7 +156,7 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtensionContext, WebExtensionContext
 
 - (NSString *)inspectionName
 {
-    return Ref { *_webExtensionContext }->backgroundWebViewInspectionName();
+    return Ref { *_webExtensionContext }->backgroundWebViewInspectionName().createNSString().get();
 }
 
 - (void)setInspectionName:(NSString *)name

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -564,15 +564,15 @@ public:
     void sendTestFinished(id argument);
 #endif
 
-#if PLATFORM(COCOA)
     URL backgroundContentURL();
+#if PLATFORM(COCOA)
     WKWebView *backgroundWebView() const { return m_backgroundWebView.get(); }
-    bool safeToLoadBackgroundContent() const { return m_safeToLoadBackgroundContent; }
 #endif
+    bool safeToLoadBackgroundContent() const { return m_safeToLoadBackgroundContent; }
 
     RefPtr<API::Error> backgroundContentLoadError() const { return m_backgroundContentLoadError; }
 
-    NSString *backgroundWebViewInspectionName();
+    const String& backgroundWebViewInspectionName();
     void setBackgroundWebViewInspectionName(const String&);
 
     bool decidePolicyForNavigationAction(WKWebView *, WKNavigationAction *);


### PR DESCRIPTION
#### 6a8b47a0b0f08c0ca508bc3e2b14642ba136c280
<pre>
Port WebExtensionContext Background and Inspector functions to C++
<a href="https://bugs.webkit.org/show_bug.cgi?id=300009">https://bugs.webkit.org/show_bug.cgi?id=300009</a>

Reviewed by Timothy Hatcher.

Port some general BackgroundWebView and Inspector functions to C++. These functions generally don&apos;t interact with the actual WebView or Inspectors themselves, they instead provide an API for the functions that do.
Those functions cannot be ported, but having these generic functions ported will make it easier to create a port of WebExtensionContext for other platforms

No tests are required, existing test coverage should catch these changes
* Source/WebCore/en.lproj/Localizable.strings:
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContext.mm:
(-[WKWebExtensionContext inspectionName]):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::loadBackgroundWebView):
(WebKit::WebExtensionContext::isNotRunningInTestRunner):
(WebKit::WebExtensionContext::backgroundContentURL): Deleted.
(WebKit::WebExtensionContext::loadBackgroundContent): Deleted.
(WebKit::WebExtensionContext::loadBackgroundWebViewDuringLoad): Deleted.
(WebKit::WebExtensionContext::backgroundWebViewInspectionName): Deleted.
(WebKit::isNotRunningInTestRunner): Deleted.
(WebKit::WebExtensionContext::scheduleBackgroundContentToUnload): Deleted.
(WebKit::WebExtensionContext::wakeUpBackgroundContentIfNecessary): Deleted.
(WebKit::WebExtensionContext::wakeUpBackgroundContentIfNecessaryToFireEvents): Deleted.
(WebKit::WebExtensionContext::inspectorBackgroundPageURL const): Deleted.
(WebKit::WebExtensionContext::inspector const): Deleted.
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp:
(WebKit::WebExtensionContext::backgroundContentURL):
(WebKit::WebExtensionContext::loadBackgroundContent):
(WebKit::WebExtensionContext::loadBackgroundWebViewDuringLoad):
(WebKit::WebExtensionContext::isBackgroundPage const):
(WebKit::WebExtensionContext::backgroundWebViewInspectionName):
(WebKit::WebExtensionContext::wakeUpBackgroundContentIfNecessary):
(WebKit::WebExtensionContext::wakeUpBackgroundContentIfNecessaryToFireEvents):
(WebKit::WebExtensionContext::inspectorBackgroundPageURL const):
(WebKit::WebExtensionContext::inspector const):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
(WebKit::WebExtensionContext::backgroundWebView const):
(WebKit::WebExtensionContext::safeToLoadBackgroundContent const):

Canonical link: <a href="https://commits.webkit.org/300905@main">https://commits.webkit.org/300905@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0ec6537d85caf7535099e79c761c3cb360171193

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124159 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43852 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34569 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130986 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76256 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/126036 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44593 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52452 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94443 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62651 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127113 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35533 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111060 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75035 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34478 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29222 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74472 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105275 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29443 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133660 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51083 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38928 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102915 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51468 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107278 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102722 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48077 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26328 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/47965 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19519 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50943 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56718 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50390 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53743 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52067 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->