### PR TITLE
Unskip imported/w3c/web-platform-tests/storage-access-api/hasStorageAccess.sub.https.window.html

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/hasStorageAccess.sub.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/hasStorageAccess.sub.https.window-expected.txt
@@ -5,12 +5,12 @@ PASS [top-level-context] document.hasStorageAccess() should reject in a document
 PASS [same-origin-frame] document.hasStorageAccess() should exist on the document interface
 PASS [same-origin-frame] document.hasStorageAccess() should not be allowed by default unless in top-level frame or same-origin iframe.
 PASS [same-origin-frame] document.hasStorageAccess() should reject in a document that isn't fully active.
-PASS [cross-site-frame] document.hasStorageAccess() should exist on the document interface
-PASS [cross-site-frame] document.hasStorageAccess() should not be allowed by default unless in top-level frame or same-origin iframe.
-PASS [cross-site-frame] document.hasStorageAccess() should reject in a document that isn't fully active.
 PASS [nested-same-origin-frame] document.hasStorageAccess() should exist on the document interface
 PASS [nested-same-origin-frame] document.hasStorageAccess() should not be allowed by default unless in top-level frame or same-origin iframe.
 PASS [nested-same-origin-frame] document.hasStorageAccess() should reject in a document that isn't fully active.
+PASS [cross-site-frame] document.hasStorageAccess() should exist on the document interface
+PASS [cross-site-frame] document.hasStorageAccess() should not be allowed by default unless in top-level frame or same-origin iframe.
+PASS [cross-site-frame] document.hasStorageAccess() should reject in a document that isn't fully active.
 PASS [nested-cross-site-frame] document.hasStorageAccess() should exist on the document interface
 PASS [nested-cross-site-frame] document.hasStorageAccess() should not be allowed by default unless in top-level frame or same-origin iframe.
 PASS [nested-cross-site-frame] document.hasStorageAccess() should reject in a document that isn't fully active.

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -2869,7 +2869,6 @@ http/tests/storageAccess/has-storage-access-false-by-default-ephemeral.https.htm
 http/tests/storageAccess/has-storage-access-true-if-third-party-has-cookies.https.html [ Pass Timeout ]
 http/tests/resourceLoadStatistics/capped-lifetime-for-cookie-set-with-link-query-using-cookiestore-api.https.html [ Pass ]
 imported/w3c/web-platform-tests/storage-access-api/ [ Pass ]
-imported/w3c/web-platform-tests/storage-access-api/hasStorageAccess.sub.https.window.html [ Skip ]
 imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-cross-origin-fetch.sub.https.window.html [ Skip ]
 imported/w3c/web-platform-tests/storage-access-api/storage-access-beyond-cookies.BlobURLDedicatedWorker.sub.https.tentative.window.html [ Skip ]
 imported/w3c/web-platform-tests/storage-access-api/storage-access-beyond-cookies.BlobURLSharedWorker.sub.https.tentative.window.html [ Skip ]

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -830,7 +830,6 @@ http/tests/resourceLoadStatistics/user-interaction-reported-after-website-data-r
 
 http/tests/storageAccess/ [ Pass ]
 imported/w3c/web-platform-tests/storage-access-api/ [ Pass ]
-imported/w3c/web-platform-tests/storage-access-api/hasStorageAccess.sub.https.window.html [ Skip ]
 imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-cross-origin-fetch.sub.https.window.html [ Skip ]
 imported/w3c/web-platform-tests/storage-access-api/storage-access-beyond-cookies.BlobURLDedicatedWorker.sub.https.tentative.window.html [ Skip ]
 imported/w3c/web-platform-tests/storage-access-api/storage-access-beyond-cookies.BlobURLSharedWorker.sub.https.tentative.window.html [ Skip ]


### PR DESCRIPTION
#### 746445b6a77a38ee46d1c71cc817a528dafb20a3
<pre>
Unskip imported/w3c/web-platform-tests/storage-access-api/hasStorageAccess.sub.https.window.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=300019">https://bugs.webkit.org/show_bug.cgi?id=300019</a>
<a href="https://rdar.apple.com/161810090">rdar://161810090</a>

Reviewed by NOBODY (OOPS!).

After enabling local DNS resolver in <a href="https://bugs.webkit.org/show_bug.cgi?id=298967">https://bugs.webkit.org/show_bug.cgi?id=298967</a>, we can unskip this test.

* LayoutTests/imported/w3c/web-platform-tests/storage-access-api/hasStorageAccess.sub.https.window-expected.txt:
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/746445b6a77a38ee46d1c71cc817a528dafb20a3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124186 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43879 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34596 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131014 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76276 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3f43a110-bb13-474b-a2db-79c884d47d4d) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44620 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52479 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94467 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62668 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127140 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35558 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111083 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75058 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/26bf00f3-d28d-4eaf-b069-c45afc5827b0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34503 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29245 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74500 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105299 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29466 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133690 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51109 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38955 "11 flakes 1 failures") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102940 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51495 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107301 "Exiting early after 10 failures. 18 tests run. 1 flakes") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102746 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48103 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26351 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48007 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50970 "Built successfully") | | | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50417 "Hash 746445b6 for PR 51674 does not build (failure)") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53769 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52093 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->