### PR TITLE
AX: [iOS] Date fields shouldn't send focused change notification when picker popup is presented

### DIFF
--- a/LayoutTests/accessibility/ios-simulator/date-picker-focus-notification-expected.txt
+++ b/LayoutTests/accessibility/ios-simulator/date-picker-focus-notification-expected.txt
@@ -1,0 +1,7 @@
+This tests that when a date field shows a popover, no focused event is fired.
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/ios-simulator/date-picker-focus-notification.html
+++ b/LayoutTests/accessibility/ios-simulator/date-picker-focus-notification.html
@@ -1,0 +1,38 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/ui-helper.js"></script>
+</head>
+<body>
+
+<input id="datefield" type="date">
+
+<script>
+var output = "This tests that when a date field shows a popover, no focused event is fired.\n\n";
+
+function focusCallback(notification) {
+    if (notification === "AXFocusChanged")
+    	output += "Received AXFocusChanged event\n";
+}
+
+if (window.accessibilityController) {
+	window.jsTestIsAsync = true;
+	var datefield = accessibilityController.accessibleElementById("datefield");
+	datefield.addNotificationListener(focusCallback);
+	
+	setTimeout(async function() {
+		await UIHelper.activateElement(document.getElementById("datefield"));
+
+		// We shouldn't receive any focused notifications for this date picker, so wait a bit to catch this bug in the future.
+		await sleep(60);
+		debug(output);
+		finishJSTest();
+	}, 0);
+}
+</script>
+
+</body>
+</html>
+

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -556,6 +556,9 @@ public:
 
 #if PLATFORM(IOS_FAMILY)
     void relayNotification(String&&, RetainPtr<NSData>&&);
+
+    void setWillPresentDatePopover(bool willPresent) { m_willPresentDatePopover = willPresent; }
+    bool willPresentDatePopover() const { return m_willPresentDatePopover; }
 #endif
 
 #if PLATFORM(MAC)
@@ -856,6 +859,10 @@ private:
     double m_loadingProgress { 0 };
 
     unsigned m_cacheUpdateDeferredCount { 0 };
+
+#if PLATFORM(IOS_FAMILY)
+    bool m_willPresentDatePopover;
+#endif
 
     // Relationships between objects.
     HashMap<AXID, AXRelations> m_relations;

--- a/Source/WebCore/html/BaseDateAndTimeInputType.cpp
+++ b/Source/WebCore/html/BaseDateAndTimeInputType.cpp
@@ -342,12 +342,19 @@ void BaseDateAndTimeInputType::showPicker()
     if (!element()->renderer())
         return;
 
-    if (!element()->document().page())
+    Ref document = element()->document();
+    if (!document->page())
         return;
 
     DateTimeChooserParameters parameters;
     if (!setupDateTimeChooserParameters(parameters))
         return;
+
+
+#if PLATFORM(IOS_FAMILY)
+    if (CheckedPtr cache = document->existingAXObjectCache())
+        cache->setWillPresentDatePopover(true);
+#endif
 
     if (auto* chrome = this->chrome()) {
         m_dateTimeChooser = chrome->createDateTimeChooser(*this);

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -5979,6 +5979,14 @@ RefPtr<MediaSessionManagerInterface> Page::mediaSessionManagerForPageIdentifier(
     return nullptr;
 }
 
+#if PLATFORM(IOS_FAMILY)
+void Page::clearIsShowingInputView()
+{
+    if (CheckedPtr cache = existingAXObjectCache())
+        cache->setWillPresentDatePopover(false);
+}
+#endif
+
 #if HAVE(SUPPORT_HDR_DISPLAY)
 bool Page::drawsHDRContent() const
 {

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -1384,6 +1384,9 @@ public:
     void setHardwareKeyboardAttached(bool attached) { m_hardwareKeyboardAttached = attached; }
     bool hardwareKeyboardAttached() const { return m_hardwareKeyboardAttached; }
 
+#if PLATFORM(IOS_FAMILY)
+    WEBCORE_EXPORT void clearIsShowingInputView();
+#endif
 private:
     explicit Page(PageConfiguration&&);
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1111,7 +1111,7 @@ public:
     void autofillLoginCredentials(const String&, const String&);
     void setFocusedElementValue(const WebCore::ElementContext&, const String&);
     void setFocusedElementSelectedIndex(const WebCore::ElementContext&, uint32_t index, bool allowMultipleSelection);
-    void setIsShowingInputViewForFocusedElement(bool showingInputView) { m_isShowingInputViewForFocusedElement = showingInputView; }
+    void setIsShowingInputViewForFocusedElement(bool);
     bool isShowingInputViewForFocusedElement() const { return m_isShowingInputViewForFocusedElement; }
     void updateSelectionAppearance();
     void getSelectionContext(CompletionHandler<void(const String&, const String&, const String&)>&&);

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -1649,6 +1649,13 @@ void WebPage::setFocusedElementSelectedIndex(const WebCore::ElementContext& cont
         select->optionSelectedByUser(index, true, allowMultipleSelection);
 }
 
+void WebPage::setIsShowingInputViewForFocusedElement(bool showingInputView)
+{
+    m_isShowingInputViewForFocusedElement = showingInputView;
+    if (!showingInputView)
+        m_page->clearIsShowingInputView();
+}
+
 void WebPage::showInspectorHighlight(const WebCore::InspectorOverlay::Highlight& highlight)
 {
     send(Messages::WebPageProxy::ShowInspectorHighlight(highlight));


### PR DESCRIPTION
#### 8c8a97961d8bdac770f70e168b00693feffccdc3
<pre>
AX: [iOS] Date fields shouldn&apos;t send focused change notification when picker popup is presented
<a href="https://bugs.webkit.org/show_bug.cgi?id=269269">https://bugs.webkit.org/show_bug.cgi?id=269269</a>
<a href="https://rdar.apple.com/122851275">rdar://122851275</a>

Reviewed by Tyler Wilcock.

VoiceOver focus wasn&apos;t being moved to the date picker&apos;s popup due to a focused element changed
notification fired on the date element as the picker was expanded. Native pop up elements will
automatically post this notification in the UI process, so this notification conflicted and
created a race condition.

To prevent this, there is a new flag in AXObjectCache that maintains the state of the picker.
If the picker will open, this flag prevents us from sending the conflicting notification. We
clear this state for new focus changes and when the picker is closed (sent via IPC from the
UI process).

Date and DateTimeLocal input types were also added to elements that should defer their focus
(shouldDeferFocusChange). This is because when this race condition occurs, the focus event
happens prior to the DOMActivate event being dispatched, which prevents us from knowing the
state of the picker before handling the notification. By deferring, we allow the DOM event
to occur in time.

Test: accessibility/ios-simulator/date-picker-focus-notification.html

* LayoutTests/accessibility/ios-simulator/date-picker-focus-notification-expected.txt: Added.
* LayoutTests/accessibility/ios-simulator/date-picker-focus-notification.html: Added.
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::shouldDeferFocusChange):
(WebCore::AXObjectCache::handleFocusedUIElementChanged):
* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebCore/html/BaseDateAndTimeInputType.cpp:
(WebCore::BaseDateAndTimeInputType::showPicker):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::clearIsShowingInputView):
* Source/WebCore/page/Page.h:
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::setIsShowingInputViewForFocusedElement):

Canonical link: <a href="https://commits.webkit.org/301057@main">https://commits.webkit.org/301057@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/07ba4e51b66034785b31bf2de74e805274b0de9c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124722 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44394 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35129 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131571 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76643 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c9b3b021-e7c0-4ab0-9b1e-4b71e95ff377) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/126599 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45098 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52964 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94896 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62950 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9b2aaa62-f639-4605-b885-7ea53ff6416a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127676 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35971 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111546 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75465 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/087a813b-6ff3-49be-a67c-09d4cdbb7b91) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34902 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29700 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75049 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105728 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29931 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134237 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51570 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39385 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103372 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51983 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107766 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103145 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26284 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48509 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26788 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48558 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51443 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57241 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50836 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54192 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52531 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->