### PR TITLE
[SaferC++] Improve memory safety in more WebProcess/* files

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -47,8 +47,6 @@ UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm
 UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.mm
 WebDriverBidiFrontendDispatchers.cpp
 WebDriverBidiProtocolObjects.h
-WebProcess/Automation/WebAutomationDOMWindowObserver.cpp
-WebProcess/Cache/WebCacheStorageConnection.cpp
 WebProcess/Extensions/API/Cocoa/WebExtensionAPIAlarmsCocoa.mm
 WebProcess/Extensions/API/Cocoa/WebExtensionAPIDeclarativeNetRequestCocoa.mm
 WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsInspectedWindowCocoa.mm

--- a/Source/WebKit/WebProcess/Automation/WebAutomationDOMWindowObserver.cpp
+++ b/Source/WebKit/WebProcess/Automation/WebAutomationDOMWindowObserver.cpp
@@ -35,14 +35,14 @@ WebAutomationDOMWindowObserver::WebAutomationDOMWindowObserver(WebCore::LocalDOM
     : m_window(window)
     , m_callback(WTFMove(callback))
 {
-    ASSERT(m_window->frame());
-    m_window->registerObserver(*this);
+    ASSERT(window.frame());
+    window.registerObserver(*this);
 }
 
 WebAutomationDOMWindowObserver::~WebAutomationDOMWindowObserver()
 {
-    if (m_window)
-        m_window->unregisterObserver(*this);
+    if (RefPtr window = m_window.get())
+        window->unregisterObserver(*this);
 }
 
 void WebAutomationDOMWindowObserver::willDestroyGlobalObjectInCachedFrame()
@@ -56,8 +56,8 @@ void WebAutomationDOMWindowObserver::willDestroyGlobalObjectInCachedFrame()
     }
 
     ASSERT(m_window);
-    if (m_window)
-        m_window->unregisterObserver(*this);
+    if (RefPtr window = m_window.get())
+        window->unregisterObserver(*this);
     m_window = nullptr;
 }
 
@@ -71,8 +71,8 @@ void WebAutomationDOMWindowObserver::willDestroyGlobalObjectInFrame()
     }
 
     ASSERT(m_window);
-    if (m_window)
-        m_window->unregisterObserver(*this);
+    if (RefPtr window = m_window.get())
+        window->unregisterObserver(*this);
     m_window = nullptr;
 }
 
@@ -87,8 +87,8 @@ void WebAutomationDOMWindowObserver::willDetachGlobalObjectFromFrame()
     m_callback(*this);
 
     ASSERT(m_window);
-    if (m_window)
-        m_window->unregisterObserver(*this);
+    if (RefPtr window = m_window.get())
+        window->unregisterObserver(*this);
     m_window = nullptr;
 }
 

--- a/Source/WebKit/WebProcess/Cache/WebCacheStorageConnection.cpp
+++ b/Source/WebKit/WebProcess/Cache/WebCacheStorageConnection.cpp
@@ -106,28 +106,28 @@ void WebCacheStorageConnection::reference(WebCore::DOMCacheIdentifier cacheIdent
 {
     Locker connectionLocker { m_connectionLock };
     if (m_connectedIdentifierCounters.add(cacheIdentifier).isNewEntry && m_connection)
-        m_connection->send(Messages::NetworkStorageManager::CacheStorageReference(cacheIdentifier), 0);
+        RefPtr { m_connection }->send(Messages::NetworkStorageManager::CacheStorageReference(cacheIdentifier), 0);
 }
 
 void WebCacheStorageConnection::dereference(WebCore::DOMCacheIdentifier cacheIdentifier)
 {
     Locker connectionLocker { m_connectionLock };
     if (m_connectedIdentifierCounters.remove(cacheIdentifier) && m_connection)
-        m_connection->send(Messages::NetworkStorageManager::CacheStorageDereference(cacheIdentifier), 0);
+        RefPtr { m_connection }->send(Messages::NetworkStorageManager::CacheStorageDereference(cacheIdentifier), 0);
 }
 
 void WebCacheStorageConnection::lockStorage(const WebCore::ClientOrigin& origin)
 {
     Locker connectionLocker { m_connectionLock };
     if (m_clientOriginLockRequestCounters.add(origin).isNewEntry && m_connection)
-        m_connection->send(Messages::NetworkStorageManager::LockCacheStorage { origin }, 0);
+        RefPtr { m_connection }->send(Messages::NetworkStorageManager::LockCacheStorage { origin }, 0);
 }
 
 void WebCacheStorageConnection::unlockStorage(const WebCore::ClientOrigin& origin)
 {
     Locker connectionLocker { m_connectionLock };
     if (m_clientOriginLockRequestCounters.remove(origin) && m_connection)
-        m_connection->send(Messages::NetworkStorageManager::UnlockCacheStorage { origin }, 0);
+        RefPtr { m_connection }->send(Messages::NetworkStorageManager::UnlockCacheStorage { origin }, 0);
 }
 
 auto WebCacheStorageConnection::clearMemoryRepresentation(const WebCore::ClientOrigin& origin) -> Ref<CompletionPromise>


### PR DESCRIPTION
#### 5d3532e329c4714304634ddd14608a1b36ee2e8e
<pre>
[SaferC++] Improve memory safety in more WebProcess/* files
<a href="https://bugs.webkit.org/show_bug.cgi?id=300142">https://bugs.webkit.org/show_bug.cgi?id=300142</a>
<a href="https://rdar.apple.com/161923534">rdar://161923534</a>

Reviewed by Ryosuke Niwa and Chris Dumez.

Fix SaferC++ violations in

    Source/WebKit/WebProcess/Automation/WebAutomationDOMWindowObserver.cpp
    Source/WebKit/WebProcess/Cache/WebCacheStorageConnection.cpp

* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKit/WebProcess/Automation/WebAutomationDOMWindowObserver.cpp:
(WebKit::WebAutomationDOMWindowObserver::WebAutomationDOMWindowObserver):
(WebKit::WebAutomationDOMWindowObserver::~WebAutomationDOMWindowObserver):
(WebKit::WebAutomationDOMWindowObserver::willDestroyGlobalObjectInCachedFrame):
(WebKit::WebAutomationDOMWindowObserver::willDestroyGlobalObjectInFrame):
(WebKit::WebAutomationDOMWindowObserver::willDetachGlobalObjectFromFrame):
* Source/WebKit/WebProcess/Cache/WebCacheStorageConnection.cpp:
(WebKit::WebCacheStorageConnection::reference):
(WebKit::WebCacheStorageConnection::dereference):
(WebKit::WebCacheStorageConnection::lockStorage):
(WebKit::WebCacheStorageConnection::unlockStorage):

Canonical link: <a href="https://commits.webkit.org/300994@main">https://commits.webkit.org/300994@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e6a5c6ed0582b0c689ad69f7db4e1fbf39e2a220

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124612 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44284 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35018 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131451 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/76549 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9fa1dbc8-3c9c-4c1f-8171-8324e74b8cc3) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44988 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52855 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/94802 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/76549 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9f6d80ab-e94a-439c-a92d-b668fd0e6e85) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127566 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35870 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111441 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75374 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4ca7ce2b-c50a-444c-ac27-a1e244eb09dd) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/34801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74930 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105626 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/29827 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134119 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51461 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39283 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/103280 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51872 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107663 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103058 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26235 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48418 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/26685 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48390 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51335 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57131 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50732 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54084 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52423 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->