### PR TITLE
[Style] Convert the 'font-style' property to strong style types

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -3287,6 +3287,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     style/values/flexbox/StyleWebKitBoxOrdinalGroup.h
 
     style/values/fonts/StyleFontPalette.h
+    style/values/fonts/StyleFontStyle.h
     style/values/fonts/StyleFontWeight.h
     style/values/fonts/StyleFontWidth.h
 

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -3222,6 +3222,7 @@ style/values/filter-effects/StyleSaturateFunction.cpp
 style/values/filter-effects/StyleSepiaFunction.cpp
 style/values/flexbox/StyleFlexBasis.cpp
 style/values/fonts/StyleFontPalette.cpp
+style/values/fonts/StyleFontStyle.cpp
 style/values/fonts/StyleFontWeight.cpp
 style/values/fonts/StyleFontWidth.cpp
 style/values/grid/StyleGridNamedLinesMap.cpp

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -3041,7 +3041,7 @@ bool AccessibilityRenderObject::hasItalicFont() const
     if (!m_renderer)
         return false;
 
-    return isItalic(m_renderer->style().fontDescription().italic());
+    return m_renderer->style().fontStyle().isConsideredItalic();
 }
 
 bool AccessibilityRenderObject::hasPlainText() const
@@ -3053,8 +3053,8 @@ bool AccessibilityRenderObject::hasPlainText() const
         return false;
 
     const RenderStyle& style = m_renderer->style();
-    return style.fontDescription().weight() == normalWeightValue()
-        && !isItalic(style.fontDescription().italic())
+    return style.fontWeight().isNormal()
+        && !style.fontStyle().isConsideredItalic()
         && style.textDecorationLineInEffect().isNone();
 }
 

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp
@@ -787,7 +787,7 @@ AccessibilityObjectAtspi::TextAttributes AccessibilityObjectAtspi::textAttribute
         addAttributeIfNeeded("family-name"_s, style.fontCascade().firstFamily());
         addAttributeIfNeeded("size"_s, makeString(std::round(style.computedFontSize() * 72 / WebCore::fontDPI()), "pt"_s));
         addAttributeIfNeeded("weight"_s, makeString(static_cast<float>(style.fontCascade().weight())));
-        addAttributeIfNeeded("style"_s, style.fontCascade().italic() ? "italic"_s : "normal"_s);
+        addAttributeIfNeeded("style"_s, style.fontCascade().fontStyleSlope() ? "italic"_s : "normal"_s);
         addAttributeIfNeeded("strikethrough"_s, style.textDecorationLine().hasLineThrough() ? "true"_s : "false"_s);
         addAttributeIfNeeded("underline"_s, style.textDecorationLine().hasUnderline() ? "single"_s : "none"_s);
         addAttributeIfNeeded("invisible"_s, style.visibility() == Visibility::Hidden ? "true"_s : "false"_s);

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -688,10 +688,10 @@
                 "oblique"
             ],
             "codegen-properties": {
-                "animation-wrapper": "FontStyleWrapper",
-                "animation-wrapper-requires-override-parameters": [],
-                "style-builder-custom": "All",
-                "style-extractor-custom": true,
+                "animation-wrapper": "StyleTypeWrapper",
+                "animation-wrapper-requires-render-style": true,
+                "style-converter": "StyleType<FontStyle>",
+                "font-property-uses-render-style-for-access": true,
                 "font-property": true,
                 "high-priority": true,
                 "parser-function": "consumeFontStyle",

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -370,7 +370,7 @@ String CanvasRenderingContext2DBase::State::fontString() const
     StringBuilder serializedFont;
     const auto& font = this->font.fontDescription();
 
-    auto italic = font.italic() ? "italic "_s : ""_s;
+    auto italic = font.fontStyleSlope() ? "italic "_s : ""_s;
     auto smallCaps = font.variantCaps() == FontVariantCaps::Small ? "small-caps "_s : ""_s;
     serializedFont.append(italic, smallCaps);
     auto weight = static_cast<int>(font.weight());

--- a/Source/WebCore/platform/graphics/FontCascade.h
+++ b/Source/WebCore/platform/graphics/FontCascade.h
@@ -188,7 +188,7 @@ public:
     const AtomString& familyAt(unsigned i) const { return m_fontDescription.familyAt(i); }
 
     // A std::nullopt return value indicates "font-style: normal".
-    std::optional<FontSelectionValue> italic() const { return m_fontDescription.italic(); }
+    std::optional<FontSelectionValue> fontStyleSlope() const { return m_fontDescription.fontStyleSlope(); }
     FontSelectionValue weight() const { return m_fontDescription.weight(); }
     FontWidthVariant widthVariant() const { return m_fontDescription.widthVariant(); }
 

--- a/Source/WebCore/platform/graphics/FontCascadeDescription.h
+++ b/Source/WebCore/platform/graphics/FontCascadeDescription.h
@@ -127,7 +127,6 @@ public:
     WEBCORE_EXPORT void resolveFontSizeAdjustFromFontIfNeeded(const Font&);
 
     // Initial values for font properties.
-    static std::optional<FontSelectionValue> initialItalic() { return std::nullopt; }
     static FontStyleAxis initialFontStyleAxis() { return FontStyleAxis::slnt; }
     static FontSelectionValue initialWeight() { return normalWeightValue(); }
     static FontSelectionValue initialWidth() { return normalWidthValue(); }

--- a/Source/WebCore/platform/graphics/FontDescription.cpp
+++ b/Source/WebCore/platform/graphics/FontDescription.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2007 Nicholas Shanks <contact@nickshanks.com>
  * Copyright (C) 2008-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -39,7 +40,7 @@ namespace WebCore {
 FontDescription::FontDescription()
     : m_variantAlternates(FontCascadeDescription::initialVariantAlternates())
     , m_fontPalette({ FontPalette::Type::Normal, nullAtom() })
-    , m_fontSelectionRequest { FontCascadeDescription::initialWeight(), FontCascadeDescription::initialWidth(), FontCascadeDescription::initialItalic() }
+    , m_fontSelectionRequest { normalWeightValue(), normalWidthValue(), std::nullopt }
     , m_orientation(enumToUnderlyingType(FontOrientation::Horizontal))
     , m_nonCJKGlyphOrientation(enumToUnderlyingType(NonCJKGlyphOrientation::Mixed))
     , m_widthVariant(enumToUnderlyingType(FontWidthVariant::RegularWidth))
@@ -64,7 +65,7 @@ FontDescription::FontDescription()
     , m_variantEastAsianRuby(enumToUnderlyingType(FontVariantEastAsianRuby::Normal))
     , m_variantEmoji(enumToUnderlyingType(FontVariantEmoji::Normal))
     , m_opticalSizing(enumToUnderlyingType(FontOpticalSizing::Enabled))
-    , m_fontStyleAxis(FontCascadeDescription::initialFontStyleAxis() == FontStyleAxis::ital)
+    , m_fontStyleAxis(enumToUnderlyingType(FontStyleAxis::slnt))
     , m_shouldAllowUserInstalledFonts(enumToUnderlyingType(AllowUserInstalledFonts::No))
     , m_shouldDisableLigaturesForSpacing(false)
 {

--- a/Source/WebCore/platform/graphics/FontDescription.h
+++ b/Source/WebCore/platform/graphics/FontDescription.h
@@ -4,6 +4,7 @@
  *           (C) 2000 Dirk Mueller (mueller@kde.org)
  * Copyright (C) 2003-2023 Apple Inc. All rights reserved.
  * Copyright (C) 2007 Nicholas Shanks <webkit@nickshanks.com>
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -42,12 +43,12 @@ class FontDescription {
 public:
     WEBCORE_EXPORT FontDescription();
 
-    friend bool operator==(const FontDescription&, const FontDescription&) = default;
+    bool operator==(const FontDescription&) const = default;
 
     float computedSize() const { return m_computedSize; }
     // Adjusted size regarding @font-face size-adjust but not regarding font-size-adjust. The latter adjustment is done with updateSizeWithFontSizeAdjust() after the font's creation.
     float adjustedSizeForFontFace(float) const;
-    std::optional<FontSelectionValue> italic() const { return m_fontSelectionRequest.slope; }
+    std::optional<FontSelectionValue> fontStyleSlope() const { return m_fontSelectionRequest.slope; }
     FontSelectionValue width() const { return m_fontSelectionRequest.width; }
     FontSelectionValue weight() const { return m_fontSelectionRequest.weight; }
     const FontSelectionRequest& fontSelectionRequest() const { return m_fontSelectionRequest; }
@@ -87,7 +88,8 @@ public:
     FontVariantEmoji variantEmoji() const { return static_cast<FontVariantEmoji>(m_variantEmoji); }
     FontVariantSettings variantSettings() const
     {
-        return { variantCommonLigatures(),
+        return {
+            variantCommonLigatures(),
             variantDiscretionaryLigatures(),
             variantHistoricalLigatures(),
             variantContextualAlternates(),
@@ -102,10 +104,11 @@ public:
             variantEastAsianVariant(),
             variantEastAsianWidth(),
             variantEastAsianRuby(),
-            variantEmoji() };
+            variantEmoji()
+        };
     }
     FontOpticalSizing opticalSizing() const { return static_cast<FontOpticalSizing>(m_opticalSizing); }
-    FontStyleAxis fontStyleAxis() const { return m_fontStyleAxis ? FontStyleAxis::ital : FontStyleAxis::slnt; }
+    FontStyleAxis fontStyleAxis() const { return static_cast<FontStyleAxis>(m_fontStyleAxis); }
     AllowUserInstalledFonts shouldAllowUserInstalledFonts() const { return static_cast<AllowUserInstalledFonts>(m_shouldAllowUserInstalledFonts); }
     bool shouldDisableLigaturesForSpacing() const { return m_shouldDisableLigaturesForSpacing; }
     const FontPalette& fontPalette() const { return m_fontPalette; }
@@ -114,10 +117,11 @@ public:
     void setComputedSize(float s) { m_computedSize = clampToFloat(s); }
     void setTextSpacingTrim(TextSpacingTrim v) { m_textSpacingTrim = v; }
     void setTextAutospace(TextAutospace v) { m_textAutospace = v; }
-    void setItalic(std::optional<FontSelectionValue> italic) { m_fontSelectionRequest.slope = italic; }
-    void setWidth(FontSelectionValue width) { m_fontSelectionRequest.width = width; }
-    void setIsItalic(bool isItalic) { setItalic(isItalic ? std::optional<FontSelectionValue> { italicValue() } : std::optional<FontSelectionValue> { }); }
+    void setFontStyleAxis(FontStyleAxis axis) { m_fontStyleAxis = enumToUnderlyingType(axis); }
+    void setFontStyleSlope(std::optional<FontSelectionValue> slope) { m_fontSelectionRequest.slope = slope; }
+    void setIsItalic(bool isItalic) { setFontStyleSlope(isItalic ? std::optional<FontSelectionValue> { italicValue() } : std::optional<FontSelectionValue> { }); }
     void setWeight(FontSelectionValue weight) { m_fontSelectionRequest.weight = weight; }
+    void setWidth(FontSelectionValue width) { m_fontSelectionRequest.width = width; }
     void setTextRenderingMode(TextRenderingMode rendering) { m_textRendering = enumToUnderlyingType(rendering); }
     void setOrientation(FontOrientation orientation) { m_orientation = enumToUnderlyingType(orientation); }
     void setNonCJKGlyphOrientation(NonCJKGlyphOrientation orientation) { m_nonCJKGlyphOrientation = enumToUnderlyingType(orientation); }
@@ -146,7 +150,6 @@ public:
     void setVariantEastAsianRuby(FontVariantEastAsianRuby variant) { m_variantEastAsianRuby = enumToUnderlyingType(variant); }
     void setVariantEmoji(FontVariantEmoji variant) { m_variantEmoji = enumToUnderlyingType(variant); }
     void setOpticalSizing(FontOpticalSizing sizing) { m_opticalSizing = enumToUnderlyingType(sizing); }
-    void setFontStyleAxis(FontStyleAxis axis) { m_fontStyleAxis = axis == FontStyleAxis::ital; }
     void setShouldAllowUserInstalledFonts(AllowUserInstalledFonts shouldAllowUserInstalledFonts) { m_shouldAllowUserInstalledFonts = enumToUnderlyingType(shouldAllowUserInstalledFonts); }
     void setShouldDisableLigaturesForSpacing(bool shouldDisableLigaturesForSpacing) { m_shouldDisableLigaturesForSpacing = shouldDisableLigaturesForSpacing; }
     void setFontPalette(const FontPalette& fontPalette) { m_fontPalette = fontPalette; }
@@ -168,33 +171,33 @@ private:
     TextSpacingTrim m_textSpacingTrim;
     TextAutospace m_textAutospace;
     float m_computedSize { 0 }; // Computed size adjusted for the minimum font size and the zoom factor.
-    unsigned m_orientation : 1; // FontOrientation - Whether the font is rendering on a horizontal line or a vertical line.
-    unsigned m_nonCJKGlyphOrientation : 1; // NonCJKGlyphOrientation - Only used by vertical text. Determines the default orientation for non-ideograph glyphs.
-    unsigned m_widthVariant : 2; // FontWidthVariant
-    unsigned m_textRendering : 2; // TextRenderingMode
-    unsigned m_script : 7; // Used to help choose an appropriate font for generic font families.
-    unsigned m_fontSynthesisWeight : 1;
-    unsigned m_fontSynthesisStyle : 1;
-    unsigned m_fontSynthesisCaps : 1;
-    unsigned m_variantCommonLigatures : 2; // FontVariantLigatures
-    unsigned m_variantDiscretionaryLigatures : 2; // FontVariantLigatures
-    unsigned m_variantHistoricalLigatures : 2; // FontVariantLigatures
-    unsigned m_variantContextualAlternates : 2; // FontVariantLigatures
-    unsigned m_variantPosition : 2; // FontVariantPosition
-    unsigned m_variantCaps : 3; // FontVariantCaps
-    unsigned m_variantNumericFigure : 2; // FontVariantNumericFigure
-    unsigned m_variantNumericSpacing : 2; // FontVariantNumericSpacing
-    unsigned m_variantNumericFraction : 2; // FontVariantNumericFraction
-    unsigned m_variantNumericOrdinal : 1; // FontVariantNumericOrdinal
-    unsigned m_variantNumericSlashedZero : 1; // FontVariantNumericSlashedZero
-    unsigned m_variantEastAsianVariant : 3; // FontVariantEastAsianVariant
-    unsigned m_variantEastAsianWidth : 2; // FontVariantEastAsianWidth
-    unsigned m_variantEastAsianRuby : 1; // FontVariantEastAsianRuby
-    unsigned m_variantEmoji : 2; // FontVariantEmoji
-    unsigned m_opticalSizing : 1; // FontOpticalSizing
-    unsigned m_fontStyleAxis : 1; // Whether "font-style: italic" or "font-style: oblique 20deg" was specified
-    unsigned m_shouldAllowUserInstalledFonts : 1; // AllowUserInstalledFonts: If this description is allowed to match a user-installed font
-    unsigned m_shouldDisableLigaturesForSpacing : 1; // If letter-spacing is nonzero, we need to disable ligatures, which affects font preparation
+    PREFERRED_TYPE(FontOrientation) unsigned m_orientation : 1; // Whether the font is rendering on a horizontal line or a vertical line.
+    PREFERRED_TYPE(NonCJKGlyphOrientation) unsigned m_nonCJKGlyphOrientation : 1; // Only used by vertical text. Determines the default orientation for non-ideograph glyphs.
+    PREFERRED_TYPE(FontWidthVariant) unsigned m_widthVariant : 2;
+    PREFERRED_TYPE(TextRenderingMode) unsigned m_textRendering : 2;
+    unsigned m_script : 7; // UScriptCode - Used to help choose an appropriate font for generic font families.
+    PREFERRED_TYPE(FontSynthesisLonghandValue) unsigned m_fontSynthesisWeight : 1;
+    PREFERRED_TYPE(FontSynthesisLonghandValue) unsigned m_fontSynthesisStyle : 1;
+    PREFERRED_TYPE(FontSynthesisLonghandValue) unsigned m_fontSynthesisCaps : 1;
+    PREFERRED_TYPE(FontVariantLigatures) unsigned m_variantCommonLigatures : 2;
+    PREFERRED_TYPE(FontVariantLigatures) unsigned m_variantDiscretionaryLigatures : 2;
+    PREFERRED_TYPE(FontVariantLigatures) unsigned m_variantHistoricalLigatures : 2;
+    PREFERRED_TYPE(FontVariantLigatures) unsigned m_variantContextualAlternates : 2;
+    PREFERRED_TYPE(FontVariantPosition) unsigned m_variantPosition : 2;
+    PREFERRED_TYPE(FontVariantCaps) unsigned m_variantCaps : 3;
+    PREFERRED_TYPE(FontVariantNumericFigure) unsigned m_variantNumericFigure : 2;
+    PREFERRED_TYPE(FontVariantNumericSpacing) unsigned m_variantNumericSpacing : 2;
+    PREFERRED_TYPE(FontVariantNumericFraction) unsigned m_variantNumericFraction : 2;
+    PREFERRED_TYPE(FontVariantNumericOrdinal) unsigned m_variantNumericOrdinal : 1;
+    PREFERRED_TYPE(FontVariantNumericSlashedZero) unsigned m_variantNumericSlashedZero : 1;
+    PREFERRED_TYPE(FontVariantEastAsianVariant) unsigned m_variantEastAsianVariant : 3;
+    PREFERRED_TYPE(FontVariantEastAsianWidth) unsigned m_variantEastAsianWidth : 2;
+    PREFERRED_TYPE(FontVariantEastAsianRuby) unsigned m_variantEastAsianRuby : 1;
+    PREFERRED_TYPE(FontVariantEmoji) unsigned m_variantEmoji : 2;
+    PREFERRED_TYPE(FontOpticalSizing) unsigned m_opticalSizing : 1;
+    PREFERRED_TYPE(FontStyleAxis) unsigned m_fontStyleAxis : 1;
+    PREFERRED_TYPE(AllowUserInstalledFonts) unsigned m_shouldAllowUserInstalledFonts : 1; // If this description is allowed to match a user-installed font
+    PREFERRED_TYPE(bool) unsigned m_shouldDisableLigaturesForSpacing : 1; // If letter-spacing is nonzero, we need to disable ligatures, which affects font preparation
 };
 
-}
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
@@ -232,7 +232,7 @@ bool FontCache::isSystemFontForbiddenForEditing(const String& fontFamily)
 static CTFontSymbolicTraits computeTraits(const FontDescription& fontDescription)
 {
     CTFontSymbolicTraits traits = 0;
-    if (fontDescription.italic())
+    if (fontDescription.fontStyleSlope())
         traits |= kCTFontTraitItalic;
     if (isFontWeightBold(fontDescription.weight()))
         traits |= kCTFontTraitBold;
@@ -257,7 +257,7 @@ SynthesisPair computeNecessarySynthesis(CTFontRef font, const FontDescription& f
 
     CTFontSymbolicTraits desiredTraits = computeTraits(fontDescription);
     CTFontSymbolicTraits actualTraits = 0;
-    if (isFontWeightBold(fontDescription.weight()) || isItalic(fontDescription.italic())) {
+    if (isFontWeightBold(fontDescription.weight()) || isItalic(fontDescription.fontStyleSlope())) {
         if (shouldComputePhysicalTraits == ShouldComputePhysicalTraits::Yes)
             actualTraits = CTFontGetPhysicalSymbolicTraits(font);
         else

--- a/Source/WebCore/platform/graphics/cocoa/SystemFontDatabaseCoreText.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/SystemFontDatabaseCoreText.cpp
@@ -235,7 +235,7 @@ SystemFontDatabaseCoreText::CascadeListParameters SystemFontDatabaseCoreText::sy
     CascadeListParameters result;
     result.locale = description.computedLocale();
     result.size = description.computedSize();
-    result.italic = isItalic(description.italic());
+    result.italic = isItalic(description.fontStyleSlope());
     result.allowUserInstalledFonts = allowUserInstalledFonts;
 
     result.weight = mapWeight(description.weight());

--- a/Source/WebCore/platform/graphics/freetype/FontCacheFreeType.cpp
+++ b/Source/WebCore/platform/graphics/freetype/FontCacheFreeType.cpp
@@ -83,7 +83,7 @@ static int fontWeightToFontconfigWeight(FontSelectionValue weight)
 
 bool FontCache::configurePatternForFontDescription(FcPattern* pattern, const FontDescription& fontDescription)
 {
-    if (!FcPatternAddInteger(pattern, FC_SLANT, fontDescription.italic() ? FC_SLANT_ITALIC : FC_SLANT_ROMAN))
+    if (!FcPatternAddInteger(pattern, FC_SLANT, fontDescription.fontStyleSlope() ? FC_SLANT_ITALIC : FC_SLANT_ROMAN))
         return false;
     if (!FcPatternAddInteger(pattern, FC_WEIGHT, fontWeightToFontconfigWeight(fontDescription.weight())))
         return false;
@@ -119,7 +119,7 @@ static void getFontPropertiesFromPattern(FcPattern* pattern, const FontDescripti
     int actualFontSlant;
     bool allowSyntheticOblique = fontDescription.hasAutoFontSynthesisStyle()
         && !options.contains(FontLookupOptions::DisallowObliqueSynthesis);
-    if (allowSyntheticOblique && fontDescription.italic()
+    if (allowSyntheticOblique && fontDescription.fontStyleSlope()
         && FcPatternGetInteger(pattern, FC_SLANT, 0, &actualFontSlant) == FcResultMatch) {
         syntheticOblique = actualFontSlant == FC_SLANT_ROMAN;
     }

--- a/Source/WebCore/platform/graphics/skia/FontCacheSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/FontCacheSkia.cpp
@@ -100,10 +100,10 @@ static SkFontStyle skiaFontStyle(const FontDescription& fontDescription)
         skWidth = SkFontStyle::kUltraExpanded_Width;
 
     SkFontStyle::Slant skSlant = SkFontStyle::kUpright_Slant;
-    if (auto italic = fontDescription.italic()) {
-        if (italic.value() > normalItalicValue() && italic.value() <= italicThreshold())
+    if (auto fontStyleSlope = fontDescription.fontStyleSlope()) {
+        if (fontStyleSlope.value() > normalItalicValue() && fontStyleSlope.value() <= italicThreshold())
             skSlant = SkFontStyle::kItalic_Slant;
-        else if (italic.value() > italicThreshold())
+        else if (fontStyleSlope.value() > italicThreshold())
             skSlant = SkFontStyle::kOblique_Slant;
     }
 
@@ -118,7 +118,7 @@ static std::pair<bool, bool> computeSynthesisProperties(const SkTypeface& typefa
     bool allowsSyntheticBold = fontDescription.hasAutoFontSynthesisWeight() && !synthesisOptions.contains(FontLookupOptions::DisallowBoldSynthesis);
     bool syntheticBold = allowsSyntheticBold && isFontWeightBold(fontDescription.weight()) && !typeface.isBold();
     bool allowsSyntheticOblique = fontDescription.hasAutoFontSynthesisStyle() && !synthesisOptions.contains(FontLookupOptions::DisallowObliqueSynthesis);
-    bool syntheticOblique = allowsSyntheticOblique && isItalic(fontDescription.italic()) && !typeface.isItalic();
+    bool syntheticOblique = allowsSyntheticOblique && isItalic(fontDescription.fontStyleSlope()) && !typeface.isItalic();
     return { syntheticBold, syntheticOblique };
 }
 

--- a/Source/WebCore/platform/graphics/skia/FontCustomPlatformDataSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/FontCustomPlatformDataSkia.cpp
@@ -72,7 +72,7 @@ FontPlatformData FontCustomPlatformData::fontPlatformData(const FontDescription&
         if (description.fontStyleAxis() == FontStyleAxis::ital)
             applyVariation({ { 'i', 't', 'a', 'l' } }, 1);
         else {
-            float slope = description.italic().value_or(normalItalicValue());
+            float slope = description.fontStyleSlope().value_or(normalItalicValue());
             if (auto slopeValue = fontCreationContext.fontFaceCapabilities().weight)
                 slope = std::max(std::min(slope, static_cast<float>(slopeValue->maximum)), static_cast<float>(slopeValue->minimum));
             applyVariation({ { 's', 'l', 'n', 't' } }, slope);

--- a/Source/WebCore/platform/graphics/win/cairo/FontCacheWinCairo.cpp
+++ b/Source/WebCore/platform/graphics/win/cairo/FontCacheWinCairo.cpp
@@ -41,7 +41,7 @@ bool isGDIFontWeightBold(LONG);
 std::unique_ptr<FontPlatformData> FontCache::createFontPlatformData(const FontDescription& fontDescription, const AtomString& family, const FontCreationContext&, OptionSet<FontLookupOptions> options)
 {
     LONG weight = adjustedGDIFontWeight(toGDIFontWeight(fontDescription.weight()), family);
-    auto hfont = createGDIFont(family, weight, isItalic(fontDescription.italic()),
+    auto hfont = createGDIFont(family, weight, isItalic(fontDescription.fontStyleSlope()),
         fontDescription.computedSize() * cWindowsFontScaleFactor);
 
     if (!hfont)
@@ -53,7 +53,7 @@ std::unique_ptr<FontPlatformData> FontCache::createFontPlatformData(const FontDe
     bool synthesizeBold = !options.contains(FontLookupOptions::DisallowBoldSynthesis)
         && isGDIFontWeightBold(weight) && !isGDIFontWeightBold(logFont.lfWeight);
     bool synthesizeItalic = !options.contains(FontLookupOptions::DisallowObliqueSynthesis)
-        && isItalic(fontDescription.italic()) && !logFont.lfItalic;
+        && isItalic(fontDescription.fontStyleSlope()) && !logFont.lfItalic;
 
     auto result = makeUnique<FontPlatformData>(WTFMove(hfont), fontDescription.computedSize(), synthesizeBold, synthesizeItalic);
 

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -2660,10 +2660,11 @@ void RenderStyle::setFontWidth(Style::FontWidth value)
     setFontDescription(WTFMove(description));
 }
 
-void RenderStyle::setFontItalic(std::optional<FontSelectionValue> value)
+void RenderStyle::setFontStyle(Style::FontStyle style)
 {
     auto description = fontDescription();
-    description.setItalic(value);
+    description.setFontStyleSlope(style.platformSlope());
+    description.setFontStyleAxis(style.platformAxis());
     setFontDescription(WTFMove(description));
 }
 

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -273,6 +273,7 @@ struct DynamicRangeLimit;
 struct Filter;
 struct FlexBasis;
 struct FontPalette;
+struct FontStyle;
 struct FontWeight;
 struct FontWidth;
 struct GapGutter;
@@ -728,9 +729,9 @@ public:
 
     inline FontOpticalSizing fontOpticalSizing() const;
     inline FontVariationSettings fontVariationSettings() const;
-    inline std::optional<FontSelectionValue> fontItalic() const;
     inline Style::FontPalette fontPalette() const;
     inline FontSizeAdjust fontSizeAdjust() const;
+    inline Style::FontStyle fontStyle() const;
     inline Style::FontWeight fontWeight() const;
     inline Style::FontWidth fontWidth() const;
 
@@ -1367,8 +1368,8 @@ public:
 
     void setFontOpticalSizing(FontOpticalSizing);
     void setFontVariationSettings(FontVariationSettings);
-    void setFontItalic(std::optional<FontSelectionValue>);
     void setFontPalette(Style::FontPalette&&);
+    void setFontStyle(Style::FontStyle);
     void setFontWeight(Style::FontWeight);
     void setFontWidth(Style::FontWidth);
 
@@ -1967,6 +1968,7 @@ public:
     static inline Style::VerticalAlign initialVerticalAlign();
     static constexpr Float initialFloating();
     static inline Style::FontPalette initialFontPalette();
+    static inline Style::FontStyle initialFontStyle();
     static inline Style::FontWeight initialFontWeight();
     static inline Style::FontWidth initialFontWidth();
     static constexpr BreakBetween initialBreakBetween();

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -45,6 +45,7 @@
 #include <WebCore/StyleFlexibleBoxData.h>
 #include <WebCore/StyleFontData.h>
 #include <WebCore/StyleFontPalette.h>
+#include <WebCore/StyleFontStyle.h>
 #include <WebCore/StyleFontWeight.h>
 #include <WebCore/StyleFontWidth.h>
 #include <WebCore/StyleGridData.h>
@@ -222,9 +223,9 @@ inline FlexDirection RenderStyle::flexDirection() const { return static_cast<Fle
 inline Style::FlexGrow RenderStyle::flexGrow() const { return m_nonInheritedData->miscData->flexibleBox->flexGrow; }
 inline Style::FlexShrink RenderStyle::flexShrink() const { return m_nonInheritedData->miscData->flexibleBox->flexShrink; }
 inline FlexWrap RenderStyle::flexWrap() const { return static_cast<FlexWrap>(m_nonInheritedData->miscData->flexibleBox->flexWrap); }
-inline std::optional<FontSelectionValue> RenderStyle::fontItalic() const { return fontDescription().italic(); }
 inline Style::FontPalette RenderStyle::fontPalette() const { return fontDescription().fontPalette(); }
 inline FontSizeAdjust RenderStyle::fontSizeAdjust() const { return fontDescription().fontSizeAdjust(); }
+inline Style::FontStyle RenderStyle::fontStyle() const { return { fontDescription().fontStyleSlope(), fontDescription().fontStyleAxis() }; }
 inline FontOpticalSizing RenderStyle::fontOpticalSizing() const { return fontDescription().opticalSizing(); }
 inline FontVariationSettings RenderStyle::fontVariationSettings() const { return fontDescription().variationSettings(); }
 inline Style::FontWeight RenderStyle::fontWeight() const { return fontDescription().weight(); }
@@ -397,6 +398,7 @@ constexpr Style::FlexShrink RenderStyle::initialFlexShrink() { return 1_css_numb
 constexpr FlexWrap RenderStyle::initialFlexWrap() { return FlexWrap::NoWrap; }
 constexpr Float RenderStyle::initialFloating() { return Float::None; }
 inline Style::FontPalette RenderStyle::initialFontPalette() { return CSS::Keyword::Normal { }; }
+inline Style::FontStyle RenderStyle::initialFontStyle() { return CSS::Keyword::Normal { }; }
 inline Style::FontWeight RenderStyle::initialFontWeight() { return CSS::Keyword::Normal { }; }
 inline Style::FontWidth RenderStyle::initialFontWidth() { return CSS::Keyword::Normal { }; }
 inline Style::GridTrackSizes RenderStyle::initialGridAutoColumns() { return CSS::Keyword::Auto { }; }

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -134,7 +134,6 @@ public:
     static OptionSet<TouchAction> convertTouchAction(BuilderState&, const CSSValue&);
 
     static FontSizeAdjust convertFontSizeAdjust(BuilderState&, const CSSValue&);
-    static std::optional<FontSelectionValue> convertFontStyleFromValue(BuilderState&, const CSSValue&);
     static FontFeatureSettings convertFontFeatureSettings(BuilderState&, const CSSValue&);
     static FontVariationSettings convertFontVariationSettings(BuilderState&, const CSSValue&);
     static PaintOrder convertPaintOrder(BuilderState&, const CSSValue&);
@@ -491,12 +490,6 @@ inline float zoomWithTextZoomFactor(BuilderState& builderState)
         return builderState.style().usedZoom() * textZoomFactor;
     }
     return builderState.cssToLengthConversionData().zoom();
-}
-
-// The input value needs to parsed and valid, this function returns std::nullopt if the input was "normal".
-inline std::optional<FontSelectionValue> BuilderConverter::convertFontStyleFromValue(BuilderState& builderState, const CSSValue& value)
-{
-    return fontStyleFromCSSValue(builderState, value);
 }
 
 inline FontFeatureSettings BuilderConverter::convertFontFeatureSettings(BuilderState& builderState, const CSSValue& value)

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -866,7 +866,7 @@ inline void BuilderCustom::applyInitialFontFamily(BuilderState& builderState)
 
 inline void BuilderCustom::applyInheritFontFamily(BuilderState& builderState)
 {
-    auto parentFontDescription = builderState.parentStyle().fontDescription();
+    auto& parentFontDescription = builderState.parentStyle().fontDescription();
 
     builderState.setFontDescriptionFamilies(parentFontDescription.families());
     builderState.setFontDescriptionIsSpecifiedFont(parentFontDescription.isSpecifiedFont());
@@ -1330,40 +1330,6 @@ inline float BuilderCustom::determineRubyTextSizeMultiplier(BuilderState& builde
         }
     }
     return 0.25f;
-}
-
-static inline void applyFontStyle(BuilderState& state, std::optional<FontSelectionValue> slope, FontStyleAxis axis)
-{
-    auto& description = state.fontDescription();
-    if (description.italic() == slope && description.fontStyleAxis() == axis)
-        return;
-
-    auto copy = description;
-    copy.setItalic(slope);
-    copy.setFontStyleAxis(axis);
-    state.setFontDescription(WTFMove(copy));
-}
-
-inline void BuilderCustom::applyInitialFontStyle(BuilderState& state)
-{
-    applyFontStyle(state, FontCascadeDescription::initialItalic(), FontCascadeDescription::initialFontStyleAxis());
-}
-
-inline void BuilderCustom::applyInheritFontStyle(BuilderState& state)
-{
-    applyFontStyle(state, state.parentFontDescription().italic(), state.parentFontDescription().fontStyleAxis());
-}
-
-inline void BuilderCustom::applyValueFontStyle(BuilderState& state, CSSValue& value)
-{
-    auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value);
-    auto keyword = primitiveValue ? primitiveValue->valueID() : CSSValueOblique;
-
-    std::optional<FontSelectionValue> slope;
-    if (!CSSPropertyParserHelpers::isSystemFontShorthand(keyword))
-        slope = BuilderConverter::convertFontStyleFromValue(state, value);
-
-    applyFontStyle(state, slope, keyword == CSSValueItalic ? FontStyleAxis::ital : FontStyleAxis::slnt);
 }
 
 inline void BuilderCustom::applyValueFontSize(BuilderState& builderState, CSSValue& value)

--- a/Source/WebCore/style/StyleBuilderState.h
+++ b/Source/WebCore/style/StyleBuilderState.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2019-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -55,16 +56,12 @@ namespace CSSCalc {
 struct RandomCachingKey;
 }
 
-namespace CSS {
-struct AppleColorFilter;
-struct Filter;
-}
-
 namespace Style {
 
 class BuilderState;
 struct Color;
 struct FontPalette;
+struct FontStyle;
 struct FontWeight;
 struct FontWidth;
 
@@ -165,6 +162,7 @@ public:
     void setFontDescriptionFontPalette(Style::FontPalette&&);
     void setFontDescriptionFontSizeAdjust(FontSizeAdjust);
     void setFontDescriptionFontSmoothing(FontSmoothingMode);
+    void setFontDescriptionFontStyle(FontStyle);
     void setFontDescriptionFontSynthesisSmallCaps(FontSynthesisLonghandValue);
     void setFontDescriptionFontSynthesisStyle(FontSynthesisLonghandValue);
     void setFontDescriptionFontSynthesisWeight(FontSynthesisLonghandValue);

--- a/Source/WebCore/style/StyleBuilderStateInlines.h
+++ b/Source/WebCore/style/StyleBuilderStateInlines.h
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2019-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -141,6 +142,18 @@ inline void BuilderState::setFontDescriptionFontSmoothing(FontSmoothingMode font
 
     m_fontDirty = true;
     m_style.mutableFontDescriptionWithoutUpdate().setFontSmoothing(WTFMove(fontSmoothing));
+}
+
+inline void BuilderState::setFontDescriptionFontStyle(FontStyle fontStyle)
+{
+    auto& description = m_style.fontDescription();
+    if (description.fontStyleSlope() == fontStyle.platformSlope() && description.fontStyleAxis() == fontStyle.platformAxis())
+        return;
+
+    m_fontDirty = true;
+    auto& mutableDescription = m_style.mutableFontDescriptionWithoutUpdate();
+    mutableDescription.setFontStyleSlope(fontStyle.platformSlope());
+    mutableDescription.setFontStyleAxis(fontStyle.platformAxis());
 }
 
 inline void BuilderState::setFontDescriptionFontSynthesisSmallCaps(FontSynthesisLonghandValue fontSynthesisSmallCaps)

--- a/Source/WebCore/style/StyleExtractorConverter.h
+++ b/Source/WebCore/style/StyleExtractorConverter.h
@@ -36,7 +36,6 @@
 #include "CSSCounterValue.h"
 #include "CSSEasingFunctionValue.h"
 #include "CSSFontFeatureValue.h"
-#include "CSSFontStyleWithAngleValue.h"
 #include "CSSFontValue.h"
 #include "CSSFontVariationValue.h"
 #include "CSSFunctionValue.h"

--- a/Source/WebCore/style/StyleInterpolationWrappers.h
+++ b/Source/WebCore/style/StyleInterpolationWrappers.h
@@ -536,38 +536,6 @@ public:
 
 #endif
 
-class FontStyleWrapper final : public Wrapper<std::optional<FontSelectionValue>> {
-    WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(FontStyleWrapper, Animation);
-public:
-    FontStyleWrapper()
-        : Wrapper(CSSPropertyFontStyle, &RenderStyle::fontItalic, &RenderStyle::setFontItalic)
-    {
-    }
-
-    bool canInterpolate(const RenderStyle& from, const RenderStyle& to, CompositeOperation) const final
-    {
-        return from.fontDescription().fontStyleAxis() == FontStyleAxis::slnt && to.fontDescription().fontStyleAxis() == FontStyleAxis::slnt;
-    }
-
-    void interpolate(RenderStyle& destination, const RenderStyle& from, const RenderStyle& to, const Context& context) const final
-    {
-        auto blendedStyleAxis = FontStyleAxis::slnt;
-        if (context.isDiscrete)
-            blendedStyleAxis = (context.progress < 0.5 ? from : to).fontDescription().fontStyleAxis();
-
-        auto fromFontItalic = from.fontItalic();
-        auto toFontItalic = to.fontItalic();
-        auto blendedFontItalic = context.progress < 0.5 ? fromFontItalic : toFontItalic;
-        if (!context.isDiscrete)
-            blendedFontItalic = blendFunc(fromFontItalic, toFontItalic, context);
-
-        auto description = destination.fontDescription();
-        description.setItalic(blendedFontItalic);
-        description.setFontStyleAxis(blendedStyleAxis);
-        destination.setFontDescription(WTFMove(description));
-    }
-};
-
 class FontSizeAdjustWrapper final : public WrapperWithGetter<FontSizeAdjust> {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(FontSizeAdjustWrapper, Animation);
 public:

--- a/Source/WebCore/style/StyleResolveForFont.h
+++ b/Source/WebCore/style/StyleResolveForFont.h
@@ -60,13 +60,8 @@ FontSelectionValue fontWeightFromCSSValueDeprecated(const CSSValue&);
 FontSelectionValue fontStretchFromCSSValueDeprecated(const CSSValue&);
 
 FontSelectionValue fontStyleAngleFromCSSValueDeprecated(const CSSValue&);
-FontSelectionValue fontStyleAngleFromCSSValue(BuilderState&, const CSSValue&);
-
 std::optional<FontSelectionValue> fontStyleAngleFromCSSFontStyleWithAngleValueDeprecated(const CSSFontStyleWithAngleValue&);
-std::optional<FontSelectionValue> fontStyleAngleFromCSSFontStyleWithAngleValue(BuilderState&, const CSSFontStyleWithAngleValue&);
-
 std::optional<FontSelectionValue> fontStyleFromCSSValueDeprecated(const CSSValue&);
-std::optional<FontSelectionValue> fontStyleFromCSSValue(BuilderState&, const CSSValue&);
 
 FontFeatureSettings fontFeatureSettingsFromCSSValue(BuilderState&, const CSSValue&);
 FontVariationSettings fontVariationSettingsFromCSSValue(BuilderState&, const CSSValue&);

--- a/Source/WebCore/style/values/fonts/StyleFontStyle.cpp
+++ b/Source/WebCore/style/values/fonts/StyleFontStyle.cpp
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "StyleFontStyle.h"
+
+#include "AnimationUtilities.h"
+#include "CSSFontStyleWithAngleValue.h"
+#include "CSSPropertyParserConsumer+Font.h"
+#include "StyleBuilderChecking.h"
+#include "StylePrimitiveKeyword+CSSValueCreation.h"
+#include "StylePrimitiveNumericTypes+Blending.h"
+#include "StylePrimitiveNumericTypes+Conversions.h"
+
+namespace WebCore {
+namespace Style {
+
+// MARK: - Conversion
+
+auto CSSValueConversion<FontStyle>::operator()(BuilderState& state, const CSSValue& value) -> FontStyle
+{
+    if (RefPtr fontStyleValue = dynamicDowncast<CSSFontStyleWithAngleValue>(value))
+        return toStyle(fontStyleValue->obliqueAngle(), state);
+
+    RefPtr primitiveValue = requiredDowncast<CSSPrimitiveValue>(state, value);
+    if (!primitiveValue)
+        return CSS::Keyword::Normal { };
+
+    switch (auto valueID = primitiveValue->valueID(); valueID) {
+    case CSSValueNormal:
+        return CSS::Keyword::Normal { };
+    case CSSValueItalic:
+        return CSS::Keyword::Italic { };
+    case CSSValueOblique:
+        return CSS::Keyword::Oblique { };
+    default:
+        if (CSSPropertyParserHelpers::isSystemFontShorthand(valueID))
+            return CSS::Keyword::Normal { };
+
+        state.setCurrentPropertyInvalidAtComputedValueTime();
+        return CSS::Keyword::Normal { };
+    }
+}
+
+auto CSSValueCreation<FontStyle>::operator()(CSSValuePool& pool, const RenderStyle& style, const FontStyle& value) -> Ref<CSSValue>
+{
+    if (!value.platformSlope() || !*value.platformSlope())
+        return createCSSValue(pool, style, CSS::Keyword::Normal { });
+
+    if (*value.platformSlope() == italicValue()) {
+        if (value.platformAxis() == FontStyleAxis::ital)
+            return createCSSValue(pool, style, CSS::Keyword::Italic { });
+        return createCSSValue(pool, style, CSS::Keyword::Oblique { });
+    }
+
+    return CSSFontStyleWithAngleValue::create(toCSS(FontStyle::Angle { static_cast<float>(*value.platformSlope()) }, style));
+}
+
+// MARK: - Blending
+
+auto Blending<FontStyle>::canBlend(const FontStyle& a, const FontStyle& b) -> bool
+{
+    return a.platformAxis() == FontStyleAxis::slnt && b.platformAxis() == FontStyleAxis::slnt;
+}
+
+auto Blending<FontStyle>::blend(const FontStyle& a, const FontStyle& b, const BlendingContext& context) -> FontStyle
+{
+    if (context.isDiscrete)
+        return context.progress < 0.5 ? a : b;
+
+    if (!a.platformSlope() && !b.platformSlope())
+        return CSS::Keyword::Normal { };
+
+    return Style::blend(a.angle().value_or(FontStyle::Angle { 0 }), b.angle().value_or(FontStyle::Angle { 0 }), context);
+}
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/fonts/StyleFontStyle.h
+++ b/Source/WebCore/style/values/fonts/StyleFontStyle.h
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/FontSelectionAlgorithm.h>
+#include <WebCore/StylePrimitiveNumericTypes.h>
+
+namespace WebCore {
+namespace Style {
+
+// <'font-style'> = normal | italic | oblique <angle [-90deg,90deg]>?
+// https://drafts.csswg.org/css-fonts-4/#propdef-font-style
+struct FontStyle {
+    using Angle = Style::Angle<CSS::Range{-90, 90}>;
+
+    FontStyle(CSS::Keyword::Normal) : m_platformSlope { std::nullopt }, m_platformAxis { FontStyleAxis::slnt } { }
+    FontStyle(CSS::Keyword::Italic) : m_platformSlope { italicValue() }, m_platformAxis { FontStyleAxis::ital } { }
+    FontStyle(CSS::Keyword::Oblique) : m_platformSlope { italicValue() }, m_platformAxis { FontStyleAxis::slnt } { }
+    FontStyle(Angle angle) : m_platformSlope { FontSelectionValue::clampFloat(angle.value) }, m_platformAxis { FontStyleAxis::slnt } { }
+
+    FontStyle(std::optional<FontSelectionValue> slope, FontStyleAxis axis) : m_platformSlope { slope }, m_platformAxis { axis } { }
+
+    bool isNormal() const { return m_platformSlope == std::nullopt && m_platformAxis == FontStyleAxis::slnt; }
+    bool isItalic() const { return m_platformSlope == italicValue() && m_platformAxis == FontStyleAxis::ital; }
+    bool isOblique() const { return m_platformSlope != std::nullopt && m_platformAxis == FontStyleAxis::slnt; }
+
+    std::optional<Angle> angle() const { return m_platformSlope ? std::make_optional(Angle { static_cast<float>(*m_platformSlope) }) : std::nullopt; }
+
+    template<typename... F> decltype(auto) switchOn(F&&... f) const
+    {
+        auto visitor = WTF::makeVisitor(std::forward<F>(f)...);
+
+        if (!m_platformSlope || !*m_platformSlope)
+            return visitor(CSS::Keyword::Normal { });
+        if (*m_platformSlope == italicValue()) {
+            if (m_platformAxis == FontStyleAxis::ital)
+                return visitor(CSS::Keyword::Italic { });
+            return visitor(CSS::Keyword::Oblique { });
+        }
+        return visitor(SpaceSeparatedTuple { CSS::Keyword::Oblique { }, Angle { static_cast<float>(*m_platformSlope) } });
+    }
+
+    std::optional<FontSelectionValue> platformSlope() const { return m_platformSlope; }
+    FontStyleAxis platformAxis() const { return m_platformAxis; }
+
+    // NOTE: This is not if the value would compute to the keyword `italic`, but rather a more general whether the slope is large enough to be considered "italic" (see `WebCore::italicThreshold()`).
+    bool isConsideredItalic() const { return WebCore::isItalic(m_platformSlope); }
+
+    bool operator==(const FontStyle&) const = default;
+
+private:
+    std::optional<FontSelectionValue> m_platformSlope;
+    FontStyleAxis m_platformAxis;
+};
+
+// MARK: - Conversion
+
+template<> struct CSSValueConversion<FontStyle> { auto operator()(BuilderState&, const CSSValue&) -> FontStyle; };
+// `FontStyle` is special-cased to return a `CSSFontStyleWithAngleValue`.
+template<> struct CSSValueCreation<FontStyle> { auto operator()(CSSValuePool&, const RenderStyle&, const FontStyle&) -> Ref<CSSValue>; };
+
+// MARK: - Blending
+
+template<> struct Blending<FontStyle> {
+    auto canBlend(const FontStyle&, const FontStyle&) -> bool;
+    auto blend(const FontStyle&, const FontStyle&, const BlendingContext&) -> FontStyle;
+};
+
+} // namespace Style
+} // namespace WebCore
+
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::FontStyle)

--- a/Source/WebCore/style/values/fonts/StyleFontWeight.h
+++ b/Source/WebCore/style/values/fonts/StyleFontWeight.h
@@ -43,6 +43,9 @@ struct FontWeight {
 
     FontWeight(FontSelectionValue platform) : m_platform { platform } { }
 
+    bool isNormal() const { return m_platform == normalWeightValue(); }
+    bool isBold() const { return m_platform == boldWeightValue(); }
+
     Number number() const { return Number { static_cast<float>(m_platform) }; }
 
     template<typename... F> decltype(auto) switchOn(F&&... f) const
@@ -52,6 +55,9 @@ struct FontWeight {
     }
 
     FontSelectionValue platform() const { return m_platform; }
+
+    // NOTE: This is not if the value would compute to the keyword `bold`, but rather a more general whether the weight is large enough to be considered "bold" (see `WebCore::boldThreshold()`).
+    bool isConsideredBold() const { return WebCore::isFontWeightBold(m_platform); }
 
     bool operator==(const FontWeight&) const = default;
 

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -9401,8 +9401,8 @@ static NSTextAlignment nsTextAlignmentFromRenderStyle(const WebCore::RenderStyle
         if (!selection.isNone()) {
             RefPtr<Node> nodeToRemove;
             if (auto* style = coreFrame->editor().styleForSelectionStart(nodeToRemove)) {
-                [_private->_textTouchBarItemController setTextIsBold:isFontWeightBold(style->fontCascade().weight())];
-                [_private->_textTouchBarItemController setTextIsItalic:isItalic(style->fontCascade().italic())];
+                [_private->_textTouchBarItemController setTextIsBold:style->fontWeight().isConsideredBold()];
+                [_private->_textTouchBarItemController setTextIsItalic:style->fontStyle().isConsideredItalic()];
 
                 RefPtr<EditingStyle> typingStyle = coreFrame->selection().typingStyle();
                 if (typingStyle && typingStyle->style()) {


### PR DESCRIPTION
#### e9ee8daa8210bf156349e743a864239befcff563
<pre>
[Style] Convert the &apos;font-style&apos; property to strong style types
<a href="https://bugs.webkit.org/show_bug.cgi?id=299701">https://bugs.webkit.org/show_bug.cgi?id=299701</a>

Reviewed by Darin Adler.

Converts the &apos;font-style&apos; property to use strong style types.

This one is a little different, as it composes two FontDescriptor
values, the &quot;fontStyleSlope&quot; (formerly, sometimes confusing called
&quot;italics&quot;) and the &quot;fontStyleAxis&quot;.

With the values bundled, the all custom style building was able
to be removed, and the normal `Style::BuilderState:setFontDescription*`
mutator could be added.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
* Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
* Source/WebCore/platform/graphics/FontCascade.h:
* Source/WebCore/platform/graphics/FontCascadeDescription.h:
* Source/WebCore/platform/graphics/FontDescription.cpp:
* Source/WebCore/platform/graphics/FontDescription.h:
* Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp:
* Source/WebCore/platform/graphics/cocoa/SystemFontDatabaseCoreText.cpp:
* Source/WebCore/platform/graphics/freetype/FontCacheFreeType.cpp:
* Source/WebCore/platform/graphics/skia/FontCacheSkia.cpp:
* Source/WebCore/platform/graphics/skia/FontCustomPlatformDataSkia.cpp:
* Source/WebCore/platform/graphics/win/cairo/FontCacheWinCairo.cpp:
* Source/WebCore/rendering/style/RenderStyle.cpp:
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
* Source/WebCore/style/StyleBuilderConverter.h:
* Source/WebCore/style/StyleBuilderCustom.h:
* Source/WebCore/style/StyleBuilderState.h:
* Source/WebCore/style/StyleBuilderStateInlines.h:
* Source/WebCore/style/StyleExtractorConverter.h:
* Source/WebCore/style/StyleExtractorCustom.h:
* Source/WebCore/style/StyleInterpolationWrappers.h:
* Source/WebCore/style/StyleResolveForFont.cpp:
* Source/WebCore/style/StyleResolveForFont.h:
* Source/WebCore/style/values/fonts/StyleFontStyle.cpp: Added.
* Source/WebCore/style/values/fonts/StyleFontStyle.h: Added.
* Source/WebCore/style/values/fonts/StyleFontWeight.h:
* Source/WebKitLegacy/mac/WebView/WebView.mm:

Canonical link: <a href="https://commits.webkit.org/300940@main">https://commits.webkit.org/300940@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9a86d2ad9edc95d5fa3ca0e9facd0e2b985c0c49

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124321 "10 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44003 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34731 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131160 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76378 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/126198 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44748 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52602 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94570 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62738 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127275 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35664 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111202 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75157 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34605 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29362 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74637 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105408 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29585 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133830 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51224 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39062 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103050 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51620 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107421 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102846 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26190 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48206 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26461 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48161 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51089 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56876 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50525 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53881 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52200 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->