### PR TITLE
Remove text-indent support from PopupMenuStyle, no ports use it

### DIFF
--- a/Source/WebCore/platform/PopupMenuStyle.h
+++ b/Source/WebCore/platform/PopupMenuStyle.h
@@ -27,7 +27,6 @@
 
 #include <WebCore/Color.h>
 #include <WebCore/FontCascade.h>
-#include <WebCore/Length.h>
 
 namespace WebCore {
 
@@ -42,7 +41,7 @@ public:
         Large,
     };
 
-    PopupMenuStyle(const Color& foreground, const Color& background, const FontCascade& font, const String& language, bool visible, bool isDisplayNone, bool hasDefaultAppearance, Length textIndent, TextDirection textDirection, bool hasTextDirectionOverride, BackgroundColorType backgroundColorType = DefaultBackgroundColor, PopupMenuType menuType = SelectPopup, Size menuSize = Size::Normal)
+    PopupMenuStyle(const Color& foreground, const Color& background, const FontCascade& font, const String& language, bool visible, bool isDisplayNone, bool hasDefaultAppearance, TextDirection textDirection, bool hasTextDirectionOverride, BackgroundColorType backgroundColorType = DefaultBackgroundColor, PopupMenuType menuType = SelectPopup, Size menuSize = Size::Normal)
         : m_foregroundColor(foreground)
         , m_backgroundColor(background)
         , m_font(font)
@@ -50,7 +49,6 @@ public:
         , m_visible(visible)
         , m_isDisplayNone(isDisplayNone)
         , m_hasDefaultAppearance(hasDefaultAppearance)
-        , m_textIndent(textIndent)
         , m_textDirection(textDirection)
         , m_hasTextDirectionOverride(hasTextDirectionOverride)
         , m_backgroundColorType(backgroundColorType)
@@ -66,7 +64,6 @@ public:
     bool isVisible() const { return m_visible; }
     bool isDisplayNone() const { return m_isDisplayNone; }
     bool hasDefaultAppearance() const { return m_hasDefaultAppearance; }
-    Length textIndent() const { return m_textIndent; }
     TextDirection textDirection() const { return m_textDirection; }
     bool hasTextDirectionOverride() const { return m_hasTextDirectionOverride; }
     BackgroundColorType backgroundColorType() const { return m_backgroundColorType; }
@@ -81,7 +78,6 @@ private:
     bool m_visible;
     bool m_isDisplayNone;
     bool m_hasDefaultAppearance;
-    Length m_textIndent;
     TextDirection m_textDirection;
     bool m_hasTextDirectionOverride;
     BackgroundColorType m_backgroundColorType;

--- a/Source/WebCore/rendering/RenderMenuList.cpp
+++ b/Source/WebCore/rendering/RenderMenuList.cpp
@@ -227,18 +227,7 @@ void RenderMenuList::updateOptionsWidth()
 
         String text = option->textIndentedToRespectGroupLabel();
         text = applyTextTransform(style(), text);
-        if (theme().popupOptionSupportsTextIndent()) {
-            // Add in the option's text indent.  We can't calculate percentage values for now.
-            float optionWidth = 0;
-            if (auto* optionStyle = option->computedStyleForEditability())
-                optionWidth += Style::evaluate<float>(optionStyle->textIndent().length, 0, Style::ZoomNeeded { });
-            if (!text.isEmpty()) {
-                const FontCascade& font = style().fontCascade();
-                TextRun run = RenderBlock::constructTextRun(text, style());
-                optionWidth += font.width(run);
-            }
-            maxOptionWidth = std::max(maxOptionWidth, optionWidth);
-        } else if (!text.isEmpty()) {
+        if (!text.isEmpty()) {
             const FontCascade& font = style().fontCascade();
             TextRun run = RenderBlock::constructTextRun(text, style());
             maxOptionWidth = std::max(maxOptionWidth, font.width(run));
@@ -549,7 +538,6 @@ PopupMenuStyle RenderMenuList::itemStyle(unsigned listIndex) const
         style->visibility() == Visibility::Visible,
         style->display() == DisplayType::None,
         true,
-        Style::toPlatform(style->textIndent().length),
         style->writingMode().bidiDirection(),
         isOverride(style->unicodeBidi()),
         itemHasCustomBackgroundColor ? PopupMenuStyle::CustomBackgroundColor : PopupMenuStyle::DefaultBackgroundColor
@@ -600,7 +588,6 @@ PopupMenuStyle RenderMenuList::menuStyle() const
         styleToUse.usedVisibility() == Visibility::Visible,
         styleToUse.display() == DisplayType::None,
         style().hasUsedAppearance() && style().usedAppearance() == StyleAppearance::Menulist,
-        Style::toPlatform(styleToUse.textIndent().length),
         style().writingMode().bidiDirection(),
         isOverride(style().unicodeBidi()),
         PopupMenuStyle::DefaultBackgroundColor,

--- a/Source/WebCore/rendering/RenderSearchField.cpp
+++ b/Source/WebCore/rendering/RenderSearchField.cpp
@@ -296,7 +296,6 @@ PopupMenuStyle RenderSearchField::menuStyle() const
         style().usedVisibility() == Visibility::Visible,
         style().display() == DisplayType::None,
         true,
-        Style::toPlatform(style().textIndent().length),
         writingMode().bidiDirection(),
         isOverride(style().unicodeBidi()),
         PopupMenuStyle::CustomBackgroundColor

--- a/Source/WebCore/rendering/RenderTheme.h
+++ b/Source/WebCore/rendering/RenderTheme.h
@@ -196,7 +196,6 @@ public:
     virtual void adjustSliderThumbSize(RenderStyle&, const Element*) const { }
 
     virtual Style::PaddingBox popupInternalPaddingBox(const RenderStyle&) const;
-    virtual bool popupOptionSupportsTextIndent() const { return false; }
     virtual PopupMenuStyle::Size popupMenuSize(const RenderStyle&, IntRect&) const { return PopupMenuStyle::Size::Normal; }
 
     virtual ScrollbarWidth scrollbarWidthStyleForPart(StyleAppearance) { return ScrollbarWidth::Auto; }

--- a/Source/WebKit/WebProcess/WebCoreSupport/win/WebPopupMenuWin.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/win/WebPopupMenuWin.cpp
@@ -28,7 +28,6 @@
 
 #include "PlatformPopupMenuData.h"
 #include "WebPage.h"
-#include <WebCore/LengthFunctions.h>
 #include <WebCore/PopupMenuClient.h>
 #include <WebCore/RenderTheme.h>
 #include <WebCore/ScrollbarTheme.h>
@@ -141,13 +140,9 @@ void WebPopupMenu::setUpPlatformData(const WebCore::IntRect& pageCoordinates, Pl
             float textX = 0;
             if (m_popupClient->menuStyle().textDirection() == TextDirection::LTR) {
                 textX = std::max<float>(0, m_popupClient->clientPaddingLeft() - m_popupClient->clientInsetLeft());
-                if (RenderTheme::singleton().popupOptionSupportsTextIndent())
-                    textX += minimumIntValueForLength(itemStyle.textIndent(), LayoutUnit::fromFloatRound(itemRect.width()), 1.0f /* FIXME FIND ZOOM */);
             } else {
                 textX = itemRect.width() - m_popupClient->menuStyle().font().width(textRun);
                 textX = std::min<float>(textX, textX - m_popupClient->clientPaddingRight() + m_popupClient->clientInsetRight());
-                if (RenderTheme::singleton().popupOptionSupportsTextIndent())
-                    textX -= minimumIntValueForLength(itemStyle.textIndent(), LayoutUnit::fromFloatRound(itemRect.width()), 1.0f /* FIXME FIND ZOOM */);
             }
             float textY = itemRect.y() + itemFontCascade.metricsOfPrimaryFont().intAscent() + (itemRect.height() - itemFontCascade.metricsOfPrimaryFont().intHeight()) / 2;
 


### PR DESCRIPTION
#### 8f0bf90fbba27ab5367c97468648bdab59717ee1
<pre>
Remove text-indent support from PopupMenuStyle, no ports use it
<a href="https://bugs.webkit.org/show_bug.cgi?id=300181">https://bugs.webkit.org/show_bug.cgi?id=300181</a>

Reviewed by Darin Adler.

`text-indent` for support in popup menus is unused and can
be removed. The only code that accessed the value was gated
behind a RenderTheme::popupOptionSupportsTextIndent() check,
but all themes return false for that (it too is being removed).

* Source/WebCore/platform/PopupMenuStyle.h:
* Source/WebCore/rendering/RenderMenuList.cpp:
* Source/WebCore/rendering/RenderSearchField.cpp:
* Source/WebCore/rendering/RenderTheme.h:
* Source/WebKit/WebProcess/WebCoreSupport/win/WebPopupMenuWin.cpp:

Canonical link: <a href="https://commits.webkit.org/301033@main">https://commits.webkit.org/301033@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a98a32dd9714630a8764da957382b6dfb5f25172

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124669 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44341 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35075 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131510 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76598 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/126546 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45045 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52911 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94848 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62909 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127623 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35921 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111491 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75418 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34851 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29646 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74990 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105678 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29877 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134176 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51517 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39333 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103322 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51929 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107712 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103097 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26261 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48472 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26734 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48473 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51391 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57188 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50785 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54140 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52479 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->