### PR TITLE
[JSC] Support `Promise.allSettled` in async stack trace

### DIFF
--- a/JSTests/stress/async-stack-trace-promise-allSettled-basic.js
+++ b/JSTests/stress/async-stack-trace-promise-allSettled-basic.js
@@ -1,0 +1,122 @@
+//@ requireOptions("--useAsyncStackTrace=1")
+
+const source = "async-stack-trace-promise-allSettled-basic.js";
+
+function nop() {}
+
+function shouldBe(a, b) {
+  if (a !== b)
+    throw new Error(`Expected ${a} to be ${b}`);
+}
+
+function testStack(error, stackFunctions) {
+  const stackTrace = error.stack;
+  if (!stackTrace) {
+    throw new Error("Expected error to have stack trace, but it was undefined");
+  }
+  const stackLines = stackTrace.split('\n').filter(line => line.trim());
+  for (let i = 0; i < stackFunctions.length; i++) {
+    const [expectedFunction, expectedLocation] = stackFunctions[i];
+    const isNativeCode = expectedLocation === "[native code]"
+    const stackLine = stackLines[i];
+
+    let found = false;
+
+    if (isNativeCode) {
+      if (stackLine === `${expectedFunction}@[native code]`)
+        found = true;
+    } else {
+      if (stackLine === `${expectedFunction}@${source}:${expectedLocation}`)
+        found = true;
+      if (stackLine === `${expectedFunction}@${source}`)
+        found = true;
+    }
+
+    if (!found) {
+      throw new Error(
+        `Expected stack trace to contain '${expectedFunction}' at '${expectedLocation}', but got '${stackLine}'` +
+        `\nActual stack trace:\n${stackTrace}\n`
+      );
+    }
+  }
+} 
+
+function unwrap(promise) {
+  let result;
+  promise.then(value => result = value);
+  drainMicrotasks();
+  return result;
+}
+
+{
+  async function fine() { }
+  async function thrower() { await fine(); throw new Error('error'); }
+  async function run() {
+    return await Promise.allSettled([thrower()]);
+  }
+  
+  for (let i = 0; i < testLoopCount; i++) {
+    const results = unwrap(run());
+    shouldBe(results.length, 1);
+    shouldBe(results[0].status, "rejected");
+    testStack(results[0].reason, [
+      ["thrower", "53:59"],
+      ["async run", "55:36"],
+      ["drainMicrotasks", "[native code]"],
+      ["unwrap", "47:18"],
+      ["global code", "59:27"]
+    ]);
+  }
+}
+
+{
+  async function fine() { }
+  async function task1() {
+    
+    await nop();
+  
+    throw new Error("error from task1");
+  }
+  async function task2() {
+    await nop();
+  
+  
+  
+    throw new Error('error from task2');
+  }
+  async function task3() { await 1; throw new Error("error from task3"); }
+  async function run() {
+    return await Promise.allSettled([fine(), task1(), fine(), task2(), task3()]);
+  }
+  
+  for (let i = 0; i < testLoopCount; i++) {
+    const results = unwrap(run());
+    shouldBe(results.length, 5);
+    shouldBe(results[0].status, "fulfilled");
+    shouldBe(results[1].status, "rejected");
+    shouldBe(results[2].status, "fulfilled");
+    shouldBe(results[3].status, "rejected");
+    shouldBe(results[4].status, "rejected");
+    testStack(results[1].reason, [
+      ["task1", "78:20"],
+      ["async run", "89:36"],
+      ["drainMicrotasks", "[native code]"],
+      ["unwrap", "47:18"],
+      ["global code", "93:27"]
+    ]);
+    testStack(results[3].reason, [
+      ["task2", "85:20"],
+      ["async run", "89:36"],
+      ["drainMicrotasks", "[native code]"],
+      ["unwrap", "47:18"],
+      ["global code", "93:27"]
+    ]);
+    testStack(results[4].reason, [
+      ["task3", "87:52"],
+      ["async run", "89:36"],
+      ["drainMicrotasks", "[native code]"],
+      ["unwrap", "47:18"],
+      ["global code", "93:27"]
+    ]);
+  }
+}

--- a/Source/JavaScriptCore/interpreter/Interpreter.cpp
+++ b/Source/JavaScriptCore/interpreter/Interpreter.cpp
@@ -497,7 +497,7 @@ void Interpreter::getAsyncStackTrace(JSCell* owner, Vector<StackFrame>& results,
             }
         }
 
-        // handle `Promise.any` and `Promise.race`
+        // handle `Promise.any`, `Promise.race` and `Promise.allSettled`
         if (auto* contextPromise = jsDynamicCast<JSPromise*>(promiseContext)) {
             if (JSValue parentContext = getContextValueFromPromise(contextPromise)) {
                 if (auto* generator = jsDynamicCast<JSGenerator*>(parentContext))


### PR DESCRIPTION
#### a4d9f6f9278a421409be76afa66900f9370bc236
<pre>
[JSC] Support `Promise.allSettled` in async stack trace
<a href="https://bugs.webkit.org/show_bug.cgi?id=300196">https://bugs.webkit.org/show_bug.cgi?id=300196</a>

Reviewed by Yusuke Suzuki.

This patch changes to support `Promise.allSettled` in async stack trace

Test: JSTests/stress/async-stack-trace-promise-allSettled-basic.js
* JSTests/stress/async-stack-trace-promise-allSettled-basic.js: Added.
(nop):
(shouldBe):
(testStack):
(async fine):
(async thrower):
(async run):
(testStack.async fine):
(testStack.async task1):
(testStack.async task2):
(testStack.async task3):
(testStack.async run):
* Source/JavaScriptCore/builtins/PromiseConstructor.js:
(allSettled):
* Source/JavaScriptCore/interpreter/Interpreter.cpp:
(JSC::Interpreter::getAsyncStackTrace):

Canonical link: <a href="https://commits.webkit.org/301257@main">https://commits.webkit.org/301257@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/67c31783550303bc8a0a51728b04a78a977241f6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124730 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44402 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35137 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131575 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76650 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45106 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52972 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94899 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62956 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127684 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35978 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111552 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75468 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34909 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29706 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75052 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/116835 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105735 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29937 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134241 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/123250 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51578 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39391 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103375 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51991 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107772 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103148 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26413 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48516 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26794 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48566 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51451 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57249 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/156313 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50844 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39155 "Found 8 new JSC stress test failures: wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.default-wasm, wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.wasm-bbq, wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.wasm-bbq-no-consts, wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.wasm-collect-continuously, wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.wasm-eager, wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.wasm-eager-jettison, wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.wasm-no-cjit, wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.wasm-slow-memory (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54200 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52539 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->