### PR TITLE
Address more Safer CPP failures in UIProcess/Cocoa

### DIFF
--- a/Source/WebCore/platform/network/mac/AuthenticationMac.h
+++ b/Source/WebCore/platform/network/mac/AuthenticationMac.h
@@ -34,6 +34,7 @@ namespace WebCore {
 class AuthenticationChallenge;
 
 WEBCORE_EXPORT NSURLAuthenticationChallenge *mac(const AuthenticationChallenge&);
+WEBCORE_EXPORT RetainPtr<NSURLAuthenticationChallenge> protectedMac(const AuthenticationChallenge&);
 
 WEBCORE_EXPORT AuthenticationChallenge core(NSURLAuthenticationChallenge *);
 

--- a/Source/WebCore/platform/network/mac/AuthenticationMac.mm
+++ b/Source/WebCore/platform/network/mac/AuthenticationMac.mm
@@ -160,6 +160,14 @@ NSURLAuthenticationChallenge *mac(const AuthenticationChallenge& coreChallenge)
     return adoptNS([[NSURLAuthenticationChallenge alloc] initWithProtectionSpace:coreChallenge.protectionSpace().protectedNSSpace().get() proposedCredential:coreChallenge.proposedCredential().protectedNSCredential().get() previousFailureCount:coreChallenge.previousFailureCount() failureResponse:coreChallenge.failureResponse().protectedNSURLResponse().get() error:coreChallenge.error().protectedNSError().get() sender:coreChallenge.protectedSender().get()]).autorelease();
 }
 
+RetainPtr<NSURLAuthenticationChallenge> protectedMac(const AuthenticationChallenge& coreChallenge)
+{
+    if (coreChallenge.nsURLAuthenticationChallenge())
+        return coreChallenge.nsURLAuthenticationChallenge();
+
+    return adoptNS([[NSURLAuthenticationChallenge alloc] initWithProtectionSpace:coreChallenge.protectionSpace().protectedNSSpace().get() proposedCredential:coreChallenge.proposedCredential().protectedNSCredential().get() previousFailureCount:coreChallenge.previousFailureCount() failureResponse:coreChallenge.failureResponse().protectedNSURLResponse().get() error:coreChallenge.error().protectedNSError().get() sender:coreChallenge.protectedSender().get()]);
+}
+
 AuthenticationChallenge core(NSURLAuthenticationChallenge *macChallenge)
 {
     return AuthenticationChallenge(macChallenge);

--- a/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
@@ -64,14 +64,8 @@ UIProcess/API/mac/WKWebViewMac.mm
 UIProcess/API/mac/WKWebViewTestingMac.mm
 UIProcess/Authentication/cocoa/AuthenticationChallengeProxyCocoa.mm
 UIProcess/Automation/mac/WebAutomationSessionMac.mm
-UIProcess/Cocoa/DiagnosticLoggingClient.mm
-UIProcess/Cocoa/GlobalFindInPageState.mm
 UIProcess/Cocoa/NavigationState.mm
-UIProcess/Cocoa/ResourceLoadDelegate.mm
-UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm
 UIProcess/Cocoa/UIDelegate.mm
-UIProcess/Cocoa/WKContactPicker.mm
-UIProcess/Cocoa/WKShareSheet.mm
 UIProcess/Cocoa/WKStorageAccessAlert.mm
 UIProcess/Cocoa/_WKWarningView.mm
 UIProcess/Inspector/Cocoa/InspectorExtensionDelegate.mm

--- a/Source/WebKit/Shared/Cocoa/WKObject.h
+++ b/Source/WebKit/Shared/Cocoa/WKObject.h
@@ -86,6 +86,16 @@ template<typename ObjectClass> inline typename WrapperTraits<ObjectClass>::Wrapp
     return wrapper(object.get());
 }
 
+template<typename ObjectClass> inline RetainPtr<typename WrapperTraits<ObjectClass>::WrapperClass> protectedWrapper(const Ref<ObjectClass>& object)
+{
+    return wrapper(object);
+}
+
+template<typename ObjectClass> inline RetainPtr<typename WrapperTraits<ObjectClass>::WrapperClass> protectedWrapper(const RefPtr<ObjectClass>& object)
+{
+    return wrapper(object);
+}
+
 template<typename ObjectClass> inline RetainPtr<typename WrapperTraits<ObjectClass>::WrapperClass> wrapper(Ref<ObjectClass>&& object)
 {
     return wrapper(object.get());

--- a/Source/WebKit/UIProcess/Cocoa/DiagnosticLoggingClient.mm
+++ b/Source/WebKit/UIProcess/Cocoa/DiagnosticLoggingClient.mm
@@ -105,7 +105,7 @@ void DiagnosticLoggingClient::logDiagnosticMessageWithEnhancedPrivacy(WebKit::We
 void DiagnosticLoggingClient::logDiagnosticMessageWithValueDictionary(WebPageProxy*, const String& message, const String& description, Ref<API::Dictionary>&& valueDictionary)
 {
     if (m_delegateMethods.webviewLogDiagnosticMessageWithValueDictionary)
-        [m_delegate.get() _webView:m_webView.get().get() logDiagnosticMessage:message.createNSString().get() description:description.createNSString().get() valueDictionary:static_cast<NSDictionary*>(valueDictionary->wrapper())];
+        [m_delegate.get() _webView:m_webView.get().get() logDiagnosticMessage:message.createNSString().get() description:description.createNSString().get() valueDictionary:RetainPtr { checked_objc_cast<NSDictionary>(valueDictionary->wrapper()) }.get()];
 }
 
 void DiagnosticLoggingClient::logDiagnosticMessageWithDomain(WebPageProxy*, const String& message, WebCore::DiagnosticLoggingDomain domain)

--- a/Source/WebKit/UIProcess/Cocoa/GlobalFindInPageState.mm
+++ b/Source/WebKit/UIProcess/Cocoa/GlobalFindInPageState.mm
@@ -37,9 +37,9 @@ namespace WebKit {
 
 #if PLATFORM(MAC)
 
-static NSPasteboard *findPasteboard()
+static RetainPtr<NSPasteboard> findPasteboard()
 {
-    return [NSPasteboard pasteboardWithName:NSPasteboardNameFind];
+    return [NSPasteboard pasteboardWithName:RetainPtr { NSPasteboardNameFind }.get()];
 }
 
 #else

--- a/Source/WebKit/UIProcess/Cocoa/ResourceLoadDelegate.mm
+++ b/Source/WebKit/UIProcess/Cocoa/ResourceLoadDelegate.mm
@@ -88,7 +88,7 @@ void ResourceLoadDelegate::ResourceLoadClient::didSendRequest(WebKit::ResourceLo
     if (!delegate)
         return;
 
-    [delegate webView:m_resourceLoadDelegate->m_webView.get().get() resourceLoad:wrapper(API::ResourceLoadInfo::create(WTFMove(loadInfo)).get()) didSendRequest:request.nsURLRequest(WebCore::HTTPBodyUpdatePolicy::UpdateHTTPBody)];
+    [delegate webView:m_resourceLoadDelegate->m_webView.get().get() resourceLoad:protectedWrapper(API::ResourceLoadInfo::create(WTFMove(loadInfo))).get() didSendRequest:request.protectedNSURLRequest(WebCore::HTTPBodyUpdatePolicy::UpdateHTTPBody).get()];
 }
 
 void ResourceLoadDelegate::ResourceLoadClient::didPerformHTTPRedirection(WebKit::ResourceLoadInfo&& loadInfo, WebCore::ResourceResponse&& response, WebCore::ResourceRequest&& request) const
@@ -100,7 +100,7 @@ void ResourceLoadDelegate::ResourceLoadClient::didPerformHTTPRedirection(WebKit:
     if (!delegate)
         return;
 
-    [delegate webView:m_resourceLoadDelegate->m_webView.get().get() resourceLoad:wrapper(API::ResourceLoadInfo::create(WTFMove(loadInfo)).get()) didPerformHTTPRedirection:response.nsURLResponse() newRequest:request.nsURLRequest(WebCore::HTTPBodyUpdatePolicy::DoNotUpdateHTTPBody)];
+    [delegate webView:m_resourceLoadDelegate->m_webView.get().get() resourceLoad:protectedWrapper(API::ResourceLoadInfo::create(WTFMove(loadInfo))).get() didPerformHTTPRedirection:response.protectedNSURLResponse().get() newRequest:request.protectedNSURLRequest(WebCore::HTTPBodyUpdatePolicy::DoNotUpdateHTTPBody).get()];
 }
 
 void ResourceLoadDelegate::ResourceLoadClient::didReceiveChallenge(WebKit::ResourceLoadInfo&& loadInfo, WebCore::AuthenticationChallenge&& challenge) const
@@ -112,7 +112,7 @@ void ResourceLoadDelegate::ResourceLoadClient::didReceiveChallenge(WebKit::Resou
     if (!delegate)
         return;
 
-    [delegate webView:m_resourceLoadDelegate->m_webView.get().get() resourceLoad:wrapper(API::ResourceLoadInfo::create(WTFMove(loadInfo)).get()) didReceiveChallenge:mac(challenge)];
+    [delegate webView:m_resourceLoadDelegate->m_webView.get().get() resourceLoad:protectedWrapper(API::ResourceLoadInfo::create(WTFMove(loadInfo))).get() didReceiveChallenge:protectedMac(challenge).get()];
 }
 
 void ResourceLoadDelegate::ResourceLoadClient::didReceiveResponse(WebKit::ResourceLoadInfo&& loadInfo, WebCore::ResourceResponse&& response) const
@@ -124,7 +124,7 @@ void ResourceLoadDelegate::ResourceLoadClient::didReceiveResponse(WebKit::Resour
     if (!delegate)
         return;
 
-    [delegate webView:m_resourceLoadDelegate->m_webView.get().get() resourceLoad:wrapper(API::ResourceLoadInfo::create(WTFMove(loadInfo)).get()) didReceiveResponse:response.nsURLResponse()];
+    [delegate webView:m_resourceLoadDelegate->m_webView.get().get() resourceLoad:protectedWrapper(API::ResourceLoadInfo::create(WTFMove(loadInfo))).get() didReceiveResponse:response.protectedNSURLResponse().get()];
 }
 
 void ResourceLoadDelegate::ResourceLoadClient::didCompleteWithError(WebKit::ResourceLoadInfo&& loadInfo, WebCore::ResourceResponse&& response, WebCore::ResourceError&& error) const
@@ -136,7 +136,7 @@ void ResourceLoadDelegate::ResourceLoadClient::didCompleteWithError(WebKit::Reso
     if (!delegate)
         return;
 
-    [delegate webView:m_resourceLoadDelegate->m_webView.get().get() resourceLoad:wrapper(API::ResourceLoadInfo::create(WTFMove(loadInfo)).get()) didCompleteWithError:error.nsError() response:response.nsURLResponse()];
+    [delegate webView:m_resourceLoadDelegate->m_webView.get().get() resourceLoad:protectedWrapper(API::ResourceLoadInfo::create(WTFMove(loadInfo))).get() didCompleteWithError:error.protectedNSError().get() response:response.protectedNSURLResponse().get()];
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm
@@ -390,7 +390,7 @@ void SOAuthorizationSession::presentViewController(SOAuthorizationViewController
 
     m_sheetWindow = [NSWindow windowWithContentViewController:m_viewController.get()];
 
-    m_sheetWindowWillCloseObserver = [[NSNotificationCenter defaultCenter] addObserverForName:NSWindowWillCloseNotification object:m_sheetWindow.get() queue:nil usingBlock:[weakThis = ThreadSafeWeakPtr { *this }] (NSNotification *) {
+    m_sheetWindowWillCloseObserver = [[NSNotificationCenter defaultCenter] addObserverForName:RetainPtr { NSWindowWillCloseNotification }.get() object:m_sheetWindow.get() queue:nil usingBlock:[weakThis = ThreadSafeWeakPtr { *this }] (NSNotification *) {
         auto protectedThis = weakThis.get();
         if (!protectedThis)
             return;
@@ -474,7 +474,7 @@ void SOAuthorizationSession::dismissViewController()
                     AUTHORIZATIONSESSION_RELEASE_LOG("dismissViewController: [Miniaturized] Already has a deminiaturized observer (%p). Hidden observer is %p", m_presentingWindowDidDeminiaturizeObserver.get(), m_applicationDidUnhideObserver.get());
                     return;
                 }
-                m_presentingWindowDidDeminiaturizeObserver = [[NSNotificationCenter defaultCenter] addObserverForName:NSWindowDidDeminiaturizeNotification object:presentingWindow.get() queue:nil usingBlock:[protectedThis = Ref { *this }, this] (NSNotification *) {
+                m_presentingWindowDidDeminiaturizeObserver = [[NSNotificationCenter defaultCenter] addObserverForName:RetainPtr { NSWindowDidDeminiaturizeNotification }.get() object:presentingWindow.get() queue:nil usingBlock:[protectedThis = Ref { *this }, this] (NSNotification *) {
                     AUTHORIZATIONSESSION_RELEASE_LOG("dismissViewController: Window has deminiaturized. Completing the dismissal.");
                     dismissViewController();
                     [[NSNotificationCenter defaultCenter] removeObserver:m_presentingWindowDidDeminiaturizeObserver.get()];
@@ -485,13 +485,15 @@ void SOAuthorizationSession::dismissViewController()
         }
     }
 
-    if (!m_isInDestructor && NSApp.hidden) {
+    // FIXME: This is a safer cpp false positive (rdar://problem/161068288).
+    SUPPRESS_UNRETAINED_ARG if (!m_isInDestructor && NSApp.hidden) {
         AUTHORIZATIONSESSION_RELEASE_LOG("dismissViewController: Application is hidden. Waiting to dismiss until active.");
         if (m_applicationDidUnhideObserver) {
             AUTHORIZATIONSESSION_RELEASE_LOG("dismissViewController: [Hidden] Already has an Unhide observer (%p). Deminiaturized observer is %p", m_presentingWindowDidDeminiaturizeObserver.get(), m_applicationDidUnhideObserver.get());
             return;
         }
-        m_applicationDidUnhideObserver = [[NSNotificationCenter defaultCenter] addObserverForName:NSApplicationDidUnhideNotification object:NSApp queue:nil usingBlock:[protectedThis = Ref { *this }, this] (NSNotification *) {
+        // FIXME: We should not need to protect NSApp here (rdar://problem/161068288).
+        m_applicationDidUnhideObserver = [[NSNotificationCenter defaultCenter] addObserverForName:RetainPtr { NSApplicationDidUnhideNotification }.get() object:RetainPtr { NSApp }.get() queue:nil usingBlock:[protectedThis = Ref { *this }, this] (NSNotification *) {
             AUTHORIZATIONSESSION_RELEASE_LOG("dismissViewController: Application is no longer hidden. Completing the dismissal.");
             dismissViewController();
             [[NSNotificationCenter defaultCenter] removeObserver:m_applicationDidUnhideObserver.get()];

--- a/Source/WebKit/UIProcess/Cocoa/WKContactPicker.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WKContactPicker.mm
@@ -231,8 +231,9 @@ SOFT_LINK_CLASS(ContactsUI, CNContactPickerViewController)
 {
     _completionHandler(WTFMove(info));
 
-    if ([_delegate respondsToSelector:@selector(contactPickerDidDismiss:)])
-        [_delegate contactPickerDidDismiss:self];
+    RetainPtr delegate = _delegate.get();
+    if ([delegate respondsToSelector:@selector(contactPickerDidDismiss:)])
+        [delegate contactPickerDidDismiss:self];
 }
 
 - (WebCore::ContactInfo)_contactInfoFromCNContact:(CNContact *)contact

--- a/Source/WebKit/UIProcess/Cocoa/WKShareSheet.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WKShareSheet.mm
@@ -328,7 +328,7 @@ static void appendFilesAsShareableURLs(RetainPtr<NSMutableArray>&& shareDataArra
 
     _completionHandler = WTFMove(completionHandler);
 
-    if (auto resolution = [_webView _resolutionForShareSheetImmediateCompletionForTesting]) {
+    if (auto resolution = [_webView.get() _resolutionForShareSheetImmediateCompletionForTesting]) {
         _didShareSuccessfully = *resolution;
         [self dismiss];
         return;
@@ -403,8 +403,9 @@ static void appendFilesAsShareableURLs(RetainPtr<NSMutableArray>&& shareDataArra
             popoverController.permittedArrowDirections = 0;
     }
 
-    if ([_delegate respondsToSelector:@selector(shareSheet:willShowActivityItems:)])
-        [_delegate shareSheet:self willShowActivityItems:sharingItems];
+    RetainPtr delegate = _delegate.get();
+    if ([delegate respondsToSelector:@selector(shareSheet:willShowActivityItems:)])
+        [delegate shareSheet:self willShowActivityItems:sharingItems];
 
     _presentationViewController = webView.get()._wk_viewControllerForFullScreenPresentation;
     [_presentationViewController presentViewController:_shareSheetViewController.get() animated:YES completion:nil];
@@ -425,7 +426,7 @@ static void appendFilesAsShareableURLs(RetainPtr<NSMutableArray>&& shareDataArra
 
 - (NSWindow *)sharingService:(NSSharingService *)sharingService sourceWindowForShareItems:(NSArray *)items sharingContentScope:(NSSharingContentScope *)sharingContentScope
 {
-    return [_webView window];
+    return [_webView.get() window];
 }
 
 - (void)sharingService:(NSSharingService *)sharingService didFailToShareItems:(NSArray *)items error:(NSError *)error
@@ -459,8 +460,9 @@ static void appendFilesAsShareableURLs(RetainPtr<NSMutableArray>&& shareDataArra
     _temporaryFileShareDirectory = nullptr;
 
     auto dispatchDidDismiss = ^{
-        if ([_delegate respondsToSelector:@selector(shareSheetDidDismiss:)])
-            [_delegate shareSheetDidDismiss:self];
+        RetainPtr delegate = _delegate.get();
+        if ([delegate respondsToSelector:@selector(shareSheetDidDismiss:)])
+            [delegate shareSheetDidDismiss:self];
     };
 
 #if PLATFORM(MAC)


### PR DESCRIPTION
#### 9e83ed025eac7c35cd7df1e29c3385517f4ced81
<pre>
Address more Safer CPP failures in UIProcess/Cocoa
<a href="https://bugs.webkit.org/show_bug.cgi?id=300081">https://bugs.webkit.org/show_bug.cgi?id=300081</a>

Reviewed by Darin Adler.

* Source/WebCore/platform/network/mac/AuthenticationMac.h:
* Source/WebCore/platform/network/mac/AuthenticationMac.mm:
(WebCore::protectedMac):
* Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations:
* Source/WebKit/Shared/Cocoa/WKObject.h:
(WebKit::protectedWrapper):
* Source/WebKit/UIProcess/Cocoa/DiagnosticLoggingClient.mm:
(WebKit::DiagnosticLoggingClient::logDiagnosticMessageWithValueDictionary):
* Source/WebKit/UIProcess/Cocoa/GlobalFindInPageState.mm:
(WebKit::findPasteboard):
* Source/WebKit/UIProcess/Cocoa/ResourceLoadDelegate.mm:
(WebKit::ResourceLoadDelegate::ResourceLoadClient::didSendRequest const):
(WebKit::ResourceLoadDelegate::ResourceLoadClient::didPerformHTTPRedirection const):
(WebKit::ResourceLoadDelegate::ResourceLoadClient::didReceiveChallenge const):
(WebKit::ResourceLoadDelegate::ResourceLoadClient::didReceiveResponse const):
(WebKit::ResourceLoadDelegate::ResourceLoadClient::didCompleteWithError const):
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm:
(WebKit::SOAuthorizationSession::presentViewController):
(WebKit::SOAuthorizationSession::dismissViewController):
* Source/WebKit/UIProcess/Cocoa/WKContactPicker.mm:
(-[WKContactPicker _contactPickerDidDismissWithContactInfo:]):
* Source/WebKit/UIProcess/Cocoa/WKShareSheet.mm:
(-[WKShareSheet presentWithParameters:inRect:completionHandler:]):
(-[WKShareSheet presentWithShareDataArray:inRect:]):
(-[WKShareSheet sharingService:sourceWindowForShareItems:sharingContentScope:]):
(-[WKShareSheet dismiss]):

Canonical link: <a href="https://commits.webkit.org/300981@main">https://commits.webkit.org/300981@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d104e3ec12cafc4e1e5a92d93e85b7549e0b4062

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124352 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44032 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34762 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131195 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76397 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b74ac790-a23a-481c-a5b5-d2f567f40063) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/126229 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44778 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52631 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94595 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62753 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c496948e-bc65-4f64-bc58-a3cf48993e2e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127306 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35688 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111223 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75182 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ac03f2a0-eb54-44a3-bb4e-5219ec5cde3e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34626 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29383 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74672 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105433 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29606 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133857 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51250 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39085 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103078 "") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51649 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107442 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102868 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26222 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48231 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26482 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48182 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51117 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56902 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50547 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53904 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52222 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->