### PR TITLE
Check for nil NSURLRequest in NetworkSessionCocoa

### DIFF
--- a/LayoutTests/ipc/networksessioncocoa-empty-resource-request-expected.txt
+++ b/LayoutTests/ipc/networksessioncocoa-empty-resource-request-expected.txt
@@ -1,0 +1,1 @@
+This test passes if WebKit does not crash

--- a/LayoutTests/ipc/networksessioncocoa-empty-resource-request.html
+++ b/LayoutTests/ipc/networksessioncocoa-empty-resource-request.html
@@ -1,0 +1,65 @@
+<!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<p>This test passes if WebKit does not crash</p>
+<script>
+testRunner?.dumpAsText();
+testRunner?.waitUntilDone();
+
+setTimeout(async () => {
+    if (!window.IPC)
+        return testRunner?.notifyDone();
+
+    const { CoreIPC } = await import('./coreipc.js');
+    CoreIPC.Networking.NetworkConnectionToWebProcess.CreateSocketChannel(
+      0, {
+      request: {
+        getRequestDataToSerialize: {
+          variantType: 'WebCore::ResourceRequestPlatformData',
+          variant: {
+            m_urlRequest: {},
+            m_isAppInitiated: {},
+            m_requester: {},
+            m_privacyProxyFailClosedForUnreachableNonMainHosts: true,
+            m_useAdvancedPrivacyProtections: false,
+            m_didFilterLinkDecoration: false,
+            m_isPrivateTokenUsageByThirdPartyAllowed: true,
+            m_wasSchemeOptimisticallyUpgraded: false
+          }
+        },
+        cachePartition: '',
+        hiddenFromInspector: false
+      },
+      protocol: '',
+      identifier: 393219,
+      webPageProxyID: IPC.webPageProxyID,
+      frameID: {},
+      pageID: {},
+      clientOrigin: {
+        topOrigin: {
+          data: {
+            variantType: 'WebCore::SecurityOriginData::Tuple',
+            variant: {
+              protocol: '',
+              host: '',
+              port: { optionalValue: 58660 }
+            }
+          }
+        },
+        clientOrigin: {
+          data: {
+            variantType: 'WebCore::SecurityOriginData::Tuple',
+            variant: { protocol: '', host: '', port: {} }
+          }
+        }
+      },
+      hadMainFrameMainResourcePrivateRelayed: false,
+      allowPrivacyProxy: true,
+      protections: 513,
+      storedCredentialsPolicy: 0
+    });
+}, 10);
+
+setTimeout(() => {
+    testRunner?.notifyDone();
+}, 2000);
+
+</script>

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -1922,6 +1922,8 @@ RefPtr<WebSocketTask> NetworkSessionCocoa::createWebSocketTask(WebPageProxyIdent
 {
     ASSERT(!request.hasHTTPHeaderField(WebCore::HTTPHeaderName::SecWebSocketProtocol));
     RetainPtr nsRequest = request.nsURLRequest(WebCore::HTTPBodyUpdatePolicy::DoNotUpdateHTTPBody);
+    if (!nsRequest)
+        return nullptr;
     RetainPtr<NSMutableURLRequest> mutableRequest;
 
     auto ensureMutableRequest = [&] {


### PR DESCRIPTION
#### 5820dfdfd2eab791c85642bc126c539db9a82589
<pre>
Check for nil NSURLRequest in NetworkSessionCocoa
<a href="https://bugs.webkit.org/show_bug.cgi?id=300063">https://bugs.webkit.org/show_bug.cgi?id=300063</a>
<a href="https://rdar.apple.com/161639791">rdar://161639791</a>

Reviewed by Matthew Finkel.

Fix CoreIPC fuzz blocker by checking that the NSURLRequest from the
ResourceRequest in NetworkSessionCocoa is not nil before use.

Test: ipc/networksessioncocoa-empty-resource-request.html

Test: ipc/networksessioncocoa-empty-resource-request.html
* LayoutTests/ipc/networksessioncocoa-empty-resource-request-expected.txt: Added.
* LayoutTests/ipc/networksessioncocoa-empty-resource-request.html: Added.
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
(WebKit::NetworkSessionCocoa::createWebSocketTask):

Canonical link: <a href="https://commits.webkit.org/300970@main">https://commits.webkit.org/300970@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2ade951846510a4045938bdd8a5d78827846d9b9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124429 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44113 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34844 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131273 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76446 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0e46ff0c-35e1-47c6-ad7c-b66619998c2c) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44858 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52710 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94664 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62793 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/dec5a521-0b84-4cfa-88b6-b99e8dfff22d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127383 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35760 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111290 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75240 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2233c704-717b-4b2b-94d0-5fcce8bfbe04) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34695 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29450 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74752 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105512 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29670 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133936 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51330 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39162 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103170 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51731 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107505 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102927 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26214 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48300 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26546 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48276 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51196 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56982 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50615 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53977 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52290 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->