### PR TITLE
Move Proxy Configuration into Password Util

### DIFF
--- a/Tools/CISupport/ews-build/twisted_additions.py
+++ b/Tools/CISupport/ews-build/twisted_additions.py
@@ -36,6 +36,8 @@ from twisted.web.client import Agent
 from twisted.web.http_headers import Headers
 from twisted.web import iweb, http, _newclient
 
+from .utils import load_password
+
 from zope.interface import implementer
 
 
@@ -169,6 +171,9 @@ class HTTPConnectSetup(http.HTTPClient):
 
 class TwistedAdditions(object):
     PROXY_RE = re.compile(r'https?://(?P<host>.+):(?P<port>\d+)')
+    HTTPS_PROXY = load_password('HTTP_PROXY', default="")
+    HTTPS_PROXY_PORT = load_password('HTTP_PROXY_PORT', default=0)
+    HOSTS = load_password('PROXY_HOSTS', default=[])
 
     class Response(object):
         def __init__(self, status_code, content=None, url=None, headers=None):
@@ -241,10 +246,8 @@ class TwistedAdditions(object):
             headers['Content-Type'] = ['application/json']
 
         try:
-            proxy = os.getenv('http_proxy') or os.getenv('https_proxy') or os.getenv('HTTP_PROXY') or os.getenv('HTTPS_PROXY')
-            match = cls.PROXY_RE.match(proxy) if proxy else None
-            if match:
-                proxy = HTTPProxyConnector(match.group('host'), int(match.group('port')))
+            if hostname in cls.HOSTS:
+                proxy = HTTPProxyConnector(cls.HTTPS_PROXY, cls.HTTPS_PROXY_PORT)
                 agent = Agent(proxy, connectTimeout=timeout)
             else:
                 agent = Agent(reactor, connectTimeout=timeout)


### PR DESCRIPTION
#### 6b6b4ae209d69709022aaccef0344f7b01df8637
<pre>
Move Proxy Configuration into Password Util
<a href="https://rdar.apple.com/161903193">rdar://161903193</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=300116">https://bugs.webkit.org/show_bug.cgi?id=300116</a>

Reviewed by NOBODY (OOPS!).

* Tools/CISupport/ews-build/twisted_additions.py:
(TwistedAdditions):
(TwistedAdditions.request):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6b6b4ae209d69709022aaccef0344f7b01df8637

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124449 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44132 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34864 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131293 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76460 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a9d60534-81c6-454b-8145-4b8a3f7c0171) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/126326 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44872 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52727 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94680 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62799 "") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8b45d2b4-42a4-4fb4-90af-ec5dc1c6447a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127403 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35770 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75257 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/eb6fe855-57ed-4898-9341-44f726c5a338) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34706 "Passed tests") | [⏳ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK1-Tests-EWS "Waiting to run tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74771 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105522 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29689 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133958 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51346 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39171 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103156 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/123869 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51747 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107524 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102945 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48307 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48291 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51212 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50629 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53991 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52306 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->