### PR TITLE
[visionOS] Define an AVKit_SPI module for Public SDK builds

### DIFF
--- a/Source/WebKit/Platform/spi/Cocoa/AVKit_SPI.swiftinterface
+++ b/Source/WebKit/Platform/spi/Cocoa/AVKit_SPI.swiftinterface
@@ -1,0 +1,301 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -enable-objc-interop -enable-library-evolution -swift-version 5 -enforce-exclusivity=checked -O -library-level spi -enable-bare-slash-regex -user-module-version 1270 -module-name AVKit_SPI -module-abi-name AVKit
+
+#if os(visionOS)
+
+@_exported import AVKit
+
+import _Concurrency
+import Combine
+import CoreMedia
+import Foundation
+import QuartzCore
+import RealityFoundation
+import Swift
+import UIKit
+// FIXME (147782145): Define a clang module for XPC to be used in Public SDK builds
+//import XPC
+
+@_inheritsConvenienceInitializers @_hasMissingDesignatedInitializers @objc(LMPlayableViewController) @_Concurrency.MainActor(unsafe) public class PlayableViewController : UIKit.UIViewController {
+  public var playable: (any Playable)? { get set }
+  public var prefersAutoDimming: Swift.Bool { get set }
+  public var automaticallyDockOnFullScreenPresentation: Swift.Bool { get set }
+  public var dismissFullScreenOnExitingDocking: Swift.Bool { get set }
+  public var environmentPickerButtonViewController: UIKit.UIViewController? { get }
+}
+
+public enum ContentType : Swift.Equatable, Swift.CaseIterable, Swift.Codable, Swift.Sendable {
+ case immersive
+ case spatial
+ case planar
+ case audioOnly
+ public static func == (a: ContentType, b: ContentType) -> Swift.Bool
+ public func hash(into hasher: inout Swift.Hasher)
+ public typealias AllCases = [ContentType]
+ public static var allCases: [ContentType] {
+   get
+ }
+ public func encode(to encoder: any Swift.Encoder) throws
+ public var hashValue: Swift.Int {
+   get
+ }
+ public init(from decoder: any Swift.Decoder) throws
+ public static func makeEntity(captionLayer: QuartzCore.CALayer) -> RealityFoundation.Entity?
+ public static func makeSpatialEntity(videoMetadata: SpatialVideoMetadata?, extruded: Swift.Bool = true) -> (any RealityFoundation.Entity & Peculiarable)?
+}
+public enum PresentationMode {
+ case inline
+ case fullscreen
+ case fullscreenFromInline
+ case pip
+ public static func == (a: PresentationMode, b: PresentationMode) -> Swift.Bool
+ public func hash(into hasher: inout Swift.Hasher)
+ public var hashValue: Swift.Int {
+   get
+ }
+}
+public struct RenderingConfiguration : Swift.Equatable {
+ public var contentType: ContentType?
+ public var wantsThumbnailLayerPublished: Swift.Bool
+ public var wantsThumbnailMaterialPublished: Swift.Bool
+ public var wantsVideoLayerPublished: Swift.Bool
+ public var wantsVideoMaterialPublished: Swift.Bool
+ public var wantsVideoAssetPublished: Swift.Bool
+ public var wantsPeculiarEntityPublished: Swift.Bool
+ public static func == (a: RenderingConfiguration, b: RenderingConfiguration) -> Swift.Bool
+}
+public enum ViewingMode {
+ case mono
+ case stereo
+ case immersive
+ public static var unique: ViewingMode {
+   get
+ }
+ case spatial
+ public static var singular: ViewingMode {
+   get
+ }
+ public static func == (a: ViewingMode, b: ViewingMode) -> Swift.Bool
+ public func hash(into hasher: inout Swift.Hasher)
+ public var hashValue: Swift.Int {
+   get
+ }
+}
+public struct SeekMetadata {
+  public enum Origin {
+    case user
+    public static func == (a: SeekMetadata.Origin, b: SeekMetadata.Origin) -> Swift.Bool
+    public func hash(into hasher: inout Swift.Hasher)
+    public var hashValue: Swift.Int {
+      get
+    }
+  }
+  public let origin: SeekMetadata.Origin
+  public init(origin: SeekMetadata.Origin)
+}
+public protocol Track : AnyObject {
+  var localizedDisplayName: Swift.String { get }
+}
+public enum ImmersiveViewingMode {
+  case portal
+  case full
+  case progressive
+  @available(*, deprecated, renamed: "full", message: "Use .full instead.")
+  public static let immersive = ImmersiveViewingMode.full
+}
+@available(*, deprecated, renamed: "ImmersiveViewingMode", message: "Use ImmersiveViewingMode instead.")
+public typealias PeculiarMode = ImmersiveViewingMode
+public struct SpatialVideoMetadata {
+  public init(width: Swift.Int32, height: Swift.Int32, horizontalFOVDegrees: Swift.Float, baseline: Swift.Float, disparityAdjustment: Swift.Float, isRecommendedForImmersive: Swift.Bool)
+  public var width: Swift.Int32
+  public var height: Swift.Int32
+  public var horizontalFOVDegrees: Swift.Float
+  public var baseline: Swift.Float
+  public var disparityAdjustment: Swift.Float
+  public var isRecommendedForImmersive: Swift.Bool
+}
+public protocol Peculiarable {
+ func setScreen(width: Swift.Float, height: Swift.Float)
+ var screenMode: PeculiarMode { get set }
+ var supportedScreenModes: [PeculiarMode] { get }
+ var screenGUIDPublisher: Combine.AnyPublisher<Swift.UInt64?, Swift.Never> { get }
+ var shouldDisplayThumbnail: Swift.Bool { get }
+ var preferStereoPlayback: Swift.Bool { get set }
+ func setVideoMetaData(to: SpatialVideoMetadata?)
+// FIXME (147782145): Define a clang module for XPC to be used in Public SDK builds
+// var videoReceiverEndpointPublisher: Combine.AnyPublisher<XPC.xpc_object_t?, Swift.Never> { get }
+}
+public typealias PeculiarEntity = RealityFoundation.Entity & Peculiarable
+public enum ContentMode : Swift.Int, Swift.CaseIterable {
+ case scaleAspectFit
+ case scaleAspectFill
+ case scaleToFill
+ public static var `default`: ContentMode
+ public init?(rawValue: Swift.Int)
+ public typealias AllCases = [ContentMode]
+ public typealias RawValue = Swift.Int
+ public static var allCases: [ContentMode] {
+   get
+ }
+ public var rawValue: Swift.Int {
+   get
+ }
+}
+public protocol ContentMetadataKey {
+ associatedtype Value : Swift.Equatable
+ static var name: Swift.String { get }
+}
+public struct ContentMetadata {
+ public enum DisplayTitle : ContentMetadataKey {
+   public typealias Value = Swift.String
+   public static var name: Swift.String
+ }
+ public let displayTitle: ContentMetadata.DisplayTitle
+ public enum DisplaySubtitle : ContentMetadataKey {
+   public typealias Value = Swift.String
+   public static var name: Swift.String
+ }
+ public let displaySubtitle: ContentMetadata.DisplaySubtitle
+ public enum AnticipatedStartDate : ContentMetadataKey {
+   public typealias Value = Foundation.Date
+   public static var name: Swift.String
+ }
+ public let anticipatedStartDate: ContentMetadata.AnticipatedStartDate
+ public enum AnticipatedEndDate : ContentMetadataKey {
+   public typealias Value = Foundation.Date
+   public static var name: Swift.String
+ }
+ public let anticipatedEndDate: ContentMetadata.AnticipatedEndDate
+}
+@dynamicMemberLookup public struct ContentMetadataContainer {
+ public init()
+ public subscript<K>(dynamicMember keyPath: Swift.KeyPath<ContentMetadata, K>) -> K.Value? where K : ContentMetadataKey {
+   get
+   set
+ }
+}
+public struct FullscreenBehaviors : Swift.OptionSet, Swift.CustomStringConvertible {
+ public let rawValue: Swift.Int
+ public init(rawValue: Swift.Int)
+ public static let sceneResize: FullscreenBehaviors
+ public static let sceneSizeRestrictions: FullscreenBehaviors
+ public static let sceneChromeOptions: FullscreenBehaviors
+ public static let hostContentInline: FullscreenBehaviors
+ public static let `default`: [FullscreenBehaviors]
+ public var description: Swift.String {
+   get
+ }
+ public typealias ArrayLiteralElement = FullscreenBehaviors
+ public typealias Element = FullscreenBehaviors
+ public typealias RawValue = Swift.Int
+}
+public protocol Playable : AnyObject {
+ var presentationModePublisher: Combine.AnyPublisher<PresentationMode, Swift.Never> { get }
+ func makeDefaultEntity() -> RealityFoundation.Entity?
+ func updateRenderingConfiguration(_ config: RenderingConfiguration)
+ var errorPublisher: Combine.AnyPublisher<(any Swift.Error)?, Swift.Never> { get }
+ var isLoadingPublisher: Combine.AnyPublisher<Swift.Bool, Swift.Never> { get }
+ @available(*, deprecated, message: "Replaced by 'playbackRatePublisher'")
+ var isPlayingPublisher: Combine.AnyPublisher<Swift.Bool, Swift.Never> { get }
+ var playbackRatePublisher: Combine.AnyPublisher<Swift.Double, Swift.Never> { get }
+ var selectedPlaybackRatePublisher: Combine.AnyPublisher<Swift.Double, Swift.Never> { get }
+ var playbackRatesPublisher: Combine.AnyPublisher<[Swift.Double], Swift.Never> { get }
+ var requiresLinearPlaybackPublisher: Combine.AnyPublisher<Swift.Bool, Swift.Never> { get }
+ var canTogglePlaybackPublisher: Combine.AnyPublisher<Swift.Bool, Swift.Never> { get }
+ var showsPlaybackControlsPublisher: Combine.AnyPublisher<Swift.Bool, Swift.Never> { get }
+ func play()
+ func pause()
+ func togglePlayback()
+ func setPlaybackRate(_ rate: Swift.Double)
+ var interstitialRangesPublisher: Combine.AnyPublisher<[Swift.Range<Foundation.TimeInterval>], Swift.Never> { get }
+ var isInterstitialActivePublisher: Combine.AnyPublisher<Swift.Bool, Swift.Never> { get }
+ func skipActiveInterstitial()
+ var currentTimePublisher: Combine.AnyPublisher<Foundation.TimeInterval, Swift.Never> { get }
+ var remainingTimePublisher: Combine.AnyPublisher<Foundation.TimeInterval, Swift.Never> { get }
+ var durationPublisher: Combine.AnyPublisher<Foundation.TimeInterval, Swift.Never> { get }
+ func setTimeResolverInterval(_ interval: Foundation.TimeInterval)
+ func setTimeResolverResolution(_ resolution: Swift.Double)
+ var thumbnailLayerPublisher: Combine.AnyPublisher<QuartzCore.CALayer?, Swift.Never> { get }
+ var thumbnailMaterialPublisher: Combine.AnyPublisher<RealityFoundation.VideoMaterial?, Swift.Never> { get }
+ func setThumbnailSize(_ size: CoreFoundation.CGSize)
+ func seekThumbnail(to time: Foundation.TimeInterval)
+ var captionLayerPublisher: Combine.AnyPublisher<QuartzCore.CALayer?, Swift.Never> { get }
+ @available(*, deprecated, message: "Use captionContentInsetsPublisher and setCaptionContentInsets instead.")
+ var captionContentInsets: UIKit.UIEdgeInsets { get set }
+ var captionContentInsetsPublisher: Combine.AnyPublisher<UIKit.UIEdgeInsets, Swift.Never> { get }
+ func setCaptionContentInsets(_ insets: UIKit.UIEdgeInsets)
+ var isSeekingPublisher: Combine.AnyPublisher<Swift.Bool, Swift.Never> { get }
+ var canSeekPublisher: Combine.AnyPublisher<Swift.Bool, Swift.Never> { get }
+ var seekableTimeRangesPublisher: Combine.AnyPublisher<[Swift.ClosedRange<Foundation.TimeInterval>], Swift.Never> { get }
+ @available(*, deprecated, message: "Replace with seek(to:from:metadata:)")
+ func seek(to time: Foundation.TimeInterval)
+ @available(*, deprecated, message: "Replace with seek(to:from:metadata:)")
+ func seek(delta: Foundation.TimeInterval)
+ func seek(to destination: Foundation.TimeInterval, from source: Foundation.TimeInterval, metadata: SeekMetadata) -> Foundation.TimeInterval
+ func beginScrubbing()
+ func endScrubbing()
+ var canScanForwardPublisher: Combine.AnyPublisher<Swift.Bool, Swift.Never> { get }
+ func beginScanningForward()
+ func endScanningForward()
+ var canScanBackwardPublisher: Combine.AnyPublisher<Swift.Bool, Swift.Never> { get }
+ func beginScanningBackward()
+ func endScanningBackward()
+ var isTrimmingPublisher: Combine.AnyPublisher<Swift.Bool, Swift.Never> { get }
+ var forwardPlaybackEndTimePublisher: Combine.AnyPublisher<CoreMedia.CMTime?, Swift.Never> { get }
+ var reversePlaybackEndTimePublisher: Combine.AnyPublisher<CoreMedia.CMTime?, Swift.Never> { get }
+ var trimViewPublisher: Combine.AnyPublisher<UIKit.UIView?, Swift.Never> { get }
+ func completeTrimming(commitChanges: Swift.Bool)
+ func updateStartTime(_ time: Foundation.TimeInterval)
+ func updateEndTime(_ time: Foundation.TimeInterval)
+ var contentTypePublisher: Combine.AnyPublisher<ContentType?, Swift.Never> { get }
+ var contentMetadataPublisher: Combine.AnyPublisher<ContentMetadataContainer, Swift.Never> { get }
+ var artworkPublisher: Combine.AnyPublisher<Foundation.Data?, Swift.Never> { get }
+ var isPlayableOfflinePublisher: Combine.AnyPublisher<Swift.Bool, Swift.Never> { get }
+ var contentInfoViewControllersPublisher: Combine.AnyPublisher<[UIKit.UIViewController], Swift.Never> { get }
+ var contextualActionsPublisher: Combine.AnyPublisher<[UIKit.UIAction], Swift.Never> { get }
+ var contextualActionsInfoViewPublisher: Combine.AnyPublisher<UIKit.UIView?, Swift.Never> { get }
+ var transportBarIncludesTitleViewPublisher: Combine.AnyPublisher<Swift.Bool, Swift.Never> { get }
+ var contentDimensionsPublisher: Combine.AnyPublisher<CoreFoundation.CGSize, Swift.Never> { get }
+ var contentModePublisher: Combine.AnyPublisher<ContentMode, Swift.Never> { get }
+ var videoLayerPublisher: Combine.AnyPublisher<QuartzCore.CALayer?, Swift.Never> { get }
+ var videoMaterialPublisher: Combine.AnyPublisher<RealityFoundation.VideoMaterial?, Swift.Never> { get }
+ @available(*, deprecated, message: "Will be removed during seed -1")
+ var peculiarEntityPublisher: Combine.AnyPublisher<(any RealityFoundation.Entity & Peculiarable)?, Swift.Never> { get }
+ func updateVideoBounds(_ bounds: CoreFoundation.CGRect)
+ var anticipatedViewingModePublisher: Combine.AnyPublisher<ViewingMode?, Swift.Never> { get }
+ func updateViewingMode(_ viewingMode: ViewingMode?)
+ var contentOverlayPublisher: Combine.AnyPublisher<UIKit.UIView?, Swift.Never> { get }
+ var contentOverlayViewControllerPublisher: Combine.AnyPublisher<UIKit.UIViewController?, Swift.Never> { get }
+// FIXME (147782145): Define a clang module for XPC to be used in Public SDK builds
+// func setVideoReceiverEndpoint(_ endpoint: XPC.xpc_object_t)
+ var volumePublisher: Combine.AnyPublisher<Swift.Double, Swift.Never> { get }
+ func setVolume(_ volume: Swift.Double)
+ func beginEditingVolume()
+ func endEditingVolume()
+ var isMutedPublisher: Combine.AnyPublisher<Swift.Bool, Swift.Never> { get }
+ func setIsMuted(_ value: Swift.Bool)
+ var sessionThumbnailPublisher: Combine.AnyPublisher<UIKit.UIImage?, Swift.Never> { get }
+ var isSessionExtendedPublisher: Combine.AnyPublisher<Swift.Bool, Swift.Never> { get }
+ var hasAudioContentPublisher: Combine.AnyPublisher<Swift.Bool, Swift.Never> { get }
+ var currentAudioTrackPublisher: Combine.AnyPublisher<(any Track)?, Swift.Never> { get }
+ var audioTracksPublisher: Combine.AnyPublisher<[any Track]?, Swift.Never> { get }
+ func setAudioTrack(_ newTrack: (any Track)?)
+ var currentLegibleTrackPublisher: Combine.AnyPublisher<(any Track)?, Swift.Never> { get }
+ var legibleTracksPublisher: Combine.AnyPublisher<[any Track]?, Swift.Never> { get }
+ func setLegibleTrack(_ newTrack: (any Track)?)
+ var allowPipPublisher: Combine.AnyPublisher<Swift.Bool, Swift.Never> { get }
+ func togglePip()
+ func toggleInlineMode()
+ var allowFullScreenFromInlinePublisher: Combine.AnyPublisher<Swift.Bool, Swift.Never> { get }
+ var isLiveStreamPublisher: Combine.AnyPublisher<Swift.Bool, Swift.Never> { get }
+ var startDatePublisher: Combine.AnyPublisher<Foundation.Date, Swift.Never> { get }
+ var endDatePublisher: Combine.AnyPublisher<Foundation.Date, Swift.Never> { get }
+ var recommendedViewingRatioPublisher: Combine.AnyPublisher<Swift.Double?, Swift.Never> { get }
+ var fullscreenSceneBehaviorsPublisher: Combine.AnyPublisher<[FullscreenBehaviors], Swift.Never> { get }
+ func willEnterFullscreen()
+ func didCompleteEnterFullscreen(result: Swift.Result<Swift.Void, any Swift.Error>)
+ func willExitFullscreen()
+ func didCompleteExitFullscreen(result: Swift.Result<Swift.Void, any Swift.Error>)
+}
+
+#endif // os(visionOS)

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -7456,6 +7456,7 @@
 		A1A4FE5818DCE9FA00B5EA8A /* _WKDownload.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKDownload.mm; sourceTree = "<group>"; };
 		A1A4FE5918DCE9FA00B5EA8A /* _WKDownloadInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKDownloadInternal.h; sourceTree = "<group>"; };
 		A1A4FE6018DD54A400B5EA8A /* _WKDownloadDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKDownloadDelegate.h; sourceTree = "<group>"; };
+		A1A53A0F2E943B3E002BAD2D /* AVKit_SPI.swiftinterface */ = {isa = PBXFileReference; lastKnownFileType = text; path = AVKit_SPI.swiftinterface; sourceTree = "<group>"; };
 		A1AE0EC12B1663D4008A2563 /* ExtensionCapabilityGranter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ExtensionCapabilityGranter.h; sourceTree = "<group>"; };
 		A1AE0EC22B1663D4008A2563 /* ExtensionCapabilityGranter.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ExtensionCapabilityGranter.mm; sourceTree = "<group>"; };
 		A1B9CA382246E54A003D6DCA /* WebPaymentCoordinatorCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WebPaymentCoordinatorCocoa.mm; sourceTree = "<group>"; };
@@ -12271,6 +12272,7 @@
 				9565083826D87A2B00E15CB7 /* AppleMediaServicesUISPI.h */,
 				EBA8D3AA27A5E31300CB7900 /* ApplePushServiceSPI.h */,
 				57FABB0E25817CF00059DC95 /* AuthenticationServicesCoreSPI.h */,
+				A1A53A0F2E943B3E002BAD2D /* AVKit_SPI.swiftinterface */,
 				1A5705101BE410E500874AF1 /* BlockSPI.h */,
 				E50620912542102000C43091 /* ContactsUISPI.h */,
 				37C21CAD1E994C0C0029D5F9 /* CorePredictionSPI.h */,

--- a/Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaPlayer.swift
+++ b/Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaPlayer.swift
@@ -30,7 +30,11 @@ import UIKit
 import os
 
 #if canImport(AVKit, _version: 1270)
+#if USE_APPLE_INTERNAL_SDK
 @_spi(LinearMediaKit) import AVKit
+#else
+import AVKit_SPI
+#endif
 #else
 import LinearMediaKit
 #endif

--- a/Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaTypes.swift
+++ b/Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaTypes.swift
@@ -24,7 +24,11 @@
 #if os(visionOS)
 
 #if canImport(AVKit, _version: 1270)
+#if USE_APPLE_INTERNAL_SDK
 @_spi(LinearMediaKit) @_spi(LinearMediaKit_WebKitOnly) import AVKit
+#else
+import AVKit_SPI
+#endif
 #else
 @_spi(WebKitOnly) import LinearMediaKit
 #endif


### PR DESCRIPTION
#### a599067e584d8888072bbe178c2692fc457d8b3c
<pre>
[visionOS] Define an AVKit_SPI module for Public SDK builds
<a href="https://bugs.webkit.org/show_bug.cgi?id=300252">https://bugs.webkit.org/show_bug.cgi?id=300252</a>
<a href="https://rdar.apple.com/162059769">rdar://162059769</a>

Reviewed by Abrar Rahman Protyasha.

Added AVKit_SPI.swiftinterface, which declares the LinearMediaKit SPI used by WebKit that -- as of
visionOS 26 -- is now part of the AVKit framework.

* Source/WebKit/Platform/spi/Cocoa/AVKit_SPI.swiftinterface: Added.
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaPlayer.swift:
* Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaTypes.swift:

Canonical link: <a href="https://commits.webkit.org/301097@main">https://commits.webkit.org/301097@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2ef53eeba5bdc2157dd5a6e94ea664bb81003801

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124905 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44575 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35311 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131753 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76796 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/930aa8c6-1c02-4b92-b61a-98cd7b6ba850) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45270 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53141 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95055 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/63069 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d29a21be-26c2-426a-9c62-5572b30d5e6c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127859 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36120 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111704 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75609 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ba18f090-59b8-4d7f-b940-f00af16cd612) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35055 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75231 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105880 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30089 "Found 1 new test failure: fast/images/imagebitmap-memory.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134425 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51739 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39543 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103535 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52160 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107918 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103309 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26307 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48654 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26943 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48760 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51618 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57422 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51002 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54358 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52695 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->