### PR TITLE
[GTK][WPE] OpenGL assets created by WebGL are not released when destroying the WebGLRenderingContext

### DIFF
--- a/Source/WebCore/platform/graphics/PlatformDisplay.cpp
+++ b/Source/WebCore/platform/graphics/PlatformDisplay.cpp
@@ -132,9 +132,6 @@ void PlatformDisplay::clearGLContexts()
 #if ENABLE(VIDEO) && USE(GSTREAMER_GL)
     m_gstGLContext = nullptr;
 #endif
-#if ENABLE(WEBGL) && !PLATFORM(WIN)
-    clearANGLESharingGLContext();
-#endif
     m_sharingGLContext = nullptr;
 }
 

--- a/Source/WebCore/platform/graphics/PlatformDisplay.h
+++ b/Source/WebCore/platform/graphics/PlatformDisplay.h
@@ -131,15 +131,10 @@ private:
     void clearSkiaGLContext();
 #endif
 
-#if ENABLE(WEBGL) && !PLATFORM(WIN)
-    void clearANGLESharingGLContext();
-#endif
-
     void terminateEGLDisplay();
 
 #if ENABLE(WEBGL) && !PLATFORM(WIN)
     mutable EGLDisplay m_angleEGLDisplay { nullptr };
-    EGLContext m_angleSharingGLContext { nullptr };
 #endif
 
 #if ENABLE(VIDEO) && USE(GSTREAMER_GL)

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h
@@ -445,6 +445,7 @@ protected:
 
     GCGLDisplay m_displayObj { nullptr };
     GCGLContext m_contextObj { nullptr };
+    GCGLContext m_angleSharingContextObj { nullptr };
     GCGLConfig m_configObj { nullptr };
 #if USE(TEXTURE_MAPPER)
     GCEGLSurface m_surfaceObj { nullptr };

--- a/Source/WebCore/platform/graphics/angle/PlatformDisplayANGLE.cpp
+++ b/Source/WebCore/platform/graphics/angle/PlatformDisplayANGLE.cpp
@@ -72,9 +72,6 @@ EGLContext PlatformDisplay::angleSharingGLContext()
 #if PLATFORM(WIN)
     return sharingGLContext()->platformContext();
 #else
-    if (m_angleSharingGLContext != EGL_NO_CONTEXT)
-        return m_angleSharingGLContext;
-
     ASSERT(m_angleEGLDisplay != EGL_NO_DISPLAY);
     auto sharingContext = sharingGLContext();
     if (!sharingContext)
@@ -103,25 +100,10 @@ EGLContext PlatformDisplay::angleSharingGLContext()
         EGL_EXTERNAL_CONTEXT_ANGLE, EGL_TRUE,
         EGL_NONE
     };
-    m_angleSharingGLContext = EGL_CreateContext(m_angleEGLDisplay, config, EGL_NO_CONTEXT, contextAttributes);
-    return m_angleSharingGLContext;
+
+    return EGL_CreateContext(m_angleEGLDisplay, config, EGL_NO_CONTEXT, contextAttributes);
 #endif
 }
-
-#if ENABLE(WEBGL) && !PLATFORM(WIN)
-void PlatformDisplay::clearANGLESharingGLContext()
-{
-    if (m_angleSharingGLContext == EGL_NO_CONTEXT)
-        return;
-
-    ASSERT(m_angleEGLDisplay);
-    ASSERT(m_sharingGLContext);
-    EGL_MakeCurrent(m_angleEGLDisplay, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
-    EGL_DestroyContext(m_angleEGLDisplay, m_angleSharingGLContext);
-    m_angleSharingGLContext = EGL_NO_CONTEXT;
-}
-#endif
-
 
 } // namespace WebCore
 


### PR DESCRIPTION
#### 1d16639f9d572ad6d75224c49b9cf0ca598e3bbc
<pre>
[GTK][WPE] OpenGL assets created by WebGL are not released when destroying the WebGLRenderingContext
<a href="https://bugs.webkit.org/show_bug.cgi?id=300085">https://bugs.webkit.org/show_bug.cgi?id=300085</a>

Reviewed by Carlos Garcia Campos.

Stop using a singleton for the ANGLE sharing context. Each ANGLE context will use
its own ANGLE sharing context instead, that will be created and destroyed together
with the ANGLE context. This ensures that all the OpenGL resources that were created
by ANGLE will be destroyed when the contexts are destroyed.

* Source/WebCore/platform/graphics/PlatformDisplay.cpp:
(WebCore::PlatformDisplay::clearGLContexts):
* Source/WebCore/platform/graphics/PlatformDisplay.h:
* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h:
* Source/WebCore/platform/graphics/angle/PlatformDisplayANGLE.cpp:
(WebCore::PlatformDisplay::angleSharingGLContext):
(WebCore::PlatformDisplay::clearANGLESharingGLContext): Deleted.
* Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp:
(WebCore::GraphicsContextGLANGLE::~GraphicsContextGLANGLE):
(WebCore::GraphicsContextGLTextureMapperANGLE::platformInitializeContext):

Canonical link: <a href="https://commits.webkit.org/301043@main">https://commits.webkit.org/301043@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/94f3132e980d37be7a2d21afde0b31aea997f23d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124378 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44058 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34788 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131217 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76416 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/126255 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44804 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52657 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94614 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/63064 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127332 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35709 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111243 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75200 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34645 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29403 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74694 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105454 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29625 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133883 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51276 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39108 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103094 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51675 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107461 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102889 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48252 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26501 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48207 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19562 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51143 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56928 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50570 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53929 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52244 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->