### PR TITLE
[JSC] WASM IPInt SIMD: fix register usage in argumINT/mINT stack_vector

### DIFF
--- a/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
@@ -10687,11 +10687,12 @@ mintAlign(_result_stack)
 
 # CallResultBytecode::ResultStackVector (0x11)
 mintAlign(_result_stack_vector)
-    # safe to use wfa0 since frN bytecodes always come before vector stack result
-    loadv [mintRetSrc], wfa0
-    addp 2 * SlotSize, mintRetSrc
     subp StackValueSize, mintRetDst
-    storev wfa0, [mintRetDst]
+    loadq [mintRetSrc], sc0
+    storeq sc0, [mintRetDst]
+    loadq 8[mintRetSrc], sc0
+    storeq sc0, 8[mintRetDst]
+    addp 2 * SlotSize, mintRetSrc
     mintRetDispatch()
 
 mintAlign(_end)
@@ -11105,9 +11106,11 @@ argumINTAlign(_stack)
     argumINTDispatch()
 
 argumINTAlign(_stack_vector)
-    loadv [argumINTSrc], ft0
+    loadq [argumINTSrc], csr0
+    storeq csr0, [argumINTDst]
+    loadq 8[argumINTSrc], csr0
+    storeq csr0, 8[argumINTDst]
     addp 2 * SlotSize, argumINTSrc
-    storev ft0, [argumINTDst]
     addp LocalSize, argumINTDst
     argumINTDispatch()
 


### PR DESCRIPTION
#### ea12b5282cdabc572524a96ebb79720da5ebb65a
<pre>
[JSC] WASM IPInt SIMD: fix register usage in argumINT/mINT stack_vector
<a href="https://bugs.webkit.org/show_bug.cgi?id=300242">https://bugs.webkit.org/show_bug.cgi?id=300242</a>
<a href="https://rdar.apple.com/162037890">rdar://162037890</a>

Reviewed by Yusuke Suzuki.

argumINT stack_vector is assuming that once the register argument
bytecodes are processed, there&apos;s no need to preserve the argument
registers themselves, since the values have been copied into
the wasm stack.

However, in the edge case when --useWasmIPInt=false and --useWasmIPIntSIMD=true,
the OSR prologue check will synchronously on-ramp to BBQ, and the
OSR prologue check happens after argumINT has run. So, let&apos;s not
clobber argument registers in argumINT. Also changing mINT to not
clobber the result results for consistency, and also because clobbering
these registers required a guarantee of bytecode ordering, which is
brittle.

Testing: Run simd-instructions-calls.js with --useWasmIPInt=false and --useWasmIPIntSIMD=true,
which had discovered this issue

* Source/JavaScriptCore/llint/InPlaceInterpreter64.asm:

Canonical link: <a href="https://commits.webkit.org/301079@main">https://commits.webkit.org/301079@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d5296e0b0311aaa3758c87eb9bb9e3dcc9583fc3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124875 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44546 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35282 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131721 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76775 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/73cbe3a1-caca-40ee-b73c-b60715066ea8) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45247 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53114 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95026 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/63054 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cd8887a8-10bb-4629-bf88-eef446ed1adf) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127829 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36098 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111678 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75583 "Found 1 new API test failure: WPE/TestWebKitWebContext:/webkit/WebKitWebContext/no-web-process-leak (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d35cdce8-df60-4921-8858-ed9688e5103c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35032 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29835 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75198 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/116983 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105858 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30063 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134389 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/123395 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51716 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39517 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103510 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52133 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107893 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103275 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26299 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48630 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26917 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48737 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51592 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57400 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/156420 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50981 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39175 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54337 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52674 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->