### PR TITLE
Unskip imported/w3c/web-platform-tests/secure-contexts/ tests

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -399,12 +399,6 @@ media/remove-video-element-in-pip-from-document.html [ Skip ]
 # This test is only relevent on iPhone where videos always play in fullscreen.
 media/video-element-fullscreen-not-in-dom-accelerated-iphone.html [ Skip ]
 
-# Tests rely on domain names our test infrastructure doesn't support.
-imported/w3c/web-platform-tests/secure-contexts/basic-shared-worker.html [ Skip ]
-imported/w3c/web-platform-tests/secure-contexts/basic-shared-worker.https.html [ Skip ]
-imported/w3c/web-platform-tests/secure-contexts/shared-worker-insecure-first.https.html [ Skip ]
-imported/w3c/web-platform-tests/secure-contexts/shared-worker-secure-first.https.html [ Skip ]
-
 # This test seems wrong as it call update() for a script that does not change and expected an updatefound event.
 # Per specification, if the scripts are identical, we do not install the new script and return the existing registration.
 imported/w3c/web-platform-tests/service-workers/service-worker/import-scripts-redirect.https.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/secure-contexts/basic-shared-worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/secure-contexts/basic-shared-worker-expected.txt
@@ -1,9 +1,7 @@
 
 
-Harness Error (TIMEOUT), message = null
-
-FAIL Shared worker assert_false: expected false got true
+PASS Shared worker
 FAIL Nested worker in shared worker assert_false: expected false got "Nested workers not supported."
-NOTRUN Shared worker from https subframe
-NOTRUN Nested worker from shared worker from https subframe
+PASS Shared worker from https subframe
+FAIL Nested worker from shared worker from https subframe assert_false: expected false got "Nested workers not supported."
 

--- a/LayoutTests/imported/w3c/web-platform-tests/secure-contexts/basic-shared-worker.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/secure-contexts/basic-shared-worker.https-expected.txt
@@ -1,9 +1,7 @@
 
 
-Harness Error (TIMEOUT), message = null
-
 PASS Shared worker
 FAIL Nested worker in shared worker assert_true: expected true got "Nested workers not supported."
-NOTRUN Shared worker from https subframe
-NOTRUN Nested worker from shared worker from https subframe
+PASS Shared worker from https subframe
+FAIL Nested worker from shared worker from https subframe assert_true: expected true got "Nested workers not supported."
 

--- a/LayoutTests/imported/w3c/web-platform-tests/secure-contexts/shared-worker-insecure-first.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/secure-contexts/shared-worker-insecure-first.https-expected.txt
@@ -1,8 +1,7 @@
 
-Harness Error (TIMEOUT), message = null
 
-NOTRUN Shared worker in subframe
-NOTRUN Nested worker in shared worker in subframe
-NOTRUN Shared worker in popup
-NOTRUN Nested worker from shared worker in popup
+FAIL Shared worker in subframe assert_true: SharedWorker connection should generate an error. expected true got false
+FAIL Nested worker in shared worker in subframe assert_true: SharedWorker connection should generate an error. expected true got false
+PASS Shared worker in popup
+FAIL Nested worker from shared worker in popup assert_false: expected false got "Nested workers not supported."
 

--- a/LayoutTests/imported/w3c/web-platform-tests/secure-contexts/shared-worker-secure-first.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/secure-contexts/shared-worker-secure-first.https-expected.txt
@@ -1,9 +1,7 @@
 
 
-Harness Error (TIMEOUT), message = null
-
-NOTRUN Shared worker in subframe
-NOTRUN Nested worker in shared worker in subframe
-NOTRUN Shared worker in popup
-NOTRUN Nested worker from shared worker in popup
+PASS Shared worker in subframe
+FAIL Nested worker in shared worker in subframe assert_true: SharedWorker is a secure context expected true got "Nested workers not supported."
+FAIL Shared worker in popup assert_true: SharedWorker connection should error out. expected true got false
+FAIL Nested worker from shared worker in popup assert_true: SharedWorker connection should error out. expected true got false
 

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -697,6 +697,10 @@ imported/w3c/web-platform-tests/html/webappapis/microtask-queuing/queue-microtas
 imported/w3c/web-platform-tests/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-agent-formalism/requires-success.any.sharedworker.html [ Skip ]
 imported/w3c/web-platform-tests/html/webappapis/scripting/processing-model-2/unhandled-promise-rejections/promise-rejection-events.sharedworker.html [ Skip ]
 imported/w3c/web-platform-tests/notifications/idlharness.https.any.sharedworker.html [ Skip ]
+imported/w3c/web-platform-tests/secure-contexts/basic-shared-worker.html [ Skip ]
+imported/w3c/web-platform-tests/secure-contexts/basic-shared-worker.https.html [ Skip ]
+imported/w3c/web-platform-tests/secure-contexts/shared-worker-insecure-first.https.html [ Skip ]
+imported/w3c/web-platform-tests/secure-contexts/shared-worker-secure-first.https.html [ Skip ]
 imported/w3c/web-platform-tests/service-workers/service-worker/claim-shared-worker-fetch.https.html [ Skip ]
 imported/w3c/web-platform-tests/streams/idlharness.any.sharedworker.html [ Skip ]
 imported/w3c/web-platform-tests/streams/piping/abort.any.sharedworker.html [ Skip ]
@@ -791,8 +795,6 @@ imported/w3c/web-platform-tests/streams/writable-streams/start.any.serviceworker
 imported/w3c/web-platform-tests/streams/writable-streams/start.any.sharedworker.html [ Skip ]
 imported/w3c/web-platform-tests/streams/writable-streams/write.any.serviceworker.html [ Skip ]
 imported/w3c/web-platform-tests/streams/writable-streams/write.any.sharedworker.html [ Skip ]
-
-
 imported/w3c/web-platform-tests/urlpattern/urlpattern-compare.tentative.any.serviceworker.html [ Skip ]
 imported/w3c/web-platform-tests/urlpattern/urlpattern-compare.tentative.any.sharedworker.html [ Skip ]
 imported/w3c/web-platform-tests/urlpattern/urlpattern-compare.tentative.https.any.serviceworker.html [ Skip ]


### PR DESCRIPTION
#### 702788ab011c19fbbb27b319602993f3ae38a248
<pre>
Unskip imported/w3c/web-platform-tests/secure-contexts/ tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=300182">https://bugs.webkit.org/show_bug.cgi?id=300182</a>
<a href="https://rdar.apple.com/161971939">rdar://161971939</a>

Reviewed by Youenn Fablet.

We can unskip these tests with custom domain support.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/secure-contexts/basic-shared-worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/secure-contexts/basic-shared-worker.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/secure-contexts/shared-worker-insecure-first.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/secure-contexts/shared-worker-secure-first.https-expected.txt:
* LayoutTests/platform/mac-wk1/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/301146@main">https://commits.webkit.org/301146@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/00669ab63bc67313fc8e1c823491e66e1a941640

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124798 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44470 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35205 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131643 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76707 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/06571f26-8c66-4f00-9dd7-b9fd01e5b88a) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45173 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53039 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94953 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62994 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/131045a5-dff8-4862-8070-ab617f8a722c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127752 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36030 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111606 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75521 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d7c838a9-f18c-4828-8857-2c4d514375be) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34962 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29762 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75119 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105787 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29991 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134310 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51643 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39445 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103430 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52058 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107826 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103200 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26342 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48567 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26848 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48646 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51517 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50909 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54263 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52604 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->