### PR TITLE
[EventTiming] keydown PerformanceEntry duration is always too long (waits for keyup event?)

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/event-timing/gap-keydown-keyup-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/event-timing/gap-keydown-keyup-expected.txt
@@ -1,0 +1,4 @@
+Click me
+
+PASS keydown duration shouldn't wait for keyup.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/event-timing/gap-keydown-keyup.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/event-timing/gap-keydown-keyup.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<meta charset=utf-8 />
+<title>Event Timing click.</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=/resources/testdriver.js></script>
+<script src=/resources/testdriver-actions.js></script>
+<script src=/resources/testdriver-vendor.js></script>
+<script src=resources/event-timing-test-utils.js></script>
+<div id='target'>Click me</div>
+<script>
+  promise_test(async t => {
+    const keyDowns = []
+    const keyUps = []
+    blockNextEventListener(window, 'keydown', 30)
+    blockNextEventListener(window, 'keyup', 30)
+    new PerformanceObserver( (entries) => {
+      entries.getEntries().forEach(  (e) => {
+        if (e.name == 'keydown')
+          keyDowns.push(e)
+        if (e.name =='keyup')
+          keyUps.push(e)
+      })
+    }).observe({type: 'event', durationThreshold: 16})
+    const keyDownHandled = new Promise( resolve => window.addEventListener('keydown', e => resolve(), true) )
+    const keyUpHandled = new Promise( resolve => window.addEventListener('keyup', e => resolve(), true) )
+
+    await new test_driver.Actions()
+      .keyDown('a')
+      .send()
+    await keyDownHandled
+    await afterNextPaint()
+    const waitStart = performance.now()
+    await t.step_wait(() => (performance.now() - waitStart > 50))
+    await new test_driver.Actions()
+      .keyUp('a')
+      .send()
+    await keyUpHandled
+    await t.step_wait(() => (keyDowns.length != 0 && keyUps.length != 0), 'Wait for the event timing entries to be processed.')
+    assert_equals(keyDowns.length, 1)
+    assert_equals(keyUps.length, 1)
+    assert_greater_than(keyUps[0].startTime, keyDowns[0].startTime + keyDowns[0].duration)
+  }, "keydown duration shouldn't wait for keyup.")
+</script>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/event-timing/gap-pointerdown-pointerup-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/event-timing/gap-pointerdown-pointerup-expected.txt
@@ -1,0 +1,4 @@
+Click me
+
+PASS pointerdown duration shouldn't wait for pointerup.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/event-timing/gap-pointerdown-pointerup.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/event-timing/gap-pointerdown-pointerup.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+<meta charset=utf-8 />
+<title>Event Timing click.</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=/resources/testdriver.js></script>
+<script src=/resources/testdriver-actions.js></script>
+<script src=/resources/testdriver-vendor.js></script>
+<script src=resources/event-timing-test-utils.js></script>
+<div id='target'>Click me</div>
+<script>
+  promise_test(async t => {
+    const pointerDowns = []
+    const pointerUps = []
+    blockNextEventListener(window, 'pointerdown', 30)
+    blockNextEventListener(window, 'pointerup', 30)
+    new PerformanceObserver( (entries) => {
+      entries.getEntries().forEach(  (e) => {
+        if (e.name == 'pointerdown')
+          pointerDowns.push(e)
+        if (e.name =='pointerup')
+          pointerUps.push(e)
+      })
+    }).observe({type: 'event', durationThreshold: 16})
+    const pointerDownHandled = new Promise( resolve => window.addEventListener('pointerdown', e => resolve(), true) )
+    const pointerUpHandled = new Promise( resolve => window.addEventListener('pointerup', e => resolve(), true) )
+
+    await new test_driver.Actions()
+      .pointerMove(0, 0)
+      .pointerDown()
+      .send()
+    await pointerDownHandled
+    await afterNextPaint()
+    const waitStart = performance.now()
+    await t.step_wait(() => (performance.now() - waitStart > 50))
+    await new test_driver.Actions()
+      .pointerUp()
+      .send()
+    await pointerUpHandled
+    await t.step_wait(() => (pointerDowns.length != 0 && pointerUps.length != 0), 'Wait for the event timing entries to be processed.')
+    assert_equals(pointerDowns.length, 1)
+    assert_equals(pointerUps.length, 1)
+    assert_greater_than(pointerUps[0].startTime, pointerDowns[0].startTime + pointerDowns[0].duration)
+  }, "pointerdown duration shouldn't wait for pointerup.")
+</script>
+</html>

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -71,6 +71,10 @@ webkit.org/b/214677 imported/w3c/web-platform-tests/event-timing/interactionid-a
 webkit.org/b/214677 imported/w3c/web-platform-tests/event-timing/interactionid-aux-pointerdown-and-pointerdown.html [ Skip ]
 webkit.org/b/214677 imported/w3c/web-platform-tests/event-timing/interactionid-aux-pointerdown.html [ Skip ]
 
+# Event timing: timing out for unclear reasons - perhaps scheduling. Events handlers are called but event timing entries aren't produced
+webkit.org/b/301110 imported/w3c/web-platform-tests/event-timing/gap-keydown-keyup.html [ Skip ]
+webkit.org/b/301110 imported/w3c/web-platform-tests/event-timing/gap-pointerdown-pointerup.html [ Skip ]
+
 # Media controls
 accessibility/gtk/media-controls-panel-title.html [ Failure ]
 

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -4545,6 +4545,10 @@ webkit.org/b/214677 imported/w3c/web-platform-tests/event-timing/shadow-dom-null
 webkit.org/b/214677 imported/w3c/web-platform-tests/event-timing/timingconditions.html [ Skip ]
 webkit.org/b/214677 imported/w3c/web-platform-tests/event-timing/toJSON.html [ Skip ]
 
+# Timing out because single down/up events are not issued by iOS when testing:
+webkit.org/b/301105 imported/w3c/web-platform-tests/event-timing/gap-keydown-keyup.html [ Skip ]
+webkit.org/b/301105 imported/w3c/web-platform-tests/event-timing/gap-pointerdown-pointerup.html [ Skip ]
+
 webkit.org/b/299907 imported/w3c/web-platform-tests/largest-contentful-paint/transparent-text.html [ Failure ]
 webkit.org/b/301028 imported/w3c/web-platform-tests/largest-contentful-paint/web-font-styled-text-resize-swap-after-interaction.html [ Failure ]
 

--- a/LayoutTests/platform/win/TestExpectations
+++ b/LayoutTests/platform/win/TestExpectations
@@ -1980,7 +1980,9 @@ imported/w3c/web-platform-tests/event-timing/interaction-count-click.html [ Skip
 imported/w3c/web-platform-tests/event-timing/interaction-count-press-key.html [ Skip ]
 
 # Timeout:
-imported/w3c/web-platform-tests/event-timing/interactionid-orphan-pointerup.html [ Skip ]
+webkit.org/b/301110 imported/w3c/web-platform-tests/event-timing/gap-keydown-keyup.html [ Skip ]
+webkit.org/b/301110 imported/w3c/web-platform-tests/event-timing/gap-pointerdown-pointerup.html [ Skip ]
+webkit.org/b/301110 imported/w3c/web-platform-tests/event-timing/interactionid-orphan-pointerup.html [ Skip ]
 
 # Fail with AccessDeniedAccess
 imported/w3c/web-platform-tests/event-timing/contextmenu.html [ Skip ]

--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -538,6 +538,10 @@ webkit.org/b/244186 imported/w3c/web-platform-tests/event-timing/large-duration-
 webkit.org/b/244186 imported/w3c/web-platform-tests/event-timing/medium-duration-threshold.html [ Skip ]
 webkit.org/b/244186 imported/w3c/web-platform-tests/event-timing/retrievability.html [ Skip ]
 
+# Event timing: timing out for unclear reasons - perhaps scheduling. Events handlers are called but event timing entries aren't produced
+webkit.org/b/301110 imported/w3c/web-platform-tests/event-timing/gap-keydown-keyup.html [ Skip ]
+webkit.org/b/301110 imported/w3c/web-platform-tests/event-timing/gap-pointerdown-pointerup.html [ Skip ]
+
 # notImplemented in WTR::UIScriptController::isShowingDateTimePicker
 fast/forms/datalist [ Skip ]
 fast/forms/date/date-show-hide-picker.html [ Skip ]


### PR DESCRIPTION
#### 1337f64ad12082bf549309e2eaec87e7e99a470a
<pre>
[EventTiming] keydown PerformanceEntry duration is always too long (waits for keyup event?)
<a href="https://bugs.webkit.org/show_bug.cgi?id=300102">https://bugs.webkit.org/show_bug.cgi?id=300102</a>
<a href="https://rdar.apple.com/161911473">rdar://161911473</a>

Reviewed by Ryan Reno.

LocalDOMWindowdispatchPendingEventTimingEntries() now assigns duration
to pending entries with nonzero duration, and doesn&apos;t overwrite
that value when queuing. Entries whose duration would round to zero
are assigned 1ms, avoiding being reassigned; this value is not exposed
to the user, as it is later rounded to zero.

Tests which verify this behavior were added; those introduce a
significant gap between the down and up events to make sure the
deferred down event had its duration set before the dispatch of
the up event:

* LayoutTests/imported/w3c/web-platform-tests/event-timing/gap-keydown-keyup.html
* LayoutTests/imported/w3c/web-platform-tests/event-timing/gap-pointerdown-pointerup.html

Unfortunately, WKTR is unable to properly send actions chains with
unpaired down/up events in several platforms, which required these
tests to be skipped a lot.

Canonical link: <a href="https://commits.webkit.org/302107@main">https://commits.webkit.org/302107@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d88822e6c90f203301289d1d1e24cdffa93ed53

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127436 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/47084 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38222 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134512 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/78991 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129308 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47700 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55607 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97004 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65048 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130384 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/38160 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114133 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77484 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36993 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32241 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/77886 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108019 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32710 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/136997 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/54095 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41690 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105530 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54606 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110482 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105230 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26951 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50707 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29149 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51674 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/54032 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/60119 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/53266 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56723 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/55025 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->