### PR TITLE
[JSC] Replace `toTypedArrayIndex` with `toIndex`

### DIFF
--- a/JSTests/microbenchmarks/ArrayBuffer-full-transfer.js
+++ b/JSTests/microbenchmarks/ArrayBuffer-full-transfer.js
@@ -1,0 +1,12 @@
+(function () {
+    var result = 0;
+    for (var i = 0; i < testLoopCount; ++i) {
+        const buffer = new ArrayBuffer(64);
+        const view = new Uint8Array(buffer);
+        view[1] = 2;
+        view[7] = 4;
+        const buffer2 = buffer.transfer();
+        if (buffer.detached && buffer2.byteLength === 64) result++;
+    }
+    if (result !== testLoopCount * 1) throw "Error: bad: " + result;
+})();

--- a/JSTests/microbenchmarks/ArrayBuffer-partial-transfer.js
+++ b/JSTests/microbenchmarks/ArrayBuffer-partial-transfer.js
@@ -1,0 +1,12 @@
+(function () {
+    var result = 0;
+    for (var i = 0; i < testLoopCount; ++i) {
+        const buffer = new ArrayBuffer(64);
+        const view = new Uint8Array(buffer);
+        view[1] = 2;
+        view[7] = 4;
+        const buffer2 = buffer.transfer(32);
+        if (buffer.detached && buffer2.byteLength === 32) result++;
+    }
+    if (result !== testLoopCount * 1) throw "Error: bad: " + result;
+})();

--- a/JSTests/stress/dataview-construct.js
+++ b/JSTests/stress/dataview-construct.js
@@ -61,7 +61,7 @@ shouldThrow(() => {
 
 shouldThrow(() => {
     new DataView(buffer, Infinity);
-}, "RangeError: byteOffset too large");
+}, "RangeError: byteOffset larger than (2 ** 53) - 1");
 
 shouldThrow(() => {
     new DataView(buffer, 0, 256);
@@ -73,4 +73,4 @@ shouldThrow(() => {
 
 shouldThrow(() => {
     new DataView(buffer, 0, Infinity);
-}, "RangeError: byteLength too large");
+}, "RangeError: byteLength larger than (2 ** 53) - 1");

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -2351,7 +2351,7 @@ JSC_DEFINE_JIT_OPERATION(operationNewTypedArrayBuffer, JSObject*, (JSGlobalObjec
     JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    size_t length = JSValue::decode(encodedArgument).toTypedArrayIndex(globalObject, "length"_s);
+    size_t length = JSValue::decode(encodedArgument).toIndex(globalObject, "length"_s);
     OPERATION_RETURN_IF_EXCEPTION(scope, nullptr);
 
     OPERATION_RETURN(scope, constructArrayBufferWithSize(globalObject, structure, length));

--- a/Source/JavaScriptCore/runtime/JSArrayBufferConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/JSArrayBufferConstructor.cpp
@@ -90,7 +90,7 @@ EncodedJSValue JSGenericArrayBufferConstructor<sharingMode>::constructImpl(JSGlo
             JSValue maxByteLengthValue = asObject(options)->get(globalObject, vm.propertyNames->maxByteLength);
             RETURN_IF_EXCEPTION(scope, { });
             if (!maxByteLengthValue.isUndefined()) {
-                maxByteLength = maxByteLengthValue.toTypedArrayIndex(globalObject, "maxByteLength"_s);
+                maxByteLength = maxByteLengthValue.toIndex(globalObject, "maxByteLength"_s);
                 RETURN_IF_EXCEPTION(scope, { });
             }
         }
@@ -110,7 +110,7 @@ EncodedJSValue JSGenericArrayBufferConstructor<sharingMode>::constructImpl(JSGlo
     size_t length = 0;
     if (hasArguments) {
         JSValue lengthDoubleValue = JSValue(JSValue::EncodeAsDouble, lengthDouble);
-        length = lengthDoubleValue.toTypedArrayIndex(globalObject, "length"_s);
+        length = lengthDoubleValue.toIndex(globalObject, "length"_s);
         RETURN_IF_EXCEPTION(scope, { });
     }
 

--- a/Source/JavaScriptCore/runtime/JSArrayBufferPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/JSArrayBufferPrototype.cpp
@@ -386,7 +386,7 @@ static JSArrayBuffer* arrayBufferProtoFuncTransferImpl(JSGlobalObject* globalObj
         if (!thisObject->impl()->isDetached())
             newByteLength = thisObject->impl()->byteLength();
     } else {
-        newByteLength = newLengthValue.toTypedArrayIndex(globalObject, "newLength"_s);
+        newByteLength = newLengthValue.toIndex(globalObject, "newLength"_s);
         RETURN_IF_EXCEPTION(scope, { });
     }
 

--- a/Source/JavaScriptCore/runtime/JSCJSValue.h
+++ b/Source/JavaScriptCore/runtime/JSCJSValue.h
@@ -322,7 +322,6 @@ public:
     int32_t toInt32(JSGlobalObject*) const;
     uint32_t toUInt32(JSGlobalObject*) const;
     uint64_t toIndex(JSGlobalObject*, ASCIILiteral errorName) const;
-    size_t toTypedArrayIndex(JSGlobalObject*, ASCIILiteral) const;
     uint64_t toLength(JSGlobalObject*) const;
 
     JS_EXPORT_PRIVATE JSValue toBigInt(JSGlobalObject*) const;

--- a/Source/JavaScriptCore/runtime/JSCJSValueInlines.h
+++ b/Source/JavaScriptCore/runtime/JSCJSValueInlines.h
@@ -95,37 +95,6 @@ inline uint64_t JSValue::toIndex(JSGlobalObject* globalObject, ASCIILiteral erro
     RELEASE_AND_RETURN(scope, d);
 }
 
-inline size_t JSValue::toTypedArrayIndex(JSGlobalObject* globalObject, ASCIILiteral errorName) const
-{
-    VM& vm = getVM(globalObject);
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    double d = toNumber(globalObject);
-    RETURN_IF_EXCEPTION(scope, 0);
-    if (d <= -1) {
-        throwException(globalObject, scope, createRangeError(globalObject, makeString(errorName, " cannot be negative"_s)));
-        return 0;
-    }
-
-    if (isInt32())
-        return asInt32();
-
-    if (d > static_cast<double>(MAX_ARRAY_BUFFER_SIZE)) {
-        throwException(globalObject, scope, createRangeError(globalObject, makeString(errorName, " too large"_s)));
-        return 0;
-    }
-
-    // All of this monstrosity is just to give the correct result on 1<<32.
-    size_t outputOffset = 0;
-    double inputOffset = 0;
-    size_t int32Max = std::numeric_limits<int32_t>::max();
-    if (d > static_cast<double>(int32Max)) {
-        outputOffset = int32Max;
-        inputOffset = int32Max;
-    }
-    RELEASE_AND_RETURN(scope, outputOffset + static_cast<size_t>(static_cast<uint32_t>(JSC::toInt32(d - inputOffset))));
-}
-
 // https://tc39.es/proposal-temporal/#sec-tointegerwithtruncation
 inline double JSValue::toIntegerWithTruncation(JSGlobalObject* globalObject) const
 {

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructorInlines.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructorInlines.h
@@ -237,7 +237,7 @@ inline JSObject* constructGenericTypedArrayViewWithArguments(JSGlobalObject* glo
         return result;
     }
 
-    size_t length = firstValue.toTypedArrayIndex(globalObject, "length"_s);
+    size_t length = firstValue.toIndex(globalObject, "length"_s);
     RETURN_IF_EXCEPTION(scope, nullptr);
 
     RELEASE_AND_RETURN(scope, ViewClass::create(globalObject, structure, length));
@@ -269,7 +269,7 @@ ALWAYS_INLINE EncodedJSValue constructGenericTypedArrayViewImpl(JSGlobalObject* 
     std::optional<size_t> length;
     if (auto* arrayBuffer = jsDynamicCast<JSArrayBuffer*>(firstValue)) {
         if (argCount > 1) {
-            offset = callFrame->uncheckedArgument(1).toTypedArrayIndex(globalObject, "byteOffset"_s);
+            offset = callFrame->uncheckedArgument(1).toIndex(globalObject, "byteOffset"_s);
             RETURN_IF_EXCEPTION(scope, { });
 
             if constexpr (ViewClass::TypedArrayStorageType == TypeDataView) {
@@ -293,7 +293,7 @@ ALWAYS_INLINE EncodedJSValue constructGenericTypedArrayViewImpl(JSGlobalObject* 
             // If the length value is present but undefined, treat it as missing.
             JSValue lengthValue = callFrame->uncheckedArgument(2);
             if (!lengthValue.isUndefined()) {
-                length = lengthValue.toTypedArrayIndex(globalObject, ViewClass::TypedArrayStorageType == TypeDataView ? "byteLength"_s : "length"_s);
+                length = lengthValue.toIndex(globalObject, ViewClass::TypedArrayStorageType == TypeDataView ? "byteLength"_s : "length"_s);
                 RETURN_IF_EXCEPTION(scope, encodedJSValue());
             }
         }


### PR DESCRIPTION
#### a13ce0a5a45e9f1f135df40e8622147bce3689d8
<pre>
[JSC] Replace `toTypedArrayIndex` with `toIndex`
<a href="https://bugs.webkit.org/show_bug.cgi?id=300195">https://bugs.webkit.org/show_bug.cgi?id=300195</a>

Reviewed by Yusuke Suzuki.

This patch replaces `toTypedArrayIndex` with `toIndex`,
since TypedArray and ArrayBuffer operations should use `toIndex` as specified
in the TC39 proposal [1][2][3].

This patch introduces no performance regressions.

                                                     TipOfTree                   Patched                            Ratio
ArrayBuffer-full-transfer                       1.7208+-0.1841            1.6495+-0.0581          might be 1.0432x faster
ArrayBuffer-Int32Array-byteOffset               2.0958+-0.1595            2.0790+-0.0754
ArrayBuffer-DataView-alloc-long-lived           6.3051+-0.2566            6.2375+-0.3518          might be 1.0108x faster
ArrayBuffer-Int8Array-alloc                     5.5919+-0.5350     ?      5.6430+-0.0639        ?
ArrayBuffer-Int8Array-alloc-large-long-lived   18.3908+-1.0884     ?     18.4150+-0.7763        ?
ArrayBuffer-partial-transfer                    1.9269+-0.1601            1.8385+-0.0674          might be 1.0481x faster
ArrayBuffer-Int8Array-alloc-long-lived-buffer
                                                8.9535+-0.8227            8.9152+-0.9278
ArrayBuffer-DataView-alloc-large-long-lived    18.3303+-0.9816           18.0020+-1.0007          might be 1.0182x faster
ArrayBuffer-Int8Array-alloc-long-lived          6.6823+-0.6723            6.5441+-0.5609          might be 1.0211x faster

[1]: <a href="https://tc39.es/ecma262/#sec-arraybuffer-length">https://tc39.es/ecma262/#sec-arraybuffer-length</a>
[2]: <a href="https://tc39.es/ecma262/#sec-arraybuffercopyanddetach">https://tc39.es/ecma262/#sec-arraybuffercopyanddetach</a>
[3]: <a href="https://tc39.es/ecma262/#sec-typedarray">https://tc39.es/ecma262/#sec-typedarray</a>

Tests: JSTests/microbenchmarks/ArrayBuffer-full-transfer.js
       JSTests/microbenchmarks/ArrayBuffer-partial-transfer.js

* JSTests/microbenchmarks/ArrayBuffer-full-transfer.js: Added.
* JSTests/microbenchmarks/ArrayBuffer-partial-transfer.js: Added.
* JSTests/stress/dataview-construct.js:
(shouldThrow):
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/runtime/JSArrayBufferConstructor.cpp:
(JSC::JSGenericArrayBufferConstructor&lt;sharingMode&gt;::constructImpl):
* Source/JavaScriptCore/runtime/JSArrayBufferPrototype.cpp:
(JSC::arrayBufferProtoFuncTransferImpl):
* Source/JavaScriptCore/runtime/JSCJSValue.h:
* Source/JavaScriptCore/runtime/JSCJSValueInlines.h:
(JSC::JSValue::toTypedArrayIndex const): Deleted.
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructorInlines.h:
(JSC::constructGenericTypedArrayViewWithArguments):
(JSC::constructGenericTypedArrayViewImpl):

Canonical link: <a href="https://commits.webkit.org/301569@main">https://commits.webkit.org/301569@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/01e8c7cb2991fbeeca87280895e961830225887b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124732 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44404 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35139 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131577 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76652 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45108 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52974 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94903 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62960 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127686 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35980 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111554 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75470 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34911 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29708 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75054 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/116837 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105737 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29939 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134243 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/123252 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51580 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39392 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103379 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51993 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107774 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103150 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48517 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26796 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/48570 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19762 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51453 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57251 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/156314 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50847 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39156 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54202 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52541 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->