### PR TITLE
AX: The Node& variant of AXObjectCache::getOrCreate scopes a renderer CheckedPtr far larger than necessary, which can cause an unnecessary crash

### DIFF
--- a/LayoutTests/accessibility/dynamic-frame-prepend-crash-expected.txt
+++ b/LayoutTests/accessibility/dynamic-frame-prepend-crash-expected.txt
@@ -1,0 +1,8 @@
+This test ensures we don't crash when prepending a frame in response to an XHR event.
+
+Test completed without crashing.
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/dynamic-frame-prepend-crash.html
+++ b/LayoutTests/accessibility/dynamic-frame-prepend-crash.html
@@ -1,0 +1,54 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body>
+
+<div id="container"></div>
+
+<script>
+var output = "This test ensures we don't crash when prepending a frame in response to an XHR event.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    // Enable accessibility by walking the tree.
+    touchAccessibilityTree(accessibilityController.rootElement);
+
+    var xhr = new XMLHttpRequest();
+    xhr.addEventListener("load", function() {
+        var iframe = document.createElement("iframe");
+        iframe.srcdoc = "<!DOCTYPE html><html><body><input type='date'></body></html>";
+        document.getElementById("container").prepend(iframe);
+
+        // Wrap the #container in a new div so that AccessibilityScrollView::parentObject getOrCreate's a new object,
+        // causing recomputeIsIgnored() to run and trigger any queued side effects.
+        var newDiv = document.createElement("div");
+        document.body.appendChild(newDiv);
+        newDiv.prepend(document.getElementById("container"));
+        // Remove the iframes renderer.
+        iframe.setAttribute("style", "display:none")
+
+        setTimeout(function() {
+            // Asynchronously queue up a style change that will destroy the renderers associated with these elements.
+            document.getElementById("container").setAttribute("style", "display:contents")
+            newDiv.setAttribute("style", "display:contents")
+        }, 0);
+
+        setTimeout(async function() {
+            touchAccessibilityTree(accessibilityController.rootElement);
+            output += "Test completed without crashing.\n";
+
+            debug(output);
+            finishJSTest();
+        }, 32 /* 32ms to wait out 2 rendering frames (which are typically 16ms apart). */);
+    });
+
+    xhr.open("GET", "data:text/plain,test");
+    xhr.send();
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -728,10 +728,11 @@ AccessibilityObject* AXObjectCache::getOrCreateSlow(Node& node, IsPartOfRelation
     ASSERT(&node.document() == document());
 #endif
 
-    CheckedPtr renderer = node.renderer();
-    if (renderer) {
+    bool isYouTubeReplacement = false;
+    if (CheckedPtr renderer = node.renderer()) {
         if (!renderer->isYouTubeReplacement()) [[likely]]
             return getOrCreate(*renderer);
+        isYouTubeReplacement = true;
     }
 
     if (CheckedPtr document = dynamicDowncast<Document>(node)) [[unlikely]]
@@ -781,7 +782,7 @@ AccessibilityObject* AXObjectCache::getOrCreateSlow(Node& node, IsPartOfRelation
         bool isAreaElement = is<HTMLAreaElement>(element);
         // YouTube embeds specifically create a render hierarchy with two elements that share a renderer.
         // In this instance, we want the <embed> element to associate its node with an AX element, so we need to create one here.
-        bool replacementWillCreateRenderer = renderer && renderer->isYouTubeReplacement();
+        bool replacementWillCreateRenderer = isYouTubeReplacement;
         if (!inCanvasSubtree && !insideMeterElement && !hasDisplayContents && !isPopover && !isNodeFocused(node) && !isAreaElement && !replacementWillCreateRenderer)
             return nullptr;
     }


### PR DESCRIPTION
#### 8cbb239f5237007ac3adc5c11a0dedf2ad10cec8
<pre>
AX: The Node&amp; variant of AXObjectCache::getOrCreate scopes a renderer CheckedPtr far larger than necessary, which can cause an unnecessary crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=300254">https://bugs.webkit.org/show_bug.cgi?id=300254</a>
<a href="https://rdar.apple.com/161953366">rdar://161953366</a>

Reviewed by Joshua Hoffman.

Limit the scope of this CheckedPtr to where it&apos;s actually used. This avoids an unnecessary crash from side effects later
in the function destroying the renderer (but we don&apos;t actually care if it&apos;s destroyed, since our use for the renderer
stopped earlier in the function).

Test: accessibility/dynamic-frame-prepend-crash.html

* LayoutTests/accessibility/dynamic-frame-prepend-crash-expected.txt: Added.
* LayoutTests/accessibility/dynamic-frame-prepend-crash.html: Added.
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::getOrCreateSlow):

Canonical link: <a href="https://commits.webkit.org/301101@main">https://commits.webkit.org/301101@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1b33579e59624bedfb4d434e0112269ab60affa2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124913 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44583 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35319 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131761 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76803 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/126790 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45277 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53149 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95066 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/63073 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127867 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36126 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111710 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75617 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35061 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29865 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75240 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105886 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30095 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134434 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51746 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39549 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103540 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52167 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107924 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103314 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26310 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48662 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26949 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48767 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51625 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57429 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51009 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54365 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52702 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->