### PR TITLE
Fix race condition between _WKJSHandle and WebKitJSHandle destruction

### DIFF
--- a/Source/WebCore/page/WebKitJSHandle.h
+++ b/Source/WebCore/page/WebKitJSHandle.h
@@ -46,7 +46,7 @@ using JSHandleIdentifier = ProcessQualified<WebProcessJSHandleIdentifier>;
 
 class WebKitJSHandle : public RefCountedAndCanMakeWeakPtr<WebKitJSHandle> {
 public:
-    WEBCORE_EXPORT static Ref<WebKitJSHandle> getOrCreate(JSC::JSGlobalObject&, JSC::JSObject*);
+    WEBCORE_EXPORT static Ref<WebKitJSHandle> create(JSC::JSGlobalObject&, JSC::JSObject*);
     WEBCORE_EXPORT static std::pair<JSC::JSGlobalObject*, JSC::JSObject*> objectForIdentifier(JSHandleIdentifier);
     WEBCORE_EXPORT static void jsHandleDestroyed(JSHandleIdentifier);
 

--- a/Source/WebCore/page/WebKitNamespace.cpp
+++ b/Source/WebCore/page/WebKitNamespace.cpp
@@ -69,9 +69,9 @@ UserMessageHandlersNamespace* WebKitNamespace::messageHandlers()
     return &m_messageHandlerNamespace.get();
 }
 
-Ref<WebKitJSHandle> WebKitNamespace::jsHandle(JSC::JSGlobalObject& globalObject, JSC::Strong<JSC::JSObject> object)
+Ref<WebKitJSHandle> WebKitNamespace::createJSHandle(JSC::JSGlobalObject& globalObject, JSC::Strong<JSC::JSObject> object)
 {
-    return WebKitJSHandle::getOrCreate(globalObject, object.get());
+    return WebKitJSHandle::create(globalObject, object.get());
 }
 
 ExceptionOr<Ref<WebKitSerializedNode>> WebKitNamespace::serializeNode(Node& node, SerializedNodeInit&& init)

--- a/Source/WebCore/page/WebKitNamespace.h
+++ b/Source/WebCore/page/WebKitNamespace.h
@@ -54,7 +54,7 @@ public:
     virtual ~WebKitNamespace();
 
     UserMessageHandlersNamespace* messageHandlers();
-    Ref<WebKitJSHandle> jsHandle(JSC::JSGlobalObject&, JSC::Strong<JSC::JSObject>);
+    Ref<WebKitJSHandle> createJSHandle(JSC::JSGlobalObject&, JSC::Strong<JSC::JSObject>);
 
     struct SerializedNodeInit {
         bool deep { false };

--- a/Source/WebCore/page/WebKitNamespace.idl
+++ b/Source/WebCore/page/WebKitNamespace.idl
@@ -31,7 +31,7 @@
     Exposed=Window
 ] interface WebKitNamespace {
     readonly attribute UserMessageHandlersNamespace messageHandlers;
-    [EnabledForGlobalObject=allowsJSHandleCreation, CallWith=CurrentGlobalObject] WebKitJSHandle jsHandle(object object);
+    [EnabledForGlobalObject=allowsJSHandleCreation, CallWith=CurrentGlobalObject] WebKitJSHandle createJSHandle(object object);
     [EnabledForWorld=allowNodeSerialization] WebKitSerializedNode serializeNode(Node node, optional WebKitSerializedNodeInit init);
 };
 

--- a/Source/WebKit/Shared/JSHandleInfo.cpp
+++ b/Source/WebKit/Shared/JSHandleInfo.cpp
@@ -38,4 +38,12 @@ JSHandleInfo::JSHandleInfo(WebCore::JSHandleIdentifier identifier, ContentWorldI
     , frameInfo(WTFMove(frameInfo))
     , windowProxyFrameIdentifier(windowProxyFrameIdentifier) { }
 
+bool JSHandleInfo::operator==(const JSHandleInfo& other) const
+{
+    // If these properties are equal, it implies the other properties are equal,
+    // so we intentionally don't need to check their equality.
+    return identifier == other.identifier
+        && worldIdentifier == other.worldIdentifier;
+}
+
 } // namespace WebKit

--- a/Source/WebKit/Shared/JSHandleInfo.h
+++ b/Source/WebKit/Shared/JSHandleInfo.h
@@ -42,6 +42,8 @@ struct JSHandleInfo {
     WTF_MAKE_STRUCT_TZONE_ALLOCATED(JSHandleInfo);
     JSHandleInfo(WebCore::JSHandleIdentifier, ContentWorldIdentifier, FrameInfoData&&, Markable<WebCore::FrameIdentifier>);
 
+    bool operator==(const JSHandleInfo&) const;
+
     WebCore::JSHandleIdentifier identifier;
     ContentWorldIdentifier worldIdentifier;
     FrameInfoData frameInfo;

--- a/Source/WebKit/Shared/JavaScriptEvaluationResult.cpp
+++ b/Source/WebKit/Shared/JavaScriptEvaluationResult.cpp
@@ -116,7 +116,7 @@ RefPtr<API::Object> JavaScriptEvaluationResult::APIInserter::toAPI(Value&& root)
         m_dictionaries.append({ WTFMove(map), dictionary });
         return { WTFMove(dictionary) };
     }, [] (UniqueRef<JSHandleInfo>&& info) -> RefPtr<API::Object> {
-        return API::JSHandle::getOrCreate(WTFMove(info.get()));
+        return API::JSHandle::create(WTFMove(info.get()));
     }, [] (UniqueRef<WebCore::SerializedNode>&& node) -> RefPtr<API::Object> {
         return API::SerializedNode::create(WTFMove(node.get()));
     });

--- a/Source/WebKit/Shared/JavaScriptEvaluationResult.mm
+++ b/Source/WebKit/Shared/JavaScriptEvaluationResult.mm
@@ -81,7 +81,7 @@ RetainPtr<id> JavaScriptEvaluationResult::ObjCInserter::toID(Value&& root)
         m_dictionaries.append({ WTFMove(map), dictionary });
         return dictionary;
     }, [] (UniqueRef<JSHandleInfo>&& info) -> RetainPtr<id> {
-        return wrapper(API::JSHandle::getOrCreate(WTFMove(info.get())));
+        return wrapper(API::JSHandle::create(WTFMove(info.get())));
     }, [] (UniqueRef<WebCore::SerializedNode>&& serializedNode) -> RetainPtr<id> {
         return wrapper(API::SerializedNode::create(WTFMove(serializedNode.get())).get());
     });

--- a/Source/WebKit/UIProcess/API/APIJSHandle.cpp
+++ b/Source/WebKit/UIProcess/API/APIJSHandle.cpp
@@ -31,30 +31,18 @@
 
 namespace API {
 
-using HandleMap = HashMap<WebCore::JSHandleIdentifier, JSHandle*>;
-static HandleMap& handleMap()
+Ref<JSHandle> JSHandle::create(WebKit::JSHandleInfo&& info)
 {
-    static MainRunLoopNeverDestroyed<HandleMap> map;
-    return map.get();
-}
-
-Ref<JSHandle> JSHandle::getOrCreate(WebKit::JSHandleInfo&& info)
-{
-    if (RefPtr existingHandle = handleMap().get(info.identifier))
-        return existingHandle.releaseNonNull();
     return adoptRef(*new JSHandle(WTFMove(info)));
 }
 
 JSHandle::JSHandle(WebKit::JSHandleInfo&& info)
     : m_info(WTFMove(info))
 {
-    handleMap().add(m_info.identifier, this);
 }
 
 JSHandle::~JSHandle()
 {
-    ASSERT(handleMap().get(m_info.identifier) == this);
-    handleMap().remove(m_info.identifier);
     if (RefPtr webProcess = WebKit::WebProcessProxy::processForIdentifier(m_info.identifier.processIdentifier()))
         webProcess->send(Messages::WebProcess::JSHandleDestroyed(m_info.identifier), 0);
 }

--- a/Source/WebKit/UIProcess/API/APIJSHandle.h
+++ b/Source/WebKit/UIProcess/API/APIJSHandle.h
@@ -32,7 +32,7 @@ namespace API {
 
 class JSHandle final : public ObjectImpl<Object::Type::JSHandle> {
 public:
-    static Ref<JSHandle> getOrCreate(WebKit::JSHandleInfo&&);
+    static Ref<JSHandle> create(WebKit::JSHandleInfo&&);
     virtual ~JSHandle();
 
     const WebKit::JSHandleInfo& info() const { return m_info; }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -4312,7 +4312,7 @@ static RetainPtr<NSArray> wkTextManipulationErrors(NSArray<_WKTextManipulationIt
     _page->hitTestAtPoint(frame ? frame->_frameInfo->frameInfoData().frameID : mainFrame->frameID(), point, [completionHandler = makeBlockPtr(completionHandler)] (auto&& result) mutable {
         if (!result)
             return completionHandler(nil, unknownError().get());
-        completionHandler(wrapper(API::JSHandle::getOrCreate(WTFMove(*result))).get(), nil);
+        completionHandler(wrapper(API::JSHandle::create(WTFMove(*result))).get(), nil);
     });
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKContentWorldConfiguration.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKContentWorldConfiguration.h
@@ -50,7 +50,7 @@ WK_CLASS_AVAILABLE(macos(15.4), ios(18.4), visionos(2.4))
 /*! @abstract A boolean value indicating whether the behavior that elements with a name attribute overrides builtin methods on document object should be disabled or not. */
 @property (nonatomic) BOOL disableLegacyBuiltinOverrides;
 
-/*! @abstract A boolean indicating whether window.webkit.jsHandle is available. */
+/*! @abstract A boolean indicating whether window.webkit.createJSHandle is available. */
 @property (nonatomic) BOOL allowJSHandleCreation WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
 /*! @abstract A boolean indicating whether window.webkit.serializeNode is available. */

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKJSHandle.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKJSHandle.h
@@ -31,7 +31,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
-@interface _WKJSHandle : NSObject
+@interface _WKJSHandle : NSObject<NSCopying>
 
 + (instancetype)new NS_UNAVAILABLE;
 - (instancetype)init NS_UNAVAILABLE;

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKJSHandle.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKJSHandle.mm
@@ -65,6 +65,27 @@
     });
 }
 
+- (BOOL)isEqual:(id)object
+{
+    if (self == object)
+        return YES;
+
+    if (![object isKindOfClass:self.class])
+        return NO;
+
+    return _ref->info() == ((_WKJSHandle *)object)->_ref->info();
+}
+
+- (NSUInteger)hash
+{
+    return _ref->info().identifier.object().toUInt64();
+}
+
+- (id)copyWithZone:(NSZone *)zone
+{
+    return [self retain];
+}
+
 - (API::Object&)_apiObject
 {
     return *_ref;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -10402,7 +10402,7 @@ void WebPage::hitTestAtPoint(WebCore::FrameIdentifier frameID, WebCore::FloatPoi
         RELEASE_ASSERT(lexicalGlobalObject->template inherits<WebCore::JSDOMGlobalObject>());
         auto* domGlobalObject = jsCast<WebCore::JSDOMGlobalObject*>(lexicalGlobalObject);
         JSLockHolder locker(lexicalGlobalObject);
-        return WebCore::WebKitJSHandle::getOrCreate(*lexicalGlobalObject, WebCore::toJS(lexicalGlobalObject, domGlobalObject, *node).toObject(lexicalGlobalObject));
+        return WebCore::WebKitJSHandle::create(*lexicalGlobalObject, WebCore::toJS(lexicalGlobalObject, domGlobalObject, *node).toObject(lexicalGlobalObject));
     }();
     completionHandler({ JSHandleInfo { nodeHandle->identifier(), pageContentWorldIdentifier(), nodeWebFrame->info(), nodeHandle->windowFrameIdentifier() } });
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewSnapshot.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewSnapshot.mm
@@ -762,7 +762,7 @@ TEST(WKWebView, SnapshotNodeByJSHandle)
 
     RetainPtr world = [WKContentWorld _worldWithConfiguration:worldConfiguration.get()];
     auto querySelector = [&](ASCIILiteral selector) -> RetainPtr<_WKJSHandle> {
-        RetainPtr script = [NSString stringWithFormat:@"webkit.jsHandle(document.querySelector('%s'))", selector.characters()];
+        RetainPtr script = [NSString stringWithFormat:@"webkit.createJSHandle(document.querySelector('%s'))", selector.characters()];
         return dynamic_objc_cast<_WKJSHandle>([webView objectByEvaluatingJavaScript:script.get() inFrame:nil inContentWorld:world.get()]);
     };
 
@@ -800,7 +800,7 @@ TEST(WKWebView, SnapshotNodeByJSHandle)
     }
 
     {
-        NSString *scriptToRun = @"window.randomObject = {'foo': 1}; webkit.jsHandle(randomObject)";
+        NSString *scriptToRun = @"window.randomObject = {'foo': 1}; webkit.createJSHandle(randomObject)";
         RetainPtr handle = dynamic_objc_cast<_WKJSHandle>([webView objectByEvaluatingJavaScript:scriptToRun inFrame:nil inContentWorld:world.get()]);
         auto [image, error] = [webView takeSnapshotOfNode:handle.get()];
         EXPECT_NOT_NULL(error);

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -1937,7 +1937,7 @@ if (window.eventSender) {
 constexpr auto testRunnerJS = R"testRunnerJS(
 if (window.testRunner) {
     let post = window.webkit.messageHandlers.webkitTestRunner.postMessage.bind(window.webkit.messageHandlers.webkitTestRunner);
-    let createHandle = (object) => object ? window.webkit.jsHandle(object) : undefined;
+    let createHandle = (object) => object ? window.webkit.createJSHandle(object) : undefined;
 
     testRunner.installTooltipDidChangeCallback = callback => post(['InstallTooltipCallback', createHandle(callback)]);
     testRunner.installDidBeginSwipeCallback = callback => post(['InstallBeginSwipeCallback', createHandle(callback)]);


### PR DESCRIPTION
#### 942298caa18b5dafb99e0843216868bfe4992071
<pre>
Fix race condition between _WKJSHandle and WebKitJSHandle destruction
<a href="https://bugs.webkit.org/show_bug.cgi?id=300073">https://bugs.webkit.org/show_bug.cgi?id=300073</a>
<a href="https://rdar.apple.com/161868858">rdar://161868858</a>

Reviewed by Timothy Hatcher.

In 299859@main I introduced a lifetime model of _WKJSHandle that allowed them to be
put into arrays and dictionaries with later messages from JS able to remove the same
object representation from the containers.  This worked well, except it introduced a
race condition if you are rapidly creating and destroying _WKJSHandles:
If a _WKJSHandle is destroyed near the same time when the web process is sending a
message to the UI process with the same handle, the web process would receive a message
saying the handle was destroyed near the same time as when the UI process receives a
message with the _WKJSHandle, which would then fail when used because the JSC::Strong
had already been removed from the map, so lookup with the identifier would fail.  This
caused assertions when running TestWebKitAPI.SiteIsolation.HitTesting:

ASSERTION FAILED: objectMap().contains(strong.get())
.../Source/WebCore/page/WebKitJSHandle.cpp(71) : static void WebCore::WebKitJSHandle::jsHandleDestroyed(JSHandleIdentifier)

I fix this issue by removing the unneeded === equality in JS and pointer equality
in ObjC while maintaining the isEqual equality in ObjC, which is what really mattered.
I make a ref counting system that allows multiple handles to point to the same object
and be destroyed whenever they are destroyed.  I also rename the JS entry point from
jsHandle back to createJSHandle because we are creating new handles each time again.

Tests: Tools/TestWebKitAPI/Tests/WebKitCocoa/JSHandle.mm
       Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewSnapshot.mm
       Tools/TestWebKitAPI/Tests/WebKitCocoa/WebTransport.mm
* Source/WebCore/page/WebKitJSHandle.cpp:
(WebCore::WebKitJSHandle::create):
(WebCore::WebKitJSHandle::jsHandleDestroyed):
(WebCore::WebKitJSHandle::WebKitJSHandle):
(WebCore::objectMap): Deleted.
(WebCore::WebKitJSHandle::getOrCreate): Deleted.
* Source/WebCore/page/WebKitJSHandle.h:
* Source/WebCore/page/WebKitNamespace.cpp:
(WebCore::WebKitNamespace::createJSHandle):
(WebCore::WebKitNamespace::jsHandle): Deleted.
* Source/WebCore/page/WebKitNamespace.h:
* Source/WebCore/page/WebKitNamespace.idl:
* Source/WebKit/Shared/JSHandleInfo.cpp:
(WebKit::JSHandleInfo::operator== const):
* Source/WebKit/Shared/JSHandleInfo.h:
* Source/WebKit/Shared/JavaScriptEvaluationResult.cpp:
(WebKit::JavaScriptEvaluationResult::APIInserter::toAPI):
* Source/WebKit/Shared/JavaScriptEvaluationResult.mm:
(WebKit::JavaScriptEvaluationResult::ObjCInserter::toID):
* Source/WebKit/UIProcess/API/APIJSHandle.cpp:
(API::JSHandle::create):
(API::JSHandle::JSHandle):
(API::JSHandle::~JSHandle):
(API::handleMap): Deleted.
(API::JSHandle::getOrCreate): Deleted.
* Source/WebKit/UIProcess/API/APIJSHandle.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _hitTestAtPoint:inFrameCoordinateSpace:completionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKContentWorldConfiguration.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKJSHandle.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKJSHandle.mm:
(-[_WKJSHandle isEqual:]):
(-[_WKJSHandle hash]):
(-[_WKJSHandle copyWithZone:]):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::hitTestAtPoint):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/JSHandle.mm:
(TestWebKitAPI::TEST(JSHandle, Basic)):
(TestWebKitAPI::TEST(JSHandle, Equality)):
(TestWebKitAPI::TEST(JSHandle, WebpagePreferences)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewSnapshot.mm:
(TestWebKitAPI::TEST(WKWebView, SnapshotNodeByJSHandle)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebTransport.mm:
(TestWebKitAPI::TEST(WebTransport, CreateStreamsBeforeReady)):
* Tools/WebKitTestRunner/TestController.cpp:

Canonical link: <a href="https://commits.webkit.org/300950@main">https://commits.webkit.org/300950@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5e2bc89bebd78128d95b577b9777300d96b0090b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124325 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44007 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34735 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131164 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76380 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4a862378-72ff-4bf7-93e3-7efe9d7c8ef8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/126202 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44752 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52605 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94571 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62743 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/70f39e52-e82b-4e3c-8aa6-9f35035c52a1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127279 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35666 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111203 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75158 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/245241c3-7f76-456c-b371-2354a8f13813) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34607 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29363 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74641 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105410 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29586 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133829 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51226 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39065 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103049 "Failed to checkout and rebase branch from PR 51726") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51623 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107422 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102845 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48208 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26462 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48163 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19531 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51092 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56878 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50527 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53883 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52202 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->