### PR TITLE
Address safer cpp warnings in JSC::Watchpoint

### DIFF
--- a/Source/JavaScriptCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/JavaScriptCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -36,7 +36,6 @@ bytecode/SetPrivateBrandStatus.cpp
 bytecode/SharedJITStubSet.h
 bytecode/StructureStubInfo.cpp
 bytecode/UnlinkedFunctionExecutable.cpp
-bytecode/Watchpoint.h
 bytecompiler/BytecodeGenerator.cpp
 bytecompiler/BytecodeGenerator.h
 bytecompiler/NodesCodegen.cpp

--- a/Source/JavaScriptCore/bytecode/Watchpoint.h
+++ b/Source/JavaScriptCore/bytecode/Watchpoint.h
@@ -341,7 +341,7 @@ public:
     void startWatching()
     {
         if (isFat()) {
-            fat()->startWatching();
+            protectedFat()->startWatching();
             return;
         }
         ASSERT(decodeState(m_data) != IsInvalidated);
@@ -352,7 +352,7 @@ public:
     void fireAll(VM& vm, T fireDetails)
     {
         if (isFat()) {
-            fat()->fireAll(vm, fireDetails);
+            protectedFat()->fireAll(vm, fireDetails);
             return;
         }
         if (decodeState(m_data) == ClearWatchpoint)
@@ -364,7 +364,7 @@ public:
     void invalidate(VM& vm, const FireDetail& detail)
     {
         if (isFat())
-            fat()->invalidate(vm, detail);
+            protectedFat()->invalidate(vm, detail);
         else
             m_data = encodeState(IsInvalidated);
     }
@@ -374,7 +374,7 @@ public:
     void touch(VM& vm, const FireDetail& detail)
     {
         if (isFat()) {
-            fat()->touch(vm, detail);
+            protectedFat()->touch(vm, detail);
             return;
         }
         uintptr_t data = m_data;
@@ -481,6 +481,9 @@ private:
         ASSERT(isFat());
         return fat(m_data);
     }
+
+    RefPtr<WatchpointSet> protectedFat() { return fat(); }
+    RefPtr<const WatchpointSet> protectedFat() const { return fat(); }
     
     JS_EXPORT_PRIVATE WatchpointSet* inflateSlow();
     JS_EXPORT_PRIVATE void freeFat();


### PR DESCRIPTION
#### 5ff7a5d0519dee14d53107f64e679fd281283926
<pre>
Address safer cpp warnings in JSC::Watchpoint
<a href="https://bugs.webkit.org/show_bug.cgi?id=300156">https://bugs.webkit.org/show_bug.cgi?id=300156</a>

Reviewed by Yusuke Suzuki.

This tested as performance neutral on JetStream.

Yusuke audit existing code and believes extending the lifetime of the
Watchpoint via RefPtr is safe:
1. JSGlobalObject fields. This is fine as it is destroyed via GC destructor
   for JSGlobalObject. And GC destruction is not driven by some random C++
   destructor calls.
2. FunctionRareData fields. This is safe as well as the same reason to (1)
3. StructureRareData fields. This is also safe. Boxed, but this is just
   shared between StructureRareData.
4. Structure field. This is fine as the same reason.
5. Only problematic case looks like ArrayBuffer&apos;s field. But all possible
   firing code for this InlinedWatchpoint is already keeping this
   ArrayBuffer-refed. So this is also fine.

* Source/JavaScriptCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/JavaScriptCore/bytecode/Watchpoint.h:
(JSC::InlineWatchpointSet::startWatching):
(JSC::InlineWatchpointSet::fireAll):
(JSC::InlineWatchpointSet::invalidate):
(JSC::InlineWatchpointSet::touch):
(JSC::InlineWatchpointSet::protectedFat):
(JSC::InlineWatchpointSet::protectedFat const):

Canonical link: <a href="https://commits.webkit.org/301037@main">https://commits.webkit.org/301037@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4adec02fb81c7f3295535cb229fe6a3160b7e9dd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124773 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44445 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35180 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131618 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/76688 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/73508910-a266-4338-b03c-9c81edc2c951) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45148 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53015 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/94931 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/76688 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0716ef35-c60a-4ce8-b18e-55a3ee060a36) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127727 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36008 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111584 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75499 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9411b3bf-b98c-4aed-9e60-492bc560f36d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34940 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/29738 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75093 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/116878 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105765 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29969 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134284 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/123293 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51619 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39424 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103406 "") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52033 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107804 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103178 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26264 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48545 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26826 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48623 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51493 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57292 "Built successfully") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/156337 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50886 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/156337 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54241 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52580 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->