### PR TITLE
[JSC] Remove Wasm string size limit

### DIFF
--- a/JSTests/wasm/stress/large-string-constants.js
+++ b/JSTests/wasm/stress/large-string-constants.js
@@ -1,0 +1,38 @@
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+function generateRandomAlphanumericString(length) {
+  if (length < 0) {
+    throw new Error("Length must be non-negative");
+  }
+
+  const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  let result = '';
+
+  for (let i = 0; i < length; i++) {
+    result += characters.charAt(Math.floor(Math.random() * characters.length));
+  }
+
+  return result;
+}
+
+async function test() {
+  let hugeStr1 = generateRandomAlphanumericString(500_000);
+  let hugeStr2 = generateRandomAlphanumericString(500_000);
+  let wat = `
+  (module
+    (import "ns" "${hugeStr2}" (global $const1 externref))
+    (func (export "${hugeStr1}") (result i32)
+      (return (i32.const 42))
+    )
+  )
+  `;
+
+  const ns = { [hugeStr2]: "foo" };
+
+  let instance = await instantiate(wat, { ns }, {});
+
+  assert.truthy(Object.hasOwn(instance.exports, hugeStr1));
+}
+
+await assert.asyncTest(test());

--- a/Source/JavaScriptCore/wasm/WasmLimits.h
+++ b/Source/JavaScriptCore/wasm/WasmLimits.h
@@ -51,7 +51,6 @@ constexpr size_t maxNumberOfRecursionGroups = 1000000;
 constexpr size_t maxSubtypeSupertypeCount = 1;
 constexpr size_t maxSubtypeDepth = 63;
 
-constexpr size_t maxStringSize = 100000;
 constexpr size_t maxModuleSize = 1024 * 1024 * 1024;
 constexpr size_t maxFunctionSize = 7654321;
 constexpr size_t maxFunctionLocals = 50000;

--- a/Source/JavaScriptCore/wasm/WasmParser.h
+++ b/Source/JavaScriptCore/wasm/WasmParser.h
@@ -179,8 +179,6 @@ ALWAYS_INLINE bool ParserBase::consumeUTF8String(Name& result, size_t stringLeng
         return true;
     if (m_source.size() < stringLength || m_offset > m_source.size() - stringLength)
         return false;
-    if (stringLength > maxStringSize)
-        return false;
     if (!result.tryReserveCapacity(stringLength))
         return false;
 


### PR DESCRIPTION
#### 81ff731cd920538a22ce601def50f29f404eb5b3
<pre>
[JSC] Remove Wasm string size limit

<a href="https://bugs.webkit.org/show_bug.cgi?id=299393">https://bugs.webkit.org/show_bug.cgi?id=299393</a>
<a href="https://rdar.apple.com/161683389">rdar://161683389</a>

Reviewed by Yusuke Suzuki.

Wasm limits were copied from V8 in 2017 for compat. The string size limit seems
to have never been used in V8, and now we _are_ running into compat problems
with V8, so we should remove it.

Test: JSTests/wasm/stress/large-string-constants.js

* JSTests/wasm/stress/large-string-constants.js: Added.
(from.string_appeared_here.import.as.assert.from.string_appeared_here.generateRandomAlphanumericString):
(async test):
* Source/JavaScriptCore/wasm/WasmLimits.h:
* Source/JavaScriptCore/wasm/WasmParser.h:
(JSC::Wasm::ParserBase::consumeUTF8String):

Canonical link: <a href="https://commits.webkit.org/300897@main">https://commits.webkit.org/300897@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2ec8ae53211ecf9a8b6139f58dc5d21c094401c6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124220 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43912 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34630 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131053 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76310 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b0bc6df7-ea80-4e4a-8eba-2c511ba3fc23) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44653 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52512 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94491 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62690 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f8ef03d3-9f41-4378-a21e-a6710df4f996) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127174 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35582 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111109 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75079 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ecee6853-77c6-4ef7-b7fb-53edec2de620) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34527 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29271 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74535 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/116367 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105324 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29492 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133727 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/122751 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51142 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38980 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102967 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51529 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107327 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102768 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26153 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48129 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26377 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/48048 "The change is no longer eligible for processing.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51003 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56779 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/153845 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50449 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39096 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53801 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52124 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->