### PR TITLE
Un-textual header in WTF modulemap

### DIFF
--- a/Source/WTF/Configurations/modulemap.toml
+++ b/Source/WTF/Configurations/modulemap.toml
@@ -1,7 +1,5 @@
 module-name = 'wtf'
 default-module = 'Cpp'
-# This header depends on surrounding preprocessor context.
-textual-headers = ['spi/mac/MetadataSPI.h']
 
 # Nearly all of WTF depends upon C++ and thus goes in this submodule.
 [module.Cpp]

--- a/Source/WTF/Scripts/modulemap-from-tapi-filelist.py
+++ b/Source/WTF/Scripts/modulemap-from-tapi-filelist.py
@@ -30,7 +30,6 @@ else:
 config.setdefault('attributes', [])
 config.setdefault('config-macros', [])
 config.setdefault('requirements', [])
-config.setdefault('textual-headers', [])
 config.setdefault('module', {})
 config.setdefault('default-module', '')
 
@@ -77,8 +76,6 @@ for module_name, paths in itertools.groupby(
         sys.stdout.write(f'{indent}requires {", ".join(reqs)}\n')
     for path in paths:
         sys.stdout.write(indent)
-        if path in config['textual-headers']:
-            sys.stdout.write('textual ')
         sys.stdout.write(f'header "{path}"\n')
     sys.stdout.write(f'{indent}export *\n')
     if in_submodule:


### PR DESCRIPTION
#### 65f1567a35fe601e2db82bbbb8e4ea49823788ee
<pre>
Un-textual header in WTF modulemap
<a href="https://bugs.webkit.org/show_bug.cgi?id=300010">https://bugs.webkit.org/show_bug.cgi?id=300010</a>
<a href="https://rdar.apple.com/161796046">rdar://161796046</a>

Reviewed by NOBODY (OOPS!).

Review comments in <a href="https://github.com/WebKit/WebKit/pull/51245">https://github.com/WebKit/WebKit/pull/51245</a> suggest that
this keyword is unnecessary and wrong. Remove it.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/65f1567a35fe601e2db82bbbb8e4ea49823788ee

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124158 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43851 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34568 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130985 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76255 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/817b255a-610b-4524-83fb-a8507af17fcf) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44592 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52451 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94442 "Found 1 new test failure: imported/w3c/web-platform-tests/webrtc/simulcast/basic.https.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62650 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f8d61018-7fce-47df-925c-0c06674f6008) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127112 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35530 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111057 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75034 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8d2f892c-cc1e-43e9-b151-78f0522ae9dc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34475 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29219 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74471 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/116305 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105272 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29440 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133659 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/122689 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51082 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38931 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102914 "Found 1 new test failure: imported/blink/fast/pagination/viewport-y-horizontal-bt-rtl.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51467 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107275 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102721 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48076 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26325 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/47964 "Hash 65f1567a for PR 51668 does not build (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50942 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56717 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/153784 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50389 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39083 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53742 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52066 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->