### PR TITLE
[GTK][WPE] Make run-api-tests support Linux ports

### DIFF
--- a/Tools/Scripts/webkitpy/api_tests/runner.py
+++ b/Tools/Scripts/webkitpy/api_tests/runner.py
@@ -247,7 +247,7 @@ class _Worker(object):
     def _run_single_test(self, binary_name, test):
         server_process = ServerProcess(
             self._port, binary_name,
-            Runner.command_for_port(self._port, [self._port._build_path(binary_name), '--gtest_filter={}'.format(test)]),
+            Runner.command_for_port(self._port, [self._port.path_to_api_test(binary_name), '--gtest_filter={}'.format(test)]),
             env=self._port.environment_for_api_tests())
 
         status = Runner.STATUS_RUNNING
@@ -338,7 +338,7 @@ class _Worker(object):
             server_process = ServerProcess(
                 self._port, binary_name,
                 Runner.command_for_port(self._port, [
-                    self._port._build_path(binary_name), '--gtest_filter={}'.format(':'.join(remaining_tests))
+                    self._port.path_to_api_test(binary_name), '--gtest_filter={}'.format(':'.join(remaining_tests))
                 ]), env=self._port.environment_for_api_tests())
 
             try:

--- a/Tools/Scripts/webkitpy/port/base.py
+++ b/Tools/Scripts/webkitpy/port/base.py
@@ -1238,8 +1238,11 @@ class Port(object):
 
     API_TEST_BINARY_NAMES = ['TestWTF', 'TestWebKitAPI']
 
+    def path_to_api_test(self, program_name):
+        return self._build_path(program_name)
+
     def path_to_api_test_binaries(self):
-        return {binary: self._build_path(binary) for binary in self.API_TEST_BINARY_NAMES}
+        return {binary: self.path_to_api_test(binary) for binary in self.API_TEST_BINARY_NAMES}
 
     def _webkit_baseline_path(self, platform):
         """Return the  full path to the top of the baseline tree for a

--- a/Tools/Scripts/webkitpy/port/glib.py
+++ b/Tools/Scripts/webkitpy/port/glib.py
@@ -200,3 +200,14 @@ class GLibPort(Port):
         if self._should_use_jhbuild():
             command = self._jhbuild_wrapper + command
         return self._executive.run_command(command + args, cwd=self.webkit_base(), stdout=None, return_stderr=False, decode_output=False, env=env)
+
+    API_TEST_BINARY_NAMES = ['TestWTF', 'TestWebCore', 'TestWebKit']
+
+    def path_to_api_test(self, program_name):
+        return self._built_executables_path('TestWebKitAPI', program_name)
+
+    def environment_for_api_tests(self):
+        environment = super(GLibPort, self).environment_for_api_tests()
+        environment['TEST_WEBKIT_API_WEBKIT2_RESOURCES_PATH'] = self.path_from_webkit_base('Tools', 'TestWebKitAPI', 'Tests', 'WebKit')
+        environment['TEST_WEBKIT_API_WEBKIT2_INJECTED_BUNDLE_PATH'] = self._build_path('lib')
+        return environment

--- a/Tools/glib/api_test_runner.py
+++ b/Tools/glib/api_test_runner.py
@@ -124,10 +124,7 @@ class TestRunner(object):
         return driver
 
     def _setup_testing_environment_for_driver(self, driver):
-        test_env = driver._setup_environ_for_test()
-        test_env["TEST_WEBKIT_API_WEBKIT2_RESOURCES_PATH"] = common.top_level_path("Tools", "TestWebKitAPI", "Tests", "WebKit")
-        test_env["TEST_WEBKIT_API_WEBKIT2_INJECTED_BUNDLE_PATH"] = common.library_build_path(self._port)
-        test_env["WEBKIT_EXEC_PATH"] = self._programs_path
+        test_env = driver._setup_environ_for_test() | self._port.environment_for_api_tests()
         # The python display-server driver may set WPE_DISPLAY, but we unset it here because it causes issues with
         # some WPE API tests like WPEPlatform/TestDisplayDefault that check the default behaviour of the APIs.
         test_env.pop("WPE_DISPLAY", None)


### PR DESCRIPTION
#### 4b94cb749c7a88ad1ffd700c6c5c13a7a57b9243
<pre>
[GTK][WPE] Make run-api-tests support Linux ports
<a href="https://bugs.webkit.org/show_bug.cgi?id=185512">https://bugs.webkit.org/show_bug.cgi?id=185512</a>

Reviewed by Adrian Perez de Castro.

TestWebKitAPI programs are located in
WebKitBuild/{GTK,WPE}/{Release,Debug}/bin/TestWebKitAPI/ directory for GTK and
WPE ports. Added a new method Port.path_to_api_test to get the path. And,
override it in glib.py.

Moved the code setting TEST_WEBKIT_API_WEBKIT2_RESOURCES_PATH and
TEST_WEBKIT_API_WEBKIT2_INJECTED_BUNDLE_PATH environment variables from
api_test_runner.py to glib.py. WEBKIT_EXEC_PATH was already set by glib.py.
Removed the code of setting WEBKIT_EXEC_PATH from api_test_runner.py.

* Tools/Scripts/webkitpy/api_tests/runner.py:
(_Worker._run_single_test):
(_Worker.run):
* Tools/Scripts/webkitpy/port/base.py:
(Port.path_to_api_test):
(Port.path_to_api_test_binaries):
* Tools/Scripts/webkitpy/port/glib.py:
(GLibPort.run_webdriver):
(GLibPort):
(GLibPort.path_to_api_test):
(GLibPort.environment_for_api_tests):
* Tools/glib/api_test_runner.py:
(TestRunner._setup_testing_environment_for_driver):

Canonical link: <a href="https://commits.webkit.org/301100@main">https://commits.webkit.org/301100@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/61536e14ea91f6e077ac5cf532685c886c7fed18

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124942 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44611 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35348 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131792 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/76824 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/126819 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45304 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53178 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95088 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/76824 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127896 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36151 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/111740 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75636 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/124298 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/35086 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29893 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75270 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105914 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/30124 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134466 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51771 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39572 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/103567 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52192 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107953 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103343 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48685 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/26974 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48791 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19579 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51650 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/51032 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54387 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/52725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->