### PR TITLE
Update dialog and popover styles to integrate better with anchor positioning

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-alignment-001-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-alignment-001-expected.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<title>Tests that popover alignment responds to anchor positioning</title>
+<link rel="author" href="mailto:tabatkins@google.com">
+<link rel="author" title="Elika J. Etemad" href="http://fantasai.inkedblade.net/contact">
+
+<style>
+button {
+  border: solid blue 15px;
+  margin: 25px;
+}
+div {
+  position: absolute;
+  border: solid orange 10px;
+  inset: 0;
+  margin: 0;
+  place-self: center;
+  padding: .25em;
+}
+</style>
+
+Orange box should be centered on the screen.
+<button></button>
+<div id="p1"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-alignment-001-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-alignment-001-ref.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<title>Tests that popover alignment responds to anchor positioning</title>
+<link rel="author" href="mailto:tabatkins@google.com">
+<link rel="author" title="Elika J. Etemad" href="http://fantasai.inkedblade.net/contact">
+
+<style>
+button {
+  border: solid blue 15px;
+  margin: 25px;
+}
+div {
+  position: absolute;
+  border: solid orange 10px;
+  inset: 0;
+  margin: 0;
+  place-self: center;
+  padding: .25em;
+}
+</style>
+
+Orange box should be centered on the screen.
+<button></button>
+<div id="p1"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-alignment-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-alignment-001.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html class=reftest-wait>
+<title>Tests that popover alignment responds to anchor positioning</title>
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#conditional-centering">
+<link rel="match" href="popover-alignment-001-ref.html">
+<link rel="author" href="mailto:tabatkins@google.com">
+<link rel="author" title="Elika J. Etemad" href="http://fantasai.inkedblade.net/contact">
+
+<style>
+button {
+  border: solid blue 15px;
+  margin: 25px;
+}
+[popover] {
+  border: solid orange 10px;
+}
+</style>
+
+Orange box should be centered on the screen.
+<button popovertarget=p1></button>
+<div id="p1" popover></div>
+
+<script>
+document.querySelector("[popover]").showPopover({ source: document.querySelector("button") });
+document.documentElement.removeAttribute("class");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-alignment-002-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-alignment-002-expected.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<title>Tests that popover alignment responds to anchor positioning</title>
+<link rel="author" href="mailto:tabatkins@google.com">
+<link rel="author" title="Elika J. Etemad" href="http://fantasai.inkedblade.net/contact">
+<style>
+button {
+  border: solid blue 15px;
+  margin: 25px;
+  anchor-name: --foo;
+}
+div {
+  position: absolute;
+  border: solid orange 10px;
+  inset: 0;
+  margin: 0;
+  padding: .25em;
+  place-self: normal;
+  position-anchor: --foo;
+}
+</style>
+
+Orange box should be centered vertically against the left edge of the blue box.
+<button></button>
+<div style="position-area: left span-all"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-alignment-002-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-alignment-002-ref.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<title>Tests that popover alignment responds to anchor positioning</title>
+<link rel="author" href="mailto:tabatkins@google.com">
+<link rel="author" title="Elika J. Etemad" href="http://fantasai.inkedblade.net/contact">
+<style>
+button {
+  border: solid blue 15px;
+  margin: 25px;
+  anchor-name: --foo;
+}
+div {
+  position: absolute;
+  border: solid orange 10px;
+  inset: 0;
+  margin: 0;
+  padding: .25em;
+  place-self: normal;
+  position-anchor: --foo;
+}
+</style>
+
+Orange box should be centered vertically against the left edge of the blue box.
+<button></button>
+<div style="position-area: left span-all"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-alignment-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-alignment-002.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html class=reftest-wait>
+<title>Tests that popover alignment responds to anchor positioning</title>
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#conditional-centering">
+<link rel="match" href="popover-alignment-002-ref.html">
+<link rel="author" href="mailto:tabatkins@google.com">
+<link rel="author" title="Elika J. Etemad" href="http://fantasai.inkedblade.net/contact">
+
+<style>
+button {
+  border: solid blue 15px;
+  margin: 25px;
+}
+[popover] {
+  border: solid orange 10px;
+}
+</style>
+
+Orange box should be centered vertically against the left edge of the blue box.
+<button popovertarget=p3></button>
+<div id="p3" popover style="position-area: left span-all"></div>
+
+<script>
+document.querySelector("[popover]").showPopover({ source: document.querySelector("button") });
+document.documentElement.removeAttribute("class");
+</script>

--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -118,9 +118,7 @@ abbr[title], acronym[title] {
 dialog {
     position: absolute;
     inset-inline: 0;
-    width: fit-content;
-    height: fit-content;
-    margin: auto;
+    justify-self: dialog;
     border: solid;
     padding: 1em;
     background-color: Canvas;
@@ -134,8 +132,9 @@ dialog[open] {
 
 dialog:modal {
     position: fixed;
-    overflow: auto;
     inset-block: 0;
+    place-self: dialog;
+    overflow: auto;
     max-width: calc(100% - 6px - 2em);
     max-height: calc(100% - 6px - 2em);
     visibility: visible;

--- a/Source/WebCore/css/popover.css
+++ b/Source/WebCore/css/popover.css
@@ -12,9 +12,7 @@ dialog:popover-open {
 [popover] {
     position: fixed;
     inset: 0;
-    width: fit-content;
-    height: fit-content;
-    margin: auto;
+    place-self: dialog;
     border: solid;
     padding: 0.25em;
     overflow: auto;


### PR DESCRIPTION
#### c53b73e15d32b157b20b335d60dfc57dd60b9aa6
<pre>
Update dialog and popover styles to integrate better with anchor positioning
<a href="https://bugs.webkit.org/show_bug.cgi?id=299630">https://bugs.webkit.org/show_bug.cgi?id=299630</a>
<a href="https://rdar.apple.com/161834630">rdar://161834630</a>

Reviewed by NOBODY (OOPS!).

Updates UA stylesheet for dialogs and popovers to work better with anchor
positioning by using &apos;dialog&apos; alignment (centers by default, but follows
anchor positioning defaults when anchor positioned). See
  <a href="https://github.com/whatwg/html/pull/11656">https://github.com/whatwg/html/pull/11656</a>
and
  <a href="https://github.com/w3c/csswg-drafts/issues/10258">https://github.com/w3c/csswg-drafts/issues/10258</a>

Also imports relevant WPT tests.

Tests: imported/w3c/web-platform-tests/html/semantics/popovers/popover-alignment-001-ref.html
       imported/w3c/web-platform-tests/html/semantics/popovers/popover-alignment-001.html
       imported/w3c/web-platform-tests/html/semantics/popovers/popover-alignment-002-ref.html
       imported/w3c/web-platform-tests/html/semantics/popovers/popover-alignment-002.html
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-alignment-001-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-alignment-001-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-alignment-001.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-alignment-002-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-alignment-002-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-alignment-002.html: Added.
* Source/WebCore/css/html.css:
(dialog):
(dialog:modal):
* Source/WebCore/css/popover.css:
([popover]):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5baaf60610dd91f620ff8282c8e129640e569811

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124354 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44034 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34764 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131192 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76399 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/17389385-19f9-44b9-abb4-daf81a0966a6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/126231 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44780 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52633 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94591 "Found 14 new test failures: fast/layers/layer-order-after-top-layer.html fast/repaint/no-backdrop-repaint.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-top-layer-006.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/top-layer-dialog-container.html imported/w3c/web-platform-tests/css/css-view-transitions/dialog-in-top-layer-during-transition-new.html imported/w3c/web-platform-tests/css/css-view-transitions/dialog-in-top-layer-during-transition-old.html imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/flow-content-0/dialog.html imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/backdrop-stacking-order.html imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-popover-overlay.html imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/modal-dialog-generated-content.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62755 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bb060b11-a0d4-4ee8-b9c9-e9a9abe6418e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127308 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35687 "Found 1 new test failure: fast/layers/layer-order-after-top-layer.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111224 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75178 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34625 "Found 12 new test failures: imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-top-layer-006.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/top-layer-dialog-container.html imported/w3c/web-platform-tests/css/css-view-transitions/dialog-in-top-layer-during-transition-new.html imported/w3c/web-platform-tests/css/css-view-transitions/dialog-in-top-layer-during-transition-old.html imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/flow-content-0/dialog.html imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/backdrop-stacking-order.html imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-popover-overlay.html imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/modal-dialog-generated-content.html imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/non-modal-dialog-layout.html imported/w3c/web-platform-tests/html/semantics/popovers/popover-anchor-multicol-display.tentative.html ... (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29384 "Found 12 new test failures: fast/layers/layer-order-after-top-layer.html fast/repaint/no-backdrop-repaint.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-top-layer-006.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/top-layer-dialog-container.html imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/flow-content-0/dialog.html imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/backdrop-stacking-order.html imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-popover-overlay.html imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/modal-dialog-generated-content.html imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/non-modal-dialog-layout.html imported/w3c/web-platform-tests/html/semantics/popovers/popover-anchor-multicol-display.tentative.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74669 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105432 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29607 "Found 14 new test failures: fast/layers/layer-order-after-top-layer.html fast/repaint/no-backdrop-repaint.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-top-layer-006.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/top-layer-dialog-container.html imported/w3c/web-platform-tests/css/css-view-transitions/dialog-in-top-layer-during-transition-new.html imported/w3c/web-platform-tests/css/css-view-transitions/dialog-in-top-layer-during-transition-old.html imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/flow-content-0/dialog.html imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/backdrop-stacking-order.html imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-popover-overlay.html imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/modal-dialog-generated-content.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133859 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51252 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39089 "Found 15 new test failures: fast/layers/layer-order-after-top-layer.html fast/repaint/no-backdrop-repaint.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-top-layer-006.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/top-layer-dialog-container.html imported/w3c/web-platform-tests/css/css-view-transitions/dialog-in-top-layer-during-transition-new.html imported/w3c/web-platform-tests/css/css-view-transitions/dialog-in-top-layer-during-transition-old.html imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-transform-popover-crash.html imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/flow-content-0/dialog.html imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/backdrop-stacking-order.html imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-popover-overlay.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103071 "Found 14 new test failures: fast/layers/layer-order-after-top-layer.html fast/repaint/no-backdrop-repaint.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-top-layer-006.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/top-layer-dialog-container.html imported/w3c/web-platform-tests/css/css-view-transitions/dialog-in-top-layer-during-transition-new.html imported/w3c/web-platform-tests/css/css-view-transitions/dialog-in-top-layer-during-transition-old.html imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/flow-content-0/dialog.html imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/backdrop-stacking-order.html imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-popover-overlay.html imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/modal-dialog-generated-content.html ... (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51651 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107443 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102867 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48233 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26483 "Found 14 new test failures: fast/layers/layer-order-after-top-layer.html fast/repaint/no-backdrop-repaint.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-top-layer-006.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/top-layer-dialog-container.html imported/w3c/web-platform-tests/css/css-view-transitions/dialog-in-top-layer-during-transition-new.html imported/w3c/web-platform-tests/css/css-view-transitions/dialog-in-top-layer-during-transition-old.html imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/flow-content-0/dialog.html imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/backdrop-stacking-order.html imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-popover-overlay.html imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/modal-dialog-generated-content.html ... (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48184 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51119 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56904 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50549 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53906 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52224 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->