### PR TITLE
Address safer cpp warnings in PageClientImplCocoa.mm

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/RetainPtrCtorAdoptCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/RetainPtrCtorAdoptCheckerExpectations
@@ -9,6 +9,5 @@ Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
 UIProcess/API/Cocoa/NSAttributedString.mm
 UIProcess/API/Cocoa/WKBackForwardListItem.mm
 UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm
-UIProcess/Cocoa/PageClientImplCocoa.mm
 UIProcess/mac/WebViewImpl.mm
 webpushd/_WKMockUserNotificationCenter.mm

--- a/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
@@ -67,7 +67,6 @@ UIProcess/Automation/mac/WebAutomationSessionMac.mm
 UIProcess/Cocoa/DiagnosticLoggingClient.mm
 UIProcess/Cocoa/GlobalFindInPageState.mm
 UIProcess/Cocoa/NavigationState.mm
-UIProcess/Cocoa/PageClientImplCocoa.mm
 UIProcess/Cocoa/ResourceLoadDelegate.mm
 UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm
 UIProcess/Cocoa/UIDelegate.mm

--- a/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
@@ -58,22 +58,23 @@ PageClientImplCocoa::~PageClientImplCocoa() = default;
 
 void PageClientImplCocoa::obscuredContentInsetsDidChange()
 {
-    [m_webView _recalculateViewportSizesWithMinimumViewportInset:[m_webView minimumViewportInset] maximumViewportInset:[m_webView maximumViewportInset] throwOnInvalidInput:NO];
+    RetainPtr webView = m_webView.get();
+    [webView _recalculateViewportSizesWithMinimumViewportInset:[webView minimumViewportInset] maximumViewportInset:[webView maximumViewportInset] throwOnInvalidInput:NO];
 }
 
 void PageClientImplCocoa::themeColorWillChange()
 {
-    [m_webView willChangeValueForKey:@"themeColor"];
+    [webView() willChangeValueForKey:@"themeColor"];
 }
 
 void PageClientImplCocoa::themeColorDidChange()
 {
-    [m_webView didChangeValueForKey:@"themeColor"];
+    [webView() didChangeValueForKey:@"themeColor"];
 }
 
 void PageClientImplCocoa::underPageBackgroundColorWillChange()
 {
-    [m_webView willChangeValueForKey:@"underPageBackgroundColor"];
+    [webView() willChangeValueForKey:@"underPageBackgroundColor"];
 }
 
 void PageClientImplCocoa::underPageBackgroundColorDidChange()
@@ -88,69 +89,70 @@ void PageClientImplCocoa::underPageBackgroundColorDidChange()
 
 void PageClientImplCocoa::sampledPageTopColorWillChange()
 {
-    [m_webView willChangeValueForKey:@"_sampledPageTopColor"];
+    [webView() willChangeValueForKey:@"_sampledPageTopColor"];
 }
 
 void PageClientImplCocoa::sampledPageTopColorDidChange()
 {
-    [m_webView didChangeValueForKey:@"_sampledPageTopColor"];
+    [webView() didChangeValueForKey:@"_sampledPageTopColor"];
 }
 
 #if ENABLE(WEB_PAGE_SPATIAL_BACKDROP)
 void PageClientImplCocoa::spatialBackdropSourceWillChange()
 {
-    [m_webView willChangeValueForKey:@"_spatialBackdropSource"];
+    [webView() willChangeValueForKey:@"_spatialBackdropSource"];
 }
 
 void PageClientImplCocoa::spatialBackdropSourceDidChange()
 {
-    [m_webView _spatialBackdropSourceDidChange];
-    [m_webView didChangeValueForKey:@"_spatialBackdropSource"];
+    RetainPtr webView = m_webView.get();
+    [webView _spatialBackdropSourceDidChange];
+    [webView didChangeValueForKey:@"_spatialBackdropSource"];
 }
 #endif
 
 void PageClientImplCocoa::isPlayingAudioWillChange()
 {
-    [m_webView willChangeValueForKey:NSStringFromSelector(@selector(_isPlayingAudio))];
+    [webView() willChangeValueForKey:RetainPtr { NSStringFromSelector(@selector(_isPlayingAudio)) }.get()];
 }
 
 void PageClientImplCocoa::isPlayingAudioDidChange()
 {
-    [m_webView didChangeValueForKey:NSStringFromSelector(@selector(_isPlayingAudio))];
+    [webView() didChangeValueForKey:RetainPtr { NSStringFromSelector(@selector(_isPlayingAudio)) }.get()];
 }
 
 bool PageClientImplCocoa::scrollingUpdatesDisabledForTesting()
 {
-    return [m_webView _scrollingUpdatesDisabledForTesting];
+    return [webView() _scrollingUpdatesDisabledForTesting];
 }
 
 #if ENABLE(ATTACHMENT_ELEMENT)
 
 void PageClientImplCocoa::didInsertAttachment(API::Attachment& attachment, const String& source)
 {
-    [m_webView _didInsertAttachment:attachment withSource:source.createNSString().get()];
+    [webView() _didInsertAttachment:attachment withSource:source.createNSString().get()];
 }
 
 void PageClientImplCocoa::didRemoveAttachment(API::Attachment& attachment)
 {
-    [m_webView _didRemoveAttachment:attachment];
+    [webView() _didRemoveAttachment:attachment];
 }
 
 void PageClientImplCocoa::didInvalidateDataForAttachment(API::Attachment& attachment)
 {
-    [m_webView _didInvalidateDataForAttachment:attachment];
+    [webView() _didInvalidateDataForAttachment:attachment];
 }
 
 NSFileWrapper *PageClientImplCocoa::allocFileWrapperInstance() const
 {
-    RetainPtr cls = [m_webView configuration]._attachmentFileWrapperClass ?: [NSFileWrapper class];
-    return [cls.get() alloc];
+    RetainPtr cls = [webView() configuration]._attachmentFileWrapperClass ?: [NSFileWrapper class];
+    SUPPRESS_RETAINPTR_CTOR_ADOPT return [cls.get() alloc];
 }
 
 NSSet *PageClientImplCocoa::serializableFileWrapperClasses() const
 {
     RetainPtr<Class> defaultFileWrapperClass = NSFileWrapper.class;
-    RetainPtr<Class> configuredFileWrapperClass = [m_webView configuration]._attachmentFileWrapperClass;
+    RetainPtr<Class> configuredFileWrapperClass = [webView() configuration]._attachmentFileWrapperClass;
     if (configuredFileWrapperClass && configuredFileWrapperClass.get() != defaultFileWrapperClass.get())
         return [NSSet setWithObjects:configuredFileWrapperClass.get(), defaultFileWrapperClass.get(), nil];
     return [NSSet setWithObjects:defaultFileWrapperClass.get(), nil];
@@ -161,7 +163,7 @@ NSSet *PageClientImplCocoa::serializableFileWrapperClasses() const
 #if ENABLE(APP_HIGHLIGHTS)
 void PageClientImplCocoa::storeAppHighlight(const WebCore::AppHighlight &highlight)
 {
-    [m_webView _storeAppHighlight:highlight];
+    [webView() _storeAppHighlight:highlight];
 }
 #endif // ENABLE(APP_HIGHLIGHTS)
 
@@ -173,28 +175,32 @@ void PageClientImplCocoa::pageClosed()
 #if ENABLE(GPU_PROCESS)
 void PageClientImplCocoa::gpuProcessDidFinishLaunching()
 {
-    [m_webView willChangeValueForKey:@"_gpuProcessIdentifier"];
-    [m_webView didChangeValueForKey:@"_gpuProcessIdentifier"];
+    RetainPtr webView = m_webView.get();
+    [webView willChangeValueForKey:@"_gpuProcessIdentifier"];
+    [webView didChangeValueForKey:@"_gpuProcessIdentifier"];
 }
 
 void PageClientImplCocoa::gpuProcessDidExit()
 {
-    [m_webView willChangeValueForKey:@"_gpuProcessIdentifier"];
-    [m_webView didChangeValueForKey:@"_gpuProcessIdentifier"];
+    RetainPtr webView = m_webView.get();
+    [webView willChangeValueForKey:@"_gpuProcessIdentifier"];
+    [webView didChangeValueForKey:@"_gpuProcessIdentifier"];
 }
 #endif
 
 #if ENABLE(MODEL_PROCESS)
 void PageClientImplCocoa::modelProcessDidFinishLaunching()
 {
-    [m_webView willChangeValueForKey:@"_modelProcessIdentifier"];
-    [m_webView didChangeValueForKey:@"_modelProcessIdentifier"];
+    RetainPtr webView = m_webView.get();
+    [webView willChangeValueForKey:@"_modelProcessIdentifier"];
+    [webView didChangeValueForKey:@"_modelProcessIdentifier"];
 }
 
 void PageClientImplCocoa::modelProcessDidExit()
 {
-    [m_webView willChangeValueForKey:@"_modelProcessIdentifier"];
-    [m_webView didChangeValueForKey:@"_modelProcessIdentifier"];
+    RetainPtr webView = m_webView.get();
+    [webView willChangeValueForKey:@"_modelProcessIdentifier"];
+    [webView didChangeValueForKey:@"_modelProcessIdentifier"];
 }
 #endif
 
@@ -215,7 +221,7 @@ void PageClientImplCocoa::removeDictationAlternatives(WebCore::DictationContext 
 
 Vector<String> PageClientImplCocoa::dictationAlternatives(WebCore::DictationContext dictationContext)
 {
-    return makeVector<String>(platformDictationAlternatives(dictationContext).alternativeStrings);
+    return makeVector<String>(RetainPtr { platformDictationAlternatives(dictationContext) }.get().alternativeStrings);
 }
 
 PlatformTextAlternatives *PageClientImplCocoa::platformDictationAlternatives(WebCore::DictationContext dictationContext)
@@ -225,57 +231,57 @@ PlatformTextAlternatives *PageClientImplCocoa::platformDictationAlternatives(Web
 
 void PageClientImplCocoa::microphoneCaptureWillChange()
 {
-    [m_webView willChangeValueForKey:@"microphoneCaptureState"];
+    [webView() willChangeValueForKey:@"microphoneCaptureState"];
 }
 
 void PageClientImplCocoa::cameraCaptureWillChange()
 {
-    [m_webView willChangeValueForKey:@"cameraCaptureState"];
+    [webView() willChangeValueForKey:@"cameraCaptureState"];
 }
 
 void PageClientImplCocoa::displayCaptureWillChange()
 {
-    [m_webView willChangeValueForKey:@"_displayCaptureState"];
+    [webView() willChangeValueForKey:@"_displayCaptureState"];
 }
 
 void PageClientImplCocoa::displayCaptureSurfacesWillChange()
 {
-    [m_webView willChangeValueForKey:@"_displayCaptureSurfaces"];
+    [webView() willChangeValueForKey:@"_displayCaptureSurfaces"];
 }
 
 void PageClientImplCocoa::systemAudioCaptureWillChange()
 {
-    [m_webView willChangeValueForKey:@"_systemAudioCaptureState"];
+    [webView() willChangeValueForKey:@"_systemAudioCaptureState"];
 }
 
 void PageClientImplCocoa::microphoneCaptureChanged()
 {
-    [m_webView didChangeValueForKey:@"microphoneCaptureState"];
+    [webView() didChangeValueForKey:@"microphoneCaptureState"];
 }
 
 void PageClientImplCocoa::cameraCaptureChanged()
 {
-    [m_webView didChangeValueForKey:@"cameraCaptureState"];
+    [webView() didChangeValueForKey:@"cameraCaptureState"];
 }
 
 void PageClientImplCocoa::displayCaptureChanged()
 {
-    [m_webView didChangeValueForKey:@"_displayCaptureState"];
+    [webView() didChangeValueForKey:@"_displayCaptureState"];
 }
 
 void PageClientImplCocoa::displayCaptureSurfacesChanged()
 {
-    [m_webView didChangeValueForKey:@"_displayCaptureSurfaces"];
+    [webView() didChangeValueForKey:@"_displayCaptureSurfaces"];
 }
 
 void PageClientImplCocoa::systemAudioCaptureChanged()
 {
-    [m_webView didChangeValueForKey:@"_systemAudioCaptureState"];
+    [webView() didChangeValueForKey:@"_systemAudioCaptureState"];
 }
 
 WindowKind PageClientImplCocoa::windowKind()
 {
-    RetainPtr window = [m_webView window];
+    RetainPtr window = [webView() window];
     if (!window)
         return WindowKind::Unparented;
     if ([window isKindOfClass:NSClassFromString(@"_SCNSnapshotWindow")])
@@ -286,44 +292,48 @@ WindowKind PageClientImplCocoa::windowKind()
 #if ENABLE(WRITING_TOOLS)
 void PageClientImplCocoa::proofreadingSessionShowDetailsForSuggestionWithIDRelativeToRect(const WebCore::WritingTools::TextSuggestion::ID& replacementID, WebCore::IntRect selectionBoundsInRootView)
 {
-    [m_webView _proofreadingSessionShowDetailsForSuggestionWithUUID:replacementID.createNSUUID().get() relativeToRect:selectionBoundsInRootView];
+    [webView() _proofreadingSessionShowDetailsForSuggestionWithUUID:replacementID.createNSUUID().get() relativeToRect:selectionBoundsInRootView];
 }
 
 void PageClientImplCocoa::proofreadingSessionUpdateStateForSuggestionWithID(WebCore::WritingTools::TextSuggestion::State state, const WebCore::WritingTools::TextSuggestion::ID& replacementID)
 {
-    [m_webView _proofreadingSessionUpdateState:state forSuggestionWithUUID:replacementID.createNSUUID().get()];
+    [webView() _proofreadingSessionUpdateState:state forSuggestionWithUUID:replacementID.createNSUUID().get()];
 }
 
-static NSString *writingToolsActiveKey = @"writingToolsActive";
+static NSString *writingToolsActiveKeySingleton()
+{
+    static NeverDestroyed<RetainPtr<NSString>> writingToolsActiveKey = retainPtr(@"writingToolsActive");
+    return writingToolsActiveKey.get().get();
+}
 
 void PageClientImplCocoa::writingToolsActiveWillChange()
 {
-    [m_webView willChangeValueForKey:writingToolsActiveKey];
+    [webView() willChangeValueForKey:writingToolsActiveKeySingleton()];
 }
 
 void PageClientImplCocoa::writingToolsActiveDidChange()
 {
-    [m_webView didChangeValueForKey:writingToolsActiveKey];
+    [webView() didChangeValueForKey:writingToolsActiveKeySingleton()];
 }
 
 void PageClientImplCocoa::didEndPartialIntelligenceTextAnimation()
 {
-    [m_webView _didEndPartialIntelligenceTextAnimation];
+    [webView() _didEndPartialIntelligenceTextAnimation];
 }
 
 bool PageClientImplCocoa::writingToolsTextReplacementsFinished()
 {
-    return [m_webView _writingToolsTextReplacementsFinished];
+    return [webView() _writingToolsTextReplacementsFinished];
 }
 
 void PageClientImplCocoa::addTextAnimationForAnimationID(const WTF::UUID& uuid, const WebCore::TextAnimationData& data)
 {
-    [m_webView _addTextAnimationForAnimationID:uuid.createNSUUID().get() withData:data];
+    [webView() _addTextAnimationForAnimationID:uuid.createNSUUID().get() withData:data];
 }
 
 void PageClientImplCocoa::removeTextAnimationForAnimationID(const WTF::UUID& uuid)
 {
-    [m_webView _removeTextAnimationForAnimationID:uuid.createNSUUID().get()];
+    [webView() _removeTextAnimationForAnimationID:uuid.createNSUUID().get()];
 }
 
 #endif
@@ -389,7 +399,7 @@ void PageClientImplCocoa::viewIsBecomingInvisible()
 #if ENABLE(GAMEPAD)
 void PageClientImplCocoa::setGamepadsRecentlyAccessed(GamepadsRecentlyAccessed gamepadsRecentlyAccessed)
 {
-    [m_webView _setGamepadsRecentlyAccessed:(gamepadsRecentlyAccessed == GamepadsRecentlyAccessed::No) ? NO : YES];
+    [webView() _setGamepadsRecentlyAccessed:(gamepadsRecentlyAccessed == GamepadsRecentlyAccessed::No) ? NO : YES];
 }
 
 #if PLATFORM(VISION)
@@ -402,32 +412,35 @@ void PageClientImplCocoa::gamepadsConnectedStateChanged()
 
 void PageClientImplCocoa::hasActiveNowPlayingSessionChanged(bool hasActiveNowPlayingSession)
 {
-    if ([m_webView _hasActiveNowPlayingSession] == hasActiveNowPlayingSession)
+    RetainPtr webView = m_webView.get();
+    if ([webView _hasActiveNowPlayingSession] == hasActiveNowPlayingSession)
         return;
 
-    RELEASE_LOG(ViewState, "%p PageClientImplCocoa::hasActiveNowPlayingSessionChanged %d", m_webView.get().get(), hasActiveNowPlayingSession);
+    RELEASE_LOG(ViewState, "%p PageClientImplCocoa::hasActiveNowPlayingSessionChanged %d", webView.get(), hasActiveNowPlayingSession);
 
-    [m_webView willChangeValueForKey:@"_hasActiveNowPlayingSession"];
-    [m_webView _setHasActiveNowPlayingSession:hasActiveNowPlayingSession];
-    [m_webView didChangeValueForKey:@"_hasActiveNowPlayingSession"];
+    [webView willChangeValueForKey:@"_hasActiveNowPlayingSession"];
+    [webView _setHasActiveNowPlayingSession:hasActiveNowPlayingSession];
+    [webView didChangeValueForKey:@"_hasActiveNowPlayingSession"];
 }
 
 void PageClientImplCocoa::videoControlsManagerDidChange()
 {
-    RELEASE_LOG(ViewState, "%p PageClientImplCocoa::videoControlsManagerDidChange %d", m_webView.get().get(), [m_webView _canEnterFullscreen]);
-    [m_webView willChangeValueForKey:@"_canEnterFullscreen"];
-    [m_webView didChangeValueForKey:@"_canEnterFullscreen"];
+    RetainPtr webView = m_webView.get();
+    RELEASE_LOG(ViewState, "%p PageClientImplCocoa::videoControlsManagerDidChange %d", webView.get(), [webView _canEnterFullscreen]);
+    [webView willChangeValueForKey:@"_canEnterFullscreen"];
+    [webView didChangeValueForKey:@"_canEnterFullscreen"];
 }
 
 CocoaWindow *PageClientImplCocoa::platformWindow() const
 {
-    return [m_webView window];
+    return [webView() window];
 }
 
 void PageClientImplCocoa::processDidUpdateThrottleState()
 {
-    [m_webView willChangeValueForKey:@"_webProcessState"];
-    [m_webView didChangeValueForKey:@"_webProcessState"];
+    RetainPtr webView = m_webView.get();
+    [webView willChangeValueForKey:@"_webProcessState"];
+    [webView didChangeValueForKey:@"_webProcessState"];
 }
 
 #if ENABLE(FULLSCREEN_API)


### PR DESCRIPTION
#### 83f31203852abe9f250efec1f54e2dfdb6e11342
<pre>
Address safer cpp warnings in PageClientImplCocoa.mm
<a href="https://bugs.webkit.org/show_bug.cgi?id=300072">https://bugs.webkit.org/show_bug.cgi?id=300072</a>

Reviewed by Ryosuke Niwa.

* Source/WebKit/SaferCPPExpectations/RetainPtrCtorAdoptCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations:
* Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm:
(WebKit::PageClientImplCocoa::obscuredContentInsetsDidChange):
(WebKit::PageClientImplCocoa::themeColorWillChange):
(WebKit::PageClientImplCocoa::themeColorDidChange):
(WebKit::PageClientImplCocoa::underPageBackgroundColorWillChange):
(WebKit::PageClientImplCocoa::sampledPageTopColorWillChange):
(WebKit::PageClientImplCocoa::sampledPageTopColorDidChange):
(WebKit::PageClientImplCocoa::spatialBackdropSourceWillChange):
(WebKit::PageClientImplCocoa::spatialBackdropSourceDidChange):
(WebKit::PageClientImplCocoa::isPlayingAudioWillChange):
(WebKit::PageClientImplCocoa::isPlayingAudioDidChange):
(WebKit::PageClientImplCocoa::scrollingUpdatesDisabledForTesting):
(WebKit::PageClientImplCocoa::didInsertAttachment):
(WebKit::PageClientImplCocoa::didRemoveAttachment):
(WebKit::PageClientImplCocoa::didInvalidateDataForAttachment):
(WebKit::PageClientImplCocoa::allocFileWrapperInstance const):
(WebKit::PageClientImplCocoa::serializableFileWrapperClasses const):
(WebKit::PageClientImplCocoa::storeAppHighlight):
(WebKit::PageClientImplCocoa::gpuProcessDidFinishLaunching):
(WebKit::PageClientImplCocoa::gpuProcessDidExit):
(WebKit::PageClientImplCocoa::modelProcessDidFinishLaunching):
(WebKit::PageClientImplCocoa::modelProcessDidExit):
(WebKit::PageClientImplCocoa::dictationAlternatives):
(WebKit::PageClientImplCocoa::microphoneCaptureWillChange):
(WebKit::PageClientImplCocoa::cameraCaptureWillChange):
(WebKit::PageClientImplCocoa::displayCaptureWillChange):
(WebKit::PageClientImplCocoa::displayCaptureSurfacesWillChange):
(WebKit::PageClientImplCocoa::systemAudioCaptureWillChange):
(WebKit::PageClientImplCocoa::microphoneCaptureChanged):
(WebKit::PageClientImplCocoa::cameraCaptureChanged):
(WebKit::PageClientImplCocoa::displayCaptureChanged):
(WebKit::PageClientImplCocoa::displayCaptureSurfacesChanged):
(WebKit::PageClientImplCocoa::systemAudioCaptureChanged):
(WebKit::PageClientImplCocoa::windowKind):
(WebKit::PageClientImplCocoa::proofreadingSessionShowDetailsForSuggestionWithIDRelativeToRect):
(WebKit::PageClientImplCocoa::proofreadingSessionUpdateStateForSuggestionWithID):
(WebKit::writingToolsActiveKeySingleton):
(WebKit::PageClientImplCocoa::writingToolsActiveWillChange):
(WebKit::PageClientImplCocoa::writingToolsActiveDidChange):
(WebKit::PageClientImplCocoa::didEndPartialIntelligenceTextAnimation):
(WebKit::PageClientImplCocoa::writingToolsTextReplacementsFinished):
(WebKit::PageClientImplCocoa::addTextAnimationForAnimationID):
(WebKit::PageClientImplCocoa::removeTextAnimationForAnimationID):
(WebKit::PageClientImplCocoa::setGamepadsRecentlyAccessed):
(WebKit::PageClientImplCocoa::hasActiveNowPlayingSessionChanged):
(WebKit::PageClientImplCocoa::videoControlsManagerDidChange):
(WebKit::PageClientImplCocoa::platformWindow const):
(WebKit::PageClientImplCocoa::processDidUpdateThrottleState):

Canonical link: <a href="https://commits.webkit.org/300926@main">https://commits.webkit.org/300926@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c2bdd3c0561441f55a4af0115f6d2dadcc9f1163

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124318 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44000 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34728 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131156 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/76375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44745 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52599 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94567 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/76375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127272 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35661 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111198 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75154 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34601 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74634 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105405 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29581 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133823 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51221 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39059 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103046 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51617 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107417 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102842 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26174 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48202 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26457 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48158 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51086 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56873 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50522 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53878 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52197 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->