### PR TITLE
bsky.app: No highlight when navigating to text fragment link generated by Safari

### DIFF
--- a/LayoutTests/http/tests/scroll-to-text-fragment/dynamic-content-is-found-expected.txt
+++ b/LayoutTests/http/tests/scroll-to-text-fragment/dynamic-content-is-found-expected.txt
@@ -1,0 +1,2 @@
+PASS: Page scrolled to text fragment.
+

--- a/LayoutTests/http/tests/scroll-to-text-fragment/dynamic-content-is-found.html
+++ b/LayoutTests/http/tests/scroll-to-text-fragment/dynamic-content-is-found.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<title>Scroll to Text Fragment - ensure that dynamically inserted content is found</title>
+<head>
+<script src="/js-test-resources/ui-helper.js"></script>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+async function runTest() {
+    location.href = "#:~:text=Scroll%20Point";
+    var output = "";
+
+    await UIHelper.ensurePresentationUpdate();
+
+    document.getElementById("destination").innerText = "Scroll Point";
+
+    addEventListener('scroll', () => {
+        if (window.pageYOffset > 9000)
+            output += "PASS: Page scrolled to text fragment.";
+        else 
+            output += "FAIL: Page did not scroll to text fragment.";
+        output += '<br>';
+
+        var target = document.getElementById('target');
+        target.innerHTML = output;
+        target.style.paddingTop = "0px";
+
+        if (window.testRunner)
+            testRunner.notifyDone();
+
+    });
+}
+
+window.addEventListener('load', () => {
+    runTest();
+});
+</script>
+</head>
+
+<body>
+    <div id="target" style="padding-top: 10000px;">
+        <p id="destination"></p>
+    </div>
+</body>
+</html>
+

--- a/Source/WebCore/dom/FragmentDirectiveUtilities.cpp
+++ b/Source/WebCore/dom/FragmentDirectiveUtilities.cpp
@@ -30,8 +30,24 @@
 #include "NodeRenderStyle.h"
 #include "NodeTraversal.h"
 #include "RenderStyleInlines.h"
+#include <wtf/text/TextStream.h>
 
 namespace WebCore {
+
+TextStream& operator<<(TextStream& ts, const ParsedTextDirective& directive)
+{
+    ts << "ParsedTextDirective [";
+    if (!directive.prefix.isEmpty())
+        ts << "prefix: " << directive.prefix << "; ";
+    if (!directive.startText.isEmpty())
+        ts << "startText: " << directive.startText << "; ";
+    if (!directive.endText.isEmpty())
+        ts << "endText: " << directive.endText << "; ";
+    if (!directive.suffix.isEmpty())
+        ts << "suffix: " << directive.suffix << "; ";
+    ts << "]";
+    return ts;
+}
 
 namespace FragmentDirectiveUtilities {
 

--- a/Source/WebCore/dom/FragmentDirectiveUtilities.h
+++ b/Source/WebCore/dom/FragmentDirectiveUtilities.h
@@ -28,6 +28,10 @@
 #include <wtf/Forward.h>
 #include <wtf/text/WTFString.h>
 
+namespace WTF {
+class TextStream;
+}
+
 namespace WebCore {
 
 class ContainerNode;
@@ -39,6 +43,8 @@ struct ParsedTextDirective {
     String endText;
     String suffix;
 };
+
+WTF::TextStream& operator<<(WTF::TextStream&, const ParsedTextDirective&);
 
 namespace FragmentDirectiveUtilities {
 

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -867,6 +867,7 @@ private:
 
     void unobscuredContentSizeChanged() final;
     
+    void scrollToTextFragmentRetryTimerFired();
     void textFragmentIndicatorTimerFired();
 
     // ScrollableArea interface
@@ -921,11 +922,13 @@ private:
 
     void updateWidgetPositionsTimerFired();
 
-    bool scrollToFragmentInternal(StringView);
+    enum class IsRetry : bool { No, Yes };
+    bool scrollToTextFragment(IsRetry = IsRetry::No);
+    bool scrollToAnchorFragment(StringView);
     void scheduleScrollToAnchorAndTextFragment();
     void scrollToAnchorAndTextFragmentNowIfNeeded();
     void scrollToAnchor();
-    void scrollToTextFragmentRange();
+    void scrollToPendingTextFragmentRange();
     void scrollPositionChanged(const ScrollPosition& oldPosition, const ScrollPosition& newPosition);
     void scrollableAreaSetChanged();
     void scheduleScrollEvent();
@@ -1006,6 +1009,9 @@ private:
     Timer m_delayedScrollToFocusedElementTimer;
     Timer m_speculativeTilingEnableTimer;
     Timer m_delayedTextFragmentIndicatorTimer;
+
+    Timer m_scrollToTextFragmentRetryTimer;
+    std::optional<MonotonicTime> m_scrollToTextFragmentInitialAttemptTime;
 
     MonotonicTime m_lastPaintTime;
 


### PR DESCRIPTION
#### e4e149e651c9263641b85591dbb8b7d9373d27d1
<pre>
bsky.app: No highlight when navigating to text fragment link generated by Safari
<a href="https://bugs.webkit.org/show_bug.cgi?id=300059">https://bugs.webkit.org/show_bug.cgi?id=300059</a>
<a href="https://rdar.apple.com/150880542">rdar://150880542</a>

Reviewed by Abrar Rahman Protyasha.

When we successfully parse a text fragment out of the URL, but fail to find
the referenced content, start a 500ms repeating timer, and re-try finding
the content each time it fires, up to 3 seconds, or when the user scrolls, or
the content is found, whichever comes first.

New test: http/tests/scroll-to-text-fragment/dynamic-content-is-found.html

* Source/WebCore/dom/FragmentDirectiveUtilities.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/dom/FragmentDirectiveUtilities.h:
Add overloads to dump parsed text fragments, for ease of debugging.

* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::LocalFrameView):
(WebCore::LocalFrameView::reset):
(WebCore::LocalFrameView::scrollToFragment):
Factor scrollToTextFragment out of scrollToFragment to make the flow a bit more clear.

(WebCore::LocalFrameView::scrollToTextFragment):
Invert the logic to be early-return-y.
When we fail, start the retry timer, with the rules explained above.

(WebCore::LocalFrameView::scrollToTextFragmentRetryTimerFired):
Retry the scroll when the timer fires.

(WebCore::LocalFrameView::scrollToAnchorFragment):
Rename this from scrollToFragmentInternal to scrollToAnchorFragment to better explain
which subset of the fragment scrolling mechanism it covers.

(WebCore::LocalFrameView::maintainScrollPositionAtScrollToTextFragmentRange):
(WebCore::LocalFrameView::scrollToAnchorAndTextFragmentNowIfNeeded):
(WebCore::LocalFrameView::scrollToPendingTextFragmentRange):
Another clarity-related rename.

(WebCore::LocalFrameView::scrollToFragmentInternal): Deleted.
(WebCore::LocalFrameView::scrollToTextFragmentRange): Deleted.
* Source/WebCore/page/LocalFrameView.h:

Canonical link: <a href="https://commits.webkit.org/300918@main">https://commits.webkit.org/300918@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6a8233850a45b079f45ea5f2f44cf9001c478b36

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124291 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43975 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34701 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131142 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76357 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a726d3a0-45e0-4f47-a667-e65c696002fc) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/126168 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44719 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52577 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94557 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/62722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e6269c1e-b7c4-4a23-8d38-3d220520a5ff) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127245 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35636 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111173 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75145 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/778125db-b896-42eb-a6f3-2c4e097f33e5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34579 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29332 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74607 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105381 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29555 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133797 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51200 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39039 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103023 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51594 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107391 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102819 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26170 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48182 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26437 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48139 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51064 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56846 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50501 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53857 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52176 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->