### PR TITLE
Address safer CPP warnings in UI process classes

### DIFF
--- a/Source/WebKit/Platform/mac/MenuUtilities.h
+++ b/Source/WebKit/Platform/mac/MenuUtilities.h
@@ -37,7 +37,7 @@ namespace WebKit {
 #if ENABLE(TELEPHONE_NUMBER_DETECTION)
 NSMenuItem *menuItemForTelephoneNumber(const String& telephoneNumber);
 RetainPtr<NSMenu> menuForTelephoneNumber(const String& telephoneNumber, NSView *webView, const WebCore::IntRect&);
-NSString *menuItemTitleForTelephoneNumberGroup();
+RetainPtr<NSString> menuItemTitleForTelephoneNumberGroup();
 #endif
 
 #if ENABLE(CONTEXT_MENU_IMAGES_ON_MAC)

--- a/Source/WebKit/Platform/mac/MenuUtilities.mm
+++ b/Source/WebKit/Platform/mac/MenuUtilities.mm
@@ -89,7 +89,7 @@ using namespace WebCore;
 
 #if ENABLE(TELEPHONE_NUMBER_DETECTION)
 
-NSString *menuItemTitleForTelephoneNumberGroup()
+RetainPtr<NSString> menuItemTitleForTelephoneNumberGroup()
 {
     return [getTUCallClassSingleton() supplementalDialTelephonyCallString];
 }

--- a/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
@@ -83,7 +83,6 @@ UIProcess/mac/SecItemShimProxy.cpp
 UIProcess/mac/WKFullScreenWindowController.mm
 UIProcess/mac/WKImmediateActionController.mm
 UIProcess/mac/WKTextAnimationManagerMac.mm
-UIProcess/mac/WebContextMenuProxyMac.mm
 UIProcess/mac/WebDataListSuggestionsDropdownMac.mm
 UIProcess/mac/WebPopupMenuProxyMac.mm
 UIProcess/mac/WebViewImpl.mm

--- a/Source/WebKit/UIProcess/API/APIAttachment.h
+++ b/Source/WebKit/UIProcess/API/APIAttachment.h
@@ -90,7 +90,7 @@ public:
 
     RefPtr<WebCore::FragmentedSharedBuffer> associatedElementData() const;
 #if PLATFORM(COCOA)
-    NSData *associatedElementNSData() const;
+    RetainPtr<NSData> associatedElementNSData() const;
 #endif
     std::optional<uint64_t> fileSizeForDisplay() const;
 

--- a/Source/WebKit/UIProcess/API/Cocoa/APIAttachmentCocoa.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/APIAttachmentCocoa.mm
@@ -161,7 +161,7 @@ RefPtr<WebCore::FragmentedSharedBuffer> Attachment::associatedElementData() cons
     return WebCore::SharedBuffer::create(data);
 }
 
-NSData *Attachment::associatedElementNSData() const
+RetainPtr<NSData> Attachment::associatedElementNSData() const
 {
     Locker locker { m_fileWrapperLock };
 

--- a/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
@@ -272,7 +272,7 @@ void WebContextMenuProxyMac::setupServicesMenu()
     RetainPtr<NSItemProvider> itemProvider;
     if (hasControlledImage) {
         if (attachment)
-            itemProvider = adoptNS([[NSItemProvider alloc] initWithItem:attachment->associatedElementNSData() typeIdentifier:attachment->utiType().createNSString().get()]);
+            itemProvider = adoptNS([[NSItemProvider alloc] initWithItem:attachment->associatedElementNSData().get() typeIdentifier:attachment->utiType().createNSString().get()]);
         else {
             RefPtr<ShareableBitmap> image = m_context.controlledImage();
             if (!image)
@@ -287,7 +287,7 @@ void WebContextMenuProxyMac::setupServicesMenu()
     } else if (RetainPtr selection = m_context.controlledSelection().nsAttributedString())
         items = @[ selection.get() ];
     else if (isPDFAttachment) {
-        itemProvider = adoptNS([[NSItemProvider alloc] initWithItem:attachment->associatedElementNSData() typeIdentifier:attachment->utiType().createNSString().get()]);
+        itemProvider = adoptNS([[NSItemProvider alloc] initWithItem:attachment->associatedElementNSData().get() typeIdentifier:attachment->utiType().createNSString().get()]);
         items = @[ itemProvider.get() ];
     } else {
         LOG_ERROR("No service controlled item represented in the context");
@@ -331,7 +331,7 @@ void WebContextMenuProxyMac::setupServicesMenu()
         else
             m_menu = adoptNS([[NSMenu alloc] init]);
         int itemPosition = 0;
-        auto groupEntry = adoptNS([[NSMenuItem alloc] initWithTitle:menuItemTitleForTelephoneNumberGroup() action:nil keyEquivalent:@""]);
+        auto groupEntry = adoptNS([[NSMenuItem alloc] initWithTitle:menuItemTitleForTelephoneNumberGroup().get() action:nil keyEquivalent:@""]);
         [groupEntry setEnabled:NO];
         [m_menu insertItem:groupEntry.get() atIndex:itemPosition++];
         for (auto& menuItem : telephoneNumberMenuItems)
@@ -581,7 +581,7 @@ bool WebContextMenuProxyMac::showAfterPostProcessingContextData()
     return false;
 }
 
-static NSString *menuItemIdentifier(const WebCore::ContextMenuAction action)
+static RetainPtr<NSString> menuItemIdentifier(const WebCore::ContextMenuAction action)
 {
     switch (action) {
     case ContextMenuItemTagCopy:
@@ -738,7 +738,7 @@ static RetainPtr<NSMenuItem> createMenuActionItem(const WebContextMenuItemData& 
     [menuItem setState:item.checked() ? NSControlStateValueOn : NSControlStateValueOff];
     [menuItem setIndentationLevel:item.indentationLevel()];
     [menuItem setTarget:[WKMenuTarget sharedMenuTarget]];
-    [menuItem setIdentifier:menuItemIdentifier(item.action())];
+    [menuItem setIdentifier:menuItemIdentifier(item.action()).get()];
 
     if (item.userData())
         [menuItem setRepresentedObject:adoptNS([[WKUserDataWrapper alloc] initWithUserData:item.protectedUserData().get()]).get()];
@@ -934,7 +934,7 @@ void WebContextMenuProxyMac::getContextMenuItem(const WebContextMenuItemData& it
             [menuItem setEnabled:enabled];
             [menuItem setIndentationLevel:indentationLevel];
             [menuItem setSubmenu:menu];
-            [menuItem setIdentifier:menuItemIdentifier(action)];
+            [menuItem setIdentifier:menuItemIdentifier(action).get()];
 #if ENABLE(CONTEXT_MENU_IMAGES_ON_MAC)
             updateMenuItemImage(menuItem.get(), action, title);
 #endif
@@ -1018,7 +1018,7 @@ void WebContextMenuProxyMac::useContextMenuItems(Vector<Ref<WebContextMenuItem>>
 
 NSWindow *WebContextMenuProxyMac::window() const
 {
-    return [m_webView window];
+    return [m_webView.get() window];
 }
 
 NSMenu *WebContextMenuProxyMac::platformMenu() const

--- a/Source/WebKit/UIProcess/mac/WebPopupMenuProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebPopupMenuProxyMac.mm
@@ -161,7 +161,7 @@ void WebPopupMenuProxyMac::showPopupMenu(const IntRect& rect, TextDirection text
     }
     RetainPtr<NSView> dummyView = adoptNS([[NSView alloc] initWithFrame:rect]);
     [dummyView.get() setUserInterfaceLayoutDirection:textDirection == TextDirection::LTR ? NSUserInterfaceLayoutDirectionLeftToRight : NSUserInterfaceLayoutDirectionRightToLeft];
-    [m_webView addSubview:dummyView.get()];
+    [m_webView.get() addSubview:dummyView.get()];
     location = [dummyView convertPoint:location fromView:m_webView.get().get()];
 
     NSControlSize controlSize;
@@ -214,7 +214,7 @@ void WebPopupMenuProxyMac::showPopupMenu(const IntRect& rect, TextDirection text
 
     [NSApp postEvent:fakeEvent.get() atStart:YES];
     fakeEvent = [NSEvent mouseEventWithType:NSEventTypeMouseMoved
-                                   location:[[m_webView window] convertPointFromScreen:[NSEvent mouseLocation]]
+                                   location:[[m_webView.get() window] convertPointFromScreen:[NSEvent mouseLocation]]
                               modifierFlags:[initiatingNSEvent modifierFlags]
                                   timestamp:[initiatingNSEvent timestamp]
                                windowNumber:[initiatingNSEvent windowNumber]


### PR DESCRIPTION
#### a06b885fae5414b9a76f60b9d9e45367404c6b6a
<pre>
Address safer CPP warnings in UI process classes
<a href="https://bugs.webkit.org/show_bug.cgi?id=300101">https://bugs.webkit.org/show_bug.cgi?id=300101</a>

Reviewed by Ryosuke Niwa.

Files that were not unskipped have false positives that
are currently being addressed in the checker.

* Source/WebKit/Platform/mac/MenuUtilities.h:
* Source/WebKit/Platform/mac/MenuUtilities.mm:
(WebKit::menuItemTitleForTelephoneNumberGroup):
* Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations:
* Source/WebKit/UIProcess/API/APIAttachment.h:
* Source/WebKit/UIProcess/API/Cocoa/APIAttachmentCocoa.mm:
(API::Attachment::associatedElementNSData const):
* Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm:
(WebKit::WebContextMenuProxyMac::setupServicesMenu):
(WebKit::menuItemIdentifier):
(WebKit::createMenuActionItem):
(WebKit::WebContextMenuProxyMac::getContextMenuItem):
(WebKit::WebContextMenuProxyMac::window const):
* Source/WebKit/UIProcess/mac/WebPopupMenuProxyMac.mm:
(WebKit::WebPopupMenuProxyMac::showPopupMenu):

Canonical link: <a href="https://commits.webkit.org/300954@main">https://commits.webkit.org/300954@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e0a7fab467e8aab7f6e076f8b8107035a56192b6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124399 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44079 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34809 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131238 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76426 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44825 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52678 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94635 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62778 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127353 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35728 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111265 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75217 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34668 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74715 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105483 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29647 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133903 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51297 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39133 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103126 "Failed to checkout and rebase branch from PR 51750") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51696 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107483 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102903 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26202 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48272 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26523 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48235 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51164 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56955 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50586 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53947 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52265 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->