### PR TITLE
[SaferC++] Improve memory safety in the Injected Bundle C API (part 2)

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -73,10 +73,8 @@ WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInNodeHandle.mm
 WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInRangeHandle.mm
 WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInScriptWorld.mm
 WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp
-WebProcess/InjectedBundle/API/c/WKBundleHitTestResult.cpp
 WebProcess/InjectedBundle/API/c/WKBundleNodeHandle.cpp
 WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
-WebProcess/InjectedBundle/API/c/WKBundlePageOverlay.cpp
 WebProcess/InjectedBundle/API/c/mac/WKBundleMac.mm
 WebProcess/InjectedBundle/API/c/mac/WKBundlePageBannerMac.mm
 WebProcess/InjectedBundle/API/mac/WKDOMDocument.mm

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleHitTestResult.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleHitTestResult.cpp
@@ -41,14 +41,14 @@ WKTypeID WKBundleHitTestResultGetTypeID()
 
 WKBundleNodeHandleRef WKBundleHitTestResultCopyNodeHandle(WKBundleHitTestResultRef hitTestResultRef)
 {
-    RefPtr<WebKit::InjectedBundleNodeHandle> nodeHandle = WebKit::toImpl(hitTestResultRef)->nodeHandle();
-    return toAPI(nodeHandle.leakRef());
+    RefPtr<WebKit::InjectedBundleNodeHandle> nodeHandle = WebKit::toProtectedImpl(hitTestResultRef)->nodeHandle();
+    SUPPRESS_UNCOUNTED_ARG return toAPI(nodeHandle.leakRef());
 }
 
 WKBundleNodeHandleRef WKBundleHitTestResultCopyURLElementHandle(WKBundleHitTestResultRef hitTestResultRef)
 {
-    RefPtr<WebKit::InjectedBundleNodeHandle> urlElementNodeHandle = WebKit::toImpl(hitTestResultRef)->urlElementHandle();
-    return toAPI(urlElementNodeHandle.leakRef());
+    RefPtr<WebKit::InjectedBundleNodeHandle> urlElementNodeHandle = WebKit::toProtectedImpl(hitTestResultRef)->urlElementHandle();
+    SUPPRESS_UNCOUNTED_ARG return toAPI(urlElementNodeHandle.leakRef());
 }
 
 WKBundleFrameRef WKBundleHitTestResultGetFrame(WKBundleHitTestResultRef)
@@ -63,47 +63,47 @@ WKBundleFrameRef WKBundleHitTestResultGetTargetFrame(WKBundleHitTestResultRef)
 
 WKURLRef WKBundleHitTestResultCopyAbsoluteImageURL(WKBundleHitTestResultRef hitTestResultRef)
 {
-    return WebKit::toCopiedURLAPI(WebKit::toImpl(hitTestResultRef)->absoluteImageURL());
+    return WebKit::toCopiedURLAPI(WebKit::toProtectedImpl(hitTestResultRef)->absoluteImageURL());
 }
 
 WKURLRef WKBundleHitTestResultCopyAbsolutePDFURL(WKBundleHitTestResultRef hitTestResultRef)
 {
-    return WebKit::toCopiedURLAPI(WebKit::toImpl(hitTestResultRef)->absolutePDFURL());
+    return WebKit::toCopiedURLAPI(WebKit::toProtectedImpl(hitTestResultRef)->absolutePDFURL());
 }
 
 WKURLRef WKBundleHitTestResultCopyAbsoluteLinkURL(WKBundleHitTestResultRef hitTestResultRef)
 {
-    return WebKit::toCopiedURLAPI(WebKit::toImpl(hitTestResultRef)->absoluteLinkURL());
+    return WebKit::toCopiedURLAPI(WebKit::toProtectedImpl(hitTestResultRef)->absoluteLinkURL());
 }
 
 WKURLRef WKBundleHitTestResultCopyAbsoluteMediaURL(WKBundleHitTestResultRef hitTestResultRef)
 {
-    return WebKit::toCopiedURLAPI(WebKit::toImpl(hitTestResultRef)->absoluteMediaURL());
+    return WebKit::toCopiedURLAPI(WebKit::toProtectedImpl(hitTestResultRef)->absoluteMediaURL());
 }
 
 bool WKBundleHitTestResultMediaIsInFullscreen(WKBundleHitTestResultRef hitTestResultRef)
 {
-    return WebKit::toImpl(hitTestResultRef)->mediaIsInFullscreen();
+    return WebKit::toProtectedImpl(hitTestResultRef)->mediaIsInFullscreen();
 }
 
 bool WKBundleHitTestResultMediaHasAudio(WKBundleHitTestResultRef hitTestResultRef)
 {
-    return WebKit::toImpl(hitTestResultRef)->mediaHasAudio();
+    return WebKit::toProtectedImpl(hitTestResultRef)->mediaHasAudio();
 }
 
 bool WKBundleHitTestResultIsDownloadableMedia(WKBundleHitTestResultRef hitTestResultRef)
 {
-    return WebKit::toImpl(hitTestResultRef)->isDownloadableMedia();
+    return WebKit::toProtectedImpl(hitTestResultRef)->isDownloadableMedia();
 }
 
 WKBundleHitTestResultMediaType WKBundleHitTestResultGetMediaType(WKBundleHitTestResultRef hitTestResultRef)
 {
-    return toAPI(WebKit::toImpl(hitTestResultRef)->mediaType());
+    return toAPI(WebKit::toProtectedImpl(hitTestResultRef)->mediaType());
 }
 
 WKRect WKBundleHitTestResultGetImageRect(WKBundleHitTestResultRef hitTestResultRef)
 {
-    return WebKit::toAPI(WebKit::toImpl(hitTestResultRef)->imageRect());
+    return WebKit::toAPI(WebKit::toProtectedImpl(hitTestResultRef)->imageRect());
 }
 
 WKImageRef WKBundleHitTestResultCopyImage(WKBundleHitTestResultRef)
@@ -113,20 +113,20 @@ WKImageRef WKBundleHitTestResultCopyImage(WKBundleHitTestResultRef)
 
 bool WKBundleHitTestResultGetIsSelected(WKBundleHitTestResultRef hitTestResultRef)
 {
-    return WebKit::toImpl(hitTestResultRef)->isSelected();
+    return WebKit::toProtectedImpl(hitTestResultRef)->isSelected();
 }
 
 WKStringRef WKBundleHitTestResultCopyLinkLabel(WKBundleHitTestResultRef hitTestResultRef)
 {
-    return WebKit::toCopiedAPI(WebKit::toImpl(hitTestResultRef)->linkLabel());
+    return WebKit::toCopiedAPI(WebKit::toProtectedImpl(hitTestResultRef)->linkLabel());
 }
 
 WKStringRef WKBundleHitTestResultCopyLinkTitle(WKBundleHitTestResultRef hitTestResultRef)
 {
-    return WebKit::toCopiedAPI(WebKit::toImpl(hitTestResultRef)->linkTitle());
+    return WebKit::toCopiedAPI(WebKit::toProtectedImpl(hitTestResultRef)->linkTitle());
 }
 
 WKStringRef WKBundleHitTestResultCopyLinkSuggestedFilename(WKBundleHitTestResultRef hitTestResultRef)
 {
-    return WebKit::toCopiedAPI(WebKit::toImpl(hitTestResultRef)->linkSuggestedFilename());
+    return WebKit::toCopiedAPI(WebKit::toProtectedImpl(hitTestResultRef)->linkSuggestedFilename());
 }

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePageOverlay.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePageOverlay.cpp
@@ -80,7 +80,7 @@ private:
 
         m_client.willMoveToPage(toAPI(&pageOverlay), toAPI(page), m_client.base.clientInfo);
     }
-    
+
     void didMoveToPage(WebKit::WebPageOverlay& pageOverlay, WebKit::WebPage* page) override
     {
         if (!m_client.didMoveToPage)
@@ -104,7 +104,7 @@ private:
 
         graphicsContext.drawConsumingImageBuffer(WTFMove(imageBuffer), dirtyRect);
     }
-    
+
     bool mouseEvent(WebKit::WebPageOverlay& pageOverlay, const WebCore::PlatformMouseEvent& event) override
     {
         switch (event.type()) {
@@ -184,7 +184,7 @@ private:
         if (!m_accessibilityClient.client().copyAccessibilityAttributeValue)
             return false;
         auto wkType = m_accessibilityClient.client().copyAccessibilityAttributeValue(toAPI(&pageOverlay), WebKit::toCopiedAPI(attribute), WKPointCreate(WKPointMake(parameter.x(), parameter.y())), m_accessibilityClient.client().base.clientInfo);
-        if (WebKit::toImpl(wkType)->type() != API::String::APIType)
+        if (WebKit::toProtectedImpl(wkType)->type() != API::String::APIType)
             return false;
         value = WebKit::toWTFString(static_cast<WKStringRef>(wkType));
         return true;
@@ -195,7 +195,7 @@ private:
         if (!m_accessibilityClient.client().copyAccessibilityAttributeValue)
             return false;
         auto wkType = m_accessibilityClient.client().copyAccessibilityAttributeValue(toAPI(&pageOverlay), WebKit::toCopiedAPI(attribute), WKPointCreate(WKPointMake(parameter.x(), parameter.y())), m_accessibilityClient.client().base.clientInfo);
-        if (WebKit::toImpl(wkType)->type() != API::Boolean::APIType)
+        if (WebKit::toProtectedImpl(wkType)->type() != API::Boolean::APIType)
             return false;
         value = WKBooleanGetValue(static_cast<WKBooleanRef>(wkType));
         return true;
@@ -212,14 +212,14 @@ private:
         names.reserveInitialCapacity(count);
         for (size_t k = 0; k < count; k++) {
             WKTypeRef item = WKArrayGetItemAtIndex(wkNames, k);
-            if (WebKit::toImpl(item)->type() == API::String::APIType)
+            if (WebKit::toProtectedImpl(item)->type() == API::String::APIType)
                 names.append(WebKit::toWTFString(static_cast<WKStringRef>(item)));
         }
         names.shrinkToFit();
 
         return names;
     }
-    
+
     API::Client<WKBundlePageOverlayAccessibilityClientBase> m_accessibilityClient;
 };
 
@@ -235,7 +235,7 @@ WKTypeID WKBundlePageOverlayGetTypeID()
 WKBundlePageOverlayRef WKBundlePageOverlayCreate(WKBundlePageOverlayClientBase* wkClient)
 {
     auto clientImpl = makeUnique<PageOverlayClientImpl>(wkClient);
-    return toAPI(&WebKit::WebPageOverlay::create(WTFMove(clientImpl)).leakRef());
+    SUPPRESS_UNCOUNTED_ARG return toAPI(&WebKit::WebPageOverlay::create(WTFMove(clientImpl)).leakRef());
 }
 
 void WKBundlePageOverlaySetAccessibilityClient(WKBundlePageOverlayRef bundlePageOverlayRef, WKBundlePageOverlayAccessibilityClientBase* client)
@@ -245,7 +245,7 @@ void WKBundlePageOverlaySetAccessibilityClient(WKBundlePageOverlayRef bundlePage
 
 void WKBundlePageOverlaySetNeedsDisplay(WKBundlePageOverlayRef bundlePageOverlayRef, WKRect rect)
 {
-    WebKit::toImpl(bundlePageOverlayRef)->setNeedsDisplay(enclosingIntRect(WebKit::toFloatRect(rect)));
+    WebKit::toProtectedImpl(bundlePageOverlayRef)->setNeedsDisplay(enclosingIntRect(WebKit::toFloatRect(rect)));
 }
 
 float WKBundlePageOverlayFractionFadedIn(WKBundlePageOverlayRef)
@@ -259,5 +259,5 @@ float WKBundlePageOverlayFractionFadedIn(WKBundlePageOverlayRef)
 
 void WKBundlePageOverlayClear(WKBundlePageOverlayRef bundlePageOverlayRef)
 {
-    WebKit::toImpl(bundlePageOverlayRef)->clear();
+    WebKit::toProtectedImpl(bundlePageOverlayRef)->clear();
 }


### PR DESCRIPTION
#### ec2a128e10341307cb18954c32814e01c1da2177
<pre>
[SaferC++] Improve memory safety in the Injected Bundle C API (part 2)
<a href="https://bugs.webkit.org/show_bug.cgi?id=300184">https://bugs.webkit.org/show_bug.cgi?id=300184</a>
<a href="https://rdar.apple.com/161974909">rdar://161974909</a>

Reviewed by Chris Dumez.

- WebProcess/InjectedBundle/API/c/WKBundlePageOverlay.cpp
- WebProcess/InjectedBundle/API/c/WKBundleHitTestResult.cpp

* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleHitTestResult.cpp:
(WKBundleHitTestResultCopyNodeHandle):
(WKBundleHitTestResultCopyURLElementHandle):
(WKBundleHitTestResultCopyAbsoluteImageURL):
(WKBundleHitTestResultCopyAbsolutePDFURL):
(WKBundleHitTestResultCopyAbsoluteLinkURL):
(WKBundleHitTestResultCopyAbsoluteMediaURL):
(WKBundleHitTestResultMediaIsInFullscreen):
(WKBundleHitTestResultMediaHasAudio):
(WKBundleHitTestResultIsDownloadableMedia):
(WKBundleHitTestResultGetMediaType):
(WKBundleHitTestResultGetImageRect):
(WKBundleHitTestResultGetIsSelected):
(WKBundleHitTestResultCopyLinkLabel):
(WKBundleHitTestResultCopyLinkTitle):
(WKBundleHitTestResultCopyLinkSuggestedFilename):
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePageOverlay.cpp:
(WKBundlePageOverlayCreate):
(WKBundlePageOverlaySetNeedsDisplay):
(WKBundlePageOverlayClear):

Canonical link: <a href="https://commits.webkit.org/301036@main">https://commits.webkit.org/301036@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9ccd6a929d9fe2f293dad285b5025c810ec57e4e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124772 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44444 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35179 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131617 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/76687 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a8b5986a-b618-46dc-a20d-4fbd52d82cb4) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45147 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53014 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/94929 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/76687 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7c02ea4b-0862-4d5d-8cbb-38a610e5c570) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127726 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/36009 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111583 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75497 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2cb9e1a6-97cc-4a63-99af-d7c41511face) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/34941 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75092 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105766 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29968 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134283 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51618 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39422 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/103403 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52032 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107803 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103174 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26263 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/48547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26825 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48622 "Failed to checkout and rebase branch from PR 51822") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51492 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57291 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/50885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/54240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52579 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->