### PR TITLE
attachShadow() should use the global registry by default

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/ShadowRoot-init-customElementRegistry-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/ShadowRoot-init-customElementRegistry-expected.txt
@@ -3,7 +3,7 @@ PASS A newly attached disconnected ShadowRoot should use the global registry by 
 PASS A newly attached connected ShadowRoot should use the global registry by default
 PASS A newly attached disconnected ShadowRoot should use the scoped registry if explicitly specified in attachShadow
 PASS A newly attached connected ShadowRoot should use the scoped registry if explicitly specified in attachShadow
-PASS attachShadow() should use the global registry when customElementRegistry is null
-PASS attachShadow() should use the shadow host's registry when customElementRegistry is null
+PASS attachShadow() should use the global registry when customElementRegistry is null (host uses global registry)
+PASS attachShadow() should use the global registry when customElementRegistry is null (host uses custom registry)
 PASS attachShadow() should use the null registry when the shadow host uses null registry and customElementRegistry is null
 

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/ShadowRoot-init-customElementRegistry.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/ShadowRoot-init-customElementRegistry.html
@@ -37,14 +37,14 @@ test(() => {
     const host = document.body.appendChild(document.createElement('div'));
     const shadowRoot = host.attachShadow({mode: 'closed', customElementRegistry: null});
     assert_equals(shadowRoot.customElementRegistry, window.customElements);
-}, 'attachShadow() should use the global registry when customElementRegistry is null');
+}, 'attachShadow() should use the global registry when customElementRegistry is null (host uses global registry)');
 
 test(() => {
     const registry = new CustomElementRegistry;
     const host = document.body.appendChild(document.createElement('div', {customElementRegistry: registry}));
     const shadowRoot = host.attachShadow({mode: 'closed', customElementRegistry: null});
-    assert_equals(shadowRoot.customElementRegistry, registry);
-}, 'attachShadow() should use the shadow host\'s registry when customElementRegistry is null');
+    assert_equals(shadowRoot.customElementRegistry, window.customElements);
+}, 'attachShadow() should use the global registry when customElementRegistry is null (host uses custom registry)');
 
 test(() => {
     const registry = new CustomElementRegistry;

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/ShadowRoot-init-declarative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/ShadowRoot-init-declarative-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Custom element inside 'shadowrootcustomelementregistry' declarative shadow root
+FAIL Built-in element inside 'shadowrootcustomelementregistry' declarative shadow root assert_equals: expected null but got object "[object CustomElementRegistry]"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/ShadowRoot-init-declarative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/ShadowRoot-init-declarative.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<title>Scoped Custom Element Registries: declarative shadow root</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id="host">
+  <template shadowrootmode="open" shadowrootcustomelementregistry>
+    <custom-element></custom-element>
+    <div></div>
+  </template>
+</div>
+<script>
+test(() => {
+  const customElement = host.shadowRoot.firstElementChild;
+  assert_equals(customElement.customElementRegistry, null);
+  customElement.attachShadow({
+    mode: "open"
+  });
+  assert_equals(customElement.shadowRoot.customElementRegistry, null);
+}, "Custom element inside 'shadowrootcustomelementregistry' declarative shadow root");
+
+test(() => {
+  const divElement = host.shadowRoot.lastElementChild;
+  assert_equals(divElement.customElementRegistry, null);
+  divElement.attachShadow({
+    mode: "open"
+  });
+  assert_equals(divElement.shadowRoot.customElementRegistry, null);
+}, "Built-in element inside 'shadowrootcustomelementregistry' declarative shadow root");
+</script>

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -3428,7 +3428,7 @@ ExceptionOr<ShadowRoot&> Element::attachShadow(const ShadowRootInit& init, std::
         ASSERT(registryKind == CustomElementRegistryKind::Window);
         scopedRegistry = ShadowRootScopedCustomElementRegistry::Yes;
     } else
-        registry = CustomElementRegistry::registryForElement(*this);
+        registry = document().customElementRegistry();
     Ref shadow = ShadowRoot::create(document(), init.mode, init.slotAssignment,
         init.delegatesFocus ? ShadowRootDelegatesFocus::Yes : ShadowRootDelegatesFocus::No,
         init.clonable ? ShadowRoot::Clonable::Yes : ShadowRoot::Clonable::No,


### PR DESCRIPTION
#### 281b5a9d7bc5f6802ea8b5a40d04277d16321a45
<pre>
attachShadow() should use the global registry by default
<a href="https://bugs.webkit.org/show_bug.cgi?id=300027">https://bugs.webkit.org/show_bug.cgi?id=300027</a>

Reviewed by Ryosuke Niwa.

Address <a href="https://github.com/whatwg/dom/issues/1407">https://github.com/whatwg/dom/issues/1407</a> by partially reverting
296896@main.

Canonical link: <a href="https://commits.webkit.org/300996@main">https://commits.webkit.org/300996@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2ff1128a31a872414491536773d4d120f661ff85

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124199 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43892 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34609 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131029 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76290 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3b922353-2e05-43b2-a6d3-6080aa7d9c9d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/126076 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44633 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52492 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94481 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62679 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b2c8e87a-73e9-42c4-84bc-192491987334) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127153 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35569 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111095 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75069 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6ac6fe9a-ef3c-4897-886f-66cab1736375) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34514 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29257 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74513 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105311 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29478 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133704 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51122 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38966 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102954 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51508 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107313 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102756 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26237 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48114 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26363 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48022 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50983 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56758 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50430 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53782 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52105 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->