### PR TITLE
Resync `webaudio` from WPT Upstream

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/k-rate-audioworklet.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/k-rate-audioworklet.https-expected.txt
@@ -1,16 +1,3 @@
 
-PASS # AUDIT TASK RUNNER STARTED.
-PASS Executing "Create Test Worklet"
-PASS Executing "AudioWorklet k-rate AudioParam"
-PASS Audit report
-PASS > [Create Test Worklet]
-PASS   Construction of AudioWorklet resolved correctly.
-PASS < [Create Test Worklet] All assertions passed. (total 1 assertions)
-PASS > [AudioWorklet k-rate AudioParam]
-PASS    k-rate output [0: 127] contains only the constant 0.
-PASS    k-rate output [128: 255] contains only the constant 2.5.
-PASS    k-rate output [256: 383] contains only the constant 5.
-PASS    k-rate output [384: 511] contains only the constant 7.5.
-PASS < [AudioWorklet k-rate AudioParam] All assertions passed. (total 4 assertions)
-PASS # AUDIT TASK RUNNER FINISHED: 2 tasks ran successfully.
+PASS AudioWorklet k-rate AudioParam
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/k-rate-audioworklet.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/k-rate-audioworklet.https.html
@@ -1,17 +1,13 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
   <head>
     <title>Test k-rate AudioParam of AudioWorkletNode</title>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
-    <script src="/webaudio/resources/audit-util.js"></script>
-    <script src="/webaudio/resources/audit.js"></script>
   </head>
 
   <body>
     <script>
-      const audit = Audit.createTaskRunner();
-
       // Use the worklet gain node to test k-rate parameters.
       const filePath =
           '../the-audioworklet-interface/processors/gain-processor.js';
@@ -19,8 +15,7 @@
       // Context for testing
       let context;
 
-      audit.define('Create Test Worklet', (task, should) => {
-
+      promise_test(async () => {
         // Arbitrary sample rate and duration.
         const sampleRate = 8000;
 
@@ -30,24 +25,16 @@
         context = new OfflineAudioContext({
           numberOfChannels: 3,
           sampleRate: sampleRate,
-          length: testDuration * sampleRate
+          length: testDuration * sampleRate,
         });
 
-        should(
-            context.audioWorklet.addModule(filePath),
-            'Construction of AudioWorklet')
-            .beResolved()
-            .then(() => task.done());
-      });
+        await context.audioWorklet.addModule(filePath);
 
-      audit.define('AudioWorklet k-rate AudioParam', (task, should) => {
-        let src = new ConstantSourceNode(context);
-
-        let kRateNode = new AudioWorkletNode(context, 'gain');
-
+        const src = new ConstantSourceNode(context);
+        const kRateNode = new AudioWorkletNode(context, 'gain');
         src.connect(kRateNode).connect(context.destination);
 
-        let kRateParam = kRateNode.parameters.get('gain');
+        const kRateParam = kRateNode.parameters.get('gain');
         kRateParam.automationRate = 'k-rate';
 
         // Automate the gain
@@ -57,23 +44,18 @@
 
         src.start();
 
-        context.startRendering()
-            .then(audioBuffer => {
-              let output = audioBuffer.getChannelData(0);
+        const audioBuffer = await context.startRendering();
+        const output = audioBuffer.getChannelData(0);
 
-              // Verify that the output from the worklet is step-wise
-              // constant.
-              for (let k = 0; k < output.length; k += 128) {
-                should(
-                    output.slice(k, k + 128),
-                    ` k-rate output [${k}: ${k + 127}]`)
-                    .beConstantValueOf(output[k]);
-              }
-            })
-            .then(() => task.done());
-      });
-
-      audit.run();
+        // Verify that the output from the worklet is step-wise
+        // constant.
+        for (let k = 0; k < output.length; k += 128) {
+          assert_array_equals(
+              output.slice(k, k + 128),
+              new Float32Array(128).fill(output[k]),
+              `k-rate output [${k}: ${k + 127}]`);
+        }
+      }, 'AudioWorklet k-rate AudioParam');
     </script>
   </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/nan-param-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/nan-param-expected.txt
@@ -1,10 +1,3 @@
 
-PASS # AUDIT TASK RUNNER STARTED.
-PASS Executing "AudioParam NaN"
-PASS Audit report
-PASS > [AudioParam NaN]
-PASS   AudioParam input contains only NaN is true.
-PASS   AudioParam output contains only the constant 100.
-PASS < [AudioParam NaN] All assertions passed. (total 2 assertions)
-PASS # AUDIT TASK RUNNER FINISHED: 1 tasks ran successfully.
+PASS AudioParam NaN should be flushed to default value
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/nan-param.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/nan-param.html
@@ -5,37 +5,35 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/webaudio/resources/audit-util.js"></script>
-    <script src="/webaudio/resources/audit.js"></script>
   </head>
 
   <body>
     <script>
-      let audit = Audit.createTaskRunner();
-
       // See
       // https://webaudio.github.io/web-audio-api/#computation-of-value.
       //
       // The computed value must replace NaN values in the output with
       // the default value of the param.
-      audit.define('AudioParam NaN', async (task, should) => {
+      promise_test(async () => {
         // For testing, we only need a small number of frames; and
         // a low sample rate is perfectly fine.  Use two channels.
         // The first channel is for the AudioParam output.  The
         // second channel is for the AudioParam input.
-        let context = new OfflineAudioContext(
+        const context = new OfflineAudioContext(
             {numberOfChannels: 2, length: 256, sampleRate: 8192});
-        let merger = new ChannelMergerNode(
+
+        const merger = new ChannelMergerNode(
             context, {numberOfInputs: context.destination.channelCount});
         merger.connect(context.destination);
 
         // A constant source with a huge value.
-        let mod = new ConstantSourceNode(context, {offset: 1e30});
+        const mod = new ConstantSourceNode(context, {offset: 1e30});
 
         // Gain nodes with a huge positive gain and huge negative
         // gain.  Combined with the huge offset in |mod|, the
         // output of the gain nodes are +Infinity and -Infinity.
-        let gainPos = new GainNode(context, {gain: 1e30});
-        let gainNeg = new GainNode(context, {gain: -1e30});
+        const gainPos = new GainNode(context, {gain: 1e30});
+        const gainNeg = new GainNode(context, {gain: -1e30});
 
         mod.connect(gainPos);
         mod.connect(gainNeg);
@@ -49,7 +47,7 @@
         // that produces NaN values.  Use a non-default value offset
         // just in case something is wrong we get default for some
         // other reason.
-        let src = new ConstantSourceNode(context, {offset: 100});
+        const src = new ConstantSourceNode(context, {offset: 100});
 
         gainPos.connect(src.offset);
         gainNeg.connect(src.offset);
@@ -61,10 +59,10 @@
         mod.start();
         src.start();
 
-        let buffer = await context.startRendering();
+        const buffer = await context.startRendering();
 
-        let input = buffer.getChannelData(1);
-        let output = buffer.getChannelData(0);
+        const input = buffer.getChannelData(1);
+        const output = buffer.getChannelData(0);
 
         // Have to test manually for NaN values in the input because
         // NaN fails all comparisons.
@@ -76,17 +74,14 @@
           }
         }
 
-        should(isNaN, 'AudioParam input contains only NaN').beTrue();
+        assert_true(isNaN, 'AudioParam input contains only NaN');
 
         // Output of the AudioParam should have all NaN values
         // replaced by the default.
-        should(output, 'AudioParam output')
-            .beConstantValueOf(src.offset.defaultValue);
-
-        task.done();
-      });
-
-      audit.run();
+        assert_constant_value(
+            output, src.offset.defaultValue,
+            'AudioParam output should flush NaN to default');
+      }, 'AudioParam NaN should be flushed to default value');
     </script>
   </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/retrospective-setTargetAtTime-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/retrospective-setTargetAtTime-expected.txt
@@ -1,11 +1,3 @@
 
-PASS # AUDIT TASK RUNNER STARTED.
-PASS Executing "test"
-PASS Audit report
-PASS > [test] Test setTargetAtTime with start time in the past
-PASS   Test[0:127] contains only the constant 1.
-PASS   Reference[0:127] contains only the constant 1.
-PASS   Test[128:] is identical to the array [expected array].
-PASS < [test] All assertions passed. (total 3 assertions)
-PASS # AUDIT TASK RUNNER FINISHED: 1 tasks ran successfully.
+PASS Test setTargetAtTime with start time in the past
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/retrospective-setTargetAtTime.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/retrospective-setTargetAtTime.html
@@ -1,80 +1,63 @@
-<!doctype html>
+<!DOCTYPE html>
 <meta charset=utf-8>
 <html>
   <head>
     <title>Test setTargetAtTime with start time in the past</title>
-    <script src=/resources/testharness.js></script>
-    <script src=/resources/testharnessreport.js></script>
-    <script src="/webaudio/resources/audit-util.js"></script>
-    <script src="/webaudio/resources/audit.js"></script>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
   </head>
   <body>
     <script>
-      let audit = Audit.createTaskRunner();
+      const suspendFrame = 128;
 
-      audit.define(
-          {
-            label: 'test',
-            description: 'Test setTargetAtTime with start time in the past'
-          },
-          (task, should) => {
-            // Use a sample rate that is a power of two to eliminate round-off
-            // in computing the currentTime.
-            let context = new OfflineAudioContext(2, 16384, 16384);
-            let source = new ConstantSourceNode(context);
+      promise_test(async () => {
+        // Use a sample rate that is a power of two to eliminate round-off
+        // in computing the currentTime.
+        const context = new OfflineAudioContext(2, 16384, 16384);
+        const source = new ConstantSourceNode(context);
 
-            // Suspend the context at this frame so we can synchronously set up
-            // automations.
-            const suspendFrame = 128;
+        const test = new GainNode(context);
+        const reference = new GainNode(context);
 
-            let test = new GainNode(context);
-            let reference = new GainNode(context);
+        source.connect(test);
+        source.connect(reference);
 
-            source.connect(test);
-            source.connect(reference);
+        const merger = new ChannelMergerNode(
+            context, {numberOfInputs: context.destination.channelCount});
+        test.connect(merger, 0, 0);
+        reference.connect(merger, 0, 1);
 
-            let merger = new ChannelMergerNode(
-                context, {numberOfInputs: context.destination.channelCount});
-            test.connect(merger, 0, 0);
-            reference.connect(merger, 0, 1);
+        merger.connect(context.destination);
 
-            merger.connect(context.destination);
+        context.suspend(suspendFrame / context.sampleRate).then(() => {
+          // Call setTargetAtTime with a time in the past
+          test.gain.setTargetAtTime(0.1, 0.5*context.currentTime, 0.1);
+          reference.gain.setTargetAtTime(0.1, context.currentTime, 0.1);
+          context.resume();
+        });
 
-            context.suspend(suspendFrame / context.sampleRate)
-                .then(() => {
-                  // Call setTargetAtTime with a time in the past
-                  test.gain.setTargetAtTime(0.1, 0.5*context.currentTime, 0.1);
-                  reference.gain.setTargetAtTime(0.1, context.currentTime, 0.1);
-                })
-                .then(() => context.resume());
+        source.start();
 
-            source.start();
+        const resultBuffer = await context.startRendering();
+        const testValue = resultBuffer.getChannelData(0);
+        const referenceValue = resultBuffer.getChannelData(1);
 
-            context.startRendering()
-                .then(resultBuffer => {
-                  let testValue = resultBuffer.getChannelData(0);
-                  let referenceValue = resultBuffer.getChannelData(1);
+        // Until the suspendFrame, both should be exactly equal to 1.
+        assert_array_equals(
+            testValue.slice(0, suspendFrame),
+            new Float32Array(suspendFrame).fill(1),
+            `Test[0:${suspendFrame - 1}]`);
+        assert_array_equals(
+            referenceValue.slice(0, suspendFrame),
+            new Float32Array(suspendFrame).fill(1),
+            `Reference[0:${suspendFrame - 1}]`);
 
-                  // Until the suspendFrame, both should be exactly equal to 1.
-                  should(
-                      testValue.slice(0, suspendFrame),
-                      `Test[0:${suspendFrame - 1}]`)
-                      .beConstantValueOf(1);
-                  should(
-                      referenceValue.slice(0, suspendFrame),
-                      `Reference[0:${suspendFrame - 1}]`)
-                      .beConstantValueOf(1);
-
-                  // After the suspendFrame, both should be equal (and not
-                  // constant)
-                  should(
-                      testValue.slice(suspendFrame), `Test[${suspendFrame}:]`)
-                      .beEqualToArray(referenceValue.slice(suspendFrame));
-                })
-                .then(() => task.done());
-          });
-
-      audit.run();
+        // After the suspendFrame, both should be equal (and not constant)
+        assert_array_equals(
+            testValue.slice(suspendFrame),
+            referenceValue.slice(suspendFrame),
+            `Test[${suspendFrame}:]`);
+      }, 'Test setTargetAtTime with start time in the past');
     </script>
   </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/set-target-conv-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/set-target-conv-expected.txt
@@ -1,13 +1,3 @@
 
-PASS # AUDIT TASK RUNNER STARTED.
-PASS Executing "convergence handled correctly"
-PASS Audit report
-PASS > [convergence handled correctly]
-PASS   src = new ConstantSourceNode(context) did not throw an exception.
-PASS   src.offset.setTargetAtTime(0.5, 0.01, 0.01) did not throw an exception.
-PASS   src.offset.setValueAtTime(0.5, 0.15) did not throw an exception.
-PASS   src.offset.linearRampToValueAtTime(1, 0.151) did not throw an exception.
-PASS   output[1072:] equals [0.5,0.5,0.5,0.5,0.5,0.5,0.5,0.5,0.5,0.5,0.5,0.5,0.5,0.5,0.5,0.5...] with an element-wise tolerance of {"absoluteThreshold":0,"relativeThreshold":0.000004}.
-PASS < [convergence handled correctly] All assertions passed. (total 5 assertions)
-PASS # AUDIT TASK RUNNER FINISHED: 1 tasks ran successfully.
+PASS setTargetAtTime: convergence handled correctly
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/set-target-conv.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/set-target-conv.html
@@ -1,93 +1,78 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<!DOCTYPE html>
 <html>
   <head>
     <title>Test convergence of setTargetAtTime</title>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
-    <script src="/webaudio/resources/audit.js"></script>
     <script src='/webaudio/resources/audio-param.js'></script>
+    <script src="/webaudio/resources/audit-util.js"></script>
   </head>
 
   <body>
     <script>
-      let audit = Audit.createTaskRunner();
+      promise_test(async () => {
+        // Two channels:
+        //  0 - actual result
+        //  1 - expected result
+        const context = new OfflineAudioContext(
+            {numberOfChannels: 2, sampleRate: 8000, length: 8000});
 
-      audit.define(
-          {task: 'setTargetAtTime', label: 'convergence handled correctly'},
-          (task, should) => {
-            // Two channels:
-            //  0 - actual result
-            //  1 - expected result
-            const context = new OfflineAudioContext(
-                {numberOfChannels: 2, sampleRate: 8000, length: 8000});
+        const merger = new ChannelMergerNode(
+            context, {numberOfChannels: context.destination.channelCount});
+        merger.connect(context.destination);
 
-            const merger = new ChannelMergerNode(
-                context, {numberOfChannels: context.destination.channelCount});
-            merger.connect(context.destination);
+        // Construct test source that will have the AudioParams being tested
+        // to verify that the AudioParams are working correctly.
+        const src = new ConstantSourceNode(context);
 
-            // Construct test source that will have tha AudioParams being tested
-            // to verify that the AudioParams are working correctly.
-            let src;
+        src.connect(merger, 0, 0);
+        src.offset.setValueAtTime(1, 0);
 
-            should(
-                () => src = new ConstantSourceNode(context),
-                'src = new ConstantSourceNode(context)')
-                .notThrow();
+        const timeConstant = 0.01;
 
-            src.connect(merger, 0, 0);
-            src.offset.setValueAtTime(1, 0);
+        // testTime must be at least 10*timeConstant. Also, this must not
+        // lie on a render boundary.
+        const testTime = 0.15;
+        const rampEnd = testTime + 0.001;
 
-            const timeConstant = 0.01;
+        src.offset.setTargetAtTime(0.5, 0.01, timeConstant);
+        src.offset.setValueAtTime(0.5, testTime);
+        src.offset.linearRampToValueAtTime(1, rampEnd);
 
-            // testTime must be at least 10*timeConstant. Also, this must not
-            // lie on a render boundary.
-            const testTime = 0.15;
-            const rampEnd = testTime + 0.001;
+        // The reference node that will generate the expected output.  We do
+        // the same automations, except we don't apply the setTarget
+        // automation.
+        const refSrc = new ConstantSourceNode(context);
+        refSrc.connect(merger, 0, 1);
 
-            should(
-                () => src.offset.setTargetAtTime(0.5, 0.01, timeConstant),
-                `src.offset.setTargetAtTime(0.5, 0.01, ${timeConstant})`)
-                .notThrow();
-            should(
-                () => src.offset.setValueAtTime(0.5, testTime),
-                `src.offset.setValueAtTime(0.5, ${testTime})`)
-                .notThrow();
-            should(
-                () => src.offset.linearRampToValueAtTime(1, rampEnd),
-                `src.offset.linearRampToValueAtTime(1, ${rampEnd})`)
-                .notThrow();
+        refSrc.offset.setValueAtTime(0.5, 0);
+        refSrc.offset.setValueAtTime(0.5, testTime);
+        refSrc.offset.linearRampToValueAtTime(1, rampEnd);
 
-            // The reference node that will generate the expected output.  We do
-            // the same automations, except we don't apply the setTarget
-            // automation.
-            const refSrc = new ConstantSourceNode(context);
-            refSrc.connect(merger, 0, 1);
+        src.start();
+        refSrc.start();
 
-            refSrc.offset.setValueAtTime(0.5, 0);
-            refSrc.offset.setValueAtTime(0.5, testTime);
-            refSrc.offset.linearRampToValueAtTime(1, rampEnd);
+        const resultBuffer = await context.startRendering();
+        const actual = resultBuffer.getChannelData(0);
+        const expected = resultBuffer.getChannelData(1);
 
-            src.start();
-            refSrc.start();
+        // Just verify that the actual output matches the expected
+        // starting a little bit before testTime.
+        const testFrame = Math.floor(testTime * context.sampleRate) - 128;
+        const actualSlice = actual.slice(testFrame);
+        const expectedSlice = expected.slice(testFrame);
 
-            context.startRendering()
-                .then(audio => {
-                  const actual = audio.getChannelData(0);
-                  const expected = audio.getChannelData(1);
+        assert_equals(
+            actualSlice.length, expectedSlice.length,
+            `output[${testFrame}:] length`);
 
-                  // Just verify that the actual output matches the expected
-                  // starting a little bit before testTime.
-                  let testFrame =
-                      Math.floor(testTime * context.sampleRate) - 128;
-                  should(actual.slice(testFrame), `output[${testFrame}:]`)
-                      .beCloseToArray(
-                          expected.slice(testFrame),
-                          {relativeThreshold: 4.1724e-6});
-                })
-                .then(() => task.done());
-          });
-
-      audit.run();
+        const relThreshold = 4.1724e-6;
+        assert_array_equal_within_eps(
+            actualSlice,
+            expectedSlice,
+            relThreshold,
+            `output[${testFrame}] approx expected (rel ${relThreshold})`);
+      }, 'setTargetAtTime: convergence handled correctly');
     </script>
   </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioworklet-interface/audioworklet-audioparam.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioworklet-interface/audioworklet-audioparam.https-expected.txt
@@ -1,14 +1,3 @@
 
-PASS # AUDIT TASK RUNNER STARTED.
-PASS Executing "Initializing AudioWorklet and Context"
-PASS Executing "Verifying AudioParam in AudioWorkletNode"
-PASS Audit report
-PASS > [Initializing AudioWorklet and Context]
-PASS < [Initializing AudioWorklet and Context] All assertions passed. (total 0 assertions)
-PASS > [Verifying AudioParam in AudioWorkletNode]
-PASS   Default gain value of gainWorkletNode is equal to 0.707000.
-PASS   Value of gainWorkletParam after setter = 0.1 is equal to 0.100000.
-PASS   The rendered buffer contains only the constant 0.
-PASS < [Verifying AudioParam in AudioWorkletNode] All assertions passed. (total 3 assertions)
-PASS # AUDIT TASK RUNNER FINISHED: 2 tasks ran successfully.
+PASS Verifying AudioParam in AudioWorkletNode
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioworklet-interface/audioworklet-audioparam.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioworklet-interface/audioworklet-audioparam.https.html
@@ -6,80 +6,60 @@
     </title>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
-    <script src="/webaudio/resources/audit.js"></script>
   </head>
   <body>
-    <script id="layout-test-code">
-      let audit = Audit.createTaskRunner();
+    <script>
+      const sampleRate = 48000;
+      const renderLength = 48000 * 0.6;
+      const filePath = 'processors/gain-processor.js';
 
-      let sampleRate = 48000;
-      let renderLength = 48000 * 0.6;
-      let context;
+      promise_test(async t => {
+        const context = new OfflineAudioContext(1, renderLength, sampleRate);
+        await context.audioWorklet.addModule(filePath);
+        const constantSourceNode = new ConstantSourceNode(context);
+        const gainNode = new GainNode(context);
+        const inverterNode = new GainNode(context, {gain: -1});
+        const gainWorkletNode = new AudioWorkletNode(context, 'gain');
+        const gainWorkletParam = gainWorkletNode.parameters.get('gain');
 
-      let filePath = 'processors/gain-processor.js';
+        assert_equals(
+            gainWorkletParam.value,
+            Math.fround(0.707),
+            'Default gain value of gainWorkletNode');
+        gainWorkletParam.value = 0.1;
+        assert_equals(
+            gainWorkletParam.value,
+            Math.fround(0.1),
+            'Value of gainWorkletParam after setter = 0.1');
 
-      // Sets up AudioWorklet and OfflineAudioContext.
-      audit.define('Initializing AudioWorklet and Context', (task, should) => {
-        context = new OfflineAudioContext(1, renderLength, sampleRate);
-        context.audioWorklet.addModule(filePath).then(() => {
-          task.done();
+        constantSourceNode.connect(gainNode)
+            .connect(inverterNode)
+            .connect(context.destination);
+        constantSourceNode.connect(gainWorkletNode)
+            .connect(context.destination);
+
+        [gainNode.gain, gainWorkletParam].forEach(param => {
+          param.setValueAtTime(0, 0);
+          param.linearRampToValueAtTime(1, 0.1);
+          param.exponentialRampToValueAtTime(0.5, 0.2);
+          param.setValueCurveAtTime([0, 2, 0.3], 0.2, 0.1);
+          param.setTargetAtTime(0.01, 0.4, 0.5);
         });
-      });
 
-      // Verifies the functionality of AudioParam in AudioWorkletNode by
-      // comparing (canceling out) values from GainNode and AudioWorkletNode
-      // with simple gain computation code by AudioParam.
-      audit.define(
-          'Verifying AudioParam in AudioWorkletNode',
-          (task, should) => {
-            let constantSourceNode = new ConstantSourceNode(context);
-            let gainNode = new GainNode(context);
-            let inverterNode = new GainNode(context, {gain: -1});
-            let gainWorkletNode = new AudioWorkletNode(context, 'gain');
-            let gainWorkletParam = gainWorkletNode.parameters.get('gain');
+        context.suspend(0.5).then(() => {
+          gainNode.gain.value = 1.5;
+          gainWorkletParam.value = 1.5;
+          context.resume();
+        });
 
-            // Test default value and setter/getter functionality.
-            should(gainWorkletParam.value,
-                   'Default gain value of gainWorkletNode')
-                .beEqualTo(Math.fround(0.707));
-            gainWorkletParam.value = 0.1;
-            should(gainWorkletParam.value,
-                   'Value of gainWorkletParam after setter = 0.1')
-                .beEqualTo(Math.fround(0.1));
-
-            constantSourceNode.connect(gainNode)
-                .connect(inverterNode)
-                .connect(context.destination);
-            constantSourceNode.connect(gainWorkletNode)
-                .connect(context.destination);
-
-            // With arbitrary times and values, test all possible AudioParam
-            // automations.
-            [gainNode.gain, gainWorkletParam].forEach((param) => {
-              param.setValueAtTime(0, 0);
-              param.linearRampToValueAtTime(1, 0.1);
-              param.exponentialRampToValueAtTime(0.5, 0.2);
-              param.setValueCurveAtTime([0, 2, 0.3], 0.2, 0.1);
-              param.setTargetAtTime(0.01, 0.4, 0.5);
-            });
-
-            // Test if the setter works correctly in the middle of rendering.
-            context.suspend(0.5).then(() => {
-              gainNode.gain.value = 1.5;
-              gainWorkletParam.value = 1.5;
-              context.resume();
-            });
-
-            constantSourceNode.start();
-            context.startRendering().then((renderedBuffer) => {
-              should(renderedBuffer.getChannelData(0),
-                     'The rendered buffer')
-                  .beConstantValueOf(0);
-              task.done();
-            });
-          });
-
-      audit.run();
+        constantSourceNode.start();
+        const renderedBuffer = await context.startRendering();
+        const actual = renderedBuffer.getChannelData(0);
+        assert_array_equals(
+            actual,
+            new Float32Array(actual.length),
+            'The rendered buffer should be constant 0');
+      }, 'Verifying AudioParam in AudioWorkletNode');
     </script>
   </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioworklet-interface/audioworkletnode-disconnected-input.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioworklet-interface/audioworkletnode-disconnected-input.https-expected.txt
@@ -1,12 +1,3 @@
 
-PASS # AUDIT TASK RUNNER STARTED.
-PASS Executing "test"
-PASS Audit report
-PASS > [test] Input array length should be zero for disconnected input
-PASS   Before connecting the source: Input array length contains only the constant 0.
-PASS   First non-zero output is equal to 128.
-PASS   While source is connected: Input array length contains only the constant 128.
-PASS   After disconnecting the source: Input array length contains only the constant 0.
-PASS < [test] All assertions passed. (total 4 assertions)
-PASS # AUDIT TASK RUNNER FINISHED: 1 tasks ran successfully.
+PASS Input array length should be zero for disconnected input
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioworklet-interface/audioworkletnode-disconnected-input.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioworklet-interface/audioworkletnode-disconnected-input.https.html
@@ -6,95 +6,84 @@
     </title>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
-    <script src="/webaudio/resources/audit.js"></script>
     <script src="/webaudio/resources/audit-util.js"></script>
   </head>
   <body>
-    <script id="layout-test-code">
-      let audit = Audit.createTaskRunner();
-
+    <script>
       // Arbitrary numbers used to align the test with render quantum boundary.
       // The sample rate is a power of two to eliminate roundoff in computing
       // the suspend time needed for the test.
-      let sampleRate = 16384;
-      let renderLength = 8 * RENDER_QUANTUM_FRAMES;
-      let context;
-
-      let filePath = 'processors/input-length-processor.js';
-
-      let testChannelValues = [1, 2, 3];
+      const sampleRate = 16384;
+      const renderLength = 8 * RENDER_QUANTUM_FRAMES;
+      const filePath = 'processors/input-length-processor.js';
 
       // Creates a 3-channel buffer and play with BufferSourceNode. The source
       // goes through a bypass AudioWorkletNode (gain value of 1).
-      audit.define(
-          {
-            label: 'test',
-            description:
-                'Input array length should be zero for disconnected input'
-          },
-          (task, should) => {
-            context = new OfflineAudioContext({
-              numberOfChannels: 1,
-              length: renderLength,
-              sampleRate: sampleRate
-            });
+      promise_test(async () => {
+        const context = new OfflineAudioContext({
+          numberOfChannels: 1,
+          length: renderLength,
+          sampleRate: sampleRate
+        });
 
-            context.audioWorklet.addModule(filePath).then(() => {
-              let sourceNode = new ConstantSourceNode(context);
-              let workletNode =
-                  new AudioWorkletNode(context, 'input-length-processor');
+        await context.audioWorklet.addModule(filePath);
 
-              workletNode.connect(context.destination);
+        const sourceNode = new ConstantSourceNode(context);
+        const workletNode =
+            new AudioWorkletNode(context, 'input-length-processor');
 
-              // Connect the source now.
-              let connectFrame = RENDER_QUANTUM_FRAMES;
+        workletNode.connect(context.destination);
 
-              context.suspend(connectFrame / sampleRate)
-                  .then(() => {
-                    sourceNode.connect(workletNode);
-                  })
-                  .then(() => context.resume());
-              ;
+        // Connect the source after one render quantum.
+        const connectFrame = RENDER_QUANTUM_FRAMES;
+        context.suspend(connectFrame / sampleRate).then(() => {
+          sourceNode.connect(workletNode);
+          return context.resume();
+        });
+        // Disconnect the source after three render quanta.
+        const disconnectFrame = 3 * RENDER_QUANTUM_FRAMES;
+        context.suspend(disconnectFrame / sampleRate).then(() => {
+          sourceNode.disconnect(workletNode);
+          return context.resume();
+        });
 
-              // Then disconnect the source after a few renders
-              let disconnectFrame = 3 * RENDER_QUANTUM_FRAMES;
-              context.suspend(disconnectFrame / sampleRate)
-                  .then(() => {
-                    sourceNode.disconnect(workletNode);
-                  })
-                  .then(() => context.resume());
+        sourceNode.start();
+        const resultBuffer = await context.startRendering();
+        const data = resultBuffer.getChannelData(0);
 
-              sourceNode.start();
-              context.startRendering()
-                  .then(resultBuffer => {
-                    let data = resultBuffer.getChannelData(0);
+        // Before connecting the source: input array length should be 0.
+        assert_array_equals(
+            data.subarray(0, connectFrame),
+            new Float32Array(connectFrame),
+            'Before connecting the source: Input array length should be 0');
 
-                    should(
-                        data.slice(0, connectFrame),
-                        'Before connecting the source: Input array length')
-                        .beConstantValueOf(0);
+        // Find where the output is no longer 0.
+        const nonZeroIndex = data.findIndex(x => x > 0);
+        assert_equals(
+            nonZeroIndex,
+            connectFrame,
+            'First non-zero output should occur exactly at connectFrame');
 
-                    // Find where the output is no longer 0.
-                    let nonZeroIndex = data.findIndex(x => x > 0);
-                    should(nonZeroIndex, 'First non-zero output')
-                        .beEqualTo(connectFrame);
+        // While source is connected: Input array length
+        // should be RENDER_QUANTUM_FRAMES
+        {
+          const expectedLength = disconnectFrame - connectFrame;
+          const expected =
+              new Float32Array(expectedLength).fill(RENDER_QUANTUM_FRAMES);
+          assert_array_equals(
+              data.subarray(connectFrame, disconnectFrame), expected,
+              'While source is connected: Input array length');
+        }
 
-                    should(
-                        data.slice(
-                            nonZeroIndex,
-                            nonZeroIndex + (disconnectFrame - connectFrame)),
-                        'While source is connected: Input array length')
-                        .beConstantValueOf(RENDER_QUANTUM_FRAMES);
-                    should(
-                        data.slice(disconnectFrame),
-                        'After disconnecting the source: Input array length')
-                        .beConstantValueOf(0);
-                  })
-                  .then(() => task.done());
-            });
-          });
-
-      audit.run();
+        // After disconnecting the source: Input array length should be zero
+        {
+          const expectedLength = data.length - disconnectFrame;
+          const expected = new Float32Array(expectedLength);
+          assert_array_equals(
+              data.subarray(disconnectFrame), expected,
+              'After disconnecting the source: Input array length');
+        }
+      }, 'Input array length should be zero for disconnected input');
     </script>
   </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioworklet-interface/simple-input-output.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioworklet-interface/simple-input-output.https-expected.txt
@@ -1,14 +1,4 @@
 
-PASS # AUDIT TASK RUNNER STARTED.
-PASS Executing "Initialize worklet"
-PASS Executing "test"
-PASS Audit report
-PASS > [Initialize worklet]
-PASS   Creation of AudioWorklet resolved correctly.
-PASS < [Initialize worklet] All assertions passed. (total 1 assertions)
-PASS > [test] Simple AudioWorklet I/O
-PASS   AudioWorklet output[0:127] equals [expected array] with an element-wise tolerance of {"absoluteThreshold":0,"relativeThreshold":0}.
-PASS   AudioWorklet output[128:] contains only the constant 1.
-PASS < [test] All assertions passed. (total 2 assertions)
-PASS # AUDIT TASK RUNNER FINISHED: 2 tasks ran successfully.
+PASS Initialize worklet: Creation of AudioWorklet
+PASS test: Simple AudioWorklet I/O
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioworklet-interface/simple-input-output.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioworklet-interface/simple-input-output.https.html
@@ -1,10 +1,11 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Test Simple AudioWorklet I/O</title>
+    <title>
+      Test Simple AudioWorklet I/O
+    </title>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
-    <script src="/webaudio/resources/audit.js"></script>
     <script src="/webaudio/resources/audit-util.js"></script>
   </head>
 
@@ -19,12 +20,10 @@
       // Location of the worklet's code
       const filePath = 'processors/add-offset.js';
 
-      let audit = Audit.createTaskRunner();
-
       // Context to be used for the tests.
       let context;
 
-      audit.define('Initialize worklet', (task, should) => {
+      promise_test(async () => {
         // Two channels for testing.  Channel 0 is the output of the
         // AudioWorklet.  Channel 1 is the oscillator so we can compare
         // the outputs.
@@ -32,59 +31,49 @@
             {numberOfChannels: 2, length: sampleRate, sampleRate: sampleRate});
 
         // Load up the code for the worklet.
-        should(
-            context.audioWorklet.addModule(filePath),
-            'Creation of AudioWorklet')
-            .beResolved()
-            .then(() => task.done());
-      });
+        await context.audioWorklet.addModule(filePath);
+      }, 'Initialize worklet: Creation of AudioWorklet');
 
-      audit.define(
-          {label: 'test', description: 'Simple AudioWorklet I/O'},
-          (task, should) => {
-            let merger = new ChannelMergerNode(
-                context, {numberOfChannels: context.destination.channelCount});
-            merger.connect(context.destination);
+      promise_test(async () => {
+        const merger = new ChannelMergerNode(
+            context, {numberOfChannels: context.destination.channelCount});
+        merger.connect(context.destination);
 
-            let src = new OscillatorNode(context);
+        const src = new OscillatorNode(context);
 
-            let worklet = new AudioWorkletNode(
-                context, 'add-offset-processor',
-                {processorOptions: {offset: offset}});
+        const worklet = new AudioWorkletNode(
+            context, 'add-offset-processor',
+            {processorOptions: {offset: offset}});
 
-            src.connect(worklet).connect(merger, 0, 0);
-            src.connect(merger, 0, 1);
+        src.connect(worklet).connect(merger, 0, 0);
+        src.connect(merger, 0, 1);
 
-            // Start and stop the source.  The stop time is fairly arbitrary,
-            // but use a render quantum boundary for simplicity.
-            const stopFrame = RENDER_QUANTUM_FRAMES;
-            src.start(0);
-            src.stop(stopFrame / context.sampleRate);
+        // Start and stop the source.  The stop time is fairly arbitrary,
+        // but use a render quantum boundary for simplicity.
+        const stopFrame = RENDER_QUANTUM_FRAMES;
+        src.start();
+        src.stop(stopFrame / context.sampleRate);
 
-            context.startRendering()
-                .then(buffer => {
-                  let ch0 = buffer.getChannelData(0);
-                  let ch1 = buffer.getChannelData(1);
+        const resultBuffer = await context.startRendering();
+        const ch0 = resultBuffer.getChannelData(0);
+        const ch1 = resultBuffer.getChannelData(1);
 
-                  let shifted = ch1.slice(0, stopFrame).map(x => x + offset);
+        const shifted = ch1.slice(0, stopFrame).map(x => x + offset);
 
-                  // The initial part of the output should be the oscillator
-                  // shifted by |offset|.
-                  should(
-                      ch0.slice(0, stopFrame),
-                      `AudioWorklet output[0:${stopFrame - 1}]`)
-                      .beCloseToArray(shifted, {absoluteThreshold: 0});
+        // The initial part of the output should be the oscillator
+        // shifted by |offset|.
+        assert_array_equal_within_eps(
+            ch0.slice(0, stopFrame),
+            shifted,
+            {absoluteThreshold: 0},
+            `AudioWorklet output[0:${stopFrame - 1}]`);
 
-                  // Output should be constant after the source has stopped.
-                  should(
-                      ch0.slice(stopFrame),
-                      `AudioWorklet output[${stopFrame}:]`)
-                      .beConstantValueOf(offset);
-                })
-                .then(() => task.done());
-          });
-
-      audit.run();
+        // Output should be constant after the source has stopped.
+        assert_array_equals(
+            ch0.slice(stopFrame),
+            new Float32Array(ch0.slice(stopFrame).length).fill(offset),
+            `AudioWorklet output[${stopFrame}:]`);
+      }, 'test: Simple AudioWorklet I/O');
     </script>
   </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-convolvernode-interface/active-processing.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-convolvernode-interface/active-processing.https-expected.txt
@@ -1,15 +1,4 @@
 
-PASS # AUDIT TASK RUNNER STARTED.
-PASS Executing "initialize"
-PASS Executing "test"
-PASS Audit report
-PASS > [initialize]
-PASS   AudioWorklet module loading resolved correctly.
-PASS < [initialize] All assertions passed. (total 1 assertions)
-PASS > [test]
-PASS   Test 0: Number of convolver output channels is equal to 2.
-PASS   Test 1: Number of convolver output channels is equal to 0.
-PASS   Number of distinct values is equal to 2.
-PASS < [test] All assertions passed. (total 3 assertions)
-PASS # AUDIT TASK RUNNER FINISHED: 2 tasks ran successfully.
+PASS AudioWorklet module should load successfully
+PASS ConvolverNode should stop active processing after source stops
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-convolvernode-interface/active-processing.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-convolvernode-interface/active-processing.https.html
@@ -6,36 +6,31 @@
     </title>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
-    <script src="/webaudio/resources/audit-util.js"></script>
-    <script src="/webaudio/resources/audit.js"></script>
   </head>
 
   <body>
-    <script id="layout-test-code">
-      // AudioProcessor that sends a message to its AudioWorkletNode whenver the
-      // number of channels on its input changes.
-      let filePath =
+    <script>
+      // AudioProcessor that sends a message to its AudioWorkletNode
+      // whenever the number of channels on its input changes.
+      const filePath =
           '../the-audioworklet-interface/processors/active-processing.js';
-
-      const audit = Audit.createTaskRunner();
 
       let context;
 
-      audit.define('initialize', (task, should) => {
+      promise_test(async () => {
         // Create context and load the module
         context = new AudioContext();
-        should(
-            context.audioWorklet.addModule(filePath),
-            'AudioWorklet module loading')
-            .beResolved()
-            .then(() => task.done());
-      });
+        await context.audioWorklet.addModule(filePath);
+      }, 'AudioWorklet module should load successfully');
 
-      audit.define('test', (task, should) => {
+      promise_test(async () => {
         const src = new OscillatorNode(context);
 
-        const response = new AudioBuffer({numberOfChannels: 2, length: 150,
-        sampleRate: context.sampleRate});
+        const response = new AudioBuffer({
+          numberOfChannels: 2,
+          length: 150,
+          sampleRate: context.sampleRate
+        });
 
         const conv = new ConvolverNode(context, {buffer: response});
 
@@ -43,51 +38,52 @@
             new AudioWorkletNode(context, 'active-processing-tester', {
               // Use as short a duration as possible to keep the test from
               // taking too much time.
-              processorOptions: {testDuration: .5},
+              processorOptions: {testDuration: 0.5},
             });
 
-        // Expected number of output channels from the convolver node.  We should
-        // start with the number of inputs, because the source (oscillator) is
-        // actively processing.  When the source stops, the number of channels
-        // should change to 0.
+        // Expected number of output channels from the convolver node.
+        // We should start with the number of inputs, because the
+        // source (oscillator) is actively processing. When the source
+        // stops, the number of channels should change to 0.
         const expectedValues = [2, 0];
         let index = 0;
 
-        testerNode.port.onmessage = event => {
-          let count = event.data.channelCount;
-          let finished = event.data.finished;
+        return new Promise(resolve => {
+          testerNode.port.onmessage = event => {
+            const count = event.data.channelCount;
+            const finished = event.data.finished;
 
-          // If we're finished, end testing.
-          if (finished) {
-            // Verify that we got the expected number of changes.
-            should(index, 'Number of distinct values')
-                .beEqualTo(expectedValues.length);
+            // If we're finished, end testing.
+            if (finished) {
+              // Verify that we got the expected number of changes.
+              assert_equals(
+                  index, expectedValues.length,
+                  'Number of distinct values');
+              resolve();
+              return;
+            }
 
-            task.done();
-            return;
-          }
+            if (index < expectedValues.length) {
+              // Verify that the number of channels matches the expected
+              // number of channels.
+              assert_equals(
+                  count, expectedValues[index],
+                  `Test ${index}: Number of convolver output channels`);
+            }
 
-          if (index < expectedValues.length) {
-            // Verify that the number of channels matches the expected number of
-            // channels.
-            should(count, `Test ${index}: Number of convolver output channels`)
-                .beEqualTo(expectedValues[index]);
-          }
+            ++index;
+          };
 
-          ++index;
-        };
+          // Create the graph and go
+          src.connect(conv).connect(testerNode).connect(context.destination);
+          src.start();
 
-        // Create the graph and go
-        src.connect(conv).connect(testerNode).connect(context.destination);
-        src.start();
-
-        // Stop the source after a short time so we can test that the convolver
-        // changes to not actively processing and thus produces a single channel
-        // of silence.
-        src.stop(context.currentTime + .1);
-      });
-
-      audit.run();
+          // Stop the source after a short time so we can test that the
+          // convolver changes to not actively processing and thus
+          // produces a single channel of silence.
+          src.stop(context.currentTime + 0.1);
+        });
+      }, 'ConvolverNode should stop active processing after source stops');
     </script>
   </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-pannernode-interface/panner-rolloff-clamping-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-pannernode-interface/panner-rolloff-clamping-expected.txt
@@ -1,9 +1,3 @@
 
-PASS # AUDIT TASK RUNNER STARTED.
-PASS Executing "linear-clamp-high"
-PASS Audit report
-PASS > [linear-clamp-high] rolloffFactor clamping for linear distance model
-PASS   Panner distanceModel: "linear", rolloffFactor: 2 is identical to the array [expected array].
-PASS < [linear-clamp-high] All assertions passed. (total 1 assertions)
-PASS # AUDIT TASK RUNNER FINISHED: 1 tasks ran successfully.
+PASS rolloffFactor clamping for linear distance model
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-pannernode-interface/panner-rolloff-clamping.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-pannernode-interface/panner-rolloff-clamping.html
@@ -6,30 +6,12 @@
     </title>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
-    <script src="../../resources/audit-util.js"></script>
-    <script src="../../resources/audit.js"></script>
   </head>
   <body>
-    <script id="layout-test-code">
+    <script>
       // Fairly arbitrary sample rate and render frames.
-      let sampleRate = 16000;
-      let renderFrames = 2048;
-
-      let audit = Audit.createTaskRunner();
-
-      audit.define(
-          {
-            label: 'linear-clamp-high',
-            description: 'rolloffFactor clamping for linear distance model'
-          },
-          (task, should) => {
-            runTest(should, {
-              distanceModel: 'linear',
-              // Fairly arbitrary value outside the nominal range
-              rolloffFactor: 2,
-              clampedRolloff: 1
-            }).then(() => task.done());
-          });
+      const sampleRate = 16000;
+      const renderFrames = 2048;
 
       // Test clamping of the rolloffFactor.  The test is done by comparing the
       // output of a panner with the rolloffFactor set outside the nominal range
@@ -42,18 +24,18 @@
       //                    nominal range of the distance model.
       //   clampedRolloff - The rolloffFactor (above) clamped to the nominal
       //                    range for the given distance model.
-      function runTest(should, options) {
+      const runTest = async (options) => {
         // Offline context with two channels.  The first channel is the panner
         // node under test.  The second channel is the reference panner node.
-        let context = new OfflineAudioContext(2, renderFrames, sampleRate);
+        const context = new OfflineAudioContext(2, renderFrames, sampleRate);
 
         // The source for the panner nodes.  This is fairly arbitrary.
-        let src = new OscillatorNode(context, {type: 'sawtooth'});
+        const src = new OscillatorNode(context, {type: 'sawtooth'});
 
         // Create the test panner with the specified rolloff factor.  The
         // position is fairly arbitrary, but something that is not the default
         // is good to show the distance model had some effect.
-        let pannerTest = new PannerNode(context, {
+        const pannerTest = new PannerNode(context, {
           rolloffFactor: options.rolloffFactor,
           distanceModel: options.distanceModel,
           positionX: 5000
@@ -61,7 +43,7 @@
 
         // Create the reference panner with the rolloff factor clamped to the
         // appropriate limit.
-        let pannerRef = new PannerNode(context, {
+        const pannerRef = new PannerNode(context, {
           rolloffFactor: options.clampedRolloff,
           distanceModel: options.distanceModel,
           positionX: 5000
@@ -69,7 +51,7 @@
 
 
         // Connect the source to the panners to the destination appropriately.
-        let merger = new ChannelMergerNode(context, {numberOfInputs: 2});
+        const merger = new ChannelMergerNode(context, {numberOfInputs: 2});
 
 
         src.connect(pannerTest).connect(merger, 0, 0);
@@ -79,20 +61,20 @@
 
         src.start();
 
-        return context.startRendering().then(function(resultBuffer) {
-          // The two channels should be the same due to the clamping.  Verify
-          // that they are the same.
-          let actual = resultBuffer.getChannelData(0);
-          let expected = resultBuffer.getChannelData(1);
-
-          let message = 'Panner distanceModel: "' + options.distanceModel +
-              '", rolloffFactor: ' + options.rolloffFactor;
-
-          should(actual, message).beEqualToArray(expected);
-        });
-      }
-
-      audit.run();
+        const resultBuffer = await context.startRendering();
+        // The two channels should be the same due to the clamping.  Verify
+        // that they are the same.
+        const actual = resultBuffer.getChannelData(0);
+        const expected = resultBuffer.getChannelData(1);
+        const message = `Panner distanceModel: "${options.distanceModel}", ` +
+            `rolloffFactor: ${options.rolloffFactor}`;
+        assert_array_equals(actual, expected, message);
+      };
+      promise_test(() => runTest({
+        distanceModel: 'linear',
+        rolloffFactor: 2,
+        clampedRolloff: 1
+      }), 'rolloffFactor clamping for linear distance model');
     </script>
   </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-waveshapernode-interface/waveshaper-copy-curve-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-waveshapernode-interface/waveshaper-copy-curve-expected.txt
@@ -1,10 +1,3 @@
 
-PASS # AUDIT TASK RUNNER STARTED.
-PASS Executing "test copying"
-PASS Audit report
-PASS > [test copying] Modifying curve should not modify WaveShaper
-PASS   Modifying curve array at time 0.016 did not throw an exception.
-PASS   Output of WaveShaper with modified curve is identical to the array [expected array].
-PASS < [test copying] All assertions passed. (total 2 assertions)
-PASS # AUDIT TASK RUNNER FINISHED: 1 tasks ran successfully.
+PASS test copying: Modifying curve should not modify WaveShaper
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-waveshapernode-interface/waveshaper-copy-curve.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-waveshapernode-interface/waveshaper-copy-curve.html
@@ -7,94 +7,74 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="../../resources/audit-util.js"></script>
-    <script src="../../resources/audit.js"></script>
   </head>
   <body>
-    <script id="layout-test-code">
+    <script>
       // Sample rate and number of frames are fairly arbitrary.  We need to
       // render, however, at least 384 frames.  1024 is a nice small value.
-      let sampleRate = 16000;
-      let renderFrames = 1024;
+      const sampleRate = 16000;
+      const renderFrames = 1024;
 
-      let audit = Audit.createTaskRunner();
+      promise_test(async () => {
+        // Two-channel context; channel 0 contains the test data and channel
+        // 1 contains the expected result.  Channel 1 has the normal
+        // WaveShaper output and channel 0 has the WaveShaper output with a
+        // modified curve.
+        const context = new OfflineAudioContext(2, renderFrames, sampleRate);
 
-      audit.define(
-          {
-            label: 'test copying',
-            description: 'Modifying curve should not modify WaveShaper'
-          },
-          (task, should) => {
-            // Two-channel context; channel 0 contains the test data and channel
-            // 1 contains the expected result.  Channel 1 has the normal
-            // WaveShaper output and channel 0 has the WaveShaper output with a
-            // modified curve.
-            let context = new OfflineAudioContext(2, renderFrames, sampleRate);
+        // Wave shaper curves.  Doesn't really matter what we use as long as
+        // it modifies the input in some way.  Thus, keep it simple and just
+        // invert the input.
+        const desiredCurve = [1, 0, -1];
+        const curve0 = Float32Array.from(desiredCurve);
+        const curve1 = Float32Array.from(desiredCurve);
 
-            // Just use a default oscillator as the source.  Doesn't really
-            // matter what we use.
-            let src = context.createOscillator();
-            src.type = 'sawtooth';
+        // Just use a default oscillator as the source.  Doesn't really
+        // matter what we use.
+        const src = new OscillatorNode(context, {type: 'sawtooth'});
 
-            // Create the wave shapers: ws0 is the test shaper, and ws1 is the
-            // reference wave shaper.
-            let ws0 = context.createWaveShaper();
-            let ws1 = context.createWaveShaper();
+        // Create the wave shapers: ws0 is the test shaper, and ws1 is the
+        // reference wave shaper.
+        const ws0 = new WaveShaperNode(context, {curve: curve0});
+        const ws1 = new WaveShaperNode(context, {curve: curve1});
 
-            // Wave shaper curves.  Doesn't really matter what we use as long as
-            // it modifies the input in some way.  Thus, keep it simple and just
-            // invert the input.
-            let desiredCurve = [1, 0, -1];
-            let curve0 = Float32Array.from(desiredCurve);
-            let curve1 = Float32Array.from(desiredCurve);
+        // Channel merger for comparing outputs (ch 0: modified-curve shaper,
+        // ch 1: reference shaper).
+        const merger = new ChannelMergerNode(context, {numberOfInputs: 2});
 
-            ws0.curve = curve0;
-            ws1.curve = curve1;
+        src.connect(ws0).connect(merger, 0, 0);
+        src.connect(ws1).connect(merger, 0, 1);
 
-            let merger = context.createChannelMerger(2);
+        merger.connect(context.destination);
 
-            // Connect the graph
-            src.connect(ws0);
-            src.connect(ws1);
+        // Let the context run for a bit and then modify the curve for ws0.
+        // Doesn't really matter what we modify the curve to as long as it's
+        // different.
+        const suspendTime = 256 / context.sampleRate;
+        context.suspend(suspendTime).then(() => {
+          // Mutate the original array we passed to ws0;
+          // node should have copied it.
+          curve0[0] = -0.5;
+          curve0[1] = 0.125;
+          curve0[2] = 0.75;
+          return context.resume();
+        });
 
-            ws0.connect(merger, 0, 0);
-            ws1.connect(merger, 0, 1);
+        src.start();
 
-            merger.connect(context.destination);
+        const renderedBuffer = await context.startRendering();
+        const actual = renderedBuffer.getChannelData(0);
+        const expected = renderedBuffer.getChannelData(1);
 
-            // Let the context run for a bit and then modify the curve for ws0.
-            // Doesn't really matter what we modify the curve to as long as it's
-            // different.
-            context.suspend(256 / context.sampleRate)
-                .then(() => {
-                  should(
-                      () => {
-                        curve0[0] = -0.5;
-                        curve0[1] = 0.125;
-                        curve0[2] = 0.75;
-                      },
-                      `Modifying curve array at time ${context.currentTime}`)
-                      .notThrow();
-                })
-                .then(context.resume.bind(context));
-
-            src.start();
-
-            context.startRendering()
-                .then(function(renderedBuffer) {
-                  let actual = renderedBuffer.getChannelData(0);
-                  let expected = renderedBuffer.getChannelData(1);
-
-                  // Modifying the wave shaper curve should not modify the
-                  // output so the outputs from the two wave shaper nodes should
-                  // be exactly identical.
-                  should(actual, 'Output of WaveShaper with modified curve')
-                      .beEqualToArray(expected);
-
-                })
-                .then(() => task.done());
-          });
-
-      audit.run();
+        // Modifying the wave shaper curve should not modify the
+        // output so the outputs from the two wave shaper nodes should
+        // be exactly identical.
+        assert_array_equals(
+            actual,
+            expected,
+            'Output of WaveShaper with modified curve ' +
+                'should equal reference output');
+      }, `test copying: Modifying curve should not modify WaveShaper`);
     </script>
   </body>
 </html>


### PR DESCRIPTION
#### 12eda6a5e61717a8683a26c33220214ec69ccf07
<pre>
Resync `webaudio` from WPT Upstream
<a href="https://bugs.webkit.org/show_bug.cgi?id=300164">https://bugs.webkit.org/show_bug.cgi?id=300164</a>

Reviewed by Antoine Quint.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/185978d758d6816cb5d544fe2384c8ca085a31a3">https://github.com/web-platform-tests/wpt/commit/185978d758d6816cb5d544fe2384c8ca085a31a3</a>

* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/k-rate-audioworklet.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/k-rate-audioworklet.https.html:
* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/nan-param-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/nan-param.html:
* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/retrospective-setTargetAtTime-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/retrospective-setTargetAtTime.html:
* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/set-target-conv-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/set-target-conv.html:
* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioworklet-interface/audioworklet-audioparam.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioworklet-interface/audioworklet-audioparam.https.html:
* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioworklet-interface/audioworkletnode-disconnected-input.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioworklet-interface/audioworkletnode-disconnected-input.https.html:
* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioworklet-interface/simple-input-output.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioworklet-interface/simple-input-output.https.html:
* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-convolvernode-interface/active-processing.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-convolvernode-interface/active-processing.https.html:
* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-pannernode-interface/panner-rolloff-clamping-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-pannernode-interface/panner-rolloff-clamping.html:
* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-waveshapernode-interface/waveshaper-copy-curve-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-waveshapernode-interface/waveshaper-copy-curve.html:

Canonical link: <a href="https://commits.webkit.org/301021@main">https://commits.webkit.org/301021@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/db2040b39dc7e9ff8d0c75c4224438e3f8abbf96

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124614 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44286 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35020 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131453 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76551 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44990 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52857 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94805 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62868 "") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/53696bfa-e241-4b13-b5c7-4ce389a65644) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127568 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35872 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111442 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75377 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/92b618be-746d-41a5-a32e-b9bc3898f4ab) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34803 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29597 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74932 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105628 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29828 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134121 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51463 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39285 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103282 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51874 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107664 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103060 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26252 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48423 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26686 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48392 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51337 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50734 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54086 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52425 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->