### PR TITLE
[iOS] Cannot scroll on gemini.google.com after sending message

### DIFF
--- a/LayoutTests/editing/selection/ios/scrolling-after-caret-selection-inside-contenteditable-div-expected.txt
+++ b/LayoutTests/editing/selection/ios/scrolling-after-caret-selection-inside-contenteditable-div-expected.txt
@@ -1,0 +1,10 @@
+When a site programmatically focuses a contenteditable div before editing or text selections are made, and that div is then edited followed by editing ending in a manner which preserves the text selection (i.e clicking a button element), scrollable areas should remain scrollable.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS The region remained scrollable after editing.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/selection/ios/scrolling-after-caret-selection-inside-contenteditable-div.html
+++ b/LayoutTests/editing/selection/ios/scrolling-after-caret-selection-inside-contenteditable-div.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true focusStartsInputSessionPolicy=disallow AsyncOverflowScrollingEnabled=true ] -->
+<html>
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <script src="../../../resources/js-test.js"></script>
+    <script src="../../../resources/basic-gestures.js"></script>
+    <script src="../../../resources/ui-helper.js"></script>
+    <style>
+        html, body {
+            padding: 0;
+            margin: 0;
+        }
+
+        #editable {
+            display: inline-block;
+            border: 1px solid black;
+            margin: 2px;
+        }
+
+        #button {
+            font-size: 16px;
+            margin-top: 20px;
+            display: inline;
+        }
+
+        #overflow_container {
+            height: 300px;
+            overflow: scroll;
+            border: 2px solid black;
+        }
+
+        #overflow {
+            background: linear-gradient(180deg, rgba(255, 199, 153, 1) 0%, rgba(255, 0, 102, 1) 100%);
+            height: 600px;
+        }
+    </style>
+</head>
+<script>
+    jsTestIsAsync = true;
+
+    addEventListener("load", async () => {
+        var editableDivClicked = false;
+        var buttonClicked = false;
+
+        var fromX = overflow_container.offsetLeft + 50;
+        var fromY = overflow_container.offsetTop + overflow_container.offsetHeight - 5;
+        var toX = fromX;
+        var toY = fromY - 100;
+
+        var initialScrollPosition = overflow_container.scrollTop;
+
+        editable.addEventListener("click", (e) => {
+            editableDivClicked = true;
+            button.addEventListener("click", (e) => {
+                buttonClicked = true;
+            });
+        });
+
+        async function finish(passed, msg) {
+            overflow_container.remove();
+            editable.remove();
+            button.remove();
+            if (window.testRunner) {
+                if (passed)
+                    testPassed(msg);
+                else
+                    testFailed(msg);
+
+                finishJSTest();
+            } else {
+                let result = passed ? "PASS: " : "FAIL: ";
+                output.innerText = result + msg;
+            }
+        }
+
+        if (window.testRunner) {
+            description(`When a site programmatically focuses a contenteditable div before editing or text selections 
+                are made, and that div is then edited followed by editing ending in a manner which preserves 
+                the text selection (i.e clicking a button element), scrollable areas should remain scrollable.`);
+
+            await UIHelper.setFocusStartsInputSessionPolicy("auto");
+            await UIHelper.activateElementAndWaitForInputSession(editable);
+            await UIHelper.activateElement(button);
+            await UIHelper.waitForKeyboardToHide();
+
+            await touchAndDragFromPointToPoint(fromX, fromY, toX, toY);
+            await liftUpAtPoint(toX, toY);
+
+            if (overflow_container.scrollTop == initialScrollPosition)
+                finish(false, "The region was no longer scrollable after editing.");
+            else if (editableDivClicked && buttonClicked)
+                finish(true, "The region remained scrollable after editing.");
+            else
+                finish(false, "The editable div and button were either not pressed or pressed in the wrong order.");
+        }
+    });
+</script>
+
+<body>
+    <div id="overflow_container">
+        <div id="overflow"></div>
+    </div>
+    <div id="editable" contenteditable>
+        Do not select any text or press the done button during editing. Tap here, then press the button
+        element. After the keyboard dismisses, try to scroll the region above. The test passes if the region is
+        scrollable.
+    </div>
+    <button id="button">Button</button>
+    <p id="output"></p>
+    <script>
+        editable.focus();
+    </script>
+</body>
+</html>

--- a/LayoutTests/resources/ui-helper.js
+++ b/LayoutTests/resources/ui-helper.js
@@ -1632,6 +1632,14 @@ window.UIHelper = class UIHelper {
         return new Promise(resolve => testRunner.runUIScript(`uiController.setKeyboardInputModeIdentifier(\`${escapedIdentifier}\`)`, resolve));
     }
 
+    static setFocusStartsInputSessionPolicy(policy)
+    {
+        if (!this.isWebKit2() || !this.isIOSFamily())
+            return Promise.resolve();
+
+        return new Promise(resolve => testRunner.runUIScript(`uiController.setFocusStartsInputSessionPolicy("${policy}")`, resolve));
+    }
+
     static contentOffset()
     {
         if (!this.isIOSFamily())

--- a/Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.mm
+++ b/Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.mm
@@ -209,8 +209,10 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(HideEditMenuScope);
         for (UIView *subview in newContainer.subviews)
             [viewsBeforeInstallingInteraction addObject:subview];
 
-        // Calling these delegate methods tells the display interaction to remove and reparent all internally
-        // managed views (e.g. selection highlight views, selection handles) in the new selection container.
+        // When the display interaction is in the activated state, calling these delegate methods tells it
+        // to remove and reparent all internally managed views (e.g. selection highlight views, selection
+        // handles) in the new selection container.
+        [self activateSelection];
         [displayInteraction willMoveToView:_view];
         [displayInteraction didMoveToView:_view];
 

--- a/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
+++ b/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
@@ -363,6 +363,7 @@ interface UIScriptController {
     readonly attribute object inputViewBounds;
 
     undefined setKeyboardInputModeIdentifier(DOMString identifier);
+    undefined setFocusStartsInputSessionPolicy(DOMString policy);
 
     undefined replaceTextAtRange(DOMString text, long location, long length);
 

--- a/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
+++ b/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
@@ -275,6 +275,7 @@ public:
     virtual void setHardwareKeyboardAttached(bool) { }
 
     virtual void setKeyboardInputModeIdentifier(JSStringRef) { notImplemented(); }
+    virtual void setFocusStartsInputSessionPolicy(JSStringRef) { notImplemented(); }
 
     virtual void replaceTextAtRange(JSStringRef, int, int) { notImplemented(); }
 

--- a/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.h
+++ b/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.h
@@ -145,6 +145,7 @@ private:
     void activateDataListSuggestion(unsigned, JSValueRef) override;
     void setSelectedColorForColorPicker(double, double, double) override;
     void setKeyboardInputModeIdentifier(JSStringRef) override;
+    void setFocusStartsInputSessionPolicy(JSStringRef) override;
     void toggleCapsLock(JSValueRef) override;
     unsigned keyboardWillHideCount() const override;
     bool keyboardIsAutomaticallyShifted() const override;

--- a/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm
+++ b/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm
@@ -1444,6 +1444,21 @@ void UIScriptControllerIOS::setKeyboardInputModeIdentifier(JSStringRef identifie
     TestController::singleton().setKeyboardInputModeIdentifier(toWTFString(identifier));
 }
 
+void UIScriptControllerIOS::setFocusStartsInputSessionPolicy(JSStringRef policyJS)
+{
+    RetainPtr webView = this->webView();
+    auto policyString = toWTFString(policyJS);
+
+    if (policyString == "allow"_s)
+        webView.get().focusStartsInputSessionPolicy = _WKFocusStartsInputSessionPolicyAllow;
+    else if (policyString == "disallow"_s)
+        webView.get().focusStartsInputSessionPolicy = _WKFocusStartsInputSessionPolicyDisallow;
+    else if (policyString == "auto"_s)
+        webView.get().focusStartsInputSessionPolicy = _WKFocusStartsInputSessionPolicyAuto;
+    else
+        NSLog(@"setFocusStartsInputSessionPolicy received an invalid policy `%s`.", policyString.utf8().data());
+}
+
 // FIXME: Write this in terms of HIDEventGenerator once we know how to reset caps lock state
 // on test completion to avoid it effecting subsequent tests.
 void UIScriptControllerIOS::toggleCapsLock(JSValueRef callback)


### PR DESCRIPTION
#### 081f5360d06e7cacd6f0c523d8428074d1b5680a
<pre>
[iOS] Cannot scroll on gemini.google.com after sending message
<a href="https://bugs.webkit.org/show_bug.cgi?id=300153">https://bugs.webkit.org/show_bug.cgi?id=300153</a>
<a href="https://rdar.apple.com/157042896">rdar://157042896</a>

Reviewed by Wenson Hsieh.

When selection honors overflow scrolling is enabled (specifically after 285350@main,
in which we switched from tracking scroll containers for the selection to tracking
the graphics layer for the selection), scrolling does not work as expected on
gemini.google.com. After typing a message and hitting the send button, it is not
possible to scroll in the conversation log until the log is tapped. This is the
result of views related to text selection impacting the results of `hitTest:` in
`WKScrollView`. To prevent this from happening, there is existing logic which calls
`makeTextSelectionViewsNonInteractiveForScope` which ensures that user interaction
is disabled for all views in `[_textInteractionWrapper managedTextSelectionViews]`.

However, `managedTextSelectionViews` may be empty even when views related to text
selection are present in the view hierarchy (this is the case on gemini.google.com).
In this scenario, `makeTextSelectionViewsNonInteractiveForScope` fails to disable
user interaction on the text selection views, causing them to impact hit test results.

The emptiness of `managedTextSelectionViews` is the result of the following:

After the page loads but before user interaction:
1. gemini.google.com programmatically focuses a contenteditable div on page load (the
   message field), causing a selection to be made.
2. `prepareToMoveSelectionContainer:(UIView *)newContainer` is called as a result
   of the selection. `newContainer` is not yet the `superview` of the display interaction&apos;s
   highlight view, so `[displayInteraction willMoveToView:_view]` &amp;
   `[displayInteraction didMoveToView:_view]` are called to move the views related to
   text selection.
3. To determine which views are related to text selection, we compare the descendants
   of newContainer before calling `willMoveToView` and `didMoveToView` as mentioned above
   to the descendants afterwards. These views are stored in _managedTextSelectionViews.
4. Critically, UIKit does not actually install any views because the interaction is not
   in the activated state (the focus which got us here was programmatic). There is no
   difference between the before and after state, so _managedTextSelectionViews remains
   empty.

After activating and typing in the message field:
5. The selection/highlight views are installed by UIKit as expected.
   `prepareToMoveSelectionContainer:(UIView *)newContainer` is called afterwards, but the
   highlight/selection views have already been appended to the new container.
   _managedTextSelectionViews is thus not updated, and remains empty.

After the send button is pressed:
6. The selection is not cleared despite editing ending. This is because the message field
   is a contenteditable div rather than a text input or textarea (see webkit.org/b/38696).
   The highlight views remain installed as a result.

After attempting to scroll:
7. To prevent the selection/highlight views from interfering with the scroll view&apos;s hit test,
   we temporarily disable user interaction for all of the selection/highlight views stored in
   _managedTextSelectionViews. In this case, _managedTextSelectionViews is empty despite the
   presence of the views. The hit test breaks, and scrolling does not work as a result.

To fix this, we simply activate the display interaction before calling `willMoveToView` and
`didMoveToView`.

Added new UIHelper method `setFocusStartsInputSessionPolicy` to change the input session policy
during a test. This is important for the newly added layout test because to mimic the behavior
of a physical device without a hardware keyboard, we must start the test with the policy set
to `disallow`, and then later restore it to &quot;auto&quot;. This is required so that we can avoid showing
keyboard UI on the initial programmatic focus (which would have started an actual editing session)
and then later show the keyboard UI after activating the input field, just like a physical device
without a hardware keyboard attached.

Test: editing/selection/ios/scrolling-after-caret-selection-inside-contenteditable-div.html
* LayoutTests/editing/selection/ios/scrolling-after-caret-selection-inside-contenteditable-div-expected.txt: Added.
* LayoutTests/editing/selection/ios/scrolling-after-caret-selection-inside-contenteditable-div.html: Added.
* LayoutTests/resources/ui-helper.js:
(window.UIHelper.setFocusStartsInputSessionPolicy):
* Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.mm:
(-[WKTextInteractionWrapper prepareToMoveSelectionContainer:]):
* Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl:
* Tools/TestRunnerShared/UIScriptContext/UIScriptController.h:
(WTR::UIScriptController::setFocusStartsInputSessionPolicy):
* Tools/WebKitTestRunner/ios/UIScriptControllerIOS.h:
* Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm:
(WTR::UIScriptControllerIOS::setFocusStartsInputSessionPolicy):

Canonical link: <a href="https://commits.webkit.org/301162@main">https://commits.webkit.org/301162@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/584c7f0980029ca7e880ab08ead9fec056e3c4b2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125131 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44798 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35537 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/131980 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/77002 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127008 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45489 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53361 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/131980 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/77002 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128085 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/36313 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/111898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/131980 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/35219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/30063 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/75459 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/106078 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/30291 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134660 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51941 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/39732 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/103724 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52375 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/108119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/103495 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/48843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/27132 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/48999 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19599 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51833 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/57616 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/51200 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/54556 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/52890 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->