### PR TITLE
WebTransport should notify JS of connection group failures

### DIFF
--- a/Source/WebCore/Modules/webtransport/WebTransport.cpp
+++ b/Source/WebCore/Modules/webtransport/WebTransport.cpp
@@ -436,7 +436,7 @@ ReadableStream& WebTransport::incomingUnidirectionalStreams()
     return m_incomingUnidirectionalStreams.get();
 }
 
-void WebTransport::networkProcessCrashed()
+void WebTransport::didFail()
 {
     cleanup(DOMException::create(ExceptionCode::AbortError), std::nullopt);
 }

--- a/Source/WebCore/Modules/webtransport/WebTransport.h
+++ b/Source/WebCore/Modules/webtransport/WebTransport.h
@@ -103,7 +103,7 @@ private:
     void receiveIncomingUnidirectionalStream(WebTransportStreamIdentifier) final;
     void receiveBidirectionalStream(Ref<WebTransportSendStreamSink>&&) final;
     void streamReceiveBytes(WebTransportStreamIdentifier, std::span<const uint8_t>, bool, std::optional<Exception>&&) final;
-    void networkProcessCrashed() final;
+    void didFail() final;
 
     RefPtr<WebTransportSession> protectedSession();
 

--- a/Source/WebCore/Modules/webtransport/WebTransportSessionClient.h
+++ b/Source/WebCore/Modules/webtransport/WebTransportSessionClient.h
@@ -46,7 +46,7 @@ public:
     virtual void receiveIncomingUnidirectionalStream(WebTransportStreamIdentifier) = 0;
     virtual void receiveBidirectionalStream(Ref<WebTransportSendStreamSink>&&) = 0;
     virtual void streamReceiveBytes(WebTransportStreamIdentifier, std::span<const uint8_t>, bool, std::optional<Exception>&&) = 0;
-    virtual void networkProcessCrashed() = 0;
+    virtual void didFail() = 0;
 };
 
 }

--- a/Source/WebCore/Modules/webtransport/WorkerWebTransportSession.cpp
+++ b/Source/WebCore/Modules/webtransport/WorkerWebTransportSession.cpp
@@ -68,14 +68,14 @@ void WorkerWebTransportSession::receiveDatagram(std::span<const uint8_t> span, b
     });
 }
 
-void WorkerWebTransportSession::networkProcessCrashed()
+void WorkerWebTransportSession::didFail()
 {
     ASSERT(RunLoop::isMain());
     ScriptExecutionContext::postTaskTo(m_contextID, [weakClient = m_client] (auto&) mutable {
         RefPtr client = weakClient.get();
         if (!client)
             return;
-        client->networkProcessCrashed();
+        client->didFail();
     });
 }
 

--- a/Source/WebCore/Modules/webtransport/WorkerWebTransportSession.h
+++ b/Source/WebCore/Modules/webtransport/WorkerWebTransportSession.h
@@ -50,7 +50,7 @@ private:
     void receiveIncomingUnidirectionalStream(WebTransportStreamIdentifier) final;
     void receiveBidirectionalStream(Ref<WebTransportSendStreamSink>&&) final;
     void streamReceiveBytes(WebTransportStreamIdentifier, std::span<const uint8_t>, bool, std::optional<Exception>&&) final;
-    void networkProcessCrashed() final;
+    void didFail() final;
 
     Ref<WebTransportSendPromise> sendDatagram(std::span<const uint8_t>) final;
     Ref<WritableStreamPromise> createOutgoingUnidirectionalStream() final;

--- a/Source/WebKit/WebProcess/Network/WebTransportSession.cpp
+++ b/Source/WebKit/WebProcess/Network/WebTransportSession.cpp
@@ -117,6 +117,15 @@ void WebTransportSession::streamReceiveBytes(WebCore::WebTransportStreamIdentifi
         ASSERT_NOT_REACHED();
 }
 
+void WebTransportSession::didFail()
+{
+    ASSERT(RunLoop::isMain());
+    if (RefPtr strongClient = m_client.get())
+        strongClient->didFail();
+    else
+        ASSERT_NOT_REACHED();
+}
+
 Ref<WebCore::WebTransportSendPromise> WebTransportSession::sendDatagram(std::span<const uint8_t> datagram)
 {
     return sendWithPromisedReply(Messages::NetworkTransportSession::SendDatagram(datagram))->whenSettled(RunLoop::mainSingleton(), [] (auto&& exception) {
@@ -191,13 +200,6 @@ Ref<WebCore::WebTransportSendPromise> WebTransportSession::streamSendBytes(WebCo
 void WebTransportSession::terminate(WebCore::WebTransportSessionErrorCode code, CString&& reason)
 {
     send(Messages::NetworkTransportSession::Terminate(code, WTFMove(reason)));
-}
-
-void WebTransportSession::networkProcessCrashed()
-{
-    ASSERT(RunLoop::isMain());
-    if (RefPtr strongClient = m_client.get())
-        strongClient->networkProcessCrashed();
 }
 
 void WebTransportSession::cancelReceiveStream(WebCore::WebTransportStreamIdentifier identifier, std::optional<WebCore::WebTransportStreamErrorCode> errorCode)

--- a/Source/WebKit/WebProcess/Network/WebTransportSession.h
+++ b/Source/WebKit/WebProcess/Network/WebTransportSession.h
@@ -71,13 +71,13 @@ public:
     void receiveIncomingUnidirectionalStream(WebCore::WebTransportStreamIdentifier);
     void receiveBidirectionalStream(WebCore::WebTransportStreamIdentifier);
     void streamReceiveBytes(WebCore::WebTransportStreamIdentifier, std::span<const uint8_t>, bool, std::optional<WebCore::Exception>&&);
+    void didFail();
 
     WTF_ABSTRACT_THREAD_SAFE_REF_COUNTED_AND_CAN_MAKE_WEAK_PTR_IMPL;
 
     // MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
 
-    void networkProcessCrashed();
 private:
     WebTransportSession(Ref<IPC::Connection>&&, ThreadSafeWeakPtr<WebCore::WebTransportSessionClient>&&, WebTransportSessionIdentifier);
 

--- a/Source/WebKit/WebProcess/Network/WebTransportSession.messages.in
+++ b/Source/WebKit/WebProcess/Network/WebTransportSession.messages.in
@@ -29,4 +29,5 @@ messages -> WebTransportSession {
     ReceiveIncomingUnidirectionalStream(WebCore::WebTransportStreamIdentifier identifier)
     ReceiveBidirectionalStream(WebCore::WebTransportStreamIdentifier identifier)
     StreamReceiveBytes(WebCore::WebTransportStreamIdentifier identifier, std::span<const uint8_t> bytes, bool withFin, std::optional<WebCore::Exception> exception)
+    DidFail()
 }

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -1451,7 +1451,7 @@ void WebProcess::networkProcessConnectionClosed(NetworkProcessConnection* connec
     }
     for (auto& weakSession : sessions) {
         if (RefPtr webtransportSession = weakSession.get())
-            webtransportSession->networkProcessCrashed();
+            webtransportSession->didFail();
     }
 }
 

--- a/Tools/TestWebKitAPI/NetworkConnection.h
+++ b/Tools/TestWebKitAPI/NetworkConnection.h
@@ -76,6 +76,7 @@ public:
     enum class ConnectionType : uint8_t { Datagram, Bidirectional, Unidirectional };
     Connection createWebTransportConnection(ConnectionType) const;
     ReceiveIncomingConnectionOperation receiveIncomingConnection() const;
+    void cancel();
 
 private:
     friend class WebTransportServer;


### PR DESCRIPTION
#### 3bb7c385b057ba06c1192847b6c0fe557d0021f6
<pre>
WebTransport should notify JS of connection group failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=300124">https://bugs.webkit.org/show_bug.cgi?id=300124</a>
<a href="https://rdar.apple.com/160150633">rdar://160150633</a>

Reviewed by Matthew Finkel.

Before this PR, if the network failed or the server terminated the connection group,
JS would receive no notification that that happened.  Now it does.

Tests: Tools/TestWebKitAPI/NetworkConnection.h
       Tools/TestWebKitAPI/NetworkConnection.mm
       Tools/TestWebKitAPI/Tests/WebKitCocoa/WebTransport.mm
* Source/WebCore/Modules/webtransport/WebTransport.cpp:
(WebCore::WebTransport::didFail):
(WebCore::WebTransport::networkProcessCrashed): Deleted.
* Source/WebCore/Modules/webtransport/WebTransport.h:
* Source/WebCore/Modules/webtransport/WebTransportSessionClient.h:
* Source/WebCore/Modules/webtransport/WorkerWebTransportSession.cpp:
(WebCore::WorkerWebTransportSession::didFail):
(WebCore::WorkerWebTransportSession::networkProcessCrashed): Deleted.
* Source/WebCore/Modules/webtransport/WorkerWebTransportSession.h:
* Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportSessionCocoa.mm:
(WebKit::NetworkTransportSession::initialize):
* Source/WebKit/WebProcess/Network/WebTransportSession.cpp:
(WebKit::WebTransportSession::didFail):
(WebKit::WebTransportSession::networkProcessCrashed): Deleted.
* Source/WebKit/WebProcess/Network/WebTransportSession.h:
* Source/WebKit/WebProcess/Network/WebTransportSession.messages.in:
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::networkProcessConnectionClosed):
* Tools/TestWebKitAPI/NetworkConnection.h:
* Tools/TestWebKitAPI/NetworkConnection.mm:
(TestWebKitAPI::ConnectionGroup::cancel):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebTransport.mm:
(TestWebKitAPI::TEST(WebTransport, ServerConnectionTermination)):

Canonical link: <a href="https://commits.webkit.org/300965@main">https://commits.webkit.org/300965@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/78fbb6767b44b8d790cd8d00cd52c2bc068ace84

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124466 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44147 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34881 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131310 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/76464 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0c224e90-259a-47ad-9068-358ed781ed79) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/126343 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/44877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52735 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94687 "") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/76464 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b886cb36-f199-4598-989b-842b9c486609) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127420 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/44877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111317 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75264 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bbb74306-1333-4119-8161-15d025fd086f) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/44877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29479 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74789 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/44877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29702 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133975 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51352 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39178 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/103173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51756 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107537 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102958 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48317 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26571 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48297 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19539 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51220 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57007 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/50634 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/53995 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52312 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->