### PR TITLE
[GFC] Populate eligibility function for layout with some initial logic

### DIFF
--- a/Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp
+++ b/Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp
@@ -26,18 +26,288 @@
 #include "config.h"
 #include "LayoutIntegrationGridCoverage.h"
 
+#include "RenderChildIterator.h"
 #include "RenderGrid.h"
 #include "Settings.h"
 
 namespace WebCore {
 namespace LayoutIntegration {
 
+enum class AvoidanceReason : uint64_t {
+    GridHasNonFixedWidth = 1LLU << 0,
+    GridHasNonFixedHeight = 1LLU << 1,
+    GridHasVerticalWritingMode = 1LLU << 2,
+    GridHasMarginTrim = 1LLU << 3,
+    GridIsNotInBFC = 1LLU << 4,
+    GridNeedsBaseline = 1LLU << 5,
+    GridHasOutOfFlowChild = 1LLU << 6,
+    GridHasNonVisibleOverflow = 1LLU << 7,
+    GridHasUnsupportedRenderer = 1LLU << 8,
+    GridIsEmpty = 1LLU << 9,
+    GridHasNonInitialMinWidth = 1LLU << 10,
+    GridHasNonInitialMaxWidth = 1LLU << 11,
+    GridHasNonInitialMinHeight = 1LLU << 12,
+    GridHasNonInitialMaxHeight = 1LLU << 13,
+    GridHasNonZeroMinWidth = 1LLU << 14,
+    GridHasGridTemplateAreas = 1LLU << 15,
+    GridHasNonInitialGridAutoFlow = 1LLU << 16,
+    GridHasGaps = 1LLU << 17,
+    GridIsOutOfFlow = 1LLU << 18,
+    GridHasContainsSize = 1LLU << 19,
+    GridHasUnsupportedGridTemplateColumns = 1LLU << 20,
+    GridHasUnsupportedGridTemplateRows = 1LLU << 21,
+    GridItemHasNonFixedWidth = 1LLU << 22,
+    GridItemHasNonFixedHeight = 1LLU << 23,
+    GridItemHasNonInitialMaxWidth = 1LLU << 24,
+    GridItemHasNonZeroMinHeight = 1LLU << 25,
+    GridItemHasNonInitialMaxHeight = 1LLU << 26,
+    GridItemHasBorder = 1LLU << 27,
+    GridItemHasPadding = 1LLU << 28,
+    GridItemHasMargin = 1LLU << 29,
+    GridItemHasVerticalWritingMode = 1LLU << 30,
+    GridItemHasAspectRatio = 1LLU << 31,
+    GridItemHasUnsupportedInlineAxisAlignment = 1LLU << 32,
+    GridItemHasUnsupportedBlockAxisAlignment = 1LLU << 33,
+    GridItemHasNonVisibleOverflow = 1LLU << 34,
+    GridItemHasContainsSize = 1LLU << 35,
+    GridItemHasUnsupportedColumnPlacement = 1LLU << 36,
+    GridItemHasUnsupportedRowPlacement = 1LLU << 37,
+};
+
+static std::optional<AvoidanceReason> gridLayoutAvoidanceReason(const RenderGrid& renderGrid)
+{
+    CheckedRef renderGridStyle = renderGrid.style();
+
+    if (!renderGridStyle->width().isFixed())
+        return AvoidanceReason::GridHasNonFixedWidth;
+
+    if (!renderGridStyle->height().isFixed())
+        return AvoidanceReason::GridHasNonFixedHeight;
+
+    if (renderGridStyle->display() == DisplayType::InlineGrid)
+        return AvoidanceReason::GridNeedsBaseline;
+
+    if (!renderGridStyle->writingMode().isHorizontal())
+        return AvoidanceReason::GridHasVerticalWritingMode;
+
+    if (!renderGridStyle->marginTrim().isEmpty())
+        return AvoidanceReason::GridHasMarginTrim;
+
+    if (!renderGridStyle->isOverflowVisible())
+        return AvoidanceReason::GridHasNonVisibleOverflow;
+
+    if (!renderGrid.firstInFlowChild())
+        return AvoidanceReason::GridIsEmpty;
+
+    if (renderGridStyle->gridAutoFlow() != GridAutoFlow::AutoFlowRow)
+        return AvoidanceReason::GridHasNonInitialGridAutoFlow;
+
+    if (!renderGridStyle->rowGap().isNormal() || !renderGridStyle->columnGap().isNormal())
+        return AvoidanceReason::GridHasGaps;
+
+    if (renderGrid.isOutOfFlowPositioned())
+        return AvoidanceReason::GridIsOutOfFlow;
+
+    if (!renderGridStyle->gridTemplateAreas().isNone())
+        return AvoidanceReason::GridHasGridTemplateAreas;
+
+    auto isInBFC = [&] {
+        for (CheckedPtr containingBlock = renderGrid.containingBlock(); containingBlock && !is<RenderView>(*containingBlock); containingBlock = containingBlock->containingBlock()) {
+            if (containingBlock->style().display() != DisplayType::Block)
+                return false;
+            if (containingBlock->createsNewFormattingContext())
+                return true;
+        }
+        return true;
+    };
+
+    if (!isInBFC())
+        return AvoidanceReason::GridIsNotInBFC;
+
+    auto& gridTemplateColumns = renderGridStyle->gridTemplateColumns();
+    auto& gridTemplateColumnsTrackList = gridTemplateColumns.list;
+    if (gridTemplateColumnsTrackList.isEmpty())
+        return AvoidanceReason::GridHasUnsupportedGridTemplateColumns;
+
+    for (auto& columnsTrackListEntry : gridTemplateColumnsTrackList) {
+
+        auto avoidanceReason = WTF::switchOn(columnsTrackListEntry,
+            [&](const Style::GridTrackSize& trackSize) -> std::optional<AvoidanceReason> {
+                // Since a GridTrackSize type of Breadth sets the MinTrackBreadth and
+                // MaxTrackBreadth to the same value we only need to check one.
+                if (!trackSize.isBreadth() || !trackSize.minTrackBreadth().isLength())
+                    return AvoidanceReason::GridHasUnsupportedGridTemplateColumns;
+
+                auto& gridTrackBreadthLength = trackSize.minTrackBreadth().length();
+                if (!gridTrackBreadthLength.isFixed())
+                    return AvoidanceReason::GridHasUnsupportedGridTemplateColumns;
+                return std::nullopt;
+            },
+            [&](const Vector<String>& names) -> std::optional<AvoidanceReason> {
+                if (!names.isEmpty())
+                    return AvoidanceReason::GridHasUnsupportedGridTemplateColumns;
+                return std::nullopt;
+            },
+            [&](const Style::GridTrackEntryRepeat&) {
+                return std::make_optional(AvoidanceReason::GridHasUnsupportedGridTemplateColumns);
+            },
+            [&](const Style::GridTrackEntryAutoRepeat&) {
+                return std::make_optional(AvoidanceReason::GridHasUnsupportedGridTemplateColumns);
+            },
+            [&](const Style::GridTrackEntrySubgrid&) {
+                return std::make_optional(AvoidanceReason::GridHasUnsupportedGridTemplateColumns);
+            },
+            [&](const Style::GridTrackEntryMasonry&) {
+                return std::make_optional(AvoidanceReason::GridHasUnsupportedGridTemplateColumns);
+            }
+        );
+
+        if (avoidanceReason)
+            return avoidanceReason;
+    }
+
+    auto& gridTemplateRows = renderGridStyle->gridTemplateRows();
+    auto& gridTemplateRowsTrackList = gridTemplateRows.list;
+    if (gridTemplateRowsTrackList.isEmpty())
+        return AvoidanceReason::GridHasUnsupportedGridTemplateRows;
+
+    for (auto& rowsTrackListEntry : gridTemplateRowsTrackList) {
+        auto avoidanceReason = WTF::switchOn(rowsTrackListEntry,
+            [&](const Style::GridTrackSize& trackSize) -> std::optional<AvoidanceReason> {
+                // Since a GridTrackSize type of Breadth sets the MinTrackBreadth and
+                // MaxTrackBreadth to the same value we only need to check one.
+                if (!trackSize.isBreadth() || !trackSize.minTrackBreadth().isLength())
+                    return AvoidanceReason::GridHasUnsupportedGridTemplateRows;
+
+                auto& gridTrackBreadthLength = trackSize.minTrackBreadth().length();
+                if (!gridTrackBreadthLength.isFixed())
+                    return AvoidanceReason::GridHasUnsupportedGridTemplateRows;
+                return std::nullopt;
+            },
+            [&](const Vector<String>& names) -> std::optional<AvoidanceReason> {
+                if (!names.isEmpty())
+                    return AvoidanceReason::GridHasUnsupportedGridTemplateColumns;
+                return std::nullopt;
+            },
+            [&](const Style::GridTrackEntryRepeat&) {
+                return std::make_optional(AvoidanceReason::GridHasUnsupportedGridTemplateColumns);
+            },
+            [&](const Style::GridTrackEntryAutoRepeat&) {
+                return std::make_optional(AvoidanceReason::GridHasUnsupportedGridTemplateColumns);
+            },
+            [&](const Style::GridTrackEntrySubgrid&) {
+                return std::make_optional(AvoidanceReason::GridHasUnsupportedGridTemplateColumns);
+            },
+            [&](const Style::GridTrackEntryMasonry&) {
+                return std::make_optional(AvoidanceReason::GridHasUnsupportedGridTemplateColumns);
+            }
+        );
+
+        if (avoidanceReason)
+            return avoidanceReason;
+    }
+
+    if (renderGridStyle->containsSize())
+        return AvoidanceReason::GridHasContainsSize;
+
+    auto linesFromGridTemplateColumnsCount = gridTemplateColumns.sizes.size() + 1;
+    auto linesFromGridTemplateRowsCount = gridTemplateRows.sizes.size() + 1;
+    for (CheckedRef gridItem : childrenOfType<RenderBox>(renderGrid)) {
+        if (!gridItem->isRenderBlockFlow())
+            return AvoidanceReason::GridHasUnsupportedRenderer;
+
+        CheckedRef gridItemStyle = gridItem->style();
+
+        if (!gridItemStyle->width().isFixed())
+            return AvoidanceReason::GridItemHasNonFixedWidth;
+
+        if (!gridItemStyle->height().isFixed())
+            return AvoidanceReason::GridItemHasNonFixedHeight;
+
+        if (auto fixedMinWidth = gridItemStyle->minWidth().tryFixed(); fixedMinWidth && fixedMinWidth->unresolvedValue())
+            return AvoidanceReason::GridHasNonZeroMinWidth;
+
+        if (!gridItemStyle->maxWidth().isNone())
+            return AvoidanceReason::GridItemHasNonInitialMaxWidth;
+
+        if (auto fixedMinHeight = gridItemStyle->minHeight().tryFixed(); fixedMinHeight && fixedMinHeight->unresolvedValue())
+            return AvoidanceReason::GridItemHasNonZeroMinHeight;
+
+        if (!gridItemStyle->maxHeight().isNone())
+            return AvoidanceReason::GridItemHasNonInitialMaxHeight;
+
+        if (gridItemStyle->border().hasBorder())
+            return AvoidanceReason::GridItemHasBorder;
+
+        auto gridItemHasPadding = [&] {
+            return gridItemStyle->paddingBox().anyOf([](const Style::PaddingEdge& paddingEdge) {
+                return !paddingEdge.isPossiblyZero();
+            });
+        };
+        if (gridItemHasPadding())
+            return AvoidanceReason::GridItemHasPadding;
+
+        auto gridItemHasMargins = [&] {
+            return gridItemStyle->marginBox().anyOf([](const Style::MarginEdge& marginEdge) {
+                return !marginEdge.isPossiblyZero();
+            });
+        };
+        if (gridItemHasMargins())
+            return AvoidanceReason::GridItemHasMargin;
+
+        auto& justifySelf = gridItemStyle->justifySelf();
+        if (justifySelf.position() != ItemPosition::Start && justifySelf.overflow() != OverflowAlignment::Default
+            && justifySelf.positionType() != ItemPositionType::NonLegacy)
+            return AvoidanceReason::GridItemHasUnsupportedInlineAxisAlignment;
+
+        auto& alignSelf = gridItemStyle->alignSelf();
+        if (alignSelf.position() != ItemPosition::Start && alignSelf.overflow() != OverflowAlignment::Default
+            && alignSelf.positionType() != ItemPositionType::NonLegacy)
+            return AvoidanceReason::GridItemHasUnsupportedBlockAxisAlignment;
+
+        auto& columnStart = gridItemStyle->gridItemColumnStart();
+        if (!columnStart.isExplicit() || !columnStart.namedGridLine().isEmpty() || columnStart.explicitPosition() < 0
+            || columnStart.explicitPosition() > static_cast<int>(linesFromGridTemplateColumnsCount))
+            return AvoidanceReason::GridItemHasUnsupportedColumnPlacement;
+
+        auto& columnEnd = gridItemStyle->gridItemColumnEnd();
+        if (!columnEnd.isExplicit() || !columnEnd.namedGridLine().isEmpty() || columnEnd.explicitPosition() < 0
+            || columnEnd.explicitPosition() > static_cast<int>(linesFromGridTemplateColumnsCount))
+            return AvoidanceReason::GridItemHasUnsupportedColumnPlacement;
+
+        auto& rowStart = gridItemStyle->gridItemRowStart();
+        if (!rowStart.isExplicit() || !rowStart.namedGridLine().isEmpty() || rowStart.explicitPosition() < 0
+            || rowStart.explicitPosition() > static_cast<int>(linesFromGridTemplateRowsCount))
+            return AvoidanceReason::GridItemHasUnsupportedRowPlacement;
+
+        auto& rowEnd = gridItemStyle->gridItemRowEnd();
+        if (!rowEnd.isExplicit() || !rowEnd.namedGridLine().isEmpty() || rowEnd.explicitPosition() < 0
+            || rowEnd.explicitPosition() > static_cast<int>(linesFromGridTemplateRowsCount))
+            return AvoidanceReason::GridItemHasUnsupportedRowPlacement;
+
+        if (gridItemStyle->writingMode().isVertical())
+            return AvoidanceReason::GridItemHasVerticalWritingMode;
+
+        if (gridItem->isOutOfFlowPositioned())
+            return AvoidanceReason::GridHasOutOfFlowChild;
+
+        if (gridItemStyle->hasAspectRatio())
+            return AvoidanceReason::GridItemHasAspectRatio;
+
+        if (!gridItemStyle->isOverflowVisible())
+            return AvoidanceReason::GridItemHasNonVisibleOverflow;
+
+        if (gridItemStyle->containsSize())
+            return AvoidanceReason::GridItemHasContainsSize;
+    }
+    return { };
+}
+
 bool canUseForGridLayout(const RenderGrid& renderGrid)
 {
-    // Grid integration is not enabled yet.
     if (!renderGrid.document().settings().gridFormattingContextIntegrationEnabled())
         return false;
-    return false;
+    return !gridLayoutAvoidanceReason(renderGrid);
 }
 
 } // namespace LayoutIntegration


### PR DESCRIPTION
#### c22965919816960450cc8290c6aac3da01b89aca
<pre>
[GFC] Populate eligibility function for layout with some initial logic
<a href="https://bugs.webkit.org/show_bug.cgi?id=300145">https://bugs.webkit.org/show_bug.cgi?id=300145</a>
<a href="https://rdar.apple.com/161924265">rdar://161924265</a>

Reviewed by Alan Baradlay.

Currently, our canUseForGridLayout eligibility function returns false
whether or not the feature flag is enabled. Now, since we have an
initial implementation that can support some very restricted content, we
should populate this function to allow it. Over time, we will ease out
the conditions here as we claim more and more content to be supported
inside of GFC.

The nature of the content that is currently allowed is essentially fixed
sized grids and items in which the grid is explicitly sized, and the
items are all explicitly placed. There are some additional pieces that
restrict content (e.g. only allows start alignment currently), but this
is the idea at a high level.

Certain AvoidanceReasons are very generic just for this initial set of
conditions but will likely become more fine-grained as we continue to
complete GFC. For example, we return GridHasUnsupportedGridTemplateColumns
in all cases where we run into grids that have any sort of column
styling outside of fixed sizes. Over time, we will likely remove this and
add additional ones that are more descriptive of the condition that
caused us to bail out.

Canonical link: <a href="https://commits.webkit.org/301063@main">https://commits.webkit.org/301063@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bd9b1bdd9f72fbba9586654e12aa3beff2f93ab6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124596 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44268 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35002 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131435 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76539 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/126473 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44972 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52839 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94787 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62856 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127550 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35854 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111425 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75359 "Found 1 new API test failure: WPE/TestWebKitWebContext:/webkit/WebKitWebContext/no-web-process-leak (failure)") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34790 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29580 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74914 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105609 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29811 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134103 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51446 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39266 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103266 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51856 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107647 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103044 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26288 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48405 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26669 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48378 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51319 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57115 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/156266 "Build is in progress. Recent messages:") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50718 "Built successfully") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/156266 "Build is in progress. Recent messages:") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54073 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52407 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->