### PR TITLE
[update-webkit] Use auto stash by default when updating repository

### DIFF
--- a/Tools/Scripts/webkitdirs.pm
+++ b/Tools/Scripts/webkitdirs.pm
@@ -8,13 +8,13 @@
 # are met:
 #
 # 1.  Redistributions of source code must retain the above copyright
-#     notice, this list of conditions and the following disclaimer. 
+#     notice, this list of conditions and the following disclaimer.
 # 2.  Redistributions in binary form must reproduce the above copyright
 #     notice, this list of conditions and the following disclaimer in the
-#     documentation and/or other materials provided with the distribution. 
+#     documentation and/or other materials provided with the distribution.
 # 3.  Neither the name of Apple Inc. ("Apple") nor the names of
 #     its contributors may be used to endorse or promote products derived
-#     from this software without specific prior written permission. 
+#     from this software without specific prior written permission.
 #
 # THIS SOFTWARE IS PROVIDED BY APPLE AND ITS CONTRIBUTORS "AS IS" AND ANY
 # EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
@@ -327,7 +327,7 @@ sub determineSourceDir
     $sourceDir = $FindBin::Bin;
     $sourceDir =~ s|/+$||; # Remove trailing '/' as we would die later
 
-    # walks up path checking each directory to see if it is the main WebKit project dir, 
+    # walks up path checking each directory to see if it is the main WebKit project dir,
     # defined by containing Sources, WebCore, and JavaScriptCore.
     until ((-d File::Spec->catdir($sourceDir, "Source") && -d File::Spec->catdir($sourceDir, "Source", "WebCore") && -d File::Spec->catdir($sourceDir, "Source", "JavaScriptCore")) || (-d File::Spec->catdir($sourceDir, "Internal") && -d File::Spec->catdir($sourceDir, "OpenSource")))
     {
@@ -603,13 +603,13 @@ sub determineXcodeDestination
     return if !isAppleCocoaWebKit();
     determineXcodeSDKPlatformName();
     determineArchitecture();
-    
+
     # Use a generic destination ("Any Mac", etc.) when there are multiple architectures, or when building to
     # a device.
-    
+
     my @architectures = split(' ', $architecture);
     my $generic = $xcodeSDKPlatformName =~ /os$/ || (scalar @architectures) > 1;
-    
+
     if (willUseIOSDeviceSDK()) {
         $destination .= 'platform=iOS';
     } elsif (willUseIOSSimulatorSDK()) {
@@ -632,7 +632,7 @@ sub determineXcodeDestination
         $destination .= ',arch=' . $architectures[0] unless $generic;
         $destination .= ',variant=Mac Catalyst' if willUseMacCatalystSDK();
     }
-        
+
     if (!$generic && $xcodeSDKPlatformName =~ /simulator$/) {
         # Two goals:
         # 1. Find a simulator device to build for, to avoid building multiple architectures.
@@ -648,7 +648,7 @@ sub determineXcodeDestination
         if ($prevBuildRequest && !$prevUDID) {
             warn "Can't find UDID in previous $xcodeSDKPlatformName build request, builds may not be incremental.\n";
         }
-        
+
         # Sort the list of devices to match the ordering in Xcode's UI.
         my @devices = sort { $a->{name} cmp $b->{name} } iOSSimulatorDevices();
         my $prevDevice = first { $prevUDID && $_->{UDID} eq $prevUDID } @devices;
@@ -656,7 +656,7 @@ sub determineXcodeDestination
             warn "Simulator with UDID '$prevUDID' not found, falling back to another available simulator. " .
                 "This build may not be incremental.\n";
         }
-        
+
         # If we found the previous device, check that the runtime being built has not changed (e.g. due to a
         # major SDK update). If it has changed, or if no previous device is available, fall back to the first
         # eligible device in the list.
@@ -667,7 +667,7 @@ sub determineXcodeDestination
         } else {
             $device = first { $_->{runtime} eq $runtime } @devices;
         }
-        
+
         if ($device) {
             $destination .= ',id=' . $device->{UDID};
         } else {
@@ -676,7 +676,7 @@ sub determineXcodeDestination
             $generic = 1;
         }
     }
-    
+
     $destination = 'generic/' . $destination if $generic;
 }
 
@@ -964,7 +964,7 @@ sub determineCrossTarget {
 sub determineXcodeSDKPlatformName {
     return if defined $xcodeSDKPlatformName;
     my $sdk;
-    
+
     # Mac Catalyst is a platform but not an sdk, so it preempts an
     # explicitly-provided sdk, unlike other platform flags.
     if (checkForArgumentAndRemoveFromARGV("--maccatalyst")) {
@@ -1415,10 +1415,10 @@ sub XcodeOptions
     foreach (@features) {
         if (checkForArgumentAndRemoveFromARGV("--no-$_->{option}")) {
             push @options, "$_->{define}=";
-        } 
+        }
         if (checkForArgumentAndRemoveFromARGV("--$_->{option}")) {
             push @options, "$_->{define}=$_->{define}";
-        }   
+        }
     }
 
     # When this environment variable is set Tools/Scripts/check-for-weak-vtables-and-externals
@@ -1621,15 +1621,15 @@ sub checkBuild
 {
     return if isAnyWindows();
 
-    # First check if the directory where the expected build products should be exists. 
-    
+    # First check if the directory where the expected build products should be exists.
+
     my $productDir = productDir();
     if (!-d $productDir) {
         print "No build products could be found for specified build:\n";
         print "  configuration: \"$configuration\" [$configurationExplanation]\n";
         print "  platform:      \"$xcodeSDKPlatformName\" [$xcodeSDKPlatformNameExplanation]" if isEmbeddedWebKit() || isMacCatalystWebKit();
-        print "  products:      $productDir\n\n"; 
-        
+        print "  products:      $productDir\n\n";
+
         my $buildWebKitCommand = scriptPathForName("build-webkit") . ' ' . join(' ', argumentsForConfiguration());
         die "To build this configuration, use the command `$buildWebKitCommand`.\n\nOnce that completes, re-run this command.\n";
     }
@@ -1646,9 +1646,9 @@ sub checkBuild
             print "A dylib, \"$framework\", needed to run this command is missing for specified build:\n";
             print "  configuration: \"$configuration\" [$configurationExplanation]\n";
             print "  platform:      \"$xcodeSDKPlatformName\" [$xcodeSDKPlatformNameExplanation]" if isEmbeddedWebKit() || isMacCatalystWebKit();
-            print "  products:      $productDir\n\n"; 
+            print "  products:      $productDir\n\n";
 
-            print "  dylib:         $dylibPath\n\n"; 
+            print "  dylib:         $dylibPath\n\n";
 
             my $buildWebKitCommand = scriptPathForName("build-webkit") . ' ' . join(' ', argumentsForConfiguration());
             die "To build this configuration, use the command `$buildWebKitCommand`.\n\nOnce that completes, re-run this command.\n";
@@ -1721,7 +1721,7 @@ sub findMatchingArguments($$)
             push(@matchingIndices, $index);
         }
     }
-    return @matchingIndices; 
+    return @matchingIndices;
 }
 
 sub hasArgument($$)
@@ -2377,7 +2377,7 @@ sub buildXcodeScheme($$@)
     if ($clean) {
         push @extraOptions, "clean";
     }
-    
+
     return system "xcodebuild", "-scheme", $scheme, @extraOptions;
 }
 
@@ -3023,15 +3023,15 @@ sub vcpkgArgsFromFeatures(\@;$)
         if ($featureName) {
             my $featureValue = ${$_->{value}}; # Undef to let the build system use its default.
             if (defined($featureValue)) {
-                if ($featureName eq "USE_AVIF") { 
+                if ($featureName eq "USE_AVIF") {
                     $avif = $featureValue;
-                } elsif ($featureName eq "USE_JPEGXL") { 
+                } elsif ($featureName eq "USE_JPEGXL") {
                     $jpegxl = $featureValue;
                 } elsif ($featureName eq "USE_LCMS") {
                     $lcms = $featureValue;
-                } elsif ($featureName eq "USE_SKIA") { 
+                } elsif ($featureName eq "USE_SKIA") {
                     $skia = $featureValue;
-                } elsif ($featureName eq "USE_WOFF2") { 
+                } elsif ($featureName eq "USE_WOFF2") {
                     $woff2 = $featureValue;
                 }
             }
@@ -3303,11 +3303,11 @@ sub relaunchIOSSimulator($)
     my ($simulatedDevice) = @_;
     shutDownIOSSimulatorDevice($simulatedDevice);
 
-    chomp(my $developerDirectory = $ENV{DEVELOPER_DIR} || `xcode-select --print-path`); 
+    chomp(my $developerDirectory = $ENV{DEVELOPER_DIR} || `xcode-select --print-path`);
     my $iosSimulatorPath = File::Spec->catfile($developerDirectory, "Applications", "Simulator.app");
     # Simulator.app needs to be running before the simulator is booted to have it visible.
-    system("open", "-a", $iosSimulatorPath, "--args", "-CurrentDeviceUDID", $simulatedDevice->{UDID}) == 0 or die "Failed to open $iosSimulatorPath: $!"; 
-    system("xcrun", "simctl", "boot", $simulatedDevice->{UDID}) == 0 or die "Failed to boot simulator $simulatedDevice->{UDID}: $!"; 
+    system("open", "-a", $iosSimulatorPath, "--args", "-CurrentDeviceUDID", $simulatedDevice->{UDID}) == 0 or die "Failed to open $iosSimulatorPath: $!";
+    system("xcrun", "simctl", "boot", $simulatedDevice->{UDID}) == 0 or die "Failed to boot simulator $simulatedDevice->{UDID}: $!";
 
     waitUntilIOSSimulatorDeviceIsInState($simulatedDevice->{UDID}, SIMULATOR_DEVICE_STATE_BOOTED);
     waitUntilProcessNotRunning("com.apple.datamigrator");
@@ -3336,7 +3336,7 @@ sub iosSimulatorDeviceByUDID($)
     while ((my $runtime, my $devicesForRuntime) = each %$runtimes) {
         next if not @$devicesForRuntime;
         die "Multiple devices found for UDID $simulatedDeviceUDID: $output" if scalar(@$devicesForRuntime) > 1;
-        return simulatorDeviceFromJSON($runtime, @$devicesForRuntime[0]);        
+        return simulatorDeviceFromJSON($runtime, @$devicesForRuntime[0]);
     }
     return undef;
 }
@@ -3605,7 +3605,7 @@ sub debugMiniBrowser
     if (isAppleMacWebKit()) {
         execMacWebKitAppForDebugging(File::Spec->catfile(productDir(), "MiniBrowser.app", "Contents", "MacOS", "MiniBrowser"));
     }
-    
+
     return 1;
 }
 
@@ -3688,7 +3688,7 @@ sub runGitUpdate()
 {
     # This will die if branch.$BRANCHNAME.merge isn't set, which is
     # almost certainly what we want.
-    system("git", "pull") == 0 or die;
+    system("git", "pull", "--autostash") == 0 or die;
 }
 
 1;


### PR DESCRIPTION
#### 17f0dd7e5143cd2782eaf2c3cd553feb4d663f1a
<pre>
[update-webkit] Use auto stash by default when updating repository
<a href="https://bugs.webkit.org/show_bug.cgi?id=300157">https://bugs.webkit.org/show_bug.cgi?id=300157</a>
<a href="https://rdar.apple.com/161933957">rdar://161933957</a>

Reviewed by Alexey Proskuryakov.

We should pass `--autostash` to git pull when updating webkit through the `update-webkit` script.

* Tools/Scripts/webkitdirs.pm:
(determineSourceDir):
(determineXcodeDestination):
(determineXcodeSDKPlatformName):
(XcodeOptions):
(checkBuild):
(findMatchingArguments):
(buildXcodeScheme):
(vcpkgArgsFromFeatures):
(relaunchIOSSimulator):
(iosSimulatorDeviceByUDID):
(debugMiniBrowser):
(runGitUpdate):

Canonical link: <a href="https://commits.webkit.org/301034@main">https://commits.webkit.org/301034@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6b4d6314e9a30caabf0756cf198a0de2a04f14df

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124573 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44246 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34979 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131408 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76525 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/dfd9b962-d2eb-473f-be1e-5b2b08eced24) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/126450 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44952 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52819 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94765 "Failed to checkout and rebase branch from PR 51797") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62842 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e07db2f1-22e2-47dc-a161-ee3a0f6238a7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127527 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35837 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111404 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75338 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/12941753-ecc2-45c1-a812-b79dafc30185) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34774 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29558 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74891 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/116681 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105592 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29790 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134077 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/123094 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51428 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39248 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103244 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51836 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107626 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103023 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26262 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48383 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26651 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48362 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51299 "Built successfully") | | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/156260 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50702 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/156260 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54058 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52388 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->