### PR TITLE
Nesting selector can't be inlined if there is a tag selector in both compounds

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nesting-basic-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nesting-basic-expected.html
@@ -28,4 +28,5 @@
   <div class="test"></div>
   <div class="test"></div>
   <div class="test"></div>
+  <div class="test"></div>
 </body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nesting-basic.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nesting-basic.html
@@ -97,6 +97,9 @@
       background-color: red;
     }
   }
+  div.test-14 {
+      div& {  background-color: green; }
+  }
 
   body * + * {
     margin-top: 8px;
@@ -120,4 +123,5 @@
   <div class="test test-11"><div></div></div>
   <div class="test test-12"></div>
   <div class="test test-13"></div>
+  <div class="test test-14"></div>
 </body>


### PR DESCRIPTION
#### 18f19fda8506bd9b7fcc5109c656e7b22c40f8cb
<pre>
Nesting selector can&apos;t be inlined if there is a tag selector in both compounds
<a href="https://bugs.webkit.org/show_bug.cgi?id=300113">https://bugs.webkit.org/show_bug.cgi?id=300113</a>
<a href="https://rdar.apple.com/161903063">rdar://161903063</a>

Reviewed by Matthieu Dubet.

* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nesting-basic-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nesting-basic-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nesting-basic.html:
* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::CSSSelectorParser::resolveNestingParent):

Check if both the compound of the nesting selector and the last compound of the nesting parent
have tag selectors. We can&apos;t inline if they do because CSS syntax only allows one tag per compound
and the codebase has assumptions around that.

Canonical link: <a href="https://commits.webkit.org/301114@main">https://commits.webkit.org/301114@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4a852c23b660b50e37ce2e5df4f26d1c059797bf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124703 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44375 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35110 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131545 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76627 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cf3e6a55-8656-4f7c-b272-665615eeddcd) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/126580 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45079 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52945 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94873 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62938 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f48ddaa4-a372-492b-9fe2-b619d99fde0c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127657 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35951 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111524 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75443 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/dde46f81-3877-4d1f-931d-f7b0cd6136fd) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34882 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29679 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75024 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105708 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29910 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134210 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51551 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39363 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103349 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51963 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107745 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103122 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26319 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48496 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26767 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48533 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51425 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57222 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50818 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54174 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52513 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->