### PR TITLE
[Swift in WebKit] The bmalloc module map is malformed (must include pas_lock.h)

### DIFF
--- a/Source/bmalloc/Configurations/module.modulemap
+++ b/Source/bmalloc/Configurations/module.modulemap
@@ -1,18 +1,10 @@
 module bmalloc [system] {
+    config_macros OS_UNFAIR_LOCK_INLINE
+
     // List of "semi-public" bmalloc headers. What does "semi-public" mean? These are
     // the headers which, in practice, are included by WTF headers. WTF headers are
     // exported as part of the WebKit SPI, and therefore these headers need to be
     // buildable as a clang module.
-    // It's important that this list excludes pas_lock.h. pas_lock.h produces
-    // an #error if OS_UNFAIR_LOCK_INLINE is not 1, because bmalloc expects
-    // the underlying OS lock APIs to be confifgured in that fashion (and
-    // has presumably been tested only in that configuration.) In a modules build,
-    // that configuration can't be enforced by the including code (bmalloc) but
-    // instead all downstream consumers of bmalloc - right up to WebKit and things
-    // that depend upon WebKit - would individually need to set OS_UNFAIR_LOCK_INLINE.
-    // Or, bmalloc would need to be tested in two different configurations instead
-    // of producing an #error. This complexity is the main reason why bmalloc
-    // has a narrower, hand-curated list of headers in its module.
     explicit module bmalloc_cpp {
         requires cplusplus11
         header "Algorithm.h"
@@ -48,6 +40,7 @@ module bmalloc [system] {
         header "pas_allocation_mode.h"
         header "pas_config.h"
         header "pas_config_prefix.h"
+        header "pas_lock.h"
         header "pas_platform.h"
         header "pas_thread.h"
         header "pas_utils.h"


### PR DESCRIPTION
#### 3ecd1b1c515adcbf7a796fa3f39a7a9c9e1a9d14
<pre>
[Swift in WebKit] The bmalloc module map is malformed (must include pas_lock.h)
<a href="https://bugs.webkit.org/show_bug.cgi?id=300198">https://bugs.webkit.org/show_bug.cgi?id=300198</a>
<a href="https://rdar.apple.com/161993222">rdar://161993222</a>

Reviewed by Mark Lam.

Currently, (in Cocoa configurations at least) bmalloc depends on its client setting `OS_UNFAIR_LOCK_INLINE` to `1`;
otherwise, a compilation error happens. However, modules require that libraries/frameworks are usable without any
explicit configuration set. Therefore, bmalloc must at least be able to compile all its translation units regardless
of the value of `OS_UNFAIR_LOCK_INLINE`.

To workaround this, the `pas_lock.h` file was initially excluded from the module map. However, this is invalid as
it results in modular headers then including non-modular headers, which is a violation. This has not been a problem
so far because (a) there is no automatic module verification for libraries and (b) there is yet a Swift/Cxx interop
include path in WebKit or WebCore that depends on a file that uses `bmalloc`. Manually performing module verification
does reveal this issue, which is a violation and needs to be remedied.

To fix, the `#error` directive must be removed so that bmalloc can be built regardless of the value of `OS_UNFAIR_LOCK_INLINE`.
Consequently, some more compilation conditions have to be added to the file to account for configurations where
`OS_UNFAIR_LOCK_INLINE` is `0` since the relevant locking APIs from the system are unavailable.

In actuality, these paths where `OS_UNFAIR_LOCK_INLINE` is `0` will never actually be executed; they just need to
be able to compile.

Since this is technically a slight change of behavior, there are several safe guards added:

1. There are currently no Cocoa bmalloc clients that set `OS_UNFAIR_LOCK_INLINE` to `0` or leave it undefined
2. If, for some reason, one of the existing clients changed the value from `1` to `0`, a compiler diagnostic message
will be emitted with the same message as the error would have given.
3. The invalid branches are limited in scope, and immediately cause a release assertion if triggered.

One alternative considered was to wrap every header and translation unit in bmalloc with a compile time guard; this
was decided against because although this would technically not be a change in behavior for bmalloc, the changes would
be quite extensive and intrusive. Additionally, this would just move the issue up one dependency to the client of bmalloc anyways.

* Source/WebKit/Configurations/WebKit.xcconfig:
* Source/bmalloc/Configurations/module.modulemap:
* Source/bmalloc/libpas/src/libpas/pas_lock.h:
(pas_lock_lock):
(pas_lock_try_lock):
(pas_lock_unlock):

Canonical link: <a href="https://commits.webkit.org/301104@main">https://commits.webkit.org/301104@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/88c07de2edc28128de9d64a2f13af0a7cb5f9042

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124955 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44624 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35361 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131805 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/76835 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f780a5ed-f7b5-4f50-85e1-2d7e9c733f55) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45317 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53191 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/95101 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/76835 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0b5578e0-503a-4fd7-818e-5cc2b6e2659d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127909 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/36163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111748 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/75649 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/39c698bf-3720-4bde-b512-1e0101d53524) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/35095 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29901 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75285 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/117053 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/105926 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30133 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134478 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/123474 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51782 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/39583 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/103579 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52205 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107961 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/103355 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26311 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/48695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/26981 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48802 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51663 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/156499 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/51042 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/39196 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/54397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/52735 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->