### PR TITLE
Remove use of `RefPtr::unsafeGet()` in `KeyframeEffect::timingFunctionForBlendingKeyframe()`

### DIFF
--- a/Source/WebCore/animation/CSSAnimation.cpp
+++ b/Source/WebCore/animation/CSSAnimation.cpp
@@ -181,7 +181,7 @@ AnimationPlayState CSSAnimation::backingAnimationPlayState() const
     return m_backingStyleAnimation.playState();
 }
 
-RefPtr<TimingFunction> CSSAnimation::backingAnimationTimingFunction() const
+TimingFunction* CSSAnimation::backingAnimationTimingFunction() const
 {
     return m_backingStyleAnimation.timingFunction().value.ptr();
 }

--- a/Source/WebCore/animation/CSSAnimation.h
+++ b/Source/WebCore/animation/CSSAnimation.h
@@ -63,7 +63,7 @@ private:
 
     void syncPropertiesWithBackingAnimation() final;
     AnimationPlayState backingAnimationPlayState() const final;
-    RefPtr<TimingFunction> backingAnimationTimingFunction() const final;
+    TimingFunction* backingAnimationTimingFunction() const final;
     Ref<StyleOriginatedAnimationEvent> createEvent(const AtomString& eventType, std::optional<Seconds> scheduledTime, double elapsedTime, const std::optional<Style::PseudoElementIdentifier>&) final;
 
     AnimationTimeline* bindingsTimeline() const final;

--- a/Source/WebCore/animation/CSSTransition.cpp
+++ b/Source/WebCore/animation/CSSTransition.cpp
@@ -117,7 +117,7 @@ AnimationPlayState CSSTransition::backingAnimationPlayState() const
     return AnimationPlayState::Running;
 }
 
-RefPtr<TimingFunction> CSSTransition::backingAnimationTimingFunction() const
+TimingFunction* CSSTransition::backingAnimationTimingFunction() const
 {
     return m_backingStyleTransition.timingFunction().value.ptr();
 }

--- a/Source/WebCore/animation/CSSTransition.h
+++ b/Source/WebCore/animation/CSSTransition.h
@@ -65,7 +65,7 @@ private:
     bool isCSSTransition() const final { return true; }
 
     AnimationPlayState backingAnimationPlayState() const final;
-    RefPtr<TimingFunction> backingAnimationTimingFunction() const final;
+    TimingFunction* backingAnimationTimingFunction() const final;
 
     AnimatableCSSProperty m_property;
     MonotonicTime m_generationTime;

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -1914,7 +1914,7 @@ const TimingFunction* KeyframeEffect::timingFunctionForBlendingKeyframe(const Bl
         }
 
         // Failing that, or for a CSS Transition, the timing function is inherited from the backing Animation object.
-        return styleOriginatedAnimation->backingAnimationTimingFunction().unsafeGet();
+        return styleOriginatedAnimation->backingAnimationTimingFunction();
     }
 
     return keyframe.timingFunction();

--- a/Source/WebCore/animation/StyleOriginatedAnimation.h
+++ b/Source/WebCore/animation/StyleOriginatedAnimation.h
@@ -70,7 +70,7 @@ public:
     void flushPendingStyleChanges() const;
 
     virtual AnimationPlayState backingAnimationPlayState() const = 0;
-    virtual RefPtr<TimingFunction> backingAnimationTimingFunction() const = 0;
+    virtual TimingFunction* backingAnimationTimingFunction() const = 0;
 
 protected:
     StyleOriginatedAnimation(const Styleable&);


### PR DESCRIPTION
#### 5305f27f68fadc17279f81198acd0adc7169fcde
<pre>
Remove use of `RefPtr::unsafeGet()` in `KeyframeEffect::timingFunctionForBlendingKeyframe()`
<a href="https://bugs.webkit.org/show_bug.cgi?id=300255">https://bugs.webkit.org/show_bug.cgi?id=300255</a>
<a href="https://rdar.apple.com/162060902">rdar://162060902</a>

Reviewed by Geoffrey Garen.

The `RefPtr::unsafeGet()` function was introduced in 301069@main to identify lifetime contradictions.
We remove the call within `KeyframeEffect::timingFunctionForBlendingKeyframe()` by returning a raw
pointer rather than a `RefPtr`.

* Source/WebCore/animation/CSSAnimation.cpp:
(WebCore::CSSAnimation::backingAnimationTimingFunction const):
* Source/WebCore/animation/CSSAnimation.h:
* Source/WebCore/animation/CSSTransition.cpp:
(WebCore::CSSTransition::backingAnimationTimingFunction const):
* Source/WebCore/animation/CSSTransition.h:
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::timingFunctionForBlendingKeyframe const):
* Source/WebCore/animation/StyleOriginatedAnimation.h:

Canonical link: <a href="https://commits.webkit.org/301329@main">https://commits.webkit.org/301329@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8aef72677966aa133e46353a7f4d7ad79576cede

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125638 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45300 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36050 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132499 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/77522 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f3b025f1-b9e0-4625-b8d5-5578eae44c86) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127509 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45987 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53862 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95712 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/77522 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f89d2577-14e7-4cb4-96f5-37af7c4bc71d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128586 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36762 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112352 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76207 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b6ce8aaa-0590-4268-af64-ab906c3a4d41) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35662 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30533 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75971 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106540 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30751 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135171 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52433 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40196 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/104182 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52879 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108563 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/103911 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49269 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27578 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49652 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19669 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52328 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58130 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51676 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55029 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53372 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->