### PR TITLE
Remove Apple internal "internalIOSLaunchStyle" attribute from SwiftBrowser.xcscheme

### DIFF
--- a/Tools/Scripts/webkitpy/style/checkers/xcscheme_unittest.py
+++ b/Tools/Scripts/webkitpy/style/checkers/xcscheme_unittest.py
@@ -1,0 +1,67 @@
+# Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Unit test for xcscheme.py."""
+
+import unittest
+from webkitpy.style.checkers import xcscheme
+
+
+class TestErrorHandler(object):
+    """Error handler for XcodeSchemeChecker unittests"""
+    def __init__(self, handler):
+        self.handler = handler
+
+    def turn_off_line_filtering(self):
+        pass
+
+    def __call__(self, line_number, category, confidence, message):
+        self.handler(self, line_number, category, confidence, message)
+        return True
+
+
+class XcodeSchemeCheckerTest(unittest.TestCase):
+    """Tests XcodeSchemeChecker class."""
+
+    def assert_no_error(self, lines):
+        def handler(error_handler, line_number, category, confidence, message):
+            self.fail('Unexpected error: %d %s %d %s' % (line_number, category, confidence, message))
+
+        error_handler = TestErrorHandler(handler)
+        checker = xcscheme.XcodeSchemeChecker('', error_handler)
+        checker.check(lines)
+
+    def assert_error(self, lines, expected_message):
+        self.had_error = False
+
+        def handler(error_handler, line_number, category, confidence, message):
+            self.assertEqual(expected_message, message)
+            self.had_error = True
+        error_handler = TestErrorHandler(handler)
+        checker = xcscheme.XcodeSchemeChecker('', error_handler)
+        checker.check(lines)
+        self.assertTrue(self.had_error, '%s should have error: %s.' % (lines, expected_message))
+
+    def test_detect_invalid_internal_attribute(self):
+        self.assert_no_error(['<Scheme><LaunchAction launchStyle = "1">\n</LaunchAction></Scheme>'])
+        self.assert_error(['<Scheme><LaunchAction launchStyle = "1" internalIOSLaunchStyle = "2">\n</LaunchAction></Scheme>'], 'internal attribute \'internalIOSLaunchStyle\' used')

--- a/Tools/SwiftBrowser/SwiftBrowser.xcodeproj/xcshareddata/xcschemes/SwiftBrowser.xcscheme
+++ b/Tools/SwiftBrowser/SwiftBrowser.xcodeproj/xcshareddata/xcschemes/SwiftBrowser.xcscheme
@@ -39,8 +39,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
-      allowLocationSimulation = "YES"
-      internalIOSLaunchStyle = "2">
+      allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
          <BuildableReference


### PR DESCRIPTION
#### 4e9e6f6ea041bda0af5fb423b7216692877ee3a3
<pre>
Remove Apple internal &quot;internalIOSLaunchStyle&quot; attribute from SwiftBrowser.xcscheme
<a href="https://bugs.webkit.org/show_bug.cgi?id=300235">https://bugs.webkit.org/show_bug.cgi?id=300235</a>

Reviewed by Abrar Rahman Protyasha.

Removes what seems to be an Apple internal attribute, &quot;internalIOSLaunchStyle&quot;,
in SwiftBrowser.xcscheme, that the public Xcode removes every time the workspace
is opened.

Adds a new style checker case to make sure it doesn&apos;t come back without causing
an error.

* Tools/Scripts/webkitpy/style/checkers/xcscheme.py:
* Tools/Scripts/webkitpy/style/checkers/xcscheme_unittest.py: Added.
* Tools/SwiftBrowser/SwiftBrowser.xcodeproj/xcshareddata/xcschemes/SwiftBrowser.xcscheme:

Canonical link: <a href="https://commits.webkit.org/301174@main">https://commits.webkit.org/301174@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/14abeb2ba69818807c11f948391b128aae3510f3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125135 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44802 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35541 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131985 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77004 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127012 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45493 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53365 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95259 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/63212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128089 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36315 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111902 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75802 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/124491 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35221 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30067 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75463 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106080 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30295 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134664 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51945 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39735 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103726 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52379 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108123 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103497 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26358 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48849 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27136 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49010 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51837 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51204 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54560 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52894 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->