### PR TITLE
Web Inspector: reduce amount of shared code in InspectorNetworkAgent and InspectorPageAgent

### DIFF
--- a/Source/JavaScriptCore/inspector/ContentSearchUtilities.h
+++ b/Source/JavaScriptCore/inspector/ContentSearchUtilities.h
@@ -28,7 +28,6 @@
 
 #pragma once
 
-#include <JavaScriptCore/InspectorProtocolObjects.h>
 #include <wtf/Forward.h>
 
 namespace JSC { namespace Yarr {
@@ -36,6 +35,9 @@ class RegularExpression;
 } }
 
 namespace Inspector {
+namespace Protocol { namespace GenericTypes {
+class SearchMatch;
+} }
 
 namespace ContentSearchUtilities {
 

--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -309,6 +309,7 @@ inspector/agents/page/PageRuntimeAgent.cpp
 inspector/agents/worker/WorkerAuditAgent.cpp
 inspector/agents/worker/WorkerDebuggerAgent.cpp
 inspector/agents/worker/WorkerRuntimeAgent.cpp
+inspector/InspectorResourceUtilities.cpp
 layout/floats/FloatingContext.cpp
 layout/floats/PlacedFloats.cpp
 layout/formattingContexts/FormattingGeometry.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -508,8 +508,10 @@ inspector/InspectorInstrumentation.cpp
 inspector/InspectorInstrumentation.h
 inspector/InspectorNodeFinder.cpp
 inspector/InspectorOverlay.cpp
+inspector/InspectorResourceUtilities.cpp
 inspector/InspectorShaderProgram.cpp
 inspector/InspectorStyleSheet.cpp
+inspector/InspectorThreadableLoaderClient.cpp
 inspector/NetworkResourcesData.cpp
 inspector/PageDebugger.cpp
 inspector/WebInjectedScriptManager.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -244,6 +244,7 @@ inspector/InspectorInstrumentation.cpp
 inspector/InspectorInstrumentation.h
 inspector/InspectorNodeFinder.cpp
 inspector/InspectorOverlay.cpp
+inspector/InspectorResourceUtilities.cpp
 inspector/InspectorShaderProgram.cpp
 inspector/InspectorStyleSheet.cpp
 inspector/PageDebugger.cpp

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1837,11 +1837,14 @@ inspector/InspectorHistory.cpp
 inspector/InspectorInstrumentation.cpp
 inspector/InspectorInstrumentationPublic.cpp
 inspector/InspectorInstrumentationWebKit.cpp
+inspector/InspectorNetworkIntercept.cpp
 inspector/InspectorNodeFinder.cpp
 inspector/InspectorOverlay.cpp
 inspector/InspectorOverlayLabel.cpp
+inspector/InspectorResourceUtilities.cpp
 inspector/InspectorShaderProgram.cpp
 inspector/InspectorStyleSheet.cpp
+inspector/InspectorThreadableLoaderClient.cpp
 inspector/InstrumentingAgents.cpp
 inspector/NetworkResourcesData.cpp
 inspector/PageDebugger.cpp

--- a/Source/WebCore/inspector/InspectorAuditResourcesObject.cpp
+++ b/Source/WebCore/inspector/InspectorAuditResourcesObject.cpp
@@ -35,7 +35,7 @@
 #include "Document.h"
 #include "ExceptionOr.h"
 #include "FrameDestructionObserverInlines.h"
-#include "InspectorPageAgent.h"
+#include "InspectorResourceUtilities.h"
 #include <wtf/Vector.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/WTFString.h>
@@ -69,7 +69,7 @@ ExceptionOr<Vector<InspectorAuditResourcesObject::Resource>> InspectorAuditResou
     if (!frame)
         return Exception { ExceptionCode::NotAllowedError, "Cannot be called with a detached document"_s };
 
-    for (auto* cachedResource : InspectorPageAgent::cachedResourcesForFrame(frame)) {
+    for (auto* cachedResource : ResourceUtilities::cachedResourcesForFrame(frame)) {
         Resource resource;
         resource.url = cachedResource->url().string();
         resource.mimeType = cachedResource->mimeType();
@@ -109,7 +109,7 @@ ExceptionOr<InspectorAuditResourcesObject::ResourceContent> InspectorAuditResour
 
     Inspector::Protocol::ErrorString errorString;
     ResourceContent resourceContent;
-    InspectorPageAgent::resourceContent(errorString, frame, cachedResource->url(), &resourceContent.data, &resourceContent.base64Encoded);
+    ResourceUtilities::resourceContent(errorString, frame, cachedResource->url(), &resourceContent.data, &resourceContent.base64Encoded);
     if (!errorString.isEmpty())
         return Exception { ExceptionCode::NotFoundError, errorString };
 

--- a/Source/WebCore/inspector/InspectorNetworkIntercept.cpp
+++ b/Source/WebCore/inspector/InspectorNetworkIntercept.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "InspectorNetworkIntercept.h"
+
+namespace Inspector {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(Inspector::PendingInterceptRequest);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(Inspector::PendingInterceptResponse);
+
+bool Intercept::matches(const String& url, NetworkStage networkStage)
+{
+    if (this->networkStage != networkStage)
+        return false;
+
+    if (this->url.isEmpty())
+        return true;
+
+    if (m_knownMatchingURLs.contains(url))
+        return true;
+
+    if (!m_urlSearcher) {
+        auto searchType = isRegex ? ContentSearchUtilities::SearchType::Regex : ContentSearchUtilities::SearchType::ExactString;
+        auto searchCaseSensitive = caseSensitive ? ContentSearchUtilities::SearchCaseSensitive::Yes : ContentSearchUtilities::SearchCaseSensitive::No;
+        m_urlSearcher = ContentSearchUtilities::createSearcherForString(this->url, searchType, searchCaseSensitive);
+    }
+    if (!ContentSearchUtilities::searcherMatchesText(*m_urlSearcher, url))
+        return false;
+
+    m_knownMatchingURLs.add(url);
+    return true;
+}
+
+} // namespace Inspector

--- a/Source/WebCore/inspector/InspectorNetworkIntercept.h
+++ b/Source/WebCore/inspector/InspectorNetworkIntercept.h
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ResourceRequest.h"
+#include "ResourceResponse.h"
+#include <JavaScriptCore/ContentSearchUtilities.h>
+#include <wtf/TZoneMalloc.h>
+
+namespace WebCore {
+class ResourceLoader;
+}
+
+namespace Inspector {
+
+enum class NetworkStage { Request, Response };
+
+struct Intercept {
+    String url;
+    bool caseSensitive { true };
+    bool isRegex { false };
+    NetworkStage networkStage { NetworkStage::Response };
+
+    inline bool operator==(const Intercept& other) const
+    {
+        return url == other.url
+            && caseSensitive == other.caseSensitive
+            && isRegex == other.isRegex
+            && networkStage == other.networkStage;
+    }
+
+    bool matches(const String& url, NetworkStage);
+
+private:
+    std::optional<Inspector::ContentSearchUtilities::Searcher> m_urlSearcher;
+
+    // Avoid having to (re)match the searcher each time a URL is requested.
+    HashSet<String> m_knownMatchingURLs;
+};
+
+class PendingInterceptRequest {
+    WTF_MAKE_TZONE_ALLOCATED(PendingInterceptRequest);
+    WTF_MAKE_NONCOPYABLE(PendingInterceptRequest);
+public:
+    PendingInterceptRequest(RefPtr<WebCore::ResourceLoader> loader, Function<void(const WebCore::ResourceRequest&)>&& callback)
+        : m_loader(loader)
+        , m_completionCallback(WTFMove(callback))
+    { }
+
+    void continueWithOriginalRequest()
+    {
+        if (!m_loader->reachedTerminalState())
+            m_completionCallback(m_loader->request());
+    }
+
+    void continueWithRequest(const WebCore::ResourceRequest& request)
+    {
+        m_completionCallback(request);
+    }
+
+    PendingInterceptRequest() = default;
+    RefPtr<WebCore::ResourceLoader> m_loader;
+    Function<void(const WebCore::ResourceRequest&)> m_completionCallback;
+};
+
+class PendingInterceptResponse {
+    WTF_MAKE_TZONE_ALLOCATED(PendingInterceptResponse);
+    WTF_MAKE_NONCOPYABLE(PendingInterceptResponse);
+public:
+    PendingInterceptResponse(const WebCore::ResourceResponse& originalResponse, CompletionHandler<void(const WebCore::ResourceResponse&, RefPtr<WebCore::FragmentedSharedBuffer>)>&& completionHandler)
+        : m_originalResponse(originalResponse)
+        , m_completionHandler(WTFMove(completionHandler))
+    { }
+
+    ~PendingInterceptResponse()
+    {
+        ASSERT(m_responded);
+    }
+
+    WebCore::ResourceResponse originalResponse() { return m_originalResponse; }
+
+    void respondWithOriginalResponse()
+    {
+        respond(m_originalResponse, nullptr);
+    }
+
+    void respond(const WebCore::ResourceResponse& response, RefPtr<WebCore::FragmentedSharedBuffer> data)
+    {
+        ASSERT(!m_responded);
+        if (m_responded)
+            return;
+
+        m_responded = true;
+
+        m_completionHandler(response, data);
+    }
+
+private:
+    WebCore::ResourceResponse m_originalResponse;
+    CompletionHandler<void(const WebCore::ResourceResponse&, RefPtr<WebCore::FragmentedSharedBuffer>)> m_completionHandler;
+    bool m_responded { false };
+};
+
+} // namespace Inspector

--- a/Source/WebCore/inspector/InspectorResourceType.h
+++ b/Source/WebCore/inspector/InspectorResourceType.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace Inspector {
+
+enum class ResourceType {
+    Document,
+    StyleSheet,
+    Image,
+    Font,
+    Script,
+    XHR,
+    Fetch,
+    Ping,
+    Beacon,
+    WebSocket,
+#if ENABLE(APPLICATION_MANIFEST)
+    ApplicationManifest,
+#endif
+    EventSource,
+    Other,
+};
+
+} // namespace Inspector

--- a/Source/WebCore/inspector/InspectorResourceUtilities.cpp
+++ b/Source/WebCore/inspector/InspectorResourceUtilities.cpp
@@ -1,0 +1,372 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "InspectorResourceUtilities.h"
+
+#include "CachedCSSStyleSheet.h"
+#include "CachedResourceLoader.h"
+#include "CachedScript.h"
+#include "DocumentInlines.h"
+#include "DocumentResourceLoader.h"
+#include "FrameLoader.h"
+#include "LocalFrame.h"
+#include "MIMETypeRegistry.h"
+#include "MemoryCache.h"
+#include "SharedBuffer.h"
+
+namespace Inspector {
+
+namespace ResourceUtilities {
+
+using namespace WebCore;
+
+Inspector::Protocol::Page::ResourceType resourceTypeToProtocol(Inspector::ResourceType resourceType)
+{
+    switch (resourceType) {
+    case ResourceType::Document:
+        return Inspector::Protocol::Page::ResourceType::Document;
+    case ResourceType::Image:
+        return Inspector::Protocol::Page::ResourceType::Image;
+    case ResourceType::Font:
+        return Inspector::Protocol::Page::ResourceType::Font;
+    case ResourceType::StyleSheet:
+        return Inspector::Protocol::Page::ResourceType::StyleSheet;
+    case ResourceType::Script:
+        return Inspector::Protocol::Page::ResourceType::Script;
+    case ResourceType::XHR:
+        return Inspector::Protocol::Page::ResourceType::XHR;
+    case ResourceType::Fetch:
+        return Inspector::Protocol::Page::ResourceType::Fetch;
+    case ResourceType::Ping:
+        return Inspector::Protocol::Page::ResourceType::Ping;
+    case ResourceType::Beacon:
+        return Inspector::Protocol::Page::ResourceType::Beacon;
+    case ResourceType::WebSocket:
+        return Inspector::Protocol::Page::ResourceType::WebSocket;
+    case ResourceType::EventSource:
+        return Inspector::Protocol::Page::ResourceType::EventSource;
+    case ResourceType::Other:
+        return Inspector::Protocol::Page::ResourceType::Other;
+#if ENABLE(APPLICATION_MANIFEST)
+    case ResourceType::ApplicationManifest:
+        break;
+#endif
+    }
+    return Inspector::Protocol::Page::ResourceType::Other;
+}
+
+static bool WARN_UNUSED_RETURN decodeBuffer(std::span<const uint8_t> buffer, const String& textEncodingName, String* result)
+{
+    if (buffer.data()) {
+        PAL::TextEncoding encoding(textEncodingName);
+        if (!encoding.isValid())
+            encoding = PAL::WindowsLatin1Encoding();
+        *result = encoding.decode(buffer);
+        return true;
+    }
+    return false;
+}
+
+static bool dataContent(std::span<const uint8_t> data, const String& textEncodingName, bool withBase64Encode, String* result)
+{
+    if (withBase64Encode) {
+        *result = base64EncodeToString(data);
+        return true;
+    }
+
+    return decodeBuffer(data, textEncodingName, result);
+}
+
+bool sharedBufferContent(RefPtr<FragmentedSharedBuffer>&& buffer, const String& textEncodingName, bool withBase64Encode, String* result)
+{
+    return dataContent(buffer ? buffer->makeContiguous()->span() : std::span<const uint8_t> { }, textEncodingName, withBase64Encode, result);
+}
+
+Vector<CachedResource*> cachedResourcesForFrame(LocalFrame* frame)
+{
+    Vector<CachedResource*> result;
+
+    for (auto& cachedResourceHandle : frame->document()->cachedResourceLoader().allCachedResources().values()) {
+        auto* cachedResource = cachedResourceHandle.get();
+        if (cachedResource->resourceRequest().hiddenFromInspector())
+            continue;
+
+        switch (cachedResource->type()) {
+        case CachedResource::Type::ImageResource:
+            // Skip images that were not auto loaded (images disabled in the user agent).
+        case CachedResource::Type::SVGFontResource:
+        case CachedResource::Type::FontResource:
+            // Skip fonts that were referenced in CSS but never used/downloaded.
+            if (cachedResource->stillNeedsLoad())
+                continue;
+            break;
+        default:
+            // All other CachedResource types download immediately.
+            break;
+        }
+
+        result.append(cachedResource);
+    }
+
+    return result;
+}
+
+bool mainResourceContent(LocalFrame* frame, bool withBase64Encode, String* result)
+{
+    RefPtr<FragmentedSharedBuffer> buffer = frame->loader().documentLoader()->mainResourceData();
+    if (!buffer)
+        return false;
+    return dataContent(buffer->makeContiguous()->span(), frame->document()->encoding(), withBase64Encode, result);
+}
+
+void resourceContent(Inspector::Protocol::ErrorString& errorString, LocalFrame* frame, const URL& url, String* result, bool* base64Encoded)
+{
+    DocumentLoader* loader = assertDocumentLoader(errorString, frame);
+    if (!loader)
+        return;
+
+    RefPtr<FragmentedSharedBuffer> buffer;
+    bool success = false;
+    if (equalIgnoringFragmentIdentifier(url, loader->url())) {
+        *base64Encoded = false;
+        success = mainResourceContent(frame, *base64Encoded, result);
+    }
+
+    if (!success) {
+        if (auto* resource = cachedResource(frame, url))
+            success = cachedResourceContent(*resource, result, base64Encoded);
+    }
+
+    if (!success)
+        errorString = "Missing resource for given url"_s;
+}
+
+String sourceMapURLForResource(CachedResource* cachedResource)
+{
+    if (!cachedResource)
+        return String();
+
+    // Scripts are handled in a separate path.
+    if (cachedResource->type() != CachedResource::Type::CSSStyleSheet)
+        return String();
+
+    String sourceMapHeader = cachedResource->response().httpHeaderField(HTTPHeaderName::SourceMap);
+    if (!sourceMapHeader.isEmpty())
+        return sourceMapHeader;
+
+    sourceMapHeader = cachedResource->response().httpHeaderField(HTTPHeaderName::XSourceMap);
+    if (!sourceMapHeader.isEmpty())
+        return sourceMapHeader;
+
+    String content;
+    bool base64Encoded;
+    if (cachedResourceContent(*cachedResource, &content, &base64Encoded) && !base64Encoded)
+        return ContentSearchUtilities::findStylesheetSourceMapURL(content);
+
+    return String();
+}
+
+CachedResource* cachedResource(const LocalFrame* frame, const URL& url)
+{
+    if (url.isNull())
+        return nullptr;
+
+    CachedResource* cachedResource = frame->document()->cachedResourceLoader().cachedResource(MemoryCache::removeFragmentIdentifierIfNeeded(url));
+    if (!cachedResource) {
+        ResourceRequest request(URL { url });
+        request.setDomainForCachePartition(frame->document()->domainForCachePartition());
+        cachedResource = MemoryCache::singleton().resourceForRequest(request, frame->page()->sessionID());
+    }
+
+    return cachedResource;
+}
+
+Inspector::ResourceType inspectorResourceType(CachedResource::Type type)
+{
+    switch (type) {
+    case CachedResource::Type::ImageResource:
+        return ResourceType::Image;
+    case CachedResource::Type::SVGFontResource:
+    case CachedResource::Type::FontResource:
+        return ResourceType::Font;
+#if ENABLE(XSLT)
+    case CachedResource::Type::XSLStyleSheet:
+#endif
+    case CachedResource::Type::CSSStyleSheet:
+        return ResourceType::StyleSheet;
+    case CachedResource::Type::JSON: // FIXME: Add ResourceType::JSON.
+    case CachedResource::Type::Script:
+        return ResourceType::Script;
+    case CachedResource::Type::MainResource:
+        return ResourceType::Document;
+    case CachedResource::Type::Beacon:
+        return ResourceType::Beacon;
+#if ENABLE(APPLICATION_MANIFEST)
+    case CachedResource::Type::ApplicationManifest:
+        return ResourceType::ApplicationManifest;
+#endif
+    case CachedResource::Type::Ping:
+        return ResourceType::Ping;
+    case CachedResource::Type::MediaResource:
+    case CachedResource::Type::Icon:
+    case CachedResource::Type::RawResource:
+    default:
+        return ResourceType::Other;
+    }
+}
+
+ResourceType inspectorResourceType(const CachedResource& cachedResource)
+{
+    if (cachedResource.type() == CachedResource::Type::MainResource && MIMETypeRegistry::isSupportedImageMIMEType(cachedResource.mimeType()))
+        return ResourceType::Image;
+
+    if (cachedResource.type() == CachedResource::Type::RawResource) {
+        switch (cachedResource.resourceRequest().requester()) {
+        case ResourceRequestRequester::Fetch:
+            return ResourceType::Fetch;
+        case ResourceRequestRequester::Main:
+            return ResourceType::Document;
+        case ResourceRequestRequester::EventSource:
+            return ResourceType::EventSource;
+        default:
+            return ResourceType::XHR;
+        }
+    }
+
+    return inspectorResourceType(cachedResource.type());
+}
+
+Inspector::Protocol::Page::ResourceType cachedResourceTypeToProtocol(const CachedResource& cachedResource)
+{
+    return resourceTypeToProtocol(inspectorResourceType(cachedResource));
+}
+
+LocalFrame* findFrameWithSecurityOrigin(Page& page, const String& originRawString)
+{
+    // FIXME: this frame tree traversal needs to be redesigned for Site Isolation.
+    for (Frame* frame = &page.mainFrame(); frame; frame = frame->tree().traverseNext()) {
+        auto* localFrame = dynamicDowncast<LocalFrame>(frame);
+        if (!localFrame)
+            continue;
+        if (localFrame->document()->securityOrigin().toRawString() == originRawString)
+            return localFrame;
+    }
+    return nullptr;
+}
+
+DocumentLoader* assertDocumentLoader(Inspector::Protocol::ErrorString& errorString, LocalFrame* frame)
+{
+    FrameLoader& frameLoader = frame->loader();
+    DocumentLoader* documentLoader = frameLoader.documentLoader();
+    if (!documentLoader)
+        errorString = "Missing document loader for given frame"_s;
+    return documentLoader;
+}
+
+bool shouldTreatAsText(const String& mimeType)
+{
+    return startsWithLettersIgnoringASCIICase(mimeType, "text/"_s)
+        || MIMETypeRegistry::isSupportedJavaScriptMIMEType(mimeType)
+        || MIMETypeRegistry::isSupportedJSONMIMEType(mimeType)
+        || MIMETypeRegistry::isXMLMIMEType(mimeType)
+        || MIMETypeRegistry::isTextMediaPlaylistMIMEType(mimeType);
+}
+
+Ref<TextResourceDecoder> createTextDecoder(const String& mimeType, const String& textEncodingName)
+{
+    if (!textEncodingName.isEmpty())
+        return TextResourceDecoder::create("text/plain"_s, textEncodingName);
+
+    if (MIMETypeRegistry::isTextMIMEType(mimeType))
+        return TextResourceDecoder::create(mimeType, "UTF-8"_s);
+
+    if (MIMETypeRegistry::isXMLMIMEType(mimeType)) {
+        auto decoder = TextResourceDecoder::create("application/xml"_s);
+        decoder->useLenientXMLDecoding();
+        return decoder;
+    }
+
+    return TextResourceDecoder::create("text/plain"_s, "UTF-8"_s);
+}
+
+std::optional<String> textContentForCachedResource(CachedResource& cachedResource)
+{
+    if (!shouldTreatAsText(cachedResource.mimeType()))
+        return std::nullopt;
+
+    String result;
+    bool base64Encoded;
+    if (cachedResourceContent(cachedResource, &result, &base64Encoded)) {
+        ASSERT(!base64Encoded);
+        return result;
+    }
+
+    return std::nullopt;
+}
+
+bool cachedResourceContent(CachedResource& resource, String* result, bool* base64Encoded)
+{
+    ASSERT(result);
+    ASSERT(base64Encoded);
+
+    if (!resource.encodedSize()) {
+        *base64Encoded = false;
+        *result = String();
+        return true;
+    }
+
+    switch (resource.type()) {
+    case CachedResource::Type::CSSStyleSheet:
+        *base64Encoded = false;
+        *result = downcast<CachedCSSStyleSheet>(resource).sheetText();
+        // The above can return a null String if the MIME type is invalid.
+        return !result->isNull();
+    case CachedResource::Type::JSON:
+    case CachedResource::Type::Script:
+        *base64Encoded = false;
+        *result = downcast<CachedScript>(resource).script().toString();
+        return true;
+    default:
+        auto* buffer = resource.resourceBuffer();
+        if (!buffer)
+            return false;
+
+        if (shouldTreatAsText(resource.mimeType())) {
+            auto decoder = createTextDecoder(resource.mimeType(), resource.response().textEncodingName());
+            *base64Encoded = false;
+            *result = decoder->decodeAndFlush(buffer->makeContiguous()->span());
+            return true;
+        }
+
+        *base64Encoded = true;
+        *result = base64EncodeToString(buffer->makeContiguous()->span());
+        return true;
+    }
+}
+
+} // namespace ResourceUtilities
+
+} // namespace Inspector

--- a/Source/WebCore/inspector/InspectorResourceUtilities.h
+++ b/Source/WebCore/inspector/InspectorResourceUtilities.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CachedResource.h" // for CachedResource::Type.
+#include <wtf/Forward.h>
+
+namespace WebCore {
+class DocumentLoader;
+class FragmentedSharedBuffer;
+class LocalFrame;
+class Page;
+class TextResourceDecoder;
+}
+
+namespace Inspector {
+namespace Protocol {
+}
+
+enum class ResourceType;
+
+namespace ResourceUtilities {
+
+bool sharedBufferContent(RefPtr<WebCore::FragmentedSharedBuffer>&&, const String& textEncodingName, bool withBase64Encode, String* result);
+Vector<WebCore::CachedResource*> cachedResourcesForFrame(WebCore::LocalFrame*);
+void resourceContent(Inspector::Protocol::ErrorString&, WebCore::LocalFrame*, const URL&, String* result, bool* base64Encoded);
+bool mainResourceContent(WebCore::LocalFrame*, bool withBase64Encode, String* result);
+
+String sourceMapURLForResource(WebCore::CachedResource*);
+WebCore::CachedResource* cachedResource(const WebCore::LocalFrame*, const URL&);
+Inspector::ResourceType inspectorResourceType(WebCore::CachedResource::Type);
+Inspector::ResourceType inspectorResourceType(const WebCore::CachedResource&);
+
+Inspector::Protocol::Page::ResourceType resourceTypeToProtocol(Inspector::ResourceType);
+Inspector::Protocol::Page::ResourceType cachedResourceTypeToProtocol(const WebCore::CachedResource&);
+WebCore::LocalFrame* findFrameWithSecurityOrigin(WebCore::Page&, const String& originRawString);
+WebCore::DocumentLoader* assertDocumentLoader(Inspector::Protocol::ErrorString&, WebCore::LocalFrame*);
+
+bool shouldTreatAsText(const String& mimeType);
+Ref<WebCore::TextResourceDecoder> createTextDecoder(const String& mimeType, const String& textEncodingName);
+std::optional<String> textContentForCachedResource(WebCore::CachedResource&);
+bool cachedResourceContent(WebCore::CachedResource&, String* result, bool* base64Encoded);
+
+} // namespace ResourceUtilities
+
+} // namespace Inspector

--- a/Source/WebCore/inspector/InspectorStyleSheet.cpp
+++ b/Source/WebCore/inspector/InspectorStyleSheet.cpp
@@ -60,6 +60,7 @@
 #include "InspectorCSSAgent.h"
 #include "InspectorDOMAgent.h"
 #include "InspectorPageAgent.h"
+#include "InspectorResourceUtilities.h"
 #include "MediaList.h"
 #include "Node.h"
 #include "SVGElementTypeHelpers.h"
@@ -1741,7 +1742,7 @@ bool InspectorStyleSheet::resourceStyleSheetText(String* result) const
 
     String error;
     bool base64Encoded;
-    InspectorPageAgent::resourceContent(error, ownerDocument()->frame(), URL({ }, m_pageStyleSheet->href()), result, &base64Encoded);
+    ResourceUtilities::resourceContent(error, ownerDocument()->frame(), URL({ }, m_pageStyleSheet->href()), result, &base64Encoded);
     return error.isEmpty() && !base64Encoded;
 }
 

--- a/Source/WebCore/inspector/InspectorStyleSheet.h
+++ b/Source/WebCore/inspector/InspectorStyleSheet.h
@@ -27,6 +27,7 @@
 
 #include "CSSPropertySourceData.h"
 #include "CSSStyleDeclaration.h"
+#include "Settings.h"
 #include <JavaScriptCore/InspectorProtocolObjects.h>
 #include <wtf/HashMap.h>
 #include <wtf/JSONValues.h>

--- a/Source/WebCore/inspector/InspectorThreadableLoaderClient.cpp
+++ b/Source/WebCore/inspector/InspectorThreadableLoaderClient.cpp
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "InspectorThreadableLoaderClient.h"
+
+#include "ThreadableLoader.h"
+
+namespace Inspector {
+
+using namespace WebCore;
+
+void InspectorThreadableLoaderClient::didReceiveResponse(ScriptExecutionContextIdentifier, std::optional<ResourceLoaderIdentifier>, const ResourceResponse& response)
+{
+    m_mimeType = response.mimeType();
+    m_statusCode = response.httpStatusCode();
+
+    // FIXME: This assumes text only responses. We should support non-text responses as well.
+    PAL::TextEncoding textEncoding(response.textEncodingName());
+    bool useDetector = false;
+    if (!textEncoding.isValid()) {
+        textEncoding = PAL::UTF8Encoding();
+        useDetector = true;
+    }
+
+    m_decoder = TextResourceDecoder::create("text/plain"_s, textEncoding, useDetector);
+}
+
+void InspectorThreadableLoaderClient::didReceiveData(const SharedBuffer& buffer)
+{
+    if (buffer.isEmpty())
+        return;
+
+    m_responseText.append(m_decoder->decode(buffer.span()));
+}
+
+void InspectorThreadableLoaderClient::didFinishLoading(ScriptExecutionContextIdentifier, std::optional<ResourceLoaderIdentifier>, const NetworkLoadMetrics&)
+{
+    if (m_decoder)
+        m_responseText.append(m_decoder->flush());
+
+    m_callback->sendSuccess(m_responseText.toString(), m_mimeType, m_statusCode);
+    dispose();
+}
+
+void InspectorThreadableLoaderClient::didFail(std::optional<ScriptExecutionContextIdentifier>, const ResourceError& error)
+{
+    m_callback->sendFailure(error.isAccessControl() ? "Loading resource for inspector failed access control check"_s : "Loading resource for inspector failed"_s);
+    dispose();
+}
+
+void InspectorThreadableLoaderClient::setLoader(RefPtr<ThreadableLoader>&& loader)
+{
+    m_loader = WTFMove(loader);
+}
+
+void InspectorThreadableLoaderClient::dispose()
+{
+    m_loader = nullptr;
+    delete this;
+}
+
+} // namespace Inspector

--- a/Source/WebCore/inspector/InspectorThreadableLoaderClient.h
+++ b/Source/WebCore/inspector/InspectorThreadableLoaderClient.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ThreadableLoaderClient.h"
+#include <JavaScriptCore/InspectorBackendDispatchers.h> // for LoadResourceCallback.
+#include <wtf/Forward.h>
+
+// FIXME: remove dependency on legacy callbacks in InspectorThreadableLoaderClient.
+using LoadResourceCallback = Inspector::NetworkBackendDispatcherHandler::LoadResourceCallback;
+
+namespace WebCore {
+class TextResourceDecoder;
+class ThreadableLoader;
+}
+
+namespace Inspector {
+
+class InspectorThreadableLoaderClient final : public WebCore::ThreadableLoaderClient {
+    WTF_MAKE_NONCOPYABLE(InspectorThreadableLoaderClient);
+    WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(InspectorThreadableLoaderClient, Loader);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(InspectorThreadableLoaderClient);
+public:
+    InspectorThreadableLoaderClient(RefPtr<LoadResourceCallback>&& callback)
+        : m_callback(WTFMove(callback))
+    {
+    }
+
+    ~InspectorThreadableLoaderClient() override = default;
+
+    void didReceiveResponse(WebCore::ScriptExecutionContextIdentifier, std::optional<WebCore::ResourceLoaderIdentifier>, const WebCore::ResourceResponse&) override;
+    void didReceiveData(const WebCore::SharedBuffer&) override;
+    void didFinishLoading(WebCore::ScriptExecutionContextIdentifier, std::optional<WebCore::ResourceLoaderIdentifier>, const WebCore::NetworkLoadMetrics&) override;
+    void didFail(std::optional<WebCore::ScriptExecutionContextIdentifier>, const WebCore::ResourceError&) override;
+    void setLoader(RefPtr<WebCore::ThreadableLoader>&&);
+private:
+    void dispose();
+
+    RefPtr<LoadResourceCallback> m_callback;
+    RefPtr<WebCore::ThreadableLoader> m_loader;
+    RefPtr<WebCore::TextResourceDecoder> m_decoder;
+    String m_mimeType;
+    StringBuilder m_responseText;
+    int m_statusCode;
+};
+
+} // namespace Inspector

--- a/Source/WebCore/inspector/NetworkResourcesData.cpp
+++ b/Source/WebCore/inspector/NetworkResourcesData.cpp
@@ -31,6 +31,7 @@
 #include "NetworkResourcesData.h"
 
 #include "CachedResource.h"
+#include "CertificateInfo.h"
 #include "InspectorNetworkAgent.h"
 #include "ResourceResponse.h"
 #include "TextResourceDecoder.h"
@@ -123,7 +124,7 @@ NetworkResourcesData::~NetworkResourcesData()
     clear();
 }
 
-void NetworkResourcesData::resourceCreated(const String& requestId, const String& loaderId, InspectorPageAgent::ResourceType type)
+void NetworkResourcesData::resourceCreated(const String& requestId, const String& loaderId, Inspector::ResourceType type)
 {
     ensureNoDataForRequestId(requestId);
 
@@ -141,7 +142,7 @@ void NetworkResourcesData::resourceCreated(const String& requestId, const String
     m_requestIdToResourceDataMap.set(requestId, WTFMove(resourceData));
 }
 
-void NetworkResourcesData::responseReceived(const String& requestId, const String& frameId, const ResourceResponse& response, InspectorPageAgent::ResourceType type, bool forceBufferData)
+void NetworkResourcesData::responseReceived(const String& requestId, const String& frameId, const ResourceResponse& response, Inspector::ResourceType type, bool forceBufferData)
 {
     ResourceData* resourceData = resourceDataForRequestId(requestId);
     if (!resourceData)
@@ -156,8 +157,8 @@ void NetworkResourcesData::responseReceived(const String& requestId, const Strin
     resourceData->setMIMEType(response.mimeType());
     resourceData->setResponseTimestamp(WallTime::now());
 
-    if (InspectorNetworkAgent::shouldTreatAsText(response.mimeType()))
-        resourceData->setDecoder(InspectorNetworkAgent::createTextDecoder(response.mimeType(), response.textEncodingName()));
+    if (ResourceUtilities::shouldTreatAsText(response.mimeType()))
+        resourceData->setDecoder(ResourceUtilities::createTextDecoder(response.mimeType(), response.textEncodingName()));
 
     if (m_settings.supportsShowingCertificate) {
         if (auto& certificateInfo = response.certificateInfo())
@@ -165,7 +166,7 @@ void NetworkResourcesData::responseReceived(const String& requestId, const Strin
     }
 }
 
-void NetworkResourcesData::setResourceType(const String& requestId, InspectorPageAgent::ResourceType type)
+void NetworkResourcesData::setResourceType(const String& requestId, Inspector::ResourceType type)
 {
     ResourceData* resourceData = resourceDataForRequestId(requestId);
     if (!resourceData)
@@ -173,11 +174,11 @@ void NetworkResourcesData::setResourceType(const String& requestId, InspectorPag
     resourceData->setType(type);
 }
 
-InspectorPageAgent::ResourceType NetworkResourcesData::resourceType(const String& requestId)
+Inspector::ResourceType NetworkResourcesData::resourceType(const String& requestId)
 {
     ResourceData* resourceData = resourceDataForRequestId(requestId);
     if (!resourceData)
-        return InspectorPageAgent::OtherResource;
+        return ResourceType::Other;
     return resourceData->type();
 }
 

--- a/Source/WebCore/inspector/NetworkResourcesData.h
+++ b/Source/WebCore/inspector/NetworkResourcesData.h
@@ -29,7 +29,7 @@
 
 #pragma once
 
-#include "InspectorPageAgent.h"
+#include "InspectorResourceType.h"
 #include "SharedBuffer.h"
 #include "TextResourceDecoder.h"
 #include <wtf/ListHashSet.h>
@@ -39,8 +39,8 @@
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
-
 class CachedResource;
+class CertificateInfo;
 class ResourceResponse;
 
 class NetworkResourcesData {
@@ -71,8 +71,8 @@ public:
         unsigned evictContent();
         bool isContentEvicted() const { return m_isContentEvicted; }
 
-        InspectorPageAgent::ResourceType type() const { return m_type; }
-        void setType(InspectorPageAgent::ResourceType type) { m_type = type; }
+        Inspector::ResourceType type() const { return m_type; }
+        void setType(Inspector::ResourceType type) { m_type = type; }
 
         int httpStatusCode() const { return m_httpStatusCode; }
         void setHTTPStatusCode(int httpStatusCode) { m_httpStatusCode = httpStatusCode; }
@@ -124,7 +124,7 @@ public:
         RefPtr<FragmentedSharedBuffer> m_buffer;
         std::optional<CertificateInfo> m_certificateInfo;
         CachedResource* m_cachedResource { nullptr };
-        InspectorPageAgent::ResourceType m_type { InspectorPageAgent::OtherResource };
+        Inspector::ResourceType m_type { Inspector::ResourceType::Other };
         int m_httpStatusCode { 0 };
         String m_httpStatusText;
         bool m_isContentEvicted { false };
@@ -146,11 +146,11 @@ public:
     NetworkResourcesData(const Settings&);
     ~NetworkResourcesData();
 
-    void resourceCreated(const String& requestId, const String& loaderId, InspectorPageAgent::ResourceType);
+    void resourceCreated(const String& requestId, const String& loaderId, Inspector::ResourceType);
     void resourceCreated(const String& requestId, const String& loaderId, CachedResource&);
-    void responseReceived(const String& requestId, const String& frameId, const ResourceResponse&, InspectorPageAgent::ResourceType, bool forceBufferData);
-    void setResourceType(const String& requestId, InspectorPageAgent::ResourceType);
-    InspectorPageAgent::ResourceType resourceType(const String& requestId);
+    void responseReceived(const String& requestId, const String& frameId, const ResourceResponse&, Inspector::ResourceType, bool forceBufferData);
+    void setResourceType(const String& requestId, Inspector::ResourceType);
+    Inspector::ResourceType resourceType(const String& requestId);
     void setResourceContent(const String& requestId, const String& content, bool base64Encoded = false);
     ResourceData const* maybeAddResourceData(const String& requestId, const SharedBuffer&);
     void maybeDecodeDataToContent(const String& requestId);

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.h
@@ -34,6 +34,7 @@
 #include "InspectorWebAgentBase.h"
 #include "Timer.h"
 #include <JavaScriptCore/Breakpoint.h>
+#include <JavaScriptCore/InjectedScriptManager.h>
 #include <JavaScriptCore/InspectorBackendDispatchers.h>
 #include <JavaScriptCore/InspectorFrontendDispatchers.h>
 #include <wtf/CheckedPtr.h>

--- a/Source/WebCore/inspector/agents/InspectorDOMStorageAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMStorageAgent.cpp
@@ -34,7 +34,7 @@
 #include "DOMException.h"
 #include "Database.h"
 #include "Document.h"
-#include "InspectorPageAgent.h"
+#include "InspectorResourceUtilities.h"
 #include "InstrumentingAgents.h"
 #include "LocalDOMWindow.h"
 #include "LocalFrame.h"
@@ -213,7 +213,7 @@ RefPtr<StorageArea> InspectorDOMStorageAgent::findStorageArea(Inspector::Protoco
         return nullptr;
     }
 
-    targetFrame = InspectorPageAgent::findFrameWithSecurityOrigin(m_inspectedPage, securityOrigin);
+    targetFrame = ResourceUtilities::findFrameWithSecurityOrigin(m_inspectedPage, securityOrigin);
     if (!targetFrame) {
         errorString = "Missing frame for given securityOrigin"_s;
         return nullptr;

--- a/Source/WebCore/inspector/agents/InspectorIndexedDBAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorIndexedDBAgent.cpp
@@ -53,7 +53,7 @@
 #include "IDBOpenDBRequest.h"
 #include "IDBRequest.h"
 #include "IDBTransaction.h"
-#include "InspectorPageAgent.h"
+#include "InspectorResourceUtilities.h"
 #include "InstrumentingAgents.h"
 #include "JSDOMWindowCustom.h"
 #include "LocalDOMWindow.h"
@@ -582,7 +582,7 @@ static bool getDocumentAndIDBFactoryFromFrameOrSendFailure(LocalFrame* frame, Do
     
 void InspectorIndexedDBAgent::requestDatabaseNames(const String& securityOrigin, Ref<RequestDatabaseNamesCallback>&& callback)
 {
-    RefPtr frame = InspectorPageAgent::findFrameWithSecurityOrigin(protectedInspectedPage(), securityOrigin);
+    RefPtr frame = ResourceUtilities::findFrameWithSecurityOrigin(protectedInspectedPage(), securityOrigin);
     Document* document;
     IDBFactory* idbFactory;
     if (!getDocumentAndIDBFactoryFromFrameOrSendFailure(frame.get(), document, idbFactory, callback))
@@ -602,7 +602,7 @@ void InspectorIndexedDBAgent::requestDatabaseNames(const String& securityOrigin,
 
 void InspectorIndexedDBAgent::requestDatabase(const String& securityOrigin, const String& databaseName, Ref<RequestDatabaseCallback>&& callback)
 {
-    RefPtr frame = InspectorPageAgent::findFrameWithSecurityOrigin(protectedInspectedPage(), securityOrigin);
+    RefPtr frame = ResourceUtilities::findFrameWithSecurityOrigin(protectedInspectedPage(), securityOrigin);
     Document* document;
     IDBFactory* idbFactory;
     if (!getDocumentAndIDBFactoryFromFrameOrSendFailure(frame.get(), document, idbFactory, callback))
@@ -614,7 +614,7 @@ void InspectorIndexedDBAgent::requestDatabase(const String& securityOrigin, cons
 
 void InspectorIndexedDBAgent::requestData(const String& securityOrigin, const String& databaseName, const String& objectStoreName, const String& indexName, int skipCount, int pageSize, RefPtr<JSON::Object>&& keyRange, Ref<RequestDataCallback>&& callback)
 {
-    RefPtr frame = InspectorPageAgent::findFrameWithSecurityOrigin(protectedInspectedPage(), securityOrigin);
+    RefPtr frame = ResourceUtilities::findFrameWithSecurityOrigin(protectedInspectedPage(), securityOrigin);
     Document* document;
     IDBFactory* idbFactory;
     if (!getDocumentAndIDBFactoryFromFrameOrSendFailure(frame.get(), document, idbFactory, callback))
@@ -719,7 +719,7 @@ private:
 
 void InspectorIndexedDBAgent::clearObjectStore(const String& securityOrigin, const String& databaseName, const String& objectStoreName, Ref<ClearObjectStoreCallback>&& callback)
 {
-    RefPtr frame = InspectorPageAgent::findFrameWithSecurityOrigin(protectedInspectedPage(), securityOrigin);
+    RefPtr frame = ResourceUtilities::findFrameWithSecurityOrigin(protectedInspectedPage(), securityOrigin);
     Document* document;
     IDBFactory* idbFactory;
     if (!getDocumentAndIDBFactoryFromFrameOrSendFailure(frame.get(), document, idbFactory, callback))

--- a/Source/WebCore/inspector/agents/InspectorPageAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorPageAgent.h
@@ -44,6 +44,10 @@
 #include <wtf/WeakRef.h>
 #include <wtf/text/WTFString.h>
 
+namespace Inspector {
+enum class ResourceType;
+}
+
 namespace WebCore {
 
 class DOMWrapperWorld;
@@ -62,36 +66,6 @@ class InspectorPageAgent final : public InspectorAgentBase, public Inspector::Pa
 public:
     InspectorPageAgent(PageAgentContext&, InspectorBackendClient*, InspectorOverlay&);
     ~InspectorPageAgent();
-
-    enum ResourceType {
-        DocumentResource,
-        StyleSheetResource,
-        ImageResource,
-        FontResource,
-        ScriptResource,
-        XHRResource,
-        FetchResource,
-        PingResource,
-        BeaconResource,
-        WebSocketResource,
-#if ENABLE(APPLICATION_MANIFEST)
-        ApplicationManifestResource,
-#endif
-        EventSourceResource,
-        OtherResource,
-    };
-
-    static bool sharedBufferContent(RefPtr<FragmentedSharedBuffer>&&, const String& textEncodingName, bool withBase64Encode, String* result);
-    static Vector<CachedResource*> cachedResourcesForFrame(LocalFrame*);
-    static void resourceContent(Inspector::Protocol::ErrorString&, LocalFrame*, const URL&, String* result, bool* base64Encoded);
-    static String sourceMapURLForResource(CachedResource*);
-    static CachedResource* cachedResource(const LocalFrame*, const URL&);
-    static Inspector::Protocol::Page::ResourceType resourceTypeJSON(ResourceType);
-    static ResourceType inspectorResourceType(CachedResource::Type);
-    static ResourceType inspectorResourceType(const CachedResource&);
-    static Inspector::Protocol::Page::ResourceType cachedResourceTypeJSON(const CachedResource&);
-    static LocalFrame* findFrameWithSecurityOrigin(Page&, const String& originRawString);
-    static DocumentLoader* assertDocumentLoader(Inspector::Protocol::ErrorString&, LocalFrame*);
 
     // InspectorAgentBase
     void didCreateFrontendAndBackend();
@@ -155,9 +129,6 @@ private:
     double timestamp();
 
     Ref<InspectorOverlay> protectedOverlay() const;
-
-    static bool mainResourceContent(LocalFrame*, bool withBase64Encode, String* result);
-    static bool dataContent(std::span<const uint8_t> data, const String& textEncodingName, bool withBase64Encode, String* result);
 
     void overridePrefersReducedMotion(std::optional<Inspector::Protocol::Page::UserPreferenceValue>&&);
     void overridePrefersContrast(std::optional<Inspector::Protocol::Page::UserPreferenceValue>&&);

--- a/Source/WebCore/inspector/agents/page/PageDebuggerAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageDebuggerAgent.cpp
@@ -36,7 +36,7 @@
 #include "DOMWrapperWorld.h"
 #include "Document.h"
 #include "FrameConsoleClient.h"
-#include "InspectorPageAgent.h"
+#include "InspectorResourceUtilities.h"
 #include "InstrumentingAgents.h"
 #include "JSDOMWindowCustom.h"
 #include "JSExecState.h"
@@ -105,7 +105,7 @@ String PageDebuggerAgent::sourceMapURLForScript(const JSC::Debugger::Script& scr
         if (!localMainFrame)
             return String();
 
-        CachedResource* resource = InspectorPageAgent::cachedResource(localMainFrame.get(), URL({ }, script.url));
+        CachedResource* resource = ResourceUtilities::cachedResource(localMainFrame.get(), URL({ }, script.url));
         if (resource) {
             String sourceMapHeader = resource->response().httpHeaderField(StringView { sourceMapHTTPHeader });
             if (!sourceMapHeader.isEmpty())


### PR DESCRIPTION
#### 680ba7115028f728b2ffb3c00fb615dfc6805ffa
<pre>
Web Inspector: reduce amount of shared code in InspectorNetworkAgent and InspectorPageAgent
<a href="https://bugs.webkit.org/show_bug.cgi?id=300051">https://bugs.webkit.org/show_bug.cgi?id=300051</a>

Reviewed by Devin Rousso.

In preparation for Site Isolation refactorings in these agents, move static helper
functions, nested classes, and other shared code out of the agent files where possible.
Method implementations have been left alone for now. Many of them need to be improved
in order to pass SaferCPP checks; this work is tracked by <a href="https://webkit.org/b/300125.">https://webkit.org/b/300125.</a>

For site isolation, we will need to coordinate the intercept structs between UIProcess
and web content processes. The same infrastructure will be used to implement network
interception for WebDriver Bidi. So it moves now, despite being used from only NetworkAgent.

* Source/JavaScriptCore/inspector/ContentSearchUtilities.h:
* Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/inspector/InspectorAuditResourcesObject.cpp:
(WebCore::InspectorAuditResourcesObject::getResources):
(WebCore::InspectorAuditResourcesObject::getResourceContent):
* Source/WebCore/inspector/InspectorNetworkIntercept.cpp: Added.
(Inspector::Intercept::matches):
* Source/WebCore/inspector/InspectorNetworkIntercept.h: Added.
(Inspector::Intercept::operator== const):
(Inspector::PendingInterceptRequest::PendingInterceptRequest):
(Inspector::PendingInterceptRequest::continueWithOriginalRequest):
(Inspector::PendingInterceptRequest::continueWithRequest):
(Inspector::PendingInterceptResponse::PendingInterceptResponse):
(Inspector::PendingInterceptResponse::~PendingInterceptResponse):
(Inspector::PendingInterceptResponse::originalResponse):
(Inspector::PendingInterceptResponse::respondWithOriginalResponse):
(Inspector::PendingInterceptResponse::respond):
* Source/WebCore/inspector/InspectorResourceType.h: Added.
* Source/WebCore/inspector/InspectorResourceUtilities.cpp: Added.
(Inspector::ResourceUtilities::resourceTypeToProtocol):
(Inspector::ResourceUtilities::decodeBuffer):
(Inspector::ResourceUtilities::dataContent):
(Inspector::ResourceUtilities::sharedBufferContent):
(Inspector::ResourceUtilities::mainResourceContent):
(Inspector::ResourceUtilities::resourceContent):
(Inspector::ResourceUtilities::sourceMapURLForResource):
(Inspector::ResourceUtilities::cachedResource):
(Inspector::ResourceUtilities::inspectorResourceType):
(Inspector::ResourceUtilities::cachedResourceTypeToProtocol):
(Inspector::ResourceUtilities::findFrameWithSecurityOrigin):
(Inspector::ResourceUtilities::assertDocumentLoader):
(Inspector::ResourceUtilities::shouldTreatAsText):
(Inspector::ResourceUtilities::createTextDecoder):
(Inspector::ResourceUtilities::textContentForCachedResource):
(Inspector::ResourceUtilities::cachedResourceContent):
* Source/WebCore/inspector/InspectorResourceUtilities.h: Added.
* Source/WebCore/inspector/InspectorStyleSheet.cpp:
(WebCore::InspectorStyleSheet::resourceStyleSheetText const):
* Source/WebCore/inspector/InspectorThreadableLoaderClient.cpp: Added.
(Inspector::InspectorThreadableLoaderClient::didReceiveResponse):
(Inspector::InspectorThreadableLoaderClient::didReceiveData):
(Inspector::InspectorThreadableLoaderClient::didFinishLoading):
(Inspector::InspectorThreadableLoaderClient::didFail):
(Inspector::InspectorThreadableLoaderClient::setLoader):
(Inspector::InspectorThreadableLoaderClient::dispose):
* Source/WebCore/inspector/InspectorThreadableLoaderClient.h: Added.
* Source/WebCore/inspector/NetworkResourcesData.cpp:
(WebCore::NetworkResourcesData::resourceCreated):
(WebCore::NetworkResourcesData::responseReceived):
(WebCore::NetworkResourcesData::setResourceType):
(WebCore::NetworkResourcesData::resourceType):
* Source/WebCore/inspector/NetworkResourcesData.h:
(WebCore::NetworkResourcesData::ResourceData::type const):
(WebCore::NetworkResourcesData::ResourceData::setType):
* Source/WebCore/inspector/agents/InspectorDOMAgent.h:
* Source/WebCore/inspector/agents/InspectorDOMStorageAgent.cpp:
(WebCore::InspectorDOMStorageAgent::findStorageArea):
* Source/WebCore/inspector/agents/InspectorIndexedDBAgent.cpp:
(WebCore::InspectorIndexedDBAgent::requestDatabaseNames):
(WebCore::InspectorIndexedDBAgent::requestDatabase):
(WebCore::InspectorIndexedDBAgent::requestData):
(WebCore::InspectorIndexedDBAgent::clearObjectStore):
* Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp:
(WebCore::InspectorNetworkAgent::buildObjectForCachedResource):
(WebCore::InspectorNetworkAgent::willSendRequest):
(WebCore::resourceTypeForCachedResource):
(WebCore::resourceTypeForLoadType):
(WebCore::InspectorNetworkAgent::didReceiveResponse):
(WebCore::InspectorNetworkAgent::didFinishLoading):
(WebCore::InspectorNetworkAgent::didFailLoading):
(WebCore::InspectorNetworkAgent::didReceiveScriptResponse):
(WebCore::InspectorNetworkAgent::didReceiveThreadableLoaderResponse):
(WebCore::InspectorNetworkAgent::willDestroyCachedResource):
(WebCore::networkStageFromProtocol):
(WebCore::InspectorNetworkAgent::shouldIntercept):
(WebCore::InspectorNetworkAgent::getResponseBody):
(WebCore::InspectorNetworkAgent::addInterception):
(WebCore::InspectorNetworkAgent::removeInterception):
(WebCore::textContentForResourceData):
(WebCore::InspectorNetworkAgent::shouldTreatAsText): Deleted.
(WebCore::InspectorNetworkAgent::createTextDecoder): Deleted.
(WebCore::InspectorNetworkAgent::textContentForCachedResource): Deleted.
(WebCore::InspectorNetworkAgent::cachedResourceContent): Deleted.
(WebCore::InspectorNetworkAgent::Intercept::matches): Deleted.
* Source/WebCore/inspector/agents/InspectorNetworkAgent.h:
(WebCore::InspectorNetworkAgent::PendingInterceptRequest::PendingInterceptRequest): Deleted.
(WebCore::InspectorNetworkAgent::PendingInterceptRequest::continueWithOriginalRequest): Deleted.
(WebCore::InspectorNetworkAgent::PendingInterceptRequest::continueWithRequest): Deleted.
(WebCore::InspectorNetworkAgent::PendingInterceptResponse::PendingInterceptResponse): Deleted.
(WebCore::InspectorNetworkAgent::PendingInterceptResponse::~PendingInterceptResponse): Deleted.
(WebCore::InspectorNetworkAgent::PendingInterceptResponse::originalResponse): Deleted.
(WebCore::InspectorNetworkAgent::PendingInterceptResponse::respondWithOriginalResponse): Deleted.
(WebCore::InspectorNetworkAgent::PendingInterceptResponse::respond): Deleted.
(WebCore::InspectorNetworkAgent::Intercept::operator== const): Deleted.
* Source/WebCore/inspector/agents/InspectorPageAgent.cpp:
(WebCore::allResourcesURLsForFrame):
(WebCore::InspectorPageAgent::getResourceContent):
(WebCore::InspectorPageAgent::searchInResource):
(WebCore::InspectorPageAgent::searchInResources):
(WebCore::InspectorPageAgent::buildObjectForFrameTree):
(WebCore::decodeBuffer): Deleted.
(WebCore::InspectorPageAgent::mainResourceContent): Deleted.
(WebCore::InspectorPageAgent::sharedBufferContent): Deleted.
(WebCore::InspectorPageAgent::dataContent): Deleted.
(): Deleted.
(WebCore::InspectorPageAgent::resourceContent): Deleted.
(WebCore::InspectorPageAgent::sourceMapURLForResource): Deleted.
(WebCore::InspectorPageAgent::cachedResource): Deleted.
(WebCore::InspectorPageAgent::resourceTypeJSON): Deleted.
(WebCore::InspectorPageAgent::inspectorResourceType): Deleted.
(WebCore::InspectorPageAgent::cachedResourceTypeJSON): Deleted.
(WebCore::InspectorPageAgent::findFrameWithSecurityOrigin): Deleted.
(WebCore::InspectorPageAgent::assertDocumentLoader): Deleted.
* Source/WebCore/inspector/agents/InspectorPageAgent.h:
* Source/WebCore/inspector/agents/page/PageDebuggerAgent.cpp:
(WebCore::PageDebuggerAgent::sourceMapURLForScript):

Canonical link: <a href="https://commits.webkit.org/301444@main">https://commits.webkit.org/301444@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f5b3ca125393a3b979f7cdbeff0712eafdbdd797

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126029 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45683 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36459 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/132860 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/77851 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cf442197-57a7-4db9-90cb-8cbca25257ba) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127900 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46352 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54229 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/132860 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/77851 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9e13902c-b078-4272-b5b0-c00fca460c4a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128977 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37083 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112704 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/132860 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9606c749-2d36-4203-8d42-f410b66a7651) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/35991 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/30890 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/76331 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/118098 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106864 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31105 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135556 "Built successfully") | | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/124535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52789 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40521 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/104470 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53243 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108918 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/104190 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26534 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49582 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27912 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/50168 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52685 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58516 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/157546 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/52022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39443 "Passed tests") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/55369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53724 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->