### PR TITLE
WebContent logs during launch are not emitted

### DIFF
--- a/Source/JavaScriptCore/API/JSValue.mm
+++ b/Source/JavaScriptCore/API/JSValue.mm
@@ -1275,7 +1275,7 @@ static StructHandlers* createStructHandlerMap()
         char idType[3];
         // Check 2nd argument type is "@"
         {
-            auto secondType = adoptSystem<char[]>(method_copyArgumentType(method, 3));
+            auto secondType = WTF::adoptSystem<char[]>(method_copyArgumentType(method, 3));
             if (strcmp(secondType.get(), "@") != 0)
                 return;
         }
@@ -1284,7 +1284,7 @@ static StructHandlers* createStructHandlerMap()
         if (strcmp(idType, "@") != 0)
             return;
         {
-            auto type = adoptSystem<char[]>(method_copyArgumentType(method, 2));
+            auto type = WTF::adoptSystem<char[]>(method_copyArgumentType(method, 2));
             structHandlers->add(StringImpl::createFromCString(type.get()), (StructTagHandler) { selector, 0 });
         }
     });
@@ -1300,7 +1300,7 @@ static StructHandlers* createStructHandlerMap()
         if (method_getNumberOfArguments(method) != 2)
             return;
         // Try to find a matching valueWith<Foo>:context: method.
-        auto type = adoptSystem<char[]>(method_copyReturnType(method));
+        auto type = WTF::adoptSystem<char[]>(method_copyReturnType(method));
         StructHandlers::iterator iter = structHandlers->find(String::fromLatin1(type.get()));
         if (iter == structHandlers->end())
             return;

--- a/Source/JavaScriptCore/API/JSWrapperMap.mm
+++ b/Source/JavaScriptCore/API/JSWrapperMap.mm
@@ -296,7 +296,7 @@ static bool parsePropertyAttributes(objc_property_t objcProperty, Property& prop
 {
     bool readonly = false;
     unsigned attributeCount;
-    auto attributes = adoptSystem<objc_property_attribute_t[]>(property_copyAttributeList(objcProperty, &attributeCount));
+    auto attributes = WTF::adoptSystem<objc_property_attribute_t[]>(property_copyAttributeList(objcProperty, &attributeCount));
     if (attributeCount) {
         for (unsigned i = 0; i < attributeCount; ++i) {
             switch (*(attributes[i].name)) {

--- a/Source/JavaScriptCore/API/ObjcRuntimeExtras.h
+++ b/Source/JavaScriptCore/API/ObjcRuntimeExtras.h
@@ -34,12 +34,6 @@
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
-template<typename T, typename U>
-inline std::unique_ptr<T, WTF::SystemFree<T>> adoptSystem(U value)
-{
-    return std::unique_ptr<T, WTF::SystemFree<T>>(value);
-}
-
 inline bool protocolImplementsProtocol(Protocol *candidate, Protocol *target)
 {
     auto protocolProtocols = protocol_copyProtocolListSpan(candidate);

--- a/Source/WTF/wtf/SystemFree.h
+++ b/Source/WTF/wtf/SystemFree.h
@@ -49,4 +49,10 @@ struct SystemFree<T[]> {
     }
 };
 
+template<typename T, typename U>
+inline std::unique_ptr<T, WTF::SystemFree<T>> adoptSystem(U value)
+{
+    return std::unique_ptr<T, WTF::SystemFree<T>>(value);
+}
+
 } // namespace WTF

--- a/Source/WebKit/Shared/Cocoa/LaunchLogHook.h
+++ b/Source/WebKit/Shared/Cocoa/LaunchLogHook.h
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2020 Apple Inc. All rights reserved.
+ /*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,15 +25,30 @@
 
 #pragma once
 
-#include <wtf/ThreadSafeRefCounted.h>
+#if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
+
+#import <wtf/Lock.h>
+#import <wtf/NeverDestroyed.h>
+#import <wtf/OSObjectPtr.h>
+#import <wtf/spi/darwin/XPCSPI.h>
 
 namespace WebKit {
 
-class XPCEventHandler : public ThreadSafeRefCounted<XPCEventHandler> {
+class LaunchLogHook {
+    friend class LazyNeverDestroyed<LaunchLogHook>;
 public:
-    virtual ~XPCEventHandler() { }
+    static LaunchLogHook& singleton();
 
-    virtual bool handleXPCEvent(xpc_object_t) = 0;
+    void initialize(xpc_connection_t);
+    void disable();
+
+private:
+    LaunchLogHook() = default;
+
+    UnfairLock m_lock;
+    OSObjectPtr<xpc_connection_t> m_connection WTF_GUARDED_BY_LOCK(m_lock);
 };
 
-}
+} // namespace WebKit
+
+#endif // ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)

--- a/Source/WebKit/Shared/Cocoa/LaunchLogHook.mm
+++ b/Source/WebKit/Shared/Cocoa/LaunchLogHook.mm
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "LaunchLogHook.h"
+
+#import "LaunchLogMessages.h"
+#import "Logging.h"
+#import "XPCEndpoint.h"
+#import <wtf/BlockPtr.h>
+#import <wtf/SystemFree.h>
+#import <wtf/spi/cocoa/OSLogSPI.h>
+
+#if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
+
+namespace WebKit {
+
+LaunchLogHook& LaunchLogHook::singleton()
+{
+    static std::once_flag onceKey;
+    static LazyNeverDestroyed<LaunchLogHook> logHook;
+    std::call_once(onceKey, [] {
+        logHook.construct();
+    });
+    return logHook.get();
+}
+
+void LaunchLogHook::initialize(xpc_connection_t connection)
+{
+    {
+        Locker locker { m_lock };
+        m_connection = connection;
+    }
+
+    static os_log_hook_t prevHook = nullptr;
+
+    auto blockPtr = makeBlockPtr([](os_log_type_t type, os_log_message_t msg) {
+        if (prevHook)
+            prevHook(type, msg);
+
+        Locker locker { LaunchLogHook::singleton().m_lock };
+
+        if (!LaunchLogHook::singleton().m_connection)
+            return;
+
+        if (type & OS_LOG_TYPE_DEBUG)
+            return;
+
+        if (type == OS_LOG_TYPE_FAULT)
+            type = OS_LOG_TYPE_ERROR;
+
+        if (auto messageString = WTF::adoptSystem<char[]>(os_log_copy_message_string(msg))) {
+            auto message = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
+            xpc_dictionary_set_string(message.get(), XPCEndpoint::xpcMessageNameKey, logMessageName);
+            if (auto* subsystem = msg->subsystem)
+                xpc_dictionary_set_string(message.get(), subsystemKey, subsystem);
+            if (auto* category = msg->category)
+                xpc_dictionary_set_string(message.get(), categoryKey, category);
+            xpc_dictionary_set_string(message.get(), messageStringKey, messageString.get());
+            xpc_dictionary_set_uint64(message.get(), logTypeKey, type);
+            xpc_connection_send_message(LaunchLogHook::singleton().m_connection.get(), message.get());
+        }
+    });
+
+    prevHook = os_log_set_hook(OS_LOG_TYPE_DEFAULT, blockPtr.get());
+    RELEASE_LOG(Process, "Installed launch log hook");
+}
+
+void LaunchLogHook::disable()
+{
+    RELEASE_LOG(Process, "Disabling launch log hook");
+
+    OSObjectPtr<xpc_connection_t> connection;
+    {
+        Locker locker { m_lock };
+        connection = m_connection;
+        m_connection = nullptr;
+    }
+    auto message = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
+    xpc_dictionary_set_string(message.get(), XPCEndpoint::xpcMessageNameKey, disableLogMessageName);
+    xpc_connection_send_message(connection.get(), message.get());
+}
+
+} // namespace WebKit
+
+#endif

--- a/Source/WebKit/Shared/Cocoa/LaunchLogMessages.h
+++ b/Source/WebKit/Shared/Cocoa/LaunchLogMessages.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,15 +25,19 @@
 
 #pragma once
 
-#include <wtf/ThreadSafeRefCounted.h>
+#if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
+
+#include <wtf/text/ASCIILiteral.h>
 
 namespace WebKit {
 
-class XPCEventHandler : public ThreadSafeRefCounted<XPCEventHandler> {
-public:
-    virtual ~XPCEventHandler() { }
-
-    virtual bool handleXPCEvent(xpc_object_t) = 0;
-};
+constexpr auto logMessageName = "log-message"_s;
+constexpr auto subsystemKey = "subsystem"_s;
+constexpr auto categoryKey = "category"_s;
+constexpr auto messageStringKey = "message-string"_s;
+constexpr auto logTypeKey = "log-type"_s;
+constexpr auto disableLogMessageName = "disable-log-message"_s;
 
 }
+
+#endif // ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)

--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm
@@ -25,6 +25,7 @@
 
 #import "config.h"
 
+#import "LaunchLogHook.h"
 #import "Logging.h"
 #import "WKCrashReporter.h"
 #import "WebKitServiceNames.h"
@@ -85,11 +86,12 @@ static void initializeCFPrefs()
 #endif // ENABLE(CFPREFS_DIRECT_MODE)
 }
 
-static void initializeLogd(bool disableLogging)
+static void initializeLogd(bool disableLogging, xpc_connection_t connection)
 {
 #if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
     if (disableLogging) {
         os_trace_set_mode(OS_TRACE_MODE_OFF);
+        LaunchLogHook::singleton().initialize(connection);
         return;
     }
 #else
@@ -177,7 +179,7 @@ void XPCServiceEventHandler(xpc_connection_t peer)
             WTF::initialize();
 
             bool disableLogging = xpc_dictionary_get_bool(event, "disable-logging");
-            initializeLogd(disableLogging);
+            initializeLogd(disableLogging, retainedPeerConnection.get());
 
             if (RetainPtr languages = xpc_dictionary_get_value(event, "OverrideLanguages")) {
                 Vector<String> newLanguages;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
@@ -173,6 +173,7 @@ struct WKAppPrivacyReportTestingData {
 - (void)_cancelFixedColorExtensionFadeAnimationsForTesting;
 
 - (unsigned)_forwardedLogsCountForTesting;
+- (bool)_receivedLogsDuringLaunchForTesting;
 
 - (void)_modelProcessModelPlayerCountForTesting:(void(^)(NSUInteger))completionHandler;
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
@@ -1080,6 +1080,15 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
 #endif
 }
 
+- (bool)_receivedLogsDuringLaunchForTesting
+{
+#if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
+    if (RefPtr mainFrame = _page->mainFrame())
+        return mainFrame->process().receivedLogsDuringLaunchForTesting();
+#endif
+    return 0;
+}
+
 - (void)_modelProcessModelPlayerCountForTesting:(void(^)(NSUInteger))completionHandler
 {
 #if ENABLE(MODEL_PROCESS)

--- a/Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm
+++ b/Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm
@@ -64,7 +64,6 @@
 #import <BrowserEngineKit/BENetworkingProcess.h>
 #import <BrowserEngineKit/BERenderingProcess.h>
 #import <BrowserEngineKit/BEWebContentProcess.h>
-
 #endif // USE(EXTENSIONKIT)
 
 namespace WebKit {

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
@@ -469,7 +469,7 @@ private:
     public:
         XPCEventHandler(const NetworkProcessProxy&);
 
-        bool handleXPCEvent(xpc_object_t) const override;
+        bool handleXPCEvent(xpc_object_t) override;
 
     private:
         WeakPtr<NetworkProcessProxy> m_networkProcess;

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxyCocoa.mm
@@ -54,7 +54,7 @@ RefPtr<XPCEventHandler> NetworkProcessProxy::xpcEventHandler() const
     return adoptRef(new NetworkProcessProxy::XPCEventHandler(*this));
 }
 
-bool NetworkProcessProxy::XPCEventHandler::handleXPCEvent(xpc_object_t event) const
+bool NetworkProcessProxy::XPCEventHandler::handleXPCEvent(xpc_object_t event)
 {
     RefPtr networkProcess = m_networkProcess.get();
     if (!networkProcess)

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -574,6 +574,10 @@ public:
     void addSandboxExtensionForFile(const String& fileName, SandboxExtension::Handle);
     void clearSandboxExtensions();
 
+#if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
+    bool receivedLogsDuringLaunchForTesting() const { return m_didReceiveLogsDuringLaunchForTesting; }
+#endif
+
 private:
     Type type() const final { return Type::WebContent; }
 
@@ -600,6 +604,9 @@ private:
     bool shouldEnableLockdownMode() const final { return m_lockdownMode == LockdownMode::Enabled; }
     bool shouldEnableEnhancedSecurity() const final { return m_enhancedSecurity == EnhancedSecurity::Enabled; }
     bool shouldDisableJITCage() const final;
+#if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
+    RefPtr<XPCEventHandler> xpcEventHandler() const final;
+#endif
 
     void validateFreezerStatus();
 
@@ -885,6 +892,22 @@ private:
 #endif
 
     HashMap<String, SandboxExtension::Handle> m_fileSandboxExtensions;
+
+#if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
+    class WebProcessXPCEventHandler final : public XPCEventHandler {
+    public:
+        explicit WebProcessXPCEventHandler(const WebProcessProxy&);
+
+        bool handleXPCEvent(xpc_object_t) final;
+
+    private:
+        WeakPtr<WebProcessProxy> m_webProcess;
+
+        bool m_logEndpointEnabled { true };
+    };
+
+    bool m_didReceiveLogsDuringLaunchForTesting { false };
+#endif // ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
 };
 
 WTF::TextStream& operator<<(WTF::TextStream&, const WebProcessProxy&);

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2335,6 +2335,9 @@
 		E3816B3D27E2463A005EAFC0 /* WebMockContentFilterManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3816B3B27E24639005EAFC0 /* WebMockContentFilterManager.cpp */; };
 		E3816B3E27E2463A005EAFC0 /* WebMockContentFilterManager.h in Headers */ = {isa = PBXBuildFile; fileRef = E3816B3C27E24639005EAFC0 /* WebMockContentFilterManager.h */; };
 		E382D57F2C21D500005F7653 /* DownloadProxyCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = E382D57E2C21D500005F7653 /* DownloadProxyCocoa.mm */; };
+		E385F3672E86D6C900461B0C /* LaunchLogHook.mm in Sources */ = {isa = PBXBuildFile; fileRef = E385F3662E86D6C900461B0C /* LaunchLogHook.mm */; };
+		E385F3692E86D75800461B0C /* LaunchLogHook.h in Headers */ = {isa = PBXBuildFile; fileRef = E385F3682E86D6DB00461B0C /* LaunchLogHook.h */; };
+		E385F37C2E87076100461B0C /* LaunchLogMessages.h in Headers */ = {isa = PBXBuildFile; fileRef = E385F37B2E87076100461B0C /* LaunchLogMessages.h */; };
 		E3866AE52397400400F88FE9 /* WebDeviceOrientationUpdateProviderProxy.mm in Sources */ = {isa = PBXBuildFile; fileRef = E3866AE42397400400F88FE9 /* WebDeviceOrientationUpdateProviderProxy.mm */; };
 		E3866AE72397405300F88FE9 /* WebDeviceOrientationUpdateProviderProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = E3866AE62397405300F88FE9 /* WebDeviceOrientationUpdateProviderProxy.h */; };
 		E3866B082399A2D100F88FE9 /* WebDeviceOrientationUpdateProviderProxyMessages.h in Headers */ = {isa = PBXBuildFile; fileRef = E3866B052399979C00F88FE9 /* WebDeviceOrientationUpdateProviderProxyMessages.h */; };
@@ -8362,6 +8365,9 @@
 		E385982C2E68CAA80012AD39 /* gpu-defines.sb */ = {isa = PBXFileReference; lastKnownFileType = text; path = "gpu-defines.sb"; sourceTree = "<group>"; };
 		E385982D2E68CAA80012AD39 /* networking-defines.sb */ = {isa = PBXFileReference; lastKnownFileType = text; path = "networking-defines.sb"; sourceTree = "<group>"; };
 		E385982E2E68CAA80012AD39 /* webcontent-defines.sb */ = {isa = PBXFileReference; lastKnownFileType = text; path = "webcontent-defines.sb"; sourceTree = "<group>"; };
+		E385F3662E86D6C900461B0C /* LaunchLogHook.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = LaunchLogHook.mm; sourceTree = "<group>"; };
+		E385F3682E86D6DB00461B0C /* LaunchLogHook.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LaunchLogHook.h; sourceTree = "<group>"; };
+		E385F37B2E87076100461B0C /* LaunchLogMessages.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LaunchLogMessages.h; sourceTree = "<group>"; };
 		E3866AE42397400400F88FE9 /* WebDeviceOrientationUpdateProviderProxy.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = WebDeviceOrientationUpdateProviderProxy.mm; path = ios/WebDeviceOrientationUpdateProviderProxy.mm; sourceTree = "<group>"; };
 		E3866AE62397405300F88FE9 /* WebDeviceOrientationUpdateProviderProxy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WebDeviceOrientationUpdateProviderProxy.h; path = ios/WebDeviceOrientationUpdateProviderProxy.h; sourceTree = "<group>"; };
 		E3866AED2398471A00F88FE9 /* WebDeviceOrientationUpdateProviderProxy.messages.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = WebDeviceOrientationUpdateProviderProxy.messages.in; path = ios/WebDeviceOrientationUpdateProviderProxy.messages.in; sourceTree = "<group>"; };
@@ -12879,6 +12885,9 @@
 				49DAA38B24CBA1A800793D75 /* DefaultWebBrowserChecks.mm */,
 				CE550E12228373C800D28791 /* InsertTextOptions.h */,
 				86E0787C2ACE0AE400B8FADC /* InsertTextOptions.serialization.in */,
+				E385F3682E86D6DB00461B0C /* LaunchLogHook.h */,
+				E385F3662E86D6C900461B0C /* LaunchLogHook.mm */,
+				E385F37B2E87076100461B0C /* LaunchLogMessages.h */,
 				C1663E5A24AEA74200C6A3B2 /* LaunchServicesDatabaseXPCConstants.h */,
 				2D1087621D2C641B00B85F82 /* LoadParametersCocoa.mm */,
 				2D440B8325EF235E00A98D87 /* PDFKitSoftLink.h */,
@@ -17735,6 +17744,8 @@
 				1C5DC46F290B27260061EC62 /* JSWebExtensionWrappable.h in Headers */,
 				1C5DC46E290B27260061EC62 /* JSWebExtensionWrapper.h in Headers */,
 				074A6FC72D5F1FAF0027F958 /* KeyEventInterpretationContext.h in Headers */,
+				E385F3692E86D75800461B0C /* LaunchLogHook.h in Headers */,
+				E385F37C2E87076100461B0C /* LaunchLogMessages.h in Headers */,
 				C1663E5B24AEAA2F00C6A3B2 /* LaunchServicesDatabaseXPCConstants.h in Headers */,
 				51E9049A27BCB9D400929E7E /* LaunchServicesSPI.h in Headers */,
 				BCE0937814FB128C001138D9 /* LayerHostingContext.h in Headers */,
@@ -21214,6 +21225,8 @@
 				2749F6442146561B008380BF /* InjectedBundleNodeHandle.cpp in Sources */,
 				2749F6452146561E008380BF /* InjectedBundleRangeHandle.cpp in Sources */,
 				1C0F05BE2CFA5D2E007D1F62 /* JSWebExtensionAPIUnified.mm in Sources */,
+				1C5DC45F2909B05A0061EC62 /* JSWebExtensionWrapperCocoa.mm in Sources */,
+				E385F3672E86D6C900461B0C /* LaunchLogHook.mm in Sources */,
 				C14D37FE24ACE086007FF014 /* LaunchServicesDatabaseManager.mm in Sources */,
 				C1710CF724AA643200D7C112 /* LaunchServicesDatabaseObserver.mm in Sources */,
 				41A0EB142641714900794471 /* LibWebRTCCodecsProxy.mm in Sources */,

--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -183,6 +183,7 @@
 #endif
 
 #if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
+#import "LaunchLogHook.h"
 #import "LogStream.h"
 #import "LogStreamMessages.h"
 #endif
@@ -849,11 +850,13 @@ static void registerLogClient(bool isDebugLoggingEnabled, std::unique_ptr<LogCli
     RELEASE_ASSERT(!logClient());
     logClient() = WTFMove(newLogClient);
 
-    static os_log_hook_t prevHook = nullptr;
-
     // OS_LOG_TYPE_DEFAULT implies default, fault, and error.
     // OS_LOG_TYPE_DEBUG implies debug, info, default, fault, and error.
     const auto minimumType = isDebugLoggingEnabled ? OS_LOG_TYPE_DEBUG : OS_LOG_TYPE_DEFAULT;
+
+    LaunchLogHook::singleton().disable();
+
+    static os_log_hook_t prevHook = nullptr;
 
     prevHook = os_log_set_hook(minimumType, makeBlockPtr([isDebugLoggingEnabled](os_log_type_t type, os_log_message_t msg) {
         if (prevHook)

--- a/Tools/TestWebKitAPI/Tests/WebKit/LogForwarding.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/LogForwarding.mm
@@ -90,4 +90,10 @@ TEST(WebKit, LogForwarding)
         TestWebKitAPI::Util::spinRunLoop(1);
 }
 
+TEST(WebKit, LaunchLogs)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300)]);
+    [webView synchronouslyLoadTestPageNamed:@"simple"];
+    EXPECT_TRUE([webView _receivedLogsDuringLaunchForTesting]);
+}
 #endif // WK_HAVE_C_SPI


### PR DESCRIPTION
#### 5ad01e38dccef1ea0d178030522e11c18e7f6fae
<pre>
WebContent logs during launch are not emitted
<a href="https://bugs.webkit.org/show_bug.cgi?id=291839">https://bugs.webkit.org/show_bug.cgi?id=291839</a>
<a href="https://rdar.apple.com/149683032">rdar://149683032</a>

Reviewed by Chris Dumez.

WebContent logs during launch are not emitted when logd is blocked in the sandbox because the log streaming channel
to the UI process is not set up until WebProcess::platformInitializeWebProcess is called. This patch addresses this
by sending logs emitted in this time interval over the XPC connection to the UI process and emit the logs there.

Test: Tools/TestWebKitAPI/Tests/WebKit/LogForwarding.mm

* Source/JavaScriptCore/API/JSValue.mm:
(createStructHandlerMap):
* Source/JavaScriptCore/API/JSWrapperMap.mm:
(parsePropertyAttributes):
* Source/JavaScriptCore/API/ObjcRuntimeExtras.h:
(adoptSystem): Deleted.
* Source/WTF/wtf/SystemFree.h:
(WTF::adoptSystem):
* Source/WebKit/Shared/Cocoa/LaunchLogHook.h: Added.
* Source/WebKit/Shared/Cocoa/LaunchLogHook.mm: Added.
(WebKit::LaunchLogHook::singleton):
(WebKit::LaunchLogHook::initialize):
(WebKit::LaunchLogHook::disable):
* Source/WebKit/Shared/Cocoa/LaunchLogMessages.h: Added.
* Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm:
(WebKit::initializeLogd):
(WebKit::XPCServiceEventHandler):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm:
(-[WKWebView _launchLogsCountForTesting]):
* Source/WebKit/UIProcess/Cocoa/WebProcessProxyCocoa.mm:
(WebKit::WebProcessProxy::xpcEventHandler const):
(WebKit::WebProcessProxy::XPCEventHandler::handleXPCEvent const):
(WebKit::WebProcessProxy::XPCEventHandler::XPCEventHandler):
* Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm:
* Source/WebKit/UIProcess/WebProcessProxy.h:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:
(WebKit::registerLogClient):
* Tools/TestWebKitAPI/Tests/WebKit/LogForwarding.mm:
(TEST(WebKit, LaunchLogs)):

Canonical link: <a href="https://commits.webkit.org/301000@main">https://commits.webkit.org/301000@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/becb49dc989423e32ac9d39b59ef0db6b756e67e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124557 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44230 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34965 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131392 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76515 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4034f359-0456-4168-b45a-91dad5e66a62) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/126434 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44940 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52807 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94754 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62837 "") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fcf1b7c3-695f-484a-915a-4f90aa37210b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127511 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35824 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111392 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75329 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bc988b55-5cd4-4311-82fd-d2535509e80b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34761 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29546 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74874 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/116669 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105578 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29778 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134061 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/123080 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51416 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39238 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103230 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51824 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107614 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103012 "Found 1 new API test failure: WebKitGTK/TestWebsiteData:/webkit/WebKitWebsiteData/configuration (failure)") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48376 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26640 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48352 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19550 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51287 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57080 "Built successfully") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/156252 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50692 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/156252 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54048 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52376 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->