### PR TITLE
Unreviewed, reverting 300874@main (ccac5c735ff6)

### DIFF
--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDatabase.cpp
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDatabase.cpp
@@ -195,14 +195,9 @@ void Database::insertPrivateClickMeasurement(WebCore::PrivateClickMeasurement&& 
         // We should never be inserting an attributed private click measurement value into the database without valid report times.
         ASSERT(sourceEarliestTimeToSend != -1 || destinationEarliestTimeToSend != -1);
 
-        auto sqlStatement = m_database.prepareStatement(insertAttributedPrivateClickMeasurementQuery);
-        if (!sqlStatement) {
-            RELEASE_LOG_ERROR(PrivateClickMeasurement, "%p - Database::insertPrivateClickMeasurement insertAttributedPrivateClickMeasurementQuery, error message: %" PRIVATE_LOG_STRING, this, m_database.lastErrorMsg());
-            ASSERT_NOT_REACHED();
-            return;
-        }
-        CheckedRef statement = sqlStatement.value();
-        if (statement->bindInt(1, *sourceID) != SQLITE_OK
+        auto statement = m_database.prepareStatement(insertAttributedPrivateClickMeasurementQuery);
+        if (!statement
+            || statement->bindInt(1, *sourceID) != SQLITE_OK
             || statement->bindInt(2, *attributionDestinationID) != SQLITE_OK
             || statement->bindInt(3, attribution.sourceID()) != SQLITE_OK
             || statement->bindInt(4, attributionTriggerData) != SQLITE_OK
@@ -226,14 +221,9 @@ void Database::insertPrivateClickMeasurement(WebCore::PrivateClickMeasurement&& 
 
     ASSERT(attributionType == PrivateClickMeasurementAttributionType::Unattributed);
 
-    auto sqlStatement = m_database.prepareStatement(insertUnattributedPrivateClickMeasurementQuery);
-    if (!sqlStatement) {
-        RELEASE_LOG_ERROR(PrivateClickMeasurement, "%p - Database::insertPrivateClickMeasurement insertUnattributedPrivateClickMeasurementQuery, error message: %" PRIVATE_LOG_STRING, this, m_database.lastErrorMsg());
-        ASSERT_NOT_REACHED();
-        return;
-    }
-    CheckedRef statement = sqlStatement.value();
-    if (statement->bindInt(1, *sourceID) != SQLITE_OK
+    auto statement = m_database.prepareStatement(insertUnattributedPrivateClickMeasurementQuery);
+    if (!statement
+        || statement->bindInt(1, *sourceID) != SQLITE_OK
         || statement->bindInt(2, *attributionDestinationID) != SQLITE_OK
         || statement->bindInt(3, attribution.sourceID()) != SQLITE_OK
         || statement->bindDouble(4, attribution.timeOfAdClick().secondsSinceEpoch().value()) != SQLITE_OK
@@ -251,13 +241,8 @@ void Database::markAllUnattributedPrivateClickMeasurementAsExpiredForTesting()
 {
     ASSERT(!RunLoop::isMain());
     auto scopedStatement = this->scopedStatement(m_setUnattributedPrivateClickMeasurementAsExpiredStatement, setUnattributedPrivateClickMeasurementAsExpiredQuery, "markAllUnattributedPrivateClickMeasurementAsExpiredForTesting"_s);
-    if (!scopedStatement) {
-        RELEASE_LOG_ERROR(PrivateClickMeasurement, "%p - Database::markAllUnattributedPrivateClickMeasurementAsExpiredForTesting, error message: %" PRIVATE_LOG_STRING, this, m_database.lastErrorMsg());
-        ASSERT_NOT_REACHED();
-        return;
-    }
-    CheckedPtr statement = scopedStatement.get();
-    if (statement->step() != SQLITE_DONE) {
+
+    if (!scopedStatement || scopedStatement->step() != SQLITE_DONE) {
         RELEASE_LOG_ERROR(PrivateClickMeasurement, "%p - Database::markAllUnattributedPrivateClickMeasurementAsExpiredForTesting, error message: %" PRIVATE_LOG_STRING, this, m_database.lastErrorMsg());
         ASSERT_NOT_REACHED();
     }
@@ -271,26 +256,18 @@ std::pair<std::optional<Database::UnattributedPrivateClickMeasurement>, std::opt
     if (!sourceSiteDomainID || !destinationSiteDomainID)
         return std::make_pair(std::nullopt, std::nullopt);
 
-    auto findUnattributedScoped = this->scopedStatement(m_findUnattributedStatement, findUnattributedQuery, "findPrivateClickMeasurement"_s);
-    if (!findUnattributedScoped) {
-        RELEASE_LOG_ERROR(PrivateClickMeasurement, "%p - Database::findPrivateClickMeasurement findUnattributedQuery, error message: %" PRIVATE_LOG_STRING, this, m_database.lastErrorMsg());
-        ASSERT_NOT_REACHED();
-    }
-    CheckedPtr findUnattributedScopedStatement = findUnattributedScoped.get();
-    if (findUnattributedScopedStatement->bindInt(1, *sourceSiteDomainID) != SQLITE_OK
+    auto findUnattributedScopedStatement = this->scopedStatement(m_findUnattributedStatement, findUnattributedQuery, "findPrivateClickMeasurement"_s);
+    if (!findUnattributedScopedStatement
+        || findUnattributedScopedStatement->bindInt(1, *sourceSiteDomainID) != SQLITE_OK
         || findUnattributedScopedStatement->bindInt(2, *destinationSiteDomainID) != SQLITE_OK
         || findUnattributedScopedStatement->bindText(3, applicationBundleIdentifier) != SQLITE_OK) {
         RELEASE_LOG_ERROR(PrivateClickMeasurement, "%p - Database::findPrivateClickMeasurement findUnattributedQuery, error message: %" PRIVATE_LOG_STRING, this, m_database.lastErrorMsg());
         ASSERT_NOT_REACHED();
     }
 
-    auto findAttributedScoped = this->scopedStatement(m_findAttributedStatement, findAttributedQuery, "findPrivateClickMeasurement"_s);
-    if (!findAttributedScoped) {
-        RELEASE_LOG_ERROR(PrivateClickMeasurement, "%p - Database::findPrivateClickMeasurement findAttributedQuery, error message: %" PRIVATE_LOG_STRING, this, m_database.lastErrorMsg());
-        ASSERT_NOT_REACHED();
-    }
-    CheckedPtr findAttributedScopedStatement = findAttributedScoped.get();
-    if (findAttributedScopedStatement->bindInt(1, *sourceSiteDomainID) != SQLITE_OK
+    auto findAttributedScopedStatement = this->scopedStatement(m_findAttributedStatement, findAttributedQuery, "findPrivateClickMeasurement"_s);
+    if (!findAttributedScopedStatement
+        || findAttributedScopedStatement->bindInt(1, *sourceSiteDomainID) != SQLITE_OK
         || findAttributedScopedStatement->bindInt(2, *destinationSiteDomainID) != SQLITE_OK
         || findAttributedScopedStatement->bindText(3, applicationBundleIdentifier) != SQLITE_OK) {
         RELEASE_LOG_ERROR(PrivateClickMeasurement, "%p - Database::findPrivateClickMeasurement findAttributedQuery, error message: %" PRIVATE_LOG_STRING, this, m_database.lastErrorMsg());
@@ -383,16 +360,11 @@ void Database::removeUnattributed(WebCore::PrivateClickMeasurement& attribution)
 
     auto scopedStatement = this->scopedStatement(m_removeUnattributedStatement, removeUnattributedQuery, "removeUnattributed"_s);
 
-    if (!scopedStatement) {
-        RELEASE_LOG_ERROR(PrivateClickMeasurement, "%p - Database::removeUnattributed, error message: %" PRIVATE_LOG_STRING, this, m_database.lastErrorMsg());
-        ASSERT_NOT_REACHED();
-        return;
-    }
-    CheckedPtr statement = scopedStatement.get();
-    if (statement->bindInt(1, *sourceSiteDomainID) != SQLITE_OK
-        || statement->bindInt(2, *destinationSiteDomainID) != SQLITE_OK
-        || statement->bindText(3, attribution.sourceApplicationBundleID()) != SQLITE_OK
-        || statement->step() != SQLITE_DONE) {
+    if (!scopedStatement
+        || scopedStatement->bindInt(1, *sourceSiteDomainID) != SQLITE_OK
+        || scopedStatement->bindInt(2, *destinationSiteDomainID) != SQLITE_OK
+        || scopedStatement->bindText(3, attribution.sourceApplicationBundleID()) != SQLITE_OK
+        || scopedStatement->step() != SQLITE_DONE) {
         RELEASE_LOG_ERROR(PrivateClickMeasurement, "%p - Database::removeUnattributed, error message: %" PRIVATE_LOG_STRING, this, m_database.lastErrorMsg());
         ASSERT_NOT_REACHED();
     }
@@ -402,16 +374,16 @@ Vector<WebCore::PrivateClickMeasurement> Database::allAttributedPrivateClickMeas
 {
     ASSERT(!RunLoop::isMain());
     auto attributedScopedStatement = this->scopedStatement(m_allAttributedPrivateClickMeasurementStatement, allAttributedPrivateClickMeasurementQuery, "allAttributedPrivateClickMeasurement"_s);
+
     if (!attributedScopedStatement) {
         RELEASE_LOG_ERROR(PrivateClickMeasurement, "%p - Database::allAttributedPrivateClickMeasurement, error message: %" PRIVATE_LOG_STRING, this, m_database.lastErrorMsg());
         ASSERT_NOT_REACHED();
         return { };
     }
 
-    CheckedPtr statement = attributedScopedStatement.get();
     Vector<WebCore::PrivateClickMeasurement> attributions;
-    while (statement->step() == SQLITE_ROW)
-        attributions.append(buildPrivateClickMeasurementFromDatabase(*statement, PrivateClickMeasurementAttributionType::Attributed));
+    while (attributedScopedStatement->step() == SQLITE_ROW)
+        attributions.append(buildPrivateClickMeasurementFromDatabase(*attributedScopedStatement.get(), PrivateClickMeasurementAttributionType::Attributed));
 
     return attributions;
 }
@@ -420,28 +392,22 @@ String Database::privateClickMeasurementToStringForTesting() const
 {
     ASSERT(!RunLoop::isMain());
     auto privateClickMeasurementDataExists = m_database.prepareStatement("SELECT (SELECT COUNT(*) FROM UnattributedPrivateClickMeasurement) as cnt1, (SELECT COUNT(*) FROM AttributedPrivateClickMeasurement) as cnt2"_s);
-    if (!privateClickMeasurementDataExists) {
-        RELEASE_LOG_ERROR(PrivateClickMeasurement, "%p - Database::privateClickMeasurementToStringForTesting failed, error message: %" PRIVATE_LOG_STRING, this, m_database.lastErrorMsg());
-        ASSERT_NOT_REACHED();
-        return { };
-    }
-    CheckedRef privateClickMeasurementDataExistsStatement = privateClickMeasurementDataExists.value();
-    if (privateClickMeasurementDataExistsStatement->step() != SQLITE_ROW) {
+    if (!privateClickMeasurementDataExists || privateClickMeasurementDataExists->step() != SQLITE_ROW) {
         RELEASE_LOG_ERROR(PrivateClickMeasurement, "%p - Database::privateClickMeasurementToStringForTesting failed, error message: %" PRIVATE_LOG_STRING, this, m_database.lastErrorMsg());
         ASSERT_NOT_REACHED();
         return { };
     }
 
-    if (!privateClickMeasurementDataExistsStatement->columnInt(0) && !privateClickMeasurementDataExistsStatement->columnInt(1))
+    if (!privateClickMeasurementDataExists->columnInt(0) && !privateClickMeasurementDataExists->columnInt(1))
         return "\nNo stored Private Click Measurement data.\n"_s;
 
-    auto unattributedScoped = this->scopedStatement(m_allUnattributedPrivateClickMeasurementAttributionsStatement, allUnattributedPrivateClickMeasurementAttributionsQuery, "privateClickMeasurementToStringForTesting"_s);
-    if (!unattributedScoped) {
+    auto unattributedScopedStatement = this->scopedStatement(m_allUnattributedPrivateClickMeasurementAttributionsStatement, allUnattributedPrivateClickMeasurementAttributionsQuery, "privateClickMeasurementToStringForTesting"_s);
+
+    if (!unattributedScopedStatement) {
         RELEASE_LOG_ERROR(PrivateClickMeasurement, "%p - Database::privateClickMeasurementToStringForTesting, error message: %" PRIVATE_LOG_STRING, this, m_database.lastErrorMsg());
         ASSERT_NOT_REACHED();
         return { };
     }
-    CheckedPtr unattributedScopedStatement = unattributedScoped.get();
 
     unsigned unattributedNumber = 0;
     StringBuilder builder;
@@ -451,14 +417,14 @@ String Database::privateClickMeasurementToStringForTesting() const
             attributionToStringForTesting(buildPrivateClickMeasurementFromDatabase(*unattributedScopedStatement.get(), PrivateClickMeasurementAttributionType::Unattributed)));
     }
 
-    auto attributedScoped = this->scopedStatement(m_allAttributedPrivateClickMeasurementStatement, allAttributedPrivateClickMeasurementQuery, "privateClickMeasurementToStringForTesting"_s);
-    if (!attributedScoped) {
+    auto attributedScopedStatement = this->scopedStatement(m_allAttributedPrivateClickMeasurementStatement, allAttributedPrivateClickMeasurementQuery, "privateClickMeasurementToStringForTesting"_s);
+
+    if (!attributedScopedStatement) {
         RELEASE_LOG_ERROR(PrivateClickMeasurement, "%p - Database::privateClickMeasurementToStringForTesting, error message: %" PRIVATE_LOG_STRING, this, m_database.lastErrorMsg());
         ASSERT_NOT_REACHED();
         return { };
     }
 
-    CheckedPtr attributedScopedStatement = attributedScoped.get();
     unsigned attributedNumber = 0;
     while (attributedScopedStatement->step() == SQLITE_ROW) {
         if (!attributedNumber)
@@ -511,25 +477,17 @@ void Database::markAttributedPrivateClickMeasurementsAsExpiredForTesting()
 
     auto transactionScope = beginTransactionIfNecessary();
 
-    auto earliestTimeToSendToSource = m_database.prepareStatement("UPDATE AttributedPrivateClickMeasurement SET earliestTimeToSendToSource = ?"_s);
-    if (!earliestTimeToSendToSource) {
-        RELEASE_LOG_ERROR(PrivateClickMeasurement, "%p - Database::markAttributedPrivateClickMeasurementsAsExpiredForTesting, error message: %" PRIVATE_LOG_STRING, this, m_database.lastErrorMsg());
-        ASSERT_NOT_REACHED();
-    }
-    CheckedRef earliestTimeToSendToSourceStatement = earliestTimeToSendToSource.value();
-    if (earliestTimeToSendToSourceStatement->bindInt(1, expiredTimeToSend.secondsSinceEpoch().value()) != SQLITE_OK
+    auto earliestTimeToSendToSourceStatement = m_database.prepareStatement("UPDATE AttributedPrivateClickMeasurement SET earliestTimeToSendToSource = ?"_s);
+    auto earliestTimeToSendToDestinationStatement = m_database.prepareStatement("UPDATE AttributedPrivateClickMeasurement SET earliestTimeToSendToDestination = null"_s);
+
+    if (!earliestTimeToSendToSourceStatement
+        || earliestTimeToSendToSourceStatement->bindInt(1, expiredTimeToSend.secondsSinceEpoch().value()) != SQLITE_OK
         || earliestTimeToSendToSourceStatement->step() != SQLITE_DONE) {
         RELEASE_LOG_ERROR(PrivateClickMeasurement, "%p - Database::markAttributedPrivateClickMeasurementsAsExpiredForTesting, error message: %" PRIVATE_LOG_STRING, this, m_database.lastErrorMsg());
         ASSERT_NOT_REACHED();
     }
 
-    auto earliestTimeToSendToDestination = m_database.prepareStatement("UPDATE AttributedPrivateClickMeasurement SET earliestTimeToSendToDestination = null"_s);
-    if (!earliestTimeToSendToDestination) {
-        RELEASE_LOG_ERROR(PrivateClickMeasurement, "%p - Database::markAttributedPrivateClickMeasurementsAsExpiredForTesting, error message: %" PRIVATE_LOG_STRING, this, m_database.lastErrorMsg());
-        ASSERT_NOT_REACHED();
-    }
-    CheckedRef earliestTimeToSendToDestinationStatement = earliestTimeToSendToDestination.value();
-    if (earliestTimeToSendToDestinationStatement->step() != SQLITE_DONE) {
+    if (!earliestTimeToSendToDestinationStatement || earliestTimeToSendToDestinationStatement->step() != SQLITE_DONE) {
         RELEASE_LOG_ERROR(PrivateClickMeasurement, "%p - Database::markAttributedPrivateClickMeasurementsAsExpiredForTesting, error message: %" PRIVATE_LOG_STRING, this, m_database.lastErrorMsg());
         ASSERT_NOT_REACHED();
     }
@@ -552,15 +510,10 @@ void Database::clearPrivateClickMeasurement(std::optional<WebCore::RegistrableDo
 
     auto transactionScope = beginTransactionIfNecessary();
 
-    auto clearAllPrivateClickMeasurementScoped = this->scopedStatement(m_clearAllPrivateClickMeasurementStatement, clearAllPrivateClickMeasurementQuery, "clearPrivateClickMeasurement"_s);
+    auto clearAllPrivateClickMeasurementScopedStatement = this->scopedStatement(m_clearAllPrivateClickMeasurementStatement, clearAllPrivateClickMeasurementQuery, "clearPrivateClickMeasurement"_s);
 
-    if (!clearAllPrivateClickMeasurementScoped) {
-        RELEASE_LOG_ERROR(PrivateClickMeasurement, "%p - ResourceLoadStatisticsStore::clearPrivateClickMeasurement clearAllPrivateClickMeasurementScopedStatement, error message: %" PRIVATE_LOG_STRING, this, m_database.lastErrorMsg());
-        ASSERT_NOT_REACHED();
-        return;
-    }
-    CheckedPtr clearAllPrivateClickMeasurementScopedStatement = clearAllPrivateClickMeasurementScoped.get();
-    if (clearAllPrivateClickMeasurementScopedStatement->bindText(1, bindParameter) != SQLITE_OK
+    if (!clearAllPrivateClickMeasurementScopedStatement
+        || clearAllPrivateClickMeasurementScopedStatement->bindText(1, bindParameter) != SQLITE_OK
         || clearAllPrivateClickMeasurementScopedStatement->step() != SQLITE_DONE) {
         RELEASE_LOG_ERROR(PrivateClickMeasurement, "%p - ResourceLoadStatisticsStore::clearPrivateClickMeasurement clearAllPrivateClickMeasurementScopedStatement, error message: %" PRIVATE_LOG_STRING, this, m_database.lastErrorMsg());
         ASSERT_NOT_REACHED();
@@ -573,14 +526,9 @@ void Database::clearExpiredPrivateClickMeasurement()
     auto expirationTimeFrame = WallTime::now() - WebCore::PrivateClickMeasurement::maxAge();
     auto scopedStatement = this->scopedStatement(m_clearExpiredPrivateClickMeasurementStatement, clearExpiredPrivateClickMeasurementQuery, "clearExpiredPrivateClickMeasurement"_s);
 
-    if (!scopedStatement) {
-        RELEASE_LOG_ERROR(PrivateClickMeasurement, "%p - Database::clearExpiredPrivateClickMeasurement, error message: %" PRIVATE_LOG_STRING, this, m_database.lastErrorMsg());
-        ASSERT_NOT_REACHED();
-        return;
-    }
-    CheckedPtr statement = scopedStatement.get();
-    if (statement->bindDouble(1, expirationTimeFrame.secondsSinceEpoch().value()) != SQLITE_OK
-        || statement->step() != SQLITE_DONE) {
+    if (!scopedStatement
+        || scopedStatement->bindDouble(1, expirationTimeFrame.secondsSinceEpoch().value()) != SQLITE_OK
+        || scopedStatement->step() != SQLITE_DONE) {
         RELEASE_LOG_ERROR(PrivateClickMeasurement, "%p - Database::clearExpiredPrivateClickMeasurement, error message: %" PRIVATE_LOG_STRING, this, m_database.lastErrorMsg());
         ASSERT_NOT_REACHED();
     }
@@ -622,14 +570,9 @@ void Database::clearSentAttribution(WebCore::PrivateClickMeasurement&& attributi
     if (destinationEarliestTimeToSend || sourceEarliestTimeToSend)
         return;
 
-    auto clearAttributed = m_database.prepareStatement("DELETE FROM AttributedPrivateClickMeasurement WHERE sourceSiteDomainID = ? AND destinationSiteDomainID = ? AND sourceApplicationBundleID = ?"_s);
-    if (!clearAttributed) {
-        RELEASE_LOG_ERROR(PrivateClickMeasurement, "%p - Database::clearSentAttribution failed to prepare, error message: %" PRIVATE_LOG_STRING, this, m_database.lastErrorMsg());
-        ASSERT_NOT_REACHED();
-        return;
-    }
-    CheckedRef clearAttributedStatement = clearAttributed.value();
-    if (clearAttributedStatement->bindInt(1, *sourceSiteDomainID) != SQLITE_OK
+    auto clearAttributedStatement = m_database.prepareStatement("DELETE FROM AttributedPrivateClickMeasurement WHERE sourceSiteDomainID = ? AND destinationSiteDomainID = ? AND sourceApplicationBundleID = ?"_s);
+    if (!clearAttributedStatement
+        || clearAttributedStatement->bindInt(1, *sourceSiteDomainID) != SQLITE_OK
         || clearAttributedStatement->bindInt(2, *destinationSiteDomainID) != SQLITE_OK
         || clearAttributedStatement->bindText(3, sourceApplicationBundleID) != SQLITE_OK
         || clearAttributedStatement->step() != SQLITE_DONE) {
@@ -643,16 +586,11 @@ void Database::markReportAsSentToDestination(SourceDomainID sourceSiteDomainID, 
     ASSERT(!RunLoop::isMain());
     auto scopedStatement = this->scopedStatement(m_markReportAsSentToDestinationStatement, markReportAsSentToDestinationQuery, "markReportAsSentToDestination"_s);
 
-    if (!scopedStatement) {
-        RELEASE_LOG_ERROR(PrivateClickMeasurement, "Database::markReportAsSentToDestination, error message: %" PUBLIC_LOG_STRING, m_database.lastErrorMsg());
-        ASSERT_NOT_REACHED();
-        return;
-    }
-    CheckedPtr statement = scopedStatement.get();
-    if (statement->bindInt(1, sourceSiteDomainID) != SQLITE_OK
-        || statement->bindInt(2, destinationSiteDomainID) != SQLITE_OK
-        || statement->bindText(3, sourceApplicationBundleID) != SQLITE_OK
-        || statement->step() != SQLITE_DONE) {
+    if (!scopedStatement
+        || scopedStatement->bindInt(1, sourceSiteDomainID) != SQLITE_OK
+        || scopedStatement->bindInt(2, destinationSiteDomainID) != SQLITE_OK
+        || scopedStatement->bindText(3, sourceApplicationBundleID) != SQLITE_OK
+        || scopedStatement->step() != SQLITE_DONE) {
         RELEASE_LOG_ERROR(PrivateClickMeasurement, "Database::markReportAsSentToDestination, error message: %" PUBLIC_LOG_STRING, m_database.lastErrorMsg());
         ASSERT_NOT_REACHED();
     }
@@ -662,16 +600,12 @@ void Database::markReportAsSentToSource(SourceDomainID sourceSiteDomainID, Desti
 {
     ASSERT(!RunLoop::isMain());
     auto scopedStatement = this->scopedStatement(m_markReportAsSentToSourceStatement, markReportAsSentToSourceQuery, "markReportAsSentToSource"_s);
-    if (!scopedStatement) {
-        RELEASE_LOG_ERROR(PrivateClickMeasurement, "Database::markReportAsSentToSource, error message: %" PUBLIC_LOG_STRING, m_database.lastErrorMsg());
-        ASSERT_NOT_REACHED();
-        return;
-    }
-    CheckedPtr statement = scopedStatement.get();
-    if (statement->bindInt(1, sourceSiteDomainID) != SQLITE_OK
-        || statement->bindInt(2, destinationSiteDomainID) != SQLITE_OK
-        || statement->bindText(3, sourceApplicationBundleID) != SQLITE_OK
-        || statement->step() != SQLITE_DONE) {
+
+    if (!scopedStatement
+        || scopedStatement->bindInt(1, sourceSiteDomainID) != SQLITE_OK
+        || scopedStatement->bindInt(2, destinationSiteDomainID) != SQLITE_OK
+        || scopedStatement->bindText(3, sourceApplicationBundleID) != SQLITE_OK
+        || scopedStatement->step() != SQLITE_DONE) {
         RELEASE_LOG_ERROR(PrivateClickMeasurement, "Database::markReportAsSentToSource, error message: %" PUBLIC_LOG_STRING, m_database.lastErrorMsg());
         ASSERT_NOT_REACHED();
     }
@@ -687,16 +621,12 @@ std::pair<std::optional<Database::SourceEarliestTimeToSend>, std::optional<Datab
         return std::make_pair(std::nullopt, std::nullopt);
 
     auto scopedStatement = this->scopedStatement(m_earliestTimesToSendStatement, earliestTimesToSendQuery, "earliestTimesToSend"_s);
-    if (!scopedStatement) {
-        RELEASE_LOG_ERROR(PrivateClickMeasurement, "Database::earliestTimesToSend, error message: %" PUBLIC_LOG_STRING, m_database.lastErrorMsg());
-        ASSERT_NOT_REACHED();
-        return { };
-    }
-    CheckedPtr statement = scopedStatement.get();
-    if (statement->bindInt(1, *sourceSiteDomainID) != SQLITE_OK
-        || statement->bindInt(2, *destinationSiteDomainID) != SQLITE_OK
-        || statement->bindText(3, attribution.sourceApplicationBundleID()) != SQLITE_OK
-        || statement->step() != SQLITE_ROW) {
+
+    if (!scopedStatement
+        || scopedStatement->bindInt(1, *sourceSiteDomainID) != SQLITE_OK
+        || scopedStatement->bindInt(2, *destinationSiteDomainID) != SQLITE_OK
+        || scopedStatement->bindText(3, attribution.sourceApplicationBundleID()) != SQLITE_OK
+        || scopedStatement->step() != SQLITE_ROW) {
         RELEASE_LOG_ERROR(PrivateClickMeasurement, "Database::earliestTimesToSend, error message: %" PUBLIC_LOG_STRING, m_database.lastErrorMsg());
         ASSERT_NOT_REACHED();
         return { };
@@ -706,11 +636,11 @@ std::pair<std::optional<Database::SourceEarliestTimeToSend>, std::optional<Datab
     std::optional<DestinationEarliestTimeToSend> earliestTimeToSendToDestination;
     
     // A value of 0.0 indicates that the report has been sent to the respective site.
-    if (statement->columnDouble(0) > 0.0)
-        earliestTimeToSendToSource = statement->columnDouble(0);
+    if (scopedStatement->columnDouble(0) > 0.0)
+        earliestTimeToSendToSource = scopedStatement->columnDouble(0);
     
-    if (statement->columnDouble(1) > 0.0)
-        earliestTimeToSendToDestination = statement->columnDouble(1);
+    if (scopedStatement->columnDouble(1) > 0.0)
+        earliestTimeToSendToDestination = scopedStatement->columnDouble(1);
     
     return std::make_pair(earliestTimeToSendToSource, earliestTimeToSendToDestination);
 }
@@ -720,22 +650,16 @@ std::optional<Database::DomainID> Database::domainID(const WebCore::RegistrableD
     ASSERT(!RunLoop::isMain());
 
     auto scopedStatement = this->scopedStatement(m_domainIDFromStringStatement, domainIDFromStringQuery, "domainID"_s);
-    if (!scopedStatement) {
-        RELEASE_LOG_ERROR(PrivateClickMeasurement, "%p - Database::domainIDFromString failed. Error message: %" PRIVATE_LOG_STRING, this, m_database.lastErrorMsg());
-        ASSERT_NOT_REACHED();
-        return std::nullopt;
-    }
-    CheckedPtr statement = scopedStatement.get();
-    if (statement->bindText(1, domain.string()) != SQLITE_OK) {
+    if (!scopedStatement || scopedStatement->bindText(1, domain.string()) != SQLITE_OK) {
         RELEASE_LOG_ERROR(PrivateClickMeasurement, "%p - Database::domainIDFromString failed. Error message: %" PRIVATE_LOG_STRING, this, m_database.lastErrorMsg());
         ASSERT_NOT_REACHED();
         return std::nullopt;
     }
     
-    if (statement->step() != SQLITE_ROW)
+    if (scopedStatement->step() != SQLITE_ROW)
         return std::nullopt;
 
-    return statement->columnInt(0);
+    return scopedStatement->columnInt(0);
 }
 
 String Database::getDomainStringFromDomainID(DomainID domainID) const
@@ -744,20 +668,15 @@ String Database::getDomainStringFromDomainID(DomainID domainID) const
     auto result = emptyString();
     
     auto scopedStatement = this->scopedStatement(m_domainStringFromDomainIDStatement, domainStringFromDomainIDQuery, "getDomainStringFromDomainID"_s);
-    if (!scopedStatement) {
-        RELEASE_LOG_ERROR(PrivateClickMeasurement, "%p - Database::getDomainStringFromDomainID. Statement failed to prepare or bind, error message: %" PRIVATE_LOG_STRING, this, m_database.lastErrorMsg());
-        ASSERT_NOT_REACHED();
-        return result;
-    }
-    CheckedPtr statement = scopedStatement.get();
-    if (statement->bindInt(1, domainID) != SQLITE_OK) {
+    if (!scopedStatement
+        || scopedStatement->bindInt(1, domainID) != SQLITE_OK) {
         RELEASE_LOG_ERROR(PrivateClickMeasurement, "%p - Database::getDomainStringFromDomainID. Statement failed to prepare or bind, error message: %" PRIVATE_LOG_STRING, this, m_database.lastErrorMsg());
         ASSERT_NOT_REACHED();
         return result;
     }
     
-    if (statement->step() == SQLITE_ROW)
-        result = statement->columnText(0);
+    if (scopedStatement->step() == SQLITE_ROW)
+        result = m_domainStringFromDomainIDStatement->columnText(0);
     
     return result;
 }
@@ -768,19 +687,14 @@ std::optional<Database::DomainID> Database::ensureDomainID(const WebCore::Regist
         return existingID;
 
     auto scopedStatement = this->scopedStatement(m_insertObservedDomainStatement, insertObservedDomainQuery, "insertObservedDomain"_s);
-    if (!scopedStatement) {
-        RELEASE_LOG_ERROR(PrivateClickMeasurement, "%p - Database::ensureDomainID failed to bind, error message: %" PRIVATE_LOG_STRING, this, m_database.lastErrorMsg());
-        ASSERT_NOT_REACHED();
-        return std::nullopt;
-    }
-    CheckedPtr statement = scopedStatement.get();
-    if (statement->bindText(1, domain.string()) != SQLITE_OK) {
+    if (!scopedStatement
+        || scopedStatement->bindText(1, domain.string()) != SQLITE_OK) {
         RELEASE_LOG_ERROR(PrivateClickMeasurement, "%p - Database::ensureDomainID failed to bind, error message: %" PRIVATE_LOG_STRING, this, m_database.lastErrorMsg());
         ASSERT_NOT_REACHED();
         return std::nullopt;
     }
 
-    if (statement->step() != SQLITE_DONE) {
+    if (scopedStatement->step() != SQLITE_DONE) {
         RELEASE_LOG_ERROR(PrivateClickMeasurement, "%p - Database::ensureDomainID failed to commit, error message: %" PRIVATE_LOG_STRING, this, m_database.lastErrorMsg());
         ASSERT_NOT_REACHED();
         return std::nullopt;

--- a/Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -1,4 +1,5 @@
 NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp
+NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDatabase.cpp
 Platform/IPC/ArgumentCoders.h
 Platform/cocoa/_WKWebViewTextInputNotifications.mm
 Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm


### PR DESCRIPTION
#### 8dc83d321db88b71e255f64cfbddd3d2c5c7fc77
<pre>
Unreviewed, reverting 300874@main (ccac5c735ff6)
<a href="https://bugs.webkit.org/show_bug.cgi?id=300091">https://bugs.webkit.org/show_bug.cgi?id=300091</a>
<a href="https://rdar.apple.com/161886673">rdar://161886673</a>

Will fix this a nicer way.

Reverted change:

    Address safer cpp warnings in PrivateClickMeasurementDatabase.cpp
    <a href="https://bugs.webkit.org/show_bug.cgi?id=300008">https://bugs.webkit.org/show_bug.cgi?id=300008</a>
    300874@main (ccac5c735ff6)

Canonical link: <a href="https://commits.webkit.org/300931@main">https://commits.webkit.org/300931@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a11044ec9a947fd3293d9e1a85821a7be5861a3c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124371 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44051 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34781 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/131211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/76408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44797 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52650 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/131211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/76408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127325 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/35711 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/111239 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/131211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/34647 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/74688 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/105456 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/29621 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/133877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51269 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/39101 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/133877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51668 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/107457 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/133877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/48247 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/26497 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48198 "Failed to checkout and rebase branch from PR 51739") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19528 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51136 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56921 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/50564 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/53923 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/52238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->