### PR TITLE
[GFC] Position items locked to a given row.

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
@@ -76,8 +76,9 @@ auto GridLayout::placeGridItems(const UnplacedGridItems& unplacedGridItems, cons
     // 2. Process the items locked to a given row.
     // Phase 1: Only single-cell items within explicit grid bounds
     auto& definiteRowPositionedGridItems = unplacedGridItems.definiteRowPositionedItems;
+    HashMap<unsigned, unsigned, DefaultHash<unsigned>, WTF::UnsignedWithZeroKeyHashTraits<unsigned>> rowCursors;
     for (auto& definiteRowPositionedItem : definiteRowPositionedGridItems)
-        implicitGrid.insertDefiniteRowItem(definiteRowPositionedItem, autoFlowOptions);
+        implicitGrid.insertDefiniteRowItem(definiteRowPositionedItem, autoFlowOptions, &rowCursors);
 
     // 3. FIXME: Process auto-positioned items (not implemented yet)
     ASSERT(unplacedGridItems.autoPositionedItems.isEmpty());

--- a/Source/WebCore/layout/formattingContexts/grid/ImplicitGrid.h
+++ b/Source/WebCore/layout/formattingContexts/grid/ImplicitGrid.h
@@ -45,11 +45,15 @@ public:
     size_t columnsCount() const { return rowsCount() ? m_gridMatrix[0].size() : 0; }
 
     void insertUnplacedGridItem(const UnplacedGridItem&);
-    void insertDefiniteRowItem(const UnplacedGridItem&, GridAutoFlowOptions);
+    void insertDefiniteRowItem(const UnplacedGridItem&, GridAutoFlowOptions, HashMap<unsigned, unsigned, DefaultHash<unsigned>, WTF::UnsignedWithZeroKeyHashTraits<unsigned>>*);
 
     GridAreas gridAreas() const;
 
 private:
+    std::optional<size_t> findFirstAvailableColumnPosition(int rowStart, int rowEnd, size_t columnSpan, size_t startSearchColumn) const;
+    bool isCellRangeEmpty(size_t columnStart, size_t columnEnd, int rowStart, int rowEnd) const;
+    void insertItemInArea(const UnplacedGridItem&, size_t columnStart, size_t columnEnd, int rowStart, int rowEnd);
+
     GridMatrix m_gridMatrix;
 };
 

--- a/Source/WebCore/layout/formattingContexts/grid/UnplacedGridItem.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/UnplacedGridItem.cpp
@@ -130,8 +130,6 @@ size_t UnplacedGridItem::columnSpanSize() const
 
 std::pair<int, int> UnplacedGridItem::definiteRowStartEnd() const
 {
-    ASSERT(hasDefiniteRowPosition());
-
     auto startPosition = m_rowPosition.first;
     auto endPosition = m_rowPosition.second;
 


### PR DESCRIPTION
#### 76c91a3029dd67d152df2ec46d83fb52bbf90bd8
<pre>
[GFC] Position items locked to a given row.
<a href="https://bugs.webkit.org/show_bug.cgi?id=299858">https://bugs.webkit.org/show_bug.cgi?id=299858</a>
&lt;<a href="https://rdar.apple.com/161626344">rdar://161626344</a>&gt;

Reviewed by Sammy Gill.

This implements step 2 of the CSS Grid auto-placement algorithm for
items that have definite row positions but auto column positions.
The implementation supports both dense and sparse packing strategies
as specified by the grid-auto-flow CSS property.

Combined changes:

* Source/WebCore/layout/formattingContexts/grid/ImplicitGrid.cpp:
(WebCore::Layout::ImplicitGrid::insertDefiniteRowItem):
(WebCore::Layout::ImplicitGrid::findFirstAvailableColumnPosition const):
(WebCore::Layout::ImplicitGrid::isAreaEmpty const):
(WebCore::Layout::ImplicitGrid::insertItemAtPosition):
(WebCore::Layout::ImplicitGrid::ensureRowCursorsSize):
(WebCore::Layout::ImplicitGrid::getRowCursor const):
(WebCore::Layout::ImplicitGrid::updateRowCursor):
* Source/WebCore/layout/formattingContexts/grid/ImplicitGrid.h:

Canonical link: <a href="https://commits.webkit.org/300930@main">https://commits.webkit.org/300930@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f30738cac949979293b39179ee6e72184fad465e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124327 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44009 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34737 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131166 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76381 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/126204 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44754 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52607 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94573 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62741 "") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127281 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35669 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111205 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75160 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34609 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29365 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74643 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105414 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29588 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133832 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51228 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39067 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103052 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51625 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107424 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102848 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26178 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48209 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26464 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48164 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51094 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56879 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50528 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53884 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52203 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->