### PR TITLE
Expose WebKit::NavigationActionData::isRequestFromClientOrUserInput through WKNavigationAction

### DIFF
--- a/Source/WebKit/UIProcess/API/APINavigationAction.h
+++ b/Source/WebKit/UIProcess/API/APINavigationAction.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -72,6 +72,7 @@ public:
     bool isProcessingUnconsumedUserGesture() const { return m_userInitiatedAction && !m_userInitiatedAction->consumed(); }
     UserInitiatedAction* userInitiatedAction() const { return m_userInitiatedAction.get(); }
     RefPtr<UserInitiatedAction> protectedUserInitiatedAction() const { return m_userInitiatedAction; }
+    bool isRequestFromClientOrUserInput() { return m_navigationActionData.isRequestFromClientOrUserInput; }
 
     Navigation* mainFrameNavigation() const { return m_mainFrameNavigation.get(); }
     RefPtr<Navigation> protectedMainFrameNavigation() const { return m_mainFrameNavigation; }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKNavigationAction.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKNavigationAction.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -73,7 +73,7 @@ WK_CLASS_AVAILABLE(macos(10.10), ios(8.0))
  */
 @property (nonatomic, readonly) WKNavigationType navigationType;
 
-/*! @abstract The navigation's request. 
+/*! @abstract The navigation's request.
  */
 @property (nonatomic, readonly, copy) NSURLRequest *request;
 
@@ -106,6 +106,10 @@ WK_CLASS_AVAILABLE(macos(10.10), ios(8.0))
 @property (nonatomic, readonly) NSInteger buttonNumber;
 
 #endif
+
+/*! @abstract Whether or not the current navigation was triggered through a WebKit Framework load request or through user input
+ */
+@property (nonatomic, readonly) BOOL isRequestFromClientOrUserInput WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKNavigationAction.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKNavigationAction.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -288,6 +288,11 @@ static WKSyntheticClickType toWKSyntheticClickType(WebKit::WebMouseEventSyntheti
 - (BOOL)_hasOpener
 {
     return _navigationAction->hasOpener();
+}
+
+- (BOOL)isRequestFromClientOrUserInput
+{
+    return _navigationAction->isRequestFromClientOrUserInput();
 }
 
 @end

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/DecidePolicyForNavigationAction.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/DecidePolicyForNavigationAction.mm
@@ -118,9 +118,13 @@ TEST(WebKit, DecidePolicyForNavigationActionReload)
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:firstURL]]];
     TestWebKitAPI::Util::run(&finishedNavigation);
 
+    EXPECT_TRUE([action isRequestFromClientOrUserInput]);
+
     decidedPolicy = false;
     [webView reload];
     TestWebKitAPI::Util::run(&decidedPolicy);
+
+    EXPECT_TRUE([action isRequestFromClientOrUserInput]);
 
     EXPECT_EQ(WKNavigationTypeReload, [action navigationType]);
     EXPECT_EQ([action sourceFrame], [action targetFrame]);
@@ -416,9 +420,13 @@ TEST(WebKit, DecidePolicyForNavigationActionForTargetedHyperlink)
     [webView loadHTMLString:@"<a style=\"display: block; height: 100%\" href=\"https://webkit.org/destination2.html\" target=\"B\">" baseURL:[NSURL URLWithString:@"http://webkit.org"]];
     TestWebKitAPI::Util::run(&finishedNavigation);
 
+    EXPECT_TRUE([action isRequestFromClientOrUserInput]);
+
     didCreateWebView = false;
     [webView evaluateJavaScript:@"window.open(\"https://webkit.org/destination1.html\", \"B\")" completionHandler:nil];
     TestWebKitAPI::Util::run(&didCreateWebView);
+
+    EXPECT_FALSE([action isRequestFromClientOrUserInput]);
 
     EXPECT_EQ(WKNavigationTypeOther, [action navigationType]);
     EXPECT_TRUE([action sourceFrame] != [action targetFrame]);
@@ -446,6 +454,7 @@ TEST(WebKit, DecidePolicyForNavigationActionForTargetedHyperlink)
     EXPECT_EQ(newWebView.get(), [[action targetFrame] webView]);
     EXPECT_WK_STREQ("http", [[[action sourceFrame] securityOrigin] protocol]);
     EXPECT_WK_STREQ("webkit.org", [[[action sourceFrame] securityOrigin] host]);
+    EXPECT_FALSE([action isRequestFromClientOrUserInput]);
 
     _WKHitTestResult *hitTestResult = [action _hitTestResult];
     EXPECT_NOT_NULL(hitTestResult);
@@ -625,6 +634,8 @@ static void runDecidePolicyForNavigationActionForHyperlinkThatRedirects(ShouldEn
     [webView loadHTMLString:@"<a style=\"display: block; height: 100%\" href=\"http://redirect/?result\">" baseURL:[NSURL URLWithString:@"http://webkit.org"]];
     TestWebKitAPI::Util::run(&finishedNavigation);
 
+    EXPECT_TRUE([action isRequestFromClientOrUserInput]);
+
     decidedPolicy = false;
     [newWebView setNavigationDelegate:controller.get()];
     NSPoint clickPoint = NSMakePoint(100, 100);
@@ -659,6 +670,7 @@ static void runDecidePolicyForNavigationActionForHyperlinkThatRedirects(ShouldEn
     EXPECT_WK_STREQ("http", [[[action sourceFrame] securityOrigin] protocol]);
     EXPECT_WK_STREQ("webkit.org", [[[action sourceFrame] securityOrigin] host]);
     EXPECT_TRUE([action _isRedirect]);
+    EXPECT_FALSE([action isRequestFromClientOrUserInput]);
 
     [TestProtocol unregister];
     newWebView = nullptr;


### PR DESCRIPTION
#### d4a924476273388abc8b3b6e6508bcc547ea208a
<pre>
Expose WebKit::NavigationActionData::isRequestFromClientOrUserInput through WKNavigationAction
<a href="https://bugs.webkit.org/show_bug.cgi?id=300035">https://bugs.webkit.org/show_bug.cgi?id=300035</a>
&lt;<a href="https://rdar.apple.com/problem/161833541">rdar://problem/161833541</a>&gt;

Reviewed by NOBODY (OOPS!).

The NavigationActionData class contains a flag that hints whether an action was triggered
through User Input or a load directive from the User Agent Chrome
(NavigationActionData::isRequestFromClientOrUserInput) (e.g., Bug 266354).

It would be helpful to expose this in the `WKNavigationAction` layer so that the User
Interface could use this as a hint about how verbose to be during certain load failures.
For example, a failed load of a custom URL scheme triggered by script while loading or
updating a page doesn&apos;t generally need to be reported to the user, since they aren&apos;t aware
of the load attempt and console logging will let a web developer see this. On the other
hand, if a user clicks on a link or enters a URL in the browser chrome and the load fails,
we want to immediately present this information so the user can understand what went wrong.

This patch exposes the existing WebKit::NavigationActionData::isRequestFromClientOrUserInput
flag through the WKNavigationAction class so a client can access it. The data is already
present in the UIProcess as internal state.

Tested by API tests.

* Source/WebKit/UIProcess/API/APINavigationAction.h:
* Source/WebKit/UIProcess/API/Cocoa/WKNavigationAction.mm:
(-[WKNavigationAction _isRequestFromClientOrUserInput]):
* Source/WebKit/UIProcess/API/Cocoa/WKNavigationActionPrivate.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/DecidePolicyForNavigationAction.mm:
(TEST(WebKit, DecidePolicyForNavigationActionReload)):
(TEST(WebKit, DecidePolicyForNavigationActionForTargetedHyperlink)):
(runDecidePolicyForNavigationActionForHyperlinkThatRedirects):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d4a924476273388abc8b3b6e6508bcc547ea208a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124517 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44194 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34929 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131353 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76491 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5c2e0235-1aa0-4d19-9bac-fec5a439586a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/126394 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44910 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52774 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94723 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62818 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/536da35e-620f-40da-878e-44c15e3d5523) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127471 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35801 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111363 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75299 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2791f8b8-e68d-4041-b9c0-77c53e8b67a0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34739 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29518 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74834 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105554 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29750 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134020 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51384 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39209 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103201 "3 flakes 55 failures") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51793 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107586 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102985 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48350 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26612 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48325 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51256 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57046 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50664 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54022 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52345 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->