### PR TITLE
StreamClientConnection::emitSendSignpost is present in traces

### DIFF
--- a/Source/WTF/wtf/SystemTracing.h
+++ b/Source/WTF/wtf/SystemTracing.h
@@ -275,8 +275,8 @@ WTF_EXTERN_C_END
     M(JSCJITPlanQueued) \
     M(JSCJITPlanReady) \
     M(JSCJSGlobalObject) \
-    M(IPCConnection) \
-    M(StreamClientConnection) \
+    M(IPCMessage) \
+    M(IPCStreamMessage) \
     M(ScrollingPerformanceTestFingerDownInterval) \
     M(ScrollingPerformanceTestMomentumInterval) \
     M(UpdateAccessibilityIsolatedTree) \

--- a/Source/WebKit/Platform/IPC/Connection.cpp
+++ b/Source/WebKit/Platform/IPC/Connection.cpp
@@ -49,12 +49,15 @@
 
 #if PLATFORM(COCOA)
 #include "MachMessage.h"
-#include <CoreFoundation/CoreFoundation.h>
 #endif
 
 #if USE(UNIX_DOMAIN_SOCKETS)
 #include "ArgumentCodersUnix.h"
 #include "UnixMessage.h"
+#endif
+
+#if ENABLE(CORE_IPC_SIGNPOSTS)
+#include "IPCSystemTracingSupport.h"
 #endif
 
 namespace IPC {
@@ -557,42 +560,13 @@ auto Connection::createSyncMessageEncoder(MessageName messageName, uint64_t dest
     return { WTFMove(encoder), syncRequestID };
 }
 
-#if ENABLE(CORE_IPC_SIGNPOSTS)
-
-static bool ipcSignpostsEnabled = false;
-
-void Connection::forceEnableSignposts()
-{
-    ipcSignpostsEnabled = true;
-}
-
-bool Connection::signpostsEnabled()
-{
-    static bool hasReadPreferences = false;
-    if (!hasReadPreferences) [[unlikely]] {
-        if (!isInAuxiliaryProcess() && CFPreferencesGetAppBooleanValue(CFSTR("WebKitDebugIPCSignposts"), kCFPreferencesCurrentApplication, nullptr))
-            ipcSignpostsEnabled = true;
-        hasReadPreferences = true;
-    }
-
-    return ipcSignpostsEnabled;
-}
-
-static uintptr_t generateSignpostIdentifier()
-{
-    static std::atomic<uintptr_t> identifier;
-    return ++identifier;
-}
-
-#endif
-
 Error Connection::sendMessage(UniqueRef<Encoder>&& encoder, OptionSet<SendOption> sendOptions, std::optional<Thread::QOS> qos)
 {
 #if ENABLE(CORE_IPC_SIGNPOSTS)
     // Signposts can turn in to log message IPCs when emitted from WebContent. Don't emit a signpost
     // for log messages to avoid an infinite number of signposts.
     if (signpostsEnabled() && receiverName(encoder->messageName()) != IPC::ReceiverName::LogStream) [[unlikely]]
-        WTFEmitSignpost(generateSignpostIdentifier(), IPCConnection, "sendMessage: %" PUBLIC_LOG_STRING, description(encoder->messageName()).characters());
+        WTFEmitSignpost(generateSignpostIdentifier(), IPCMessage, "sendMessage: %" PUBLIC_LOG_STRING, description(encoder->messageName()).characters());
 #endif
 
     return sendMessageImpl(WTFMove(encoder), sendOptions, qos);
@@ -705,10 +679,10 @@ Error Connection::sendMessageWithAsyncReply(UniqueRef<Encoder>&& encoder, AsyncR
 #if ENABLE(CORE_IPC_SIGNPOSTS)
     if (signpostsEnabled()) [[unlikely]] {
         auto signpostIdentifier = generateSignpostIdentifier();
-        WTFBeginSignpost(signpostIdentifier, IPCConnection, "sendMessageWithAsyncReply: %" PUBLIC_LOG_STRING, description(encoder->messageName()).characters());
+        WTFBeginSignpost(signpostIdentifier, IPCMessage, "sendMessageWithAsyncReply: %" PUBLIC_LOG_STRING, description(encoder->messageName()).characters());
 
         replyHandler.completionHandler = CompletionHandler<void(Connection*, Decoder*)>([signpostIdentifier, handler = WTFMove(replyHandler.completionHandler)](Connection* connection, Decoder *decoder) mutable {
-            WTFEndSignpost(signpostIdentifier, IPCConnection);
+            WTFEndSignpost(signpostIdentifier, IPCMessage);
             handler(connection, decoder);
         });
     }
@@ -766,12 +740,12 @@ auto Connection::waitForMessage(MessageName messageName, uint64_t destinationID,
     uintptr_t signpostIdentifier = 0;
     if (signpostsEnabled()) [[unlikely]] {
         signpostIdentifier = generateSignpostIdentifier();
-        WTFBeginSignpost(signpostIdentifier, IPCConnection, "waitForMessage: %" PUBLIC_LOG_STRING, description(messageName).characters());
+        WTFBeginSignpost(signpostIdentifier, IPCMessage, "waitForMessage: %" PUBLIC_LOG_STRING, description(messageName).characters());
     }
 
     auto endSignpost = makeScopeExit([signpostIdentifier] {
         if (signpostIdentifier) [[unlikely]]
-            WTFEndSignpost(signpostIdentifier, IPCConnection);
+            WTFEndSignpost(signpostIdentifier, IPCMessage);
     });
 #endif
 
@@ -916,7 +890,7 @@ auto Connection::sendSyncMessage(SyncRequestID syncRequestID, UniqueRef<Encoder>
     uintptr_t signpostIdentifier = 0;
     if (signpostsEnabled()) [[unlikely]] {
         signpostIdentifier = generateSignpostIdentifier();
-        WTFBeginSignpost(signpostIdentifier, IPCConnection, "sendSyncMessage: %" PUBLIC_LOG_STRING, description(messageName).characters());
+        WTFBeginSignpost(signpostIdentifier, IPCMessage, "sendSyncMessage: %" PUBLIC_LOG_STRING, description(messageName).characters());
     }
 #endif
 
@@ -931,7 +905,7 @@ auto Connection::sendSyncMessage(SyncRequestID syncRequestID, UniqueRef<Encoder>
 
 #if ENABLE(CORE_IPC_SIGNPOSTS)
     if (signpostIdentifier) [[unlikely]]
-        WTFEndSignpost(signpostIdentifier, IPCConnection);
+        WTFEndSignpost(signpostIdentifier, IPCMessage);
 #endif
 
     popPendingSyncRequestID(syncRequestID);

--- a/Source/WebKit/Platform/IPC/Connection.h
+++ b/Source/WebKit/Platform/IPC/Connection.h
@@ -543,11 +543,6 @@ public:
 
     void markCurrentlyDispatchedMessageAsInvalid();
 
-#if ENABLE(CORE_IPC_SIGNPOSTS)
-    static bool signpostsEnabled();
-    static void forceEnableSignposts();
-#endif
-
     static bool shouldCrashOnMessageCheckFailure();
     static void setShouldCrashOnMessageCheckFailure(bool);
 

--- a/Source/WebKit/Platform/IPC/IPCSystemTracingSupport.h
+++ b/Source/WebKit/Platform/IPC/IPCSystemTracingSupport.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,21 +25,26 @@
 
 #pragma once
 
-#include <wtf/HashSet.h>
-#include <wtf/text/WTFString.h>
-
-namespace WebKit {
-
-// Parameters that are sent to the process object as the first message after process has started.
-struct AuxiliaryProcessCreationParameters {
-    String wtfLoggingChannels;
-    String webCoreLoggingChannels;
-    String webKitLoggingChannels;
-    std::unique_ptr<HashSet<String>> classNamesExemptFromSecureCodingCrash;
-
 #if ENABLE(CORE_IPC_SIGNPOSTS)
-    bool shouldEnableIPCSignposts { false };
-#endif
-};
 
-} // namespace WebKit
+#include <wtf/SystemTracing.h>
+
+namespace IPC {
+
+namespace Detail {
+
+extern std::atomic<bool> signpostsState;
+
+}
+
+inline bool signpostsEnabled()
+{
+    return Detail::signpostsState.load(std::memory_order_relaxed);
+}
+
+void setSignpostsEnabled(bool);
+
+uintptr_t generateSignpostIdentifier();
+
+}
+#endif

--- a/Source/WebKit/Platform/IPC/StreamClientConnection.cpp
+++ b/Source/WebKit/Platform/IPC/StreamClientConnection.cpp
@@ -176,37 +176,24 @@ void StreamClientConnection::removeWorkQueueMessageReceiver(ReceiverName name, u
 
 #if ENABLE(CORE_IPC_SIGNPOSTS)
 
-static bool streamingIPCSignpostsEnabled = false;
-
-void StreamClientConnection::forceEnableSignposts()
-{
-    streamingIPCSignpostsEnabled = true;
-}
-
-bool StreamClientConnection::signpostsEnabled()
-{
-    static bool hasReadPreferences = false;
-    if (!hasReadPreferences) [[unlikely]] {
-        if (!isInAuxiliaryProcess() && CFPreferencesGetAppBooleanValue(CFSTR("WebKitDebugStreamingIPCSignposts"), kCFPreferencesCurrentApplication, nullptr))
-            streamingIPCSignpostsEnabled = true;
-        hasReadPreferences = true;
-    }
-
-    return streamingIPCSignpostsEnabled;
-}
-
-uintptr_t StreamClientConnection::generateSignpostIdentifier()
-{
-    static std::atomic<uintptr_t> identifier;
-    return ++identifier;
-}
-
-void StreamClientConnection::emitSendSignpost(MessageName messageName)
+void StreamClientConnection::emitSignpost(MessageName messageName)
 {
     // Signposts can turn in to log message IPCs when emitted from WebContent. Don't emit a signpost
     // for log messages to avoid an infinite number of signposts.
-    if (signpostsEnabled() && receiverName(messageName) != IPC::ReceiverName::LogStream) [[unlikely]]
-        WTFEmitSignpost(generateSignpostIdentifier(), StreamClientConnection, "send: %" PUBLIC_LOG_STRING, description(messageName).characters());
+    if (receiverName(messageName) == IPC::ReceiverName::LogStream) [[unlikely]]
+        return;
+    WTFEmitSignpost(generateSignpostIdentifier(), IPCStreamMessage, "send: %" PUBLIC_LOG_STRING, description(messageName).characters());
+}
+
+uintptr_t StreamClientConnection::beginSignpost(IntervalSignpostOperation operation, MessageName messageName)
+{
+    ASSERT(receiverName(messageName) != IPC::ReceiverName::LogStream);
+    auto signpostIdentifier = generateSignpostIdentifier();
+    if (operation == IntervalSignpostOperation::SendWithAsyncReply)
+        WTFBeginSignpost(signpostIdentifier, IPCStreamMessage, "sendWithAsyncReply: %" PUBLIC_LOG_STRING, description(messageName).characters());
+    else
+        WTFBeginSignpost(signpostIdentifier, IPCStreamMessage, "sendSync: %" PUBLIC_LOG_STRING, description(messageName).characters());
+    return signpostIdentifier;
 }
 
 #endif

--- a/Source/WebKit/Platform/IPC/StreamClientConnection.h
+++ b/Source/WebKit/Platform/IPC/StreamClientConnection.h
@@ -39,6 +39,11 @@
 #include <wtf/TZoneMalloc.h>
 #include <wtf/Threading.h>
 
+#if ENABLE(CORE_IPC_SIGNPOSTS)
+#include "IPCSystemTracingSupport.h"
+#endif
+
+
 namespace WebKit {
 namespace IPCTestingAPI {
 class JSIPCStreamClientConnection;
@@ -112,11 +117,6 @@ public:
     // used in conjunction with the connection.
     Seconds defaultTimeoutDuration() const { return m_defaultTimeoutDuration; }
 
-#if ENABLE(CORE_IPC_SIGNPOSTS)
-    static bool signpostsEnabled();
-    static void forceEnableSignposts();
-#endif
-
 private:
     StreamClientConnection(Ref<Connection>, StreamClientConnectionBuffer&&, Seconds defaultTimeoutDuration);
 
@@ -131,8 +131,13 @@ private:
     void wakeUpServer(WakeUpServer);
 
 #if ENABLE(CORE_IPC_SIGNPOSTS)
-    static uintptr_t generateSignpostIdentifier();
-    void emitSendSignpost(MessageName);
+    void emitSignpost(MessageName);
+    enum class IntervalSignpostOperation {
+        SendWithAsyncReply,
+        SendSync
+    };
+    // Non-zero return values should be issued to WTFEndSignpost(..., IPCStreamMessage).
+    uintptr_t beginSignpost(IntervalSignpostOperation, MessageName);
 #endif
 
     const Ref<Connection> m_connection;
@@ -167,7 +172,8 @@ template<typename T, typename U, typename V, typename W>
 Error StreamClientConnection::send(T&& message, ObjectIdentifierGeneric<U, V, W> destinationID)
 {
 #if ENABLE(CORE_IPC_SIGNPOSTS)
-    emitSendSignpost(message.name());
+    if (signpostsEnabled())
+        emitSignpost(message.name());
 #endif
 
     static_assert(!T::isSync, "Message is sync!");
@@ -192,10 +198,8 @@ std::optional<StreamClientConnection::AsyncReplyID> StreamClientConnection::send
 {
 #if ENABLE(CORE_IPC_SIGNPOSTS)
     uintptr_t signpostIdentifier = 0;
-    if (signpostsEnabled()) [[unlikely]] {
-        signpostIdentifier = generateSignpostIdentifier();
-        WTFBeginSignpost(signpostIdentifier, StreamClientConnection, "sendWithAsyncReply: %" PUBLIC_LOG_STRING, description(message.name()).characters());
-    }
+    if (signpostsEnabled()) [[unlikely]]
+        signpostIdentifier = beginSignpost(IntervalSignpostOperation::SendWithAsyncReply, message.name());
 #endif
 
     static_assert(!T::isSync, "Message is sync!");
@@ -214,7 +218,7 @@ std::optional<StreamClientConnection::AsyncReplyID> StreamClientConnection::send
 #if ENABLE(CORE_IPC_SIGNPOSTS)
     if (signpostIdentifier) [[unlikely]] {
         handler.completionHandler = CompletionHandler<void(Connection*, Decoder*)>([signpostIdentifier, handler = WTFMove(handler.completionHandler)](Connection* connection, Decoder* decoder) mutable {
-            WTFEndSignpost(signpostIdentifier, StreamClientConnection);
+            WTFEndSignpost(signpostIdentifier, IPCStreamMessage);
             handler(connection, decoder);
         });
     }
@@ -266,13 +270,11 @@ StreamClientConnection::SendSyncResult<T> StreamClientConnection::sendSync(T&& m
 {
 #if ENABLE(CORE_IPC_SIGNPOSTS)
     uintptr_t signpostIdentifier = 0;
-    if (signpostsEnabled()) [[unlikely]] {
-        signpostIdentifier = generateSignpostIdentifier();
-        WTFBeginSignpost(signpostIdentifier, StreamClientConnection, "sendSync: %" PUBLIC_LOG_STRING, description(message.name()).characters());
-    }
+    if (signpostsEnabled()) [[unlikely]]
+        signpostIdentifier = beginSignpost(IntervalSignpostOperation::SendSync, message.name());
     auto endSignpost = makeScopeExit([signpostIdentifier] {
         if (signpostIdentifier) [[unlikely]]
-            WTFEndSignpost(signpostIdentifier, StreamClientConnection);
+            WTFEndSignpost(signpostIdentifier, IPCStreamMessage);
     });
 #endif
 

--- a/Source/WebKit/Platform/IPC/cocoa/IPCSystemTracingSupportCocoa.cpp
+++ b/Source/WebKit/Platform/IPC/cocoa/IPCSystemTracingSupportCocoa.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -22,24 +22,28 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
-
-#pragma once
-
-#include <wtf/HashSet.h>
-#include <wtf/text/WTFString.h>
-
-namespace WebKit {
-
-// Parameters that are sent to the process object as the first message after process has started.
-struct AuxiliaryProcessCreationParameters {
-    String wtfLoggingChannels;
-    String webCoreLoggingChannels;
-    String webKitLoggingChannels;
-    std::unique_ptr<HashSet<String>> classNamesExemptFromSecureCodingCrash;
+#include "config.h"
+#include "IPCSystemTracingSupport.h"
 
 #if ENABLE(CORE_IPC_SIGNPOSTS)
-    bool shouldEnableIPCSignposts { false };
-#endif
-};
 
-} // namespace WebKit
+namespace IPC {
+
+namespace Detail {
+std::atomic<bool> signpostsState;
+}
+
+void setSignpostsEnabled(bool isEnabled)
+{
+    Detail::signpostsState = isEnabled;
+}
+
+uintptr_t generateSignpostIdentifier()
+{
+    static std::atomic<uintptr_t> identifier;
+    return ++identifier;
+}
+
+}
+
+#endif

--- a/Source/WebKit/Platform/SourcesCocoa.txt
+++ b/Source/WebKit/Platform/SourcesCocoa.txt
@@ -14,6 +14,7 @@ Platform/foundation/LoggingFoundation.mm @nonARC
 Platform/IPC/cocoa/ConnectionCocoa.mm @nonARC
 Platform/IPC/cocoa/DaemonConnectionCocoa.mm @nonARC
 Platform/IPC/cocoa/MachMessage.cpp
+Platform/IPC/cocoa/IPCSystemTracingSupportCocoa.cpp
 
 Platform/IPC/darwin/IPCEventDarwin.cpp
 Platform/IPC/darwin/IPCSemaphoreDarwin.cpp

--- a/Source/WebKit/Shared/AuxiliaryProcess.cpp
+++ b/Source/WebKit/Shared/AuxiliaryProcess.cpp
@@ -55,6 +55,10 @@
 #include "CoreIPCSecureCoding.h"
 #endif
 
+#if ENABLE(CORE_IPC_SIGNPOSTS)
+#include "IPCSystemTracingSupport.h"
+#endif
+
 namespace WebKit {
 using namespace WebCore;
 
@@ -259,10 +263,8 @@ void AuxiliaryProcess::applyProcessCreationParameters(AuxiliaryProcessCreationPa
     SecureCoding::applyProcessCreationParameters(WTFMove(parameters));
 #endif
 #if ENABLE(CORE_IPC_SIGNPOSTS)
-    if (parameters.shouldEnableIPCSignposts)
-        IPC::Connection::forceEnableSignposts();
-    if (parameters.shouldEnableStreamingIPCSignposts)
-        IPC::StreamClientConnection::forceEnableSignposts();
+    // Note: some messages have already been sent at this point.
+    IPC::setSignpostsEnabled(parameters.shouldEnableIPCSignposts);
 #endif
 }
 

--- a/Source/WebKit/Shared/AuxiliaryProcessCreationParameters.serialization.in
+++ b/Source/WebKit/Shared/AuxiliaryProcessCreationParameters.serialization.in
@@ -28,6 +28,5 @@ struct WebKit::AuxiliaryProcessCreationParameters {
 
 #if ENABLE(CORE_IPC_SIGNPOSTS)
     bool shouldEnableIPCSignposts;
-    bool shouldEnableStreamingIPCSignposts;
 #endif
 };

--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
@@ -565,8 +565,7 @@ AuxiliaryProcessCreationParameters AuxiliaryProcessProxy::auxiliaryProcessParame
 #endif
 
 #if ENABLE(CORE_IPC_SIGNPOSTS)
-    parameters.shouldEnableIPCSignposts = IPC::Connection::signpostsEnabled();
-    parameters.shouldEnableStreamingIPCSignposts = IPC::StreamClientConnection::signpostsEnabled();
+    parameters.shouldEnableIPCSignposts = IPC::signpostsEnabled();
 #endif
 
     return parameters;

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -34,6 +34,7 @@
 #import "CookieStorageUtilsCF.h"
 #import "DefaultWebBrowserChecks.h"
 #import "ExtensionCapabilityGranter.h"
+#import "IPCSystemTracingSupport.h"
 #import "LegacyCustomProtocolManagerClient.h"
 #import "LockdownModeObserver.h"
 #import "Logging.h"
@@ -371,6 +372,8 @@ void WebProcessPool::platformInitialize(NeedsGlobalStaticInitialization needsGlo
     });
 #endif
 
+    if ([[NSUserDefaults standardUserDefaults] boolForKey:@"WebKitEnableIPCSignposts"])
+        IPC::setSignpostsEnabled(true);
 }
 
 void WebProcessPool::platformResolvePathsForSandboxExtensions()

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1593,6 +1593,7 @@
 		7B483F1F25CDDA9C00120486 /* MessageReceiveQueueMap.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B483F1B25CDDA9B00120486 /* MessageReceiveQueueMap.h */; };
 		7B483F2025CDDA9C00120486 /* MessageReceiveQueue.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B483F1C25CDDA9B00120486 /* MessageReceiveQueue.h */; };
 		7B483F2225CDDA9C00120486 /* MessageReceiveQueues.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B483F1E25CDDA9B00120486 /* MessageReceiveQueues.h */; };
+		7B5C14892E93D0A500D1EC07 /* IPCSystemTracingSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B5C14882E93D0A500D1EC07 /* IPCSystemTracingSupport.h */; };
 		7B73123A25CC8525003B2796 /* StreamConnectionBuffer.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B73123125CC8523003B2796 /* StreamConnectionBuffer.h */; };
 		7B73123C25CC8525003B2796 /* StreamClientConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B73123325CC8523003B2796 /* StreamClientConnection.h */; };
 		7B73123E25CC8525003B2796 /* StreamConnectionWorkQueue.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B73123525CC8524003B2796 /* StreamConnectionWorkQueue.h */; };
@@ -6784,6 +6785,8 @@
 		7B5A3DA727A7DCBC006C6F97 /* RemoteVideoFrameObjectHeap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RemoteVideoFrameObjectHeap.h; sourceTree = "<group>"; };
 		7B5A3DA827A7DCBC006C6F97 /* RemoteVideoFrameObjectHeap.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteVideoFrameObjectHeap.cpp; sourceTree = "<group>"; };
 		7B5A3DC527AE501A006C6F97 /* ObjectIdentifierReferenceTracker.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ObjectIdentifierReferenceTracker.h; sourceTree = "<group>"; };
+		7B5C14882E93D0A500D1EC07 /* IPCSystemTracingSupport.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IPCSystemTracingSupport.h; sourceTree = "<group>"; };
+		7B5C148A2E93DC1F00D1EC07 /* IPCSystemTracingSupportCocoa.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = IPCSystemTracingSupportCocoa.cpp; sourceTree = "<group>"; };
 		7B64C0B6254C5C250006B4AF /* RemoteGraphicsContextGLIdentifier.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteGraphicsContextGLIdentifier.h; sourceTree = "<group>"; };
 		7B72BB642E57405300D48E7D /* RemoteDisplayListIdentifier.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteDisplayListIdentifier.h; sourceTree = "<group>"; };
 		7B72BB652E57419400D48E7D /* RemoteDisplayListRecorderIdentifier.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteDisplayListRecorderIdentifier.h; sourceTree = "<group>"; };
@@ -10512,6 +10515,7 @@
 				46BB389C2B69764600F02BE0 /* IPCEvent.serialization.in */,
 				A31F60A225CC7DB800AF14F4 /* IPCSemaphore.h */,
 				46CD8C442B059FF500360248 /* IPCSemaphore.serialization.in */,
+				7B5C14882E93D0A500D1EC07 /* IPCSystemTracingSupport.h */,
 				7B9FC5AC28A3B440007570E7 /* IPCUtilities.cpp */,
 				7B9FC5AB28A3B440007570E7 /* IPCUtilities.h */,
 				9BF5EC6325410E9900984E77 /* JSIPCBinding.cpp */,
@@ -16054,6 +16058,7 @@
 				1A30EAC5115D7DA30053E937 /* ConnectionCocoa.mm */,
 				5C1579E627172A5100ED5280 /* DaemonConnectionCocoa.mm */,
 				1A1EC69D1872092100B951F0 /* ImportanceAssertion.h */,
+				7B5C148A2E93DC1F00D1EC07 /* IPCSystemTracingSupportCocoa.cpp */,
 				1A6D86BF1DF75265007745E8 /* MachMessage.cpp */,
 				1A6D86C01DF75265007745E8 /* MachMessage.h */,
 				93468E6C2714AF88009983E3 /* SharedFileHandleCocoa.cpp */,
@@ -17166,6 +17171,7 @@
 			files = (
 				561A54612B6438C000073A72 /* CoreIPCSecKeychainItem.h in Headers */,
 				562674F52B69B4C8008BB425 /* CoreIPCSecTrust.h in Headers */,
+				7B5C14892E93D0A500D1EC07 /* IPCSystemTracingSupport.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
#### 1a48fc65ac7296125f1f081ee3af7889910dd79f
<pre>
StreamClientConnection::emitSendSignpost is present in traces
<a href="https://bugs.webkit.org/show_bug.cgi?id=300230">https://bugs.webkit.org/show_bug.cgi?id=300230</a>
<a href="https://rdar.apple.com/problem/162025212">rdar://problem/162025212</a>

Reviewed by NOBODY (OOPS!).

Since being enabled by default, the emitSendSignpost would be visible
in traces, for example 34/4000 samples in MotionMark Lines. Try to
optimize the IPC related signposts a bit to avoid spending
time in the function call.

Simplify the signpostsEnabled() accessor. Lazy-initialization from
defaults does not make sense, as it&apos;s ever loadable from defaults and
toggled at one specific point, when the UI process initializes the
first WCP connection.

Remove separate debug toggles for Connection vs StreamClientConnection
to simplify the implementation, improve consistency and remove user
error possibilities. When investigating StreamClientConnction message
behavior, having both is consistent. Presumably when investigating
Connection message behavior, having stream messages present is not
overly hard to use.

Rename signpost names to be more consistent with each other.

Rename defaults pref name to WebKitEnableIPCSignposts. This is more
consistent with other defaults as well as remove the &quot;debug&quot; word to
indicate that it&apos;s present in non-Debug builds too.

* Source/WTF/wtf/SystemTracing.h:
* Source/WebKit/Platform/IPC/Connection.cpp:
(IPC::Connection::sendMessage):
(IPC::Connection::sendMessageWithAsyncReply):
(IPC::Connection::waitForMessage):
(IPC::Connection::sendSyncMessage):
(IPC::Connection::forceEnableSignposts): Deleted.
(IPC::Connection::signpostsEnabled): Deleted.
(IPC::generateSignpostIdentifier): Deleted.
* Source/WebKit/Platform/IPC/Connection.h:
* Source/WebKit/Platform/IPC/IPCSystemTracingSupport.h: Copied from Source/WebKit/Shared/AuxiliaryProcessCreationParameters.h.
(IPC::signpostsEnabled):
* Source/WebKit/Platform/IPC/StreamClientConnection.cpp:
(IPC::StreamClientConnection::emitSignpost):
(IPC::StreamClientConnection::beginSignpost):
(IPC::StreamClientConnection::forceEnableSignposts): Deleted.
(IPC::StreamClientConnection::signpostsEnabled): Deleted.
(IPC::StreamClientConnection::generateSignpostIdentifier): Deleted.
(IPC::StreamClientConnection::emitSendSignpost): Deleted.
* Source/WebKit/Platform/IPC/StreamClientConnection.h:
(IPC::StreamClientConnection::send):
(IPC::StreamClientConnection::sendWithAsyncReply):
(IPC::StreamClientConnection::sendSync):
* Source/WebKit/Platform/IPC/cocoa/IPCSystemTracingSupportCocoa.cpp: Copied from Source/WebKit/Shared/AuxiliaryProcessCreationParameters.h.
(IPC::setSignpostsEnabled):
(IPC::generateSignpostIdentifier):
* Source/WebKit/Platform/SourcesCocoa.txt:
* Source/WebKit/Shared/AuxiliaryProcess.cpp:
(WebKit::AuxiliaryProcess::applyProcessCreationParameters):
* Source/WebKit/Shared/AuxiliaryProcessCreationParameters.h:
* Source/WebKit/Shared/AuxiliaryProcessCreationParameters.serialization.in:
* Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp:
(WebKit::AuxiliaryProcessProxy::auxiliaryProcessParameters):
* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(WebKit::WebProcessPool::platformInitialize):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1a48fc65ac7296125f1f081ee3af7889910dd79f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125022 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44691 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35428 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131871 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76899 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1f293749-cbae-4060-81fc-600570433e0f) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45383 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53257 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95167 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/63144 "Found 60 new test failures: compositing/clipping/border-radius-with-composited-descendant-nested.html compositing/clipping/border-radius-with-composited-descendant.html compositing/overlap-blending/children-opacity-huge.html compositing/overlap-blending/children-opacity-no-overlap.html compositing/overlap-blending/nested-non-overlap-clipping.html compositing/overlap-blending/nested-overlap.html compositing/transforms/clipping-layer-and-flattening-layer.html compositing/transforms/perspective-transform-box.html compositing/transforms/perspective-with-clipping.html compositing/webgl/update-composited-canvas-layer.html ... (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/726cf5df-7832-497b-b570-3775d27c8a48) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127976 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36224 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111812 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75710 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/eb192ea4-3d16-498c-a383-39b67eab4839) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35142 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29966 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75353 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/117120 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105987 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30195 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134547 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/123540 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51844 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39642 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103638 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52269 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108024 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103412 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48752 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27042 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48890 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51729 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57522 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/156565 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51103 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39209 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54460 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52794 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->