### PR TITLE
_WKWebPushDaemonConnectionConfiguration leaks instance variables

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebPushDaemonConnection.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebPushDaemonConnection.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2024-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -44,9 +44,9 @@ WK_EXTERN
 
 - (instancetype)init;
 @property (nonatomic, copy) NSString *machServiceName;
-@property (nonatomic, copy) NSString *partition;
+@property (nonatomic, copy, nullable) NSString *partition;
 @property (nonatomic, assign) audit_token_t hostApplicationAuditToken;
-@property (nonatomic, copy) NSString *bundleIdentifierOverrideForTesting;
+@property (nonatomic, copy, nullable) NSString *bundleIdentifierOverrideForTesting;
 @end
 
 WK_EXTERN

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebPushDaemonConnection.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebPushDaemonConnection.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2024-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -51,11 +51,22 @@
         return nil;
 
 #if ENABLE(RELOCATABLE_WEBPUSHD)
-    _machServiceName = @"com.apple.webkit.webpushd.relocatable.service";
+    self.machServiceName = @"com.apple.webkit.webpushd.relocatable.service";
 #else
-    _machServiceName = @"com.apple.webkit.webpushd.service";
+    self.machServiceName = @"com.apple.webkit.webpushd.service";
 #endif
     return self;
+}
+
+- (void)dealloc
+{
+IGNORE_NULL_CHECK_WARNINGS_BEGIN
+    self.machServiceName = nil;
+IGNORE_NULL_CHECK_WARNINGS_END
+    self.partition = nil;
+    self.bundleIdentifierOverrideForTesting = nil;
+
+    [super dealloc];
 }
 
 @end


### PR DESCRIPTION
#### 6a3704d355a10e3145b598af170faef8208175fc
<pre>
_WKWebPushDaemonConnectionConfiguration leaks instance variables
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=300173">https://bugs.webkit.org/show_bug.cgi?id=300173</a>&gt;
&lt;<a href="https://rdar.apple.com/161958379">rdar://161958379</a>&gt;

Reviewed by Geoffrey Garen.

Regressed in 283218@main.

* Source/WebKit/UIProcess/API/Cocoa/_WKWebPushDaemonConnection.h:
(_WKWebPushDaemonConnectionConfiguration.partition):
(_WKWebPushDaemonConnectionConfiguration.bundleIdentifierOverrideForTesting):
- Mark properties as `nullable` since the init method doesn&apos;t set them.
* Source/WebKit/UIProcess/API/Cocoa/_WKWebPushDaemonConnection.mm:
(-[_WKWebPushDaemonConnectionConfiguration init]):
- Use setter to make sure `_machServiceName` is retained.
(-[_WKWebPushDaemonConnectionConfiguration dealloc]): Add.
- Release instance variables to fix leaks.

Canonical link: <a href="https://commits.webkit.org/301312@main">https://commits.webkit.org/301312@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/843f85d326bc73d36096c1796ec960b5d4a14dcb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125485 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45150 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35893 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132344 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77428 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/178e5136-9157-45ac-a38f-91815e89fc1e) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45837 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53712 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95563 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 18 flakes 28 failures; Uploaded test results") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/63509 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4cf340b0-d91c-4aae-a550-1755cf8e7b5d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128436 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36629 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; Running layout-tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112220 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76086 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75818 "Built successfully") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106401 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Running apply-patch; Checked out pull request; Running run-api-tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30620 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135021 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52291 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40058 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Running apply-patch; Checked out pull request; Running run-layout-tests-in-stress-mode; Running layout-tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104041 "") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52728 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108436 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103782 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; 1 api test failed or timed out; 1 api test failed or timed out; Running compile-webkit-without-change") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49146 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27451 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49446 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Failed to compile WebKit; Running compile-webkit-without-change") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19663 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52183 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57969 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51534 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54890 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53229 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->