### PR TITLE
[Site Isolation] Add support for copying web content in webarchive format

### DIFF
--- a/Source/WebCore/editing/cocoa/EditorCocoa.mm
+++ b/Source/WebCore/editing/cocoa/EditorCocoa.mm
@@ -177,6 +177,12 @@ void Editor::writeSelectionToPasteboard(Pasteboard& pasteboard)
     if (!pasteboard.isStatic()) {
         if (!document->isTextDocument()) {
             content.dataInWebArchiveFormat = selectionInWebArchiveFormat();
+            LegacyWebArchive::ArchiveOptions options {
+                LegacyWebArchive::ShouldSaveScriptsFromMemoryCache::Yes,
+                LegacyWebArchive::ShouldArchiveSubframes::No
+            };
+            if (document->settings().siteIsolationEnabled())
+                content.webArchive = LegacyWebArchive::createFromSelection(document->frame(), WTFMove(options));
             populateRichTextDataIfNeeded(content, document);
         }
         client()->getClientPasteboardData(selectedRange(), content.clientTypesAndData);

--- a/Source/WebCore/loader/archive/cf/LegacyWebArchive.h
+++ b/Source/WebCore/loader/archive/cf/LegacyWebArchive.h
@@ -45,10 +45,10 @@ class LegacyWebArchive final : public Archive {
 public:
     // Archive is created directly from data or members so ArchiveOptions is not needed.
     WEBCORE_EXPORT static Ref<LegacyWebArchive> create();
-    WEBCORE_EXPORT static Ref<LegacyWebArchive> create(Ref<ArchiveResource>&& mainResource, Vector<Ref<ArchiveResource>>&& subresources, Vector<FrameIdentifier>&& subframeIdentifiers);
+    WEBCORE_EXPORT static Ref<LegacyWebArchive> create(Ref<ArchiveResource>&& mainResource, Vector<Ref<ArchiveResource>>&& subresources, Vector<FrameIdentifier>&& subframeIdentifiers, std::optional<FrameIdentifier> mainFrameIdentifier);
     WEBCORE_EXPORT static RefPtr<LegacyWebArchive> create(FragmentedSharedBuffer&);
     WEBCORE_EXPORT static RefPtr<LegacyWebArchive> create(const URL&, FragmentedSharedBuffer&);
-    WEBCORE_EXPORT static Ref<LegacyWebArchive> create(Ref<ArchiveResource>&& mainResource, Vector<Ref<ArchiveResource>>&& subresources, Vector<Ref<LegacyWebArchive>>&& subframeArchives);
+    WEBCORE_EXPORT static Ref<LegacyWebArchive> create(Ref<ArchiveResource>&& mainResource, Vector<Ref<ArchiveResource>>&& subresources, Vector<Ref<LegacyWebArchive>>&& subframeArchives, std::optional<FrameIdentifier> mainFrameIdentifier);
 
     enum class ShouldSaveScriptsFromMemoryCache : bool { No, Yes };
     enum class ShouldArchiveSubframes : bool { No, Yes };
@@ -70,12 +70,13 @@ public:
     WEBCORE_EXPORT RetainPtr<CFDataRef> rawDataRepresentation();
 
     Ref<ArchiveResource> protectedMainResource() const { return *mainResource(); }
+    std::optional<FrameIdentifier> frameIdentifier() const { return m_frameIdentifier; }
     Vector<FrameIdentifier> subframeIdentifiers() const { return m_subframeIdentifiers; }
     void appendSubframeArchive(Ref<Archive>&& subframeArchive) { addSubframeArchive(WTFMove(subframeArchive)); }
 
 private:
     LegacyWebArchive() = default;
-    LegacyWebArchive(Vector<FrameIdentifier>&&);
+    LegacyWebArchive(std::optional<FrameIdentifier>, Vector<FrameIdentifier>&& subFrameIdentifiers);
 
     bool shouldLoadFromArchiveOnly() const final { return false; }
     bool shouldOverrideBaseURL() const final { return false; }
@@ -96,6 +97,7 @@ private:
 
     bool extract(CFDictionaryRef);
 
+    std::optional<FrameIdentifier> m_frameIdentifier;
     Vector<FrameIdentifier> m_subframeIdentifiers;
 };
 

--- a/Source/WebCore/platform/Pasteboard.h
+++ b/Source/WebCore/platform/Pasteboard.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <WebCore/DragImage.h>
+#include <WebCore/FrameIdentifier.h>
 #include <WebCore/PasteboardContext.h>
 #include <WebCore/PasteboardCustomData.h>
 #include <WebCore/PasteboardItemInfo.h>
@@ -45,6 +46,7 @@ OBJC_CLASS NSString;
 
 #if PLATFORM(COCOA)
 #include <WebCore/AttributedString.h>
+#include <WebCore/LegacyWebArchive.h>
 OBJC_CLASS NSArray;
 #endif
 
@@ -87,12 +89,18 @@ struct PasteboardWebContent {
     String contentOrigin;
     bool canSmartCopyOrDelete;
     RefPtr<SharedBuffer> dataInWebArchiveFormat;
+    RefPtr<LegacyWebArchive> webArchive;
     RefPtr<SharedBuffer> dataInRTFDFormat;
     RefPtr<SharedBuffer> dataInRTFFormat;
     std::optional<WebCore::AttributedString> dataInAttributedStringFormat;
     String dataInHTMLFormat;
     String dataInStringFormat;
     Vector<std::pair<String, RefPtr<WebCore::SharedBuffer>>> clientTypesAndData;
+#endif
+#if PLATFORM(IOS_FAMILY)
+    // WebArchive-only parameters.
+    HashMap<WebCore::FrameIdentifier, Ref<WebCore::LegacyWebArchive>> localFrameArchives;
+    Vector<WebCore::FrameIdentifier> remoteFrameIdentifiers;
 #endif
 #if PLATFORM(GTK) || PLATFORM(WPE)
     String contentOrigin;
@@ -387,13 +395,13 @@ private:
 };
 
 #if PLATFORM(IOS_FAMILY)
-extern NSString *WebArchivePboardType;
+WEBCORE_EXPORT extern NSString *WebArchivePboardType;
 extern NSString *UIColorPboardType;
 extern NSString *UIImagePboardType;
 #endif
 
 #if PLATFORM(MAC)
-extern const ASCIILiteral WebArchivePboardType;
+WEBCORE_EXPORT extern const ASCIILiteral WebArchivePboardType;
 extern const ASCIILiteral WebURLNamePboardType;
 extern const ASCIILiteral WebURLsWithTitlesPboardType;
 #endif

--- a/Source/WebCore/platform/PasteboardStrategy.h
+++ b/Source/WebCore/platform/PasteboardStrategy.h
@@ -34,6 +34,7 @@
 namespace WebCore {
 
 class Color;
+class LegacyWebArchive;
 class SharedBuffer;
 class PasteboardContext;
 class PasteboardCustomData;
@@ -72,6 +73,7 @@ public:
     virtual int64_t setURL(const PasteboardURL&, const String& pasteboardName, const PasteboardContext*) = 0;
     virtual int64_t setColor(const Color&, const String& pasteboardName, const PasteboardContext*) = 0;
     virtual int64_t setStringForType(const String&, const String& pasteboardType, const String& pasteboardName, const PasteboardContext*) = 0;
+    virtual int64_t writeWebArchive(LegacyWebArchive&, const String& pasteboardName) = 0;
 
     virtual bool containsURLStringSuitableForLoading(const String& pasteboardName, const PasteboardContext*) = 0;
     virtual String urlStringSuitableForLoading(const String& pasteboardName, String& title, const PasteboardContext*) = 0;

--- a/Source/WebCore/platform/mac/PasteboardMac.mm
+++ b/Source/WebCore/platform/mac/PasteboardMac.mm
@@ -168,11 +168,18 @@ void Pasteboard::write(const PasteboardWebContent& content)
         m_changeCount = platformStrategies()->pasteboardStrategy()->setBufferForType(clientData[i].get(), clientTypes[i], m_pasteboardName, context());
     if (content.canSmartCopyOrDelete)
         m_changeCount = platformStrategies()->pasteboardStrategy()->setBufferForType(nullptr, WebSmartPastePboardType, m_pasteboardName, context());
-    if (content.dataInWebArchiveFormat) {
+
+    bool didWriteWebArchive = false;
+    if (RefPtr webArchive = content.webArchive) {
+        m_changeCount = platformStrategies()->pasteboardStrategy()->writeWebArchive(*webArchive, m_pasteboardName);
+        didWriteWebArchive = !!m_changeCount;
+    }
+    if (!didWriteWebArchive && content.dataInWebArchiveFormat) {
         m_changeCount = platformStrategies()->pasteboardStrategy()->setBufferForType(content.dataInWebArchiveFormat.get(), WebArchivePboardType, m_pasteboardName, context());
 
         m_changeCount = platformStrategies()->pasteboardStrategy()->setBufferForType(content.dataInWebArchiveFormat.get(), UTTypeWebArchive.identifier, m_pasteboardName, context());
     }
+
     if (content.dataInRTFDFormat)
         m_changeCount = platformStrategies()->pasteboardStrategy()->setBufferForType(content.dataInRTFDFormat.get(), legacyRTFDPasteboardTypeSingleton(), m_pasteboardName, context());
     if (content.dataInRTFFormat)

--- a/Source/WebKit/Shared/APIWebArchive.mm
+++ b/Source/WebKit/Shared/APIWebArchive.mm
@@ -79,7 +79,7 @@ WebArchive::WebArchive(WebArchiveResource* mainResource, RefPtr<API::Array>&& su
         return Ref<LegacyWebArchive> { *subframeWebArchive->coreLegacyWebArchive() };
     });
 
-    lazyInitialize(m_legacyWebArchive, LegacyWebArchive::create(*coreMainResource, WTFMove(coreArchiveResources), WTFMove(coreSubframeLegacyWebArchives)));
+    lazyInitialize(m_legacyWebArchive, LegacyWebArchive::create(*coreMainResource, WTFMove(coreArchiveResources), WTFMove(coreSubframeLegacyWebArchives), std::nullopt));
 }
 
 WebArchive::WebArchive(API::Data* data)

--- a/Source/WebKit/Shared/Pasteboard.serialization.in
+++ b/Source/WebKit/Shared/Pasteboard.serialization.in
@@ -47,12 +47,17 @@ header: <WebCore/Pasteboard.h>
     String contentOrigin;
     bool canSmartCopyOrDelete;
     RefPtr<WebCore::SharedBuffer> dataInWebArchiveFormat;
+    RefPtr<WebCore::LegacyWebArchive> webArchive;
     RefPtr<WebCore::SharedBuffer> dataInRTFDFormat;
     RefPtr<WebCore::SharedBuffer> dataInRTFFormat;
     std::optional<WebCore::AttributedString> dataInAttributedStringFormat;
     String dataInHTMLFormat;
     String dataInStringFormat;
     Vector<std::pair<String, RefPtr<WebCore::SharedBuffer>>> clientTypesAndData;
+#endif
+#if PLATFORM(IOS_FAMILY)
+    HashMap<WebCore::FrameIdentifier, Ref<WebCore::LegacyWebArchive>> localFrameArchives;
+    Vector<WebCore::FrameIdentifier> remoteFrameIdentifiers;
 #endif
 #if PLATFORM(GTK) || PLATFORM(WPE)
     String contentOrigin;

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -3546,6 +3546,7 @@ enum class WebCore::WasPrivateRelayed : bool;
     Ref<WebCore::ArchiveResource> protectedMainResource();
     Vector<Ref<WebCore::ArchiveResource>> subresources();
     Vector<WebCore::FrameIdentifier> subframeIdentifiers();
+    std::optional<WebCore::FrameIdentifier> frameIdentifier();
 };
 #endif
 

--- a/Source/WebKit/UIProcess/Cocoa/LegacyWebArchiveCallbackAggregator.h
+++ b/Source/WebKit/UIProcess/Cocoa/LegacyWebArchiveCallbackAggregator.h
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/FrameIdentifier.h>
+#include <wtf/CompletionHandler.h>
+
+namespace WebKit {
+
+class LegacyWebArchiveCallbackAggregator final : public ThreadSafeRefCounted<LegacyWebArchiveCallbackAggregator, WTF::DestructionThread::MainRunLoop> {
+public:
+    static Ref<LegacyWebArchiveCallbackAggregator> create(WebCore::FrameIdentifier rootFrameIdentifier, HashMap<WebCore::FrameIdentifier, Ref<WebCore::LegacyWebArchive>>&& frameArchives, CompletionHandler<void(RefPtr<LegacyWebArchive>&&)>&& callback)
+    {
+        return adoptRef(*new LegacyWebArchiveCallbackAggregator(rootFrameIdentifier, WTFMove(frameArchives), WTFMove(callback)));
+    }
+
+    RefPtr<WebCore::LegacyWebArchive> completeFrameArchive(WebCore::FrameIdentifier identifier)
+    {
+        RefPtr archive = m_frameArchives.take(identifier);
+        if (!archive)
+            return archive;
+
+        for (auto subframeIdentifier : archive->subframeIdentifiers()) {
+            if (auto subframeArchive = completeFrameArchive(subframeIdentifier))
+                archive->appendSubframeArchive(subframeArchive.releaseNonNull());
+        }
+
+        return archive;
+    }
+
+    ~LegacyWebArchiveCallbackAggregator()
+    {
+        RELEASE_ASSERT(m_callback);
+        m_callback(completeFrameArchive(m_rootFrameIdentifier));
+    }
+
+    void addResult(HashMap<WebCore::FrameIdentifier, Ref<WebCore::LegacyWebArchive>>&& frameArchives)
+    {
+        for (auto&& [frameIdentifier, archive] : frameArchives)
+            m_frameArchives.set(frameIdentifier, WTFMove(archive));
+    }
+
+private:
+    LegacyWebArchiveCallbackAggregator(WebCore::FrameIdentifier rootFrameIdentifier, HashMap<WebCore::FrameIdentifier, Ref<WebCore::LegacyWebArchive>>&& frameArchives, CompletionHandler<void(RefPtr<LegacyWebArchive>&&)>&& callback)
+        : m_rootFrameIdentifier(rootFrameIdentifier)
+        , m_frameArchives(WTFMove(frameArchives))
+        , m_callback(WTFMove(callback))
+    {
+    }
+
+    WebCore::FrameIdentifier m_rootFrameIdentifier;
+    HashMap<WebCore::FrameIdentifier, Ref<WebCore::LegacyWebArchive>> m_frameArchives;
+    CompletionHandler<void(RefPtr<WebCore::LegacyWebArchive>&&)> m_callback;
+};
+
+} // namespace WebKit

--- a/Source/WebKit/UIProcess/WebPasteboardProxy.h
+++ b/Source/WebKit/UIProcess/WebPasteboardProxy.h
@@ -28,6 +28,7 @@
 #include "MessageReceiver.h"
 #include "SandboxExtension.h"
 #include "WebPageProxyIdentifier.h"
+#include <WebCore/FrameIdentifier.h>
 #include <WebCore/SharedMemory.h>
 #include <wtf/HashMap.h>
 #include <wtf/WeakHashSet.h>
@@ -41,6 +42,7 @@ class SharedBufferReference;
 namespace WebCore {
 enum class DataOwnerType : uint8_t;
 class Color;
+class LegacyWebArchive;
 class PasteboardCustomData;
 class SelectionData;
 struct PasteboardBuffer;
@@ -93,6 +95,7 @@ private:
 #if PLATFORM(IOS_FAMILY)
     void writeURLToPasteboard(IPC::Connection&, const WebCore::PasteboardURL&, const String& pasteboardName, std::optional<WebPageProxyIdentifier>);
     void writeWebContentToPasteboard(IPC::Connection&, const WebCore::PasteboardWebContent&, const String& pasteboardName, std::optional<WebPageProxyIdentifier>);
+    void writeWebContentToPasteboardInternal(IPC::Connection&, const WebCore::PasteboardWebContent&, const String& pasteboardName, std::optional<WebPageProxyIdentifier>);
     void writeImageToPasteboard(IPC::Connection&, const WebCore::PasteboardImage&, const String& pasteboardName, std::optional<WebPageProxyIdentifier>);
     void writeStringToPasteboard(IPC::Connection&, const String& pasteboardType, const String&, const String& pasteboardName, std::optional<WebPageProxyIdentifier>);
     void updateSupportedTypeIdentifiers(const Vector<String>& identifiers, const String& pasteboardName, std::optional<WebPageProxyIdentifier>);
@@ -113,6 +116,8 @@ private:
     void setPasteboardColor(IPC::Connection&, const String&, const WebCore::Color&, std::optional<WebPageProxyIdentifier>, CompletionHandler<void(int64_t)>&&);
     void setPasteboardStringForType(IPC::Connection&, const String& pasteboardName, const String& pasteboardType, const String&, std::optional<WebPageProxyIdentifier>, CompletionHandler<void(int64_t)>&&);
     void setPasteboardBufferForType(IPC::Connection&, const String& pasteboardName, const String& pasteboardType, RefPtr<WebCore::SharedBuffer>&&, std::optional<WebPageProxyIdentifier>, CompletionHandler<void(int64_t)>&&);
+    void writeWebArchiveToPasteBoard(IPC::Connection&, const String& pasteboardName, WebCore::FrameIdentifier, HashMap<WebCore::FrameIdentifier, Ref<WebCore::LegacyWebArchive>>&&, const Vector<WebCore::FrameIdentifier>&, CompletionHandler<void(int64_t)>&&);
+    void createOneWebArchiveFromFrames(WebProcessProxy&, WebCore::FrameIdentifier, HashMap<WebCore::FrameIdentifier, Ref<WebCore::LegacyWebArchive>>&&, const Vector<WebCore::FrameIdentifier>&, CompletionHandler<void(RefPtr<WebCore::LegacyWebArchive>&&)>&&);
 
 #if ENABLE(IPC_TESTING_API)
     void testIPCSharedMemory(IPC::Connection&, const String& pasteboardName, const String& pasteboardType, WebCore::SharedMemory::Handle&&, std::optional<WebPageProxyIdentifier>, CompletionHandler<void(int64_t, String)>&&);

--- a/Source/WebKit/UIProcess/WebPasteboardProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPasteboardProxy.messages.in
@@ -28,7 +28,7 @@
 messages -> WebPasteboardProxy {
 #if PLATFORM(IOS_FAMILY)
     WriteURLToPasteboard(struct WebCore::PasteboardURL url, String pasteboardName, std::optional<WebKit::WebPageProxyIdentifier> pageID)
-    WriteWebContentToPasteboard(struct WebCore::PasteboardWebContent content, String pasteboardName, std::optional<WebKit::WebPageProxyIdentifier> pageID)x
+    WriteWebContentToPasteboard(struct WebCore::PasteboardWebContent content, String pasteboardName, std::optional<WebKit::WebPageProxyIdentifier> pageID)
     WriteImageToPasteboard(struct WebCore::PasteboardImage pasteboardImage, String pasteboardName, std::optional<WebKit::WebPageProxyIdentifier> pageID)
     WriteStringToPasteboard(String pasteboardType, String text, String pasteboardName, std::optional<WebKit::WebPageProxyIdentifier> pageID)
     UpdateSupportedTypeIdentifiers(Vector<String> identifiers, String pasteboardName, std::optional<WebKit::WebPageProxyIdentifier> pageID)
@@ -61,6 +61,7 @@ messages -> WebPasteboardProxy {
     SetPasteboardColor(String pasteboardName, WebCore::Color color, std::optional<WebKit::WebPageProxyIdentifier> pageID) -> (int64_t changeCount) Synchronous
     SetPasteboardStringForType(String pasteboardName, String pasteboardType, String string, std::optional<WebKit::WebPageProxyIdentifier> pageID) -> (int64_t changeCount) Synchronous
     SetPasteboardBufferForType(String pasteboardName, String pasteboardType, RefPtr<WebCore::SharedBuffer> buffer, std::optional<WebKit::WebPageProxyIdentifier> pageID) -> (int64_t changeCount) Synchronous
+    WriteWebArchiveToPasteBoard(String pasteboardName, WebCore::FrameIdentifier rootFrameIdentifier, HashMap<WebCore::FrameIdentifier, Ref<WebCore::LegacyWebArchive>> localFrameArchives, Vector<WebCore::FrameIdentifier> remoteFrameIdentifiers) -> (int64_t changeCount) Synchronous
     ContainsURLStringSuitableForLoading(String pasteboardName, std::optional<WebKit::WebPageProxyIdentifier> pageID) -> (bool result) Synchronous
     URLStringSuitableForLoading(String pasteboardName, std::optional<WebKit::WebPageProxyIdentifier> pageID) -> (String url, String title) Synchronous
 

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1010,6 +1010,7 @@
 		3A12CDBB29D4D30200D57EAE /* WebSWRegistrationStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AC4C04529D35D1500402716 /* WebSWRegistrationStore.h */; };
 		3A18A2EF2AFF004C00DB976C /* _WKArchiveConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A18A2EE2AFF004C00DB976C /* _WKArchiveConfiguration.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		3A18A2F52B02969900DB976C /* _WKArchiveExclusionRule.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A18A2F32B02969800DB976C /* _WKArchiveExclusionRule.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		3A4DC9CA2E9463AE0083A531 /* LegacyWebArchiveCallbackAggregator.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A4DC9C92E9463AE0083A531 /* LegacyWebArchiveCallbackAggregator.h */; };
 		3A7D62D629D38DD300D57DAC /* ServiceWorkerStorageManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A7D62D429D38DD300D57DAC /* ServiceWorkerStorageManager.h */; };
 		3AE104C029CBC8BB00661165 /* OriginQuotaManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AE104BE29CBC8BB00661165 /* OriginQuotaManager.h */; };
 		3CAECB6627465AE400AB78D0 /* UnifiedSource113.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3CAECB5E27465AE300AB78D0 /* UnifiedSource113.cpp */; };
@@ -5334,6 +5335,7 @@
 		3A18A2F32B02969800DB976C /* _WKArchiveExclusionRule.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKArchiveExclusionRule.h; sourceTree = "<group>"; };
 		3A26F82D2B258CEF00FEB1B0 /* PlatformXR.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = PlatformXR.serialization.in; sourceTree = "<group>"; };
 		3A36AFAF2B9667770098631A /* WebCookieJarCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebCookieJarCocoa.mm; sourceTree = "<group>"; };
+		3A4DC9C92E9463AE0083A531 /* LegacyWebArchiveCallbackAggregator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LegacyWebArchiveCallbackAggregator.h; sourceTree = "<group>"; };
 		3A5B68962AC266D400B11868 /* WKARPresentationSession.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKARPresentationSession.h; sourceTree = "<group>"; };
 		3A5B68972AC266D400B11868 /* WKARPresentationSession.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKARPresentationSession.mm; sourceTree = "<group>"; };
 		3A7D62D229D35D9D00D57DAC /* WebSWRegistrationStore.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebSWRegistrationStore.cpp; sourceTree = "<group>"; };
@@ -10374,6 +10376,7 @@
 				7A821F4D1E2F679E00604577 /* LegacyCustomProtocolManagerClient.mm */,
 				A1DF631118E0B7C8003A3E2A /* LegacyDownloadClient.h */,
 				A1DF631018E0B7C8003A3E2A /* LegacyDownloadClient.mm */,
+				3A4DC9C92E9463AE0083A531 /* LegacyWebArchiveCallbackAggregator.h */,
 				9342588F2555DCA50059EEDD /* MediaPermissionUtilities.mm */,
 				411286EF21C8A90C003A8550 /* MediaUtilities.h */,
 				411286F021C8A90D003A8550 /* MediaUtilities.mm */,
@@ -17755,6 +17758,7 @@
 				2984F57D164B915F004BC0C6 /* LegacyCustomProtocolManagerProxyMessages.h in Headers */,
 				A1DF631318E0B7C8003A3E2A /* LegacyDownloadClient.h in Headers */,
 				1A1DC340196346D700FF7059 /* LegacySessionStateCoding.h in Headers */,
+				3A4DC9CA2E9463AE0083A531 /* LegacyWebArchiveCallbackAggregator.h in Headers */,
 				411B22641E371BA6004F7363 /* LibWebRTCNetwork.h in Headers */,
 				413075B41DE85F580039EC69 /* LibWebRTCProvider.h in Headers */,
 				41FAF5F81E3C1021001AE678 /* LibWebRTCResolver.h in Headers */,

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebPlatformStrategies.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebPlatformStrategies.h
@@ -82,6 +82,7 @@ private:
     int64_t setURL(const WebCore::PasteboardURL&, const String& pasteboardName, const WebCore::PasteboardContext*) override;
     int64_t setColor(const WebCore::Color&, const String& pasteboardName, const WebCore::PasteboardContext*) override;
     int64_t setStringForType(const String&, const String& pasteboardType, const String& pasteboardName, const WebCore::PasteboardContext*) override;
+    int64_t writeWebArchive(WebCore::LegacyWebArchive&, const String& pasteboardName) override;
 
     bool containsURLStringSuitableForLoading(const String& pasteboardName, const WebCore::PasteboardContext*) override;
     String urlStringSuitableForLoading(const String& pasteboardName, String& title, const WebCore::PasteboardContext*) override;

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebPlatformStrategies.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebPlatformStrategies.h
@@ -84,6 +84,7 @@ private:
     int64_t setURL(const WebCore::PasteboardURL&, const String& pasteboardName, const WebCore::PasteboardContext*) override;
     int64_t setColor(const WebCore::Color&, const String& pasteboardName, const WebCore::PasteboardContext*) override;
     int64_t setStringForType(const String&, const String& pasteboardType, const String& pasteboardName, const WebCore::PasteboardContext*) override;
+    int64_t writeWebArchive(WebCore::LegacyWebArchive&, const String& pasteboardName) override { return 0; }
     bool containsStringSafeForDOMToReadForType(const String&, const String& pasteboardName, const WebCore::PasteboardContext*) override;
     bool containsURLStringSuitableForLoading(const String& pasteboardName, const WebCore::PasteboardContext*) override;
     String urlStringSuitableForLoading(const String& pasteboardName, String& title, const WebCore::PasteboardContext*) override;

--- a/Source/WebKitLegacy/mac/WebView/WebArchive.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebArchive.mm
@@ -176,7 +176,7 @@ static BOOL isArrayOfClass(id object, Class elementClass)
     for (WebArchive *subframeArchive in subframeArchives)
         coreArchives.append(*[subframeArchive->_private coreArchive]);
 
-    [_private setCoreArchive:LegacyWebArchive::create([mainResource _coreResource].get(), WTFMove(coreResources), WTFMove(coreArchives))];
+    [_private setCoreArchive:LegacyWebArchive::create([mainResource _coreResource].get(), WTFMove(coreResources), WTFMove(coreArchives), std::nullopt)];
     return self;
 }
 


### PR DESCRIPTION
#### 4d90d6f12000158908e404e90adc2225a8671a62
<pre>
[Site Isolation] Add support for copying web content in webarchive format
<a href="https://rdar.apple.com/161923006">rdar://161923006</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=300138">https://bugs.webkit.org/show_bug.cgi?id=300138</a>

Reviewed by Ryosuke Niwa.

In existing implementation, when selecting and copying web content, web process creates webarchive for the selected
range (which might include subframe&apos;s content) and send the webarchive data to UI process. When UI process receives the
data it will add it to pasteboard. With site isolation on, web process only has access to local frame content, so
the data web process sends to UI process is missing content for remote subframes.

To fix it, this patch makes web process not only send selected frame webarchive to UI process, but also remote subframe
identifiers and local subframe webarchives. On receiving the message (WebPasteboardProxy::WriteWebArchiveToPasteBoard),
UI process will collect remote subframe archives from other web processes. After collection, UI process combines all
webarchvies to get a full webarchive for the selected content (the same content it will get wihout site isolaiton).

API Test: SiteIsolation.CreateWebArchiveForCopy
              SiteIsolation.CreateWebArchiveNestedFrameForCopy

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/editing/cocoa/EditorCocoa.mm:
(WebCore::Editor::writeSelectionToPasteboard):
* Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp:
(WebCore::LegacyWebArchive::LegacyWebArchive):
(WebCore::LegacyWebArchive::create):
(WebCore::LegacyWebArchive::createInternal):
(WebCore::LegacyWebArchive::createFromSelection):
* Source/WebCore/loader/archive/cf/LegacyWebArchive.h:
* Source/WebCore/platform/Pasteboard.h:
* Source/WebCore/platform/PasteboardStrategy.h:
* Source/WebCore/platform/mac/PasteboardMac.mm:
(WebCore::Pasteboard::write):
* Source/WebKit/Shared/APIWebArchive.mm:
(API::WebArchive::WebArchive):
* Source/WebKit/Shared/Pasteboard.serialization.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/Cocoa/LegacyWebArchiveCallbackAggregator.h: Added.
* Source/WebKit/UIProcess/Cocoa/WebPasteboardProxyCocoa.mm:
(WebKit::WebPasteboardProxy::writeWebContentToPasteboardInternal):
(WebKit::WebPasteboardProxy::writeWebContentToPasteboard):
(WebKit::WebPasteboardProxy::writeWebArchiveToPasteBoard):
(WebKit::WebPasteboardProxy::createOneWebArchiveFromFrames):
* Source/WebKit/UIProcess/WebPasteboardProxy.h:
* Source/WebKit/UIProcess/WebPasteboardProxy.messages.in:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/WebCoreSupport/WebPlatformStrategies.cpp:
(WebKit::collectFrameWebArchives):
(WebKit::WebPlatformStrategies::writeWebArchive):
(WebKit::updateContentForWebArchive):
(WebKit::WebPlatformStrategies::writeToPasteboard):
* Source/WebKit/WebProcess/WebCoreSupport/WebPlatformStrategies.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebPlatformStrategies.h:
* Source/WebKitLegacy/mac/WebView/WebArchive.mm:
(-[WebArchive initWithMainResource:subresources:subframeArchives:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::(SiteIsolation, CreateWebArchiveForCopy)):
(TestWebKitAPI::(SiteIsolation, CreateWebArchiveNestedFrameForCopy)):
(TestWebKitAPI::(SiteIsolation, DoAfterNextPresentationUpdate)):

Canonical link: <a href="https://commits.webkit.org/301206@main">https://commits.webkit.org/301206@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c9f6a0adfe85b806250f24fed29a2d985ccce2c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125219 "16 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44886 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35625 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132070 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77079 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/aee6fcae-4851-41ed-85d5-15694aade1be) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127096 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45577 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53447 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95329 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/63268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2c914316-5d16-4d14-a8dc-8debc65c6cae) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128173 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36386 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111975 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75869 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/08b930bf-0faf-4ea8-bafc-217e156d1b90) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35283 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30143 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75548 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106153 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30368 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134751 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52028 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39809 "Found 6 new test failures: http/tests/media/modern-media-controls/overflow-support/playback-speed-live-broadcast.html http/tests/media/video-redirect.html http/wpt/fetch/dnt-header-after-redirection.html imported/w3c/web-platform-tests/html/infrastructure/urls/resolving-urls/query-encoding/utf-8.html?include=loading imported/w3c/web-platform-tests/html/infrastructure/urls/resolving-urls/query-encoding/windows-1252.html?include=loading imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/loading-the-media-resource/load-events-networkState.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103795 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52463 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108196 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103565 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26379 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48918 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27208 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49114 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51920 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57699 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51282 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54638 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52976 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->