### PR TITLE
[Temporal] Implement TemporalDuration::round() according to the spec

### DIFF
--- a/JSTests/stress/temporal-duration.js
+++ b/JSTests/stress/temporal-duration.js
@@ -226,6 +226,19 @@ shouldBe(Temporal.Duration.from('-PT31S').round({ smallestUnit: 'second', roundi
 shouldBe(Temporal.Duration.from('-PT31S').round({ smallestUnit: 'second', roundingIncrement: 30, roundingMode: 'floor' }).toString(), '-PT60S');
 shouldBe(Temporal.Duration.from('-PT45S').round({ smallestUnit: 'second', roundingIncrement: 30 }).toString(), '-PT60S');
 shouldBe(Temporal.Duration.from('-PT45S').round({ smallestUnit: 'second', roundingIncrement: 30, roundingMode: 'trunc' }).toString(), '-PT30S');
+// Rounding would exceed maxTimeDuration
+shouldThrow(() => Temporal.Duration.from({ seconds: Number.MAX_SAFE_INTEGER }).round({ smallestUnit: 'seconds', roundingMode: 'ceil', roundingIncrement: 30 }), RangeError);
+
+const seconds = 8692288669465520;
+const nanoseconds = 321_414_345;
+const d = new Temporal.Duration(0, 0, 0, 0, 0, 0, seconds, 0, 0, nanoseconds);
+const result = d.round({ largestUnit: "nanoseconds" });
+const expectedNanoseconds = Number(BigInt(seconds) * 1_000_000_000n + BigInt(nanoseconds));
+shouldBe(expectedNanoseconds, 8692288669465520_321_414_345);
+shouldBe(result.nanoseconds, expectedNanoseconds);
+
+// Rounding would exceed maxTimeDuration
+shouldThrow(() => Temporal.Duration.from({ seconds: Number.MAX_SAFE_INTEGER }).round({ smallestUnit: 'seconds', roundingMode: 'ceil', roundingIncrement: 30 }), RangeError);
 
 shouldBe(Temporal.Duration.prototype.total.length, 1);
 shouldThrow(() => Temporal.Duration.prototype.total.call({}), TypeError);
@@ -300,6 +313,9 @@ shouldBe(pos.toString({ roundingMode: 'trunc' }), pos.toString());
 shouldBe(pos.toString({ fractionalSecondDigits: 7, roundingMode: 'ceil' }), 'P1Y2M3W4DT5H6M7.0080091S');
 shouldBe(pos.toString({ fractionalSecondDigits: 2, roundingMode: 'floor' }), 'P1Y2M3W4DT5H6M7.00S');
 shouldBe(pos.toString({ fractionalSecondDigits: 2, roundingMode: 'halfExpand' }), 'P1Y2M3W4DT5H6M7.01S');
+
+const maxSeconds = Temporal.Duration.from({ seconds: Number.MAX_SAFE_INTEGER, milliseconds: 999 });
+shouldThrow(() => maxSeconds.toString({ smallestUnit: "seconds", roundingMode: "ceil" }), RangeError);
 
 shouldBe(Temporal.Duration.prototype.valueOf.length, 0);
 shouldThrow(() => new Temporal.Duration().valueOf(), TypeError);

--- a/JSTests/test262/config.yaml
+++ b/JSTests/test262/config.yaml
@@ -207,7 +207,6 @@ skip:
     - test/built-ins/Temporal/Duration/prototype/round/roundingmode-trunc.js
     - test/built-ins/Temporal/Duration/prototype/round/total-duration-nanoseconds-too-large-with-zoned-datetime.js
     - test/built-ins/Temporal/Duration/prototype/round/year-zero.js
-    - test/built-ins/Temporal/Duration/prototype/round/precision-exact-in-balance-time-duration.js
     - test/built-ins/Temporal/Duration/prototype/total/balances-days-up-to-both-years-and-months.js
     - test/built-ins/Temporal/Duration/prototype/total/calendar-possibly-required.js
     - test/built-ins/Temporal/Duration/prototype/total/calendar-temporal-object.js
@@ -324,8 +323,6 @@ skip:
     - test/built-ins/Temporal/PlainDateTime/prototype/equals/argument-string-calendar-annotation.js
     - test/built-ins/Temporal/PlainDateTime/prototype/equals/argument-string-time-zone-annotation.js
     - test/built-ins/Temporal/PlainDateTime/prototype/equals/calendar-temporal-object.js
-    - test/built-ins/Temporal/PlainDateTime/prototype/round/smallestunit-plurals-accepted.js
-    - test/built-ins/Temporal/PlainDateTime/prototype/round/smallestunit-string-shorthand.js
     - test/built-ins/Temporal/PlainDateTime/prototype/toString/calendarname-always.js
     - test/built-ins/Temporal/PlainDateTime/prototype/toString/calendarname-auto.js
     - test/built-ins/Temporal/PlainDateTime/prototype/toString/calendarname-critical.js

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -79,9 +79,6 @@ test/built-ins/Temporal/Duration/compare/relativeto-string-limits.js:
 test/built-ins/Temporal/Duration/compare/throws-when-target-zoned-date-time-outside-valid-limits.js:
   default: "TypeError: undefined is not a constructor (evaluating 'new Temporal.ZonedDateTime(864n * 10n**19n, \"UTC\")')"
   strict mode: "TypeError: undefined is not a constructor (evaluating 'new Temporal.ZonedDateTime(864n * 10n**19n, \"UTC\")')"
-test/built-ins/Temporal/Duration/from/argument-duration-precision-exact-numerical-values.js:
-  default: 'Test262Error: case where floating point inaccuracy brings total below limit, positive Expected SameValue(«"PT9007199254740992.000424S"», «"PT9007199254740991.975424S"») to be true'
-  strict mode: 'Test262Error: case where floating point inaccuracy brings total below limit, positive Expected SameValue(«"PT9007199254740992.000424S"», «"PT9007199254740991.975424S"») to be true'
 test/built-ins/Temporal/Duration/prototype/round/accepts-datetime-strings-for-relative-to.js:
   default: 'Error: FIXME: years, months, or weeks rounding with relativeTo not implemented yet'
   strict mode: 'Error: FIXME: years, months, or weeks rounding with relativeTo not implemented yet'
@@ -127,12 +124,6 @@ test/built-ins/Temporal/Duration/prototype/round/largestunit-smallestunit-combin
 test/built-ins/Temporal/Duration/prototype/round/next-day-out-of-range.js:
   default: "TypeError: undefined is not a constructor (evaluating 'new Temporal.ZonedDateTime(86400_0000_0000_000_000_000n, \"UTC\")')"
   strict mode: "TypeError: undefined is not a constructor (evaluating 'new Temporal.ZonedDateTime(86400_0000_0000_000_000_000n, \"UTC\")')"
-test/built-ins/Temporal/Duration/prototype/round/options-read-before-algorithmic-validation.js:
-  default: 'Test262Error: Actual [get options.smallestUnit, get options.smallestUnit.toString, call options.smallestUnit.toString, get options.largestUnit, get options.largestUnit.toString, call options.largestUnit.toString] and expected [get options.largestUnit, get options.largestUnit.toString, call options.largestUnit.toString, get options.relativeTo, get options.roundingIncrement, get options.roundingIncrement.valueOf, call options.roundingIncrement.valueOf, get options.roundingMode, get options.roundingMode.toString, call options.roundingMode.toString, get options.smallestUnit, get options.smallestUnit.toString, call options.smallestUnit.toString] should have the same contents. all options should be read first'
-  strict mode: 'Test262Error: Actual [get options.smallestUnit, get options.smallestUnit.toString, call options.smallestUnit.toString, get options.largestUnit, get options.largestUnit.toString, call options.largestUnit.toString] and expected [get options.largestUnit, get options.largestUnit.toString, call options.largestUnit.toString, get options.relativeTo, get options.roundingIncrement, get options.roundingIncrement.valueOf, call options.roundingIncrement.valueOf, get options.roundingMode, get options.roundingMode.toString, call options.roundingMode.toString, get options.smallestUnit, get options.smallestUnit.toString, call options.smallestUnit.toString] should have the same contents. all options should be read first'
-test/built-ins/Temporal/Duration/prototype/round/precision-exact-in-round-duration.js:
-  default: 'Test262Error: hours result: Expected SameValue(«100000», «100001») to be true'
-  strict mode: 'Test262Error: hours result: Expected SameValue(«100000», «100001») to be true'
 test/built-ins/Temporal/Duration/prototype/round/relative-to-required-for-rounding-durations-with-calendar-units.js:
   default: 'Test262Error: Expected a RangeError but got a Error'
   strict mode: 'Test262Error: Expected a RangeError but got a Error'
@@ -142,6 +133,9 @@ test/built-ins/Temporal/Duration/prototype/round/relative-to-required-to-round-c
 test/built-ins/Temporal/Duration/prototype/round/relativeTo-ignores-incorrect-properties.js:
   default: 'RangeError: Cannot round a duration of years, months, or weeks without a relativeTo option'
   strict mode: 'RangeError: Cannot round a duration of years, months, or weeks without a relativeTo option'
+test/built-ins/Temporal/Duration/prototype/round/options-read-before-algorithmic-validation.js:
+  default: 'Test262Error: Actual [get options.smallestUnit, get options.smallestUnit.toString, call options.smallestUnit.toString, get options.largestUnit, get options.largestUnit.toString, call options.largestUnit.toString] and expected [get options.largestUnit, get options.largestUnit.toString, call options.largestUnit.toString, get options.relativeTo, get options.roundingIncrement, get options.roundingIncrement.valueOf, call options.roundingIncrement.valueOf, get options.roundingMode, get options.roundingMode.toString, call options.roundingMode.toString, get options.smallestUnit, get options.smallestUnit.toString, call options.smallestUnit.toString] should have the same contents. all options should be read first'
+  strict mode: 'Test262Error: Actual [get options.smallestUnit, get options.smallestUnit.toString, call options.smallestUnit.toString, get options.largestUnit, get options.largestUnit.toString, call options.largestUnit.toString] and expected [get options.largestUnit, get options.largestUnit.toString, call options.largestUnit.toString, get options.relativeTo, get options.roundingIncrement, get options.roundingIncrement.valueOf, call options.roundingIncrement.valueOf, get options.roundingMode, get options.roundingMode.toString, call options.roundingMode.toString, get options.smallestUnit, get options.smallestUnit.toString, call options.smallestUnit.toString] should have the same contents. all options should be read first'
 test/built-ins/Temporal/Duration/prototype/round/relativeTo-required-properties.js:
   default: 'Test262Error: Expected a TypeError to be thrown but no exception was thrown at all'
   strict mode: 'Test262Error: Expected a TypeError to be thrown but no exception was thrown at all'
@@ -175,24 +169,12 @@ test/built-ins/Temporal/Duration/prototype/round/throws-on-wrong-offset-for-zone
 test/built-ins/Temporal/Duration/prototype/round/valid-increments.js:
   default: 'Error: FIXME: years, months, or weeks rounding with relativeTo not implemented yet'
   strict mode: 'Error: FIXME: years, months, or weeks rounding with relativeTo not implemented yet'
-test/built-ins/Temporal/Duration/prototype/toString/max-value.js:
-  default: 'Test262Error: values do not lose precision intermediately Expected SameValue(«"PT9007199254740.992S"», «"PT9007199254740.993S"») to be true'
-  strict mode: 'Test262Error: values do not lose precision intermediately Expected SameValue(«"PT9007199254740.992S"», «"PT9007199254740.993S"») to be true'
-test/built-ins/Temporal/Duration/prototype/toString/no-precision-loss.js:
-  default: 'Test262Error: Expected SameValue(«"PT9016206453995.732991S"», «"PT9016206453995.731991S"») to be true'
-  strict mode: 'Test262Error: Expected SameValue(«"PT9016206453995.732991S"», «"PT9016206453995.731991S"») to be true'
 test/built-ins/Temporal/Duration/prototype/toString/options-read-before-algorithmic-validation.js:
-  default: 'Test262Error: exception thrown when result is out of range Expected a RangeError to be thrown but no exception was thrown at all'
-  strict mode: 'Test262Error: exception thrown when result is out of range Expected a RangeError to be thrown but no exception was thrown at all'
+  default: 'Test262Error: Actual [get options.smallestUnit, get options.smallestUnit.toString, call options.smallestUnit.toString, get options.roundingMode, get options.roundingMode.toString, call options.roundingMode.toString] and expected [get options.fractionalSecondDigits, get options.fractionalSecondDigits.toString, call options.fractionalSecondDigits.toString, get options.roundingMode, get options.roundingMode.toString, call options.roundingMode.toString, get options.smallestUnit, get options.smallestUnit.toString, call options.smallestUnit.toString] should have the same contents. all options should be read first'
+  strict mode: 'Test262Error: Actual [get options.smallestUnit, get options.smallestUnit.toString, call options.smallestUnit.toString, get options.roundingMode, get options.roundingMode.toString, call options.roundingMode.toString] and expected [get options.fractionalSecondDigits, get options.fractionalSecondDigits.toString, call options.fractionalSecondDigits.toString, get options.roundingMode, get options.roundingMode.toString, call options.roundingMode.toString, get options.smallestUnit, get options.smallestUnit.toString, call options.smallestUnit.toString] should have the same contents. all options should be read first'
 test/built-ins/Temporal/Duration/prototype/toString/order-of-operations.js:
   default: 'Test262Error: Actual [get options.smallestUnit, get options.smallestUnit.toString, call options.smallestUnit.toString, get options.roundingMode, get options.roundingMode.toString, call options.roundingMode.toString] and expected [get options.fractionalSecondDigits, get options.fractionalSecondDigits.toString, call options.fractionalSecondDigits.toString, get options.roundingMode, get options.roundingMode.toString, call options.roundingMode.toString, get options.smallestUnit, get options.smallestUnit.toString, call options.smallestUnit.toString] should have the same contents. order of operations'
   strict mode: 'Test262Error: Actual [get options.smallestUnit, get options.smallestUnit.toString, call options.smallestUnit.toString, get options.roundingMode, get options.roundingMode.toString, call options.roundingMode.toString] and expected [get options.fractionalSecondDigits, get options.fractionalSecondDigits.toString, call options.fractionalSecondDigits.toString, get options.roundingMode, get options.roundingMode.toString, call options.roundingMode.toString, get options.smallestUnit, get options.smallestUnit.toString, call options.smallestUnit.toString] should have the same contents. order of operations'
-test/built-ins/Temporal/Duration/prototype/toString/round-cross-unit-boundary.js:
-  default: 'Test262Error: 1:59:60 balances to 2 hours Expected SameValue(«"PT1H59M60S"», «"PT2H0S"») to be true'
-  strict mode: 'Test262Error: 1:59:60 balances to 2 hours Expected SameValue(«"PT1H59M60S"», «"PT2H0S"») to be true'
-test/built-ins/Temporal/Duration/prototype/toString/throws-when-rounded-duration-is-invalid.js:
-  default: 'Test262Error: Expected a RangeError to be thrown but no exception was thrown at all'
-  strict mode: 'Test262Error: Expected a RangeError to be thrown but no exception was thrown at all'
 test/built-ins/Temporal/Duration/prototype/toString/total-of-duration-time-units-out-of-range.js:
   default: 'Test262Error: Expected a RangeError to be thrown but no exception was thrown at all'
   strict mode: 'Test262Error: Expected a RangeError to be thrown but no exception was thrown at all'

--- a/Source/JavaScriptCore/runtime/TemporalDuration.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalDuration.cpp
@@ -38,8 +38,6 @@
 
 namespace JSC {
 
-static constexpr double nanosecondsPerDay = 24.0 * 60 * 60 * 1000 * 1000 * 1000;
-
 const ClassInfo TemporalDuration::s_info = { "Object"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(TemporalDuration) };
 
 TemporalDuration* TemporalDuration::create(VM& vm, Structure* structure, ISO8601::Duration&& duration)
@@ -203,14 +201,16 @@ TemporalDuration* TemporalDuration::from(JSGlobalObject* globalObject, JSValue i
     return toTemporalDuration(globalObject, itemValue);
 }
 
-// TotalDurationNanoseconds ( days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds, offsetShift )
-// https://tc39.es/proposal-temporal/#sec-temporal-totaldurationnanoseconds
-static double totalNanoseconds(ISO8601::Duration& duration)
+static double totalSeconds(ISO8601::Duration& duration)
 {
     auto hours = 24 * duration.days() + duration.hours();
     auto minutes = 60 * hours + duration.minutes();
-    auto seconds = 60 * minutes + duration.seconds();
-    auto milliseconds = 1000 * seconds + duration.milliseconds();
+    return 60 * minutes + duration.seconds();
+}
+
+static double totalSubseconds(ISO8601::Duration& duration)
+{
+    auto milliseconds = duration.milliseconds();
     auto microseconds = 1000 * milliseconds + duration.microseconds();
     return 1000 * microseconds + duration.nanoseconds();
 }
@@ -399,19 +399,21 @@ ISO8601::Duration TemporalDuration::toDateDurationRecordWithoutTime(JSGlobalObje
 // https://tc39.es/proposal-temporal/#sec-temporal-balanceduration
 std::optional<double> TemporalDuration::balance(ISO8601::Duration& duration, TemporalUnit largestUnit)
 {
-    auto nanoseconds = totalNanoseconds(duration);
+
+    auto nanoseconds = totalSubseconds(duration);
+    auto seconds = totalSeconds(duration);
+
     if (!std::isfinite(nanoseconds))
         return nanoseconds;
     duration.clear();
 
     if (largestUnit <= TemporalUnit::Day) {
-        duration.setDays(std::trunc(nanoseconds / nanosecondsPerDay));
-        nanoseconds = std::fmod(nanoseconds, nanosecondsPerDay);
+        duration.setDays(std::trunc(seconds / secondsPerDay));
+        seconds = std::fmod(seconds, secondsPerDay);
     }
 
     double microseconds = std::trunc(nanoseconds / 1000);
     double milliseconds = std::trunc(microseconds / 1000);
-    double seconds = std::trunc(milliseconds / 1000);
     double minutes = std::trunc(seconds / 60);
     if (largestUnit <= TemporalUnit::Hour) {
         duration.setNanoseconds(std::fmod(nanoseconds, 1000));
@@ -434,12 +436,16 @@ std::optional<double> TemporalDuration::balance(ISO8601::Duration& duration, Tem
     } else if (largestUnit == TemporalUnit::Millisecond) {
         duration.setNanoseconds(std::fmod(nanoseconds, 1000));
         duration.setMicroseconds(std::fmod(microseconds, 1000));
+        milliseconds += seconds * 1000;
         duration.setMilliseconds(milliseconds);
     } else if (largestUnit == TemporalUnit::Microsecond) {
         duration.setNanoseconds(std::fmod(nanoseconds, 1000));
+        microseconds += seconds * 1000 * 1000;
         duration.setMicroseconds(microseconds);
-    } else
+    } else {
+        nanoseconds += seconds * 1000 * 1000 * 1000;
         duration.setNanoseconds(nanoseconds);
+    }
 
     return std::nullopt;
 }
@@ -913,57 +919,29 @@ void TemporalDuration::roundRelativeDuration(JSGlobalObject* globalObject, ISO86
 
 // RoundDuration ( years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds, increment, unit, roundingMode [ , relativeTo ] )
 // https://tc39.es/proposal-temporal/#sec-temporal-roundduration
-double TemporalDuration::round(ISO8601::Duration& duration, double increment, TemporalUnit unit, RoundingMode mode)
+ISO8601::InternalDuration TemporalDuration::round(JSGlobalObject* globalObject, ISO8601::InternalDuration internalDuration, double increment, TemporalUnit unit, RoundingMode mode)
 {
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
     ASSERT(unit >= TemporalUnit::Day);
-    double remainder = 0;
 
     if (unit == TemporalUnit::Day) {
-        auto originalDays = duration.days();
-        duration.setDays(0);
-        auto nanoseconds = totalNanoseconds(duration);
-
-        auto fractionalDays = originalDays + nanoseconds / nanosecondsPerDay;
-        auto newDays = roundNumberToIncrement(fractionalDays, increment, mode);
-        remainder = fractionalDays - newDays;
-        duration.setDays(newDays);
-    } else if (unit == TemporalUnit::Hour) {
-        auto fractionalSeconds = duration.seconds() + duration.milliseconds() * 1e-3 + duration.microseconds() * 1e-6 + duration.nanoseconds() * 1e-9;
-        auto fractionalHours = duration.hours() + (duration.minutes() + fractionalSeconds / 60) / 60;
-        auto newHours = roundNumberToIncrement(fractionalHours, increment, mode);
-        remainder = fractionalHours - newHours;
-        duration.setHours(newHours);
-    } else if (unit == TemporalUnit::Minute) {
-        auto fractionalSeconds = duration.seconds() + duration.milliseconds() * 1e-3 + duration.microseconds() * 1e-6 + duration.nanoseconds() * 1e-9;
-        auto fractionalMinutes = duration.minutes() + fractionalSeconds / 60;
-        auto newMinutes = roundNumberToIncrement(fractionalMinutes, increment, mode);
-        remainder = fractionalMinutes - newMinutes;
-        duration.setMinutes(newMinutes);
-    } else if (unit == TemporalUnit::Second) {
-        auto fractionalSeconds = duration.seconds() + duration.milliseconds() * 1e-3 + duration.microseconds() * 1e-6 + duration.nanoseconds() * 1e-9;
-        auto newSeconds = roundNumberToIncrement(fractionalSeconds, increment, mode);
-        remainder = fractionalSeconds - newSeconds;
-        duration.setSeconds(newSeconds);
-    } else if (unit == TemporalUnit::Millisecond) {
-        auto fractionalMilliseconds = duration.milliseconds() + duration.microseconds() * 1e-3 + duration.nanoseconds() * 1e-6;
-        auto newMilliseconds = roundNumberToIncrement(fractionalMilliseconds, increment, mode);
-        remainder = fractionalMilliseconds - newMilliseconds;
-        duration.setMilliseconds(newMilliseconds);
-    } else if (unit == TemporalUnit::Microsecond) {
-        auto fractionalMicroseconds = duration.microseconds() + duration.nanoseconds() * 1e-3;
-        auto newMicroseconds = roundNumberToIncrement(fractionalMicroseconds, increment, mode);
-        remainder = fractionalMicroseconds - newMicroseconds;
-        duration.setMicroseconds(newMicroseconds);
-    } else {
-        auto newNanoseconds = roundNumberToIncrement(duration.nanoseconds(), increment, mode);
-        remainder = duration.nanoseconds() - newNanoseconds;
-        duration.setNanoseconds(newNanoseconds);
+        double fractionalDays = totalTimeDuration(internalDuration.time(), TemporalUnit::Day);
+        double days = roundNumberToIncrementDouble(fractionalDays, increment, mode);
+        return ISO8601::InternalDuration::combineDateAndTimeDuration(
+            ISO8601::Duration { 0, 0, 0, (double) days, 0, 0, 0, 0, 0, 0 },
+            0);
+    } else  {
+        std::optional<Int128> timeDuration =
+            ISO8601::roundTimeDuration(globalObject, internalDuration.time(), increment, unit, mode);
+        RETURN_IF_EXCEPTION(scope, { });
+        if (!timeDuration) {
+            throwRangeError(globalObject, scope, "Rounded duration exceeds maximum time duration"_s);
+            return { };
+        }
+        return ISO8601::InternalDuration::combineDateAndTimeDuration(ISO8601::Duration(), timeDuration.value());
     }
-
-    for (auto i = static_cast<uint8_t>(unit) + 1u; i < numberOfTemporalUnits; i++)
-        duration[i] = 0;
-
-    return remainder;
 }
 
 ISO8601::Duration TemporalDuration::round(JSGlobalObject* globalObject, JSValue optionsValue) const
@@ -1023,10 +1001,11 @@ ISO8601::Duration TemporalDuration::round(JSGlobalObject* globalObject, JSValue 
         return { };
     }
 
-    ISO8601::Duration newDuration = m_duration;
-    round(newDuration, increment, smallestUnit, roundingMode);
-    balance(newDuration, largestUnit);
-    return newDuration;
+    ISO8601::InternalDuration internalDuration = toInternalDurationRecordWith24HourDays(globalObject, m_duration);
+    RETURN_IF_EXCEPTION(scope, { });
+    auto result = round(globalObject, internalDuration, increment, smallestUnit, roundingMode);
+    RETURN_IF_EXCEPTION(scope, { });
+    return temporalDurationFromInternal(result, largestUnit);
 }
 
 double TemporalDuration::total(JSGlobalObject* globalObject, JSValue optionsValue) const
@@ -1088,6 +1067,7 @@ String TemporalDuration::toString(JSGlobalObject* globalObject, JSValue optionsV
         throwRangeError(globalObject, scope, "smallestUnit must not be \"minute\""_s);
         return { };
     }
+    auto smallestUnit = data.unit;
 
     auto roundingMode = temporalRoundingMode(globalObject, options, RoundingMode::Trunc);
     RETURN_IF_EXCEPTION(scope, { });
@@ -1096,9 +1076,38 @@ String TemporalDuration::toString(JSGlobalObject* globalObject, JSValue optionsV
     if (std::get<0>(data.precision) == Precision::Auto && roundingMode == RoundingMode::Trunc)
         RELEASE_AND_RETURN(scope, toString(globalObject));
 
-    ISO8601::Duration newDuration = m_duration;
-    round(newDuration, data.increment, data.unit, roundingMode);
-    RELEASE_AND_RETURN(scope, toString(globalObject, newDuration, data.precision));
+    auto internalDuration = toInternalDuration(m_duration);
+    auto timeDuration = ISO8601::roundTimeDuration(globalObject, internalDuration.time(),
+        data.increment, smallestUnit, roundingMode);
+    RETURN_IF_EXCEPTION(scope, { });
+    internalDuration = ISO8601::InternalDuration::combineDateAndTimeDuration(internalDuration.dateDuration(),
+        timeDuration);
+    auto roundedLargestUnit = std::min(largestSubduration(m_duration), TemporalUnit::Second);
+    auto roundedDuration = temporalDurationFromInternal(internalDuration, roundedLargestUnit);
+    RELEASE_AND_RETURN(scope, toString(globalObject, roundedDuration, data.precision));
+}
+
+static TemporalUnit defaultTemporalLargestUnit(const ISO8601::Duration& duration)
+{
+    if (duration.years())
+        return TemporalUnit::Year;
+    if (duration.months())
+        return TemporalUnit::Month;
+    if (duration.weeks())
+        return TemporalUnit::Week;
+    if (duration.days())
+        return TemporalUnit::Day;
+    if (duration.hours())
+        return TemporalUnit::Hour;
+    if (duration.minutes())
+        return TemporalUnit::Minute;
+    if (duration.seconds())
+        return TemporalUnit::Second;
+    if (duration.milliseconds())
+        return TemporalUnit::Millisecond;
+    if (duration.microseconds())
+        return TemporalUnit::Microsecond;
+    return TemporalUnit::Nanosecond;
 }
 
 static void appendInteger(JSGlobalObject* globalObject, StringBuilder& builder, double value)
@@ -1132,15 +1141,7 @@ String TemporalDuration::toString(JSGlobalObject* globalObject, const ISO8601::D
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto balancedMicroseconds = duration.microseconds() + std::trunc(duration.nanoseconds() / 1000);
-    auto balancedNanoseconds = std::fmod(duration.nanoseconds(), 1000);
-    auto balancedMilliseconds = duration.milliseconds() + std::trunc(balancedMicroseconds / 1000);
-    balancedMicroseconds = std::fmod(balancedMicroseconds, 1000);
-    auto balancedSeconds = duration.seconds() + std::trunc(balancedMilliseconds / 1000);
-    balancedMilliseconds = std::fmod(balancedMilliseconds, 1000);
-
     StringBuilder builder;
-
     auto sign = TemporalDuration::sign(duration);
     if (sign < 0)
         builder.append('-');
@@ -1167,9 +1168,9 @@ String TemporalDuration::toString(JSGlobalObject* globalObject, const ISO8601::D
         builder.append('D');
     }
 
-    // The zero value is displayed in seconds.
-    auto usesSeconds = balancedSeconds || balancedMilliseconds || balancedMicroseconds || balancedNanoseconds || !sign || std::get<0>(precision) != Precision::Auto;
-    if (!duration.hours() && !duration.minutes() && !usesSeconds)
+    auto secondsDuration = timeDurationFromComponents(0, 0, duration.seconds(), duration.milliseconds(), duration.microseconds(), duration.nanoseconds());
+
+    if (!duration.hours() && !duration.minutes() && !secondsDuration && sign && std::get<0>(precision) == Precision::Auto)
         return builder.toString();
 
     builder.append('T');
@@ -1183,22 +1184,15 @@ String TemporalDuration::toString(JSGlobalObject* globalObject, const ISO8601::D
         RETURN_IF_EXCEPTION(scope, { });
         builder.append('M');
     }
-    if (usesSeconds) {
-        // TEMPORARY! (pending spec discussion about rebalancing @ https://github.com/tc39/proposal-temporal/issues/2195)
-        // Although we must be able to display Number values beyond MAX_SAFE_INTEGER, it does not seem reasonable
-        // to require that calculations be performed outside of double space purely to support a case like
-        // `Temporal.Duration.from({ microseconds: Number.MAX_VALUE, nanoseconds: Number.MAX_VALUE }).toString()`.
-        if (!std::isfinite(balancedSeconds)) [[unlikely]] {
-            throwRangeError(globalObject, scope, "Cannot display infinite seconds!"_s);
-            return { };
-        }
 
-        appendInteger(globalObject, builder, balancedSeconds);
+    bool zeroMinutesAndHigher = defaultTemporalLargestUnit(duration) >= TemporalUnit::Second;
+
+    if (secondsDuration || (zeroMinutesAndHigher || std::get<0>(precision) != Precision::Auto)) {
+        double secondsPart = std::abs(std::trunc((double) (secondsDuration / 1000000000)));
+        double subSecondsPart = std::abs((double) (secondsDuration % 1000000000));
+        appendInteger(globalObject, builder, secondsPart);
         RETURN_IF_EXCEPTION(scope, { });
-
-        auto fraction = std::abs(balancedMilliseconds) * 1e6 + std::abs(balancedMicroseconds) * 1e3 + std::abs(balancedNanoseconds);
-        formatSecondsStringFraction(builder, fraction, precision);
-
+        formatSecondsStringFraction(builder, subSecondsPart, precision);
         builder.append('S');
     }
 

--- a/Source/JavaScriptCore/runtime/TemporalDuration.h
+++ b/Source/JavaScriptCore/runtime/TemporalDuration.h
@@ -98,7 +98,7 @@ public:
     static ISO8601::Duration toISO8601Duration(JSGlobalObject*, JSValue);
 
     static int sign(const ISO8601::Duration&);
-    static double round(ISO8601::Duration&, double increment, TemporalUnit, RoundingMode);
+    static ISO8601::InternalDuration round(JSGlobalObject*, ISO8601::InternalDuration, double increment, TemporalUnit, RoundingMode);
     static void roundRelativeDuration(JSGlobalObject*, ISO8601::InternalDuration&, Int128, ISO8601::PlainDate, TemporalUnit, double, TemporalUnit, RoundingMode);
     static std::optional<ISO8601::PlainDate> regulateISODate(double, double, double, TemporalOverflow);
     static ISO8601::Duration toDateDurationRecordWithoutTime(JSGlobalObject*, const ISO8601::Duration&);

--- a/Source/JavaScriptCore/runtime/TemporalObject.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalObject.cpp
@@ -588,7 +588,9 @@ double temporalRoundingIncrement(JSGlobalObject* globalObject, JSObject* options
 
 // RoundNumberToIncrement ( x, increment, roundingMode )
 // https://tc39.es/proposal-temporal/#sec-temporal-roundnumbertoincrement
-double roundNumberToIncrement(double x, double increment, RoundingMode mode)
+// See comment on roundNumberToIncrementInt128() for why there are two
+// roundNumberToIncrement functions.
+double roundNumberToIncrementDouble(double x, double increment, RoundingMode mode)
 {
     auto quotient = x / increment;
     auto truncatedQuotient = std::trunc(quotient);
@@ -664,7 +666,7 @@ Int128 roundNumberToIncrementAsIfPositive(Int128 x, Int128 increment, RoundingMo
 
 // There are two different versions of this method due to the lack
 // of float128. The names are different (roundNumberToIncrementInt128() and
-// roundNumberToIncrement()) to avoid confusion in the presence of
+// roundNumberToIncrementDouble()) to avoid confusion in the presence of
 // implicit casts.
 // https://tc39.es/proposal-temporal/#sec-temporal-roundnumbertoincrement
 Int128 roundNumberToIncrementInt128(Int128 x, Int128 increment, RoundingMode mode)

--- a/Source/JavaScriptCore/runtime/TemporalObject.h
+++ b/Source/JavaScriptCore/runtime/TemporalObject.h
@@ -154,9 +154,8 @@ void formatSecondsStringPart(StringBuilder&, unsigned second, unsigned fraction,
 std::optional<double> maximumRoundingIncrement(TemporalUnit);
 double temporalRoundingIncrement(JSGlobalObject*, JSObject* options, std::optional<double> dividend, bool inclusive);
 double roundNumberToIncrement(double, double increment, RoundingMode);
-Int128 roundNumberToIncrement(Int128, Int128 increment, RoundingMode);
+double roundNumberToIncrementDouble(double, double increment, RoundingMode);
 Int128 roundNumberToIncrementInt128(Int128, Int128, RoundingMode);
-Int128 roundNumberToIncrementInt128(Int128, Int128 increment, RoundingMode);
 Int128 roundNumberToIncrementAsIfPositive(Int128, Int128, RoundingMode);
 double applyUnsignedRoundingMode(double, double, double, UnsignedRoundingMode);
 void rejectObjectWithCalendarOrTimeZone(JSGlobalObject*, JSObject*);

--- a/Source/JavaScriptCore/runtime/TemporalPlainTime.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainTime.cpp
@@ -175,37 +175,37 @@ ISO8601::Duration TemporalPlainTime::roundTime(ISO8601::PlainTime plainTime, dou
     case TemporalUnit::Day: {
         double length = dayLengthNs.value_or(8.64 * 1e13);
         quantity = (((((plainTime.hour() * 60.0 + plainTime.minute()) * 60.0 + plainTime.second()) * 1000.0 + plainTime.millisecond()) * 1000.0 + plainTime.microsecond()) * 1000.0 + plainTime.nanosecond()) / length;
-        auto result = roundNumberToIncrement(quantity, increment, roundingMode);
+        auto result = roundNumberToIncrementDouble(quantity, increment, roundingMode);
         return ISO8601::Duration(0, 0, 0, result, 0, 0, 0, 0, 0, 0);
     }
     case TemporalUnit::Hour: {
         quantity = (fractionalSecond(plainTime) / 60.0 + plainTime.minute()) / 60.0 + plainTime.hour();
-        auto result = roundNumberToIncrement(quantity, increment, roundingMode);
+        auto result = roundNumberToIncrementDouble(quantity, increment, roundingMode);
         return balanceTime(result, 0, 0, 0, 0, 0);
     }
     case TemporalUnit::Minute: {
         quantity = fractionalSecond(plainTime) / 60.0 + plainTime.minute();
-        auto result = roundNumberToIncrement(quantity, increment, roundingMode);
+        auto result = roundNumberToIncrementDouble(quantity, increment, roundingMode);
         return balanceTime(plainTime.hour(), result, 0, 0, 0, 0);
     }
     case TemporalUnit::Second: {
         quantity = fractionalSecond(plainTime);
-        auto result = roundNumberToIncrement(quantity, increment, roundingMode);
+        auto result = roundNumberToIncrementDouble(quantity, increment, roundingMode);
         return balanceTime(plainTime.hour(), plainTime.minute(), result, 0, 0, 0);
     }
     case TemporalUnit::Millisecond: {
         quantity = plainTime.millisecond() + plainTime.microsecond() * 1e-3 + plainTime.nanosecond() * 1e-6;
-        auto result = roundNumberToIncrement(quantity, increment, roundingMode);
+        auto result = roundNumberToIncrementDouble(quantity, increment, roundingMode);
         return balanceTime(plainTime.hour(), plainTime.minute(), plainTime.second(), result, 0, 0);
     }
     case TemporalUnit::Microsecond: {
         quantity = plainTime.microsecond() + plainTime.nanosecond() * 1e-3;
-        auto result = roundNumberToIncrement(quantity, increment, roundingMode);
+        auto result = roundNumberToIncrementDouble(quantity, increment, roundingMode);
         return balanceTime(plainTime.hour(), plainTime.minute(), plainTime.second(), plainTime.millisecond(), result, 0);
     }
     case TemporalUnit::Nanosecond: {
         quantity = plainTime.nanosecond();
-        auto result = roundNumberToIncrement(quantity, increment, roundingMode);
+        auto result = roundNumberToIncrementDouble(quantity, increment, roundingMode);
         return balanceTime(plainTime.hour(), plainTime.minute(), plainTime.second(), plainTime.millisecond(), plainTime.microsecond(), result);
     }
     default:


### PR DESCRIPTION
#### 52738be17296a535153ae4490b75ff54f3a4a8e2
<pre>
[Temporal] Implement TemporalDuration::round() according to the spec
<a href="https://bugs.webkit.org/show_bug.cgi?id=298565">https://bugs.webkit.org/show_bug.cgi?id=298565</a>

Reviewed by Yusuke Suzuki.

Also reimplement TemporalDuration::toString() according to the spec,
since it depends on round().

This enables some tests for Temporal/Duration/prototype/round and
Temporal/Duration/prototype/toString, as well as Temporal/Duration/from
(which uses toString).

* JSTests/stress/temporal-duration.js:
* JSTests/test262/config.yaml:
* JSTests/test262/expectations.yaml:
* Source/JavaScriptCore/runtime/TemporalDuration.cpp:
(JSC::totalSeconds):
(JSC::totalSubseconds):
(JSC::TemporalDuration::balance):
(JSC::TemporalDuration::round):
(JSC::TemporalDuration::round const):
(JSC::TemporalDuration::toString const):
(JSC::defaultTemporalLargestUnit):
(JSC::TemporalDuration::toString):
(JSC::totalNanoseconds): Deleted.
* Source/JavaScriptCore/runtime/TemporalDuration.h:
* Source/JavaScriptCore/runtime/TemporalObject.cpp:
(JSC::roundNumberToIncrementDouble):
(JSC::roundNumberToIncrement): Deleted.
* Source/JavaScriptCore/runtime/TemporalObject.h:
* Source/JavaScriptCore/runtime/TemporalPlainTime.cpp:
(JSC::TemporalPlainTime::roundTime):

Canonical link: <a href="https://commits.webkit.org/301182@main">https://commits.webkit.org/301182@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b6deb5e4f76ef1cc6ab0bc5577299676054224b3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124945 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44614 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35351 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131795 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76827 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45307 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53181 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95092 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/63088 "An unexpected error occured. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; layout-tests (exception)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127899 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36152 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111744 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75640 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35087 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29897 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75275 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/117044 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105915 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30128 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134468 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/123464 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51773 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39575 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103570 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52195 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107957 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103346 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48683 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26977 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/48794 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19603 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51653 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57454 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/156489 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51034 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39193 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54389 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52727 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->