### PR TITLE
Address safer cpp warnings in NavigationState.mm

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
@@ -64,7 +64,6 @@ UIProcess/API/mac/WKWebViewMac.mm
 UIProcess/API/mac/WKWebViewTestingMac.mm
 UIProcess/Authentication/cocoa/AuthenticationChallengeProxyCocoa.mm
 UIProcess/Automation/mac/WebAutomationSessionMac.mm
-UIProcess/Cocoa/NavigationState.mm
 UIProcess/Cocoa/UIDelegate.mm
 UIProcess/Cocoa/WKStorageAccessAlert.mm
 UIProcess/Cocoa/_WKWarningView.mm


### PR DESCRIPTION
#### 1ec07b43ebe1bba68fc2ff597c20eaf29e848a5f
<pre>
Address safer cpp warnings in NavigationState.mm
<a href="https://bugs.webkit.org/show_bug.cgi?id=300079">https://bugs.webkit.org/show_bug.cgi?id=300079</a>

Reviewed by Darin Adler and Ryosuke Niwa.

* Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations:
* Source/WebKit/UIProcess/Cocoa/NavigationState.mm:
(WebKit::NavigationState::navigationGestureWillEnd):
(WebKit::NavigationState::navigationGestureDidEnd):
(WebKit::NavigationState::willRecordNavigationSnapshot):
(WebKit::NavigationState::NavigationClient::didChangeBackForwardList):
(WebKit::NavigationState::NavigationClient::shouldGoToBackForwardListItem):
(WebKit::NavigationState::NavigationClient::decidePolicyForNavigationAction):
(WebKit::NavigationState::NavigationClient::contentRuleListNotification):
(WebKit::NavigationState::NavigationClient::decidePolicyForNavigationResponse):
(WebKit::NavigationState::NavigationClient::didStartProvisionalNavigation):
(WebKit::NavigationState::NavigationClient::didStartProvisionalLoadForFrame):
(WebKit::NavigationState::NavigationClient::didReceiveServerRedirectForProvisionalNavigation):
(WebKit::createErrorWithRecoveryAttempter):
(WebKit::NavigationState::NavigationClient::didFailProvisionalNavigationWithError):
(WebKit::NavigationState::NavigationClient::didFailProvisionalLoadWithErrorForFrame):
(WebKit::NavigationState::NavigationClient::didCommitNavigation):
(WebKit::NavigationState::NavigationClient::didCommitLoadForFrame):
(WebKit::NavigationState::NavigationClient::didFinishDocumentLoad):
(WebKit::NavigationState::NavigationClient::didFinishNavigation):
(WebKit::NavigationState::NavigationClient::didFinishLoadForFrame):
(WebKit::NavigationState::NavigationClient::didFailNavigationWithError):
(WebKit::NavigationState::NavigationClient::didFailLoadWithErrorForFrame):
(WebKit::NavigationState::NavigationClient::didSameDocumentNavigation):
(WebKit::NavigationState::NavigationClient::didReceiveAuthenticationChallenge):
(WebKit::NavigationState::NavigationClient::shouldAllowLegacyTLS):
(WebKit::NavigationState::NavigationClient::navigationActionDidBecomeDownload):
(WebKit::NavigationState::NavigationClient::navigationResponseDidBecomeDownload):
(WebKit::NavigationState::NavigationClient::contextMenuDidCreateDownload):

Canonical link: <a href="https://commits.webkit.org/300984@main">https://commits.webkit.org/300984@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a8d2acf66d389ab0d5d4c943ecdd7fc24659c14c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124571 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44244 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34977 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131406 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/76524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b724c129-2cc0-43d1-ac5c-626870478e8b) 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/44950 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/52817 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/94762 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/76524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/24b25ece-3c70-43fc-b8da-30eae0abb1eb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127525 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/44950 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111396 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75335 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3cca40f9-d20b-45aa-a511-834c6b286bcf) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/44950 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74889 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/44950 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/29782 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134074 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/51426 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/52817 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/103238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/51834 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107618 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/103019 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26225 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/26644 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/48361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/51297 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/57090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/50701 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/54057 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/52386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->