### PR TITLE
[WPE][GTK] Speakers enumeration doesn't show ALSA virtual sinks

### DIFF
--- a/Source/WebCore/Modules/speech/SpeechRecognitionCaptureSource.cpp
+++ b/Source/WebCore/Modules/speech/SpeechRecognitionCaptureSource.cpp
@@ -51,7 +51,7 @@ std::optional<CaptureDevice> SpeechRecognitionCaptureSource::findCaptureDevice()
     std::optional<CaptureDevice> captureDevice;
     auto devices = RealtimeMediaSourceCenter::singleton().audioCaptureFactory().audioCaptureDeviceManager().captureDevices();
     for (auto device : devices) {
-        if (!device.enabled())
+        if (!device.enabled() || device.isSpeakerDevice())
             continue;
 
         if (!captureDevice)

--- a/Source/WebCore/platform/mediastream/CaptureDevice.h
+++ b/Source/WebCore/platform/mediastream/CaptureDevice.h
@@ -93,6 +93,11 @@ public:
         return m_type == DeviceType::Microphone || m_type == DeviceType::Camera;
     }
 
+    bool isSpeakerDevice() const
+    {
+        return m_type == DeviceType::Speaker;
+    }
+
     explicit operator bool() const { return m_type != DeviceType::Unknown; }
 
     CaptureDevice isolatedCopy() &&;

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.cpp
@@ -72,7 +72,7 @@ void RealtimeMediaSourceCenter::createMediaStream(Ref<const Logger>&& logger, Ne
     Vector<Ref<RealtimeMediaSource>> videoSources;
 
     RefPtr<RealtimeMediaSource> audioSource;
-    if (audioDevice) {
+    if (audioDevice && !audioDevice.isSpeakerDevice()) {
         auto source = audioCaptureFactory().createAudioCaptureSource(WTFMove(audioDevice), MediaDeviceHashSalts { hashSalts }, &request.audioConstraints, request.pageIdentifier);
         if (!source) {
             completionHandler(makeUnexpected(WTFMove(source.error)));
@@ -245,7 +245,7 @@ void RealtimeMediaSourceCenter::getUserMediaDevices(const MediaStreamRequest& re
         bool sameFitnessScore = true;
         std::optional<double> fitnessScore;
         for (auto& device : audioCaptureFactory().audioCaptureDeviceManager().captureDevices()) {
-            if (!device.enabled())
+            if (!device.enabled() || device.isSpeakerDevice())
                 continue;
 
             auto sourceOrError = audioCaptureFactory().createAudioCaptureSource(device, MediaDeviceHashSalts { hashSalts }, { }, request.pageIdentifier);

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCaptureSource.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCaptureSource.cpp
@@ -47,6 +47,7 @@ class GStreamerAudioCaptureSourceFactory : public AudioCaptureFactory {
 public:
     CaptureSourceOrError createAudioCaptureSource(const CaptureDevice& device, MediaDeviceHashSalts&& hashSalts, const MediaConstraints* constraints, std::optional<PageIdentifier>) final
     {
+        ASSERT(!device.isSpeakerDevice());
         // Here, like in GStreamerVideoCaptureSource, we could rely on the DesktopPortal and
         // PipeWireCaptureDeviceManager, but there is no audio desktop portal yet. See
         // https://github.com/flatpak/xdg-desktop-portal/discussions/1142.

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.cpp
@@ -226,9 +226,9 @@ std::optional<GStreamerCaptureDevice> GStreamerCaptureDeviceManager::captureDevi
     auto nodeName = gstStructureGetString(properties.get(), "node.name"_s);
     String identifier;
     if (nodeName.isEmpty())
-        identifier = makeString(deviceName.span());
+        identifier = makeString(deviceName.span(), ", "_s, deviceClass, ", "_s, deviceClassString.toString());
     else
-        identifier = nodeName.toString();
+        identifier = makeString(nodeName.toString(), ", "_s, deviceClass, ", "_s, deviceClassString.toString());
 
     bool isMock = false;
     if (auto persistentId = gstStructureGetString(properties.get(), "persistent-id"_s)) {

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.cpp
@@ -176,6 +176,7 @@ GstElement* GStreamerCapturer::createSource()
         g_object_set(m_src.get(), "path", path.string().ascii().data(), "fd", m_pipewireDevice->fd(), nullptr);
     } else {
         ASSERT(m_device);
+        ASSERT(gst_device_has_classes(m_device->device(), GST_ELEMENT_FACTORY_KLASS_SRC));
         auto sourceName = makeString(unsafeSpan(name()), hex(reinterpret_cast<uintptr_t>(this)));
         m_src = gst_device_create_element(m_device->device(), sourceName.ascii().data());
         ASSERT(m_src);

--- a/Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp
@@ -316,14 +316,14 @@ class MockRealtimeAudioSourceFactory final
 public:
     CaptureSourceOrError createAudioCaptureSource(const CaptureDevice& device, MediaDeviceHashSalts&& hashSalts, const MediaConstraints* constraints, std::optional<PageIdentifier> pageIdentifier) final
     {
-        ASSERT(device.type() == CaptureDevice::DeviceType::Microphone || device.type() == CaptureDevice::DeviceType::Speaker);
+        ASSERT(device.type() == CaptureDevice::DeviceType::Microphone);
         if (!MockRealtimeMediaSourceCenter::captureDeviceWithPersistentID(device.type(), device.persistentId()))
-            return CaptureSourceOrError({ "Unable to find mock microphone or speaker device with given persistentID"_s, MediaAccessDenialReason::PermissionDenied });
+            return CaptureSourceOrError({ "Unable to find mock microphone device with given persistentID"_s, MediaAccessDenialReason::PermissionDenied });
 
         auto mock = MockRealtimeMediaSourceCenter::mockDeviceWithPersistentID(device.persistentId());
         ASSERT(mock);
         if (mock->flags.contains(MockMediaDevice::Flag::Invalid))
-            return CaptureSourceOrError({ "Invalid mock microphone or speaker device"_s, MediaAccessDenialReason::PermissionDenied });
+            return CaptureSourceOrError({ "Invalid mock microphone device"_s, MediaAccessDenialReason::PermissionDenied });
 
         return MockRealtimeAudioSource::create(String { device.persistentId() }, AtomString { device.label() }, WTFMove(hashSalts), constraints, pageIdentifier);
     }


### PR DESCRIPTION
#### a420a8c5cf2113698903a874a565592cc18a127c
<pre>
[WPE][GTK] Speakers enumeration doesn&apos;t show ALSA virtual sinks
<a href="https://bugs.webkit.org/show_bug.cgi?id=300109">https://bugs.webkit.org/show_bug.cgi?id=300109</a>

Reviewed by Philippe Normand.

- The audio devices management system was considering the speakers as capture
  devices and so was automatically creating GStreamer pipelines with an
  underlying `alsasink` element opening the raw audio hardware. As ALSA
  devices have usually an exclusive access, maintaining the device open was
  impeding to list the other virtual sinks in the ALSA configuration. During
  the listing of the virtual sinks, it needs to open the underlying real
  audio device to fetch information about the audio samples format but
  it cannot because the audio real device is already open. In all cases, there
  should not be any GStreamer pipeline at all created for a speaker device as
  it produces no audio. Doing so was also producing some warnings at the
  GStreamer level as it was trying to set a property reserved for source
  elements on a sink element. The fix is filtering out the speaker devices
  when creating the `GStreamerAudioCaptureSource` instances in order to not
  build broken capture pipelines with sink elements.
- Indeed, the `GStreamerCaptureDeviceManager` was not creating unique IDs
  for the different input/output interfaces. Those unique IDs are used to link
  together different audio elements but, as they were not unique, a same sound
  card with a microphone and a speaker had the same ID for both interfaces. At
  the moment of creating a `GStreamerAudioCaptureSource` instance for the
  microphone, the system was fetching the speaker interface instead and not
  the microphone one and, so, was locking the real hardware sound card just
  like in the former point. In addition to the device name, the fix also adds
  the device GStreamer class to differentiate inputs from outputs in the
  device ID.

* Source/WebCore/Modules/speech/SpeechRecognitionCaptureSource.cpp:
(WebCore::SpeechRecognitionCaptureSource::findCaptureDevice):
* Source/WebCore/platform/mediastream/CaptureDevice.h:
(WebCore::CaptureDevice::isSpeakerDevice const):
* Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.cpp:
(WebCore::RealtimeMediaSourceCenter::createMediaStream):
(WebCore::RealtimeMediaSourceCenter::getUserMediaDevices):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCaptureSource.cpp:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.cpp:
(WebCore::GStreamerCaptureDeviceManager::captureDeviceFromGstDevice):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.cpp:
(WebCore::GStreamerCapturer::createSource):
* Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp:

Canonical link: <a href="https://commits.webkit.org/301082@main">https://commits.webkit.org/301082@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2b5902d30f85536f2ace7b26f02b5a296959f30b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124885 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44555 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35291 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131730 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/76780 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/126762 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45253 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53121 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95036 "22 flakes 26 failures") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/76780 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127839 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36106 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111689 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75592 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35041 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/29845 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75209 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105866 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30074 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134400 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51722 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39523 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103515 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52141 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107904 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103289 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26294 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48638 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26928 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48743 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51599 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57406 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50986 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54342 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52679 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->