### PR TITLE
Address safer CPP warnings in WKFullScreenWindowController

### DIFF
--- a/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm
+++ b/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm
@@ -374,12 +374,13 @@ static RetainPtr<CGImageRef> createImageWithCopiedData(CGImageRef sourceImage)
     RetainPtr screen = [NSScreen mainScreen];
 
     NSRect screenFrame = WebCore::safeScreenFrame(screen.get());
-    NSRect webViewFrame = convertRectToScreen([_webView window], [_webView convertRect:[_webView frame] toView:nil]);
+    RetainPtr webView = _webView.get();
+    NSRect webViewFrame = convertRectToScreen([webView window], [webView convertRect:[webView frame] toView:nil]);
 
     // Flip coordinate system:
     webViewFrame.origin.y = NSMaxY([[[NSScreen screens] objectAtIndex:0] frame]) - NSMaxY(webViewFrame);
 
-    CGWindowID windowID = [[_webView window] windowNumber];
+    CGWindowID windowID = [[webView window] windowNumber];
     RetainPtr webViewContents = WebCore::cgWindowListCreateImage(NSRectToCGRect(webViewFrame), kCGWindowListOptionIncludingWindow, windowID, kCGWindowImageShouldBeOpaque);
 
     // Using the returned CGImage directly would result in calls to the WindowServer every time
@@ -395,7 +396,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     page->startDeferringResizeEvents();
     page->startDeferringScrollEvents();
 #if HAVE(LIQUID_GLASS)
-    RetainPtr scrollPocketForPlaceholder = [_webView _copyTopScrollPocket];
+    RetainPtr scrollPocketForPlaceholder = [webView _copyTopScrollPocket];
 #endif
     _savedObscuredContentInsets = page->obscuredContentInsets();
     page->setObscuredContentInsets({ });
@@ -409,11 +410,11 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
     // Swap the webView placeholder into place.
     if (!_webViewPlaceholder)
-        _webViewPlaceholder = adoptNS([[WKFullScreenPlaceholderView alloc] initWithFrame:[_webView frame]]);
+        _webViewPlaceholder = adoptNS([[WKFullScreenPlaceholderView alloc] initWithFrame:[webView frame]]);
     [_webViewPlaceholder setTarget:nil];
     [_webViewPlaceholder setContents:(__bridge id)webViewContents.get()];
-    [self _saveConstraintsOf:[_webView superview]];
-    [self _replaceView:_webView.get().get() with:_webViewPlaceholder.get()];
+    [self _saveConstraintsOf:[webView superview]];
+    [self _replaceView:webView.get() with:_webViewPlaceholder.get()];
 #if HAVE(LIQUID_GLASS)
     [_webViewPlaceholder setTopScrollPocket:scrollPocketForPlaceholder.get() obscuredContentInsets:_savedObscuredContentInsets];
     [[_webViewPlaceholder window] registerScrollViewSeparatorTrackingAdapter:_webViewPlaceholder.get()];
@@ -421,9 +422,9 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     
     // Then insert the WebView into the full screen window
     RetainPtr contentView = [[self window] contentView];
-    [_clipView addSubview:_webView.get().get() positioned:NSWindowBelow relativeTo:nil];
+    [_clipView addSubview:webView.get() positioned:NSWindowBelow relativeTo:nil];
     auto obscuredContentInsets = page->obscuredContentInsets();
-    [_webView setFrame:NSInsetRect(contentView.get().bounds, -obscuredContentInsets.left(), -obscuredContentInsets.top())];
+    [webView setFrame:NSInsetRect(contentView.get().bounds, -obscuredContentInsets.left(), -obscuredContentInsets.top())];
 
     _savedScale = page->pageScaleFactor();
     page->scalePageRelativeToScrollPosition(1, { });
@@ -535,13 +536,14 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         page->setSuppressVisibilityUpdates(false);
 
         RetainPtr firstResponder = [[self window] firstResponder];
-        [self _replaceView:_webViewPlaceholder.get() with:_webView.get().get()];
+        RetainPtr webView = _webView.get();
+        [self _replaceView:_webViewPlaceholder.get() with:webView.get()];
         BEGIN_BLOCK_OBJC_EXCEPTIONS
         [NSLayoutConstraint activateConstraints:self.savedConstraints];
         END_BLOCK_OBJC_EXCEPTIONS
         self.savedConstraints = nil;
-        makeResponderFirstResponderIfDescendantOfView([_webView window], firstResponder.get(), _webView.get().get());
-        [[_webView window] makeKeyAndOrderFront:self];
+        makeResponderFirstResponderIfDescendantOfView([webView window], firstResponder.get(), webView.get());
+        [[webView window] makeKeyAndOrderFront:self];
 
         page->scalePageRelativeToScrollPosition(_savedScale, { });
         page->setObscuredContentInsets(_savedObscuredContentInsets);
@@ -553,12 +555,12 @@ ALLOW_DEPRECATED_DECLARATIONS_END
             location:[NSEvent mouseLocation]
             modifierFlags:[[NSApp currentEvent] modifierFlags]
             timestamp:[NSDate timeIntervalSinceReferenceDate]
-            windowNumber:[[_webView window] windowNumber]
+            windowNumber:[[webView window] windowNumber]
             context:nullptr
             eventNumber:0
             clickCount:0
             pressure:0];
-        WebKit::NativeWebMouseEvent webEvent(fakeEvent.get(), nil, _webView.get().get());
+        WebKit::NativeWebMouseEvent webEvent(fakeEvent.get(), nil, webView.get());
         page->handleMouseEvent(webEvent);
     }
     page->flushDeferredResizeEvents();
@@ -691,17 +693,18 @@ static RetainPtr<CGImageRef> takeWindowSnapshot(CGSWindowID windowID, bool captu
     NSRect exitPlaceholderScreenRect = _initialFrame;
     exitPlaceholderScreenRect.origin.y = NSMaxY(WebCore::safeScreenFrame([[NSScreen screens] objectAtIndex:0])) - NSMaxY(exitPlaceholderScreenRect);
 
-    RetainPtr<CGImageRef> webViewContents = takeWindowSnapshot([[_webView window] windowNumber], true);
+    RetainPtr webView = _webView.get();
+    RetainPtr<CGImageRef> webViewContents = takeWindowSnapshot([[webView window] windowNumber], true);
     webViewContents = adoptCF(CGImageCreateWithImageInRect(webViewContents.get(), NSRectToCGRect(exitPlaceholderScreenRect)));
     
-    _exitPlaceholder = adoptNS([[NSView alloc] initWithFrame:[_webView frame]]);
+    _exitPlaceholder = adoptNS([[NSView alloc] initWithFrame:[webView frame]]);
     [_exitPlaceholder setWantsLayer: YES];
     [_exitPlaceholder setAutoresizesSubviews: YES];
     [_exitPlaceholder setLayerContentsPlacement: NSViewLayerContentsPlacementScaleProportionallyToFit];
     [_exitPlaceholder setLayerContentsRedrawPolicy: NSViewLayerContentsRedrawNever];
-    [_exitPlaceholder setFrame:[_webView frame]];
+    [_exitPlaceholder setFrame:[webView frame]];
     [[_exitPlaceholder layer] setContents:(__bridge id)webViewContents.get()];
-    [[_webView superview] addSubview:_exitPlaceholder.get() positioned:NSWindowAbove relativeTo:_webView.get().get()];
+    [[webView superview] addSubview:_exitPlaceholder.get() positioned:NSWindowAbove relativeTo:webView.get()];
 
     [CATransaction commit];
     [CATransaction flush];
@@ -712,16 +715,16 @@ static RetainPtr<CGImageRef> takeWindowSnapshot(CGSWindowID windowID, bool captu
     [_backgroundView.get().layer removeAllAnimations];
     RefPtr page = _page.get();
     page->setSuppressVisibilityUpdates(true);
-    [_webView removeFromSuperview];
-    [_webView setFrame:[_webViewPlaceholder frame]];
-    [_webView setAutoresizingMask:[_webViewPlaceholder autoresizingMask]];
-    [[_webViewPlaceholder superview] addSubview:_webView.get().get() positioned:NSWindowBelow relativeTo:_webViewPlaceholder.get()];
+    [webView removeFromSuperview];
+    [webView setFrame:[_webViewPlaceholder frame]];
+    [webView setAutoresizingMask:[_webViewPlaceholder autoresizingMask]];
+    [[_webViewPlaceholder superview] addSubview:webView.get() positioned:NSWindowBelow relativeTo:_webViewPlaceholder.get()];
 
     BEGIN_BLOCK_OBJC_EXCEPTIONS
     [NSLayoutConstraint activateConstraints:self.savedConstraints];
     END_BLOCK_OBJC_EXCEPTIONS
     self.savedConstraints = nil;
-    makeResponderFirstResponderIfDescendantOfView([_webView window], firstResponder.get(), _webView.get().get());
+    makeResponderFirstResponderIfDescendantOfView([webView window], firstResponder.get(), webView.get());
 
     // These messages must be sent after the swap or flashing will occur during forceRepaint:
     manager->setAnimatingFullScreen(false);
@@ -741,7 +744,8 @@ static RetainPtr<CGImageRef> takeWindowSnapshot(CGSWindowID windowID, bool captu
     }
 
     page->updateRenderingWithForcedRepaint([weakSelf = WeakObjCPtr<WKFullScreenWindowController>(self)] {
-        [weakSelf completeFinishExitFullScreenAnimation];
+        if (RetainPtr strongSelf = weakSelf.get())
+            [strongSelf completeFinishExitFullScreenAnimation];
     });
 }
 
@@ -780,7 +784,7 @@ static RetainPtr<CGImageRef> takeWindowSnapshot(CGSWindowID windowID, bool captu
     [[_exitPlaceholder layer] setContents:nil];
     _exitPlaceholder = nil;
     
-    [[_webView window] makeKeyAndOrderFront:self];
+    [[_webView.get() window] makeKeyAndOrderFront:self];
     _webViewPlaceholder = nil;
     
     RefPtr page = _page.get();
@@ -946,7 +950,7 @@ static RetainPtr<CGImageRef> takeWindowSnapshot(CGSWindowID windowID, bool captu
     self.savedConstraints = [constraints objectsAtIndexes:validConstraints.get()];
 }
 
-static CAMediaTimingFunction *timingFunctionForDuration(CFTimeInterval duration)
+static RetainPtr<CAMediaTimingFunction> timingFunctionForDuration(CFTimeInterval duration)
 {
     if (duration >= 0.8)
         return [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionEaseInEaseOut];
@@ -973,7 +977,7 @@ static RetainPtr<CAAnimation> zoomAnimation(const WebCore::FloatRect& initialFra
     scaleAnimation.get().speed = speed;
     scaleAnimation.get().removedOnCompletion = NO;
     scaleAnimation.get().fillMode = kCAFillModeBoth;
-    scaleAnimation.get().timingFunction = timingFunctionForDuration(duration);
+    scaleAnimation.get().timingFunction = timingFunctionForDuration(duration).get();
     return scaleAnimation;
 }
 
@@ -1010,7 +1014,7 @@ static RetainPtr<CAAnimation> maskAnimation(const WebCore::FloatRect& initialFra
     animation.get().speed = speed;
     animation.get().removedOnCompletion = NO;
     animation.get().fillMode = kCAFillModeBoth;
-    animation.get().timingFunction = timingFunctionForDuration(duration);
+    animation.get().timingFunction = timingFunctionForDuration(duration).get();
     return animation;
 }
 
@@ -1024,7 +1028,7 @@ static RetainPtr<CAAnimation> fadeAnimation(CFTimeInterval duration, AnimationDi
     fadeAnimation.get().duration = duration;
     fadeAnimation.get().removedOnCompletion = NO;
     fadeAnimation.get().fillMode = kCAFillModeBoth;
-    fadeAnimation.get().timingFunction = timingFunctionForDuration(duration);
+    fadeAnimation.get().timingFunction = timingFunctionForDuration(duration).get();
     return fadeAnimation;
 }
 


### PR DESCRIPTION
#### 9efb84d8988d03291bb36a8e0a56a6e5e68a3f64
<pre>
Address safer CPP warnings in WKFullScreenWindowController
<a href="https://bugs.webkit.org/show_bug.cgi?id=300240">https://bugs.webkit.org/show_bug.cgi?id=300240</a>

Reviewed by Chris Dumez.

File not unskipped due to some seemingly false-positives left.

* Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm:
(-[WKFullScreenWindowController _continueEnteringFullscreenAfterPostingNotification:]):
(-[WKFullScreenWindowController finishedEnterFullScreenAnimation:]):
(-[WKFullScreenWindowController _continueExitingFullscreenAfterPostingNotificationAndExitImmediately:]):
(-[WKFullScreenWindowController completeFinishExitFullScreenAnimation]):
(timingFunctionForDuration):
(zoomAnimation):
(maskAnimation):
(fadeAnimation):

Canonical link: <a href="https://commits.webkit.org/301121@main">https://commits.webkit.org/301121@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0904c2a8d4623e3566564b99cc93fc43ac3c23b8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125014 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44683 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35420 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131863 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/76888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45375 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53249 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/95156 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/76888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127968 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36213 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111799 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75699 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/35134 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75345 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105976 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30182 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134539 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51836 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39635 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/103626 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52261 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108011 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103400 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26323 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48742 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27029 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48878 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51721 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/57514 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51095 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54452 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52786 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->