### PR TITLE
[Style] Convert the 'font-size-adjust' property to strong style types

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -3293,6 +3293,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     style/values/flexbox/StyleWebKitBoxOrdinalGroup.h
 
     style/values/fonts/StyleFontPalette.h
+    style/values/fonts/StyleFontSizeAdjust.h
     style/values/fonts/StyleFontStyle.h
     style/values/fonts/StyleFontWeight.h
     style/values/fonts/StyleFontWidth.h

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -870,7 +870,6 @@ style/StyleInterpolation.cpp
 style/StyleInvalidator.cpp
 style/StylePendingResources.cpp
 style/StyleResolveForDocument.cpp
-style/StyleResolveForFont.cpp
 style/StyleResolver.cpp
 style/StyleScope.cpp
 style/StyleScopeRuleSets.cpp

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -3229,6 +3229,7 @@ style/values/filter-effects/StyleSaturateFunction.cpp
 style/values/filter-effects/StyleSepiaFunction.cpp
 style/values/flexbox/StyleFlexBasis.cpp
 style/values/fonts/StyleFontPalette.cpp
+style/values/fonts/StyleFontSizeAdjust.cpp
 style/values/fonts/StyleFontStyle.cpp
 style/values/fonts/StyleFontWeight.cpp
 style/values/fonts/StyleFontWidth.cpp

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -660,10 +660,10 @@
                 "from-font"
             ],
             "codegen-properties": {
-                "animation-wrapper": "FontSizeAdjustWrapper",
-                "animation-wrapper-requires-override-parameters": [],
-                "style-converter": "FontSizeAdjust",
-                "style-builder-custom": "Value",
+                "animation-wrapper": "StyleTypeWrapper",
+                "animation-wrapper-requires-render-style": true,
+                "style-converter": "StyleType<FontSizeAdjust>",
+                "font-property-uses-render-style-for-access": true,
                 "font-property": true,
                 "high-priority": true,
                 "separator": " ",

--- a/Source/WebCore/platform/graphics/FontCascadeDescription.h
+++ b/Source/WebCore/platform/graphics/FontCascadeDescription.h
@@ -127,9 +127,6 @@ public:
     WEBCORE_EXPORT void resolveFontSizeAdjustFromFontIfNeeded(const Font&);
 
     // Initial values for font properties.
-    static FontStyleAxis initialFontStyleAxis() { return FontStyleAxis::slnt; }
-    static FontSelectionValue initialWeight() { return normalWeightValue(); }
-    static FontSelectionValue initialWidth() { return normalWidthValue(); }
     static FontSmallCaps initialSmallCaps() { return FontSmallCaps::Off; }
     static Kerning initialKerning() { return Kerning::Auto; }
     static FontSmoothingMode initialFontSmoothing() { return FontSmoothingMode::AutoSmoothing; }
@@ -143,7 +140,6 @@ public:
     static FontVariantEmoji initialVariantEmoji() { return FontVariantEmoji::Normal; }
     static FontOpticalSizing initialOpticalSizing() { return FontOpticalSizing::Enabled; }
     static const AtomString& initialSpecifiedLocale() { return nullAtom(); }
-    static FontSizeAdjust initialFontSizeAdjust() { return { FontSizeAdjust::Metric::ExHeight }; }
     static TextSpacingTrim initialTextSpacingTrim() { return { }; }
     static TextAutospace initialTextAutospace() { return { }; }
     static FontFeatureSettings initialFeatureSettings() { return { }; }

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -2625,10 +2625,10 @@ void RenderStyle::setFontSize(float size)
     setFontDescription(WTFMove(description));
 }
 
-void RenderStyle::setFontSizeAdjust(FontSizeAdjust sizeAdjust)
+void RenderStyle::setFontSizeAdjust(Style::FontSizeAdjust sizeAdjust)
 {
     auto description = fontDescription();
-    description.setFontSizeAdjust(sizeAdjust);
+    description.setFontSizeAdjust(sizeAdjust.platform());
     setFontDescription(WTFMove(description));
 }
 

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -220,7 +220,6 @@ enum class WordBreak : uint8_t;
 
 struct CSSPropertiesBitSet;
 struct CounterDirectiveMap;
-struct FontSizeAdjust;
 struct GridTrackList;
 struct ImageOrientation;
 struct Length;
@@ -273,6 +272,7 @@ struct DynamicRangeLimit;
 struct Filter;
 struct FlexBasis;
 struct FontPalette;
+struct FontSizeAdjust;
 struct FontStyle;
 struct FontWeight;
 struct FontWidth;
@@ -730,7 +730,7 @@ public:
     inline FontOpticalSizing fontOpticalSizing() const;
     inline FontVariationSettings fontVariationSettings() const;
     inline Style::FontPalette fontPalette() const;
-    inline FontSizeAdjust fontSizeAdjust() const;
+    inline Style::FontSizeAdjust fontSizeAdjust() const;
     inline Style::FontStyle fontStyle() const;
     inline Style::FontWeight fontWeight() const;
     inline Style::FontWidth fontWidth() const;
@@ -1364,11 +1364,10 @@ public:
 
     // Only used for blending font sizes when animating, for MathML anonymous blocks, and for text autosizing.
     void setFontSize(float);
-    void setFontSizeAdjust(FontSizeAdjust);
-
     void setFontOpticalSizing(FontOpticalSizing);
     void setFontVariationSettings(FontVariationSettings);
     void setFontPalette(Style::FontPalette&&);
+    void setFontSizeAdjust(Style::FontSizeAdjust);
     void setFontStyle(Style::FontStyle);
     void setFontWeight(Style::FontWeight);
     void setFontWidth(Style::FontWidth);
@@ -1968,6 +1967,7 @@ public:
     static inline Style::VerticalAlign initialVerticalAlign();
     static constexpr Float initialFloating();
     static inline Style::FontPalette initialFontPalette();
+    static inline Style::FontSizeAdjust initialFontSizeAdjust();
     static inline Style::FontStyle initialFontStyle();
     static inline Style::FontWeight initialFontWeight();
     static inline Style::FontWidth initialFontWidth();

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -45,6 +45,7 @@
 #include <WebCore/StyleFlexibleBoxData.h>
 #include <WebCore/StyleFontData.h>
 #include <WebCore/StyleFontPalette.h>
+#include <WebCore/StyleFontSizeAdjust.h>
 #include <WebCore/StyleFontStyle.h>
 #include <WebCore/StyleFontWeight.h>
 #include <WebCore/StyleFontWidth.h>
@@ -224,7 +225,7 @@ inline Style::FlexGrow RenderStyle::flexGrow() const { return m_nonInheritedData
 inline Style::FlexShrink RenderStyle::flexShrink() const { return m_nonInheritedData->miscData->flexibleBox->flexShrink; }
 inline FlexWrap RenderStyle::flexWrap() const { return static_cast<FlexWrap>(m_nonInheritedData->miscData->flexibleBox->flexWrap); }
 inline Style::FontPalette RenderStyle::fontPalette() const { return fontDescription().fontPalette(); }
-inline FontSizeAdjust RenderStyle::fontSizeAdjust() const { return fontDescription().fontSizeAdjust(); }
+inline Style::FontSizeAdjust RenderStyle::fontSizeAdjust() const { return fontDescription().fontSizeAdjust(); }
 inline Style::FontStyle RenderStyle::fontStyle() const { return { fontDescription().fontStyleSlope(), fontDescription().fontStyleAxis() }; }
 inline FontOpticalSizing RenderStyle::fontOpticalSizing() const { return fontDescription().opticalSizing(); }
 inline FontVariationSettings RenderStyle::fontVariationSettings() const { return fontDescription().variationSettings(); }
@@ -398,6 +399,7 @@ constexpr Style::FlexShrink RenderStyle::initialFlexShrink() { return 1_css_numb
 constexpr FlexWrap RenderStyle::initialFlexWrap() { return FlexWrap::NoWrap; }
 constexpr Float RenderStyle::initialFloating() { return Float::None; }
 inline Style::FontPalette RenderStyle::initialFontPalette() { return CSS::Keyword::Normal { }; }
+inline Style::FontSizeAdjust RenderStyle::initialFontSizeAdjust() { return CSS::Keyword::None { }; }
 inline Style::FontStyle RenderStyle::initialFontStyle() { return CSS::Keyword::Normal { }; }
 inline Style::FontWeight RenderStyle::initialFontWeight() { return CSS::Keyword::Normal { }; }
 inline Style::FontWidth RenderStyle::initialFontWidth() { return CSS::Keyword::Normal { }; }

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -133,7 +133,6 @@ public:
     static GridAutoFlow convertGridAutoFlow(BuilderState&, const CSSValue&);
     static OptionSet<TouchAction> convertTouchAction(BuilderState&, const CSSValue&);
 
-    static FontSizeAdjust convertFontSizeAdjust(BuilderState&, const CSSValue&);
     static FontFeatureSettings convertFontFeatureSettings(BuilderState&, const CSSValue&);
     static FontVariationSettings convertFontVariationSettings(BuilderState&, const CSSValue&);
     static PaintOrder convertPaintOrder(BuilderState&, const CSSValue&);
@@ -500,11 +499,6 @@ inline FontFeatureSettings BuilderConverter::convertFontFeatureSettings(BuilderS
 inline FontVariationSettings BuilderConverter::convertFontVariationSettings(BuilderState& builderState, const CSSValue& value)
 {
     return fontVariationSettingsFromCSSValue(builderState, value);
-}
-
-inline FontSizeAdjust BuilderConverter::convertFontSizeAdjust(BuilderState& builderState, const CSSValue& value)
-{
-    return fontSizeAdjustFromCSSValue(builderState, value);
 }
 
 inline OptionSet<TouchAction> BuilderConverter::convertTouchAction(BuilderState&, const CSSValue& value)

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -1394,11 +1394,6 @@ inline void BuilderCustom::applyValueFontSize(BuilderState& builderState, CSSVal
     builderState.setFontDescriptionFontSize(std::min(maximumAllowedFontSize, size));
 }
 
-inline void BuilderCustom::applyValueFontSizeAdjust(BuilderState& builderState, CSSValue& value)
-{
-    builderState.setFontDescriptionFontSizeAdjust(BuilderConverter::convertFontSizeAdjust(builderState, value));
-}
-
 inline void BuilderCustom::applyValueStrokeWidth(BuilderState& builderState, CSSValue& value)
 {
     builderState.style().setStrokeWidth(toStyleFromCSSValue<StrokeWidth>(builderState, value));

--- a/Source/WebCore/style/StyleBuilderState.h
+++ b/Source/WebCore/style/StyleBuilderState.h
@@ -50,8 +50,6 @@ class StyleResolver;
 class TextAutospace;
 class TextSpacingTrim;
 
-struct FontSizeAdjust;
-
 namespace CSSCalc {
 struct RandomCachingKey;
 }
@@ -61,6 +59,7 @@ namespace Style {
 class BuilderState;
 struct Color;
 struct FontPalette;
+struct FontSizeAdjust;
 struct FontStyle;
 struct FontWeight;
 struct FontWidth;
@@ -159,7 +158,7 @@ public:
     void setFontDescriptionFamilies(Vector<AtomString>&);
     void setFontDescriptionIsSpecifiedFont(bool);
     void setFontDescriptionFeatureSettings(FontFeatureSettings&&);
-    void setFontDescriptionFontPalette(Style::FontPalette&&);
+    void setFontDescriptionFontPalette(FontPalette&&);
     void setFontDescriptionFontSizeAdjust(FontSizeAdjust);
     void setFontDescriptionFontSmoothing(FontSmoothingMode);
     void setFontDescriptionFontStyle(FontStyle);

--- a/Source/WebCore/style/StyleBuilderStateInlines.h
+++ b/Source/WebCore/style/StyleBuilderStateInlines.h
@@ -117,7 +117,7 @@ inline void BuilderState::setFontDescriptionFeatureSettings(FontFeatureSettings&
     fontCascade.updateRequiresShaping();
 }
 
-inline void BuilderState::setFontDescriptionFontPalette(Style::FontPalette&& fontPalette)
+inline void BuilderState::setFontDescriptionFontPalette(FontPalette&& fontPalette)
 {
     if (m_style.fontDescription().fontPalette() == fontPalette.platform())
         return;
@@ -128,11 +128,11 @@ inline void BuilderState::setFontDescriptionFontPalette(Style::FontPalette&& fon
 
 inline void BuilderState::setFontDescriptionFontSizeAdjust(FontSizeAdjust fontSizeAdjust)
 {
-    if (m_style.fontDescription().fontSizeAdjust() == fontSizeAdjust)
+    if (m_style.fontDescription().fontSizeAdjust() == fontSizeAdjust.platform())
         return;
 
     m_fontDirty = true;
-    m_style.mutableFontDescriptionWithoutUpdate().setFontSizeAdjust(WTFMove(fontSizeAdjust));
+    m_style.mutableFontDescriptionWithoutUpdate().setFontSizeAdjust(fontSizeAdjust.platform());
 }
 
 inline void BuilderState::setFontDescriptionFontSmoothing(FontSmoothingMode fontSmoothing)

--- a/Source/WebCore/style/StyleExtractorConverter.h
+++ b/Source/WebCore/style/StyleExtractorConverter.h
@@ -179,7 +179,6 @@ public:
     // MARK: Font conversions
 
     static Ref<CSSValue> convertFontFamily(ExtractorState&, const AtomString&);
-    static Ref<CSSValue> convertFontSizeAdjust(ExtractorState&, const FontSizeAdjust&);
     static Ref<CSSValue> convertFontFeatureSettings(ExtractorState&, const FontFeatureSettings&);
     static Ref<CSSValue> convertFontVariationSettings(ExtractorState&, const FontVariationSettings&);
 
@@ -1009,22 +1008,6 @@ inline Ref<CSSValue> ExtractorConverter::convertFontFamily(ExtractorState& state
     if (auto familyIdentifier = identifierForFamily(family))
         return CSSPrimitiveValue::create(familyIdentifier);
     return state.pool.createFontFamilyValue(family);
-}
-
-inline Ref<CSSValue> ExtractorConverter::convertFontSizeAdjust(ExtractorState& state, const FontSizeAdjust& fontSizeAdjust)
-{
-    if (fontSizeAdjust.isNone())
-        return CSSPrimitiveValue::create(CSSValueNone);
-
-    auto metric = fontSizeAdjust.metric;
-    auto value = fontSizeAdjust.shouldResolveFromFont() ? fontSizeAdjust.resolve(state.style.computedFontSize(), state.style.metricsOfPrimaryFont()) : fontSizeAdjust.value.asOptional();
-    if (!value)
-        return CSSPrimitiveValue::create(CSSValueNone);
-
-    if (metric == FontSizeAdjust::Metric::ExHeight)
-        return CSSPrimitiveValue::create(*value);
-
-    return CSSValuePair::create(convert(state, metric), CSSPrimitiveValue::create(*value));
 }
 
 inline Ref<CSSValue> ExtractorConverter::convertFontFeatureSettings(ExtractorState& state, const FontFeatureSettings& fontFeatureSettings)

--- a/Source/WebCore/style/StyleExtractorSerializer.h
+++ b/Source/WebCore/style/StyleExtractorSerializer.h
@@ -113,8 +113,6 @@ public:
     // MARK: Font serializations
 
     static void serializeFontFamily(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const AtomString&);
-    static void serializeFontSizeAdjust(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const FontSizeAdjust&);
-    static void serializeFontPalette(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const FontPalette&);
     static void serializeFontFeatureSettings(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const FontFeatureSettings&);
     static void serializeFontVariationSettings(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const FontVariationSettings&);
 
@@ -986,31 +984,6 @@ inline void ExtractorSerializer::serializeFontFamily(ExtractorState&, StringBuil
         builder.append(nameLiteralForSerialization(familyIdentifier));
     else
         builder.append(WebCore::serializeFontFamily(family));
-}
-
-inline void ExtractorSerializer::serializeFontSizeAdjust(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, const FontSizeAdjust& fontSizeAdjust)
-{
-    if (fontSizeAdjust.isNone()) {
-        serializationForCSS(builder, context, state.style, CSS::Keyword::None { });
-        return;
-    }
-
-    auto metric = fontSizeAdjust.metric;
-    auto value = fontSizeAdjust.shouldResolveFromFont() ? fontSizeAdjust.resolve(state.style.computedFontSize(), state.style.metricsOfPrimaryFont()) : fontSizeAdjust.value.asOptional();
-
-    if (!value) {
-        serializationForCSS(builder, context, state.style, CSS::Keyword::None { });
-        return;
-    }
-
-    if (metric == FontSizeAdjust::Metric::ExHeight) {
-        CSS::serializationForCSS(builder, context, CSS::NumberRaw<> { *value });
-        return;
-    }
-
-    serialize(state, builder, context, metric);
-    builder.append(' ');
-    CSS::serializationForCSS(builder, context, CSS::NumberRaw<> { *value });
 }
 
 inline void ExtractorSerializer::serializeFontFeatureSettings(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, const FontFeatureSettings& fontFeatureSettings)

--- a/Source/WebCore/style/StyleFontSizeFunctions.cpp
+++ b/Source/WebCore/style/StyleFontSizeFunctions.cpp
@@ -33,6 +33,7 @@
 #include "Document.h"
 #include "DocumentInlines.h"
 #include "FontMetrics.h"
+#include "FontSizeAdjust.h"
 #include "FrameDestructionObserverInlines.h"
 #include "LocalFrame.h"
 #include "RenderStyleInlines.h"
@@ -192,20 +193,20 @@ static float adjustedFontSize(float size, float sizeAdjust, float metricValue)
     return size * (sizeAdjust / aspectValue);
 }
 
-float adjustedFontSize(float size, const FontSizeAdjust& sizeAdjust, const FontMetrics& metrics)
+float adjustedFontSize(float size, const WebCore::FontSizeAdjust& sizeAdjust, const FontMetrics& metrics)
 {
     // FIXME: The behavior for missing metrics has yet to be defined.
     // https://github.com/w3c/csswg-drafts/issues/6384
     switch (sizeAdjust.metric) {
-    case FontSizeAdjust::Metric::CapHeight:
+    case WebCore::FontSizeAdjust::Metric::CapHeight:
         return metrics.capHeight() ? adjustedFontSize(size, *sizeAdjust.value, *metrics.capHeight()) : size;
-    case FontSizeAdjust::Metric::ChWidth:
+    case WebCore::FontSizeAdjust::Metric::ChWidth:
         return metrics.zeroWidth() ? adjustedFontSize(size, *sizeAdjust.value, *metrics.zeroWidth()) : size;
     // FIXME: Are ic-height and ic-width the same? Gecko treats them the same.
-    case FontSizeAdjust::Metric::IcWidth:
-    case FontSizeAdjust::Metric::IcHeight:
+    case WebCore::FontSizeAdjust::Metric::IcWidth:
+    case WebCore::FontSizeAdjust::Metric::IcHeight:
         return metrics.ideogramWidth() ? adjustedFontSize(size, *sizeAdjust.value, *metrics.ideogramWidth()) : size;
-    case FontSizeAdjust::Metric::ExHeight:
+    case WebCore::FontSizeAdjust::Metric::ExHeight:
     default:
         return metrics.xHeight() ? adjustedFontSize(size, *sizeAdjust.value, *metrics.xHeight()) : size;
     }

--- a/Source/WebCore/style/StyleFontSizeFunctions.h
+++ b/Source/WebCore/style/StyleFontSizeFunctions.h
@@ -25,15 +25,13 @@
 
 #pragma once
 
-#include "FontSizeAdjust.h"
-#include "Settings.h"
-
 namespace WebCore {
 
 class Document;
 class RenderStyle;
 class FontMetrics;
 struct FontSizeAdjust;
+struct SettingsValues;
 
 namespace Style {
 
@@ -42,7 +40,7 @@ enum class MinimumFontSizeRule : uint8_t { None, Absolute, AbsoluteAndRelative }
 float computedFontSizeFromSpecifiedSize(float specifiedSize, bool isAbsoluteSize, float zoomFactor, MinimumFontSizeRule, const SettingsValues&);
 float computedFontSizeFromSpecifiedSize(float specifiedSize, bool isAbsoluteSize, bool useSVGZoomRules, const RenderStyle*, const Document&);
 float computedFontSizeFromSpecifiedSizeForSVGInlineText(float specifiedSize, bool isAbsoluteSize, float zoomFactor, const Document&);
-float adjustedFontSize(float size, const FontSizeAdjust&, const FontMetrics&);
+float adjustedFontSize(float size, const WebCore::FontSizeAdjust&, const FontMetrics&);
 
 // Given a CSS keyword id in the range (CSSValueXxSmall to CSSValueXxxLarge), this function will return
 // the correct font size scaled relative to the user's default (medium).
@@ -52,5 +50,5 @@ float fontSizeForKeyword(unsigned keywordID, bool shouldUseFixedDefaultSize, con
 // Given a font size in pixel, this function will return legacy font size between 1 and 7.
 int legacyFontSizeForPixelSize(int pixelFontSize, bool shouldUseFixedDefaultSize, const Document&);
 
-}
-}
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/StyleInterpolationFunctions.h
+++ b/Source/WebCore/style/StyleInterpolationFunctions.h
@@ -168,23 +168,4 @@ inline FontVariationSettings blendFunc(const FontVariationSettings& from, const 
 
 #endif
 
-inline FontSelectionValue blendFunc(FontSelectionValue from, FontSelectionValue to, const Context& context)
-{
-    return FontSelectionValue(std::max(0.0f, blendFunc(static_cast<float>(from), static_cast<float>(to), context)));
-}
-
-inline std::optional<FontSelectionValue> blendFunc(std::optional<FontSelectionValue> from, std::optional<FontSelectionValue> to, const Context& context)
-{
-    if (!from && !to)
-        return std::nullopt;
-
-    auto valueOrDefault = [](std::optional<FontSelectionValue> fontSelectionValue) {
-        if (!fontSelectionValue)
-            return 0.0f;
-        return static_cast<float>(fontSelectionValue.value());
-    };
-
-    return normalizedFontItalicValue(blendFunc(valueOrDefault(from), valueOrDefault(to), context));
-}
-
 } // namespace WebCore::Style::Interpolation

--- a/Source/WebCore/style/StyleInterpolationWrappers.h
+++ b/Source/WebCore/style/StyleInterpolationWrappers.h
@@ -536,39 +536,6 @@ public:
 
 #endif
 
-class FontSizeAdjustWrapper final : public WrapperWithGetter<FontSizeAdjust> {
-    WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(FontSizeAdjustWrapper, Animation);
-public:
-    FontSizeAdjustWrapper()
-        : WrapperWithGetter(CSSPropertyFontSizeAdjust, &RenderStyle::fontSizeAdjust)
-    {
-    }
-
-    bool canInterpolate(const RenderStyle& from, const RenderStyle& to, CompositeOperation) const final
-    {
-        auto fromFontSizeAdjust = from.fontSizeAdjust();
-        auto toFontSizeAdjust = to.fontSizeAdjust();
-        return fromFontSizeAdjust.metric == toFontSizeAdjust.metric
-            && fromFontSizeAdjust.value && toFontSizeAdjust.value;
-    }
-
-    void interpolate(RenderStyle& destination, const RenderStyle& from, const RenderStyle& to, const Context& context) const final
-    {
-        auto blendedFontSizeAdjust = [&]() -> FontSizeAdjust {
-            if (context.isDiscrete)
-                return (!context.progress ? from : to).fontSizeAdjust();
-
-            ASSERT(from.fontSizeAdjust().value && to.fontSizeAdjust().value);
-            auto blendedAdjust = blendFunc(*from.fontSizeAdjust().value, *to.fontSizeAdjust().value, context);
-
-            ASSERT(from.fontSizeAdjust().metric == to.fontSizeAdjust().metric);
-            return { to.fontSizeAdjust().metric, FontSizeAdjust::ValueType::Number, std::max(blendedAdjust, 0.0f) };
-        };
-
-        destination.setFontSizeAdjust(blendedFontSizeAdjust());
-    }
-};
-
 class LineHeightWrapper final : public LengthWrapper {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(LineHeightWrapper, Animation);
 public:

--- a/Source/WebCore/style/StyleResolveForFont.cpp
+++ b/Source/WebCore/style/StyleResolveForFont.cpp
@@ -382,39 +382,6 @@ FontVariationSettings fontVariationSettingsFromCSSValue(BuilderState& builderSta
     return settings;
 }
 
-// MARK: 'font-size-adjust'
-
-FontSizeAdjust fontSizeAdjustFromCSSValue(BuilderState& builderState, const CSSValue& value)
-{
-    if (auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
-        if (primitiveValue->valueID() == CSSValueNone
-            || CSSPropertyParserHelpers::isSystemFontShorthand(primitiveValue->valueID()))
-            return FontCascadeDescription::initialFontSizeAdjust();
-
-        auto defaultMetric = FontSizeAdjust::Metric::ExHeight;
-        if (primitiveValue->isNumber())
-            return { defaultMetric, FontSizeAdjust::ValueType::Number, primitiveValue->resolveAsNumber(builderState.cssToLengthConversionData()) };
-
-        ASSERT(primitiveValue->valueID() == CSSValueFromFont);
-        // We cannot determine the primary font here, so we defer resolving the
-        // aspect value for from-font to when the primary font is created.
-        // See FontCascadeFonts::primaryFont().
-        return { defaultMetric, FontSizeAdjust::ValueType::FromFont, std::nullopt };
-    }
-
-    auto pair = requiredPairDowncast<CSSPrimitiveValue>(builderState, value);
-    if (!pair)
-        return { };
-
-    auto metric = fromCSSValueID<FontSizeAdjust::Metric>(pair->first->valueID());
-    if (pair->second->isNumber())
-        return { metric, FontSizeAdjust::ValueType::Number, pair->second->resolveAsNumber(builderState.cssToLengthConversionData()) };
-
-    ASSERT(pair->second->valueID() == CSSValueFromFont);
-    return { metric, FontSizeAdjust::ValueType::FromFont, std::nullopt };
-}
-
-
 // MARK: - Unresolved Font Shorthand Resolution
 
 std::optional<FontCascade> resolveForUnresolvedFont(const CSSPropertyParserHelpers::UnresolvedFont& unresolvedFont, FontCascadeDescription&& fontDescription, ScriptExecutionContext& context)

--- a/Source/WebCore/style/StyleResolveForFont.h
+++ b/Source/WebCore/style/StyleResolveForFont.h
@@ -41,8 +41,6 @@ class FontCascadeDescription;
 class FontSelectionValue;
 class ScriptExecutionContext;
 
-struct FontSizeAdjust;
-
 template<typename> class FontTaggedSettings;
 using FontFeatureSettings = FontTaggedSettings<int>;
 using FontVariationSettings = FontTaggedSettings<float>;
@@ -65,7 +63,6 @@ std::optional<FontSelectionValue> fontStyleFromCSSValueDeprecated(const CSSValue
 
 FontFeatureSettings fontFeatureSettingsFromCSSValue(BuilderState&, const CSSValue&);
 FontVariationSettings fontVariationSettingsFromCSSValue(BuilderState&, const CSSValue&);
-FontSizeAdjust fontSizeAdjustFromCSSValue(BuilderState&, const CSSValue&);
 
 std::optional<FontCascade> resolveForUnresolvedFont(const CSSPropertyParserHelpers::UnresolvedFont&, FontCascadeDescription&&, ScriptExecutionContext&);
 

--- a/Source/WebCore/style/values/fonts/StyleFontSizeAdjust.cpp
+++ b/Source/WebCore/style/values/fonts/StyleFontSizeAdjust.cpp
@@ -1,0 +1,165 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "StyleFontSizeAdjust.h"
+
+#include "AnimationUtilities.h"
+#include "CSSPropertyParserConsumer+Font.h"
+#include "RenderStyle.h"
+#include "StyleBuilderChecking.h"
+#include "StylePrimitiveKeyword+CSSValueConversion.h"
+#include "StylePrimitiveKeyword+CSSValueCreation.h"
+#include "StylePrimitiveKeyword+Serialization.h"
+#include "StylePrimitiveNumericTypes+CSSValueConversion.h"
+#include "StylePrimitiveNumericTypes+CSSValueCreation.h"
+#include "StylePrimitiveNumericTypes+Serialization.h"
+
+namespace WebCore {
+namespace Style {
+
+static constexpr auto defaultMetric = FontSizeAdjust::Metric::ExHeight;
+
+std::optional<float> FontSizeAdjust::resolvedMetricValue(const RenderStyle& style) const
+{
+    if (m_platform.shouldResolveFromFont())
+        return m_platform.resolve(style.computedFontSize(), style.metricsOfPrimaryFont());
+    return m_platform.value;
+}
+
+// MARK: - Conversion
+
+auto CSSValueConversion<FontSizeAdjust>::operator()(BuilderState& state, const CSSValue& value) -> FontSizeAdjust
+{
+    if (RefPtr primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
+        switch (auto valueID = primitiveValue->valueID(); valueID) {
+        case CSSValueNone:
+            return CSS::Keyword::None { };
+
+        case CSSValueFromFont:
+            // We cannot determine the primary font here, so we defer resolving the
+            // aspect value for from-font to when the primary font is created.
+            // See FontCascadeFonts::primaryFont().
+            return { defaultMetric, CSS::Keyword::FromFont { } };
+
+        case CSSValueInvalid:
+            return { defaultMetric, toStyleFromCSSValue<FontSizeAdjust::Number>(state, *primitiveValue) };
+
+        default:
+            if (CSSPropertyParserHelpers::isSystemFontShorthand(valueID))
+                return CSS::Keyword::None { };
+
+            state.setCurrentPropertyInvalidAtComputedValueTime();
+            return CSS::Keyword::None { };
+        }
+    }
+
+    auto pair = requiredPairDowncast<CSSPrimitiveValue>(state, value);
+    if (!pair)
+        return CSS::Keyword::None { };
+
+    auto metric = fromCSSValueID<FontSizeAdjust::Metric>(pair->first->valueID());
+
+    if (pair->second->valueID() == CSSValueFromFont) {
+        // We cannot determine the primary font here, so we defer resolving the
+        // aspect value for from-font to when the primary font is created.
+        // See FontCascadeFonts::primaryFont().
+        return { metric, CSS::Keyword::FromFont { } };
+    }
+
+    return { metric, toStyleFromCSSValue<FontSizeAdjust::Number>(state, pair->second) };
+}
+
+auto CSSValueCreation<FontSizeAdjust>::operator()(CSSValuePool& pool, const RenderStyle& style, const FontSizeAdjust& value) -> Ref<CSSValue>
+{
+    if (value.isNone())
+        return createCSSValue(pool, style, CSS::Keyword::None { });
+
+    auto metric = value.metric();
+    auto metricValue = value.resolvedMetricValue(style);
+
+    if (!metricValue)
+        return createCSSValue(pool, style, CSS::Keyword::None { });
+
+    if (metric == defaultMetric)
+        return createCSSValue(pool, style, FontSizeAdjust::Number { *metricValue });
+
+    return createCSSValue(pool, style, SpaceSeparatedTuple { metric, FontSizeAdjust::Number { *metricValue } });
+}
+
+// MARK: - Serialization
+
+void Serialize<FontSizeAdjust>::operator()(StringBuilder& builder, const CSS::SerializationContext& context, const RenderStyle& style, const FontSizeAdjust& value)
+{
+    if (value.isNone()) {
+        serializationForCSS(builder, context, style, CSS::Keyword::None { });
+        return;
+    }
+
+    auto metric = value.metric();
+    auto metricValue = value.resolvedMetricValue(style);
+
+    if (!metricValue) {
+        serializationForCSS(builder, context, style, CSS::Keyword::None { });
+        return;
+    }
+
+    if (metric == defaultMetric) {
+        serializationForCSS(builder, context, style, FontSizeAdjust::Number { *metricValue });
+        return;
+    }
+
+    serializationForCSS(builder, context, style, SpaceSeparatedTuple { metric, FontSizeAdjust::Number { *metricValue } });
+}
+
+// MARK: Blending
+
+auto Blending<FontSizeAdjust>::canBlend(const FontSizeAdjust& a, const FontSizeAdjust& b) -> bool
+{
+    return a.metric() == b.metric()
+        && a.metricValue() && b.metricValue();
+}
+
+auto Blending<FontSizeAdjust>::blend(const FontSizeAdjust& a, const FontSizeAdjust& b, const BlendingContext& context) -> FontSizeAdjust
+{
+    if (context.isDiscrete)
+        return !context.progress ? a : b;
+
+    ASSERT(canBlend(a, b));
+    return {
+        a.metric(),
+        Style::blend(FontSizeAdjust::Number { *a.metricValue() }, FontSizeAdjust::Number { *b.metricValue() }, context)
+    };
+}
+
+// MARK: - Logging
+
+TextStream& operator<<(TextStream& ts, const FontSizeAdjust& value)
+{
+    return ts << value.platform();
+}
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/fonts/StyleFontSizeAdjust.h
+++ b/Source/WebCore/style/values/fonts/StyleFontSizeAdjust.h
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/FontSizeAdjust.h>
+#include <WebCore/StylePrimitiveNumericTypes.h>
+
+namespace WebCore {
+namespace Style {
+
+// <'font-size-adjust'> = none | [ [ ex-height | cap-height | ch-width | ic-width | ic-height ]? [ from-font | <number [0,inf]> ] ]
+// FIXME: Current spec grammar is `none | <number [0,∞]>`
+// https://drafts.csswg.org/css-fonts-4/#propdef-font-size-adjust
+struct FontSizeAdjust {
+    using Number = Style::Number<CSS::Nonnegative>;
+    using Metric = WebCore::FontSizeAdjust::Metric;
+    using ValueType = WebCore::FontSizeAdjust::ValueType;
+
+    FontSizeAdjust(CSS::Keyword::None) : m_platform { Metric::ExHeight } { }
+    FontSizeAdjust(Metric metric, CSS::Keyword::FromFont) : m_platform { metric, ValueType::FromFont, std::nullopt } { }
+    FontSizeAdjust(Metric metric, Number metricValue) : m_platform { metric, ValueType::Number, metricValue.value } { }
+
+    FontSizeAdjust(WebCore::FontSizeAdjust platform) : m_platform { platform } { }
+
+    bool isNone() const { return m_platform.isNone(); }
+    bool isFromFont() const { return m_platform.isFromFont(); }
+
+    Metric metric() const { return m_platform.metric; }
+    std::optional<float> metricValue() const { return m_platform.value; }
+    std::optional<float> resolvedMetricValue(const RenderStyle&) const;
+
+    WebCore::FontSizeAdjust platform() const { return m_platform; }
+
+    bool operator==(const FontSizeAdjust&) const = default;
+
+private:
+    WebCore::FontSizeAdjust m_platform;
+};
+
+// MARK: - Conversion
+
+template<> struct CSSValueConversion<FontSizeAdjust> { auto operator()(BuilderState&, const CSSValue&) -> FontSizeAdjust; };
+// NOTE: `FontSizeAdjust` is special-cased to allow resolution of `from-font`.
+template<> struct CSSValueCreation<FontSizeAdjust> { auto operator()(CSSValuePool&, const RenderStyle&, const FontSizeAdjust&) -> Ref<CSSValue>; };
+
+// MARK: - Serialization
+
+// NOTE: `FontSizeAdjust` is special-cased to allow resolution of `from-font`.
+template<> struct Serialize<FontSizeAdjust> { void operator()(StringBuilder&, const CSS::SerializationContext&, const RenderStyle&, const FontSizeAdjust&); };
+
+// MARK: - Blending
+
+template<> struct Blending<FontSizeAdjust> {
+    auto canBlend(const FontSizeAdjust&, const FontSizeAdjust&) -> bool;
+    auto blend(const FontSizeAdjust&, const FontSizeAdjust&, const BlendingContext&) -> FontSizeAdjust;
+};
+
+// MARK: - Logging
+
+TextStream& operator<<(TextStream&, const FontSizeAdjust&);
+
+} // namespace Style
+} // namespace WebCore
+
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::FontSizeAdjust)

--- a/Source/WebCore/style/values/transforms/StyleRotate.cpp
+++ b/Source/WebCore/style/values/transforms/StyleRotate.cpp
@@ -27,6 +27,7 @@
 
 #include "StyleBuilderChecking.h"
 #include "StylePrimitiveNumericTypes+Blending.h"
+#include "StylePrimitiveNumericTypes+CSSValueConversion.h"
 #include "StylePrimitiveNumericTypes+CSSValueCreation.h"
 
 namespace WebCore {

--- a/Source/WebCore/style/values/transforms/StyleScale.cpp
+++ b/Source/WebCore/style/values/transforms/StyleScale.cpp
@@ -27,6 +27,7 @@
 
 #include "StyleBuilderChecking.h"
 #include "StylePrimitiveNumericTypes+Blending.h"
+#include "StylePrimitiveNumericTypes+CSSValueConversion.h"
 #include "StylePrimitiveNumericTypes+CSSValueCreation.h"
 
 namespace WebCore {

--- a/Source/WebCore/style/values/transforms/StyleTranslate.cpp
+++ b/Source/WebCore/style/values/transforms/StyleTranslate.cpp
@@ -29,7 +29,9 @@
 #include "StyleBuilderChecking.h"
 #include "StyleBuilderConverter.h"
 #include "StyleLengthWrapper+Blending.h"
+#include "StyleLengthWrapper+CSSValueConversion.h"
 #include "StylePrimitiveNumericTypes+Blending.h"
+#include "StylePrimitiveNumericTypes+CSSValueConversion.h"
 #include "StylePrimitiveNumericTypes+CSSValueCreation.h"
 
 namespace WebCore {


### PR DESCRIPTION
#### 1ae88c6afc0a54b20b3fed095d59a6e11122ffad
<pre>
[Style] Convert the &apos;font-size-adjust&apos; property to strong style types
<a href="https://bugs.webkit.org/show_bug.cgi?id=299702">https://bugs.webkit.org/show_bug.cgi?id=299702</a>

Reviewed by Darin Adler.

Converts the &apos;font-size-adjust&apos; property to use strong style types.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/platform/graphics/FontCascadeDescription.h:
* Source/WebCore/platform/graphics/FontDescription.cpp:
* Source/WebCore/rendering/style/RenderStyle.cpp:
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
* Source/WebCore/style/StyleBuilderConverter.h:
* Source/WebCore/style/StyleBuilderCustom.h:
* Source/WebCore/style/StyleBuilderState.h:
* Source/WebCore/style/StyleBuilderStateInlines.h:
* Source/WebCore/style/StyleExtractorConverter.h:
* Source/WebCore/style/StyleExtractorSerializer.h:
* Source/WebCore/style/StyleFontSizeFunctions.cpp:
* Source/WebCore/style/StyleFontSizeFunctions.h:
* Source/WebCore/style/StyleInterpolationFunctions.h:
* Source/WebCore/style/StyleInterpolationWrappers.h:
* Source/WebCore/style/StyleResolveForFont.cpp:
* Source/WebCore/style/StyleResolveForFont.h:
* Source/WebCore/style/values/fonts/StyleFontSizeAdjust.cpp: Added.
* Source/WebCore/style/values/fonts/StyleFontSizeAdjust.h: Added.

Canonical link: <a href="https://commits.webkit.org/300958@main">https://commits.webkit.org/300958@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/361e857750cec5f272ab70f3afffe820be38ea2a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124421 "7 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44105 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34836 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131263 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/76440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/126298 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44851 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52702 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94659 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/76440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127375 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35750 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111288 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75236 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34685 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29448 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74744 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105502 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29668 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133937 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51322 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39152 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103141 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51723 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107503 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102929 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26205 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48290 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26544 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48269 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51188 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56974 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50609 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53971 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52283 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->