### PR TITLE
Add entitlement assertions for JIT disabling on macOS

### DIFF
--- a/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
+++ b/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
@@ -172,6 +172,10 @@ void ExecutableAllocator::disableJIT()
     bool shouldDisableJITMemory = processHasEntitlement("com.apple.security.cs.allow-jit"_s) && !isKernOpenSource();
 #endif
     if (shouldDisableJITMemory) {
+#if PLATFORM(MAC)
+        RELEASE_ASSERT(processHasEntitlement("com.apple.private.verified-jit"));
+        RELEASE_ASSERT(processHasEntitlement("com.apple.security.cs.single-jit"));
+#endif
         // Because of an OS quirk, even after the JIT region has been unmapped,
         // the OS thinks that region is reserved, and as such, can cause Gigacage
         // allocation to fail. We work around this by initializing the Gigacage


### PR DESCRIPTION
#### 9cc524ed511e7ec4127c7dda5cef25610542f8ac
<pre>
Add entitlement assertions for JIT disabling on macOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=300127">https://bugs.webkit.org/show_bug.cgi?id=300127</a>
<a href="https://rdar.apple.com/problem/161912390">rdar://problem/161912390</a>

Reviewed by Mark Lam.

Add release assertions to verify that verified-jit and single-jit
entitlements are present when disabling JIT on macOS. This ensures
processes disabling JIT have the required entitlements for proper
JIT region unmapping behavior.

* Source/JavaScriptCore/jit/ExecutableAllocator.cpp:
(JSC::ExecutableAllocator::disableJIT):

Canonical link: <a href="https://commits.webkit.org/301264@main">https://commits.webkit.org/301264@main</a>
</pre>
