### PR TITLE
[GFC] Add initial alignment support with start alignment.

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp
@@ -114,6 +114,21 @@ PlacedGridItems GridFormattingContext::constructPlacedGridItems(const GridAreas&
     for (auto [ unplacedGridItem, gridAreaLines ] : gridAreas) {
 
         CheckedRef gridItemStyle = unplacedGridItem.m_layoutBox->style();
+
+        auto usedJustifySelf = [&] {
+            if (auto gridItemJustifySelf = gridItemStyle->justifySelf(); gridItemJustifySelf.position() != ItemPosition::Auto)
+                return gridItemJustifySelf;
+            auto& formattingContextRootStyle = root().style();
+            return formattingContextRootStyle.justifyItems();
+        };
+
+        auto usedAlignSelf = [&] {
+            if (auto gridItemAlignSelf = gridItemStyle->alignSelf(); gridItemAlignSelf.position() != ItemPosition::Auto)
+                return gridItemAlignSelf;
+            auto& formattingContextRootStyle = root().style();
+            return formattingContextRootStyle.alignItems();
+        };
+
         PlacedGridItem::ComputedSizes inlineAxisSizes {
             gridItemStyle->width(),
             gridItemStyle->minWidth(),
@@ -130,7 +145,7 @@ PlacedGridItems GridFormattingContext::constructPlacedGridItems(const GridAreas&
             gridItemStyle->marginBottom()
         };
 
-        placedGridItems.constructAndAppend(unplacedGridItem, gridAreaLines, inlineAxisSizes, blockAxisSizes);
+        placedGridItems.constructAndAppend(unplacedGridItem, gridAreaLines, inlineAxisSizes, blockAxisSizes, usedJustifySelf(), usedAlignSelf());
     }
     return placedGridItems;
 }

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
@@ -126,6 +126,67 @@ void GridLayout::layout(GridFormattingContext::GridLayoutConstraints, const Unpl
     // https://drafts.csswg.org/css-grid-1/#alignment
     auto usedInlineMargins = computeInlineMargins(placedGridItems);
     auto usedBlockMargins = computeBlockMargins(placedGridItems);
+
+    // https://drafts.csswg.org/css-grid-1/#alignment
+    // After a grid container’s grid tracks have been sized, and the dimensions of all grid items
+    // are finalized, grid items can be aligned within their grid areas.
+    auto inlineAxisPositions = performInlineAxisSelfAlignment(placedGridItems, usedInlineMargins);
+    auto blockAxisPositions = performBlockAxisSelfAlignment(placedGridItems, usedBlockMargins);
+
+    UNUSED_VARIABLE(inlineAxisPositions);
+    UNUSED_VARIABLE(blockAxisPositions);
+}
+
+GridLayout::BorderBoxPositions GridLayout::performInlineAxisSelfAlignment(const PlacedGridItems& placedGridItems, const Vector<UsedMargins>& inlineMargins)
+{
+    BorderBoxPositions borderBoxPositions;
+    borderBoxPositions.reserveInitialCapacity(placedGridItems.size());
+
+    auto computeMarginBoxPosition = [](const PlacedGridItem& placedGridItem) -> LayoutUnit {
+        switch (placedGridItem.inlineAxisAlignment().position()) {
+        case ItemPosition::FlexStart:
+        case ItemPosition::SelfStart:
+        case ItemPosition::Start:
+            return { };
+        default:
+            ASSERT_NOT_IMPLEMENTED_YET();
+            return { };
+        }
+    };
+
+    for (size_t gridItemIndex = 0; gridItemIndex < placedGridItems.size(); ++gridItemIndex) {
+        auto& gridItem = placedGridItems[gridItemIndex];
+        auto marginBoxPosition = computeMarginBoxPosition(gridItem);
+        borderBoxPositions.append(marginBoxPosition + inlineMargins[gridItemIndex].marginStart);
+    }
+
+    return borderBoxPositions;
+}
+
+GridLayout::BorderBoxPositions GridLayout::performBlockAxisSelfAlignment(const PlacedGridItems& placedGridItems, const Vector<UsedMargins>& blockMargins)
+{
+    BorderBoxPositions borderBoxPositions;
+    borderBoxPositions.reserveInitialCapacity(placedGridItems.size());
+
+    auto computeMarginBoxPosition = [](const PlacedGridItem& placedGridItem) -> LayoutUnit {
+        switch (placedGridItem.blockAxisAlignment().position()) {
+        case ItemPosition::FlexStart:
+        case ItemPosition::SelfStart:
+        case ItemPosition::Start:
+            return { };
+        default:
+            ASSERT_NOT_IMPLEMENTED_YET();
+            return { };
+        }
+    };
+
+    for (size_t gridItemIndex = 0; gridItemIndex < placedGridItems.size(); ++gridItemIndex) {
+        auto& gridItem = placedGridItems[gridItemIndex];
+        auto marginBoxPosition = computeMarginBoxPosition(gridItem);
+        borderBoxPositions.append(marginBoxPosition + blockMargins[gridItemIndex].marginStart);
+    }
+
+    return borderBoxPositions;
 }
 
 TrackSizingFunctionsList GridLayout::trackSizingFunctions(size_t implicitGridTracksCount, const Vector<Style::GridTrackSize> gridTemplateTrackSizes)

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayout.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayout.h
@@ -79,6 +79,10 @@ private:
     static Vector<UsedMargins> computeInlineMargins(const PlacedGridItems&);
     static Vector<UsedMargins> computeBlockMargins(const PlacedGridItems&);
 
+    using BorderBoxPositions = Vector<LayoutUnit>;
+    static BorderBoxPositions performInlineAxisSelfAlignment(const PlacedGridItems&, const Vector<UsedMargins>&);
+    static BorderBoxPositions performBlockAxisSelfAlignment(const PlacedGridItems&, const Vector<UsedMargins>&);
+
     const GridFormattingContext& formattingContext() const { return m_gridFormattingContext.get(); }
 
     const ElementBox& gridContainer() const;

--- a/Source/WebCore/layout/formattingContexts/grid/PlacedGridItem.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/PlacedGridItem.cpp
@@ -33,10 +33,13 @@ namespace WebCore {
 namespace Layout {
 
 PlacedGridItem::PlacedGridItem(const UnplacedGridItem& unplacedGridItem, GridAreaLines gridAreaLines,
-    ComputedSizes inlineAxisSizes, ComputedSizes blockAxisSizes)
+    const ComputedSizes& inlineAxisSizes, const ComputedSizes& blockAxisSizes, const StyleSelfAlignmentData& inlineAxisAlignment,
+    const StyleSelfAlignmentData& blockAxisAlignment)
     : m_layoutBox(unplacedGridItem.m_layoutBox)
     , m_inlineAxisSizes(inlineAxisSizes)
     , m_blockAxisSizes(blockAxisSizes)
+    , m_inlineAxisAlignment(inlineAxisAlignment)
+    , m_blockAxisAlignment(blockAxisAlignment)
     , m_gridAreaLines(gridAreaLines)
 {
 }

--- a/Source/WebCore/layout/formattingContexts/grid/PlacedGridItem.h
+++ b/Source/WebCore/layout/formattingContexts/grid/PlacedGridItem.h
@@ -31,6 +31,7 @@
 #include "StyleMaximumSize.h"
 #include "StyleMinimumSize.h"
 #include "StylePreferredSize.h"
+#include "StyleSelfAlignmentData.h"
 #include <wtf/HashTraits.h>
 
 namespace WebCore {
@@ -49,7 +50,8 @@ public:
         Style::MarginEdge marginEnd;
     };
 
-    PlacedGridItem(const UnplacedGridItem&, GridAreaLines, ComputedSizes inlineAxisSizes, ComputedSizes blockAxisSizes);
+    PlacedGridItem(const UnplacedGridItem&, GridAreaLines, const ComputedSizes& inlineAxisSizes, const ComputedSizes& blockAxisSizes,
+    const StyleSelfAlignmentData& inlineAxisAlignment, const StyleSelfAlignmentData& blockAxisAlignment);
 
     const ComputedSizes& inlineAxisSizes() const { return m_inlineAxisSizes; }
     const ComputedSizes& blockAxisSizes() const { return m_blockAxisSizes; }
@@ -60,12 +62,17 @@ public:
     size_t rowEndLine() const { return m_gridAreaLines.rowEndLine; }
 
     const ElementBox& layoutBox() const { return m_layoutBox; }
+    const StyleSelfAlignmentData& inlineAxisAlignment() const { return m_inlineAxisAlignment; }
+    const StyleSelfAlignmentData& blockAxisAlignment() const { return m_blockAxisAlignment; }
 
 private:
     const CheckedRef<const ElementBox> m_layoutBox;
 
     const ComputedSizes m_inlineAxisSizes;
     const ComputedSizes m_blockAxisSizes;
+
+    const StyleSelfAlignmentData m_inlineAxisAlignment;
+    const StyleSelfAlignmentData m_blockAxisAlignment;
 
     GridAreaLines m_gridAreaLines;
 };


### PR DESCRIPTION
#### d820e29f6f554d387152d87e5008926328b13092
<pre>
[GFC] Add initial alignment support with start alignment.
<a href="https://bugs.webkit.org/show_bug.cgi?id=300058">https://bugs.webkit.org/show_bug.cgi?id=300058</a>
<a href="https://rdar.apple.com/problem/161856764">rdar://problem/161856764</a>

Reviewed by Alan Baradlay.

This patch adds the overall logic that we will use to support aligning
grid items after we have determined their sizes. Note that since
alignment is done with respect to the grid area, which acts as the
containing block for the grid item, the border box position that is
returned will be in the coordinate space of the grid area.

With this patch, we only support start alignment for the flex items, so
there is realistically no movement that is needed for the grid item&apos;s
margin box, so the final border box position will just be the same as
the value of the top margin. In order to support other alignment values,
we will likely need the size of the grid area along with the border box
dimensions of the grid item.

* Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp:
(WebCore::Layout::GridFormattingContext::constructPlacedGridItems const):
In order to perform alignment, we will need the align-self and
justify-self values for the grid item. If the value for this property is
not auto, then that is the value that will be used; otherwise, we refer to
the value of align-items/justify-items on the grid.

* Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp:
(WebCore::Layout::GridLayout::layout):

(WebCore::Layout::GridLayout::performInlineAxisSelfAlignment):
(WebCore::Layout::GridLayout::performBlockAxisSelfAlignment):
The basic idea between these two functions is the same: first, we need to
find out what the margin box position will be to satisfy the needs of
the alignment value, and from there, we can just add in the start margin
to get the final position of the item&apos;s border box. Since the most basic
version of start alignment (without considering any sort of safety) does
not move the item from the start of the grid area, we can just return a
value of 0 to indicate that it is at the start of the grid area.

Canonical link: <a href="https://commits.webkit.org/300961@main">https://commits.webkit.org/300961@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d6e6dcbbe79dcddbcc30c6e06ee32a2eff8260e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124440 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44123 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34855 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131284 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/76453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/94301c91-8b6c-4b97-ae47-3f12b9039443) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/126317 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44865 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52719 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94669 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/76453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c4962595-0596-44b8-b7b3-1b33e5fa66e0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127394 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35761 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75247 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e3bc99ab-e577-435d-b304-524154f47126) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34696 "Passed tests") | [⏳ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK1-Tests-EWS "Waiting to run tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74762 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105513 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29681 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133949 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51338 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39167 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103151 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51739 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107516 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102940 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26207 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48302 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48284 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51204 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56991 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50622 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/53984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52298 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->