### PR TITLE
Expand position-area CB to include in-flow scrollable area for ICB

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-overflow-icb-001-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-overflow-icb-001-expected.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html dir=rtl>
+<title>Reference: position-area overflow alignment against ICB - non-scrollable RTL</title>
+<style>
+.anchor {
+  border: solid orange 20px;
+  position: absolute;
+  margin: auto;
+  top: 50%;
+  left: 50%;
+}
+.above, .below, .left, .right {
+  border: solid blue 3px;
+  padding: 2px;
+  position: absolute;
+  width: 0;
+  height: 0;
+}
+.above { top: 0;     left: 50%;    height: 60vh;  margin-left:   25px; }
+.below { bottom: 0;  left: 50%;    height: 60vh;  margin-left:    5px; }
+.left  { left: 0;    top: 50%;     width:  60vw;  margin-top:    25px; }
+.right { right: 0;   top: 50%;     width:  60vw;  margin-top:     5px; }
+</style>
+
+<div class=anchor></div>
+<div class=above></div>
+<div class=below></div>
+<div class=left></div>
+<div class=right></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-overflow-icb-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-overflow-icb-001.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html dir=rtl>
+<title>position-area overflow alignment against ICB - non-scrollable RTL</title>
+<link rel="help" href="https://www.w3.org/TR/css-anchor-position/#position-area">
+<link rel="help" href="https://www.w3.org/TR/css-align-3/#auto-safety-position">
+<meta name=assert content="Test passes if the positioned box is aligned as specified to the extent possible within the scrollable area.">
+
+<link rel="match" href="position-area-overflow-icb-001.html">
+<style>
+.anchor {
+  anchor-name: --foo;
+  border: solid orange 20px;
+  position: absolute;
+  margin: auto;
+  top: 50%;
+  left: 50%;
+}
+.above, .below, .left, .right {
+  border: solid blue 3px;
+  padding: 2px;
+  position: absolute;
+  position-anchor: --foo;
+}
+.above { position-area: top center;    height: 60vh;  margin-left:   20px; }
+.below { position-area: bottom center; height: 60vh;  margin-right:  20px; }
+.left  { position-area: left center;   width:  60vw;  margin-top:    20px; }
+.right { position-area: right center;  width:  60vw;  margin-bottom: 20px; }
+</style>
+
+<div class=anchor></div>
+<div class=above></div>
+<div class=below></div>
+<div class=left></div>
+<div class=right></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-overflow-icb-002-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-overflow-icb-002-expected.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html dir=rtl>
+<title>Reference: position-area overflow alignment against ICB - scrollable RTL</title>
+<style>
+.anchor {
+  border: solid orange 20px;
+  position: absolute;
+  margin: auto;
+  top: 50%;
+  left: 50%;
+}
+.above, .below, .left, .right {
+  border: solid blue 3px;
+  padding: 2px;
+  position: absolute;
+  width: 0;
+  height: 0;
+}
+.above { top: 0;     left: 50%;    height: 60vh;  margin-left:   25px; }
+.below { top: 50%;   left: 50%;    height: 60vh;  margin-left:    5px; margin-top: 40px; }
+.left  { right: 50%; top: 50%;     width:  60vw;  margin-top:    25px; }
+.right { right: 0;   top: 50%;     width:  60vw;  margin-top:     5px; }
+
+html { height: 150vh; width: 150vw; }
+</style>
+
+<div class=anchor></div>
+<div class=above></div>
+<div class=below></div>
+<div class=left></div>
+<div class=right></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-overflow-icb-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-overflow-icb-002.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html dir=rtl>
+<title>position-area overflow alignment against ICB - scrollable RTL</title>
+<link rel="help" href="https://www.w3.org/TR/css-anchor-position/#position-area">
+<link rel="help" href="https://www.w3.org/TR/css-align-3/#auto-safety-position">
+<meta name=assert content="Test passes if the positioned box is aligned as specified to the extent possible within the scrollable area.">
+
+<link rel="match" href="position-area-overflow-icb-002.html">
+<style>
+.anchor {
+  anchor-name: --foo;
+  border: solid orange 20px;
+  position: absolute;
+  margin: auto;
+  top: 50%;
+  left: 50%;
+}
+.above, .below, .left, .right {
+  border: solid blue 3px;
+  padding: 2px;
+  position: absolute;
+  position-anchor: --foo;
+}
+.above { position-area: top center;    height: 60vh;  margin-left:   20px; }
+.below { position-area: bottom center; height: 60vh;  margin-right:  20px; }
+.left  { position-area: left center;   width:  60vw;  margin-top:    20px; }
+.right { position-area: right center;  width:  60vw;  margin-bottom: 20px; }
+
+html { height: 150vh; width: 150vw; }
+</style>
+
+<div class=anchor></div>
+<div class=above></div>
+<div class=below></div>
+<div class=left></div>
+<div class=right></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-scrolling-003.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-scrolling-003.tentative-expected.txt
@@ -1,9 +1,9 @@
 
 
-PASS Initial scroll position
-PASS Scroll to 40,60
-PASS Reattach at 40,60
+FAIL Initial scroll position assert_equals: e7 height expected 100 but got 350
+FAIL Scroll to 40,60 assert_equals: e7 height expected 100 but got 350
+FAIL Reattach at 40,60 assert_equals: e7 height expected 100 but got 350
 FAIL Redisplay at 40,60 assert_equals: e1 x expected 120 but got 100
 FAIL Scroll to 0,0 and relayout assert_equals: e1 x expected 120 but got 100
-PASS Redisplay at 0,0
+FAIL Redisplay at 0,0 assert_equals: e7 height expected 100 but got 350
 

--- a/Source/WebCore/rendering/PositionedLayoutConstraints.h
+++ b/Source/WebCore/rendering/PositionedLayoutConstraints.h
@@ -94,6 +94,7 @@ private:
     bool containingCoordsAreFlipped() const;
 
     void captureInsets();
+    void captureScrollableArea();
     void captureGridArea();
     void captureAnchorGeometry();
     LayoutRange adjustForPositionArea(const LayoutRange rangeToAdjust, const LayoutRange anchorArea, const BoxAxis containerAxis);


### PR DESCRIPTION
#### 6d342d3c33b948e336800d85c61561cc94019730
<pre>
Expand position-area CB to include in-flow scrollable area for ICB
<a href="https://bugs.webkit.org/show_bug.cgi?id=299950">https://bugs.webkit.org/show_bug.cgi?id=299950</a>
<a href="https://rdar.apple.com/161741583">rdar://161741583</a>

Reviewed by Alan Baradlay.

This is not a complete fix for the spec requirement to cover the scrollable
area of scrollable containing blocks, but it fixes the most problematic case:
typical overflow of the initial containing block.

See <a href="https://bugs.webkit.org/show_bug.cgi?id=291864">https://bugs.webkit.org/show_bug.cgi?id=291864</a> for more complete follow-up.

Tests: imported/w3c/web-platform-tests/css/css-anchor-position/position-area-overflow-icb-001.html
       imported/w3c/web-platform-tests/css/css-anchor-position/position-area-overflow-icb-002.html
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-overflow-icb-001-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-overflow-icb-001.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-overflow-icb-002-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-overflow-icb-002.html: Added.

Add some basic reftests for this case.

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-scrolling-003.tentative-expected.txt:

Mark test as failing. The test is wrong in any case, but also not worth fixing
until we have a more complete fix for this issue.

* Source/WebCore/rendering/PositionedLayoutConstraints.cpp:
(WebCore::PositionedLayoutConstraints::captureScrollableArea):
* Source/WebCore/rendering/PositionedLayoutConstraints.h:

Expand the position-area ICB to cover the area of an in-flow root element.

Canonical link: <a href="https://commits.webkit.org/300921@main">https://commits.webkit.org/300921@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d80be718c95fba3da5a73bf084379021e5305fe4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124306 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43988 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34716 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131144 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/76369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3d428fe6-57c2-49d2-b85b-42a508e5078e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/126183 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44733 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52589 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94555 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/76369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/911ca6c6-607d-4c54-9d26-48b4a2e42bf5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127260 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35649 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111181 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75143 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d8a1a0cd-393d-4943-9176-2531c221f734) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34590 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29341 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74622 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105392 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29564 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133811 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51212 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39049 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103035 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51607 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107400 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102831 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26172 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48194 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26445 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48151 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51076 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56862 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50513 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53869 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52188 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->