### PR TITLE
[TestWebKitAPI][GTK][WPE] Use the custom main() for TestJavaScriptCore

### DIFF
--- a/Tools/Scripts/run-wpe-tests
+++ b/Tools/Scripts/run-wpe-tests
@@ -31,7 +31,7 @@ import flatpakutils
 from api_test_runner import TestRunner, create_option_parser, get_runner_args
 
 class WPETestRunner(TestRunner):
-    TestRunner.TEST_TARGETS = [ "WPE", "WPEPlatform", "WPEQt", "TestWebKit", "TestJSC", "TestWTF", "TestWebCore" ]
+    TestRunner.TEST_TARGETS = [ "WPE", "WPEPlatform", "WPEQt", "TestWebKit", "TestJSC", "TestWTF", "TestWebCore", "TestJavaScriptCore" ]
 
     def __init__(self, options, tests=[]):
         super(WPETestRunner, self).__init__("wpe", options, tests)
@@ -40,7 +40,7 @@ class WPETestRunner(TestRunner):
         return os.path.basename(os.path.dirname(test_program)) in ["WPE", "WPEPlatform"] or os.path.basename(test_program) in ["TestJSC"]
 
     def is_google_test(self, test_program):
-        return os.path.basename(test_program) in ["TestWebKit", "TestWTF", "TestWebCore"]
+        return os.path.basename(test_program) in ["TestWebKit", "TestWTF", "TestWebCore", "TestJavaScriptCore"]
 
     def is_qt_test(self, test_program):
         return os.path.basename(os.path.dirname(test_program)) == "WPEQt"

--- a/Tools/Scripts/webkitpy/port/glib.py
+++ b/Tools/Scripts/webkitpy/port/glib.py
@@ -201,7 +201,7 @@ class GLibPort(Port):
             command = self._jhbuild_wrapper + command
         return self._executive.run_command(command + args, cwd=self.webkit_base(), stdout=None, return_stderr=False, decode_output=False, env=env)
 
-    API_TEST_BINARY_NAMES = ['TestWTF', 'TestWebCore', 'TestWebKit']
+    API_TEST_BINARY_NAMES = ['TestWTF', 'TestJavaScriptCore', 'TestWebCore', 'TestWebKit']
 
     def path_to_api_test(self, program_name):
         return self._built_executables_path('TestWebKitAPI', program_name)

--- a/Tools/TestWebKitAPI/PlatformGTK.cmake
+++ b/Tools/TestWebKitAPI/PlatformGTK.cmake
@@ -31,6 +31,15 @@ list(APPEND TestWTF_LIBRARIES
     GTK::GTK
 )
 
+# TestJavaScriptCore
+list(APPEND TestJavaScriptCore_SOURCES
+    ${test_main_SOURCES}
+)
+
+list(APPEND TestJavaScriptCore_LIBRARIES
+    GTK::GTK
+)
+
 # TestWebCore
 list(APPEND TestWebCore_SOURCES
     ${test_main_SOURCES}

--- a/Tools/TestWebKitAPI/PlatformWPE.cmake
+++ b/Tools/TestWebKitAPI/PlatformWPE.cmake
@@ -28,6 +28,10 @@ list(APPEND TestWTF_SYSTEM_INCLUDE_DIRECTORIES
 )
 
 # TestJavaScriptCore
+list(APPEND TestJavaScriptCore_SOURCES
+    ${test_main_SOURCES}
+)
+
 list(APPEND TestJavaScriptCore_SYSTEM_INCLUDE_DIRECTORIES
     ${GLIB_INCLUDE_DIRS}
 )


### PR DESCRIPTION
#### 9e98f550b371eb496e419495e67ad7a12969da50
<pre>
[TestWebKitAPI][GTK][WPE] Use the custom main() for TestJavaScriptCore
<a href="https://bugs.webkit.org/show_bug.cgi?id=300276">https://bugs.webkit.org/show_bug.cgi?id=300276</a>

Reviewed by Nikolas Zimmermann.

Only TestJavaScriptCore didn&apos;t use TestWebKitAPI&apos;s custom main(), and output
the google tests default messages. Use the custom main().

Added TestJavaScriptCore to run-api-tests and run-wpe-tests.

* Tools/Scripts/run-wpe-tests:
(WPETestRunner):
(WPETestRunner.is_google_test):
* Tools/Scripts/webkitpy/port/glib.py:
(GLibPort):
* Tools/TestWebKitAPI/PlatformGTK.cmake:
* Tools/TestWebKitAPI/PlatformWPE.cmake:

Canonical link: <a href="https://commits.webkit.org/301111@main">https://commits.webkit.org/301111@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/758b9f8620a358cb9a2e9e7e8fc8fb0278dd1aae

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124958 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44627 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35364 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131808 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76839 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/126835 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45320 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53194 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95109 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/63097 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127912 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36168 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111755 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75657 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/124314 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35099 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29908 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75288 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105931 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30139 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134481 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51785 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39586 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103583 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52208 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107968 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103359 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48698 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26987 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48805 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19582 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51666 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51044 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54400 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52737 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->