### PR TITLE
[build tooling] Make build-webkit script respect output verbosity defaults

### DIFF
--- a/Tools/Scripts/build-webkit
+++ b/Tools/Scripts/build-webkit
@@ -11,13 +11,13 @@
 # are met:
 #
 # 1.  Redistributions of source code must retain the above copyright
-#     notice, this list of conditions and the following disclaimer. 
+#     notice, this list of conditions and the following disclaimer.
 # 2.  Redistributions in binary form must reproduce the above copyright
 #     notice, this list of conditions and the following disclaimer in the
-#     documentation and/or other materials provided with the distribution. 
+#     documentation and/or other materials provided with the distribution.
 # 3.  Neither the name of Apple Inc. ("Apple") nor the names of
 #     its contributors may be used to endorse or promote products derived
-#     from this software without specific prior written permission. 
+#     from this software without specific prior written permission.
 #
 # THIS SOFTWARE IS PROVIDED BY APPLE AND ITS CONTRIBUTORS "AS IS" AND ANY
 # EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
@@ -67,6 +67,8 @@ chdirWebKit();
 
 my $showHelp = 0;
 my $verbose = 0;
+my $quiet = 0;
+my $verbosity = "default";
 my $clean = 0;
 my $minimal = 0;
 my $installHeaders;
@@ -110,6 +112,8 @@ my $usage = <<EOF;
 Usage: $programName [options] [options to pass to build system]
   -h, --help                        Show this help message
   -v, --verbose                     Show verbose build output
+  -q, --quiet                       Filter Xcode build output to one line per task
+  --verbosity                       Filter Xcode build output according to the given filter-build-webkit format ("default", "quiet", "oneline")
   --clean                           Cleanup the build directory
   --generate-project-only           Only generate project files
   --debug                           Compile with Debug configuration
@@ -123,7 +127,7 @@ Usage: $programName [options] [options to pass to build system]
   --tvos-device                     Use "appletvos.internal" SDK if installed, else "appletvos" SDK (tvOS only)
   --tvos-simulator                  Use "appletvsimulator" (tvOS only)
   --visionos-device                 Use "xros.internal" SDK if installed, else "xros" SDK (visionOS only)
-  --visionos-simulator              Use "xrsimulator" (visionOS only) 
+  --visionos-simulator              Use "xrsimulator" (visionOS only)
   --watchos-device                  Use "watchos.internal" SDK if installed, else "watchos" SDK (watchOS only)
   --watchos-simulator               Use "watchsimulator" (watchOS only)
   --coverage                        Enable code coverage support (Mac only)
@@ -155,11 +159,16 @@ Usage: $programName [options] [options to pass to build system]
 
   --export-compile-commands         Generate compile_commands.json (Xcode builds only)
 
+On macOS, the default verbosity can be persisted using
+\`defaults write org.webkit.BuildConfiguration BuildTranscriptVerbosity <verbosity>\`.
+
 EOF
 
 my %options = (
     'h|help' => \$showHelp,
     'v|verbose' => \$verbose,
+    'q|quiet' => \$quiet,
+    'verbosity=s' => \$verbosity,
     'clean' => \$clean,
     'install-headers=s' => \$installHeaders,
     'install-libs=s' => \$installLibs,
@@ -189,6 +198,22 @@ GetOptions(%options);
 if ($showHelp) {
    print STDERR $usage;
    exit 1;
+}
+
+die "--verbose and --quiet are mutually exclusive.\n" if $verbose && $quiet;
+$verbosity = "quiet" if $quiet;
+
+if (isAppleCocoaWebKit()) {
+    my $defaultVerbosity = `defaults read org.webkit.BuildConfiguration BuildTranscriptVerbosity 2>/dev/null`;
+    chomp($defaultVerbosity);
+    $verbosity = $defaultVerbosity if $defaultVerbosity && $verbosity eq "default";
+}
+
+my @outputFilter;
+if (isAppleCocoaWebKit() && !$verbose) {
+    if ($verbosity eq "quiet" || $verbosity eq "oneline") {
+        push @outputFilter, "-f", "oneline" if $verbosity eq "oneline";
+    }
 }
 
 $ENV{'VERBOSE'} = 1 if $verbose;
@@ -322,6 +347,9 @@ if (isWin() || isPlayStation() || (isJSCOnly() && isWindows())) {
     push @local_options, XcodeStaticAnalyzerOption() if $shouldRunStaticAnalyzer;
     push @local_options, "WK_LTO_MODE=$ltoMode" if ($ltoMode ne "default");
     push @local_options, XcodeExportCompileCommandsOptions() if $exportCompileCommands;
+    if ($verbosity eq "default" && !$verbose) {
+        push @local_options, "-hideShellScriptEnvironment";
+    }
     # FIXME: Move this setting to xcconfigs once all local Xcode builds of WebKit
     # happen in the workspace. When this is only passed on the command line, it
     # invalidates build results made in the IDE (rdar://88135402).
@@ -330,12 +358,22 @@ if (isWin() || isPlayStation() || (isJSCOnly() && isWindows())) {
     ## a script phase or not) influence the actual VALIDATE_DEPENDENCIES setting
     ## recognized by the build system.
     #push @local_options, "WK_VALIDATE_DEPENDENCIES=YES_ERROR";
- 
+
     markBaseProductDirectoryAsCreatedByXcodeBuildSystem();
+
+    my $filterBuildWebKit;
+    my $oldout;
+    if (@outputFilter || $verbosity eq "quiet") {
+        open ($oldout, ">&STDOUT") or die "can't dup STDOUT: $!";
+        my $filterScript = File::Spec->catfile(sourceDir(), "Tools", "Scripts", "filter-build-webkit");
+        my $filterPID = open ($filterBuildWebKit, "|-", $filterScript, @outputFilter);
+        die "fork failed: $!" unless defined $filterPID;
+        open (STDOUT, ">&", $filterBuildWebKit) or die "can't redirect STDOUT: $!";
+    }
 
     # Build, and abort if the build fails.
     my $scheme = $xcodeScheme // "Everything up to WebKit + Tools";
-    $result = buildXcodeScheme($scheme, $clean, @local_options, @ARGV);
+    my $result = buildXcodeScheme($scheme, $clean, @local_options, @ARGV);
     if (exitStatus($result)) {
         exit exitStatus($result);
     }
@@ -362,6 +400,11 @@ if (isWin() || isPlayStation() || (isJSCOnly() && isWindows())) {
     $result = system(@command);
     if (exitStatus($result)) {
         exit exitStatus($result);
+    }
+
+    if (@outputFilter || $verbosity eq "quiet") {
+        open (STDOUT, ">&", $oldout) or die "can't restore STDOUT: $!";
+        close $filterBuildWebKit or die "wait failed: $!";
     }
 }
 


### PR DESCRIPTION
#### a8ff9a266fcef1bf89db74d1562b83b190ce747f
<pre>
[build tooling] Make build-webkit script respect output verbosity defaults
<a href="https://bugs.webkit.org/show_bug.cgi?id=300210">https://bugs.webkit.org/show_bug.cgi?id=300210</a>
<a href="https://rdar.apple.com/162009595">rdar://162009595</a>

Reviewed by NOBODY (OOPS!).

We should respect the user defaults set when doing a build, a piping the output through filter-build-webkit when appropriate.

`defaults write org.webkit.BuildConfiguration BuildTranscriptVerbosity {quiet, oneline, default}`

We already had this logic in makefile.shared, so port it to the `build-webkit` script.

* Tools/Scripts/build-webkit:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a8ff9a266fcef1bf89db74d1562b83b190ce747f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145175 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17856 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9631 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153847 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98811 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7ece860b-8fd7-4ac3-ae60-f17e06d167ea) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147050 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18339 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17748 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111625 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80016 "2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7a337bad-5574-403c-b29b-a7f101950289) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148138 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13988 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130398 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92523 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b4e1706d-1541-4555-bd52-8aab4adf4c6f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13348 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11110 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1292 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/137166 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122871 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7156 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156159 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/5984 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17707 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8244 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119633 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17753 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14773 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119967 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15738 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128414 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73371 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17328 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6672 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/176464 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17065 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45387 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17273 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17128 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->