### PR TITLE
Adopt LIFETIME_BOUND for WTF::RefPtr

### DIFF
--- a/Source/JavaScriptCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/JavaScriptCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -110,7 +110,6 @@ runtime/TypeSet.cpp
 runtime/VMTraps.cpp
 runtime/WaiterListManager.h
 tools/JSDollarVM.cpp
-tools/VMInspector.cpp
 wasm/WasmBBQJIT.cpp
 wasm/WasmBBQJIT64.cpp
 wasm/WasmBBQPlan.cpp

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
@@ -2371,7 +2371,7 @@ RegisterID* BytecodeGenerator::emitResolveScopeForHoistingFuncDeclInEval(Registe
     else
         OpGetScope::emit(this, scope.get());
     OpResolveScopeForHoistingFuncDeclInEval::emit(this, kill(result.get()), scope.get(), addConstant(property));
-    return result.get();
+    return result.unsafeGet();
 }
 
 void BytecodeGenerator::popLexicalScope(VariableEnvironmentNode* node)
@@ -4775,7 +4775,7 @@ RegisterID* BytecodeGenerator::emitGetTemplateObject(RegisterID* dst, TaggedTemp
     }
     RefPtr<RegisterID> constant = addTemplateObjectConstant(TemplateObjectDescriptor::create(WTFMove(rawStrings), WTFMove(cookedStrings)), taggedTemplate->endOffset());
     if (!dst)
-        return constant.get();
+        return constant.unsafeGet();
     return move(dst, constant.get());
 }
 
@@ -5133,7 +5133,7 @@ RegisterID* BytecodeGenerator::emitGetGenericIterator(RegisterID* argument, Thro
     RefPtr<RegisterID> iterator = emitGetById(newTemporary(), argument, propertyNames().iteratorSymbol);
     emitCallIterator(iterator.get(), argument, node);
 
-    return iterator.get();
+    return iterator.unsafeGet();
 }
 
 RegisterID* BytecodeGenerator::emitIteratorGenericNext(RegisterID* dst, RegisterID* nextMethod, RegisterID* iterator, const ThrowableExpressionData* node, EmitAwait doEmitAwait)
@@ -5221,7 +5221,7 @@ RegisterID* BytecodeGenerator::emitGetAsyncIterator(RegisterID* argument, Throwa
     emitCallIterator(iterator.get(), argument, node);
     emitLabel(iteratorReceived.get());
 
-    return iterator.get();
+    return iterator.unsafeGet();
 }
 
 RegisterID* BytecodeGenerator::emitDelegateYield(RegisterID* argument, ThrowableExpressionData* node)
@@ -5342,7 +5342,7 @@ RegisterID* BytecodeGenerator::emitDelegateYield(RegisterID* argument, Throwable
     }
 
     emitGetById(value.get(), value.get(), propertyNames().value);
-    return value.get();
+    return value.unsafeGet();
 }
 
 

--- a/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
+++ b/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
@@ -1031,7 +1031,7 @@ RegisterID* BracketAccessorNode::emitBytecode(BytecodeGenerator& generator, Regi
         }
 
         generator.emitProfileType(finalDest.get(), divotStart(), divotEnd());
-        return finalDest.get();
+        return finalDest.unsafeGet();
     }
 
     RegisterID* ret;
@@ -1335,7 +1335,7 @@ RegisterID* EvalFunctionCallNode::emitBytecode(BytecodeGenerator& generator, Reg
     } else
         generator.emitCallDirectEval(returnValue.get(), func.get(), callArguments, divot(), divotStart(), divotEnd(), DebuggableCall::No);
 
-    return returnValue.get();
+    return returnValue.unsafeGet();
 }
 
 // ------------------------------ FunctionCallValueNode ----------------------------------
@@ -1410,7 +1410,7 @@ RegisterID* StaticBlockFunctionCallNode::emitBytecode(BytecodeGenerator& generat
     RefPtr result = generator.emitCallInTailPosition(returnValue.get(), function.get(), NoExpectedFunction, callArguments, divot(), divotStart(), divotEnd(), DebuggableCall::Yes);
 
     generator.emitProfileType(returnValue.get(), divotStart(), divotEnd());
-    return result.get();
+    return result.unsafeGet();
 }
 
 // ------------------------------ FunctionCallResolveNode ----------------------------------
@@ -2495,7 +2495,7 @@ RegisterID* BytecodeIntrinsicNode::emit_intrinsic_newArrayWithSize(JSC::Bytecode
 
     RefPtr<RegisterID> finalDestination = generator.finalDestination(dst);
     generator.emitNewArrayWithSize(finalDestination.get(), size.get());
-    return finalDestination.get();
+    return finalDestination.unsafeGet();
 }
 
 RegisterID* BytecodeIntrinsicNode::emit_intrinsic_newArrayWithSpecies(JSC::BytecodeGenerator& generator, JSC::RegisterID* dst)
@@ -2508,7 +2508,7 @@ RegisterID* BytecodeIntrinsicNode::emit_intrinsic_newArrayWithSpecies(JSC::Bytec
 
     RefPtr<RegisterID> finalDestination = generator.finalDestination(dst);
     generator.emitNewArrayWithSpecies(finalDestination.get(), size.get(), array.get());
-    return finalDestination.get();
+    return finalDestination.unsafeGet();
 }
 
 RegisterID* BytecodeIntrinsicNode::emit_intrinsic_createPromise(JSC::BytecodeGenerator& generator, JSC::RegisterID* dst)
@@ -2528,7 +2528,7 @@ RegisterID* BytecodeIntrinsicNode::emit_intrinsic_newPromise(JSC::BytecodeGenera
     RefPtr<RegisterID> finalDestination = generator.finalDestination(dst);
     bool isInternalPromise = false;
     generator.emitNewPromise(finalDestination.get(), isInternalPromise);
-    return finalDestination.get();
+    return finalDestination.unsafeGet();
 }
 
 
@@ -2709,7 +2709,7 @@ RegisterID* CallFunctionCallDotNode::emitBytecode(BytecodeGenerator& generator, 
         generator.move(callArguments.thisRegister(), base.get());
         generator.emitCallInTailPosition(returnValue.get(), function.get(), NoExpectedFunction, callArguments, divot(), divotStart(), divotEnd(), DebuggableCall::Yes);
         generator.move(dst, returnValue.get());
-        return returnValue.get();
+        return returnValue.unsafeGet();
     }
 
     Ref<Label> realCall = generator.newLabel();
@@ -2755,7 +2755,7 @@ RegisterID* CallFunctionCallDotNode::emitBytecode(BytecodeGenerator& generator, 
         generator.emitLabel(end.get());
     }
     generator.emitProfileType(returnValue.get(), divotStart(), divotEnd());
-    return returnValue.get();
+    return returnValue.unsafeGet();
 }
 
 RegisterID* HasOwnPropertyFunctionCallDotNode::emitBytecode(BytecodeGenerator& generator, RegisterID* dst)
@@ -2824,7 +2824,7 @@ RegisterID* HasOwnPropertyFunctionCallDotNode::emitBytecode(BytecodeGenerator& g
     }
 
     generator.emitProfileType(returnValue.get(), divotStart(), divotEnd());
-    return returnValue.get();
+    return returnValue.unsafeGet();
 }
 
 static bool areTrivialApplyArguments(ArgumentsNode* args)
@@ -2865,7 +2865,7 @@ RegisterID* ApplyFunctionCallDotNode::emitBytecode(BytecodeGenerator& generator,
         generator.move(callArguments.thisRegister(), base.get());
         generator.emitCallInTailPosition(returnValue.get(), function.get(), NoExpectedFunction, callArguments, divot(), divotStart(), divotEnd(), DebuggableCall::Yes);
         generator.move(dst, returnValue.get());
-        return returnValue.get();
+        return returnValue.unsafeGet();
     }
 
     Ref<Label> realCall = generator.newLabel();
@@ -2948,7 +2948,7 @@ RegisterID* ApplyFunctionCallDotNode::emitBytecode(BytecodeGenerator& generator,
         generator.emitLabel(end.get());
     }
     generator.emitProfileType(returnValue.get(), divotStart(), divotEnd());
-    return returnValue.get();
+    return returnValue.unsafeGet();
 }
 
 // ------------------------------ PostfixNode ----------------------------------
@@ -2991,7 +2991,7 @@ RegisterID* PostfixNode::emitResolve(BytecodeGenerator& generator, RegisterID* d
         }
         RefPtr<RegisterID> oldValue = emitPostIncOrDec(generator, generator.finalDestination(dst), localReg.get(), m_operator);
         generator.emitProfileType(localReg.get(), var, divotStart(), divotEnd());
-        return oldValue.get();
+        return oldValue.unsafeGet();
     }
 
     generator.emitExpressionInfo(newDivot, divotStart(), newDivot);
@@ -3001,7 +3001,7 @@ RegisterID* PostfixNode::emitResolve(BytecodeGenerator& generator, RegisterID* d
     if (var.isReadOnly()) {
         bool threwException = generator.emitReadOnlyExceptionIfNeeded(var);
         if (threwException)
-            return value.get();
+            return value.unsafeGet();
     }
     RefPtr<RegisterID> oldValue = emitPostIncOrDec(generator, generator.finalDestination(dst), value.get(), m_operator);
     if (!var.isReadOnly()) {
@@ -3009,7 +3009,7 @@ RegisterID* PostfixNode::emitResolve(BytecodeGenerator& generator, RegisterID* d
         generator.emitProfileType(value.get(), var, divotStart(), divotEnd());
     }
 
-    return oldValue.get();
+    return oldValue.unsafeGet();
 }
 
 RegisterID* PostfixNode::emitBracket(BytecodeGenerator& generator, RegisterID* dst)
@@ -3304,7 +3304,7 @@ RegisterID* PrefixNode::emitResolve(BytecodeGenerator& generator, RegisterID* ds
     if (var.isReadOnly()) {
         bool threwException = generator.emitReadOnlyExceptionIfNeeded(var);
         if (threwException)
-            return value.get();
+            return value.unsafeGet();
     }
 
     emitIncOrDec(generator, value.get(), m_operator);
@@ -3956,7 +3956,7 @@ RegisterID* OptionalChainNode::emitBytecode(BytecodeGenerator& generator, Regist
     if (m_isOutermost)
         generator.popOptionalChainTarget(finalDest.get(), m_expr->isDeleteNode());
 
-    return finalDest.get();
+    return finalDest.unsafeGet();
 }
 
 // ------------------------------ ConditionalNode ------------------------------
@@ -3983,7 +3983,7 @@ RegisterID* ConditionalNode::emitBytecode(BytecodeGenerator& generator, Register
 
     generator.emitProfileControlFlow(m_expr2->endOffset() + 1);
 
-    return newDst.get();
+    return newDst.unsafeGet();
 }
 
 // ------------------------------ ReadModifyResolveNode -----------------------------------
@@ -4274,7 +4274,7 @@ RegisterID* AssignResolveNode::emitBytecode(BytecodeGenerator& generator, Regist
     if (isReadOnly) {
         bool threwException = generator.emitReadOnlyExceptionIfNeeded(var);
         if (threwException)
-            return result.get();
+            return result.unsafeGet();
     }
     RegisterID* returnResult = result.get();
     if (!isReadOnly) {
@@ -4316,7 +4316,7 @@ RegisterID* ReadModifyDotNode::emitBytecode(BytecodeGenerator& generator, Regist
     generator.emitExpressionInfo(divot(), divotStart(), divotEnd());
     RefPtr<RegisterID> ret = emitPutProperty(generator, base.get(), updatedValue, thisValue);
     generator.emitProfileType(updatedValue, divotStart(), divotEnd());
-    return ret.get();
+    return ret.unsafeGet();
 }
 
 // ------------------------------ ShortCircuitReadModifyDotNode -----------------------------------

--- a/Source/JavaScriptCore/dfg/DFGGraph.cpp
+++ b/Source/JavaScriptCore/dfg/DFGGraph.cpp
@@ -1289,7 +1289,7 @@ unsigned Graph::stackPointerOffset()
 unsigned Graph::requiredRegisterCountForExit()
 {
     unsigned count = JIT::frameRegisterCountFor(m_profiledBlock);
-    for (InlineCallFrameSet::iterator iter = m_plan.inlineCallFrames()->begin(); !!iter; ++iter) {
+    for (InlineCallFrameSet::iterator iter = m_plan.inlineCallFrames().unsafeGet()->begin(); !!iter; ++iter) {
         InlineCallFrame* inlineCallFrame = *iter;
         CodeBlock* codeBlock = baselineCodeBlockForInlineCallFrame(inlineCallFrame);
         unsigned requiredCount = VirtualRegister(inlineCallFrame->stackOffset).toLocal() + 1 + JIT::frameRegisterCountFor(codeBlock);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -121,7 +121,7 @@ SpeculativeJIT::SpeculativeJIT(Graph& dfg)
     , m_compileOkay(true)
     , m_state(m_graph)
     , m_interpreter(m_graph, m_state)
-    , m_minifiedGraph(&jitCode()->minifiedDFG)
+    , m_minifiedGraph(&jitCode().unsafeGet()->minifiedDFG)
 {
 }
 
@@ -2383,7 +2383,8 @@ void SpeculativeJIT::linkOSREntries(LinkBuffer& linkBuffer)
         WTF::dataFile().atomically([&](auto& out) {
             DumpContext dumpContext;
             dataLogLn("OSR Entries:");
-            for (OSREntryData& entryData : jitCode()->m_osrEntry)
+            RefPtr jitCode = this->jitCode();
+            for (OSREntryData& entryData : jitCode->m_osrEntry)
                 dataLogLn("    ", inContext(entryData, &dumpContext));
             if (!dumpContext.isEmpty())
                 dumpContext.dump(out);

--- a/Source/JavaScriptCore/dfg/DFGStackLayoutPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGStackLayoutPhase.cpp
@@ -103,7 +103,7 @@ public:
             }
         }
 
-        for (InlineCallFrameSet::iterator iter = m_graph.m_plan.inlineCallFrames()->begin(); !!iter; ++iter) {
+        for (InlineCallFrameSet::iterator iter = m_graph.m_plan.inlineCallFrames().unsafeGet()->begin(); !!iter; ++iter) {
             InlineCallFrame* inlineCallFrame = *iter;
             
             if (inlineCallFrame->isVarargs()) {

--- a/Source/JavaScriptCore/interpreter/StackVisitor.cpp
+++ b/Source/JavaScriptCore/interpreter/StackVisitor.cpp
@@ -639,8 +639,8 @@ void StackVisitor::Frame::dump(PrintStream& out, Indenter indent, WTF::Function<
 
                     JITType jitType = codeBlock->jitType();
                     if (jitType != JITType::FTLJIT) {
-                        JITCode* jitCode = codeBlock->jitCode().get();
-                        out.print(indent, "jitCode: ", RawPointer(jitCode),
+                        RefPtr jitCode = codeBlock->jitCode();
+                        out.print(indent, "jitCode: ", RawPointer(jitCode.get()),
                             " start ", RawPointer(jitCode->start()),
                             " end ", RawPointer(jitCode->end()), "\n");
                     }

--- a/Source/JavaScriptCore/runtime/CachedTypes.cpp
+++ b/Source/JavaScriptCore/runtime/CachedTypes.cpp
@@ -765,7 +765,7 @@ public:
                 symbol = vm.propertyNames->builtinNames().lookUpPrivateName(buffer);
             RELEASE_ASSERT(symbol);
             String str = symbol;
-            StringImpl* impl = str.releaseImpl().get();
+            StringImpl* impl = str.releaseImpl().unsafeGet();
             ASSERT(impl->isSymbol());
             if (m_isWellKnownSymbol)
                 ASSERT(!static_cast<SymbolImpl*>(impl)->isPrivate());

--- a/Source/JavaScriptCore/runtime/JSArrayBufferView.cpp
+++ b/Source/JavaScriptCore/runtime/JSArrayBufferView.cpp
@@ -329,7 +329,7 @@ ArrayBuffer* JSArrayBufferView::slowDownAndWasteMemory()
     }
     heap->addReference(this, buffer.get());
 
-    return buffer.get();
+    return buffer.unsafeGet();
 }
 
 // Allocates the full-on native buffer and moves data into the C heap if

--- a/Source/JavaScriptCore/tools/VMInspector.cpp
+++ b/Source/JavaScriptCore/tools/VMInspector.cpp
@@ -120,7 +120,7 @@ auto VMInspector::codeBlockForMachinePC(void* machinePC) -> Expected<CodeBlock*,
 
         Locker locker { AdoptLock, codeBlockSetLock };
         vm.heap.forEachCodeBlockIgnoringJITPlans(locker, [&] (CodeBlock* cb) {
-            JITCode* jitCode = cb->jitCode().get();
+            RefPtr jitCode = cb->jitCode();
             if (!jitCode) {
                 // If the codeBlock is a replacement codeBlock which is in the process of being
                 // compiled, its jitCode will be null, and we can disregard it as a match for

--- a/Source/WTF/wtf/RefPtr.h
+++ b/Source/WTF/wtf/RefPtr.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2019 Apple Inc. All rights reserved.
+ *  Copyright (C) 2005-2025 Apple Inc. All rights reserved.
  *
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Library General Public
@@ -60,14 +60,15 @@ public:
 
     ALWAYS_INLINE ~RefPtr() { RefDerefTraits::derefIfNotNull(PtrTraits::exchange(m_ptr, nullptr)); }
 
-    T* get() const { return PtrTraits::unwrap(m_ptr); }
+    T* get() const LIFETIME_BOUND { return PtrTraits::unwrap(m_ptr); }
+    T* unsafeGet() const { return PtrTraits::unwrap(m_ptr); } // FIXME: Replace with get() then remove.
 
     Ref<T> releaseNonNull() { ASSERT(m_ptr); Ref<T> tmp(adoptRef(*m_ptr)); m_ptr = nullptr; return tmp; }
 
     T* leakRef() WARN_UNUSED_RETURN;
 
-    T& operator*() const { ASSERT(m_ptr); return *PtrTraits::unwrap(m_ptr); }
-    ALWAYS_INLINE T* operator->() const { return PtrTraits::unwrap(m_ptr); }
+    T& operator*() const LIFETIME_BOUND { ASSERT(m_ptr); return *PtrTraits::unwrap(m_ptr); }
+    ALWAYS_INLINE T* operator->() const LIFETIME_BOUND { return PtrTraits::unwrap(m_ptr); }
 
     bool operator!() const { return !m_ptr; }
 

--- a/Source/WebCore/Modules/fetch/FetchBodyConsumer.h
+++ b/Source/WebCore/Modules/fetch/FetchBodyConsumer.h
@@ -61,7 +61,7 @@ public:
     void append(const SharedBuffer&);
 
     bool hasData() const { return !!m_buffer; }
-    const FragmentedSharedBuffer* data() const LIFETIME_BOUND { return m_buffer.get().get(); }
+    const FragmentedSharedBuffer* data() const LIFETIME_BOUND { return m_buffer.get().unsafeGet(); }
     void setData(Ref<FragmentedSharedBuffer>&&);
 
     RefPtr<FragmentedSharedBuffer> takeData();

--- a/Source/WebCore/accessibility/AXCoreObject.cpp
+++ b/Source/WebCore/accessibility/AXCoreObject.cpp
@@ -346,13 +346,13 @@ AXCoreObject* AXCoreObject::firstUnignoredChild()
     const auto& children = childrenIncludingIgnored(/* updateChildrenIfNeeded */ true);
     RefPtr descendant = children.size() ? children[0].ptr() : nullptr;
     if (onlyAddsUnignoredChildren())
-        return descendant.get();
+        return descendant.unsafeGet();
 
     bool isExposedTable = isExposableTable();
     while (descendant && descendant != this) {
         bool childIsValid = !isExposedTable || isValidChildForTable(*descendant);
         if (childIsValid && !descendant->isIgnored())
-            return descendant.get();
+            return descendant.unsafeGet();
         descendant = descendant->nextInPreOrder(/* updateChildrenIfNeeded */ true, /* stayWithin */ this);
     }
     return nullptr;
@@ -390,7 +390,7 @@ AXCoreObject* AXCoreObject::crossFrameParentObjectUnignored() const
     }
 #endif
 
-    return result.get();
+    return result.unsafeGet();
 }
 
 AXCoreObject::AccessibilityChildrenVector AXCoreObject::crossFrameChildrenIncludingIgnored(bool updateChildrenIfNeeded)
@@ -431,7 +431,7 @@ AXCoreObject* AXCoreObject::parentObjectIncludingCrossFrame() const
     }
 #endif
 
-    return result.get();
+    return result.unsafeGet();
 }
 
 
@@ -480,7 +480,7 @@ AXCoreObject* AXCoreObject::nextInPreOrder(bool updateChildrenIfNeeded , AXCoreO
         if (!current || stayWithin == current)
             return nullptr;
     }
-    return next.get();
+    return next.unsafeGet();
 }
 
 AXCoreObject* AXCoreObject::previousInPreOrder(bool updateChildrenIfNeeded, AXCoreObject* stayWithin)
@@ -492,7 +492,7 @@ AXCoreObject* AXCoreObject::previousInPreOrder(bool updateChildrenIfNeeded, AXCo
         const auto& children = sibling->childrenIncludingIgnored(updateChildrenIfNeeded);
         if (children.size())
             return sibling->deepestLastChildIncludingIgnored(updateChildrenIfNeeded);
-        return sibling.get();
+        return sibling.unsafeGet();
     }
     return parentObject();
 }
@@ -583,8 +583,8 @@ AXCoreObject* AXCoreObject::nextSiblingIncludingIgnoredOrParent() const
 {
     RefPtr parent = parentObject();
     if (RefPtr nextSibling = nextSiblingIncludingIgnored(/* updateChildrenIfNeeded */ true))
-        return nextSibling.get();
-    return parent.get();
+        return nextSibling.unsafeGet();
+    return parent.unsafeGet();
 }
 
 String AXCoreObject::autoCompleteValue() const
@@ -1795,7 +1795,7 @@ AXCoreObject* AXCoreObject::parentObjectUnignored() const
 {
     if (role() == AccessibilityRole::Row) {
         if (RefPtr table = exposedTableAncestor())
-            return table.get();
+            return table.unsafeGet();
     }
 
     return Accessibility::findAncestor<AXCoreObject>(*this, false, [&] (const AXCoreObject& object) {

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -1439,7 +1439,7 @@ T* crossFrameFindAncestor(const T& object, bool includeSelf, const MatchFunction
             return nullptr;
 
         if (matches(*current))
-            return current.get();
+            return current.unsafeGet();
     }
     return nullptr;
 }
@@ -1458,7 +1458,7 @@ T* findAncestor(const T& object, bool includeSelf, const MatchFunctionT& matches
             return nullptr;
 
         if (matches(*current))
-            return current.get();
+            return current.unsafeGet();
     }
     return nullptr;
 }
@@ -1512,7 +1512,7 @@ T* clickableSelfOrAncestor(const T& startObject, const F& shouldStop)
     // Presentational objects should not be allowed to be clicked.
     if (ancestor && ancestor->role() == AccessibilityRole::Presentational)
         return nullptr;
-    return ancestor.get();
+    return ancestor.unsafeGet();
 }
 
 template<typename T>
@@ -1539,7 +1539,7 @@ T* highestEditableAncestor(T& startObject)
         previousEditableAncestor = editableAncestor;
         editableAncestor = editableAncestor->editableAncestor();
     }
-    return previousEditableAncestor.get();
+    return previousEditableAncestor.unsafeGet();
 }
 
 template<typename T>
@@ -1551,7 +1551,7 @@ T* findRelatedObjectInAncestry(const T& object, AXRelation relation, const T& de
             return relatedObject.get() == &ancestor;
         });
         if (ancestor)
-            return ancestor.get();
+            return ancestor.unsafeGet();
     }
     return nullptr;
 }
@@ -1580,7 +1580,7 @@ AXCoreObject* findUnignoredDescendant(T& object, bool includeSelf, const F& matc
 
     for (Ref child : object.childrenIncludingIgnored()) {
         if (RefPtr descendant = findUnignoredDescendant(child.get(), /* includeSelf */ true, matches))
-            return descendant.get();
+            return descendant.unsafeGet();
     }
     return nullptr;
 }

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -405,7 +405,7 @@ void AXObjectCache::updateCurrentModalNode()
         // Pick the document active modal <dialog> element if it exists.
         if (RefPtr activeModalDialog = document->activeModalDialog()) {
             ASSERT(m_modalElements.contains(activeModalDialog.get()));
-            return activeModalDialog.get();
+            return activeModalDialog.unsafeGet();
         }
 
         SetForScope retrievingCurrentModalNode(m_isRetrievingCurrentModalNode, true);
@@ -446,7 +446,7 @@ void AXObjectCache::updateCurrentModalNode()
         RefPtr object = getOrCreate(modalElementToReturn.get());
         if (!object || object->isAXHidden())
             return nullptr;
-        return modalElementToReturn.get();
+        return modalElementToReturn.unsafeGet();
     };
 
     RefPtr previousModal = m_currentModalElement.get();
@@ -587,7 +587,7 @@ AccessibilityObject* AXObjectCache::focusedObjectForNode(Node* focusedNode)
 
     if (focus->isIgnored())
         return focus->parentObjectUnignored();
-    return focus.get();
+    return focus.unsafeGet();
 }
 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
@@ -699,7 +699,7 @@ AccessibilityObject* AXObjectCache::exportedGetOrCreate(Node& node)
 AccessibilityObject* AXObjectCache::getOrCreate(Widget& widget)
 {
     if (RefPtr object = get(widget))
-        return object.get();
+        return object.unsafeGet();
 
     RefPtr<AccessibilityObject> newObject;
     if (auto* scrollView = dynamicDowncast<ScrollView>(widget))
@@ -716,7 +716,7 @@ AccessibilityObject* AXObjectCache::getOrCreate(Widget& widget)
         return nullptr;
 
     cacheAndInitializeWrapper(*newObject, &widget);
-    return newObject.get();
+    return newObject.unsafeGet();
 }
 
 AccessibilityObject* AXObjectCache::getOrCreateSlow(Node& node, IsPartOfRelation isPartOfRelation)
@@ -759,7 +759,7 @@ AccessibilityObject* AXObjectCache::getOrCreateSlow(Node& node, IsPartOfRelation
         } else
             object = AccessibilityListBoxOption::create(AXID::generate(), downcast<HTMLElement>(node), *this);
         cacheAndInitializeWrapper(*object, &node);
-        return object.get();
+        return object.unsafeGet();
     }
 
     bool inCanvasSubtree = lineageOfType<HTMLCanvasElement>(*composedParent).first();
@@ -788,7 +788,7 @@ AccessibilityObject* AXObjectCache::getOrCreateSlow(Node& node, IsPartOfRelation
 
     // The object may have already been created during relations update.
     if (RefPtr object = get(node))
-        return object.get();
+        return object.unsafeGet();
 
     // Fallback content is only focusable as long as the canvas is displayed and visible.
     // Update the style before Element::isFocusable() gets called.
@@ -806,7 +806,7 @@ AccessibilityObject* AXObjectCache::getOrCreateSlow(Node& node, IsPartOfRelation
     // it will disappear when this function is finished, leading to a use-after-free.
     if (newObject->isDetached())
         return nullptr;
-    return newObject.get();
+    return newObject.unsafeGet();
 }
 
 AccessibilityObject* AXObjectCache::getOrCreate(RenderObject& renderer)
@@ -815,7 +815,7 @@ AccessibilityObject* AXObjectCache::getOrCreate(RenderObject& renderer)
         return getOrCreate(renderer.node());
 
     if (RefPtr object = get(renderer))
-        return object.get();
+        return object.unsafeGet();
 
     // Don't create an object for this renderer if it's being destroyed.
     if (renderer.beingDestroyed())
@@ -958,7 +958,7 @@ AccessibilityObject* AXObjectCache::create(AccessibilityRole role)
         return nullptr;
 
     cacheAndInitializeWrapper(*object);
-    return object.get();
+    return object.unsafeGet();
 }
 
 void AXObjectCache::remove(AXID axID)
@@ -1461,7 +1461,7 @@ AccessibilityObject* AXObjectCache::getIncludingAncestors(RenderObject& renderer
 {
     for (CheckedPtr current = &renderer; current; current = current->parent()) {
         if (RefPtr object = get(*current))
-            return object.get();
+            return object.unsafeGet();
     }
     return nullptr;
 }
@@ -4098,7 +4098,7 @@ static Node* parentEditingBoundary(Node* node)
     while (boundary != documentElement && boundary->nonShadowBoundaryParentNode() && node->hasEditableStyle() == boundary->parentNode()->hasEditableStyle())
         boundary = boundary->nonShadowBoundaryParentNode();
 
-    return boundary.get();
+    return boundary.unsafeGet();
 }
 
 CharacterOffset AXObjectCache::nextBoundary(const CharacterOffset& characterOffset, BoundarySearchFunction searchFunction)

--- a/Source/WebCore/accessibility/AXObjectCacheInlines.h
+++ b/Source/WebCore/accessibility/AXObjectCacheInlines.h
@@ -72,14 +72,14 @@ inline Node* AXObjectCache::nodeForID(std::optional<AXID> axID) const
 inline AccessibilityObject* AXObjectCache::getOrCreate(Node& node, IsPartOfRelation isPartOfRelation)
 {
     if (RefPtr object = get(node))
-        return object.get();
+        return object.unsafeGet();
     return getOrCreateSlow(node, isPartOfRelation);
 }
 
 inline AccessibilityObject* AXObjectCache::getOrCreate(Element& element, IsPartOfRelation isPartOfRelation)
 {
     if (RefPtr object = get(element))
-        return object.get();
+        return object.unsafeGet();
     return getOrCreateSlow(element, isPartOfRelation);
 }
 

--- a/Source/WebCore/accessibility/AXTextMarker.cpp
+++ b/Source/WebCore/accessibility/AXTextMarker.cpp
@@ -1649,7 +1649,7 @@ AXIsolatedObject* findObjectWithRuns(AXIsolatedObject& start, AXDirection direct
             exitObject(*current);
             current = nextInPreOrder(*current);
         }
-        return current.get();
+        return current.unsafeGet();
     }
     ASSERT(direction == AXDirection::Previous);
 
@@ -1675,7 +1675,7 @@ AXIsolatedObject* findObjectWithRuns(AXIsolatedObject& start, AXDirection direct
         exitObject(*current);
         current = previousInPreOrder(*current);
     }
-    return current.get();
+    return current.unsafeGet();
 }
 
 } // namespace Accessibility

--- a/Source/WebCore/accessibility/AXUtilities.cpp
+++ b/Source/WebCore/accessibility/AXUtilities.cpp
@@ -53,7 +53,7 @@ ContainerNode* composedParentIgnoringDocumentFragments(const Node& node)
     RefPtr ancestor = node.parentInComposedTree();
     while (is<DocumentFragment>(ancestor.get()))
         ancestor = ancestor->parentInComposedTree();
-    return ancestor.get();
+    return ancestor.unsafeGet();
 }
 
 ContainerNode* composedParentIgnoringDocumentFragments(const Node* node)

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -182,7 +182,7 @@ AccessibilityObject* AccessibilityNodeObject::firstChild() const
         currentChild = currentChild->nextSibling();
         axCurrentChild = cache->getOrCreate(currentChild.get());
     }
-    return axCurrentChild.get();
+    return axCurrentChild.unsafeGet();
 }
 
 AccessibilityObject* AccessibilityNodeObject::lastChild() const
@@ -247,7 +247,7 @@ AccessibilityObject* AccessibilityNodeObject::parentObject() const
     }
 
     if (RefPtr ownerParent = ownerParentObject()) [[unlikely]]
-        return ownerParent.get();
+        return ownerParent.unsafeGet();
 
 #if USE(ATSPI)
     // FIXME: Consider removing this ATSPI-only branch with https://bugs.webkit.org/show_bug.cgi?id=282117.
@@ -1428,7 +1428,7 @@ Element* AccessibilityNodeObject::anchorElement() const
         return nullptr;
 
     if (RefPtr areaElement = dynamicDowncast<HTMLAreaElement>(*node))
-        return areaElement.get();
+        return areaElement.unsafeGet();
 
     AXObjectCache* cache = axObjectCache();
     if (!cache)
@@ -1438,7 +1438,7 @@ Element* AccessibilityNodeObject::anchorElement() const
     // NOTE: this assumes that any non-image with an anchor is an HTMLAnchorElement
     for ( ; node; node = node->parentNode()) {
         if (is<HTMLAnchorElement>(*node) || (node->renderer() && cache->getOrCreate(*node)->isLink()))
-            return downcast<Element>(node).get();
+            return downcast<Element>(node).unsafeGet();
     }
 
     return nullptr;
@@ -1538,10 +1538,10 @@ static Element* nativeActionElement(Node* start)
 
     for (RefPtr child = start->firstChild(); child; child = child->nextSibling()) {
         if (RefPtr element = nodeActionElement(*child))
-            return element.get();
+            return element.unsafeGet();
 
         if (RefPtr subChild = nativeActionElement(child.get()))
-            return subChild.get();
+            return subChild.unsafeGet();
     }
     return nullptr;
 }
@@ -1553,10 +1553,10 @@ Element* AccessibilityNodeObject::actionElement() const
         return nullptr;
 
     if (RefPtr element = nodeActionElement(*node))
-        return element.get();
+        return element.unsafeGet();
 
     if (AccessibilityObject::isARIAInput(ariaRoleAttribute()))
-        return downcast<Element>(node).get();
+        return downcast<Element>(node).unsafeGet();
 
     switch (role()) {
     case AccessibilityRole::Button:
@@ -1569,14 +1569,14 @@ Element* AccessibilityNodeObject::actionElement() const
     case AccessibilityRole::ListItem:
         // Check if the author is hiding the real control element inside the ARIA element.
         if (RefPtr nativeElement = nativeActionElement(node.get()))
-            return nativeElement.get();
-        return downcast<Element>(node).get();
+            return nativeElement.unsafeGet();
+        return downcast<Element>(node).unsafeGet();
     default:
         break;
     }
 
     if (RefPtr element = anchorElement())
-        return element.get();
+        return element.unsafeGet();
 
     if (RefPtr clickableObject = this->clickableSelfOrAncestor())
         return clickableObject->element();
@@ -2624,7 +2624,7 @@ AccessibilityObject* AccessibilityNodeObject::parentTable() const
                 // we don't want to choose another ancestor table as this cell's table.
                 if (ancestor->isTable()) {
                     if (ancestor->isExposableTable())
-                        return ancestor.get();
+                        return ancestor.unsafeGet();
                     if (ancestor->node())
                         break;
                 }
@@ -2632,7 +2632,7 @@ AccessibilityObject* AccessibilityNodeObject::parentTable() const
             return nullptr;
         }
 
-        return tableFromRenderTree.get();
+        return tableFromRenderTree.unsafeGet();
     }
 
     if (isTableRow()) {
@@ -2642,7 +2642,7 @@ AccessibilityObject* AccessibilityNodeObject::parentTable() const
             if (ancestor->isTable()) {
                 bool isNonGridRowOrValidAriaTable = !isARIAGridRow() || ancestor->isAriaTable() || elementName() == ElementName::HTML_tr;
                 if (ancestor->isExposableTable() && isNonGridRowOrValidAriaTable)
-                    return ancestor.get();
+                    return ancestor.unsafeGet();
 
                 // If this is a non-anonymous table object, but not an accessibility table, we should stop because we don't want to
                 // choose another ancestor table as this row's table.
@@ -2805,7 +2805,7 @@ AXCoreObject* AccessibilityNodeObject::parentTableIfExposedTableRow() const
         return nullptr;
 
     RefPtr table = parentTable();
-    return table && table->isExposableTable() ? table.get() : nullptr;
+    return table && table->isExposableTable() ? table.unsafeGet() : nullptr;
 }
 
 bool AccessibilityNodeObject::isTableCell() const

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -591,7 +591,7 @@ AccessibilityObject* firstAccessibleObjectFromNode(const Node* node, NOESCAPE co
         accessibleObject = cache->getOrCreate(const_cast<Node&>(*axNode));
     }
 
-    return accessibleObject.get();
+    return accessibleObject.unsafeGet();
 }
 
 // FIXME: Usages of this function should be replaced by a new flag in AccessibilityObject::m_ancestorFlags.
@@ -3045,7 +3045,7 @@ AccessibilityObject* AccessibilityObject::elementAccessibilityHitTest(const IntP
                 if (RefPtr remoteHostWidget = cache->getOrCreate(*widget)) {
                     remoteHostWidget->updateChildrenIfNecessary();
                     RefPtr scrollView = dynamicDowncast<AccessibilityScrollView>(*remoteHostWidget);
-                    return scrollView ? scrollView->remoteFrame().get() : nullptr;
+                    return scrollView ? scrollView->remoteFrame().unsafeGet() : nullptr;
                 }
             }
         }

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -471,7 +471,7 @@ AccessibilityObject* AccessibilityRenderObject::nextSibling() const
     RefPtr nextRenderParent = nextAXRenderObject ? cache->getOrCreate(nextAXRenderObject->renderParentObject()) : nullptr;
 
     // Make sure the next sibling has the same render parent.
-    return !nextRenderParent || nextRenderParent == cache->getOrCreate(renderParentObject()) ? nextObject.get() : nullptr;
+    return !nextRenderParent || nextRenderParent == cache->getOrCreate(renderParentObject()) ? nextObject.unsafeGet() : nullptr;
 }
 
 static RenderBoxModelObject* nextContinuation(RenderObject& renderer)
@@ -531,7 +531,7 @@ RenderObject* AccessibilityRenderObject::renderParentObject() const
 AccessibilityObject* AccessibilityRenderObject::parentObject() const
 {
     if (RefPtr ownerParent = ownerParentObject()) [[unlikely]]
-        return ownerParent.get();
+        return ownerParent.unsafeGet();
 
 #if USE(ATSPI)
     // FIXME: Consider removing this ATSPI-only branch with https://bugs.webkit.org/show_bug.cgi?id=282117.
@@ -551,7 +551,7 @@ AccessibilityObject* AccessibilityRenderObject::parentObject() const
     RefPtr node = this->node();
     if (RefPtr parentNode = composedParentIgnoringDocumentFragments(node.get())) {
         if (RefPtr parent = cache->getOrCreate(*parentNode))
-            return parent.get();
+            return parent.unsafeGet();
     }
 
     if (CheckedPtr renderElement = dynamicDowncast<RenderElement>(m_renderer.get()); renderElement && renderElement->isBeforeOrAfterContent()) {
@@ -560,7 +560,7 @@ AccessibilityObject* AccessibilityRenderObject::parentObject() const
         // generating element as their parent rather than their "natural" render tree parent. This avoids
         // a parent-child mismatch which can cause issues for ATs.
         if (RefPtr parent = cache->getOrCreate(renderElement->generatingElement()))
-            return parent.get();
+            return parent.unsafeGet();
     }
 #endif // !USE(ATSPI)
 
@@ -569,7 +569,7 @@ AccessibilityObject* AccessibilityRenderObject::parentObject() const
         for (auto& listItemAncestor : ancestorsOfType<RenderListItem>(*m_renderer)) {
             RefPtr parent = dynamicDowncast<AccessibilityRenderObject>(axObjectCache()->getOrCreate(listItemAncestor));
             if (parent && parent->markerRenderer() == m_renderer)
-                return parent.get();
+                return parent.unsafeGet();
         }
     }
 
@@ -2272,7 +2272,7 @@ AccessibilityObject* AccessibilityRenderObject::elementAccessibilityHitTest(cons
             }
 
             if (listBoxOption && !listBoxOption->isIgnored())
-                return listBoxOption.get();
+                return listBoxOption.unsafeGet();
 
             CheckedPtr cache = axObjectCache();
             return cache ? cache->getOrCreate(*renderListBox) : nullptr;
@@ -2323,11 +2323,11 @@ AccessibilityObject* AccessibilityRenderObject::accessibilityHitTest(const IntPo
         // If this element is the label of a control, a hit test should return the control.
         RefPtr controlObject = result->controlForLabelElement();
         if (controlObject && !controlObject->titleUIElement())
-            return controlObject.get();
+            return controlObject.unsafeGet();
 
         result = result->parentObjectUnignored();
     }
-    return result.get();
+    return result.unsafeGet();
 }
 
 bool AccessibilityRenderObject::renderObjectIsObservable(RenderObject& renderer) const
@@ -2682,7 +2682,7 @@ AccessibilitySVGObject* AccessibilityRenderObject::remoteSVGRootElement(CreateIf
 
     RefPtr rootSVGObject = createIfNecessary == CreateIfNecessary::Yes ? cache->getOrCreate(*rendererRoot) : cache->get(rendererRoot);
     ASSERT(createIfNecessary == CreateIfNecessary::No || rootSVGObject);
-    return dynamicDowncast<AccessibilitySVGObject>(rootSVGObject).get();
+    return dynamicDowncast<AccessibilitySVGObject>(rootSVGObject).unsafeGet();
 }
 
 void AccessibilityRenderObject::addRemoteSVGChildren()

--- a/Source/WebCore/accessibility/AccessibilitySVGObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilitySVGObject.cpp
@@ -123,7 +123,7 @@ Element* AccessibilitySVGObject::childElementWithMatchingLanguage(ChildrenType& 
     if (index < childLanguageCodes.size())
         return elements[index];
 
-    return fallback.get();
+    return fallback.unsafeGet();
 }
 
 void AccessibilitySVGObject::accessibilityText(Vector<AccessibilityText>& textOrder) const

--- a/Source/WebCore/accessibility/AccessibilityScrollView.cpp
+++ b/Source/WebCore/accessibility/AccessibilityScrollView.cpp
@@ -446,7 +446,7 @@ Document* AccessibilityScrollView::document() const
 LocalFrameView* AccessibilityScrollView::documentFrameView() const
 {
     if (RefPtr localFrameView = dynamicDowncast<LocalFrameView>(m_scrollView.get()))
-        return localFrameView.get();
+        return localFrameView.unsafeGet();
 
     if (m_frameOwnerElement && m_frameOwnerElement->contentDocument())
         return m_frameOwnerElement->contentDocument()->view();
@@ -480,7 +480,7 @@ AccessibilityObject* AccessibilityScrollView::parentObject() const
             break;
         ancestorElement = ancestorElement->parentElementInComposedTree();
     }
-    return ancestorAccessibilityObject.get();
+    return ancestorAccessibilityObject.unsafeGet();
 }
 
 #if ENABLE_ACCESSIBILITY_LOCAL_FRAME

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -339,11 +339,11 @@ private:
     AXIsolatedObject* accessibilityHitTest(const IntPoint&) const final;
     AXIsolatedObject* focusedUIElement() const final
     {
-        return tree()->focusedNode().get();
+        return tree()->focusedNode().unsafeGet();
     }
     AXIsolatedObject* focusedUIElementInAnyLocalFrame() const final
     {
-        return tree()->focusedNode().get();
+        return tree()->focusedNode().unsafeGet();
     }
     AXIsolatedObject* internalLinkElement() const final { return objectAttributeValue(AXProperty::InternalLinkElement); }
     AccessibilityChildrenVector radioButtonGroup() const final { return tree()->objectsForIDs(vectorAttributeValue<AXID>(AXProperty::RadioButtonGroupMembers)); }

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm
@@ -606,7 +606,7 @@ std::optional<SimpleRange> makeDOMRange(Document* document, NSRange range)
         return nullptr;
     RefPtr<AXCoreObject> backingObject = self.axBackingObject;
 #endif
-    return backingObject.get();
+    return backingObject.unsafeGet();
 }
 
 - (NSArray<NSDictionary *> *)lineRectsAndText
@@ -958,7 +958,7 @@ AccessibilitySearchCriteria accessibilitySearchCriteriaForSearchPredicate(AXCore
             criteria.startRange = *nsRange;
 
         if (!criteria.startObject)
-            criteria.startObject = markerRange.start().object().get();
+            criteria.startObject = markerRange.start().object().unsafeGet();
     }
 #endif
 

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -1914,7 +1914,7 @@ const TimingFunction* KeyframeEffect::timingFunctionForBlendingKeyframe(const Bl
         }
 
         // Failing that, or for a CSS Transition, the timing function is inherited from the backing Animation object.
-        return styleOriginatedAnimation->backingAnimationTimingFunction().get();
+        return styleOriginatedAnimation->backingAnimationTimingFunction().unsafeGet();
     }
 
     return keyframe.timingFunction();
@@ -3163,7 +3163,7 @@ const ViewTimeline* KeyframeEffect::activeViewTimeline()
 
     RefPtr viewTimeline = dynamicDowncast<ViewTimeline>(animation->timeline());
     if (viewTimeline && viewTimeline->currentTime())
-        return viewTimeline.get();
+        return viewTimeline.unsafeGet();
 
     return nullptr;
 }

--- a/Source/WebCore/animation/ScrollTimeline.cpp
+++ b/Source/WebCore/animation/ScrollTimeline.cpp
@@ -129,12 +129,12 @@ Element* ScrollTimeline::source() const
                     Ref document = nearestSource->document();
                     RefPtr documentElement = document->documentElement();
                     if (nearestSource != documentElement)
-                        return nearestSource.get();
+                        return nearestSource.unsafeGet();
                     // RenderObject::enclosingScrollableContainer() will return the document element even in
                     // quirks mode, but the scrolling element in that case is the <body> element, so we must
                     // make sure to return Document::scrollingElement() in case the document element is
                     // returned by enclosingScrollableContainer() but it was not explicitly set as the source.
-                    return &source->element == documentElement ? nearestSource.get() : document->scrollingElement();
+                    return &source->element == documentElement ? nearestSource.unsafeGet() : document->scrollingElement();
                 }
             }
         }

--- a/Source/WebCore/dom/CharacterData.cpp
+++ b/Source/WebCore/dom/CharacterData.cpp
@@ -87,8 +87,8 @@ static ContainerNode::ChildChange makeChildChange(CharacterData& characterData, 
     return {
         ContainerNode::ChildChange::Type::TextChanged,
         nullptr,
-        RefPtr { ElementTraversal::previousSibling(characterData) }.get(),
-        RefPtr { ElementTraversal::nextSibling(characterData) }.get(),
+        RefPtr { ElementTraversal::previousSibling(characterData) }.unsafeGet(),
+        RefPtr { ElementTraversal::nextSibling(characterData) }.unsafeGet(),
         source,
         ContainerNode::ChildChange::AffectsElements::No
     };

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -2415,7 +2415,7 @@ Element* Document::scrollingElement()
         // 1. If the HTML body element exists, and it is not potentially scrollable, return the
         // HTML body element and abort these steps.
         if (RefPtr firstBody = body(); firstBody && !isBodyPotentiallyScrollable(*firstBody))
-            return firstBody.get();
+            return firstBody.unsafeGet();
 
         // 2. Return null and abort these steps.
         return nullptr;
@@ -8977,7 +8977,7 @@ MediaCanStartListener* Document::takeAnyMediaCanStartListener()
     RefPtr listener = m_mediaCanStartListeners.begin().get();
     m_mediaCanStartListeners.remove(*listener);
 
-    return listener.get();
+    return listener.unsafeGet();
 }
 
 void Document::addDisplayChangedObserver(const DisplayChangedObserver& observer)
@@ -10878,7 +10878,7 @@ HTMLDialogElement* Document::activeModalDialog() const
 {
     for (auto& element : makeReversedRange(m_topLayerElements)) {
         if (RefPtr dialog = dynamicDowncast<HTMLDialogElement>(element.get()); dialog && dialog->isModal())
-            return dialog.get();
+            return dialog.unsafeGet();
     }
 
     return nullptr;

--- a/Source/WebCore/dom/DocumentFragment.cpp
+++ b/Source/WebCore/dom/DocumentFragment.cpp
@@ -121,7 +121,7 @@ Element* DocumentFragment::getElementById(const AtomString& id) const
 
     // Fast path for ShadowRoot, where we are both a DocumentFragment and a TreeScope.
     if (isTreeScope())
-        return protectedTreeScope()->getElementById(id).get();
+        return protectedTreeScope()->getElementById(id).unsafeGet();
 
     // Otherwise, fall back to iterating all of the element descendants.
     for (Ref element : descendantsOfType<Element>(*this)) {

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -3522,7 +3522,7 @@ RefPtr<ShadowRoot> Element::protectedUserAgentShadowRoot() const
 ShadowRoot& Element::ensureUserAgentShadowRoot()
 {
     if (RefPtr shadow = userAgentShadowRoot())
-        return *shadow;
+        return *shadow.unsafeGet();
     return createUserAgentShadowRoot();
 }
 
@@ -6406,7 +6406,7 @@ HTMLElement* Element::topmostPopoverAncestor(TopLayerElementType topLayerType)
     if (topLayerType == TopLayerElementType::Popover)
         checkAncestor(popoverData()->invoker());
 
-    return topmostAncestor.get();
+    return topmostAncestor.unsafeGet();
 }
 
 double Element::lookupCSSRandomBaseValue(const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier, const CSSCalc::RandomCachingKey& key) const

--- a/Source/WebCore/dom/EventPath.h
+++ b/Source/WebCore/dom/EventPath.h
@@ -80,7 +80,7 @@ inline Node* EventPath::eventTargetRespectingTargetRules(Node& referenceNode)
     // Events sent to elements inside an SVG use element's shadow tree go to the use element.
     if (auto* svgElement = dynamicDowncast<SVGElement>(referenceNode)) {
         if (auto useElement = svgElement->correspondingUseElement())
-            return useElement.get();
+            return useElement.unsafeGet();
     }
 
     return &referenceNode;

--- a/Source/WebCore/dom/SelectorQuery.cpp
+++ b/Source/WebCore/dom/SelectorQuery.cpp
@@ -303,7 +303,7 @@ static ContainerNode& filterRootById(ContainerNode& rootNode, const CSSSelector&
                     if (inAdjacentChain)
                         searchRoot = searchRoot->parentNode();
                     if (searchRoot && (rootNode.isTreeScope() || searchRoot->isInclusiveDescendantOf(rootNode)))
-                        return *searchRoot;
+                        return *searchRoot.unsafeGet();
                 }
             }
         }

--- a/Source/WebCore/dom/StyledElement.cpp
+++ b/Source/WebCore/dom/StyledElement.cpp
@@ -93,7 +93,7 @@ MutableStyleProperties& StyledElement::ensureMutableInlineStyle()
         return mutableProperties.get();
     }
     if (RefPtr mutableProperties = dynamicDowncast<MutableStyleProperties>(*inlineStyle))
-        return *mutableProperties;
+        return *mutableProperties.unsafeGet();
     Ref mutableProperties = inlineStyle->mutableCopy();
     inlineStyle = mutableProperties.copyRef();
     return mutableProperties.get();

--- a/Source/WebCore/editing/CompositeEditCommand.cpp
+++ b/Source/WebCore/editing/CompositeEditCommand.cpp
@@ -455,7 +455,7 @@ EditCommandComposition* CompositeEditCommand::composition() const
     for (RefPtr command = this; command; command = command->parent()) {
         if (auto composition = command->m_composition) {
             ASSERT(!command->parent());
-            return composition.get();
+            return composition.unsafeGet();
         }
     }
     return nullptr;
@@ -468,7 +468,7 @@ EditCommandComposition& CompositeEditCommand::ensureComposition()
         command = WTFMove(parent);
     if (!command->m_composition)
         command->m_composition = EditCommandComposition::create(document(), startingSelection(), endingSelection(), editingAction());
-    return *command->m_composition;
+    return *command->m_composition.unsafeGet();
 }
 
 bool CompositeEditCommand::preservesTypingStyle() const

--- a/Source/WebCore/editing/Editing.cpp
+++ b/Source/WebCore/editing/Editing.cpp
@@ -203,7 +203,7 @@ Element* unsplittableElementForPosition(const Position& position)
     // Since enclosingNodeOfType won't search beyond the highest root editable node,
     // this code works even if the closest table cell was outside of the root editable node.
     if (auto enclosingCell = downcast<Element>(enclosingNodeOfType(position, &isTableCell)))
-        return enclosingCell.get();
+        return enclosingCell.unsafeGet();
     return editableRootForPosition(position);
 }
 

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -2258,7 +2258,7 @@ Node* Editor::nodeBeforeWritingSuggestions() const
         return nullptr;
 
     if (RefPtr text = dynamicDowncast<Text>(container))
-        return text.get();
+        return text.unsafeGet();
 
     return position.computeNodeBeforePosition();
 }

--- a/Source/WebCore/editing/MarkupAccumulator.cpp
+++ b/Source/WebCore/editing/MarkupAccumulator.cpp
@@ -389,7 +389,7 @@ const ShadowRoot* MarkupAccumulator::suitableShadowRoot(const Node& node)
     RefPtr shadowRoot = dynamicDowncast<ShadowRoot>(node);
     if (!shadowRoot || !includeShadowRoot(*shadowRoot))
         return nullptr;
-    return shadowRoot.get();
+    return shadowRoot.unsafeGet();
 }
 
 void MarkupAccumulator::startAppendingNode(const Node& node, Namespaces* namespaces)

--- a/Source/WebCore/editing/TextIterator.cpp
+++ b/Source/WebCore/editing/TextIterator.cpp
@@ -358,7 +358,7 @@ static Node* firstNode(const BoundaryPoint& point)
     if (point.container->isCharacterDataNode())
         return point.container.ptr();
     if (RefPtr child = point.container->traverseToChildAt(point.offset))
-        return child.get();
+        return child.unsafeGet();
     if (!point.offset)
         return point.container.ptr();
     return NodeTraversal::nextSkippingChildren(point.container);

--- a/Source/WebCore/editing/cocoa/NodeHTMLConverter.mm
+++ b/Source/WebCore/editing/cocoa/NodeHTMLConverter.mm
@@ -795,7 +795,7 @@ Element* HTMLConverter::_blockLevelElementForNode(Node* node)
         element = node->parentElement();
     if (element && !_caches->isBlockElement(*element))
         element = _blockLevelElementForNode(element->parentInComposedTree());
-    return element.get();
+    return element.unsafeGet();
 }
 
 static Color normalizedColor(Color color, bool ignoreDefaultColor, Element& element)

--- a/Source/WebCore/html/CachedHTMLCollectionInlines.h
+++ b/Source/WebCore/html/CachedHTMLCollectionInlines.h
@@ -130,7 +130,7 @@ Element* CachedHTMLCollection<HTMLCollectionClass, traversalType>::namedItem(con
 
         if (candidate && collection().elementMatches(*candidate)) {
             if (traversalType == CollectionTraversalType::ChildrenOnly ? candidate->parentNode() == &root : candidate->isDescendantOf(root))
-                return candidate.get();
+                return candidate.unsafeGet();
         }
     }
 

--- a/Source/WebCore/html/CheckboxInputType.cpp
+++ b/Source/WebCore/html/CheckboxInputType.cpp
@@ -153,7 +153,7 @@ static Touch* findTouchWithIdentifier(TouchList& list, unsigned identifier)
     for (unsigned i = 0; i < length; ++i) {
         RefPtr touch = list.item(i);
         if (touch->identifier() == identifier)
-            return touch.get();
+            return touch.unsafeGet();
     }
     return nullptr;
 }

--- a/Source/WebCore/html/FormAssociatedElement.cpp
+++ b/Source/WebCore/html/FormAssociatedElement.cpp
@@ -38,7 +38,7 @@ FormAssociatedElement::FormAssociatedElement(HTMLFormElement* form)
 HTMLFormElement* FormAssociatedElement::formForBindings() const
 {
     // FIXME: The downcast should be unnecessary, but the WPT was written before https://github.com/WICG/webcomponents/issues/1072 was resolved. Update once the WPT has been updated.
-    return dynamicDowncast<HTMLFormElement>(asHTMLElement().retargetReferenceTargetForBindings(form())).get();
+    return dynamicDowncast<HTMLFormElement>(asHTMLElement().retargetReferenceTargetForBindings(form())).unsafeGet();
 }
 
 void FormAssociatedElement::setFormInternal(RefPtr<HTMLFormElement>&& newForm)

--- a/Source/WebCore/html/HTMLCanvasElement.cpp
+++ b/Source/WebCore/html/HTMLCanvasElement.cpp
@@ -487,7 +487,7 @@ WebGLRenderingContextBase* HTMLCanvasElement::getContextWebGL(WebGLVersion type,
     if ((type == WebGLVersion::WebGL1) != glContext->isWebGL1())
         return nullptr;
 
-    return glContext.get();
+    return glContext.unsafeGet();
 }
 
 #endif // ENABLE(WEBGL)

--- a/Source/WebCore/html/HTMLFormControlsCollection.cpp
+++ b/Source/WebCore/html/HTMLFormControlsCollection.cpp
@@ -97,7 +97,7 @@ HTMLElement* HTMLFormControlsCollection::customElementAfter(Element* current) co
         if (element->asFormListedElement()->isEnumeratable()) {
             m_cachedElement = element.get();
             m_cachedElementOffsetInArray = i;
-            return element.get();
+            return element.unsafeGet();
         }
     }
     return nullptr;

--- a/Source/WebCore/html/HTMLLabelElement.cpp
+++ b/Source/WebCore/html/HTMLLabelElement.cpp
@@ -108,7 +108,7 @@ HTMLFormElement* HTMLLabelElement::form() const
 HTMLFormElement* HTMLLabelElement::formForBindings() const
 {
     // FIXME: The downcast should be unnecessary, but the WPT was written before https://github.com/WICG/webcomponents/issues/1072 was resolved. Update once the WPT has been updated.
-    return dynamicDowncast<HTMLFormElement>(retargetReferenceTargetForBindings(form())).get();
+    return dynamicDowncast<HTMLFormElement>(retargetReferenceTargetForBindings(form())).unsafeGet();
 }
 
 void HTMLLabelElement::setActive(bool down, Style::InvalidationScope invalidationScope)

--- a/Source/WebCore/html/HTMLLegendElement.cpp
+++ b/Source/WebCore/html/HTMLLegendElement.cpp
@@ -59,7 +59,7 @@ HTMLFormElement* HTMLLegendElement::form() const
 HTMLFormElement* HTMLLegendElement::formForBindings() const
 {
     // FIXME: The downcast should be unnecessary, but the WPT was written before https://github.com/WICG/webcomponents/issues/1072 was resolved. Update once the WPT has been updated.
-    return dynamicDowncast<HTMLFormElement>(retargetReferenceTargetForBindings(form())).get();
+    return dynamicDowncast<HTMLFormElement>(retargetReferenceTargetForBindings(form())).unsafeGet();
 }
     
 } // namespace

--- a/Source/WebCore/html/HTMLOptionElement.cpp
+++ b/Source/WebCore/html/HTMLOptionElement.cpp
@@ -149,7 +149,7 @@ HTMLFormElement* HTMLOptionElement::form() const
 HTMLFormElement* HTMLOptionElement::formForBindings() const
 {
     // FIXME: The downcast should be unnecessary, but the WPT was written before https://github.com/WICG/webcomponents/issues/1072 was resolved. Update once the WPT has been updated.
-    return dynamicDowncast<HTMLFormElement>(retargetReferenceTargetForBindings(form())).get();
+    return dynamicDowncast<HTMLFormElement>(retargetReferenceTargetForBindings(form())).unsafeGet();
 }
 
 int HTMLOptionElement::index() const

--- a/Source/WebCore/html/shadow/SliderThumbElement.cpp
+++ b/Source/WebCore/html/shadow/SliderThumbElement.cpp
@@ -421,7 +421,7 @@ static Touch* findTouchWithIdentifier(TouchList& list, unsigned identifier)
     for (unsigned i = 0; i < length; ++i) {
         RefPtr<Touch> touch = list.item(i);
         if (touch->identifier() == identifier)
-            return touch.get();
+            return touch.unsafeGet();
     }
     return nullptr;
 }

--- a/Source/WebCore/inspector/agents/InspectorCSSAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorCSSAgent.cpp
@@ -1276,7 +1276,7 @@ InspectorStyleSheet* InspectorCSSAgent::bindStyleSheet(CSSStyleSheet* styleSheet
             inspectorStyleSheetsForDocument.append(inspectorStyleSheet);
         }
     }
-    return inspectorStyleSheet.get();
+    return inspectorStyleSheet.unsafeGet();
 }
 
 InspectorStyleSheet* InspectorCSSAgent::assertStyleSheetForId(Inspector::Protocol::ErrorString& errorString, const String& styleSheetId)

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
@@ -476,7 +476,7 @@ Node* InspectorDOMAgent::assertNode(Inspector::Protocol::ErrorString& errorStrin
         errorString = "Missing node for given nodeId"_s;
         return nullptr;
     }
-    return node.get();
+    return node.unsafeGet();
 }
 
 Document* InspectorDOMAgent::assertDocument(Inspector::Protocol::ErrorString& errorString, Inspector::Protocol::DOM::NodeId nodeId)
@@ -487,7 +487,7 @@ Document* InspectorDOMAgent::assertDocument(Inspector::Protocol::ErrorString& er
     RefPtr document = dynamicDowncast<Document>(*node);
     if (!document)
         errorString = "Node for given nodeId is not a document"_s;
-    return document.get();
+    return document.unsafeGet();
 }
 
 Element* InspectorDOMAgent::assertElement(Inspector::Protocol::ErrorString& errorString, Inspector::Protocol::DOM::NodeId nodeId)
@@ -498,7 +498,7 @@ Element* InspectorDOMAgent::assertElement(Inspector::Protocol::ErrorString& erro
     RefPtr element = dynamicDowncast<Element>(*node);
     if (!element)
         errorString = "Node for given nodeId is not an element"_s;
-    return element.get();
+    return element.unsafeGet();
 }
 
 Node* InspectorDOMAgent::assertEditableNode(Inspector::Protocol::ErrorString& errorString, Inspector::Protocol::DOM::NodeId nodeId)
@@ -514,7 +514,7 @@ Node* InspectorDOMAgent::assertEditableNode(Inspector::Protocol::ErrorString& er
         errorString = "Node for given nodeId is a pseudo-element"_s;
         return nullptr;
     }
-    return node.get();
+    return node.unsafeGet();
 }
 
 Element* InspectorDOMAgent::assertEditableElement(Inspector::Protocol::ErrorString& errorString, Inspector::Protocol::DOM::NodeId nodeId)
@@ -525,7 +525,7 @@ Element* InspectorDOMAgent::assertEditableElement(Inspector::Protocol::ErrorStri
     RefPtr element = dynamicDowncast<Element>(node);
     if (!element)
         errorString = "Node for given nodeId is not an element"_s;
-    return element.get();
+    return element.unsafeGet();
 }
 
 Inspector::Protocol::ErrorStringOr<Ref<Inspector::Protocol::DOM::Node>> InspectorDOMAgent::getDocument()

--- a/Source/WebCore/loader/ResourceLoader.cpp
+++ b/Source/WebCore/loader/ResourceLoader.cpp
@@ -385,7 +385,7 @@ void ResourceLoader::addBuffer(const FragmentedSharedBuffer& buffer, DataPayload
 
 const FragmentedSharedBuffer* ResourceLoader::resourceData() const
 {
-    return m_resourceData.get().get();
+    return m_resourceData.get().unsafeGet();
 }
 
 RefPtr<const FragmentedSharedBuffer> ResourceLoader::protectedResourceData() const

--- a/Source/WebCore/loader/SubstituteResource.h
+++ b/Source/WebCore/loader/SubstituteResource.h
@@ -37,7 +37,7 @@ public:
 
     const URL& url() const { return m_url; }
     const ResourceResponse& response() const { return m_response; }
-    FragmentedSharedBuffer& data() const { return *m_data.get(); }
+    FragmentedSharedBuffer& data() const { return *m_data.get().unsafeGet(); }
     Ref<FragmentedSharedBuffer> protectedData() const { return data(); }
     void append(const SharedBuffer& buffer) { m_data.append(buffer); }
     void clear() { m_data.empty(); }

--- a/Source/WebCore/loader/archive/ArchiveResourceCollection.cpp
+++ b/Source/WebCore/loader/archive/ArchiveResourceCollection.cpp
@@ -60,7 +60,7 @@ void ArchiveResourceCollection::addResource(Ref<ArchiveResource>&& resource)
 ArchiveResource* ArchiveResourceCollection::archiveResourceForURL(const URL& url)
 {
     if (RefPtr resource = m_subresources.get(url.string()))
-        return resource.get();
+        return resource.unsafeGet();
     if (!url.protocolIs("https"_s))
         return nullptr;
     URL httpURL = url;

--- a/Source/WebCore/loader/cache/CachedImage.cpp
+++ b/Source/WebCore/loader/cache/CachedImage.cpp
@@ -290,9 +290,9 @@ Image* CachedImage::imageForRenderer(const RenderObject* renderer)
     if (m_image->drawsSVGImage()) {
         RefPtr image = m_svgImageCache->imageForRenderer(renderer);
         if (image != &Image::nullImage())
-            return image.get();
+            return image.unsafeGet();
     }
-    return m_image.get();
+    return m_image.unsafeGet();
 }
 
 void CachedImage::setContainerContextForClient(const CachedImageClient& client, const LayoutSize& containerSize, float containerZoom, const URL& imageURL)

--- a/Source/WebCore/mathml/MathMLSelectElement.cpp
+++ b/Source/WebCore/mathml/MathMLSelectElement.cpp
@@ -154,7 +154,7 @@ Element* MathMLSelectElement::getSelectedActionChild()
         child = selectedChild;
     }
 
-    return child.get();
+    return child.unsafeGet();
 }
 
 Element* MathMLSelectElement::getSelectedSemanticsChild()
@@ -170,7 +170,7 @@ Element* MathMLSelectElement::getSelectedSemanticsChild()
         child = child->nextElementSibling();
     } else if (!downcast<MathMLElement>(*child).isSemanticAnnotation()) {
         // The first child is a presentation MathML but not an annotation, so we can just display it.
-        return child.get();
+        return child.unsafeGet();
     }
     // Otherwise, the first child is an <annotation> or <annotation-xml> element. This is invalid, but some people use this syntax so we take care of this case too and start the search from this first child.
 
@@ -183,7 +183,7 @@ Element* MathMLSelectElement::getSelectedSemanticsChild()
             if (child->hasAttributeWithoutSynchronization(MathMLNames::srcAttr))
                 continue;
             // Otherwise, we assume it is a text annotation that can always be displayed and we stop here.
-            return child.get();
+            return child.unsafeGet();
         }
 
         if (child->hasTagName(MathMLNames::annotation_xmlTag)) {
@@ -193,7 +193,7 @@ Element* MathMLSelectElement::getSelectedSemanticsChild()
             // If the <annotation-xml> element has an encoding attribute describing presentation MathML, SVG or HTML we assume the content can be displayed and we stop here.
             auto& value = child->attributeWithoutSynchronization(MathMLNames::encodingAttr);
             if (isMathMLEncoding(value) || isSVGEncoding(value) || isHTMLEncoding(value))
-                return child.get();
+                return child.unsafeGet();
         }
     }
 

--- a/Source/WebCore/page/DragController.cpp
+++ b/Source/WebCore/page/DragController.cpp
@@ -410,7 +410,7 @@ static Element* elementUnderMouse(Document& documentUnderMouse, const IntPoint& 
     if (!element)
         element = node->parentElement();
     auto* host = element->shadowHost();
-    return host ? host : element.get();
+    return host ? host : element.unsafeGet();
 }
 
 #if !PLATFORM(IOS_FAMILY)

--- a/Source/WebCore/page/ElementTargetingController.cpp
+++ b/Source/WebCore/page/ElementTargetingController.cpp
@@ -200,7 +200,7 @@ static inline bool querySelectorMatchesOneElement(const Element& element, const 
 {
     Ref container = [&]() -> ContainerNode& {
         if (RefPtr shadowRoot = element.containingShadowRoot())
-            return *shadowRoot;
+            return *shadowRoot.unsafeGet();
         return element.document();
     }();
 
@@ -771,7 +771,7 @@ static const HTMLElement* findOnlyMainElement(const HTMLBodyElement& bodyElement
 
         onlyMainElement = descendant;
     }
-    return onlyMainElement.get();
+    return onlyMainElement.unsafeGet();
 }
 
 static bool isNavigationalElement(const Element& element)
@@ -1052,7 +1052,7 @@ static Element* searchForElementContainingText(ContainerNode& container, const S
     auto documentElements = collectDocumentElementsFromChildFrames(container);
     for (auto& documentElement : documentElements) {
         if (RefPtr target = searchForElementContainingText(documentElement, searchText))
-            return target.get();
+            return target.unsafeGet();
     }
 
     return nullptr;
@@ -1411,7 +1411,7 @@ static inline Element& elementToAdjust(Element& element)
 {
     if (RefPtr pseudoElement = dynamicDowncast<PseudoElement>(element)) {
         if (RefPtr host = pseudoElement->hostElement())
-            return *host;
+            return *host.unsafeGet();
     }
     return element;
 }

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -562,7 +562,7 @@ static Node* nodeToSelectOnMouseDownForNode(Node& targetNode)
         return nullptr;
 
     if (RefPtr rootUserSelectAll = Position::rootUserSelectAllForNode(&targetNode))
-        return rootUserSelectAll.get();
+        return rootUserSelectAll.unsafeGet();
 
     if (targetNode.shouldSelectOnMouseDown())
         return &targetNode;

--- a/Source/WebCore/page/FocusController.cpp
+++ b/Source/WebCore/page/FocusController.cpp
@@ -93,7 +93,7 @@ static Element* openPopoverForInvoker(const Node* candidateInvoker)
         return nullptr;
     RefPtr popover = invoker->invokedPopover();
     if (popover && popover->isPopoverShowing() && popover->popoverData()->invoker() == invoker)
-        return popover.get();
+        return popover.unsafeGet();
     return nullptr;
 }
 
@@ -504,7 +504,7 @@ LocalFrame* FocusController::focusedOrMainFrame() const
     if (auto* frame = focusedLocalFrame())
         return frame;
     if (RefPtr localMainFrame = m_page->localMainFrame())
-        return localMainFrame.get();
+        return localMainFrame.unsafeGet();
     ASSERT(m_page->settings().siteIsolationEnabled());
     return nullptr;
 }

--- a/Source/WebCore/page/FrameTree.cpp
+++ b/Source/WebCore/page/FrameTree.cpp
@@ -158,7 +158,7 @@ Frame* FrameTree::scopedChild(unsigned index, TreeScope* scope) const
     for (RefPtr result = firstChild(); result; result = result->tree().nextSibling()) {
         if (inScope(*result, *scope)) {
             if (scopedIndex == index)
-                return result.get();
+                return result.unsafeGet();
             scopedIndex++;
         }
     }
@@ -173,7 +173,7 @@ inline Frame* FrameTree::scopedChild(NOESCAPE const Function<bool(const FrameTre
 
     for (RefPtr child = firstChild(); child; child = child->tree().nextSibling()) {
         if (isMatch(child->tree()) && inScope(*child, *scope))
-            return child.get();
+            return child.unsafeGet();
     }
     return nullptr;
 }
@@ -305,13 +305,13 @@ inline Frame* FrameTree::find(const AtomString& name, F&& nameGetter, Frame& act
     Ref thisFrame = m_thisFrame.get();
     for (RefPtr frame = thisFrame.ptr(); frame; frame = frame->tree().traverseNext(thisFrame.ptr())) {
         if (nameGetter(frame->tree()) == name)
-            return frame.get();
+            return frame.unsafeGet();
     }
 
     // Then the rest of the tree.
     for (RefPtr frame = &thisFrame->mainFrame(); frame; frame = frame->tree().traverseNext()) {
         if (nameGetter(frame->tree()) == name)
-            return frame.get();
+            return frame.unsafeGet();
     }
 
     // Search the entire tree of each of the other pages in this namespace.
@@ -325,7 +325,7 @@ inline Frame* FrameTree::find(const AtomString& name, F&& nameGetter, Frame& act
             continue;
         for (RefPtr frame = &otherPage->mainFrame(); frame; frame = frame->tree().traverseNext()) {
             if (nameGetter(frame->tree()) == name && isFrameFamiliarWith(activeFrame, *frame))
-                return frame.get();
+                return frame.unsafeGet();
         }
     }
 

--- a/Source/WebCore/page/LargestContentfulPaint.cpp
+++ b/Source/WebCore/page/LargestContentfulPaint.cpp
@@ -115,7 +115,7 @@ Element* LargestContentfulPaint::element() const
     if (!LargestContentfulPaintData::isExposedForPaintTiming(*element))
         return nullptr;
 
-    return element.get();
+    return element.unsafeGet();
 }
 
 void LargestContentfulPaint::setElement(Element* element)

--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -747,7 +747,7 @@ const UserContentProvider* LocalFrame::userContentProvider() const
     RefPtr document = this->document();
     RefPtr documentLoader = document ? document->loader() : nullptr;
     if (RefPtr userContentProvider = documentLoader ? documentLoader->preferences().userContentProvider : nullptr)
-        return userContentProvider.get();
+        return userContentProvider.unsafeGet();
     if (RefPtr page = this->page())
         return page->protectedUserContentProviderForFrame().ptr();
     return nullptr;
@@ -758,7 +758,7 @@ UserContentProvider* LocalFrame::userContentProvider()
     RefPtr document = this->document();
     RefPtr documentLoader = document ? document->loader() : nullptr;
     if (RefPtr userContentProvider = documentLoader ? documentLoader->preferences().userContentProvider : nullptr)
-        return userContentProvider.get();
+        return userContentProvider.unsafeGet();
     if (RefPtr page = this->page())
         return page->protectedUserContentProviderForFrame().ptr();
     return nullptr;

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -4432,7 +4432,7 @@ Document* Page::outermostFullscreenDocument() const
 
         currentDocument = fullscreenFrame->contentDocument();
     }
-    return outermostFullscreenDocument.get();
+    return outermostFullscreenDocument.unsafeGet();
 #else
     return nullptr;
 #endif

--- a/Source/WebCore/page/PerformanceEventTiming.cpp
+++ b/Source/WebCore/page/PerformanceEventTiming.cpp
@@ -65,7 +65,7 @@ Node* PerformanceEventTiming::target() const
     if (!node->isConnected() || !document->isFullyActive())
         return nullptr;
 
-    return node.get();
+    return node.unsafeGet();
 }
 
 PerformanceEntry::Type PerformanceEventTiming::performanceEntryType() const

--- a/Source/WebCore/page/PointerCaptureController.cpp
+++ b/Source/WebCore/page/PointerCaptureController.cpp
@@ -63,7 +63,7 @@ Element* PointerCaptureController::pointerCaptureElement(Document* document, Poi
     if (auto capturingData = m_activePointerIdsToCapturingData.get(pointerId)) {
         auto pointerCaptureElement = capturingData->targetOverride;
         if (pointerCaptureElement && &pointerCaptureElement->document() == document)
-            return pointerCaptureElement.get();
+            return pointerCaptureElement.unsafeGet();
     }
     return nullptr;
 }

--- a/Source/WebCore/page/RemoteFrame.cpp
+++ b/Source/WebCore/page/RemoteFrame.cpp
@@ -197,7 +197,7 @@ const SecurityOrigin& RemoteFrame::frameDocumentSecurityOriginOrOpaque() const
 {
     RefPtr securityOrigin = frameDocumentSecurityOrigin();
     if (securityOrigin)
-        return *securityOrigin;
+        return *securityOrigin.unsafeGet();
     return SecurityOrigin::opaqueOrigin();
 }
 

--- a/Source/WebCore/page/UserMessageHandlersNamespace.cpp
+++ b/Source/WebCore/page/UserMessageHandlersNamespace.cpp
@@ -90,7 +90,7 @@ UserMessageHandler* UserMessageHandlersNamespace::namedItem(DOMWrapperWorld& wor
 
     RefPtr handler = m_messageHandlers.get({ name, &world });
     if (handler)
-        return handler.get();
+        return handler.unsafeGet();
 
     userContentProvider->forEachUserMessageHandler([&](const UserMessageHandlerDescriptor& descriptor) {
         if (descriptor.name() != name || &descriptor.world() != &world)
@@ -102,7 +102,7 @@ UserMessageHandler* UserMessageHandlersNamespace::namedItem(DOMWrapperWorld& wor
         handler = addResult.iterator->value.get();
     });
 
-    return handler.get();
+    return handler.unsafeGet();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
+++ b/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
@@ -618,7 +618,7 @@ LocalFrameView* AsyncScrollingCoordinator::frameViewForScrollingNode(std::option
         return nullptr;
     for (const auto& rootFrame : page()->rootFrames()) {
         if (RefPtr frameView = frameViewForScrollingNode(rootFrame.get(), scrollingNodeID))
-            return frameView.get();
+            return frameView.unsafeGet();
     }
     return nullptr;
 }

--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNodeDelegate.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNodeDelegate.h
@@ -40,8 +40,8 @@ public:
     WEBCORE_EXPORT virtual ~ScrollingTreeScrollingNodeDelegate();
 
     RefPtr<ScrollingTreeScrollingNode> protectedScrollingNode() const { return m_scrollingNode.get(); }
-    ScrollingTreeScrollingNode& scrollingNode() { return  *protectedScrollingNode().get(); }
-    const ScrollingTreeScrollingNode& scrollingNode() const { return  *protectedScrollingNode().get(); }
+    ScrollingTreeScrollingNode& scrollingNode() { return  *protectedScrollingNode().unsafeGet(); }
+    const ScrollingTreeScrollingNode& scrollingNode() const { return  *protectedScrollingNode().unsafeGet(); }
     
     virtual bool startAnimatedScrollToPosition(FloatPoint) = 0;
     virtual void stopAnimatedScroll() = 0;

--- a/Source/WebCore/platform/PreviewConverter.cpp
+++ b/Source/WebCore/platform/PreviewConverter.cpp
@@ -67,7 +67,7 @@ const ResourceError& PreviewConverter::previewError() const
 
 const FragmentedSharedBuffer& PreviewConverter::previewData() const
 {
-    return *m_previewData.get();
+    return *m_previewData.get().unsafeGet();
 }
 
 void PreviewConverter::updateMainResource()

--- a/Source/WebCore/platform/cocoa/WebAVPlayerLayer.mm
+++ b/Source/WebCore/platform/cocoa/WebAVPlayerLayer.mm
@@ -122,7 +122,7 @@ private:
 
 - (VideoPresentationModel*)presentationModel
 {
-    return _presentationModel.get().get();
+    return _presentationModel.get().unsafeGet();
 }
 
 - (void)setPresentationModel:(VideoPresentationModel*)presentationModel

--- a/Source/WebCore/platform/graphics/DisplayRefreshMonitorManager.cpp
+++ b/Source/WebCore/platform/graphics/DisplayRefreshMonitorManager.cpp
@@ -132,7 +132,7 @@ DisplayRefreshMonitor* DisplayRefreshMonitorManager::monitorForClient(DisplayRef
     if (monitor)
         monitor->addClient(client);
 
-    return monitor.get();
+    return monitor.unsafeGet();
 }
 
 DisplayRefreshMonitor* DisplayRefreshMonitorManager::monitorForDisplayID(PlatformDisplayID displayID) const

--- a/Source/WebCore/platform/graphics/Path.cpp
+++ b/Source/WebCore/platform/graphics/Path.cpp
@@ -111,7 +111,7 @@ PathImpl& Path::ensureImpl()
         return setImpl(PathStream::create(WTFMove(*segment)));
 
     if (auto impl = asImpl())
-        return *impl;
+        return *impl.unsafeGet();
     ASSERT_NOT_REACHED(); // Impl is never empty.
     return setImpl(PathStream::create());
 }

--- a/Source/WebCore/platform/graphics/SystemFallbackFontCache.cpp
+++ b/Source/WebCore/platform/graphics/SystemFallbackFontCache.cpp
@@ -82,7 +82,7 @@ RefPtr<Font> SystemFallbackFontCache::systemFallbackFontForCharacterCluster(cons
         RefPtr fallbackFont = FontCache::forCurrentThread()->systemFallbackForCharacterCluster(description, *font, isForPlatformFont, FontCache::PreferColoredFont::No, stringBuilder);
         if (fallbackFont)
             fallbackFont->setIsUsedInSystemFallbackFontCache();
-        return fallbackFont.get();
+        return fallbackFont.unsafeGet();
     }).iterator->value;
 }
 

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -4007,12 +4007,12 @@ const TimingFunction& GraphicsLayerCA::timingFunctionForAnimationValue(const Ani
         // its mode set to SingleProperty. In this case, we chose not to set set the
         // animation-wide timing function, so we set it on the single keyframe interval
         // to work around a Core Animation limitation.
-        return *anim.timingFunction();
+        return *anim.timingFunction().unsafeGet();
     }
     if (animValue.timingFunction())
         return *animValue.timingFunction();
     if (anim.defaultTimingFunctionForKeyframes())
-        return *anim.defaultTimingFunctionForKeyframes();
+        return *anim.defaultTimingFunctionForKeyframes().unsafeGet();
     return LinearTimingFunction::identity();
 }
 

--- a/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
+++ b/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
@@ -472,7 +472,7 @@ void PlatformCALayerCocoa::copyContentsFromLayer(PlatformCALayer* layer)
 
 PlatformCALayer* PlatformCALayerCocoa::superlayer() const
 {
-    return platformCALayerForLayer((__bridge void*)[m_layer superlayer]).get();
+    return platformCALayerForLayer((__bridge void*)[m_layer superlayer]).unsafeGet();
 }
 
 void PlatformCALayerCocoa::removeFromSuperlayer()

--- a/Source/WebCore/rendering/CounterNode.cpp
+++ b/Source/WebCore/rendering/CounterNode.cpp
@@ -109,7 +109,7 @@ CounterNode* CounterNode::nextInPreOrderAfterChildren(const CounterNode* stayWit
         if (!current || current == stayWithin)
             return nullptr;
     }
-    return next.get();
+    return next.unsafeGet();
 }
 
 CounterNode* CounterNode::nextInPreOrder(const CounterNode* stayWithin) const

--- a/Source/WebCore/rendering/RenderImage.cpp
+++ b/Source/WebCore/rendering/RenderImage.cpp
@@ -749,7 +749,7 @@ ImageDrawResult RenderImage::paintIntoRect(PaintInfo& paintInfo, const FloatRect
         return ImageDrawResult::DidNothing;
 
     // FIXME: Document when image != img.get().
-    auto* image = imageResource().image().get();
+    auto* image = imageResource().image().unsafeGet();
 
     ImagePaintingOptions options = {
         CompositeOperator::SourceOver,

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -3614,7 +3614,7 @@ GraphicsLayer* RenderLayerBacking::childForSuperlayersExcludingViewTransitions()
         return m_ancestorClippingStack->firstLayer();
 
     if (RefPtr viewportConstrainedLayer = viewportClippingOrAnchorLayer())
-        return viewportConstrainedLayer.get();
+        return viewportConstrainedLayer.unsafeGet();
 
     if (m_contentsContainmentLayer)
         return m_contentsContainmentLayer.get();

--- a/Source/WebCore/style/ContainerQueryEvaluator.cpp
+++ b/Source/WebCore/style/ContainerQueryEvaluator.cpp
@@ -174,7 +174,7 @@ const Element* ContainerQueryEvaluator::selectContainer(OptionSet<CQ::Axis> requ
         // For selectors with pseudo elements, query containers can be established by the shadow-including inclusive ancestors of the ultimate originating element.
         for (RefPtr ancestor = originatingElement; ancestor; ancestor = ancestor->parentOrShadowHostElement()) {
             if (isContainerForQuery(*ancestor.get(), originatingElement.get()))
-                return ancestor.get();
+                return ancestor.unsafeGet();
         }
         return nullptr;
     }
@@ -194,7 +194,7 @@ const Element* ContainerQueryEvaluator::selectContainer(OptionSet<CQ::Axis> requ
 
     for (RefPtr ancestor = element.parentOrShadowHostElement(); ancestor; ancestor = ancestor->parentOrShadowHostElement()) {
         if (isContainerForQuery(*ancestor.get()))
-            return ancestor.get();
+            return ancestor.unsafeGet();
     }
     return { };
 }

--- a/Source/WebCore/svg/SVGSVGElement.cpp
+++ b/Source/WebCore/svg/SVGSVGElement.cpp
@@ -860,7 +860,7 @@ Element* SVGSVGElement::getElementById(const AtomString& id)
 
     RefPtr element = treeScope().getElementById(id);
     if (element && element->isDescendantOf(*this))
-        return element.get();
+        return element.unsafeGet();
     if (treeScope().containsMultipleElementsWithId(id)) {
         for (auto& element : *treeScope().getAllElementsById(id)) {
             if (element->isDescendantOf(*this))

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -1679,7 +1679,7 @@ void Internals::setCanShowPlaceholder(Element& element, bool canShowPlaceholder)
 Element* Internals::insertTextPlaceholder(int width, int height)
 {
     RefPtr localFrame = frame();
-    return localFrame ? localFrame->editor().insertTextPlaceholder(IntSize { width, height }).get() : nullptr;
+    return localFrame ? localFrame->editor().insertTextPlaceholder(IntSize { width, height }).unsafeGet() : nullptr;
 }
 
 void Internals::removeTextPlaceholder(Element& element)

--- a/Source/WebGPU/WebGPU/Queue.mm
+++ b/Source/WebGPU/WebGPU/Queue.mm
@@ -691,7 +691,7 @@ const Device& Queue::device() const
 {
     auto device = m_device.get();
     RELEASE_ASSERT(device);
-    return *device;
+    return *device.unsafeGet();
 }
 
 void Queue::clearTextureIfNeeded(const WGPUImageCopyTexture& destination, NSUInteger slice)

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -1575,13 +1575,13 @@ void NetworkSessionCocoa::initializeNSURLSessionsInSet(SessionSet& sessionSet, N
 SessionSet& NetworkSessionCocoa::sessionSetForPage(std::optional<WebPageProxyIdentifier> webPageProxyID)
 {
     RefPtr sessionSet = webPageProxyID ? m_perPageSessionSets.get(*webPageProxyID) : nullptr;
-    return sessionSet ? *sessionSet : m_defaultSessionSet.get();
+    return sessionSet ? *sessionSet.unsafeGet() : m_defaultSessionSet.get();
 }
 
 const SessionSet& NetworkSessionCocoa::sessionSetForPage(std::optional<WebPageProxyIdentifier> webPageProxyID) const
 {
     RefPtr sessionSet = webPageProxyID ? m_perPageSessionSets.get(*webPageProxyID) : nullptr;
-    return sessionSet ? *sessionSet : m_defaultSessionSet.get();
+    return sessionSet ? *sessionSet.unsafeGet() : m_defaultSessionSet.get();
 }
 
 SessionWrapper& NetworkSessionCocoa::initializeEphemeralStatelessSessionIfNeeded(std::optional<WebPageProxyIdentifier> webPageProxyID, NavigatingToAppBoundDomain isNavigatingToAppBoundDomain)

--- a/Source/WebKit/Platform/IPC/Connection.cpp
+++ b/Source/WebKit/Platform/IPC/Connection.cpp
@@ -1517,7 +1517,7 @@ SerialFunctionDispatcher& Connection::dispatcher()
     // Our syncState is specific to the SerialFunctionDispatcher we have been
     // bound to during open(), so we can retrieve the SerialFunctionDispatcher
     // from it (rather than storing another pointer on this class).
-    return *dispatcher; // FIXME: This is unsafe. This function should return RefPtr instead.
+    return *dispatcher.unsafeGet(); // FIXME: This is unsafe. This function should return RefPtr instead.
 }
 
 void Connection::dispatchOneIncomingMessage()

--- a/Source/WebKit/Platform/classifier/cocoa/TextExtractionFilter.mm
+++ b/Source/WebKit/Platform/classifier/cocoa/TextExtractionFilter.mm
@@ -47,7 +47,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(TextExtractionFilter);
 TextExtractionFilter& TextExtractionFilter::singleton()
 {
     if (RefPtr instance = WebKit::singleton())
-        return *instance;
+        return *instance.unsafeGet();
 
     WebKit::singleton() = adoptRef(*new TextExtractionFilter);
     return singleton();

--- a/Source/WebKit/UIProcess/API/APIFrameInfo.cpp
+++ b/Source/WebKit/UIProcess/API/APIFrameInfo.cpp
@@ -70,12 +70,12 @@ WTF::String FrameInfo::title() const
 
 const WebKit::WebPageProxy* FrameInfo::page() const
 {
-    return WebKit::WebPageProxy::fromIdentifier(m_data.webPageProxyID).get();
+    return WebKit::WebPageProxy::fromIdentifier(m_data.webPageProxyID).unsafeGet();
 }
 
 WebKit::WebPageProxy* FrameInfo::page()
 {
-    return WebKit::WebPageProxy::fromIdentifier(m_data.webPageProxyID).get();
+    return WebKit::WebPageProxy::fromIdentifier(m_data.webPageProxyID).unsafeGet();
 }
 
 } // namespace API

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -2381,7 +2381,7 @@ WebsiteDataStore* WebExtensionContext::websiteDataStore(std::optional<PAL::Sessi
     if (result && !result->isPersistent() && !hasAccessToPrivateData())
         return nullptr;
 
-    return result.get();
+    return result.unsafeGet();
 }
 
 void WebExtensionContext::cookiesDidChange(API::HTTPCookieStore&)

--- a/Source/WebKit/UIProcess/Gamepad/ios/UIGamepadProviderIOS.mm
+++ b/Source/WebKit/UIProcess/Gamepad/ios/UIGamepadProviderIOS.mm
@@ -46,7 +46,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 #if ENABLE(WEBXR) && !USE(OPENXR)
     if (auto page = WebProcessProxy::webPageWithActiveXRSession())
-        return page.get();
+        return page.unsafeGet();
 #endif
 
     return nullptr;

--- a/Source/WebKit/UIProcess/WebBackForwardList.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardList.cpp
@@ -76,7 +76,7 @@ WebBackForwardListItem* WebBackForwardList::itemForID(BackForwardItemIdentifier 
         return nullptr;
 
     ASSERT(item->pageID() == m_page->identifier());
-    return item.get();
+    return item.unsafeGet();
 }
 
 void WebBackForwardList::pageClosed()

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -731,7 +731,7 @@ WebFrameProxy* WebFrameProxy::deepLastChild()
     RefPtr result = this;
     for (RefPtr last = lastChild(); last; last = last->lastChild())
         result = last;
-    return result.get();
+    return result.unsafeGet();
 }
 
 WebFrameProxy* WebFrameProxy::firstChild() const

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -6580,7 +6580,7 @@ void WebViewImpl::togglePictureInPicture()
 PlatformPlaybackSessionInterface* WebViewImpl::playbackSessionInterface() const
 {
     if (RefPtr manager = m_page->playbackSessionManager())
-        return manager->controlsManagerInterface().get();
+        return manager->controlsManagerInterface().unsafeGet();
 
     return nullptr;
 }

--- a/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
+++ b/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
@@ -371,7 +371,7 @@ WebCore::AccessibilityObject* WebAutomationSessionProxy::getAccessibilityObjectF
         axObjectCache->performDeferredCacheUpdate(ForceLayout::Yes);
 
         if (RefPtr<WebCore::AccessibilityObject> axObject = axObjectCache->exportedGetOrCreate(*coreElement))
-            return axObject.get();
+            return axObject.unsafeGet();
     }
 
     errorType = Inspector::Protocol::AutomationHelpers::getEnumConstantValue(Inspector::Protocol::Automation::ErrorMessage::InternalError);
@@ -667,16 +667,16 @@ static WebCore::Element* containerElementForElement(WebCore::Element& element)
     // https://w3c.github.io/webdriver/webdriver-spec.html#dfn-container.
     if (is<WebCore::HTMLOptionElement>(element)) {
         if (RefPtr parentElement = WebCore::ancestorsOfType<WebCore::HTMLDataListElement>(element).first())
-            return parentElement.get();
+            return parentElement.unsafeGet();
         if (RefPtr parentElement = downcast<WebCore::HTMLOptionElement>(element).ownerSelectElement())
-            return parentElement.get();
+            return parentElement.unsafeGet();
 
         return nullptr;
     }
 
     if (RefPtr optgroup = dynamicDowncast<WebCore::HTMLOptGroupElement>(element)) {
         if (RefPtr parentElement = optgroup->ownerSelectElement())
-            return parentElement.get();
+            return parentElement.unsafeGet();
 
         return nullptr;
     }

--- a/Source/WebKit/WebProcess/GPU/graphics/wc/RemoteWCLayerTreeHostProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/wc/RemoteWCLayerTreeHostProxy.cpp
@@ -67,7 +67,7 @@ GPUProcessConnection& RemoteWCLayerTreeHostProxy::ensureGPUProcessConnection()
             Messages::GPUConnectionToWebProcess::CreateWCLayerTreeHost(wcLayerTreeHostIdentifier(), m_page->nativeWindowHandle(), m_usesOffscreenRendering),
             0, IPC::SendOption::DispatchMessageEvenWhenWaitingForSyncReply);
     }
-    return *gpuProcessConnection;
+    return *gpuProcessConnection.unsafeGet();
 }
 
 void RemoteWCLayerTreeHostProxy::disconnectGpuProcessIfNeeded()

--- a/Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVFManager.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVFManager.cpp
@@ -96,7 +96,7 @@ GPUProcessConnection& RemoteImageDecoderAVFManager::ensureGPUProcessConnection()
         gpuProcessConnection->addClient(*this);
         gpuProcessConnection->messageReceiverMap().addMessageReceiver(Messages::RemoteImageDecoderAVFManager::messageReceiverName(), *this);
     }
-    return *gpuProcessConnection;
+    return *gpuProcessConnection.unsafeGet();
 }
 
 void RemoteImageDecoderAVFManager::setUseGPUProcess(bool useGPUProcess)

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.cpp
@@ -278,7 +278,7 @@ GPUProcessConnection& RemoteMediaPlayerManager::gpuProcessConnection()
         gpuProcessConnection->addClient(*this);
     }
 
-    return *gpuProcessConnection;
+    return *gpuProcessConnection.unsafeGet();
 }
 
 Ref<GPUProcessConnection> RemoteMediaPlayerManager::protectedGPUProcessConnection()

--- a/Source/WebKit/WebProcess/GPU/media/RemoteRemoteCommandListener.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteRemoteCommandListener.cpp
@@ -67,7 +67,7 @@ GPUProcessConnection& RemoteRemoteCommandListener::ensureGPUProcessConnection()
         gpuProcessConnection->messageReceiverMap().addMessageReceiver(Messages::RemoteRemoteCommandListener::messageReceiverName(), identifier().toUInt64(), *this);
         gpuProcessConnection->connection().send(Messages::GPUConnectionToWebProcess::CreateRemoteCommandListener(identifier()), { });
     }
-    return *gpuProcessConnection;
+    return *gpuProcessConnection.unsafeGet();
 }
 
 void RemoteRemoteCommandListener::gpuProcessConnectionDidClose(GPUProcessConnection& gpuProcessConnection)

--- a/Source/WebKit/WebProcess/GPU/media/cocoa/VideoLayerRemoteCocoa.mm
+++ b/Source/WebKit/WebProcess/GPU/media/cocoa/VideoLayerRemoteCocoa.mm
@@ -85,7 +85,7 @@ static const Seconds PostAnimationDelay { 100_ms };
 
 - (WebKit::VideoLayerRemoteParent*)parent
 {
-    return _parent.get().get();
+    return _parent.get().unsafeGet();
 }
 
 - (void)setParent:(WebKit::VideoLayerRemoteParent*)parent

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -1845,14 +1845,14 @@ RefPtr<API::Object> userDataFromJSONData(JSON::Value& value)
         return API::String::create(value.asString());
     case JSON::Value::Type::Object: {
         auto result = API::Dictionary::create();
-        for (auto [key, value] : *value.asObject())
+        for (auto [key, value] : *value.asObject().unsafeGet())
             result->add(key, userDataFromJSONData(value));
         return result;
     }
     case JSON::Value::Type::Array: {
         auto array = value.asArray();
         Vector<RefPtr<API::Object>> result;
-        for (auto& item : *value.asArray())
+        for (auto& item : *value.asArray().unsafeGet())
             result.append(userDataFromJSONData(item));
         return API::Array::create(WTFMove(result));
     }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -927,7 +927,7 @@ LocalFrame* WebLocalFrameLoaderClient::dispatchCreatePage(const NavigationAction
     if (!newPage)
         return nullptr;
     
-    return newPage->localMainFrame().get();
+    return newPage->localMainFrame().unsafeGet();
 }
 
 void WebLocalFrameLoaderClient::dispatchShow()

--- a/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp
@@ -516,7 +516,7 @@ WebCore::LocalFrame* WebFoundTextRangeController::frameForFoundTextRange(const W
         return nullptr;
 
     if (range.frameIdentifier.isEmpty())
-        return mainFrame.get();
+        return mainFrame.unsafeGet();
 
     return dynamicDowncast<WebCore::LocalFrame>(mainFrame->tree().findByUniqueName(AtomString { range.frameIdentifier }, *mainFrame));
 }

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -1342,7 +1342,7 @@ inline DocumentLoader* WebFrame::policySourceDocumentLoader() const
     if (!policySourceDocumentLoader->request().url().hasSpecialScheme() && document->url().protocolIsInHTTPFamily())
         policySourceDocumentLoader = document->loader();
 
-    return policySourceDocumentLoader.get();
+    return policySourceDocumentLoader.unsafeGet();
 }
 
 OptionSet<WebCore::AdvancedPrivacyProtections> WebFrame::advancedPrivacyProtections() const

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -1307,7 +1307,7 @@ void WebPage::sendTapHighlightForNodeIfNecessary(WebKit::TapIdentifier requestID
     }
 
     if (RefPtr area = dynamicDowncast<HTMLAreaElement>(*node)) {
-        node = area->imageElement().get();
+        node = area->imageElement().unsafeGet();
         if (!node)
             return;
     }

--- a/Tools/Scripts/webkitpy/style/checkers/cpp.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp.py
@@ -2817,6 +2817,28 @@ def check_wtf_move(clean_lines, line_number, file_state, error):
     error(line_number, 'runtime/wtf_move', 4, "Use 'WTFMove()' instead of 'std::move()'.")
 
 
+def check_unsafe_get(clean_lines, line_number, file_state, error):
+    """Looks for use of 'unsafeGet()' which should be avoided.
+
+    Args:
+      clean_lines: A CleansedLines instance containing the file.
+      line_number: The number of the line to check.
+      file_state: A _FileState instance which maintains information about
+                  the state of things in the file.
+      error: The function to call with any errors found.
+    """
+
+    # This check doesn't apply to C implementation files.
+    if file_state.is_c():
+        return
+
+    line = clean_lines.elided[line_number]  # Get rid of comments and strings.
+
+    using_unsafe_get = search(r'\bunsafeGet\s*\(\s*\)', line)
+    if using_unsafe_get:
+        error(line_number, 'runtime/unsafe_get', 5, "Avoid using 'unsafeGet()' by extending the lifetime of the RefPtr.")
+
+
 def check_callonmainthread(filename, clean_lines, line_number, file_state, error):
     """Looks for use of 'callOnMainThread()' which should be replaced with 'callOnMainRunLoop()'.
 
@@ -3732,6 +3754,7 @@ def check_style(clean_lines, line_number, file_extension, class_state, file_stat
     check_max_min_macros(clean_lines, line_number, file_state, error)
     check_wtf_checked_size(clean_lines, line_number, file_state, error)
     check_wtf_move(clean_lines, line_number, file_state, error)
+    check_unsafe_get(clean_lines, line_number, file_state, error)
     check_wtf_make_unique(clean_lines, line_number, file_state, error)
     check_wtf_never_destroyed(clean_lines, line_number, file_state, error)
     check_lock_guard(clean_lines, line_number, file_state, error)
@@ -5007,6 +5030,7 @@ class CppChecker(object):
         'runtime/soft-linked-alloc',
         'runtime/string',
         'runtime/threadsafe_fn',
+        'runtime/unsafe_get',
         'runtime/unsigned',
         'runtime/virtual',
         'runtime/wtf_checked_size',

--- a/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
@@ -6105,6 +6105,24 @@ class WebKitStyleTest(CppStyleTestBase):
             "  [runtime/wtf_move] [4]",
             'foo.mm')
 
+    def test_unsafe_get(self):
+        self.assert_lint(
+            'auto ptr = obj.get();',
+            '',
+            'foo.cpp')
+
+        self.assert_lint(
+            'auto ptr = obj.unsafeGet();',
+            "Avoid using 'unsafeGet()' by extending the lifetime of the RefPtr."
+            "  [runtime/unsafe_get] [5]",
+            'foo.cpp')
+
+        self.assert_lint(
+            'auto ptr = obj.unsafeGet();',
+            "Avoid using 'unsafeGet()' by extending the lifetime of the RefPtr."
+            "  [runtime/unsafe_get] [5]",
+            'foo.mm')
+
     def test_wtf_never_destroyed(self):
         self.assert_lint(
              'static NeverDestroyed<Foo> foo;',

--- a/Tools/TestWebKitAPI/Tests/WebCore/CSSParser.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/CSSParser.cpp
@@ -45,7 +45,7 @@ TEST(CSSParser, ParseColorInput)
     auto properties = MutableStyleProperties::create();
 
     ASSERT_TRUE(CSSParser::parseDeclarationList(properties, "color: #ff0000;"_s, strictCSSParserContext()));
-    auto value = properties->getPropertyCSSValue(CSSPropertyColor).get();
+    auto value = properties->getPropertyCSSValue(CSSPropertyColor).unsafeGet();
 
     ASSERT_TRUE(is<CSSValue>(value));
     Color valueColor(Color::red);
@@ -59,7 +59,7 @@ TEST(CSSParser, ParseColorWithNewlineAndWhitespacesInput)
     auto properties = MutableStyleProperties::create();
 
     ASSERT_TRUE(CSSParser::parseDeclarationList(properties, "color:  \n    #ff0000;"_s, strictCSSParserContext()));
-    auto value = properties->getPropertyCSSValue(CSSPropertyColor).get();
+    auto value = properties->getPropertyCSSValue(CSSPropertyColor).unsafeGet();
 
     ASSERT_TRUE(is<CSSValue>(value));
     Color valueColor(Color::red);

--- a/Tools/TestWebKitAPI/Tests/WebCore/DocumentOrder.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/DocumentOrder.cpp
@@ -272,7 +272,7 @@ TEST(DocumentOrder, Positions)
     TEST_ALL_POSITION_TYPES(g, 0, c, 1, less);
     TEST_ALL_POSITION_TYPES(g, 0, c, 2, less);
 
-    auto& h = *g->innerTextElement();
+    auto& h = *g->innerTextElement().unsafeGet();
     TEST_ALL_POSITION_TYPES(body, 1, h, 0, less);
     TEST_ALL_POSITION_TYPES(c, 0, h, 0, less);
     TEST_ALL_POSITION_TYPES(h, 0, c, 1, less);

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/SharedBuffer.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/SharedBuffer.mm
@@ -85,7 +85,7 @@ TEST_F(FragmentedSharedBufferTest, createNSDataForDataSegment)
         NSUInteger expectedSize = helloData.length + worldData.length;
 
         NSUInteger segmentCount = 0;
-        for (auto& segment : *builder.get())
+        for (auto& segment : *builder.get().unsafeGet())
             EXPECT_TRUE([segment.segment->createNSData() isEqualToData:expectedData[segmentCount++]]);
         EXPECT_EQ(expectedData.count, segmentCount);
 


### PR DESCRIPTION
#### 74dea8980fbdde16d46fd8327f098ea62d6a9a94
<pre>
Adopt LIFETIME_BOUND for WTF::RefPtr
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=300201">https://bugs.webkit.org/show_bug.cgi?id=300201</a>&gt;
&lt;<a href="https://rdar.apple.com/162003473">rdar://162003473</a>&gt;

Reviewed by Geoffrey Garen.

Add LIFETIME_BOUND attribute for get(), operator*() and operator-&gt;() to
WTF::RefPtr, and introduce unsafeGet() since there are too many unsafe
uses of get() to fix in a single patch.

Add a style checker to warn when unsafeGet() is used or when the code is
modified without fixing it.

Fix three locations in JavaScriptCore where the return value of
jitCode() was being discarded in debug logging code.

* Source/JavaScriptCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
- Remove tools/VMInspector.cpp.
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp:
(JSC::BytecodeGenerator::emitResolveScopeForHoistingFuncDeclInEval):
(JSC::BytecodeGenerator::emitGetTemplateObject):
(JSC::BytecodeGenerator::emitGetGenericIterator):
(JSC::BytecodeGenerator::emitGetAsyncIterator):
(JSC::BytecodeGenerator::emitDelegateYield):
* Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp:
(JSC::BracketAccessorNode::emitBytecode):
(JSC::EvalFunctionCallNode::emitBytecode):
(JSC::StaticBlockFunctionCallNode::emitBytecode):
(JSC::BytecodeIntrinsicNode::emit_intrinsic_newArrayWithSize):
(JSC::BytecodeIntrinsicNode::emit_intrinsic_newArrayWithSpecies):
(JSC::BytecodeIntrinsicNode::emit_intrinsic_newPromise):
(JSC::CallFunctionCallDotNode::emitBytecode):
(JSC::HasOwnPropertyFunctionCallDotNode::emitBytecode):
(JSC::ApplyFunctionCallDotNode::emitBytecode):
(JSC::PostfixNode::emitResolve):
(JSC::PrefixNode::emitResolve):
(JSC::OptionalChainNode::emitBytecode):
(JSC::ConditionalNode::emitBytecode):
(JSC::AssignResolveNode::emitBytecode):
(JSC::ReadModifyDotNode::emitBytecode):
* Source/JavaScriptCore/dfg/DFGGraph.cpp:
(JSC::DFG::Graph::requiredRegisterCountForExit):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
(JSC::DFG::SpeculativeJIT::SpeculativeJIT):
(JSC::DFG::SpeculativeJIT::linkOSREntries):
- Fix lifetime of `jitCode()` return value.
* Source/JavaScriptCore/dfg/DFGStackLayoutPhase.cpp:
(JSC::DFG::StackLayoutPhase::run):
* Source/JavaScriptCore/interpreter/StackVisitor.cpp:
(JSC::StackVisitor::Frame::dump const):
- Fix lifetime of `jitCode()` return value.
* Source/JavaScriptCore/runtime/CachedTypes.cpp:
(JSC::CachedUniquedStringImplBase::decode const):
* Source/JavaScriptCore/runtime/JSArrayBufferView.cpp:
(JSC::JSArrayBufferView::slowDownAndWasteMemory):
* Source/JavaScriptCore/tools/VMInspector.cpp:
(JSC::VMInspector::codeBlockForMachinePC):
- Fix lifetime of `jitCode()` return value.

* Source/WTF/wtf/RefPtr.h:
(WTF::RefPtr::get const):
(WTF::RefPtr::unsafeGet const): Add.
(WTF::RefPtr::operator* const):
(WTF::RefPtr::operator-&gt; const):
- Add LIFETIME_BOUND to existing methods.
- Add unsafeGet() as a workaround.

* Source/WebCore/Modules/fetch/FetchBodyConsumer.h:
* Source/WebCore/accessibility/AXCoreObject.cpp:
(WebCore::AXCoreObject::firstUnignoredChild):
(WebCore::AXCoreObject::crossFrameParentObjectUnignored const):
(WebCore::AXCoreObject::parentObjectIncludingCrossFrame const):
(WebCore::AXCoreObject::nextInPreOrder):
(WebCore::AXCoreObject::previousInPreOrder):
(WebCore::AXCoreObject::nextSiblingIncludingIgnoredOrParent const):
(WebCore::AXCoreObject::parentObjectUnignored const):
* Source/WebCore/accessibility/AXCoreObject.h:
(WebCore::Accessibility::crossFrameFindAncestor):
(WebCore::Accessibility::findAncestor):
(WebCore::Accessibility::clickableSelfOrAncestor):
(WebCore::Accessibility::highestEditableAncestor):
(WebCore::Accessibility::findRelatedObjectInAncestry):
(WebCore::Accessibility::findUnignoredDescendant):
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::updateCurrentModalNode):
(WebCore::AXObjectCache::focusedObjectForNode):
(WebCore::AXObjectCache::getOrCreate):
(WebCore::AXObjectCache::getOrCreateSlow):
(WebCore::AXObjectCache::create):
(WebCore::AXObjectCache::getIncludingAncestors const):
(WebCore::parentEditingBoundary):
* Source/WebCore/accessibility/AXObjectCacheInlines.h:
(WebCore::AXObjectCache::getOrCreate):
* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::Accessibility::findObjectWithRuns):
* Source/WebCore/accessibility/AXUtilities.cpp:
(WebCore::composedParentIgnoringDocumentFragments):
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::firstChild const):
(WebCore::AccessibilityNodeObject::parentObject const):
(WebCore::AccessibilityNodeObject::anchorElement const):
(WebCore::nativeActionElement):
(WebCore::AccessibilityNodeObject::actionElement const):
(WebCore::AccessibilityNodeObject::parentTable const):
(WebCore::AccessibilityNodeObject::parentTableIfExposedTableRow const):
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::firstAccessibleObjectFromNode):
(WebCore::AccessibilityObject::elementAccessibilityHitTest const):
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::nextSibling const):
(WebCore::AccessibilityRenderObject::parentObject const):
(WebCore::AccessibilityRenderObject::elementAccessibilityHitTest const):
(WebCore::AccessibilityRenderObject::accessibilityHitTest const):
(WebCore::AccessibilityRenderObject::remoteSVGRootElement const):
* Source/WebCore/accessibility/AccessibilitySVGObject.cpp:
(WebCore::AccessibilitySVGObject::childElementWithMatchingLanguage const):
* Source/WebCore/accessibility/AccessibilityScrollView.cpp:
(WebCore::AccessibilityScrollView::documentFrameView const):
(WebCore::AccessibilityScrollView::parentObject const):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm:
(-[WebAccessibilityObjectWrapperBase baseUpdateBackingStore]):
(accessibilitySearchCriteriaForSearchPredicate):
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::timingFunctionForBlendingKeyframe const):
(WebCore::KeyframeEffect::activeViewTimeline):
* Source/WebCore/animation/ScrollTimeline.cpp:
(WebCore::ScrollTimeline::source const):
* Source/WebCore/dom/CharacterData.cpp:
(WebCore::makeChildChange):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::scrollingElement):
(WebCore::Document::takeAnyMediaCanStartListener):
(WebCore::Document::activeModalDialog const):
* Source/WebCore/dom/DocumentFragment.cpp:
(WebCore::DocumentFragment::getElementById const):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::ensureUserAgentShadowRoot):
(WebCore::Element::topmostPopoverAncestor):
* Source/WebCore/dom/EventPath.h:
(WebCore::EventPath::eventTargetRespectingTargetRules):
* Source/WebCore/dom/SelectorQuery.cpp:
(WebCore::filterRootById):
* Source/WebCore/dom/StyledElement.cpp:
(WebCore::StyledElement::ensureMutableInlineStyle):
* Source/WebCore/editing/CompositeEditCommand.cpp:
(WebCore::CompositeEditCommand::composition const):
(WebCore::CompositeEditCommand::ensureComposition):
* Source/WebCore/editing/Editing.cpp:
(WebCore::unsplittableElementForPosition):
* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::nodeBeforeWritingSuggestions const):
* Source/WebCore/editing/MarkupAccumulator.cpp:
(WebCore::MarkupAccumulator::suitableShadowRoot):
* Source/WebCore/editing/TextIterator.cpp:
(WebCore::firstNode):
* Source/WebCore/editing/cocoa/NodeHTMLConverter.mm:
(HTMLConverter::_blockLevelElementForNode):
* Source/WebCore/html/CachedHTMLCollectionInlines.h:
(WebCore::traversalType&gt;::namedItem const):
* Source/WebCore/html/CheckboxInputType.cpp:
(WebCore::findTouchWithIdentifier):
* Source/WebCore/html/FormAssociatedElement.cpp:
(WebCore::FormAssociatedElement::formForBindings const):
* Source/WebCore/html/HTMLCanvasElement.cpp:
(WebCore::HTMLCanvasElement::getContextWebGL):
* Source/WebCore/html/HTMLFormControlsCollection.cpp:
(WebCore::HTMLFormControlsCollection::customElementAfter const):
* Source/WebCore/html/HTMLLabelElement.cpp:
(WebCore::HTMLLabelElement::formForBindings const):
* Source/WebCore/html/HTMLLegendElement.cpp:
(WebCore::HTMLLegendElement::formForBindings const):
* Source/WebCore/html/HTMLOptionElement.cpp:
(WebCore::HTMLOptionElement::formForBindings const):
* Source/WebCore/html/shadow/SliderThumbElement.cpp:
(WebCore::findTouchWithIdentifier):
* Source/WebCore/inspector/agents/InspectorCSSAgent.cpp:
(WebCore::InspectorCSSAgent::bindStyleSheet):
* Source/WebCore/inspector/agents/InspectorDOMAgent.cpp:
(WebCore::InspectorDOMAgent::assertNode):
(WebCore::InspectorDOMAgent::assertDocument):
(WebCore::InspectorDOMAgent::assertElement):
(WebCore::InspectorDOMAgent::assertEditableNode):
(WebCore::InspectorDOMAgent::assertEditableElement):
* Source/WebCore/loader/ResourceLoader.cpp:
(WebCore::ResourceLoader::resourceData const):
* Source/WebCore/loader/SubstituteResource.h:
(WebCore::SubstituteResource::data const):
* Source/WebCore/loader/archive/ArchiveResourceCollection.cpp:
(WebCore::ArchiveResourceCollection::archiveResourceForURL):
* Source/WebCore/loader/cache/CachedImage.cpp:
(WebCore::CachedImage::imageForRenderer):
* Source/WebCore/mathml/MathMLSelectElement.cpp:
(WebCore::MathMLSelectElement::getSelectedActionChild):
(WebCore::MathMLSelectElement::getSelectedSemanticsChild):
* Source/WebCore/page/DragController.cpp:
(WebCore::elementUnderMouse):
* Source/WebCore/page/ElementTargetingController.cpp:
(WebCore::querySelectorMatchesOneElement):
(WebCore::findOnlyMainElement):
(WebCore::searchForElementContainingText):
(WebCore::elementToAdjust):
* Source/WebCore/page/EventHandler.cpp:
(WebCore::nodeToSelectOnMouseDownForNode):
* Source/WebCore/page/FocusController.cpp:
(WebCore::openPopoverForInvoker):
(WebCore::FocusController::focusedOrMainFrame const):
* Source/WebCore/page/FrameTree.cpp:
(WebCore::FrameTree::scopedChild const):
(WebCore::FrameTree::find const):
* Source/WebCore/page/LargestContentfulPaint.cpp:
(WebCore::LargestContentfulPaint::element const):
* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::userContentProvider const):
(WebCore::LocalFrame::userContentProvider):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::outermostFullscreenDocument const):
* Source/WebCore/page/PerformanceEventTiming.cpp:
(WebCore::PerformanceEventTiming::target const):
* Source/WebCore/page/PointerCaptureController.cpp:
(WebCore::PointerCaptureController::pointerCaptureElement const):
* Source/WebCore/page/RemoteFrame.cpp:
(WebCore::RemoteFrame::frameDocumentSecurityOriginOrOpaque const):
* Source/WebCore/page/UserMessageHandlersNamespace.cpp:
(WebCore::UserMessageHandlersNamespace::namedItem):
* Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp:
(WebCore::AsyncScrollingCoordinator::frameViewForScrollingNode const):
* Source/WebCore/page/scrolling/ScrollingTreeScrollingNodeDelegate.h:
(WebCore::ScrollingTreeScrollingNodeDelegate::scrollingNode):
(WebCore::ScrollingTreeScrollingNodeDelegate::scrollingNode const):
* Source/WebCore/platform/PreviewConverter.cpp:
(WebCore::PreviewConverter::previewData const):
* Source/WebCore/platform/cocoa/WebAVPlayerLayer.mm:
(-[WebAVPlayerLayer presentationModel]):
* Source/WebCore/platform/graphics/DisplayRefreshMonitorManager.cpp:
(WebCore::DisplayRefreshMonitorManager::monitorForClient):
* Source/WebCore/platform/graphics/Path.cpp:
(WebCore::Path::ensureImpl):
* Source/WebCore/platform/graphics/SystemFallbackFontCache.cpp:
(WebCore::SystemFallbackFontCache::systemFallbackFontForCharacterCluster):
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::GraphicsLayerCA::ensureStructuralLayer):
* Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm:
(WebCore::PlatformCALayerCocoa::superlayer const):
* Source/WebCore/rendering/CounterNode.cpp:
(WebCore::CounterNode::nextInPreOrderAfterChildren const):
* Source/WebCore/rendering/RenderImage.cpp:
(WebCore::RenderImage::paintIntoRect):
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::childForSuperlayersExcludingViewTransitions const):
* Source/WebCore/style/ContainerQueryEvaluator.cpp:
(WebCore::Style::ContainerQueryEvaluator::selectContainer):
* Source/WebCore/svg/SVGSVGElement.cpp:
(WebCore::SVGSVGElement::getElementById):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::insertTextPlaceholder):

* Source/WebGPU/WebGPU/Queue.mm:
(WebGPU::Queue::device const):

* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
(WebKit::NetworkSessionCocoa::sessionSetForPage):
(WebKit::NetworkSessionCocoa::sessionSetForPage const):
* Source/WebKit/Platform/IPC/Connection.cpp:
(IPC::Connection::dispatcher):
* Source/WebKit/Platform/classifier/cocoa/TextExtractionFilter.mm:
(WebKit::TextExtractionFilter::singleton):
* Source/WebKit/UIProcess/API/APIFrameInfo.cpp:
(API::FrameInfo::page const):
(API::FrameInfo::page):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::websiteDataStore const):
* Source/WebKit/UIProcess/Gamepad/ios/UIGamepadProviderIOS.mm:
(WebKit::UIGamepadProvider::platformWebPageProxyForGamepadInput):
* Source/WebKit/UIProcess/WebBackForwardList.cpp:
(WebKit::WebBackForwardList::itemForID):
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::deepLastChild):
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::playbackSessionInterface const):
* Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp:
(WebKit::WebAutomationSessionProxy::getAccessibilityObjectForNode):
(WebKit::containerElementForElement):
* Source/WebKit/WebProcess/GPU/graphics/wc/RemoteWCLayerTreeHostProxy.cpp:
(WebKit::RemoteWCLayerTreeHostProxy::ensureGPUProcessConnection):
* Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVFManager.cpp:
(WebKit::RemoteImageDecoderAVFManager::ensureGPUProcessConnection):
* Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.cpp:
(WebKit::RemoteMediaPlayerManager::gpuProcessConnection):
* Source/WebKit/WebProcess/GPU/media/RemoteRemoteCommandListener.cpp:
(WebKit::RemoteRemoteCommandListener::ensureGPUProcessConnection):
* Source/WebKit/WebProcess/GPU/media/cocoa/VideoLayerRemoteCocoa.mm:
(-[WKVideoLayerRemote parent]):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::userDataFromJSONData):
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:
(WebKit::WebLocalFrameLoaderClient::dispatchCreatePage):
* Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp:
(WebKit::WebFoundTextRangeController::frameForFoundTextRange const):
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::policySourceDocumentLoader const):
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::sendTapHighlightForNodeIfNecessary):

* Tools/Scripts/webkitpy/style/checkers/cpp.py:
(check_unsafe_get):
(check_style):
(CppChecker):
* Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py:
(WebKitStyleTest.test_unsafe_get):
- Add style checker to warn when using unsafeGet().
* Tools/TestWebKitAPI/Tests/WebCore/CSSParser.cpp:
(TestWebKitAPI::TEST(CSSParser, ParseColorInput)):
(TestWebKitAPI::TEST(CSSParser, ParseColorWithNewlineAndWhitespacesInput)):
* Tools/TestWebKitAPI/Tests/WebCore/DocumentOrder.cpp:
(TestWebKitAPI::TEST(DocumentOrder, Positions)):
* Tools/TestWebKitAPI/Tests/WebCore/cocoa/SharedBuffer.mm:
(TestWebKitAPI::TEST_F(FragmentedSharedBufferTest, createNSDataForDataSegment)):

Canonical link: <a href="https://commits.webkit.org/301069@main">https://commits.webkit.org/301069@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/68455b232a8b14cbe78df7f792e7efa22367b1f6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124878 "213 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44549 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35285 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131724 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/76777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/914d105f-1d52-4448-86e3-1f3df7920d26) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/126755 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45249 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53116 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/95037 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/76777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f027700d-a851-49ea-a500-27916e4ac1d4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127832 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/36104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111686 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75593 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ed6c01d6-3622-4540-967d-e3db6cc67489) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/124234 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/35039 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/29842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75203 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/116986 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/105864 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30071 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134398 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/123398 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51718 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39519 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/103514 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52135 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107901 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103280 "Passed tests") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/48637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/26925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48739 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19565 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51594 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/57402 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/156423 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/50983 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/39176 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54339 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/52676 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->