### PR TITLE
[JSC] WASM IPInt SIMD: support GC types with v128 fields/elements

### DIFF
--- a/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
@@ -3312,8 +3312,9 @@ end)
 ipintOp(_struct_get, macro()
     popQuad(a1)  # object
     loadi IPInt::StructGetSetMetadata::fieldIndex[MC], a2  # field index
-    operationCallMayThrow(macro() cCall3(_ipint_extern_struct_get) end)
-    pushQuad(r0)
+    subp StackValueSize, sp  # allocate space for result
+    move sp, a3  # result location
+    operationCallMayThrow(macro() cCall4(_ipint_extern_struct_get) end)
 
     loadb IPInt::StructGetSetMetadata::length[MC], t0
     advancePCByReg(t0)
@@ -3324,8 +3325,9 @@ end)
 ipintOp(_struct_get_s, macro()
     popQuad(a1)  # object
     loadi IPInt::StructGetSetMetadata::fieldIndex[MC], a2  # field index
-    operationCallMayThrow(macro() cCall3(_ipint_extern_struct_get_s) end)
-    pushQuad(r0)
+    subp StackValueSize, sp  # allocate space for result
+    move sp, a3  # result location
+    operationCallMayThrow(macro() cCall4(_ipint_extern_struct_get_s) end)
 
     loadb IPInt::StructGetSetMetadata::length[MC], t0
     advancePCByReg(t0)
@@ -3336,8 +3338,9 @@ end)
 ipintOp(_struct_get_u, macro()
     popQuad(a1)  # object
     loadi IPInt::StructGetSetMetadata::fieldIndex[MC], a2  # field index
-    operationCallMayThrow(macro() cCall3(_ipint_extern_struct_get) end)
-    pushQuad(r0)
+    subp StackValueSize, sp  # allocate space for result
+    move sp, a3  # result location
+    operationCallMayThrow(macro() cCall4(_ipint_extern_struct_get) end)
 
     loadb IPInt::StructGetSetMetadata::length[MC], t0
     advancePCByReg(t0)
@@ -3360,9 +3363,10 @@ end)
 
 ipintOp(_array_new, macro()
     loadi IPInt::ArrayNewMetadata::type[MC], a1  # type
-    popInt32(a3, t0)  # length
-    popQuad(a2)  # default value
+    popInt32(a2, t0)  # length
+    move sp, a3  # pointer to default value
     operationCallMayThrow(macro() cCall4(_ipint_extern_array_new) end)
+    addp StackValueSize, sp # pop default value
 
     pushQuad(r0)
 
@@ -3436,9 +3440,9 @@ ipintOp(_array_get, macro()
     loadi IPInt::ArrayGetSetMetadata::type[MC], a1  # type
     popInt32(a3, a0)  # index
     popQuad(a2)  # array
+    subp StackValueSize, sp  # allocate space for result
+    move sp, a4  # result location
     operationCallMayThrow(macro() cCall4(_ipint_extern_array_get) end)
-
-    pushQuad(r0)
 
     loadb IPInt::ArrayGetSetMetadata::length[MC], t0
     advancePCByReg(t0)
@@ -3450,9 +3454,9 @@ ipintOp(_array_get_s, macro()
     loadi IPInt::ArrayGetSetMetadata::type[MC], a1  # type
     popInt32(a3, a0)  # index
     popQuad(a2)  # array
+    subp StackValueSize, sp  # allocate space for result
+    move sp, a4  # result location
     operationCallMayThrow(macro() cCall4(_ipint_extern_array_get_s) end)
-
-    pushQuad(r0)
 
     loadb IPInt::ArrayGetSetMetadata::length[MC], t0
     advancePCByReg(t0)
@@ -3464,9 +3468,10 @@ ipintOp(_array_get_u, macro()
     loadi IPInt::ArrayGetSetMetadata::type[MC], a1  # type
     popInt32(a3, a0)  # index
     popQuad(a2)  # array
-    operationCallMayThrow(macro() cCall4(_ipint_extern_array_get) end)
+    subp StackValueSize, sp  # allocate space for result
+    move sp, a4  # result location
 
-    pushQuad(r0)
+    operationCallMayThrow(macro() cCall4(_ipint_extern_array_get) end)
 
     loadb IPInt::ArrayGetSetMetadata::length[MC], t0
     advancePCByReg(t0)

--- a/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.h
+++ b/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.h
@@ -100,17 +100,17 @@ WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(table_size, int32_t);
 // Wasm-GC
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(struct_new, uint32_t, IPIntStackEntry* sp);
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(struct_new_default, uint32_t);
-WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(struct_get, EncodedJSValue, uint32_t);
-WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(struct_get_s, EncodedJSValue, uint32_t);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(struct_get, EncodedJSValue, uint32_t, IPIntStackEntry*);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(struct_get_s, EncodedJSValue, uint32_t, IPIntStackEntry*);
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(struct_set, EncodedJSValue, uint32_t, IPIntStackEntry*);
 
-WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(array_new, uint32_t, EncodedJSValue, uint32_t);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(array_new, uint32_t, uint32_t, IPIntStackEntry*);
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(array_new_default, uint32_t, uint32_t);
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(array_new_fixed, uint32_t, uint32_t, IPIntStackEntry*);
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(array_new_data, IPInt::ArrayNewDataMetadata*, uint32_t, uint32_t);
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(array_new_elem, IPInt::ArrayNewElemMetadata*, uint32_t, uint32_t);
-WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(array_get, uint32_t, EncodedJSValue, uint32_t);
-WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(array_get_s, uint32_t, EncodedJSValue, uint32_t);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(array_get, uint32_t, EncodedJSValue, uint32_t, IPIntStackEntry*);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(array_get_s, uint32_t, EncodedJSValue, uint32_t, IPIntStackEntry*);
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(array_set, uint32_t, IPIntStackEntry*);
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(array_fill, IPIntStackEntry* sp);
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(array_copy, IPIntStackEntry* sp);

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.h
@@ -81,6 +81,7 @@ public:
     ALWAYS_INLINE auto visitSpanNonVector(auto functor);
 
     inline uint64_t get(uint32_t index);
+    inline v128_t getVector(uint32_t index);
     inline void set(VM&, uint32_t index, uint64_t value);
     inline void set(VM&, uint32_t index, v128_t value);
 

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyArrayInlines.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyArrayInlines.h
@@ -136,6 +136,12 @@ uint64_t JSWebAssemblyArray::get(uint32_t index)
     });
 }
 
+v128_t JSWebAssemblyArray::getVector(uint32_t index)
+{
+    ASSERT(elementType().type.unpacked().isV128());
+    return span<v128_t>()[index];
+}
+
 void JSWebAssemblyArray::set(VM& vm, uint32_t index, uint64_t value)
 {
     visitSpanNonVector([&]<typename T>(std::span<T> span) ALWAYS_INLINE_LAMBDA {

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.cpp
@@ -97,11 +97,19 @@ uint64_t JSWebAssemblyStruct::get(uint32_t fieldIndex) const
     case TypeKind::RefNull:
         return JSValue::encode(std::bit_cast<WriteBarrierBase<Unknown>*>(targetPointer)->get());
     case TypeKind::V128:
-        // V128 is not supported in IPInt.
+        ASSERT_NOT_REACHED("V128 values should use getVector() method");
+        return 0;
     default:
         ASSERT_NOT_REACHED();
         return 0;
     }
+}
+
+v128_t JSWebAssemblyStruct::getVector(uint32_t fieldIndex) const
+{
+    const uint8_t* targetPointer = fieldPointer(fieldIndex);
+    ASSERT(fieldType(fieldIndex).type.unpacked().isV128());
+    return *std::bit_cast<const v128_t*>(targetPointer);
 }
 
 void JSWebAssemblyStruct::set(uint32_t fieldIndex, uint64_t argument)

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.h
@@ -60,6 +60,7 @@ public:
     DECLARE_VISIT_CHILDREN;
 
     uint64_t get(uint32_t) const;
+    v128_t getVector(uint32_t) const;
     void set(uint32_t, uint64_t);
     void set(uint32_t, v128_t);
     const Wasm::TypeDefinition& typeDefinition() const { return gcStructure()->typeDefinition(); }


### PR DESCRIPTION
#### 3f16b36fa13c7eea5b5fd945c2475eb1d3f9c1b5
<pre>
[JSC] WASM IPInt SIMD: support GC types with v128 fields/elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=300054">https://bugs.webkit.org/show_bug.cgi?id=300054</a>
<a href="https://rdar.apple.com/161853921">rdar://161853921</a>

Reviewed by Yusuke Suzuki.

Add support for GC struct and arrays with v128 field and element type.

Testing: run JSTests/wasm/gc/simd.js with --useWasmIPIntSIMD=true

* Source/JavaScriptCore/llint/InPlaceInterpreter64.asm:
* Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp:
(JSC::IPInt::WASM_IPINT_EXTERN_CPP_DECL):
* Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.h:
* Source/JavaScriptCore/wasm/WasmOperationsInlines.h:
(JSC::Wasm::arrayNew):
(JSC::Wasm::tryCopyElementsInReverse):
(JSC::Wasm::arrayNewFixed):
(JSC::Wasm::arrayGet):
(JSC::Wasm::arraySet):
(JSC::Wasm::structNew):
(JSC::Wasm::structGet):
(JSC::Wasm::structSet):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.h:
* Source/JavaScriptCore/wasm/js/JSWebAssemblyArrayInlines.h:
(JSC::JSWebAssemblyArray::getVector):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.cpp:
(JSC::JSWebAssemblyStruct::get const):
(JSC::JSWebAssemblyStruct::getVector const):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.h:

Canonical link: <a href="https://commits.webkit.org/300962@main">https://commits.webkit.org/300962@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6d990b645a40dd4aa2cc7dfa26ff5bc5a87119f1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124276 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43962 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34686 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131112 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76347 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44705 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52564 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94535 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62717 "") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127230 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35625 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111158 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75123 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34570 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29317 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74593 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/116419 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105378 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29539 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133783 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/122805 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51189 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39029 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103012 "Found 1 new test failure: imported/w3c/web-platform-tests/wasm/jsapi/js-string/basic.any.worker.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51580 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107374 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102810 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26208 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48171 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26422 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48129 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51051 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56833 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/153901 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50490 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39111 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53846 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52165 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->