### PR TITLE
Update SQLiteDatabase::prepareStatement() to return a std::unique_ptr instead of an std::expected

### DIFF
--- a/LayoutTests/storage/websql/private-browsing-noread-nowrite-expected.txt
+++ b/LayoutTests/storage/websql/private-browsing-noread-nowrite-expected.txt
@@ -3,7 +3,7 @@ This test makes sure that attempts to change the database during private browsin
 Setup statement 1 completed successfully
 Setup statement 2 completed successfully
 Private browsing statement 1 completed with an error
-could not prepare statement (1 not authorized)
+could not prepare statement (23 not authorized)
 Private browsing statement 2 completed with an error
 could not prepare statement (23 not authorized)
 Private browsing statement 3 completed with an error

--- a/Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp
@@ -2624,7 +2624,7 @@ void SQLiteIDBBackingStore::deleteBackingStore()
     if (CheckedPtr sqliteDB = m_sqliteDB.get()) {
         Vector<String> blobFiles;
         {
-            auto statement = sqliteDB->prepareHeapStatement("SELECT fileName FROM BlobFiles;"_s);
+            auto statement = sqliteDB->prepareStatement("SELECT fileName FROM BlobFiles;"_s);
             if (!statement)
                 LOG_ERROR("Error preparing statement to get blob filenames (%i) - %s", sqliteDB->lastError(), sqliteDB->lastErrorMsg());
             else {
@@ -2670,7 +2670,7 @@ SQLiteStatementAutoResetScope SQLiteIDBBackingStore::cachedStatement(SQLiteIDBBa
         return SQLiteStatementAutoResetScope { m_cachedStatements[static_cast<size_t>(sql)].get() };
 
     if (CheckedPtr sqliteDB = m_sqliteDB.get()) {
-        if (auto statement = sqliteDB->prepareHeapStatement(query))
+        if (auto statement = sqliteDB->prepareStatement(query))
             m_cachedStatements[static_cast<size_t>(sql)] = WTFMove(statement);
     }
 

--- a/Source/WebCore/Modules/indexeddb/server/SQLiteIDBCursor.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/SQLiteIDBCursor.cpp
@@ -198,7 +198,7 @@ bool SQLiteIDBCursor::createSQLiteStatement(StringView sql)
     ASSERT(m_transaction->sqliteDatabase());
 
     CheckedPtr database = m_transaction->sqliteDatabase();
-    auto statement = database->prepareHeapStatementSlow(sql);
+    auto statement = database->prepareStatementSlow(sql);
     if (!statement) {
         LOG_ERROR("Could not create cursor statement (prepare/id) - '%s'", database->lastErrorMsg());
         return false;
@@ -305,7 +305,7 @@ bool SQLiteIDBCursor::resetAndRebindPreIndexStatementIfNecessary()
 
     CheckedPtr database = m_transaction->sqliteDatabase();
     if (!m_preIndexStatement) {
-        m_preIndexStatement = database->prepareHeapStatementSlow(buildPreIndexStatement(isDirectionNext()));
+        m_preIndexStatement = database->prepareStatementSlow(buildPreIndexStatement(isDirectionNext()));
         if (!m_preIndexStatement) {
             LOG_ERROR("Could not prepare pre statement - '%s'", database->lastErrorMsg());
             return false;
@@ -550,7 +550,7 @@ SQLiteIDBCursor::FetchResult SQLiteIDBCursor::internalFetchNextRecord(SQLiteCurs
         }
 
         if (!m_cachedObjectStoreStatement || CheckedRef { *m_cachedObjectStoreStatement }->reset() != SQLITE_OK) {
-            if (auto cachedObjectStoreStatement = database->prepareHeapStatement("SELECT rowid, value FROM Records WHERE key = CAST(? AS TEXT) and objectStoreID = ?;"_s))
+            if (auto cachedObjectStoreStatement = database->prepareStatement("SELECT rowid, value FROM Records WHERE key = CAST(? AS TEXT) and objectStoreID = ?;"_s))
                 m_cachedObjectStoreStatement = WTFMove(cachedObjectStoreStatement);
         }
 

--- a/Source/WebCore/Modules/push-api/PushDatabase.cpp
+++ b/Source/WebCore/Modules/push-api/PushDatabase.cpp
@@ -327,7 +327,7 @@ SQLiteStatementAutoResetScope PushDatabase::cachedStatementOnQueue(ASCIILiteral 
     if (it != m_statements.end())
         return SQLiteStatementAutoResetScope(it->value.ptr());
 
-    auto statement = m_db->prepareHeapStatement(query);
+    auto statement = m_db->prepareStatement(query);
     if (!statement) {
         PUSHDB_RELEASE_LOG_ERROR("Failed with '%" PUBLIC_LOG_STRING "' preparing statement: %" PUBLIC_LOG_STRING, m_db->lastErrorMsg(), query.characters());
         return SQLiteStatementAutoResetScope(nullptr);

--- a/Source/WebCore/Modules/webdatabase/Database.cpp
+++ b/Source/WebCore/Modules/webdatabase/Database.cpp
@@ -134,7 +134,7 @@ static bool retrieveTextResultFromDatabase(SQLiteDatabase& db, StringView query,
 {
     auto statement = db.prepareStatementSlow(query);
     if (!statement) {
-        LOG_ERROR("Error (%i) preparing statement to read text result from database (%s)", statement.error(), query.utf8().data());
+        LOG_ERROR("Error (%i) preparing statement to read text result from database (%s)", db.lastError(), query.utf8().data());
         return false;
     }
 

--- a/Source/WebCore/Modules/webdatabase/SQLStatement.cpp
+++ b/Source/WebCore/Modules/webdatabase/SQLStatement.cpp
@@ -117,11 +117,11 @@ bool SQLStatement::execute(Database& db)
 
     auto statement = database.prepareStatementSlow(m_statement);
     if (!statement) {
-        LOG(StorageAPI, "Unable to verify correctness of statement %s - error %i (%s)", m_statement.ascii().data(), statement.error(), database.lastErrorMsg());
-        if (statement.error() == SQLITE_INTERRUPT)
-            m_error = SQLError::create(SQLError::DATABASE_ERR, "could not prepare statement"_s, statement.error(), "interrupted"_s);
+        LOG(StorageAPI, "Unable to verify correctness of statement %s - error %i (%s)", m_statement.ascii().data(), database.lastError(), database.lastErrorMsg());
+        if (database.lastError() == SQLITE_INTERRUPT)
+            m_error = SQLError::create(SQLError::DATABASE_ERR, "could not prepare statement"_s, database.lastError(), "interrupted"_s);
         else
-            m_error = SQLError::create(SQLError::SYNTAX_ERR, "could not prepare statement"_s, statement.error(), database.lastErrorMsg());
+            m_error = SQLError::create(SQLError::SYNTAX_ERR, "could not prepare statement"_s, database.lastError(), database.lastErrorMsg());
         return false;
     }
 

--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -22,9 +22,7 @@ Modules/webdatabase/ChangeVersionWrapper.cpp
 Modules/webdatabase/Database.cpp
 Modules/webdatabase/DatabaseContext.cpp
 Modules/webdatabase/DatabaseManager.cpp
-Modules/webdatabase/DatabaseTracker.cpp
 Modules/webdatabase/LocalDOMWindowWebDatabase.cpp
-Modules/webdatabase/SQLStatement.cpp
 Modules/webdatabase/SQLTransaction.cpp
 Modules/websockets/WebSocketChannelInspector.cpp
 Modules/websockets/WorkerThreadableWebSocketChannel.cpp

--- a/Source/WebCore/loader/ResourceMonitorPersistence.cpp
+++ b/Source/WebCore/loader/ResourceMonitorPersistence.cpp
@@ -134,7 +134,7 @@ bool ResourceMonitorPersistence::openDatabase(String&& directoryPath)
         RESOURCEMONITOR_RELEASE_LOG("openDatabase: Index %" PUBLIC_LOG_STRING " created", accessIndexName.characters());
     }
 
-    m_insertSQLStatement = m_sqliteDB->prepareHeapStatement(insertRecordSQL);
+    m_insertSQLStatement = m_sqliteDB->prepareStatement(insertRecordSQL);
     if (!m_insertSQLStatement)
         return reportErrorAndCloseDatabase("prepare insert statement"_s);
 

--- a/Source/WebCore/platform/network/curl/CookieJarDB.cpp
+++ b/Source/WebCore/platform/network/curl/CookieJarDB.cpp
@@ -638,7 +638,7 @@ bool CookieJarDB::deleteAllCookies()
 
 void CookieJarDB::createPrepareStatement(ASCIILiteral sql)
 {
-    auto statement = m_database.prepareHeapStatement(sql);
+    auto statement = m_database.prepareStatement(sql);
     ASSERT(statement);
     m_statements.add(sql, WTFMove(statement));
 }
@@ -651,9 +651,9 @@ SQLiteStatement& CookieJarDB::preparedStatement(const String& sql)
     return *statement;
 }
 
-bool CookieJarDB::executeSQLStatement(Expected<SQLiteStatement, int>&& statement)
+bool CookieJarDB::executeSQLStatement(std::unique_ptr<SQLiteStatement>&& statement)
 {
-    if (!statement && !checkSQLiteReturnCode(statement.error())) {
+    if (!statement && !checkSQLiteReturnCode(m_database.lastError())) {
         LOG_ERROR("Failed to prepare sql statement with error: %s", m_database.lastErrorMsg());
         return false;
     }

--- a/Source/WebCore/platform/network/curl/CookieJarDB.h
+++ b/Source/WebCore/platform/network/curl/CookieJarDB.h
@@ -96,7 +96,7 @@ private:
 
     void createPrepareStatement(ASCIILiteral);
     SQLiteStatement& preparedStatement(const String&);
-    bool executeSQLStatement(Expected<SQLiteStatement, int>&&);
+    bool executeSQLStatement(std::unique_ptr<SQLiteStatement>&&);
 
     bool deleteCookieInternal(const String& name, const String& domain, const String& path);
     bool hasHttpOnlyCookie(const String& name, const String& domain, const String& path);

--- a/Source/WebCore/platform/sql/SQLiteDatabase.h
+++ b/Source/WebCore/platform/sql/SQLiteDatabase.h
@@ -83,10 +83,8 @@ public:
     
     bool transactionInProgress() const { return m_transactionInProgress; }
 
-    WEBCORE_EXPORT Expected<SQLiteStatement, int> prepareStatementSlow(StringView query);
-    WEBCORE_EXPORT Expected<SQLiteStatement, int> prepareStatement(ASCIILiteral query);
-    WEBCORE_EXPORT std::unique_ptr<SQLiteStatement> prepareHeapStatementSlow(StringView query);
-    WEBCORE_EXPORT std::unique_ptr<SQLiteStatement> prepareHeapStatement(ASCIILiteral query);
+    WEBCORE_EXPORT std::unique_ptr<SQLiteStatement> prepareStatementSlow(StringView query);
+    WEBCORE_EXPORT std::unique_ptr<SQLiteStatement> prepareStatement(ASCIILiteral query);
 
     // Aborts the current database operation. This is thread safe.
     WEBCORE_EXPORT void interrupt();

--- a/Source/WebCore/platform/win/SearchPopupMenuDB.cpp
+++ b/Source/WebCore/platform/win/SearchPopupMenuDB.cpp
@@ -272,11 +272,11 @@ void SearchPopupMenuDB::checkSQLiteReturnCode(int actual)
     }
 }
 
-int SearchPopupMenuDB::executeSQLStatement(Expected<SQLiteStatement, int>&& statement)
+int SearchPopupMenuDB::executeSQLStatement(std::unique_ptr<SQLiteStatement>&& statement)
 {
     if (!statement) {
-        checkSQLiteReturnCode(statement.error());
-        return statement.error();
+        checkSQLiteReturnCode(m_database.lastError());
+        return m_database.lastError();
     }
 
     int ret = statement->step();
@@ -287,7 +287,7 @@ int SearchPopupMenuDB::executeSQLStatement(Expected<SQLiteStatement, int>&& stat
 
 std::unique_ptr<SQLiteStatement> SearchPopupMenuDB::createPreparedStatement(ASCIILiteral sql)
 {
-    auto statement = m_database.prepareHeapStatement(sql);
+    auto statement = m_database.prepareStatement(sql);
     ASSERT(statement);
     return statement;
 }

--- a/Source/WebCore/platform/win/SearchPopupMenuDB.h
+++ b/Source/WebCore/platform/win/SearchPopupMenuDB.h
@@ -49,7 +49,7 @@ private:
     bool checkDatabaseValidity();
     void deleteAllDatabaseFiles();
     void verifySchemaVersion();
-    int executeSQLStatement(Expected<SQLiteStatement, int>&&);
+    int executeSQLStatement(std::unique_ptr<SQLiteStatement>&&);
     void checkSQLiteReturnCode(int actual);
     std::unique_ptr<SQLiteStatement> createPreparedStatement(ASCIILiteral sql);
 

--- a/Source/WebCore/workers/service/server/SWRegistrationDatabase.cpp
+++ b/Source/WebCore/workers/service/server/SWRegistrationDatabase.cpp
@@ -199,7 +199,7 @@ SQLiteStatementAutoResetScope SWRegistrationDatabase::cachedStatement(StatementT
 
     auto index = enumToUnderlyingType(type);
     if (!m_cachedStatements[index]) {
-        if (auto statement = CheckedRef { *m_database }->prepareHeapStatement(statementString(type)))
+        if (auto statement = CheckedRef { *m_database }->prepareStatement(statementString(type)))
             m_cachedStatements[index] = WTFMove(statement);
     }
 

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDatabase.cpp
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDatabase.cpp
@@ -195,7 +195,7 @@ void Database::insertPrivateClickMeasurement(WebCore::PrivateClickMeasurement&& 
         // We should never be inserting an attributed private click measurement value into the database without valid report times.
         ASSERT(sourceEarliestTimeToSend != -1 || destinationEarliestTimeToSend != -1);
 
-        auto statement = m_database.prepareHeapStatement(insertAttributedPrivateClickMeasurementQuery);
+        auto statement = m_database.prepareStatement(insertAttributedPrivateClickMeasurementQuery);
         if (!statement
             || statement->bindInt(1, *sourceID) != SQLITE_OK
             || statement->bindInt(2, *attributionDestinationID) != SQLITE_OK
@@ -221,7 +221,7 @@ void Database::insertPrivateClickMeasurement(WebCore::PrivateClickMeasurement&& 
 
     ASSERT(attributionType == PrivateClickMeasurementAttributionType::Unattributed);
 
-    auto statement = m_database.prepareHeapStatement(insertUnattributedPrivateClickMeasurementQuery);
+    auto statement = m_database.prepareStatement(insertUnattributedPrivateClickMeasurementQuery);
     if (!statement
         || statement->bindInt(1, *sourceID) != SQLITE_OK
         || statement->bindInt(2, *attributionDestinationID) != SQLITE_OK
@@ -391,7 +391,7 @@ Vector<WebCore::PrivateClickMeasurement> Database::allAttributedPrivateClickMeas
 String Database::privateClickMeasurementToStringForTesting() const
 {
     ASSERT(!RunLoop::isMain());
-    auto privateClickMeasurementDataExists = m_database.prepareHeapStatement("SELECT (SELECT COUNT(*) FROM UnattributedPrivateClickMeasurement) as cnt1, (SELECT COUNT(*) FROM AttributedPrivateClickMeasurement) as cnt2"_s);
+    auto privateClickMeasurementDataExists = m_database.prepareStatement("SELECT (SELECT COUNT(*) FROM UnattributedPrivateClickMeasurement) as cnt1, (SELECT COUNT(*) FROM AttributedPrivateClickMeasurement) as cnt2"_s);
     if (!privateClickMeasurementDataExists || privateClickMeasurementDataExists->step() != SQLITE_ROW) {
         RELEASE_LOG_ERROR(PrivateClickMeasurement, "%p - Database::privateClickMeasurementToStringForTesting failed, error message: %" PRIVATE_LOG_STRING, this, m_database.lastErrorMsg());
         ASSERT_NOT_REACHED();
@@ -477,8 +477,8 @@ void Database::markAttributedPrivateClickMeasurementsAsExpiredForTesting()
 
     auto transactionScope = beginTransactionIfNecessary();
 
-    auto earliestTimeToSendToSourceStatement = m_database.prepareHeapStatement("UPDATE AttributedPrivateClickMeasurement SET earliestTimeToSendToSource = ?"_s);
-    auto earliestTimeToSendToDestinationStatement = m_database.prepareHeapStatement("UPDATE AttributedPrivateClickMeasurement SET earliestTimeToSendToDestination = null"_s);
+    auto earliestTimeToSendToSourceStatement = m_database.prepareStatement("UPDATE AttributedPrivateClickMeasurement SET earliestTimeToSendToSource = ?"_s);
+    auto earliestTimeToSendToDestinationStatement = m_database.prepareStatement("UPDATE AttributedPrivateClickMeasurement SET earliestTimeToSendToDestination = null"_s);
 
     if (!earliestTimeToSendToSourceStatement
         || earliestTimeToSendToSourceStatement->bindInt(1, expiredTimeToSend.secondsSinceEpoch().value()) != SQLITE_OK
@@ -570,7 +570,7 @@ void Database::clearSentAttribution(WebCore::PrivateClickMeasurement&& attributi
     if (destinationEarliestTimeToSend || sourceEarliestTimeToSend)
         return;
 
-    auto clearAttributedStatement = m_database.prepareHeapStatement("DELETE FROM AttributedPrivateClickMeasurement WHERE sourceSiteDomainID = ? AND destinationSiteDomainID = ? AND sourceApplicationBundleID = ?"_s);
+    auto clearAttributedStatement = m_database.prepareStatement("DELETE FROM AttributedPrivateClickMeasurement WHERE sourceSiteDomainID = ? AND destinationSiteDomainID = ? AND sourceApplicationBundleID = ?"_s);
     if (!clearAttributedStatement
         || clearAttributedStatement->bindInt(1, *sourceSiteDomainID) != SQLITE_OK
         || clearAttributedStatement->bindInt(2, *destinationSiteDomainID) != SQLITE_OK

--- a/Source/WebKit/NetworkProcess/storage/SQLiteStorageArea.cpp
+++ b/Source/WebKit/NetworkProcess/storage/SQLiteStorageArea.cpp
@@ -235,7 +235,7 @@ WebCore::SQLiteStatementAutoResetScope SQLiteStorageArea::cachedStatement(Statem
 
     auto index = static_cast<uint8_t>(type);
     if (!m_cachedStatements[index]) {
-        if (auto result = checkedDatabase()->prepareHeapStatement(statementString(type)))
+        if (auto result = checkedDatabase()->prepareStatement(statementString(type)))
             m_cachedStatements[index] = WTFMove(result);
     }
 

--- a/Source/WebKit/UIProcess/API/glib/IconDatabase.cpp
+++ b/Source/WebKit/UIProcess/API/glib/IconDatabase.cpp
@@ -220,7 +220,7 @@ void IconDatabase::pruneTimerFired()
     ASSERT(m_db.isOpen());
 
     if (!m_pruneIconsStatement) {
-        m_pruneIconsStatement = m_db.prepareHeapStatement("DELETE FROM IconInfo WHERE stamp <= (?);"_s);
+        m_pruneIconsStatement = m_db.prepareStatement("DELETE FROM IconInfo WHERE stamp <= (?);"_s);
         if (m_pruneIconsStatement) {
             LOG_ERROR("Preparing statement pruneIcons failed");
             return;
@@ -290,7 +290,7 @@ std::optional<int64_t> IconDatabase::iconIDForIconURL(const String& iconURL, boo
     ASSERT(m_db.isOpen());
 
     if (!m_iconIDForIconURLStatement) {
-        m_iconIDForIconURLStatement = m_db.prepareHeapStatement("SELECT IconInfo.iconID, IconInfo.stamp FROM IconInfo WHERE IconInfo.url = (?);"_s);
+        m_iconIDForIconURLStatement = m_db.prepareStatement("SELECT IconInfo.iconID, IconInfo.stamp FROM IconInfo WHERE IconInfo.url = (?);"_s);
         if (!m_iconIDForIconURLStatement) {
             LOG_ERROR("Preparing statement iconIDForIconURL failed");
             return std::nullopt;
@@ -319,7 +319,7 @@ bool IconDatabase::setIconIDForPageURL(int64_t iconID, const String& pageURL)
     ASSERT(m_allowDatabaseWrite == AllowDatabaseWrite::Yes);
 
     if (!m_setIconIDForPageURLStatement) {
-        m_setIconIDForPageURLStatement = m_db.prepareHeapStatement("INSERT INTO PageURL (url, iconID) VALUES ((?), ?);"_s);
+        m_setIconIDForPageURLStatement = m_db.prepareStatement("INSERT INTO PageURL (url, iconID) VALUES ((?), ?);"_s);
         if (!m_setIconIDForPageURLStatement) {
             LOG_ERROR("Preparing statement setIconIDForPageURL failed");
             return false;
@@ -345,7 +345,7 @@ Vector<uint8_t> IconDatabase::iconData(int64_t iconID)
     ASSERT(m_db.isOpen());
 
     if (!m_iconDataStatement) {
-        m_iconDataStatement = m_db.prepareHeapStatement("SELECT IconData.data FROM IconData WHERE IconData.iconID = (?);"_s);
+        m_iconDataStatement = m_db.prepareStatement("SELECT IconData.data FROM IconData WHERE IconData.iconID = (?);"_s);
         if (!m_iconDataStatement) {
             LOG_ERROR("Preparing statement iconData failed");
             return { };
@@ -369,14 +369,14 @@ std::optional<int64_t> IconDatabase::addIcon(const String& iconURL, const Vector
     ASSERT(m_allowDatabaseWrite == AllowDatabaseWrite::Yes);
 
     if (!m_addIconStatement) {
-        m_addIconStatement = m_db.prepareHeapStatement("INSERT INTO IconInfo (url, stamp) VALUES (?, 0);"_s);
+        m_addIconStatement = m_db.prepareStatement("INSERT INTO IconInfo (url, stamp) VALUES (?, 0);"_s);
         if (!m_addIconStatement) {
             LOG_ERROR("Preparing statement addIcon failed");
             return std::nullopt;
         }
     }
     if (!m_addIconDataStatement) {
-        m_addIconDataStatement = m_db.prepareHeapStatement("INSERT INTO IconData (iconID, data) VALUES (?, ?);"_s);
+        m_addIconDataStatement = m_db.prepareStatement("INSERT INTO IconData (iconID, data) VALUES (?, ?);"_s);
         if (!m_addIconDataStatement) {
             LOG_ERROR("Preparing statement addIconData failed");
             return std::nullopt;
@@ -410,7 +410,7 @@ void IconDatabase::updateIconTimestamp(int64_t iconID, int64_t timestamp)
     ASSERT(m_allowDatabaseWrite == AllowDatabaseWrite::Yes);
 
     if (!m_updateIconTimestampStatement) {
-        m_updateIconTimestampStatement = m_db.prepareHeapStatement("UPDATE IconInfo SET stamp = ? WHERE iconID = ?;"_s);
+        m_updateIconTimestampStatement = m_db.prepareStatement("UPDATE IconInfo SET stamp = ? WHERE iconID = ?;"_s);
         if (!m_updateIconTimestampStatement) {
             LOG_ERROR("Preparing statement updateIconTimestamp failed");
             return;
@@ -433,21 +433,21 @@ void IconDatabase::deleteIcon(int64_t iconID)
     ASSERT(m_allowDatabaseWrite == AllowDatabaseWrite::Yes);
 
     if (!m_deletePageURLsForIconStatement) {
-        m_deletePageURLsForIconStatement = m_db.prepareHeapStatement("DELETE FROM PageURL WHERE PageURL.iconID = (?);"_s);
+        m_deletePageURLsForIconStatement = m_db.prepareStatement("DELETE FROM PageURL WHERE PageURL.iconID = (?);"_s);
         if (!m_deletePageURLsForIconStatement) {
             LOG_ERROR("Preparing statement deletePageURLsForIcon failed");
             return;
         }
     }
     if (!m_deleteIconDataStatement) {
-        m_deleteIconDataStatement = m_db.prepareHeapStatement("DELETE FROM IconData WHERE IconData.iconID = (?);"_s);
+        m_deleteIconDataStatement = m_db.prepareStatement("DELETE FROM IconData WHERE IconData.iconID = (?);"_s);
         if (!m_deleteIconDataStatement) {
             LOG_ERROR("Preparing statement deleteIcon failed");
             return;
         }
     }
     if (!m_deleteIconStatement) {
-        m_deleteIconStatement = m_db.prepareHeapStatement("DELETE FROM IconInfo WHERE IconInfo.iconID = (?);"_s);
+        m_deleteIconStatement = m_db.prepareStatement("DELETE FROM IconInfo WHERE IconInfo.iconID = (?);"_s);
         if (!m_deleteIconStatement) {
             LOG_ERROR("Preparing statement deleteIcon failed");
             return;

--- a/Source/WebKitLegacy/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebKitLegacy/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -1,7 +1,5 @@
 Storage/InProcessIDBServer.cpp
-Storage/StorageAreaSync.cpp
 Storage/StorageSyncManager.cpp
-Storage/StorageTracker.cpp
 Storage/WebDatabaseProvider.cpp
 WebCoreSupport/SocketStreamHandleImpl.cpp
 WebCoreSupport/WebSocketChannel.cpp


### PR DESCRIPTION
#### a6e7d5013931af9ce1813908dc8672dceab114e2
<pre>
Update SQLiteDatabase::prepareStatement() to return a std::unique_ptr instead of an std::expected
<a href="https://bugs.webkit.org/show_bug.cgi?id=300158">https://bugs.webkit.org/show_bug.cgi?id=300158</a>

Reviewed by Ryosuke Niwa.

* LayoutTests/storage/websql/private-browsing-noread-nowrite-expected.txt:
* Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp:
(WebCore::IDBServer::SQLiteIDBBackingStore::deleteBackingStore):
(WebCore::IDBServer::SQLiteIDBBackingStore::cachedStatement):
* Source/WebCore/Modules/indexeddb/server/SQLiteIDBCursor.cpp:
(WebCore::IDBServer::SQLiteIDBCursor::createSQLiteStatement):
(WebCore::IDBServer::SQLiteIDBCursor::resetAndRebindPreIndexStatementIfNecessary):
(WebCore::IDBServer::SQLiteIDBCursor::internalFetchNextRecord):
* Source/WebCore/Modules/push-api/PushDatabase.cpp:
(WebCore::PushDatabase::cachedStatementOnQueue):
* Source/WebCore/Modules/webdatabase/Database.cpp:
(WebCore::retrieveTextResultFromDatabase):
* Source/WebCore/Modules/webdatabase/SQLStatement.cpp:
(WebCore::SQLStatement::execute):
* Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebCore/loader/ResourceMonitorPersistence.cpp:
(WebCore::ResourceMonitorPersistence::openDatabase):
* Source/WebCore/platform/network/curl/CookieJarDB.cpp:
(WebCore::CookieJarDB::createPrepareStatement):
(WebCore::CookieJarDB::executeSQLStatement):
* Source/WebCore/platform/network/curl/CookieJarDB.h:
* Source/WebCore/platform/sql/SQLiteDatabase.cpp:
(WebCore::SQLiteDatabase::useWALJournalMode):
(WebCore::SQLiteDatabase::maximumSize):
(WebCore::SQLiteDatabase::setMaximumSize):
(WebCore::SQLiteDatabase::pageSize):
(WebCore::SQLiteDatabase::freeSpaceSize):
(WebCore::SQLiteDatabase::totalSize):
(WebCore::SQLiteDatabase::executeSlow):
(WebCore::SQLiteDatabase::execute):
(WebCore::SQLiteDatabase::tableSQL):
(WebCore::SQLiteDatabase::indexSQL):
(WebCore::SQLiteDatabase::clearAllTables):
(WebCore::SQLiteDatabase::runIncrementalVacuumCommand):
(WebCore::SQLiteDatabase::turnOnIncrementalAutoVacuum):
(WebCore::SQLiteDatabase::prepareStatementSlow):
(WebCore::SQLiteDatabase::prepareStatement):
(WebCore::SQLiteDatabase::prepareHeapStatementSlow): Deleted.
(WebCore::SQLiteDatabase::prepareHeapStatement): Deleted.
* Source/WebCore/platform/sql/SQLiteDatabase.h:
* Source/WebCore/platform/win/SearchPopupMenuDB.cpp:
(WebCore::SearchPopupMenuDB::executeSQLStatement):
(WebCore::SearchPopupMenuDB::createPreparedStatement):
* Source/WebCore/platform/win/SearchPopupMenuDB.h:
* Source/WebCore/workers/service/server/SWRegistrationDatabase.cpp:
(WebCore::SWRegistrationDatabase::cachedStatement):
* Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp:
(WebKit::ResourceLoadStatisticsStore::loadWebsitesWithUserInteraction):
(WebKit::ResourceLoadStatisticsStore::deleteTable):
(WebKit::ResourceLoadStatisticsStore::missingUniqueIndices):
(WebKit::ResourceLoadStatisticsStore::migrateDataToPCMDatabaseIfNecessary):
(WebKit::ResourceLoadStatisticsStore::insertDomainRelationshipList):
(WebKit::ResourceLoadStatisticsStore::aggregatedThirdPartyData const):
(WebKit::ResourceLoadStatisticsStore::incrementRecordsDeletedCountForDomains):
(WebKit::ResourceLoadStatisticsStore::recursivelyFindNonPrevalentDomainsThatRedirectedToThisDomain):
(WebKit::ResourceLoadStatisticsStore::markAsPrevalentIfHasRedirectedToPrevalent):
(WebKit::ResourceLoadStatisticsStore::findNotVeryPrevalentResources):
(WebKit::ResourceLoadStatisticsStore::requestStorageAccess):
(WebKit::ResourceLoadStatisticsStore::revokeStorageAccessPermission):
(WebKit::ResourceLoadStatisticsStore::grandfatherDataForDomains):
(WebKit::ResourceLoadStatisticsStore::clearTopFrameUniqueRedirectsToSinceSameSiteStrictEnforcement):
(WebKit::ResourceLoadStatisticsStore::setDomainsAsPrevalent):
(WebKit::ResourceLoadStatisticsStore::cookieAccess):
(WebKit::ResourceLoadStatisticsStore::hasUserGrantedStorageAccessThroughPrompt):
(WebKit::ResourceLoadStatisticsStore::domainsToBlockAndDeleteCookiesFor const):
(WebKit::ResourceLoadStatisticsStore::domainsToBlockButKeepCookiesFor const):
(WebKit::ResourceLoadStatisticsStore::domainsWithUserInteractionAsFirstParty const):
(WebKit::ResourceLoadStatisticsStore::domainsWithStorageAccess const):
(WebKit::ResourceLoadStatisticsStore::domains const):
(WebKit::ResourceLoadStatisticsStore::clearGrandfathering):
(WebKit::ResourceLoadStatisticsStore::pruneStatisticsIfNeeded):
(WebKit::ResourceLoadStatisticsStore::isCorrectSubStatisticsCount):
(WebKit::ResourceLoadStatisticsStore::appendSubStatisticList const):
(WebKit::ResourceLoadStatisticsStore::updateOperatingDatesParameters):
(WebKit::ResourceLoadStatisticsStore::includeTodayAsOperatingDateIfNecessary):
(WebKit::ResourceLoadStatisticsStore::insertExpiredStatisticForTesting):
* Source/WebKit/NetworkProcess/DatabaseUtilities.cpp:
(WebKit::DatabaseUtilities::scopedStatement const):
(WebKit::evaluateStatementAndExpect):
(WebKit::DatabaseUtilities::currentTableAndIndexQueries):
(WebKit::insertDistinctValuesInTableStatement):
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDatabase.cpp:
(WebKit::PCM::Database::insertPrivateClickMeasurement):
(WebKit::PCM::Database::privateClickMeasurementToStringForTesting const):
(WebKit::PCM::Database::markAttributedPrivateClickMeasurementsAsExpiredForTesting):
(WebKit::PCM::Database::clearSentAttribution):
* Source/WebKit/NetworkProcess/storage/SQLiteStorageArea.cpp:
(WebKit::SQLiteStorageArea::cachedStatement):
* Source/WebKit/UIProcess/API/glib/IconDatabase.cpp:
(WebKit::IconDatabase::pruneTimerFired):
(WebKit::IconDatabase::iconIDForIconURL):
(WebKit::IconDatabase::setIconIDForPageURL):
(WebKit::IconDatabase::iconData):
(WebKit::IconDatabase::addIcon):
(WebKit::IconDatabase::updateIconTimestamp):
(WebKit::IconDatabase::deleteIcon):
* Source/WebKitLegacy/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:

Canonical link: <a href="https://commits.webkit.org/301020@main">https://commits.webkit.org/301020@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/15ef726843570a7958e1fdbd58a5ccc12eaf7d52

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124711 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44383 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35118 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131553 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76632 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7947da0e-eefd-4bcc-a338-2e666693ce06) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/126588 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45087 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52953 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/94881 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62937 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/394039d5-c411-44a7-8353-9dd4c7467abd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127665 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35955 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111528 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75450 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/07054d2c-f42e-4474-89ce-0f437d717d5b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34886 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29683 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75032 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105712 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29914 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134219 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51559 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/39371 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/103358 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51971 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107749 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103131 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26250 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48501 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26771 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48542 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51432 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57230 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50825 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54181 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52520 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->