### PR TITLE
[JSC] WASM IPInt SIMD: disallow --useWasmIPIntSIMD=1 and --useWasmRelaxedSIMD=1

### DIFF
--- a/JSTests/wasm/stress/simd-const-relaxed-f32-madd.js
+++ b/JSTests/wasm/stress/simd-const-relaxed-f32-madd.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWasmSIMD=1", "--useWasmRelaxedSIMD=1")
+//@ requireOptions("--useWasmSIMD=1", "--useWasmRelaxedSIMD=1", "--useWasmIPIntSIMD=0")
 //@ skip if !$isSIMDPlatform
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"

--- a/JSTests/wasm/stress/simd-const-relaxed-f32-trunc.js
+++ b/JSTests/wasm/stress/simd-const-relaxed-f32-trunc.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWasmSIMD=1", "--useWasmRelaxedSIMD=1")
+//@ requireOptions("--useWasmSIMD=1", "--useWasmRelaxedSIMD=1", "--useWasmIPIntSIMD=0")
 //@ skip if !$isSIMDPlatform
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"

--- a/JSTests/wasm/stress/simd-const-relaxed-f64-madd.js
+++ b/JSTests/wasm/stress/simd-const-relaxed-f64-madd.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWasmSIMD=1", "--useWasmRelaxedSIMD=1")
+//@ requireOptions("--useWasmSIMD=1", "--useWasmRelaxedSIMD=1", "--useWasmIPIntSIMD=0")
 //@ skip if !$isSIMDPlatform
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"

--- a/JSTests/wasm/stress/simd-const-relaxed-f64-trunc.js
+++ b/JSTests/wasm/stress/simd-const-relaxed-f64-trunc.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWasmSIMD=1", "--useWasmRelaxedSIMD=1")
+//@ requireOptions("--useWasmSIMD=1", "--useWasmRelaxedSIMD=1", "--useWasmIPIntSIMD=0")
 //@ skip if !$isSIMDPlatform
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"

--- a/JSTests/wasm/stress/simd-const-relaxed-lane-select.js
+++ b/JSTests/wasm/stress/simd-const-relaxed-lane-select.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWasmSIMD=1", "--useWasmRelaxedSIMD=1")
+//@ requireOptions("--useWasmSIMD=1", "--useWasmRelaxedSIMD=1", "--useWasmIPIntSIMD=0")
 //@ skip if !$isSIMDPlatform
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"

--- a/JSTests/wasm/stress/simd-const-relaxed-swizzle.js
+++ b/JSTests/wasm/stress/simd-const-relaxed-swizzle.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWasmSIMD=1", "--useWasmRelaxedSIMD=1")
+//@ requireOptions("--useWasmSIMD=1", "--useWasmRelaxedSIMD=1", "--useWasmIPIntSIMD=0")
 //@ skip if !$isSIMDPlatform
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"

--- a/Source/JavaScriptCore/runtime/Options.cpp
+++ b/Source/JavaScriptCore/runtime/Options.cpp
@@ -1367,6 +1367,10 @@ void Options::assertOptionsAreCoherent()
         coherent = false;
         dataLog("INCOHERENT OPTIONS: at least one of useWasmIPInt, or useBBQJIT must be true\n");
     }
+    if (useWasmIPIntSIMD() && useWasmRelaxedSIMD()) {
+        coherent = false;
+        dataLog("INCOHERENT OPTIONS: useWasmIPIntSIMD and useWasmRelaxedSIMD cannot both be enabled (relaxed SIMD opcodes 0x100-0x10c are not yet supported in IPInt)\n");
+    }
     if (useProfiler() && useConcurrentJIT()) {
         coherent = false;
         dataLogLn("Bytecode profiler is not concurrent JIT safe.");


### PR DESCRIPTION
#### 58946d58c0ebe75a6a8db33bb1ecb1e9d72c3736
<pre>
[JSC] WASM IPInt SIMD: disallow --useWasmIPIntSIMD=1 and --useWasmRelaxedSIMD=1
<a href="https://bugs.webkit.org/show_bug.cgi?id=300112">https://bugs.webkit.org/show_bug.cgi?id=300112</a>
<a href="https://rdar.apple.com/161901342">rdar://161901342</a>

Reviewed by Daniel Liu.

Let&apos;s not block enabling --useWasmIPIntSIMD by default on relaxed SIMD
support in IPInt.

However, we won&apos;t be able to remove the path that tiers up immediately
to BBQ until the relaxed SIMD support is added to IPInt (or we stop
testing --useWasmRelaxedSIMD=1 until the relaxed SIMD support is
completed).

* JSTests/wasm/stress/simd-const-relaxed-f32-madd.js:
* JSTests/wasm/stress/simd-const-relaxed-f32-trunc.js:
* JSTests/wasm/stress/simd-const-relaxed-f64-madd.js:
* JSTests/wasm/stress/simd-const-relaxed-f64-trunc.js:
* JSTests/wasm/stress/simd-const-relaxed-lane-select.js:
* JSTests/wasm/stress/simd-const-relaxed-swizzle.js:
* Source/JavaScriptCore/runtime/Options.cpp:
(JSC::Options::assertOptionsAreCoherent):

Canonical link: <a href="https://commits.webkit.org/300963@main">https://commits.webkit.org/300963@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8c09f4973a83c95b4307319f6db16d463b701f00

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124431 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44115 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34846 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131275 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/76447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/58632ef3-8ae6-4d49-92ba-d30ef3ec5fa0) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44859 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52712 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94666 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/76447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/55859ee1-5889-4f8d-ae7a-9cf4291450fe) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127385 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35759 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111298 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75242 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/86fba13e-5a48-468c-8652-56d293030729) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34694 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29458 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74754 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/116566 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105511 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29678 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133940 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/122961 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51332 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39161 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103143 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51733 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107513 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102931 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26209 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48301 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26554 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48278 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51198 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56984 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/154056 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50616 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39143 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53978 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52292 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->