### PR TITLE
Remove the custom binding for ReadableStream cancel

### DIFF
--- a/Source/WebCore/Modules/streams/ReadableStream.cpp
+++ b/Source/WebCore/Modules/streams/ReadableStream.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "ReadableStream.h"
 
+#include "ContextDestructionObserverInlines.h"
 #include "InternalWritableStreamWriter.h"
 #include "JSDOMPromise.h"
 #include "JSDOMPromiseDeferred.h"
@@ -133,12 +134,12 @@ ExceptionOr<Ref<ReadableStream>> ReadableStream::createFromJSValues(JSC::JSGloba
     if (result.hasException())
         return result.releaseException();
 
-    return adoptRef(*new ReadableStream(result.releaseReturnValue()));
+    return adoptRef(*new ReadableStream(jsDOMGlobalObject.protectedScriptExecutionContext().get(), result.releaseReturnValue()));
 }
 
 ExceptionOr<Ref<ReadableStream>> ReadableStream::createFromByteUnderlyingSource(JSDOMGlobalObject& globalObject, JSC::JSValue underlyingSource, UnderlyingSource&& underlyingSourceDict, double highWaterMark)
 {
-    Ref readableStream = adoptRef(*new ReadableStream());
+    Ref readableStream = adoptRef(*new ReadableStream(globalObject.protectedScriptExecutionContext().get()));
 
     auto exception = readableStream->setupReadableByteStreamControllerFromUnderlyingSource(globalObject, underlyingSource, WTFMove(underlyingSourceDict), highWaterMark);
     if (exception.hasException())
@@ -159,30 +160,35 @@ ExceptionOr<Ref<ReadableStream>> ReadableStream::create(JSDOMGlobalObject& globa
 
 Ref<ReadableStream> ReadableStream::create(Ref<InternalReadableStream>&& internalReadableStream)
 {
-    return adoptRef(*new ReadableStream(WTFMove(internalReadableStream)));
+    auto* globalObject = internalReadableStream->globalObject();
+    return adoptRef(*new ReadableStream(globalObject->protectedScriptExecutionContext().get(), WTFMove(internalReadableStream)));
 }
 
-ReadableStream::ReadableStream(RefPtr<InternalReadableStream>&& internalReadableStream, RefPtr<ReadableStream>&& relatedStreamForGC)
-    : m_internalReadableStream(WTFMove(internalReadableStream))
+ReadableStream::ReadableStream(ScriptExecutionContext* context, RefPtr<InternalReadableStream>&& internalReadableStream, RefPtr<ReadableStream>&& relatedStreamForGC)
+    : ContextDestructionObserver(context)
+    , m_internalReadableStream(WTFMove(internalReadableStream))
     , m_relatedStreamForGC(WTFMove(relatedStreamForGC))
 {
 }
 
 ReadableStream::~ReadableStream() = default;
 
+// https://streams.spec.whatwg.org/#rs-cancel
+Ref<DOMPromise> ReadableStream::cancelForBindings(JSDOMGlobalObject& globalObject, JSC::JSValue reason)
+{
+    if (isLocked()) {
+        auto [promise, deferred] = createPromiseAndWrapper(globalObject);
+        deferred->reject(Exception { ExceptionCode::TypeError, "ReadableStream is locked"_s });
+        return promise;
+    }
+
+    return cancel(globalObject, reason);
+}
+
 // https://streams.spec.whatwg.org/#rs-get-reader
 ExceptionOr<ReadableStreamReader> ReadableStream::getReader(JSDOMGlobalObject& currentGlobalObject, const GetReaderOptions& options)
 {
-    if (!m_internalReadableStream) {
-        ASSERT(m_controller);
-        if (options.mode) {
-            auto readerOrException = ReadableStreamBYOBReader::create(currentGlobalObject, *this);
-            if (readerOrException.hasException())
-                return readerOrException.releaseException();
-
-            return ReadableStreamReader { RefPtr { readerOrException.releaseReturnValue() } };
-        }
-
+    if (!options.mode) {
         auto readerOrException = ReadableStreamDefaultReader::create(currentGlobalObject, *this);
         if (readerOrException.hasException())
             return readerOrException.releaseException();
@@ -190,14 +196,14 @@ ExceptionOr<ReadableStreamReader> ReadableStream::getReader(JSDOMGlobalObject& c
         return ReadableStreamReader { RefPtr { readerOrException.releaseReturnValue() } };
     }
 
-    if (options.mode)
+    ASSERT(*options.mode == ReaderMode::Byob);
+
+    if (m_internalReadableStream)
         return Exception { ExceptionCode::TypeError, "Invalid mode is specified"_s };
 
-    auto* jsDOMGlobalObject = JSC::jsCast<JSDOMGlobalObject*>(m_internalReadableStream->globalObject());
-    if (!jsDOMGlobalObject)
-        return Exception { ExceptionCode::InvalidStateError, "No global object"_s };
+    ASSERT(m_controller);
 
-    auto readerOrException = ReadableStreamDefaultReader::create(*jsDOMGlobalObject, *m_internalReadableStream);
+    auto readerOrException = ReadableStreamBYOBReader::create(currentGlobalObject, *this);
     if (readerOrException.hasException())
         return readerOrException.releaseException();
 
@@ -245,9 +251,27 @@ bool ReadableStream::isDisturbed() const
 
 void ReadableStream::cancel(Exception&& exception)
 {
-    // FIXME: support byte stream.
-    if (RefPtr internalReadableStream = m_internalReadableStream)
+    if (RefPtr internalReadableStream = m_internalReadableStream) {
         internalReadableStream->cancel(WTFMove(exception));
+        return;
+    }
+
+    RefPtr context = scriptExecutionContext();
+    auto* globalObject = context ? JSC::jsCast<JSDOMGlobalObject*>(context->globalObject()): nullptr;
+    if (!globalObject)
+        return;
+
+    Ref vm = globalObject->vm();
+    JSC::JSLockHolder lock(vm);
+    auto scope = DECLARE_CATCH_SCOPE(vm);
+    auto jsException = createDOMException(globalObject, exception.code(), exception.message());
+
+    if (scope.exception()) [[unlikely]] {
+        scope.clearException();
+        return;
+    }
+
+    cancel(*globalObject, jsException);
 }
 
 void ReadableStream::pipeTo(ReadableStreamSink& sink)
@@ -280,7 +304,7 @@ ReadableStreamDefaultReader* ReadableStream::defaultReader()
 // https://streams.spec.whatwg.org/#abstract-opdef-createreadablebytestream
 Ref<ReadableStream> ReadableStream::createReadableByteStream(JSDOMGlobalObject& globalObject, ReadableByteStreamController::PullAlgorithm&& pullAlgorithm, ReadableByteStreamController::CancelAlgorithm&& cancelAlgorithm, RefPtr<ReadableStream>&& relatedStreamForGC)
 {
-    Ref readableStream = adoptRef(*new ReadableStream({ }, WTFMove(relatedStreamForGC)));
+    Ref readableStream = adoptRef(*new ReadableStream(globalObject.protectedScriptExecutionContext().get(), { }, WTFMove(relatedStreamForGC)));
     readableStream->setupReadableByteStreamController(globalObject, WTFMove(pullAlgorithm), WTFMove(cancelAlgorithm), 0);
     return readableStream;
 }
@@ -389,21 +413,30 @@ void ReadableStream::error(JSDOMGlobalObject& globalObject, JSC::JSValue reason)
 }
 
 // https://streams.spec.whatwg.org/#readable-stream-cancel
-void ReadableStream::cancel(JSDOMGlobalObject& globalObject, JSC::JSValue reason, Ref<DeferredPromise>&& promise)
+Ref<DOMPromise> ReadableStream::cancel(JSDOMGlobalObject& globalObject, JSC::JSValue reason)
 {
-    ASSERT(!m_internalReadableStream);
+    auto [promise, deferred] = createPromiseAndWrapper(globalObject);
+
+    if (RefPtr internalStream = m_internalReadableStream) {
+        auto result = internalStream->cancel(globalObject, reason);
+        auto* jsPromise = jsCast<JSC::JSPromise*>(result);
+        if (!jsPromise)
+            return promise;
+
+        return DOMPromise::create(globalObject, *jsPromise);
+    }
 
     m_disturbed = true;
     if (m_state == State::Closed) {
-        promise->resolve();
-        return;
+        deferred->resolve();
+        return promise;
     }
 
     if (m_state == State::Errored) {
-        promise->rejectWithCallback([&] (auto&) {
+        deferred->rejectWithCallback([&] (auto&) {
             return m_controller->storedError();
         });
-        return;
+        return promise;
     }
 
     close();
@@ -414,15 +447,17 @@ void ReadableStream::cancel(JSDOMGlobalObject& globalObject, JSC::JSValue reason
             byobReader->takeFirstReadIntoRequest()->runCloseSteps(JSC::jsUndefined());
     }
 
-    m_controller->runCancelSteps(globalObject, reason, [promise = WTFMove(promise)] (auto&& error) mutable {
+    m_controller->runCancelSteps(globalObject, reason, [deferred = WTFMove(deferred)] (auto&& error) mutable {
         if (error) {
-            promise->rejectWithCallback([&] (auto&) {
+            deferred->rejectWithCallback([&] (auto&) {
                 return *error;
             });
             return;
         }
-        promise->resolve();
+        deferred->resolve();
     });
+
+    return promise;
 }
 
 // https://streams.spec.whatwg.org/#readable-stream-get-num-read-into-requests
@@ -509,24 +544,6 @@ JSC::JSValue ReadableStream::storedError(JSDOMGlobalObject& globalObject) const
         return internalReadableStream->storedError(globalObject);
 
     return m_controller->storedError();
-}
-
-JSC::JSValue JSReadableStream::cancel(JSC::JSGlobalObject& globalObject, JSC::CallFrame& callFrame)
-{
-    RefPtr internalReadableStream = wrapped().internalReadableStream();
-    if (!internalReadableStream) {
-        return callPromiseFunction(globalObject, callFrame, [this](auto& globalObject, auto& callFrame, auto&& promise) {
-            Ref protectedWrapped = this->wrapped();
-            if (protectedWrapped->isLocked()) {
-                promise->reject(Exception { ExceptionCode::TypeError, "ReadableStream is locked"_s });
-                return;
-            }
-
-            protectedWrapped->cancel(globalObject, callFrame.argument(0), WTFMove(promise));
-        });
-    }
-
-    return internalReadableStream->cancelForBindings(globalObject, callFrame.argument(0));
 }
 
 void ReadableStream::visitAdditionalChildren(JSC::AbstractSlotVisitor& visitor)

--- a/Source/WebCore/Modules/streams/ReadableStream.idl
+++ b/Source/WebCore/Modules/streams/ReadableStream.idl
@@ -50,7 +50,7 @@ typedef (ReadableStreamDefaultReader or ReadableStreamBYOBReader) ReadableStream
 ] interface ReadableStream {
     [CallWith=CurrentGlobalObject] constructor(optional object underlyingSource, optional object options);
 
-    [Custom, ReturnsOwnPromise] Promise<undefined> cancel(optional any reason);
+    [CallWith=CurrentGlobalObject, ReturnsOwnPromise, ImplementedAs=cancelForBindings] Promise<undefined> cancel(optional any reason);
     [CallWith=CurrentGlobalObject] ReadableStreamReader getReader(optional ReadableStreamGetReaderOptions options = { });
     [CallWith=CurrentGlobalObject] Promise<undefined> pipeTo(WritableStream destination, optional StreamPipeOptions options = {});
     [CallWith=CurrentGlobalObject] ReadableStream pipeThrough(ReadableWritablePair transform, optional StreamPipeOptions options = {});

--- a/Source/WebCore/Modules/streams/ReadableStreamBYOBReader.h
+++ b/Source/WebCore/Modules/streams/ReadableStreamBYOBReader.h
@@ -59,7 +59,7 @@ public:
 
     DOMPromise& closedPromise();
 
-    void cancel(JSDOMGlobalObject&, JSC::JSValue, Ref<DeferredPromise>&&);
+    Ref<DOMPromise> cancel(JSDOMGlobalObject&, JSC::JSValue);
 
     Ref<ReadableStreamReadIntoRequest> takeFirstReadIntoRequest();
     size_t readIntoRequestsSize() const { return m_readIntoRequests.size(); }
@@ -84,7 +84,7 @@ private:
     void genericRelease(JSDOMGlobalObject&);
     void errorReadIntoRequests(Exception&&);
 
-    void genericCancel(JSDOMGlobalObject&, JSC::JSValue, Ref<DeferredPromise>&&);
+    Ref<DOMPromise> genericCancel(JSDOMGlobalObject&, JSC::JSValue);
 
     Ref<DOMPromise> m_closedPromise;
     Ref<DeferredPromise> m_closedDeferred;

--- a/Source/WebCore/Modules/streams/ReadableStreamBYOBReader.idl
+++ b/Source/WebCore/Modules/streams/ReadableStreamBYOBReader.idl
@@ -42,5 +42,5 @@ dictionary ReadableStreamBYOBReaderReadOptions {
 
     // ReadableStreamGenericReader
     [ImplementedAs=closedPromise] readonly attribute Promise<undefined> closed;
-    [CallWith=CurrentGlobalObject] Promise<undefined> cancel(optional any reason);
+    [CallWith=CurrentGlobalObject, ReturnsOwnPromise] Promise<undefined> cancel(optional any reason);
 };

--- a/Source/WebCore/Modules/streams/ReadableStreamDefaultReader.h
+++ b/Source/WebCore/Modules/streams/ReadableStreamDefaultReader.h
@@ -47,8 +47,6 @@ class ReadableStreamDefaultReader : public ScriptWrappable, public RefCountedAnd
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(ReadableStreamDefaultReader);
 public:
     static ExceptionOr<Ref<ReadableStreamDefaultReader>> create(JSDOMGlobalObject&, ReadableStream&);
-    static ExceptionOr<Ref<ReadableStreamDefaultReader>> create(JSDOMGlobalObject&, InternalReadableStream&);
-    static Ref<ReadableStreamDefaultReader> create(Ref<InternalReadableStreamDefaultReader>&&, Ref<DOMPromise>&&, Ref<DeferredPromise>&&);
 
     ~ReadableStreamDefaultReader();
 
@@ -63,7 +61,8 @@ public:
     void addReadRequest(Ref<ReadableStreamReadRequest>&&);
     Ref<ReadableStreamReadRequest> takeFirstReadRequest();
 
-    void genericCancel(JSDOMGlobalObject&, JSC::JSValue, Ref<DeferredPromise>&&);
+    Ref<DOMPromise> cancel(JSDOMGlobalObject&, JSC::JSValue);
+    Ref<DOMPromise> genericCancel(JSDOMGlobalObject&, JSC::JSValue);
 
     void resolveClosedPromise();
     void rejectClosedPromise(JSC::JSValue);
@@ -76,12 +75,11 @@ public:
     template<typename Visitor> void visitAdditionalChildren(Visitor&);
 
 private:
-    ReadableStreamDefaultReader(Ref<InternalReadableStreamDefaultReader>&&, Ref<DOMPromise>&&, Ref<DeferredPromise>&&);
-    ReadableStreamDefaultReader(Ref<ReadableStream>&&, Ref<DOMPromise>&&, Ref<DeferredPromise>&&);
+    ReadableStreamDefaultReader(Ref<ReadableStream>&&, RefPtr<InternalReadableStreamDefaultReader>&&, Ref<DOMPromise>&&, Ref<DeferredPromise>&&);
 
     ExceptionOr<void> setup(JSDOMGlobalObject&);
     void genericRelease(JSDOMGlobalObject&);
-    void errorReadRequests(JSDOMGlobalObject&, const Exception&);
+    void errorReadRequests(const Exception&);
 
     Ref<DOMPromise> m_closedPromise;
     Ref<DeferredPromise> m_closedDeferred;

--- a/Source/WebCore/Modules/streams/ReadableStreamDefaultReader.idl
+++ b/Source/WebCore/Modules/streams/ReadableStreamDefaultReader.idl
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2015 Canon Inc.
  * Copyright (C) 2015 Igalia S.L.
+ * Copyright (C) 2025 Apple Inc.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted, provided that the following conditions
@@ -38,6 +39,7 @@
     [Custom, ReturnsOwnPromise] Promise<any> read();
     [CallWith=CurrentGlobalObject] undefined releaseLock();
 
+    // ReadableStreamGenericReader
     [Custom] readonly attribute Promise<boolean> closed;
-    [Custom, ReturnsOwnPromise] Promise<any> cancel(optional any reason);
+    [CallWith=CurrentGlobalObject, ReturnsOwnPromise] Promise<undefined> cancel(optional any reason);
 };

--- a/Source/WebCore/Modules/streams/ReadableStreamInternals.js
+++ b/Source/WebCore/Modules/streams/ReadableStreamInternals.js
@@ -85,18 +85,6 @@ function createInternalReadableStreamFromUnderlyingSource(underlyingSource, stra
     return stream;
 }
 
-function readableStreamCancelForBindings(stream, reason)
-{
-    "use strict";
-
-    @assert(@isReadableStream(stream));
-
-    if (@isReadableStreamLocked(stream))
-        return @Promise.@reject(@makeTypeError("ReadableStream is locked"));
-
-    return @readableStreamCancel(stream, reason);
-}
-
 function readableStreamPipeThroughForBindings(thisStream, streams, options)
 {
     "use strict";

--- a/Source/WebCore/Modules/streams/StreamTeeUtilities.cpp
+++ b/Source/WebCore/Modules/streams/StreamTeeUtilities.cpp
@@ -233,8 +233,7 @@ ExceptionOr<Vector<Ref<ReadableStream>>> byteStreamTee(JSDOMGlobalObject& global
             list.append(state->takeReason2().get());
             JSC::JSValue reason = JSC::constructArray(&globalObject, static_cast<JSC::ArrayAllocationProfile*>(nullptr), list);
 
-            auto [promise, deferred] = createPromiseAndWrapper(globalObject);
-            state->stream().cancel(globalObject, reason, WTFMove(deferred));
+            Ref promise = state->stream().cancel(globalObject, reason);
             promise->whenSettled([state, promise] {
                 if (promise->status() == DOMPromise::Status::Rejected) {
                     state->rejectCancelPromise(promise->result());
@@ -258,8 +257,7 @@ ExceptionOr<Vector<Ref<ReadableStream>>> byteStreamTee(JSDOMGlobalObject& global
             list.append(state->takeReason2().get());
             JSC::JSValue reason = JSC::constructArray(&globalObject, static_cast<JSC::ArrayAllocationProfile*>(nullptr), list);
 
-            auto [promise, deferred] = createPromiseAndWrapper(globalObject);
-            state->stream().cancel(globalObject, reason, WTFMove(deferred));
+            Ref promise = state->stream().cancel(globalObject, reason);
             promise->whenSettled([state, promise] {
                 if (promise->status() == DOMPromise::Status::Rejected) {
                     state->rejectCancelPromise(promise->result());

--- a/Source/WebCore/Modules/webtransport/WebTransportReceiveStream.cpp
+++ b/Source/WebCore/Modules/webtransport/WebTransportReceiveStream.cpp
@@ -42,11 +42,11 @@ ExceptionOr<Ref<WebTransportReceiveStream>> WebTransportReceiveStream::create(We
     if (result.hasException())
         return result.releaseException();
 
-    return adoptRef(*new WebTransportReceiveStream(identifier, session, result.releaseReturnValue()));
+    return adoptRef(*new WebTransportReceiveStream(globalObject.protectedScriptExecutionContext().get(), identifier, session, result.releaseReturnValue()));
 }
 
-WebTransportReceiveStream::WebTransportReceiveStream(WebTransportStreamIdentifier identifier, WebTransportSession& session, Ref<InternalReadableStream>&& stream)
-    : ReadableStream(WTFMove(stream))
+WebTransportReceiveStream::WebTransportReceiveStream(ScriptExecutionContext* context, WebTransportStreamIdentifier identifier, WebTransportSession& session, Ref<InternalReadableStream>&& stream)
+    : ReadableStream(context, WTFMove(stream))
     , m_identifier(identifier)
     , m_session(session) { }
 

--- a/Source/WebCore/Modules/webtransport/WebTransportReceiveStream.h
+++ b/Source/WebCore/Modules/webtransport/WebTransportReceiveStream.h
@@ -44,7 +44,7 @@ public:
 
     void getStats(ScriptExecutionContext&, Ref<DeferredPromise>&&);
 private:
-    WebTransportReceiveStream(WebTransportStreamIdentifier, WebTransportSession&, Ref<InternalReadableStream>&&);
+    WebTransportReceiveStream(ScriptExecutionContext*, WebTransportStreamIdentifier, WebTransportSession&, Ref<InternalReadableStream>&&);
 
     virtual Type type() const { return Type::WebTransport; }
 

--- a/Source/WebCore/bindings/js/InternalReadableStream.cpp
+++ b/Source/WebCore/bindings/js/InternalReadableStream.cpp
@@ -171,7 +171,7 @@ void InternalReadableStream::cancel(Exception&& exception)
 
     auto scope = DECLARE_CATCH_SCOPE(globalObject->vm());
     JSC::JSLockHolder lock(globalObject->vm());
-    cancel(*globalObject, toJSNewlyCreated(globalObject, JSC::jsCast<JSDOMGlobalObject*>(globalObject), DOMException::create(WTFMove(exception))), Use::Private);
+    cancel(*globalObject, toJSNewlyCreated(globalObject, JSC::jsCast<JSDOMGlobalObject*>(globalObject), DOMException::create(WTFMove(exception))));
     if (scope.exception()) [[unlikely]]
         scope.clearException();
 }
@@ -240,11 +240,10 @@ ExceptionOr<std::pair<Ref<InternalReadableStream>, Ref<InternalReadableStream>>>
     return std::make_pair(InternalReadableStream::fromObject(jsDOMGlobalObject, *results[0].get()), InternalReadableStream::fromObject(jsDOMGlobalObject, *results[1].get()));
 }
 
-JSC::JSValue InternalReadableStream::cancel(JSC::JSGlobalObject& globalObject, JSC::JSValue reason, Use use)
+JSC::JSValue InternalReadableStream::cancel(JSC::JSGlobalObject& globalObject, JSC::JSValue reason)
 {
     auto* clientData = downcast<JSVMClientData>(globalObject.vm().clientData);
-    auto& names = clientData->builtinFunctions().readableStreamInternalsBuiltins();
-    auto& privateName = use == Use::Bindings ? names.readableStreamCancelForBindingsPrivateName() : names.readableStreamCancelPrivateName();
+    auto& privateName = clientData->builtinFunctions().readableStreamInternalsBuiltins().readableStreamCancelPrivateName();
 
     JSC::MarkedArgumentBuffer arguments;
     arguments.append(guardedObject());

--- a/Source/WebCore/bindings/js/InternalReadableStream.h
+++ b/Source/WebCore/bindings/js/InternalReadableStream.h
@@ -48,12 +48,10 @@ public:
     void pipeTo(ReadableStreamSink&);
     ExceptionOr<std::pair<Ref<InternalReadableStream>, Ref<InternalReadableStream>>> tee(bool shouldClone);
 
-    JSC::JSValue cancelForBindings(JSC::JSGlobalObject& globalObject, JSC::JSValue value) { return cancel(globalObject, value, Use::Bindings); }
     JSC::JSValue pipeTo(JSC::JSGlobalObject&, JSC::JSValue, JSC::JSValue);
     JSC::JSValue pipeThrough(JSC::JSGlobalObject&, JSC::JSValue, JSC::JSValue);
 
-    enum class Use : bool { Bindings, Private };
-    JSC::JSValue cancel(JSC::JSGlobalObject&, JSC::JSValue, Use);
+    JSC::JSValue cancel(JSC::JSGlobalObject&, JSC::JSValue);
 
     enum class State : uint8_t { Readable, Closed, Errored };
     State state() const;

--- a/Source/WebCore/bindings/js/JSDOMConvertPromise.h
+++ b/Source/WebCore/bindings/js/JSDOMConvertPromise.h
@@ -76,12 +76,17 @@ template<typename T> struct JSConverter<IDLPromise<T>> {
 
     static JSC::JSValue convert(JSC::JSGlobalObject&, JSDOMGlobalObject&, DOMPromise& promise)
     {
-        return promise.promise();
+        return promise.guardedObject();
     }
 
     static JSC::JSValue convert(JSC::JSGlobalObject&, JSDOMGlobalObject&, const RefPtr<DOMPromise>& promise)
     {
-        return promise->promise();
+        return promise->guardedObject();
+    }
+
+    static JSC::JSValue convert(JSC::JSGlobalObject&, JSDOMGlobalObject&, const Ref<DOMPromise>& promise)
+    {
+        return promise->guardedObject();
     }
 
     template<template<typename> class U>

--- a/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
+++ b/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
@@ -6782,7 +6782,7 @@ sub GenerateParametersCheck
         $argumentIndex++;
     }
 
-    push(@arguments, "WTFMove(promise)") if $operation->type && $codeGenerator->IsPromiseType($operation->type) && !$operation->extendedAttributes->{PromiseProxy};
+    push(@arguments, "WTFMove(promise)") if $operation->type && $codeGenerator->IsPromiseType($operation->type) && !$operation->extendedAttributes->{PromiseProxy} && !$operation->extendedAttributes->{ReturnsOwnPromise};
     push(@arguments, "WTFMove(promise), WTFMove(promise2)") if $operation->extendedAttributes->{ReturnsPromisePair};
 
     return "$functionName(" . join(", ", @arguments) . ")";

--- a/Source/WebCore/page/mac/EventHandlerMac.mm
+++ b/Source/WebCore/page/mac/EventHandlerMac.mm
@@ -34,6 +34,7 @@
 #import "DataTransfer.h"
 #import "DictionaryLookup.h"
 #import "DocumentPage.h"
+#import "DocumentQuirks.h"
 #import "DocumentView.h"
 #import "DragController.h"
 #import "Editor.h"


### PR DESCRIPTION
#### 2197c9117f451116809cf36bec7b9acdb0babb5e
<pre>
Remove the custom binding for ReadableStream cancel
<a href="https://rdar.apple.com/161897092">rdar://161897092</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=300107">https://bugs.webkit.org/show_bug.cgi?id=300107</a>

Reviewed by Chris Dumez.

We do a refactoring to prepare ground for Readable byte stream native sources (especially fetch responses).
This patch does the following:
- Remove custom binding for ReadableStream and reader cancel methods. We update the binding generator so that methods can return their own promise. This is necessary to support the byte stream code path as well as the default stream code path (JS built-in).
- We do a small refactoring to simplify the construction of a ReadableStreamDefaultReader so that it always has a ReadableStream. This is now necessary for the cancel code path.
- We update getReader accordingly, which gets closer to the step-by-step spec.
- We make ReadableStream a ContextDestructionObserver so that we can get its JSDOMGlobalObject, which is used when cancelling with a DOMException (used by native sources).

We also update the conversion of DOMPromise to JSValue by using guardedObject() directly.
This removes hitting the ASSERT in DOMPromise::promise(), which is similar to the the regular JSDOMPromiseDeferred.h callPromiseFunction code path.

Covered by existing tests.

Canonical link: <a href="https://commits.webkit.org/301120@main">https://commits.webkit.org/301120@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/11991aa02f0a66dc418310db6f9515b1656d0f17

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124876 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44547 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35283 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131722 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76776 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ad808ba1-f769-465f-9780-34f4b191020b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/126753 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45248 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53115 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95030 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/63055 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/407c5d66-9703-4547-b188-4c31e9a2f8c6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127830 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36102 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111681 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75587 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2aad058a-6f95-49b1-8277-266ce8540802) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35037 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29838 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75199 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105862 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30066 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134390 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51717 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39520 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103508 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52134 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107896 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103272 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26322 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48629 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26920 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48738 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51593 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57401 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50982 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54338 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52675 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->