### PR TITLE
[ARMv7] [Draft] Add build option for using 64-bit offline asm JSRs

### DIFF
--- a/Source/JavaScriptCore/jit/RegisterSet.cpp
+++ b/Source/JavaScriptCore/jit/RegisterSet.cpp
@@ -229,7 +229,15 @@ RegisterSet RegisterSetBuilder::llintBaselineCalleeSaveRegisters()
     result.add(GPRInfo::regCS4, IgnoreVectors);
 #elif CPU(ARM_THUMB2)
     result.add(GPRInfo::regCS0, IgnoreVectors);
-    result.add(GPRInfo::regCS1, IgnoreVectors);
+    result.add(GPRInfo::regCS1, IgnoreVectors);i
+    result.add(FPRInfo::fpRegCS0, IgnoreVectors);
+    result.add(FPRInfo::fpRegCS1, IgnoreVectors);
+    result.add(FPRInfo::fpRegCS2, IgnoreVectors);
+    result.add(FPRInfo::fpRegCS3, IgnoreVectors);
+    result.add(FPRInfo::fpRegCS4, IgnoreVectors);
+    result.add(FPRInfo::fpRegCS5, IgnoreVectors);
+    result.add(FPRInfo::fpRegCS6, IgnoreVectors);
+    result.add(FPRInfo::fpRegCS7, IgnoreVectors);
 #elif CPU(ARM64) || CPU(RISCV64)
     result.add(GPRInfo::regCS6, IgnoreVectors);
     static_assert(GPRInfo::regCS7 == GPRInfo::jitDataRegister);
@@ -238,6 +246,14 @@ RegisterSet RegisterSetBuilder::llintBaselineCalleeSaveRegisters()
     result.add(GPRInfo::regCS7, IgnoreVectors);
     result.add(GPRInfo::regCS8, IgnoreVectors);
     result.add(GPRInfo::regCS9, IgnoreVectors);
+    result.add(FPRInfo::fpRegCS0, IgnoreVectors);
+    result.add(FPRInfo::fpRegCS1, IgnoreVectors);
+    result.add(FPRInfo::fpRegCS2, IgnoreVectors);
+    result.add(FPRInfo::fpRegCS3, IgnoreVectors);
+    result.add(FPRInfo::fpRegCS4, IgnoreVectors);
+    result.add(FPRInfo::fpRegCS5, IgnoreVectors);
+    result.add(FPRInfo::fpRegCS6, IgnoreVectors);
+    result.add(FPRInfo::fpRegCS7, IgnoreVectors);
 #else
     UNREACHABLE_FOR_PLATFORM();
 #endif
@@ -428,20 +444,36 @@ RegisterSet RegisterSetBuilder::wasmPinnedRegisters()
 
 RegisterSet RegisterSetBuilder::ipintCalleeSaveRegisters()
 {
-    RegisterSet registers;
+    RegisterSet result;
 #if CPU(X86_64)
-    registers.add(GPRInfo::regCS1, IgnoreVectors); // MC (pointer to metadata)
-    registers.add(GPRInfo::regCS2, IgnoreVectors); // PB
+    result.add(GPRInfo::regCS1, IgnoreVectors); // MC (pointer to metadata)
+    result.add(GPRInfo::regCS2, IgnoreVectors); // PB
 #elif CPU(ARM64) || CPU(RISCV64)
-    registers.add(GPRInfo::regCS6, IgnoreVectors); // MC
-    registers.add(GPRInfo::regCS7, IgnoreVectors); // PB
+    result.add(GPRInfo::regCS6, IgnoreVectors); // MC
+    result.add(GPRInfo::regCS7, IgnoreVectors); // PB
+    result.add(FPRInfo::fpRegCS0, IgnoreVectors);
+    result.add(FPRInfo::fpRegCS1, IgnoreVectors);
+    result.add(FPRInfo::fpRegCS2, IgnoreVectors);
+    result.add(FPRInfo::fpRegCS3, IgnoreVectors);
+    result.add(FPRInfo::fpRegCS4, IgnoreVectors);
+    result.add(FPRInfo::fpRegCS5, IgnoreVectors);
+    result.add(FPRInfo::fpRegCS6, IgnoreVectors);
+    result.add(FPRInfo::fpRegCS7, IgnoreVectors);
 #elif CPU(ARM)
-    registers.add(GPRInfo::regCS0, IgnoreVectors); // MC
-    registers.add(GPRInfo::regCS1, IgnoreVectors); // PB
+    result.add(GPRInfo::regCS0, IgnoreVectors); // MC
+    result.add(GPRInfo::regCS1, IgnoreVectors); // PB
+    result.add(FPRInfo::fpRegCS0, IgnoreVectors);
+    result.add(FPRInfo::fpRegCS1, IgnoreVectors);
+    result.add(FPRInfo::fpRegCS2, IgnoreVectors);
+    result.add(FPRInfo::fpRegCS3, IgnoreVectors);
+    result.add(FPRInfo::fpRegCS4, IgnoreVectors);
+    result.add(FPRInfo::fpRegCS5, IgnoreVectors);
+    result.add(FPRInfo::fpRegCS6, IgnoreVectors);
+    result.add(FPRInfo::fpRegCS7, IgnoreVectors);
 #else
 #error Unsupported architecture.
 #endif
-    return registers;
+    return result;
 }
 
 RegisterSet RegisterSetBuilder::bbqCalleeSaveRegisters()

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
@@ -29,7 +29,15 @@ macro saveIPIntRegisters()
     # to be observable within the same Wasm module.
     subp IPIntCalleeSaveSpaceStackAligned, sp
     if ARM64 or ARM64E
-        storepairq MC, PC, -2 * SlotSize[cfr]
+        storepairq MC, PC, - 8 * 8 - 2 * SlotSize[cfr]
+        stored csfr7, - 8 * 1[cfr]
+        stored csfr6, - 8 * 2[cfr]
+        stored csfr5, - 8 * 3[cfr]
+        stored csfr4, - 8 * 4[cfr]
+        stored csfr3, - 8 * 5[cfr]
+        stored csfr2, - 8 * 6[cfr]
+        stored csfr1, - 8 * 7[cfr]
+        stored csfr0, - 8 * 8[cfr]
     elsif X86_64 or RISCV64
         storep PC, -1 * SlotSize[cfr]
         storep MC, -2 * SlotSize[cfr]
@@ -41,7 +49,15 @@ macro restoreIPIntRegisters()
     # and restored when entering Wasm by the JSToWasm wrapper and changes to them are meant
     # to be observable within the same Wasm module.
     if ARM64 or ARM64E
-        loadpairq -2 * SlotSize[cfr], MC, PC
+        loadpairq - 8 * 8 - 2 * SlotSize[cfr], MC, PC
+        loadd -8 * 1[cfr], csfr7
+        loadd -8 * 2[cfr], csfr6
+        loadd -8 * 3[cfr], csfr5
+        loadd -8 * 4[cfr], csfr4
+        loadd -8 * 5[cfr], csfr3
+        loadd -8 * 6[cfr], csfr2
+        loadd -8 * 7[cfr], csfr1
+        loadd -8 * 8[cfr], csfr0
     elsif X86_64 or RISCV64
         loadp -1 * SlotSize[cfr], PC
         loadp -2 * SlotSize[cfr], MC

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
@@ -226,11 +226,11 @@ end
 const maxFrameExtentForSlowPathCall = constexpr maxFrameExtentForSlowPathCall
 
 if X86_64 or ARM64 or ARM64E or RISCV64
-    const CalleeSaveSpaceAsVirtualRegisters = 4
+    const CalleeSaveSpaceAsVirtualRegisters = 4 + 8
 elsif C_LOOP
     const CalleeSaveSpaceAsVirtualRegisters = 1
 elsif ARMv7
-    const CalleeSaveSpaceAsVirtualRegisters = 1
+    const CalleeSaveSpaceAsVirtualRegisters = 1 + 8 * 2
 else
     const CalleeSaveSpaceAsVirtualRegisters = 0
 end
@@ -968,11 +968,29 @@ macro preserveCalleeSavesUsedByLLInt()
     if C_LOOP
         storep metadataTable, -PtrSize[cfr]
     elsif ARMv7
-        storep PB, -4[cfr]
-        storep metadataTable, -8[cfr]
+        storep PB, - 8 * 8 - 4[cfr]
+        storep metadataTable, - 8 * 8 - 8[cfr]
+        stored csfr7, - 8 * 1[cfr]
+        stored csfr6, - 8 * 2[cfr]
+        stored csfr5, - 8 * 3[cfr]
+        stored csfr4, - 8 * 4[cfr]
+        stored csfr3, - 8 * 5[cfr]
+        stored csfr2, - 8 * 6[cfr]
+        stored csfr1, - 8 * 7[cfr]
+        stored csfr0, - 8 * 8[cfr]
+
     elsif ARM64 or ARM64E
-        storepairq csr8, csr9, -16[cfr]
-        storepairq csr6, csr7, -32[cfr]
+        storepairq csr8, csr9, - 8 * 8 - 16[cfr]
+        storepairq csr6, csr7, - 8 * 8 - 32[cfr]
+        stored csfr7, - 8 * 1[cfr]
+        stored csfr6, - 8 * 2[cfr]
+        stored csfr5, - 8 * 3[cfr]
+        stored csfr4, - 8 * 4[cfr]
+        stored csfr3, - 8 * 5[cfr]
+        stored csfr2, - 8 * 6[cfr]
+        stored csfr1, - 8 * 7[cfr]
+        stored csfr0, - 8 * 8[cfr]
+
     elsif X86_64
         storep csr4, -8[cfr]
         storep csr3, -16[cfr]
@@ -990,11 +1008,27 @@ macro restoreCalleeSavesUsedByLLInt()
     if C_LOOP
         loadp -PtrSize[cfr], metadataTable
     elsif ARMv7
-        loadp -4[cfr], PB
-        loadp -8[cfr], metadataTable
+        loadp - 8 * 8 - 4[cfr], PB
+        loadp - 8 * 8 - 8[cfr], metadataTable
+        stored csfr7, - 8 * 1[cfr]
+        stored csfr6, - 8 * 2[cfr]
+        stored csfr5, - 8 * 3[cfr]
+        stored csfr4, - 8 * 4[cfr]
+        stored csfr3, - 8 * 5[cfr]
+        stored csfr2, - 8 * 6[cfr]
+        stored csfr1, - 8 * 7[cfr]
+        stored csfr0, - 8 * 8[cfr]
     elsif ARM64 or ARM64E
-        loadpairq -32[cfr], csr6, csr7
-        loadpairq -16[cfr], csr8, csr9
+        loadpairq - 8 * 8 - 32[cfr], csr6, csr7
+        loadpairq - 8 * 8 - 16[cfr], csr8, csr9
+        loadd -8 * 1[cfr], csfr7
+        loadd -8 * 2[cfr], csfr6
+        loadd -8 * 3[cfr], csfr5
+        loadd -8 * 4[cfr], csfr4
+        loadd -8 * 5[cfr], csfr3
+        loadd -8 * 6[cfr], csfr2
+        loadd -8 * 7[cfr], csfr1
+        loadd -8 * 8[cfr], csfr0
     elsif X86_64
         loadp -32[cfr], csr1
         loadp -24[cfr], csr2

--- a/Source/JavaScriptCore/runtime/AssertInvariants.cpp
+++ b/Source/JavaScriptCore/runtime/AssertInvariants.cpp
@@ -73,9 +73,9 @@ void assertInvariants()
 #if ENABLE(C_LOOP)
         ASSERT(CodeBlock::llintBaselineCalleeSaveSpaceAsVirtualRegisters() == 1);
 #elif USE(JSVALUE32_64)
-        ASSERT(CodeBlock::llintBaselineCalleeSaveSpaceAsVirtualRegisters() == 1);
+        ASSERT(CodeBlock::llintBaselineCalleeSaveSpaceAsVirtualRegisters() == 1 + 8 * 2);
 #elif CPU(X86_64) || CPU(ARM64)
-        ASSERT(CodeBlock::llintBaselineCalleeSaveSpaceAsVirtualRegisters() == 4);
+        ASSERT(CodeBlock::llintBaselineCalleeSaveSpaceAsVirtualRegisters() == 4 + (isARM64() ? 8 : 0));
 #endif
 
         ASSERT(!(reinterpret_cast<ptrdiff_t>((reinterpret_cast<WriteBarrier<JSCell>*>(0x4000)->slot())) - 0x4000));

--- a/Source/JavaScriptCore/wasm/WasmCallingConvention.h
+++ b/Source/JavaScriptCore/wasm/WasmCallingConvention.h
@@ -40,7 +40,7 @@
 
 namespace JSC { namespace Wasm {
 
-constexpr unsigned numberOfIPIntCalleeSaveRegisters = 2;
+constexpr unsigned numberOfIPIntCalleeSaveRegisters = 2 + 8;
 constexpr unsigned numberOfIPIntInternalRegisters = 1; // UnboxedWasmCalleeStackSlot
 constexpr ptrdiff_t WasmToJSScratchSpaceSize = 0x8 * 1 + 0x8; // Needs to be aligned to 0x10.
 constexpr ptrdiff_t WasmToJSCallableFunctionSlot = -0x8;


### PR DESCRIPTION
#### 5ad0c8d092c64b26d7d12b1d99a01b0b36c3a098
<pre>
[ARMv7] [Draft] Add build option for using 64-bit offline asm JSRs
<a href="https://bugs.webkit.org/show_bug.cgi?id=300246">https://bugs.webkit.org/show_bug.cgi?id=300246</a>

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

No new tests (OOPS!).
* Source/JavaScriptCore/jit/RegisterSet.cpp:
(JSC::RegisterSetBuilder::llintBaselineCalleeSaveRegisters):
(JSC::RegisterSetBuilder::ipintCalleeSaveRegisters):
* Source/JavaScriptCore/llint/InPlaceInterpreter64.asm:
* Source/JavaScriptCore/llint/LowLevelInterpreter.asm:
* Source/JavaScriptCore/runtime/AssertInvariants.cpp:
(JSC::assertInvariants):
* Source/JavaScriptCore/wasm/WasmCallingConvention.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5ad0c8d092c64b26d7d12b1d99a01b0b36c3a098

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124891 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44561 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35297 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131737 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76821 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45257 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53127 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95045 "Failure limit exceed. At least found 198 new test failures: accessibility/accessibility-crash-with-dynamic-inline-content.html accessibility/accessibility-node-memory-management.html accessibility/accessibility-node-reparent.html accessibility/accessibility-object-update-during-style-resolution-crash.html accessibility/alt-tag-on-image-with-nonimage-role.html accessibility/anchor-linked-anonymous-block-crash.html accessibility/combobox/aria-combobox-control-owns-elements.html accessibility/combobox/aria-combobox-no-owns.html accessibility/combobox/combobox-active-element-selected-children.html accessibility/custom-elements/autocomplete.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/63087 "Found 60 new test failures: animations/3d/animate-to-transform-perpective-to-none.html animations/3d/change-transform-in-end-event.html animations/3d/full-rotation-animation.html animations/3d/replace-filling-transform.html animations/3d/state-at-end-event-transform.html animations/3d/transform-origin-vs-functions.html animations/3d/transform-perspective.html animations/CSSKeyframesRule-name-null.html animations/CSSKeyframesRule-parameters.html animations/added-while-suspended.html ... (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127845 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36113 "Found 60 new test failures: compositing/geometry/clipped-video-controller.html compositing/repaint/absolute-painted-into-composited-ancestor.html compositing/transforms/transformed-replaced-with-shadow-children.html compositing/video/video-controls-layer-creation.html contentfiltering/allow-media-document.html crypto/workers/subtle/aes-generate-export-key-jwk.html cssom/cssvalue-comparison.html editing/execCommand/change-list-type.html editing/execCommand/format-block-multiple-paragraphs.html editing/execCommand/insert-nested-lists-in-table.html ... (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111692 "Found 23 new API test failures: TestWebKitAPI.WKWebExtensionAPIDevTools.MessagePassingFromPanelToDevToolsBackground, TestWebKitAPI.WKInspectorDelegate.InspectorConfiguration, TestWebKitAPI.WKWebExtensionAPIDevTools.PortMessagePassingFromPanelToBackground, TestWebKitAPI.WebKit2.WebRTCAndRemoteCommands, TestWebKitAPI.WebKit.OnDeviceChangeCrash, TestWebKitAPI.Fullscreen.VideoLifecycle, TestWebKitAPI.WKInspectorExtensionHost.UnregisterExtension, TestWebKitAPI.WKInspectorExtensionHost.RegisterExtension, TestWebKitAPI.WKWebExtensionAPIDevTools.PortMessagePassingFromPanelToDevToolsBackground, TestWebKitAPI.WKInspectorExtension.EvaluateScriptOnPage ... (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75600 "Found 122 new API test failures: TestWebKit:WebKit.PrivateBrowsingPushStateNoHistoryCallback, WPE/TestWebKitWebView:/webkit/WebKitWebView/disable-web-security, TestJSC:/jsc/json, WPE/TestCookieManager:/webkit/WebKitCookieManager/sync-with-webview, WPE/TestWebKitWebContext:/webkit/WebKitWebContext/timezone, WPE/TestInputMethodContext:/webkit/WebKitInputMethodContext/content-type, WPE/TestWebKitUserContentManager:/webkit/WebKitUserContentManager/injected-style-sheet, WPE/TestWebKitWebView:/webkit/WebKitWebView/page-visibility, TestWebKit:WebKit.GeolocationBasicWithHighAccuracy, WPE/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy ... (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35048 "Found 60 new test failures: imported/w3c/web-platform-tests/FileAPI/blob/Blob-constructor.any.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-slice.any.worker.html imported/w3c/web-platform-tests/FileAPI/idlharness.any.html imported/w3c/web-platform-tests/FileAPI/idlharness.any.worker.html imported/w3c/web-platform-tests/FileAPI/idlharness.html imported/w3c/web-platform-tests/FileAPI/idlharness.worker.html imported/w3c/web-platform-tests/IndexedDB/idlharness.any.html imported/w3c/web-platform-tests/IndexedDB/idlharness.any.serviceworker.html imported/w3c/web-platform-tests/IndexedDB/idlharness.any.sharedworker.html imported/w3c/web-platform-tests/IndexedDB/idlharness.any.worker.html ... (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29848 "Found 60 new test failures: accessibility/mac/details-summary.html cssom/cssvalue-comparison.html editing/execCommand/change-list-type.html editing/execCommand/format-block-multiple-paragraphs.html editing/execCommand/insert-nested-lists-in-table.html editing/pasteboard/datatransfer-idl.html editing/pasteboard/paste-table-with-unrendered-text-nodes.html fast/canvas/webgl/gl-teximage-imagebitmap-memory.html fast/canvas/webgl/premultiplyalpha-test.html fast/canvas/webgl/renderbuffer-initialization.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75216 "Built successfully") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/116998 "Found 1 new JSC binary failure: testapi, Found 122385 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/ArrayBtreeBadCodeGen.js.default, ChakraCore.yaml/ChakraCore/test/Array/ArrayElementMissingValueSetToZero.js.default, ChakraCore.yaml/ChakraCore/test/Array/InlineArrayPopWithIntConstSrc.js.default, ChakraCore.yaml/ChakraCore/test/Array/LastUsedSegmentHasNULLElement.js.default, ChakraCore.yaml/ChakraCore/test/Array/SegmentMapFlagResetInJSArrayConstructor.js.default, ChakraCore.yaml/ChakraCore/test/Array/TryGrowHeadSegmentBug.js.default, ChakraCore.yaml/ChakraCore/test/Array/arr_bailout.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_apply.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_ctr.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_fastinit.js.default ... (failure)") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105873 "Found 41 new API test failures: TestWebKitAPI.SiteIsolation.PlayAudioInRemoteFrameThenRemove, TestWebKitAPI.Fullscreen.DisallowsInlinePlaybackInMobileContentMode, TestWebKitAPI.URLSchemeHandler.Ranges, TestWebKitAPI.NowPlayingMetadataObserver.VideoTitleUpdatedByMediaSession, TestWebKitAPI.WKWebViewSuspendAllMediaPlayback.PauseWhenResume, TestWebKitAPI.WebKit2.GetUserMediaAfterMuting, TestWebKitAPI.WebKit2.CaptureIndicatorDelay, TestWebKitAPI.WebKit.MSEHasMediaStreamingActivity, TestWebKitAPI.WebKit2.CaptureIndicatorDelayWhenClosed, TestWebKitAPI.WebKit2.CloseWKWebViewShortlyAfterStartingToCapture ... (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30077 "Found 60 new test failures: editing/execCommand/change-list-type.html editing/execCommand/format-block-multiple-paragraphs.html editing/execCommand/insert-nested-lists-in-table.html editing/pasteboard/datatransfer-idl.html fast/canvas/webgl/gl-teximage-imagebitmap-memory.html fast/canvas/webgl/premultiplyalpha-test.html fast/canvas/webgl/tex-image-and-sub-image-2d-with-video-rgba4444.html fast/canvas/webgl/uninitialized-test.html fast/canvas/webgl/webgl2/constants.html fast/css-grid-layout/grid-simplified-layout-positioned.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134418 "Built successfully") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/123410 "Found 6159 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/ControlFlow/enumeration_adddelete.js.default, ChakraCore.yaml/ChakraCore/test/Error/CallNonFunction.js.default, ChakraCore.yaml/ChakraCore/test/Function/callmissingtgt.js.default, ChakraCore.yaml/ChakraCore/test/es5/defineIndexProperty.js.default, ChakraCore.yaml/ChakraCore/test/es5/defineProperty.js.default, airjs-tests.yaml/stress-test.js.bytecode-cache, airjs-tests.yaml/stress-test.js.default, airjs-tests.yaml/stress-test.js.dfg-eager, airjs-tests.yaml/stress-test.js.dfg-eager-no-cjit-validate, airjs-tests.yaml/stress-test.js.eager-jettison-no-cjit ... (failure)") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51726 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39531 "Found 60 new test failures: editing/execCommand/change-list-type.html editing/execCommand/format-block-multiple-paragraphs.html editing/pasteboard/datatransfer-idl.html fast/canvas/webgl/debug-messages-to-console.html fast/canvas/webgl/gl-teximage-imagebitmap-memory.html fast/canvas/webgl/webgl-clear-composited-notshowing.html fast/canvas/webgl/webgl2/constants.html fast/dom/SelectorAPI/resig-SelectorsAPI-test.xhtml fast/events/media-element-focus-tab.html fast/forms/input-implicit-length-limit.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103529 "2 flakes 1 failures") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52147 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107907 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103301 "Found 135 new API test failures: TestWebKit:WebKit.PrivateBrowsingPushStateNoHistoryCallback, WebKitGTK/TestOptionMenu:/webkit/WebKitWebView/option-menu-activate, WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/is-web-process-responsive, TestJSC:/jsc/global-object, TestWebKit:WebKit.GeolocationTransitionToHighAccuracy, WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/notification-initial-permission-allowed, TestJSC:/jsc/object, TestWebKit:WebKit.UserMediaBasic, TestWebKit:WebKit.PageLoadDidChangeLocationWithinPage, WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/notification ... (failure)") | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48643 "Found 1 new test failure: imported/w3c/web-platform-tests/webxr/idlharness.https.window.html (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26931 "Found 60 new test failures: accessibility/ARIA-reflection.html accessibility/accessibility-crash-focused-element-change.html accessibility/accessibility-crash-setattribute.html accessibility/combobox/aria-combobox-control-owns-elements.html accessibility/combobox/aria-combobox-hierarchy.html accessibility/combobox/aria-combobox-no-owns.html accessibility/combobox/mac/aria-combobox-activedescendant.html accessibility/combobox/mac/combobox-activedescendant-notifications.html accessibility/combobox/mac/combobox-inherited-role.html accessibility/custom-elements/autocomplete.html ... (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48747 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51603 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57410 "Built successfully") | [❌ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/156436 "Hash 5ad0c8d0 for PR 51879 does not build (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50990 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/156436 "Hash 5ad0c8d0 for PR 51879 does not build (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54346 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52683 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->