### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException from Modules/webauthn

### DIFF
--- a/Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.cpp
+++ b/Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.cpp
@@ -119,9 +119,22 @@ static ScopeAndCrossOriginParent scopeAndCrossOriginParent(const Document& docum
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(AuthenticatorCoordinator);
 
-AuthenticatorCoordinator::AuthenticatorCoordinator(std::unique_ptr<AuthenticatorCoordinatorClient>&& client)
-    : m_client(WTFMove(client))
+AuthenticatorCoordinator::AuthenticatorCoordinator(Page& page, std::unique_ptr<AuthenticatorCoordinatorClient>&& client)
+    : m_page(page)
+    , m_client(WTFMove(client))
 {
+}
+
+AuthenticatorCoordinator::~AuthenticatorCoordinator() = default;
+
+void AuthenticatorCoordinator::ref() const
+{
+    m_page->ref();
+}
+
+void AuthenticatorCoordinator::deref() const
+{
+    m_page->deref();
 }
 
 void AuthenticatorCoordinator::setClient(std::unique_ptr<AuthenticatorCoordinatorClient>&& client)

--- a/Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.h
+++ b/Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.h
@@ -41,11 +41,7 @@ enum class Scope;
 
 namespace WebCore {
 class AuthenticatorCoordinator;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::AuthenticatorCoordinator> : std::true_type { };
+class Page;
 }
 
 namespace WebCore {
@@ -71,8 +67,12 @@ class AuthenticatorCoordinator final : public CanMakeWeakPtr<AuthenticatorCoordi
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(AuthenticatorCoordinator, WEBCORE_EXPORT);
     WTF_MAKE_NONCOPYABLE(AuthenticatorCoordinator);
 public:
-    WEBCORE_EXPORT explicit AuthenticatorCoordinator(std::unique_ptr<AuthenticatorCoordinatorClient>&&);
+    WEBCORE_EXPORT AuthenticatorCoordinator(Page&, std::unique_ptr<AuthenticatorCoordinatorClient>&&);
     WEBCORE_EXPORT void setClient(std::unique_ptr<AuthenticatorCoordinatorClient>&&);
+    ~AuthenticatorCoordinator();
+
+    void ref() const;
+    void deref() const;
 
     // The following methods implement static methods of PublicKeyCredential.
     void create(const Document&, CredentialCreationOptions&&, RefPtr<AbortSignal>&&, CredentialPromise&&);
@@ -87,8 +87,7 @@ public:
     void signalCurrentUserDetails(const Document&, CurrentUserDetailsOptions&&, DOMPromiseDeferred<void>&&);
 
 private:
-    AuthenticatorCoordinator() = default;
-
+    WeakRef<Page> m_page;
     std::unique_ptr<AuthenticatorCoordinatorClient> m_client;
     bool m_isCancelling = false;
     CompletionHandler<void()> m_queuedRequest;

--- a/Source/WebCore/Modules/webauthn/AuthenticatorCoordinatorClient.h
+++ b/Source/WebCore/Modules/webauthn/AuthenticatorCoordinatorClient.h
@@ -37,11 +37,6 @@ namespace WebCore {
 class AuthenticatorCoordinatorClient;
 }
 
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::AuthenticatorCoordinatorClient> : std::true_type { };
-}
-
 namespace WebAuthn {
 enum class Scope;
 }
@@ -64,7 +59,7 @@ using CapabilitiesCompletionHandler = CompletionHandler<void(Vector<KeyValuePair
 using RequestCompletionHandler = CompletionHandler<void(WebCore::AuthenticatorResponseData&&, WebCore::AuthenticatorAttachment, WebCore::ExceptionData&&)>;
 using QueryCompletionHandler = CompletionHandler<void(bool)>;
 
-class AuthenticatorCoordinatorClient : public CanMakeWeakPtr<AuthenticatorCoordinatorClient> {
+class AuthenticatorCoordinatorClient {
     WTF_MAKE_TZONE_ALLOCATED(AuthenticatorCoordinatorClient);
     WTF_MAKE_NONCOPYABLE(AuthenticatorCoordinatorClient);
 public:

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -443,7 +443,7 @@ Page::Page(PageConfiguration&& pageConfiguration)
     , m_paymentCoordinator(PaymentCoordinator::create(WTFMove(pageConfiguration.paymentCoordinatorClient)))
 #endif
 #if ENABLE(WEB_AUTHN)
-    , m_authenticatorCoordinator(makeUniqueRef<AuthenticatorCoordinator>(WTFMove(pageConfiguration.authenticatorCoordinatorClient)))
+    , m_authenticatorCoordinator(makeUniqueRefWithoutRefCountedCheck<AuthenticatorCoordinator>(*this, WTFMove(pageConfiguration.authenticatorCoordinatorClient)))
 #endif
 #if HAVE(DIGITAL_CREDENTIALS_UI)
     , m_credentialRequestCoordinator(CredentialRequestCoordinator::create(WTFMove(pageConfiguration.credentialRequestCoordinatorClient), *this))


### PR DESCRIPTION
#### e4ebf2db0c5e6464001a031662096a82104fc846
<pre>
Drop IsDeprecatedWeakRefSmartPointerException from Modules/webauthn
<a href="https://bugs.webkit.org/show_bug.cgi?id=300207">https://bugs.webkit.org/show_bug.cgi?id=300207</a>

Reviewed by Darin Adler.

* Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.cpp:
(WebCore::AuthenticatorCoordinator::AuthenticatorCoordinator):
(WebCore::AuthenticatorCoordinator::ref const):
(WebCore::AuthenticatorCoordinator::deref const):
* Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.h:
* Source/WebCore/Modules/webauthn/AuthenticatorCoordinatorClient.h:
* Source/WebCore/page/Page.cpp:

Canonical link: <a href="https://commits.webkit.org/301102@main">https://commits.webkit.org/301102@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/452215397f359b66439a8184d53119a6e70ba07d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124778 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44450 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35185 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131623 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76693 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ebc0c538-e3fe-4b54-9089-8332d8c44c46) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/126655 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45153 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53020 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94935 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62985 "") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0139af12-ab45-48f5-a0f4-3db114b2047c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127732 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36015 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111589 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75503 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5482f5ed-b5ff-4f66-8e87-30d8f703acf3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34947 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29744 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75099 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105772 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29974 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134289 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51624 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39428 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103409 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52038 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107809 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103181 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26312 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48550 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26831 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48628 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51498 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57297 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50891 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54246 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52585 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->