### PR TITLE
ASSERTION FAILED: constructor.isObject() when OSR from an inlined function

### DIFF
--- a/JSTests/stress/instanceof-osr-exit-hasInstance-getter.js
+++ b/JSTests/stress/instanceof-osr-exit-hasInstance-getter.js
@@ -1,0 +1,19 @@
+function F1() {
+    Object instanceof Proxy;
+}
+noInline(F1);
+
+let count = 0;
+function f20() {
+    count++;
+    OSRExit();
+    return () => { };
+}
+Object.defineProperty(Proxy, Symbol.hasInstance, { get: f20 });
+
+globalThis.testLoopCount ??= 1e4;
+for (let i = 0; i < testLoopCount; i++) {
+    F1();
+}
+if (count != testLoopCount)
+    throw new Error("bad!");

--- a/JSTests/stress/instanceof-osr-exit-prototype-getter.js
+++ b/JSTests/stress/instanceof-osr-exit-prototype-getter.js
@@ -1,0 +1,19 @@
+function F1() {
+    Object instanceof Proxy;
+}
+noInline(F1);
+
+let count = 0;
+function f20() {
+    count++;
+    OSRExit();
+    return f20;
+}
+Object.defineProperty(Proxy, "prototype", { get: f20 });
+
+globalThis.testLoopCount ??= 1e4;
+for (let i = 0; i < testLoopCount; i++) {
+    F1();
+}
+if (count != testLoopCount)
+    throw new Error("bad!");

--- a/Source/JavaScriptCore/bytecode/BytecodeList.rb
+++ b/Source/JavaScriptCore/bytecode/BytecodeList.rb
@@ -1478,6 +1478,7 @@ op :op_put_by_val_return_location
 op :op_put_by_val_direct_return_location
 op :op_in_by_id_return_location
 op :op_in_by_val_return_location
+op :op_instanceof_return_location
 op :op_enumerator_get_by_val_return_location
 op :op_enumerator_put_by_val_return_location
 op :op_enumerator_in_by_val_return_location

--- a/Source/JavaScriptCore/bytecode/LLIntPrototypeLoadAdaptiveStructureWatchpoint.cpp
+++ b/Source/JavaScriptCore/bytecode/LLIntPrototypeLoadAdaptiveStructureWatchpoint.cpp
@@ -110,10 +110,10 @@ void LLIntPrototypeLoadAdaptiveStructureWatchpoint::fireInternal(VM& vm, const F
     case op_instanceof: {
         auto& metadata = instruction->as<OpInstanceof>().metadata(m_owner.get());
         switch (m_bytecodeIndex.get().checkpoint()) {
-        case OpInstanceof::getPrototype:
+        case OpInstanceof::getHasInstance:
             clearLLIntGetByIdCache(metadata.m_hasInstanceModeMetadata);
             break;
-        case OpInstanceof::instanceof:
+        case OpInstanceof::getPrototype:
             clearLLIntGetByIdCache(metadata.m_prototypeModeMetadata);
             break;
         default:

--- a/Source/JavaScriptCore/dfg/DFGOSRExitCompilerCommon.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOSRExitCompilerCommon.cpp
@@ -198,6 +198,8 @@ static CodePtr<JSEntryPtrTag> callerReturnPC(CodeBlock* baselineCodeBlockForCall
                 jumpTarget = LLINT_RETURN_LOCATION(op_get_by_val);
             else if (callInstruction.opcodeID() == op_enumerator_get_by_val)
                 jumpTarget = LLINT_RETURN_LOCATION(op_enumerator_get_by_val);
+            else if (callInstruction.opcodeID() == op_instanceof)
+                jumpTarget = LLINT_RETURN_LOCATION(op_instanceof);
             else
                 RELEASE_ASSERT_NOT_REACHED();
             break;

--- a/Source/JavaScriptCore/llint/LLIntOpcode.h
+++ b/Source/JavaScriptCore/llint/LLIntOpcode.h
@@ -75,4 +75,5 @@
     macro(op_enumerator_get_by_val) \
     macro(op_enumerator_put_by_val) \
     macro(op_enumerator_in_by_val) \
+    macro(op_instanceof) \
 

--- a/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
@@ -2759,37 +2759,21 @@ extern "C" UGPRPair SYSV_ABI llint_slow_path_checkpoint_osr_exit_from_inlined_ca
     }
 
     case op_instanceof: {
-        auto& dst = callFrame->uncheckedR(destinationFor(pc->as<OpInstanceof>(), bytecodeIndex.checkpoint()).virtualRegister());
         const auto& bytecode = pc->as<OpInstanceof>();
-        auto value = getOperand(callFrame, bytecode.m_value);
-        auto hasInstanceOrPrototype = JSValue::decode(result);
-
         switch (bytecodeIndex.checkpoint()) {
-        case OpInstanceof::getHasInstance: {
+        case OpInstanceof::getHasInstance: // First one is not handled by checkpoint.
+        case OpInstanceof::instanceof: // No inlined calls exist at the last checkpoint.
             RELEASE_ASSERT_NOT_REACHED();
             break;
-        }
         case OpInstanceof::getPrototype: {
-            auto constructor = getOperand(callFrame, bytecode.m_constructor);
-            ASSERT(constructor.isObject());
-            if (hasInstanceOrPrototype != globalObject->functionProtoHasInstanceSymbolFunction() || !constructor.getObject()->structure()->typeInfo().implementsDefaultHasInstance()) {
-                dst = jsBoolean(constructor.getObject()->hasInstance(globalObject, value, hasInstanceOrPrototype));
-                RETURN_IF_EXCEPTION(throwScope, { });
-                break;
-            }
-            if (!value.isObject()) {
-                dst = jsBoolean(false);
-                break;
-            }
-            hasInstanceOrPrototype = constructor.get(globalObject, vm.propertyNames->prototype);
-            RETURN_IF_EXCEPTION(throwScope, { });
-            [[fallthrough]];
-        }
-        case OpInstanceof::instanceof:
-            bool result = JSObject::defaultHasInstance(globalObject, value, hasInstanceOrPrototype);
+            auto& dst = callFrame->uncheckedR(bytecode.m_dst);
+            auto value = getOperand(callFrame, bytecode.m_value);
+            auto prototype = JSValue::decode(result);
+            bool result = JSObject::defaultHasInstance(globalObject, value, prototype);
             RETURN_IF_EXCEPTION(throwScope, { });
             dst = jsBoolean(result);
             break;
+        }
         }
         break;
     }

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter64.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter64.asm
@@ -3267,6 +3267,15 @@ llintOpWithMetadata(op_instanceof, OpInstanceof, macro (size, get, dispatch, met
         store(result, m_hasInstanceOrPrototype)
         jmp .getPrototype
     end)
+    jmp .getPrototype
+
+.getHasInstanceInlinedGetterOSRReturnPoint:
+    # This can only be reached if we're exiting to the LLInt and we're exiting 
+    # from an inlined getter for Symbol.hasInstance. Other exits e.g. for a "prototype" 
+    # getter will exit directly to op_checkpoint_osr_exit_from_inlined_call_trampoline.
+    getterSetterOSRExitReturnPoint(op_instanceof, size)
+    valueProfile(size, OpInstanceof, m_hasInstanceValueProfile, r0, t2)
+    store(r0, m_hasInstanceOrPrototype)
 
 .getPrototype:
     overridesHasInstance(m_hasInstanceOrPrototype, m_constructor, .instanceofCustom)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/media-session-capture.html
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/media-session-capture.html
@@ -28,6 +28,34 @@ function startCapture()
     });
 }
 
+function startAudioCapture()
+{
+    navigator.mediaDevices.getUserMedia({ audio:true }).then(stream => {
+        window.actionState = "";
+        video.srcObject = stream;
+
+        if (window.webkit)
+            window.webkit.messageHandlers.gum.postMessage("PASS");
+    }, (e) => {
+        if (window.webkit)
+            window.webkit.messageHandlers.gum.postMessage("FAIL: "  + e);
+    });
+}
+
+function startVideoCapture()
+{
+    navigator.mediaDevices.getUserMedia({ video:true }).then(stream => {
+        window.actionState = "";
+        video.srcObject = stream;
+
+        if (window.webkit)
+            window.webkit.messageHandlers.gum.postMessage("PASS");
+    }, (e) => {
+        if (window.webkit)
+            window.webkit.messageHandlers.gum.postMessage("FAIL: "  + e);
+    });
+}
+
 function startScreenshareCapture()
 {
     if (!window.internals) {


### PR DESCRIPTION
#### 8b9fc1b8515151cca3a4a46b3b537ab81948bb61
<pre>
ASSERTION FAILED: constructor.isObject() when OSR from an inlined function
<a href="https://bugs.webkit.org/show_bug.cgi?id=296042">https://bugs.webkit.org/show_bug.cgi?id=296042</a>
<a href="https://rdar.apple.com/155947925">rdar://155947925</a>

Reviewed by Keith Miller.

The checkpoint OSR exit handler for op_instanceof was incorrectly trying to
re-execute the instanceof logic instead of processing the result of the
already-completed inlined call.

The fix simplifies the OpInstanceof::getPrototype case to directly use the
inlined call result and proceed with JSObject::defaultHasInstance(), which
is the correct behavior for OSR exit handlers.

In addition, both OpInstanceof::getHasInstance and OpInstanceof::instanceof
should never be reached in llint_slow_path_checkpoint_osr_exit_from_inlined_call
since:
1. OpInstanceof::instanceof has no inlined calls.
2. OpInstanceof::getHasInstance as the first checkpoint, the inlined call exit
   would directly exit to the OSR exit site in the callee and finish the callee,
   then resume the caller from baseline/LLInt.

Originally-landed-as: 297297.141@safari-7622-branch (ed4e91038f2b). <a href="https://rdar.apple.com/159890919">rdar://159890919</a>
Canonical link: <a href="https://commits.webkit.org/301016@main">https://commits.webkit.org/301016@main</a>
</pre>
----------------------------------------------------------------------
#### 75633338db6f14ada96d61fd6385086a17255570
<pre>
[JSC] Fix instanceof metadata fields in LLIntPrototypeLoadAdaptiveStructureWatchpoint
<a href="https://bugs.webkit.org/show_bug.cgi?id=296226">https://bugs.webkit.org/show_bug.cgi?id=296226</a>
<a href="https://rdar.apple.com/156196469">rdar://156196469</a>

Reviewed by Mark Lam and Yusuke Suzuki.

OpInstanceof::getHasInstance should clear m_hasInstanceModeMetadata.
OpInstanceof::getPrototype should clear m_prototypeModeMetadata.

Originally-landed-as: 297297.140@safari-7622-branch (881d4e9ef8e5). <a href="https://rdar.apple.com/159891098">rdar://159891098</a>
Canonical link: <a href="https://commits.webkit.org/301015@main">https://commits.webkit.org/301015@main</a>
</pre>
----------------------------------------------------------------------
#### c420ed2f891b194801c3ceaf17a9e17887300bb5
<pre>
gUM() for video does not issue permission request after muting and requesting gUM() for audio
<a href="https://rdar.apple.com/150695123">rdar://150695123</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=296153">https://bugs.webkit.org/show_bug.cgi?id=296153</a>

Reviewed by Andy Estes.

Apply the adjusted media capture state to WebPageProxy&apos;s internal capture state, which
forces each capture type to require a permission prompt to unmute.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::setMuted):
* Tools/TestWebKitAPI/Tests/WebKit/GetUserMedia.mm:
(TestWebKitAPI::(WebKit2, GetUserMediaAfterMuting)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/media-session-capture.html:

Originally-landed-as: 297297.104@safari-7622-branch (e36cad1573d4). <a href="https://rdar.apple.com/159891139">rdar://159891139</a>
Canonical link: <a href="https://commits.webkit.org/301014@main">https://commits.webkit.org/301014@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/40ba1e0607ea8dff4a1c4931c1de6809ded9f614

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124558 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44231 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34966 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131393 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76516 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9fabf8b6-83a2-4da1-bff0-600429798aba) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/126435 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44941 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52808 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94758 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62838 "") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/502626ad-a77a-497c-b860-dc4f22b9a06e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127512 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35829 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111394 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75330 "Found 1 new API test failure: WPE/TestWebKitWebContext:/webkit/WebKitWebContext/no-web-process-leak (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/223d9260-7731-4944-9d3d-19dd75854a2f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34766 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29548 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74880 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/116670 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105583 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29780 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134062 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/123081 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51417 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39239 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103232 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51825 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107616 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103014 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26247 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48377 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26642 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48353 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51288 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57081 "Built successfully") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/156253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50693 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/156253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54049 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52377 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->