### PR TITLE
Add support for the Speculation-Rules HTTP header

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https.html
@@ -69,8 +69,9 @@
     let speculation_rule_set_url = `ruleset.py?url=${executor_url}&uuid=${uuid}&page=${page}&status=${options.status}&valid_mime=${options.useValidMimeTypeForSpeculationRulesSet}&valid_json=${options.useValidJsonForSpeculationRulesSet}&empty_json=${options.useEmptySpeculationRulesSet}&fail_cors=${options.failCors}&valid_encoding=${options.useUtf8EncodingForSpeculationRulesSet}&redirect=${options.redirect}`;
     if (!options.useRelativeUrlForSpeculationRulesSet) {
       let base_url = new URL(SR_PREFETCH_UTILS_URL);
-      base_url.hostname = get_host_info().NOTSAMESITE_HOST;
-      speculation_rule_set_url = new URL(speculation_rule_set_url, base_url).toString();
+      const cross_origin_url = new URL(get_host_info().HTTPS_NOTSAMESITE_ORIGIN);
+      cross_origin_url.pathname = base_url.pathname;
+      speculation_rule_set_url = new URL(speculation_rule_set_url, cross_origin_url).toString();
     }
     if (!options.useValidUrlForSpeculationRulesSet) {
       speculation_rule_set_url = "http://:80/";

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=BaseCase-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=BaseCase-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Base case. assert_in_array: Prefetch should work for request {"shouldPrefetch":true,"status":200,"redirect":false,"useRelativeUrlForCandidate":false,"useRelativeUrlForSpeculationRulesSet":false,"useUtf8EncodingForSpeculationRulesSet":true,"failCors":false,"useValidSpeculationRulesHeaderValue":true,"useInnerListInSpeculationRulesHeaderValue":false,"useEmptySpeculationRulesSet":false,"useValidJsonForSpeculationRulesSet":true,"useValidUrlForSpeculationRulesSet":true,"useValidMimeTypeForSpeculationRulesSet":true,"strictCSP":false}. value undefined not in array ["prefetch", "prefetch;anonymous-client-ip"]
+PASS Base case.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=CSPExemption-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=CSPExemption-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL It should accept the speculation rules when the main page has strict CSP. assert_in_array: Prefetch should work for request {"shouldPrefetch":true,"status":200,"redirect":false,"useRelativeUrlForCandidate":false,"useRelativeUrlForSpeculationRulesSet":false,"useUtf8EncodingForSpeculationRulesSet":true,"failCors":false,"useValidSpeculationRulesHeaderValue":true,"useInnerListInSpeculationRulesHeaderValue":false,"useEmptySpeculationRulesSet":false,"useValidJsonForSpeculationRulesSet":true,"useValidUrlForSpeculationRulesSet":true,"useValidMimeTypeForSpeculationRulesSet":true,"strictCSP":true}. value undefined not in array ["prefetch", "prefetch;anonymous-client-ip"]
+PASS It should accept the speculation rules when the main page has strict CSP.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=FollowRedirect-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=FollowRedirect-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL It should follow redirects and fetch the speculation rules set. assert_in_array: Prefetch should work for request {"shouldPrefetch":true,"status":200,"redirect":true,"useRelativeUrlForCandidate":false,"useRelativeUrlForSpeculationRulesSet":false,"useUtf8EncodingForSpeculationRulesSet":true,"failCors":false,"useValidSpeculationRulesHeaderValue":true,"useInnerListInSpeculationRulesHeaderValue":false,"useEmptySpeculationRulesSet":false,"useValidJsonForSpeculationRulesSet":true,"useValidUrlForSpeculationRulesSet":true,"useValidMimeTypeForSpeculationRulesSet":true,"strictCSP":false}. value undefined not in array ["prefetch", "prefetch;anonymous-client-ip"]
+PASS It should follow redirects and fetch the speculation rules set.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=RelativeUrlForSpeculationRulesSet-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=RelativeUrlForSpeculationRulesSet-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL It should fetch a speculation rules set using its relative URL. assert_in_array: Prefetch should work for request {"shouldPrefetch":true,"status":200,"redirect":false,"useRelativeUrlForCandidate":false,"useRelativeUrlForSpeculationRulesSet":true,"useUtf8EncodingForSpeculationRulesSet":true,"failCors":false,"useValidSpeculationRulesHeaderValue":true,"useInnerListInSpeculationRulesHeaderValue":false,"useEmptySpeculationRulesSet":false,"useValidJsonForSpeculationRulesSet":true,"useValidUrlForSpeculationRulesSet":true,"useValidMimeTypeForSpeculationRulesSet":true,"strictCSP":false}. value undefined not in array ["prefetch", "prefetch;anonymous-client-ip"]
+PASS It should fetch a speculation rules set using its relative URL.
 

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1403,6 +1403,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     dom/LiveNodeListInlines.h
     dom/LoadableClassicScript.h
     dom/LoadableModuleScript.h
+    dom/LoadableSpeculationRules.h
     dom/LoadableScript.h
     dom/LoadableScriptClient.h
     dom/LoadableScriptError.h

--- a/Source/WebCore/Modules/fetch/FetchRequestDestination.idl
+++ b/Source/WebCore/Modules/fetch/FetchRequestDestination.idl
@@ -46,6 +46,7 @@ enum FetchRequestDestination {
     "script",
     "serviceworker",
     "sharedworker",
+    "speculationrules",
     "style",
     "track",
     "video",

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1300,6 +1300,7 @@ dom/KeyboardEvent.cpp
 dom/LiveNodeList.cpp
 dom/LoadableClassicScript.cpp
 dom/LoadableModuleScript.cpp
+dom/LoadableSpeculationRules.cpp
 dom/LoadableScript.cpp
 dom/MessageChannel.cpp
 dom/MessageEvent.cpp

--- a/Source/WebCore/bindings/js/ScriptController.cpp
+++ b/Source/WebCore/bindings/js/ScriptController.cpp
@@ -977,13 +977,13 @@ void ScriptController::registerImportMap(const ScriptSourceCode& sourceCode, con
         globalObject->importMap().mergeExistingAndNewImportMaps(WTFMove(newImportMap.value()), reporter);
 }
 
-void ScriptController::registerSpeculationRules(const ScriptSourceCode& sourceCode, const URL& baseURL)
+bool ScriptController::registerSpeculationRules(const ScriptSourceCode& sourceCode, const URL& baseURL)
 {
     RefPtr document = m_frame->document();
     if (!document || !document->settings().speculationRulesPrefetchEnabled())
-        return;
+        return false;
 
-    document->speculationRules()->parseSpeculationRules(sourceCode.source(), baseURL, document->url());
+    return document->speculationRules()->parseSpeculationRules(sourceCode.source(), baseURL, document->url());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/ScriptController.h
+++ b/Source/WebCore/bindings/js/ScriptController.h
@@ -176,7 +176,7 @@ public:
     void reportExceptionFromScriptError(LoadableScript::Error, bool);
 
     void registerImportMap(const ScriptSourceCode&, const URL& baseURL);
-    void registerSpeculationRules(const ScriptSourceCode&, const URL& baseURL);
+    bool registerSpeculationRules(const ScriptSourceCode&, const URL& baseURL);
 
 private:
     ValueOrException executeScriptInWorld(DOMWrapperWorld&, RunJavaScriptParameters&&);

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -248,6 +248,7 @@ class Settings;
 class SleepDisabler;
 class SpaceSplitString;
 class SpeculationRules;
+class LoadableSpeculationRules;
 class SpeechRecognition;
 class StorageConnection;
 class StringCallback;
@@ -2029,6 +2030,8 @@ public:
 
     WEBCORE_EXPORT void prefetch(const URL&, const Vector<String>&, const String&, bool lowPriority = false);
 
+    void processSpeculationRulesHeader(const String& headerValue, const URL& baseURL);
+
 protected:
     enum class ConstructionFlag : uint8_t {
         Synthesized = 1 << 0,
@@ -2776,6 +2779,8 @@ private:
     mutable RefPtr<CSSCalc::RandomCachingKeyMap> m_randomCachingKeyMap;
 
     const Ref<DocumentSyncData> m_syncData;
+
+    Vector<Ref<LoadableSpeculationRules>> m_loadableSpeculationRules;
 }; // class Document
 
 inline AXObjectCache* Document::existingAXObjectCache() const

--- a/Source/WebCore/dom/LoadableSpeculationRules.cpp
+++ b/Source/WebCore/dom/LoadableSpeculationRules.cpp
@@ -1,0 +1,147 @@
+/*
+ * Copyright (C) 2025 Shopify Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "LoadableSpeculationRules.h"
+
+#include "CachedResourceLoader.h"
+#include "CachedResourceRequest.h"
+#include "CachedScript.h"
+#include "CrossOriginAccessControl.h"
+#include "Document.h"
+#include "DocumentInlines.h"
+#include "DocumentResourceLoader.h"
+#include "FrameDestructionObserverInlines.h"
+#include "LocalFrame.h"
+#include "ResourceRequest.h"
+#include "ScriptController.h"
+#include "ScriptSourceCode.h"
+
+#include <wtf/text/MakeString.h>
+#include <wtf/text/StringConcatenate.h>
+
+namespace WebCore {
+
+Ref<LoadableSpeculationRules> LoadableSpeculationRules::create(Document& document, const URL& url)
+{
+    return adoptRef(*new LoadableSpeculationRules(document, url));
+}
+
+LoadableSpeculationRules::LoadableSpeculationRules(Document& document, const URL& url)
+    : m_document(document)
+    , m_url(url)
+{
+}
+
+LoadableSpeculationRules::~LoadableSpeculationRules()
+{
+    if (m_cachedScript)
+        m_cachedScript->removeClient(*this);
+}
+
+CachedResourceHandle<CachedScript> LoadableSpeculationRules::requestSpeculationRules(Document& document, const URL& sourceURL)
+{
+    // https://html.spec.whatwg.org/C#the-speculation-rules-header
+    // 3.4.2.2.1. Let request be a new request whose URL is url, destination is "speculationrules", and mode is "cors".
+    if (!document.settings().isScriptEnabled())
+        return nullptr;
+
+    ResourceLoaderOptions options = CachedResourceLoader::defaultCachedResourceOptions();
+    options.contentSecurityPolicyImposition = ContentSecurityPolicyImposition::DoPolicyCheck;
+    options.sameOriginDataURLFlag = SameOriginDataURLFlag::Set;
+    options.serviceWorkersMode = ServiceWorkersMode::All;
+    options.integrity = ""_s;
+    options.referrerPolicy = ReferrerPolicy::EmptyString;
+    options.fetchPriority = RequestPriority::Auto;
+    options.destination = FetchOptionsDestination::Speculationrules;
+
+    auto request = createPotentialAccessControlRequest(URL { sourceURL }, WTFMove(options), document, ""_s);
+    request.upgradeInsecureRequestIfNeeded(document);
+    request.setPriority(ResourceLoadPriority::Low);
+
+    return document.protectedCachedResourceLoader()->requestScript(WTFMove(request)).value_or(nullptr);
+}
+
+bool LoadableSpeculationRules::load(Document& document, const URL& url)
+{
+    ASSERT(!m_cachedScript);
+
+    if (!url.isValid())
+        return false;
+
+    CachedResourceHandle cachedScript = requestSpeculationRules(document, m_url);
+    m_cachedScript = cachedScript;
+    if (!cachedScript)
+        return false;
+    cachedScript->addClient(*this);
+
+    return true;
+}
+
+// https://html.spec.whatwg.org/C#the-speculation-rules-header
+// 3.4.2.2. processResponseConsumeBody
+void LoadableSpeculationRules::notifyFinished(CachedResource& resource, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess)
+{
+    ASSERT(&resource == m_cachedScript.get());
+
+    RefPtr document = m_document.get();
+    if (!document)
+        return;
+
+    // 1. If bodyBytes is null or failure, then abort these steps.
+    // 2. If response's status is not an ok status, then abort these steps.
+    if (m_cachedScript->errorOccurred()) {
+        document->addConsoleMessage(MessageSource::Other, MessageLevel::Error, makeString("Failed to load speculation rules from "_s, m_url.string()));
+        return;
+    }
+
+    // 3. If the result of extracting a MIME type from response's header list does not have an essence of "application/speculationrules+json", then abort these steps.
+    if (resource.mimeType() != "application/speculationrules+json") {
+        document->addConsoleMessage(MessageSource::Other, MessageLevel::Error, makeString("Invalid speculation rules MIME type "_s, m_url.string()));
+        return;
+    }
+
+    // 4. Let bodyText be the result of UTF-8 decoding bodyBytes.
+    if (resource.encoding() != "UTF-8"_s) {
+        document->addConsoleMessage(MessageSource::Other, MessageLevel::Error, makeString("Invalid speculation rules encoding "_s, m_url.string()));
+        return;
+    }
+
+    String speculationRulesText = m_cachedScript->script().toString();
+    if (speculationRulesText.isEmpty())
+        return;
+
+    if (RefPtr frame = document->frame()) {
+        ScriptSourceCode sourceCode(speculationRulesText, JSC::SourceTaintedOrigin::Untainted, URL(m_url), TextPosition(), JSC::SourceProviderSourceType::Program);
+        // 5. Let ruleSet be the result of parsing a speculation rule set string given bodyText, document, and response's URL. If this throws an exception, then abort these steps.
+        // 6. Append ruleSet to document's speculation rule sets.
+        if (frame->checkedScript()->registerSpeculationRules(sourceCode, m_url)) {
+            // 7. Consider speculative loads for document.
+            document->considerSpeculationRules();
+        }
+    }
+}
+
+} // namespace WebCore

--- a/Source/WebCore/dom/LoadableSpeculationRules.h
+++ b/Source/WebCore/dom/LoadableSpeculationRules.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2025 Shopify Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CachedResourceClient.h"
+#include "CachedResourceHandle.h"
+#include "FetchOptionsDestination.h"
+#include "ResourceLoaderOptions.h"
+#include "ResourceRequest.h"
+#include <wtf/FastMalloc.h>
+#include <wtf/RefCounted.h>
+#include <wtf/URL.h>
+#include <wtf/WeakPtr.h>
+
+namespace WebCore {
+
+class CachedScript;
+class Document;
+class NetworkLoadMetrics;
+class WeakPtrImplWithEventTargetData;
+enum class LoadWillContinueInAnotherProcess : bool;
+
+class LoadableSpeculationRules final : public RefCounted<LoadableSpeculationRules>, public CachedResourceClient {
+public:
+    static Ref<LoadableSpeculationRules> create(Document&, const URL&);
+    ~LoadableSpeculationRules();
+
+    bool load(Document&, const URL&);
+    void notifyFinished(CachedResource&, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess = LoadWillContinueInAnotherProcess::No) final;
+
+private:
+    LoadableSpeculationRules(Document&, const URL&);
+
+    CachedResourceHandle<CachedScript> requestSpeculationRules(Document&, const URL& sourceURL);
+
+    CachedResourceHandle<CachedScript> m_cachedScript;
+    WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
+    URL m_url;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/dom/ScriptElement.cpp
+++ b/Source/WebCore/dom/ScriptElement.cpp
@@ -667,8 +667,8 @@ void ScriptElement::registerSpeculationRules(const ScriptSourceCode& sourceCode)
     if (!frame)
         return;
 
-    frame->checkedScript()->registerSpeculationRules(sourceCode, document->baseURL());
-    document->considerSpeculationRules();
+    if (frame->checkedScript()->registerSpeculationRules(sourceCode, document->baseURL()))
+        document->considerSpeculationRules();
 }
 
 // TODO: Also implement unregister/update speculation rules

--- a/Source/WebCore/dom/TaskSource.h
+++ b/Source/WebCore/dom/TaskSource.h
@@ -48,6 +48,7 @@ enum class TaskSource : uint8_t {
     Reporting,
     ScreenWakelock,
     Speech,
+    SpeculationRules,
     Timer,
     UserInteraction,
     WebGL,

--- a/Source/WebCore/loader/FetchOptions.h
+++ b/Source/WebCore/loader/FetchOptions.h
@@ -142,6 +142,7 @@ template<> struct EnumTraitsForPersistence<WebCore::FetchOptions::Destination> {
         WebCore::FetchOptions::Destination::Script,
         WebCore::FetchOptions::Destination::Serviceworker,
         WebCore::FetchOptions::Destination::Sharedworker,
+        WebCore::FetchOptions::Destination::Speculationrules,
         WebCore::FetchOptions::Destination::Style,
         WebCore::FetchOptions::Destination::Track,
         WebCore::FetchOptions::Destination::Video,

--- a/Source/WebCore/loader/FetchOptionsDestination.h
+++ b/Source/WebCore/loader/FetchOptionsDestination.h
@@ -47,6 +47,7 @@ enum class FetchOptionsDestination : uint8_t {
     Script,
     Serviceworker,
     Sharedworker,
+    Speculationrules,
     Style,
     Track,
     Video,

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -794,6 +794,12 @@ void FrameLoader::receivedFirstData()
     LinkLoader::loadLinksFromHeader(documentLoader->response().httpHeaderField(HTTPHeaderName::Link), document->url(), document, LinkLoader::MediaAttributeCheck::MediaAttributeEmpty);
 
     scheduleRefreshIfNeeded(document, documentLoader->response().httpHeaderField(HTTPHeaderName::Refresh), IsMetaRefresh::No);
+
+    if (document->settings().speculationRulesPrefetchEnabled()) {
+        String speculationRulesHeader = documentLoader->response().httpHeaderField(HTTPHeaderName::SpeculationRules);
+        if (!speculationRulesHeader.isEmpty())
+            document->processSpeculationRulesHeader(speculationRulesHeader, documentLoader->response().url());
+    }
 }
 
 void FrameLoader::setOutgoingReferrer(const URL& url)

--- a/Source/WebCore/loader/LinkLoader.cpp
+++ b/Source/WebCore/loader/LinkLoader.cpp
@@ -187,6 +187,8 @@ std::optional<CachedResource::Type> LinkLoader::resourceTypeFromAsAttribute(cons
         return CachedResource::Type::Script;
     case FetchRequestDestination::Sharedworker:
         return CachedResource::Type::Script;
+    case FetchRequestDestination::Speculationrules:
+        return CachedResource::Type::Script;
     case FetchRequestDestination::Style:
         return CachedResource::Type::CSSStyleSheet;
     case FetchRequestDestination::Track:

--- a/Source/WebCore/loader/SpeculationRules.cpp
+++ b/Source/WebCore/loader/SpeculationRules.cpp
@@ -327,29 +327,30 @@ static std::optional<Vector<SpeculationRules::Rule>> parseRules(const JSON::Obje
 }
 
 // https://wicg.github.io/nav-speculation/speculation-rules.html#parse-speculation-rules
-void SpeculationRules::parseSpeculationRules(const StringView& text, const URL& rulesetBaseURL, const URL& documentBaseURL)
+bool SpeculationRules::parseSpeculationRules(const StringView& text, const URL& rulesetBaseURL, const URL& documentBaseURL)
 {
     auto jsonValue = JSON::Value::parseJSON(text);
     if (!jsonValue)
-        return;
+        return false;
 
     auto jsonObject = jsonValue->asObject();
     if (!jsonObject)
-        return;
+        return false;
 
     String rulesetLevelTag;
     auto tagValue = jsonObject->getValue("tag"_s);
     if (tagValue && tagValue->type() == JSON::Value::Type::String) {
         String candidateTag = tagValue->asString();
         if (!candidateTag.containsOnlyASCII() || !candidateTag.containsOnly<isASCIIPrintable>())
-            return;
+            return false;
         rulesetLevelTag = candidateTag;
     }
 
     auto prefetch = parseRules(*jsonObject, "prefetch"_s, rulesetLevelTag, rulesetBaseURL, documentBaseURL);
     if (!prefetch)
-        return;
+        return false;
     m_prefetchRules.appendVector(WTFMove(*prefetch));
+    return true;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/loader/SpeculationRules.h
+++ b/Source/WebCore/loader/SpeculationRules.h
@@ -98,7 +98,7 @@ public:
     static Ref<SpeculationRules> create();
 
     // https://wicg.github.io/nav-speculation/speculation-rules.html#parse-speculation-rules
-    WEBCORE_EXPORT void parseSpeculationRules(const StringView&, const URL& rulesetBaseURL, const URL& documentBaseURL);
+    WEBCORE_EXPORT bool parseSpeculationRules(const StringView&, const URL& rulesetBaseURL, const URL& documentBaseURL);
 
     const Vector<Rule>& prefetchRules() const;
 

--- a/Source/WebCore/platform/network/HTTPHeaderNames.in
+++ b/Source/WebCore/platform/network/HTTPHeaderNames.in
@@ -92,6 +92,7 @@ Sec-Fetch-Mode
 Sec-Fetch-Site
 Sec-Purpose
 Sec-Speculation-Tags
+Speculation-Rules
 Sec-WebSocket-Accept
 Sec-WebSocket-Extensions
 Sec-WebSocket-Key

--- a/Source/WebCore/platform/network/RFC8941.h
+++ b/Source/WebCore/platform/network/RFC8941.h
@@ -65,6 +65,7 @@ using InnerList = Vector<std::pair<BareItem, Parameters>>;
 using ItemOrInnerList = Variant<BareItem, InnerList>;
 
 WEBCORE_EXPORT std::optional<std::pair<BareItem, Parameters>> parseItemStructuredFieldValue(StringView header);
+WEBCORE_EXPORT std::optional<Vector<std::pair<ItemOrInnerList, Parameters>>> parseListStructuredFieldValue(StringView header);
 WEBCORE_EXPORT std::optional<HashMap<String, std::pair<ItemOrInnerList, Parameters>>> parseDictionaryStructuredFieldValue(StringView header);
 
 } // namespace RFC8941

--- a/Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp
@@ -372,6 +372,7 @@ bool NetworkLoadChecker::isAllowedByContentSecurityPolicy(const ResourceRequest&
         return contentSecurityPolicy->allowWorkerFromSource(request.url(), redirectResponseReceived, preRedirectURL);
     case FetchOptions::Destination::Json:
     case FetchOptions::Destination::Script:
+    case FetchOptions::Destination::Speculationrules:
         if (request.requester() == ResourceRequestRequester::ImportScripts && !contentSecurityPolicy->allowScriptFromSource(request.url(), redirectResponseReceived, preRedirectURL))
             return false;
         // FIXME: Check CSP for non-importScripts() initiated loads.

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -528,6 +528,8 @@ ResourceLoadInfo NetworkResourceLoader::resourceLoadInfo()
             return ResourceLoadInfo::Type::Other;
         case WebCore::FetchOptions::Destination::Sharedworker:
             return ResourceLoadInfo::Type::Other;
+        case WebCore::FetchOptions::Destination::Speculationrules:
+            return ResourceLoadInfo::Type::Other;
         case WebCore::FetchOptions::Destination::Style:
             return ResourceLoadInfo::Type::Stylesheet;
         case WebCore::FetchOptions::Destination::Track:

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -3752,6 +3752,7 @@ enum class WebCore::FetchOptionsDestination : uint8_t {
     Script,
     Serviceworker,
     Sharedworker,
+    Speculationrules,
     Style,
     Track,
     Video,


### PR DESCRIPTION
#### d7e8f73dd5abdd8b94c014847a5fb75c61de85f6
<pre>
Add support for the Speculation-Rules HTTP header
<a href="https://bugs.webkit.org/show_bug.cgi?id=300110">https://bugs.webkit.org/show_bug.cgi?id=300110</a>

Reviewed by Alex Christensen.

This PR adds support for the Speculation-Rules header, which allows
servers to add speculation rules into pages without modifying their HTML.

* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https.html: Fix up cross-origin host.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=BaseCase-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=CSPExemption-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=FollowRedirect-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=RelativeUrlForSpeculationRulesSet-expected.txt: Progression.
* Source/WebCore/Headers.cmake: Add LoadableSpeculationRules.h
* Source/WebCore/Modules/fetch/FetchRequestDestination.idl: Add a speculationrules destination.
* Source/WebCore/Sources.txt: Add LoadableSpeculationRules.cpp
* Source/WebCore/WebCore.xcodeproj/project.pbxproj: Add new files.
* Source/WebCore/bindings/js/ScriptController.cpp:
(WebCore::ScriptController::registerSpeculationRules): Return false when speculation rules parsing fails.
* Source/WebCore/bindings/js/ScriptController.h:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::processSpeculationRulesHeader): Implement header processing.
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/LoadableSpeculationRules.cpp: Added.
(WebCore::LoadableSpeculationRules::create):
(WebCore::LoadableSpeculationRules::LoadableSpeculationRules):
(WebCore::LoadableSpeculationRules::~LoadableSpeculationRules):
(WebCore::LoadableSpeculationRules::requestSpeculationRules):
(WebCore::LoadableSpeculationRules::load): Load the speculation rules ruleset.
(WebCore::LoadableSpeculationRules::notifyFinished): Process the ruleset.
* Source/WebCore/dom/LoadableSpeculationRules.h: Copied from Source/WebCore/loader/FetchOptionsDestination.h.
* Source/WebCore/dom/ScriptElement.cpp:
(WebCore::ScriptElement::registerSpeculationRules): Only consider rules when parsing was successful.
* Source/WebCore/dom/TaskSource.h: Add speculationrules.
* Source/WebCore/loader/FetchOptions.h: Add speculationrules.
* Source/WebCore/loader/FetchOptionsDestination.h: Add speculationrules.
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::receivedFirstData): Call the Speculation-Rules header processing when the response first data is received.
* Source/WebCore/loader/LinkLoader.cpp:
(WebCore::LinkLoader::resourceTypeFromAsAttribute): Handle speculationrules destination.
* Source/WebCore/loader/SpeculationRules.cpp:
(WebCore::SpeculationRules::parseSpeculationRules): Return false on parsing failure.
* Source/WebCore/loader/SpeculationRules.h:
* Source/WebCore/platform/network/HTTPHeaderNames.in: Add Speculation-Rules.
* Source/WebCore/platform/network/RFC8941.cpp:
(RFC8941::parseList): List parsing implementation.
(RFC8941::parseListStructuredFieldValue): Parse a structured field list.
* Source/WebCore/platform/network/RFC8941.h:
* Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp:
(WebKit::NetworkLoadChecker::isAllowedByContentSecurityPolicy): Handle speculationrules destination.
* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::resourceLoadInfo): Handle speculationrules destination.
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in: Add speculationrules destination.

Canonical link: <a href="https://commits.webkit.org/301084@main">https://commits.webkit.org/301084@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/93b012e932bd8b4a315cd6f02f7670adea818aac

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124744 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44416 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35151 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131590 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76663 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/126621 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45120 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52986 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94910 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62967 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127698 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35988 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111562 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75479 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34919 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29716 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75066 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105745 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29947 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134255 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51592 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39401 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103387 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52005 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107782 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103158 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26300 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48526 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26804 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48591 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51465 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57263 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50859 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54214 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52553 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->