### PR TITLE
[GTK][WPE] Implement RunLoopObserver for glib ports

### DIFF
--- a/Source/WTF/wtf/PlatformGTK.cmake
+++ b/Source/WTF/wtf/PlatformGTK.cmake
@@ -30,6 +30,7 @@ list(APPEND WTF_SOURCES
 )
 
 list(APPEND WTF_PUBLIC_HEADERS
+    glib/ActivityObserver.h
     glib/Application.h
     glib/ChassisType.h
     glib/GMutexLocker.h

--- a/Source/WTF/wtf/PlatformWPE.cmake
+++ b/Source/WTF/wtf/PlatformWPE.cmake
@@ -39,6 +39,7 @@ list(APPEND WTF_SOURCES
 list(APPEND WTF_PUBLIC_HEADERS
     android/RefPtrAndroid.h
 
+    glib/ActivityObserver.h
     glib/Application.h
     glib/ChassisType.h
     glib/GMutexLocker.h

--- a/Source/WTF/wtf/glib/ActivityObserver.h
+++ b/Source/WTF/wtf/glib/ActivityObserver.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2025 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#pragma once
+
+#if USE(GLIB_EVENT_LOOP)
+
+#include <wtf/RunLoop.h>
+
+namespace WTF {
+
+// Activity observers (used to implement WebCore::RunLoopObserver)
+class ActivityObserver : public RefCounted<ActivityObserver> {
+    WTF_MAKE_TZONE_ALLOCATED(ActivityObserver);
+public:
+    enum class ContinueObservation { Yes, No };
+    using Callback = Function<ContinueObservation()>;
+
+    static Ref<ActivityObserver> create(uint8_t order, OptionSet<RunLoop::Activity> activities, Callback&& callback)
+    {
+        return adoptRef(*new ActivityObserver(order, activities, WTFMove(callback)));
+    }
+
+    uint8_t order() const { return m_order; }
+    OptionSet<RunLoop::Activity> activities() const { return m_activities; }
+
+    ContinueObservation notify() const { return m_callback(); }
+
+private:
+    ActivityObserver(uint8_t order, OptionSet<RunLoop::Activity> activities, Callback&& callback)
+        : m_order(order)
+        , m_activities(activities)
+        , m_callback(WTFMove(callback))
+    {
+        ASSERT(m_callback);
+    }
+
+private:
+    uint8_t m_order { 0 };
+    OptionSet<RunLoop::Activity> m_activities;
+    Callback m_callback;
+};
+
+} // namespace WTF
+
+using WTF::ActivityObserver;
+
+#endif // USE(GLIB_EVENT_LOOP)

--- a/Source/WebCore/SourcesGTK.txt
+++ b/Source/WebCore/SourcesGTK.txt
@@ -58,6 +58,7 @@ platform/generic/ScrollbarsControllerGeneric.cpp
 
 platform/glib/DragDataGLib.cpp
 platform/glib/PasteboardGLib.cpp
+platform/glib/RunLoopObserverGLib.cpp
 
 platform/graphics/PlatformDisplay.cpp @no-unify
 

--- a/Source/WebCore/SourcesWPE.txt
+++ b/Source/WebCore/SourcesWPE.txt
@@ -60,6 +60,7 @@ platform/generic/ScrollbarsControllerGeneric.cpp
 
 platform/glib/DragDataGLib.cpp
 platform/glib/PasteboardGLib.cpp
+platform/glib/RunLoopObserverGLib.cpp
 
 platform/graphics/PlatformDisplay.cpp @no-unify
 

--- a/Source/WebCore/inspector/agents/page/PageTimelineAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageTimelineAgent.cpp
@@ -129,7 +129,7 @@ void PageTimelineAgent::internalStart(std::optional<int>&& maxCallStackDepth)
 
     m_runLoopNestingLevel = 1;
 #elif USE(GLIB_EVENT_LOOP)
-    m_runLoopObserver = makeUnique<RunLoop::Observer>([this](RunLoop::Event event, const String& name) {
+    m_runLoopObserver = makeUnique<RunLoop::EventObserver>([this](RunLoop::Event event, const String& name) {
         if (!tracking() || m_environment.debugger()->isPaused())
             return;
 
@@ -144,7 +144,7 @@ void PageTimelineAgent::internalStart(std::optional<int>&& maxCallStackDepth)
             break;
         }
     });
-    RunLoop::currentSingleton().observe(*m_runLoopObserver);
+    RunLoop::currentSingleton().observeEvent(*m_runLoopObserver);
 #endif
 
     InspectorTimelineAgent::internalStart(WTFMove(maxCallStackDepth));

--- a/Source/WebCore/inspector/agents/page/PageTimelineAgent.h
+++ b/Source/WebCore/inspector/agents/page/PageTimelineAgent.h
@@ -83,7 +83,7 @@ private:
     std::unique_ptr<WebCore::RunLoopObserver> m_frameStopObserver;
     int m_runLoopNestingLevel { 0 };
 #elif USE(GLIB_EVENT_LOOP)
-    std::unique_ptr<RunLoop::Observer> m_runLoopObserver;
+    std::unique_ptr<RunLoop::EventObserver> m_runLoopObserver;
 #endif
     bool m_startedComposite { false };
     bool m_isCapturingScreenshot { false };

--- a/Source/WebCore/platform/RunLoopObserver.cpp
+++ b/Source/WebCore/platform/RunLoopObserver.cpp
@@ -38,13 +38,13 @@ RunLoopObserver::~RunLoopObserver()
 
 void RunLoopObserver::runLoopObserverFired()
 {
-#if USE(CF)
+#if USE(CF) || USE(GLIB)
     ASSERT(m_runLoopObserver);
 #endif
     m_callback();
 }
 
-#if !USE(CF)
+#if !USE(CF) && !USE(GLIB)
 
 void RunLoopObserver::schedule(PlatformRunLoop, OptionSet<Activity>)
 {

--- a/Source/WebCore/platform/glib/RunLoopObserverGLib.cpp
+++ b/Source/WebCore/platform/glib/RunLoopObserverGLib.cpp
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2025 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "RunLoopObserver.h"
+
+#if USE(GLIB_EVENT_LOOP)
+namespace WebCore {
+
+void RunLoopObserver::schedule(PlatformRunLoop, OptionSet<Activity> activities)
+{
+    if (m_runLoopObserver)
+        return;
+
+    m_runLoopObserver = ActivityObserver::create(static_cast<uint8_t>(m_order), activities, [this]() {
+        runLoopObserverFired();
+        return isRepeating() ? ActivityObserver::ContinueObservation::Yes : ActivityObserver::ContinueObservation::No;
+    });
+
+    RunLoop::currentSingleton().observeActivity(*m_runLoopObserver);
+}
+
+void RunLoopObserver::invalidate()
+{
+    if (m_runLoopObserver) {
+        RunLoop::currentSingleton().unobserveActivity(*m_runLoopObserver);
+        m_runLoopObserver = nullptr;
+    }
+}
+
+bool RunLoopObserver::isScheduled() const
+{
+    return !!m_runLoopObserver;
+}
+
+} // namespace WebCore
+
+#endif // USE(GLIB_EVENT_LOOP)

--- a/Tools/TestWebKitAPI/PlatformGTK.cmake
+++ b/Tools/TestWebKitAPI/PlatformGTK.cmake
@@ -17,6 +17,7 @@ set(test_main_SOURCES gtk/main.cpp)
 list(APPEND TestWTF_SOURCES
     ${test_main_SOURCES}
 
+    Tests/WTF/glib/ActivityObserver.cpp
     Tests/WTF/glib/GRefPtr.cpp
     Tests/WTF/glib/GUniquePtr.cpp
     Tests/WTF/glib/GWeakPtr.cpp
@@ -48,6 +49,7 @@ list(APPEND TestWebCore_SOURCES
 
     Tests/WebCore/glib/Damage.cpp
     Tests/WebCore/glib/GraphicsContextGLTextureMapper.cpp
+    Tests/WebCore/glib/RunLoopObserver.cpp
 
     Tests/WebCore/gstreamer/GStreamerTest.cpp
     Tests/WebCore/gstreamer/GstElementHarness.cpp

--- a/Tools/TestWebKitAPI/PlatformWPE.cmake
+++ b/Tools/TestWebKitAPI/PlatformWPE.cmake
@@ -17,6 +17,7 @@ set(test_main_SOURCES generic/main.cpp)
 list(APPEND TestWTF_SOURCES
     ${test_main_SOURCES}
 
+    Tests/WTF/glib/ActivityObserver.cpp
     Tests/WTF/glib/GRefPtr.cpp
     Tests/WTF/glib/GUniquePtr.cpp
     Tests/WTF/glib/GWeakPtr.cpp
@@ -44,6 +45,7 @@ list(APPEND TestWebCore_SOURCES
 
     Tests/WebCore/glib/Damage.cpp
     Tests/WebCore/glib/GraphicsContextGLTextureMapper.cpp
+    Tests/WebCore/glib/RunLoopObserver.cpp
 
     Tests/WebCore/gstreamer/GStreamerTest.cpp
     Tests/WebCore/gstreamer/GstElementHarness.cpp

--- a/Tools/TestWebKitAPI/Tests/WTF/glib/ActivityObserver.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/glib/ActivityObserver.cpp
@@ -1,0 +1,258 @@
+/*
+ * Copyright (C) 2025 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "config.h"
+#include <wtf/glib/ActivityObserver.h>
+
+#include "Test.h"
+#include <wtf/RunLoop.h>
+
+namespace TestWebKitAPI {
+
+using namespace WTF;
+
+static void dispatchChecker(bool& done)
+{
+    RunLoop::currentSingleton().dispatchAfter(0_ms, [&] {
+        if (done)
+            RunLoop::currentSingleton().stop();
+        else {
+            // Re-dispatch to check again after current work completes
+            dispatchChecker(done);
+        }
+    });
+}
+
+// Helper function to run a test while the RunLoop is already active
+static void runTestWhileRunLoopIsActive(Function<void()>&& testFunction, bool& done)
+{
+    ASSERT(!done);
+
+    // Schedule test to run immediately after RunLoop starts (0ms delay)
+    RunLoop::currentSingleton().dispatchAfter(0_ms, [testFunction = WTFMove(testFunction)] {
+        testFunction();
+    });
+
+    // Start checker to stop RunLoop when test completes
+    dispatchChecker(done);
+    RunLoop::run();
+}
+
+// ============================================================================
+// 1. Basic ActivityObserver tests
+// ============================================================================
+
+TEST(WTF_ActivityObserver, Create)
+{
+    WTF::initializeMainThread();
+
+    bool observerCalled = false;
+    RefPtr observer = ActivityObserver::create(10, { RunLoop::Activity::BeforeWaiting }, [&] {
+        observerCalled = true;
+        return ActivityObserver::ContinueObservation::Yes;
+    });
+
+    EXPECT_TRUE(observer.get());
+    EXPECT_EQ(observer->order(), 10u);
+    EXPECT_FALSE(observer->activities().contains(RunLoop::Activity::AfterWaiting));
+    EXPECT_FALSE(observer->activities().contains(RunLoop::Activity::Entry));
+    EXPECT_FALSE(observer->activities().contains(RunLoop::Activity::Exit));
+    EXPECT_TRUE(observer->activities().contains(RunLoop::Activity::BeforeWaiting));
+    EXPECT_FALSE(observerCalled);
+
+    // Manually trigger notification
+    observer->notify();
+    EXPECT_TRUE(observerCalled);
+}
+
+TEST(WTF_ActivityObserver, MatchingActivity)
+{
+    WTF::initializeMainThread();
+
+    bool done = false;
+
+    bool observerCalled = false;
+    RefPtr<ActivityObserver> observer;
+
+    runTestWhileRunLoopIsActive([&] {
+        observer = ActivityObserver::create(1, { RunLoop::Activity::BeforeWaiting }, [&] {
+            observerCalled = true;
+            return ActivityObserver::ContinueObservation::Yes;
+        });
+
+        RunLoop::currentSingleton().observeActivity(*observer);
+
+        RunLoop::currentSingleton().dispatchAfter(0_ms, [&] {
+            done = true;
+            RunLoop::currentSingleton().unobserveActivity(*observer);
+        });
+    }, done);
+
+    EXPECT_TRUE(observerCalled);
+}
+
+TEST(WTF_ActivityObserver, NonMatchingActivity)
+{
+    WTF::initializeMainThread();
+
+    bool done = false;
+
+    bool lateObserverCalled = false;
+    RefPtr<ActivityObserver> lateObserver;
+
+    // This observer will fire upon run loop entry, as we observe the Entry activity.
+    bool earlyObserverCalled = false;
+    RefPtr<ActivityObserver> earlyObserver = ActivityObserver::create(1, { RunLoop::Activity::Entry }, [&] {
+        earlyObserverCalled = true;
+        return ActivityObserver::ContinueObservation::Yes;
+    });
+
+    RunLoop::currentSingleton().observeActivity(*earlyObserver);
+
+    runTestWhileRunLoopIsActive([&] {
+        lateObserver = ActivityObserver::create(1, { RunLoop::Activity::Entry }, [&] {
+            lateObserverCalled = true;
+            return ActivityObserver::ContinueObservation::Yes;
+        });
+
+        RunLoop::currentSingleton().observeActivity(*lateObserver);
+
+        RunLoop::currentSingleton().dispatchAfter(0_ms, [&] {
+            done = true;
+            RunLoop::currentSingleton().unobserveActivity(*earlyObserver);
+            RunLoop::currentSingleton().unobserveActivity(*lateObserver);
+        });
+    }, done);
+
+    EXPECT_TRUE(earlyObserverCalled);
+    EXPECT_FALSE(lateObserverCalled);
+}
+
+TEST(WTF_ActivityObserver, MultipleActivities)
+{
+    WTF::initializeMainThread();
+
+    bool done = false;
+
+    unsigned observerCallCount = 0;
+    RefPtr<ActivityObserver> observer;
+
+    runTestWhileRunLoopIsActive([&] {
+        observer = ActivityObserver::create(1, { RunLoop::Activity::BeforeWaiting }, [&] {
+            ++observerCallCount;
+            return ActivityObserver::ContinueObservation::Yes;
+        });
+
+        RunLoop::currentSingleton().observeActivity(*observer);
+
+        RunLoop::currentSingleton().dispatchAfter(0_ms, [&] {
+            done = true;
+            RunLoop::currentSingleton().unobserveActivity(*observer);
+        });
+    }, done);
+
+    EXPECT_GT(observerCallCount, 0u);
+}
+
+// ============================================================================
+// 2. Observer ordering tests
+// ============================================================================
+
+TEST(WTF_ActivityObserver, Ordering)
+{
+    WTF::initializeMainThread();
+
+    bool done = false;
+
+    Vector<unsigned> observerExecutionOrder;
+    RefPtr<ActivityObserver> observer1;
+    RefPtr<ActivityObserver> observer2;
+    RefPtr<ActivityObserver> observer3;
+
+    runTestWhileRunLoopIsActive([&] {
+        observer1 = ActivityObserver::create(30, { RunLoop::Activity::BeforeWaiting }, [&] {
+            observerExecutionOrder.append(30);
+            return ActivityObserver::ContinueObservation::Yes;
+        });
+
+        observer2 = ActivityObserver::create(10, { RunLoop::Activity::BeforeWaiting }, [&] {
+            observerExecutionOrder.append(10);
+            return ActivityObserver::ContinueObservation::Yes;
+        });
+
+        observer3 = ActivityObserver::create(20, { RunLoop::Activity::BeforeWaiting }, [&] {
+            observerExecutionOrder.append(20);
+            return ActivityObserver::ContinueObservation::Yes;
+        });
+
+        RunLoop::currentSingleton().observeActivity(*observer1);
+        RunLoop::currentSingleton().observeActivity(*observer2);
+        RunLoop::currentSingleton().observeActivity(*observer3);
+
+        RunLoop::currentSingleton().dispatchAfter(0_ms, [&] {
+            done = true;
+            RunLoop::currentSingleton().unobserveActivity(*observer1);
+            RunLoop::currentSingleton().unobserveActivity(*observer2);
+            RunLoop::currentSingleton().unobserveActivity(*observer3);
+        });
+    }, done);
+
+    EXPECT_EQ(observerExecutionOrder.size(), 3u);
+    EXPECT_EQ(observerExecutionOrder[0], 10u);
+    EXPECT_EQ(observerExecutionOrder[1], 20u);
+    EXPECT_EQ(observerExecutionOrder[2], 30u);
+}
+
+TEST(WTF_ActivityObserver, SameOrder)
+{
+    WTF::initializeMainThread();
+
+    bool done = false;
+
+    unsigned observerCallCount1 = 0;
+    unsigned observerCallCount2 = 0;
+    RefPtr<ActivityObserver> observer1;
+    RefPtr<ActivityObserver> observer2;
+
+    runTestWhileRunLoopIsActive([&] {
+        observer1 = ActivityObserver::create(10, { RunLoop::Activity::BeforeWaiting }, [&] {
+            ++observerCallCount1;
+            return ActivityObserver::ContinueObservation::Yes;
+        });
+
+        observer2 = ActivityObserver::create(10, { RunLoop::Activity::Entry, RunLoop::Activity::BeforeWaiting }, [&] {
+            ++observerCallCount2;
+            return ActivityObserver::ContinueObservation::Yes;
+        });
+
+        RunLoop::currentSingleton().observeActivity(*observer1);
+        RunLoop::currentSingleton().observeActivity(*observer2);
+
+        RunLoop::currentSingleton().dispatchAfter(0_ms, [&] {
+            done = true;
+            RunLoop::currentSingleton().unobserveActivity(*observer1);
+            RunLoop::currentSingleton().unobserveActivity(*observer2);
+        });
+    }, done);
+
+    EXPECT_EQ(observerCallCount1, 1u);
+    EXPECT_EQ(observerCallCount2, 1u);
+}
+
+} // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/WebCore/glib/RunLoopObserver.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/glib/RunLoopObserver.cpp
@@ -1,0 +1,669 @@
+/*
+ * Copyright (C) 2025 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "config.h"
+
+#include "Test.h"
+#include "Utilities.h"
+#include <WebCore/PlatformExportMacros.h>
+#include <WebCore/RunLoopObserver.h>
+
+namespace TestWebKitAPI {
+
+using namespace WTF;
+using namespace WebCore;
+
+static void setUpTest()
+{
+    WTF::initializeMainThread();
+
+#if PLATFORM(GTK)
+    // GTK under X11 has pending sources from gtk_init() when we run the loop,
+    // we need to process them to ensure the tests start with no pending sources.
+    auto* context = RunLoop::currentSingleton().mainContext();
+    while (g_main_context_pending(context))
+        g_main_context_iteration(context, FALSE);
+#endif
+}
+
+// ============================================================================
+// 1. RunLoopObserver lifecycle tests
+// ============================================================================
+
+TEST(RunLoopObserver, Schedule)
+{
+    setUpTest();
+
+    bool observerCalled = false;
+    auto observer = makeUniqueRef<RunLoopObserver>(RunLoopObserver::WellKnownOrder::PostRenderingUpdate, [&] {
+        observerCalled = true;
+    });
+
+    EXPECT_FALSE(observer->isScheduled());
+
+    observer->schedule();
+    EXPECT_TRUE(observer->isScheduled());
+
+    bool done = false;
+    RunLoop::currentSingleton().dispatch([&] {
+        done = true;
+    });
+
+    Util::run(&done);
+
+    EXPECT_TRUE(observerCalled);
+    EXPECT_TRUE(observer->isScheduled());
+
+    observer->invalidate();
+    EXPECT_FALSE(observer->isScheduled());
+}
+
+TEST(RunLoopObserver, Invalidate)
+{
+    setUpTest();
+
+    unsigned observerCallCount = 0;
+    auto observer = makeUniqueRef<RunLoopObserver>(RunLoopObserver::WellKnownOrder::PostRenderingUpdate, [&] {
+        ++observerCallCount;
+    });
+
+    observer->schedule(nullptr, { RunLoop::Activity::BeforeWaiting });
+    EXPECT_TRUE(observer->isScheduled());
+
+    bool done1 = false;
+    RunLoop::currentSingleton().dispatch([&] {
+        done1 = true;
+    });
+
+    Util::run(&done1);
+
+    EXPECT_EQ(observerCallCount, 1u);
+
+    bool done2 = false;
+    RunLoop::currentSingleton().dispatch([&] {
+        done2 = true;
+    });
+
+    Util::run(&done2);
+
+    EXPECT_EQ(observerCallCount, 2u);
+
+    observer->invalidate();
+    EXPECT_FALSE(observer->isScheduled());
+
+    bool done3 = false;
+    RunLoop::currentSingleton().dispatch([&] {
+        done3 = true;
+    });
+    Util::run(&done3);
+
+    EXPECT_EQ(observerCallCount, 2u);
+}
+
+TEST(RunLoopObserver, MultipleSchedule)
+{
+    setUpTest();
+
+    unsigned observerCallCount = 0;
+    auto observer = makeUniqueRef<RunLoopObserver>(RunLoopObserver::WellKnownOrder::PostRenderingUpdate, [&] {
+        ++observerCallCount;
+    });
+
+    observer->schedule(nullptr, { RunLoop::Activity::BeforeWaiting });
+    EXPECT_TRUE(observer->isScheduled());
+
+    observer->schedule(nullptr, { RunLoop::Activity::BeforeWaiting });
+    EXPECT_TRUE(observer->isScheduled());
+
+    bool done1 = false;
+    RunLoop::currentSingleton().dispatch([&] {
+        done1 = true;
+    });
+
+    Util::run(&done1);
+
+    EXPECT_EQ(observerCallCount, 1u);
+
+    bool done2 = false;
+    RunLoop::currentSingleton().dispatch([&] {
+        done2 = true;
+    });
+
+    Util::run(&done2);
+
+    EXPECT_EQ(observerCallCount, 2u);
+
+    observer->invalidate();
+    EXPECT_FALSE(observer->isScheduled());
+
+    bool done3 = false;
+    RunLoop::currentSingleton().dispatch([&] {
+        done3 = true;
+    });
+    Util::run(&done3);
+
+    EXPECT_EQ(observerCallCount, 2u);
+}
+
+TEST(RunLoopObserver, MultipleInvalidate)
+{
+    setUpTest();
+
+    unsigned observerCallCount = 0;
+    auto observer = makeUniqueRef<RunLoopObserver>(RunLoopObserver::WellKnownOrder::PostRenderingUpdate, [&] {
+        ++observerCallCount;
+    });
+
+    observer->schedule(nullptr, { RunLoop::Activity::BeforeWaiting });
+    EXPECT_TRUE(observer->isScheduled());
+
+    observer->schedule(nullptr, { RunLoop::Activity::BeforeWaiting });
+    EXPECT_TRUE(observer->isScheduled());
+
+    bool done1 = false;
+    RunLoop::currentSingleton().dispatch([&] {
+        done1 = true;
+    });
+
+    Util::run(&done1);
+
+    EXPECT_EQ(observerCallCount, 1u);
+
+    bool done2 = false;
+    RunLoop::currentSingleton().dispatch([&] {
+        done2 = true;
+    });
+
+    Util::run(&done2);
+
+    EXPECT_EQ(observerCallCount, 2u);
+
+    observer->invalidate();
+    EXPECT_FALSE(observer->isScheduled());
+
+    observer->invalidate();
+    EXPECT_FALSE(observer->isScheduled());
+
+    bool done3 = false;
+    RunLoop::currentSingleton().dispatch([&] {
+        done3 = true;
+    });
+    Util::run(&done3);
+
+    EXPECT_EQ(observerCallCount, 2u);
+}
+
+TEST(RunLoopObserver, Destruction)
+{
+    setUpTest();
+
+    unsigned observerCallCount = 0;
+    {
+        auto observer = makeUniqueRef<RunLoopObserver>(RunLoopObserver::WellKnownOrder::PostRenderingUpdate, [&] {
+            ++observerCallCount;
+        });
+
+        observer->schedule(nullptr, { RunLoop::Activity::BeforeWaiting });
+        EXPECT_TRUE(observer->isScheduled());
+    }
+
+    bool done = false;
+    RunLoop::currentSingleton().dispatch([&] {
+        done = true;
+    });
+
+    Util::run(&done);
+
+    EXPECT_EQ(observerCallCount, 0u);
+}
+
+// ============================================================================
+// 2. Repeating vs. one-shot tests
+// ============================================================================
+
+TEST(RunLoopObserver, Repeating)
+{
+    setUpTest();
+
+    unsigned observerCallCount = 0;
+
+    auto observer = makeUniqueRef<RunLoopObserver>(RunLoopObserver::WellKnownOrder::PostRenderingUpdate, [&] {
+        ++observerCallCount;
+    }, RunLoopObserver::Type::Repeating);
+
+    observer->schedule(nullptr, { RunLoop::Activity::BeforeWaiting });
+
+    bool done1 = false;
+    RunLoop::currentSingleton().dispatch([&] {
+        done1 = true;
+    });
+
+    Util::run(&done1);
+    EXPECT_EQ(observerCallCount, 1u);
+
+    bool done2 = false;
+    RunLoop::currentSingleton().dispatch([&] {
+        done2 = true;
+    });
+
+    Util::run(&done2);
+    EXPECT_EQ(observerCallCount, 2u);
+
+    bool done3 = false;
+    RunLoop::currentSingleton().dispatch([&] {
+        done3 = true;
+    });
+
+    Util::run(&done3);
+    EXPECT_EQ(observerCallCount, 3u);
+
+    observer->invalidate();
+}
+
+TEST(RunLoopObserver, OneShot)
+{
+    setUpTest();
+
+    unsigned observerCallCount = 0;
+
+    auto observer = makeUniqueRef<RunLoopObserver>(RunLoopObserver::WellKnownOrder::PostRenderingUpdate, [&] {
+        ++observerCallCount;
+    }, RunLoopObserver::Type::OneShot);
+
+    observer->schedule(nullptr, { RunLoop::Activity::BeforeWaiting });
+
+    bool done1 = false;
+    RunLoop::currentSingleton().dispatch([&] {
+        done1 = true;
+    });
+
+    Util::run(&done1);
+    EXPECT_EQ(observerCallCount, 1u);
+
+    bool done2 = false;
+    RunLoop::currentSingleton().dispatch([&] {
+        done2 = true;
+    });
+
+    Util::run(&done2);
+    EXPECT_EQ(observerCallCount, 1u);
+
+    bool done3 = false;
+    RunLoop::currentSingleton().dispatch([&] {
+        done3 = true;
+    });
+
+    Util::run(&done3);
+    EXPECT_EQ(observerCallCount, 1u);
+
+    observer->invalidate();
+}
+
+// ============================================================================
+// 3. Activity type coverage tests
+// ============================================================================
+TEST(RunLoopObserver, DefaultActivities)
+{
+    setUpTest();
+
+    unsigned observerCallCount = 0;
+
+    auto observer = makeUniqueRef<RunLoopObserver>(RunLoopObserver::WellKnownOrder::PostRenderingUpdate, [&] {
+        ++observerCallCount;
+    });
+
+    // Schedule with default activities (BeforeWaiting | Exit)
+    observer->schedule();
+
+    bool done = false;
+    RunLoop::currentSingleton().dispatch([&] {
+        done = true;
+    });
+
+    Util::run(&done);
+
+    // With default activities, only the BeforeWaiting observer should fire.
+    EXPECT_EQ(observerCallCount, 1u);
+
+    observer->invalidate();
+}
+
+TEST(RunLoopObserver, ActivityEntry)
+{
+    setUpTest();
+
+    unsigned observerCallCount = 0;
+
+    auto observer = makeUniqueRef<RunLoopObserver>(RunLoopObserver::WellKnownOrder::PostRenderingUpdate, [&] {
+        ++observerCallCount;
+    });
+
+    observer->schedule(nullptr, { RunLoop::Activity::Entry });
+
+    bool done = false;
+    RunLoop::currentSingleton().dispatch([&] {
+        done = true;
+    });
+
+    Util::run(&done);
+
+    // Entry observer doesn't fire if we only iterate the run loop.
+    EXPECT_EQ(observerCallCount, 0u);
+
+    observer->invalidate();
+}
+
+TEST(RunLoopObserver, ActivityExit)
+{
+    setUpTest();
+
+    unsigned observerCallCount = 0;
+
+    auto observer = makeUniqueRef<RunLoopObserver>(RunLoopObserver::WellKnownOrder::PostRenderingUpdate, [&] {
+        ++observerCallCount;
+    });
+
+    observer->schedule(nullptr, { RunLoop::Activity::Exit });
+
+    bool done = false;
+    RunLoop::currentSingleton().dispatch([&] {
+        done = true;
+    });
+
+    Util::run(&done);
+
+    // Exit observer doesn't fire if we only iterate the run loop.
+    EXPECT_EQ(observerCallCount, 0u);
+
+    observer->invalidate();
+}
+
+TEST(RunLoopObserver, ActivityBeforeWaiting)
+{
+    setUpTest();
+
+    unsigned observerCallCount = 0;
+
+    auto observer = makeUniqueRef<RunLoopObserver>(RunLoopObserver::WellKnownOrder::PostRenderingUpdate, [&] {
+        ++observerCallCount;
+    });
+
+    observer->schedule(nullptr, { RunLoop::Activity::BeforeWaiting });
+
+    bool done = false;
+    RunLoop::currentSingleton().dispatch([&] {
+        done = true;
+    });
+
+    Util::run(&done);
+
+    EXPECT_EQ(observerCallCount, 1u);
+
+    observer->invalidate();
+}
+
+TEST(RunLoopObserver, ActivityAfterWaiting)
+{
+    setUpTest();
+
+    unsigned observerCallCount = 0;
+
+    auto observer = makeUniqueRef<RunLoopObserver>(RunLoopObserver::WellKnownOrder::PostRenderingUpdate, [&] {
+        ++observerCallCount;
+    });
+
+    observer->schedule(nullptr, { RunLoop::Activity::AfterWaiting });
+
+    bool done = false;
+    RunLoop::currentSingleton().dispatch([&] {
+        done = true;
+    });
+
+    Util::run(&done);
+
+    EXPECT_EQ(observerCallCount, 1u);
+
+    observer->invalidate();
+}
+
+TEST(RunLoopObserver, ActivityCombination)
+{
+    setUpTest();
+
+    unsigned observerCallCount = 0;
+
+    auto observer = makeUniqueRef<RunLoopObserver>(RunLoopObserver::WellKnownOrder::PostRenderingUpdate, [&] {
+        ++observerCallCount;
+    });
+
+    observer->schedule(nullptr, { RunLoop::Activity::BeforeWaiting, RunLoop::Activity::Exit });
+
+    bool done = false;
+    RunLoop::currentSingleton().dispatch([&] {
+        done = true;
+    });
+
+    Util::run(&done);
+
+    // Exit observer doesn't fire if we only iterate the run loop.
+    EXPECT_EQ(observerCallCount, 1u);
+
+    observer->invalidate();
+}
+
+// ============================================================================
+// 4. Edge cases tests
+// ============================================================================
+
+TEST(RunLoopObserver, RemovesSelfDuringCallback)
+{
+    setUpTest();
+
+    unsigned observerCallCount = 0;
+
+    std::unique_ptr<RunLoopObserver> observer;
+    observer = makeUnique<RunLoopObserver>(RunLoopObserver::WellKnownOrder::PostRenderingUpdate, [&] {
+        ++observerCallCount;
+        if (observerCallCount == 1) {
+            // Invalidate self during first callback
+            observer->invalidate();
+        }
+    });
+
+    observer->schedule(nullptr, { RunLoop::Activity::BeforeWaiting });
+
+    bool done1 = false;
+    RunLoop::currentSingleton().dispatch([&] {
+        done1 = true;
+    });
+
+    Util::run(&done1);
+    EXPECT_EQ(observerCallCount, 1u);
+
+    // Run again to verify observer doesn't fire after self-invalidation
+    bool done2 = false;
+    RunLoop::currentSingleton().dispatch([&] {
+        done2 = true;
+    });
+
+    Util::run(&done2);
+    EXPECT_EQ(observerCallCount, 1u);
+}
+
+TEST(RunLoopObserver, AddsNewObserverDuringCallback)
+{
+    setUpTest();
+
+    unsigned observerCallCount1 = 0;
+    unsigned observerCallCount2 = 0;
+    std::unique_ptr<RunLoopObserver> observer2;
+
+    auto observer1 = makeUniqueRef<RunLoopObserver>(RunLoopObserver::WellKnownOrder::PostRenderingUpdate, [&] {
+        ++observerCallCount1;
+        if (observerCallCount1 == 1) {
+            // Create and schedule a new observer during first callback
+            observer2 = makeUnique<RunLoopObserver>(RunLoopObserver::WellKnownOrder::PostRenderingUpdate, [&] {
+                ++observerCallCount2;
+            });
+            observer2->schedule(nullptr, { RunLoop::Activity::BeforeWaiting });
+        }
+    });
+
+    observer1->schedule(nullptr, { RunLoop::Activity::BeforeWaiting });
+
+    bool done1 = false;
+    RunLoop::currentSingleton().dispatch([&] {
+        done1 = true;
+    });
+
+    Util::run(&done1);
+    EXPECT_EQ(observerCallCount1, 1u);
+    EXPECT_EQ(observerCallCount2, 0u);
+
+    // Run again to verify the newly added observer fires
+    bool done2 = false;
+    RunLoop::currentSingleton().dispatch([&] {
+        done2 = true;
+    });
+
+    Util::run(&done2);
+    EXPECT_EQ(observerCallCount1, 2u);
+    EXPECT_EQ(observerCallCount2, 1u);
+
+    observer1->invalidate();
+    if (observer2)
+        observer2->invalidate();
+}
+
+TEST(RunLoopObserver, AcrossMultipleIterations)
+{
+    setUpTest();
+
+    unsigned observerCallCount = 0;
+
+    auto observer = makeUniqueRef<RunLoopObserver>(RunLoopObserver::WellKnownOrder::PostRenderingUpdate, [&] {
+        ++observerCallCount;
+    });
+
+    observer->schedule(nullptr, { RunLoop::Activity::BeforeWaiting });
+
+    for (unsigned i = 0; i < 5; ++i) {
+        bool done = false;
+        RunLoop::currentSingleton().dispatch([&] {
+            done = true;
+        });
+        Util::run(&done);
+    }
+
+    EXPECT_EQ(observerCallCount, 5u);
+
+    observer->invalidate();
+}
+
+// ============================================================================
+// 5. WellKnownOrder tests
+// ============================================================================
+
+TEST(RunLoopObserver, WellKnownOrderValues)
+{
+    setUpTest();
+
+    Vector<unsigned> observerExecutionOrder;
+
+    auto observer1 = makeUniqueRef<RunLoopObserver>(RunLoopObserver::WellKnownOrder::GraphicsCommit, [&observerExecutionOrder] {
+        observerExecutionOrder.append(static_cast<int>(RunLoopObserver::WellKnownOrder::GraphicsCommit));
+    });
+
+    auto observer2 = makeUniqueRef<RunLoopObserver>(RunLoopObserver::WellKnownOrder::RenderingUpdate, [&observerExecutionOrder] {
+        observerExecutionOrder.append(static_cast<int>(RunLoopObserver::WellKnownOrder::RenderingUpdate));
+    });
+
+    auto observer3 = makeUniqueRef<RunLoopObserver>(RunLoopObserver::WellKnownOrder::PostRenderingUpdate, [&observerExecutionOrder] {
+        observerExecutionOrder.append(static_cast<int>(RunLoopObserver::WellKnownOrder::PostRenderingUpdate));
+    });
+
+    observer1->schedule(nullptr, { RunLoop::Activity::BeforeWaiting });
+    observer2->schedule(nullptr, { RunLoop::Activity::BeforeWaiting });
+    observer3->schedule(nullptr, { RunLoop::Activity::BeforeWaiting });
+
+    bool done = false;
+    RunLoop::currentSingleton().dispatch([&] {
+        done = true;
+    });
+
+    Util::run(&done);
+
+    EXPECT_EQ(observerExecutionOrder.size(), 3u);
+    EXPECT_LE(observerExecutionOrder[0], observerExecutionOrder[1]);
+    EXPECT_LE(observerExecutionOrder[1], observerExecutionOrder[2]);
+
+    observer1->invalidate();
+    observer2->invalidate();
+    observer3->invalidate();
+}
+
+TEST(RunLoopObserver, DifferentWellKnownOrderValues)
+{
+    setUpTest();
+
+    unsigned observerCallCount1 = 0;
+    unsigned observerCallCount2 = 0;
+    unsigned observerCallCount3 = 0;
+    unsigned observerCallCount4 = 0;
+
+    auto observer1 = makeUniqueRef<RunLoopObserver>(RunLoopObserver::WellKnownOrder::InspectorFrameBegin, [&] {
+        ++observerCallCount1;
+    });
+
+    auto observer2 = makeUniqueRef<RunLoopObserver>(RunLoopObserver::WellKnownOrder::InspectorFrameBegin, [&] {
+        ++observerCallCount2;
+    });
+
+    auto observer3 = makeUniqueRef<RunLoopObserver>(RunLoopObserver::WellKnownOrder::InspectorFrameEnd, [&] {
+        ++observerCallCount3;
+    });
+
+    auto observer4 = makeUniqueRef<RunLoopObserver>(RunLoopObserver::WellKnownOrder::OpportunisticTask, [&] {
+        ++observerCallCount4;
+    });
+
+    observer1->schedule(nullptr, { RunLoop::Activity::BeforeWaiting });
+    observer2->schedule(nullptr, { RunLoop::Activity::BeforeWaiting });
+    observer3->schedule(nullptr, { RunLoop::Activity::BeforeWaiting });
+    observer4->schedule(nullptr, { RunLoop::Activity::BeforeWaiting });
+
+    bool done = false;
+    RunLoop::currentSingleton().dispatch([&] {
+        done = true;
+    });
+
+    Util::run(&done);
+
+    EXPECT_EQ(observerCallCount1, 1u);
+    EXPECT_EQ(observerCallCount2, 1u);
+    EXPECT_EQ(observerCallCount3, 1u);
+    EXPECT_EQ(observerCallCount4, 1u);
+
+    observer1->invalidate();
+    observer2->invalidate();
+    observer3->invalidate();
+    observer4->invalidate();
+}
+
+} // namespace TestWebKitAPI


### PR DESCRIPTION
#### 8615019f48b156e271af8f0ae345697c14ed99d7
<pre>
[GTK][WPE] Implement RunLoopObserver for glib ports
<a href="https://bugs.webkit.org/show_bug.cgi?id=300022">https://bugs.webkit.org/show_bug.cgi?id=300022</a>

Reviewed by Carlos Garcia Campos.

Implement RunLoopObserver for GTK/WPE - ports using the GLib event loop.
This has been available on Apple platforms since a decade, and was used to
drive e.g. the rendering prior to GPUProcess. OpportunisticTaskScheduler
functionality (executing GC in &apos;good moments&apos;, not blocking rendering
etc.) depends on RunLoopObserver, which we failed to provide so far.

Add new API tests covering the ActiviyObserver/RunLoopObserver
implementation for the glib ports.

Tests: Tools/TestWebKitAPI/Tests/WTF/glib/ActivityObserver.cpp
       Tools/TestWebKitAPI/Tests/WebCore/glib/RunLoopObserver.cpp

* Source/WTF/wtf/PlatformGTK.cmake:
* Source/WTF/wtf/PlatformWPE.cmake:
* Source/WTF/wtf/RunLoop.h:
* Source/WTF/wtf/glib/ActivityObserver.h: Added.
(WTF::ActivityObserver::create):
(WTF::ActivityObserver::order const):
(WTF::ActivityObserver::activities const):
(WTF::ActivityObserver::notify const):
(WTF::ActivityObserver::ActivityObserver):
* Source/WTF/wtf/glib/RunLoopGLib.cpp:
(WTF::RunLoop::RunLoop):
(WTF::RunLoop::~RunLoop):
(WTF::RunLoop::runGLibMainLoopIteration):
(WTF::RunLoop::runGLibMainLoop):
(WTF::RunLoop::run):
(WTF::RunLoop::stop):
(WTF::RunLoop::cycle):
(WTF::RunLoop::observeEvent):
(WTF::RunLoop::observeActivity):
(WTF::RunLoop::unobserveActivity):
(WTF::RunLoop::notifyActivity):
(WTF::RunLoop::notifyEvent):
(WTF::RunLoop::observe): Deleted.
(WTF::RunLoop::notify): Deleted.
* Source/WebCore/SourcesGTK.txt:
* Source/WebCore/SourcesWPE.txt:
* Source/WebCore/inspector/agents/page/PageTimelineAgent.cpp:
(WebCore::PageTimelineAgent::internalStart):
* Source/WebCore/inspector/agents/page/PageTimelineAgent.h:
* Source/WebCore/platform/RunLoopObserver.cpp:
(WebCore::RunLoopObserver::runLoopObserverFired):
* Source/WebCore/platform/RunLoopObserver.h:
(WebCore::RunLoopObserver::RunLoopObserver):
* Source/WebCore/platform/glib/RunLoopObserverGLib.cpp: Added.
(WebCore::RunLoopObserver::schedule):
(WebCore::RunLoopObserver::invalidate):
(WebCore::RunLoopObserver::isScheduled const):
* Tools/TestWebKitAPI/PlatformGTK.cmake:
* Tools/TestWebKitAPI/PlatformWPE.cmake:
* Tools/TestWebKitAPI/Tests/WTF/glib/ActivityObserver.cpp: Added.
(TestWebKitAPI::dispatchChecker):
(TestWebKitAPI::runTestWhileRunLoopIsActive):
(TestWebKitAPI::TEST(WTF_ActivityObserver, Create)):
(TestWebKitAPI::TEST(WTF_ActivityObserver, MatchingActivity)):
(TestWebKitAPI::TEST(WTF_ActivityObserver, NonMatchingActivity)):
(TestWebKitAPI::TEST(WTF_ActivityObserver, MultipleActivities)):
(TestWebKitAPI::TEST(WTF_ActivityObserver, Ordering)):
(TestWebKitAPI::TEST(WTF_ActivityObserver, SameOrder)):
* Tools/TestWebKitAPI/Tests/WebCore/glib/RunLoopObserver.cpp: Added.
(TestWebKitAPI::setUpTest):
(TestWebKitAPI::TEST(RunLoopObserver, Schedule)):
(TestWebKitAPI::TEST(RunLoopObserver, Invalidate)):
(TestWebKitAPI::TEST(RunLoopObserver, MultipleSchedule)):
(TestWebKitAPI::TEST(RunLoopObserver, MultipleInvalidate)):
(TestWebKitAPI::TEST(RunLoopObserver, Destruction)):
(TestWebKitAPI::TEST(RunLoopObserver, Repeating)):
(TestWebKitAPI::TEST(RunLoopObserver, OneShot)):
(TestWebKitAPI::TEST(RunLoopObserver, DefaultActivities)):
(TestWebKitAPI::TEST(RunLoopObserver, ActivityEntry)):
(TestWebKitAPI::TEST(RunLoopObserver, ActivityExit)):
(TestWebKitAPI::TEST(RunLoopObserver, ActivityBeforeWaiting)):
(TestWebKitAPI::TEST(RunLoopObserver, ActivityAfterWaiting)):
(TestWebKitAPI::TEST(RunLoopObserver, ActivityCombination)):
(TestWebKitAPI::TEST(RunLoopObserver, RemovesSelfDuringCallback)):
(TestWebKitAPI::TEST(RunLoopObserver, AddsNewObserverDuringCallback)):
(TestWebKitAPI::TEST(RunLoopObserver, AcrossMultipleIterations)):
(TestWebKitAPI::TEST(RunLoopObserver, WellKnownOrderValues)):
(TestWebKitAPI::TEST(RunLoopObserver, DifferentWellKnownOrderValues)):

Canonical link: <a href="https://commits.webkit.org/301378@main">https://commits.webkit.org/301378@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a1069df357f7f03477e555757811de2ff1abb5d6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125779 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45441 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36192 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132647 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77657 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127650 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46124 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54000 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95819 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/63937 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128727 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36875 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112475 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76311 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35777 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30659 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76120 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/117860 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106654 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30872 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135329 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/124286 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52566 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40315 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104288 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53014 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108685 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104016 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26488 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49380 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27698 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49871 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52461 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58270 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/157298 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51809 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39378 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55158 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53503 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->