### PR TITLE
Increase HTMLNameCache max capacity to reduce cache misses

### DIFF
--- a/Source/WebCore/html/parser/HTMLNameCache.h
+++ b/Source/WebCore/html/parser/HTMLNameCache.h
@@ -100,7 +100,7 @@ private:
         return *slot;
     }
 
-    ALWAYS_INLINE static size_t slotIndex(char16_t firstCharacter, char16_t lastCharacter, char16_t length)
+    ALWAYS_INLINE static size_t slotIndex(char16_t firstCharacter, char16_t lastCharacter, char16_t length, size_t capacity)
     {
         unsigned hash = (firstCharacter << 6) ^ ((lastCharacter << 14) ^ firstCharacter);
         hash += (hash >> 14) + (length << 14);
@@ -110,21 +110,22 @@ private:
 
     ALWAYS_INLINE static AtomString& atomStringCacheSlot(char16_t firstCharacter, char16_t lastCharacter, char16_t length)
     {
-        auto index = slotIndex(firstCharacter, lastCharacter, length);
+        auto index = slotIndex(firstCharacter, lastCharacter, length, atomStringCacheCapacity);
         return atomStringCache()[index];
     }
 
     ALWAYS_INLINE static RefPtr<QualifiedName::QualifiedNameImpl>& qualifiedNameCacheSlot(char16_t firstCharacter, char16_t lastCharacter, char16_t length)
     {
-        auto index = slotIndex(firstCharacter, lastCharacter, length);
+        auto index = slotIndex(firstCharacter, lastCharacter, length, qualifiedNameCacheCapacity);
         return qualifiedNameCache()[index];
     }
 
     static constexpr auto maxStringLengthForCache = 36;
-    static constexpr auto capacity = 512;
+    static constexpr auto atomStringCacheCapacity = 2048;
+    static constexpr auto qualifiedNameCacheCapacity = 512;
 
-    using AtomStringCache = std::array<AtomString, capacity>;
-    using QualifiedNameCache = std::array<RefPtr<QualifiedName::QualifiedNameImpl>, capacity>;
+    using AtomStringCache = std::array<AtomString, atomStringCacheCapacity>;
+    using QualifiedNameCache = std::array<RefPtr<QualifiedName::QualifiedNameImpl>, qualifiedNameCacheCapacity>;
 
     static AtomStringCache& atomStringCache();
     static QualifiedNameCache& qualifiedNameCache();


### PR DESCRIPTION
#### 1061bbd0c00ff7f5e9a198b540355df1ea67645f
<pre>
Increase HTMLNameCache max capacity to reduce cache misses
<a href="https://bugs.webkit.org/show_bug.cgi?id=300227">https://bugs.webkit.org/show_bug.cgi?id=300227</a>
<a href="https://rdar.apple.com/162019828">rdar://162019828</a>

Reviewed by Ryosuke Niwa.

We currently use the HTMLNameCache to cache frequently seen attribute names and values in the HTMLFastPathParser.
HTMLNameCache uses two caches under the hood - an AtomString cache for storing attributes and a QualifiedName cache for storing common attribute names. They both have the same max size.

The maximum cache size was initially set to 512 for both. Increasing the max size to 2048 for AtomString cache has these effects:

On SP3, it increases the hit rate from from 93.35% -&gt; 96.71% (+3.36%) on SP3.
On a real-world workload: it increases hit rate from 56.11% -&gt; 60.61% (Real-world: +4.5%)

This is mostly insiginficant overall on SP3, but it is a .75 - 1.2%% improvement on TODOMVC-Jquery subtest.

* Source/WebCore/html/parser/HTMLNameCache.h:

Canonical link: <a href="https://commits.webkit.org/302119@main">https://commits.webkit.org/302119@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c31201d9e56693b84c2f409879db0dfcb68f8807

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128079 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/362 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38911 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135447 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/79578 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/129951 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/280 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/236 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/97502 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/79578 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131027 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114742 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78071 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/32849 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78757 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/108533 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33335 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137936 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/217 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/216 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/106031 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/247 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111085 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105769 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26958 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/29641 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52395 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/263 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/61735 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/177 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/251 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/224 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->