### PR TITLE
TestContextMenuDriver should adopt -clickDriver:shouldBegin:(void(^)(_UIClickInteractionShouldBeginResult)) SPI

### DIFF
--- a/Tools/TestRunnerShared/spi/UIKitSPIForTesting.h
+++ b/Tools/TestRunnerShared/spi/UIKitSPIForTesting.h
@@ -63,6 +63,7 @@
 #import <UIKit/UIWebFormAccessory.h>
 #import <UIKit/UIWindowScene_RequiresApproval.h>
 #import <UIKit/UIWindow_Private.h>
+#import <UIKit/_UIClickInteractionDriving.h>
 #import <UIKit/_UINavigationInteractiveTransition.h>
 
 IGNORE_WARNINGS_BEGIN("deprecated-implementations")
@@ -478,6 +479,23 @@ typedef enum {
 @end
 #endif
 
+typedef NS_ENUM(NSUInteger, _UIClickInteractionEvent) {
+    _UIClickInteractionEventBegan = 0,
+    _UIClickInteractionEventClickedDown,
+    _UIClickInteractionEventClickedUp,
+    _UIClickInteractionEventEnded,
+};
+
+typedef NS_ENUM(NSUInteger, _UIClickInteractionShouldBeginResult) {
+    _UIClickInteractionShouldBeginResultBegin
+};
+
+@protocol _UIClickInteractionDriving;
+@protocol _UIClickInteractionDriverDelegate <NSObject>
+- (void)clickDriver:(id<_UIClickInteractionDriving>)driver shouldBegin:(void(^)(_UIClickInteractionShouldBeginResult))completion;
+- (void)clickDriver:(id<_UIClickInteractionDriving>)driver didPerformEvent:(_UIClickInteractionEvent)event;
+@end
+
 #endif // USE(APPLE_INTERNAL_SDK)
 
 // Start of UIKit IPI
@@ -504,31 +522,6 @@ typedef enum {
 @property (nonatomic, readonly) BOOL hasInlineCompletionAsMarkedText;
 @property (nonatomic, readonly) UIKeyboardInputMode *currentInputModeInPreference;
 @property (nonatomic, readonly) BOOL hardwareKeyboardAttached;
-@end
-
-#if PLATFORM(IOS) || PLATFORM(VISION)
-
-@protocol UIDropInteractionDelegate_Private <UIDropInteractionDelegate>
-- (void)_dropInteraction:(UIDropInteraction *)interaction delayedPreviewProviderForDroppingItem:(UIDragItem *)item previewProvider:(void(^)(UITargetedDragPreview *preview))previewProvider;
-@end
-
-#endif // PLATFORM(IOS) || PLATFORM(VISION)
-
-typedef NS_ENUM(NSUInteger, _UIClickInteractionEvent) {
-    _UIClickInteractionEventBegan = 0,
-    _UIClickInteractionEventClickedDown,
-    _UIClickInteractionEventClickedUp,
-    _UIClickInteractionEventEnded,
-    _UIClickInteractionEventCount
-};
-
-@protocol _UIClickInteractionDriving;
-@protocol _UIClickInteractionDriverDelegate <NSObject>
-- (void)clickDriver:(id<_UIClickInteractionDriving>)driver shouldBegin:(void(^)(BOOL))completion;
-- (void)clickDriver:(id<_UIClickInteractionDriving>)driver didPerformEvent:(_UIClickInteractionEvent)event;
-@optional
-- (void)clickDriver:(id<_UIClickInteractionDriving>)driver didUpdateHighlightProgress:(CGFloat)progress;
-- (BOOL)clickDriver:(id<_UIClickInteractionDriving>)driver shouldDelayGestureRecognizer:(UIGestureRecognizer *)gestureRecognizer;
 @end
 
 @protocol UITextInputInternal

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ContextMenus.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ContextMenus.mm
@@ -47,14 +47,14 @@ static RetainPtr<NSURL> linkURL;
 
 static RetainPtr<TestContextMenuDriver> contextMenuWebViewDriver(Class delegateClass, NSString *customHTMLString = nil)
 {
-    static auto window = adoptNS([[UIWindow alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
-    static auto driver = adoptNS([TestContextMenuDriver new]);
-    static auto uiDelegate = adoptNS((NSObject<WKUIDelegate> *)[delegateClass new]);
-    static auto configuration = adoptNS([WKWebViewConfiguration new]);
+    static RetainPtr window = adoptNS([[UIWindow alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    static RetainPtr driver = adoptNS([TestContextMenuDriver new]);
+    static RetainPtr uiDelegate = adoptNS((NSObject<WKUIDelegate> *)[delegateClass new]);
+    static RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     [configuration _setClickInteractionDriverForTesting:driver.get()];
-    static auto webViewController = adoptNS([[TestWKWebViewController alloc] initWithFrame:CGRectMake(0, 0, 200, 200) configuration:configuration.get()]);
-    TestWKWebView *webView = [webViewController webView];
-    [window addSubview:webView];
+    static RetainPtr webViewController = adoptNS([[TestWKWebViewController alloc] initWithFrame:CGRectMake(0, 0, 200, 200) configuration:configuration.get()]);
+    RetainPtr webView = [webViewController webView];
+    [window addSubview:webView.get()];
     [webView setUIDelegate:uiDelegate.get()];
     if (!customHTMLString) {
         linkURL = [NSURL URLWithString:@"http://127.0.0.1/"];
@@ -103,9 +103,9 @@ static RetainPtr<TestContextMenuDriver> contextMenuWebViewDriver(Class delegateC
 
 TEST(ContextMenu, Click)
 {
-    auto driver = contextMenuWebViewDriver([TestContextMenuUIDelegate class]);
+    RetainPtr driver = contextMenuWebViewDriver([TestContextMenuUIDelegate class]);
     [driver begin:^(BOOL result) {
-        EXPECT_FALSE(result);
+        EXPECT_TRUE(result);
         [driver clickDown];
         [driver clickUp];
     }];
@@ -118,9 +118,9 @@ TEST(ContextMenu, Click)
 
 TEST(ContextMenu, End)
 {
-    auto driver = contextMenuWebViewDriver([TestContextMenuUIDelegate class]);
+    RetainPtr driver = contextMenuWebViewDriver([TestContextMenuUIDelegate class]);
     [driver begin:^(BOOL result) {
-        EXPECT_FALSE(result);
+        EXPECT_TRUE(result);
         [driver end];
     }];
     TestWebKitAPI::Util::run(&didEndCalled);
@@ -164,9 +164,9 @@ TEST(ContextMenu, End)
 
 TEST(ContextMenu, APIBeforeSPI)
 {
-    auto driver = contextMenuWebViewDriver([TestContextMenuAPIBeforeSPIUIDelegate class]);
+    RetainPtr driver = contextMenuWebViewDriver([TestContextMenuAPIBeforeSPIUIDelegate class]);
     [driver begin:^(BOOL result) {
-        EXPECT_FALSE(result);
+        EXPECT_TRUE(result);
         [driver clickDown];
         [driver clickUp];
     }];
@@ -213,9 +213,9 @@ TEST(ContextMenu, APIBeforeSPI)
 TEST(ContextMenu, Image)
 {
     linkURL = [NSURL URLWithString:@"http://127.0.0.1/image"];
-    auto driver = contextMenuWebViewDriver([TestContextMenuImageUIDelegate class], @"<img style='width:400px;height:400px' src='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAABGdBTUEAALGPC/xhBQAABBlpQ0NQa0NHQ29sb3JTcGFjZUdlbmVyaWNSR0IAADiNjVVdaBxVFD67c2cjJM5TbDSFdKg/DSUNk1Y0obS6f93dNm6WSTbaIuhk9u7OmMnOODO7/aFPRVB8MeqbFMS/t4AgKPUP2z60L5UKJdrUICg+tPiDUOiLpuuZOzOZabqx3mXufPOd75577rln7wXouapYlpEUARaari0XMuJzh4+IPSuQhIegFwahV1EdK12pTAI2Twt3tVvfQ8J7X9nV3f6frbdGHRUgcR9is+aoC4iPAfCnVct2AXr6kR8/6loe9mLotzFAxC96uOFj18NzPn6NaWbkLOLTiAVVU2qIlxCPzMX4Rgz7MbDWX6BNauuq6OWiYpt13aCxcO9h/p9twWiF823Dp8+Znz6E72Fc+ys1JefhUcRLqpKfRvwI4mttfbYc4NuWm5ERPwaQ3N6ar6YR70RcrNsHqr6fpK21iiF+54Q28yziLYjPN+fKU8HYq6qTxZzBdsS3NVry8jsEwIm6W5rxx3L7bVOe8ufl6jWay3t5RPz6vHlI9n1ynznt6Xzo84SWLQf8pZeUgxXEg4h/oUZB9ufi/rHcShADGWoa5Ul/LpKjDlsv411tpujPSwwXN9QfSxbr+oFSoP9Es4tygK9ZBqtRjI1P2i256uv5UcXOF3yffIU2q4F/vg2zCQUomDCHvQpNWAMRZChABt8W2Gipgw4GMhStFBmKX6FmFxvnwDzyOrSZzcG+wpT+yMhfg/m4zrQqZIc+ghayGvyOrBbTZfGrhVxjEz9+LDcCPyYZIBLZg89eMkn2kXEyASJ5ijxN9pMcshNk7/rYSmxFXjw31v28jDNSpptF3Tm0u6Bg/zMqTFxT16wsDraGI8sp+wVdvfzGX7Fc6Sw3UbbiGZ26V875X/nr/DL2K/xqpOB/5Ffxt3LHWsy7skzD7GxYc3dVGm0G4xbw0ZnFicUd83Hx5FcPRn6WyZnnr/RdPFlvLg5GrJcF+mr5VhlOjUSs9IP0h7QsvSd9KP3Gvc19yn3Nfc59wV0CkTvLneO+4S5wH3NfxvZq8xpa33sWeRi3Z+mWa6xKISNsFR4WcsI24VFhMvInDAhjQlHYgZat6/sWny+ePR0OYx/mp/tcvi5WAYn7sQL0Tf5VVVTpcJQpHVZvTTi+QROMJENkjJQ2VPe4V/OhIpVP5VJpEFM7UxOpsdRBD4ezpnagbQL7/B3VqW6yUurSY959AlnTOm7rDc0Vd0vSk2IarzYqlprq6IioGIbITI5oU4fabVobBe/e9I/0mzK7DxNbLkec+wzAvj/x7Psu4o60AJYcgIHHI24Yz8oH3gU484TastvBHZFIfAvg1Pfs9r/6Mnh+/dTp3MRzrOctgLU3O52/3+901j5A/6sAZ41/AaCffFUDXAvvAAAAIGNIUk0AAHomAACAhAAA+gAAAIDoAAB1MAAA6mAAADqYAAAXcJy6UTwAAAB4ZVhJZk1NACoAAAAIAAUBEgADAAAAAQABAAABGgAFAAAAAQAAAEoBGwAFAAAAAQAAAFIBKAADAAAAAQACAACHaQAEAAAAAQAAAFoAAAAAAAAASAAAAAEAAABIAAAAAQACoAIABAAAAAEAAAAFoAMABAAAAAEAAAAFAAAAAMNY+UAAAAAJcEhZcwAACxMAAAsTAQCanBgAAAFZaVRYdFhNTDpjb20uYWRvYmUueG1wAAAAAAA8eDp4bXBtZXRhIHhtbG5zOng9ImFkb2JlOm5zOm1ldGEvIiB4OnhtcHRrPSJYTVAgQ29yZSA1LjQuMCI+CiAgIDxyZGY6UkRGIHhtbG5zOnJkZj0iaHR0cDovL3d3dy53My5vcmcvMTk5OS8wMi8yMi1yZGYtc3ludGF4LW5zIyI+CiAgICAgIDxyZGY6RGVzY3JpcHRpb24gcmRmOmFib3V0PSIiCiAgICAgICAgICAgIHhtbG5zOnRpZmY9Imh0dHA6Ly9ucy5hZG9iZS5jb20vdGlmZi8xLjAvIj4KICAgICAgICAgPHRpZmY6T3JpZW50YXRpb24+MTwvdGlmZjpPcmllbnRhdGlvbj4KICAgICAgPC9yZGY6RGVzY3JpcHRpb24+CiAgIDwvcmRmOlJERj4KPC94OnhtcG1ldGE+CkzCJ1kAAAAXSURBVAgdY2RgYPgPxCiACYUH5VAoCABnEQEJC5HbTwAAAABJRU5ErkJggg=='>");
+    RetainPtr driver = contextMenuWebViewDriver([TestContextMenuImageUIDelegate class], @"<img style='width:400px;height:400px' src='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAABGdBTUEAALGPC/xhBQAABBlpQ0NQa0NHQ29sb3JTcGFjZUdlbmVyaWNSR0IAADiNjVVdaBxVFD67c2cjJM5TbDSFdKg/DSUNk1Y0obS6f93dNm6WSTbaIuhk9u7OmMnOODO7/aFPRVB8MeqbFMS/t4AgKPUP2z60L5UKJdrUICg+tPiDUOiLpuuZOzOZabqx3mXufPOd75577rln7wXouapYlpEUARaari0XMuJzh4+IPSuQhIegFwahV1EdK12pTAI2Twt3tVvfQ8J7X9nV3f6frbdGHRUgcR9is+aoC4iPAfCnVct2AXr6kR8/6loe9mLotzFAxC96uOFj18NzPn6NaWbkLOLTiAVVU2qIlxCPzMX4Rgz7MbDWX6BNauuq6OWiYpt13aCxcO9h/p9twWiF823Dp8+Znz6E72Fc+ys1JefhUcRLqpKfRvwI4mttfbYc4NuWm5ERPwaQ3N6ar6YR70RcrNsHqr6fpK21iiF+54Q28yziLYjPN+fKU8HYq6qTxZzBdsS3NVry8jsEwIm6W5rxx3L7bVOe8ufl6jWay3t5RPz6vHlI9n1ynznt6Xzo84SWLQf8pZeUgxXEg4h/oUZB9ufi/rHcShADGWoa5Ul/LpKjDlsv411tpujPSwwXN9QfSxbr+oFSoP9Es4tygK9ZBqtRjI1P2i256uv5UcXOF3yffIU2q4F/vg2zCQUomDCHvQpNWAMRZChABt8W2Gipgw4GMhStFBmKX6FmFxvnwDzyOrSZzcG+wpT+yMhfg/m4zrQqZIc+ghayGvyOrBbTZfGrhVxjEz9+LDcCPyYZIBLZg89eMkn2kXEyASJ5ijxN9pMcshNk7/rYSmxFXjw31v28jDNSpptF3Tm0u6Bg/zMqTFxT16wsDraGI8sp+wVdvfzGX7Fc6Sw3UbbiGZ26V875X/nr/DL2K/xqpOB/5Ffxt3LHWsy7skzD7GxYc3dVGm0G4xbw0ZnFicUd83Hx5FcPRn6WyZnnr/RdPFlvLg5GrJcF+mr5VhlOjUSs9IP0h7QsvSd9KP3Gvc19yn3Nfc59wV0CkTvLneO+4S5wH3NfxvZq8xpa33sWeRi3Z+mWa6xKISNsFR4WcsI24VFhMvInDAhjQlHYgZat6/sWny+ePR0OYx/mp/tcvi5WAYn7sQL0Tf5VVVTpcJQpHVZvTTi+QROMJENkjJQ2VPe4V/OhIpVP5VJpEFM7UxOpsdRBD4ezpnagbQL7/B3VqW6yUurSY959AlnTOm7rDc0Vd0vSk2IarzYqlprq6IioGIbITI5oU4fabVobBe/e9I/0mzK7DxNbLkec+wzAvj/x7Psu4o60AJYcgIHHI24Yz8oH3gU484TastvBHZFIfAvg1Pfs9r/6Mnh+/dTp3MRzrOctgLU3O52/3+901j5A/6sAZ41/AaCffFUDXAvvAAAAIGNIUk0AAHomAACAhAAA+gAAAIDoAAB1MAAA6mAAADqYAAAXcJy6UTwAAAB4ZVhJZk1NACoAAAAIAAUBEgADAAAAAQABAAABGgAFAAAAAQAAAEoBGwAFAAAAAQAAAFIBKAADAAAAAQACAACHaQAEAAAAAQAAAFoAAAAAAAAASAAAAAEAAABIAAAAAQACoAIABAAAAAEAAAAFoAMABAAAAAEAAAAFAAAAAMNY+UAAAAAJcEhZcwAACxMAAAsTAQCanBgAAAFZaVRYdFhNTDpjb20uYWRvYmUueG1wAAAAAAA8eDp4bXBtZXRhIHhtbG5zOng9ImFkb2JlOm5zOm1ldGEvIiB4OnhtcHRrPSJYTVAgQ29yZSA1LjQuMCI+CiAgIDxyZGY6UkRGIHhtbG5zOnJkZj0iaHR0cDovL3d3dy53My5vcmcvMTk5OS8wMi8yMi1yZGYtc3ludGF4LW5zIyI+CiAgICAgIDxyZGY6RGVzY3JpcHRpb24gcmRmOmFib3V0PSIiCiAgICAgICAgICAgIHhtbG5zOnRpZmY9Imh0dHA6Ly9ucy5hZG9iZS5jb20vdGlmZi8xLjAvIj4KICAgICAgICAgPHRpZmY6T3JpZW50YXRpb24+MTwvdGlmZjpPcmllbnRhdGlvbj4KICAgICAgPC9yZGY6RGVzY3JpcHRpb24+CiAgIDwvcmRmOlJERj4KPC94OnhtcG1ldGE+CkzCJ1kAAAAXSURBVAgdY2RgYPgPxCiACYUH5VAoCABnEQEJC5HbTwAAAABJRU5ErkJggg=='>");
     [driver begin:^(BOOL result) {
-        EXPECT_FALSE(result);
+        EXPECT_TRUE(result);
         [driver clickDown];
         [driver clickUp];
     }];
@@ -279,9 +279,9 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
 
 TEST(ContextMenu, Legacy)
 {
-    auto driver = contextMenuWebViewDriver([LegacyContextMenuUIDelegate class]);
+    RetainPtr driver = contextMenuWebViewDriver([LegacyContextMenuUIDelegate class]);
     [driver begin:^(BOOL result) {
-        EXPECT_FALSE(result);
+        EXPECT_TRUE(result);
         [driver clickDown];
         [driver clickUp];
     }];
@@ -336,9 +336,9 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 TEST(ContextMenu, SuggestedActions)
 {
-    auto driver = contextMenuWebViewDriver([TestContextMenuSuggestedActionsUIDelegate class]);
+    RetainPtr driver = contextMenuWebViewDriver([TestContextMenuSuggestedActionsUIDelegate class]);
     [driver begin:^(BOOL result) {
-        EXPECT_FALSE(result);
+        EXPECT_TRUE(result);
         [driver clickDown];
         [driver clickUp];
     }];
@@ -367,9 +367,9 @@ TEST(ContextMenu, SuggestedActions)
 
 TEST(ContextMenu, HintPreviewContainer)
 {
-    auto driver = contextMenuWebViewDriver([TestContextMenuHintPreviewContainerUIDelegate class]);
+    RetainPtr driver = contextMenuWebViewDriver([TestContextMenuHintPreviewContainerUIDelegate class]);
     [driver begin:^(BOOL result) {
-        EXPECT_FALSE(result);
+        EXPECT_TRUE(result);
         [driver clickDown];
         [driver clickUp];
     }];

--- a/Tools/TestWebKitAPI/cocoa/TestContextMenuDriver.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestContextMenuDriver.mm
@@ -95,9 +95,9 @@
 - (void)begin:(void(^)(BOOL))completionHandler
 {
     auto completionBlock = makeBlockPtr(completionHandler);
-    [self.delegate clickDriver:(id<_UIClickInteractionDriving>)self shouldBegin:^(BOOL result) {
+    [self.delegate clickDriver:(id<_UIClickInteractionDriving>)self shouldBegin:^(_UIClickInteractionShouldBeginResult result) {
         [self.delegate clickDriver:(id<_UIClickInteractionDriving>)self didPerformEvent:_UIClickInteractionEventBegan];
-        completionBlock(result);
+        completionBlock(result == _UIClickInteractionShouldBeginResultBegin);
     }];
 }
 


### PR DESCRIPTION
#### fc6aac253ffd80a9d112ecbe27b78682ebd03c62
<pre>
TestContextMenuDriver should adopt -clickDriver:shouldBegin:(void(^)(_UIClickInteractionShouldBeginResult)) SPI
<a href="https://bugs.webkit.org/show_bug.cgi?id=300186">https://bugs.webkit.org/show_bug.cgi?id=300186</a>
<a href="https://rdar.apple.com/161975075">rdar://161975075</a>

Reviewed by Richard Robinson.

TestContextMenuDriver currently uses _UIClickInteractionDriverDelegate
IPI, which is the shouldBegin: variant accepting a boolean argument
completion handler. This causes issues with module verification since
the signature does not exist in SDKs.

This patch does a few things:

1. Moves the _UIClickInteractionDriverDelegate-adjacent SPI declarations
   to !USE(APPLE_INTERNAL_SDK) section, given internal SDK builds can
   pick up the declarations through _UIClickInteractionDriving.h.
2. Remove the now unnecessary UIDropInteractionDelegate_Private SPI
   declaration.
3. Adopt shouldBegin: accepting a _UIClickInteractionShouldBeginResult
   argument completion handler. Note that TestContextMenuDriver API need
   not change.

* Tools/TestRunnerShared/spi/UIKitSPIForTesting.h:
* Tools/TestWebKitAPI/cocoa/TestContextMenuDriver.mm:
(-[TestContextMenuDriver begin:]):

Canonical link: <a href="https://commits.webkit.org/301019@main">https://commits.webkit.org/301019@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e3de716de8d76b4636c4c6fbbefc92f70750de41

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124701 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44373 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35108 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131543 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76625 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7e157bb5-1943-436c-bad4-245f4cb19af4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/126578 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45077 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52943 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94872 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62930 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7988e6b9-90ab-487e-a0d9-d4686f8ebc5d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127655 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35947 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/111523 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75442 "Found 1 new API test failure: WPE/TestWebsiteData:/webkit/WebKitWebsiteData/configuration (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/900c6430-f0e0-47e8-a2f7-1020ffdd578e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34878 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29678 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75022 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105704 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29909 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134208 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51549 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39362 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103348 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51961 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107744 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103121 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48494 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26766 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48525 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19556 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51423 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50816 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54172 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52511 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->