### PR TITLE
[CoordinatedGraphics] Compute the layers tile size instead of using a fixed value

### DIFF
--- a/LayoutTests/compositing/clipping/border-radius-async-overflow-non-stacking.html
+++ b/LayoutTests/compositing/clipping/border-radius-async-overflow-non-stacking.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
 <html>
 <head>
-    <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-400" />
+    <meta name="fuzzy" content="maxDifference=0-42; totalPixels=0-400" />
     <style>
         .scroller {
             margin: 10px;

--- a/LayoutTests/compositing/clipping/border-radius-async-overflow-stacking.html
+++ b/LayoutTests/compositing/clipping/border-radius-async-overflow-stacking.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
 <html>
 <head>
+    <meta name="fuzzy" content="maxDifference=0-42; totalPixels=0-47" />
     <style>
         .scroller {
             margin: 10px;

--- a/LayoutTests/fast/text/multiple-text-shadow-overflow-layout-rect.html
+++ b/LayoutTests/fast/text/multiple-text-shadow-overflow-layout-rect.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+<meta name="fuzzy" content="maxDifference=0-7; totalPixels=0-74" />
 <style>
 @font-face {
 	font-family: fontoverfowlayoutrect;

--- a/LayoutTests/imported/mozilla/svg/pattern-transformed-01.svg
+++ b/LayoutTests/imported/mozilla/svg/pattern-transformed-01.svg
@@ -4,6 +4,8 @@
 -->
 <svg width="800" height="600" xmlns="http://www.w3.org/2000/svg">
 
+  <meta name="fuzzy" content="maxDifference=0-5; totalPixels=0-7" />
+
   <!-- From https://bugzilla.mozilla.org/show_bug.cgi?id=773595 -->
 
   <pattern x="0" y="0" width="1" height="1" id="pattern">

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/css-box-shadow-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/css-box-shadow-001.html
@@ -6,7 +6,7 @@
     <link rel="help" href="http://www.w3.org/TR/css3-background/#the-box-shadow">
     <link rel="help" href="http://www.w3.org/TR/css3-background/#the-border-radius">
     <link rel="match" href="reference/css-box-shadow-ref-001.html">
-    <meta name="fuzzy" content="maxDifference=0-56; totalPixels=0-250">
+    <meta name="fuzzy" content="maxDifference=0-68; totalPixels=0-250">
     <style type="text/css">
 		.greenSquare-shadow{
             position: absolute;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/outline-028.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/outline-028.html
@@ -6,6 +6,7 @@
 <link rel="match" href="reference/outline-028-ref.html">
 <meta name="assert" content="Test checks that 'auto' outline works as expected in an element with floatted descendants with different margins and paddings.">
 <meta name="flags" content="ahem">
+<meta name="fuzzy" content="maxDifference=0-2; totalPixels=0-4" />
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
 .outline-container {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-clip-rect-zoom.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-clip-rect-zoom.html
@@ -4,7 +4,7 @@
 <link rel="author" href="mailto:masonf@chromium.org">
 <link rel="help" href="https://drafts.fxtf.org/filter-effects-2/#BackdropFilterProperty">
 <link rel="match"  href="backdrop-filter-clip-rect-zoom-ref.html">
-<meta name="fuzzy" content="0-1;0-3">
+<meta name="fuzzy" content="0-56;0-169">
 
 <div class="box"></div>
 <div class="navbar">

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/painting/reftests/marker-path-001.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/painting/reftests/marker-path-001.svg
@@ -11,7 +11,7 @@
     <html:link rel="help"
           href="https://www.w3.org/TR/SVG2/painting.html#Markers"/>
     <html:link rel="match"  href="marker-path-001-ref.svg" />
-    <html:meta name="fuzzy" content="0-8;0-8"/>
+    <html:meta name="fuzzy" content="0-15;0-49"/>
   </g>
 
   <defs>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -3461,6 +3461,9 @@ webkit.org/b/98925 fast/viewport/viewport-legacy-ordering-6.html [ Skip ]
 webkit.org/b/98925 fast/viewport/viewport-legacy-xhtmlmp-remove-and-add.html [ Skip ]
 webkit.org/b/98925 fast/viewport/viewport-legacy-xhtmlmp.html [ Skip ]
 
+# Expects a particular fixed size ofr layer tiles.
+fast/images/low-memory-decode.html [ Skip ]
+
 #////////////////////////////////////////////////////////////////////////////////////////
 # End of UNSUPPORTED tests.
 #////////////////////////////////////////////////////////////////////////////////////////

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -1627,7 +1627,6 @@ http/tests/css/css-masking/mask-inline-svg-image.html [ ImageOnlyFailure ]
 http/tests/css/css-masking/mask-inline-svg-mask.html [ ImageOnlyFailure ]
 
 imported/w3c/web-platform-tests/svg/geometry/reftests/circle-003.svg [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/svg/painting/reftests/marker-path-001.svg [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/painting/reftests/marker-path-011.svg [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/fonts/font-size-adjust-scale-text.svg [ ImageOnlyFailure ]
 

--- a/LayoutTests/svg/as-image/svg-as-image-pattern-scale.html
+++ b/LayoutTests/svg/as-image/svg-as-image-pattern-scale.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<meta name="fuzzy" content="maxDifference=0-10; totalPixels=0-963">
+<meta name="fuzzy" content="maxDifference=0-83; totalPixels=0-963">
 <style>
     body {
         zoom: 800%;

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.h
@@ -38,10 +38,9 @@ class GraphicsLayer;
 class CoordinatedBackingStoreProxy final : public ThreadSafeRefCounted<CoordinatedBackingStoreProxy> {
     WTF_MAKE_TZONE_ALLOCATED(CoordinatedBackingStoreProxy);
 public:
-    static Ref<CoordinatedBackingStoreProxy> create(float contentsScale, std::optional<IntSize> tileSize = std::nullopt);
-    ~CoordinatedBackingStoreProxy();
+    static Ref<CoordinatedBackingStoreProxy> create();
+    ~CoordinatedBackingStoreProxy() = default;
 
-    bool setContentsScale(float);
     const IntRect& coverRect() const { return m_coverRect; }
 
     class Update {
@@ -77,7 +76,7 @@ public:
         TilesPending = 1 << 1,
         TilesChanged = 1 << 2
     };
-    OptionSet<UpdateResult> updateIfNeeded(const IntRect& unscaledVisibleRect, const IntRect& unscaledContentsRect, bool shouldCreateAndDestroyTiles, const Vector<IntRect, 1>&, CoordinatedPlatformLayer&);
+    OptionSet<UpdateResult> updateIfNeeded(const IntRect& unscaledVisibleRect, const IntRect& unscaledContentsRect, float contentsScale, bool shouldCreateAndDestroyTiles, const Vector<IntRect, 1>&, CoordinatedPlatformLayer&);
     Update takePendingUpdate();
 
     void waitUntilPaintingComplete();
@@ -126,13 +125,12 @@ private:
         IntRect dirtyRect;
     };
 
-    CoordinatedBackingStoreProxy(float contentsScale, const IntSize& tileSize);
+    CoordinatedBackingStoreProxy() = default;
 
-    void reset();
     void invalidateRegion(const Vector<IntRect, 1>&);
-    void createOrDestroyTiles(const IntRect& visibleRect, const IntRect& scaledContentsRect, float coverAreaMultiplier, Vector<uint32_t>& tilesToCreate, Vector<uint32_t>& tilesToRemove);
+    void createOrDestroyTiles(const IntRect& unscaledVisibleRect, const IntRect& unscaledContentsRect, const IntSize& unscaledViewportSize, float contentsScale, int maxTextureSize, Vector<uint32_t>& tilesToCreate, Vector<uint32_t>& tilesToRemove);
+    IntSize computeTileSize(const IntSize& viewportSize, int maxTextureSize) const;
     std::pair<IntRect, IntRect> computeCoverAndKeepRect() const;
-
     void adjustForContentsRect(IntRect&) const;
 
     IntRect mapToContents(const IntRect&) const;

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
@@ -76,6 +76,7 @@ public:
         virtual bool isCompositionRequiredOrOngoing() const = 0;
         virtual void requestComposition() = 0;
         virtual RunLoop* compositingRunLoop() const = 0;
+        virtual int maxTextureSize() const = 0;
     };
 
     static Ref<CoordinatedPlatformLayer> create();
@@ -123,6 +124,7 @@ public:
     void didUpdateLayerTransform();
 
     void setVisibleRect(const FloatRect&);
+    const FloatRect& visibleRect() const;
     void setTransformedVisibleRect(IntRect&& visibleRect, IntRect&& visibleRectIncludingFuture);
 
 #if ENABLE(SCROLLING_THREAD)
@@ -181,6 +183,7 @@ public:
     bool isCompositionRequiredOrOngoing() const;
     void requestComposition();
     RunLoop* compositingRunLoop() const;
+    int maxTextureSize() const;
 
     Ref<CoordinatedTileBuffer> paint(const IntRect&);
 #if USE(SKIA)

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
@@ -409,6 +409,11 @@ RunLoop* LayerTreeHost::compositingRunLoop() const
     return m_compositor->runLoop();
 }
 
+int LayerTreeHost::maxTextureSize() const
+{
+    return m_compositor->maxTextureSize();
+}
+
 #if USE(CAIRO)
 Cairo::PaintingEngine& LayerTreeHost::paintingEngine()
 {

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h
@@ -141,6 +141,7 @@ private:
     bool isCompositionRequiredOrOngoing() const override;
     void requestComposition() override;
     RunLoop* compositingRunLoop() const override;
+    int maxTextureSize() const override;
 
     // GraphicsLayerFactory
     Ref<WebCore::GraphicsLayer> createGraphicsLayer(WebCore::GraphicsLayer::Type, WebCore::GraphicsLayerClient&) override;

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostPlayStation.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostPlayStation.cpp
@@ -422,6 +422,11 @@ RunLoop* LayerTreeHost::compositingRunLoop() const
     return m_compositor->runLoop();
 }
 
+int LayerTreeHost::maxTextureSize() const
+{
+    return m_compositor->maxTextureSize();
+}
+
 #if USE(CAIRO)
 Cairo::PaintingEngine& LayerTreeHost::paintingEngine()
 {

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostPlayStation.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostPlayStation.h
@@ -152,6 +152,7 @@ private:
     bool isCompositionRequiredOrOngoing() const override;
     void requestComposition() override;
     RunLoop* compositingRunLoop() const override;
+    int maxTextureSize() const override;
 
     // GraphicsLayerFactory
     Ref<WebCore::GraphicsLayer> createGraphicsLayer(WebCore::GraphicsLayer::Type, WebCore::GraphicsLayerClient&) override;

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp
@@ -97,6 +97,7 @@ ThreadedCompositor::ThreadedCompositor(LayerTreeHost& layerTreeHost)
         if (m_context && m_context->makeContextCurrent()) {
             if (!nativeSurfaceHandle)
                 m_flipY = !m_flipY;
+            glGetIntegerv(GL_MAX_TEXTURE_SIZE, &m_maxTextureSize);
         }
     });
 }

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.h
@@ -60,6 +60,7 @@ public:
     virtual ~ThreadedCompositor();
 
     uint64_t surfaceID() const;
+    int maxTextureSize() const { return m_maxTextureSize; }
 
     void backgroundColorDidChange();
 #if PLATFORM(WPE) && USE(GBM) && ENABLE(WPE_PLATFORM)
@@ -109,6 +110,7 @@ private:
     std::unique_ptr<WebCore::GLContext> m_context;
 
     bool m_flipY { false };
+    int m_maxTextureSize { 0 };
     std::atomic<unsigned> m_suspendedCount { 0 };
 
     std::unique_ptr<CompositingRunLoop> m_compositingRunLoop;

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositorPlayStation.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositorPlayStation.cpp
@@ -122,6 +122,7 @@ ThreadedCompositor::ThreadedCompositor(LayerTreeHost& layerTreeHost, ThreadedDis
         if (m_context && m_context->makeContextCurrent()) {
             if (!nativeSurfaceHandle)
                 m_flipY = !m_flipY;
+            glGetIntegerv(GL_MAX_TEXTURE_SIZE, &m_maxTextureSize);
         }
     });
 }

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositorPlayStation.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositorPlayStation.h
@@ -68,6 +68,7 @@ public:
     virtual ~ThreadedCompositor();
 
     uint64_t surfaceID() const;
+    int maxTextureSize() const { return m_maxTextureSize; }
 
     void backgroundColorDidChange();
 
@@ -128,6 +129,7 @@ private:
     std::unique_ptr<WebCore::GLContext> m_context;
 
     bool m_flipY { false };
+    int m_maxTextureSize { 0 };
     std::atomic<unsigned> m_suspendedCount { 0 };
 
     std::unique_ptr<CompositingRunLoop> m_compositingRunLoop;


### PR DESCRIPTION
#### 51a8c38ce20633b24ff72b87c2e3429e7cfc69f5
<pre>
[CoordinatedGraphics] Compute the layers tile size instead of using a fixed value
<a href="https://bugs.webkit.org/show_bug.cgi?id=300093">https://bugs.webkit.org/show_bug.cgi?id=300093</a>

Reviewed by Miguel Gomez.

This way we can use a different logic depending on whether we are using
CPU or GPU rendering for the tiles. In the case of CPU rendering we use
smaller tiles of 256x256 by default, while for GPU rendering we use the
visible size for the width and 1/4 of the visible height, similar to what
chromium does.

Canonical link: <a href="https://commits.webkit.org/301398@main">https://commits.webkit.org/301398@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4e19011dfc78ca3c3ee3abf97ae178d6ed033f03

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125694 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45356 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36105 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132559 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77578 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127565 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46040 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53914 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95759 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/63878 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128642 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36806 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112399 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76251 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35708 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30583 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76027 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106584 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30798 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135234 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52484 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40244 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104224 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52931 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108611 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103952 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49312 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27625 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49723 "Hash 4e19011d for PR 51742 does not build (failure)") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19693 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52379 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58185 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51727 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55078 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53423 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->