### PR TITLE
[World Leaks] Investigate leaks in LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/

### DIFF
--- a/LayoutTests/fast/css/contain-intrinsic-size-does-not-leak-expected.txt
+++ b/LayoutTests/fast/css/contain-intrinsic-size-does-not-leak-expected.txt
@@ -1,0 +1,10 @@
+Tests that ResizeObserver with contain-intrinsic-size does not leak the document object
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS The iframe document didn't leak.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/css/contain-intrinsic-size-does-not-leak.html
+++ b/LayoutTests/fast/css/contain-intrinsic-size-does-not-leak.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+</head>
+<body>
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/document-leak-test.js"></script>
+<script>
+    description("Tests that ResizeObserver with contain-intrinsic-size does not leak the document object");
+    onload = () => runDocumentLeakTest({ frameURL: "resources/contain-intrinsic-size-leak-test.html", framesToCreate: 20 });
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/css/resources/contain-intrinsic-size-leak-test.html
+++ b/LayoutTests/fast/css/resources/contain-intrinsic-size-leak-test.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+
+<div style="height: 2000px;"></div>
+
+<div style="contain-intrinsic-size: auto 1px;" id="test">
+  <div style="height: 50px;"></div>
+</div>
+
+<script>
+function finalize() {
+  el.style.contentVisibility = "auto";
+  window.parent.postMessage("ready", "*");
+}
+
+var el = document.getElementById("test");
+var observer = new ResizeObserver(function() {
+  requestAnimationFrame(finalize);
+  observer.unobserve(el);
+});
+
+observer.observe(el);
+el.offsetWidth;
+</script>

--- a/Source/WebCore/bindings/js/JSResizeObserverCustom.cpp
+++ b/Source/WebCore/bindings/js/JSResizeObserverCustom.cpp
@@ -29,6 +29,7 @@
 
 #include "Element.h"
 #include "JSNodeCustom.h"
+#include "WebCoreOpaqueRootInlines.h"
 #include <JavaScriptCore/JSCInlines.h>
 
 namespace WebCore {
@@ -39,6 +40,18 @@ void JSResizeObserver::visitAdditionalChildren(Visitor& visitor)
     ResizeObserverCallback* callback = wrapped().callbackConcurrently();
     if (callback)
         callback->visitJSFunction(visitor);
+
+    Locker locker { wrapped().observationTargetsLock() };
+
+    for (const auto& weakTarget : wrapped().activeObservationTargets()) {
+        SUPPRESS_UNCHECKED_LOCAL if (auto* element = weakTarget.get())
+            addWebCoreOpaqueRoot(visitor, element);
+    }
+
+    for (const auto& weakTarget : wrapped().targetsWaitingForFirstObservation()) {
+        SUPPRESS_UNCHECKED_LOCAL if (auto* element = weakTarget.get())
+            addWebCoreOpaqueRoot(visitor, element);
+    }
 }
 
 DEFINE_VISIT_ADDITIONAL_CHILDREN(JSResizeObserver);

--- a/Source/WebCore/page/ResizeObserver.cpp
+++ b/Source/WebCore/page/ResizeObserver.cpp
@@ -92,7 +92,10 @@ void ResizeObserver::observeInternal(Element& target, const ResizeObserverBoxOpt
     // Per the specification, we should dispatch at least one observation for the target. For this reason, we make sure to keep the
     // target alive until this first observation. This, in turn, will keep the ResizeObserver's JS wrapper alive via
     // isReachableFromOpaqueRoots(), so the callback stays alive.
-    m_targetsWaitingForFirstObservation.append(target);
+    {
+        Locker locker { m_observationTargetsLock };
+        m_targetsWaitingForFirstObservation.append(target);
+    }
 
     if (m_document && isJSCallback()) {
         m_document->addResizeObserver(*this);
@@ -144,7 +147,10 @@ size_t ResizeObserver::gatherObservations(size_t deeperThan)
                 LOG_WITH_STREAM(ResizeObserver, stream << "ResizeObserver " << this << " gatherObservations - recording observation " << observation.get());
 
                 m_activeObservations.append(observation.get());
-                m_activeObservationTargets.append(*observation->protectedTarget());
+                {
+                    Locker locker { m_observationTargetsLock };
+                    m_activeObservationTargets.append(*observation->protectedTarget());
+                }
                 minObservedDepth = std::min(depth, minObservedDepth);
             } else
                 m_hasSkippedObservations = true;
@@ -162,9 +168,14 @@ void ResizeObserver::deliverObservations()
         return ResizeObserverEntry::create(observation->target(), observation->computeContentRect(), observation->borderBoxSize(), observation->contentBoxSize());
     });
     m_activeObservations.clear();
-    auto activeObservationTargets = std::exchange(m_activeObservationTargets, { });
 
-    auto targetsWaitingForFirstObservation = std::exchange(m_targetsWaitingForFirstObservation, { });
+    Vector<WeakPtr<Element, WeakPtrImplWithEventTargetData>> activeObservationTargets;
+    Vector<WeakPtr<Element, WeakPtrImplWithEventTargetData>> targetsWaitingForFirstObservation;
+    {
+        Locker locker { m_observationTargetsLock };
+        activeObservationTargets = std::exchange(m_activeObservationTargets, { });
+        targetsWaitingForFirstObservation = std::exchange(m_targetsWaitingForFirstObservation, { });
+    }
 
     if (isNativeCallback()) {
         std::get<NativeResizeObserverCallback>(m_JSOrNativeCallback)(entries, *this);
@@ -193,13 +204,19 @@ bool ResizeObserver::isReachableFromOpaqueRoots(JSC::AbstractSlotVisitor& visito
         if (auto* target = observation->target(); target && containsWebCoreOpaqueRoot(visitor, target))
             return true;
     }
-    for (auto& target : m_activeObservationTargets) {
-        SUPPRESS_UNCOUNTED_ARG {
-            if (containsWebCoreOpaqueRoot(visitor, target.get()))
-                return true;
-        }
+
+    Locker locker { m_observationTargetsLock };
+
+    for (const auto& weakTarget : m_activeObservationTargets) {
+        RefPtr target = weakTarget.get();
+        if (target && containsWebCoreOpaqueRoot(visitor, target.get()))
+            return true;
     }
-    return !m_targetsWaitingForFirstObservation.isEmpty();
+    for (const auto& weakTarget : m_targetsWaitingForFirstObservation) {
+        if (auto* element = weakTarget.get(); element && containsWebCoreOpaqueRoot(visitor, element))
+            return true;
+    }
+    return false;
 }
 
 bool ResizeObserver::removeTarget(Element& target)
@@ -218,17 +235,23 @@ void ResizeObserver::removeAllTargets()
         bool removed = removeTarget(*observation->protectedTarget());
         ASSERT_UNUSED(removed, removed);
     }
-    m_activeObservationTargets.clear();
+    {
+        Locker locker { m_observationTargetsLock };
+        m_activeObservationTargets.clear();
+        m_targetsWaitingForFirstObservation.clear();
+    }
     m_activeObservations.clear();
-    m_targetsWaitingForFirstObservation.clear();
     m_observations.clear();
 }
 
 bool ResizeObserver::removeObservation(const Element& target)
 {
-    m_targetsWaitingForFirstObservation.removeFirstMatching([&target](auto& pendingTarget) {
-        return pendingTarget.ptr() == &target;
-    });
+    {
+        Locker locker { m_observationTargetsLock };
+        m_targetsWaitingForFirstObservation.removeFirstMatching([&target](auto& pendingTarget) {
+            return pendingTarget.get() == &target;
+        });
+    }
     return m_observations.removeFirstMatching([&target](auto& observation) {
         return observation->target() == &target;
     });

--- a/Source/WebCore/page/ResizeObserver.h
+++ b/Source/WebCore/page/ResizeObserver.h
@@ -76,6 +76,10 @@ public:
 
     void resetObservationSize(Element&);
 
+    const Vector<WeakPtr<Element, WeakPtrImplWithEventTargetData>>& activeObservationTargets() const WTF_REQUIRES_LOCK(m_observationTargetsLock) { return m_activeObservationTargets; }
+    const Vector<WeakPtr<Element, WeakPtrImplWithEventTargetData>>& targetsWaitingForFirstObservation() const WTF_REQUIRES_LOCK(m_observationTargetsLock) { return m_targetsWaitingForFirstObservation; }
+    Lock& observationTargetsLock() WTF_RETURNS_LOCK(m_observationTargetsLock) { return m_observationTargetsLock; }
+
     ResizeObserverCallback* callbackConcurrently();
     bool isReachableFromOpaqueRoots(JSC::AbstractSlotVisitor&) const;
 
@@ -94,9 +98,10 @@ private:
     Vector<Ref<ResizeObservation>> m_observations;
 
     Vector<Ref<ResizeObservation>> m_activeObservations;
-    Vector<GCReachableRef<Element>> m_activeObservationTargets;
-    Vector<GCReachableRef<Element>> m_targetsWaitingForFirstObservation;
+    Vector<WeakPtr<Element, WeakPtrImplWithEventTargetData>> m_activeObservationTargets WTF_GUARDED_BY_LOCK(m_observationTargetsLock);
+    Vector<WeakPtr<Element, WeakPtrImplWithEventTargetData>> m_targetsWaitingForFirstObservation WTF_GUARDED_BY_LOCK(m_observationTargetsLock);
 
+    mutable Lock m_observationTargetsLock;
     bool m_hasSkippedObservations { false };
 };
 


### PR DESCRIPTION
#### 687f8f0e2b6b52578f3ebb78d1d0e0d63555c749
<pre>
[World Leaks] Investigate leaks in LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/
<a href="https://bugs.webkit.org/show_bug.cgi?id=300275">https://bugs.webkit.org/show_bug.cgi?id=300275</a>
<a href="https://rdar.apple.com/162081020">rdar://162081020</a>

Reviewed by Ryosuke Niwa.

Document holds a RefPtr&lt;m_resizeObserverForContainIntrinsicSize&gt; which holds a
Vector&lt;GCReachableRef&lt;Element&gt;&gt;, which internally is a vector of RefPtr&lt;Element&gt;
causing a leak, which impacts approximately 15 tests. This is fixed by changing the
vector to a Vector&lt;WeakPtr&lt;Element&gt;&gt;.

Test: fast/css/contain-intrinsic-size-does-not-leak.html

* LayoutTests/fast/css/contain-intrinsic-size-does-not-leak-expected.txt: Added.
* LayoutTests/fast/css/contain-intrinsic-size-does-not-leak.html: Added.
* LayoutTests/fast/css/resources/contain-intrinsic-size-leak-test.html: Added.
* Source/WebCore/bindings/js/JSResizeObserverCustom.cpp:
(WebCore::JSResizeObserver::visitAdditionalChildren):
* Source/WebCore/page/ResizeObserver.cpp:
(WebCore::ResizeObserver::observeInternal):
(WebCore::ResizeObserver::gatherObservations):
(WebCore::ResizeObserver::deliverObservations):
(WebCore::ResizeObserver::isReachableFromOpaqueRoots const):
(WebCore::ResizeObserver::removeAllTargets):
(WebCore::ResizeObserver::removeObservation):
* Source/WebCore/page/ResizeObserver.h:
(WebCore::ResizeObserver::WTF_REQUIRES_LOCK):
(WebCore::ResizeObserver::WTF_RETURNS_LOCK):

Canonical link: <a href="https://commits.webkit.org/301243@main">https://commits.webkit.org/301243@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/27e100e6586be3be4fac42b1dc1341b662b53ea0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125287 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44952 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35693 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132136 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77157 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127164 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45640 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53519 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95385 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/63323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128241 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36448 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112033 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75925 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35347 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30207 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75613 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106215 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30426 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134821 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52091 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39875 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103896 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52529 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108254 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103621 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26404 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48979 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27266 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/49196 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51986 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57767 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51346 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54700 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53038 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->