### PR TITLE
[GFC] Initial implementation of grid item layout.

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1936,6 +1936,7 @@ layout/formattingContexts/flex/FlexFormattingUtils.cpp
 layout/formattingContexts/flex/FlexLayout.cpp
 layout/formattingContexts/grid/GridFormattingContext.cpp
 layout/formattingContexts/grid/GridLayout.cpp
+layout/formattingContexts/grid/GridLayoutUtils.cpp
 layout/formattingContexts/grid/ImplicitGrid.cpp
 layout/formattingContexts/grid/PlacedGridItem.cpp
 layout/formattingContexts/grid/TrackSizingAlgorithm.cpp

--- a/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp
@@ -27,6 +27,7 @@
 #include "GridFormattingContext.h"
 
 #include "GridLayout.h"
+#include "LayoutBoxGeometry.h"
 #include "LayoutChildIterator.h"
 #include "PlacedGridItem.h"
 #include "RenderStyleInlines.h"
@@ -41,6 +42,7 @@ namespace Layout {
 GridFormattingContext::GridFormattingContext(const ElementBox& gridBox, LayoutState& layoutState)
     : m_gridBox(gridBox)
     , m_globalLayoutState(layoutState)
+    , m_integrationUtils(layoutState)
 {
 }
 
@@ -131,6 +133,12 @@ PlacedGridItems GridFormattingContext::constructPlacedGridItems(const GridAreas&
         placedGridItems.constructAndAppend(unplacedGridItem, gridAreaLines, inlineAxisSizes, blockAxisSizes);
     }
     return placedGridItems;
+}
+
+const BoxGeometry GridFormattingContext::geometryForGridItem(const ElementBox& gridItem) const
+{
+    ASSERT(gridItem.isGridItem());
+    return layoutState().geometryForBox(gridItem);
 }
 
 } // namespace Layout

--- a/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "GridTypeAliases.h"
+#include "LayoutIntegrationUtils.h"
 #include "LayoutState.h"
 #include "LayoutUnit.h"
 #include <wtf/CheckedRef.h>
@@ -59,11 +60,18 @@ public:
 
     const ElementBox& root() const { return m_gridBox; }
 
+    const IntegrationUtils& integrationUtils() const { return m_integrationUtils; }
+
+    const BoxGeometry geometryForGridItem(const ElementBox& gridItem) const;
+
 private:
     UnplacedGridItems constructUnplacedGridItems() const;
 
+    const LayoutState& layoutState() const { return m_globalLayoutState; }
+
     const CheckedRef<const ElementBox> m_gridBox;
     const CheckedRef<LayoutState> m_globalLayoutState;
+    const IntegrationUtils m_integrationUtils;
 };
 
 } // namespace Layout

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayout.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayout.h
@@ -72,6 +72,9 @@ private:
 
     static UsedTrackSizes performGridSizingAlgorithm(const PlacedGridItems&, const TrackSizingFunctionsList& columnTrackSizingFunctionsList, const TrackSizingFunctionsList& rowTrackSizingFunctionsList);
 
+    using UsedInlineSizes = Vector<LayoutUnit>;
+    using UsedBlockSizes = Vector<LayoutUnit>;
+    std::pair<UsedInlineSizes, UsedBlockSizes> layoutGridItems(const PlacedGridItems&, const UsedTrackSizes&) const;
 
     static Vector<UsedMargins> computeInlineMargins(const PlacedGridItems&);
     static Vector<UsedMargins> computeBlockMargins(const PlacedGridItems&);

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "GridLayoutUtils.h"
+
+namespace WebCore {
+namespace Layout {
+namespace GridLayoutUtils {
+
+LayoutUnit usedInlineSizeForGridItem(const PlacedGridItem& placedGridItem)
+{
+    auto& inlineAxisSizes = placedGridItem.inlineAxisSizes();
+    if (auto fixedInlineSize = inlineAxisSizes.preferredSize.tryFixed())
+        return LayoutUnit { fixedInlineSize->resolveZoom(Style::ZoomNeeded { }) };
+
+    ASSERT_NOT_IMPLEMENTED_YET();
+    return { };
+}
+
+LayoutUnit usedBlockSizeForGridItem(const PlacedGridItem& placedGridItem)
+{
+    auto& blockAxisSizes = placedGridItem.blockAxisSizes();
+    if (auto fixedBlockSize = blockAxisSizes.preferredSize.tryFixed())
+        return LayoutUnit { fixedBlockSize->resolveZoom(Style::ZoomNeeded { }) };
+
+    ASSERT_NOT_IMPLEMENTED_YET();
+    return { };
+}
+
+}
+}
+}

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace WebCore {
+
+class LayoutUnit;
+
+namespace Layout {
+
+class PlacedGridItem;
+
+namespace GridLayoutUtils {
+
+LayoutUnit usedInlineSizeForGridItem(const PlacedGridItem&);
+LayoutUnit usedBlockSizeForGridItem(const PlacedGridItem&);
+
+} // namespace GridLayoutUtils
+} // namespace Layout
+} // namespace WebCore

--- a/Source/WebCore/layout/formattingContexts/grid/PlacedGridItem.h
+++ b/Source/WebCore/layout/formattingContexts/grid/PlacedGridItem.h
@@ -59,6 +59,8 @@ public:
     size_t rowStartLine() const { return m_gridAreaLines.rowStartLine; }
     size_t rowEndLine() const { return m_gridAreaLines.rowEndLine; }
 
+    const ElementBox& layoutBox() const { return m_layoutBox; }
+
 private:
     const CheckedRef<const ElementBox> m_layoutBox;
 


### PR DESCRIPTION
#### 6fe1ca7509aad10227e3a96a1a4e42410532c678
<pre>
[GFC] Initial implementation of grid item layout.
<a href="https://bugs.webkit.org/show_bug.cgi?id=300062">https://bugs.webkit.org/show_bug.cgi?id=300062</a>
<a href="https://rdar.apple.com/problem/161860162">rdar://problem/161860162</a>

Reviewed by Alan Baradlay.

This patch provides the initial implementation of grid item layout as
described in the final step of the &quot;Grid Layout Algorithm,&quot;:
<a href="https://drafts.csswg.org/css-grid-1/#layout-algorithm">https://drafts.csswg.org/css-grid-1/#layout-algorithm</a>

At this point we have resolved the grid area sizes for each grid item.
As a result, we have a definite containing block size for the grid item
so we can resolve the size of the item if needed to provide as
constraints for layout of its contents. For now we keep this as simple
as possible since we will only allow content in which the grid item has
a fixed width and size. This is done via some utility functions that
determine the used width and heights of the items and then pass these
values into our integration API as constraints for the box&apos;s formatting
context.

Canonical link: <a href="https://commits.webkit.org/300943@main">https://commits.webkit.org/300943@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/542c903a79ce070ad5c28e6757ca284d19ad3f62

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124301 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43983 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34711 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131137 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76365 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2d6e2aec-2cc7-47c5-8d47-4be037be3b18) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/126178 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44728 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52585 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94562 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/forms/constraints/infinite_backtracking.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62731 "") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8c8dda91-1ff9-4abe-aad6-23af965bbf4f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127255 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35645 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111184 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75138 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a4b97a19-de15-4c26-af2f-59c41df95db4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34588 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29344 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74617 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105390 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29567 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133806 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51208 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39046 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103030 "") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51602 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107403 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102826 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26194 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48189 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26447 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48147 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51072 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56857 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50509 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53865 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52184 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->