### PR TITLE
WIP (Web Inspector, Site Isolation): Attempting to fix broken inspector tests due to implementing console domain for frame targets

### DIFF
--- a/LayoutTests/http/tests/site-isolation/inspector/console/console-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/console/console-expected.txt
@@ -1,0 +1,17 @@
+CONSOLE MESSAGE: Log message
+CONSOLE MESSAGE: Warn message
+CONSOLE MESSAGE: Error message
+CONSOLE MESSAGE: Info message
+CONSOLE MESSAGE: Debug message
+CONSOLE MESSAGE: Uncaught error
+
+== Running test suite: SiteIsolation.Console
+-- Running test case: SiteIsolation.Console.MessageAdded
+{"eventType":"console-manager-message-added","messageLevel":"log","messageText":"Log message"}
+{"eventType":"console-manager-message-added","messageLevel":"warning","messageText":"Warn message"}
+{"eventType":"console-manager-message-added","messageLevel":"error","messageText":"Error message"}
+{"eventType":"console-manager-message-added","messageLevel":"info","messageText":"Info message"}
+{"eventType":"console-manager-message-added","messageLevel":"debug","messageText":"Debug message"}
+Uncaught exception in test page: Uncaught error [:1]
+{"eventType":"console-manager-message-added","messageLevel":"error","messageText":"Uncaught error"}
+

--- a/LayoutTests/http/tests/site-isolation/inspector/console/console.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/console/console.html
@@ -1,0 +1,46 @@
+<script src="../../../inspector/resources/inspector-test.js"></script>
+<script>
+TestPage.allowUncaughtExceptions = true;
+
+function test() {
+    let suite = InspectorTest.createAsyncSuite("SiteIsolation.Console");
+
+    // FIXME: <before landing> Add more tests involving (cross-origin) iframes.
+    suite.addTestCase({
+        name: "SiteIsolation.Console.MessageAdded",
+        description: "Test the Console.messageAdded event with site isolation.",
+        async test() {
+            function logEvent(event) {
+                let { message } = event.data;
+                InspectorTest.log({
+                    eventType: event.type,
+                    messageLevel: message.level,
+                    messageText: message.messageText,
+                });
+            };
+
+            InspectorTest.evaluateInPage(`console.log("Log message");`);
+            logEvent(await WI.consoleManager.awaitEvent(WI.ConsoleManager.Event.MessageAdded));
+
+            InspectorTest.evaluateInPage(`console.warn("Warn message");`);
+            logEvent(await WI.consoleManager.awaitEvent(WI.ConsoleManager.Event.MessageAdded));
+
+            InspectorTest.evaluateInPage(`console.error("Error message");`);
+            logEvent(await WI.consoleManager.awaitEvent(WI.ConsoleManager.Event.MessageAdded));
+
+            InspectorTest.evaluateInPage(`console.info("Info message");`);
+            logEvent(await WI.consoleManager.awaitEvent(WI.ConsoleManager.Event.MessageAdded));
+
+            InspectorTest.evaluateInPage(`console.debug("Debug message");`);
+            logEvent(await WI.consoleManager.awaitEvent(WI.ConsoleManager.Event.MessageAdded));
+
+            InspectorTest.evaluateInPage(`setTimeout(() => { throw "Uncaught error"; }, 0);`);
+            logEvent(await WI.consoleManager.awaitEvent(WI.ConsoleManager.Event.MessageAdded));
+        },
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+
+<body onload="runTest()"></body>

--- a/LayoutTests/inspector/console/console-message.html
+++ b/LayoutTests/inspector/console/console-message.html
@@ -6,76 +6,93 @@
 <script>
 function test()
 {
-    let suite = ProtocolTest.createAsyncSuite("Console.MessagesFromCommandLineAPI");
-
-    ProtocolTest.Console.addTestCase(suite, {
-        name: "ConsoleLogString",
-        description: "Test `console.log(\"log\")`",
-        expression: 'console.log("log");',
-        expected: {
-            source: 'console-api',
-            level: 'log',
-            text: 'log',
-            parameters: ['string']
+    (async () => {
+        try {
+            await InspectorProtocol.awaitCommand({ method: "Runtime.enable" });
+            console.log(`runtime ok`);
+        } catch (e) {
+            console.log(`runtime bad: ${e} ${JSON.stringify(e)}`);
         }
-    });
-
-    ProtocolTest.Console.addTestCase(suite, {
-        name: "ConsoleInfoString",
-        description: "Test `console.info(\"info\")`",
-        expression: 'console.info("info");',
-        expected: {
-            source: 'console-api',
-            level: 'info',
-            text: 'info',
-            parameters: ['string']
+        try {
+            // This won't work because the message was still sent to the page first in Internals.cpp.
+            await InspectorProtocol.awaitCommand({ method: "Console.enable" });
+            console.log(`console ok`);
+        } catch (e) {
+            console.log(`console bad: ${e} ${JSON.stringify(e)}`);
         }
-    });
+        testRunner.notifyDone();
+    })();
 
-    ProtocolTest.Console.addTestCase(suite, {
-        name: "ConsoleWarnString",
-        description: "Test `console.warn(\"warn\")`",
-        expression: 'console.warn("warn");',
-        expected: {
-            source: 'console-api',
-            level: 'warning',
-            text: 'warn',
-            parameters: ['string']
-        }
-    });
+    // let suite = ProtocolTest.createAsyncSuite("Console.MessagesFromCommandLineAPI");
 
-    ProtocolTest.Console.addTestCase(suite, {
-        name: "ConsoleErrorString",
-        description: "Test `console.error(\"error\")`",
-        expression: 'console.error("error");',
-        expected: {
-            source: 'console-api',
-            level: 'error',
-            text: 'error',
-            parameters: ['string']
-        }
-    });
+    // ProtocolTest.Console.addTestCase(suite, {
+    //     name: "ConsoleLogString",
+    //     description: "Test `console.log(\"log\")`",
+    //     expression: 'console.log("log");',
+    //     expected: {
+    //         source: 'console-api',
+    //         level: 'log',
+    //         text: 'log',
+    //         parameters: ['string']
+    //     }
+    // });
 
-    ProtocolTest.Console.addTestCase(suite, {
-        name: "ConsoleDebugString",
-        description: "Test `console.debug(\"debug\")`",
-        expression: 'console.debug("debug");',
-        expected: {
-            source: 'console-api',
-            level: 'debug',
-            text: 'debug',
-            parameters: ['string']
-        }
-    });
+    // ProtocolTest.Console.addTestCase(suite, {
+    //     name: "ConsoleInfoString",
+    //     description: "Test `console.info(\"info\")`",
+    //     expression: 'console.info("info");',
+    //     expected: {
+    //         source: 'console-api',
+    //         level: 'info',
+    //         text: 'info',
+    //         parameters: ['string']
+    //     }
+    // });
 
-    InspectorProtocol.awaitCommand({method: "Console.enable", params: {}})
-        .then(() => { suite.runTestCasesAndFinish(); })
-        .catch(fatalError);
+    // ProtocolTest.Console.addTestCase(suite, {
+    //     name: "ConsoleWarnString",
+    //     description: "Test `console.warn(\"warn\")`",
+    //     expression: 'console.warn("warn");',
+    //     expected: {
+    //         source: 'console-api',
+    //         level: 'warning',
+    //         text: 'warn',
+    //         parameters: ['string']
+    //     }
+    // });
 
-    function fatalError(e) {
-        ProtocolTest.log("Test failed with fatal error: " + JSON.stringify(e));
-        ProtocolTest.completeTest();
-    }
+    // ProtocolTest.Console.addTestCase(suite, {
+    //     name: "ConsoleErrorString",
+    //     description: "Test `console.error(\"error\")`",
+    //     expression: 'console.error("error");',
+    //     expected: {
+    //         source: 'console-api',
+    //         level: 'error',
+    //         text: 'error',
+    //         parameters: ['string']
+    //     }
+    // });
+
+    // ProtocolTest.Console.addTestCase(suite, {
+    //     name: "ConsoleDebugString",
+    //     description: "Test `console.debug(\"debug\")`",
+    //     expression: 'console.debug("debug");',
+    //     expected: {
+    //         source: 'console-api',
+    //         level: 'debug',
+    //         text: 'debug',
+    //         parameters: ['string']
+    //     }
+    // });
+
+    // InspectorProtocol.awaitCommand({method: "Console.enable", params: {}})
+    //     .then(() => { suite.runTestCasesAndFinish(); })
+    //     .catch(fatalError);
+
+    // function fatalError(e) {
+    //     ProtocolTest.log("Test failed with fatal error: " + JSON.stringify(e));
+    //     ProtocolTest.completeTest();
+    // }
 }
 </script>
 </head>

--- a/Source/JavaScriptCore/inspector/InspectorBackendDispatcher.cpp
+++ b/Source/JavaScriptCore/inspector/InspectorBackendDispatcher.cpp
@@ -95,7 +95,6 @@ bool BackendDispatcher::isActive() const
 
 void BackendDispatcher::registerDispatcherForDomain(const String& domain, SupplementalBackendDispatcher* dispatcher)
 {
-    WTFLogAlways("#=# BackendDispatcher::registerDispatcherForDomain this=%p domain=\"%s\" dispatcher=%p", this, domain.utf8().data(), dispatcher);
     ASSERT_ARG(dispatcher, dispatcher);
 
     // FIXME: <https://webkit.org/b/148492> Agents should only register with the backend once,

--- a/Source/JavaScriptCore/inspector/InspectorBackendDispatcher.cpp
+++ b/Source/JavaScriptCore/inspector/InspectorBackendDispatcher.cpp
@@ -95,6 +95,7 @@ bool BackendDispatcher::isActive() const
 
 void BackendDispatcher::registerDispatcherForDomain(const String& domain, SupplementalBackendDispatcher* dispatcher)
 {
+    WTFLogAlways("#=# BackendDispatcher::registerDispatcherForDomain this=%p domain=\"%s\" dispatcher=%p", this, domain.utf8().data(), dispatcher);
     ASSERT_ARG(dispatcher, dispatcher);
 
     // FIXME: <https://webkit.org/b/148492> Agents should only register with the backend once,

--- a/Source/JavaScriptCore/inspector/protocol/Console.json
+++ b/Source/JavaScriptCore/inspector/protocol/Console.json
@@ -2,7 +2,7 @@
     "domain": "Console",
     "description": "Console domain defines methods and events for interaction with the JavaScript console. Console collects messages created by means of the <a href='http://getfirebug.com/wiki/index.php/Console_API'>JavaScript Console API</a>. One needs to enable this domain using <code>enable</code> command in order to start receiving the console messages. Browser collects messages issued while console domain is not enabled as well and reports them using <code>messageAdded</code> notification upon enabling.",
     "debuggableTypes": ["itml", "javascript", "page", "service-worker", "web-page"],
-    "targetTypes": ["itml", "javascript", "page", "service-worker", "worker"],
+    "targetTypes": ["itml", "javascript", "frame", "service-worker", "worker"],
     "types": [
         {
             "id": "ChannelSource",

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -132,6 +132,7 @@ set(WebCore_PRIVATE_INCLUDE_DIRECTORIES
     "${WEBCORE_DIR}/html/track"
     "${WEBCORE_DIR}/inspector"
     "${WEBCORE_DIR}/inspector/agents"
+    "${WEBCORE_DIR}/inspector/agents/frame"
     "${WEBCORE_DIR}/inspector/agents/page"
     "${WEBCORE_DIR}/inspector/agents/worker"
     "${WEBCORE_DIR}/layout"

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1745,6 +1745,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     inspector/InspectorFrontendHost.h
     inspector/InspectorInstrumentationPublic.h
     inspector/InspectorInstrumentationWebKit.h
+    inspector/InstrumentingAgents.h
     inspector/InspectorOverlay.h
     inspector/InspectorOverlayLabel.h
     inspector/InspectorWebAgentBase.h

--- a/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
@@ -62,7 +62,6 @@ inspector/InspectorFrontendHost.h
 inspector/InspectorInstrumentation.h
 inspector/InspectorOverlay.h
 inspector/InspectorStyleSheet.h
-inspector/InspectorWebAgentBase.h
 inspector/InstrumentingAgents.h
 inspector/UserGestureEmulationScope.h
 inspector/agents/InspectorDOMAgent.h

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -531,9 +531,9 @@ inspector/agents/InspectorNetworkAgent.cpp
 inspector/agents/InspectorPageAgent.cpp
 inspector/agents/InspectorTimelineAgent.cpp
 inspector/agents/InspectorWorkerAgent.cpp
+inspector/agents/frame/FrameConsoleAgent.cpp
 inspector/agents/page/PageAuditAgent.cpp
 inspector/agents/page/PageCanvasAgent.cpp
-inspector/agents/page/PageConsoleAgent.cpp
 inspector/agents/page/PageDOMDebuggerAgent.cpp
 inspector/agents/page/PageDebuggerAgent.cpp
 inspector/agents/page/PageNetworkAgent.cpp

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1882,9 +1882,9 @@ inspector/agents/InspectorWorkerAgent.cpp
 inspector/agents/WebConsoleAgent.cpp
 inspector/agents/WebDebuggerAgent.cpp
 inspector/agents/WebHeapAgent.cpp
+inspector/agents/frame/FrameConsoleAgent.cpp
 inspector/agents/page/PageAuditAgent.cpp
 inspector/agents/page/PageCanvasAgent.cpp
-inspector/agents/page/PageConsoleAgent.cpp
 inspector/agents/page/PageDOMDebuggerAgent.cpp
 inspector/agents/page/PageDebuggerAgent.cpp
 inspector/agents/page/PageHeapAgent.cpp

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -4331,7 +4331,7 @@
 		A5B81CB51FAA44620037D1E6 /* WebConsoleAgent.h in Headers */ = {isa = PBXBuildFile; fileRef = A5B81C8E1FAA44260037D1E6 /* WebConsoleAgent.h */; };
 		A5B81CB61FAA44620037D1E6 /* WebDebuggerAgent.h in Headers */ = {isa = PBXBuildFile; fileRef = A5B81C9B1FAA44260037D1E6 /* WebDebuggerAgent.h */; };
 		A5B81CB71FAA44620037D1E6 /* WebHeapAgent.h in Headers */ = {isa = PBXBuildFile; fileRef = A5B81C9F1FAA44260037D1E6 /* WebHeapAgent.h */; };
-		A5B81CC21FAA44BC0037D1E6 /* PageConsoleAgent.h in Headers */ = {isa = PBXBuildFile; fileRef = A5B81CBB1FAA44B70037D1E6 /* PageConsoleAgent.h */; };
+		A5B81CC21FAA44BC0037D1E6 /* FrameConsoleAgent.h in Headers */ = {isa = PBXBuildFile; fileRef = A5B81CBB1FAA44B70037D1E6 /* FrameConsoleAgent.h */; };
 		A5B81CC31FAA44BC0037D1E6 /* PageDebuggerAgent.h in Headers */ = {isa = PBXBuildFile; fileRef = A5B81CBE1FAA44B70037D1E6 /* PageDebuggerAgent.h */; };
 		A5B81CC41FAA44BC0037D1E6 /* PageHeapAgent.h in Headers */ = {isa = PBXBuildFile; fileRef = A5B81CBC1FAA44B70037D1E6 /* PageHeapAgent.h */; };
 		A5B81CC51FAA44BC0037D1E6 /* PageRuntimeAgent.h in Headers */ = {isa = PBXBuildFile; fileRef = A5B81CBF1FAA44B70037D1E6 /* PageRuntimeAgent.h */; };
@@ -16867,12 +16867,12 @@
 		A5B81CA41FAA44270037D1E6 /* InspectorLayerTreeAgent.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = InspectorLayerTreeAgent.cpp; path = inspector/agents/InspectorLayerTreeAgent.cpp; sourceTree = SOURCE_ROOT; };
 		A5B81CA61FAA44270037D1E6 /* InspectorTimelineAgent.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = InspectorTimelineAgent.cpp; path = inspector/agents/InspectorTimelineAgent.cpp; sourceTree = SOURCE_ROOT; };
 		A5B81CBA1FAA44B70037D1E6 /* PageHeapAgent.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PageHeapAgent.cpp; sourceTree = "<group>"; };
-		A5B81CBB1FAA44B70037D1E6 /* PageConsoleAgent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PageConsoleAgent.h; sourceTree = "<group>"; };
+		A5B81CBB1FAA44B70037D1E6 /* FrameConsoleAgent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FrameConsoleAgent.h; sourceTree = "<group>"; };
 		A5B81CBC1FAA44B70037D1E6 /* PageHeapAgent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PageHeapAgent.h; sourceTree = "<group>"; };
 		A5B81CBD1FAA44B70037D1E6 /* PageDebuggerAgent.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PageDebuggerAgent.cpp; sourceTree = "<group>"; };
 		A5B81CBE1FAA44B70037D1E6 /* PageDebuggerAgent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PageDebuggerAgent.h; sourceTree = "<group>"; };
 		A5B81CBF1FAA44B70037D1E6 /* PageRuntimeAgent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PageRuntimeAgent.h; sourceTree = "<group>"; };
-		A5B81CC01FAA44B70037D1E6 /* PageConsoleAgent.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PageConsoleAgent.cpp; sourceTree = "<group>"; };
+		A5B81CC01FAA44B70037D1E6 /* FrameConsoleAgent.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FrameConsoleAgent.cpp; sourceTree = "<group>"; };
 		A5B81CC11FAA44B70037D1E6 /* PageRuntimeAgent.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PageRuntimeAgent.cpp; sourceTree = "<group>"; };
 		A5B81CC71FAA44DA0037D1E6 /* WorkerRuntimeAgent.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WorkerRuntimeAgent.cpp; sourceTree = "<group>"; };
 		A5B81CC81FAA44DA0037D1E6 /* WorkerDebuggerAgent.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WorkerDebuggerAgent.cpp; sourceTree = "<group>"; };
@@ -32663,6 +32663,7 @@
 		A5B81C831FAA44060037D1E6 /* agents */ = {
 			isa = PBXGroup;
 			children = (
+				F35F82472E832AA300215E26 /* frame */,
 				A5B81CB91FAA44820037D1E6 /* page */,
 				A5B81CC61FAA44C30037D1E6 /* worker */,
 				913FE5982362799900F9446A /* InspectorAnimationAgent.cpp */,
@@ -32712,8 +32713,6 @@
 				91278D5C21DEDAD500B57184 /* PageAuditAgent.h */,
 				953C6E6B2A0E05F100ACABC4 /* PageCanvasAgent.cpp */,
 				953C6E6A2A0E05F100ACABC4 /* PageCanvasAgent.h */,
-				A5B81CC01FAA44B70037D1E6 /* PageConsoleAgent.cpp */,
-				A5B81CBB1FAA44B70037D1E6 /* PageConsoleAgent.h */,
 				A5B81CBD1FAA44B70037D1E6 /* PageDebuggerAgent.cpp */,
 				A5B81CBE1FAA44B70037D1E6 /* PageDebuggerAgent.h */,
 				91E0DDBD230B41E40019E1E3 /* PageDOMDebuggerAgent.cpp */,
@@ -39067,6 +39066,15 @@
 			path = mac;
 			sourceTree = "<group>";
 		};
+		F35F82472E832AA300215E26 /* frame */ = {
+			isa = PBXGroup;
+			children = (
+				A5B81CC01FAA44B70037D1E6 /* FrameConsoleAgent.cpp */,
+				A5B81CBB1FAA44B70037D1E6 /* FrameConsoleAgent.h */,
+			);
+			path = frame;
+			sourceTree = "<group>";
+		};
 		F4034F8B275C0867003A81F8 /* cookie-consent */ = {
 			isa = PBXGroup;
 			children = (
@@ -42893,6 +42901,7 @@
 				2D9153F028AE0E330073A385 /* FragmentDirectiveRangeFinder.h in Headers */,
 				2DDF3EE42C8D94B30047786D /* FragmentDirectiveUtilities.h in Headers */,
 				46B95196207D633A00A7D2DD /* Frame.h in Headers */,
+				A5B81CC21FAA44BC0037D1E6 /* FrameConsoleAgent.h in Headers */,
 				DAED203116F244480070EC0F /* FrameConsoleClient.h in Headers */,
 				974A862314B7ADBB003FDC76 /* FrameDestructionObserver.h in Headers */,
 				46014ACC28333F65004C0B84 /* FrameDestructionObserverInlines.h in Headers */,
@@ -44950,7 +44959,6 @@
 				953C6E6C2A0E05F100ACABC4 /* PageCanvasAgent.h in Headers */,
 				95F45D27264DFBF100D0B8B8 /* PageColorSampler.h in Headers */,
 				CD5E5B5F1A15CE54000C609E /* PageConfiguration.h in Headers */,
-				A5B81CC21FAA44BC0037D1E6 /* PageConsoleAgent.h in Headers */,
 				A5A2AF0C1829734300DE1729 /* PageDebuggable.h in Headers */,
 				A5F36D3B18F758720054C024 /* PageDebugger.h in Headers */,
 				A5B81CC31FAA44BC0037D1E6 /* PageDebuggerAgent.h in Headers */,

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -6719,7 +6719,7 @@
 		F32BDCD92363AACA0073B6AE /* UserGestureEmulationScope.h in Headers */ = {isa = PBXBuildFile; fileRef = F32BDCD72363AACA0073B6AE /* UserGestureEmulationScope.h */; };
 		F344C7141125B82C00F26EEE /* InspectorFrontendClient.h in Headers */ = {isa = PBXBuildFile; fileRef = F344C7121125B82C00F26EEE /* InspectorFrontendClient.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		F344C75311294D9D00F26EEE /* InspectorFrontendClientLocal.h in Headers */ = {isa = PBXBuildFile; fileRef = F344C75211294D9D00F26EEE /* InspectorFrontendClientLocal.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		F3ABFE0C130E9DA000E7F7D1 /* InstrumentingAgents.h in Headers */ = {isa = PBXBuildFile; fileRef = F3ABFE0B130E9DA000E7F7D1 /* InstrumentingAgents.h */; };
+		F3ABFE0C130E9DA000E7F7D1 /* InstrumentingAgents.h in Headers */ = {isa = PBXBuildFile; fileRef = F3ABFE0B130E9DA000E7F7D1 /* InstrumentingAgents.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		F3D461491161D53200CA0D09 /* JSErrorHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = F3D461471161D53200CA0D09 /* JSErrorHandler.h */; };
 		F4023C4A2D3C4E670008A06D /* TextDirection.h in Headers */ = {isa = PBXBuildFile; fileRef = F4023C472D3C4E670008A06D /* TextDirection.h */; };
 		F4023C4B2D3C4E670008A06D /* UnicodeHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = F4023C482D3C4E670008A06D /* UnicodeHelpers.h */; };

--- a/Source/WebCore/inspector/CommandLineAPIHost.cpp
+++ b/Source/WebCore/inspector/CommandLineAPIHost.cpp
@@ -84,10 +84,11 @@ void CommandLineAPIHost::disconnect()
 
 void CommandLineAPIHost::inspect(JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSValue object, JSC::JSValue hints)
 {
-    if (!m_instrumentingAgents)
+    RefPtr agents = m_instrumentingAgents.get();
+    if (!agents)
         return;
 
-    auto* inspectorAgent = m_instrumentingAgents->persistentInspectorAgent();
+    auto* inspectorAgent = agents->persistentInspectorAgent();
     if (!inspectorAgent)
         return;
 

--- a/Source/WebCore/inspector/FrameInspectorController.cpp
+++ b/Source/WebCore/inspector/FrameInspectorController.cpp
@@ -32,7 +32,9 @@
 
 #include "CommonVM.h"
 #include "FrameInlines.h"
+#include "InspectorController.h"
 #include "InspectorInstrumentation.h"
+#include "InspectorWebAgentBase.h"
 #include "InstrumentingAgents.h"
 #include "JSDOMBindingSecurity.h"
 #include "JSDOMWindow.h"
@@ -57,7 +59,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(FrameInspectorController);
 
 FrameInspectorController::FrameInspectorController(LocalFrame& frame)
     : m_frame(frame)
-    , m_instrumentingAgents(InstrumentingAgents::create(*this))
+    , m_instrumentingAgents(InstrumentingAgents::create(*this, frame.protectedPage()->protectedInspectorController()->instrumentingAgents()))
     , m_injectedScriptManager(makeUniqueRef<WebInjectedScriptManager>(*this, WebInjectedScriptHost::create()))
     , m_frontendRouter(FrontendRouter::create())
     , m_backendDispatcher(BackendDispatcher::create(m_frontendRouter.copyRef()))
@@ -80,6 +82,24 @@ void FrameInspectorController::deref() const
     m_frame->deref();
 }
 
+FrameAgentContext FrameInspectorController::frameAgentContext()
+{
+    AgentContext baseContext = {
+        *this,
+        m_injectedScriptManager,
+        m_frontendRouter,
+        m_backendDispatcher
+    };
+    WebAgentContext webContext = {
+        baseContext,
+        m_instrumentingAgents.get()
+    };
+    return {
+        webContext,
+        m_frame
+    };
+}
+
 void FrameInspectorController::createLazyAgents()
 {
     if (m_didCreateLazyAgents)
@@ -100,14 +120,46 @@ void FrameInspectorController::connectFrontend(Inspector::FrontendChannel& front
     if (RefPtr page = m_frame->page())
         page->settings().setDeveloperExtrasEnabled(true);
 
+    bool connectedFirstFrontend = !m_frontendRouter->hasFrontends();
+
+    createLazyAgents();
     m_frontendRouter->connectFrontend(frontendChannel);
     InspectorInstrumentation::frontendCreated();
+
+    if (connectedFirstFrontend) {
+        m_agents.didCreateFrontendAndBackend();
+        InspectorInstrumentation::registerInstrumentingAgents(m_instrumentingAgents.get());
+    }
 }
 
 void FrameInspectorController::disconnectFrontend(Inspector::FrontendChannel& frontendChannel)
 {
     m_frontendRouter->disconnectFrontend(frontendChannel);
     InspectorInstrumentation::frontendDeleted();
+
+    bool disconnectedLastFrontend = !m_frontendRouter->hasFrontends();
+    if (disconnectedLastFrontend) {
+        InspectorInstrumentation::unregisterInstrumentingAgents(m_instrumentingAgents.get());
+        m_agents.willDestroyFrontendAndBackend(DisconnectReason::InspectorDestroyed);
+        m_injectedScriptManager->discardInjectedScripts();
+    }
+}
+
+void FrameInspectorController::inspectedFrameDestroyed()
+{
+    if (!m_frontendRouter->hasFrontends())
+        return;
+
+    for (unsigned i = 0; i < m_frontendRouter->frontendCount(); ++i)
+        InspectorInstrumentation::frontendDeleted();
+
+    InspectorInstrumentation::unregisterInstrumentingAgents(m_instrumentingAgents.get());
+    m_agents.willDestroyFrontendAndBackend(DisconnectReason::InspectedTargetDestroyed);
+
+    m_injectedScriptManager->disconnect();
+    m_frontendRouter->disconnectAllFrontends();
+
+    m_agents.discardValues();
 }
 
 void FrameInspectorController::dispatchMessageFromFrontend(const String& message)

--- a/Source/WebCore/inspector/FrameInspectorController.cpp
+++ b/Source/WebCore/inspector/FrameInspectorController.cpp
@@ -31,6 +31,7 @@
 #include "FrameInspectorController.h"
 
 #include "CommonVM.h"
+#include "FrameConsoleAgent.h"
 #include "FrameInlines.h"
 #include "InspectorController.h"
 #include "InspectorInstrumentation.h"
@@ -65,6 +66,11 @@ FrameInspectorController::FrameInspectorController(LocalFrame& frame)
     , m_backendDispatcher(BackendDispatcher::create(m_frontendRouter.copyRef()))
     , m_executionStopwatch(Stopwatch::create())
 {
+    auto agentContext = frameAgentContext();
+
+    std::unique_ptr consoleAgent = makeUnique<FrameConsoleAgent>(agentContext);
+    m_instrumentingAgents->setWebConsoleAgent(consoleAgent.get());
+    m_agents.append(WTFMove(consoleAgent));
 }
 
 FrameInspectorController::~FrameInspectorController()

--- a/Source/WebCore/inspector/FrameInspectorController.h
+++ b/Source/WebCore/inspector/FrameInspectorController.h
@@ -53,6 +53,7 @@ class InspectorInstrumentation;
 class InstrumentingAgents;
 class LocalFrame;
 class WebInjectedScriptManager;
+struct FrameAgentContext;
 
 class FrameInspectorController final : public Inspector::InspectorEnvironment, public CanMakeWeakPtr<FrameInspectorController> {
     WTF_MAKE_NONCOPYABLE(FrameInspectorController);
@@ -68,6 +69,8 @@ public:
     WEBCORE_EXPORT void disconnectFrontend(Inspector::FrontendChannel&);
     WEBCORE_EXPORT void dispatchMessageFromFrontend(const String& message);
 
+    void inspectedFrameDestroyed();
+
     // InspectorEnvironment
     bool developerExtrasEnabled() const override;
     bool canAccessInspectedScriptState(JSC::JSGlobalObject*) const override;
@@ -81,6 +84,7 @@ public:
 private:
     friend class InspectorInstrumentation;
 
+    FrameAgentContext frameAgentContext();
     void createLazyAgents();
 
     WeakRef<LocalFrame> m_frame;

--- a/Source/WebCore/inspector/InspectorController.cpp
+++ b/Source/WebCore/inspector/InspectorController.cpp
@@ -58,7 +58,6 @@
 #include "Page.h"
 #include "PageAuditAgent.h"
 #include "PageCanvasAgent.h"
-#include "PageConsoleAgent.h"
 #include "PageDOMDebuggerAgent.h"
 #include "PageDebugger.h"
 #include "PageDebuggerAgent.h"
@@ -104,12 +103,6 @@ InspectorController::InspectorController(Page& page, std::unique_ptr<InspectorBa
     , m_inspectorBackendClient(WTFMove(inspectorBackendClient))
 {
     ASSERT_ARG(inspectorBackendClient, m_inspectorBackendClient);
-
-    auto pageContext = pageAgentContext();
-
-    auto consoleAgent = makeUnique<PageConsoleAgent>(pageContext);
-    m_instrumentingAgents->setWebConsoleAgent(consoleAgent.get());
-    m_agents.append(WTFMove(consoleAgent));
 }
 
 InspectorController::~InspectorController()
@@ -152,6 +145,7 @@ PageAgentContext InspectorController::pageAgentContext()
 
 void InspectorController::createLazyAgents()
 {
+    WTFLogAlways("#=# InspectorController::createLazyAgents m_didCreateLazyAgents=%i", m_didCreateLazyAgents);
     if (m_didCreateLazyAgents)
         return;
 

--- a/Source/WebCore/inspector/InspectorController.cpp
+++ b/Source/WebCore/inspector/InspectorController.cpp
@@ -145,7 +145,6 @@ PageAgentContext InspectorController::pageAgentContext()
 
 void InspectorController::createLazyAgents()
 {
-    WTFLogAlways("#=# InspectorController::createLazyAgents m_didCreateLazyAgents=%i", m_didCreateLazyAgents);
     if (m_didCreateLazyAgents)
         return;
 

--- a/Source/WebCore/inspector/InspectorController.h
+++ b/Source/WebCore/inspector/InspectorController.h
@@ -118,6 +118,8 @@ public:
     InspectorBackendClient* inspectorBackendClient() const { return m_inspectorBackendClient.get(); }
     InspectorFrontendClient* inspectorFrontendClient() const { return m_inspectorFrontendClient; }
 
+    InstrumentingAgents& instrumentingAgents() const { return m_instrumentingAgents.get(); }
+
     Inspector::InspectorAgent& ensureInspectorAgent();
     InspectorDOMAgent& ensureDOMAgent();
     WEBCORE_EXPORT InspectorPageAgent& ensurePageAgent();

--- a/Source/WebCore/inspector/InspectorFrontendClientLocal.h
+++ b/Source/WebCore/inspector/InspectorFrontendClientLocal.h
@@ -97,7 +97,7 @@ public:
     virtual void attachWindow(DockSide) = 0;
     virtual void detachWindow() = 0;
 
-    WEBCORE_EXPORT void sendMessageToBackend(const String& message) final;
+    WEBCORE_EXPORT void sendMessageToBackend(const String& message) override;
 
     WEBCORE_EXPORT bool isUnderTest() final;
     bool isRemote() const final { return false; }

--- a/Source/WebCore/inspector/InspectorInstrumentation.cpp
+++ b/Source/WebCore/inspector/InspectorInstrumentation.cpp
@@ -39,6 +39,7 @@
 #include "DocumentLoader.h"
 #include "Event.h"
 #include "EventTargetInlines.h"
+#include "FrameInspectorController.h"
 #include "InspectorAnimationAgent.h"
 #include "InspectorCSSAgent.h"
 #include "InspectorCanvasAgent.h"
@@ -1292,7 +1293,7 @@ void InspectorInstrumentation::unregisterInstrumentingAgents(InstrumentingAgents
     }
 }
 
-InstrumentingAgents* InspectorInstrumentation::instrumentingAgents(const RenderObject& renderer)
+InstrumentingAgents& InspectorInstrumentation::instrumentingAgents(const RenderObject& renderer)
 {
     return instrumentingAgents(renderer.frame());
 }
@@ -1319,14 +1320,14 @@ InstrumentingAgents& InspectorInstrumentation::instrumentingAgents(ServiceWorker
     return globalScope.inspectorController().m_instrumentingAgents;
 }
 
-InstrumentingAgents* InspectorInstrumentation::instrumentingAgents(const LocalFrameView& frameView)
+InstrumentingAgents& InspectorInstrumentation::instrumentingAgents(const LocalFrameView& frameView)
 {
     return instrumentingAgents(frameView.frame());
 }
 
-InstrumentingAgents* InspectorInstrumentation::instrumentingAgents(const Frame& frame)
+InstrumentingAgents& InspectorInstrumentation::instrumentingAgents(const LocalFrame& frame)
 {
-    return instrumentingAgents(frame.page());
+    return frame.protectedInspectorController()->m_instrumentingAgents.get();
 }
 
 InstrumentingAgents* InspectorInstrumentation::instrumentingAgents(Document& document)

--- a/Source/WebCore/inspector/InspectorInstrumentation.h
+++ b/Source/WebCore/inspector/InspectorInstrumentation.h
@@ -240,7 +240,7 @@ public:
     static void loaderDetachedFromFrame(LocalFrame&, DocumentLoader&);
     static void frameStartedLoading(LocalFrame&);
     static void frameStoppedLoading(LocalFrame&);
-    static void didCompleteRenderingFrame(Frame&);
+    static void didCompleteRenderingFrame(LocalFrame&);
     static void accessibilitySettingsDidChange(Page&);
 #if ENABLE(DARK_MODE_CSS)
     static void defaultAppearanceDidChange(Page&);
@@ -534,24 +534,23 @@ private:
     static void renderLayerDestroyedImpl(InstrumentingAgents&, const RenderLayer&);
 
     static InstrumentingAgents& instrumentingAgents(Page&);
+    static InstrumentingAgents& instrumentingAgents(const LocalFrame&);
+    static InstrumentingAgents& instrumentingAgents(const LocalFrameView&);
     static InstrumentingAgents& instrumentingAgents(WorkerOrWorkletGlobalScope&);
     static InstrumentingAgents& instrumentingAgents(ServiceWorkerGlobalScope&);
+    static InstrumentingAgents& instrumentingAgents(const RenderObject&);
 
-    static InstrumentingAgents* instrumentingAgents(const LocalFrameView&);
-    static InstrumentingAgents* instrumentingAgents(const Frame&);
-    static InstrumentingAgents* instrumentingAgents(const Frame*);
+    static InstrumentingAgents* instrumentingAgents(const LocalFrame*);
     static InstrumentingAgents* instrumentingAgents(ScriptExecutionContext&);
     static InstrumentingAgents* instrumentingAgents(Document&);
     static InstrumentingAgents* instrumentingAgents(Document*);
-    static InstrumentingAgents* instrumentingAgents(const RenderObject&);
     static InstrumentingAgents* instrumentingAgents(WorkerOrWorkletGlobalScope*);
 };
 
 inline void InspectorInstrumentation::didClearWindowObjectInWorld(LocalFrame& frame, DOMWrapperWorld& world)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(frame))
-        didClearWindowObjectInWorldImpl(*agents, frame, world);
+    didClearWindowObjectInWorldImpl(instrumentingAgents(frame), frame, world);
 }
 
 inline bool InspectorInstrumentation::isDebuggerPaused(LocalFrame* frame)
@@ -622,15 +621,13 @@ inline void InspectorInstrumentation::didChangeRendererForDOMNode(Node& node)
 inline void InspectorInstrumentation::didAddOrRemoveScrollbars(LocalFrameView& frameView)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(frameView))
-        didAddOrRemoveScrollbarsImpl(*agents, frameView);
+    didAddOrRemoveScrollbarsImpl(instrumentingAgents(frameView), frameView);
 }
 
 inline void InspectorInstrumentation::didAddOrRemoveScrollbars(RenderObject& renderer)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(renderer))
-        didAddOrRemoveScrollbarsImpl(*agents, renderer);
+    didAddOrRemoveScrollbarsImpl(instrumentingAgents(renderer), renderer);
 }
 
 inline void InspectorInstrumentation::willModifyDOMAttr(Document& document, Element& element, const AtomString& oldValue, const AtomString& newValue)
@@ -677,8 +674,7 @@ inline void InspectorInstrumentation::documentDetached(Document& document)
 
 inline void InspectorInstrumentation::frameWindowDiscarded(LocalFrame& frame, LocalDOMWindow* domWindow)
 {
-    if (auto* agents = instrumentingAgents(frame))
-        frameWindowDiscardedImpl(*agents, domWindow);
+    frameWindowDiscardedImpl(instrumentingAgents(frame), domWindow);
 }
 
 inline void InspectorInstrumentation::mediaQueryResultChanged(Document& document)
@@ -788,17 +784,13 @@ inline void InspectorInstrumentation::mouseDidMoveOverElement(Page& page, const 
 inline bool InspectorInstrumentation::handleTouchEvent(LocalFrame& frame, Node& node)
 {
     FAST_RETURN_IF_NO_FRONTENDS(false);
-    if (auto* agents = instrumentingAgents(frame))
-        return handleTouchEventImpl(*agents, node);
-    return false;
+    return handleTouchEventImpl(instrumentingAgents(frame), node);
 }
 
 inline bool InspectorInstrumentation::handleMousePress(LocalFrame& frame)
 {
     FAST_RETURN_IF_NO_FRONTENDS(false);
-    if (auto* agents = instrumentingAgents(frame))
-        return handleMousePressImpl(*agents);
-    return false;
+    return handleMousePressImpl(instrumentingAgents(frame));
 }
 
 inline bool InspectorInstrumentation::forcePseudoState(const Element& element, CSSSelector::PseudoClass pseudoState)
@@ -869,37 +861,31 @@ inline bool InspectorInstrumentation::isEventListenerDisabled(EventTarget& targe
 inline int InspectorInstrumentation::willPostMessage(LocalFrame& frame)
 {
     FAST_RETURN_IF_NO_FRONTENDS(0);
-    if (auto* agents = instrumentingAgents(frame))
-        return willPostMessageImpl(*agents);
-    return 0;
+    return willPostMessageImpl(instrumentingAgents(frame));
 }
 
 inline void InspectorInstrumentation::didPostMessage(LocalFrame& frame, int postMessageIdentifier, JSC::JSGlobalObject& state)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(frame))
-        didPostMessageImpl(*agents, postMessageIdentifier, state);
+    didPostMessageImpl(instrumentingAgents(frame), postMessageIdentifier, state);
 }
 
 inline void InspectorInstrumentation::didFailPostMessage(LocalFrame& frame, int postMessageIdentifier)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(frame))
-        didFailPostMessageImpl(*agents, postMessageIdentifier);
+    didFailPostMessageImpl(instrumentingAgents(frame), postMessageIdentifier);
 }
 
 inline void InspectorInstrumentation::willDispatchPostMessage(LocalFrame& frame, int postMessageIdentifier)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(frame))
-        willDispatchPostMessageImpl(*agents, postMessageIdentifier);
+    willDispatchPostMessageImpl(instrumentingAgents(frame), postMessageIdentifier);
 }
 
 inline void InspectorInstrumentation::didDispatchPostMessage(LocalFrame& frame, int postMessageIdentifier)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(frame))
-        didDispatchPostMessageImpl(*agents, postMessageIdentifier);
+    didDispatchPostMessageImpl(instrumentingAgents(frame), postMessageIdentifier);
 }
 
 inline void InspectorInstrumentation::willCallFunction(ScriptExecutionContext* context, const String& scriptName, int scriptLine, int scriptColumn)
@@ -973,8 +959,7 @@ inline void InspectorInstrumentation::eventDidResetAfterDispatch(const Event& ev
 inline void InspectorInstrumentation::willEvaluateScript(LocalFrame& frame, const String& url, int lineNumber, int columnNumber)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(frame))
-        willEvaluateScriptImpl(*agents, url, lineNumber, columnNumber);
+    willEvaluateScriptImpl(instrumentingAgents(frame), url, lineNumber, columnNumber);
 }
 
 inline void InspectorInstrumentation::willEvaluateScript(WorkerOrWorkletGlobalScope& globalScope, const String& url, int lineNumber, int columnNumber)
@@ -986,8 +971,7 @@ inline void InspectorInstrumentation::willEvaluateScript(WorkerOrWorkletGlobalSc
 inline void InspectorInstrumentation::didEvaluateScript(LocalFrame& frame)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(frame))
-        didEvaluateScriptImpl(*agents);
+    didEvaluateScriptImpl(instrumentingAgents(frame));
 }
 
 inline void InspectorInstrumentation::didEvaluateScript(WorkerOrWorkletGlobalScope& globalScope)
@@ -1013,22 +997,19 @@ inline void InspectorInstrumentation::didFireTimer(ScriptExecutionContext& conte
 inline void InspectorInstrumentation::didInvalidateLayout(LocalFrame& frame)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(frame))
-        didInvalidateLayoutImpl(*agents);
+    didInvalidateLayoutImpl(instrumentingAgents(frame));
 }
 
 inline void InspectorInstrumentation::willLayout(LocalFrame& frame)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(frame))
-        willLayoutImpl(*agents);
+    willLayoutImpl(instrumentingAgents(frame));
 }
 
 inline void InspectorInstrumentation::didLayout(LocalFrame& frame, const Vector<FloatQuad>& layoutAreas)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(frame))
-        didLayoutImpl(*agents, layoutAreas);
+    didLayoutImpl(instrumentingAgents(frame), layoutAreas);
 }
 
 inline void InspectorInstrumentation::didScroll(Page& page)
@@ -1040,29 +1021,25 @@ inline void InspectorInstrumentation::didScroll(Page& page)
 inline void InspectorInstrumentation::willComposite(LocalFrame& frame)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(frame))
-        willCompositeImpl(*agents);
+    willCompositeImpl(instrumentingAgents(frame));
 }
 
 inline void InspectorInstrumentation::didComposite(LocalFrame& frame)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(frame))
-        didCompositeImpl(*agents);
+    didCompositeImpl(instrumentingAgents(frame));
 }
 
 inline void InspectorInstrumentation::willPaint(RenderObject& renderer)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(renderer))
-        return willPaintImpl(*agents);
+    willPaintImpl(instrumentingAgents(renderer));
 }
 
 inline void InspectorInstrumentation::didPaint(RenderObject& renderer, const LayoutRect& rect)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(renderer))
-        didPaintImpl(*agents, renderer, rect);
+    didPaintImpl(instrumentingAgents(renderer), renderer, rect);
 }
 
 inline void InspectorInstrumentation::willRecalculateStyle(Document& document)
@@ -1089,29 +1066,25 @@ inline void InspectorInstrumentation::didScheduleStyleRecalculation(Document& do
 inline void InspectorInstrumentation::applyUserAgentOverride(LocalFrame& frame, String& userAgent)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(frame))
-        applyUserAgentOverrideImpl(*agents, userAgent);
+    applyUserAgentOverrideImpl(instrumentingAgents(frame), userAgent);
 }
 
 inline void InspectorInstrumentation::applyEmulatedMedia(LocalFrame& frame, AtomString& media)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(frame))
-        applyEmulatedMediaImpl(*agents, media);
+    applyEmulatedMediaImpl(instrumentingAgents(frame), media);
 }
 
 inline void InspectorInstrumentation::flexibleBoxRendererBeganLayout(const RenderObject& renderer)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(renderer))
-        flexibleBoxRendererBeganLayoutImpl(*agents, renderer);
+    flexibleBoxRendererBeganLayoutImpl(instrumentingAgents(renderer), renderer);
 }
 
 inline void InspectorInstrumentation::flexibleBoxRendererWrappedToNextLine(const RenderObject& renderer, size_t lineStartItemIndex)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(renderer))
-        flexibleBoxRendererWrappedToNextLineImpl(*agents, renderer, lineStartItemIndex);
+    flexibleBoxRendererWrappedToNextLineImpl(instrumentingAgents(renderer), renderer, lineStartItemIndex);
 }
 
 inline void InspectorInstrumentation::willSendRequest(LocalFrame* frame, ResourceLoaderIdentifier identifier, DocumentLoader* loader, ResourceRequest& request, const ResourceResponse& redirectResponse, const CachedResource* cachedResource, ResourceLoader* resourceLoader)
@@ -1142,8 +1115,7 @@ inline void InspectorInstrumentation::didLoadResourceFromMemoryCache(Page& page,
 
 inline void InspectorInstrumentation::didReceiveResourceResponse(LocalFrame& frame, ResourceLoaderIdentifier identifier, DocumentLoader* loader, const ResourceResponse& response, ResourceLoader* resourceLoader)
 {
-    if (auto* agents = instrumentingAgents(frame))
-        didReceiveResourceResponseImpl(*agents, identifier, loader, response, resourceLoader);
+    didReceiveResourceResponseImpl(instrumentingAgents(frame), identifier, loader, response, resourceLoader);
 }
 
 inline void InspectorInstrumentation::didReceiveResourceResponse(ServiceWorkerGlobalScope& globalScope, ResourceLoaderIdentifier identifier, const ResourceResponse& response)
@@ -1198,22 +1170,19 @@ inline void InspectorInstrumentation::didFailLoading(ServiceWorkerGlobalScope& g
 inline void InspectorInstrumentation::continueAfterXFrameOptionsDenied(LocalFrame& frame, ResourceLoaderIdentifier identifier, DocumentLoader& loader, const ResourceResponse& response)
 {
     // Treat the same as didReceiveResponse.
-    if (auto* agents = instrumentingAgents(frame))
-        didReceiveResourceResponseImpl(*agents, identifier, &loader, response, nullptr);
+    didReceiveResourceResponseImpl(instrumentingAgents(frame), identifier, &loader, response, nullptr);
 }
 
 inline void InspectorInstrumentation::continueWithPolicyDownload(LocalFrame& frame, ResourceLoaderIdentifier identifier, DocumentLoader& loader, const ResourceResponse& response)
 {
     // Treat the same as didReceiveResponse.
-    if (auto* agents = instrumentingAgents(frame))
-        didReceiveResourceResponseImpl(*agents, identifier, &loader, response, nullptr);
+    didReceiveResourceResponseImpl(instrumentingAgents(frame), identifier, &loader, response, nullptr);
 }
 
 inline void InspectorInstrumentation::continueWithPolicyIgnore(LocalFrame& frame, ResourceLoaderIdentifier identifier, DocumentLoader& loader, const ResourceResponse& response)
 {
     // Treat the same as didReceiveResponse.
-    if (auto* agents = instrumentingAgents(frame))
-        didReceiveResourceResponseImpl(*agents, identifier, &loader, response, nullptr);
+    didReceiveResourceResponseImpl(instrumentingAgents(frame), identifier, &loader, response, nullptr);
 }
 
 inline void InspectorInstrumentation::willLoadXHRSynchronously(ScriptExecutionContext* context)
@@ -1254,8 +1223,7 @@ inline void InspectorInstrumentation::didReceiveScriptResponse(ScriptExecutionCo
 inline void InspectorInstrumentation::domContentLoadedEventFired(LocalFrame& frame)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(frame))
-        domContentLoadedEventFiredImpl(*agents, frame);
+    domContentLoadedEventFiredImpl(instrumentingAgents(frame), frame);
 }
 
 inline void InspectorInstrumentation::loadEventFired(LocalFrame* frame)
@@ -1268,49 +1236,42 @@ inline void InspectorInstrumentation::loadEventFired(LocalFrame* frame)
 inline void InspectorInstrumentation::frameDetachedFromParent(LocalFrame& frame)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(frame))
-        frameDetachedFromParentImpl(*agents, frame);
+    frameDetachedFromParentImpl(instrumentingAgents(frame), frame);
 }
 
 inline void InspectorInstrumentation::didCommitLoad(LocalFrame& frame, DocumentLoader* loader)
 {
-    if (auto* agents = instrumentingAgents(frame))
-        didCommitLoadImpl(*agents, frame, loader);
+    didCommitLoadImpl(instrumentingAgents(frame), frame, loader);
 }
 
 inline void InspectorInstrumentation::frameDocumentUpdated(LocalFrame& frame)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(frame))
-        frameDocumentUpdatedImpl(*agents, frame);
+    frameDocumentUpdatedImpl(instrumentingAgents(frame), frame);
 }
 
 inline void InspectorInstrumentation::loaderDetachedFromFrame(LocalFrame& frame, DocumentLoader& loader)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(frame))
-        loaderDetachedFromFrameImpl(*agents, loader);
+    loaderDetachedFromFrameImpl(instrumentingAgents(frame), loader);
 }
 
 inline void InspectorInstrumentation::frameStartedLoading(LocalFrame& frame)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(frame))
-        frameStartedLoadingImpl(*agents, frame);
+    frameStartedLoadingImpl(instrumentingAgents(frame), frame);
 }
 
-inline void InspectorInstrumentation::didCompleteRenderingFrame(Frame& frame)
+inline void InspectorInstrumentation::didCompleteRenderingFrame(LocalFrame& frame)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(frame))
-        didCompleteRenderingFrameImpl(*agents);
+    didCompleteRenderingFrameImpl(instrumentingAgents(frame));
 }
 
 inline void InspectorInstrumentation::frameStoppedLoading(LocalFrame& frame)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(frame))
-        frameStoppedLoadingImpl(*agents, frame);
+    frameStoppedLoadingImpl(instrumentingAgents(frame), frame);
 }
 
 inline void InspectorInstrumentation::accessibilitySettingsDidChange(Page& page)
@@ -1352,9 +1313,7 @@ inline bool InspectorInstrumentation::shouldInterceptRequest(const ResourceLoade
 inline bool InspectorInstrumentation::shouldInterceptResponse(const LocalFrame& frame, const ResourceResponse& response)
 {
     ASSERT(InspectorInstrumentationPublic::hasFrontends());
-    if (auto* agents = instrumentingAgents(frame))
-        return shouldInterceptResponseImpl(*agents, response);
-    return false;
+    return shouldInterceptResponseImpl(instrumentingAgents(frame), response);
 }
 
 inline void InspectorInstrumentation::interceptRequest(ResourceLoader& loader, Function<void(const ResourceRequest&)>&& handler)
@@ -1367,8 +1326,7 @@ inline void InspectorInstrumentation::interceptRequest(ResourceLoader& loader, F
 inline void InspectorInstrumentation::interceptResponse(const LocalFrame& frame, const ResourceResponse& response, ResourceLoaderIdentifier identifier, CompletionHandler<void(const ResourceResponse&, RefPtr<FragmentedSharedBuffer>)>&& handler)
 {
     ASSERT(InspectorInstrumentation::shouldInterceptResponse(frame, response));
-    if (auto* agents = instrumentingAgents(frame))
-        interceptResponseImpl(*agents, response, identifier, WTFMove(handler));
+    interceptResponseImpl(instrumentingAgents(frame), response, identifier, WTFMove(handler));
 }
 
 inline void InspectorInstrumentation::didDispatchDOMStorageEvent(Page& page, const String& key, const String& oldValue, const String& newValue, StorageType storageType, const SecurityOrigin& securityOrigin)
@@ -1574,8 +1532,7 @@ inline void InspectorInstrumentation::willDestroyWebAnimation(WebAnimation& anim
 
 inline void InspectorInstrumentation::addMessageToConsole(LocalFrame& frame, std::unique_ptr<Inspector::ConsoleMessage> message)
 {
-    if (auto* agents = instrumentingAgents(frame))
-        addMessageToConsoleImpl(*agents, WTFMove(message));
+    addMessageToConsoleImpl(instrumentingAgents(frame), WTFMove(message));
 }
 
 inline void InspectorInstrumentation::addMessageToConsole(WorkerOrWorkletGlobalScope& globalScope, std::unique_ptr<Inspector::ConsoleMessage> message)
@@ -1585,8 +1542,7 @@ inline void InspectorInstrumentation::addMessageToConsole(WorkerOrWorkletGlobalS
 
 inline void InspectorInstrumentation::consoleCount(LocalFrame& frame, JSC::JSGlobalObject* state, const String& label)
 {
-    if (auto* agents = instrumentingAgents(frame))
-        consoleCountImpl(*agents, state, label);
+    consoleCountImpl(instrumentingAgents(frame), state, label);
 }
 
 inline void InspectorInstrumentation::consoleCount(WorkerOrWorkletGlobalScope& globalScope, JSC::JSGlobalObject* state, const String& label)
@@ -1596,8 +1552,7 @@ inline void InspectorInstrumentation::consoleCount(WorkerOrWorkletGlobalScope& g
 
 inline void InspectorInstrumentation::consoleCountReset(LocalFrame& frame, JSC::JSGlobalObject* state, const String& label)
 {
-    if (auto* agents = instrumentingAgents(frame))
-        consoleCountResetImpl(*agents, state, label);
+    consoleCountResetImpl(instrumentingAgents(frame), state, label);
 }
 
 inline void InspectorInstrumentation::consoleCountReset(WorkerOrWorkletGlobalScope& globalScope, JSC::JSGlobalObject* state, const String& label)
@@ -1608,8 +1563,7 @@ inline void InspectorInstrumentation::consoleCountReset(WorkerOrWorkletGlobalSco
 inline void InspectorInstrumentation::takeHeapSnapshot(LocalFrame& frame, const String& title)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(frame))
-        takeHeapSnapshotImpl(*agents, title);
+    takeHeapSnapshotImpl(instrumentingAgents(frame), title);
 }
 
 inline void InspectorInstrumentation::takeHeapSnapshot(WorkerOrWorkletGlobalScope& globalScope, const String& title)
@@ -1620,8 +1574,7 @@ inline void InspectorInstrumentation::takeHeapSnapshot(WorkerOrWorkletGlobalScop
 
 inline void InspectorInstrumentation::startConsoleTiming(LocalFrame& frame, JSC::JSGlobalObject* exec, const String& label)
 {
-    if (auto* agents = instrumentingAgents(frame))
-        startConsoleTimingImpl(*agents, exec, label);
+    startConsoleTimingImpl(instrumentingAgents(frame), exec, label);
 }
 
 inline void InspectorInstrumentation::startConsoleTiming(WorkerOrWorkletGlobalScope& globalScope, JSC::JSGlobalObject* exec, const String& label)
@@ -1631,8 +1584,7 @@ inline void InspectorInstrumentation::startConsoleTiming(WorkerOrWorkletGlobalSc
 
 inline void InspectorInstrumentation::logConsoleTiming(LocalFrame& frame, JSC::JSGlobalObject* exec, const String& label, Ref<Inspector::ScriptArguments>&& arguments)
 {
-    if (auto* agents = instrumentingAgents(frame))
-        logConsoleTimingImpl(*agents, exec, label, WTFMove(arguments));
+    logConsoleTimingImpl(instrumentingAgents(frame), exec, label, WTFMove(arguments));
 }
 
 inline void InspectorInstrumentation::logConsoleTiming(WorkerOrWorkletGlobalScope& globalScope, JSC::JSGlobalObject* exec, const String& label, Ref<Inspector::ScriptArguments>&& arguments)
@@ -1642,8 +1594,7 @@ inline void InspectorInstrumentation::logConsoleTiming(WorkerOrWorkletGlobalScop
 
 inline void InspectorInstrumentation::stopConsoleTiming(LocalFrame& frame, JSC::JSGlobalObject* exec, const String& label)
 {
-    if (auto* agents = instrumentingAgents(frame))
-        stopConsoleTimingImpl(*agents, exec, label);
+    stopConsoleTimingImpl(instrumentingAgents(frame), exec, label);
 }
 
 inline void InspectorInstrumentation::stopConsoleTiming(WorkerOrWorkletGlobalScope& globalScope, JSC::JSGlobalObject* exec, const String& label)
@@ -1654,8 +1605,7 @@ inline void InspectorInstrumentation::stopConsoleTiming(WorkerOrWorkletGlobalSco
 inline void InspectorInstrumentation::consoleTimeStamp(LocalFrame& frame, Ref<Inspector::ScriptArguments>&& arguments)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(frame))
-        consoleTimeStampImpl(*agents, WTFMove(arguments));
+    consoleTimeStampImpl(instrumentingAgents(frame), WTFMove(arguments));
 }
 
 inline void InspectorInstrumentation::consoleTimeStamp(WorkerOrWorkletGlobalScope& globalScope, Ref<Inspector::ScriptArguments>&& arguments)
@@ -1667,8 +1617,7 @@ inline void InspectorInstrumentation::consoleTimeStamp(WorkerOrWorkletGlobalScop
 inline void InspectorInstrumentation::startProfiling(LocalFrame& frame, const String &title)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(frame))
-        startProfilingImpl(*agents, title);
+    startProfilingImpl(instrumentingAgents(frame), title);
 }
 
 inline void InspectorInstrumentation::startProfiling(WorkerOrWorkletGlobalScope& globalScope, const String &title)
@@ -1681,8 +1630,7 @@ inline void InspectorInstrumentation::stopProfiling(LocalFrame& frame, const Str
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
 
-    if (auto* agents = instrumentingAgents(frame))
-        stopProfilingImpl(*agents, title);
+    stopProfilingImpl(instrumentingAgents(frame), title);
 }
 
 inline void InspectorInstrumentation::stopProfiling(WorkerOrWorkletGlobalScope& globalScope, const String &title)
@@ -1771,9 +1719,9 @@ inline InstrumentingAgents* InspectorInstrumentation::instrumentingAgents(Script
     return context ? instrumentingAgents(*context) : nullptr;
 }
 
-inline InstrumentingAgents* InspectorInstrumentation::instrumentingAgents(const Frame* frame)
+inline InstrumentingAgents* InspectorInstrumentation::instrumentingAgents(const LocalFrame* frame)
 {
-    return frame ? instrumentingAgents(*frame) : nullptr;
+    return frame ? &instrumentingAgents(*frame) : nullptr;
 }
 
 inline InstrumentingAgents* InspectorInstrumentation::instrumentingAgents(Document* document)

--- a/Source/WebCore/inspector/InspectorWebAgentBase.h
+++ b/Source/WebCore/inspector/InspectorWebAgentBase.h
@@ -27,13 +27,13 @@
 #pragma once
 
 #include <JavaScriptCore/InspectorAgentBase.h>
+#include <WebCore/InstrumentingAgents.h>
 #include <WebCore/Page.h>
 #include <WebCore/WorkerOrWorkletGlobalScope.h>
+#include <wtf/WeakRef.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
-
-class InstrumentingAgents;
 
 // FIXME: move this to Inspector namespace when remaining agents move.
 struct WebAgentContext : public Inspector::AgentContext {
@@ -75,7 +75,7 @@ protected:
     {
     }
 
-    InstrumentingAgents& m_instrumentingAgents;
+    WeakRef<InstrumentingAgents> m_instrumentingAgents;
     Inspector::InspectorEnvironment& m_environment;
 };
     

--- a/Source/WebCore/inspector/InspectorWebAgentBase.h
+++ b/Source/WebCore/inspector/InspectorWebAgentBase.h
@@ -28,6 +28,7 @@
 
 #include <JavaScriptCore/InspectorAgentBase.h>
 #include <WebCore/InstrumentingAgents.h>
+#include <WebCore/LocalFrame.h>
 #include <WebCore/Page.h>
 #include <WebCore/WorkerOrWorkletGlobalScope.h>
 #include <wtf/WeakRef.h>
@@ -54,6 +55,16 @@ struct PageAgentContext : public WebAgentContext {
     }
 
     WeakRef<Page> inspectedPage;
+};
+
+struct FrameAgentContext : public WebAgentContext {
+    FrameAgentContext(WebAgentContext& context, LocalFrame& inspectedFrame)
+        : WebAgentContext(context)
+        , inspectedFrame(inspectedFrame)
+    {
+    }
+
+    WeakRef<LocalFrame> inspectedFrame;
 };
 
 struct WorkerAgentContext : public WebAgentContext {

--- a/Source/WebCore/inspector/InstrumentingAgents.cpp
+++ b/Source/WebCore/inspector/InstrumentingAgents.cpp
@@ -32,16 +32,25 @@
 #include "config.h"
 #include "InstrumentingAgents.h"
 #include <wtf/TZoneMallocInlines.h>
-
-
 namespace WebCore {
 
 using namespace Inspector;
 
+Ref<InstrumentingAgents> InstrumentingAgents::create(Inspector::InspectorEnvironment& environment)
+{
+    return adoptRef(*new InstrumentingAgents(environment, nullptr));
+}
+
+Ref<InstrumentingAgents> InstrumentingAgents::create(Inspector::InspectorEnvironment& environment, InstrumentingAgents& fallbackAgents)
+{
+    return adoptRef(*new InstrumentingAgents(environment, &fallbackAgents));
+}
+
 WTF_MAKE_TZONE_ALLOCATED_IMPL(InstrumentingAgents);
 
-InstrumentingAgents::InstrumentingAgents(InspectorEnvironment& environment)
+InstrumentingAgents::InstrumentingAgents(InspectorEnvironment& environment, InstrumentingAgents* fallbackAgents)
     : m_environment(environment)
+    , m_fallbackAgents(fallbackAgents)
 {
 }
 
@@ -53,5 +62,25 @@ void InstrumentingAgents::reset()
 FOR_EACH_INSPECTOR_AGENT(RESET_MEMBER_VARIABLE_FOR_INSPECTOR_AGENT)
 #undef RESET_MEMBER_VARIABLE_FOR_INSPECTOR_AGENT
 }
+
+// FIXME: <https://webkit.org/b/???> To smoothen the transition agents and functionalities from page target
+// to frame target, we added this fallback mechanism to let the frame use its page's agents as delegates
+// for agents not yet supported. Remove this once we complete implementing/migrating the frame target's agents.
+#define DEFINE_GETTER_SETTER_FOR_INSPECTOR_AGENT(Class, Name, Getter, Setter) \
+Class* InstrumentingAgents::Getter##Name() const \
+{ \
+    if (m_##Getter##Name) \
+        return m_##Getter##Name; \
+    if (RefPtr fallbackAgents = m_fallbackAgents.get()) \
+        return fallbackAgents->Getter##Name(); \
+    return nullptr; \
+} \
+void InstrumentingAgents::set##Setter##Name(Class* agent) \
+{ \
+    m_##Getter##Name = agent; \
+}
+
+FOR_EACH_INSPECTOR_AGENT(DEFINE_GETTER_SETTER_FOR_INSPECTOR_AGENT)
+#undef DEFINE_GETTER_SETTER_FOR_INSPECTOR_AGENT
 
 } // namespace WebCore

--- a/Source/WebCore/inspector/InstrumentingAgents.h
+++ b/Source/WebCore/inspector/InstrumentingAgents.h
@@ -33,7 +33,7 @@
 
 #include <JavaScriptCore/InspectorEnvironment.h>
 #include <wtf/Noncopyable.h>
-#include <wtf/RefCounted.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/TZoneMalloc.h>
 
 namespace Inspector {
@@ -138,12 +138,10 @@ class WebHeapAgent;
     DEFINE_TRACKING_INSPECTOR_AGENT(macro, Timeline) \
     DEFINE_TRACKING_INSPECTOR_AGENT(macro, Timeline_Page) \
 
-class InstrumentingAgents : public RefCounted<InstrumentingAgents> {
+class InstrumentingAgents : public WTF::RefCountedAndCanMakeWeakPtr<InstrumentingAgents> {
     WTF_MAKE_NONCOPYABLE(InstrumentingAgents);
     WTF_MAKE_TZONE_ALLOCATED(InstrumentingAgents);
 public:
-    // FIXME: InstrumentingAgents could be uniquely owned by InspectorController if instrumentation
-    // cookies kept only a weak reference to InstrumentingAgents. Then, reset() would be unnecessary.
     static Ref<InstrumentingAgents> create(Inspector::InspectorEnvironment& environment)
     {
         return adoptRef(*new InstrumentingAgents(environment));

--- a/Source/WebCore/inspector/InstrumentingAgents.h
+++ b/Source/WebCore/inspector/InstrumentingAgents.h
@@ -35,6 +35,7 @@
 #include <wtf/Noncopyable.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/WeakPtr.h>
 
 namespace Inspector {
 class InspectorAgent;
@@ -142,26 +143,26 @@ class InstrumentingAgents : public WTF::RefCountedAndCanMakeWeakPtr<Instrumentin
     WTF_MAKE_NONCOPYABLE(InstrumentingAgents);
     WTF_MAKE_TZONE_ALLOCATED(InstrumentingAgents);
 public:
-    static Ref<InstrumentingAgents> create(Inspector::InspectorEnvironment& environment)
-    {
-        return adoptRef(*new InstrumentingAgents(environment));
-    }
+    static Ref<InstrumentingAgents> create(Inspector::InspectorEnvironment&);
+    static Ref<InstrumentingAgents> create(Inspector::InspectorEnvironment&, InstrumentingAgents& fallbackAgents);
+
     ~InstrumentingAgents() = default;
     void reset();
 
     Inspector::InspectorEnvironment& inspectorEnvironment() const { return m_environment; }
 
 #define DECLARE_GETTER_SETTER_FOR_INSPECTOR_AGENT(Class, Name, Getter, Setter) \
-    Class* Getter##Name() const { return m_##Getter##Name; } \
-    void set##Setter##Name(Class* agent) { m_##Getter##Name = agent; } \
+    Class* Getter##Name() const; \
+    void set##Setter##Name(Class* agent); \
 
 FOR_EACH_INSPECTOR_AGENT(DECLARE_GETTER_SETTER_FOR_INSPECTOR_AGENT)
 #undef DECLARE_GETTER_SETTER_FOR_INSPECTOR_AGENT
 
 private:
-    InstrumentingAgents(Inspector::InspectorEnvironment&);
+    InstrumentingAgents(Inspector::InspectorEnvironment&, InstrumentingAgents* fallbackAgents);
 
     Inspector::InspectorEnvironment& m_environment;
+    const WeakPtr<InstrumentingAgents> m_fallbackAgents;
 
 #define DECLARE_MEMBER_VARIABLE_FOR_INSPECTOR_AGENT(Class, Name, Getter, Setter) \
     Class* m_##Getter##Name { nullptr }; \

--- a/Source/WebCore/inspector/agents/InspectorCPUProfilerAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorCPUProfilerAgent.cpp
@@ -51,14 +51,14 @@ InspectorCPUProfilerAgent::~InspectorCPUProfilerAgent() = default;
 
 void InspectorCPUProfilerAgent::didCreateFrontendAndBackend()
 {
-    m_instrumentingAgents.setPersistentCPUProfilerAgent(this);
+    Ref { m_instrumentingAgents.get() }->setPersistentCPUProfilerAgent(this);
 }
 
 void InspectorCPUProfilerAgent::willDestroyFrontendAndBackend(DisconnectReason)
 {
     stopTracking();
 
-    m_instrumentingAgents.setPersistentCPUProfilerAgent(nullptr);
+    Ref { m_instrumentingAgents.get() }->setPersistentCPUProfilerAgent(nullptr);
 }
 
 Inspector::Protocol::ErrorStringOr<void> InspectorCPUProfilerAgent::startTracking()

--- a/Source/WebCore/inspector/agents/InspectorCanvasAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorCanvasAgent.cpp
@@ -137,14 +137,14 @@ Inspector::Protocol::ErrorStringOr<void> InspectorCanvasAgent::disable()
 
 bool InspectorCanvasAgent::enabled() const
 {
-    return m_instrumentingAgents.enabledCanvasAgent() == this;
+    return Ref { m_instrumentingAgents.get() }->enabledCanvasAgent() == this;
 }
 
 void InspectorCanvasAgent::internalEnable()
 {
     ASSERT(!enabled());
 
-    m_instrumentingAgents.setEnabledCanvasAgent(this);
+    Ref { m_instrumentingAgents.get() }->setEnabledCanvasAgent(this);
 
     {
         Locker locker { CanvasRenderingContext::instancesLock() };
@@ -179,7 +179,7 @@ void InspectorCanvasAgent::internalEnable()
 
 void InspectorCanvasAgent::internalDisable()
 {
-    m_instrumentingAgents.setEnabledCanvasAgent(nullptr);
+    Ref { m_instrumentingAgents.get() }->setEnabledCanvasAgent(nullptr);
 
     reset();
 

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
@@ -329,7 +329,7 @@ void InspectorDOMAgent::didCreateFrontendAndBackend()
     m_history = makeUnique<InspectorHistory>();
     m_domEditor = makeUnique<DOMEditor>(*m_history);
 
-    m_instrumentingAgents.setPersistentDOMAgent(this);
+    Ref { m_instrumentingAgents.get() }->setPersistentDOMAgent(this);
     m_document = m_inspectedPage->localTopDocument();
 
     // Force a layout so that we can collect additional information from the layout process.
@@ -360,7 +360,7 @@ void InspectorDOMAgent::willDestroyFrontendAndBackend(Inspector::DisconnectReaso
     overlay->clearAllGridOverlays();
     overlay->clearAllFlexOverlays();
 
-    m_instrumentingAgents.setPersistentDOMAgent(nullptr);
+    Ref { m_instrumentingAgents.get() }->setPersistentDOMAgent(nullptr);
     m_documentRequested = false;
     reset();
 }
@@ -457,7 +457,7 @@ void InspectorDOMAgent::unbind(Node& node)
             unbind(*afterElement);
     }
 
-    if (auto* cssAgent = m_instrumentingAgents.enabledCSSAgent())
+    if (auto* cssAgent = Ref { m_instrumentingAgents.get() }->enabledCSSAgent())
         cssAgent->didRemoveDOMNode(node, id);
 
     if (m_childrenRequested.remove(id)) {
@@ -1507,7 +1507,8 @@ Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::highlightSelector(co
     RefPtr<Document> document;
 
     if (!!frameId) {
-        auto* pageAgent = m_instrumentingAgents.enabledPageAgent();
+        Ref agents = m_instrumentingAgents.get();
+        auto* pageAgent = agents->enabledPageAgent();
         if (!pageAgent)
             return makeUnexpected("Page domain must be enabled"_s);
 
@@ -1681,7 +1682,8 @@ Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::highlightFrame(const
 {
     Inspector::Protocol::ErrorString errorString;
 
-    auto* pageAgent = m_instrumentingAgents.enabledPageAgent();
+    Ref agents = m_instrumentingAgents.get();
+    auto* pageAgent = agents->enabledPageAgent();
     if (!pageAgent)
         return makeUnexpected("Page domain must be enabled"_s);
 
@@ -2012,12 +2014,13 @@ Ref<Inspector::Protocol::DOM::Node> InspectorDOMAgent::buildObjectForNode(Node* 
             value->setChildren(WTFMove(children));
     }
 
-    if (auto* cssAgent = m_instrumentingAgents.enabledCSSAgent()) {
+    Ref agents = m_instrumentingAgents.get();
+    if (auto* cssAgent = agents->enabledCSSAgent()) {
         if (auto layoutFlags = cssAgent->protocolLayoutFlagsForNode(*node))
             value->setLayoutFlags(layoutFlags.releaseNonNull());
     }
 
-    auto* pageAgent = m_instrumentingAgents.enabledPageAgent();
+    auto* pageAgent = agents->enabledPageAgent();
     if (pageAgent) {
         if (auto* frameView = node->document().view())
             value->setFrameId(pageAgent->frameId(&frameView->frame()));
@@ -2747,7 +2750,7 @@ void InspectorDOMAgent::willDestroyDOMNode(Node& node)
     m_idToNode.remove(nodeId);
     m_childrenRequested.remove(nodeId);
 
-    if (auto* cssAgent = m_instrumentingAgents.enabledCSSAgent())
+    if (auto* cssAgent = Ref { m_instrumentingAgents.get() }->enabledCSSAgent())
         cssAgent->didRemoveDOMNode(node, nodeId);
 
     // This can be called in response to GC. Due to the single-process model used in WebKit1, the
@@ -2795,7 +2798,7 @@ void InspectorDOMAgent::didModifyDOMAttr(Element& element, const AtomString& nam
     if (!id)
         return;
 
-    if (auto* cssAgent = m_instrumentingAgents.enabledCSSAgent())
+    if (auto* cssAgent = Ref { m_instrumentingAgents.get() }->enabledCSSAgent())
         cssAgent->didModifyDOMAttr(element);
 
     m_frontendDispatcher->attributeModified(id, name, value);
@@ -2807,7 +2810,7 @@ void InspectorDOMAgent::didRemoveDOMAttr(Element& element, const AtomString& nam
     if (!id)
         return;
 
-    if (auto* cssAgent = m_instrumentingAgents.enabledCSSAgent())
+    if (auto* cssAgent = Ref { m_instrumentingAgents.get() }->enabledCSSAgent())
         cssAgent->didModifyDOMAttr(element);
 
     m_frontendDispatcher->attributeRemoved(id, name);
@@ -2816,12 +2819,13 @@ void InspectorDOMAgent::didRemoveDOMAttr(Element& element, const AtomString& nam
 void InspectorDOMAgent::styleAttributeInvalidated(const Vector<Element*>& elements)
 {
     auto nodeIds = JSON::ArrayOf<Inspector::Protocol::DOM::NodeId>::create();
+    Ref agents = m_instrumentingAgents.get();
     for (auto& element : elements) {
         auto id = boundNodeId(element);
         if (!id)
             continue;
 
-        if (auto* cssAgent = m_instrumentingAgents.enabledCSSAgent())
+        if (auto* cssAgent = agents->enabledCSSAgent())
             cssAgent->didModifyDOMAttr(*element);
 
         nodeIds->addItem(id);

--- a/Source/WebCore/inspector/agents/InspectorDOMDebuggerAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMDebuggerAgent.cpp
@@ -70,17 +70,17 @@ InspectorDOMDebuggerAgent::~InspectorDOMDebuggerAgent() = default;
 
 bool InspectorDOMDebuggerAgent::enabled() const
 {
-    return m_instrumentingAgents.enabledDOMDebuggerAgent() == this;
+    return Ref { m_instrumentingAgents.get() }->enabledDOMDebuggerAgent() == this;
 }
 
 void InspectorDOMDebuggerAgent::enable()
 {
-    m_instrumentingAgents.setEnabledDOMDebuggerAgent(this);
+    Ref { m_instrumentingAgents.get() }->setEnabledDOMDebuggerAgent(this);
 }
 
 void InspectorDOMDebuggerAgent::disable()
 {
-    m_instrumentingAgents.setEnabledDOMDebuggerAgent(nullptr);
+    Ref { m_instrumentingAgents.get() }->setEnabledDOMDebuggerAgent(nullptr);
 
     m_listenerBreakpoints.clear();
     m_pauseOnAllIntervalsBreakpoint = nullptr;
@@ -288,7 +288,8 @@ void InspectorDOMDebuggerAgent::willHandleEvent(ScriptExecutionContext& scriptEx
     if (!m_debuggerAgent->breakpointsActive())
         return;
 
-    auto* domAgent = m_instrumentingAgents.persistentDOMAgent();
+    Ref agents = m_instrumentingAgents.get();
+    auto* domAgent = agents->persistentDOMAgent();
 
     auto breakpoint = m_pauseOnAllListenersBreakpoint;
     if (!breakpoint) {
@@ -347,7 +348,8 @@ void InspectorDOMDebuggerAgent::didHandleEvent(ScriptExecutionContext& scriptExe
         }
     }
     if (!breakpoint) {
-        if (auto* domAgent = m_instrumentingAgents.persistentDOMAgent())
+        Ref agents = m_instrumentingAgents.get();
+        if (auto* domAgent = agents->persistentDOMAgent())
             breakpoint = domAgent->breakpointForEventListener(*event.currentTarget(), event.type(), registeredEventListener.callback(), registeredEventListener.useCapture());
     }
     if (!breakpoint)

--- a/Source/WebCore/inspector/agents/InspectorDOMStorageAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMStorageAgent.cpp
@@ -79,20 +79,22 @@ void InspectorDOMStorageAgent::willDestroyFrontendAndBackend(Inspector::Disconne
 
 Inspector::Protocol::ErrorStringOr<void> InspectorDOMStorageAgent::enable()
 {
-    if (m_instrumentingAgents.enabledDOMStorageAgent() == this)
+    Ref agents = m_instrumentingAgents.get();
+    if (agents->enabledDOMStorageAgent() == this)
         return makeUnexpected("DOMStorage domain already enabled"_s);
 
-    m_instrumentingAgents.setEnabledDOMStorageAgent(this);
+    agents->setEnabledDOMStorageAgent(this);
 
     return { };
 }
 
 Inspector::Protocol::ErrorStringOr<void> InspectorDOMStorageAgent::disable()
 {
-    if (m_instrumentingAgents.enabledDOMStorageAgent() != this)
+    Ref agents = m_instrumentingAgents.get();
+    if (agents->enabledDOMStorageAgent() != this)
         return makeUnexpected("DOMStorage domain already disabled"_s);
 
-    m_instrumentingAgents.setEnabledDOMStorageAgent(nullptr);
+    agents->setEnabledDOMStorageAgent(nullptr);
 
     return { };
 }

--- a/Source/WebCore/inspector/agents/InspectorLayerTreeAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorLayerTreeAgent.cpp
@@ -80,14 +80,14 @@ void InspectorLayerTreeAgent::reset()
 
 Inspector::Protocol::ErrorStringOr<void> InspectorLayerTreeAgent::enable()
 {
-    m_instrumentingAgents.setEnabledLayerTreeAgent(this);
+    Ref { m_instrumentingAgents.get() }->setEnabledLayerTreeAgent(this);
 
     return { };
 }
 
 Inspector::Protocol::ErrorStringOr<void> InspectorLayerTreeAgent::disable()
 {
-    m_instrumentingAgents.setEnabledLayerTreeAgent(nullptr);
+    Ref { m_instrumentingAgents.get() }->setEnabledLayerTreeAgent(nullptr);
 
     reset();
 
@@ -116,7 +116,7 @@ void InspectorLayerTreeAgent::pseudoElementDestroyed(PseudoElement& pseudoElemen
 
 Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Inspector::Protocol::LayerTree::Layer>>> InspectorLayerTreeAgent::layersForNode(Inspector::Protocol::DOM::NodeId nodeId)
 {
-    auto* node = m_instrumentingAgents.persistentDOMAgent()->nodeForId(nodeId);
+    auto* node = Ref { m_instrumentingAgents.get() }->persistentDOMAgent()->nodeForId(nodeId);
     if (!node)
         return makeUnexpected("Missing node for given nodeId"_s);
 
@@ -220,7 +220,8 @@ Inspector::Protocol::DOM::NodeId InspectorLayerTreeAgent::idForNode(Node* node)
     if (!node)
         return 0;
 
-    InspectorDOMAgent* domAgent = m_instrumentingAgents.persistentDOMAgent();
+    Ref agents = m_instrumentingAgents.get();
+    InspectorDOMAgent* domAgent = agents->persistentDOMAgent();
     
     auto nodeId = domAgent->boundNodeId(node);
     if (!nodeId) {

--- a/Source/WebCore/inspector/agents/InspectorMemoryAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorMemoryAgent.cpp
@@ -52,32 +52,36 @@ InspectorMemoryAgent::~InspectorMemoryAgent() = default;
 
 void InspectorMemoryAgent::didCreateFrontendAndBackend()
 {
-    m_instrumentingAgents.setPersistentMemoryAgent(this);
+    Ref agents = m_instrumentingAgents.get();
+    agents->setPersistentMemoryAgent(this);
 }
 
 void InspectorMemoryAgent::willDestroyFrontendAndBackend(DisconnectReason)
 {
     disable();
 
-    m_instrumentingAgents.setPersistentMemoryAgent(nullptr);
+    Ref agents = m_instrumentingAgents.get();
+    agents->setPersistentMemoryAgent(nullptr);
 }
 
 Inspector::Protocol::ErrorStringOr<void> InspectorMemoryAgent::enable()
 {
-    if (m_instrumentingAgents.enabledMemoryAgent() == this)
+    Ref agents = m_instrumentingAgents.get();
+    if (agents->enabledMemoryAgent() == this)
         return makeUnexpected("Memory domain already enabled"_s);
 
-    m_instrumentingAgents.setEnabledMemoryAgent(this);
+    agents->setEnabledMemoryAgent(this);
 
     return { };
 }
 
 Inspector::Protocol::ErrorStringOr<void> InspectorMemoryAgent::disable()
 {
-    if (m_instrumentingAgents.enabledMemoryAgent() != this)
+    Ref agents = m_instrumentingAgents.get();
+    if (agents->enabledMemoryAgent() != this)
         return makeUnexpected("Memory domain already disabled"_s);
 
-    m_instrumentingAgents.setEnabledMemoryAgent(nullptr);
+    agents->setEnabledMemoryAgent(nullptr);
 
     m_tracking = false;
 

--- a/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
@@ -802,7 +802,8 @@ Ref<Inspector::Protocol::Network::Initiator> InspectorNetworkAgent::buildInitiat
         initiatorObject->setLineNumber(document->scriptableDocumentParser()->textPosition().m_line.oneBasedInt());
     }
 
-    auto domAgent = m_instrumentingAgents.persistentDOMAgent();
+    Ref agents = m_instrumentingAgents.get();
+    auto domAgent = agents->persistentDOMAgent();
     if (domAgent && resourceRequest) {
         if (auto inspectorInitiatorNodeIdentifier = resourceRequest->inspectorInitiatorNodeIdentifier()) {
             if (!initiatorObject) {
@@ -871,7 +872,8 @@ void InspectorNetworkAgent::didReceiveWebSocketFrameError(WebSocketChannelIdenti
 Inspector::Protocol::ErrorStringOr<void> InspectorNetworkAgent::enable()
 {
     m_enabled = true;
-    m_instrumentingAgents.setEnabledNetworkAgent(this);
+    Ref agents = m_instrumentingAgents.get();
+    agents->setEnabledNetworkAgent(this);
 
     {
         Locker locker { WebSocket::allActiveWebSocketsLock() };
@@ -909,7 +911,8 @@ Inspector::Protocol::ErrorStringOr<void> InspectorNetworkAgent::disable()
     m_enabled = false;
     m_interceptionEnabled = false;
     m_intercepts.clear();
-    m_instrumentingAgents.setEnabledNetworkAgent(nullptr);
+    Ref agents = m_instrumentingAgents.get();
+    agents->setEnabledNetworkAgent(nullptr);
     m_resourcesData->clear();
     m_extraRequestHeaders.clear();
 

--- a/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
@@ -368,10 +368,11 @@ void InspectorPageAgent::willDestroyFrontendAndBackend(Inspector::DisconnectReas
 
 Inspector::Protocol::ErrorStringOr<void> InspectorPageAgent::enable()
 {
-    if (m_instrumentingAgents.enabledPageAgent() == this)
+    Ref agents = m_instrumentingAgents.get();
+    if (agents->enabledPageAgent() == this)
         return makeUnexpected("Page domain already enabled"_s);
 
-    m_instrumentingAgents.setEnabledPageAgent(this);
+    agents->setEnabledPageAgent(this);
 
     auto& stopwatch = m_environment.executionStopwatch();
     stopwatch.reset();
@@ -384,7 +385,8 @@ Inspector::Protocol::ErrorStringOr<void> InspectorPageAgent::enable()
 
 Inspector::Protocol::ErrorStringOr<void> InspectorPageAgent::disable()
 {
-    m_instrumentingAgents.setEnabledPageAgent(nullptr);
+    Ref agents = m_instrumentingAgents.get();
+    agents->setEnabledPageAgent(nullptr);
 
     setShowPaintRects(false);
 #if !PLATFORM(IOS_FAMILY)
@@ -825,7 +827,8 @@ Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Inspector::Protocol::Generi
     Inspector::Protocol::ErrorString errorString;
 
     if (!!requestId) {
-        if (auto* networkAgent = m_instrumentingAgents.enabledNetworkAgent()) {
+        Ref agents = m_instrumentingAgents.get();
+        if (auto* networkAgent = agents->enabledNetworkAgent()) {
             RefPtr<JSON::ArrayOf<Inspector::Protocol::GenericTypes::SearchMatch>> result;
             networkAgent->searchInRequest(errorString, requestId, query, caseSensitive && *caseSensitive, isRegex && *isRegex, result);
             if (!result)
@@ -894,7 +897,8 @@ Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Inspector::Protocol::Page::
         }
     }
 
-    if (auto* networkAgent = m_instrumentingAgents.enabledNetworkAgent())
+    Ref agents = m_instrumentingAgents.get();
+    if (auto* networkAgent = agents->enabledNetworkAgent())
         networkAgent->searchOtherRequests(regex, result);
 
     return result;
@@ -1187,7 +1191,8 @@ Inspector::Protocol::ErrorStringOr<String> InspectorPageAgent::snapshotNode(Insp
 {
     Inspector::Protocol::ErrorString errorString;
 
-    InspectorDOMAgent* domAgent = m_instrumentingAgents.persistentDOMAgent();
+    Ref agents = m_instrumentingAgents.get();
+    InspectorDOMAgent* domAgent = agents->persistentDOMAgent();
     ASSERT(domAgent);
     Node* node = domAgent->assertNode(errorString, nodeId);
     if (!node)

--- a/Source/WebCore/inspector/agents/InspectorTimelineAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorTimelineAgent.cpp
@@ -141,19 +141,22 @@ Inspector::Protocol::ErrorStringOr<void> InspectorTimelineAgent::setInstruments(
 
 bool InspectorTimelineAgent::enabled() const
 {
-    return m_instrumentingAgents.enabledTimelineAgent() == this;
+    Ref agents = m_instrumentingAgents.get();
+    return agents->enabledTimelineAgent() == this;
 }
 
 void InspectorTimelineAgent::internalEnable()
 {
     ASSERT(!enabled());
 
-    m_instrumentingAgents.setEnabledTimelineAgent(this);
+    Ref agents = m_instrumentingAgents.get();
+    agents->setEnabledTimelineAgent(this);
 }
 
 void InspectorTimelineAgent::internalDisable()
 {
-    m_instrumentingAgents.setEnabledTimelineAgent(nullptr);
+    Ref agents = m_instrumentingAgents.get();
+    agents->setEnabledTimelineAgent(nullptr);
 
     stop();
 
@@ -162,7 +165,8 @@ void InspectorTimelineAgent::internalDisable()
 
 bool InspectorTimelineAgent::tracking() const
 {
-    return m_instrumentingAgents.trackingTimelineAgent() == this;
+    Ref agents = m_instrumentingAgents.get();
+    return agents->trackingTimelineAgent() == this;
 }
 
 void InspectorTimelineAgent::internalStart(std::optional<int>&& maxCallStackDepth)
@@ -174,7 +178,8 @@ void InspectorTimelineAgent::internalStart(std::optional<int>&& maxCallStackDept
     else
         m_maxCallStackDepth = 5;
 
-    m_instrumentingAgents.setTrackingTimelineAgent(this);
+    Ref agents = m_instrumentingAgents.get();
+    agents->setTrackingTimelineAgent(this);
 
     m_environment.debugger()->addObserver(*this);
 
@@ -183,7 +188,8 @@ void InspectorTimelineAgent::internalStart(std::optional<int>&& maxCallStackDept
 
 void InspectorTimelineAgent::internalStop()
 {
-    m_instrumentingAgents.setTrackingTimelineAgent(nullptr);
+    Ref agents = m_instrumentingAgents.get();
+    agents->setTrackingTimelineAgent(nullptr);
 
     m_environment.debugger()->removeObserver(*this, true);
 
@@ -221,7 +227,8 @@ void InspectorTimelineAgent::startFromConsole(const String& title)
         for (const TimelineRecordEntry& record : m_pendingConsoleProfileRecords) {
             auto recordTitle = record.data->getString("title"_s);
             if (recordTitle == title) {
-                if (auto* consoleAgent = m_instrumentingAgents.webConsoleAgent()) {
+                Ref agents = m_instrumentingAgents.get();
+                if (auto* consoleAgent = agents->webConsoleAgent()) {
                     // FIXME: Send an enum to the frontend for localization?
                     String warning = title.isEmpty() ? "Unnamed Profile already exists"_s : makeString("Profile \""_s, ScriptArguments::truncateStringForConsoleMessage(title), "\" already exists"_s);
                     consoleAgent->addMessageToConsole(makeUnique<ConsoleMessage>(MessageSource::ConsoleAPI, MessageType::Profile, MessageLevel::Warning, warning));
@@ -256,7 +263,8 @@ void InspectorTimelineAgent::stopFromConsole(const String& title)
         }
     }
 
-    if (auto* consoleAgent = m_instrumentingAgents.webConsoleAgent()) {
+    Ref agents = m_instrumentingAgents.get();
+    if (auto* consoleAgent = agents->webConsoleAgent()) {
         // FIXME: Send an enum to the frontend for localization?
         String warning = title.isEmpty() ? "No profiles exist"_s : makeString("Profile \""_s, ScriptArguments::truncateStringForConsoleMessage(title), "\" does not exist"_s);
         consoleAgent->addMessageToConsole(makeUnique<ConsoleMessage>(MessageSource::ConsoleAPI, MessageType::ProfileEnd, MessageLevel::Warning, warning));
@@ -350,8 +358,9 @@ void InspectorTimelineAgent::startProgrammaticCapture()
 {
     ASSERT(!tracking());
 
+    Ref agents = m_instrumentingAgents.get();
     // Disable breakpoints during programmatic capture.
-    if (auto* webDebuggerAgent = m_instrumentingAgents.enabledWebDebuggerAgent()) {
+    if (auto* webDebuggerAgent = agents->enabledWebDebuggerAgent()) {
         m_programmaticCaptureRestoreBreakpointActiveValue = webDebuggerAgent->breakpointsActive();
         if (m_programmaticCaptureRestoreBreakpointActiveValue)
             webDebuggerAgent->setBreakpointsActive(false);
@@ -374,7 +383,8 @@ void InspectorTimelineAgent::stopProgrammaticCapture()
 
     // Re-enable breakpoints if they were enabled.
     if (m_programmaticCaptureRestoreBreakpointActiveValue) {
-        if (auto* webDebuggerAgent = m_instrumentingAgents.enabledWebDebuggerAgent())
+        Ref agents = m_instrumentingAgents.get();
+        if (auto* webDebuggerAgent = agents->enabledWebDebuggerAgent())
             webDebuggerAgent->setBreakpointsActive(true);
     }
 }
@@ -414,7 +424,8 @@ void InspectorTimelineAgent::toggleInstruments(InstrumentState state)
 
 void InspectorTimelineAgent::toggleScriptProfilerInstrument(InstrumentState state)
 {
-    if (auto* scriptProfilerAgent = m_instrumentingAgents.persistentScriptProfilerAgent()) {
+    Ref agents = m_instrumentingAgents.get();
+    if (auto* scriptProfilerAgent = agents->persistentScriptProfilerAgent()) {
         if (state == InstrumentState::Start)
             scriptProfilerAgent->startTracking(true);
         else
@@ -424,7 +435,8 @@ void InspectorTimelineAgent::toggleScriptProfilerInstrument(InstrumentState stat
 
 void InspectorTimelineAgent::toggleHeapInstrument(InstrumentState state)
 {
-    if (auto* heapAgent = m_instrumentingAgents.persistentWebHeapAgent()) {
+    Ref agents = m_instrumentingAgents.get();
+    if (auto* heapAgent = agents->persistentWebHeapAgent()) {
         if (state == InstrumentState::Start) {
             if (shouldStartHeapInstrument())
                 heapAgent->startTracking();
@@ -436,7 +448,8 @@ void InspectorTimelineAgent::toggleHeapInstrument(InstrumentState state)
 void InspectorTimelineAgent::toggleCPUInstrument(InstrumentState state)
 {
 #if ENABLE(RESOURCE_USAGE)
-    if (auto* cpuProfilerAgent = m_instrumentingAgents.persistentCPUProfilerAgent()) {
+    Ref agents = m_instrumentingAgents.get();
+    if (auto* cpuProfilerAgent = agents->persistentCPUProfilerAgent()) {
         if (state == InstrumentState::Start)
             cpuProfilerAgent->startTracking();
         else
@@ -450,7 +463,8 @@ void InspectorTimelineAgent::toggleCPUInstrument(InstrumentState state)
 void InspectorTimelineAgent::toggleMemoryInstrument(InstrumentState state)
 {
 #if ENABLE(RESOURCE_USAGE)
-    if (auto* memoryAgent = m_instrumentingAgents.persistentMemoryAgent()) {
+    Ref agents = m_instrumentingAgents.get();
+    if (auto* memoryAgent = agents->persistentMemoryAgent()) {
         if (state == InstrumentState::Start)
             memoryAgent->startTracking();
         else
@@ -474,7 +488,8 @@ void InspectorTimelineAgent::toggleTimelineInstrument(InstrumentState state)
 
 void InspectorTimelineAgent::toggleAnimationInstrument(InstrumentState state)
 {
-    if (auto* animationAgent = m_instrumentingAgents.persistentAnimationAgent()) {
+    Ref agents = m_instrumentingAgents.get();
+    if (auto* animationAgent = agents->persistentAnimationAgent()) {
         if (state == InstrumentState::Start)
             animationAgent->startTracking();
         else

--- a/Source/WebCore/inspector/agents/InspectorWorkerAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorWorkerAgent.cpp
@@ -51,12 +51,14 @@ InspectorWorkerAgent::~InspectorWorkerAgent()
 
 void InspectorWorkerAgent::didCreateFrontendAndBackend()
 {
-    m_instrumentingAgents.setPersistentWorkerAgent(this);
+    Ref agents = m_instrumentingAgents.get();
+    agents->setPersistentWorkerAgent(this);
 }
 
 void InspectorWorkerAgent::willDestroyFrontendAndBackend(DisconnectReason)
 {
-    m_instrumentingAgents.setPersistentWorkerAgent(nullptr);
+    Ref agents = m_instrumentingAgents.get();
+    agents->setPersistentWorkerAgent(nullptr);
 
     disable();
 }

--- a/Source/WebCore/inspector/agents/WebDebuggerAgent.cpp
+++ b/Source/WebCore/inspector/agents/WebDebuggerAgent.cpp
@@ -49,19 +49,22 @@ WebDebuggerAgent::~WebDebuggerAgent() = default;
 
 bool WebDebuggerAgent::enabled() const
 {
-    return m_instrumentingAgents.enabledWebDebuggerAgent() == this && InspectorDebuggerAgent::enabled();
+    Ref agents = m_instrumentingAgents.get();
+    return agents->enabledWebDebuggerAgent() == this && InspectorDebuggerAgent::enabled();
 }
 
 void WebDebuggerAgent::internalEnable()
 {
-    m_instrumentingAgents.setEnabledWebDebuggerAgent(this);
+    Ref agents = m_instrumentingAgents.get();
+    agents->setEnabledWebDebuggerAgent(this);
 
     InspectorDebuggerAgent::internalEnable();
 }
 
 void WebDebuggerAgent::internalDisable(bool isBeingDestroyed)
 {
-    m_instrumentingAgents.setEnabledWebDebuggerAgent(nullptr);
+    Ref agents = m_instrumentingAgents.get();
+    agents->setEnabledWebDebuggerAgent(nullptr);
 
     InspectorDebuggerAgent::internalDisable(isBeingDestroyed);
 }

--- a/Source/WebCore/inspector/agents/WebDebuggerAgent.h
+++ b/Source/WebCore/inspector/agents/WebDebuggerAgent.h
@@ -28,6 +28,7 @@
 #include "InspectorWebAgentBase.h"
 #include <JavaScriptCore/InspectorDebuggerAgent.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/WeakRef.h>
 
 namespace WebCore {
 
@@ -66,7 +67,7 @@ protected:
 
     void didClearAsyncStackTraceData() final;
 
-    InstrumentingAgents& m_instrumentingAgents;
+    WeakRef<InstrumentingAgents> m_instrumentingAgents;
 
 private:
     HashMap<const RegisteredEventListener*, int> m_registeredEventListeners;

--- a/Source/WebCore/inspector/agents/WebHeapAgent.cpp
+++ b/Source/WebCore/inspector/agents/WebHeapAgent.cpp
@@ -115,23 +115,26 @@ void WebHeapAgent::didCreateFrontendAndBackend()
 {
     InspectorHeapAgent::didCreateFrontendAndBackend();
 
-    ASSERT(m_instrumentingAgents.persistentWebHeapAgent() != this);
-    m_instrumentingAgents.setPersistentWebHeapAgent(this);
+    Ref agents = m_instrumentingAgents.get();
+    ASSERT(agents->persistentWebHeapAgent() != this);
+    agents->setPersistentWebHeapAgent(this);
 }
 
 void WebHeapAgent::willDestroyFrontendAndBackend(DisconnectReason reason)
 {
     InspectorHeapAgent::willDestroyFrontendAndBackend(reason);
 
-    ASSERT(m_instrumentingAgents.persistentWebHeapAgent() == this);
-    m_instrumentingAgents.setPersistentWebHeapAgent(nullptr);
+    Ref agents = m_instrumentingAgents.get();
+    ASSERT(agents->persistentWebHeapAgent() == this);
+    agents->setPersistentWebHeapAgent(nullptr);
 }
 
 Inspector::Protocol::ErrorStringOr<void> WebHeapAgent::enable()
 {
     auto result = InspectorHeapAgent::enable();
 
-    if (auto* consoleAgent = m_instrumentingAgents.webConsoleAgent())
+    Ref agents = m_instrumentingAgents.get();
+    if (auto* consoleAgent = agents->webConsoleAgent())
         consoleAgent->setHeapAgent(this);
 
     return result;
@@ -141,7 +144,8 @@ Inspector::Protocol::ErrorStringOr<void> WebHeapAgent::disable()
 {
     m_sendGarbageCollectionEventsTask->reset();
 
-    if (auto* consoleAgent = m_instrumentingAgents.webConsoleAgent())
+    Ref agents = m_instrumentingAgents.get();
+    if (auto* consoleAgent = agents->webConsoleAgent())
         consoleAgent->setHeapAgent(nullptr);
 
     return InspectorHeapAgent::disable();

--- a/Source/WebCore/inspector/agents/WebHeapAgent.h
+++ b/Source/WebCore/inspector/agents/WebHeapAgent.h
@@ -29,6 +29,7 @@
 #include <JavaScriptCore/InspectorHeapAgent.h>
 #include <wtf/Forward.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/WeakRef.h>
 
 namespace WebCore {
 
@@ -55,7 +56,7 @@ protected:
     void dispatchGarbageCollectedEvent(Inspector::Protocol::Heap::GarbageCollection::Type, Seconds startTime, Seconds endTime) final;
     void dispatchGarbageCollectionEventsAfterDelay(Vector<GarbageCollectionData>&& collections);
 
-    InstrumentingAgents& m_instrumentingAgents;
+    WeakRef<InstrumentingAgents> m_instrumentingAgents;
 
     const UniqueRef<SendGarbageCollectionEventsTask> m_sendGarbageCollectionEventsTask;
 };

--- a/Source/WebCore/inspector/agents/frame/FrameConsoleAgent.h
+++ b/Source/WebCore/inspector/agents/frame/FrameConsoleAgent.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2011 Google Inc. All rights reserved.
- * Copyright (C) 2015 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -37,19 +37,19 @@
 
 namespace WebCore {
 
-class PageConsoleAgent final : public WebConsoleAgent {
-    WTF_MAKE_NONCOPYABLE(PageConsoleAgent);
-    WTF_MAKE_TZONE_ALLOCATED(PageConsoleAgent);
+class FrameConsoleAgent final : public WebConsoleAgent {
+    WTF_MAKE_NONCOPYABLE(FrameConsoleAgent);
+    WTF_MAKE_TZONE_ALLOCATED(FrameConsoleAgent);
 public:
-    PageConsoleAgent(PageAgentContext&);
-    ~PageConsoleAgent();
+    FrameConsoleAgent(FrameAgentContext&);
+    ~FrameConsoleAgent();
 
     // ConsoleBackendDispatcherHandler
     Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Inspector::Protocol::Console::Channel>>> getLoggingChannels();
     Inspector::Protocol::ErrorStringOr<void> setLoggingChannelLevel(Inspector::Protocol::Console::ChannelSource, Inspector::Protocol::Console::ChannelLevel);
 
 private:
-    WeakRef<Page> m_inspectedPage;
+    WeakRef<Frame> m_inspectedFrame;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/inspector/agents/page/PageCanvasAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageCanvasAgent.cpp
@@ -68,19 +68,22 @@ PageCanvasAgent::~PageCanvasAgent() = default;
 
 bool PageCanvasAgent::enabled() const
 {
-    return m_instrumentingAgents.enabledPageCanvasAgent() == this && InspectorCanvasAgent::enabled();
+    Ref agents = m_instrumentingAgents.get();
+    return agents->enabledPageCanvasAgent() == this && InspectorCanvasAgent::enabled();
 }
 
 void PageCanvasAgent::internalEnable()
 {
-    m_instrumentingAgents.setEnabledPageCanvasAgent(this);
+    Ref agents = m_instrumentingAgents.get();
+    agents->setEnabledPageCanvasAgent(this);
 
     InspectorCanvasAgent::internalEnable();
 }
 
 void PageCanvasAgent::internalDisable()
 {
-    m_instrumentingAgents.setEnabledPageCanvasAgent(nullptr);
+    Ref agents = m_instrumentingAgents.get();
+    agents->setEnabledPageCanvasAgent(nullptr);
 
     InspectorCanvasAgent::internalDisable();
 }
@@ -98,18 +101,20 @@ Inspector::Protocol::ErrorStringOr<Inspector::Protocol::DOM::NodeId> PageCanvasA
         return makeUnexpected("Missing element of canvas for given canvasId"_s);
 
     // FIXME: <https://webkit.org/b/213499> Web Inspector: allow DOM nodes to be instrumented at any point, regardless of whether the main document has also been instrumented
-    int documentNodeId = m_instrumentingAgents.persistentDOMAgent()->boundNodeId(&node->document());
+    Ref agents = m_instrumentingAgents.get();
+    int documentNodeId = agents->persistentDOMAgent()->boundNodeId(&node->document());
     if (!documentNodeId)
         return makeUnexpected("Document must have been requested"_s);
 
-    return m_instrumentingAgents.persistentDOMAgent()->pushNodeToFrontend(errorString, documentNodeId, node);
+    return agents->persistentDOMAgent()->pushNodeToFrontend(errorString, documentNodeId, node);
 }
 
 Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Inspector::Protocol::DOM::NodeId>>> PageCanvasAgent::requestClientNodes(const Inspector::Protocol::Canvas::CanvasId& canvasId)
 {
     Inspector::Protocol::ErrorString errorString;
 
-    auto* domAgent = m_instrumentingAgents.persistentDOMAgent();
+    Ref agents = m_instrumentingAgents.get();
+    auto* domAgent = agents->persistentDOMAgent();
     if (!domAgent)
         return makeUnexpected("DOM domain must be enabled"_s);
 

--- a/Source/WebCore/inspector/agents/page/PageDOMDebuggerAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageDOMDebuggerAgent.cpp
@@ -45,19 +45,22 @@ PageDOMDebuggerAgent::~PageDOMDebuggerAgent() = default;
 
 bool PageDOMDebuggerAgent::enabled() const
 {
-    return m_instrumentingAgents.enabledPageDOMDebuggerAgent() == this && InspectorDOMDebuggerAgent::enabled();
+    Ref agents = m_instrumentingAgents.get();
+    return agents->enabledPageDOMDebuggerAgent() == this && InspectorDOMDebuggerAgent::enabled();
 }
 
 void PageDOMDebuggerAgent::enable()
 {
-    m_instrumentingAgents.setEnabledPageDOMDebuggerAgent(this);
+    Ref agents = m_instrumentingAgents.get();
+    agents->setEnabledPageDOMDebuggerAgent(this);
 
     InspectorDOMDebuggerAgent::enable();
 }
 
 void PageDOMDebuggerAgent::disable()
 {
-    m_instrumentingAgents.setEnabledPageDOMDebuggerAgent(nullptr);
+    Ref agents = m_instrumentingAgents.get();
+    agents->setEnabledPageDOMDebuggerAgent(nullptr);
 
     m_domSubtreeModifiedBreakpoints.clear();
     m_domAttributeModifiedBreakpoints.clear();
@@ -70,7 +73,8 @@ Inspector::Protocol::ErrorStringOr<void> PageDOMDebuggerAgent::setDOMBreakpoint(
 {
     Inspector::Protocol::ErrorString errorString;
 
-    auto* domAgent = m_instrumentingAgents.persistentDOMAgent();
+    Ref agents = m_instrumentingAgents.get();
+    auto* domAgent = agents->persistentDOMAgent();
     if (!domAgent)
         return makeUnexpected("DOM domain must be enabled"_s);
 
@@ -107,7 +111,8 @@ Inspector::Protocol::ErrorStringOr<void> PageDOMDebuggerAgent::removeDOMBreakpoi
 {
     Inspector::Protocol::ErrorString errorString;
 
-    auto* domAgent = m_instrumentingAgents.persistentDOMAgent();
+    Ref agents = m_instrumentingAgents.get();
+    auto* domAgent = agents->persistentDOMAgent();
     if (!domAgent)
         return makeUnexpected("DOM domain must be enabled"_s);
 
@@ -252,7 +257,8 @@ void PageDOMDebuggerAgent::willRemoveDOMNode(Node& node)
     ASSERT(closestBreakpointOwner);
 
     auto pauseData = buildPauseDataForDOMBreakpoint(*closestBreakpointType, *closestBreakpointOwner);
-    if (auto* domAgent = m_instrumentingAgents.persistentDOMAgent()) {
+    Ref agents = m_instrumentingAgents.get();
+    if (auto* domAgent = agents->persistentDOMAgent()) {
         if (&node != closestBreakpointOwner) {
             if (auto targetNodeId = domAgent->pushNodeToFrontend(&node))
                 pauseData->setInteger("targetNodeId"_s, targetNodeId);
@@ -311,7 +317,8 @@ Ref<JSON::Object> PageDOMDebuggerAgent::buildPauseDataForDOMBreakpoint(Inspector
 
     auto pauseData = JSON::Object::create();
     pauseData->setString("type"_s, Inspector::Protocol::Helpers::getEnumConstantValue(breakpointType));
-    if (auto* domAgent = m_instrumentingAgents.persistentDOMAgent()) {
+    Ref agents = m_instrumentingAgents.get();
+    if (auto* domAgent = agents->persistentDOMAgent()) {
         if (auto breakpointOwnerNodeId = domAgent->pushNodeToFrontend(&breakpointOwner))
             pauseData->setInteger("nodeId"_s, breakpointOwnerNodeId);
     }

--- a/Source/WebCore/inspector/agents/page/PageDebuggerAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageDebuggerAgent.cpp
@@ -68,7 +68,8 @@ PageDebuggerAgent::~PageDebuggerAgent() = default;
 
 bool PageDebuggerAgent::enabled() const
 {
-    return m_instrumentingAgents.enabledPageDebuggerAgent() == this && WebDebuggerAgent::enabled();
+    Ref agents = m_instrumentingAgents.get();
+    return agents->enabledPageDebuggerAgent() == this && WebDebuggerAgent::enabled();
 }
 
 Inspector::Protocol::ErrorStringOr<std::tuple<Ref<Inspector::Protocol::Runtime::RemoteObject>, std::optional<bool> /* wasThrown */, std::optional<int> /* savedResultIndex */>> PageDebuggerAgent::evaluateOnCallFrame(const Inspector::Protocol::Debugger::CallFrameId& callFrameId, const String& expression, const String& objectGroup, std::optional<bool>&& includeCommandLineAPI, std::optional<bool>&& doNotPauseOnExceptionsAndMuteConsole, std::optional<bool>&& returnByValue, std::optional<bool>&& generatePreview, std::optional<bool>&& saveResult, std::optional<bool>&& emulateUserGesture)
@@ -83,14 +84,16 @@ Inspector::Protocol::ErrorStringOr<std::tuple<Ref<Inspector::Protocol::Runtime::
 
 void PageDebuggerAgent::internalEnable()
 {
-    m_instrumentingAgents.setEnabledPageDebuggerAgent(this);
+    Ref agents = m_instrumentingAgents.get();
+    agents->setEnabledPageDebuggerAgent(this);
 
     WebDebuggerAgent::internalEnable();
 }
 
 void PageDebuggerAgent::internalDisable(bool isBeingDestroyed)
 {
-    m_instrumentingAgents.setEnabledPageDebuggerAgent(nullptr);
+    Ref agents = m_instrumentingAgents.get();
+    agents->setEnabledPageDebuggerAgent(nullptr);
 
     WebDebuggerAgent::internalDisable(isBeingDestroyed);
 }

--- a/Source/WebCore/inspector/agents/page/PageHeapAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageHeapAgent.cpp
@@ -50,14 +50,16 @@ Inspector::Protocol::ErrorStringOr<void> PageHeapAgent::enable()
 {
     auto result = WebHeapAgent::enable();
 
-    m_instrumentingAgents.setEnabledPageHeapAgent(this);
+    Ref agents = m_instrumentingAgents.get();
+    agents->setEnabledPageHeapAgent(this);
 
     return result;
 }
 
 Inspector::Protocol::ErrorStringOr<void> PageHeapAgent::disable()
 {
-    m_instrumentingAgents.setEnabledPageHeapAgent(nullptr);
+    Ref agents = m_instrumentingAgents.get();
+    agents->setEnabledPageHeapAgent(nullptr);
 
     return WebHeapAgent::disable();
 }

--- a/Source/WebCore/inspector/agents/page/PageHeapAgent.h
+++ b/Source/WebCore/inspector/agents/page/PageHeapAgent.h
@@ -29,6 +29,7 @@
 #include "InstrumentingAgents.h"
 #include "WebHeapAgent.h"
 #include <wtf/TZoneMalloc.h>
+#include <wtf/WeakRef.h>
 
 namespace WebCore {
 
@@ -51,7 +52,7 @@ public:
     void mainFrameNavigated();
 
 private:
-    InstrumentingAgents& m_instrumentingAgents;
+    WeakRef<InstrumentingAgents> m_instrumentingAgents;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/inspector/agents/page/PageNetworkAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageNetworkAgent.cpp
@@ -62,7 +62,8 @@ PageNetworkAgent::~PageNetworkAgent() = default;
 Inspector::Protocol::Network::LoaderId PageNetworkAgent::loaderIdentifier(DocumentLoader* loader)
 {
     if (loader) {
-        if (auto* pageAgent = m_instrumentingAgents.enabledPageAgent())
+        Ref agents = m_instrumentingAgents.get();
+        if (auto* pageAgent = agents->enabledPageAgent())
             return pageAgent->loaderId(loader);
     }
     return { };
@@ -71,7 +72,8 @@ Inspector::Protocol::Network::LoaderId PageNetworkAgent::loaderIdentifier(Docume
 Inspector::Protocol::Network::FrameId PageNetworkAgent::frameIdentifier(DocumentLoader* loader)
 {
     if (loader) {
-        if (auto* pageAgent = m_instrumentingAgents.enabledPageAgent())
+        Ref agents = m_instrumentingAgents.get();
+        if (auto* pageAgent = agents->enabledPageAgent())
             return pageAgent->frameId(loader->frame());
     }
     return { };
@@ -119,7 +121,8 @@ bool PageNetworkAgent::setEmulatedConditionsInternal(std::optional<int>&& bytesP
 
 ScriptExecutionContext* PageNetworkAgent::scriptExecutionContext(Inspector::Protocol::ErrorString& errorString, const Inspector::Protocol::Network::FrameId& frameId)
 {
-    auto* pageAgent = m_instrumentingAgents.enabledPageAgent();
+    Ref agents = m_instrumentingAgents.get();
+    auto* pageAgent = agents->enabledPageAgent();
     if (!pageAgent) {
         errorString = "Page domain must be enabled"_s;
         return nullptr;

--- a/Source/WebCore/inspector/agents/page/PageRuntimeAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageRuntimeAgent.cpp
@@ -68,7 +68,8 @@ PageRuntimeAgent::~PageRuntimeAgent() = default;
 
 Inspector::Protocol::ErrorStringOr<void> PageRuntimeAgent::enable()
 {
-    if (m_instrumentingAgents.enabledPageRuntimeAgent() == this)
+    Ref agents = m_instrumentingAgents.get();
+    if (agents->enabledPageRuntimeAgent() == this)
         return { };
 
     auto result = InspectorRuntimeAgent::enable();
@@ -79,14 +80,15 @@ Inspector::Protocol::ErrorStringOr<void> PageRuntimeAgent::enable()
     // can force creation of script state which could result in duplicate notifications.
     reportExecutionContextCreation();
 
-    m_instrumentingAgents.setEnabledPageRuntimeAgent(this);
+    agents->setEnabledPageRuntimeAgent(this);
 
     return result;
 }
 
 Inspector::Protocol::ErrorStringOr<void> PageRuntimeAgent::disable()
 {
-    m_instrumentingAgents.setEnabledPageRuntimeAgent(nullptr);
+    Ref agents = m_instrumentingAgents.get();
+    agents->setEnabledPageRuntimeAgent(nullptr);
 
     return InspectorRuntimeAgent::disable();
 }
@@ -99,7 +101,8 @@ void PageRuntimeAgent::frameNavigated(LocalFrame& frame)
 
 void PageRuntimeAgent::didClearWindowObjectInWorld(LocalFrame& frame, DOMWrapperWorld& world)
 {
-    auto* pageAgent = m_instrumentingAgents.enabledPageAgent();
+    Ref agents = m_instrumentingAgents.get();
+    auto* pageAgent = agents->enabledPageAgent();
     if (!pageAgent)
         return;
 
@@ -137,7 +140,8 @@ void PageRuntimeAgent::unmuteConsole()
 
 void PageRuntimeAgent::reportExecutionContextCreation()
 {
-    auto* pageAgent = m_instrumentingAgents.enabledPageAgent();
+    Ref agents = m_instrumentingAgents.get();
+    auto* pageAgent = agents->enabledPageAgent();
     if (!pageAgent)
         return;
 

--- a/Source/WebCore/inspector/agents/page/PageRuntimeAgent.h
+++ b/Source/WebCore/inspector/agents/page/PageRuntimeAgent.h
@@ -35,6 +35,7 @@
 #include <JavaScriptCore/InspectorFrontendDispatchers.h>
 #include <JavaScriptCore/InspectorRuntimeAgent.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/WeakRef.h>
 
 namespace JSC {
 class CallFrame;
@@ -74,7 +75,7 @@ private:
     const UniqueRef<Inspector::RuntimeFrontendDispatcher> m_frontendDispatcher;
     const Ref<Inspector::RuntimeBackendDispatcher> m_backendDispatcher;
 
-    InstrumentingAgents& m_instrumentingAgents;
+    WeakRef<InstrumentingAgents> m_instrumentingAgents;
 
     WeakRef<Page> m_inspectedPage;
 };

--- a/Source/WebCore/inspector/agents/page/PageTimelineAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageTimelineAgent.cpp
@@ -80,19 +80,22 @@ PageTimelineAgent::~PageTimelineAgent() = default;
 
 bool PageTimelineAgent::enabled() const
 {
-    return m_instrumentingAgents.enabledPageTimelineAgent() == this && InspectorTimelineAgent::enabled();
+    Ref agents = m_instrumentingAgents.get();
+    return agents->enabledPageTimelineAgent() == this && InspectorTimelineAgent::enabled();
 }
 
 void PageTimelineAgent::internalEnable()
 {
-    m_instrumentingAgents.setEnabledPageTimelineAgent(this);
+    Ref agents = m_instrumentingAgents.get();
+    agents->setEnabledPageTimelineAgent(this);
 
     InspectorTimelineAgent::internalEnable();
 }
 
 void PageTimelineAgent::internalDisable()
 {
-    m_instrumentingAgents.setEnabledPageTimelineAgent(nullptr);
+    Ref agents = m_instrumentingAgents.get();
+    agents->setEnabledPageTimelineAgent(nullptr);
 
     m_autoCaptureEnabled = false;
 
@@ -101,12 +104,14 @@ void PageTimelineAgent::internalDisable()
 
 bool PageTimelineAgent::tracking() const
 {
-    return m_instrumentingAgents.trackingPageTimelineAgent() == this && InspectorTimelineAgent::tracking();
+    Ref agents = m_instrumentingAgents.get();
+    return agents->trackingPageTimelineAgent() == this && InspectorTimelineAgent::tracking();
 }
 
 void PageTimelineAgent::internalStart(std::optional<int>&& maxCallStackDepth)
 {
-    m_instrumentingAgents.setTrackingPageTimelineAgent(this);
+    Ref agents = m_instrumentingAgents.get();
+    agents->setTrackingPageTimelineAgent(this);
 
     // FIXME: Abstract away platform-specific code once https://bugs.webkit.org/show_bug.cgi?id=142748 is fixed.
 
@@ -154,7 +159,8 @@ void PageTimelineAgent::internalStart(std::optional<int>&& maxCallStackDepth)
 
 void PageTimelineAgent::internalStop()
 {
-    m_instrumentingAgents.setTrackingPageTimelineAgent(nullptr);
+    Ref agents = m_instrumentingAgents.get();
+    agents->setTrackingPageTimelineAgent(nullptr);
 
     m_autoCapturePhase = AutoCapturePhase::None;
 
@@ -271,7 +277,8 @@ void PageTimelineAgent::mainFrameStartedLoading()
     m_autoCapturePhase = AutoCapturePhase::BeforeLoad;
 
     // Pre-emptively disable breakpoints. The frontend must re-enable them.
-    if (auto* webDebuggerAgent = m_instrumentingAgents.enabledWebDebuggerAgent())
+    Ref agents = m_instrumentingAgents.get();
+    if (auto* webDebuggerAgent = agents->enabledWebDebuggerAgent())
         webDebuggerAgent->setBreakpointsActive(false);
 
     // Inform the frontend we started an auto capture. The frontend must stop capture.

--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -238,6 +238,8 @@ LocalFrame::~LocalFrame()
 {
     setView(nullptr);
 
+    m_inspectorController->inspectedFrameDestroyed();
+
     Ref loader = this->loader();
     if (!loader->isComplete())
         loader->closeURL();
@@ -1642,7 +1644,7 @@ RefPtr<SecurityOrigin> LocalFrame::frameDocumentSecurityOrigin() const
     return nullptr;
 }
 
-Ref<FrameInspectorController> LocalFrame::protectedInspectorController()
+Ref<FrameInspectorController> LocalFrame::protectedInspectorController() const
 {
     return m_inspectorController.get();
 }

--- a/Source/WebCore/page/LocalFrame.h
+++ b/Source/WebCore/page/LocalFrame.h
@@ -353,7 +353,7 @@ public:
     bool frameCanCreatePaymentSession() const final;
 
     FrameInspectorController& inspectorController() { return m_inspectorController.get(); }
-    WEBCORE_EXPORT Ref<FrameInspectorController> protectedInspectorController();
+    WEBCORE_EXPORT Ref<FrameInspectorController> protectedInspectorController() const;
     FrameConsoleClient& console() { return m_consoleClient.get(); }
     const FrameConsoleClient& console() const { return m_consoleClient.get(); }
 

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -2544,7 +2544,8 @@ void Page::didCompleteRenderingFrame()
 
     // FIXME: This is where we'd call requestPostAnimationFrame callbacks: webkit.org/b/249798.
     // FIXME: Run WindowEventLoop tasks from here: webkit.org/b/249684.
-    InspectorInstrumentation::didCompleteRenderingFrame(m_mainFrame);
+    if (RefPtr localMainFrame = this->localMainFrame())
+        InspectorInstrumentation::didCompleteRenderingFrame(*localMainFrame);
 }
 
 void Page::didUpdateRendering()

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -96,6 +96,7 @@
 #include "FontCache.h"
 #include "FormController.h"
 #include "FragmentDirectiveGenerator.h"
+#include "FrameInspectorController.h"
 #include "FrameLoader.h"
 #include "FrameMemoryMonitor.h"
 #include "FrameSnapshotting.h"
@@ -280,6 +281,7 @@
 #include <wtf/RunLoop.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/URLHelpers.h>
+#include <wtf/WeakPtr.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringBuilder.h>
 #include <wtf/text/StringToIntegerConversion.h>
@@ -443,7 +445,7 @@ using namespace HTMLNames;
 class InspectorStubFrontend final : public InspectorFrontendClientLocal, public FrontendChannel {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(InspectorStubFrontend);
 public:
-    InspectorStubFrontend(Page& inspectedPage, RefPtr<LocalDOMWindow>&& frontendWindow);
+    InspectorStubFrontend(Page& inspectedPage, LocalFrame& mainFrame, RefPtr<LocalDOMWindow>&& frontendWindow);
     virtual ~InspectorStubFrontend();
 
 private:
@@ -466,20 +468,26 @@ private:
     void setAttachedWindowWidth(unsigned) final { }
     void setSheetRect(const FloatRect&) final { }
 
+    void sendMessageToBackend(const String& message) final;
+
     void sendMessageToFrontend(const String& message) final;
     ConnectionType connectionType() const final { return ConnectionType::Local; }
 
     RefPtr<LocalDOMWindow> m_frontendWindow;
+
+    WeakPtr<FrameInspectorController> m_mainFrameInspectorController;
 };
 
-InspectorStubFrontend::InspectorStubFrontend(Page& inspectedPage, RefPtr<LocalDOMWindow>&& frontendWindow)
+InspectorStubFrontend::InspectorStubFrontend(Page& inspectedPage, LocalFrame& mainFrame, RefPtr<LocalDOMWindow>&& frontendWindow)
     : InspectorFrontendClientLocal(&inspectedPage.inspectorController(), frontendWindow->document()->page(), makeUnique<InspectorFrontendClientLocal::Settings>())
     , m_frontendWindow(frontendWindow.copyRef())
+    , m_mainFrameInspectorController(mainFrame.inspectorController())
 {
     ASSERT_ARG(frontendWindow, frontendWindow);
 
     frontendPage()->inspectorController().setInspectorFrontendClient(this);
     inspectedPage.inspectorController().connectFrontend(*this);
+    mainFrame.protectedInspectorController()->connectFrontend(*this);
 }
 
 InspectorStubFrontend::~InspectorStubFrontend()
@@ -494,9 +502,26 @@ void InspectorStubFrontend::closeWindow()
 
     frontendPage()->inspectorController().setInspectorFrontendClient(nullptr);
     inspectedPage()->inspectorController().disconnectFrontend(*this);
+    if (RefPtr controller = m_mainFrameInspectorController.get())
+        controller->disconnectFrontend(*this);
 
     m_frontendWindow->close();
     m_frontendWindow = nullptr;
+}
+
+void InspectorStubFrontend::sendMessageToBackend(const String& message)
+{
+    // FIXME before landing: By sending the message to both the page and the frame like below,
+    // this was my attempt to deal with certain agents (like Console) is only present in the frame
+    // where others (the rest) only in the page. This attempt doesn't work because as soon as the
+    // page's version fails (like in the case of Console, that domain doesn't exist), the frontend
+    // will get a fail message already. We might need to somehow figure out which backend target
+    // to send this message to rather than broadcasting it.
+
+    inspectedPage()->inspectorController().dispatchMessageFromFrontend(message);
+
+    if (RefPtr controller = m_mainFrameInspectorController.get())
+        controller->dispatchMessageFromFrontend(message);
 }
 
 void InspectorStubFrontend::sendMessageToFrontend(const String& message)
@@ -3288,7 +3313,7 @@ RefPtr<WindowProxy> Internals::openDummyInspectorFrontend(const String& url)
 #endif
 
     auto frontendWindowProxy = window->open(*window, *window, url, emptyAtom(), emptyString()).releaseReturnValue();
-    m_inspectorFrontend = makeUnique<InspectorStubFrontend>(*inspectedPage, downcast<LocalDOMWindow>(frontendWindowProxy->window()));
+    m_inspectorFrontend = makeUnique<InspectorStubFrontend>(*inspectedPage, *localMainFrame, downcast<LocalDOMWindow>(frontendWindowProxy->window()));
     return frontendWindowProxy;
 }
 

--- a/Source/WebInspectorUI/UserInterface/Controllers/ConsoleManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/ConsoleManager.js
@@ -90,8 +90,7 @@ WI.ConsoleManager = class ConsoleManager extends WI.Object
 
     initializeTarget(target)
     {
-        // FIXME: <https://webkit.org/b/298911> Add Console support for FrameTarget.
-        if (target instanceof WI.FrameTarget)
+        if (!target.hasDomain("Console"))
             return;
 
         // Intentionally defer ConsoleAgent initialization to the end. We do this so that any
@@ -256,11 +255,8 @@ WI.ConsoleManager = class ConsoleManager extends WI.Object
         this._clearMessagesRequested = true;
 
         for (let target of WI.targets) {
-            // FIXME: <https://webkit.org/b/298911> Add Console support for FrameTarget.
-            if (target instanceof WI.FrameTarget)
-                continue;
-
-            target.ConsoleAgent.clearMessages();
+            if (target.hasDomain("Console"))
+                target.ConsoleAgent.clearMessages();
         }
     }
 

--- a/Source/WebInspectorUI/UserInterface/Protocol/Target.js
+++ b/Source/WebInspectorUI/UserInterface/Protocol/Target.js
@@ -57,10 +57,10 @@ WI.Target = class Target extends WI.Object
 
         // Agents we always expect in every target.
         if (!(this instanceof WI.FrameTarget)) {
-            // FIXME: <https://webkit.org/b/298909, https://webkit.org/b/298910, https://webkit.org/b/298911> Add support for Runtime, Debugger, and Console domains for FrameTarget.
+            // FIXME: <https://webkit.org/b/298910> Add Runtime support for FrameTarget.
+            // FIXME: <https://webkit.org/b/298909> Add Debugger support for FrameTarget.
             console.assert(this.hasDomain("Target") || this.hasDomain("Runtime"));
             console.assert(this.hasDomain("Target") || this.hasDomain("Debugger"));
-            console.assert(this.hasDomain("Target") || this.hasDomain("Console"));
         }
     }
 
@@ -86,10 +86,8 @@ WI.Target = class Target extends WI.Object
         // previous initialization messages will have their responses arrive before a stream
         // of console message added events come in after enabling Console.
         // See WI.ConsoleManager.prototype.initializeTarget.
-        if (!(this instanceof WI.FrameTarget)) {
-            // FIXME: <https://webkit.org/b/298911> Add Console support for FrameTarget.
+        if (this.hasDomain("Console"))
             this.ConsoleAgent.enable();
-        }
 
         setTimeout(() => {
             // Use this opportunity to run any one time frontend initialization

--- a/Source/WebInspectorUI/UserInterface/Views/SettingsTabContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/SettingsTabContentView.js
@@ -390,11 +390,8 @@ WI.SettingsTabContentView = class SettingsTabContentView extends WI.TabContentVi
                 logEditor.value = channel.level;
                 logEditor.addEventListener(WI.SettingEditor.Event.ValueDidChange, function(event) {
                     for (let target of WI.targets) {
-                        // FIXME: <https://webkit.org/b/298911> Add Console support for FrameTarget.
-                        if (target instanceof WI.FrameTarget)
-                            continue;
-
-                        target.ConsoleAgent.setLoggingChannelLevel(channel.source, this.value);
+                        if (target.hasDomain("Console"))
+                            target.ConsoleAgent.setLoggingChannelLevel(channel.source, this.value);
                     }
                 }, logEditor);
             }


### PR DESCRIPTION
#### f08a566731f323fcdade699c7d9506880f05997d
<pre>
WIP (Web Inspector, Site Isolation): Attempting to fix broken inspector tests due to implementing console domain for frame targets
</pre>
----------------------------------------------------------------------
#### add7b2266829bbc48bd830944db1d6fa5b3f59f1
<pre>
Web Inspector: Implement the Console domain and agent for the frame target type
<a href="https://webkit.org/b/298911">https://webkit.org/b/298911</a>
<a href="https://rdar.apple.com/161133171">rdar://161133171</a>

Reviewed by NOBODY (OOPS!).

Implement the commands and events in the console inspector domain,
replacing the existing console agent of the page target.

Test: http/tests/site-isolation/inspector/console/console.html

WIP:
- Still need more tests, especially site isolated ones.
- Need to fix existing tests that broke, some as a result of still
  trying to send console-related protocol messages to the page target.

* LayoutTests/http/tests/site-isolation/inspector/console/console-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/inspector/console/console.html: Added.
* Source/JavaScriptCore/inspector/InspectorBackendDispatcher.cpp:
(Inspector::BackendDispatcher::registerDispatcherForDomain):
* Source/JavaScriptCore/inspector/protocol/Console.json:
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/inspector/FrameInspectorController.cpp:
(WebCore::FrameInspectorController::FrameInspectorController):
* Source/WebCore/inspector/InspectorController.cpp:
(WebCore::InspectorController::InspectorController):
(WebCore::InspectorController::createLazyAgents):
* Source/WebCore/inspector/agents/frame/FrameConsoleAgent.cpp: Renamed from Source/WebCore/inspector/agents/page/PageConsoleAgent.cpp.
(WebCore::FrameConsoleAgent::FrameConsoleAgent):
(WebCore::FrameConsoleAgent::getLoggingChannels):
(WebCore::FrameConsoleAgent::setLoggingChannelLevel):
* Source/WebCore/inspector/agents/frame/FrameConsoleAgent.h: Renamed from Source/WebCore/inspector/agents/page/PageConsoleAgent.h.
* Source/WebInspectorUI/UserInterface/Controllers/ConsoleManager.js:
(WI.ConsoleManager.prototype.initializeTarget):
(WI.ConsoleManager.prototype.requestClearMessages):
* Source/WebInspectorUI/UserInterface/Protocol/Target.js:
(WI.Target.prototype.initialize):
* Source/WebInspectorUI/UserInterface/Views/SettingsTabContentView.js:
(WI.SettingsTabContentView.prototype._createConsoleSettingsView):
</pre>
----------------------------------------------------------------------
#### 74aad7001a0593745852b450b95eb1de04881f67
<pre>
[Site Isolation] Web Inspector: Register the frame target&apos;s agents for instrumentation
<a href="https://webkit.org/b/299607">https://webkit.org/b/299607</a>
<a href="https://rdar.apple.com/161414130">rdar://161414130</a>

Reviewed by NOBODY (OOPS!).

This patch adds the registering and unregistering logic for the frame
target&apos;s agents. The plan is to slowly implement all agents of the
page target for the frame target, by mostly rewriting or moving them.
Given this anticipated transition, we also updated InstrumentingAgents
to allow the frame to use its page&apos;s agents as delegates replacing the
not yet implemented ones. This way, objects that interact with the
inspector or the inspector frontend can start viewing the frame as
having all agents that its page has, albeit without site isolation
support.

No new test as no new difference in behavior is expected.

No new tests (OOPS!).
* Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations:
* Source/WebCore/inspector/FrameInspectorController.cpp:
(WebCore::FrameInspectorController::FrameInspectorController):
(WebCore::FrameInspectorController::frameAgentContext):
(WebCore::FrameInspectorController::connectFrontend):
(WebCore::FrameInspectorController::disconnectFrontend):
(WebCore::FrameInspectorController::inspectedFrameDestroyed):
* Source/WebCore/inspector/FrameInspectorController.h:
* Source/WebCore/inspector/InspectorController.h:
   Add support to use another set of InstrumentingAgents to fallback to.

* Source/WebCore/inspector/InspectorInstrumentation.cpp:
(WebCore::InspectorInstrumentation::instrumentingAgents):
* Source/WebCore/inspector/InspectorInstrumentation.h:
(WebCore::InspectorInstrumentation::didClearWindowObjectInWorld):
(WebCore::InspectorInstrumentation::didAddOrRemoveScrollbars):
(WebCore::InspectorInstrumentation::frameWindowDiscarded):
(WebCore::InspectorInstrumentation::handleTouchEvent):
(WebCore::InspectorInstrumentation::handleMousePress):
(WebCore::InspectorInstrumentation::willPostMessage):
(WebCore::InspectorInstrumentation::didPostMessage):
(WebCore::InspectorInstrumentation::didFailPostMessage):
(WebCore::InspectorInstrumentation::willDispatchPostMessage):
(WebCore::InspectorInstrumentation::didDispatchPostMessage):
(WebCore::InspectorInstrumentation::willEvaluateScript):
(WebCore::InspectorInstrumentation::didEvaluateScript):
(WebCore::InspectorInstrumentation::didInvalidateLayout):
(WebCore::InspectorInstrumentation::willLayout):
(WebCore::InspectorInstrumentation::didLayout):
(WebCore::InspectorInstrumentation::willComposite):
(WebCore::InspectorInstrumentation::didComposite):
(WebCore::InspectorInstrumentation::willPaint):
(WebCore::InspectorInstrumentation::didPaint):
(WebCore::InspectorInstrumentation::applyUserAgentOverride):
(WebCore::InspectorInstrumentation::applyEmulatedMedia):
(WebCore::InspectorInstrumentation::flexibleBoxRendererBeganLayout):
(WebCore::InspectorInstrumentation::flexibleBoxRendererWrappedToNextLine):
(WebCore::InspectorInstrumentation::didReceiveResourceResponse):
(WebCore::InspectorInstrumentation::continueAfterXFrameOptionsDenied):
(WebCore::InspectorInstrumentation::continueWithPolicyDownload):
(WebCore::InspectorInstrumentation::continueWithPolicyIgnore):
(WebCore::InspectorInstrumentation::domContentLoadedEventFired):
(WebCore::InspectorInstrumentation::frameDetachedFromParent):
(WebCore::InspectorInstrumentation::didCommitLoad):
(WebCore::InspectorInstrumentation::frameDocumentUpdated):
(WebCore::InspectorInstrumentation::loaderDetachedFromFrame):
(WebCore::InspectorInstrumentation::frameStartedLoading):
(WebCore::InspectorInstrumentation::didCompleteRenderingFrame):
(WebCore::InspectorInstrumentation::frameStoppedLoading):
(WebCore::InspectorInstrumentation::shouldInterceptResponse):
(WebCore::InspectorInstrumentation::interceptResponse):
(WebCore::InspectorInstrumentation::addMessageToConsole):
(WebCore::InspectorInstrumentation::consoleCount):
(WebCore::InspectorInstrumentation::consoleCountReset):
(WebCore::InspectorInstrumentation::takeHeapSnapshot):
(WebCore::InspectorInstrumentation::startConsoleTiming):
(WebCore::InspectorInstrumentation::logConsoleTiming):
(WebCore::InspectorInstrumentation::stopConsoleTiming):
(WebCore::InspectorInstrumentation::consoleTimeStamp):
(WebCore::InspectorInstrumentation::startProfiling):
(WebCore::InspectorInstrumentation::stopProfiling):
(WebCore::InspectorInstrumentation::instrumentingAgents):
* Source/WebCore/inspector/InspectorWebAgentBase.h:
(WebCore::FrameAgentContext::FrameAgentContext):
   Register and unregister the frame&apos;s inspector agents, mimicking
   the page target&apos;s behavior for timing.

* Source/WebCore/inspector/InstrumentingAgents.cpp:
(WebCore::InstrumentingAgents::create):
(WebCore::InstrumentingAgents::InstrumentingAgents):
* Source/WebCore/inspector/InstrumentingAgents.h:
(WebCore::InstrumentingAgents::create): Deleted.
* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::~LocalFrame):
(WebCore::LocalFrame::protectedInspectorController const):
(WebCore::LocalFrame::protectedInspectorController): Deleted.
   Since the frame now always has an InstrumentingAgents object, make
   its getter return a reference instead of pointer.

* Source/WebCore/page/LocalFrame.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::didCompleteRenderingFrame):
   Adapt to the instrumentation function only accepting a LocalFrame,
   which was the behavior before the commit https://github.com/WebKit/WebKit/commit/a368459ce9a9e6b637a366dd90ba655f57031e23)
</pre>
----------------------------------------------------------------------
#### 0d50bccbe97dc395e4e2a4a7687c43d332b44429
<pre>
WIP; Experimenting with fixing safer-cpp failures in #51354

* Source/WebCore/Headers.cmake:
* Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/inspector/CommandLineAPIHost.cpp:
(WebCore::CommandLineAPIHost::inspect):
* Source/WebCore/inspector/InspectorWebAgentBase.h:
* Source/WebCore/inspector/InstrumentingAgents.h:
* Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp:
(WebCore::InspectorAnimationAgent::didCreateFrontendAndBackend):
(WebCore::InspectorAnimationAgent::willDestroyFrontendAndBackend):
(WebCore::InspectorAnimationAgent::enable):
(WebCore::InspectorAnimationAgent::disable):
(WebCore::InspectorAnimationAgent::requestEffectTarget):
(WebCore::InspectorAnimationAgent::startTracking):
(WebCore::InspectorAnimationAgent::stopTracking):
(WebCore::InspectorAnimationAgent::willApplyKeyframeEffect):
* Source/WebCore/inspector/agents/InspectorCPUProfilerAgent.cpp:
(WebCore::InspectorCPUProfilerAgent::didCreateFrontendAndBackend):
(WebCore::InspectorCPUProfilerAgent::willDestroyFrontendAndBackend):
* Source/WebCore/inspector/agents/InspectorCSSAgent.cpp:
(WebCore::InspectorCSSAgent::enable):
(WebCore::InspectorCSSAgent::disable):
(WebCore::InspectorCSSAgent::forcePseudoState):
(WebCore::InspectorCSSAgent::collectAllStyleSheets):
(WebCore::InspectorCSSAgent::setStyleSheetText):
(WebCore::InspectorCSSAgent::setStyleText):
(WebCore::InspectorCSSAgent::setRuleSelector):
(WebCore::InspectorCSSAgent::setGroupingHeaderText):
(WebCore::InspectorCSSAgent::createStyleSheet):
(WebCore::InspectorCSSAgent::addRule):
(WebCore::InspectorCSSAgent::setLayoutContextTypeChangedMode):
(WebCore::InspectorCSSAgent::nodesWithPendingLayoutFlagsChangeDispatchTimerFired):
(WebCore::InspectorCSSAgent::asInspectorStyleSheet):
(WebCore::InspectorCSSAgent::elementForId):
(WebCore::InspectorCSSAgent::nodeForId):
(WebCore::InspectorCSSAgent::bindStyleSheet):
* Source/WebCore/inspector/agents/InspectorCanvasAgent.cpp:
(WebCore::InspectorCanvasAgent::enabled const):
(WebCore::InspectorCanvasAgent::internalEnable):
(WebCore::InspectorCanvasAgent::internalDisable):
* Source/WebCore/inspector/agents/InspectorDOMAgent.cpp:
(WebCore::InspectorDOMAgent::didCreateFrontendAndBackend):
(WebCore::InspectorDOMAgent::willDestroyFrontendAndBackend):
(WebCore::InspectorDOMAgent::unbind):
(WebCore::InspectorDOMAgent::highlightSelector):
(WebCore::InspectorDOMAgent::highlightFrame):
(WebCore::InspectorDOMAgent::buildObjectForNode):
(WebCore::InspectorDOMAgent::willDestroyDOMNode):
(WebCore::InspectorDOMAgent::didModifyDOMAttr):
(WebCore::InspectorDOMAgent::didRemoveDOMAttr):
(WebCore::InspectorDOMAgent::styleAttributeInvalidated):
* Source/WebCore/inspector/agents/InspectorDOMDebuggerAgent.cpp:
(WebCore::InspectorDOMDebuggerAgent::enabled const):
(WebCore::InspectorDOMDebuggerAgent::enable):
(WebCore::InspectorDOMDebuggerAgent::disable):
(WebCore::InspectorDOMDebuggerAgent::willHandleEvent):
(WebCore::InspectorDOMDebuggerAgent::didHandleEvent):
* Source/WebCore/inspector/agents/InspectorDOMStorageAgent.cpp:
(WebCore::InspectorDOMStorageAgent::enable):
(WebCore::InspectorDOMStorageAgent::disable):
* Source/WebCore/inspector/agents/InspectorLayerTreeAgent.cpp:
(WebCore::InspectorLayerTreeAgent::enable):
(WebCore::InspectorLayerTreeAgent::disable):
(WebCore::InspectorLayerTreeAgent::layersForNode):
(WebCore::InspectorLayerTreeAgent::idForNode):
* Source/WebCore/inspector/agents/InspectorMemoryAgent.cpp:
(WebCore::InspectorMemoryAgent::didCreateFrontendAndBackend):
(WebCore::InspectorMemoryAgent::willDestroyFrontendAndBackend):
(WebCore::InspectorMemoryAgent::enable):
(WebCore::InspectorMemoryAgent::disable):
* Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp:
(WebCore::InspectorNetworkAgent::buildInitiatorObject):
(WebCore::InspectorNetworkAgent::enable):
(WebCore::InspectorNetworkAgent::disable):
* Source/WebCore/inspector/agents/InspectorPageAgent.cpp:
(WebCore::InspectorPageAgent::enable):
(WebCore::InspectorPageAgent::disable):
(WebCore::InspectorPageAgent::searchInResource):
(WebCore::InspectorPageAgent::searchInResources):
(WebCore::InspectorPageAgent::snapshotNode):
* Source/WebCore/inspector/agents/InspectorTimelineAgent.cpp:
(WebCore::InspectorTimelineAgent::enabled const):
(WebCore::InspectorTimelineAgent::internalEnable):
(WebCore::InspectorTimelineAgent::internalDisable):
(WebCore::InspectorTimelineAgent::tracking const):
(WebCore::InspectorTimelineAgent::internalStart):
(WebCore::InspectorTimelineAgent::internalStop):
(WebCore::InspectorTimelineAgent::startFromConsole):
(WebCore::InspectorTimelineAgent::stopFromConsole):
(WebCore::InspectorTimelineAgent::startProgrammaticCapture):
(WebCore::InspectorTimelineAgent::stopProgrammaticCapture):
(WebCore::InspectorTimelineAgent::toggleScriptProfilerInstrument):
(WebCore::InspectorTimelineAgent::toggleHeapInstrument):
(WebCore::InspectorTimelineAgent::toggleCPUInstrument):
(WebCore::InspectorTimelineAgent::toggleMemoryInstrument):
(WebCore::InspectorTimelineAgent::toggleAnimationInstrument):
* Source/WebCore/inspector/agents/InspectorWorkerAgent.cpp:
(WebCore::InspectorWorkerAgent::didCreateFrontendAndBackend):
(WebCore::InspectorWorkerAgent::willDestroyFrontendAndBackend):
* Source/WebCore/inspector/agents/WebDebuggerAgent.cpp:
(WebCore::WebDebuggerAgent::enabled const):
(WebCore::WebDebuggerAgent::internalEnable):
(WebCore::WebDebuggerAgent::internalDisable):
* Source/WebCore/inspector/agents/WebDebuggerAgent.h:
* Source/WebCore/inspector/agents/WebHeapAgent.cpp:
(WebCore::WebHeapAgent::didCreateFrontendAndBackend):
(WebCore::WebHeapAgent::willDestroyFrontendAndBackend):
(WebCore::WebHeapAgent::enable):
(WebCore::WebHeapAgent::disable):
* Source/WebCore/inspector/agents/WebHeapAgent.h:
* Source/WebCore/inspector/agents/page/PageCanvasAgent.cpp:
(WebCore::PageCanvasAgent::enabled const):
(WebCore::PageCanvasAgent::internalEnable):
(WebCore::PageCanvasAgent::internalDisable):
(WebCore::PageCanvasAgent::requestNode):
(WebCore::PageCanvasAgent::requestClientNodes):
* Source/WebCore/inspector/agents/page/PageDOMDebuggerAgent.cpp:
(WebCore::PageDOMDebuggerAgent::enabled const):
(WebCore::PageDOMDebuggerAgent::enable):
(WebCore::PageDOMDebuggerAgent::disable):
(WebCore::PageDOMDebuggerAgent::setDOMBreakpoint):
(WebCore::PageDOMDebuggerAgent::removeDOMBreakpoint):
(WebCore::PageDOMDebuggerAgent::willRemoveDOMNode):
(WebCore::PageDOMDebuggerAgent::buildPauseDataForDOMBreakpoint):
* Source/WebCore/inspector/agents/page/PageDebuggerAgent.cpp:
(WebCore::PageDebuggerAgent::enabled const):
(WebCore::PageDebuggerAgent::internalEnable):
(WebCore::PageDebuggerAgent::internalDisable):
* Source/WebCore/inspector/agents/page/PageHeapAgent.cpp:
(WebCore::PageHeapAgent::enable):
(WebCore::PageHeapAgent::disable):
* Source/WebCore/inspector/agents/page/PageHeapAgent.h:
* Source/WebCore/inspector/agents/page/PageNetworkAgent.cpp:
(WebCore::PageNetworkAgent::loaderIdentifier):
(WebCore::PageNetworkAgent::frameIdentifier):
(WebCore::PageNetworkAgent::scriptExecutionContext):
* Source/WebCore/inspector/agents/page/PageRuntimeAgent.cpp:
(WebCore::PageRuntimeAgent::enable):
(WebCore::PageRuntimeAgent::disable):
(WebCore::PageRuntimeAgent::didClearWindowObjectInWorld):
(WebCore::PageRuntimeAgent::reportExecutionContextCreation):
* Source/WebCore/inspector/agents/page/PageRuntimeAgent.h:
* Source/WebCore/inspector/agents/page/PageTimelineAgent.cpp:
(WebCore::PageTimelineAgent::enabled const):
(WebCore::PageTimelineAgent::internalEnable):
(WebCore::PageTimelineAgent::internalDisable):
(WebCore::PageTimelineAgent::tracking const):
(WebCore::PageTimelineAgent::internalStart):
(WebCore::PageTimelineAgent::internalStop):
(WebCore::PageTimelineAgent::mainFrameStartedLoading):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f08a566731f323fcdade699c7d9506880f05997d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124295 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43979 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34705 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131129 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76361 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d45f00b7-0d85-45ef-b1f6-c8d4c1c821b2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/126172 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44723 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52581 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94546 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62725 "") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1d7a0fdd-bf1c-452a-b37e-f45ea133de10) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127249 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35643 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111178 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75133 "Found 1 new API test failure: WPE/TestWebKitWebContext:/webkit/WebKitWebContext/no-web-process-leak (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6ae24d83-d332-4b8e-9b82-e300f1af94a7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34586 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29338 "Found 60 new test failures: imported/w3c/web-platform-tests/css/CSS2/tables/table-anonymous-objects-110.xht imported/w3c/web-platform-tests/css/css-conditional/container-queries/crashtests/chrome-bug-439886903-crash.html imported/w3c/web-platform-tests/css/css-grid/alignment/grid-alignment-implies-size-change-002.html imported/w3c/web-platform-tests/css/css-position/multicol/vlr-rtl-rtl-in-multicols.html imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-nested-top.html imported/w3c/web-platform-tests/css/css-text/i18n/css3-text-line-break-baspglwj-048.html imported/w3c/web-platform-tests/css/css-values/round-mod-rem-invalid.html imported/w3c/web-platform-tests/dom/collections/HTMLCollection-as-prototype.html imported/w3c/web-platform-tests/html/canvas/element/text/2d.text.measure.index-from-offset-edge-cases.tentative.html imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-cues-cuechange.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74611 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/116434 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105388 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29561 "Found 60 new test failures: fast/scrolling/keyboard-scrolling-distance-downArrow.html fast/scrolling/mac/stateless-user-scroll-scrollend.html http/tests/lists/list-new-parent-no-sibling-append.html http/tests/multipart/multipart-async-image.html http/tests/site-isolation/history/add-iframes-and-go-back.html imported/w3c/web-platform-tests/editing/other/typing-around-link-element-at-collapsed-selection.tentative.html?target=DesignMode&parent=b&child=i imported/w3c/web-platform-tests/editing/other/typing-around-link-element-at-non-collapsed-selection.tentative.html?target=DesignMode imported/w3c/web-platform-tests/editing/other/typing-around-link-element-at-non-collapsed-selection.tentative.html?target=DesignMode&child=b imported/w3c/web-platform-tests/editing/other/typing-around-link-element-at-non-collapsed-selection.tentative.html?target=DesignMode&parent=b imported/w3c/web-platform-tests/editing/other/typing-around-link-element-at-non-collapsed-selection.tentative.html?target=DesignMode&parent=b&child=i ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133801 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/122824 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51204 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39042 "Found 60 new test failures: fast/mediastream/enumerateDevices-camera-denied-expose-with-capture.html http/tests/navigation/redirect-to-random-url-versus-memory-cache.html http/tests/security/cookie-module-propagate.html http/tests/xmlhttprequest/cors-non-standard-safelisted-headers-should-trigger-preflight.html imported/w3c/web-platform-tests/fullscreen/rendering/ua-style-iframe.html imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/cross-origin-top-navigation-with-user-activation-in-parent.window.html imported/w3c/web-platform-tests/pointerevents/pointerevent_pointer_boundary_events_after_removing_last_over_element.html inspector/animation/tracking.html inspector/console/console-message.html inspector/console/message-stack-trace.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103031 "43 flakes 202 failures") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51598 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107397 "Exiting early after 10 failures. 51 tests run. 1 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102825 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48185 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26442 "Found 60 new test failures: css3/filters/clipping-overflow-scroll-with-pixel-moving-effect-on.html css3/masking/mask-base64.html http/tests/site-isolation/inspector/console/console.html imported/w3c/web-platform-tests/fullscreen/rendering/fullscreen-root-block-scroll.html imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/cross-origin-top-navigation-with-user-activation-in-parent.window.html imported/w3c/web-platform-tests/largest-contentful-paint/video-poster.html imported/w3c/web-platform-tests/permissions/permissions-garbage-collect.https.html inspector/console/console-message.html inspector/console/message-stack-trace.html inspector/console/messageAdded-from-named-evaluations.html ... (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48143 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51068 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56850 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/153920 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50505 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39114 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53861 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52180 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->