### PR TITLE
SpeculationRules: Test that inline rules after an external stylesheet work

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/inline-speculation-rules-after-stylesheet.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/inline-speculation-rules-after-stylesheet.https-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Inline speculation rules script after an external stylesheet should work
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/inline-speculation-rules-after-stylesheet.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/inline-speculation-rules-after-stylesheet.https.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/utils.js"></script>
+<script src="/common/dispatcher/dispatcher.js"></script>
+<script src="../resources/utils.js"></script>
+<script src="resources/utils.sub.js"></script>
+<link rel="stylesheet" href="/css/cssom/support/black.css">
+
+<body>
+<script type="speculationrules">
+{
+  "prefetch": [{
+    "where": { "href_matches": "*prefetch.py*" },
+    "eagerness":"immediate"
+  }]
+}
+</script>
+
+<script>
+  setup(() => assertSpeculationRulesIsSupported());
+
+  promise_test(async t => {
+    const url = getPrefetchUrl();
+    addLink(url);
+
+    await new Promise(resolve => t.step_timeout(resolve, 2000));
+
+    assert_equals(await isUrlPrefetched(url), 1, 'URL should be prefetched');
+  }, 'Inline speculation rules script after an external stylesheet should work');
+
+</script>
+</body>
+</html>


### PR DESCRIPTION
#### bca3cf4a99ae2b51d7424929b82b306788cdcb0f
<pre>
SpeculationRules: Test that inline rules after an external stylesheet work
<a href="https://bugs.webkit.org/show_bug.cgi?id=300078">https://bugs.webkit.org/show_bug.cgi?id=300078</a>

Reviewed by Alex Christensen.

<a href="https://bugs.webkit.org/show_bug.cgi?id=300039">https://bugs.webkit.org/show_bug.cgi?id=300039</a> was a result of an untested path: inline speculation rules script after an external stylesheet.
Scripts after a stylesheet are handled in executePendingScript, and that code wasn&apos;t ready for speculation rules.
As a result, we triggered an ASSERT that didn&apos;t take the speculation rules type into account, and weren&apos;t registering speculation rules in that case.

This PR adds the relevant tests to make sure this path is exercised.

* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/inline-speculation-rules-after-stylesheet.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/inline-speculation-rules-after-stylesheet.https.html: Added.

Canonical link: <a href="https://commits.webkit.org/301051@main">https://commits.webkit.org/301051@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d60a594d6ed46ac6711878a2a0ecdb041dafd3be

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124828 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44500 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35235 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131673 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76738 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45203 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53069 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/94986 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/63020 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127782 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36064 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111637 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75548 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/34998 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29793 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75149 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105823 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30022 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134340 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51673 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39478 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/103467 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52088 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107852 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103227 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26277 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48593 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26876 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48688 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51547 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50939 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54294 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52634 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->