### PR TITLE
[Build Speed] Make WebKit/LoggingClient.h less expensive to include

### DIFF
--- a/Source/WebKit/Platform/LogClient.h
+++ b/Source/WebKit/Platform/LogClient.h
@@ -25,16 +25,23 @@
 
 #if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
 
-#include "Connection.h"
 #include "LogStreamIdentifier.h"
-#include "LogStreamMessages.h"
-#include "StreamClientConnection.h"
-#include "WebKitLogDefinitions.h"
 #include <WebCore/LogClient.h>
-#include <WebCore/WebCoreLogDefinitions.h>
 #include <wtf/Identified.h>
 #include <wtf/Lock.h>
-#include <wtf/Locker.h>
+
+#if __has_include("WebKitLogClientDeclarations.h")
+#include "WebKitLogClientDeclarations.h"
+#endif
+
+#if __has_include("WebCoreLogClientDeclarations.h")
+#include "WebCoreLogClientDeclarations.h"
+#endif
+
+namespace IPC {
+class Connection;
+class StreamClientConnection;
+}
 
 namespace WebKit {
 
@@ -54,13 +61,13 @@ public:
 
     void log(std::span<const uint8_t> logChannel, std::span<const uint8_t> logCategory, std::span<const uint8_t> logString, os_log_type_t) final;
 
-#if __has_include("WebKitLogClientDeclarations.h")
-#include "WebKitLogClientDeclarations.h"
-#endif
+#undef DECLARE_LOG_MESSAGE
+#define DECLARE_LOG_MESSAGE(messageName, argumentDeclarations, arguments) \
+    void messageName argumentDeclarations;
 
-#if __has_include("WebCoreLogClientDeclarations.h")
-#include "WebCoreLogClientDeclarations.h"
-#endif
+    WEBCORE_LOG_CLIENT_MESSAGES(DECLARE_LOG_MESSAGE)
+    WEBKIT2_LOG_CLIENT_MESSAGES(DECLARE_LOG_MESSAGE)
+#undef DECLARE_LOG_MESSAGE
 
 private:
     bool isWebKitLogClient() const final { return true; }
@@ -78,15 +85,6 @@ private:
     const Ref<IPC::Connection> m_connection;
 #endif
 };
-
-template<typename T>
-void LogClient::send(T&& message)
-{
-#if ENABLE(STREAMING_IPC_IN_LOG_FORWARDING)
-    Locker locker { m_lock };
-#endif
-    m_connection->send(WTFMove(message), identifier());
-}
 
 }
 

--- a/Source/WebKit/Scripts/generate-derived-log-sources.py
+++ b/Source/WebKit/Scripts/generate-derived-log-sources.py
@@ -32,20 +32,18 @@ def generate_messages_file(log_messages, log_messages_receiver_input_file, strea
     return
 
 
-def generate_log_client_declarations_file(log_messages, log_client_declarations_file):
+def generate_log_client_declarations_file(prefix, log_messages, log_client_declarations_file):
     with open(log_client_declarations_file, 'w') as file:
-
+        file.write("#pragma once\n")
+        file.write("\n")
+        file.write("#define " + prefix + "_LOG_CLIENT_MESSAGES(M) \\\n")
         for log_message in log_messages:
             function_name = log_message[0]
             parameters = log_message[2]
-            arguments_string = log_declarations_module.get_arguments_string(parameters, log_declarations_module.PARAMETER_LIST_INCLUDE_TYPE | log_declarations_module.PARAMETER_LIST_INCLUDE_NAME | log_declarations_module.PARAMETER_LIST_MODIFY_CSTRING)
-            file.write("    void " + function_name + "(" + arguments_string + ")\n")
-            file.write("    {\n")
-            parameters_string = log_declarations_module.get_arguments_string(parameters, log_declarations_module.PARAMETER_LIST_INCLUDE_NAME)
-            file.write("        send(Messages::LogStream::" + function_name + "(" + parameters_string + "));\n")
-            file.write("    }\n")
+            arguments_declarations = log_declarations_module.get_arguments_string(parameters, log_declarations_module.PARAMETER_LIST_INCLUDE_TYPE | log_declarations_module.PARAMETER_LIST_INCLUDE_NAME | log_declarations_module.PARAMETER_LIST_MODIFY_CSTRING)
+            arguments = ', '.join("arg" + str(i) for i in range(0, len(log_declarations_module.get_argument_list(parameters))))
+            file.write("    M(" + function_name + ", (" + arguments_declarations + "), (" + arguments + ")) \\\n")
         file.close()
-
     return
 
 
@@ -133,8 +131,8 @@ def main(argv):
     generate_message_receiver_declarations_file(log_messages, message_receiver_declarations_file)
     generate_message_receiver_implementations_file(log_messages, message_receiver_implementations_file)
 
-    generate_log_client_declarations_file(webkit_log_messages, webkit_log_client_declarations_file)
-    generate_log_client_declarations_file(webcore_log_messages, webcore_log_client_declarations_file)
+    generate_log_client_declarations_file("WEBKIT2", webkit_log_messages, webkit_log_client_declarations_file)
+    generate_log_client_declarations_file("WEBCORE", webcore_log_messages, webcore_log_client_declarations_file)
 
     return 0
 

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -8053,6 +8053,8 @@
 		CD20CE7525CC999F0069B542 /* RemoteAudioHardwareListenerProxy.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteAudioHardwareListenerProxy.cpp; sourceTree = "<group>"; };
 		CD20CE7725CD2B9D0069B542 /* RemoteAudioHardwareListenerMessageReceiver.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteAudioHardwareListenerMessageReceiver.cpp; sourceTree = "<group>"; };
 		CD20CE7925CD2B9E0069B542 /* RemoteAudioHardwareListenerMessages.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteAudioHardwareListenerMessages.h; sourceTree = "<group>"; };
+		CD3480952E8F23FD0040CEF9 /* WebCoreLogClientDeclarations.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebCoreLogClientDeclarations.h; sourceTree = "<group>"; };
+		CD3480962E8F23FD0040CEF9 /* WebKitLogClientDeclarations.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebKitLogClientDeclarations.h; sourceTree = "<group>"; };
 		CD36C16C260A6EBE00C8C529 /* LocalAudioSessionRoutingArbitrator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LocalAudioSessionRoutingArbitrator.h; sourceTree = "<group>"; };
 		CD36C16D260A6EBE00C8C529 /* LocalAudioSessionRoutingArbitrator.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = LocalAudioSessionRoutingArbitrator.cpp; sourceTree = "<group>"; };
 		CD3EEF3125799618006563BB /* RemoteMediaEngineConfigurationFactory.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteMediaEngineConfigurationFactory.h; sourceTree = "<group>"; };
@@ -16561,6 +16563,7 @@
 				1C0A195B1C916E1B00FE0EBB /* WebAutomationSessionProxyScriptSource.h */,
 				330934431315B9220097A7BC /* WebCookieManagerMessageReceiver.cpp */,
 				330934441315B9220097A7BC /* WebCookieManagerMessages.h */,
+				CD3480952E8F23FD0040CEF9 /* WebCoreLogClientDeclarations.h */,
 				E3866B062399979C00F88FE9 /* WebDeviceOrientationUpdateProviderMessageReceiver.cpp */,
 				E3866B072399979D00F88FE9 /* WebDeviceOrientationUpdateProviderMessages.h */,
 				E3866B042399979C00F88FE9 /* WebDeviceOrientationUpdateProviderProxyMessageReceiver.cpp */,
@@ -16601,6 +16604,7 @@
 				996B2B9625E2448200719379 /* WebInspectorUIExtensionControllerProxyMessages.h */,
 				1CBBE49E19B66C53006B7D81 /* WebInspectorUIMessageReceiver.cpp */,
 				1CBBE49F19B66C53006B7D81 /* WebInspectorUIMessages.h */,
+				CD3480962E8F23FD0040CEF9 /* WebKitLogClientDeclarations.h */,
 				5C9E0F972A577EC400FC2664 /* WebKitPlatformGeneratedSerializers.mm */,
 				31BA9248148830810062EDB5 /* WebNotificationManagerMessageReceiver.cpp */,
 				31BA9249148830810062EDB5 /* WebNotificationManagerMessages.h */,


### PR DESCRIPTION
#### 02e86e63291c1efc71da8f1be4002f2fe2626768
<pre>
[Build Speed] Make WebKit/LoggingClient.h less expensive to include
<a href="https://rdar.apple.com/161924655">rdar://161924655</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=300147">https://bugs.webkit.org/show_bug.cgi?id=300147</a>

Reviewed by Per Arne Vollan.

Prior to this patch, LogClient.h was the 4th most expensive header used in WebKit; it was included
266 times in a WebKit Unified build, and on this machine each include of that file took the
compiler 930ms to parse, for a total of 4.1m CPU minutes of time spent parsing this header.

The high cost of this header occurs because nearly the entire implementation is inlined. The
generate-derived-log-sources.py produces code which can only exist in the header of the class, and
the templated send() method which sends log messages out-of-process must also exist in the header.

Restructure the way these log messages are generated using pre-processor macros. This allows the
derived sources step to generate message names and arguments, but allows the structure of the
implementation to be decided by clients. The log messages generate a macro which will apply another
preprocessor macro to each message in turn. This is similar to how Logging.h or SoftLinking.h
headers work in other parts of the project.

The WebKitLogClientMessageDefinitions.h and WebCoreLogClientMessageDefinitions.h
header files will now contain a macro which looks like this:

    M(SUBRESOURCELOADER_DIDFINISHLOADING, (uint64_t arg0, uint64_t arg1, uint64_t arg2), (arg0, arg1, arg2)) \
...

LogClient.h will generate method declarations by passing a macro into
`WEBCORE_LOG_CLIENT_MESSAGES()`, which will turn the macro above into:

    void SUBRESOURCELOADER_DIDFINISHLOADING(uint64_t arg0, uint64_t arg1, uint64_t arg2);

LogClient.cpp will generate method implementation by passing a macro into
`WEBCORE_LOG_CLIENT_MESSAGES()`, which will turn the macro above into:

void LogClient::SUBRESOURCELOADER_DIDFINISHLOADING(uint64_t arg0, uint64_t arg1, uint64_t arg2)
{
    send(Messages::LogStream::SUBRESOURCELOADER_DIDFINISHLOADING(arg0, arg1, arg2));
}

This allows the LogClient.h header to have it&apos;s parse time significantly reduced
by moving all implementation details into the .cpp file.

After this patch, LogClient.h is now the 124th most expensive header file used in WebKit; it is
included 268 times, for a total of 12s CPU seconds of time spent parsing this header, a reduction
of 3.9m.

* Source/WebKit/Platform/LogClient.cpp:
(WebKit::LogClient::send):
* Source/WebKit/Platform/LogClient.h:
(WebKit::LogClient::send): Deleted.
* Source/WebKit/Scripts/generate-derived-log-sources.py:
(generate_log_client_declarations_file):
(main):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/301009@main">https://commits.webkit.org/301009@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1c7fc51196a33233e742b1eb590fb23bba1da6eb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124666 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44338 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35072 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131507 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76595 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/287b9352-611f-40aa-9520-496ceebd1262) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45042 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52908 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94846 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62904 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6cdb9b8e-da5a-4f7b-a89b-713ece3988c3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127620 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35920 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111490 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75416 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/88efa1fe-e9d8-47cc-8b50-235887826f42) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/124022 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34850 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74987 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105677 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29876 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134173 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51514 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39330 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103321 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51926 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107711 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103096 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26245 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48469 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26733 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48470 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51388 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57185 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50782 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54137 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52476 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->