### PR TITLE
byteStreamTee should not be observable from JS

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/tee.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/tee.any-expected.txt
@@ -1,6 +1,4 @@
 
-Harness Error (FAIL), message = Unhandled rejection: Type error
-
 PASS ReadableStream teeing with byte source: rs.tee() returns an array of two ReadableStreams
 PASS ReadableStream teeing with byte source: should be able to read one branch to the end without affecting the other
 PASS ReadableStream teeing with byte source: chunks should be cloned for each branch

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/tee.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/tee.any.serviceworker-expected.txt
@@ -1,6 +1,4 @@
 
-Harness Error (FAIL), message = Unhandled rejection: Type error
-
 PASS ReadableStream teeing with byte source: rs.tee() returns an array of two ReadableStreams
 PASS ReadableStream teeing with byte source: should be able to read one branch to the end without affecting the other
 PASS ReadableStream teeing with byte source: chunks should be cloned for each branch

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/tee.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/tee.any.sharedworker-expected.txt
@@ -1,6 +1,4 @@
 
-Harness Error (FAIL), message = Unhandled rejection: Type error
-
 PASS ReadableStream teeing with byte source: rs.tee() returns an array of two ReadableStreams
 PASS ReadableStream teeing with byte source: should be able to read one branch to the end without affecting the other
 PASS ReadableStream teeing with byte source: chunks should be cloned for each branch

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/tee.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-byte-streams/tee.any.worker-expected.txt
@@ -1,6 +1,4 @@
 
-Harness Error (FAIL), message = Unhandled rejection: Type error
-
 PASS ReadableStream teeing with byte source: rs.tee() returns an array of two ReadableStreams
 PASS ReadableStream teeing with byte source: should be able to read one branch to the end without affecting the other
 PASS ReadableStream teeing with byte source: chunks should be cloned for each branch

--- a/LayoutTests/streams/overriding-then-expected.txt
+++ b/LayoutTests/streams/overriding-then-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Object.prototype.then should not allow observing the tee algorithm
+

--- a/LayoutTests/streams/overriding-then.html
+++ b/LayoutTests/streams/overriding-then.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<script src='../resources/testharness.js'></script>
+<script src='../resources/testharnessreport.js'></script>
+<script>
+
+promise_test(async () => {
+  add_completion_callback(() => delete Object.prototype.then);
+  let thenCounter = 0;
+  Object.prototype.then = (onFulfilled) => {
+    ++thenCounter;
+    onFulfilled({ then : null });
+  };
+
+  const a = new ReadableStream({
+    start: (c) => {
+      c.enqueue(new Uint8Array([0]));
+      c.enqueue(new Uint8Array([1]));
+      c.close();
+    },
+    type: "bytes"
+  });
+
+  const [b, c] = a.tee();
+
+  const reader = b.getReader();
+
+  await reader.read();
+
+  assert_equals(thenCounter, 1);
+}, "Object.prototype.then should not allow observing the tee algorithm")
+</script>

--- a/Source/WebCore/Modules/streams/ReadableByteStreamController.h
+++ b/Source/WebCore/Modules/streams/ReadableByteStreamController.h
@@ -27,6 +27,7 @@
 
 #include "ExceptionOr.h"
 #include "JSValueInWrappedObject.h"
+#include "ReadableStreamReadRequest.h"
 #include <wtf/RefCounted.h>
 #include <wtf/Deque.h>
 #include <wtf/WeakPtr.h>
@@ -45,6 +46,7 @@ class DeferredPromise;
 class JSDOMGlobalObject;
 class ReadableStream;
 class ReadableStreamBYOBRequest;
+class ReadableStreamReadRequest;
 class UnderlyingSourceCancelCallback;
 class UnderlyingSourcePullCallback;
 class UnderlyingSourceStartCallback;
@@ -65,10 +67,10 @@ public:
     ReadableStream& stream();
     Ref<ReadableStream> protectedStream();
 
-    void pullInto(JSDOMGlobalObject&, JSC::ArrayBufferView&, size_t, Ref<DeferredPromise>&&);
+    void pullInto(JSDOMGlobalObject&, JSC::ArrayBufferView&, size_t, Ref<ReadableStreamReadIntoRequest>&&);
 
     void runCancelSteps(JSDOMGlobalObject&, JSC::JSValue, Function<void(std::optional<JSC::JSValue>&&)>&&);
-    void runPullSteps(JSDOMGlobalObject&, Ref<DeferredPromise>&&);
+    void runPullSteps(JSDOMGlobalObject&, Ref<ReadableStreamReadRequest>&&);
     void runReleaseSteps();
 
     void storeError(JSDOMGlobalObject&, JSC::JSValue);
@@ -148,7 +150,7 @@ private:
     void respondInReadableState(JSDOMGlobalObject&, size_t, PullIntoDescriptor&);
 
     void processReadRequestsUsingQueue(JSDOMGlobalObject&);
-    void fillReadRequestFromQueue(JSDOMGlobalObject&, Ref<DeferredPromise>&&);
+    void fillReadRequestFromQueue(JSDOMGlobalObject&, Ref<ReadableStreamReadRequest>&&);
     void handleQueueDrain(JSDOMGlobalObject&);
 
     static void handleSourcePromise(DOMPromise&, Callback&&);

--- a/Source/WebCore/Modules/streams/ReadableStream.h
+++ b/Source/WebCore/Modules/streams/ReadableStream.h
@@ -43,6 +43,7 @@ class InternalReadableStream;
 class JSDOMGlobalObject;
 class ReadableStreamBYOBReader;
 class ReadableStreamDefaultReader;
+class ReadableStreamReadRequest;
 class ReadableStreamSource;
 class WritableStream;
 
@@ -105,10 +106,10 @@ public:
     JSC::JSValue storedError(JSDOMGlobalObject&) const;
 
     size_t getNumReadRequests() const;
-    void addReadRequest(Ref<DeferredPromise>&&);
+    void addReadRequest(Ref<ReadableStreamReadRequest>&&);
 
     size_t getNumReadIntoRequests() const;
-    void addReadIntoRequest(Ref<DeferredPromise>&&);
+    void addReadIntoRequest(Ref<ReadableStreamReadIntoRequest>&&);
 
     void error(JSDOMGlobalObject&, JSC::JSValue);
     void pipeTo(JSDOMGlobalObject&, WritableStream&, StreamPipeOptions&&, Ref<DeferredPromise>&&);

--- a/Source/WebCore/Modules/streams/ReadableStreamBYOBReader.h
+++ b/Source/WebCore/Modules/streams/ReadableStreamBYOBReader.h
@@ -40,6 +40,7 @@ namespace WebCore {
 class DOMPromise;
 class DeferredPromise;
 class ReadableStream;
+class ReadableStreamReadIntoRequest;
 
 template<typename IDLType> class DOMPromiseProxy;
 
@@ -53,16 +54,16 @@ public:
         size_t min { 1 };
     };
 
-    void read(JSDOMGlobalObject&, JSC::ArrayBufferView&, ReadOptions, Ref<DeferredPromise>&&);
+    void readForBindings(JSDOMGlobalObject&, JSC::ArrayBufferView&, ReadOptions, Ref<DeferredPromise>&&);
     void releaseLock(JSDOMGlobalObject&);
 
     DOMPromise& closedPromise();
 
     void cancel(JSDOMGlobalObject&, JSC::JSValue, Ref<DeferredPromise>&&);
 
-    Ref<DeferredPromise> takeFirstReadIntoRequest();
+    Ref<ReadableStreamReadIntoRequest> takeFirstReadIntoRequest();
     size_t readIntoRequestsSize() const { return m_readIntoRequests.size(); }
-    void addReadIntoRequest(Ref<DeferredPromise>&&);
+    void addReadIntoRequest(Ref<ReadableStreamReadIntoRequest>&&);
 
     void resolveClosedPromise();
     void rejectClosedPromise(JSC::JSValue);
@@ -71,7 +72,7 @@ public:
     using ClosedCallback = Function<void(JSDOMGlobalObject&, JSC::JSValue)>;
     void onClosedPromiseRejection(ClosedCallback&&);
 
-    void read(JSDOMGlobalObject&, JSC::ArrayBufferView&, size_t, Ref<DeferredPromise>&&);
+    void read(JSDOMGlobalObject&, JSC::ArrayBufferView&, size_t, Ref<ReadableStreamReadIntoRequest>&&);
 
     template<typename Visitor> void visitAdditionalChildren(Visitor&);
 
@@ -88,7 +89,7 @@ private:
     Ref<DOMPromise> m_closedPromise;
     Ref<DeferredPromise> m_closedDeferred;
     RefPtr<ReadableStream> m_stream;
-    Deque<Ref<DeferredPromise>> m_readIntoRequests;
+    Deque<Ref<ReadableStreamReadIntoRequest>> m_readIntoRequests;
 
     ClosedCallback m_closedCallback;
 };

--- a/Source/WebCore/Modules/streams/ReadableStreamBYOBReader.idl
+++ b/Source/WebCore/Modules/streams/ReadableStreamBYOBReader.idl
@@ -37,7 +37,7 @@ dictionary ReadableStreamBYOBReaderReadOptions {
 ] interface ReadableStreamBYOBReader {
     [CallWith=CurrentGlobalObject] constructor(ReadableStream stream);
 
-    [CallWith=CurrentGlobalObject] Promise<ReadableStreamReadResult> read(ArrayBufferView view, optional ReadableStreamBYOBReaderReadOptions options = {});
+    [CallWith=CurrentGlobalObject, ImplementedAs=readForBindings] Promise<ReadableStreamReadResult> read(ArrayBufferView view, optional ReadableStreamBYOBReaderReadOptions options = {});
     [CallWith=CurrentGlobalObject] undefined releaseLock();
 
     // ReadableStreamGenericReader

--- a/Source/WebCore/Modules/streams/ReadableStreamDefaultReader.h
+++ b/Source/WebCore/Modules/streams/ReadableStreamDefaultReader.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "InternalReadableStreamDefaultReader.h"
+#include "ReadableStreamReadRequest.h"
 #include "ScriptWrappable.h"
 #include "WebCoreOpaqueRoot.h"
 #include <JavaScriptCore/Strong.h>
@@ -40,6 +41,7 @@ class DeferredPromise;
 class InternalReadableStreamDefaultReader;
 class JSDOMGlobalObject;
 class ReadableStream;
+class ReadableStreamReadRequest;
 
 class ReadableStreamDefaultReader : public ScriptWrappable, public RefCountedAndCanMakeWeakPtr<ReadableStreamDefaultReader> {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(ReadableStreamDefaultReader);
@@ -51,13 +53,15 @@ public:
     ~ReadableStreamDefaultReader();
 
     DOMPromise& closedPromise() const;
-    void read(JSDOMGlobalObject&, Ref<DeferredPromise>&&);
+    void readForBindings(JSDOMGlobalObject&, Ref<DeferredPromise>&&);
+    void read(JSDOMGlobalObject&, Ref<ReadableStreamReadRequest>&&);
+
     ExceptionOr<void> releaseLock(JSDOMGlobalObject&);
 
     InternalReadableStreamDefaultReader* internalDefaultReader() { return m_internalDefaultReader.get(); }
     size_t getNumReadRequests() const { return m_readRequests.size(); }
-    void addReadRequest(Ref<DeferredPromise>&&);
-    Ref<DeferredPromise> takeFirstReadRequest();
+    void addReadRequest(Ref<ReadableStreamReadRequest>&&);
+    Ref<ReadableStreamReadRequest> takeFirstReadRequest();
 
     void genericCancel(JSDOMGlobalObject&, JSC::JSValue, Ref<DeferredPromise>&&);
 
@@ -82,7 +86,7 @@ private:
     Ref<DOMPromise> m_closedPromise;
     Ref<DeferredPromise> m_closedDeferred;
     RefPtr<ReadableStream> m_stream;
-    Deque<Ref<DeferredPromise>> m_readRequests;
+    Deque<Ref<ReadableStreamReadRequest>> m_readRequests;
 
     const RefPtr<InternalReadableStreamDefaultReader> m_internalDefaultReader;
     ClosedRejectionCallback m_closedRejectionCallback;

--- a/Source/WebCore/Modules/streams/ReadableStreamReadRequest.cpp
+++ b/Source/WebCore/Modules/streams/ReadableStreamReadRequest.cpp
@@ -1,0 +1,146 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ReadableStreamReadRequest.h"
+
+#include "JSDOMExceptionHandling.h"
+#include "JSDOMGuardedObject.h"
+#include "JSDOMPromiseDeferred.h"
+#include "JSReadableStreamReadResult.h"
+#include <JavaScriptCore/CatchScope.h>
+
+namespace WebCore {
+
+class ReadableStreamDefaultReadRequest : public ReadableStreamReadRequest {
+public:
+    static Ref<ReadableStreamDefaultReadRequest> create(Ref<DeferredPromise>&& promise) { return adoptRef(*new ReadableStreamDefaultReadRequest(WTFMove(promise))); }
+    ~ReadableStreamDefaultReadRequest() = default;
+
+private:
+    explicit ReadableStreamDefaultReadRequest(Ref<DeferredPromise>&& promise)
+        : m_promise(WTFMove(promise))
+    {
+    }
+
+    void runChunkSteps(JSC::JSValue value) final
+    {
+        m_promise->resolve<IDLDictionary<ReadableStreamReadResult>>({ value, false });
+    }
+
+    void runCloseSteps() final
+    {
+        m_promise->resolve<IDLDictionary<ReadableStreamReadResult>>({ JSC::jsUndefined(), true });
+    }
+
+    void runErrorSteps(JSC::JSValue value) final
+    {
+        m_promise->rejectWithCallback([&](auto&) {
+            return value;
+        });
+    }
+
+    void runErrorSteps(Exception&& exception) final
+    {
+        m_promise->reject(WTFMove(exception));
+    }
+
+    JSDOMGlobalObject* globalObject() final
+    {
+        return m_promise->globalObject();
+    }
+
+    const Ref<DeferredPromise> m_promise;
+};
+
+class ReadableStreamDefaultReadIntoRequest : public ReadableStreamReadIntoRequest {
+public:
+    static Ref<ReadableStreamDefaultReadIntoRequest> create(Ref<DeferredPromise>&& promise) { return adoptRef(*new ReadableStreamDefaultReadIntoRequest(WTFMove(promise))); }
+    ~ReadableStreamDefaultReadIntoRequest() = default;
+
+private:
+    explicit ReadableStreamDefaultReadIntoRequest(Ref<DeferredPromise>&& promise)
+        : m_promise(WTFMove(promise))
+    {
+    }
+
+    void runChunkSteps(JSC::JSValue value) final
+    {
+        m_promise->resolve<IDLDictionary<ReadableStreamReadResult>>({ value, false });
+    }
+
+    void runCloseSteps(JSC::JSValue value) final
+    {
+        m_promise->resolve<IDLDictionary<ReadableStreamReadResult>>({ value, true });
+    }
+
+    void runErrorSteps(JSC::JSValue value) final
+    {
+        m_promise->rejectWithCallback([&](auto&) {
+            return value;
+        });
+    }
+
+    void runErrorSteps(Exception&& exception) final
+    {
+        m_promise->reject(WTFMove(exception));
+    }
+
+    JSDOMGlobalObject* globalObject() final
+    {
+        return m_promise->globalObject();
+    }
+
+    const Ref<DeferredPromise> m_promise;
+};
+
+void ReadableStreamReadRequestBase::runErrorSteps(Exception&& exception)
+{
+    auto* globalObject = this->globalObject();
+    if (!globalObject)
+        return;
+
+    Ref vm = globalObject->vm();
+    JSC::JSLockHolder locker(vm);
+    auto scope = DECLARE_CATCH_SCOPE(vm);
+    auto jsException = createDOMException(*globalObject, WTFMove(exception));
+    if (scope.exception()) [[unlikely]] {
+        scope.clearException();
+        return;
+    }
+    runErrorSteps(jsException);
+}
+
+Ref<ReadableStreamReadRequest> ReadableStreamReadRequest::create(Ref<DeferredPromise>&& promise)
+{
+    return ReadableStreamDefaultReadRequest::create(WTFMove(promise));
+}
+
+Ref<ReadableStreamReadIntoRequest> ReadableStreamReadIntoRequest::create(Ref<DeferredPromise>&& promise)
+{
+    return ReadableStreamDefaultReadIntoRequest::create(WTFMove(promise));
+}
+
+} // namespace WebCore

--- a/Source/WebCore/Modules/streams/ReadableStreamReadRequest.h
+++ b/Source/WebCore/Modules/streams/ReadableStreamReadRequest.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/RefCounted.h>
+
+namespace JSC {
+class JSValue;
+}
+
+namespace WebCore {
+
+class DeferredPromise;
+class Exception;
+class JSDOMGlobalObject;
+
+class ReadableStreamReadRequestBase : public RefCounted<ReadableStreamReadRequestBase> {
+public:
+    virtual ~ReadableStreamReadRequestBase() = default;
+    virtual void runChunkSteps(JSC::JSValue) = 0;
+    virtual void runErrorSteps(JSC::JSValue) = 0;
+    virtual void runErrorSteps(Exception&&);
+
+    virtual JSDOMGlobalObject* globalObject() = 0;
+};
+
+class ReadableStreamReadRequest : public ReadableStreamReadRequestBase {
+public:
+    static Ref<ReadableStreamReadRequest> create(Ref<DeferredPromise>&&);
+
+    virtual void runCloseSteps() = 0;
+};
+
+class ReadableStreamReadIntoRequest : public ReadableStreamReadRequestBase {
+public:
+    static Ref<ReadableStreamReadIntoRequest> create(Ref<DeferredPromise>&&);
+
+    virtual void runCloseSteps(JSC::JSValue) = 0;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -381,6 +381,7 @@ Modules/streams/ReadableStream.cpp
 Modules/streams/ReadableStreamBYOBReader.cpp
 Modules/streams/ReadableStreamBYOBRequest.cpp
 Modules/streams/ReadableStreamDefaultReader.cpp
+Modules/streams/ReadableStreamReadRequest.cpp
 Modules/streams/ReadableStreamSink.cpp
 Modules/streams/ReadableStreamSource.cpp
 Modules/streams/StreamTeeUtilities.cpp


### PR DESCRIPTION
#### e9225c70f71ec8804d155b8c905cc77b44aa5ae1
<pre>
byteStreamTee should not be observable from JS
<a href="https://rdar.apple.com/161883428">rdar://161883428</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=300087">https://bugs.webkit.org/show_bug.cgi?id=300087</a>

Reviewed by Chris Dumez.

We were previously relying on promise based reads for byteStreamTee.
But this is observable to JS via Object.prototype.then.
To prevent this, we introduce read requests as defined in the specification.
The read request (ReadRequest for default reading and ReadIntoRequest for byob reading) will be used for both the JS read methods and byteStreamTee.

For the JS read methods, the read requests encapsulate a promise and resolve/reject it as defined in the spec.
See <a href="https://streams.spec.whatwg.org/#default-reader-read">https://streams.spec.whatwg.org/#default-reader-read</a> and <a href="https://streams.spec.whatwg.org/#byob-reader-read.">https://streams.spec.whatwg.org/#byob-reader-read.</a>

For byteStreamTee, the read requests will be used to fuel the teed streams as per <a href="https://streams.spec.whatwg.org/#abstract-opdef-readablebytestreamtee.">https://streams.spec.whatwg.org/#abstract-opdef-readablebytestreamtee.</a>

In byteStreamTee, we need to queue a micro task, which was done by the previous promise-based mechanism.
To do so, we make StreamTeeState a ContextDestructionObserver, which allows us to get to the event loop.
We also make use of ContextDestructionObserver to clean-up StreamTeeState whenver its context is destroyed, which can help for potential ref cycles.

Test: streams/overriding-then.html
Canonical link: <a href="https://commits.webkit.org/300941@main">https://commits.webkit.org/300941@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/73cb8b428335d0bb3e97059cb94f4053c7a0634f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124394 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44074 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34804 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131233 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/76424 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/126271 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44820 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52673 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94626 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/76424 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5ce6df00-d8c4-4dcd-8bd5-50b75f107c2e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127348 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35722 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111267 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75212 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/823bc2b4-fe4f-4cc5-81e9-f15628207222) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34663 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29421 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74710 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105481 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29641 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133898 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51292 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39125 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/103113 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51691 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107477 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102900 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26188 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48269 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26517 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48229 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51159 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56951 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50582 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53942 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52257 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->