### PR TITLE
Unreviewed, reverting 301009@main (02e86e63291c)

### DIFF
--- a/Source/WebKit/Platform/LogClient.cpp
+++ b/Source/WebKit/Platform/LogClient.cpp
@@ -26,13 +26,6 @@
 
 #if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
 
-#include "Connection.h"
-#include "LogStreamMessages.h"
-#include "StreamClientConnection.h"
-#include "WebKitLogDefinitions.h"
-#include <WebCore/WebCoreLogDefinitions.h>
-#include <wtf/Locker.h>
-
 namespace WebKit {
 
 LogClient::LogClient(Ref<ConnectionType>&& connection)
@@ -43,26 +36,6 @@ LogClient::LogClient(Ref<ConnectionType>&& connection)
 void LogClient::log(std::span<const uint8_t> logChannel, std::span<const uint8_t> logCategory, std::span<const uint8_t> logString, os_log_type_t type)
 {
     send(Messages::LogStream::LogOnBehalfOfWebContent(logChannel, logCategory, logString, type));
-}
-
-
-#undef DEFINE_LOG_MESSAGE
-#define DEFINE_LOG_MESSAGE(messageName, argumentDeclarations, arguments) \
-void LogClient::messageName argumentDeclarations \
-{ \
-    send(Messages::LogStream::messageName arguments); \
-}
-WEBCORE_LOG_CLIENT_MESSAGES(DEFINE_LOG_MESSAGE);
-WEBKIT2_LOG_CLIENT_MESSAGES(DEFINE_LOG_MESSAGE);
-#undef DEFINE_LOG_MESSAGE
-
-template<typename T>
-void LogClient::send(T&& message)
-{
-#if ENABLE(STREAMING_IPC_IN_LOG_FORWARDING)
-    Locker locker { m_lock };
-#endif
-    m_connection->send(WTFMove(message), identifier());
 }
 
 }

--- a/Source/WebKit/Scripts/generate-derived-log-sources.py
+++ b/Source/WebKit/Scripts/generate-derived-log-sources.py
@@ -32,18 +32,20 @@ def generate_messages_file(log_messages, log_messages_receiver_input_file, strea
     return
 
 
-def generate_log_client_declarations_file(prefix, log_messages, log_client_declarations_file):
+def generate_log_client_declarations_file(log_messages, log_client_declarations_file):
     with open(log_client_declarations_file, 'w') as file:
-        file.write("#pragma once\n")
-        file.write("\n")
-        file.write("#define " + prefix + "_LOG_CLIENT_MESSAGES(M) \\\n")
+
         for log_message in log_messages:
             function_name = log_message[0]
             parameters = log_message[2]
-            arguments_declarations = log_declarations_module.get_arguments_string(parameters, log_declarations_module.PARAMETER_LIST_INCLUDE_TYPE | log_declarations_module.PARAMETER_LIST_INCLUDE_NAME | log_declarations_module.PARAMETER_LIST_MODIFY_CSTRING)
-            arguments = ', '.join("arg" + str(i) for i in range(0, len(log_declarations_module.get_argument_list(parameters))))
-            file.write("    M(" + function_name + ", (" + arguments_declarations + "), (" + arguments + ")) \\\n")
+            arguments_string = log_declarations_module.get_arguments_string(parameters, log_declarations_module.PARAMETER_LIST_INCLUDE_TYPE | log_declarations_module.PARAMETER_LIST_INCLUDE_NAME | log_declarations_module.PARAMETER_LIST_MODIFY_CSTRING)
+            file.write("    void " + function_name + "(" + arguments_string + ")\n")
+            file.write("    {\n")
+            parameters_string = log_declarations_module.get_arguments_string(parameters, log_declarations_module.PARAMETER_LIST_INCLUDE_NAME)
+            file.write("        send(Messages::LogStream::" + function_name + "(" + parameters_string + "));\n")
+            file.write("    }\n")
         file.close()
+
     return
 
 
@@ -131,8 +133,8 @@ def main(argv):
     generate_message_receiver_declarations_file(log_messages, message_receiver_declarations_file)
     generate_message_receiver_implementations_file(log_messages, message_receiver_implementations_file)
 
-    generate_log_client_declarations_file("WEBKIT2", webkit_log_messages, webkit_log_client_declarations_file)
-    generate_log_client_declarations_file("WEBCORE", webcore_log_messages, webcore_log_client_declarations_file)
+    generate_log_client_declarations_file(webkit_log_messages, webkit_log_client_declarations_file)
+    generate_log_client_declarations_file(webcore_log_messages, webcore_log_client_declarations_file)
 
     return 0
 

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -8053,8 +8053,6 @@
 		CD20CE7525CC999F0069B542 /* RemoteAudioHardwareListenerProxy.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteAudioHardwareListenerProxy.cpp; sourceTree = "<group>"; };
 		CD20CE7725CD2B9D0069B542 /* RemoteAudioHardwareListenerMessageReceiver.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteAudioHardwareListenerMessageReceiver.cpp; sourceTree = "<group>"; };
 		CD20CE7925CD2B9E0069B542 /* RemoteAudioHardwareListenerMessages.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteAudioHardwareListenerMessages.h; sourceTree = "<group>"; };
-		CD3480952E8F23FD0040CEF9 /* WebCoreLogClientDeclarations.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebCoreLogClientDeclarations.h; sourceTree = "<group>"; };
-		CD3480962E8F23FD0040CEF9 /* WebKitLogClientDeclarations.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebKitLogClientDeclarations.h; sourceTree = "<group>"; };
 		CD36C16C260A6EBE00C8C529 /* LocalAudioSessionRoutingArbitrator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LocalAudioSessionRoutingArbitrator.h; sourceTree = "<group>"; };
 		CD36C16D260A6EBE00C8C529 /* LocalAudioSessionRoutingArbitrator.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = LocalAudioSessionRoutingArbitrator.cpp; sourceTree = "<group>"; };
 		CD3EEF3125799618006563BB /* RemoteMediaEngineConfigurationFactory.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteMediaEngineConfigurationFactory.h; sourceTree = "<group>"; };
@@ -16563,7 +16561,6 @@
 				1C0A195B1C916E1B00FE0EBB /* WebAutomationSessionProxyScriptSource.h */,
 				330934431315B9220097A7BC /* WebCookieManagerMessageReceiver.cpp */,
 				330934441315B9220097A7BC /* WebCookieManagerMessages.h */,
-				CD3480952E8F23FD0040CEF9 /* WebCoreLogClientDeclarations.h */,
 				E3866B062399979C00F88FE9 /* WebDeviceOrientationUpdateProviderMessageReceiver.cpp */,
 				E3866B072399979D00F88FE9 /* WebDeviceOrientationUpdateProviderMessages.h */,
 				E3866B042399979C00F88FE9 /* WebDeviceOrientationUpdateProviderProxyMessageReceiver.cpp */,
@@ -16604,7 +16601,6 @@
 				996B2B9625E2448200719379 /* WebInspectorUIExtensionControllerProxyMessages.h */,
 				1CBBE49E19B66C53006B7D81 /* WebInspectorUIMessageReceiver.cpp */,
 				1CBBE49F19B66C53006B7D81 /* WebInspectorUIMessages.h */,
-				CD3480962E8F23FD0040CEF9 /* WebKitLogClientDeclarations.h */,
 				5C9E0F972A577EC400FC2664 /* WebKitPlatformGeneratedSerializers.mm */,
 				31BA9248148830810062EDB5 /* WebNotificationManagerMessageReceiver.cpp */,
 				31BA9249148830810062EDB5 /* WebNotificationManagerMessages.h */,


### PR DESCRIPTION
#### 51e241d84832a63b2faf264c22816acaeb0673c9
<pre>
Unreviewed, reverting 301009@main (02e86e63291c)
<a href="https://bugs.webkit.org/show_bug.cgi?id=300188">https://bugs.webkit.org/show_bug.cgi?id=300188</a>
<a href="https://rdar.apple.com/161978465">rdar://161978465</a>

REGRESSION(301009@main): Broke Internal macOS builds

Reverted change:

    [Build Speed] Make WebKit/LoggingClient.h less expensive to include
    <a href="https://rdar.apple.com/161924655">rdar://161924655</a>
    <a href="https://bugs.webkit.org/show_bug.cgi?id=300147">https://bugs.webkit.org/show_bug.cgi?id=300147</a>
    301009@main (02e86e63291c)

Canonical link: <a href="https://commits.webkit.org/301013@main">https://commits.webkit.org/301013@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ca8001f7cb6458bec7f4631a7071935fdea769d7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124690 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44362 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35097 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131532 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76614 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b54238f7-d23f-4b53-868f-88cc02cc6c2f) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45066 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52932 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/94864 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62922 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/37427ad7-050b-4e8c-b6d2-255f14aa974e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127644 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35939 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/111513 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/75434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/43c5fa88-8a63-4ecf-82da-3001398fd6bb) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/124046 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34870 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75011 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105696 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/29899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134197 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51538 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/39353 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/103340 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51950 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/107734 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/103113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48488 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/26756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48503 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19555 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51412 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57209 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50805 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54161 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52500 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->