### PR TITLE
[Build Speed] Make GraphicsLayer.h less expensive

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2600,6 +2600,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/GraphicsLayerAnimation.h
     platform/graphics/GraphicsLayerClient.h
     platform/graphics/GraphicsLayerContentsDisplayDelegate.h
+    platform/graphics/GraphicsLayerEnums.h
     platform/graphics/GraphicsLayerFactory.h
     platform/graphics/GraphicsLayerTransform.h
     platform/graphics/GraphicsStyle.h

--- a/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
@@ -83,6 +83,7 @@ page/PageOverlayController.cpp
 page/WheelEventTestMonitor.h
 page/mac/ImageOverlayControllerMac.mm
 page/mac/ServicesOverlayController.mm
+page/scrolling/ScrollingCoordinator.h
 page/scrolling/ScrollingStateNode.h
 page/scrolling/ScrollingStateScrollingNode.cpp
 platform/PODRedBlackTree.h

--- a/Source/WebCore/dom/ViewTransition.h
+++ b/Source/WebCore/dom/ViewTransition.h
@@ -30,6 +30,7 @@
 #include "Element.h"
 #include "EventLoop.h"
 #include "ImageBuffer.h"
+#include "LayoutRect.h"
 #include "MutableStyleProperties.h"
 #include "Styleable.h"
 #include "ViewTransitionUpdateCallback.h"

--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm
@@ -33,6 +33,7 @@
 #include "GPUPresentationContextDescriptor.h"
 #include "GPUTextureDescriptor.h"
 #include "GraphicsLayerContentsDisplayDelegate.h"
+#include "GraphicsLayerEnums.h"
 #include "ImageBitmap.h"
 #include "PlatformCALayerDelegatedContents.h"
 #include "PlatformScreen.h"
@@ -66,9 +67,9 @@ public:
         } else
             layer.clearContents();
     }
-    GraphicsLayer::CompositingCoordinatesOrientation orientation() const final
+    GraphicsLayerCompositingCoordinatesOrientation orientation() const final
     {
-        return GraphicsLayer::CompositingCoordinatesOrientation::TopDown;
+        return GraphicsLayerCompositingCoordinatesOrientation::TopDown;
     }
     void setDisplayBuffer(WTF::MachSendRight& displayBuffer)
     {

--- a/Source/WebCore/html/canvas/PlaceholderRenderingContext.cpp
+++ b/Source/WebCore/html/canvas/PlaceholderRenderingContext.cpp
@@ -29,6 +29,7 @@
 #if ENABLE(OFFSCREEN_CANVAS)
 
 #include "ContextDestructionObserverInlines.h"
+#include "GraphicsLayer.h"
 #include "GraphicsLayerContentsDisplayDelegate.h"
 #include "HTMLCanvasElement.h"
 #include "NodeInlines.h"

--- a/Source/WebCore/inspector/InspectorCanvas.cpp
+++ b/Source/WebCore/inspector/InspectorCanvas.cpp
@@ -68,6 +68,7 @@
 #include "SVGPathUtilities.h"
 #include "StringAdaptors.h"
 #include <JavaScriptCore/IdentifiersFactory.h>
+#include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/ScriptCallStackFactory.h>
 #include <wtf/Function.h>
 #include <wtf/RefPtr.h>

--- a/Source/WebCore/inspector/InspectorCanvas.h
+++ b/Source/WebCore/inspector/InspectorCanvas.h
@@ -37,6 +37,11 @@
 #include <wtf/HashSet.h>
 #include <wtf/WeakRef.h>
 
+namespace JSC {
+class JSValue;
+class JSGlobalObject;
+}
+
 namespace WebCore {
 
 class CanvasGradient;

--- a/Source/WebCore/inspector/agents/InspectorLayerTreeAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorLayerTreeAgent.cpp
@@ -32,6 +32,7 @@
 #include "InspectorLayerTreeAgent.h"
 
 #include "EventTargetInlines.h"
+#include "GraphicsLayer.h"
 #include "InspectorDOMAgent.h"
 #include "InstrumentingAgents.h"
 #include "IntRect.h"

--- a/Source/WebCore/loader/EmptyClients.h
+++ b/Source/WebCore/loader/EmptyClients.h
@@ -31,6 +31,7 @@
 #include <WebCore/ChromeClient.h>
 #include <WebCore/CryptoClient.h>
 #include <WebCore/ExceptionOr.h>
+#include <WebCore/PageIdentifier.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/Platform.h>
 #include <wtf/TZoneMalloc.h>
@@ -40,6 +41,10 @@
 //
 // First created for SVGImage as it had no way to access the current Page (nor should it, since Images are not tied to a page).
 // See http://bugs.webkit.org/show_bug.cgi?id=5971 for the original discussion about this file.
+
+namespace PAL {
+class SessionID;
+}
 
 namespace WebCore {
 
@@ -82,7 +87,7 @@ class EmptyChromeClient : public ChromeClient {
 
     void setResizable(bool) final { }
 
-    void addMessageToConsole(MessageSource, MessageLevel, const String&, unsigned, unsigned, const String&) final { }
+    void addMessageToConsole(JSC::MessageSource, JSC::MessageLevel, const String&, unsigned, unsigned, const String&) final { }
 
     bool canRunBeforeUnloadConfirmPanel() final { return false; }
     bool runBeforeUnloadConfirmPanel(String&&, LocalFrame&) final { return true; }

--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -30,15 +30,18 @@
 #include <WebCore/ExceptionData.h>
 #include <WebCore/ExceptionOr.h>
 #include <WebCore/FocusDirection.h>
+#include <WebCore/FrameIdentifier.h>
 #include <WebCore/HTMLMediaElementEnums.h>
 #include <WebCore/HighlightVisibility.h>
 #include <WebCore/ImageBuffer.h>
 #include <WebCore/ImageBufferResourceLimits.h>
 #include <WebCore/InputMode.h>
 #include <WebCore/MediaControlsContextMenuItem.h>
+#include <WebCore/PlaybackTargetClientContextIdentifier.h>
 #include <WebCore/PointerCharacteristics.h>
 #include <WebCore/SyntheticClickResult.h>
 #include <WebCore/WebCoreKeyboardUIMode.h>
+#include <WebCore/Widget.h>
 #include <wtf/Assertions.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/Forward.h>
@@ -87,6 +90,11 @@ class HTMLModelElement;
 
 OBJC_CLASS NSResponder;
 
+namespace JSC {
+enum class MessageSource : uint8_t;
+enum class MessageLevel : uint8_t;
+}
+
 namespace WebCore {
 
 class AccessibilityObject;
@@ -102,10 +110,13 @@ class Element;
 class FileChooser;
 class FileIconLoader;
 class FloatRect;
+class Frame;
 class FrameDamageHistory;
+class FrameSelection;
 class Geolocation;
 class GraphicsLayer;
 class GraphicsLayerFactory;
+class HTMLAttachmentElement;
 class HTMLImageElement;
 class HTMLInputElement;
 class HTMLMediaElement;
@@ -116,6 +127,7 @@ class HitTestResult;
 class Icon;
 class IntRect;
 class LocalFrame;
+class LocalFrameView;
 class NavigationAction;
 class Node;
 class Page;
@@ -123,9 +135,10 @@ class PopupMenu;
 class PopupMenuClient;
 class Region;
 class RegistrableDomain;
-class SearchPopupMenu;
 class SVGImageElement;
+class ScrollableArea;
 class ScrollingCoordinator;
+class SearchPopupMenu;
 class SecurityOrigin;
 class SecurityOriginData;
 class ViewportConstraints;
@@ -154,6 +167,8 @@ struct FocusOptions;
 struct GraphicsDeviceAdapter;
 struct MockWebAuthenticationConfiguration;
 struct ShareDataWithParsedURL;
+struct SimpleRange;
+struct StringWithDirection;
 struct SystemPreviewInfo;
 struct TextIndicatorData;
 struct TextRecognitionOptions;
@@ -176,10 +191,14 @@ enum class PluginUnavailabilityReason : uint8_t;
 enum class PointerLockRequestResult : uint8_t;
 enum class RouteSharingPolicy : uint8_t;
 enum class ScriptTrackingPrivacyCategory : uint8_t;
+enum class ScrollbarOverlayStyle : uint8_t;
+enum class ScrollbarStyle : uint8_t;
 enum class TextAnimationRunMode : uint8_t;
 
 enum class MediaProducerMediaState : uint32_t;
 using MediaProducerMediaStateFlags = OptionSet<MediaProducerMediaState>;
+
+typedef int32_t IntDegrees;
 
 namespace ShapeDetection {
 class BarcodeDetector;
@@ -238,7 +257,7 @@ public:
 
     virtual void setResizable(bool) = 0;
 
-    virtual void addMessageToConsole(MessageSource, MessageLevel, const String& message, unsigned lineNumber, unsigned columnNumber, const String& sourceID) = 0;
+    virtual void addMessageToConsole(JSC::MessageSource, JSC::MessageLevel, const String& message, unsigned lineNumber, unsigned columnNumber, const String& sourceID) = 0;
 
     virtual bool canRunBeforeUnloadConfirmPanel() = 0;
     virtual bool runBeforeUnloadConfirmPanel(String&& message, LocalFrame&) = 0;

--- a/Source/WebCore/page/DebugPageOverlays.cpp
+++ b/Source/WebCore/page/DebugPageOverlays.cpp
@@ -33,6 +33,7 @@
 #include "FloatRoundedRect.h"
 #include "Gradient.h"
 #include "GraphicsContext.h"
+#include "GraphicsLayer.h"
 #include "HitTestResult.h"
 #include "InteractionRegion.h"
 #include "LocalFrameView.h"

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -95,6 +95,7 @@
 #include "FrameSelection.h"
 #include "FrameTree.h"
 #include "GeolocationController.h"
+#include "GraphicsLayer.h"
 #include "HTMLElement.h"
 #include "HTMLImageElement.h"
 #include "HTMLMediaElement.h"

--- a/Source/WebCore/page/PageOverlayController.cpp
+++ b/Source/WebCore/page/PageOverlayController.cpp
@@ -447,6 +447,11 @@ void PageOverlayController::didChangeOverlayBackgroundColor(PageOverlay& overlay
         layer->setBackgroundColor(overlay.backgroundColor());
 }
 
+int PageOverlayController::overlayCount() const
+{
+    return m_overlayGraphicsLayers.computeSize();
+}
+
 bool PageOverlayController::shouldSkipLayerInDump(const GraphicsLayer*, OptionSet<LayerTreeAsTextOptions> options) const
 {
     return !options.contains(LayerTreeAsTextOptions::IncludePageOverlayLayers);

--- a/Source/WebCore/page/PageOverlayController.h
+++ b/Source/WebCore/page/PageOverlayController.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <WebCore/GraphicsLayer.h>
 #include <WebCore/GraphicsLayerClient.h>
 #include <WebCore/PageOverlay.h>
 #include <wtf/RefPtr.h>
@@ -35,6 +34,7 @@
 
 namespace WebCore {
 
+class GraphicsLayer;
 class LocalFrame;
 class Page;
 class PlatformMouseEvent;
@@ -73,7 +73,7 @@ public:
     void didChangeOverlayFrame(PageOverlay&);
     void didChangeOverlayBackgroundColor(PageOverlay&);
 
-    int overlayCount() const { return m_overlayGraphicsLayers.computeSize(); }
+    int overlayCount() const;
 
     bool handleMouseEvent(const PlatformMouseEvent&);
 

--- a/Source/WebCore/page/TextIndicator.cpp
+++ b/Source/WebCore/page/TextIndicator.cpp
@@ -39,6 +39,7 @@
 #include "FrameSnapshotting.h"
 #include "GeometryUtilities.h"
 #include "GraphicsContext.h"
+#include "GraphicsLayer.h"
 #include "ImageBuffer.h"
 #include "IntRect.h"
 #include "LocalFrame.h"

--- a/Source/WebCore/page/cocoa/ResourceUsageOverlayCocoa.mm
+++ b/Source/WebCore/page/cocoa/ResourceUsageOverlayCocoa.mm
@@ -30,6 +30,7 @@
 
 #import "ColorSpaceCG.h"
 #import "CommonVM.h"
+#import "GraphicsLayer.h"
 #import "JSDOMWindow.h"
 #import "PlatformCALayer.h"
 #import "ResourceUsageThread.h"

--- a/Source/WebCore/page/mac/ServicesOverlayController.h
+++ b/Source/WebCore/page/mac/ServicesOverlayController.h
@@ -28,7 +28,6 @@
 #if (ENABLE(SERVICE_CONTROLS) || ENABLE(TELEPHONE_NUMBER_DETECTION)) && PLATFORM(MAC)
 
 #include "DataDetectorHighlight.h"
-#include "GraphicsLayer.h"
 #include "GraphicsLayerClient.h"
 #include "PageOverlay.h"
 #include "Timer.h"
@@ -38,7 +37,8 @@
 #include <wtf/WeakHashSet.h>
 
 namespace WebCore {
-    
+
+class GraphicsLayer;
 class LayoutRect;
 class Page;
 

--- a/Source/WebCore/platform/graphics/GraphicsLayer.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.cpp
@@ -636,7 +636,7 @@ void GraphicsLayer::setOffsetFromRenderer(const FloatSize& offset, ShouldSetNeed
     m_offsetFromRenderer = offset;
 
     // If the compositing layer offset changes, we need to repaint.
-    if (shouldSetNeedsDisplay == SetNeedsDisplay)
+    if (shouldSetNeedsDisplay == ShouldSetNeedsDisplay::Set)
         setNeedsDisplay();
 }
 
@@ -648,7 +648,7 @@ void GraphicsLayer::setScrollOffset(const ScrollOffset& offset, ShouldSetNeedsDi
     m_scrollOffset = offset;
 
     // If the compositing layer offset changes, we need to repaint.
-    if (shouldSetNeedsDisplay == SetNeedsDisplay)
+    if (shouldSetNeedsDisplay == ShouldSetNeedsDisplay::Set)
         setNeedsDisplay();
 }
 

--- a/Source/WebCore/platform/graphics/GraphicsLayerContentsDisplayDelegate.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsLayerContentsDisplayDelegate.cpp
@@ -39,7 +39,7 @@ void GraphicsLayerContentsDisplayDelegate::prepareToDelegateDisplay(PlatformCALa
 {
 }
 
-GraphicsLayer::CompositingCoordinatesOrientation GraphicsLayerContentsDisplayDelegate::orientation() const
+GraphicsLayerCompositingCoordinatesOrientation GraphicsLayerContentsDisplayDelegate::orientation() const
 {
     return GraphicsLayerCA::defaultContentsOrientation;
 }

--- a/Source/WebCore/platform/graphics/GraphicsLayerContentsDisplayDelegate.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayerContentsDisplayDelegate.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <WebCore/GraphicsLayer.h>
 #include <wtf/RefCounted.h>
 
 #if !USE(CA) && !USE(COORDINATED_GRAPHICS)
@@ -42,6 +41,8 @@ class CoordinatedPlatformLayerBuffer;
 class Damage;
 #endif
 
+enum class GraphicsLayerCompositingCoordinatesOrientation : uint8_t;
+
 // Platform specific interface for attaching contents to GraphicsLayer.
 // Responsible for creating compositor resources to show the particular contents
 // in the platform specific GraphicsLayer.
@@ -53,7 +54,7 @@ public:
     virtual void prepareToDelegateDisplay(PlatformCALayer&);
     // Must not detach the platform layer backing store.
     virtual void display(PlatformCALayer&) = 0;
-    virtual GraphicsLayer::CompositingCoordinatesOrientation orientation() const;
+    virtual GraphicsLayerCompositingCoordinatesOrientation orientation() const;
 #elif USE(COORDINATED_GRAPHICS)
     virtual void setDisplayBuffer(std::unique_ptr<CoordinatedPlatformLayerBuffer>&&) = 0;
     virtual bool display(CoordinatedPlatformLayer&, std::optional<Damage>&&) = 0;

--- a/Source/WebCore/platform/graphics/GraphicsLayerEnums.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayerEnums.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,22 +25,45 @@
 
 #pragma once
 
-#include <wtf/Forward.h>
-#include <wtf/TZoneMallocInlines.h>
-
 namespace WebCore {
 
-class GraphicsLayer;
-class GraphicsLayerClient;
-
-enum class GraphicsLayerType : uint8_t;
-
-class GraphicsLayerFactory {
-    WTF_MAKE_TZONE_ALLOCATED_INLINE(GraphicsLayerFactory);
-public:
-    virtual ~GraphicsLayerFactory() = default;
-
-    virtual Ref<GraphicsLayer> createGraphicsLayer(GraphicsLayerType, GraphicsLayerClient&) = 0;
+enum class GraphicsLayerType : uint8_t {
+    Normal,
+    Structural, // Supports position and transform only, and doesn't flatten (i.e. behaves like preserves3D is true). Uses CATransformLayer on Cocoa platforms.
+    PageTiledBacking,
+    TiledBacking,
+    ScrollContainer,
+    ScrolledContents,
+    Shape
 };
 
-} // namespace WebCore
+enum class GraphicsLayerMode : uint8_t {
+    PlatformLayer,
+    LayerHostingContextId
+};
+
+enum class GraphicsLayerContentsLayerPurpose : uint8_t {
+    None = 0,
+    Image,
+    Media,
+    Canvas,
+    BackgroundColor,
+    Plugin,
+    Model,
+    HostedModel,
+    Host,
+};
+
+
+enum class GraphicsLayerShouldSetNeedsDisplay : bool { DoNotSet, Set };
+enum class GraphicsLayerShouldClipToLayer : bool { DoNotClip, Clip };
+
+#if ENABLE(MODEL_ELEMENT)
+enum class GraphicsLayerModelInteraction : bool { Disabled, Enabled };
+#endif
+
+enum class GraphicsLayerCompositingCoordinatesOrientation : uint8_t { TopDown, BottomUp };
+enum class GraphicsLayerScalingFilter : uint8_t { Linear, Nearest, Trilinear };
+enum class GraphicsLayerCustomAppearance : bool { None, ScrollingShadow };
+
+}

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -1000,7 +1000,7 @@ void GraphicsLayerCA::setNeedsDisplayInRect(const FloatRect& r, ShouldClipToLaye
         return;
 
     FloatRect rect(r);
-    if (shouldClip == ClipToLayer) {
+    if (shouldClip == ShouldClipToLayer::Clip) {
         FloatRect layerBounds(FloatPoint(), m_size);
         rect.intersect(layerBounds);
     }

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
@@ -142,7 +142,7 @@ public:
     WEBCORE_EXPORT void setBlendMode(BlendMode) override;
 
     WEBCORE_EXPORT void setNeedsDisplay() override;
-    WEBCORE_EXPORT void setNeedsDisplayInRect(const FloatRect&, ShouldClipToLayer = ClipToLayer) override;
+    WEBCORE_EXPORT void setNeedsDisplayInRect(const FloatRect&, ShouldClipToLayer = ShouldClipToLayer::Clip) override;
     WEBCORE_EXPORT void setContentsNeedsDisplay() override;
     
     WEBCORE_EXPORT void setContentsRect(const FloatRect&) override;

--- a/Source/WebCore/platform/graphics/ca/PlatformCALayer.h
+++ b/Source/WebCore/platform/graphics/ca/PlatformCALayer.h
@@ -25,8 +25,13 @@
 
 #pragma once
 
+#include <WebCore/Color.h>
+#include <WebCore/FloatPoint3D.h>
 #include <WebCore/FloatRoundedRect.h>
-#include <WebCore/GraphicsLayer.h>
+#include <WebCore/LayerHostingContextIdentifier.h>
+#include <WebCore/PlatformLayer.h>
+#include <WebCore/PlatformLayerIdentifier.h>
+#include <WebCore/ScrollingNodeID.h>
 #include <wtf/Platform.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/ThreadSafeWeakPtr.h>
@@ -39,17 +44,25 @@ typedef struct CGContext *CGContextRef;
 
 namespace WebCore {
 
+class AcceleratedEffect;
+class EventRegion;
+class FilterOperations;
+class GraphicsContext;
+class GraphicsLayer;
 class LayerPool;
 class PlatformCALayer;
 class PlatformCAAnimation;
 class PlatformCALayerClient;
+class TiledBacking;
 
+struct AppleVisualEffectData;
 struct PlatformCALayerDelegatedContents;
 struct PlatformCALayerDelegatedContentsFinishedEvent;
 struct PlatformCALayerInProcessDelegatedContents;
 struct PlatformCALayerInProcessDelegatedContentsFinishedEvent;
 
 typedef Vector<RefPtr<PlatformCALayer>> PlatformCALayerList;
+using AcceleratedEffects = Vector<Ref<AcceleratedEffect>>;
 
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
 class AcceleratedEffect;
@@ -57,8 +70,13 @@ struct AcceleratedEffectValues;
 #endif
 
 enum class AppleVisualEffect : uint8_t;
-enum class MediaPlayerVideoGravity : uint8_t;
+enum class BlendMode : uint8_t;
 enum class ContentsFormat : uint8_t;
+enum class GraphicsLayerCustomAppearance : bool;
+enum class GraphicsLayerPaintBehavior : uint8_t;
+enum class MediaPlayerVideoGravity : uint8_t;
+enum class PlatformLayerTreeAsTextFlags : uint8_t;
+enum class WindRule : bool;
 
 enum class PlatformCALayerFilterType : uint8_t {
     Linear,
@@ -298,8 +316,8 @@ public:
     virtual void setScrollingNodeID(std::optional<ScrollingNodeID>) { }
 #endif
 
-    virtual GraphicsLayer::CustomAppearance customAppearance() const = 0;
-    virtual void updateCustomAppearance(GraphicsLayer::CustomAppearance) = 0;
+    virtual GraphicsLayerCustomAppearance customAppearance() const = 0;
+    virtual void updateCustomAppearance(GraphicsLayerCustomAppearance) = 0;
 
 #if HAVE(SUPPORT_HDR_DISPLAY)
     virtual bool setNeedsDisplayIfEDRHeadroomExceeds(float);

--- a/Source/WebCore/platform/graphics/ca/PlatformCALayer.mm
+++ b/Source/WebCore/platform/graphics/ca/PlatformCALayer.mm
@@ -33,6 +33,7 @@
 #include "LayerPool.h"
 #include "PlatformCALayerClient.h"
 #include "PlatformCALayerDelegatedContents.h"
+#include "PlatformScreen.h"
 #include <CoreFoundation/CoreFoundation.h>
 #include <CoreText/CoreText.h>
 #include <QuartzCore/CABase.h>

--- a/Source/WebCore/platform/graphics/ca/PlatformCALayerClient.h
+++ b/Source/WebCore/platform/graphics/ca/PlatformCALayerClient.h
@@ -25,7 +25,9 @@
 
 #pragma once
 
-#include <WebCore/GraphicsLayer.h>
+#include <WebCore/GraphicsLayerEnums.h>
+#include <WebCore/PlatformLayerIdentifier.h>
+#include <wtf/MonotonicTime.h>
 
 #if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
 #include  "DynamicContentScalingDisplayList.h"
@@ -36,6 +38,9 @@ namespace WebCore {
 class FloatRect;
 class GraphicsContext;
 class PlatformCALayer;
+
+enum class ContentsFormat : uint8_t;
+enum class GraphicsLayerPaintBehavior : uint8_t;
 
 class PlatformCALayerClient {
 public:
@@ -48,7 +53,7 @@ public:
 
     virtual void platformCALayerAnimationStarted(const String& /*animationKey*/, MonotonicTime) { }
     virtual void platformCALayerAnimationEnded(const String& /*animationKey*/) { }
-    virtual GraphicsLayer::CompositingCoordinatesOrientation platformCALayerContentsOrientation() const { return GraphicsLayer::CompositingCoordinatesOrientation::TopDown; }
+    virtual GraphicsLayerCompositingCoordinatesOrientation platformCALayerContentsOrientation() const { return GraphicsLayerCompositingCoordinatesOrientation::TopDown; }
     virtual void platformCALayerPaintContents(PlatformCALayer*, GraphicsContext&, const FloatRect& inClip, OptionSet<GraphicsLayerPaintBehavior>) = 0;
     virtual bool platformCALayerShowDebugBorders() const { return false; }
     virtual bool platformCALayerShowRepaintCounter(PlatformCALayer*) const { return false; }

--- a/Source/WebCore/platform/graphics/ca/TileController.h
+++ b/Source/WebCore/platform/graphics/ca/TileController.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <WebCore/BoxExtents.h>
+#include <WebCore/ContentsFormat.h>
 #include <WebCore/FloatRect.h>
 #include <WebCore/IntRect.h>
 #include <WebCore/PlatformCALayer.h>

--- a/Source/WebCore/platform/graphics/ca/TileCoverageMap.h
+++ b/Source/WebCore/platform/graphics/ca/TileCoverageMap.h
@@ -63,7 +63,7 @@ public:
 private:
     // PlatformCALayerClient
     PlatformLayerIdentifier platformCALayerIdentifier() const override;
-    GraphicsLayer::CompositingCoordinatesOrientation platformCALayerContentsOrientation() const override { return GraphicsLayer::CompositingCoordinatesOrientation::TopDown; }
+    GraphicsLayerCompositingCoordinatesOrientation platformCALayerContentsOrientation() const override { return GraphicsLayerCompositingCoordinatesOrientation::TopDown; }
     bool platformCALayerContentsOpaque() const override { return true; }
     bool platformCALayerDrawsContent() const override { return true; }
     void platformCALayerPaintContents(PlatformCALayer*, GraphicsContext&, const FloatRect&, OptionSet<GraphicsLayerPaintBehavior>) override;

--- a/Source/WebCore/platform/graphics/ca/TileGrid.cpp
+++ b/Source/WebCore/platform/graphics/ca/TileGrid.cpp
@@ -30,10 +30,12 @@
 #include "TileGrid.h"
 
 #include "GraphicsContext.h"
+#include "GraphicsLayerClient.h"
 #include "LayerPool.h"
 #include "Logging.h"
 #include "PlatformCALayer.h"
 #include "TileController.h"
+#include "TransformationMatrix.h"
 #include <wtf/MainThread.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/CString.h>

--- a/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
+++ b/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
@@ -1287,7 +1287,7 @@ void PlatformCALayer::drawLayerContents(GraphicsContext& graphicsContext, WebCor
         std::optional<FontAntialiasingStateSaver> fontAntialiasingState;
 #endif
         // We never use CompositingCoordinatesOrientation::BottomUp on Mac.
-        ASSERT(layerContents->platformCALayerContentsOrientation() == GraphicsLayer::CompositingCoordinatesOrientation::TopDown);
+        ASSERT(layerContents->platformCALayerContentsOrientation() == GraphicsLayerCompositingCoordinatesOrientation::TopDown);
 
         if (graphicsContext.hasPlatformContext()) {
             platformContextSaver.emplace(graphicsContext);

--- a/Source/WebCore/platform/graphics/cg/ImageUtilitiesCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageUtilitiesCG.cpp
@@ -39,6 +39,7 @@
 #include <CoreFoundation/CoreFoundation.h>
 #include <ImageIO/ImageIO.h>
 #include <WebCore/ShareableBitmap.h>
+#include <wtf/CompletionHandler.h>
 #include <wtf/FileHandle.h>
 #include <wtf/FileSystem.h>
 #include <wtf/cf/VectorCF.h>

--- a/Source/WebCore/platform/graphics/texmap/GraphicsLayerTextureMapper.h
+++ b/Source/WebCore/platform/graphics/texmap/GraphicsLayerTextureMapper.h
@@ -66,7 +66,7 @@ public:
     void setBackdropFiltersRect(const FloatRoundedRect&) override;
 
     void setNeedsDisplay() override;
-    void setNeedsDisplayInRect(const FloatRect&, ShouldClipToLayer = ClipToLayer) override;
+    void setNeedsDisplayInRect(const FloatRect&, ShouldClipToLayer = ShouldClipToLayer::Clip) override;
     void setContentsNeedsDisplay() override;
     void setContentsRect(const FloatRect&) override;
     void setContentsClippingRect(const FloatRoundedRect&) override;

--- a/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerAsyncContentsDisplayDelegateCoordinated.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerAsyncContentsDisplayDelegateCoordinated.h
@@ -27,6 +27,7 @@
 
 #if USE(COORDINATED_GRAPHICS)
 #include "GraphicsLayerContentsDisplayDelegate.h"
+#include <wtf/Ref.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerContentsDisplayDelegateCoordinated.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerContentsDisplayDelegateCoordinated.h
@@ -27,6 +27,7 @@
 
 #if USE(COORDINATED_GRAPHICS)
 #include "GraphicsLayerContentsDisplayDelegate.h"
+#include <wtf/Ref.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.cpp
@@ -105,7 +105,7 @@ void GraphicsLayerCoordinated::setNeedsDisplayInRect(const FloatRect& initialRec
         return;
 
     auto rect = initialRect;
-    if (shouldClip == ClipToLayer)
+    if (shouldClip == ShouldClipToLayer::Clip)
         rect.intersect({ { }, m_size });
 
     if (rect.isEmpty())

--- a/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.h
@@ -117,7 +117,7 @@ private:
     Vector<std::pair<String, double>> acceleratedAnimationsForTesting(const Settings&) const override;
 
     void setNeedsDisplay() override;
-    void setNeedsDisplayInRect(const FloatRect&, ShouldClipToLayer = ClipToLayer) override;
+    void setNeedsDisplayInRect(const FloatRect&, ShouldClipToLayer = ShouldClipToLayer::Clip) override;
 
     FloatSize pixelAlignmentOffset() const override { return m_pixelAlignmentOffset; }
 

--- a/Source/WebCore/platform/mac/DataDetectorHighlight.h
+++ b/Source/WebCore/platform/mac/DataDetectorHighlight.h
@@ -29,7 +29,6 @@
 
 #if ENABLE(DATA_DETECTION) && PLATFORM(MAC)
 
-#import <WebCore/GraphicsLayer.h>
 #import <WebCore/GraphicsLayerClient.h>
 #import <WebCore/SimpleRange.h>
 #import <WebCore/Timer.h>

--- a/Source/WebCore/rendering/CSSFilterRenderer.h
+++ b/Source/WebCore/rendering/CSSFilterRenderer.h
@@ -31,6 +31,7 @@
 
 namespace WebCore {
 
+class FilterOperation;
 class FilterOperations;
 class GraphicsContext;
 class RenderElement;

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -75,6 +75,7 @@
 #include "FrameTree.h"
 #include "Gradient.h"
 #include "GraphicsContext.h"
+#include "GraphicsLayer.h"
 #include "HTMLCanvasElement.h"
 #include "HTMLFormControlElement.h"
 #include "HTMLFrameElement.h"
@@ -5926,7 +5927,7 @@ void RenderLayer::setBackingNeedsRepaint(GraphicsLayer::ShouldClipToLayer should
         backing()->setContentsNeedDisplay(shouldClip);
 }
 
-void RenderLayer::setBackingNeedsRepaintInRect(const LayoutRect& r, GraphicsLayer::ShouldClipToLayer shouldClip)
+void RenderLayer::setBackingNeedsRepaintInRect(const LayoutRect& r, GraphicsLayerShouldClipToLayer shouldClip)
 {
     // https://bugs.webkit.org/show_bug.cgi?id=61159 describes an unreproducible crash here,
     // so assert but check that the layer is composited.

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -45,7 +45,7 @@
 #pragma once
 
 #include <WebCore/ClipRect.h>
-#include <WebCore/GraphicsLayer.h>
+#include <WebCore/GraphicsLayerEnums.h>
 #include <WebCore/LayerFragment.h>
 #include <WebCore/LayoutRect.h>
 #include <WebCore/PaintFrequencyTracker.h>
@@ -54,6 +54,7 @@
 #include <WebCore/RenderPtr.h>
 #include <WebCore/RenderSVGModelObject.h>
 #include <WebCore/ScrollBehavior.h>
+#include <WebCore/TransformationMatrix.h>
 #include <memory>
 #include <wtf/CheckedRef.h>
 #include <wtf/Markable.h>
@@ -452,10 +453,10 @@ public:
 
     // Indicate that the layer contents need to be repainted. Only has an effect
     // if layer compositing is being used.
-    void setBackingNeedsRepaint(GraphicsLayer::ShouldClipToLayer = GraphicsLayer::ClipToLayer);
+    void setBackingNeedsRepaint(GraphicsLayerShouldClipToLayer = GraphicsLayerShouldClipToLayer::Clip);
 
     // The rect is in the coordinate space of the layer's render object.
-    void setBackingNeedsRepaintInRect(const LayoutRect&, GraphicsLayer::ShouldClipToLayer = GraphicsLayer::ClipToLayer);
+    void setBackingNeedsRepaintInRect(const LayoutRect&, GraphicsLayerShouldClipToLayer = GraphicsLayerShouldClipToLayer::Clip);
     void repaintIncludingNonCompositingDescendants(const RenderLayerModelObject* repaintContainer);
 
     void styleChanged(StyleDifference, const RenderStyle* oldStyle);

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -1698,8 +1698,8 @@ void RenderLayerBacking::updateGeometry(const RenderLayer* compositedAncestor)
             m_scrolledContentsLayer->setNeedsDisplay();
 
         m_scrolledContentsLayer->setSize(scrollSize);
-        m_scrolledContentsLayer->setScrollOffset(scrollOffset, GraphicsLayer::DontSetNeedsDisplay);
-        m_scrolledContentsLayer->setOffsetFromRenderer(toLayoutSize(scrollContainerBox.location()), GraphicsLayer::DontSetNeedsDisplay);
+        m_scrolledContentsLayer->setScrollOffset(scrollOffset, GraphicsLayer::ShouldSetNeedsDisplay::DoNotSet);
+        m_scrolledContentsLayer->setOffsetFromRenderer(toLayoutSize(scrollContainerBox.location()), GraphicsLayer::ShouldSetNeedsDisplay::DoNotSet);
         
         adjustTiledBackingCoverage();
     }
@@ -1717,11 +1717,11 @@ void RenderLayerBacking::updateGeometry(const RenderLayer* compositedAncestor)
     if (m_foregroundLayer) {
         FloatSize foregroundSize;
         FloatSize foregroundOffset;
-        GraphicsLayer::ShouldSetNeedsDisplay needsDisplayOnOffsetChange = GraphicsLayer::SetNeedsDisplay;
+        auto needsDisplayOnOffsetChange = GraphicsLayer::ShouldSetNeedsDisplay::Set;
         if (m_scrolledContentsLayer) {
             foregroundSize = m_scrolledContentsLayer->size();
             foregroundOffset = m_scrolledContentsLayer->offsetFromRenderer() - toLayoutSize(m_scrolledContentsLayer->scrollOffset());
-            needsDisplayOnOffsetChange = GraphicsLayer::DontSetNeedsDisplay;
+            needsDisplayOnOffsetChange = GraphicsLayer::ShouldSetNeedsDisplay::DoNotSet;
         } else if (hasClippingLayer()) {
             // If we have a clipping layer (which clips descendants), then the foreground layer is a child of it,
             // so that it gets correctly sorted with children. In that case, position relative to the clipping layer.

--- a/Source/WebCore/rendering/RenderLayerBacking.h
+++ b/Source/WebCore/rendering/RenderLayerBacking.h
@@ -27,8 +27,8 @@
 
 #include <WebCore/FloatPoint.h>
 #include <WebCore/FloatPoint3D.h>
-#include <WebCore/GraphicsLayer.h>
 #include <WebCore/GraphicsLayerClient.h>
+#include <WebCore/GraphicsLayerEnums.h>
 #include <WebCore/RenderLayer.h>
 #include <WebCore/RenderLayerCompositor.h>
 #include <WebCore/ScrollingCoordinator.h>
@@ -39,6 +39,7 @@
 namespace WebCore {
 
 class BlendingKeyframes;
+class GraphicsLayer;
 class GraphicsLayerAnimation;
 class PaintedContentsInfo;
 class RegionContext;
@@ -52,6 +53,10 @@ enum CompositingLayerType {
     MediaCompositingLayer, // layer that contains an image, video, WebGL or plugin
     ContainerCompositingLayer // layer with no backing store
 };
+
+namespace DisplayList {
+enum class AsTextFlag : uint8_t;
+}
 
 // RenderLayerBacking controls the compositing behavior for a single RenderLayer.
 // It holds the various GraphicsLayers, and makes decisions about intra-layer rendering
@@ -171,9 +176,9 @@ public:
 
     void setRequiresOwnBackingStore(bool);
 
-    void setContentsNeedDisplay(GraphicsLayer::ShouldClipToLayer = GraphicsLayer::ClipToLayer);
+    void setContentsNeedDisplay(GraphicsLayerShouldClipToLayer = GraphicsLayerShouldClipToLayer::Clip);
     // r is in the coordinate space of the layer's render object
-    void setContentsNeedDisplayInRect(const LayoutRect&, GraphicsLayer::ShouldClipToLayer = GraphicsLayer::ClipToLayer);
+    void setContentsNeedDisplayInRect(const LayoutRect&, GraphicsLayerShouldClipToLayer = GraphicsLayerShouldClipToLayer::Clip);
 
     // Notification from the renderer that its content changed.
     void contentChanged(ContentChangeType, const std::optional<FloatRect>&);
@@ -322,7 +327,7 @@ private:
 
     LayoutRect compositedBoundsIncludingMargin() const;
     
-    Ref<GraphicsLayer> createGraphicsLayer(const String&, GraphicsLayer::Type = GraphicsLayer::Type::Normal);
+    Ref<GraphicsLayer> createGraphicsLayer(const String&, GraphicsLayerType = GraphicsLayerType::Normal);
 
     RenderLayerModelObject& renderer() const { return m_owningLayer.renderer(); }
     RenderBox* renderBox() const { return m_owningLayer.renderBox(); }

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -1033,7 +1033,7 @@ void RenderObject::repaintUsingContainer(SingleThreadWeakPtr<const RenderLayerMo
     if (view().usesCompositing()) {
         ASSERT(repaintContainer->isComposited());
         if (CheckedPtr layer = repaintContainer->layer())
-            layer->setBackingNeedsRepaintInRect(r, shouldClipToLayer ? GraphicsLayer::ClipToLayer : GraphicsLayer::DoNotClipToLayer);
+            layer->setBackingNeedsRepaintInRect(r, shouldClipToLayer ? GraphicsLayer::ShouldClipToLayer::Clip : GraphicsLayer::ShouldClipToLayer::DoNotClip);
     }
 }
 

--- a/Source/WebCore/rendering/RenderTreeAsText.cpp
+++ b/Source/WebCore/rendering/RenderTreeAsText.cpp
@@ -32,6 +32,7 @@
 #include "Document.h"
 #include "ElementInlines.h"
 #include "FrameSelection.h"
+#include "GraphicsLayer.h"
 #include "HTMLElement.h"
 #include "HTMLNames.h"
 #include "HTMLSpanElement.h"

--- a/Source/WebCore/rendering/RenderView.cpp
+++ b/Source/WebCore/rendering/RenderView.cpp
@@ -26,6 +26,7 @@
 #include "Element.h"
 #include "FloatQuad.h"
 #include "GraphicsContext.h"
+#include "GraphicsLayerEnums.h"
 #include "HTMLBodyElement.h"
 #include "HTMLFrameOwnerElement.h"
 #include "HTMLFrameSetElement.h"
@@ -485,7 +486,7 @@ bool RenderView::shouldRepaint(const LayoutRect& rect) const
 void RenderView::repaintRootContents()
 {
     if (layer()->isComposited()) {
-        layer()->setBackingNeedsRepaint(GraphicsLayer::DoNotClipToLayer);
+        layer()->setBackingNeedsRepaint(GraphicsLayerShouldClipToLayer::DoNotClip);
         return;
     }
 

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -103,6 +103,7 @@
 #include "FrameMemoryMonitor.h"
 #include "FrameSnapshotting.h"
 #include "GCObservation.h"
+#include "GraphicsLayer.h"
 #include "HEVCUtilities.h"
 #include "HTMLAnchorElement.h"
 #include "HTMLAttachmentElement.h"

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
@@ -53,6 +53,7 @@
 #include "StreamMessageReceiver.h"
 #include "StreamServerConnection.h"
 #include <WebCore/Font.h>
+#include <WebCore/FrameIdentifier.h>
 #include <WebCore/PixelFormat.h>
 #include <WebCore/ProcessIdentity.h>
 #include <WebCore/RenderingResourceIdentifier.h>

--- a/Source/WebKit/Shared/RemoteLayerTree/LayerProperties.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/LayerProperties.h
@@ -26,7 +26,18 @@
 #pragma once
 
 #include "PlatformCAAnimationRemote.h"
+#include <WebCore/EventRegion.h>
+#include <WebCore/GraphicsLayerEnums.h>
+#include <WebCore/MediaPlayerEnums.h>
 #include <WebCore/PlatformCALayer.h>
+
+#if HAVE(CORE_MATERIAL)
+#include <WebCore/AppleVisualEffect.h>
+#endif
+
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+#include <WebCore/AcceleratedEffectValues.h>
+#endif
 
 namespace WebKit {
 
@@ -176,7 +187,7 @@ struct LayerProperties {
     float opacity { 1 };
     WebCore::Color backgroundColor { WebCore::Color::transparentBlack };
     WebCore::Color borderColor { WebCore::Color::black };
-    WebCore::GraphicsLayer::CustomAppearance customAppearance { WebCore::GraphicsLayer::CustomAppearance::None };
+    WebCore::GraphicsLayerCustomAppearance customAppearance { WebCore::GraphicsLayerCustomAppearance::None };
     WebCore::PlatformCALayer::FilterType minificationFilter { WebCore::PlatformCALayer::FilterType::Linear };
     WebCore::PlatformCALayer::FilterType magnificationFilter { WebCore::PlatformCALayer::FilterType::Linear };
     WebCore::BlendMode blendMode { WebCore::BlendMode::Normal };

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
@@ -34,6 +34,7 @@
 #import "WKVideoView.h"
 #import <QuartzCore/QuartzCore.h>
 #import <WebCore/ContentsFormatCocoa.h>
+#import <WebCore/GraphicsLayerEnums.h>
 #import <WebCore/MediaPlayerEnumsCocoa.h>
 #import <WebCore/PlatformCAFilters.h>
 #import <WebCore/ScrollbarThemeMac.h>
@@ -367,14 +368,14 @@ static void updateAppleVisualEffect(CALayer *layer, RemoteLayerTreeNode* layerTr
 
 #endif
 
-static void updateCustomAppearance(CALayer *layer, GraphicsLayer::CustomAppearance customAppearance)
+static void updateCustomAppearance(CALayer *layer, GraphicsLayerCustomAppearance customAppearance)
 {
 #if HAVE(RUBBER_BANDING)
     switch (customAppearance) {
-    case GraphicsLayer::CustomAppearance::None:
+    case GraphicsLayerCustomAppearance::None:
         ScrollbarThemeMac::removeOverhangAreaShadow(layer);
         break;
-    case GraphicsLayer::CustomAppearance::ScrollingShadow:
+    case GraphicsLayerCustomAppearance::ScrollingShadow:
         ScrollbarThemeMac::setUpOverhangAreaShadow(layer);
         break;
     }

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm
@@ -31,6 +31,7 @@
 #import "PlatformCALayerRemote.h"
 #import <QuartzCore/QuartzCore.h>
 #import <WebCore/EventRegion.h>
+#import <WebCore/GraphicsLayer.h>
 #import <WebCore/Model.h>
 #import <WebCore/TimingFunction.h>
 #import <ranges>

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -8704,6 +8704,7 @@ enum class WebCore::TransformOperationType : uint8_t {
 
 enum class WebCore::GraphicsContextGLSurfaceBuffer : bool;
 
+header: <WebCore/GraphicsLayer.h>
 [Nested] enum class WebCore::GraphicsLayer::CustomAppearance : bool;
 
 [OptionSet] enum class GCGLErrorCode : uint8_t {

--- a/Source/WebKit/UIProcess/ModelElementController.h
+++ b/Source/WebKit/UIProcess/ModelElementController.h
@@ -29,7 +29,6 @@
 
 #include "ModelIdentifier.h"
 #include <WebCore/ElementContext.h>
-#include <WebCore/GraphicsLayer.h>
 #include <WebCore/HTMLModelElementCamera.h>
 #include <WebCore/ResourceError.h>
 #include <wtf/MachSendRight.h>
@@ -43,6 +42,10 @@ OBJC_CLASS ASVInlinePreview;
 #if ENABLE(ARKIT_INLINE_PREVIEW_IOS)
 OBJC_CLASS WKModelView;
 #endif
+
+namespace WebCore {
+class LayoutPoint;
+}
 
 namespace WebKit {
 

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteSnapshotRecorderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteSnapshotRecorderProxy.h
@@ -29,6 +29,7 @@
 
 #include "RemoteGraphicsContextProxy.h"
 #include "RemoteSnapshotRecorderIdentifier.h"
+#include <WebCore/FrameIdentifier.h>
 
 namespace WebKit {
 

--- a/Source/WebKit/WebProcess/GPU/graphics/cocoa/RemoteGraphicsContextGLProxyCocoa.mm
+++ b/Source/WebKit/WebProcess/GPU/graphics/cocoa/RemoteGraphicsContextGLProxyCocoa.mm
@@ -35,6 +35,7 @@
 #import "WebProcess.h"
 #import <WebCore/CVUtilities.h>
 #import <WebCore/GraphicsLayerContentsDisplayDelegate.h>
+#import <WebCore/GraphicsLayerEnums.h>
 #import <WebCore/IOSurface.h>
 #import <WebCore/PlatformCALayer.h>
 #import <WebCore/PlatformCALayerDelegatedContents.h>
@@ -100,9 +101,9 @@ public:
             layer.clearContents();
     }
 
-    WebCore::GraphicsLayer::CompositingCoordinatesOrientation orientation() const final
+    WebCore::GraphicsLayerCompositingCoordinatesOrientation orientation() const final
     {
-        return WebCore::GraphicsLayer::CompositingCoordinatesOrientation::BottomUp;
+        return WebCore::GraphicsLayerCompositingCoordinatesOrientation::BottomUp;
     }
 
     void setDisplayBuffer(MachSendRight&& displayBuffer, RefPtr<DisplayBufferFence> finishedFence)

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
@@ -66,6 +66,7 @@
 #import <WebCore/FrameDestructionObserverInlines.h>
 #import <WebCore/FrameLoader.h>
 #import <WebCore/GraphicsContext.h>
+#import <WebCore/GraphicsLayer.h>
 #import <WebCore/HTMLPlugInElement.h>
 #import <WebCore/LegacyNSPasteboardTypes.h>
 #import <WebCore/LoaderNSURLExtras.h>

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.h
@@ -30,7 +30,6 @@
 #include "PDFDocumentLayout.h"
 #include "PDFPageCoverage.h"
 #include <WebCore/FloatRect.h>
-#include <WebCore/GraphicsLayer.h>
 #include <WebCore/IntPoint.h>
 #include <WebCore/TiledBacking.h>
 #include <limits>
@@ -47,6 +46,10 @@
 #endif
 
 OBJC_CLASS PDFDocument;
+
+namespace WebCore {
+class GraphicsLayer;
+}
 
 namespace WebKit {
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.mm
@@ -35,6 +35,7 @@
 #include <PDFKit/PDFKit.h>
 #include <WebCore/GeometryUtilities.h>
 #include <WebCore/GraphicsContext.h>
+#include <WebCore/GraphicsLayer.h>
 #include <WebCore/ImageBuffer.h>
 #include <WebCore/NativeImage.h>
 #include <wtf/NumberOfCores.h>

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorOverlayController.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorOverlayController.h
@@ -29,7 +29,6 @@
 
 #include "PDFDocumentLayout.h"
 #include <WebCore/DataDetectorHighlight.h>
-#include <WebCore/GraphicsLayer.h>
 #include <WebCore/PageOverlay.h>
 #include <wtf/Forward.h>
 #include <wtf/HashMap.h>

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.h
@@ -30,7 +30,6 @@
 #include "PDFDocumentLayout.h"
 #include "PDFPageCoverage.h"
 #include "UnifiedPDFPlugin.h"
-#include <WebCore/GraphicsLayer.h>
 #include <WebCore/PlatformLayerIdentifier.h>
 #include <wtf/OptionSet.h>
 #include <wtf/RefPtr.h>
@@ -41,7 +40,9 @@
 OBJC_CLASS PDFDocument;
 
 namespace WebCore {
+enum class GraphicsLayerType : uint8_t;
 enum class TiledBackingScrollability : uint8_t;
+class GraphicsLayer;
 class GraphicsLayerClient;
 };
 
@@ -123,7 +124,7 @@ public:
     virtual void setSelectionLayerEnabled(bool) { }
 
 protected:
-    RefPtr<WebCore::GraphicsLayer> createGraphicsLayer(const String&, WebCore::GraphicsLayer::Type);
+    RefPtr<WebCore::GraphicsLayer> createGraphicsLayer(const String&, WebCore::GraphicsLayerType);
     RefPtr<WebCore::GraphicsLayer> makePageContainerLayer(PDFDocumentLayout::PageIndex);
     struct LayerCoverage {
         Ref<WebCore::GraphicsLayer> layer;

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -31,7 +31,6 @@
 #include "PDFPageCoverage.h"
 #include "PDFPluginBase.h"
 #include <WebCore/ContextMenuItem.h>
-#include <WebCore/GraphicsLayer.h>
 #include <WebCore/GraphicsLayerClient.h>
 #include <WebCore/NodeIdentifier.h>
 #include <WebCore/Page.h>
@@ -52,6 +51,8 @@ class TextStream;
 
 namespace WebCore {
 class FrameView;
+class GraphicsLayer;
+class GraphicsLayerFactory;
 class LocalFrameView;
 class PageOverlay;
 class PlatformWheelEvent;
@@ -59,6 +60,7 @@ class ShadowRoot;
 class AXCoreObject;
 
 enum class DelegatedScrollingMode : uint8_t;
+enum class GraphicsLayerType : uint8_t;
 
 struct DataDetectorElementInfo;
 }
@@ -573,8 +575,8 @@ private:
     void revealAnnotation(PDFAnnotation *);
 
     WebCore::GraphicsLayerFactory* graphicsLayerFactory() const;
-    RefPtr<WebCore::GraphicsLayer> createGraphicsLayer(GraphicsLayerClient&, WebCore::GraphicsLayer::Type);
-    RefPtr<WebCore::GraphicsLayer> createGraphicsLayer(const String& name, WebCore::GraphicsLayer::Type);
+    RefPtr<WebCore::GraphicsLayer> createGraphicsLayer(GraphicsLayerClient&, WebCore::GraphicsLayerType);
+    RefPtr<WebCore::GraphicsLayer> createGraphicsLayer(const String& name, WebCore::GraphicsLayerType);
 
     void setNeedsRepaintForIncrementalLoad();
     void setNeedsRepaintForAnnotation(PDFAnnotation *, RepaintRequirements);
@@ -653,8 +655,8 @@ private:
 
     RefPtr<PDFPresentationController> protectedPresentationController() const;
 
-    RefPtr<WebCore::GraphicsLayer> protectedScrollContainerLayer() const { return m_scrollContainerLayer; }
-    RefPtr<WebCore::GraphicsLayer> protectedOverflowControlsContainer() const { return m_overflowControlsContainer; }
+    RefPtr<WebCore::GraphicsLayer> protectedScrollContainerLayer() const;
+    RefPtr<WebCore::GraphicsLayer> protectedOverflowControlsContainer() const;
 
     RefPtr<PDFPresentationController> m_presentationController;
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -4850,6 +4850,16 @@ RefPtr<PDFPresentationController> UnifiedPDFPlugin::protectedPresentationControl
     return m_presentationController;
 }
 
+RefPtr<WebCore::GraphicsLayer> UnifiedPDFPlugin::protectedScrollContainerLayer() const
+{
+    return m_scrollContainerLayer;
+}
+
+RefPtr<WebCore::GraphicsLayer> UnifiedPDFPlugin::protectedOverflowControlsContainer() const
+{
+    return m_overflowControlsContainer;
+}
+
 ViewportConfiguration::Parameters UnifiedPDFPlugin::viewportParameters()
 {
     ViewportConfiguration::Parameters parameters;

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemoteProperties.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemoteProperties.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <WebCore/PlatformCAAnimation.h>
+#include <WebCore/TimingFunction.h>
 #include <wtf/Forward.h>
 
 namespace WebKit {

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h
@@ -44,6 +44,7 @@ struct AcceleratedEffectValues;
 #if ENABLE(MODEL_PROCESS)
 class ModelContext;
 #endif
+enum class GraphicsLayerCustomAppearance : bool;
 }
 
 namespace WebKit {
@@ -213,8 +214,8 @@ public:
     WebCore::WindRule shapeWindRule() const override;
     void setShapeWindRule(WebCore::WindRule) override;
 
-    WebCore::GraphicsLayer::CustomAppearance customAppearance() const override;
-    void updateCustomAppearance(WebCore::GraphicsLayer::CustomAppearance) override;
+    WebCore::GraphicsLayerCustomAppearance customAppearance() const override;
+    void updateCustomAppearance(WebCore::GraphicsLayerCustomAppearance) override;
 
     void setEventRegion(const WebCore::EventRegion&) override;
 

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.h
@@ -40,6 +40,8 @@
 #include <wtf/Vector.h>
 
 namespace WebCore {
+class HTMLVideoElement;
+enum class GraphicsLayerType : uint8_t;
 enum class UseLosslessCompression : bool;
 }
 
@@ -117,7 +119,7 @@ private:
     explicit RemoteLayerTreeContext(WebPage&);
 
     // WebCore::GraphicsLayerFactory
-    Ref<WebCore::GraphicsLayer> createGraphicsLayer(WebCore::GraphicsLayer::Type, WebCore::GraphicsLayerClient&) override;
+    Ref<WebCore::GraphicsLayer> createGraphicsLayer(WebCore::GraphicsLayerType, WebCore::GraphicsLayerClient&) override;
 
     WeakRef<WebPage> m_webPage;
 

--- a/Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.cpp
+++ b/Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.cpp
@@ -177,7 +177,7 @@ std::optional<PlatformLayerIdentifier> GraphicsLayerWC::primaryLayerID() const
 
 void GraphicsLayerWC::setNeedsDisplay()
 {
-    setNeedsDisplayInRect({ { }, m_size }, ClipToLayer);
+    setNeedsDisplayInRect({ { }, m_size }, ShouldClipToLayer::Clip);
 }
 
 void GraphicsLayerWC::setNeedsDisplayInRect(const WebCore::FloatRect& rect, ShouldClipToLayer shouldClip)

--- a/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h
+++ b/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h
@@ -30,6 +30,7 @@
 #include "MessageReceiver.h"
 #include <WebCore/EventListener.h>
 #include <WebCore/HTMLMediaElementEnums.h>
+#include <WebCore/HTMLMediaElementIdentifier.h>
 #include <WebCore/MediaPlayerClientIdentifier.h>
 #if HAVE(PIP_SKIP_PREROLL)
 #include <WebCore/MediaSession.h>


### PR DESCRIPTION
#### 0635672c86b4a255ce06cea8223b248703ee6151
<pre>
[Build Speed] Make GraphicsLayer.h less expensive
<a href="https://rdar.apple.com/161829723">rdar://161829723</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=300033">https://bugs.webkit.org/show_bug.cgi?id=300033</a>

Reviewed by Ryosuke Niwa.

Prior to this patch, GraphicsLayer.h was the 3rd most expensive header used in
WebCore; it is included 268 times in a WebCore Unified build, and on this
machine, each include of that file took the compiler on avegare 1.3s to parse,
for a total of 5.9m CPU minutes of time spent parsing this header.

The primary cause of GraphicsLayer.h being included in a compliation unit was
that it was included by GraphicsLayerContentsDisplayDelegate.h, which only
needed a forward declaration of an enum defined within the GraphicsLayer class
itself. This enum–along with every other enum defined within GraphicsLayer–was
moved into a new GraphicsLayerEnums.h header, and those enums were pulled back
into GraphicsLayer via a using statement. I then looked at every header which
included GraphicsLayer.h and: converted every use of GraphicsLayer enums to use
the new enums defined in GraphicsLayerEnums.h, added a forward declaration for
GraphicsLayer, and removed the GraphicsLayer.h header where possible.

After this patch, GraphicsLayer.h is now the 67th most expensive header used in
WebCore; it is included 37 times, for a total of 49s CPU seconds of time spent
parsing this header, a reduction of 5.1m.

Canonical link: <a href="https://commits.webkit.org/301010@main">https://commits.webkit.org/301010@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e07a65c3442a184963a548a803d375133132ef8c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124668 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44340 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35074 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131509 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76597 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a7a19f94-34c2-47b3-8560-ebbe2f055847) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/126545 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45044 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52910 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94851 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62907 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/29948f9f-6bf5-4f4a-9700-cfef2c082c9c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127622 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35919 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111492 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75421 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ba76ce2b-a06b-422b-8d60-1840ddbc5b82) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34849 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29647 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74989 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105676 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29878 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134175 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51516 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39332 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103324 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51928 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107713 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103099 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26244 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48470 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26735 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48472 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51390 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57187 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50784 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54139 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52478 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->