### PR TITLE
Split up WTF C modules

### DIFF
--- a/Source/WTF/Configurations/modulemap.toml
+++ b/Source/WTF/Configurations/modulemap.toml
@@ -9,13 +9,26 @@ textual-headers = ['spi/mac/MetadataSPI.h']
 requirements = ['cplusplus20']
 
 # The following WTF headers can be used in C contexts as well as C++
-# so we put them in a separate submodule. We'll call it Platform
-# since the majority of the files are Platform-related.
-# (Some are interdependent so we couldn't split them into
-# totally standalone submodules even if we wanted to.)
+# so we put them in separate submodules.
+[module.Assertions]
+headers = ['Assertions.h']
+
+[module.Compiler]
+headers = ['Compiler.h']
+
+[module.ExportMacros]
+headers = ['ExportMacros.h']
+
+[module.IOSurfaceSPI]
+headers = ['spi/cocoa/IOSurfaceSPI.h']
+
+[module.SwiftBridging]
+headers = ['SwiftBridging.h']
+
+# Users of these headers do not reliably Include What They Use,
+# so for now make them into one big module
 [module.Platform]
-headers = ['Assertions.h',
-    'Compiler.h', 'ExportMacros.h', 'spi/cocoa/IOSurfaceSPI.h', 'SwiftBridging.h',
+headers = [
     'Platform.h', 'PlatformCallingConventions.h', 'PlatformCPU.h',
     'PlatformEnable.h', 'PlatformEnableCocoa.h', 'PlatformHave.h',
     'PlatformLegacy.h', 'PlatformOS.h', 'PlatformUse.h']


### PR DESCRIPTION
#### 166c6adcdf485505be5e98c4e962008b1c2c54aa
<pre>
Split up WTF C modules
<a href="https://bugs.webkit.org/show_bug.cgi?id=300011">https://bugs.webkit.org/show_bug.cgi?id=300011</a>
<a href="https://rdar.apple.com/161796662">rdar://161796662</a>

Reviewed by Richard Robinson.

Comments on <a href="https://github.com/WebKit/WebKit/pull/51245">https://github.com/WebKit/WebKit/pull/51245</a> suggest that
this is a better way to structure this modulemap.

Canonical link: <a href="https://commits.webkit.org/300948@main">https://commits.webkit.org/300948@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1d15d053cb99bd0eea00ce528c36b3476907f1d2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124161 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43854 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34571 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130988 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76257 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/249d870a-f2a0-477f-91d4-8c67be2e6cbd) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44595 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52454 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94445 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62652 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c2fd63c7-c38a-4253-9803-9931066150fc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127115 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35534 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111059 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75037 "Found 1 new API test failure: WPE/TestWebKitWebContext:/webkit/WebKitWebContext/no-web-process-leak (failure)") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34479 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29221 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74474 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/116308 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105276 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29442 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133662 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/122692 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51085 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38930 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102917 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51470 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107277 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102724 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26197 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48079 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26327 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/47968 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50945 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56720 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/153787 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50392 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39084 "Found 5 new JSC binary failures: testair, testapi, testb3, testdfg, testmasm, Found 8 new JSC stress test failures: wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.default-wasm, wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.wasm-bbq, wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.wasm-bbq-no-consts, wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.wasm-collect-continuously, wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.wasm-eager, wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.wasm-eager-jettison, wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.wasm-no-cjit, wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.wasm-slow-memory (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53745 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52069 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->