### PR TITLE
Implement a Stop the World mechanism for JSC.

### DIFF
--- a/Source/JavaScriptCore/API/tests/VMManagerStopTheWorldTest.cpp
+++ b/Source/JavaScriptCore/API/tests/VMManagerStopTheWorldTest.cpp
@@ -1,0 +1,1394 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "VMManagerStopTheWorldTest.h"
+
+#include "JavaScript.h"
+#include <JavaScriptCore/APICast.h>
+#include <JavaScriptCore/InitializeThreading.h>
+#include <JavaScriptCore/JSCConfig.h>
+#include <JavaScriptCore/Options.h>
+#include <JavaScriptCore/VMManager.h>
+#include <string>
+#include <thread>
+#include <vector>
+#include <wtf/Condition.h>
+#include <wtf/DataLog.h>
+#include <wtf/Forward.h>
+#include <wtf/HashSet.h>
+#include <wtf/Lock.h>
+#include <wtf/MainThread.h>
+#include <wtf/MonotonicTime.h>
+#include <wtf/Scope.h>
+#include <wtf/Threading.h>
+#include <wtf/Vector.h>
+#include <wtf/text/CString.h>
+
+namespace VMManagerStopTheWorldTest {
+
+using JSC::JSGlobalObject;
+using JSC::Options;
+using JSC::StopTheWorldEvent;
+using JSC::StopTheWorldStatus;
+using JSC::VM;
+using JSC::VMManager;
+
+/*
+ The Stop the World (STW) feature basically involves multiple threads:
+ 1. Mutator threads running VMs
+ 2. An optional agent thread (like GC or a Debugger)
+
+ The Actors
+ ==========
+ This test exercises the Stop the World feature using the following VMs / threads:
+ 1. main thread
+    - this is the conductor that orchesrates the test.
+    - see test().
+ 2. worker threads
+    - there are numberOfTestVMs of these, and they each run a VM.
+    - each worker will run through a series of checkpoints, which will serve as
+      synchronization points for the test.
+    - see checkpointCallback(), scriptString(), and inactiveWorkerScriptString().
+ 3. inactiveVM thread
+    - this is a thread with a VM that is not executing some of the time
+      i.e. the thread is executing code outside of the VM
+      a.k.a. the thread has not entered the VM
+      a.k.a. the VM is not activated, hence "inactive".
+    - the purpose of having this inactiveVM is to ensure that the existence
+      of an deactivated VM does not block active VMs from reaching world stopped mode.
+    - we also the scenario where this inactiveVM gets activate while the world is
+      already stopped. In such a case, the inactiveVM should block on VM entry and
+      not actually execute any code in the VM.
+ 4. extraVM thread
+    - this is a thread that creates a new VM after we've in Stop the World.
+      This tests that the new VM will block on VM construction. We need this because
+      GlobalGC needs heap activity to stop while the world is stopped. During VM
+      construction, a lot of JS objects are allocated (i.e. heap activity). Hence,
+      we need to test that VM construction is blocked while the world is stopped.
+
+ The Timeline and Script
+ =======================
+ All the test scenarios are outlined in the STEPs below. The way to think of the
+ STEPs is that each STEP represents a point in time. The orchestration of the test
+ may bounce around between the different threads above, and sometimes, more than
+ one thread may be running at the same time. However, the execution of all the
+ threads are structured so that they obey the STEPS. Depending on the current STEP,
+ each thread will perform different work / tests (as outlined below).
+
+ Lastly, this test employs 2 agents: a WasmDebugger and a MemoryDebugger. These are
+ only in debuggers in name. We're using them because VMManager provide hooks to
+ customize the callbacks for these debuggers.
+ - see wasmDebuggerTestCallback() and memoryDebuggerTestCallback().
+
+ In this test, the test WasmDebugger will exercise STW feature like the real
+ WasmDebugger would. This include allowing a single VM to run in RunOne mode while
+ all other VMs (and their threads) are stopped.
+
+ In this test, the test MemoryDebugger will behave like the GlobalGC agent. The key
+ scenario we want to test with it is one where the WasmDebugger has a VM running in
+ RunOne mode, and a GC is triggered. This means that the test MemoryDebugger
+ (representing GlobalGC) needs to be able to Stop the World while we're in RunOne
+ mode, and after it is done, it can resume automatically back in RunOne mode allowing
+ the WasmDebugger to continue.
+
+ We will run through the STEPS numberOfIterationsToRun times to ensure that the same
+ STW operations can be performed more than once, and that there are no residual state
+ that interferes with subsequent operation.
+
+ Outline of the STEPs (test script)
+ ==================================
+ Setup and Initialization
+    STEP 0000 Record VMs pre-existing before this test
+    STEP 0001 Start and count inactive workers
+    STEP 0001 Start workers
+    STEP 0003 Wait till worker threads arrive @ checkpoint 0, and are ready to run tests
+    STEP 0004 All workers arrived at Checkpoint 0.
+    STEP 0005 Record worker VMs
+
+ Run tests
+    STEP 1000 Start test iteration
+    STEP 1000.1 Wake all workers
+    STEP 1000.2 Wait for workers to arrive at Checkpoint 1
+
+    // Test 1: Stop the World.
+    STEP 1100 All workers arrived at Checkpoint 1
+    STEP 1100.1 Wake all workers
+    STEP 1100.2 Request Stop the World
+    STEP 1100.3 Wait for WasmDebugger to stop at Checkpoint 1
+    STEP 1190 Success: Stopped in WasmDebugger
+
+    // Test 2: While in StopTheWorld, test that new VM will stop at VM construction.
+    STEP 1200 Start Test 2
+    STEP 1200.1 All workers have stopped in WasmDebugger
+    STEP 1200.2 Start a new thread and confirm that it stops at VM construction
+    STEP 1250 Wait for WasmDebugger to detect new thread
+    STEP 1290 Success: Found new stopped VM / thread
+
+    // Test 3: While in StopTheWorld, activating the inactive thread should stop at entry.
+    STEP 1300 Start Test 3
+    STEP 1300.1 Activate the inactive VM
+    STEP 1350 Wait for WasmDebugger to detect new thread
+    STEP 1390 Success: Found new stopped VM / thread
+
+    // Test 4: Context switch between VMs.
+    STEP 1400 Start Test 4
+    STEP 1400.1 Switching to a targetVM
+    STEP 1490 Success: Context switched thru all test VMs
+
+    // Test 5: RunOne mode in a targetVM thread.
+    STEP 1500 Start Test 5
+    STEP 1510 RunOne mode initiated
+    STEP 1590 Success: TargetVM reached Checkpoint2
+    
+    // Test 6: While in RunOne mode, another STW request (MemoryDebugger) should succeed.
+    STEP 1500 Start Test 6
+    STEP 1690 Success: TargetVM reached MemoryDebugger
+
+    // Test 7: MemoryDebugger's Resume should return to RunOne mode.
+    STEP 1700 Start Test 7
+    STEP 1710 Resumed from MemoryDebugger
+    STEP 1790 Success: MemoryDebugger resumed RunOne mode
+
+    // Test 8: While in StopTheWorld, thread completion should ResumeAll
+    STEP 1800 Start Test 8
+    STEP 1810 RunOne thread breaks out of Checkpoint2
+    STEP 1820 RunOne thread will exit imminently
+    STEP 1830 World has automatically resumed RunAll mode
+    STEP 1890 Success: all threads parked after resuming RunAll
+
+    // Test 9: VM deactivation on RunOne thread should automatically ResumeAll.
+    STEP 1900 Start Test 9
+    STEP 1910 Request Stop the World
+    STEP 1920 Stopped in WasmDebugger
+    STEP 1930 RunOne in the inactiveVM worker and get it to exit
+    STEP 1940 Wait for VM deactivation to resume RunAll from RunOne
+    STEP 1990 Success: All workers auro-resumed RunOne VM deactivated
+
+ To find out what each of the test actors are doing for each STEP, search for the
+ corresponding 4 digit STEP number in the code below.
+*/
+
+// Debugging options
+constexpr int verboseLevel = 0; // 0 = most quiet, 1 = print SET_STEP, 2 = print all.
+constexpr bool crashOnAbort = false; // Crash on first failure if true.
+constexpr bool logVMManagerInfoOnEachStep = false; // print VMManager::info() on each STEP if true.
+constexpr double timeoutIfTestIsUnresponsive = true;
+
+// Test configuration
+constexpr unsigned numberOfInactiveVMs = 1; // Must be 1. Do not change.
+constexpr unsigned numberOfTestVMs = 5;
+constexpr unsigned numberOfIterationsToRun = 3;
+
+// Test runtime state
+unsigned step = 0;
+bool needAbort = false;
+int failuresFound = 0;
+Lock lock;
+Condition mainThreadConditionVariable;
+Condition extraVMConditionVariable;
+Condition workersConditionVariable;
+Condition inactiveWorkersTerminationConditionVariable;
+
+bool needToNotifyVMDestruction = false;
+bool mainIsWaitingForVMDestruction = false;
+Condition okToNotifyVMDestructionConditionVariable;
+Condition vmDestructionConditionVariable;
+
+Atomic<unsigned> inactiveVMsCreated;
+Vector<VM*>* testVMsPtr = nullptr;
+
+bool isCreatingInactiveVM = false;
+
+unsigned totalNumberOfVMs = 0;
+unsigned totalNumberOfActiveVMs = 0;
+Atomic<unsigned> numberOfThreadsStarted = 0;
+
+namespace Test0 {
+Atomic<unsigned> totalNumberOfVMsReady = 0;
+}
+
+namespace Test1 {
+Atomic<unsigned> numberOfVMsReady = 0;
+}
+
+namespace Test2 {
+bool reachedCheckpoint0 = false;
+unsigned numberOfStoppedVMsAtStart = 0;
+VM* extraVM = nullptr;
+}
+
+namespace Test3 {
+bool reachedCheckpoint5 = false;
+unsigned numberOfStoppedVMsAtStart = 0;
+}
+
+namespace Test4 {
+unsigned numberOfContextSwitches = 0;
+VM* targetVM = nullptr;
+}
+
+namespace Test5 {
+VM* targetVM = nullptr;
+}
+
+namespace Test8 {
+VM* targetVM = nullptr;
+Atomic<unsigned> numberOfRunningThreads = 0;
+Atomic<unsigned> numberOfWaitingThreads = 0;
+}
+
+namespace Test9 {
+VM* targetVM = nullptr;
+Atomic<unsigned> numberOfWaitingThreads = 0;
+}
+
+namespace TestEnd {
+bool doneTesting = false;
+}
+
+#undef TID
+#undef DLOG
+#undef PAD
+#undef LOG_STEP_IMPL
+#undef LOG_STEP
+#undef LOG_INFO
+#undef SET_STEP
+#undef CHECK
+#undef EXPECT_EQ
+#undef EXPECT_NE
+#undef VMID
+#undef WAIT_TIMEOUT_S
+
+#define TID "t", Thread::currentSingleton().uid()
+
+#define DLOG(threadNameOrLabel, ...) \
+    dataLogLnIf(verboseLevel >= 2, "<", TID, "> " #threadNameOrLabel " @ ", __LINE__, ": ", __VA_ARGS__)
+
+#define PAD(__step) (verboseLevel > 1 && sizeof(#__step) == 5 ? "  " : "")
+
+#define LOG_STEP_IMPL(__doPrint, __step, threadNameOrLabel, ...) do { \
+        dataLogLnIf((__doPrint), "STEP ",  #__step, PAD(__step), " <", TID, "> " #threadNameOrLabel, " @ ", __LINE__, ": ", __VA_ARGS__); \
+    } while (false)
+
+#define LOG_STEP(__step, threadNameOrLabel, ...) do { \
+        LOG_STEP_IMPL(verboseLevel >= 2, __step, threadNameOrLabel, __VA_ARGS__); \
+    } while (false)
+
+#define LOG_INFO(__step, threadNameOrLabel) do { \
+        auto info = VMManager::info(); \
+        LOG_STEP_IMPL(logVMManagerInfoOnEachStep, __step, threadNameOrLabel, "-- info VMs: ", info.numberOfVMs, ", ActiveVMs: ", info.numberOfActiveVMs, ", StoppedVMs ", info.numberOfStoppedVMs, ", mode: ", info.worldMode); \
+    } while (false)
+
+#define SET_STEP(__step, threadNameOrLabel, ...) do { \
+        LOG_STEP_IMPL(verboseLevel >= 1, __step, threadNameOrLabel, __VA_ARGS__); \
+        LOG_INFO(__step, threadNameOrLabel); \
+        step = (unsigned)__step; \
+    } while (false)
+
+#define CHECK(condition, ...) do { \
+        if (!(condition)) { \
+            dataLogLn("FAIL: ", #condition, " @ thread<", TID, ">: ", __VA_ARGS__); \
+            dataLogLn("    @ " __FILE__, ":", __LINE__); \
+            failuresFound++; \
+        } \
+    } while (false)
+
+#define EXPECT_EQ(actual, expected, ...) do { \
+        auto expectedValue = expected; \
+        decltype(expectedValue) actualValue = actual; \
+        if (expectedValue != actualValue) { \
+            dataLogLn("FAIL: EXPECT_EQ(", #actual, ", ", #expected, ", ... @ thread<", TID, ">: ", __VA_ARGS__); \
+            dataLogLn("    @ " __FILE__, ":", __LINE__); \
+            dataLogLn("    actual: ", actual); \
+            dataLogLn("  expected: ", expected); \
+            failuresFound++; \
+        } \
+    } while (false)
+
+#define EXPECT_NE(actual, expected, ...) do { \
+        auto expectedValue = expected; \
+        decltype(expectedValue) actualValue = actual; \
+        if (expectedValue == actualValue) { \
+            dataLogLn("FAIL: EXPECT_NE(", #actual, ", ",  #expected, ", ... @ thread<", TID, ">: ", __VA_ARGS__); \
+            dataLogLn("    @ " __FILE__, ":", __LINE__); \
+            dataLogLn("    actual: ", actual); \
+            dataLogLn("  expected: !", expected); \
+            failuresFound++; \
+        } \
+    } while (false)
+
+#define VMID(__vm) \
+    "vm<", (__vm).identifier(), ">:", RawPointer(&(__vm))
+
+#define WAIT_TIMEOUT_S (timeoutIfTestIsUnresponsive ? Seconds(1.0) : Seconds(std::numeric_limits<double>::infinity()))
+
+class APIString {
+    WTF_MAKE_NONCOPYABLE(APIString);
+public:
+
+    APIString(const char* string)
+        : m_string(JSStringCreateWithUTF8CString(string))
+    {
+    }
+
+    APIString(JSGlobalContextRef context, JSValueRef value)
+        : m_string(JSValueToStringCopy(context, value, nullptr))
+    {
+    }
+
+    ~APIString()
+    {
+        if (m_string)
+            SUPPRESS_UNCOUNTED_ARG JSStringRelease(m_string);
+    }
+
+    operator JSStringRef() { return m_string; }
+
+private:
+    SUPPRESS_UNCOUNTED_MEMBER JSStringRef m_string;
+};
+
+static int abortTest(Locker<Lock>&)
+{
+    needAbort = true;
+    DLOG(abort, "abortTest");
+    mainThreadConditionVariable.notifyAll();
+    workersConditionVariable.notifyAll();
+    inactiveWorkersTerminationConditionVariable.notifyAll();
+    VMManager::requestResumeAll(VMManager::StopReason::WasmDebugger);
+    VMManager::requestResumeAll(VMManager::StopReason::MemoryDebugger);
+    RELEASE_ASSERT(!crashOnAbort || !needAbort);
+    return -1;
+}
+
+static int abortTest()
+{
+    Locker locker { lock };
+    return abortTest(locker);
+}
+
+static std::vector<std::thread>& threadsList()
+{
+    static std::vector<std::thread>* list;
+    static std::once_flag flag;
+    std::call_once(flag, [] () {
+        list = new std::vector<std::thread>();
+    });
+    return *list;
+}
+
+static JSValueRef checkpointCallback(JSContextRef ctx, JSObjectRef functionObject, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
+{
+    JSGlobalObject* globalObject = toJS(ctx);
+    VM& vm = globalObject->vm();
+
+    UNUSED_PARAM(functionObject);
+    UNUSED_PARAM(thisObject);
+
+    RELEASE_ASSERT(argumentCount == 1);
+    RELEASE_ASSERT(!*exception);
+
+    unsigned checkpointID = JSValueToInt32(ctx, arguments[0], exception);
+    RELEASE_ASSERT(!*exception);
+
+    if (needAbort)
+        *exception = JSValueMakeNumber(ctx, 42);
+
+    JSValueRef result = nullptr;
+    switch (checkpointID) {
+    case 0: {
+        if (step >= 1820) {
+            // Later tests should rendezvous at later checkpoints.
+            result = JSValueMakeBoolean(ctx, false);
+            break;
+        }
+
+        Locker locker { lock };
+
+        if (step >= 1200 && step <= 1290)
+            Test2::reachedCheckpoint0 = true;
+
+        // Have all worker threads wait till the main thread is ready before proceeding.
+        auto previous = Test0::totalNumberOfVMsReady.exchangeAdd(1);
+        if (previous + 1 == numberOfTestVMs) {
+            mainThreadConditionVariable.notifyAll();
+            SET_STEP(0004, worker, "All workers arrived at Checkpoint 0");
+        }
+        workersConditionVariable.wait(lock);
+
+        result = JSValueMakeUndefined(ctx);
+        break;
+    }
+    case 1: {
+        if (step == 1000) {
+            Locker locker { lock };
+
+            // Make sure all threads have reached checkpoint 1.
+            auto previous = Test1::numberOfVMsReady.exchangeAdd(1);
+            if (previous + 1 == numberOfTestVMs) {
+                mainThreadConditionVariable.notifyAll();
+                SET_STEP(1100, worker, "All workers arrived at Checkpoint 1");
+            }
+            workersConditionVariable.wait(lock);
+
+            result = JSValueMakeBoolean(ctx, true);
+            break;
+        }
+        if (step <= 1290) {
+            result = JSValueMakeBoolean(ctx, true);
+            break;
+        }
+        if (step <= 1490) {
+            LOG_STEP(1490, worker, "Checkpoint 1: Worker should not run while world is stopped in Test 4");
+            abortTest();
+            break;
+        }
+        if (step >= 1510) {
+            // Later tests should rendezvous at later checkpoints.
+            result = JSValueMakeBoolean(ctx, false);
+            break;
+        }
+        LOG_STEP(9999, worker, "Checkpoint 1: should not reach here");
+        abortTest(); // Should not reach here.
+        break;
+    }
+    case 2: {
+        if (step == 1510) {
+            EXPECT_EQ(Test5::targetVM, &vm, "Checkpoint2 reached from the wrong VM thread");
+            if (failuresFound) {
+                abortTest();
+                break;
+            }
+        }
+        if (step < 1590) {
+            Locker locker { lock };
+            mainThreadConditionVariable.notifyAll();
+            SET_STEP(1590, worker, "Success: TargetVM reached Checkpoint2");
+            result = JSValueMakeBoolean(ctx, true);
+            break;
+        }
+        if (step == 1710) {
+            Locker locker { lock };
+            EXPECT_EQ(VMManager::info().worldMode, VMManager::Mode::RunOne, "Should be RunOne");
+            mainThreadConditionVariable.notifyAll();
+            SET_STEP(1720, worker, "Confirmed transitioned to RunOne mode at Checkpoint2");
+            result = JSValueMakeBoolean(ctx, true);
+            break;
+        }
+        if (step == 1800) {
+            SET_STEP(1810, worker, "RunOne thread breaks out of Checkpoint2");
+            Test8::targetVM = &vm;
+            result = JSValueMakeBoolean(ctx, false);
+            break;
+        }
+        if (step >= 1820) {
+            // Later tests should rendezvous at later checkpoints.
+            result = JSValueMakeBoolean(ctx, false);
+            break;
+        }
+        result = JSValueMakeBoolean(ctx, true);
+        break;
+    }
+    case 3: {
+        if (step == 1810) {
+            ASSERT(Test8::targetVM == &vm);
+            // This VM is imminently exiting and its thread is terminating. Hence, we need to
+            // decrement the expected number of VMs and active VMs by 1.
+            totalNumberOfActiveVMs--;
+            SET_STEP(1820, worker, "RunOne thread will exit imminently");
+            result = JSValueMakeBoolean(ctx, true);
+            break;
+        }
+        if (step >= 1820) {
+            // Later tests should rendezvous at later checkpoints.
+            result = JSValueMakeBoolean(ctx, false);
+            break;
+        }
+        LOG_STEP(9999, worker, "Checkpoint 1: should not reach here");
+        abortTest(); // Should not reach here.
+        break;
+    }
+    case 4: {
+        // Fall through to Checkpoint 5's code intentionally so that Checkpoint 4
+        // will do the equivalent work of Checkpoint 5 because:
+        // 1. the regular worker VMs will execute the regular script that goes through
+        //    Checkpoint 4.
+        // 2. the inactive worker VM will never go through Checkpoint 3, but will end up
+        //    here in Checkpoint 5.
+        //
+        // Test 8 and Test 9 will rely on this same checkpoint behavior.
+        [[fallthrough]];
+    }
+    case 5: {
+        // This part is only for Checkpoint 5. When Checkpoint 4 code falls through to here,
+        // step will be at least 1820, and will skip this part.
+        if (step >= 1300 && step <= 1390) {
+            LOG_STEP(1388.5, worker, "@ Checkpoint 5: Test3::reachedCheckpoint5");
+            Test3::reachedCheckpoint5 = true;
+            abortTest();
+            break;
+        }
+
+        // The following is common to Checkpoint 4 and 5.
+        if (step == 1820) {
+            auto previous = Test8::numberOfRunningThreads.exchangeAdd(1);
+            if (previous + 1 == totalNumberOfActiveVMs) {
+                SET_STEP(1830, worker, "Success: World automatically resumed RunAll mode");
+                WTF::storeLoadFence();
+            }
+            result = JSValueMakeBoolean(ctx, true);
+            break;
+        }
+        if (step == 1830) {
+            Locker locker { lock };
+            auto previous = Test8::numberOfWaitingThreads.exchangeAdd(1);
+            if (previous + 1 == totalNumberOfActiveVMs) {
+                SET_STEP(1890, worker, "Success: all threads parked after resuming RunAll");
+                mainThreadConditionVariable.notifyAll();
+            }
+            workersConditionVariable.wait(lock);
+
+            result = JSValueMakeBoolean(ctx, true);
+            break;
+        }
+        if (step == 1940) {
+            if (checkpointID == 5) {
+                // Get the "inactiveVM" worker to exit its script and deactivate its VM.
+                result = JSValueMakeBoolean(ctx, false);
+                break;
+            }
+
+            Locker locker { lock };
+            auto previous = Test9::numberOfWaitingThreads.exchangeAdd(1);
+            if (previous + 1 == totalNumberOfActiveVMs) {
+                mainThreadConditionVariable.notifyAll();
+                SET_STEP(1990, worker, "Success: All workers auro-resumed RunOne VM deactivated");
+            }
+
+            workersConditionVariable.wait(lock);
+            break;
+        }
+        // The "inactiveVM" may end up stuck in the Checkpoint 5 loop. So, make it
+        // return false (i.e.stop looping) if we're done.
+        result = JSValueMakeBoolean(ctx, !TestEnd::doneTesting);
+        break;
+    }
+    case 6: {
+        result = JSValueMakeBoolean(ctx, TestEnd::doneTesting);
+        break;
+    }
+    } // end switch (checkpointID)
+
+    if (needAbort)
+        *exception = JSValueMakeNumber(ctx, 42);
+    return result;
+}
+
+// This function is just to act as a sink for JS variables to make sure that the JITs don't
+// optimize them away.
+static JSValueRef ensureAliveCallback(JSContextRef ctx, JSObjectRef functionObject, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
+{
+    UNUSED_PARAM(functionObject);
+    UNUSED_PARAM(thisObject);
+    UNUSED_PARAM(argumentCount);
+    UNUSED_PARAM(arguments);
+    UNUSED_PARAM(exception);
+    return JSValueMakeUndefined(ctx);
+}
+
+static StopTheWorldStatus wasmDebuggerTestCallback(VM& vm, StopTheWorldEvent)
+{
+    if (step == 1100) {
+        // Test 1: Stop the World test.
+        Locker locker { lock };
+        SET_STEP(1190, wasmDebugger, "Success: Stopped in WasmDebugger");
+        mainThreadConditionVariable.notifyAll();
+        return STW_CONTINUE();
+    }
+
+    // Test 2: While in StopTheWorld, test that new VM will stop at construction.
+    if (step <= 1200) {
+        std::this_thread::yield();
+        return STW_CONTINUE();
+    }
+    if (step == 1250) {
+        auto info = VMManager::info();
+        if (info.numberOfStoppedVMs <= Test2::numberOfStoppedVMsAtStart) {
+            std::this_thread::yield();
+            return STW_CONTINUE();
+        }
+
+        Locker locker { lock };
+        SET_STEP(1290, wasmDebugger, "Success: Found new stopped VM / thread");
+        mainThreadConditionVariable.notifyAll();
+        return STW_CONTINUE();
+    }
+
+    // Test 3: Activated VM should stop.
+    if (step < 1300) {
+        std::this_thread::yield();
+        return STW_CONTINUE();
+    }
+    if (step == 1350) {
+        auto info = VMManager::info();
+        if (info.numberOfStoppedVMs <= Test3::numberOfStoppedVMsAtStart) {
+            std::this_thread::yield();
+            return STW_CONTINUE();
+        }
+
+        Locker locker { lock };
+        SET_STEP(1390, wasmDebugger, "Success: Found new stopped VM / thread");
+        mainThreadConditionVariable.notifyAll();
+        return STW_CONTINUE();
+    }
+
+    // Test 4: Context switch test.
+    if (step < 1400) {
+        std::this_thread::yield();
+        return STW_CONTINUE();
+    }
+    if (step < 1490) {
+        if (Test4::targetVM) {
+            if (&vm != Test4::targetVM) {
+                SET_STEP(9999, wasmDebugger, "Failed: Context switched did not reach targetVM");
+                abortTest();
+                return STW_RESUME_ALL();
+            }
+        }
+        if (Test4::numberOfContextSwitches < testVMsPtr->size()) {
+            RELEASE_ASSERT(!Test4::numberOfContextSwitches || &vm == Test4::targetVM);
+            Test4::targetVM = testVMsPtr->at(Test4::numberOfContextSwitches);
+            LOG_STEP(1400.1, wasmDebugger, "Switch [", Test4::numberOfContextSwitches, "] from ", VMID(vm), " to targetVM ", VMID(*Test4::targetVM));
+            Test4::numberOfContextSwitches++;
+            return STW_CONTEXT_SWITCH(Test4::targetVM);
+        }
+        RELEASE_ASSERT(&vm == Test4::targetVM);
+
+        Locker locker { lock };
+        SET_STEP(1490, wasmDebugger, "Success: All context switches succeeded");
+        mainThreadConditionVariable.notifyAll();
+        return STW_CONTINUE();
+    }
+
+    // Test 5: RunOne mode in a targetVM thread.
+    if (step < 1500) {
+        std::this_thread::yield();
+        return STW_CONTINUE();
+    }
+    if (step < 1510) {
+        SET_STEP(1510, wasmDebugger, "RunOne mode initiated targetting ", VMID(*Test5::targetVM));
+        return STW_RESUME_ONE(Test5::targetVM);
+    }
+    RELEASE_ASSERT(step != 1510);
+    if (step < 1590) {
+        std::this_thread::yield();
+        return STW_CONTINUE();
+    }
+
+    // Test 9: VM deactivation on RunOne thread should automatically ResumeAll.
+    if (step < 1900) {
+        SET_STEP(9999, wasmDebugger, "Failed: Should not have stopped in the WasmDebugger");
+        abortTest();
+        return STW_RESUME_ALL();
+    }
+    if (step == 1910) {
+        Locker locker { lock };
+        SET_STEP(1920, wasmDebugger, "Stopped in WasmDebugger");
+        mainThreadConditionVariable.notifyAll();
+        return STW_CONTINUE();
+    }
+    if (step == 1930) {
+        SET_STEP(1940, wasmDebugger, "Wait for VM deactivation to resume RunAll from RunOne");
+        return STW_RESUME_ONE(Test9::targetVM);
+    }
+    if (step < 1990) {
+        std::this_thread::yield();
+        return STW_CONTINUE();
+    }
+
+    return STW_RESUME_ALL();
+}
+
+static StopTheWorldStatus memoryDebuggerTestCallback(VM&, StopTheWorldEvent)
+{
+    // Test 6: While in RunOne mode, another STW request (MemoryDebugger) should succeed.
+    if (step == 1600) {
+        Locker locker { lock };
+        SET_STEP(1690, memoryDebugger, "Success: Stopped in MemoryDebugger");
+        mainThreadConditionVariable.notifyAll();
+        return STW_CONTINUE();
+    }
+    if (step < 1700) {
+        std::this_thread::yield();
+        return STW_CONTINUE();
+    }
+    if (step == 1700) {
+        Locker locker { lock };
+        SET_STEP(1710, memoryDebugger, "Resumed from MemoryDebugger");
+        return STW_RESUME();
+    }
+
+    SET_STEP(9999, memoryDebugger, "Failed: Should not have stopped in the MemoryDebugger");
+    abortTest();
+    return STW_RESUME_ALL();
+}
+
+static void notifyVMDestruction()
+{
+    Locker locker { lock };
+    // Either the main thread reaches the rendezvous first or the worker does.
+    //
+    // If the main thread is first, then the worker's only job is to tell the
+    // main thread that they have sync'ed up and both can move forward.
+    //
+    // If the worker is first, then it needs to give the main thread time to
+    // catch up. Hence, the worker should wait for the main thread in that case.
+    if (!mainIsWaitingForVMDestruction) {
+        // Worker is first. So, wait.
+        okToNotifyVMDestructionConditionVariable.wait(lock);
+    }
+    vmDestructionConditionVariable.notifyAll();
+    needToNotifyVMDestruction = false;
+}
+
+static void waitForVMDestruction() WTF_REQUIRES_LOCK(lock)
+{
+    mainIsWaitingForVMDestruction = true;
+    okToNotifyVMDestructionConditionVariable.notifyAll();
+    vmDestructionConditionVariable.wait(lock);
+    WTF::compilerFence();
+    mainIsWaitingForVMDestruction = false;
+    WTF::loadLoadFence();
+}
+
+static int test()
+{
+    JSC::Config::configureForTesting();
+    WTF::initializeMainThread();
+    JSC::initialize();
+
+    auto startTime = MonotonicTime::now();
+    dataLogLn("");
+    dataLogLn("Starting VMManager StopTheWorld Test");
+
+    auto* originalWasmDebugger = g_jscConfig.wasmDebuggerStopTheWorld;
+    auto* originalMemoryDebugger = g_jscConfig.memoryDebuggerStopTheWorld;
+    VMManager::setWasmDebuggerCallback(wasmDebuggerTestCallback);
+    VMManager::setMemoryDebuggerCallback(memoryDebuggerTestCallback);
+
+    // FIXME: for now, VMTraps doesn't completely work on JIT runs yet. Once we fix that, we'll need
+    // to upgrade these tests to explicitly trigger and test JIT cases.
+    StringBuilder savedOptionsBuilder;
+    Options::dumpAllOptionsInALine(savedOptionsBuilder);
+    Options::setOptions("--useBaselineJIT=false");
+
+    auto resetSettings = makeScopeExit([&] {
+        Options::setOptions(savedOptionsBuilder.toString().ascii().data());
+        VMManager::setWasmDebuggerCallback(originalWasmDebugger);
+        VMManager::setMemoryDebuggerCallback(originalMemoryDebugger);
+    });
+
+#define ABORT_IF_FAILED() do { \
+        if (failuresFound) { \
+            abortTest(locker); \
+            return true; \
+        } \
+    } while (false)
+
+    // Code for worker threads.
+    auto task = [] (VM** addressOfVMToExport) {
+        int ret = 0;
+        // Script for regular worker.
+        std::string scriptString = R"script({
+            // For active VM workers.
+            function foo() { return 1; }
+            function bar() { return 2; }
+            function baz() { return 3; }
+
+            checkpoint(0);
+
+            // Run the whole thing more than once (controlled by checkpoint(3)) so that we can verify
+            // that there's no stuck state between all the stop and resumes.
+            for (;;) {
+                var x = 0;
+                while (checkpoint(1))
+                    x += foo();
+
+                while (checkpoint(2))
+                    x += bar();
+
+                if (checkpoint(3))
+                    break;
+
+                while (checkpoint(4))
+                    x += baz();
+
+                if (checkpoint(6))
+                    break;
+            }
+            ensureAlive(x);
+        })script";
+
+        // Test 8: The inactive worker creates the worker and then just waits.
+        // Script for the "inactiveVM" worker.
+        std::string inactiveWorkerScriptString = R"script({
+            // For the inactive VM which we later activate.
+            function foo() { return 1; }
+            var x = 0;
+            while (checkpoint(5))
+                x += foo();
+            ensureAlive(x);
+        })script";
+
+        bool isInactiveWorker = isCreatingInactiveVM;
+
+        if (isInactiveWorker)
+            LOG_STEP(0001.1, worker, "START thread");
+        else {
+            numberOfThreadsStarted.exchangeAdd(1);
+            LOG_STEP(0002.1, worker, "START thread");
+        }
+
+        totalNumberOfVMs++; // JSGlobalContextCreateInGroup will create a VM.
+        JSGlobalContextRef context = JSGlobalContextCreateInGroup(nullptr, nullptr);
+        JSObjectRef globalObject = JSContextGetGlobalObject(context);
+        RELEASE_ASSERT(JSValueIsObject(context, globalObject));
+        VM& vm = toJS(context)->vm();
+        if (addressOfVMToExport)
+            *addressOfVMToExport = &vm;
+
+        if (isInactiveWorker)
+            LOG_STEP(0001.2, worker, "Created ", VMID(vm));
+        else
+            LOG_STEP(0002.2, worker, "Created ", VMID(vm));
+
+        auto installGlobalFunction = [&] (const char* name, auto callback) {
+            APIString nameStr(name);
+            JSObjectRef function = JSObjectMakeFunctionWithCallback(context, nameStr, callback);
+            SUPPRESS_UNCOUNTED_ARG JSObjectSetProperty(context, globalObject, nameStr, function, kJSPropertyAttributeNone, nullptr);
+        };
+
+        installGlobalFunction("checkpoint", checkpointCallback);
+        installGlobalFunction("ensureAlive", ensureAliveCallback);
+
+        while (!TestEnd::doneTesting) {
+            if (isInactiveWorker) {
+                // Initially, the inactive worker creates the worker and then just waits.
+                Locker locker { lock };
+                auto previous = inactiveVMsCreated.exchangeAdd(1);
+                LOG_STEP(0001.3, worker, "previous ", previous, " inactiveVMsCreated ", inactiveVMsCreated.loadRelaxed());
+                if (previous + 1 == numberOfInactiveVMs)
+                    mainThreadConditionVariable.notifyAll();
+
+                if (TestEnd::doneTesting)
+                    break;
+
+                inactiveWorkersTerminationConditionVariable.wait(lock);
+            }
+
+            std::string* scriptStringToEvaluate = isInactiveWorker ? &inactiveWorkerScriptString : &scriptString;
+            APIString jsScriptString(scriptStringToEvaluate->c_str());
+            CHECK(jsScriptString, "script C string to jsString");
+
+            JSValueRef exception = nullptr;
+            SUPPRESS_UNCOUNTED_ARG JSValueRef jsScript = JSEvaluateScript(context, jsScriptString, nullptr, nullptr, 0, &exception);
+            CHECK(!exception, "unexpected exception from script evaluation");
+            if (exception) {
+                APIString string(context, exception);
+                if (string) {
+                    SUPPRESS_UNCOUNTED_ARG Vector<char> buffer(JSStringGetMaximumUTF8CStringSize(string));
+                    SUPPRESS_UNCOUNTED_ARG JSStringGetUTF8CString(string, buffer.mutableSpan().data(), buffer.size());
+                    dataLogLn("FAIL: thread<", TID, "> ", __FILE__, ":", __LINE__, ": ", buffer.span().data());
+                } else
+                    dataLogLn("FAIL: thread<", TID, "> ", __FILE__, ":", __LINE__, ": stringifying exception failed");
+            }
+
+            CHECK(jsScript, "script evaluation");
+
+            if (step >= 1800 && step < 1890) {
+                // In Test 8, the RunOne thread should terminate.
+                break; // Don't loop again.
+            }
+        }
+
+        JSGlobalContextRelease(context);
+        totalNumberOfVMs--; // JSGlobalContextRelease will destroy the VM.
+
+        if (needToNotifyVMDestruction)
+            notifyVMDestruction();
+
+        return ret;
+    };
+
+    UncheckedKeyHashSet<VM*> preexistingVMs;
+    Vector<VM*> testVMs;
+    VM* inactiveVM = nullptr;
+
+    // === Set up and prepare for testing ===================================================
+
+    // Setup initial conditions.
+    // If we ever want to run this test more than once (for some internal debugging),
+    // explicitly re-initializing to their expected default values will be essential.
+    inactiveVMsCreated.exchange(0);
+    testVMsPtr = &testVMs; // Hack so that STW callbacks can access this list.
+    isCreatingInactiveVM = false;
+    numberOfThreadsStarted.exchange(0);
+    Test0::totalNumberOfVMsReady.exchange(0);
+    Test1::numberOfVMsReady.exchange(0);
+    Test2::reachedCheckpoint0 = false;
+    TestEnd::doneTesting = false;
+
+    // We should ideally run this test in its own process so that we're in full control of
+    // the number of VMs in play. However, for this first cut, we're going to piggy back
+    // off of testapi. So, we need to account for pre-existing VMs that may be left over
+    // from other tests that testapi runs. We need to track and discount those VMs.
+
+    SET_STEP(0000, main, "Record VMs pre-existing before this test");
+    auto error = VMManager::forEachVMWithTimeout(WAIT_TIMEOUT_S, [&] (VM& vm) {
+        preexistingVMs.add(&vm);
+        return IterationStatus::Continue;
+    });
+    EXPECT_EQ(error, VMManager::Error::None, "Failed to collect pre-existing VMs.");
+
+    // We expect that no other tests are running concurrently while this test is executing.
+    // Hence, the only VMs added/removed should be from this test, and we can track them
+    // with some tricks.
+    totalNumberOfVMs = preexistingVMs.size();
+
+    // Start our worker threads.
+    SET_STEP(0001, main, "Start and count inactive workers");
+
+    // Start our inactive worker threads.
+    isCreatingInactiveVM = true;
+    WTF::storeLoadFence();
+    for (unsigned t = 0; t < numberOfInactiveVMs; ++t)
+        threadsList().push_back(std::thread(task, &inactiveVM));
+
+    if (numberOfInactiveVMs) {
+        Locker locker { lock };
+        bool workersReady = mainThreadConditionVariable.waitFor(lock, WAIT_TIMEOUT_S);
+        if (!workersReady) {
+            CHECK(workersReady, "Not all inactive VM workers were started");
+            return abortTest(locker);
+        }
+    }
+    isCreatingInactiveVM = false;
+    CHECK(inactiveVM != nullptr, "inactiveVM should be available by now");
+
+    // Start our normal worker threads.
+    SET_STEP(0002, main, "Start workers");
+    for (unsigned t = 0; t < numberOfTestVMs; ++t)
+        threadsList().push_back(std::thread(task, nullptr));
+
+    SET_STEP(0003, main, "Wait till worker threads arrive @ checkpoint 0, and are ready to run tests");
+    {
+        Locker locker { lock };
+        bool workersReady = mainThreadConditionVariable.waitFor(lock, WAIT_TIMEOUT_S);
+        if (!workersReady) {
+            CHECK(workersReady, "Not all VM workers were started");
+            return abortTest(locker);
+        }
+    }
+
+    RELEASE_ASSERT(step == 0004);
+
+    // Check that we can see the new number of VM threads created.
+    EXPECT_EQ(VMManager::numberOfVMs() - preexistingVMs.size() - numberOfInactiveVMs, numberOfTestVMs, "unexpected number of VMs");
+    EXPECT_EQ(numberOfThreadsStarted.loadRelaxed(), numberOfTestVMs, "unexpected number of VMs");
+
+    SET_STEP(0005, main, "Record worker VMs");
+    error = VMManager::forEachVMWithTimeout(WAIT_TIMEOUT_S, [&] (VM& vm) {
+        if (!preexistingVMs.contains(&vm) && inactiveVM != &vm) {
+            LOG_STEP(0005.1, main, "Found test ", VMID(vm));
+            testVMs.append(&vm);
+        }
+        return IterationStatus::Continue;
+    });
+    EXPECT_EQ(error, VMManager::Error::None, "Failed to collect test VMs");
+    EXPECT_EQ(testVMs.size(), numberOfTestVMs, "unexpected number of VMs");
+
+    totalNumberOfActiveVMs = testVMs.size();
+    LOG_STEP(0005.2, main, "totalNumberOfVMs ", totalNumberOfVMs, " | pre-existing ", preexistingVMs.size(), " inactiveVMs ", numberOfInactiveVMs, " testVMs ", testVMs.size());
+
+    {
+        Locker locker { lock };
+        auto info = VMManager::info();
+        EXPECT_EQ(info.numberOfVMs, totalNumberOfVMs, "unexpected number of VMs");
+        // info.numberOfActiveVMs is invalid until we have a StopTheWorld request.
+        EXPECT_EQ(info.numberOfStoppedVMs, 0, "unexpected number of stopped VMs");
+        EXPECT_EQ(info.worldMode, VMManager::Mode::RunAll, "unexpected VMManager mode");
+        ABORT_IF_FAILED();
+    }
+
+    // === Ready to run the real tests now ===================================================
+
+    RELEASE_ASSERT(step == 0005);
+
+    for (unsigned iteration = 0; iteration < numberOfIterationsToRun; ++iteration) {
+        Locker locker { lock };
+        bool ready;
+        VMManager::Info info;
+
+        Test1::numberOfVMsReady.exchange(0);
+        WTF::storeLoadFence();
+
+        dataLogLnIf(verboseLevel >= 1 && !iteration);
+        dataLogLn("=== iteration ", iteration, " START ==============================");
+        SET_STEP(1000, main, "Start test iteration [", iteration, "]");
+
+        LOG_STEP(1000.1, main, "Wake all workers");
+        workersConditionVariable.notifyAll();
+
+        LOG_STEP(1000.2, main, "Wait for workers to arrive at Checkpoint 1");
+        ready = mainThreadConditionVariable.waitFor(lock, WAIT_TIMEOUT_S);
+        if (!ready) {
+            CHECK(ready, "Not all worker threads reached Checkpoint 1: expect ", numberOfTestVMs, ", actual ", Test1::numberOfVMsReady.loadRelaxed());
+            return abortTest(locker);
+        }
+
+        EXPECT_EQ(Test1::numberOfVMsReady.loadRelaxed(), numberOfTestVMs, "");
+
+        // === Test 1 ==============================================================
+        EXPECT_EQ(step, 1100, "Unexpected step: expect 1100, actual ", step);
+
+        LOG_STEP(1100.1, main, "Wake all workers");
+        workersConditionVariable.notifyAll();
+
+        LOG_STEP(1100.2, main, "Request Stop the World");
+        VMManager::requestStopAll(VMManager::StopReason::WasmDebugger);
+
+        LOG_STEP(1100.3, main, "Wait for WasmDebugger to stop at Checkpoint 1");
+        ready = mainThreadConditionVariable.waitFor(lock, WAIT_TIMEOUT_S);
+        if (!ready) {
+            CHECK(ready, "WasmDebugger did NOT stop in checkpoint 1 loop");
+            return abortTest(locker);
+        }
+        EXPECT_EQ(step, 1190, "unexpected step");
+
+        // === Test 2 ==============================================================
+        Test2::extraVM = nullptr;
+
+        SET_STEP(1200, main, "Start Test 2");
+
+        LOG_STEP(1200.1, main, "All workers have stopped in WasmDebugger");
+        info = VMManager::info();
+        EXPECT_EQ(info.numberOfVMs, totalNumberOfVMs, "Unexpected number of VMs");
+        EXPECT_EQ(info.numberOfActiveVMs, totalNumberOfActiveVMs, "unexpected number of active VMs");
+        EXPECT_EQ(info.numberOfStoppedVMs, totalNumberOfActiveVMs, "Unexpected number of stopped VMs");
+        EXPECT_EQ(info.worldMode, VMManager::Mode::Stopped, "Unexpected VMManager mode");
+        ABORT_IF_FAILED();
+
+        Test2::reachedCheckpoint0 = false;
+        Test2::numberOfStoppedVMsAtStart = VMManager::info().numberOfStoppedVMs;
+
+        LOG_STEP(1200.2, main, "Start a new thread and confirm that it stops at VM construction");
+        threadsList().push_back(std::thread(task, &Test2::extraVM));
+        WTF::storeStoreFence();
+
+        SET_STEP(1250, main, "Wait for WasmDebugger to detect new thread");
+        WTF::storeStoreFence();
+        ready = mainThreadConditionVariable.waitFor(lock, WAIT_TIMEOUT_S);
+        if (!ready) {
+            CHECK(ready, "WasmDebugger did NOT detect new thread");
+            return abortTest(locker);
+        }
+
+        EXPECT_EQ(step, 1290, "unexpected step");
+
+        CHECK(Test2::extraVM == nullptr, "Should have blocked at VM construction and not set Test2::extraVM yet");
+
+        totalNumberOfActiveVMs++;
+
+        info = VMManager::info();
+        EXPECT_EQ(info.numberOfVMs, totalNumberOfVMs, "unexpected number of VMs");
+        EXPECT_EQ(info.numberOfActiveVMs, totalNumberOfActiveVMs, "unexpected number of active VMs");
+        EXPECT_EQ(info.numberOfStoppedVMs, totalNumberOfActiveVMs, "unexpected number of stopped VMs");
+        EXPECT_EQ(info.worldMode, VMManager::Mode::Stopped, "unexpected VMManager mode");
+        EXPECT_EQ(Test2::reachedCheckpoint0, false, "new VM did not stop on construction");
+        ABORT_IF_FAILED();
+
+        // === Test 3 ==============================================================
+        Test3::reachedCheckpoint5 = false;
+        Test3::numberOfStoppedVMsAtStart = VMManager::info().numberOfStoppedVMs;
+        WTF::storeLoadFence();
+
+        SET_STEP(1300, main, "Start Test 3");
+
+        LOG_STEP(1300.1, main, "Activate the inactive VM");
+        inactiveWorkersTerminationConditionVariable.notifyAll();
+
+        SET_STEP(1350, main, "Wait for WasmDebugger to detect new thread");
+        WTF::storeStoreFence();
+        ready = mainThreadConditionVariable.waitFor(lock, WAIT_TIMEOUT_S);
+        if (!ready) {
+            CHECK(ready, "WasmDebugger did NOT detect new thread");
+            return abortTest(locker);
+        }
+
+        EXPECT_EQ(step, 1390, "unexpected step");
+
+        // totalNumberOfActiveVMs has increased by 1 because of the new thread we just activated.
+        // Though the thread would have stopped at VM entry, it counts as active.
+        totalNumberOfActiveVMs++;
+
+        info = VMManager::info();
+        LOG_STEP(1390.1, main, "Test3::reachedCheckpoint5 ", Test3::reachedCheckpoint5);
+        LOG_STEP(1390.1, main, "Test3::numberOfStoppedVMsAtStart ", Test3::numberOfStoppedVMsAtStart);
+        LOG_STEP(1390.1, main, "info.numberOfVMs ", info.numberOfVMs, " totalNumberOfVMs ", totalNumberOfVMs);
+        LOG_STEP(1390.1, main, "info.numberOfActiveVMs ", info.numberOfActiveVMs, " totalNumberOfActiveVMs ", totalNumberOfActiveVMs);
+        LOG_STEP(1390.1, main, "info.numberOfStoppedVMs ", info.numberOfStoppedVMs, " totalNumberOfActiveVMs ", totalNumberOfActiveVMs);
+
+        EXPECT_EQ(info.numberOfVMs, totalNumberOfVMs, "unexpected number of VMs");
+        EXPECT_EQ(info.numberOfActiveVMs, totalNumberOfActiveVMs, "unexpected number of active VMs");
+        EXPECT_EQ(info.numberOfStoppedVMs, totalNumberOfActiveVMs, "unexpected number of stopped VMs");
+        EXPECT_EQ(info.worldMode, VMManager::Mode::Stopped, "unexpected VMManager mode");
+        EXPECT_EQ(Test3::reachedCheckpoint5, false, "Activated VM did not stop on entry");
+        ABORT_IF_FAILED();
+
+        // === Test 4 ==============================================================
+        Test4::numberOfContextSwitches = 0;
+        Test4::targetVM = nullptr;
+        WTF::storeStoreFence();
+
+        SET_STEP(1400, main, "Start Test 4");
+        WTF::storeStoreFence();
+        ready = mainThreadConditionVariable.waitFor(lock, WAIT_TIMEOUT_S);
+        if (!ready) {
+            CHECK(ready, "Context switch test did not complete");
+            return abortTest(locker);
+        }
+        EXPECT_EQ(step, 1490, "unexpected step");
+
+        info = VMManager::info();
+        EXPECT_EQ(info.numberOfVMs, totalNumberOfVMs, "unexpected number of VMs");
+        EXPECT_EQ(info.numberOfActiveVMs, totalNumberOfActiveVMs, "unexpected number of active VMs");
+        EXPECT_EQ(info.numberOfStoppedVMs, totalNumberOfActiveVMs, "unexpected number of stopped VMs");
+        EXPECT_EQ(info.worldMode, VMManager::Mode::Stopped, "unexpected VMManager mode");
+        ABORT_IF_FAILED();
+
+        // === Test 5 ==============================================================
+        EXPECT_NE(Test4::targetVM, testVMs.at(0), "WasmDebugger should have context switched away from the 0th test VM");
+        ABORT_IF_FAILED();
+
+        Test5::targetVM = testVMs.at(0); // Let's do RunOne mode with a context switch.
+        WTF::storeStoreFence();
+
+        SET_STEP(1500, main, "Start Test 5");
+        WTF::storeStoreFence();
+        ready = mainThreadConditionVariable.waitFor(lock, WAIT_TIMEOUT_S);
+        if (!ready) {
+            CHECK(ready, "RunOne mode in targetVM did not reach Checkpoint 2");
+            return abortTest(locker);
+        }
+        EXPECT_EQ(step, 1590, "unexpected step");
+
+        info = VMManager::info();
+        EXPECT_EQ(info.numberOfVMs, totalNumberOfVMs, "unexpected number of VMs");
+        EXPECT_EQ(info.numberOfActiveVMs, totalNumberOfActiveVMs, "unexpected number of active VMs");
+        EXPECT_EQ(info.numberOfStoppedVMs, totalNumberOfActiveVMs - 1, "unexpected number of stopped VMs");
+        EXPECT_EQ(info.worldMode, VMManager::Mode::RunOne, "unexpected VMManager mode");
+        ABORT_IF_FAILED();
+
+        // === Test 6 ==============================================================
+        SET_STEP(1600, main, "Start Test 6");
+        WTF::storeStoreFence();
+        VMManager::requestStopAll(VMManager::StopReason::MemoryDebugger);
+
+        ready = mainThreadConditionVariable.waitFor(lock, WAIT_TIMEOUT_S);
+        if (!ready) {
+            CHECK(ready, "Did not stop in MemoryDebugger");
+            return abortTest(locker);
+        }
+        EXPECT_EQ(step, 1690, "unexpected step");
+
+        info = VMManager::info();
+        EXPECT_EQ(info.numberOfVMs, totalNumberOfVMs, "unexpected number of VMs");
+        EXPECT_EQ(info.numberOfActiveVMs, totalNumberOfActiveVMs, "unexpected number of active VMs");
+        EXPECT_EQ(info.numberOfStoppedVMs, totalNumberOfActiveVMs, "unexpected number of stopped VMs");
+        EXPECT_EQ(info.worldMode, VMManager::Mode::Stopped, "unexpected VMManager mode");
+        ABORT_IF_FAILED();
+
+        // === Test 7 ==============================================================
+        SET_STEP(1700, main, "Start Test 7");
+        WTF::storeStoreFence();
+
+        ready = mainThreadConditionVariable.waitFor(lock, WAIT_TIMEOUT_S);
+        if (!ready) {
+            CHECK(ready, "MemoryDebugger did not resume");
+            return abortTest(locker);
+        }
+        EXPECT_EQ(step, 1720, "unexpected step");
+
+        info = VMManager::info();
+        EXPECT_EQ(info.numberOfVMs, totalNumberOfVMs, "unexpected number of VMs");
+        EXPECT_EQ(info.numberOfActiveVMs, totalNumberOfActiveVMs, "unexpected number of active VMs");
+        EXPECT_EQ(info.numberOfStoppedVMs, totalNumberOfActiveVMs - 1, "unexpected number of stopped VMs");
+        EXPECT_EQ(info.worldMode, VMManager::Mode::RunOne, "unexpected VMManager mode");
+        ABORT_IF_FAILED();
+
+        SET_STEP(1790, main, "Success: MemoryDebugger resumed RunOne mode");
+
+        // === Test 8 ==============================================================
+        needToNotifyVMDestruction = true;
+        Test8::targetVM = nullptr;
+        Test8::numberOfRunningThreads.exchange(0);
+        Test8::numberOfWaitingThreads.exchange(0);
+        WTF::storeStoreFence();
+
+        SET_STEP(1800, main, "Start Test 8");
+        WTF::storeStoreFence();
+
+        ready = mainThreadConditionVariable.waitFor(lock, WAIT_TIMEOUT_S);
+        if (!ready) {
+            CHECK(ready, "World did not ResumeAll");
+            return abortTest(locker);
+        }
+        EXPECT_EQ(step, 1890, "unexpected step");
+        CHECK(Test2::extraVM != nullptr, "Failed to create extra VM");
+
+        // Note: we already decremented totalNumberOfVMs and totalNumberOfActiveVMs for
+        // the exiting thread back in STEP 1810 in Checkpoint 3.
+
+        waitForVMDestruction(); // totalNumberOfVMs should be accurate after this.
+
+        // Fix up the testVMs list now that Test5::targetVM has exited.
+        RELEASE_ASSERT(Test5::targetVM == testVMs.at(0));
+        testVMs.at(0) = Test2::extraVM; // Replace the terminated VM with the extra VM.
+        Test2::extraVM = nullptr;
+        Test5::targetVM = nullptr;
+
+        info = VMManager::info();
+        EXPECT_EQ(info.numberOfVMs, totalNumberOfVMs, "unexpected number of VMs");
+        // We have ResumeAll at this point i.e. we're no longer in StopTheWorld. Hence,
+        // info.numberOfActiveVMs is invalid.
+        EXPECT_EQ(info.numberOfStoppedVMs, 0, "unexpected number of stopped VMs");
+        EXPECT_EQ(info.worldMode, VMManager::Mode::RunAll, "unexpected VMManager mode");
+        ABORT_IF_FAILED();
+
+        // === Test 9 ==============================================================
+        Test9::targetVM = inactiveVM;
+        RELEASE_ASSERT(Test9::targetVM);
+        Test9::numberOfWaitingThreads.exchange(0);
+        WTF::storeLoadFence();
+
+        SET_STEP(1900, main, "Start Test 9");
+        workersConditionVariable.notifyAll(); // Set the workers free.
+
+        SET_STEP(1910, main, "Request Stop the World");
+        VMManager::requestStopAll(VMManager::StopReason::WasmDebugger);
+
+        ready = mainThreadConditionVariable.waitFor(lock, WAIT_TIMEOUT_S);
+        if (!ready) {
+            CHECK(ready, "WasmDebugger did NOT stop at checkpoints 4 and 5");
+            return abortTest(locker);
+        }
+        EXPECT_EQ(step, 1920, "unexpected step");
+
+        info = VMManager::info();
+        EXPECT_EQ(info.numberOfVMs, totalNumberOfVMs, "unexpected number of VMs");
+        EXPECT_EQ(info.numberOfActiveVMs, totalNumberOfActiveVMs, "unexpected number of stopped VMs");
+        EXPECT_EQ(info.numberOfStoppedVMs, totalNumberOfActiveVMs, "unexpected number of stopped VMs");
+        EXPECT_EQ(info.worldMode, VMManager::Mode::Stopped, "unexpected VMManager mode");
+        ABORT_IF_FAILED();
+
+        Test9::numberOfWaitingThreads.exchange(0);
+        WTF::storeLoadFence();
+
+        SET_STEP(1930, main, "RunOne in the inactiveVM worker and get it to exit");
+        // The number of active VMs won't actual decrement until the inactiveVM exits and
+        // deactivates. However, no one will use the value in totalNumberOfActiveVMs until
+        // step 1940. So, we'll pre-emptively decrement it as there's no other convenience
+        // place to decrement this.
+        totalNumberOfActiveVMs--;
+
+        ready = mainThreadConditionVariable.waitFor(lock, WAIT_TIMEOUT_S);
+        if (!ready) {
+            CHECK(ready, "WasmDebugger did NOT auto-resume RunAll after VM deactivation");
+            return abortTest(locker);
+        }
+        EXPECT_EQ(step, 1990, "unexpected step");
+
+        info = VMManager::info();
+        EXPECT_EQ(info.numberOfVMs, totalNumberOfVMs, "unexpected number of VMs");
+        // We have ResumeAll at this point i.e. we're no longer in StopTheWorld. Hence,
+        // info.numberOfActiveVMs is invalid.
+        EXPECT_EQ(info.numberOfStoppedVMs, 0, "unexpected number of stopped VMs");
+        EXPECT_EQ(info.worldMode, VMManager::Mode::RunAll, "unexpected VMManager mode");
+        ABORT_IF_FAILED();
+
+        // Test Loop End: Prepare to run another iteration or exit.
+        dataLogLn("=== iteration ", iteration, " END ================================");
+        dataLogLnIf(verboseLevel >= 1, "");
+
+        if (iteration < numberOfIterationsToRun - 1) {
+            TestEnd::doneTesting = false;
+            step = 0005; // Reset step to run next test iteration
+        } else
+            TestEnd::doneTesting = true;
+
+        workersConditionVariable.notifyAll();
+    }
+
+    // === Shutting down ===================================================
+    {
+        Locker locker { lock };
+        workersConditionVariable.notifyAll();
+        inactiveWorkersTerminationConditionVariable.notifyAll();
+    }
+
+    DLOG(main, "Waiting for workers to shut down");
+    auto& threads = threadsList();
+    for (auto& thread : threads)
+        thread.join();
+    threads.clear();
+
+    auto endTime = MonotonicTime::now();
+
+    dataLogLn(failuresFound ? "FAIL"_s : "PASS"_s, " VMManager StopTheWorld Test (running time: ", (endTime - startTime).millisecondsAs<long>(), " ms)");
+    return (failuresFound > 0);
+
+#undef ABORT_IF_FAILED
+}
+
+#undef TID
+#undef DLOG
+#undef PAD
+#undef LOG_STEP_IMPL
+#undef LOG_STEP
+#undef LOG_INFO
+#undef SET_STEP
+#undef CHECK
+#undef EXPECT_EQ
+#undef EXPECT_NE
+#undef VMID
+#undef WAIT_TIMEOUT_S
+
+} // namespace VMManagerStopTheWorldTest
+
+int testVMManagerStopTheWorld()
+{
+    return VMManagerStopTheWorldTest::test();
+}

--- a/Source/JavaScriptCore/API/tests/VMManagerStopTheWorldTest.h
+++ b/Source/JavaScriptCore/API/tests/VMManagerStopTheWorldTest.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Returns the number of failures encountered.  If all sub-tests passed,
+   0 will be returned. */
+extern int testVMManagerStopTheWorld(void);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif

--- a/Source/JavaScriptCore/API/tests/testapi.c
+++ b/Source/JavaScriptCore/API/tests/testapi.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -70,6 +70,7 @@
 #include "MultithreadedMultiVMExecutionTest.h"
 #include "PingPongStackOverflowTest.h"
 #include "TypedArrayCTest.h"
+#include "VMManagerStopTheWorldTest.h"
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
@@ -2400,6 +2401,7 @@ int main(int argc, char* argv[])
     // For now, we'll just run them here at the end as a workaround.
     failed |= testPingPongStackOverflow();
     failed |= testExecutionTimeLimit();
+    failed |= testVMManagerStopTheWorld();
 
     if (failed) {
         printf("FAIL: Some tests failed.\n");

--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -1336,6 +1336,7 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     runtime/StackFrame.h
     runtime/StackManager.h
     runtime/StackManagerInlines.h
+    runtime/StopTheWorldCallback.h
     runtime/StringIteratorPrototype.h
     runtime/StringObject.h
     runtime/StringPrototype.h
@@ -1385,6 +1386,7 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     runtime/VMEntryScopeInlines.h
     runtime/VMInlines.h
     runtime/VMManager.h
+    runtime/VMThreadContext.h
     runtime/VMTraps.h
     runtime/VMTrapsInlines.h
     runtime/WaiterListManager.h

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -2139,7 +2139,7 @@
 		F6D67D4226F902E9006E0349 /* TemporalInstantConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = F6D67D3C26F902E7006E0349 /* TemporalInstantConstructor.h */; };
 		F6D67D4426F902E9006E0349 /* TemporalInstantPrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = F6D67D3E26F902E8006E0349 /* TemporalInstantPrototype.h */; };
 		FE041553252EC0730091EB5D /* SlotVisitorMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = FE041552252EC0730091EB5D /* SlotVisitorMacros.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		FE05D3A62E53FBE5007668DD /* VMManager.h in Headers */ = {isa = PBXBuildFile; fileRef = FE05D3A42E53FBE5007668DD /* VMManager.h */; };
+		FE05D3A62E53FBE5007668DD /* VMManager.h in Headers */ = {isa = PBXBuildFile; fileRef = FE05D3A42E53FBE5007668DD /* VMManager.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FE086BCA2123DEFB003F2929 /* EntryFrame.h in Headers */ = {isa = PBXBuildFile; fileRef = FE086BC92123DEFA003F2929 /* EntryFrame.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FE0D4A061AB8DD0A002F54BF /* ExecutionTimeLimitTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE0D4A041AB8DD0A002F54BF /* ExecutionTimeLimitTest.cpp */; };
 		FE0D4A091ABA2437002F54BF /* GlobalContextWithFinalizerTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE0D4A071ABA2437002F54BF /* GlobalContextWithFinalizerTest.cpp */; };
@@ -2188,6 +2188,8 @@
 		FE48E6381EB118D2005D7A96 /* ObjectInitializationScope.h in Headers */ = {isa = PBXBuildFile; fileRef = FE48E6361EB1188F005D7A96 /* ObjectInitializationScope.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FE4BFF2C1AD476E700088F87 /* FunctionOverrides.h in Headers */ = {isa = PBXBuildFile; fileRef = FE4BFF2A1AD476E700088F87 /* FunctionOverrides.h */; };
 		FE5068651AE246390009DAB7 /* DeferredSourceDump.h in Headers */ = {isa = PBXBuildFile; fileRef = FE5068641AE246390009DAB7 /* DeferredSourceDump.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		FE5069912E849692006EE832 /* StopTheWorldCallback.h in Headers */ = {isa = PBXBuildFile; fileRef = FE5069902E849676006EE832 /* StopTheWorldCallback.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		FE50699D2E85E571006EE832 /* VMManagerStopTheWorldTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE50699C2E85E571006EE832 /* VMManagerStopTheWorldTest.cpp */; };
 		FE533CA51F217DB30016A1FE /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 51F0EB6105C86C6B00E6DF1B /* Foundation.framework */; };
 		FE533CA61F217DB30016A1FE /* JavaScriptCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 932F5BD90822A1C700736975 /* JavaScriptCore.framework */; };
 		FE533CAD1F217EA50016A1FE /* testmasm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE533CA01F217C310016A1FE /* testmasm.cpp */; };
@@ -2248,6 +2250,7 @@
 		FF0F568D2E33437C002A232A /* JavaScriptCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 932F5BD90822A1C700736975 /* JavaScriptCore.framework */; };
 		FF0F569A2E3348CA002A232A /* testwasmdebugger.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FF0F56992E3348CA002A232A /* testwasmdebugger.cpp */; };
 		FF0F569C2E334C90002A232A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FF0F569B2E334C90002A232A /* Foundation.framework */; };
+		FEFF211D2E73558000533F23 /* VMThreadContext.h in Headers */ = {isa = PBXBuildFile; fileRef = FEFF211C2E73558000533F23 /* VMThreadContext.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FF1D8E872CE7C9BF00E211DD /* VerifierSlotVisitorScope.h in Headers */ = {isa = PBXBuildFile; fileRef = FF1D8E862CE7C9BF00E211DD /* VerifierSlotVisitorScope.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FF31EC8E2D947F0500D9CB81 /* DFGCloneHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = FF31EC8B2D947F0500D9CB81 /* DFGCloneHelper.h */; };
 		FF3394AA2CB4944E004AFF6A /* RegExpSubstringGlobalAtomCache.h in Headers */ = {isa = PBXBuildFile; fileRef = FF3394A92CB4941B004AFF6A /* RegExpSubstringGlobalAtomCache.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -6160,6 +6163,9 @@
 		FE4BFF2A1AD476E700088F87 /* FunctionOverrides.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FunctionOverrides.h; sourceTree = "<group>"; };
 		FE5068641AE246390009DAB7 /* DeferredSourceDump.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DeferredSourceDump.h; sourceTree = "<group>"; };
 		FE5068661AE25E280009DAB7 /* DeferredSourceDump.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DeferredSourceDump.cpp; sourceTree = "<group>"; };
+		FE5069902E849676006EE832 /* StopTheWorldCallback.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StopTheWorldCallback.h; sourceTree = "<group>"; };
+		FE50699B2E85E571006EE832 /* VMManagerStopTheWorldTest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = VMManagerStopTheWorldTest.h; path = API/tests/VMManagerStopTheWorldTest.h; sourceTree = "<group>"; };
+		FE50699C2E85E571006EE832 /* VMManagerStopTheWorldTest.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = VMManagerStopTheWorldTest.cpp; path = API/tests/VMManagerStopTheWorldTest.cpp; sourceTree = "<group>"; };
 		FE533CA01F217C310016A1FE /* testmasm.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = testmasm.cpp; sourceTree = "<group>"; };
 		FE533CAC1F217DB40016A1FE /* testmasm */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = testmasm; sourceTree = BUILT_PRODUCTS_DIR; };
 		FE54DEFA1E8C6D7200A892C5 /* DisallowVMEntry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DisallowVMEntry.h; sourceTree = "<group>"; };
@@ -6274,6 +6280,7 @@
 		FF0F56942E33437C002A232A /* testwasmdebugger */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = testwasmdebugger; sourceTree = BUILT_PRODUCTS_DIR; };
 		FF0F56992E3348CA002A232A /* testwasmdebugger.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = testwasmdebugger.cpp; sourceTree = "<group>"; };
 		FF0F569B2E334C90002A232A /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
+		FEFF211C2E73558000533F23 /* VMThreadContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VMThreadContext.h; sourceTree = "<group>"; };
 		FF1D8E862CE7C9BF00E211DD /* VerifierSlotVisitorScope.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VerifierSlotVisitorScope.h; sourceTree = "<group>"; };
 		FF27D0E42BE2AEDB00397A8C /* OrderedHashTable.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = OrderedHashTable.cpp; sourceTree = "<group>"; };
 		FF31EC8B2D947F0500D9CB81 /* DFGCloneHelper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = DFGCloneHelper.h; path = dfg/DFGCloneHelper.h; sourceTree = "<group>"; };
@@ -7038,6 +7045,8 @@
 				651122E5140469BA002B101D /* testRegExp.cpp */,
 				534902821C7242C80012BCB8 /* TypedArrayCTest.cpp */,
 				534902831C7242C80012BCB8 /* TypedArrayCTest.h */,
+				FE50699C2E85E571006EE832 /* VMManagerStopTheWorldTest.cpp */,
+				FE50699B2E85E571006EE832 /* VMManagerStopTheWorldTest.h */,
 			);
 			name = tests;
 			sourceTree = "<group>";
@@ -9064,6 +9073,7 @@
 				FE2BCD5E2E4AF65A005FE224 /* StackManager.cpp */,
 				FE2BCD5D2E4AF65A005FE224 /* StackManager.h */,
 				FE3040872E43E58D00E5087B /* StackManagerInlines.h */,
+				FE5069902E849676006EE832 /* StopTheWorldCallback.h */,
 				A730B6111250068F009D25B1 /* StrictEvalActivation.cpp */,
 				A730B6101250068F009D25B1 /* StrictEvalActivation.h */,
 				276B388C2A71D18700252F4E /* StrictEvalActivationInlines.h */,
@@ -9207,6 +9217,7 @@
 				FE90BB3A1B7CF64E006B3F03 /* VMInlines.h */,
 				FE05D3A52E53FBE5007668DD /* VMManager.cpp */,
 				FE05D3A42E53FBE5007668DD /* VMManager.h */,
+				FEFF211C2E73558000533F23 /* VMThreadContext.h */,
 				FE6F56DC1E64E92000D17801 /* VMTraps.cpp */,
 				FE6F56DD1E64E92000D17801 /* VMTraps.h */,
 				FEF5B42B2628CBC80016E776 /* VMTrapsInlines.h */,
@@ -12082,6 +12093,7 @@
 				14CA958B16AB50DE00938A06 /* StaticPropertyAnalyzer.h in Headers */,
 				0F4F828C1E31B9760075184C /* StochasticSpaceTimeMutatorScheduler.h in Headers */,
 				0F7CF9521DC027D90098CC12 /* StopIfNecessaryTimer.h in Headers */,
+				FE5069912E849692006EE832 /* StopTheWorldCallback.h in Headers */,
 				A730B6121250068F009D25B1 /* StrictEvalActivation.h in Headers */,
 				276B38902A71D18700252F4E /* StrictEvalActivationInlines.h in Headers */,
 				BC18C4660E16F5CD00B34460 /* StringConstructor.h in Headers */,
@@ -12221,6 +12233,7 @@
 				FE3022D71E42857300BAC493 /* VMInspector.h in Headers */,
 				FEC5797323105B5100BCA83F /* VMInspectorInlines.h in Headers */,
 				FE05D3A62E53FBE5007668DD /* VMManager.h in Headers */,
+				FEFF211D2E73558000533F23 /* VMThreadContext.h in Headers */,
 				FE6F56DE1E64EAD600D17801 /* VMTraps.h in Headers */,
 				FEF5B42C2628CBC80016E776 /* VMTrapsInlines.h in Headers */,
 				FF41590C28FF3C6B00F80B96 /* WaiterListManager.h in Headers */,
@@ -13417,6 +13430,7 @@
 				86D2221A167EF9440024C804 /* testapi.mm in Sources */,
 				530FDE7521FAB00600059D65 /* testIncludes.m in Sources */,
 				534902851C7276B70012BCB8 /* TypedArrayCTest.cpp in Sources */,
+				FE50699D2E85E571006EE832 /* VMManagerStopTheWorldTest.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Source/JavaScriptCore/heap/MarkedBlock.cpp
+++ b/Source/JavaScriptCore/heap/MarkedBlock.cpp
@@ -622,6 +622,9 @@ NO_RETURN_DUE_TO_CRASH NEVER_INLINE void MarkedBlock::dumpInfoAndCrashForInvalid
     if (!foundInBlockVM) {
         // Search all VMs to see if this block belongs to any VM.
         VMManager::forEachVM([&](VM& vm) {
+            if (!vm.isInService())
+                return IterationStatus::Continue;
+
             MarkedSpace& objectSpace = vm.heap.objectSpace();
             isBlockInSet = objectSpace.blocks().set().contains(this);
             handle = objectSpace.findMarkedBlockHandleDebug(this);

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
@@ -275,9 +275,9 @@ const NoPtrTag = constexpr NoPtrTag
 const VMTrapsAsyncEvents = constexpr VMTraps::AsyncEvents
 
 # VM offsets
-const VMTrapAwareSoftStackLimitOffset = VM::m_traps + VMTraps::m_stack + StackManager::m_trapAwareSoftStackLimit
-const VMCLoopStackLimitOffset = VM::m_traps + VMTraps::m_stack + StackManager::m_cloopStackLimit
-const VMSoftStackLimitOffset = VM::m_traps + VMTraps::m_stack + StackManager::m_softStackLimit
+const VMTrapAwareSoftStackLimitOffset = VM::m_threadContext + VMThreadContext::m_traps + VMTraps::m_stack + StackManager::m_trapAwareSoftStackLimit
+const VMCLoopStackLimitOffset = VM::m_threadContext + VMThreadContext::m_traps + VMTraps::m_stack + StackManager::m_cloopStackLimit
+const VMSoftStackLimitOffset = VM::m_threadContext + VMThreadContext::m_traps + VMTraps::m_stack + StackManager::m_softStackLimit
 
 # Registers
 
@@ -2511,7 +2511,7 @@ end)
 macro checkTraps(dispatch)
     loadp CodeBlock[cfr], t1
     loadp CodeBlock::m_vm[t1], t1
-    loadi VM::m_traps+VMTraps::m_trapBits[t1], t0
+    loadi VM::m_threadContext+VMThreadContext::m_traps+VMTraps::m_trapBits[t1], t0
     andi VMTrapsAsyncEvents, t0
     btpnz t0, .handleTraps
 .afterHandlingTraps:

--- a/Source/JavaScriptCore/runtime/JSCConfig.h
+++ b/Source/JavaScriptCore/runtime/JSCConfig.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,6 +29,8 @@
 #include <JavaScriptCore/Opcode.h>
 #include <JavaScriptCore/OptionsList.h>
 #include <JavaScriptCore/SecureARM64EHashPins.h>
+#include <JavaScriptCore/StopTheWorldCallback.h>
+#include <wtf/PtrTag.h>
 #include <wtf/WTFConfig.h>
 
 namespace JSC {
@@ -40,6 +42,9 @@ class VM;
 #if ENABLE(SEPARATED_WX_HEAP)
 using JITWriteSeparateHeapsFunction = void (*)(off_t, const void*, size_t);
 #endif
+
+#define JSC_CONFIG_METHOD(method) \
+    WTF_FUNCPTR_PTRAUTH_STR("JSCConfig." #method) method
 
 struct Config {
     static Config& singleton();
@@ -98,7 +103,11 @@ struct Config {
 
     OptionsStorage options;
 
-    void (*shellTimeoutCheckCallback)(VM&);
+    using ShellTimeoutCheckCallback = void (*)(VM&);
+    ShellTimeoutCheckCallback JSC_CONFIG_METHOD(shellTimeoutCheckCallback);
+
+    StopTheWorldCallback JSC_CONFIG_METHOD(wasmDebuggerStopTheWorld);
+    StopTheWorldCallback JSC_CONFIG_METHOD(memoryDebuggerStopTheWorld);
 
     struct {
         uint8_t exceptionInstructions[maxBytecodeStructLength + 1];

--- a/Source/JavaScriptCore/runtime/StopTheWorldCallback.h
+++ b/Source/JavaScriptCore/runtime/StopTheWorldCallback.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <utility>
+#include <wtf/IterationStatus.h>
+
+namespace JSC {
+
+class VM;
+
+using StopTheWorldStatus = std::pair<IterationStatus, VM*>;
+
+#define STW_RESUME_ALL_TOKEN reinterpret_cast<VM*>(1)
+
+// StopTheWorldCallback return values:
+#define STW_CONTINUE() StopTheWorldStatus(IterationStatus::Continue, nullptr)
+#define STW_CONTEXT_SWITCH(targetVM) StopTheWorldStatus(IterationStatus::Continue, targetVM)
+#define STW_RESUME_ONE(targetVM) StopTheWorldStatus(IterationStatus::Done, targetVM)
+#define STW_RESUME_ALL() StopTheWorldStatus(IterationStatus::Done, STW_RESUME_ALL_TOKEN)
+#define STW_RESUME() StopTheWorldStatus(IterationStatus::Done, nullptr)
+
+enum class StopTheWorldEvent : uint8_t {
+    VMCreated,
+    VMActivated,
+    VMStopped,
+};
+
+// The VMManager Stop the World (STW) mechanism will call handlers of this shape once the world
+// is stopped. The handler is expected to return one of the above StopTheWorldStatus results.
+//
+// STW_CONTINUE means that the handler expects to be called again on the same thread, unless
+// an external agent requestResumeAll. In practice, this result is not really useful except
+// for tests.
+//
+// STW_CONTEXT_SWITCH means that the handler wants to switch to another thread as specified
+// by the targetVM. The VMManager will stop the current thread, and call the handler back
+// from the targetVM thread while all threads remain stopped (Stopped mode).
+//
+// STW_RESUME_ONE means that the handler wants a specific thread to start running while all
+// other VM threads remain stopped (RunOne mode). This may or may not result in a deadlock,
+// as the targetVM thread to run may be blocked on resources held by other VM threads that
+// remain stopped. It is the responsibility of the client to detect if this occurs (perhaps
+// with a timeout), and call VMManager::requestResumeAll() to unblock the deadlock of necessary.
+//
+// STW_RESUME_ALL means that the handler wants all VM threads to resume execution after
+// this (RunAll mode).
+//
+// STW_RESUME means that the handler wants to resume execution with previous mode (either
+// RunAll or RunOne mode).
+
+using StopTheWorldCallback = StopTheWorldStatus (*)(VM&, StopTheWorldEvent);
+
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/VMManager.cpp
+++ b/Source/JavaScriptCore/runtime/VMManager.cpp
@@ -26,32 +26,30 @@
 #include "config.h"
 #include "VMManager.h"
 
+#include "JSCConfig.h"
 #include "VM.h"
+#include "VMThreadContext.h"
 
 namespace JSC {
 
-Lock g_vmListLock;
 VM* VMManager::s_recentVM { nullptr };
 
-static DoublyLinkedList<VM>& vmList() WTF_REQUIRES_LOCK(g_vmListLock)
+VMManager& VMManager::singleton()
 {
-    static NeverDestroyed<DoublyLinkedList<VM>> list;
-    return list;
+    static NeverDestroyed<VMManager> manager;
+    return manager;
 }
 
-void VMManager::add(VM* vm)
+VMThreadContext::VMThreadContext()
 {
-    Locker locker { g_vmListLock };
-    s_recentVM = vm;
-    vmList().append(vm);
+    VM* vm = VM::fromThreadContext(this);
+    VMManager::singleton().notifyVMConstruction(*vm);
 }
 
-void VMManager::remove(VM* vm)
+VMThreadContext::~VMThreadContext()
 {
-    Locker locker { g_vmListLock };
-    if (s_recentVM == vm)
-        s_recentVM = nullptr;
-    vmList().remove(vm);
+    VM* vm = VM::fromThreadContext(this);
+    VMManager::singleton().notifyVMDestruction(*vm);
 }
 
 bool VMManager::isValidVMSlow(VM* vm)
@@ -78,10 +76,11 @@ void VMManager::dumpVMs()
     });
 }
 
-static void iterateVMs(const Invocable<IterationStatus(VM&)> auto& functor) WTF_REQUIRES_LOCK(g_vmListLock)
+void VMManager::iterateVMs(const Invocable<IterationStatus(VM&)> auto& functor) WTF_REQUIRES_LOCK(m_worldLock)
 {
-    for (VM* vm = vmList().head(); vm; vm = vm->next()) {
-        IterationStatus status = functor(*vm);
+    for (auto* context = m_vmList.head(); context; context = context->next()) {
+        VM& vm = *VM::fromThreadContext(context);
+        IterationStatus status = functor(vm);
         if (status == IterationStatus::Done)
             return;
     }
@@ -89,7 +88,7 @@ static void iterateVMs(const Invocable<IterationStatus(VM&)> auto& functor) WTF_
 
 VM* VMManager::findMatchingVMImpl(const ScopedLambda<VMManager::TestCallback>& test)
 {
-    Locker lock { g_vmListLock };
+    Locker lock { m_worldLock };
     if (s_recentVM && test(*s_recentVM))
         return s_recentVM;
 
@@ -107,18 +106,422 @@ VM* VMManager::findMatchingVMImpl(const ScopedLambda<VMManager::TestCallback>& t
 
 void VMManager::forEachVMImpl(const ScopedLambda<VMManager::IteratorCallback>& func)
 {
-    Locker lock { g_vmListLock };
+    Locker lock { m_worldLock };
     iterateVMs(func);
 }
 
 VMManager::Error VMManager::forEachVMWithTimeoutImpl(Seconds timeout, const ScopedLambda<VMManager::IteratorCallback>& func)
 {
-    if (!g_vmListLock.tryLockWithTimeout(timeout))
+    if (!m_worldLock.tryLockWithTimeout(timeout))
         return Error::TimedOut;
 
-    Locker locker { AdoptLock, g_vmListLock };
+    Locker locker { AdoptLock, m_worldLock };
     iterateVMs(func);
     return Error::None;
+}
+
+auto VMManager::info() -> Info
+{
+    Info info;
+    auto& manager = singleton();
+
+    // The reason for locking here is so that we capture a consistent snapshot
+    // of all the values in info.
+    Locker lock { manager.m_worldLock };
+    info.numberOfVMs = manager.m_numberOfVMs;
+    info.numberOfActiveVMs = manager.m_numberOfActiveVMs;
+    info.numberOfStoppedVMs = manager.m_numberOfStoppedVMs.loadRelaxed();
+    info.worldMode = manager.m_worldMode;
+    return info;
+}
+
+void VMManager::setWasmDebuggerCallback(StopTheWorldCallback callback)
+{
+    g_jscConfig.wasmDebuggerStopTheWorld = callback;
+}
+
+void VMManager::setMemoryDebuggerCallback(StopTheWorldCallback callback)
+{
+    g_jscConfig.memoryDebuggerStopTheWorld = callback;
+}
+
+void VMManager::incrementActiveVMs(VM& vm) WTF_REQUIRES_LOCK(m_worldLock)
+{
+    if (!vm.traps().m_hasBeenCountedAsActive) {
+        m_numberOfActiveVMs++;
+        vm.traps().m_hasBeenCountedAsActive = true;
+    }
+}
+
+void VMManager::decrementActiveVMs(VM& vm) WTF_REQUIRES_LOCK(m_worldLock)
+{
+    // We only need to track m_numberOfActiveVMs changes if we're in RunOne
+    // mode. If we're running because the world was resumed with RunAll,
+    // then m_numberOfActiveVMs is invalid, and resumeTheWorld() would set
+    // it to a token value of invalidNumberOfActiveVMs (to aid debugging).
+    if (m_worldMode == Mode::RunAll)
+        ASSERT(m_numberOfActiveVMs == invalidNumberOfActiveVMs);
+    else
+        m_numberOfActiveVMs--;
+    vm.traps().m_hasBeenCountedAsActive = false;
+
+    auto shouldResumeAll = [&] {
+        if (m_worldMode != Mode::RunAll && !m_numberOfActiveVMs)
+            return true;
+        if (m_worldMode == Mode::RunOne) {
+            RELEASE_ASSERT(m_targetVM == &vm);
+            return true;
+        }
+        return false;
+    };
+
+    if (shouldResumeAll()) {
+        if (m_targetVM) {
+            // There's a designated targetVM thread to continue in, but we don't have the
+            // ability to just wake the desired one up. So, wake up all the threads and let
+            // them sort themselves out.
+            //
+            // But if the targetVM thread is this thread, then pass the control to another
+            // thread, any thread. That's because this thread is dying imminently.
+            if (m_targetVM == &vm) {
+                m_targetVM = nullptr;
+                m_useRunOneMode = false;
+            }
+            m_worldConditionVariable.notifyAll();
+        } else {
+            // There's no designated targetVM thread. So, just waking up any one thread will do.
+            m_worldConditionVariable.notifyOne();
+        }
+    }
+}
+
+CONCURRENT_SAFE void VMManager::requestStopAllInternal(StopReason reason)
+{
+    // StopReason is synonymous with "StopRequest".
+    // From the client's perspective, it is the reason for a stop request.
+    // From the VMManager's perspective, it is the type of stop request.
+    auto requestBits = static_cast<StopRequestBits>(reason);
+    m_pendingStopRequestBits.exchangeOr(requestBits);
+    {
+        Locker lock { m_worldLock };
+        if (m_worldMode >= Mode::Stopping)
+            return;
+
+        if (m_worldMode == Mode::RunAll) {
+            // RunOne mode allows execution of 1 VM without resumeTheWorld(). We did not clear
+            // the m_hasBeenCountedAsActive flags on each VM on resuming with RunOne. As a
+            // result, m_numberOfActiveVMs is still valid in RunOne mode. We don't want
+            // to reset m_numberOfActiveVMs to 0 here because we won't be re-calculating
+            // it on stop like we do for RunAll mode.
+            //
+            // For RunAll mode, do want to reset m_numberOfActiveVMs, and incrementActiveVMs()
+            // below will re-calculate the current true value of m_numberOfActiveVMs.
+            m_numberOfActiveVMs = 0;
+        }
+
+        m_worldMode = Mode::Stopping;
+
+        // Have to use iterateVMs() instead of forEachVM() because we're already
+        // holding the m_worldLock.
+        iterateVMs(scopedLambda<IteratorCallback>([&] (VM& vm) {
+            vm.requestStop();
+            WTF::storeLoadFence();
+            if (vm.isEntered()) {
+                // incrementActiveVMs() relies on m_worldLock being held, which it
+                // obviously is above. However, Clang is not smart enough to see this.
+                // So, we need to suppress this warning here.
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wthread-safety-analysis"
+#endif
+                incrementActiveVMs(vm);
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+            }
+            return IterationStatus::Continue;
+        }));
+    }
+}
+
+CONCURRENT_SAFE void VMManager::requestResumeAllInternal(StopReason reason)
+{
+    // StopReason is synonymous with StopRequest.
+    // From the client's perspective, it is the reason for a stop request.
+    // From the VMManager's perspective, it is the type of stop request.
+    auto requestBits = static_cast<StopRequestBits>(reason);
+    m_pendingStopRequestBits.exchangeAnd(~requestBits);
+    if (hasPendingStopRequests())
+        return; // There are still pending stop requests. Nothing more to do.
+
+    Locker lock { m_worldLock };
+    resumeTheWorld();
+}
+
+void VMManager::resumeTheWorld() WTF_REQUIRES_LOCK(m_worldLock)
+{
+    // We can call resumeTheWorld() more than once. Hence, we may already be in RunAll mode.
+    if (m_worldMode == Mode::RunAll)
+        return; // Already resumed. Nothing more to do.
+
+    // If we're in RunOne mode, then we want to still call into notifyVMStop() all
+    // the time. So, we don't want to resumeTheWorld() just yet as that will disable
+    // all the stop checks yet.
+    if (m_useRunOneMode)
+        return;
+
+    // Have to use iterateVMs() instead of forEachVM() because we're already
+    // holding the m_worldLock.
+    iterateVMs(scopedLambda<IteratorCallback>([&] (VM& vm) {
+        vm.cancelStop();
+        vm.traps().m_hasBeenCountedAsActive = false;
+        return IterationStatus::Continue;
+    }));
+
+    m_targetVM = nullptr;
+    m_numberOfActiveVMs = invalidNumberOfActiveVMs; // invalid when not Stopped.
+    m_worldMode = Mode::RunAll;
+    m_worldConditionVariable.notifyAll();
+}
+
+void VMManager::notifyVMStop(VM& vm, StopTheWorldEvent event)
+{
+    // Due to races, we may end up calling notifyVMStop() even when there is no stop to be serviced.
+    // It should always be safe to call notifyVMStop() as many times as we like. The only cost is
+    // is performance.
+    //
+    // In Mode::RunOne, we will call notifyVMStop() even if there are no requested stops. The code
+    // below will simply determine that there's nothing to do and return back out. This is fine
+    // since Mode::RunOne is only used by debuggers, and peek performance is not a concern.
+    // We need to ensure that StopTheWorld VMTraps remained installed and that notifyVMStop() gets
+    // called when in Mode::RunOne because new VM thread can be started, and we want those new
+    // threads to also stop since they aren't the targetVM thread.
+
+    m_numberOfStoppedVMs.exchangeAdd(1);
+
+    for (;;) {
+        {
+            Locker lock { m_worldLock };
+
+            auto fetchTopPriorityStopReason = [&] {
+                auto pendingRequests = m_pendingStopRequestBits.loadRelaxed();
+                for (unsigned i = 0; i < NumberOfStopReasons; ++i) {
+                    auto requestToCheck = static_cast<StopRequestBits>(1 << i);
+                    if (pendingRequests & requestToCheck)
+                        return static_cast<StopReason>(requestToCheck);
+                }
+                return StopReason::None;
+            };
+
+            // Fetch the top priority stop request and finish servicing it before entertaining
+            // another one. This reduces complexity as servicing a different stop request while
+            // one is in still being processed may result in unexpected state change that the
+            // the current stop request handler is unprepared to handle.
+            if (m_currentStopReason == StopReason::None) {
+                m_currentStopReason = fetchTopPriorityStopReason();
+                // We cannot break out early here even if m_currentStopReason is None. That's
+                // because we may be in RunOne mode, and the current thread may not be the
+                // targetVM thead. So, we must flow thru to the target VM check and wait loop
+                // below.
+            }
+
+            auto shouldStop = [&] {
+                // 1. If the targetVM is already selected, and we're not the targetVM, then stop.
+                //    We need to check this first because in RunOne mode, even if there is no more
+                //    STW request to service, any VM that is not the targetVM still needs to stop.
+                if (m_targetVM)
+                    return m_targetVM != &vm;
+
+                // 2. If there's no more STW requests, then we don't need to stop.
+                //    This is superseded by the condition above during RunOne mode.
+                if (m_currentStopReason == StopReason::None)
+                    return false;
+
+                // 3. We have a STW request. If not all active VMs are at the stopping point yet,
+                //    then stop and wait for the last VM to stop.
+                return m_numberOfStoppedVMs.loadRelaxed() != m_numberOfActiveVMs;
+            };
+
+            while (shouldStop())
+                m_worldConditionVariable.wait(m_worldLock);
+
+            // We can only get here under one the following possible circumstance:
+            // 1. No targetVM thread was specified (therefore, any thread may service this stop)
+            //    and this is the last thread that stopped. Or ...
+            // 2. This is a subsequent iteration through this loop after context switches (see the
+            //    m_worldConditionVariable.notifyAll() at the bottom of the loop). In which case,
+            //    the targetVM thread is the only one that can get past the wait() above. Or ...
+            // 3. We're executing in RunOne mode and entering this function due to a subsequent
+            //    stop request. In that case, all other threads remained stopped, and only the
+            //    targetVM thread is allowed to run.
+            RELEASE_ASSERT(!m_targetVM || m_targetVM == &vm);
+
+            // Now we can break out of the handler loop is there are no more requests.
+            if (m_currentStopReason == StopReason::None) {
+                if (m_useRunOneMode) {
+                    m_worldMode = Mode::RunOne;
+                    RELEASE_ASSERT(m_targetVM);
+                } else if (m_worldMode != Mode::RunAll)
+                    resumeTheWorld(); // Sets m_worldMode = Mode::RunAll.
+                break; // Exit this loop.
+            }
+
+            m_targetVM = &vm;
+            m_worldMode = Mode::Stopped;
+        }
+
+        auto status = STW_RESUME();
+        switch (m_currentStopReason) {
+        case StopReason::GC:
+            RELEASE_ASSERT_NOT_REACHED();
+        case StopReason::WasmDebugger:
+            status = g_jscConfig.wasmDebuggerStopTheWorld(vm, event);
+            break;
+        case StopReason::MemoryDebugger:
+            status = g_jscConfig.memoryDebuggerStopTheWorld(vm, event);
+            break;
+        case StopReason::None:
+            RELEASE_ASSERT_NOT_REACHED();
+        }
+
+        if (status.first == IterationStatus::Done) {
+            // Done servicing this request. We can't just exit the loop here yet because there
+            // may be other requests that need to be serviced. So, we'll just clear the
+            // current request and go back to the top of the loop to check if there are other
+            // requests. It's safe to clear m_currentStopReason without acquiring m_worldLock
+            // here because currently, all other VM threads are already stopped.
+            // Same reason for why it's safe to set m_useRunOneMode here.
+            auto requestBits = static_cast<StopRequestBits>(m_currentStopReason);
+            m_pendingStopRequestBits.exchangeAnd(~requestBits);
+            m_currentStopReason = StopReason::None;
+
+            // targetVM not being specified means that we should not change m_useRunOneMode.
+            if (status.second)
+                m_useRunOneMode = status.second != STW_RESUME_ALL_TOKEN;
+        }
+
+        if (status.second && status.second != STW_RESUME_ALL_TOKEN && status.second != m_targetVM) {
+            // A context switch was requested. Wake all so that a context switch can occur, and
+            // continue on the targetVM thread.
+            Locker lock { m_worldLock };
+            m_targetVM = status.second;
+            m_worldConditionVariable.notifyAll();
+        }
+    }
+
+    m_numberOfStoppedVMs.exchangeSub(1);
+
+    // If we get here, we're either transitioning to RunOne or Running mode.
+    RELEASE_ASSERT(!m_targetVM || m_targetVM == &vm);
+}
+
+void VMManager::notifyVMConstruction(VM& vm)
+{
+    bool needsStopping = false;
+    {
+        Locker locker { m_worldLock };
+        s_recentVM = &vm;
+        m_vmList.append(vm.threadContext());
+        m_numberOfVMs++;
+        needsStopping = m_worldMode != Mode::RunAll;
+        if (needsStopping) {
+            // Since this is the VM construction point, the VM is obviously not active yet.
+            // However, notifyVMStop()'s accounting logic relies on the VM being active in
+            // order to stop it. So, pretend the VM is active and undo this on exit.
+            incrementActiveVMs(vm);
+        }
+    }
+    if (needsStopping) {
+        // If a stop is in progress, we cannot proceed onto initializing (i.e. mutating)
+        // the heap in the VM constructor. GlobalGC may be expecting a quiescent world
+        // state at this point. So, go park this thread if needed.
+        vm.requestStop();
+        notifyVMStop(vm, StopTheWorldEvent::VMCreated); // Cannot be called while holding m_worldLock.
+
+        Locker locker { m_worldLock };
+        decrementActiveVMs(vm);
+    }
+}
+
+void VMManager::notifyVMDestruction(VM& vm)
+{
+    bool worldIsStopped = false;
+    {
+        Locker locker { m_worldLock };
+        if (s_recentVM == &vm)
+            s_recentVM = nullptr;
+        m_vmList.remove(vm.threadContext());
+        m_numberOfVMs--;
+
+        worldIsStopped = (m_worldMode != Mode::RunAll);
+    }
+    if (worldIsStopped) {
+        // If a stop is in progress, some threads may have stopped, and may need to be
+        // woken up.
+        handleVMDestructionWhileWorldStopped(vm);
+    }
+}
+
+void VMManager::notifyVMActivation(VM& vm)
+{
+    // The main concern for this notification is that if we are currently Stopping or Stopped,
+    // then we need to block this newly activated VM from executing.
+    bool needsStopping = false;
+    {
+        Locker lock { m_worldLock };
+        s_recentVM = &vm;
+        incrementActiveVMs(vm);
+        needsStopping = m_worldMode != Mode::RunAll;
+    }
+    if (needsStopping) {
+        vm.requestStop();
+        notifyVMStop(vm, StopTheWorldEvent::VMActivated);
+    }
+}
+
+void VMManager::notifyVMDeactivation(VM& vm)
+{
+    // The main concern for this notification is that if we are currently Stopping or Stopped,
+    // then we may need to wake up another thread to potentially service the StopTheWorld
+    // request. That's because this may be the last thread that STW is waiting on.
+    Locker lock { m_worldLock };
+    decrementActiveVMs(vm);
+}
+
+void VMManager::handleVMDestructionWhileWorldStopped(VM& vm)
+{
+    Locker lock { m_worldLock };
+    if (m_worldMode == Mode::RunAll) {
+        // World has been resumed already. Nothing more to do.
+        return;
+    }
+
+    if (!m_numberOfVMs) {
+        // We're the last VM, and we're about to shutdown. So, there's nothing to
+        // resume. Fix m_worldMode to reflect this.
+        m_worldMode = Mode::RunAll;
+        return;
+    }
+
+    // If we get here, then the world is either in Stopping / Stopped / RunOne state,
+    // and there's at least one other VM thread in play out there. Wake them up so
+    // that the right thread can take next step.
+    if (m_targetVM) {
+        // There's a designated targetVM thread to continue in, but we don't have the
+        // ability to just wake the desired one up. So, wake up all the threads and let
+        // them sort themselves out.
+        //
+        // But if the targetVM thread is this thread, then pass the control to another
+        // thread, any thread. That's because this thread is dying imminently.
+        if (m_targetVM == &vm) {
+            m_targetVM = nullptr;
+            m_useRunOneMode = false;
+        }
+        m_worldConditionVariable.notifyAll();
+    } else {
+        // There's no designated targetVM thread. So, just waking up any one thread will do.
+        m_worldConditionVariable.notifyOne();
+    }
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/VMManager.h
+++ b/Source/JavaScriptCore/runtime/VMManager.h
@@ -25,9 +25,13 @@
 
 #pragma once
 
+#include <JavaScriptCore/StopTheWorldCallback.h>
+#include <JavaScriptCore/VMThreadContext.h>
+#include <wtf/Atomics.h>
+#include <wtf/Condition.h>
 #include <wtf/DoublyLinkedList.h>
-#include <wtf/IterationStatus.h>
 #include <wtf/Lock.h>
+#include <wtf/NeverDestroyed.h>
 #include <wtf/ScopedLambda.h>
 #include <wtf/Seconds.h>
 #include <wtf/StdLibExtras.h>
@@ -36,50 +40,346 @@ namespace JSC {
 
 class VM;
 
+// Understanding Stop the World (STW)
+// ==================================
+//
+// Intuition on how to think about things?
+// =======================================
+// The actors in play for a Stop the World story are:
+// 1. VMManager
+// 2. VM
+// 3. a Conductor Agent
+//
+// Events / actions involved in the Stop the World story are:
+// 1. Stop requests (with a given StopReason)
+// 2. Stop callback handlers
+//
+// An intuitive way to think about the Stop the World story is:
+//
+// 1. VMManager is an abstraction representing the process. There is only 1 singleton
+//    VMManager instance, and it coordinates the tracking and scheduling of VMs.
+//
+// 2. VM (and its VMThreadContext) represents a thread. A VM instance may actually
+//    run on different machine threads at different times (JSC's API allows this).
+//    However, from VMManager's perspective, each VM is like a thread that can be
+//    suspended / stopped, and resumed.
+//
+//    FIXME: the current VMManager does NOT yet handle cases where more than one VM
+//    is run on the same machine thread e.g. one VM1 calls into C++, which in turn
+//    calls into VM2. VM2 now has control of the CPU, but VMManager does not know
+//    that VM1 is in a way "deactivated". This scenario cannot manifest in WebKit
+//    with web workloads though.
+//
+// 3. The Conductor Agent is something like a Debugger agent that tells VMManager
+//    to stop or resume VMs / threads.
+//
+// 4. Stop requests are like interrupts. A stop being requested is analogous to an
+//    interrupt firing.
+//
+// 5. Stop callback handlers are like interrupt handlers that masked out all interrupts
+//    so that no other interrupts can fire while the current one is being handled.
+//
+//    When a stop request occurs, VMManager::notifyVMStop() will dispatch a callback
+//    to the appropriate handler for that request. Similar to the interrupt
+//    analogy, only one request can be serviced at one time. All other requests
+//    regardless of priority will be blocked (and held in pending) until the current
+//    request is done being serviced.
+//
+// World Execution Modes
+// =====================
+// The VMManager has a notion of a world mode (see VMManager::Mode). These modes are:
+// 1. RunAll - all threads can run or are running.
+// 2. RunOne - only one thread can run, like when a debugger is single stepping.
+// 3. Stopping - a stop has been requested, and VMs are in the process of stopping.
+// 4. Stopped - all threads have been stopped, and the highest priority stop request
+//              can now be serviced.
+//
+// Querying VMManager Info
+// =======================
+// VMManager::info() provides a view into a few pieces of VMManager state:
+// 1. numberOfVMs - the number of VMs that have been constructed and are alive.
+// 2. numberOfActiveVMs - the number of VMs that are activated i.e. their threads
+//        have entered the VM. This numberOfActiveVMs is only available while the
+//        world is NOT in Mode::RunAll (i.e. must be in some form of stoppage).
+// 3. numberOfStoppedVMs - the number of VMs that have reached the stopping point
+//        in VMManager::notifyVMStop(). The currently executing targetVM is counted
+//        as stopped when single stepping in Mode::RunOne.
+// 3. worldMode - this is the current VM world mode (as described above).
+//
+// Currently, this info is mainly used for testing purposes only.
+//
+// Initiating Stop the World
+// =========================
+// Stop the World begins with some agent calling VMManager::requestStopAll() with a
+// StopReason. This agent can be from mutator threads or from a helper thread like
+// those employed by debuggers.
+//
+// More than one agent can request STW at the same time. Hence, there can be multiple
+// stop requests queued up while the world is being stopped.
+//
+// StopReason and their Priority
+// =============================
+// Current StopReasons are:
+//     None - no requests
+//     GC - requesting stop for Global GC
+//     WasmDebugger - requesting stop for Wasm Debugger (like Ctrl-C in lldb)
+//     MemoryDebugger - similar to WasmDebugger, but for the Memory Debugger.
+//
+// The priority of these requests are defined by their order of declaration.
+// See definition of FOR_EACH_STOP_THE_WORLD_REASON and enum class StopReason.
+// StopReason::None is a special case and has no priority.
+// StopReason::GC is the current highest priority request.
+// StopReason::MemoryDebugger is the current lowest priority request.
+//
+// StopReason is synonymous with "StopRequest".
+// From the client's perspective, it is the reason for a stop request.
+// From the VMManager's perspective, it is the type of stop request.
+//
+// Servicing Order: one request at a time
+// ======================================
+// The order the stop requests came in does not matter. Once the world is finally
+// stopped, the higher priority request is serviced first.
+// See fetchTopPriorityStopReason() and m_currentStopReason.
+//
+// While this request is being serviced, other requests will be ignored. During
+// this time of service, new stop requests can be added to m_pendingStopRequestBits,
+// but they will be ignored even if they are higher priority. We will service them
+// only after the current request has resumed with RunOne or RunAll mode.
+//
+// StopTheWorldCallback (i.e. stop request handlers)
+// =================================================
+// When the world is stopped, VMManager will call back to a request handler
+// based on what StopReason is in m_currentStopReason. See VMManager::notifyVMStop().
+//
+// The handler for GC should be static but is not currently implemented yet.
+// The handlers for WasmDebugger and MemoryDebugger may be overridden. They are
+// made to be overrideable only to enable testing. See VMManagerStopTheWorldTest.cpp
+// for how they are used in testing.
+//
+// Each handler must be of the shape StopTheWorldCallback. See StopTheWorldCallback.h
+// The handler will be called with a StopTheWorldEvent. The StopTheWorldEvent indicates
+// where the handler is called from. This may have a use later on, but for now, the
+// StopTheWorldEvent is only informational.
+//
+// After the handler is done, it controls how execution will proceed thereafter by
+// returning one of the StopTheWorldCallback return values (see StopTheWorldCallback.h).
+// The possible return values are:
+//
+// 1. STW_CONTINUE()
+//    - this is only used for testing purposes where we want to loop inside
+//      VMManager::notifyVMStop() while waiting for more things to handle.
+//    - VMManager::m_worldMode will remain in Mode::Stopped.
+// 2. STW_CONTEXT_SWITCH(targetVM)
+//    - this is used to switch control of the handler to another VM on a different
+//      thread without resuming any execution. lldb's  "thread select ..." can be
+//      implemented this way.
+//    - VMManager::m_worldMode will remain in Mode::Stopped.
+// 3. STW_RESUME_ONE()
+//    - this is used to resume only the current VM thread in RunOne mode. This is
+//      useful for debuggers that wish to single step in the current VM. It keeps
+//      other threads paused / stopped while this thread executes. It is up to the
+//      client to detect potential resource deadlocks (e.g. using a timeout) that
+//      may arise from only resuming 1 thread.
+//    - VMManager::m_worldMode will transition from Mode::Stopped to Mode::RunOne.
+// 4. STW_RESUME_ALL()
+//    - forces all threads to resume from a stop.
+//    - VMManager::m_worldMode will transition from Mode::Stopped to Mode::RunAll.
+// 5. STW_RESUME()
+//    - Return to whatever run mode we were executing with before the current Stop
+//      the World request. That may be either Mode::RunOne or Mode::RunAll.
+//    - This allows the GC to run (with its own Stop the World requests) even while
+//      while we're single stepping in a debugger with Mode::RunOne.
+//
+// Edge Cases and Special Circumstances
+// ====================================
+// While in Mode::RunOne, if the VM that is running either exits the VM (aka
+// deactivates) or its VM is destructed (aka shutdown), the VMManager will transition
+// the world mode back to RunAll (unblocking other VMs and threads)  since the current
+// VM is no longer viable for continuing execution.
+
+#define FOR_EACH_STOP_THE_WORLD_REASON(v) \
+    v(GC) \
+    v(WasmDebugger) \
+    v(MemoryDebugger) \
+
 class VMManager {
-    WTF_FORBID_HEAP_ALLOCATION;
     WTF_MAKE_NONCOPYABLE(VMManager);
+
+#define DECLARE_STOP_THE_WORLD_REASON_BIT_SHIFT(reason__) reason__##BitShift,
+    enum StopReasonBitShift {
+        FOR_EACH_STOP_THE_WORLD_REASON(DECLARE_STOP_THE_WORLD_REASON_BIT_SHIFT)
+    };
+#undef DECLARE_STOP_THE_WORLD_REASON_BIT_SHIFT
+
+#define COUNT_STOP_REASON(event) + 1
+    static constexpr unsigned NumberOfStopReasons = FOR_EACH_STOP_THE_WORLD_REASON(COUNT_STOP_REASON);
+#undef COUNT_STOP_REASON
+
 public:
-    enum class Error {
+    using StopRequestBits = uint32_t;
+    static_assert(NumberOfStopReasons <= (sizeof(StopRequestBits) * CHAR_BIT));
+
+#define DECLARE_STOP_THE_WORLD_REASON(reason__) reason__ = (1 << reason__##BitShift),
+    enum class StopReason : StopRequestBits {
+        None = 0,
+        FOR_EACH_STOP_THE_WORLD_REASON(DECLARE_STOP_THE_WORLD_REASON)
+    };
+#undef DECLARE_STOP_THE_WORLD_REASON
+
+    enum class Error : uint8_t {
         None,
         TimedOut
     };
 
-    static void add(VM*);
-    static void remove(VM*);
+    JS_EXPORT_PRIVATE static VMManager& singleton();
+
     ALWAYS_INLINE static bool isValidVM(VM* vm)
     {
         return vm == s_recentVM ? true : isValidVMSlow(vm);
     }
 
+    // StopTheWorld APIs ======================================================
+
+    enum class Mode : uint8_t {
+        RunAll, // no threads are stopped.
+        RunOne, // all threads are stopped except for the 1 thread the debugger wants to run.
+        Stopping, // still waiting for the right thread to service the stop.
+        Stopped, // all threads have stopped, and the right thread is now servicing the stop.
+    };
+
+    struct Info {
+        unsigned numberOfVMs;
+        unsigned numberOfActiveVMs;
+        unsigned numberOfStoppedVMs;
+        Mode worldMode;
+    };
+
+    JS_EXPORT_PRIVATE static Info info();
+    static unsigned numberOfVMs() { return singleton().m_numberOfVMs; }
+
+    JS_EXPORT_PRIVATE static void setWasmDebuggerCallback(StopTheWorldCallback);
+    JS_EXPORT_PRIVATE static void setMemoryDebuggerCallback(StopTheWorldCallback);
+
+    ALWAYS_INLINE CONCURRENT_SAFE static void requestStopAll(StopReason reason)
+    {
+        singleton().requestStopAllInternal(reason);
+    }
+    ALWAYS_INLINE CONCURRENT_SAFE static void requestResumeAll(StopReason reason)
+    {
+        singleton().requestResumeAllInternal(reason);
+    }
+
+    void notifyVMConstruction(VM&);
+    void notifyVMDestruction(VM&);
+    void notifyVMActivation(VM&);
+    void notifyVMDeactivation(VM&);
+    void notifyVMStop(VM&, StopTheWorldEvent);
+
+    void handleVMDestructionWhileWorldStopped(VM&);
+
+    // Interation APIs ======================================================
+
     using IteratorCallback = IterationStatus(VM&);
     using TestCallback = bool(VM&);
 
-    static VM* findMatchingVM(const Invocable<TestCallback> auto& test)
+    static inline VM* findMatchingVM(const Invocable<TestCallback> auto& test)
     {
-        SUPPRESS_FORWARD_DECL_ARG return findMatchingVMImpl(scopedLambda<TestCallback>(test));
+        SUPPRESS_FORWARD_DECL_ARG return singleton().findMatchingVMImpl(scopedLambda<TestCallback>(test));
     }
 
-    static void forEachVM(const Invocable<IteratorCallback> auto& functor)
+    static inline void forEachVM(const Invocable<IteratorCallback> auto& functor)
     {
-        SUPPRESS_FORWARD_DECL_ARG forEachVMImpl(scopedLambda<IteratorCallback>(functor));
+        SUPPRESS_FORWARD_DECL_ARG singleton().forEachVMImpl(scopedLambda<IteratorCallback>(functor));
     }
 
-    static Error forEachVMWithTimeout(Seconds timeout, const Invocable<IteratorCallback> auto& functor)
+    static inline Error forEachVMWithTimeout(Seconds timeout, const Invocable<IteratorCallback> auto& functor)
     {
-        SUPPRESS_FORWARD_DECL_ARG return forEachVMWithTimeoutImpl(timeout, scopedLambda<IteratorCallback>(functor));
+        SUPPRESS_FORWARD_DECL_ARG return singleton().forEachVMWithTimeoutImpl(timeout, scopedLambda<IteratorCallback>(functor));
     }
 
     JS_EXPORT_PRIVATE static void dumpVMs();
 
 private:
+    VMManager() = default;
+
+    bool hasPendingStopRequests() const { return m_pendingStopRequestBits.loadRelaxed(); }
+
+    JS_EXPORT_PRIVATE CONCURRENT_SAFE void requestStopAllInternal(StopReason);
+    JS_EXPORT_PRIVATE CONCURRENT_SAFE void requestResumeAllInternal(StopReason);
+
+    void resumeTheWorld() WTF_REQUIRES_LOCK(m_worldLock);
+    void incrementActiveVMs(VM&) WTF_REQUIRES_LOCK(m_worldLock);
+    void decrementActiveVMs(VM&) WTF_REQUIRES_LOCK(m_worldLock);
+
     JS_EXPORT_PRIVATE static bool isValidVMSlow(VM*);
-    JS_EXPORT_PRIVATE static VM* findMatchingVMImpl(const ScopedLambda<TestCallback>&);
-    JS_EXPORT_PRIVATE static void forEachVMImpl(const ScopedLambda<IteratorCallback>&);
-    JS_EXPORT_PRIVATE static Error forEachVMWithTimeoutImpl(Seconds timeout, const ScopedLambda<IteratorCallback>&);
+    JS_EXPORT_PRIVATE VM* findMatchingVMImpl(const ScopedLambda<TestCallback>&);
+    JS_EXPORT_PRIVATE void forEachVMImpl(const ScopedLambda<IteratorCallback>&);
+    JS_EXPORT_PRIVATE Error forEachVMWithTimeoutImpl(Seconds timeout, const ScopedLambda<IteratorCallback>&);
+
+    void iterateVMs(const Invocable<IterationStatus(VM&)> auto&) WTF_REQUIRES_LOCK(m_worldLock);
+
+    DoublyLinkedList<VMThreadContext> m_vmList WTF_GUARDED_BY_LOCK(m_worldLock);
+    Lock m_worldLock;
+    Condition m_worldConditionVariable;
+
+    // === Variables only relevant for StopTheWorld ===================================
+
+    // Indicates if the world is running or stopped (see Modes for details).
+    // Requires m_worldLock to write to this, but not to read it.
+    Mode m_worldMode { Mode::RunAll };
+
+    // Indicates if the world needs to be in RunOne mode (and if it should resume in RunOne mode
+    // after stops).
+    bool m_useRunOneMode { false };
+
+    // Indicates if there are pending StopTheWorld requests (analogous to pending interrupts).
+    // In RunOne mode, all VM threads (except one) will be stopped even when m_pendingStopRequestBits
+    // is empty. Hence, m_pendingStopRequestBits says nothing about whether threads are / should be
+    // running or not.
+    // Can be written and read concurrently without m_worldLock.
+    Atomic<StopRequestBits> m_pendingStopRequestBits { 0 };
+
+    // We need to track a m_currentStopReason because we may need to continue servicing the current
+    // request after a context switch to a different targetVM. Conceptually, if StopTheWorld requests
+    // are analogous to interrupts, then when a specific interrupt is being serviced, all other
+    // interrupts are blocked / disabled though their status remains pending. Similarly, all other
+    // pending StopTheWorld requests will be blocked, and only serviced after the current one being
+    // serviced is done.
+    // Only notifyVMStop() may modify m_currentStopReason.
+    StopReason m_currentStopReason { StopReason::None };
+
+    // Indicates the targetVM that will service the StopTheWorld request, or the targetVM that may
+    // continue running in RunOne mode.
+    // Can obly be written to while holding the m_worldLock.
+    // Can be read without the m_worldLock under some restricted circumstances.
+    VM* m_targetVM { nullptr };
+
+    // We'll set m_numberOfActiveVMs to 99999999 when it's not supposed to hold a valid value.
+    // 99999999 is just some arbitrary token value that is easy to recognize but we're not likely
+    // to see in any real world value of m_numberOfActiveVMs. The 99999999 value will easily
+    // convey the idea that the value is invalid at any given point in time that info() is sampled.
+    static constexpr unsigned invalidNumberOfActiveVMs = 99999999;
+
+    // Indicated the number of VMs that have non-null EntryScopes.
+    // This value is only valid while a StopTheWorld request is being processed. It is calculated
+    // when the first requesting VM stops of all VMs. While a StopTheWorld request is being serviced,
+    // it will be updated using the VM's ConcurrentEntryScopeService.
+    //
+    // The choice to not track a valid m_numberOfActiveVMs at all times is just an optimization so
+    // that we can skip this work when not doing Stop the World.
+    unsigned m_numberOfActiveVMs { invalidNumberOfActiveVMs };
+
+    Atomic<unsigned> m_numberOfStoppedVMs { 0 };
+
+    // === End of variables only relevant for StopTheWorld =================================
+
+    unsigned m_numberOfVMs { 0 };
 
     JS_EXPORT_PRIVATE static VM* s_recentVM;
+
+    friend class NeverDestroyed<VMManager>;
 };
 
-} // namespace JSC
+#undef FOR_EACH_STOP_THE_WORLD_REASON
 
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/VMThreadContext.h
+++ b/Source/JavaScriptCore/runtime/VMThreadContext.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <JavaScriptCore/VMTraps.h>
+#include <wtf/DoublyLinkedList.h>
+
+namespace JSC {
+
+class VMThreadContext : public DoublyLinkedListNode<VMThreadContext> {
+public:
+    VMThreadContext();
+    ~VMThreadContext();
+
+    VMThreadContext* next() const { return m_next; }
+    VMTraps& traps() { return m_traps; }
+    const VMTraps& traps() const { return m_traps; }
+
+    static constexpr ptrdiff_t offsetOfTraps()
+    {
+        return OBJECT_OFFSETOF(VMThreadContext, m_traps);
+    }
+
+private:
+    VMTraps m_traps;
+    VMThreadContext* m_prev; // Required by DoublyLinkedListNode.
+    VMThreadContext* m_next; // Required by DoublyLinkedListNode.
+
+    friend class DoublyLinkedListNode<VMThreadContext>;
+    friend class LLIntOffsetsExtractor;
+};
+
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/VMTraps.cpp
+++ b/Source/JavaScriptCore/runtime/VMTraps.cpp
@@ -37,6 +37,7 @@
 #include "MachineContext.h"
 #include "MacroAssemblerCodeRef.h"
 #include "VMEntryScopeInlines.h"
+#include "VMManager.h"
 #include "VMTrapsInlines.h"
 #include "WaiterListManager.h"
 #include "Watchdog.h"
@@ -506,6 +507,11 @@ bool VMTraps::handleTraps(VMTraps::BitField mask)
             if (!isDeferringTermination())
                 vm.throwTerminationException();
             return true;
+
+        case NeedStopTheWorld:
+            VMManager::singleton().notifyVMStop(vm, StopTheWorldEvent::VMStopped);
+            didHandleTrap = true;
+            break;
 
         case NeedExceptionHandling:
         default:

--- a/Source/JavaScriptCore/runtime/VMTraps.h
+++ b/Source/JavaScriptCore/runtime/VMTraps.h
@@ -152,6 +152,7 @@ public:
     v(NeedTermination) \
     v(NeedWatchdogCheck) \
     v(NeedDebuggerBreak) \
+    v(NeedStopTheWorld) \
     v(NeedExceptionHandling)
 
 #define DECLARE_VMTRAPS_EVENT_BIT_SHIFT(event__)  event__##BitShift,
@@ -322,6 +323,10 @@ private:
     bool m_threadStopRequested { false };
     bool m_trapsDeferred { false };
 
+    // Protects against a race between VMManager::requestResumeAll() and VMManager::notifyVMActivation()
+    // to increment their m_numberOfActiveVMs.
+    bool m_hasBeenCountedAsActive { false };
+
     Box<Lock> m_trapSignalingLock;
     Box<Condition> m_condition;
 
@@ -332,6 +337,7 @@ private:
     friend class LLIntOffsetsExtractor;
     friend class SignalSender;
     friend class DeferTraps;
+    friend class VMManager;
 };
 
 class DeferTraps {

--- a/Source/JavaScriptCore/runtime/VMTrapsInlines.h
+++ b/Source/JavaScriptCore/runtime/VMTrapsInlines.h
@@ -31,7 +31,7 @@ namespace JSC {
 
 ALWAYS_INLINE VM& VMTraps::vm() const
 {
-    return *std::bit_cast<VM*>(std::bit_cast<uintptr_t>(this) - OBJECT_OFFSETOF(VM, m_traps));
+    return *std::bit_cast<VM*>(std::bit_cast<uintptr_t>(this) - VM::offsetOfTraps());
 }
 
 inline void VMTraps::deferTermination(DeferAction deferAction)

--- a/Source/JavaScriptCore/shell/CMakeLists.txt
+++ b/Source/JavaScriptCore/shell/CMakeLists.txt
@@ -38,6 +38,7 @@ if (DEVELOPER_MODE)
         ../API/tests/MultithreadedMultiVMExecutionTest.cpp
         ../API/tests/PingPongStackOverflowTest.cpp
         ../API/tests/TypedArrayCTest.cpp
+        ../API/tests/VMManagerStopTheWorldTest.cpp
         ../API/tests/testapi.cpp
     )
     set(testapi_C_SOURCES

--- a/Source/JavaScriptCore/wasm/WasmCallee.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCallee.cpp
@@ -82,7 +82,8 @@ void Callee::reportToVMsForDestruction()
 {
     // We don't know which VMs a Module has ever run on so we just report to all of them.
     VMManager::forEachVM([&] (VM& vm) {
-        vm.heap.reportWasmCalleePendingDestruction(Ref(*this));
+        if (vm.isInService())
+            vm.heap.reportWasmCalleePendingDestruction(Ref(*this));
         return IterationStatus::Continue;
     });
 }


### PR DESCRIPTION
#### 2e80a204eb24e3950edd84a43ad42fe8aa8ba693
<pre>
Implement a Stop the World mechanism for JSC.
<a href="https://bugs.webkit.org/show_bug.cgi?id=300046">https://bugs.webkit.org/show_bug.cgi?id=300046</a>
<a href="https://rdar.apple.com/161844101">rdar://161844101</a>

Reviewed by Yijia Huang.

This is needed by Global GC, the Wasm Debugger, and the Memory Debugger that we&apos;re exploring
implementing.

The following is documented in VMManager.h, but is replicated here for your convenience in
reading and discovery:

    Understanding Stop the World (STW)
    ==================================

    Intuition on how to think about things?
    =======================================
    The actors in play for a Stop the World story are:
    1. VMManager
    2. VM
    3. a Conductor Agent

    Events / actions involved in the Stop the World story are:
    1. Stop requests (with a given StopReason)
    2. Stop callback handlers

    An intuitive way to think about the Stop the World story is:

    1. VMManager is an abstraction representing the process. There is only 1 singleton
       VMManager instance, and it coordinates the tracking and scheduling of VMs.

    2. VM (and its VMThreadContext) represents a thread. A VM instance may actually
       run on different machine threads at different times (JSC&apos;s API allows this).
       However, from VMManager&apos;s perspective, each VM is like a thread that can be
       suspended / stopped, and resumed.

       FIXME: the current VMManager does NOT yet handle cases where more than one VM
       is run on the same machine thread e.g. one VM1 calls into C++, which in turn
       calls into VM2. VM2 now has control of the CPU, but VMManager does not know
       that VM1 is in a way &quot;deactivated&quot;. This scenario cannot manifest in WebKit
       with web workloads though.

    3. The Conductor Agent is something like a Debugger agent that tells VMManager
       to stop or resume VMs / threads.

    4. Stop requests are like interrupts. A stop being requested is analogous to an
       interrupt firing.

    5. Stop callback handlers are like interrupt handlers that masked out all interrupts
       so that no other interrupts can fire while the current one is being handled.

       When a stop request occurs, VMManager::notifyVMStop() will dispatch a callback
       to the appropriate handler for that request. Similar to the interrupt
       analogy, only one request can be serviced at one time. All other requests
       regardless of priority will be blocked (and held in pending) until the current
       request is done being serviced.

    World Execution Modes
    =====================
    The VMManager has a notion of a world mode (see VMManager::Mode). These modes are:
    1. RunAll - all threads can run or are running.
    2. RunOne - only one thread can run, like when a debugger is single stepping.
    3. Stopping - a stop has been requested, and VMs are in the process of stopping.
    4. Stopped - all threads have been stopped, and the highest priority stop request
                 can now be serviced.

    Querying VMManager Info
    =======================
    VMManager::info() provides a view into a few pieces of VMManager state:
    1. numberOfVMs - the number of VMs that have been constructed and are alive.
    2. numberOfActiveVMs - the number of VMs that are activated i.e. their threads
           have entered the VM. This numberOfActiveVMs is only available while the
           world is NOT in Mode::RunAll (i.e. must be in some form of stoppage).
    3. numberOfStoppedVMs - the number of VMs that have reached the stopping point
           in VMManager::notifyVMStop(). The currently executing targetVM is counted
           as stopped when single stepping in Mode::RunOne.
    3. worldMode - this is the current VM world mode (as described above).

    Currently, this info is mainly used for testing purposes only.

    Initiating Stop the World
    =========================
    Stop the World begins with some agent calling VMManager::requestStopAll() with a
    StopReason. This agent can be from mutator threads or from a helper thread like
    those employed by debuggers.

    More than one agent can request STW at the same time. Hence, there can be multiple
    stop requests queued up while the world is being stopped.

    StopReason and their Priority
    =============================
    Current StopReasons are:
        None - no requests
        GC - requesting stop for Global GC
        WasmDebugger - requesting stop for Wasm Debugger (like Ctrl-C in lldb)
        MemoryDebugger - similar to WasmDebugger, but for the Memory Debugger.

    The priority of these requests are defined by their order of declaration.
    See definition of FOR_EACH_STOP_THE_WORLD_REASON and enum class StopReason.
    StopReason::None is a special case and has no priority.
    StopReason::GC is the current highest priority request.
    StopReason::MemoryDebugger is the current lowest priority request.

    StopReason is synonymous with &quot;StopRequest&quot;.
    From the client&apos;s perspective, it is the reason for a stop request.
    From the VMManager&apos;s perspective, it is the type of stop request.

    Servicing Order: one request at a time
    ======================================
    The order the stop requests came in does not matter. Once the world is finally
    stopped, the higher priority request is serviced first.
    See fetchTopPriorityStopReason() and m_currentStopReason.

    While this request is being serviced, other requests will be ignored. During
    this time of service, new stop requests can be added to m_pendingStopRequestBits,
    but they will be ignored even if they are higher priority. We will service them
    only after the current request has resumed with RunOne or RunAll mode.

    StopTheWorldCallback (i.e. stop request handlers)
    =================================================
    When the world is stopped, VMManager will call back to a request handler
    based on what StopReason is in m_currentStopReason. See VMManager::notifyVMStop().

    The handler for GC should be static but is not currently implemented yet.
    The handlers for WasmDebugger and MemoryDebugger may be overridden. They are
    made to be overrideable only to enable testing. See VMManagerStopTheWorldTest.cpp
    for how they are used in testing.

    Each handler must be of the shape StopTheWorldCallback. See StopTheWorldCallback.h
    The handler will be called with a StopTheWorldEvent. The StopTheWorldEvent indicates
    where the handler is called from. This may have a use later on, but for now, the
    StopTheWorldEvent is only informational.

    After the handler is done, it controls how execution will proceed thereafter by
    returning one of the StopTheWorldCallback return values (see StopTheWorldCallback.h).
    The possible return values are:

    1. STW_CONTINUE()
       - this is only used for testing purposes where we want to loop inside
         VMManager::notifyVMStop() while waiting for more things to handle.
       - VMManager::m_worldMode will remain in Mode::Stopped.
    2. STW_CONTEXT_SWITCH(targetVM)
       - this is used to switch control of the handler to another VM on a different
         thread without resuming any execution. lldb&apos;s  &quot;thread select ...&quot; can be
         implemented this way.
       - VMManager::m_worldMode will remain in Mode::Stopped.
    3. STW_RESUME_ONE()
       - this is used to resume only the current VM thread in RunOne mode. This is
         useful for debuggers that wish to single step in the current VM. It keeps
         other threads paused / stopped while this thread executes. It is up to the
         client to detect potential resource deadlocks (e.g. using a timeout) that
         may arise from only resuming 1 thread.
       - VMManager::m_worldMode will transition from Mode::Stopped to Mode::RunOne.
    4. STW_RESUME_ALL()
       - forces all threads to resume from a stop.
       - VMManager::m_worldMode will transition from Mode::Stopped to Mode::RunAll.
    5. STW_RESUME()
       - Return to whatever run mode we were executing with before the current Stop
         the World request. That may be either Mode::RunOne or Mode::RunAll.
       - This allows the GC to run (with its own Stop the World requests) even while
         while we&apos;re single stepping in a debugger with Mode::RunOne.

    Edge Cases and Special Circumstances
    ====================================
    While in Mode::RunOne, if the VM that is running either exits the VM (aka
    deactivates) or its VM is destructed (aka shutdown), the VMManager will transition
    the world mode back to RunAll (unblocking other VMs and threads)  since the current
    VM is no longer viable for continuing execution.

Tests: Source/JavaScriptCore/API/tests/VMManagerStopTheWorldTest.cpp
       Source/JavaScriptCore/API/tests/VMManagerStopTheWorldTest.h
       Source/JavaScriptCore/API/tests/testapi.c
* Source/JavaScriptCore/API/tests/VMManagerStopTheWorldTest.cpp: Added.
(VMManagerStopTheWorldTest::abortTest):
(VMManagerStopTheWorldTest::threadsList):
(VMManagerStopTheWorldTest::checkpointCallback):
(VMManagerStopTheWorldTest::ensureAliveCallback):
(VMManagerStopTheWorldTest::wasmDebuggerTestCallback):
(VMManagerStopTheWorldTest::memoryDebuggerTestCallback):
(VMManagerStopTheWorldTest::notifyVMDestruction):
(VMManagerStopTheWorldTest::WTF_REQUIRES_LOCK):
(VMManagerStopTheWorldTest::test):
* Source/JavaScriptCore/API/tests/VMManagerStopTheWorldTest.h: Added.
* Source/JavaScriptCore/API/tests/testapi.c:
(main):
* Source/JavaScriptCore/CMakeLists.txt:
* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/heap/MarkedBlock.cpp:
(JSC::MarkedBlock::dumpInfoAndCrashForInvalidHandleV2):
* Source/JavaScriptCore/llint/LowLevelInterpreter.asm:
* Source/JavaScriptCore/runtime/JSCConfig.h:
* Source/JavaScriptCore/runtime/StopTheWorldCallback.h: Added.
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::checkStaticAsserts):
(JSC::VM::VM):
(JSC::VM::~VM):
(JSC::VM::hasExceptionsAfterHandlingTraps):
(JSC::VM::throwTerminationException):
(JSC::VM::updateStackLimits):
(JSC::VM::executeEntryScopeServicesOnEntry):
(JSC::VM::executeEntryScopeServicesOnExit):
* Source/JavaScriptCore/runtime/VM.h:
(JSC::VM::hasEntryScopeServiceRequest):
(JSC::VM::offsetOfTraps):
(JSC::VM::fromThreadContext):
(JSC::VM::threadContext):
(JSC::VM::clearLastException):
(JSC::VM::softStackLimit const):
(JSC::VM::addressOfSoftStackLimit):
(JSC::VM::cloopStack):
(JSC::VM::cloopStack const):
(JSC::VM::cloopStackLimit):
(JSC::VM::currentCLoopStackPointer const):
(JSC::VM::traps):
(JSC::VM::traps const):
(JSC::VM::notifyNeedDebuggerBreak):
(JSC::VM::notifyNeedShellTimeoutCheck):
(JSC::VM::notifyNeedTermination):
(JSC::VM::notifyNeedWatchdogCheck):
(JSC::VM::requestStop):
(JSC::VM::cancelStop):
* Source/JavaScriptCore/runtime/VMManager.cpp:
(JSC::VMManager::singleton):
(JSC::VMThreadContext::VMThreadContext):
(JSC::VMThreadContext::~VMThreadContext):
(JSC::WTF_REQUIRES_LOCK):
(JSC::VMManager::findMatchingVMImpl):
(JSC::VMManager::forEachVMImpl):
(JSC::VMManager::forEachVMWithTimeoutImpl):
(JSC::VMManager::info):
(JSC::VMManager::setWasmDebuggerCallback):
(JSC::VMManager::setMemoryDebuggerCallback):
(JSC::VMManager::requestStopAllInternal):
(JSC::VMManager::requestResumeAllInternal):
(JSC::VMManager::notifyVMStop):
(JSC::VMManager::notifyVMConstruction):
(JSC::VMManager::notifyVMDestruction):
(JSC::VMManager::notifyVMActivation):
(JSC::VMManager::notifyVMDeactivation):
(JSC::VMManager::handleVMDestructionWhileWorldStopped):
(JSC::VMManager::add): Deleted.
(JSC::VMManager::remove): Deleted.
* Source/JavaScriptCore/runtime/VMManager.h:
(JSC::VMManager::numberOfVMs):
(JSC::VMManager::requestStopAll):
(JSC::VMManager::requestResumeAll):
(JSC::VMManager::findMatchingVM):
(JSC::VMManager::forEachVM):
(JSC::VMManager::forEachVMWithTimeout):
(JSC::VMManager::hasPendingStopRequests const):
* Source/JavaScriptCore/runtime/VMThreadContext.h: Added.
(JSC::VMThreadContext::next const):
(JSC::VMThreadContext::traps):
(JSC::VMThreadContext::traps const):
(JSC::VMThreadContext::offsetOfTraps):
* Source/JavaScriptCore/runtime/VMTraps.cpp:
(JSC::VMTraps::handleTraps):
* Source/JavaScriptCore/runtime/VMTraps.h:
* Source/JavaScriptCore/runtime/VMTrapsInlines.h:
(JSC::VMTraps::vm const):
* Source/JavaScriptCore/shell/CMakeLists.txt:
* Source/JavaScriptCore/wasm/WasmCallee.cpp:
(JSC::Wasm::Callee::reportToVMsForDestruction):

Canonical link: <a href="https://commits.webkit.org/301027@main">https://commits.webkit.org/301027@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e27d2fc058b988ceefaae5f6df20b2b2bfcfe7b5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124672 "9 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44344 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35078 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131513 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76599 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9c332daf-97bf-4c9f-a5e3-d140404243f9) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45048 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52914 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94853 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62912 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f38e3b28-9e05-4368-8535-6fe7bb537f09) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127626 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35924 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111496 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75423 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6512cdd7-347c-40ae-84cd-acb60e147b7e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34854 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29651 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74993 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/116777 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105681 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29882 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134179 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/123192 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51520 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39336 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103327 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51932 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107717 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103101 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48476 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26739 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48476 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19559 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51394 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57191 "Built successfully") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/156296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50787 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/156296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54143 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52482 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->