### PR TITLE
Send PolicyAction::LoadWillContinueInAnotherProcess before continuing navigation in new process

### DIFF
--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -5078,9 +5078,8 @@ void WebPageProxy::receivedNavigationActionPolicyDecision(WebProcessProxy& proce
                 suspendedPage = nullptr;
 
             auto isPerformingHTTPFallback = navigationAction->data().isPerformingHTTPFallback ? IsPerformingHTTPFallback::Yes : IsPerformingHTTPFallback::No;
-            continueNavigationInNewProcess(navigation, frame.get(), WTFMove(suspendedPage), browsingContextGroup, WTFMove(processNavigatingTo), processSwapRequestedByClient, ShouldTreatAsContinuingLoad::YesAfterNavigationPolicyDecision, std::nullopt, loadedWebArchive, isPerformingHTTPFallback, WebCore::ProcessSwapDisposition::None, replacedDataStoreForWebArchiveLoad.get());
-
             receivedPolicyDecision(policyAction, navigation.ptr(), std::nullopt, WTFMove(navigationAction), WillContinueLoadInNewProcess::Yes, std::nullopt, WTFMove(message), WTFMove(completionHandler));
+            continueNavigationInNewProcess(navigation, frame.get(), WTFMove(suspendedPage), browsingContextGroup, WTFMove(processNavigatingTo), processSwapRequestedByClient, ShouldTreatAsContinuingLoad::YesAfterNavigationPolicyDecision, std::nullopt, loadedWebArchive, isPerformingHTTPFallback, WebCore::ProcessSwapDisposition::None, replacedDataStoreForWebArchiveLoad.get());
             return;
         }
 


### PR DESCRIPTION
#### 579c1775de1beb3e120ecc9fec28aff79c1039d0
<pre>
Send PolicyAction::LoadWillContinueInAnotherProcess before continuing navigation in new process
<a href="https://bugs.webkit.org/show_bug.cgi?id=300136">https://bugs.webkit.org/show_bug.cgi?id=300136</a>
<a href="https://rdar.apple.com/161919928">rdar://161919928</a>

Reviewed by Brian Weinstein.

This is needed to fix the TestWebKitAPI.SiteIsolation.NavigateIframeToProvisionalNavigationFailure
after unrelated changes in <a href="https://github.com/WebKit/WebKit/pull/51676.">https://github.com/WebKit/WebKit/pull/51676.</a>  Particularly, in
DocumentLoader::willSendRequest, we need to make this early return work when the parent frame is a RemoteFrame:

RefPtr parentFrame = dynamicDowncast&lt;LocalFrame&gt;(frame-&gt;tree().parent());
if (!parentFrame)
   return completionHandler(WTFMove(newRequest));

Removing that early return makes it so the test navigating the iframe to <a href="https://webkit.org/redirect_to_webkit_terminate">https://webkit.org/redirect_to_webkit_terminate</a>
results in an _WKErrorCodeFrameLoadInterruptedByPolicyChange instead of the correct NSURLErrorNetworkConnectionLost
because the call to continueNavigationInNewProcess happens before telling the &quot;old&quot; process that the load will continue
in a new process, which results in the ProvisionalFrameProxy being destroyed, which sends
Messages::WebFrame::DestroyProvisionalFrame, which calls invalidatePolicyListeners with this stack trace:

WebKit::WebFrame::invalidatePolicyListeners()
WebKit::WebLocalFrameLoaderClient::cancelPolicyCheck()
WebCore::PolicyChecker::stopCheck()
WebCore::FrameLoader::stopLoading(WebCore::UnloadEventPolicy)
WebCore::FrameLoader::closeURL()
WebCore::FrameLoader::detachFromParent()
WebKit::WebFrame::destroyProvisionalFrame()

That policy listener invalidation uses PolicyAction::Ignore which sends a _WKErrorCodeFrameLoadInterruptedByPolicyChange
to the UI process.  With this change, the policy listener is correctly taken care of with
PolicyAction::LoadWillContinueInAnotherProcess before destroying the provisional frame.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::receivedNavigationActionPolicyDecision):

Canonical link: <a href="https://commits.webkit.org/300979@main">https://commits.webkit.org/300979@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d815334e6cff8ada658e540d217f752be17cf8f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124519 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44196 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34931 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131355 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/76492 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8fe40d27-351e-4f23-bdd2-4eff26d52fc8) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44911 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52775 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94726 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/76492 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3c2ab4c1-72d6-4ad8-b7bb-03134f1fe754) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127473 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/35799 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111364 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75302 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ae38e120-d1cd-48eb-9019-226fb8dd5734) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/34737 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74836 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105552 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29751 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134022 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51385 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39211 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103202 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51794 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107587 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102986 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48349 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26613 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/48326 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19544 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51257 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57047 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50665 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/54023 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52346 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->