### PR TITLE
[AutoFill Debugging] Refactor debug text extraction to work with non-Cocoa ports

### DIFF
--- a/LayoutTests/fast/text-extraction/debug-text-extraction-basic-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-basic-expected.txt
@@ -31,4 +31,3 @@ root
         '    \nFooter content with ',[…]
         role='img',aria-label='copyright symbol','©',[…]
         ' 2024',[…]
-

--- a/Source/WebKit/Shared/Extensions/WebExtensionSQLiteStatement.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionSQLiteStatement.h
@@ -79,7 +79,7 @@ public:
     HashMap<String, int> columnNamesToIndicies();
 private:
     sqlite3_stmt* m_handle;
-    Ref<WebExtensionSQLiteDatabase> m_db;
+    const Ref<WebExtensionSQLiteDatabase> m_db;
 
     Vector<String> m_columnNames;
     HashMap<String, int> m_columnNamesToIndicies;

--- a/Source/WebKit/Shared/TextExtractionToStringConversion.cpp
+++ b/Source/WebKit/Shared/TextExtractionToStringConversion.cpp
@@ -1,0 +1,412 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "TextExtractionToStringConversion.h"
+
+#include <WebCore/TextExtractionTypes.h>
+#include <wtf/text/MakeString.h>
+#include <wtf/text/StringBuilder.h>
+#include <wtf/TZoneMallocInlines.h>
+
+namespace WebKit {
+
+using namespace WebCore;
+
+struct TextExtractionLine {
+    unsigned lineIndex { 0 };
+    unsigned indentLevel { 0 };
+};
+
+class TextExtractionAggregator : public RefCounted<TextExtractionAggregator> {
+    WTF_MAKE_NONCOPYABLE(TextExtractionAggregator);
+    WTF_MAKE_TZONE_ALLOCATED(TextExtractionAggregator);
+public:
+    TextExtractionAggregator(CompletionHandler<void(String&&)>&& completion)
+        : m_completion(WTFMove(completion))
+    {
+    }
+
+    ~TextExtractionAggregator()
+    {
+        m_completion(makeStringByJoining(WTFMove(m_lines), "\n"_s));
+    }
+
+    static Ref<TextExtractionAggregator> create(CompletionHandler<void(String&&)>&& completion)
+    {
+        return adoptRef(*new TextExtractionAggregator(WTFMove(completion)));
+    }
+
+    void addResult(const TextExtractionLine& line, Vector<String>&& components)
+    {
+        if (components.isEmpty())
+            return;
+
+        auto [lineIndex, indentLevel] = line;
+        if (lineIndex >= m_lines.size()) {
+            ASSERT_NOT_REACHED();
+            return;
+        }
+
+        auto text = makeStringByJoining(WTFMove(components), ","_s);
+
+        if (!m_lines[lineIndex].isEmpty()) {
+            m_lines[lineIndex] = makeString(m_lines[lineIndex], ',', WTFMove(text));
+            return;
+        }
+
+        StringBuilder indentation;
+        indentation.reserveCapacity(indentLevel);
+        for (unsigned i = 0; i < indentLevel; ++i)
+            indentation.append('\t');
+        m_lines[lineIndex] = makeString(indentation.toString(), WTFMove(text));
+    }
+
+    unsigned advanceToNextLine()
+    {
+        auto index = m_nextLineIndex++;
+        m_lines.resize(m_nextLineIndex);
+        return index;
+    }
+
+private:
+    Vector<String> m_lines;
+    unsigned m_nextLineIndex { 0 };
+    CompletionHandler<void(String&&)> m_completion;
+};
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(TextExtractionAggregator);
+
+static String commaSeparatedString(const Vector<String>& parts)
+{
+    return makeStringByJoining(parts, ","_s);
+}
+
+static String escapeString(const String& string)
+{
+    auto result = string;
+    result = makeStringByReplacingAll(result, '\\', "\\\\"_s);
+    result = makeStringByReplacingAll(result, '\n', "\\n"_s);
+    result = makeStringByReplacingAll(result, '\r', "\\r"_s);
+    result = makeStringByReplacingAll(result, '\t', "\\t"_s);
+    result = makeStringByReplacingAll(result, '\'', "\\'"_s);
+    result = makeStringByReplacingAll(result, '"', "\\\""_s);
+    result = makeStringByReplacingAll(result, '\0', "\\0"_s);
+    result = makeStringByReplacingAll(result, '\b', "\\b"_s);
+    result = makeStringByReplacingAll(result, '\f', "\\f"_s);
+    result = makeStringByReplacingAll(result, '\v', "\\v"_s);
+    return result;
+}
+
+static Vector<String> eventListenerTypesToStringArray(OptionSet<TextExtraction::EventListenerCategory> eventListeners)
+{
+    Vector<String> result;
+    if (eventListeners.contains(TextExtraction::EventListenerCategory::Click))
+        result.append("click"_s);
+    if (eventListeners.contains(TextExtraction::EventListenerCategory::Hover))
+        result.append("hover"_s);
+    if (eventListeners.contains(TextExtraction::EventListenerCategory::Touch))
+        result.append("touch"_s);
+    if (eventListeners.contains(TextExtraction::EventListenerCategory::Wheel))
+        result.append("wheel"_s);
+    if (eventListeners.contains(TextExtraction::EventListenerCategory::Keyboard))
+        result.append("keyboard"_s);
+    return result;
+}
+
+static Vector<String> partsForItem(const TextExtraction::Item& item)
+{
+    Vector<String> parts;
+
+    if (item.nodeIdentifier)
+        parts.append(makeString("uid="_s, item.nodeIdentifier->toUInt64()));
+
+    if (item.children.isEmpty()) {
+        auto origin = item.rectInRootView.location();
+        auto size = item.rectInRootView.size();
+        parts.append(makeString("["_s,
+            static_cast<int>(origin.x()), ',', static_cast<int>(origin.y()), ";"_s,
+            static_cast<int>(size.width()), 'x', static_cast<int>(size.height()), ']'));
+    }
+
+    if (!item.accessibilityRole.isEmpty())
+        parts.append(makeString("role='"_s, escapeString(item.accessibilityRole), '\''));
+
+    auto listeners = eventListenerTypesToStringArray(item.eventListeners);
+    if (!listeners.isEmpty())
+        parts.append(makeString("events=["_s, commaSeparatedString(listeners), ']'));
+
+    auto attributeKeys = copyToVector(item.ariaAttributes.keys());
+    std::ranges::sort(attributeKeys, codePointCompareLessThan);
+
+    for (auto& key : attributeKeys)
+        parts.append(makeString(key, "='"_s, escapeString(item.ariaAttributes.get(key)), '\''));
+
+    return parts;
+}
+
+static void addPartsForText(const TextExtraction::TextItemData& textItem, Vector<String>&& itemParts, std::optional<NodeIdentifier>&& enclosingNode, const TextExtractionLine& line, const TextExtractionFilterCallback& filter, Ref<TextExtractionAggregator>&& aggregator)
+{
+    auto completion = [itemParts = WTFMove(itemParts), selectedRange = textItem.selectedRange, aggregator = WTFMove(aggregator), line](const String& filteredText) mutable {
+        Vector<String> textParts;
+        if (!filteredText.isEmpty()) {
+            auto isNewline = [](UChar character) {
+                return character == '\n' || character == '\r';
+            };
+
+            auto startIndex = filteredText.find([&](auto character) {
+                return !isNewline(character);
+            });
+
+            if (startIndex == notFound) {
+                textParts.append("''"_s);
+                textParts.append("selected=[0,0]"_s);
+            } else {
+                size_t endIndex = filteredText.length() - 1;
+                for (size_t i = filteredText.length(); i > 0; --i) {
+                    if (!isNewline(filteredText.characterAt(i - 1))) {
+                        endIndex = i - 1;
+                        break;
+                    }
+                }
+
+                auto trimmedContent = filteredText.substring(startIndex, endIndex - startIndex + 1);
+                textParts.append(makeString('\'', escapeString(trimmedContent), '\''));
+
+                if (selectedRange && selectedRange->length > 0) {
+                    if (!trimmedContent.isEmpty()) {
+                        int newLocation = std::max(0, static_cast<int>(selectedRange->location) - static_cast<int>(startIndex));
+                        int maxLength = static_cast<int>(trimmedContent.length()) - newLocation;
+                        int newLength = std::min(static_cast<int>(selectedRange->length), std::max(0, maxLength));
+                        if (newLocation < static_cast<int>(trimmedContent.length()) && newLength > 0)
+                            textParts.append(makeString("selected=["_s, newLocation, ',', newLocation + newLength, ']'));
+                        else
+                            textParts.append("selected=[0,0]"_s);
+                    } else
+                        textParts.append("selected=[0,0]"_s);
+                }
+            }
+        } else if (selectedRange)
+            textParts.append("selected=[0,0]"_s);
+
+        textParts.appendVector(WTFMove(itemParts));
+        aggregator->addResult(line, WTFMove(textParts));
+    };
+
+    if (!filter) {
+        completion(textItem.content);
+        return;
+    }
+
+    filter(textItem.content, WTFMove(enclosingNode))->whenSettled(RunLoop::mainSingleton(), [originalContent = textItem.content, completion = WTFMove(completion)](auto&& result) mutable {
+        if (result)
+            completion(WTFMove(*result));
+        else
+            completion(WTFMove(originalContent));
+    });
+}
+
+static void addPartsForItem(const TextExtraction::Item& item, std::optional<NodeIdentifier>&& enclosingNode, const TextExtractionLine& line, const TextExtractionFilterCallback& filter, TextExtractionAggregator& aggregator)
+{
+    Vector<String> parts;
+    WTF::switchOn(item.data,
+        [&](const TextExtraction::ContainerType& containerType) {
+            String containerString;
+            switch (containerType) {
+            case TextExtraction::ContainerType::Root:
+                containerString = "root"_s;
+                break;
+            case TextExtraction::ContainerType::ViewportConstrained:
+                containerString = "overlay"_s;
+                break;
+            case TextExtraction::ContainerType::List:
+                containerString = "list"_s;
+                break;
+            case TextExtraction::ContainerType::ListItem:
+                containerString = "list-item"_s;
+                break;
+            case TextExtraction::ContainerType::BlockQuote:
+                containerString = "block-quote"_s;
+                break;
+            case TextExtraction::ContainerType::Article:
+                containerString = "article"_s;
+                break;
+            case TextExtraction::ContainerType::Section:
+                containerString = "section"_s;
+                break;
+            case TextExtraction::ContainerType::Nav:
+                containerString = "navigation"_s;
+                break;
+            case TextExtraction::ContainerType::Button:
+                containerString = "button"_s;
+                break;
+            case TextExtraction::ContainerType::Canvas:
+                containerString = "canvas"_s;
+                break;
+            case TextExtraction::ContainerType::Generic:
+                break;
+            }
+
+            if (!containerString.isEmpty())
+                parts.append(WTFMove(containerString));
+
+            parts.appendVector(partsForItem(item));
+            aggregator.addResult(line, WTFMove(parts));
+        },
+        [&](const TextExtraction::TextItemData& textData) {
+            addPartsForText(textData, partsForItem(item), WTFMove(enclosingNode), line, filter, aggregator);
+        },
+        [&](const TextExtraction::ContentEditableData& editableData) {
+            parts.append("contentEditable"_s);
+            parts.appendVector(partsForItem(item));
+
+            if (editableData.isFocused)
+                parts.append("focused"_s);
+
+            if (editableData.isPlainTextOnly)
+                parts.append("plaintext"_s);
+
+            aggregator.addResult(line, WTFMove(parts));
+        },
+        [&](const TextExtraction::TextFormControlData& controlData) {
+            parts.append("textFormControl"_s);
+            parts.appendVector(partsForItem(item));
+
+            if (!controlData.controlType.isEmpty())
+                parts.insert(1, makeString('\'', controlData.controlType, '\''));
+
+            if (!controlData.autocomplete.isEmpty())
+                parts.append(makeString("autocomplete='"_s, controlData.autocomplete, '\''));
+
+            if (controlData.isReadonly)
+                parts.append("readonly"_s);
+
+            if (controlData.isDisabled)
+                parts.append("disabled"_s);
+
+            if (controlData.isChecked)
+                parts.append("checked"_s);
+
+            if (!controlData.editable.label.isEmpty())
+                parts.append(makeString("label='"_s, escapeString(controlData.editable.label), '\''));
+
+            if (!controlData.editable.placeholder.isEmpty())
+                parts.append(makeString("placeholder='"_s, escapeString(controlData.editable.placeholder), '\''));
+
+            if (controlData.editable.isSecure)
+                parts.append("secure"_s);
+
+            if (controlData.editable.isFocused)
+                parts.append("focused"_s);
+
+        aggregator.addResult(line, WTFMove(parts));
+        },
+        [&](const TextExtraction::LinkItemData& linkData) {
+            parts.append("link"_s);
+            parts.appendVector(partsForItem(item));
+
+            if (!linkData.completedURL.isEmpty())
+                parts.append(makeString("url='"_s, escapeString(linkData.completedURL.string()), '\''));
+
+            if (!linkData.target.isEmpty())
+                parts.append(makeString("target='"_s, escapeString(linkData.target), '\''));
+
+            aggregator.addResult(line, WTFMove(parts));
+        },
+        [&](const TextExtraction::ScrollableItemData& scrollableData) {
+            parts.append("scrollable"_s);
+            parts.appendVector(partsForItem(item));
+            parts.append(makeString("contentSize=["_s, scrollableData.contentSize.width(), 'x', scrollableData.contentSize.height(), ']'));
+            aggregator.addResult(line, WTFMove(parts));
+        },
+        [&](const TextExtraction::SelectData& selectData) {
+            parts.append("select"_s);
+            parts.appendVector(partsForItem(item));
+
+            if (!selectData.selectedValues.isEmpty()) {
+                auto escapedValues = selectData.selectedValues.map([](auto& value) {
+                    return makeString('\'', escapeString(value), '\'');
+                });
+                parts.append(makeString("selected=["_s, commaSeparatedString(escapedValues), ']'));
+            }
+
+            if (selectData.isMultiple)
+                parts.append("multiple"_s);
+
+            aggregator.addResult(line, WTFMove(parts));
+        },
+        [&](const TextExtraction::ImageItemData& imageData) {
+            parts.append("image"_s);
+            parts.appendVector(partsForItem(item));
+
+            if (!imageData.name.isEmpty())
+                parts.append(makeString("name='"_s, escapeString(imageData.name), '\''));
+
+            if (!imageData.altText.isEmpty())
+                parts.append(makeString("alt='"_s, escapeString(imageData.altText), '\''));
+
+            aggregator.addResult(line, WTFMove(parts));
+        }
+    );
+}
+
+static void addTextRepresentationRecursive(const TextExtraction::Item& item, std::optional<NodeIdentifier>&& enclosingNode, unsigned depth, const TextExtractionFilterCallback& filter, TextExtractionAggregator& aggregator)
+{
+    auto identifier = item.nodeIdentifier;
+    if (!identifier)
+        identifier = enclosingNode;
+
+    TextExtractionLine line { aggregator.advanceToNextLine(), depth };
+    addPartsForItem(item, std::optional { identifier }, line, filter, aggregator);
+
+    if (item.children.size() == 1 && std::holds_alternative<TextExtraction::TextItemData>(item.children[0].data)) {
+        // In the case of a single text child, we append that text to the same line.
+        addPartsForItem(item.children[0], WTFMove(identifier), line, filter, aggregator);
+        return;
+    }
+
+    for (auto& child : item.children)
+        addTextRepresentationRecursive(child, std::optional { identifier }, depth + 1, filter, aggregator);
+}
+
+void convertToText(TextExtraction::Item&& item, CompletionHandler<void(String&&)>&& completion, TextExtractionFilterCallback&& filter, Vector<String>&& nativeMenuItems)
+{
+    Ref aggregator = TextExtractionAggregator::create(WTFMove(completion));
+    addTextRepresentationRecursive(item, { }, 0, WTFMove(filter), aggregator);
+
+    if (nativeMenuItems.isEmpty())
+        return;
+
+    auto escapedQuotedItemTitles = nativeMenuItems.map([](auto& itemTitle) {
+        return makeString('\'', escapeString(itemTitle), '\'');
+    });
+
+    aggregator->addResult({ aggregator->advanceToNextLine(), 0 }, {
+        "nativePopupMenu"_s,
+        makeString("items=["_s, commaSeparatedString(escapedQuotedItemTitles), ']')
+    });
+}
+
+} // namespace WebKit

--- a/Source/WebKit/Shared/TextExtractionToStringConversion.h
+++ b/Source/WebKit/Shared/TextExtractionToStringConversion.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,30 +25,28 @@
 
 #pragma once
 
-#if USE(APPLE_INTERNAL_SDK) || (!PLATFORM(WATCHOS) && !PLATFORM(APPLETV))
-
-#import <wtf/Function.h>
-#import <wtf/RetainPtr.h>
-
-OBJC_CLASS NSString;
-OBJC_CLASS WKTextExtractionItem;
-OBJC_CLASS WKWebView;
+#include <wtf/CompletionHandler.h>
+#include <wtf/NativePromise.h>
+#include <wtf/RefCounted.h>
+#include <wtf/text/WTFString.h>
 
 namespace WebCore {
-class FloatRect;
 
 namespace TextExtraction {
+
 struct Item;
-}
-}
+
+} // namespace TextExtraction
+
+struct NodeIdentifierType;
+using NodeIdentifier = ObjectIdentifier<NodeIdentifierType>;
+
+} // namespace WebCore
 
 namespace WebKit {
 
-using RootViewToWebViewConverter = Function<WebCore::FloatRect(const WebCore::FloatRect&)>;
-RetainPtr<WKTextExtractionItem> createItem(const WebCore::TextExtraction::Item&, RootViewToWebViewConverter&&);
-
-std::optional<double> computeSimilarity(NSString *a, NSString *b, unsigned minimumLength = 1);
+using TextExtractionFilterPromise = NativePromise<String, void>;
+using TextExtractionFilterCallback = Function<Ref<TextExtractionFilterPromise>(const String&, std::optional<WebCore::NodeIdentifier>&&)>;
+void convertToText(WebCore::TextExtraction::Item&&, CompletionHandler<void(String&&)>&&, TextExtractionFilterCallback&& = { }, Vector<String>&& nativeMenuItems = { });
 
 } // namespace WebKit
-
-#endif // USE(APPLE_INTERNAL_SDK) || (!PLATFORM(WATCHOS) && !PLATFORM(APPLETV))

--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -247,6 +247,7 @@ Shared/SessionState.cpp
 Shared/SharedStringHashStore.cpp
 Shared/SharedStringHashTableReadOnly.cpp
 Shared/SharedStringHashTable.cpp
+Shared/TextExtractionToStringConversion.cpp
 Shared/UserData.cpp
 Shared/WebBackForwardListFrameItem.cpp
 Shared/WebBackForwardListItem.cpp

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -126,6 +126,9 @@ struct DigitalCredentialsResponseData;
 struct MobileDocumentRequest;
 struct OpenID4VPRequest;
 #endif
+
+struct NodeIdentifierType;
+using NodeIdentifier = ObjectIdentifier<NodeIdentifierType>;
 } // namespace WebCore
 
 namespace WebKit {
@@ -642,7 +645,6 @@ WebCore::CocoaColor *sampledFixedPositionContentColor(const WebCore::FixedContai
 #if ENABLE(TEXT_EXTRACTION_FILTER)
 
 @interface WKWebView (TextExtractionFilter)
-- (void)_validateText:(NSString *)text inNode:(NSString *)nodeIdentifier completionHandler:(void(^)(NSString *))completionHandler;
 - (void)_clearTextExtractionFilterCache;
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtractionInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtractionInternal.h
@@ -111,11 +111,6 @@ typedef NS_ENUM(NSInteger, WKTextExtractionEditableType) {
 @property (nonatomic, readonly, getter=isFocused) BOOL focused;
 @end
 
-@interface WKTextExtractionPopupMenu : NSObject
-- (instancetype)initWithItemTitles:(NSArray<NSString *> *)titles;
-@property (nonatomic, readonly) NSArray<NSString *> *itemTitles;
-@end
-
 @interface WKTextExtractionItem : NSObject
 @property (nonatomic, readonly) NSArray<WKTextExtractionItem *> *children;
 @property (nonatomic, readonly) CGRect rectInWebView;
@@ -181,10 +176,8 @@ typedef NS_ENUM(NSInteger, WKTextExtractionEditableType) {
 @end
 
 @interface WKTextExtractionResult : NSObject
-- (instancetype)initWithRootItem:(WKTextExtractionItem *)rootItem popupMenu:(nullable WKTextExtractionPopupMenu *)popupMenu;
+- (instancetype)initWithRootItem:(WKTextExtractionItem *)rootItem;
 @property (nonatomic, readonly) WKTextExtractionItem *rootItem;
-@property (nonatomic, readonly, nullable) WKTextExtractionPopupMenu *popupMenu;
-@property (nonatomic, readonly) NSString *textRepresentation;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -8544,6 +8544,8 @@
 		F416F1BF2C5C3E360085D8DD /* WKScrollViewTrackingTapGestureRecognizer.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = WKScrollViewTrackingTapGestureRecognizer.mm; path = ios/WKScrollViewTrackingTapGestureRecognizer.mm; sourceTree = "<group>"; };
 		F41795A42AC619A2007F5F12 /* CompactContextMenuPresenter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = CompactContextMenuPresenter.h; path = ios/CompactContextMenuPresenter.h; sourceTree = "<group>"; };
 		F41795A52AC619A2007F5F12 /* CompactContextMenuPresenter.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = CompactContextMenuPresenter.mm; path = ios/CompactContextMenuPresenter.mm; sourceTree = "<group>"; };
+		F4217F1C2E8EFF8A0036AAC1 /* TextExtractionToStringConversion.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TextExtractionToStringConversion.h; sourceTree = "<group>"; };
+		F4217F1D2E8EFF8A0036AAC1 /* TextExtractionToStringConversion.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = TextExtractionToStringConversion.cpp; sourceTree = "<group>"; };
 		F425374F2AF9A25A00873864 /* InteractionInformationRequest.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; name = InteractionInformationRequest.serialization.in; path = ios/InteractionInformationRequest.serialization.in; sourceTree = "<group>"; };
 		F4299506270E234C0032298B /* StreamMessageReceiver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StreamMessageReceiver.h; sourceTree = "<group>"; };
 		F42A046C2CA1B2A4000D3118 /* _WKTextRun.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = _WKTextRun.h; sourceTree = "<group>"; };
@@ -10061,6 +10063,8 @@
 				932CA81B283C35EB00C20BEB /* StorageAreaIdentifier.h */,
 				07E2C0782C13FC0100BE6743 /* TextAnimationTypes.serialization.in */,
 				1A5E4DA312D3BD3D0099A2BB /* TextCheckerState.h */,
+				F4217F1D2E8EFF8A0036AAC1 /* TextExtractionToStringConversion.cpp */,
+				F4217F1C2E8EFF8A0036AAC1 /* TextExtractionToStringConversion.h */,
 				86DD518B28EF028500DF2A58 /* TextFlags.serialization.in */,
 				86890B81294B6FD900DB95CE /* TextRecognitionResult.serialization.in */,
 				F4A7CE842667EB4E00228685 /* TextRecognitionUpdateResult.h */,


### PR DESCRIPTION
#### b7f73eb8a257afa72ba6adec0ebb0bb19017eaad
<pre>
[AutoFill Debugging] Refactor debug text extraction to work with non-Cocoa ports
<a href="https://bugs.webkit.org/show_bug.cgi?id=300135">https://bugs.webkit.org/show_bug.cgi?id=300135</a>
<a href="https://rdar.apple.com/161919662">rdar://161919662</a>

Reviewed by Abrar Rahman Protyasha.

This patch moves logic to convert a `WebCore::TextExtraction::Item` into a hierarchical debug text
representation out of platform-specific Swift/ObjC code in `_WKTextExtraction.swift` and
`WKTextExtractionUtilities.mm`, and into a new `TextExtractionToStringConversion.cpp`, which is
platform agnostic.

This also allows us to skip the conversion from `WebCore::TextExtraction::Item` to a tree of
`WKTextExtractionItem` Objective-C objects for the purposes of extracting `-_debugText:`, and
instead directly convert from `WebCore::TextExtraction::Item` to a string representation.

Note that this new helper file is in `Source/WebKit/Shared`, so that it can be invoked from within
the web process if necessary, in a subsequent patch. For now, this helper is only invoked from the
UI process.

No change in behavior (beyond the lack of trailing newline in the output below); see below for more
details.

* LayoutTests/fast/text-extraction/debug-text-extraction-basic-expected.txt:

Rebaseline a layout test; the debug text extraction no longer has a trailing newline with the new
way of aggregating text results per line.

* Source/WebKit/Shared/Extensions/WebExtensionSQLiteStatement.h:
* Source/WebKit/Shared/TextExtractionToStringConversion.cpp: Added.
(WebKit::TextExtractionAggregator::TextExtractionAggregator):
(WebKit::TextExtractionAggregator::~TextExtractionAggregator):

Create a new RAII object to encapsulate the debug text conversion lifecycle. This is necessary
because `TextExtraction::Item` itself is just a struct (not ref-counted) that&apos;s passed back in the
completion handler of `WebPageProxy::requestTextExtraction`, but when recursively converting these
text extraction results, we may need to perform asynchronous filtering operations to verify that
(e.g.) text content in extracted text items represent user-visible text, and the
`TextExtractionFilter`&apos;s classifier considers the text valid. This was previously not necessary,
because we took advantage of the fact that we first converted `TextExtraction::Item` to ObjC objects
which we just retained while performing async filtering (and whose text we could mutate as needed).

This is created with the overall completion handler, which is invoked in the destructor. See
`convertToText` below for the usage.

(WebKit::TextExtractionAggregator::create):
(WebKit::TextExtractionAggregator::addResult):

Add a helper method to add results (give a line number, indentation level and comma-separated
components) to the final text extraction. Importantly, note that these results don&apos;t necessary come
in in order by line number, due to the fact that extraction for text nodes may involve additional
async validation.

(WebKit::TextExtractionAggregator::advanceToNextLine):

Add a helper method to advance to the next line (i.e. claiming the next line number) when dumping
text for a new item in the extraction result tree.

(WebKit::commaSeparatedString):
(WebKit::escapeString):
(WebKit::eventListenerTypesToStringArray):

Migrate several helper methods over from `_WKTextExtraction.swift`.

(WebKit::partsForItem):
(WebKit::addPartsForText):
(WebKit::addPartsForItem):
(WebKit::addTextRepresentationRecursive):

Implement the bulk of the algorithm here. This recursively traverses extraction results, adding
results to the `aggregator` in the process. This takes an async filtering callback (which returns a
`NativePromise`) which applies to all extracted text items. While any of these promises is pending,
the `aggregator` will be kept alive.

(WebKit::convertToText):
* Source/WebKit/Shared/TextExtractionToStringConversion.h: Copied from Source/WebKit/UIProcess/Cocoa/TextExtraction/WKTextExtractionUtilities.h.
(WebKit::convertToText):
* Source/WebKit/Sources.txt:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _activeNativeMenuItemTitles]):

Make this return a list of item titles, now that we no longer use `WKTextExtractionPopupMenu`.

(-[WKWebView _debugTextWithConfiguration:completionHandler:]):

Reimplement this in terms of `-_requestTextExtractionInternal:completion:`; instead of getting a
`WKTextExtractionResult` and converting that into a text representation, we now go directly from
`TextExtraction::Item` to `NSString *`.

We also reimplement the async filtering logic here (i.e. passing text through
`WebKit::TextExtractionFilter` and `-_validateText:`) using the `TextExtractionFilterCallback` in
`convertToText`, which allows us to delete the now-unused helpers to recursively filter out text in
the ObjC extraction result tree, in `WKTextExtractionUtilities.mm`.

(-[WKWebView _requestTextExtractionInternal:completion:]):

Pull common logic to obtain an `TextExtraction::Item` out into a separate helper method.

(-[WKWebView _requestTextExtraction:completionHandler:]):
(-[WKWebView _validateText:inNode:completionHandler:]):
(-[WKWebView _popupMenuForTextExtractionResults]): Deleted.

Remove `WKTextExtractionPopupMenu` entirely, now that debug text extraction no longer depends on
producing a `WKTextExtractionResult` and asking it for a text representation.

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.swift:
(WKTextExtractionEventListenerTypes.description): Deleted.
(eventListenerTypesAsArray(_:)): Deleted.
(String.escaped): Deleted.
(WKTextExtractionItem.textRepresentationRecursive(_:)): Deleted.
(WKTextExtractionItem.textRepresentationParts): Deleted.
(WKTextExtractionContainerItem.textRepresentationParts): Deleted.
(WKTextExtractionContentEditableItem.textRepresentationParts): Deleted.
(WKTextExtractionTextFormControlItem.textRepresentationParts): Deleted.
(WKTextExtractionLinkItem.textRepresentationParts): Deleted.
(WKTextExtractionTextItem.textRepresentationParts): Deleted.
(WKTextExtractionScrollableItem.textRepresentationParts): Deleted.
(WKTextExtractionSelectItem.textRepresentationParts): Deleted.
(WKTextExtractionImageItem.textRepresentationParts): Deleted.
(WKTextExtractionPopupMenu.textRepresentation): Deleted.
(WKTextExtractionResult.textRepresentation): Deleted.

Delete now-unused code (see `TextExtractionToStringConversion.cpp` above).

* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtractionInternal.h:
* Source/WebKit/UIProcess/Cocoa/TextExtraction/WKTextExtractionUtilities.h:
* Source/WebKit/UIProcess/Cocoa/TextExtraction/WKTextExtractionUtilities.mm:
(WebKit::filterTextRecursive): Deleted.
(WebKit::filterText): Deleted.

Moved into `WKWebView.mm` (see above).

* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/301002@main">https://commits.webkit.org/301002@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6c1924f5ffbe33299bb386e0ba9bdce33ecd4380

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124593 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44265 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34999 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131432 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76536 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/293ff1eb-30cf-4a46-a2dd-d463fd0e4e85) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44969 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52836 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94784 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62853 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/01d167ea-3326-41b5-8eef-89caa41eeebf) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127547 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35851 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111422 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75355 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5a43e053-5f90-4359-bd9d-bd32a3e42623) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34786 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29577 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74911 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105606 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29808 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134100 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51443 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39263 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103262 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51853 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107644 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103041 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26240 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48402 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26666 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48375 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51316 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57112 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50715 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54070 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52404 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->