### PR TITLE
Opus and Vorbis webm aren't available in the content process on some platforms.

### DIFF
--- a/LayoutTests/media/media-can-play-webm-expected.txt
+++ b/LayoutTests/media/media-can-play-webm-expected.txt
@@ -7,5 +7,7 @@ EXPECTED (video.canPlayType('audio/webm') == 'maybe') OK
 EXPECTED (video.canPlayType('video/webm') == 'maybe') OK
 EXPECTED (video.canPlayType('audio/webm; codecs=vorbis') == 'probably') OK
 EXPECTED (video.canPlayType('video/webm; codecs=vp8,vorbis') == 'probably') OK
+EXPECTED (video.canPlayType('audio/webm; codecs=opus') == 'probably') OK
+EXPECTED (video.canPlayType('video/webm; codecs=vp8,opus') == 'probably') OK
 END OF TEST
 

--- a/LayoutTests/media/media-can-play-webm.html
+++ b/LayoutTests/media/media-can-play-webm.html
@@ -12,6 +12,9 @@
                 testExpected("video.canPlayType('audio/webm; codecs=vorbis')", "probably");
                 testExpected("video.canPlayType('video/webm; codecs=vp8,vorbis')", "probably");
 
+                testExpected("video.canPlayType('audio/webm; codecs=opus')", "probably");
+                testExpected("video.canPlayType('video/webm; codecs=vp8,opus')", "probably");
+
                 endTest();
             }
         </script>

--- a/LayoutTests/platform/mac-wk1/media/media-can-play-webm-expected.txt
+++ b/LayoutTests/platform/mac-wk1/media/media-can-play-webm-expected.txt
@@ -7,5 +7,7 @@ EXPECTED (video.canPlayType('audio/webm') == 'maybe'), OBSERVED '' FAIL
 EXPECTED (video.canPlayType('video/webm') == 'maybe'), OBSERVED '' FAIL
 EXPECTED (video.canPlayType('audio/webm; codecs=vorbis') == 'probably'), OBSERVED '' FAIL
 EXPECTED (video.canPlayType('video/webm; codecs=vp8,vorbis') == 'probably'), OBSERVED '' FAIL
+EXPECTED (video.canPlayType('audio/webm; codecs=opus') == 'probably'), OBSERVED '' FAIL
+EXPECTED (video.canPlayType('video/webm; codecs=vp8,opus') == 'probably'), OBSERVED '' FAIL
 END OF TEST
 

--- a/Source/WebCore/platform/graphics/cocoa/WebMAudioUtilitiesCocoa.h
+++ b/Source/WebCore/platform/graphics/cocoa/WebMAudioUtilitiesCocoa.h
@@ -70,6 +70,13 @@ bool parseOpusTOCData(std::span<const uint8_t> frameData, OpusCookieContents&);
 RefPtr<AudioInfo> createOpusAudioInfo(const OpusCookieContents&);
 Vector<uint8_t> createOpusPrivateData(const AudioStreamBasicDescription&, uint16_t preSkip = 0);
 
+#if ENABLE(OPUS)
+WEBCORE_EXPORT void setHasOpusDecoder(bool);
+#endif
+#if ENABLE(VORBIS)
+WEBCORE_EXPORT void setHasVorbisDecoder(bool);
+#endif
+
 }
 
 #endif // && PLATFORM(COCOA)

--- a/Source/WebCore/platform/graphics/cocoa/WebMAudioUtilitiesCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/WebMAudioUtilitiesCocoa.mm
@@ -51,6 +51,22 @@
 
 namespace WebCore {
 
+namespace WebMAudioUtilities {
+#if ENABLE(OPUS)
+static std::optional<bool> s_hasOpusDecoder;
+#endif
+#if ENABLE(VORBIS)
+static std::optional<bool> s_hasVorbisDecoder;
+#endif
+}
+
+#if ENABLE(OPUS)
+void setHasOpusDecoder(bool hasDecoder) { WebMAudioUtilities::s_hasOpusDecoder = hasDecoder; }
+#endif
+#if ENABLE(VORBIS)
+void setHasVorbisDecoder(bool hasDecoder) { WebMAudioUtilities::s_hasVorbisDecoder = hasDecoder; }
+#endif
+
 #if ENABLE(VORBIS) || ENABLE(OPUS)
 static bool registerDecoderFactory(ASCIILiteral decoderName, OSType decoderType)
 {
@@ -368,7 +384,9 @@ static Vector<uint8_t> cookieFromOpusCookieContents(const OpusCookieContents& co
 bool isOpusDecoderAvailable()
 {
 #if ENABLE(OPUS)
-    return registerOpusDecoderIfNeeded();
+    if (registerOpusDecoderIfNeeded())
+        return true;
+    return WebMAudioUtilities::s_hasOpusDecoder.value_or(false);
 #else
     return false;
 #endif
@@ -493,7 +511,9 @@ static Vector<uint8_t> cookieFromVorbisCodecPrivate(std::span<const uint8_t> cod
 bool isVorbisDecoderAvailable()
 {
 #if ENABLE(VORBIS)
-    return registerVorbisDecoderIfNeeded();
+    if (registerVorbisDecoderIfNeeded())
+        return true;
+    return WebMAudioUtilities::s_hasVorbisDecoder.value_or(false);
 #else
     return false;
 #endif

--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -485,6 +485,7 @@ set(WebKit_SERIALIZATION_IN_FILES
     Shared/FrameTreeNodeData.serialization.in
     Shared/FullScreenMediaDetails.serialization.in
     Shared/GPUProcessConnectionParameters.serialization.in
+    Shared/GPUProcessMediaCodecCapabilities.serialization.in
     Shared/GoToBackForwardItemParameters.serialization.in
     Shared/ImageOptions.serialization.in
     Shared/InspectorExtensionTypes.serialization.in

--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -316,6 +316,7 @@ $(PROJECT_DIR)/Shared/FrameTreeCreationParameters.serialization.in
 $(PROJECT_DIR)/Shared/FrameTreeNodeData.serialization.in
 $(PROJECT_DIR)/Shared/FullScreenMediaDetails.serialization.in
 $(PROJECT_DIR)/Shared/GPUProcessConnectionParameters.serialization.in
+$(PROJECT_DIR)/Shared/GPUProcessMediaCodecCapabilities.serialization.in
 $(PROJECT_DIR)/Shared/Gamepad/GamepadData.serialization.in
 $(PROJECT_DIR)/Shared/GoToBackForwardItemParameters.serialization.in
 $(PROJECT_DIR)/Shared/HTTPSUpgrade/HTTPSUpgradeList.txt

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -726,6 +726,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	Shared/FullScreenMediaDetails.serialization.in \
 	Shared/Gamepad/GamepadData.serialization.in \
 	Shared/GPUProcessConnectionParameters.serialization.in \
+	Shared/GPUProcessMediaCodecCapabilities.serialization.in \
 	Shared/GoToBackForwardItemParameters.serialization.in \
 	Shared/ImageOptions.serialization.in \
 	Shared/InspectorExtensionTypes.serialization.in \

--- a/Source/WebKit/Shared/GPUProcessConnectionParameters.serialization.in
+++ b/Source/WebKit/Shared/GPUProcessConnectionParameters.serialization.in
@@ -35,12 +35,7 @@
 #if PLATFORM(COCOA)
     String applicationBundleIdentifier;
 #endif
-#if ENABLE(VP9)
-    std::optional<bool> hasVP9HardwareDecoder;
-#endif
-#if ENABLE(AV1)
-    std::optional<bool> hasAV1HardwareDecoder;
-#endif
+    std::optional<WebKit::GPUProcessMediaCodecCapabilities> mediaCodecCapabilities;
 };
 
 #endif

--- a/Source/WebKit/Shared/GPUProcessMediaCodecCapabilities.h
+++ b/Source/WebKit/Shared/GPUProcessMediaCodecCapabilities.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,34 +27,27 @@
 
 #if ENABLE(GPU_PROCESS)
 
-#include "GPUProcessMediaCodecCapabilities.h"
-#include "SharedPreferencesForWebProcess.h"
-#include <WebCore/ProcessIdentity.h>
-#include <wtf/MachSendRight.h>
-
-#if HAVE(AUDIT_TOKEN)
-#include "CoreIPCAuditToken.h"
-#include <WebCore/PageIdentifier.h>
-#endif
+#include <optional>
 
 namespace WebKit {
 
-struct GPUProcessConnectionParameters {
-    WebCore::ProcessIdentity webProcessIdentity;
-    SharedPreferencesForWebProcess sharedPreferencesForWebProcess;
-    bool isLockdownModeEnabled { false };
-#if ENABLE(IPC_TESTING_API)
-    bool ignoreInvalidMessageForTesting { false };
+struct GPUProcessMediaCodecCapabilities {
+#if ENABLE(VP9)
+    bool hasVP9HardwareDecoder { false };
 #endif
-#if HAVE(AUDIT_TOKEN)
-    HashMap<WebCore::PageIdentifier, CoreIPCAuditToken> presentingApplicationAuditTokens;
+#if ENABLE(AV1)
+    bool hasAV1HardwareDecoder { false };
 #endif
 #if PLATFORM(COCOA)
-    String applicationBundleIdentifier;
+#if ENABLE(OPUS)
+    bool hasOpusDecoder { false };
 #endif
-    std::optional<GPUProcessMediaCodecCapabilities> mediaCodecCapabilities;
+#if ENABLE(VORBIS)
+    bool hasVorbisDecoder { false };
+#endif
+#endif
 };
 
-}; // namespace WebKit
+} // namespace WebKit
 
 #endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/Shared/GPUProcessMediaCodecCapabilities.serialization.in
+++ b/Source/WebKit/Shared/GPUProcessMediaCodecCapabilities.serialization.in
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Apple Inc. All rights reserved.
+# Copyright (C) 2025 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -22,13 +22,21 @@
 
 #if ENABLE(GPU_PROCESS)
 
-struct WebKit::GPUProcessConnectionInfo {
-
-#if HAVE(AUDIT_TOKEN)
-    std::optional<WebKit::CoreIPCAuditToken> auditToken;
+struct WebKit::GPUProcessMediaCodecCapabilities {
+#if ENABLE(VP9)
+    bool hasVP9HardwareDecoder;
 #endif
-
-    WebKit::GPUProcessMediaCodecCapabilities mediaCodecCapabilities;
-}
+#if ENABLE(AV1)
+    bool hasAV1HardwareDecoder;
+#endif
+#if PLATFORM(COCOA)
+#if ENABLE(OPUS)
+    bool hasOpusDecoder;
+#endif
+#if ENABLE(VORBIS)
+    bool hasVorbisDecoder;
+#endif
+#endif
+};
 
 #endif

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
@@ -516,21 +516,11 @@ void GPUProcessProxy::processWillShutDown(IPC::Connection& connection)
         singleton() = nullptr;
 }
 
-#if ENABLE(VP9)
-std::optional<bool> GPUProcessProxy::s_hasVP9HardwareDecoder;
-#endif
-#if ENABLE(AV1)
-std::optional<bool> GPUProcessProxy::s_hasAV1HardwareDecoder;
-#endif
+std::optional<GPUProcessMediaCodecCapabilities> GPUProcessProxy::s_gpuProcessMediaCodecCapabilities;
 
 void GPUProcessProxy::createGPUProcessConnection(WebProcessProxy& webProcessProxy, IPC::Connection::Handle&& connectionIdentifier, GPUProcessConnectionParameters&& parameters)
 {
-#if ENABLE(VP9)
-    parameters.hasVP9HardwareDecoder = s_hasVP9HardwareDecoder;
-#endif
-#if ENABLE(AV1)
-    parameters.hasAV1HardwareDecoder = s_hasAV1HardwareDecoder;
-#endif
+    parameters.mediaCodecCapabilities = s_gpuProcessMediaCodecCapabilities;
 
     if (RefPtr store = webProcessProxy.websiteDataStore())
         addSession(*store);
@@ -641,7 +631,7 @@ void GPUProcessProxy::didFinishLaunching(ProcessLauncher* launcher, IPC::Connect
         gpuProcessExited(ProcessTerminationReason::Crash);
         return;
     }
-    
+
 #if PLATFORM(COCOA)
     if (auto networkProcess = NetworkProcessProxy::defaultNetworkProcess())
         networkProcess->sendXPCEndpointToProcess(*this);

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.h
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.h
@@ -28,6 +28,7 @@
 #if ENABLE(GPU_PROCESS)
 
 #include "AuxiliaryProcessProxy.h"
+#include "GPUProcessMediaCodecCapabilities.h"
 #include "ProcessLauncher.h"
 #include "ProcessThrottler.h"
 #include "RemoteSnapshotIdentifier.h"
@@ -219,12 +220,7 @@ private:
     void didCreateContextForVisibilityPropagation(WebPageProxyIdentifier, WebCore::PageIdentifier, LayerHostingContextID);
 #endif
 
-#if ENABLE(VP9)
-    void setHasVP9HardwareDecoder(bool hasVP9HardwareDecoder) { s_hasVP9HardwareDecoder = hasVP9HardwareDecoder; }
-#endif
-#if ENABLE(AV1)
-    void setHasAV1HardwareDecoder(bool hasAV1HardwareDecoder) { s_hasAV1HardwareDecoder = hasAV1HardwareDecoder; }
-#endif
+    void setMediaCodecCapabilities(GPUProcessMediaCodecCapabilities&& mediaCodecCapabilities) { s_gpuProcessMediaCodecCapabilities = WTFMove(mediaCodecCapabilities); }
 
 #if ENABLE(MEDIA_STREAM)
     void voiceActivityDetected();
@@ -263,12 +259,7 @@ private:
 #if HAVE(SCREEN_CAPTURE_KIT)
     bool m_hasEnabledScreenCaptureKit { false };
 #endif
-#if ENABLE(VP9)
-    static std::optional<bool> s_hasVP9HardwareDecoder;
-#endif
-#if ENABLE(AV1)
-    static std::optional<bool> s_hasAV1HardwareDecoder;
-#endif
+    static std::optional<GPUProcessMediaCodecCapabilities> s_gpuProcessMediaCodecCapabilities;
 #if PLATFORM(COCOA)
     static bool s_enableMetalDebugDeviceInNewGPUProcessesForTesting;
     static bool s_enableMetalShaderValidationInNewGPUProcessesForTesting;

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.messages.in
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.messages.in
@@ -33,12 +33,8 @@ messages -> GPUProcessProxy {
     DidCreateContextForVisibilityPropagation(WebKit::WebPageProxyIdentifier pageProxyID, WebCore::PageIdentifier pageID, WebKit::LayerHostingContextID contextID)
 #endif
 
-#if ENABLE(VP9)
-    SetHasVP9HardwareDecoder(bool hasVP9HardwareDecoder)
-#endif
-#if ENABLE(AV1)
-    SetHasAV1HardwareDecoder(bool hasAV1HardwareDecoder)
-#endif
+    SetMediaCodecCapabilities(struct WebKit::GPUProcessMediaCodecCapabilities mediaCodecCapabilities)
+
 #if ENABLE(MEDIA_STREAM)
     VoiceActivityDetected()
     StartMonitoringCaptureDeviceRotation(WebCore::PageIdentifier pageID, String devicePersistentId);

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1200,6 +1200,7 @@
 		515BE1AB1D555AA000DD7C68 /* WebGamepad.h in Headers */ = {isa = PBXBuildFile; fileRef = 515BE1A01D550AB000DD7C68 /* WebGamepad.h */; };
 		515BE1B31D5902DD00DD7C68 /* GamepadData.h in Headers */ = {isa = PBXBuildFile; fileRef = 515BE1B01D59006900DD7C68 /* GamepadData.h */; };
 		515BE1B51D5917FF00DD7C68 /* UIGamepad.h in Headers */ = {isa = PBXBuildFile; fileRef = 515BE1AD1D555C5100DD7C68 /* UIGamepad.h */; };
+		515CA7C92E8E90E200F8A78E /* GPUProcessMediaCodecCapabilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 515CA7C62E8E7C0100F8A78E /* GPUProcessMediaCodecCapabilities.h */; };
 		5163199516289A6300E22F00 /* NetworkProcessMessages.h in Headers */ = {isa = PBXBuildFile; fileRef = 51ACC9351628064800342550 /* NetworkProcessMessages.h */; };
 		51632FDB2C4A1CA30038F759 /* UserNotificationsSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 51632FDA2C4A1C960038F759 /* UserNotificationsSPI.h */; };
 		5164658027A9C77400E1F2BA /* ServiceWorkerNotificationHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 5164657F27A9C76700E1F2BA /* ServiceWorkerNotificationHandler.h */; };
@@ -5869,6 +5870,8 @@
 		515BE1B61D5A94F900DD7C68 /* UIGamepadProviderMac.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = UIGamepadProviderMac.mm; sourceTree = "<group>"; };
 		515C415A207D74E000726E02 /* SuspendedPageProxy.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SuspendedPageProxy.cpp; sourceTree = "<group>"; };
 		515C415B207D74E100726E02 /* SuspendedPageProxy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SuspendedPageProxy.h; sourceTree = "<group>"; };
+		515CA7C62E8E7C0100F8A78E /* GPUProcessMediaCodecCapabilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GPUProcessMediaCodecCapabilities.h; sourceTree = "<group>"; };
+		515CA7C72E8E7DDF00F8A78E /* GPUProcessMediaCodecCapabilities.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = GPUProcessMediaCodecCapabilities.serialization.in; sourceTree = "<group>"; };
 		5160BFE013381DF900918999 /* LoggingFoundation.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = LoggingFoundation.mm; sourceTree = "<group>"; };
 		51632FDA2C4A1C960038F759 /* UserNotificationsSPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UserNotificationsSPI.h; sourceTree = "<group>"; };
 		5164657E27A9C76500E1F2BA /* ServiceWorkerNotificationHandler.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ServiceWorkerNotificationHandler.cpp; sourceTree = "<group>"; };
@@ -9919,6 +9922,8 @@
 				46C71AC82A942E1800E459AF /* GoToBackForwardItemParameters.serialization.in */,
 				46AC532425DED81E003B57EC /* GPUProcessConnectionParameters.h */,
 				86D196BF29A7890F0083B077 /* GPUProcessConnectionParameters.serialization.in */,
+				515CA7C62E8E7C0100F8A78E /* GPUProcessMediaCodecCapabilities.h */,
+				515CA7C72E8E7DDF00F8A78E /* GPUProcessMediaCodecCapabilities.serialization.in */,
 				1AC75A1A1B3368270056745B /* HangDetectionDisabler.h */,
 				0FD2CB2526CDD7A30008B11C /* IdentifierTypes.h */,
 				A78A5FE32B0EB39E005036D3 /* ImageBufferSetIdentifier.h */,
@@ -17656,6 +17661,7 @@
 				2DA944A41884E4F000ED86DB /* GestureTypes.h in Headers */,
 				46C71AC92A942E2900E459AF /* GoToBackForwardItemParameters.h in Headers */,
 				4614F13225DED875007006E7 /* GPUProcessConnectionParameters.h in Headers */,
+				515CA7C92E8E90E200F8A78E /* GPUProcessMediaCodecCapabilities.h in Headers */,
 				2DA049B8180CCD0A00AAFA9E /* GraphicsLayerCARemote.h in Headers */,
 				C0CE72AD1247E78D00BC0EC4 /* HandleMessage.h in Headers */,
 				1AC75A1B1B3368270056745B /* HangDetectionDisabler.h in Headers */,

--- a/Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp
+++ b/Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp
@@ -96,6 +96,10 @@
 #include <WebCore/VP9UtilitiesCocoa.h>
 #endif
 
+#if (ENABLE(OPUS) || ENABLE(VORBIS)) && PLATFORM(COCOA)
+#include <WebCore/WebMAudioUtilitiesCocoa.h>
+#endif
+
 #if ENABLE(ROUTING_ARBITRATION)
 #include "AudioSessionRoutingArbitrator.h"
 #endif
@@ -326,16 +330,24 @@ void GPUProcessConnection::didInitialize(std::optional<GPUProcessConnectionInfo>
     m_hasInitialized = true;
     RELEASE_LOG(Process, "%p - GPUProcessConnection::didInitialize", this);
 
-#if USE(LIBWEBRTC) && PLATFORM(COCOA)
+#if PLATFORM(COCOA)
+#if USE(LIBWEBRTC)
 #if ENABLE(VP9)
-    WebProcess::singleton().libWebRTCCodecs().setVP9VTBSupport(info->hasVP9HardwareDecoder);
+    WebProcess::singleton().libWebRTCCodecs().setVP9VTBSupport(info->mediaCodecCapabilities.hasVP9HardwareDecoder);
 #endif
 #if ENABLE(AV1)
-    WebProcess::singleton().protectedLibWebRTCCodecs()->setHasAV1HardwareDecoder(info->hasAV1HardwareDecoder);
+    WebProcess::singleton().protectedLibWebRTCCodecs()->setHasAV1HardwareDecoder(info->mediaCodecCapabilities.hasAV1HardwareDecoder);
 #endif
 #endif
-#if PLATFORM(COCOA) && ENABLE(VP9)
-    VP9TestingOverrides::singleton().setVP9HardwareDecoderEnabledOverride(info->hasVP9HardwareDecoder);
+#if ENABLE(VP9)
+    VP9TestingOverrides::singleton().setVP9HardwareDecoderEnabledOverride(info->mediaCodecCapabilities.hasVP9HardwareDecoder);
+#endif
+#if ENABLE(OPUS)
+    WebCore::setHasOpusDecoder(info->mediaCodecCapabilities.hasOpusDecoder);
+#endif
+#if ENABLE(VORBIS)
+    WebCore::setHasVorbisDecoder(info->mediaCodecCapabilities.hasVorbisDecoder);
+#endif
 #endif
 }
 

--- a/Source/WebKit/WebProcess/GPU/GPUProcessConnectionInfo.h
+++ b/Source/WebKit/WebProcess/GPU/GPUProcessConnectionInfo.h
@@ -33,18 +33,15 @@
 #include "CoreIPCAuditToken.h"
 #endif
 
+#include "GPUProcessMediaCodecCapabilities.h"
+
 namespace WebKit {
 
 struct GPUProcessConnectionInfo {
 #if HAVE(AUDIT_TOKEN)
-    std::optional<CoreIPCAuditToken> auditToken;
+    std::optional<CoreIPCAuditToken> auditToken { };
 #endif
-#if ENABLE(VP9)
-    bool hasVP9HardwareDecoder { false };
-#endif
-#if ENABLE(AV1)
-    bool hasAV1HardwareDecoder { false };
-#endif
+    GPUProcessMediaCodecCapabilities mediaCodecCapabilities;
 };
 
 } // namespace WebKit


### PR DESCRIPTION
#### 5e174d0a75e215fe0987f4966d6ccb1502075ced
<pre>
Opus and Vorbis webm aren&apos;t available in the content process on some platforms.
<a href="https://bugs.webkit.org/show_bug.cgi?id=300013">https://bugs.webkit.org/show_bug.cgi?id=300013</a>
<a href="https://rdar.apple.com/161800673">rdar://161800673</a>

Reviewed by Youenn Fablet.

We check the Opus and Vorbis capabilities on creation of the GPU process.
This value is then cached in the UI process and passed on follow-up WebContent
process creation; re-using the infrastucture that used to exist for VP9 and AV1
hardware detection.

We simplify the code and combine all the media codecs information into a single
GPUProcessMediaCodecCapabilities structure.

Added test for opus.
* LayoutTests/media/media-can-play-webm-expected.txt:
* LayoutTests/media/media-can-play-webm.html:
* Source/WebCore/platform/graphics/cocoa/WebMAudioUtilitiesCocoa.h:
* Source/WebCore/platform/graphics/cocoa/WebMAudioUtilitiesCocoa.mm:
(WebCore::setHasOpusDecoder):
(WebCore::setHasVorbisDecoder):
(WebCore::isOpusDecoderAvailable):
(WebCore::isVorbisDecoderAvailable):
* Source/WebKit/CMakeLists.txt:
* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp:
(WebKit::m_sharedPreferencesForWebProcess):
* Source/WebKit/Shared/GPUProcessConnectionParameters.h:
* Source/WebKit/Shared/GPUProcessConnectionParameters.serialization.in:
* Source/WebKit/Shared/GPUProcessMediaCodecCapabilities.h: Copied from Source/WebKit/Shared/GPUProcessConnectionParameters.h.
* Source/WebKit/Shared/GPUProcessMediaCodecCapabilities.serialization.in: Copied from Source/WebKit/WebProcess/GPU/GPUProcessConnectionInfo.serialization.in.
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp:
(WebKit::GPUProcessProxy::createGPUProcessConnection):
(WebKit::GPUProcessProxy::didFinishLaunching):
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.h:
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.messages.in:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp:
(WebKit::GPUProcessConnection::didInitialize):
* Source/WebKit/WebProcess/GPU/GPUProcessConnectionInfo.h:
* Source/WebKit/WebProcess/GPU/GPUProcessConnectionInfo.serialization.in:

Canonical link: <a href="https://commits.webkit.org/300939@main">https://commits.webkit.org/300939@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ed0f18acfb35643dd68216384cdd35ec0aa26c18

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124400 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44080 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34810 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131239 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/76427 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/aff112c5-0f35-4d5f-a526-1e48ff930bb6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/126277 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44826 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52679 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/94636 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/76427 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0fa930a4-3a1f-4374-9b04-ba2d20bc07b6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127354 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35729 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111264 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75218 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/574a9b09-b821-4fb3-a419-eb014193974f) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/34669 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29426 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74716 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/105490 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29646 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133904 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51298 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/39134 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/103122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51697 "Failed to checkout and rebase branch from PR 51673") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107482 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102905 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26191 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26522 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48236 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51165 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56956 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50590 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53954 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52262 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->