### PR TITLE
[Bindings] Drop [JSGenerateToJSObject] from interfaces and callbacks

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUDevice.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUDevice.idl
@@ -29,10 +29,8 @@
     EnabledBySetting=WebGPUEnabled,
     ActiveDOMObject,
     Exposed=(Window,Worker),
-    SecureContext,
-    JSGenerateToJSObject
-]
-interface GPUDevice : EventTarget {
+    SecureContext
+] interface GPUDevice : EventTarget {
     [SameObject] readonly attribute GPUSupportedFeatures features;
     [SameObject] readonly attribute GPUSupportedLimits limits;
     [SameObject] readonly attribute GPUAdapterInfo adapterInfo;

--- a/Source/WebCore/Modules/indexeddb/IDBOpenDBRequest.idl
+++ b/Source/WebCore/Modules/indexeddb/IDBOpenDBRequest.idl
@@ -25,7 +25,6 @@
 
 [
     EnabledBySetting=IndexedDBAPIEnabled,
-    JSGenerateToJSObject,
     JSGenerateToNativeObject,
     SkipVTableValidation,
     Exposed=(Window,Worker)

--- a/Source/WebCore/Modules/mediasession/MediaSessionCoordinator.idl
+++ b/Source/WebCore/Modules/mediasession/MediaSessionCoordinator.idl
@@ -28,8 +28,7 @@
     Conditional=MEDIA_SESSION_COORDINATOR,
     EnabledBySetting=MediaSessionCoordinatorEnabled,
     Exposed=Window,
-    ExportMacro=WEBCORE_EXPORT,
-    JSGenerateToJSObject,
+    ExportMacro=WEBCORE_EXPORT
 ] interface MediaSessionCoordinator : EventTarget {
 
     Promise<undefined> join();

--- a/Source/WebCore/Modules/mediastream/InputDeviceInfo.idl
+++ b/Source/WebCore/Modules/mediastream/InputDeviceInfo.idl
@@ -25,7 +25,6 @@
 
 [
     Conditional=MEDIA_STREAM,
-    JSGenerateToJSObject,
     Exposed=Window,
     SecureContext,
 ] interface InputDeviceInfo : MediaDeviceInfo {

--- a/Source/WebCore/Modules/mediastream/MediaDeviceInfo.idl
+++ b/Source/WebCore/Modules/mediastream/MediaDeviceInfo.idl
@@ -25,7 +25,6 @@
 
 [
     Conditional=MEDIA_STREAM,
-    JSGenerateToJSObject,
     Exposed=Window
 ] interface MediaDeviceInfo {
     readonly attribute DOMString deviceId;

--- a/Source/WebCore/Modules/speech/SpeechSynthesisUtterance.idl
+++ b/Source/WebCore/Modules/speech/SpeechSynthesisUtterance.idl
@@ -29,7 +29,6 @@
     EnabledBySetting=SpeechSynthesisAPIEnabled,
     Conditional=SPEECH_SYNTHESIS,
     ExportMacro=WEBCORE_EXPORT,
-    JSGenerateToJSObject,
     Exposed=Window
 ] interface SpeechSynthesisUtterance : EventTarget {
     [CallWith=CurrentScriptExecutionContext] constructor(optional DOMString text);

--- a/Source/WebCore/Modules/webaudio/AnalyserNode.idl
+++ b/Source/WebCore/Modules/webaudio/AnalyserNode.idl
@@ -25,7 +25,6 @@
 [
     Conditional=WEB_AUDIO,
     EnabledBySetting=WebAudioEnabled,
-    JSGenerateToJSObject,
     Exposed=Window
 ] interface AnalyserNode : AudioNode {
     [EnabledBySetting=WebAudioEnabled] constructor (BaseAudioContext context, optional AnalyserOptions options);

--- a/Source/WebCore/Modules/webaudio/AudioBuffer.idl
+++ b/Source/WebCore/Modules/webaudio/AudioBuffer.idl
@@ -31,7 +31,6 @@
     EnabledBySetting=WebAudioEnabled,
     GenerateIsReachable=Impl,
     JSCustomMarkFunction,
-    JSGenerateToJSObject,
     ReportExtraMemoryCost,
     Exposed=Window
 ] interface AudioBuffer {

--- a/Source/WebCore/Modules/webaudio/AudioBufferCallback.idl
+++ b/Source/WebCore/Modules/webaudio/AudioBufferCallback.idl
@@ -29,6 +29,5 @@
 
 [
     Conditional=WEB_AUDIO,
-    JSGenerateToJSObject,
     GenerateIsReachable=ImplScriptExecutionContext
 ] callback AudioBufferCallback = undefined (AudioBuffer? audioBuffer);

--- a/Source/WebCore/Modules/webaudio/AudioBufferSourceNode.idl
+++ b/Source/WebCore/Modules/webaudio/AudioBufferSourceNode.idl
@@ -28,7 +28,6 @@
     Conditional=WEB_AUDIO,
     EnabledBySetting=WebAudioEnabled,
     JSCustomMarkFunction,
-    JSGenerateToJSObject,
     Exposed=Window
 ] interface AudioBufferSourceNode : AudioScheduledSourceNode {
     [EnabledBySetting=WebAudioEnabled] constructor (BaseAudioContext context, optional AudioBufferSourceOptions options);

--- a/Source/WebCore/Modules/webaudio/AudioDestinationNode.idl
+++ b/Source/WebCore/Modules/webaudio/AudioDestinationNode.idl
@@ -25,7 +25,6 @@
 [
     Conditional=WEB_AUDIO,
     EnabledBySetting=WebAudioEnabled,
-    JSGenerateToJSObject,
     SkipVTableValidation,
     Exposed=Window
 ] interface AudioDestinationNode : AudioNode {

--- a/Source/WebCore/Modules/webaudio/AudioProcessingEvent.idl
+++ b/Source/WebCore/Modules/webaudio/AudioProcessingEvent.idl
@@ -25,7 +25,6 @@
 [
     Conditional=WEB_AUDIO,
     EnabledBySetting=WebAudioEnabled,
-    JSGenerateToJSObject,
     Exposed=Window
 ] interface AudioProcessingEvent : Event {
     [EnabledBySetting=WebAudioEnabled] constructor ([AtomString] DOMString type, AudioProcessingEventInit eventInitDict);

--- a/Source/WebCore/Modules/webaudio/AudioScheduledSourceNode.idl
+++ b/Source/WebCore/Modules/webaudio/AudioScheduledSourceNode.idl
@@ -25,7 +25,6 @@
 [
     Conditional=WEB_AUDIO,
     EnabledBySetting=WebAudioEnabled,
-    JSGenerateToJSObject,
     ActiveDOMObject,
     Exposed=Window
 ] interface AudioScheduledSourceNode : AudioNode {

--- a/Source/WebCore/Modules/webaudio/AudioWorklet.idl
+++ b/Source/WebCore/Modules/webaudio/AudioWorklet.idl
@@ -30,7 +30,6 @@
     Conditional=WEB_AUDIO,
     EnabledBySetting=WebAudioEnabled,
     Exposed=Window,
-    JSGenerateToJSObject,
     SecureContext
 ] interface AudioWorklet : Worklet {
 };

--- a/Source/WebCore/Modules/webaudio/AudioWorkletNode.idl
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletNode.idl
@@ -31,7 +31,6 @@
     Conditional=WEB_AUDIO,
     EnabledBySetting=WebAudioEnabled,
     Exposed=Window,
-    JSGenerateToJSObject,
     SecureContext
 ] interface AudioWorkletNode : AudioNode {
     [CallWith=CurrentGlobalObject] constructor (BaseAudioContext context, DOMString name, optional AudioWorkletNodeOptions options);

--- a/Source/WebCore/Modules/webaudio/BiquadFilterNode.idl
+++ b/Source/WebCore/Modules/webaudio/BiquadFilterNode.idl
@@ -26,7 +26,6 @@
 [
     Conditional=WEB_AUDIO,
     EnabledBySetting=WebAudioEnabled,
-    JSGenerateToJSObject,
     Exposed=Window
 ] interface BiquadFilterNode : AudioNode {
     [EnabledBySetting=WebAudioEnabled] constructor (BaseAudioContext context, optional BiquadFilterOptions options);

--- a/Source/WebCore/Modules/webaudio/ChannelMergerNode.idl
+++ b/Source/WebCore/Modules/webaudio/ChannelMergerNode.idl
@@ -29,7 +29,6 @@
 [
     Conditional=WEB_AUDIO,
     EnabledBySetting=WebAudioEnabled,
-    JSGenerateToJSObject,
     Exposed=Window
 ] interface ChannelMergerNode : AudioNode {
     [EnabledBySetting=WebAudioEnabled] constructor (BaseAudioContext context, optional ChannelMergerOptions options);

--- a/Source/WebCore/Modules/webaudio/ChannelSplitterNode.idl
+++ b/Source/WebCore/Modules/webaudio/ChannelSplitterNode.idl
@@ -25,7 +25,6 @@
 [
     Conditional=WEB_AUDIO,
     EnabledBySetting=WebAudioEnabled,
-    JSGenerateToJSObject,
     Exposed=Window
 ] interface ChannelSplitterNode : AudioNode {
     [EnabledBySetting=WebAudioEnabled] constructor (BaseAudioContext context, optional ChannelSplitterOptions options);

--- a/Source/WebCore/Modules/webaudio/ConstantSourceNode.idl
+++ b/Source/WebCore/Modules/webaudio/ConstantSourceNode.idl
@@ -25,7 +25,6 @@
 
 [
     Conditional=WEB_AUDIO,
-    JSGenerateToJSObject,
     EnabledBySetting=WebAudioEnabled,
     Exposed=Window
 ] interface ConstantSourceNode : AudioScheduledSourceNode {

--- a/Source/WebCore/Modules/webaudio/ConvolverNode.idl
+++ b/Source/WebCore/Modules/webaudio/ConvolverNode.idl
@@ -27,7 +27,6 @@
 [
     Conditional=WEB_AUDIO,
     EnabledBySetting=WebAudioEnabled,
-    JSGenerateToJSObject,
     Exposed=Window
 ] interface ConvolverNode : AudioNode {
     [EnabledBySetting=WebAudioEnabled] constructor (BaseAudioContext context, optional ConvolverOptions options);

--- a/Source/WebCore/Modules/webaudio/DelayNode.idl
+++ b/Source/WebCore/Modules/webaudio/DelayNode.idl
@@ -25,7 +25,6 @@
 [
     Conditional=WEB_AUDIO,
     EnabledBySetting=WebAudioEnabled,
-    JSGenerateToJSObject,
     Exposed=Window
 ] interface DelayNode : AudioNode {
     [EnabledBySetting=WebAudioEnabled] constructor (BaseAudioContext context, optional DelayOptions options);

--- a/Source/WebCore/Modules/webaudio/DynamicsCompressorNode.idl
+++ b/Source/WebCore/Modules/webaudio/DynamicsCompressorNode.idl
@@ -26,7 +26,6 @@
 [
     Conditional=WEB_AUDIO,
     EnabledBySetting=WebAudioEnabled,
-    JSGenerateToJSObject,
     Exposed=Window
 ] interface DynamicsCompressorNode : AudioNode {
     [EnabledBySetting=WebAudioEnabled] constructor (BaseAudioContext context, optional DynamicsCompressorOptions options);

--- a/Source/WebCore/Modules/webaudio/GainNode.idl
+++ b/Source/WebCore/Modules/webaudio/GainNode.idl
@@ -25,7 +25,6 @@
 [
     Conditional=WEB_AUDIO,
     EnabledBySetting=WebAudioEnabled,
-    JSGenerateToJSObject,
     Exposed=Window
 ] interface GainNode : AudioNode {
     [EnabledBySetting=WebAudioEnabled] constructor (BaseAudioContext context, optional GainOptions options);

--- a/Source/WebCore/Modules/webaudio/IIRFilterNode.idl
+++ b/Source/WebCore/Modules/webaudio/IIRFilterNode.idl
@@ -24,7 +24,6 @@
 
 [
     Conditional=WEB_AUDIO,
-    JSGenerateToJSObject,
     EnabledBySetting=WebAudioEnabled,
     Exposed=Window
 ] interface IIRFilterNode : AudioNode {

--- a/Source/WebCore/Modules/webaudio/MediaElementAudioSourceNode.idl
+++ b/Source/WebCore/Modules/webaudio/MediaElementAudioSourceNode.idl
@@ -26,7 +26,6 @@
 [
     Conditional=WEB_AUDIO&VIDEO,
     EnabledBySetting=WebAudioEnabled,
-    JSGenerateToJSObject,
     Exposed=Window
 ] interface MediaElementAudioSourceNode : AudioNode {
     [EnabledBySetting=WebAudioEnabled] constructor (AudioContext context, MediaElementAudioSourceOptions options);

--- a/Source/WebCore/Modules/webaudio/MediaStreamAudioDestinationNode.idl
+++ b/Source/WebCore/Modules/webaudio/MediaStreamAudioDestinationNode.idl
@@ -25,7 +25,6 @@
 [
     Conditional=WEB_AUDIO&MEDIA_STREAM,
     EnabledBySetting=WebAudioEnabled,
-    JSGenerateToJSObject,
     Exposed=Window
 ] interface MediaStreamAudioDestinationNode : AudioNode {
     [EnabledBySetting=WebAudioEnabled] constructor (AudioContext context, optional AudioNodeOptions options);

--- a/Source/WebCore/Modules/webaudio/MediaStreamAudioSourceNode.idl
+++ b/Source/WebCore/Modules/webaudio/MediaStreamAudioSourceNode.idl
@@ -25,7 +25,6 @@
 [
     Conditional=WEB_AUDIO&MEDIA_STREAM,
     EnabledBySetting=WebAudioEnabled,
-    JSGenerateToJSObject,
     Exposed=Window
 ] interface MediaStreamAudioSourceNode : AudioNode {
     [EnabledBySetting=WebAudioEnabled] constructor (AudioContext context, MediaStreamAudioSourceOptions options);

--- a/Source/WebCore/Modules/webaudio/OfflineAudioCompletionEvent.idl
+++ b/Source/WebCore/Modules/webaudio/OfflineAudioCompletionEvent.idl
@@ -25,7 +25,6 @@
 [
     Conditional=WEB_AUDIO,
     EnabledBySetting=WebAudioEnabled,
-    JSGenerateToJSObject,
     Exposed=Window
 ] interface OfflineAudioCompletionEvent : Event {
     constructor ([AtomString] DOMString type, OfflineAudioCompletionEventInit eventInitDict);

--- a/Source/WebCore/Modules/webaudio/OfflineAudioContext.idl
+++ b/Source/WebCore/Modules/webaudio/OfflineAudioContext.idl
@@ -25,7 +25,6 @@
 [
     Conditional=WEB_AUDIO,
     EnabledBySetting=WebAudioEnabled,
-    JSGenerateToJSObject,
     Exposed=Window
 ] interface OfflineAudioContext : BaseAudioContext {
     [CallWith=CurrentScriptExecutionContext] constructor(OfflineAudioContextOptions contextOptions);

--- a/Source/WebCore/Modules/webaudio/OscillatorNode.idl
+++ b/Source/WebCore/Modules/webaudio/OscillatorNode.idl
@@ -26,7 +26,6 @@
 [
     Conditional=WEB_AUDIO,
     EnabledBySetting=WebAudioEnabled,
-    JSGenerateToJSObject,
     ActiveDOMObject,
     Exposed=Window
 ] interface OscillatorNode : AudioScheduledSourceNode {

--- a/Source/WebCore/Modules/webaudio/PannerNode.idl
+++ b/Source/WebCore/Modules/webaudio/PannerNode.idl
@@ -24,7 +24,6 @@
 
 [
     Conditional=WEB_AUDIO,
-    JSGenerateToJSObject,
     EnabledBySetting=WebAudioEnabled,
     Exposed=Window
 ] interface PannerNode : AudioNode {

--- a/Source/WebCore/Modules/webaudio/ScriptProcessorNode.idl
+++ b/Source/WebCore/Modules/webaudio/ScriptProcessorNode.idl
@@ -25,7 +25,6 @@
 // For real-time audio stream synthesis/processing in JavaScript 
 [
     Conditional=WEB_AUDIO,
-    JSGenerateToJSObject,
     JSGenerateToNativeObject,
     ActiveDOMObject,
     Exposed=Window

--- a/Source/WebCore/Modules/webaudio/StereoPannerNode.idl
+++ b/Source/WebCore/Modules/webaudio/StereoPannerNode.idl
@@ -25,7 +25,6 @@
 
 [
     Conditional=WEB_AUDIO,
-    JSGenerateToJSObject,
     EnabledBySetting=WebAudioEnabled,
     Exposed=Window
 ] interface StereoPannerNode : AudioNode {

--- a/Source/WebCore/Modules/webaudio/WaveShaperNode.idl
+++ b/Source/WebCore/Modules/webaudio/WaveShaperNode.idl
@@ -25,7 +25,6 @@
 [
     Conditional=WEB_AUDIO,
     EnabledBySetting=WebAudioEnabled,
-    JSGenerateToJSObject,
     Exposed=Window
 ] interface WaveShaperNode : AudioNode {
     [EnabledBySetting=WebAudioEnabled] constructor(BaseAudioContext context, optional WaveShaperOptions options);

--- a/Source/WebCore/Modules/webtransport/WebTransportBidirectionalStream.idl
+++ b/Source/WebCore/Modules/webtransport/WebTransportBidirectionalStream.idl
@@ -27,7 +27,6 @@
     EnabledBySetting=WebTransportEnabled,
     Exposed=(Window,Worker),
     SecureContext,
-    JSGenerateToJSObject,
     JSGenerateToNativeObject
 ] interface WebTransportBidirectionalStream {
     readonly attribute WebTransportReceiveStream readable;

--- a/Source/WebCore/Modules/webtransport/WebTransportReceiveStream.idl
+++ b/Source/WebCore/Modules/webtransport/WebTransportReceiveStream.idl
@@ -28,7 +28,6 @@
     Exposed=(Window,Worker),
     SecureContext,
     Transferable,
-    JSGenerateToJSObject,
     JSGenerateToNativeObject
 ] interface WebTransportReceiveStream : ReadableStream {
     [CallWith=CurrentScriptExecutionContext] Promise<WebTransportReceiveStreamStats> getStats();

--- a/Source/WebCore/Modules/webxr/WebXRJointPose.idl
+++ b/Source/WebCore/Modules/webxr/WebXRJointPose.idl
@@ -26,7 +26,6 @@
 [
     Conditional=WEBXR_HANDS,
     EnabledBySetting=WebXREnabled&WebXRHandInputModuleEnabled,
-    JSGenerateToJSObject,
     JSGenerateToNativeObject,
     SecureContext,
     Exposed=Window,

--- a/Source/WebCore/Modules/webxr/WebXRJointSpace.idl
+++ b/Source/WebCore/Modules/webxr/WebXRJointSpace.idl
@@ -26,7 +26,6 @@
 [
     Conditional=WEBXR_HANDS,
     EnabledBySetting=WebXREnabled&WebXRHandInputModuleEnabled,
-    JSGenerateToJSObject,
     JSGenerateToNativeObject,
     SecureContext,
     Exposed=Window,

--- a/Source/WebCore/Modules/webxr/WebXRViewerPose.idl
+++ b/Source/WebCore/Modules/webxr/WebXRViewerPose.idl
@@ -29,7 +29,6 @@
     EnabledBySetting=WebXREnabled,
     SecureContext,
     Exposed=Window,
-    JSGenerateToJSObject,
     JSGenerateToNativeObject,
     InterfaceName=XRViewerPose
 ] interface WebXRViewerPose : WebXRPose {

--- a/Source/WebCore/Modules/webxr/WebXRWebGLLayer.idl
+++ b/Source/WebCore/Modules/webxr/WebXRWebGLLayer.idl
@@ -32,7 +32,6 @@ typedef (WebGLRenderingContext or WebGL2RenderingContext) WebXRWebGLRenderingCon
     EnabledBySetting=WebXREnabled,
     SecureContext,
     Exposed=Window,
-    JSGenerateToJSObject,
     JSGenerateToNativeObject,
     InterfaceName=XRWebGLLayer
 ] interface WebXRWebGLLayer : WebXRLayer {

--- a/Source/WebCore/Modules/webxr/XRCompositionLayer.idl
+++ b/Source/WebCore/Modules/webxr/XRCompositionLayer.idl
@@ -29,7 +29,6 @@
     EnabledBySetting=WebXRLayersAPIEnabled,
     ExportMacro=WEBCORE_EXPORT,
     Exposed=Window,
-    JSGenerateToJSObject,
     JSGenerateToNativeObject
 ] interface XRCompositionLayer : WebXRLayer {
     readonly attribute XRLayerLayout layout;

--- a/Source/WebCore/Modules/webxr/XRGPUSubImage.idl
+++ b/Source/WebCore/Modules/webxr/XRGPUSubImage.idl
@@ -28,7 +28,6 @@
     Conditional=WEBXR_LAYERS,
     EnabledBySetting=WebXRWebGPUBindingsEnabled,
     Exposed=Window,
-    JSGenerateToJSObject,
     JSGenerateToNativeObject,
 ] interface XRGPUSubImage : XRSubImage {
     [SameObject] readonly attribute GPUTexture colorTexture;

--- a/Source/WebCore/Modules/webxr/XRProjectionLayer.idl
+++ b/Source/WebCore/Modules/webxr/XRProjectionLayer.idl
@@ -29,7 +29,6 @@
     EnabledBySetting=WebXRLayersAPIEnabled,
     ExportMacro=WEBCORE_EXPORT,
     Exposed=Window,
-    JSGenerateToJSObject,
     JSGenerateToNativeObject,
 ] interface XRProjectionLayer : XRCompositionLayer {
     readonly attribute unsigned long textureWidth;

--- a/Source/WebCore/Modules/webxr/XRSubImage.idl
+++ b/Source/WebCore/Modules/webxr/XRSubImage.idl
@@ -28,7 +28,6 @@
     Conditional=WEBXR_LAYERS,
     EnabledBySetting=WebXRLayersAPIEnabled,
     Exposed=Window,
-    JSGenerateToJSObject,
     JSGenerateToNativeObject,
 ] interface XRSubImage {
     [SameObject] readonly attribute WebXRViewport viewport;

--- a/Source/WebCore/animation/ScrollTimeline.idl
+++ b/Source/WebCore/animation/ScrollTimeline.idl
@@ -25,8 +25,7 @@
 
 [
     EnabledBySetting=ScrollDrivenAnimationsEnabled,
-    Exposed=Window,
-    JSGenerateToJSObject
+    Exposed=Window
 ] interface ScrollTimeline : AnimationTimeline {
     [CallWith=CurrentDocument] constructor(optional ScrollTimelineOptions options = {});
     [ImplementedAs=bindingsSource] readonly attribute Element? source;

--- a/Source/WebCore/animation/ViewTimeline.idl
+++ b/Source/WebCore/animation/ViewTimeline.idl
@@ -25,8 +25,7 @@
 
 [
     EnabledBySetting=ScrollDrivenAnimationsEnabled,
-    Exposed=Window,
-    JSGenerateToJSObject
+    Exposed=Window
 ] interface ViewTimeline : ScrollTimeline {
     [CallWith=CurrentDocument] constructor(optional ViewTimelineOptions options = {});
     readonly attribute Element subject;

--- a/Source/WebCore/bindings/scripts/IDLAttributes.json
+++ b/Source/WebCore/bindings/scripts/IDLAttributes.json
@@ -315,7 +315,7 @@
             "contextsAllowed": ["interface"]
         },
         "JSGenerateToJSObject": {
-            "contextsAllowed": ["interface", "dictionary", "callback-function"]
+            "contextsAllowed": ["dictionary"]
         },
         "JSGenerateToNativeObject": {
             "contextsAllowed": ["interface", "dictionary"]

--- a/Source/WebCore/css/CSSFontFaceDescriptors.idl
+++ b/Source/WebCore/css/CSSFontFaceDescriptors.idl
@@ -27,7 +27,6 @@
 typedef USVString CSSOMString;
 
 [
-    JSGenerateToJSObject,
     JSGenerateToNativeObject,
     Exposed=Window,
 ] interface CSSFontFaceDescriptors : CSSStyleDeclaration {

--- a/Source/WebCore/css/CSSFontFaceRule.idl
+++ b/Source/WebCore/css/CSSFontFaceRule.idl
@@ -21,7 +21,6 @@
 // https://drafts.csswg.org/css-fonts/#cssfontfacerule
 
 [
-    JSGenerateToJSObject,
     JSGenerateToNativeObject,
     Exposed=Window
 ] interface CSSFontFaceRule : CSSRule {

--- a/Source/WebCore/css/CSSPageDescriptors.idl
+++ b/Source/WebCore/css/CSSPageDescriptors.idl
@@ -27,7 +27,6 @@
 typedef USVString CSSOMString;
 
 [
-    JSGenerateToJSObject,
     JSGenerateToNativeObject,
     Exposed=Window,
 ] interface CSSPageDescriptors : CSSStyleDeclaration {

--- a/Source/WebCore/css/CSSPositionTryDescriptors.idl
+++ b/Source/WebCore/css/CSSPositionTryDescriptors.idl
@@ -28,7 +28,6 @@ typedef USVString CSSOMString;
 
 [
     EnabledBySetting=CSSAnchorPositioningEnabled,
-    JSGenerateToJSObject,
     JSGenerateToNativeObject,
     Exposed=Window,
 ] interface CSSPositionTryDescriptors : CSSStyleDeclaration {

--- a/Source/WebCore/css/CSSStyleProperties.idl
+++ b/Source/WebCore/css/CSSStyleProperties.idl
@@ -23,7 +23,6 @@
 typedef USVString CSSOMString;
 
 [
-    JSGenerateToJSObject,
     JSGenerateToNativeObject,
     SkipVTableValidation,
     Exposed=Window,

--- a/Source/WebCore/css/typedom/CSSKeywordValue.idl
+++ b/Source/WebCore/css/typedom/CSSKeywordValue.idl
@@ -26,7 +26,6 @@
 // https://drafts.css-houdini.org/css-typed-om/#csskeywordvalue
 [
     Exposed=(Window,Worker,PaintWorklet),
-    JSGenerateToJSObject,
     JSGenerateToNativeObject,
 ] interface CSSKeywordValue : CSSStyleValue {
     constructor(USVString value);

--- a/Source/WebCore/css/typedom/StylePropertyMap.idl
+++ b/Source/WebCore/css/typedom/StylePropertyMap.idl
@@ -26,8 +26,7 @@
 // https://drafts.css-houdini.org/css-typed-om/#cssstylepropertymap
 [
     Exposed=Window,
-    SkipVTableValidation,
-    JSGenerateToJSObject
+    SkipVTableValidation
 ] interface StylePropertyMap : StylePropertyMapReadOnly {
     [CallWith=CurrentDocument] undefined set([AtomString] USVString property, (CSSStyleValue or USVString)... values);
     [CallWith=CurrentDocument] undefined append([AtomString] USVString property, (CSSStyleValue or USVString)... values);

--- a/Source/WebCore/css/typedom/StylePropertyMapReadOnly.idl
+++ b/Source/WebCore/css/typedom/StylePropertyMapReadOnly.idl
@@ -27,7 +27,6 @@
 [
     Exposed=(Window,Worker,PaintWorklet),
     SkipVTableValidation,
-    JSGenerateToJSObject,
     JSCustomMarkFunction
 ] interface StylePropertyMapReadOnly {
     iterable<USVString, sequence<CSSStyleValue>>;

--- a/Source/WebCore/dom/Attr.idl
+++ b/Source/WebCore/dom/Attr.idl
@@ -20,7 +20,6 @@
 
 [
     JSCustomMarkFunction,
-    JSGenerateToJSObject,
     JSGenerateToNativeObject,
     Exposed=Window
 ] interface Attr : Node {

--- a/Source/WebCore/dom/CDATASection.idl
+++ b/Source/WebCore/dom/CDATASection.idl
@@ -18,7 +18,6 @@
  */
 
 [
-    JSGenerateToJSObject,
     Exposed=Window
 ] interface CDATASection : Text {
 };

--- a/Source/WebCore/dom/Comment.idl
+++ b/Source/WebCore/dom/Comment.idl
@@ -18,7 +18,6 @@
  */
 
 [
-    JSGenerateToJSObject,
     Exposed=Window
 ] interface Comment : CharacterData {
     [CallWith=CurrentDocument] constructor(optional DOMString data = "");

--- a/Source/WebCore/dom/DataTransferItemList.idl
+++ b/Source/WebCore/dom/DataTransferItemList.idl
@@ -32,7 +32,6 @@
 [
     EnabledBySetting=DataTransferItemsEnabled,
     JSGenerateToNativeObject,
-    JSGenerateToJSObject,
     Exposed=Window
 ] interface DataTransferItemList {
     readonly attribute long length;

--- a/Source/WebCore/dom/DocumentType.idl
+++ b/Source/WebCore/dom/DocumentType.idl
@@ -19,7 +19,6 @@
 
 [
     JSGenerateToNativeObject,
-    JSGenerateToJSObject,
     Exposed=Window
 ] interface DocumentType : Node {
     readonly attribute DOMString name;

--- a/Source/WebCore/dom/ProcessingInstruction.idl
+++ b/Source/WebCore/dom/ProcessingInstruction.idl
@@ -20,7 +20,6 @@
  */
 
 [
-    JSGenerateToJSObject,
     Exposed=Window
 ] interface ProcessingInstruction : CharacterData {
     readonly attribute DOMString target;

--- a/Source/WebCore/dom/ShadowRoot.idl
+++ b/Source/WebCore/dom/ShadowRoot.idl
@@ -26,7 +26,6 @@
 // https://dom.spec.whatwg.org/#interface-shadowroot
 
 [
-    JSGenerateToJSObject,
     JSGenerateToNativeObject,
     Exposed=Window
 ] interface ShadowRoot : DocumentFragment {

--- a/Source/WebCore/fileapi/File.idl
+++ b/Source/WebCore/fileapi/File.idl
@@ -28,7 +28,6 @@ typedef (BufferSource or Blob or USVString) BlobPart;
 [
     ExportMacro=WEBCORE_EXPORT,
     Exposed=(Window,Worker),
-    JSGenerateToJSObject,
     JSGenerateToNativeObject,
 ] interface File : Blob {
     [CallWith=CurrentScriptExecutionContext] constructor(sequence<BlobPart> fileBits, USVString fileName, optional FilePropertyBag options);

--- a/Source/WebCore/html/DOMFormData.idl
+++ b/Source/WebCore/html/DOMFormData.idl
@@ -33,7 +33,6 @@ typedef (File or USVString) FormDataEntryValue;
 [
     Exposed=(Window,Worker),
     JSGenerateToNativeObject,
-    JSGenerateToJSObject,
     InterfaceName=FormData,
 ] interface DOMFormData {
     [CallWith=CurrentScriptExecutionContext] constructor(optional HTMLFormElement form, optional HTMLElement? submitter = null);

--- a/Source/WebCore/html/DOMURL.idl
+++ b/Source/WebCore/html/DOMURL.idl
@@ -28,7 +28,6 @@
     ExportMacro=WEBCORE_EXPORT,
     Exposed=*,
     InterfaceName=URL,
-    JSGenerateToJSObject,
     JSGenerateToNativeObject,
     LegacyWindowAlias=webkitURL,
 ] interface DOMURL {

--- a/Source/WebCore/html/RadioNodeList.idl
+++ b/Source/WebCore/html/RadioNodeList.idl
@@ -24,7 +24,6 @@
  */
 
 [
-    JSGenerateToJSObject,
     Exposed=Window
 ] interface RadioNodeList : NodeList {
     attribute DOMString value;

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2D.idl
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2D.idl
@@ -32,7 +32,6 @@ enum RenderingMode {
 
 [
     CustomIsReachable,
-    JSGenerateToJSObject,
     JSCustomMarkFunction,
     CallTracer=InspectorCanvasCallTracer,
     Exposed=Window

--- a/Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.idl
+++ b/Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.idl
@@ -30,7 +30,6 @@
     ConditionalForWorker=OFFSCREEN_CANVAS_IN_WORKERS,
     EnabledForContext,
     Exposed=(Window,Worker),
-    JSGenerateToJSObject,
     JSCustomMarkFunction,
     TaggedWrapper,
     CallTracer=InspectorCanvasCallTracer,

--- a/Source/WebCore/html/canvas/PaintRenderingContext2D.idl
+++ b/Source/WebCore/html/canvas/PaintRenderingContext2D.idl
@@ -26,7 +26,6 @@
 [
     CustomIsReachable,
     EnabledBySetting=CSSPaintingAPIEnabled,
-    JSGenerateToJSObject,
     JSCustomMarkFunction,
     Exposed=PaintWorklet,
     TaggedWrapper,

--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.idl
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.idl
@@ -62,7 +62,6 @@ typedef (ImageBitmap or ImageData or HTMLImageElement or HTMLCanvasElement
     EnabledBySetting=WebGLEnabled,
     GenerateIsReachable=ImplCanvasBase,
     JSCustomMarkFunction,
-    JSGenerateToJSObject,
     DoNotCheckConstants,
     Exposed=(Window,Worker),
     CallTracer=InspectorCanvasCallTracer,

--- a/Source/WebCore/html/canvas/WebGLRenderingContext.idl
+++ b/Source/WebCore/html/canvas/WebGLRenderingContext.idl
@@ -45,7 +45,6 @@ typedef (ImageBitmap or ImageData or HTMLImageElement or HTMLCanvasElement
     EnabledBySetting=WebGLEnabled,
     GenerateIsReachable=ImplCanvasBase,
     JSCustomMarkFunction,
-    JSGenerateToJSObject,
     DoNotCheckConstants,
     ExportMacro=WEBCORE_EXPORT,
     Exposed=(Window,Worker),

--- a/Source/WebCore/html/track/TextTrackCueGeneric.idl
+++ b/Source/WebCore/html/track/TextTrackCueGeneric.idl
@@ -25,7 +25,6 @@
 
 [
     Conditional=VIDEO,
-    JSGenerateToJSObject,
     JSGenerateToNativeObject,
     LegacyNoInterfaceObject,
     ExportMacro=WEBCORE_EXPORT,

--- a/Source/WebCore/html/track/VTTCue.idl
+++ b/Source/WebCore/html/track/VTTCue.idl
@@ -36,7 +36,6 @@ enum AlignSetting { "start", "center", "end", "left", "right" };
 [
     Conditional=VIDEO,
     ExportMacro=WEBCORE_EXPORT,
-    JSGenerateToJSObject,
     JSGenerateToNativeObject,
     Exposed=Window
 ] interface VTTCue : TextTrackCue {

--- a/Source/WebCore/inspector/InspectorAuditAccessibilityObject.idl
+++ b/Source/WebCore/inspector/InspectorAuditAccessibilityObject.idl
@@ -24,8 +24,7 @@
  */
 
 [
-    JSGenerateToJSObject,
-    LegacyNoInterfaceObject,
+    LegacyNoInterfaceObject
 ] interface InspectorAuditAccessibilityObject {
     [CallWith=CurrentDocument] sequence<Node> getElementsByComputedRole(DOMString role, optional Node? container);
 

--- a/Source/WebCore/inspector/InspectorAuditDOMObject.idl
+++ b/Source/WebCore/inspector/InspectorAuditDOMObject.idl
@@ -24,8 +24,7 @@
  */
 
 [
-    JSGenerateToJSObject,
-    LegacyNoInterfaceObject,
+    LegacyNoInterfaceObject
 ] interface InspectorAuditDOMObject {
     boolean hasEventListeners(Node node, optional DOMString type);
 

--- a/Source/WebCore/inspector/InspectorAuditResourcesObject.idl
+++ b/Source/WebCore/inspector/InspectorAuditResourcesObject.idl
@@ -24,8 +24,7 @@
  */
 
 [
-    JSGenerateToJSObject,
-    LegacyNoInterfaceObject,
+    LegacyNoInterfaceObject
 ] interface InspectorAuditResourcesObject {
     [CallWith=CurrentDocument] sequence<Resource> getResources();
     [CallWith=CurrentDocument] ResourceContent getResourceContent(DOMString id);

--- a/Source/WebCore/svg/SVGViewSpec.idl
+++ b/Source/WebCore/svg/SVGViewSpec.idl
@@ -28,7 +28,6 @@
 // It would require that any of those classes would be RefCounted, and we want to avoid that.
 [
     JSCustomMarkFunction,
-    JSGenerateToJSObject,
     Exposed=Window
 ] interface SVGViewSpec {
     readonly attribute SVGTransformList transform;

--- a/Source/WebCore/testing/InternalSettings.idl
+++ b/Source/WebCore/testing/InternalSettings.idl
@@ -34,7 +34,6 @@ enum UserInterfaceDirectionPolicy { "Content", "System" };
 
 [
     LegacyNoInterfaceObject,
-    JSGenerateToJSObject,
     ExportMacro=WEBCORE_TESTSUPPORT_EXPORT,
 ] interface InternalSettings : InternalSettingsGenerated {
     // Settings

--- a/Source/WebCore/workers/service/ExtendableMessageEvent.idl
+++ b/Source/WebCore/workers/service/ExtendableMessageEvent.idl
@@ -26,8 +26,7 @@
 [
     EnabledBySetting=ServiceWorkersEnabled,
     Exposed=ServiceWorker,
-    JSCustomMarkFunction,
-    JSGenerateToJSObject,
+    JSCustomMarkFunction
 ] interface ExtendableMessageEvent : ExtendableEvent {
     [Custom] constructor([AtomString] DOMString type, optional ExtendableMessageEventInit eventInitDict);
 

--- a/Source/WebCore/xml/XMLHttpRequest.idl
+++ b/Source/WebCore/xml/XMLHttpRequest.idl
@@ -42,7 +42,6 @@ enum XMLHttpRequestResponseType {
     ExportMacro=WEBCORE_EXPORT,
     Exposed=(Window,DedicatedWorker,SharedWorker),
     JSCustomMarkFunction,
-    JSGenerateToJSObject,
     JSGenerateToNativeObject,
     ReportExtraMemoryCost,
 ] interface XMLHttpRequest : XMLHttpRequestEventTarget {

--- a/Source/WebCore/xml/XMLHttpRequestUpload.idl
+++ b/Source/WebCore/xml/XMLHttpRequestUpload.idl
@@ -28,8 +28,7 @@
 
 [
     Exposed=(Window,Worker),
-    GenerateIsReachable=Impl,
-    JSGenerateToJSObject,
+    GenerateIsReachable=Impl
 ] interface XMLHttpRequestUpload : XMLHttpRequestEventTarget {
 };
 


### PR DESCRIPTION
#### 270ea55d2fe307237a70928e6d05683d15a2e6ce
<pre>
[Bindings] Drop [JSGenerateToJSObject] from interfaces and callbacks
<a href="https://bugs.webkit.org/show_bug.cgi?id=300212">https://bugs.webkit.org/show_bug.cgi?id=300212</a>

Reviewed by Ryosuke Niwa.

Drop [JSGenerateToJSObject] from interfaces and callbacks and it has
not effect after 301038@main.

* Source/WebCore/Modules/WebGPU/GPUDevice.idl:
* Source/WebCore/Modules/indexeddb/IDBOpenDBRequest.idl:
* Source/WebCore/Modules/mediasession/MediaSessionCoordinator.idl:
* Source/WebCore/Modules/mediastream/InputDeviceInfo.idl:
* Source/WebCore/Modules/mediastream/MediaDeviceInfo.idl:
* Source/WebCore/Modules/speech/SpeechSynthesisUtterance.idl:
* Source/WebCore/Modules/webaudio/AnalyserNode.idl:
* Source/WebCore/Modules/webaudio/AudioBuffer.idl:
* Source/WebCore/Modules/webaudio/AudioBufferCallback.idl:
* Source/WebCore/Modules/webaudio/AudioBufferSourceNode.idl:
* Source/WebCore/Modules/webaudio/AudioDestinationNode.idl:
* Source/WebCore/Modules/webaudio/AudioProcessingEvent.idl:
* Source/WebCore/Modules/webaudio/AudioScheduledSourceNode.idl:
* Source/WebCore/Modules/webaudio/AudioWorklet.idl:
* Source/WebCore/Modules/webaudio/AudioWorkletNode.idl:
* Source/WebCore/Modules/webaudio/BiquadFilterNode.idl:
* Source/WebCore/Modules/webaudio/ChannelMergerNode.idl:
* Source/WebCore/Modules/webaudio/ChannelSplitterNode.idl:
* Source/WebCore/Modules/webaudio/ConstantSourceNode.idl:
* Source/WebCore/Modules/webaudio/ConvolverNode.idl:
* Source/WebCore/Modules/webaudio/DelayNode.idl:
* Source/WebCore/Modules/webaudio/DynamicsCompressorNode.idl:
* Source/WebCore/Modules/webaudio/GainNode.idl:
* Source/WebCore/Modules/webaudio/IIRFilterNode.idl:
* Source/WebCore/Modules/webaudio/MediaElementAudioSourceNode.idl:
* Source/WebCore/Modules/webaudio/MediaStreamAudioDestinationNode.idl:
* Source/WebCore/Modules/webaudio/MediaStreamAudioSourceNode.idl:
* Source/WebCore/Modules/webaudio/OfflineAudioCompletionEvent.idl:
* Source/WebCore/Modules/webaudio/OfflineAudioContext.idl:
* Source/WebCore/Modules/webaudio/OscillatorNode.idl:
* Source/WebCore/Modules/webaudio/PannerNode.idl:
* Source/WebCore/Modules/webaudio/ScriptProcessorNode.idl:
* Source/WebCore/Modules/webaudio/StereoPannerNode.idl:
* Source/WebCore/Modules/webaudio/WaveShaperNode.idl:
* Source/WebCore/Modules/webtransport/WebTransportBidirectionalStream.idl:
* Source/WebCore/Modules/webtransport/WebTransportReceiveStream.idl:
* Source/WebCore/Modules/webxr/WebXRJointPose.idl:
* Source/WebCore/Modules/webxr/WebXRJointSpace.idl:
* Source/WebCore/Modules/webxr/WebXRViewerPose.idl:
* Source/WebCore/Modules/webxr/WebXRWebGLLayer.idl:
* Source/WebCore/Modules/webxr/XRCompositionLayer.idl:
* Source/WebCore/Modules/webxr/XRGPUSubImage.idl:
* Source/WebCore/Modules/webxr/XRProjectionLayer.idl:
* Source/WebCore/Modules/webxr/XRSubImage.idl:
* Source/WebCore/animation/ScrollTimeline.idl:
* Source/WebCore/animation/ViewTimeline.idl:
* Source/WebCore/bindings/scripts/IDLAttributes.json:
* Source/WebCore/css/CSSFontFaceDescriptors.idl:
* Source/WebCore/css/CSSFontFaceRule.idl:
* Source/WebCore/css/CSSPageDescriptors.idl:
* Source/WebCore/css/CSSPositionTryDescriptors.idl:
* Source/WebCore/css/CSSStyleProperties.idl:
* Source/WebCore/css/typedom/CSSKeywordValue.idl:
* Source/WebCore/css/typedom/StylePropertyMap.idl:
* Source/WebCore/css/typedom/StylePropertyMapReadOnly.idl:
* Source/WebCore/dom/Attr.idl:
* Source/WebCore/dom/CDATASection.idl:
* Source/WebCore/dom/Comment.idl:
* Source/WebCore/dom/DataTransferItemList.idl:
* Source/WebCore/dom/DocumentType.idl:
* Source/WebCore/dom/ProcessingInstruction.idl:
* Source/WebCore/dom/ShadowRoot.idl:
* Source/WebCore/fileapi/File.idl:
* Source/WebCore/html/DOMFormData.idl:
* Source/WebCore/html/DOMURL.idl:
* Source/WebCore/html/RadioNodeList.idl:
* Source/WebCore/html/canvas/CanvasRenderingContext2D.idl:
* Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.idl:
* Source/WebCore/html/canvas/PaintRenderingContext2D.idl:
* Source/WebCore/html/canvas/WebGL2RenderingContext.idl:
* Source/WebCore/html/canvas/WebGLRenderingContext.idl:
* Source/WebCore/html/track/TextTrackCueGeneric.idl:
* Source/WebCore/html/track/VTTCue.idl:
* Source/WebCore/inspector/InspectorAuditAccessibilityObject.idl:
* Source/WebCore/inspector/InspectorAuditDOMObject.idl:
* Source/WebCore/inspector/InspectorAuditResourcesObject.idl:
* Source/WebCore/svg/SVGViewSpec.idl:
* Source/WebCore/testing/InternalSettings.idl:
* Source/WebCore/workers/service/ExtendableMessageEvent.idl:
* Source/WebCore/xml/XMLHttpRequest.idl:
* Source/WebCore/xml/XMLHttpRequestUpload.idl:

Canonical link: <a href="https://commits.webkit.org/301044@main">https://commits.webkit.org/301044@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4162288f642af57b4fe11557bae63481ffa27912

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124804 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44476 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35211 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131649 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76713 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b91ffc84-22af-4d53-858b-0d7632e90a94) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/126681 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45179 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53045 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94957 "19 flakes 27 failures") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/63001 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6e57c3e6-011b-4ca7-9082-30443eb36d23) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127758 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36035 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111612 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75525 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/88027fa3-b17e-4c8a-960d-193bf91cf42a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34967 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29767 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75125 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105792 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29996 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134316 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51649 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39450 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103436 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52064 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107831 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103206 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26270 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48572 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26853 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48654 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51523 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57323 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50916 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54269 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52610 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->