### PR TITLE
Add feature flag for panorama image controls

### DIFF
--- a/LayoutTests/platform/visionos/TestExpectations
+++ b/LayoutTests/platform/visionos/TestExpectations
@@ -82,7 +82,6 @@ interaction-region [ Pass ]
 media/media-css-volume-locked.html [ Pass ]
 overlay-region [ Pass ]
 platform/visionos/transforms [ Pass ]
-fast/images/spatial-image-controls.html [ Pass ]
 fast/images/spatial-image-controls-rtl.html [ Pass ]
 
 imported/w3c/web-platform-tests/webxr [ Pass ]

--- a/Source/WebCore/html/shadow/SpatialImageControls.cpp
+++ b/Source/WebCore/html/shadow/SpatialImageControls.cpp
@@ -100,7 +100,11 @@ bool shouldHaveSpatialControls(HTMLImageElement& element)
     if (!image)
         return false;
 
-    return hasSpatialcontrolsAttribute && (image->isSpatial() || image->isMaybePanoramic());
+    return hasSpatialcontrolsAttribute && (image->isSpatial()
+#if ENABLE(PANORAMA_IMAGE_CONTROLS)
+        || image->isMaybePanoramic()
+#endif
+    );
 }
 
 void ensureSpatialControls(HTMLImageElement& imageElement)
@@ -116,6 +120,7 @@ void ensureSpatialControls(HTMLImageElement& imageElement)
         if (hasSpatialImageControls(*element))
             return;
 
+#if ENABLE(PANORAMA_IMAGE_CONTROLS)
         // Determine if this is a spatial or panoramic image
         auto* cachedImage = element->cachedImage();
         if (!cachedImage)
@@ -130,6 +135,7 @@ void ensureSpatialControls(HTMLImageElement& imageElement)
 
         if (!isSpatialImage && !isPanoramicImage)
             return;
+#endif // ENABLE(PANORAMA_IMAGE_CONTROLS)
 
         RefPtr page = element->document().page();
         bool isRTL = page && page->userInterfaceLayoutDirection() == UserInterfaceLayoutDirection::RTL;
@@ -184,11 +190,19 @@ void ensureSpatialControls(HTMLImageElement& imageElement)
 
         Ref bottomLabelText = HTMLDivElement::create(document.get());
         bottomLabelText->setIdAttribute("label"_s);
+#if ENABLE(PANORAMA_IMAGE_CONTROLS)
         bottomLabelText->setTextContent(isSpatialImage ? imageControlsLabelSpatial() : imageControlsLabelPanorama());
+#else
+        bottomLabelText->setTextContent(imageControlsLabelSpatial());
+#endif
         controlLayer->appendChild(bottomLabelText);
 
         Ref glyphSpan = HTMLSpanElement::create(document.get());
+#if ENABLE(PANORAMA_IMAGE_CONTROLS)
         glyphSpan->setIdAttribute(isSpatialImage ? "spatial-glyph"_s : "pano-glyph"_s);
+#else
+        glyphSpan->setIdAttribute("spatial-glyph"_s);
+#endif
         bottomLabelText->insertBefore(glyphSpan, bottomLabelText->protectedFirstChild());
 
         if (CheckedPtr renderImage = dynamicDowncast<RenderImage>(element->renderer()))

--- a/Source/WebCore/html/shadow/spatialImageControls.css
+++ b/Source/WebCore/html/shadow/spatialImageControls.css
@@ -104,6 +104,7 @@ span#spatial-glyph {
     margin-bottom: -8px;
     margin-inline-end: -8px;
 }
+#if defined(ENABLE_PANORAMA_IMAGE_CONTROLS) && ENABLE_PANORAMA_IMAGE_CONTROLS
 span#pano-glyph {
     width: 30px;
     height: 30px;
@@ -115,5 +116,6 @@ span#pano-glyph {
     margin-inline-end: 5px;
     margin-inline-start: 10px;
 }
+#endif // defined(ENABLE_PANORAMA_IMAGE_CONTROLS) && ENABLE_PANORAMA_IMAGE_CONTROLS
 
 #endif


### PR DESCRIPTION
#### 6e43cb831efc6195eb5e20393cedc8eb358cb4b5
<pre>
Add feature flag for panorama image controls
<a href="https://bugs.webkit.org/show_bug.cgi?id=300134">https://bugs.webkit.org/show_bug.cgi?id=300134</a>
&lt;<a href="https://rdar.apple.com/161909905">rdar://161909905</a>&gt;

Reviewed by Aditya Keerthi and Abrar Rahman Protyasha.

Guard relevant recent changes with PANORAMA_IMAGE_CONTROLS feature flag.

* Source/WebCore/html/shadow/SpatialImageControls.cpp:
(WebCore::SpatialImageControls::shouldHaveSpatialControls):
(WebCore::SpatialImageControls::ensureSpatialControls):
* Source/WebCore/html/shadow/spatialImageControls.css:
Add new compile-time feature flag.

* LayoutTests/platform/visionos/TestExpectations:
Skip layout test since necessary changes are now compiled out.

Canonical link: <a href="https://commits.webkit.org/300976@main">https://commits.webkit.org/300976@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e6fa3b710ac491f82d778ae9e74c306b4ba9783c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124512 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44190 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34924 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131349 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/76488 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/126389 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44906 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52770 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94719 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/76488 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127466 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/35795 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/111358 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75294 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/34732 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29514 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74830 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105548 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29746 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134016 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51380 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39207 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103194 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51789 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107582 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102978 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26219 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48347 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26608 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/48322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51252 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57042 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/50660 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/54019 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52341 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->