### PR TITLE
WTF and bmalloc modulemaps system

### DIFF
--- a/Source/WTF/Configurations/modulemap.toml
+++ b/Source/WTF/Configurations/modulemap.toml
@@ -1,4 +1,5 @@
 module-name = 'wtf'
+attributes = ['system']
 default-module = 'Cpp'
 # This header depends on surrounding preprocessor context.
 textual-headers = ['spi/mac/MetadataSPI.h']

--- a/Source/bmalloc/Configurations/module.modulemap
+++ b/Source/bmalloc/Configurations/module.modulemap
@@ -1,4 +1,4 @@
-module bmalloc {
+module bmalloc [system] {
     // List of "semi-public" bmalloc headers. What does "semi-public" mean? These are
     // the headers which, in practice, are included by WTF headers. WTF headers are
     // exported as part of the WebKit SPI, and therefore these headers need to be


### PR DESCRIPTION
#### 72e9ca691b047274296fd2809074173bce5c465f
<pre>
WTF and bmalloc modulemaps system
<a href="https://bugs.webkit.org/show_bug.cgi?id=300012">https://bugs.webkit.org/show_bug.cgi?id=300012</a>

Reviewed by Richard Robinson.

Comments on
<a href="https://github.com/WebKit/WebKit/pull/51245">https://github.com/WebKit/WebKit/pull/51245</a>
suggest that the WTF modulemap should have the system attribute, and that
probably applies to bmalloc too.

Canonical link: <a href="https://commits.webkit.org/300944@main">https://commits.webkit.org/300944@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e62229ef64854c85ba6d9006eabaad3a4bcac1bf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124163 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43856 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34573 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130990 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76260 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5222f7cf-b4f3-4039-b14b-787a57007d1a) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44597 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52456 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94447 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62657 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/636c4206-38fc-46fc-a7ee-16b729d527d0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127117 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35535 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111063 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75039 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1a63d3a3-a956-4005-9742-4ce6ebe0a487) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34480 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29225 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74476 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/116310 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105277 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29446 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133664 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/122694 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51087 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38934 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102919 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51472 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107281 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102726 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26196 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48081 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26331 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/47972 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50947 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56722 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/153789 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50395 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39085 "Found 5 new JSC binary failures: testair, testapi, testb3, testdfg, testmasm, Found 8 new JSC stress test failures: wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.default-wasm, wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.wasm-bbq, wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.wasm-bbq-no-consts, wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.wasm-collect-continuously, wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.wasm-eager, wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.wasm-eager-jettison, wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.wasm-no-cjit, wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.wasm-slow-memory (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53747 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52071 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->