### PR TITLE
[css-anchor-position-1] Support safe with anchor-center

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-safe-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-safe-expected.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<title>Tests whether safe alignment works correctly on the anchor element.</title>
+<div style="position: relative;">
+  <div class="anchor">Anchor</div>
+  <div class="infobox">
+    <p>Anchored element</p>
+  </div>
+</div>
+<style>
+.anchor {
+  position: fixed; 
+  left: 0px;
+  top: 0px; 
+  height: 30px;
+  font-size: 1.8rem;
+  color: white;
+  background-color: green;
+}
+.infobox {
+  color: darkblue;
+  background-color: azure;
+  border: 1px solid #ddd;
+  padding: 10px;
+  border-radius: 10px;
+  font-size: 1rem;
+  position: fixed;
+  top: 35px;
+  left: 0px;
+}
+</style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-safe-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-safe-ref.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<title>Tests whether safe alignment works correctly on the anchor element.</title>
+<div style="position: relative;">
+  <div class="anchor">Anchor</div>
+  <div class="infobox">
+    <p>Anchored element</p>
+  </div>
+</div>
+<style>
+.anchor {
+  position: fixed; 
+  left: 0px;
+  top: 0px; 
+  height: 30px;
+  font-size: 1.8rem;
+  color: white;
+  background-color: green;
+}
+.infobox {
+  color: darkblue;
+  background-color: azure;
+  border: 1px solid #ddd;
+  padding: 10px;
+  border-radius: 10px;
+  font-size: 1rem;
+  position: fixed;
+  top: 35px;
+  left: 0px;
+}
+</style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-safe-rtl-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-safe-rtl-expected.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<title>Tests whether safe alignment works correctly on the anchor element.</title>
+<div style="position: relative;">
+  <div class="anchor">Anchor</div>
+  <div class="infobox">
+    <p>Anchored element</p>
+  </div>
+</div>
+<style>
+.anchor {
+  position: fixed; 
+  top: 0px; 
+  right: 0px;
+  height: 30px;
+  font-size: 1.8rem;
+  color: white;
+  background-color: green;
+}
+.infobox {
+  color: darkblue;
+  background-color: azure;
+  border: 1px solid #ddd;
+  padding: 10px;
+  border-radius: 10px;
+  font-size: 1rem;
+  position: fixed;
+  top: 35px;
+  right: 0px;
+}
+</style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-safe-rtl-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-safe-rtl-ref.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<title>Tests whether safe alignment works correctly on the anchor element.</title>
+<div style="position: relative;">
+  <div class="anchor">Anchor</div>
+  <div class="infobox">
+    <p>Anchored element</p>
+  </div>
+</div>
+<style>
+.anchor {
+  position: fixed; 
+  top: 0px; 
+  right: 0px;
+  height: 30px;
+  font-size: 1.8rem;
+  color: white;
+  background-color: green;
+}
+.infobox {
+  color: darkblue;
+  background-color: azure;
+  border: 1px solid #ddd;
+  padding: 10px;
+  border-radius: 10px;
+  font-size: 1rem;
+  position: fixed;
+  top: 35px;
+  right: 0px;
+}
+</style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-safe-rtl.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-safe-rtl.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<title>Tests whether safe alignment works correctly on the anchor element.</title>
+<link rel="match" href="anchor-center-safe-ref.html">
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#anchor-center">
+<div class="anchor">Anchor</div>
+<div class="infobox">
+  <p>Anchored element</p>
+</div>
+<style>
+body {
+ direction: rtl; 
+ display: inline;
+}
+.anchor {
+  position: fixed; 
+  top: 0px; 
+  right: 0px;
+  height: 30px;
+  font-size: 1.8rem;
+  color: white;
+  background-color: green;
+  anchor-name: --myAnchor;
+}
+.infobox {
+  color: darkblue;
+  background-color: azure;
+  border: 1px solid #ddd;
+  padding: 10px;
+  border-radius: 10px;
+  font-size: 1rem;
+  position: fixed;
+  position-anchor: --myAnchor;
+  top: calc(anchor(bottom) + 5px);
+  right: 0px;
+  justify-self: safe anchor-center;
+}
+</style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-safe.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-safe.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<title>Tests whether safe alignment works correctly on the anchor element.</title>
+<link rel="match" href="anchor-center-safe-ref.html">
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#anchor-center">
+<div class="anchor">Anchor</div>
+<div class="infobox">
+  <p>Anchored element</p>
+</div>
+<style>
+.anchor {
+  position: fixed; 
+  left: 0px;
+  top: 0px; 
+  height: 30px;
+  font-size: 1.8rem;
+  color: white;
+  background-color: green;
+  anchor-name: --myAnchor;
+}
+.infobox {
+  color: darkblue;
+  background-color: azure;
+  border: 1px solid #ddd;
+  padding: 10px;
+  border-radius: 10px;
+  font-size: 1rem;
+  position: fixed;
+  position-anchor: --myAnchor;
+  top: calc(anchor(bottom) + 5px);
+  left: 0px;
+  justify-self: safe anchor-center;
+}
+</style>

--- a/Source/WebCore/rendering/PositionedLayoutConstraints.cpp
+++ b/Source/WebCore/rendering/PositionedLayoutConstraints.cpp
@@ -353,8 +353,17 @@ LayoutUnit PositionedLayoutConstraints::resolveAlignmentShift(LayoutUnit unusedS
 
     LayoutUnit shift;
     if (ItemPosition::AnchorCenter == resolvedAlignment) {
-        auto anchorCenterPosition = m_anchorArea.min() + (m_anchorArea.size() - itemSize) / 2;
+        LayoutUnit anchorCenterPosition = m_anchorArea.min() + (m_anchorArea.size() - itemSize) / 2;
         shift = anchorCenterPosition - m_insetModifiedContainingRange.min();
+        if (m_alignment.overflow() == OverflowAlignment::Safe) {
+            if (startIsBefore) {
+                if (shift < 0)
+                    shift = 0;
+            } else {
+                if (shift > unusedSpace)
+                    shift = unusedSpace;
+            }
+        }
         if (!isOverflowing && OverflowAlignment::Default == m_alignment.overflow()) {
             // Avoid introducing overflow of the IMCB.
             if (shift < 0)


### PR DESCRIPTION
#### 4f6214591145e54a19c6aee8f85872b9883190b4
<pre>
[css-anchor-position-1] Support safe with anchor-center
<a href="https://bugs.webkit.org/show_bug.cgi?id=295503">https://bugs.webkit.org/show_bug.cgi?id=295503</a>

Reviewed by NOBODY (OOPS!).

Make safe keyword work with anchor-aligned element as specified in CSS Anchor Positioning spec:
<a href="https://drafts.csswg.org/css-anchor-position-1/#anchor-center">https://drafts.csswg.org/css-anchor-position-1/#anchor-center</a>

&quot;When using anchor-center, by default if the anchor is too close to the edge of the box’s original containing block,
it will &quot;shift&quot; from being purely centered, in order to remain within the original containing block.
See CSS Box Alignment 3 §4.4 Overflow Alignment:
the safe and unsafe keywords and scroll safety limits for more details.&quot;

* Source/WebCore/rendering/PositionedLayoutConstraints.cpp:
(WebCore::PositionedLayoutConstraints::resolveAlignmentShift const):
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-safe-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-safe.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-safe-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-safe-rtl-expected.html: Copied from LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-safe-expected.html.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-safe-rtl-ref.html: Copied from LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-safe-expected.html.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-safe-rtl.html: Copied from LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-safe.html.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4f6214591145e54a19c6aee8f85872b9883190b4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124502 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/44180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/138/builds/34914 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/131340 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/76482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/126379 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/44897 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/52761 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/131340 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/76482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127456 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/44897 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/138/builds/34914 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/131340 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/44897 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/138/builds/34914 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/74819 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/44897 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/34914 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/134005 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/51373 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/52761 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/134005 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/51780 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/138/builds/34914 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/134005 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/34914 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/48316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/51243 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/57033 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/50654 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/54013 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/52334 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->