### PR TITLE
Address safer CPP warnings in PageClientImplMac

### DIFF
--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
@@ -142,7 +142,7 @@ WebCore::FloatPoint PageClientImpl::viewScrollPosition()
 
 IntSize PageClientImpl::viewSize()
 {
-    return IntSize([m_view bounds].size);
+    return IntSize([m_view.get() bounds].size);
 }
 
 NSView *PageClientImpl::activeView() const
@@ -158,7 +158,7 @@ NSWindow *PageClientImpl::activeWindow() const
         return [impl->thumbnailView() window];
     if (impl && impl->targetWindowForMovePreparation())
         return impl->targetWindowForMovePreparation();
-    return [m_view window];
+    return [m_view.get() window];
 }
 
 bool PageClientImpl::isViewWindowActive()
@@ -180,7 +180,7 @@ bool PageClientImpl::isViewFocused()
 
 void PageClientImpl::assistiveTechnologyMakeFirstResponder()
 {
-    [[m_view window] makeFirstResponder:m_view.get().get()];
+    [[m_view.get() window] makeFirstResponder:m_view.get().get()];
 }
     
 void PageClientImpl::makeFirstResponder()
@@ -188,7 +188,7 @@ void PageClientImpl::makeFirstResponder()
     if (m_shouldSuppressFirstResponderChanges)
         return;
 
-    [[m_view window] makeFirstResponder:m_view.get().get()];
+    [[m_view.get() window] makeFirstResponder:m_view.get().get()];
 }
     
 bool PageClientImpl::isViewVisible(NSView *view, NSWindow *viewWindow)
@@ -225,14 +225,14 @@ bool PageClientImpl::isActiveViewVisible()
 bool PageClientImpl::isMainViewVisible()
 {
     RetainPtr mainView = m_view.get();
-    RetainPtr mainViewWindow = [m_view window];
+    RetainPtr mainViewWindow = [mainView window];
 
     return isViewVisible(mainView.get(), mainViewWindow.get());
 }
 
 bool PageClientImpl::isViewVisibleOrOccluded()
 {
-    return activeWindow().isVisible;
+    return RetainPtr { activeWindow() }.get().isVisible;
 }
 
 bool PageClientImpl::isViewInWindow()
@@ -369,7 +369,7 @@ void PageClientImpl::registerEditCommand(Ref<WebEditCommandProxy>&& command, Und
 
 void PageClientImpl::registerInsertionUndoGrouping()
 {
-    registerInsertionUndoGroupingWithUndoManager([m_view undoManager]);
+    registerInsertionUndoGroupingWithUndoManager([m_view.get() undoManager]);
 }
 
 void PageClientImpl::createPDFHUD(PDFPluginIdentifier identifier, WebCore::FrameIdentifier frameID, const WebCore::IntRect& rect)
@@ -399,12 +399,12 @@ void PageClientImpl::clearAllEditCommands()
 
 bool PageClientImpl::canUndoRedo(UndoOrRedo undoOrRedo)
 {
-    return (undoOrRedo == UndoOrRedo::Undo) ? [[m_view undoManager] canUndo] : [[m_view undoManager] canRedo];
+    return (undoOrRedo == UndoOrRedo::Undo) ? [[m_view.get() undoManager] canUndo] : [[m_view.get() undoManager] canRedo];
 }
 
 void PageClientImpl::executeUndoRedo(UndoOrRedo undoOrRedo)
 {
-    return (undoOrRedo == UndoOrRedo::Undo) ? [[m_view undoManager] undo] : [[m_view undoManager] redo];
+    return (undoOrRedo == UndoOrRedo::Undo) ? [[m_view.get() undoManager] undo] : [[m_view.get() undoManager] redo];
 }
 
 void PageClientImpl::startDrag(const WebCore::DragItem& item, ShareableBitmap::Handle&& image, const std::optional<WebCore::NodeIdentifier>& nodeID)
@@ -437,12 +437,12 @@ void PageClientImpl::notifyInputContextAboutDiscardedComposition()
 
 FloatRect PageClientImpl::convertToDeviceSpace(const FloatRect& rect)
 {
-    return toDeviceSpace(rect, [m_view window]);
+    return toDeviceSpace(rect, [m_view.get() window]);
 }
 
 FloatRect PageClientImpl::convertToUserSpace(const FloatRect& rect)
 {
-    return toUserSpace(rect, [m_view window]);
+    return toUserSpace(rect, [m_view.get() window]);
 }
 
 void PageClientImpl::pinnedStateWillChange()
@@ -462,27 +462,30 @@ void PageClientImpl::drawPageBorderForPrinting(WebCore::FloatSize&& size)
     
 IntPoint PageClientImpl::screenToRootView(const IntPoint& point)
 {
-    NSPoint windowCoord = [[m_view window] convertPointFromScreen:point];
-    return IntPoint([m_view convertPoint:windowCoord fromView:nil]);
+    RetainPtr view = m_view.get();
+    NSPoint windowCoord = [[view window] convertPointFromScreen:point];
+    return IntPoint([view convertPoint:windowCoord fromView:nil]);
 }
 
 IntPoint PageClientImpl::rootViewToScreen(const IntPoint& point)
 {
-    return IntPoint([[m_view window] convertPointToScreen:[m_view convertPoint:point toView:nil]]);
+    RetainPtr view = m_view.get();
+    return IntPoint([[view window] convertPointToScreen:[view convertPoint:point toView:nil]]);
 }
 
 IntRect PageClientImpl::rootViewToScreen(const IntRect& rect)
 {
     NSRect tempRect = rect;
-    tempRect = [m_view convertRect:tempRect toView:nil];
-    tempRect.origin = [[m_view window] convertPointToScreen:tempRect.origin];
+    RetainPtr view = m_view.get();
+    tempRect = [view convertRect:tempRect toView:nil];
+    tempRect.origin = [[view window] convertPointToScreen:tempRect.origin];
     return enclosingIntRect(tempRect);
 }
 
 IntRect PageClientImpl::rootViewToWindow(const WebCore::IntRect& rect)
 {
     NSRect tempRect = rect;
-    tempRect = [m_view convertRect:tempRect toView:nil];
+    tempRect = [m_view.get() convertRect:tempRect toView:nil];
     return enclosingIntRect(tempRect);
 }
 
@@ -498,7 +501,7 @@ IntRect PageClientImpl::rootViewToAccessibilityScreen(const IntRect& rect)
 
 void PageClientImpl::doneWithKeyEvent(const NativeWebKeyboardEvent& event, bool eventWasHandled)
 {
-    checkedImpl()->doneWithKeyEvent(event.nativeEvent(), eventWasHandled);
+    checkedImpl()->doneWithKeyEvent(RetainPtr { event.nativeEvent() }.get(), eventWasHandled);
 }
 
 #if ENABLE(IMAGE_ANALYSIS)
@@ -624,7 +627,7 @@ void PageClientImpl::updateAcceleratedCompositingMode(const LayerTreeContext& la
 
 void PageClientImpl::setRemoteLayerTreeRootNode(RemoteLayerTreeNode* rootNode)
 {
-    checkedImpl()->setAcceleratedCompositingRootLayer(rootNode ? rootNode->layer() : nil);
+    checkedImpl()->setAcceleratedCompositingRootLayer(rootNode ? rootNode->protectedLayer().get() : nil);
 }
 
 CALayer *PageClientImpl::acceleratedCompositingRootLayer() const
@@ -678,7 +681,7 @@ void PageClientImpl::dismissDigitalCredentialsPicker(WTF::CompletionHandler<void
 void PageClientImpl::wheelEventWasNotHandledByWebCore(const NativeWebWheelEvent& event)
 {
     if (RefPtr gestureController = m_impl->gestureController())
-        gestureController->wheelEventWasNotHandledByWebCore(event.nativeEvent());
+        gestureController->wheelEventWasNotHandledByWebCore(RetainPtr { event.nativeEvent() }.get());
 }
 
 #if ENABLE(MAC_GESTURE_EVENTS)
@@ -948,7 +951,7 @@ void PageClientImpl::didChangeBackgroundColor()
 
 CGRect PageClientImpl::boundsOfLayerInLayerBackedWindowCoordinates(CALayer *layer) const
 {
-    RetainPtr<CALayer> windowContentLayer = static_cast<NSView *>([m_view window].contentView).layer;
+    RetainPtr<CALayer> windowContentLayer = static_cast<NSView *>([m_view.get() window].contentView).layer;
     ASSERT(windowContentLayer);
 
     return [windowContentLayer convertRect:layer.bounds fromLayer:layer];
@@ -1036,15 +1039,16 @@ void PageClientImpl::requestScrollToRect(const WebCore::FloatRect& targetRect, c
 
 bool PageClientImpl::windowIsFrontWindowUnderMouse(const NativeWebMouseEvent& event)
 {
-    return checkedImpl()->windowIsFrontWindowUnderMouse(event.nativeEvent());
+    return checkedImpl()->windowIsFrontWindowUnderMouse(RetainPtr { event.nativeEvent() }.get());
 }
 
 std::optional<float> PageClientImpl::computeAutomaticTopObscuredInset()
 {
-    RetainPtr window = [m_view window];
-    if (([window styleMask] & NSWindowStyleMaskFullSizeContentView) && ![window titlebarAppearsTransparent] && ![m_view enclosingScrollView]) {
+    RetainPtr view = m_view.get();
+    RetainPtr window = [view window];
+    if (([window styleMask] & NSWindowStyleMaskFullSizeContentView) && ![window titlebarAppearsTransparent] && ![view enclosingScrollView]) {
         [window updateConstraintsIfNeeded];
-        NSRect contentLayoutRectInWebViewCoordinates = [m_view convertRect:[window contentLayoutRect] fromView:nil];
+        NSRect contentLayoutRectInWebViewCoordinates = [view convertRect:[window contentLayoutRect] fromView:nil];
         return std::max<float>(contentLayoutRectInWebViewCoordinates.origin.y, 0);
     }
 
@@ -1091,7 +1095,7 @@ void PageClientImpl::requestDOMPasteAccess(WebCore::DOMPasteAccessCategory paste
 
 void PageClientImpl::makeViewBlank(bool makeBlank)
 {
-    m_impl->acceleratedCompositingRootLayer().opacity = makeBlank ? 0 : 1;
+    RetainPtr { m_impl->acceleratedCompositingRootLayer() }.get().opacity = makeBlank ? 0 : 1;
 }
 
 #if HAVE(APP_ACCENT_COLORS)


### PR DESCRIPTION
#### 008b65cc75bf2572e6167acddee1de091db127fb
<pre>
Address safer CPP warnings in PageClientImplMac
<a href="https://bugs.webkit.org/show_bug.cgi?id=300023">https://bugs.webkit.org/show_bug.cgi?id=300023</a>

Reviewed by Chris Dumez.

Not unskipping the file due to a few false-positives
that should be addressed by recent changes in the checker
and a few that are addressed in a separate MR.

* Source/WebKit/UIProcess/mac/PageClientImplMac.mm:
(WebKit::PageClientImpl::viewSize):
(WebKit::PageClientImpl::activeWindow const):
(WebKit::PageClientImpl::assistiveTechnologyMakeFirstResponder):
(WebKit::PageClientImpl::makeFirstResponder):
(WebKit::PageClientImpl::isMainViewVisible):
(WebKit::PageClientImpl::isViewVisibleOrOccluded):
(WebKit::PageClientImpl::registerInsertionUndoGrouping):
(WebKit::PageClientImpl::canUndoRedo):
(WebKit::PageClientImpl::executeUndoRedo):
(WebKit::PageClientImpl::convertToDeviceSpace):
(WebKit::PageClientImpl::convertToUserSpace):
(WebKit::PageClientImpl::screenToRootView):
(WebKit::PageClientImpl::rootViewToScreen):
(WebKit::PageClientImpl::rootViewToWindow):
(WebKit::PageClientImpl::doneWithKeyEvent):
(WebKit::PageClientImpl::setRemoteLayerTreeRootNode):
(WebKit::PageClientImpl::wheelEventWasNotHandledByWebCore):
(WebKit::PageClientImpl::boundsOfLayerInLayerBackedWindowCoordinates const):
(WebKit::PageClientImpl::windowIsFrontWindowUnderMouse):
(WebKit::PageClientImpl::computeAutomaticTopObscuredInset):
(WebKit::PageClientImpl::makeViewBlank):

Canonical link: <a href="https://commits.webkit.org/301138@main">https://commits.webkit.org/301138@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/45333759cbe7f7e307569929eb502d1c1c55b771

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125054 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44722 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35460 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131902 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76931 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45413 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53287 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95190 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/63161 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128008 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36247 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111840 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75733 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35162 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29993 "Build is in progress. Recent messages:") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75384 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106010 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30222 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134581 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51873 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39669 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103660 "2 flakes 56 failures") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52299 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108051 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103434 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26338 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48780 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27069 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48922 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51759 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57552 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51132 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54489 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52823 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->