### PR TITLE
More safer CPP fixes in the UI process

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations
@@ -25,6 +25,4 @@ UIProcess/API/Cocoa/_WKTextManipulationToken.h
 UIProcess/API/Cocoa/_WKWebPushAction.mm
 UIProcess/API/Cocoa/_WKWebPushDaemonConnection.h
 UIProcess/API/Cocoa/_WKWebPushMessage.h
-UIProcess/mac/WKImmediateActionController.h
-UIProcess/mac/WKTextFinderClient.mm
 UIProcess/mac/WebViewImpl.mm

--- a/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
@@ -74,7 +74,6 @@ UIProcess/mac/DisplayCaptureSessionManager.mm
 UIProcess/mac/PageClientImplMac.mm
 UIProcess/mac/SecItemShimProxy.cpp
 UIProcess/mac/WKFullScreenWindowController.mm
-UIProcess/mac/WKImmediateActionController.mm
 UIProcess/mac/WKTextAnimationManagerMac.mm
 UIProcess/mac/WebDataListSuggestionsDropdownMac.mm
 UIProcess/mac/WebPopupMenuProxyMac.mm

--- a/Source/WebKit/UIProcess/mac/WKImmediateActionController.h
+++ b/Source/WebKit/UIProcess/mac/WKImmediateActionController.h
@@ -56,7 +56,7 @@ enum class ImmediateActionState {
 @interface WKImmediateActionController : NSObject <NSImmediateActionGestureRecognizerDelegate> {
 @private
     WeakPtr<WebKit::WebPageProxy> _page;
-    NSView *_view;
+    WeakObjCPtr<NSView> _view;
     WeakPtr<WebKit::WebViewImpl> _viewImpl;
 
     WebKit::ImmediateActionState _state;

--- a/Source/WebKit/UIProcess/mac/WKTextFinderClient.mm
+++ b/Source/WebKit/UIProcess/mac/WKTextFinderClient.mm
@@ -114,8 +114,8 @@ private:
 @end
 
 @implementation WKTextFinderMatch {
-    __weak WKTextFinderClient *_client;
-    __weak NSView *_view;
+    WeakObjCPtr<WKTextFinderClient> _client;
+    WeakObjCPtr<NSView> _view;
     RetainPtr<NSArray> _rects;
     unsigned _index;
 }
@@ -138,7 +138,7 @@ private:
 - (NSView *)containingView
 {
     // To maintain binary compatibility, this is weakly held even though `containingView` is marked `retain`.
-    return _view;
+    return _view.getAutoreleased();
 }
 
 - (NSArray *)textRects
@@ -148,7 +148,7 @@ private:
 
 - (void)generateTextImage:(void (^)(NSImage *generatedImage))completionHandler
 {
-    RetainPtr strongClient = _client;
+    RetainPtr strongClient = _client.get();
     if (!strongClient)
         return completionHandler(nil);
 
@@ -164,7 +164,7 @@ private:
 
 @implementation WKTextFinderClient {
     WeakPtr<WebKit::WebPageProxy> _page;
-    NSView *_view;
+    WeakObjCPtr<NSView> _view;
     Deque<WTF::Function<void(NSArray *, bool didWrap)>> _findReplyCallbacks;
     Deque<WTF::Function<void(NSImage *)>> _imageReplyCallbacks;
     BOOL _usePlatformFindUI;
@@ -299,7 +299,7 @@ private:
             rectsArray = createNSArray(rects);
         else
             rectsArray = @[];
-        RetainPtr strongView = _view;
+        RetainPtr strongView = _view.get();
         return adoptNS([[WKTextFinderMatch alloc] initWithClient:self view:strongView.get() index:index++ rects:rectsArray.get()]);
     });
 


### PR DESCRIPTION
#### d6c1196585db4df9b41231b4c41e87b1e55bcd53
<pre>
More safer CPP fixes in the UI process
<a href="https://bugs.webkit.org/show_bug.cgi?id=300108">https://bugs.webkit.org/show_bug.cgi?id=300108</a>

Reviewed by Ryosuke Niwa.

* Source/WebKit/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations:
* Source/WebKit/UIProcess/mac/WKImmediateActionController.h:
* Source/WebKit/UIProcess/mac/WKImmediateActionController.mm:
(-[WKImmediateActionController _updateImmediateActionItem]):
(-[WKImmediateActionController menuItem:viewAtScreenPoint:]):
(-[WKImmediateActionController menuItem:itemFrameForPoint:]):
(-[WKImmediateActionController menuItem:maxSizeForPoint:]):
(-[WKImmediateActionController _animationControllerForDataDetectedText]):
(-[WKImmediateActionController _animationControllerForDataDetectedLink]):
(-[WKImmediateActionController _animationControllerForText]):
* Source/WebKit/UIProcess/mac/WKTextFinderClient.mm:
(-[WKTextFinderMatch containingView]):
(-[WKTextFinderMatch generateTextImage:]):
(-[WKTextFinderClient didFindStringMatchesWithRects:didWrapAround:]):

Canonical link: <a href="https://commits.webkit.org/300990@main">https://commits.webkit.org/300990@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5a3dbb917a9f2efcd3e516e6db15699737ef2f60

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124597 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44269 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35003 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131436 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/76540 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44973 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52840 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94786 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/76540 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127551 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35856 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111426 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75358 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/34792 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74915 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105611 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29812 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134104 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/51447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/39267 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103265 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51857 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107648 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103043 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26230 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48408 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/26670 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/48379 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51320 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57116 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/50719 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/54074 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52408 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->