### PR TITLE
[JSC] Make all of Microtask defined via InternalMicrotask ID

### DIFF
--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -3470,9 +3470,9 @@ void JSGlobalObject::bumpGlobalLexicalBindingEpoch(VM& vm)
     }
 }
 
-void JSGlobalObject::queueMicrotask(JSValue job, JSValue argument0, JSValue argument1, JSValue argument2, JSValue argument3)
+void JSGlobalObject::queueMicrotask(InternalMicrotask job, JSValue argument0, JSValue argument1, JSValue argument2, JSValue argument3)
 {
-    QueuedTask task { nullptr, this, job, argument0, argument1, argument2, argument3 };
+    QueuedTask task { nullptr, job, this, argument0, argument1, argument2, argument3 };
     if (globalObjectMethodTable()->queueMicrotaskToEventLoop) {
         globalObjectMethodTable()->queueMicrotaskToEventLoop(*this, WTFMove(task));
         return;

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -1126,7 +1126,7 @@ public:
     static bool shouldInterruptScriptBeforeTimeout(const JSGlobalObject*) { return false; }
     static RuntimeFlags javaScriptRuntimeFlags(const JSGlobalObject*) { return RuntimeFlags(); }
 
-    JS_EXPORT_PRIVATE void queueMicrotask(JSValue job, JSValue, JSValue, JSValue, JSValue);
+    JS_EXPORT_PRIVATE void queueMicrotask(InternalMicrotask, JSValue, JSValue, JSValue, JSValue);
 
     static void reportViolationForUnsafeEval(const JSGlobalObject*, const String&) { }
 

--- a/Source/JavaScriptCore/runtime/JSMicrotask.h
+++ b/Source/JavaScriptCore/runtime/JSMicrotask.h
@@ -31,7 +31,6 @@
 
 namespace JSC {
 
-void runJSMicrotask(JSGlobalObject*, MicrotaskIdentifier, JSValue job, std::span<const JSValue, maxMicrotaskArguments>);
-JS_EXPORT_PRIVATE void runInternalMirotask(JSGlobalObject*, InternalMicrotask, std::span<const JSValue, maxMicrotaskArguments>);
+JS_EXPORT_PRIVATE void runInternalMicrotask(JSGlobalObject*, InternalMicrotask, std::span<const JSValue, maxMicrotaskArguments>);
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSPromise.cpp
+++ b/Source/JavaScriptCore/runtime/JSPromise.cpp
@@ -289,19 +289,19 @@ void JSPromise::performPromiseThen(JSGlobalObject* globalObject, JSValue onFulfi
         }
         scope.release();
         if (promiseOrCapability.isUndefinedOrNull()) {
-            globalObject->queueMicrotask(jsNumber(static_cast<int32_t>(InternalMicrotask::PromiseReactionJobWithoutPromise)), onRejected, reactionsOrResult, context, jsUndefined());
+            globalObject->queueMicrotask(InternalMicrotask::PromiseReactionJobWithoutPromise, onRejected, reactionsOrResult, context, jsUndefined());
             break;
         }
-        globalObject->queueMicrotask(jsNumber(static_cast<int32_t>(InternalMicrotask::PromiseReactionJob)), promiseOrCapability, onRejected, reactionsOrResult, context);
+        globalObject->queueMicrotask(InternalMicrotask::PromiseReactionJob, promiseOrCapability, onRejected, reactionsOrResult, context);
         break;
     }
     case JSPromise::Status::Fulfilled: {
         scope.release();
         if (promiseOrCapability.isUndefinedOrNull()) {
-            globalObject->queueMicrotask(jsNumber(static_cast<int32_t>(InternalMicrotask::PromiseReactionJobWithoutPromise)), onFulfilled, reactionsOrResult, context, jsUndefined());
+            globalObject->queueMicrotask(InternalMicrotask::PromiseReactionJobWithoutPromise, onFulfilled, reactionsOrResult, context, jsUndefined());
             break;
         }
-        globalObject->queueMicrotask(jsNumber(static_cast<int32_t>(InternalMicrotask::PromiseReactionJob)), promiseOrCapability, onFulfilled, reactionsOrResult, context);
+        globalObject->queueMicrotask(InternalMicrotask::PromiseReactionJob, promiseOrCapability, onFulfilled, reactionsOrResult, context);
         break;
     }
     }
@@ -363,7 +363,7 @@ void JSPromise::resolvePromise(JSGlobalObject* globalObject, JSValue resolution)
     if (resolutionObject->inherits<JSPromise>()) {
         auto* promise = jsCast<JSPromise*>(resolutionObject);
         if (promise->isThenFastAndNonObservable())
-            return globalObject->queueMicrotask(jsNumber(static_cast<int32_t>(InternalMicrotask::PromiseResolveThenableJobFast)), resolutionObject, this, jsUndefined(), jsUndefined());
+            return globalObject->queueMicrotask(InternalMicrotask::PromiseResolveThenableJobFast, resolutionObject, this, jsUndefined(), jsUndefined());
     }
 
     JSValue then;
@@ -384,7 +384,7 @@ void JSPromise::resolvePromise(JSGlobalObject* globalObject, JSValue resolution)
         return fulfillPromise(globalObject, resolutionObject);
 
     auto [ resolve, reject ] = createResolvingFunctions(vm, globalObject);
-    return globalObject->queueMicrotask(jsNumber(static_cast<int32_t>(InternalMicrotask::PromiseResolveThenableJob)), resolutionObject, then, resolve, reject);
+    return globalObject->queueMicrotask(InternalMicrotask::PromiseResolveThenableJob, resolutionObject, then, resolve, reject);
 }
 
 JSC_DEFINE_HOST_FUNCTION(promiseResolvingFunctionResolve, (JSGlobalObject* globalObject, CallFrame* callFrame))
@@ -574,18 +574,18 @@ void JSPromise::triggerPromiseReactions(JSGlobalObject* globalObject, Status sta
         current = jsDynamicCast<JSPromiseReaction*>(current->next());
 
         if (handler.isUndefinedOrNull()) {
-            globalObject->queueMicrotask(jsNumber(static_cast<int32_t>(InternalMicrotask::PromiseResolveWithoutHandlerJob)), promise, argument, jsNumber(static_cast<int32_t>(status)), jsUndefined());
+            globalObject->queueMicrotask(InternalMicrotask::PromiseResolveWithoutHandlerJob, promise, argument, jsNumber(static_cast<int32_t>(status)), jsUndefined());
             RETURN_IF_EXCEPTION(scope, void());
             continue;
         }
 
         if (promise.isUndefinedOrNull()) {
-            globalObject->queueMicrotask(jsNumber(static_cast<int32_t>(InternalMicrotask::PromiseReactionJobWithoutPromise)), handler, argument, context, jsUndefined());
+            globalObject->queueMicrotask(InternalMicrotask::PromiseReactionJobWithoutPromise, handler, argument, context, jsUndefined());
             RETURN_IF_EXCEPTION(scope, void());
             continue;
         }
 
-        globalObject->queueMicrotask(jsNumber(static_cast<int32_t>(InternalMicrotask::PromiseReactionJob)), promise, handler, argument, context);
+        globalObject->queueMicrotask(InternalMicrotask::PromiseReactionJob, promise, handler, argument, context);
         RETURN_IF_EXCEPTION(scope, void());
     }
 }
@@ -641,7 +641,7 @@ void JSPromise::resolveWithoutPromise(JSGlobalObject* globalObject, JSValue reso
     if (resolutionObject->inherits<JSPromise>()) {
         auto* promise = jsCast<JSPromise*>(resolutionObject);
         if (promise->isThenFastAndNonObservable())
-            return globalObject->queueMicrotask(jsNumber(static_cast<int32_t>(InternalMicrotask::PromiseResolveThenableJobWithoutPromiseFast)), resolutionObject, onFulfilled, onRejected, context);
+            return globalObject->queueMicrotask(InternalMicrotask::PromiseResolveThenableJobWithoutPromiseFast, resolutionObject, onFulfilled, onRejected, context);
     }
 
     JSValue then;
@@ -662,19 +662,19 @@ void JSPromise::resolveWithoutPromise(JSGlobalObject* globalObject, JSValue reso
         return fulfillWithoutPromise(globalObject, resolution, onFulfilled, onRejected, context);
 
     auto [ resolve, reject ] = createResolvingFunctionsWithoutPromise(vm, globalObject, onFulfilled, onRejected, context);
-    return globalObject->queueMicrotask(jsNumber(static_cast<int32_t>(InternalMicrotask::PromiseResolveThenableJob)), resolutionObject, then, resolve, reject);
+    return globalObject->queueMicrotask(InternalMicrotask::PromiseResolveThenableJob, resolutionObject, then, resolve, reject);
 }
 
 void JSPromise::rejectWithoutPromise(JSGlobalObject* globalObject, JSValue argument, JSValue onFulfilled, JSValue onRejected, JSValue context)
 {
     UNUSED_PARAM(onFulfilled);
-    globalObject->queueMicrotask(jsNumber(static_cast<int32_t>(InternalMicrotask::PromiseReactionJobWithoutPromise)), onRejected, argument, context, jsUndefined());
+    globalObject->queueMicrotask(InternalMicrotask::PromiseReactionJobWithoutPromise, onRejected, argument, context, jsUndefined());
 }
 
 void JSPromise::fulfillWithoutPromise(JSGlobalObject* globalObject, JSValue argument, JSValue onFulfilled, JSValue onRejected, JSValue context)
 {
     UNUSED_PARAM(onRejected);
-    globalObject->queueMicrotask(jsNumber(static_cast<int32_t>(InternalMicrotask::PromiseReactionJobWithoutPromise)), onFulfilled, argument, context, jsUndefined());
+    globalObject->queueMicrotask(InternalMicrotask::PromiseReactionJobWithoutPromise, onFulfilled, argument, context, jsUndefined());
 }
 
 bool JSPromise::isThenFastAndNonObservable()

--- a/Source/JavaScriptCore/runtime/Microtask.h
+++ b/Source/JavaScriptCore/runtime/Microtask.h
@@ -39,6 +39,8 @@ enum class InternalMicrotask : int32_t {
     PromiseResolveWithoutHandlerJob,
     PromiseReactionJob,
     PromiseReactionJobWithoutPromise,
+    InvokeFunctionJob,
+    Opaque, // Dispatch must handle everything.
 };
 
 constexpr unsigned maxMicrotaskArguments = 4;

--- a/Source/JavaScriptCore/runtime/MicrotaskQueue.cpp
+++ b/Source/JavaScriptCore/runtime/MicrotaskQueue.cpp
@@ -100,7 +100,6 @@ void MarkedMicrotaskDeque::visitAggregateImpl(Visitor& visitor)
     for (auto iterator = m_queue.begin() + m_markedBefore, end = m_queue.end(); iterator != end; ++iterator) {
         auto& task = *iterator;
         visitor.appendUnbarriered(task.m_globalObject);
-        visitor.appendUnbarriered(task.m_job);
         visitor.appendUnbarriered(task.m_arguments, QueuedTask::maxArguments);
     }
     m_markedBefore = m_queue.size();

--- a/Source/JavaScriptCore/runtime/MicrotaskQueue.h
+++ b/Source/JavaScriptCore/runtime/MicrotaskQueue.h
@@ -54,18 +54,19 @@ public:
         Suspended,
     };
 
-    QueuedTask(RefPtr<MicrotaskDispatcher>&& dispatcher, JSGlobalObject* globalObject)
+    QueuedTask(Ref<MicrotaskDispatcher>&& dispatcher)
         : m_dispatcher(WTFMove(dispatcher))
         , m_identifier(MicrotaskIdentifier::generate())
-        , m_globalObject(globalObject)
+        , m_job(InternalMicrotask::Opaque)
+        , m_globalObject(nullptr)
     {
     }
 
-    QueuedTask(RefPtr<MicrotaskDispatcher>&& dispatcher, JSGlobalObject* globalObject, JSValue job, JSValue argument0, JSValue argument1, JSValue argument2, JSValue argument3)
+    QueuedTask(RefPtr<MicrotaskDispatcher>&& dispatcher, InternalMicrotask job, JSGlobalObject* globalObject, JSValue argument0, JSValue argument1, JSValue argument2, JSValue argument3)
         : m_dispatcher(WTFMove(dispatcher))
         , m_identifier(MicrotaskIdentifier::generate())
-        , m_globalObject(globalObject)
         , m_job(job)
+        , m_globalObject(globalObject)
         , m_arguments { argument0, argument1, argument2, argument3 }
     {
     }
@@ -80,14 +81,14 @@ public:
     MicrotaskDispatcher* dispatcher() const { return m_dispatcher.get(); }
     MicrotaskIdentifier identifier() const { return m_identifier; }
     JSGlobalObject* globalObject() const { return m_globalObject; }
-    JSValue job() const { return m_job; }
+    InternalMicrotask job() const { return m_job; }
     std::span<const JSValue, maxArguments> arguments() const { return std::span<const JSValue, maxArguments> { m_arguments, maxArguments }; }
 
 private:
     RefPtr<MicrotaskDispatcher> m_dispatcher;
     MicrotaskIdentifier m_identifier;
+    InternalMicrotask m_job;
     JSGlobalObject* m_globalObject;
-    JSValue m_job { };
     JSValue m_arguments[maxArguments] { };
 };
 

--- a/Source/WebCore/bindings/js/JSDOMWindowCustom.cpp
+++ b/Source/WebCore/bindings/js/JSDOMWindowCustom.cpp
@@ -604,8 +604,10 @@ JSValue JSDOMWindow::queueMicrotask(JSGlobalObject& lexicalGlobalObject, CallFra
     if (!functionValue.isCallable()) [[unlikely]]
         return JSValue::decode(throwArgumentMustBeFunctionError(lexicalGlobalObject, scope, 0, "callback"_s, "Window"_s, "queueMicrotask"_s));
 
+    auto* globalObject = asObject(functionValue)->globalObject();
+
     scope.release();
-    globalObjectMethodTable()->queueMicrotaskToEventLoop(*this, JSC::QueuedTask { nullptr, this, functionValue, { }, { }, { }, { } });
+    globalObjectMethodTable()->queueMicrotaskToEventLoop(*this, JSC::QueuedTask { nullptr, JSC::InternalMicrotask::InvokeFunctionJob, globalObject, functionValue, { }, { }, { } });
     return jsUndefined();
 }
 

--- a/Source/WebCore/bindings/js/JSWorkerGlobalScopeCustom.cpp
+++ b/Source/WebCore/bindings/js/JSWorkerGlobalScopeCustom.cpp
@@ -68,8 +68,10 @@ JSValue JSWorkerGlobalScope::queueMicrotask(JSGlobalObject& lexicalGlobalObject,
     if (!functionValue.isCallable()) [[unlikely]]
         return JSValue::decode(throwArgumentMustBeFunctionError(lexicalGlobalObject, scope, 0, "callback"_s, "WorkerGlobalScope"_s, "queueMicrotask"_s));
 
+    auto* globalObject = asObject(functionValue)->globalObject();
+
     scope.release();
-    globalObjectMethodTable()->queueMicrotaskToEventLoop(*this, JSC::QueuedTask { nullptr, this, functionValue, { }, { }, { }, { } });
+    globalObjectMethodTable()->queueMicrotaskToEventLoop(*this, JSC::QueuedTask { nullptr, JSC::InternalMicrotask::InvokeFunctionJob, globalObject, functionValue, { }, { }, { } });
     return jsUndefined();
 }
 

--- a/Source/WebCore/dom/EventLoop.cpp
+++ b/Source/WebCore/dom/EventLoop.cpp
@@ -560,7 +560,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(EventLoopFunctionMicrotaskDispatcher);
 
 void EventLoopTaskGroup::queueMicrotask(EventLoop::TaskFunction&& function)
 {
-    queueMicrotask(JSC::QueuedTask { EventLoopFunctionMicrotaskDispatcher::create(*this, WTFMove(function)), nullptr });
+    queueMicrotask(JSC::QueuedTask { EventLoopFunctionMicrotaskDispatcher::create(*this, WTFMove(function)) });
 }
 
 void EventLoopTaskGroup::queueMicrotask(JSC::QueuedTask&& task)


### PR DESCRIPTION
#### 8844dcdf0fce4a67613282cc4cbba29aa37cfc31
<pre>
[JSC] Make all of Microtask defined via InternalMicrotask ID
<a href="https://bugs.webkit.org/show_bug.cgi?id=300274">https://bugs.webkit.org/show_bug.cgi?id=300274</a>
<a href="https://rdar.apple.com/162080573">rdar://162080573</a>

Reviewed by Yijia Huang.

With this patch, all microtasks are defined as InternalMicrotask.
We add InternalMicrotask::InvokeFunction to handle self.queueMicrotask
use in WebCore. Then we also add InternalMicrotask::Opaque when
MicrotaskDispatcher::run completely handles the code execution (this is
for C++ task defined for EventLoop, so they do not have JS functions).

* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::queueMicrotask):
* Source/JavaScriptCore/runtime/JSGlobalObject.h:
* Source/JavaScriptCore/runtime/JSMicrotask.cpp:
(JSC::runInternalMicrotask):
(JSC::runInternalMirotask):
(JSC::runJSMicrotask): Deleted.
* Source/JavaScriptCore/runtime/JSMicrotask.h:
* Source/JavaScriptCore/runtime/JSPromise.cpp:
(JSC::JSPromise::performPromiseThen):
(JSC::JSPromise::resolvePromise):
(JSC::JSPromise::triggerPromiseReactions):
(JSC::JSPromise::resolveWithoutPromise):
(JSC::JSPromise::rejectWithoutPromise):
(JSC::JSPromise::fulfillWithoutPromise):
* Source/JavaScriptCore/runtime/Microtask.h:
* Source/JavaScriptCore/runtime/MicrotaskQueue.cpp:
(JSC::MarkedMicrotaskDeque::visitAggregateImpl):
* Source/JavaScriptCore/runtime/MicrotaskQueue.h:
(JSC::QueuedTask::QueuedTask):
(JSC::QueuedTask::job const):
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::drainMicrotasks):
* Source/WebCore/bindings/js/JSDOMWindowCustom.cpp:
(WebCore::JSDOMWindow::queueMicrotask):
* Source/WebCore/bindings/js/JSWorkerGlobalScopeCustom.cpp:
(WebCore::JSWorkerGlobalScope::queueMicrotask):
* Source/WebCore/dom/EventLoop.cpp:
(WebCore::EventLoopTaskGroup::queueMicrotask):
* Source/WebCore/dom/Microtasks.cpp:
(WebCore::MicrotaskQueue::runJSMicrotask):

Canonical link: <a href="https://commits.webkit.org/301178@main">https://commits.webkit.org/301178@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9a8d09ab4cc07c358a0f16732e7db714a4431762

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125167 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44834 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35573 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132017 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/77029 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d7577132-ad49-43cb-bb56-8239dc65ce22) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127044 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45525 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53395 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/95287 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/77029 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/66370385-cc48-4344-9a03-e78c98bc03b1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128121 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/36343 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111932 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75827 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d59be959-e96a-4eab-ace1-7cad52aa8e38) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/35245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30098 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75495 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/117258 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106110 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/30325 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134704 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/123685 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51976 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/39763 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/103756 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52411 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108153 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/103526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48877 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/27166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49041 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19602 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51868 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/57647 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/156708 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51232 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39241 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54588 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52925 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->