### PR TITLE
Strip StoragePartition from cookies returned by WKHTTPCookieStore API

### DIFF
--- a/Source/WebKit/Configurations/AllowedSPI.toml
+++ b/Source/WebKit/Configurations/AllowedSPI.toml
@@ -115,6 +115,14 @@ selectors = [
 ]
 requires = ["ENABLE_OPT_IN_PARTITIONED_COOKIES"]
 
+[[temporary-usage]]
+request = "rdar://157886016"
+cleanup = "rdar://157886056"
+selectors = [
+    { name = "_storagePartition", class = "NSHTTPCookie" },
+]
+requires = ["ENABLE_OPT_IN_PARTITIONED_COOKIES"]
+
 [[equivalent-api]]
 request = "rdar://157885997"
 selectors = [

--- a/Source/WebKit/UIProcess/API/APIHTTPCookieStore.cpp
+++ b/Source/WebKit/UIProcess/API/APIHTTPCookieStore.cpp
@@ -186,6 +186,15 @@ void HTTPCookieStore::unregisterObserver(HTTPCookieStoreObserver& observer)
         networkProcess->send(Messages::WebCookieManager::StopObservingCookieChanges(m_sessionID), 0);
 }
 
+bool HTTPCookieStore::isOptInCookiePartitioningEnabled() const
+{
+#if ENABLE(OPT_IN_PARTITIONED_COOKIES)
+    if (RefPtr dataStore = m_owningDataStore.get())
+        return dataStore->isOptInCookiePartitioningEnabled();
+#endif
+    return false;
+}
+
 void HTTPCookieStore::cookiesDidChange()
 {
     for (Ref observer : m_observers)

--- a/Source/WebKit/UIProcess/API/APIHTTPCookieStore.h
+++ b/Source/WebKit/UIProcess/API/APIHTTPCookieStore.h
@@ -85,6 +85,8 @@ public:
 
     void filterAppBoundCookies(Vector<WebCore::Cookie>&&, CompletionHandler<void(Vector<WebCore::Cookie>&&)>&&);
 
+    bool isOptInCookiePartitioningEnabled() const;
+
 #if USE(SOUP)
     void replaceCookies(Vector<WebCore::Cookie>&&, CompletionHandler<void()>&&);
     void getAllCookies(CompletionHandler<void(const Vector<WebCore::Cookie>&)>&&);


### PR DESCRIPTION
#### 38021f3656b229039212e174f4a44d997c3a9c06
<pre>
Strip StoragePartition from cookies returned by WKHTTPCookieStore API
<a href="https://rdar.apple.com/147233516">rdar://147233516</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=292351">https://bugs.webkit.org/show_bug.cgi?id=292351</a>

Reviewed by Alex Christensen.

The WKHTTPCookieStore API returns a NSHTTPCookie. When opt-in partitioned
cookies is enabled, a partitioned cookie can be set in either of a first or
third party context. As such, when a first party cookie is &quot;partitioned&quot;, its
NSHTTPCookie will contain the &quot;StoragePartition&quot; property.  This is internal
state that does not need to be exposed to an application that uses the
WKHTTPCookieStore API, and it can cause breakage in some situations.

This change clears the cookie property before the cookie is returned to the
application when the WKHTTPCookieStore API is used.

Adds a new API test.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/WKHTTPCookieStore.mm

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/WKHTTPCookieStore.mm
* Source/WebKit/Configurations/AllowedSPI.toml:
* Source/WebKit/UIProcess/API/APIHTTPCookieStore.cpp:
(API::HTTPCookieStore::isOptInCookiePartitioningEnabled const):
* Source/WebKit/UIProcess/API/APIHTTPCookieStore.h:
* Source/WebKit/UIProcess/API/Cocoa/WKHTTPCookieStore.mm:
(clearCookiePartitionPropertyIfNeeded):
(-[WKHTTPCookieStore getAllCookies:]):
(-[WKHTTPCookieStore _getCookiesForURL:completionHandler:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKHTTPCookieStore.mm:
(TEST(WKHTTPCookieStore, PartitionedCookieShouldNotHavePartitionProperty)):

Canonical link: <a href="https://commits.webkit.org/300947@main">https://commits.webkit.org/300947@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3dbc0bde9042670ae61bdd63301da31d317f8e1d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124271 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43957 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34681 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131107 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76343 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/126148 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44700 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52559 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94530 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62713 "") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127225 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35628 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111156 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75118 "Found 1 new API test failure: WPE/TestWebKitWebContext:/webkit/WebKitWebContext/no-web-process-leak (failure)") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34572 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29315 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74588 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105372 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29537 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133778 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51184 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39023 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103003 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51575 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107372 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102803 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26195 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48166 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26420 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48124 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51046 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56828 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50485 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53841 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52160 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->