### PR TITLE
Hide layers until activity state change is processed.

### DIFF
--- a/Source/WebKit/UIProcess/DrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/DrawingAreaProxy.h
@@ -121,6 +121,8 @@ public:
     // Hide the content until any update arrives.
     virtual void hideContentUntilAnyUpdate() { }
 
+    virtual void hideContentUntilDidUpdateActivityState(ActivityStateChangeID) { hideContentUntilAnyUpdate(); }
+
     virtual bool hasVisibleContent() const { return true; }
 
 #if PLATFORM(COCOA)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
@@ -154,6 +154,7 @@ private:
     void waitForDidUpdateActivityState(ActivityStateChangeID) final;
     void hideContentUntilPendingUpdate() final;
     void hideContentUntilAnyUpdate() final;
+    void hideContentUntilDidUpdateActivityState(ActivityStateChangeID) final;
     bool hasVisibleContent() const final;
 
     WebCore::FloatPoint indicatorLocation() const;
@@ -207,6 +208,8 @@ private:
     Deque<Seconds> m_frameDurations;
 
     Markable<IPC::AsyncReplyID> m_replyForUnhidingContent;
+    std::optional<ActivityStateChangeID> m_activityStateChangeForUnhidingContent;
+    bool m_hasDetachedRootLayer { false };
 
 #if ASSERT_ENABLED
     TransactionID m_lastVisibleTransactionID;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
@@ -372,6 +372,11 @@ void RemoteLayerTreeDrawingAreaProxy::commitLayerTreeTransaction(IPC::Connection
         m_transactionIDForPendingCACommit = layerTreeTransaction.transactionID();
         m_activityStateChangeID = layerTreeTransaction.activityStateChangeID();
 
+        if (m_activityStateChangeID == m_activityStateChangeForUnhidingContent) {
+            RELEASE_LOG(RemoteLayerTree, "RemoteLayerTreeDrawingAreaProxy(%" PRIu64 ")::hideContentUntilDidUpdateActivityState completed", identifier().toUInt64());
+            m_activityStateChangeForUnhidingContent = std::nullopt;
+        }
+
         // FIXME(site-isolation): Editor state should be updated for subframes.
         didUpdateEditorState = layerTreeTransaction.hasEditorState() && page->updateEditorState(EditorState { layerTreeTransaction.editorState() }, WebPageProxy::ShouldMergeVisualEditorState::Yes);
     }
@@ -385,6 +390,7 @@ void RemoteLayerTreeDrawingAreaProxy::commitLayerTreeTransaction(IPC::Connection
     if (layerTreeTransaction.isMainFrameProcessTransaction()) {
         for (auto& callbackID : layerTreeTransaction.callbackIDs()) {
             if (callbackID == m_replyForUnhidingContent) {
+                RELEASE_LOG(RemoteLayerTree, "RemoteLayerTreeDrawingAreaProxy(%" PRIu64 ")::hideContentUntilPendingUpdate completed", identifier().toUInt64());
                 m_replyForUnhidingContent = std::nullopt;
                 break;
             }
@@ -397,9 +403,12 @@ void RemoteLayerTreeDrawingAreaProxy::commitLayerTreeTransaction(IPC::Connection
             ++m_countOfTransactionsWithNonEmptyLayerChanges;
 
         if (m_remoteLayerTreeHost->updateLayerTree(connection, layerTreeTransaction)) {
-            if (!m_replyForUnhidingContent)
+            if (!m_replyForUnhidingContent && !m_activityStateChangeForUnhidingContent) {
+                if (m_hasDetachedRootLayer)
+                    RELEASE_LOG(RemoteLayerTree, "RemoteLayerTreeDrawingAreaProxy(%" PRIu64 ") Unhiding layer tree", identifier().toUInt64());
                 page->setRemoteLayerTreeRootNode(m_remoteLayerTreeHost->protectedRootNode().get());
-            else
+                m_hasDetachedRootLayer = false;
+            } else
                 m_remoteLayerTreeHost->detachRootLayer();
         }
 #if ENABLE(ASYNC_SCROLLING)
@@ -765,13 +774,29 @@ void RemoteLayerTreeDrawingAreaProxy::waitForDidUpdateActivityState(ActivityStat
 
 void RemoteLayerTreeDrawingAreaProxy::hideContentUntilPendingUpdate()
 {
+    RELEASE_LOG(RemoteLayerTree, "RemoteLayerTreeDrawingAreaProxy(%" PRIu64 ")::hideContentUntilPendingUpdate", identifier().toUInt64());
     m_replyForUnhidingContent = webProcessProxy().sendWithAsyncReply(Messages::DrawingArea::DispatchAfterEnsuringDrawing(), [] () { }, messageSenderDestinationID(), { }, WebProcessProxy::ShouldStartProcessThrottlerActivity::No);
     m_remoteLayerTreeHost->detachRootLayer();
+    m_hasDetachedRootLayer = true;
+}
+
+void RemoteLayerTreeDrawingAreaProxy::hideContentUntilDidUpdateActivityState(ActivityStateChangeID activityStateChangeID)
+{
+    if (activityStateChangeID == ActivityStateChangeAsynchronous) {
+        hideContentUntilAnyUpdate();
+        return;
+    }
+    RELEASE_LOG(RemoteLayerTree, "RemoteLayerTreeDrawingAreaProxy(%" PRIu64 ")::hideContentUntilDidUpdateActivityState", identifier().toUInt64());
+    m_activityStateChangeForUnhidingContent = activityStateChangeID;
+    m_remoteLayerTreeHost->detachRootLayer();
+    m_hasDetachedRootLayer = true;
 }
 
 void RemoteLayerTreeDrawingAreaProxy::hideContentUntilAnyUpdate()
 {
+    RELEASE_LOG(RemoteLayerTree, "RemoteLayerTreeDrawingAreaProxy(%" PRIu64 ")::hideContentUntilAnyUpdate", identifier().toUInt64());
     m_remoteLayerTreeHost->detachRootLayer();
+    m_hasDetachedRootLayer = true;
 }
 
 bool RemoteLayerTreeDrawingAreaProxy::hasVisibleContent() const

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -3268,7 +3268,7 @@ void WebPageProxy::dispatchActivityStateChange()
 #endif
 
     if (isNowInWindow)
-        protectedDrawingArea()->hideContentUntilAnyUpdate();
+        protectedDrawingArea()->hideContentUntilDidUpdateActivityState(activityStateChangeID);
 
     updateBackingStoreDiscardableState();
 


### PR DESCRIPTION
#### 209615afb42df06f67b0c639100daca689b996e7
<pre>
Hide layers until activity state change is processed.
<a href="https://bugs.webkit.org/show_bug.cgi?id=300065">https://bugs.webkit.org/show_bug.cgi?id=300065</a>
&lt;<a href="https://rdar.apple.com/problem/161860753">rdar://problem/161860753</a>&gt;

Reviewed by Tim Horton.

We currently hide layers when we make a tab visible, until the next layer tree
transaction is processed. This probably should specifically wait for the
transaction that was generated after the activity state change was handled in
the web process.

Adds a new DrawingAreaProxy option to wait on the transaction containing the
activity state change, not just the next transaction. Also adds some new logging
for layer hiding.

* Source/WebKit/UIProcess/DrawingAreaProxy.h:
(WebKit::DrawingAreaProxy::hideContentUntilDidUpdateActivityState):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxy::commitLayerTreeTransaction):
(WebKit::RemoteLayerTreeDrawingAreaProxy::hideContentUntilPendingUpdate):
(WebKit::RemoteLayerTreeDrawingAreaProxy::hideContentUntilDidUpdateActivityState):
(WebKit::RemoteLayerTreeDrawingAreaProxy::hideContentUntilAnyUpdate):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::dispatchActivityStateChange):

Canonical link: <a href="https://commits.webkit.org/301093@main">https://commits.webkit.org/301093@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4c08f1814f13964746711ec415030ac86d72727d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124302 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43984 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34712 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131138 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76366 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f269b9a0-9580-42e3-a053-248455c3c3b4) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44729 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52586 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94552 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62728 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a1421686-53b4-4183-bae4-ce61993421e1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127256 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35646 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111187 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75140 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b9aefa1b-83a7-4a7a-bafe-5eb2160bca84) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34589 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74618 "Built successfully") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105391 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Running apply-patch; Checked out pull request; run-api-tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29570 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133807 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51209 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39048 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103033 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51603 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107406 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102828 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26306 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48190 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26449 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48148 "Hash 4c08f181 for PR 51715 does not build (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51073 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56858 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50510 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53866 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52185 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->