### PR TITLE
REGRESSION (300681@main): [visionOS] Web process crashes when editing any text

### DIFF
--- a/Source/WebCore/editing/cocoa/AttributedString.mm
+++ b/Source/WebCore/editing/cocoa/AttributedString.mm
@@ -789,21 +789,28 @@ AttributedString AttributedString::fromNSAttributedStringAndDocumentAttributes(R
 
 std::optional<AttributedString::FontWrapper> AttributedString::FontWrapper::createFromIPCData(const String& postScriptName, double pointSize, const CTFontDescriptorOptions& fontDescriptorOptions, const std::optional<WebCore::FontPlatformSerializedAttributes>& fontSerializedAttributes)
 {
-    RetainPtr<CTFontDescriptorRef> fontDescriptor;
-    if (fontSerializedAttributes)
-        fontDescriptor = adoptCF(CTFontDescriptorCreateWithAttributesAndOptions(fontSerializedAttributes->toCFDictionary().get(), fontDescriptorOptions));
-    else
-        fontDescriptor = adoptCF(CTFontDescriptorCreateWithNameAndSize(postScriptName.createCFString().get(), pointSize));
-    RetainPtr<CFArrayRef> matched = adoptCF(CTFontDescriptorCreateMatchingFontDescriptorsWithOptions(fontDescriptor.get(), NULL, kCTFontDescriptorMatchingOptionIncludeHiddenFonts));
+    RetainPtr font = [&] -> RetainPtr<CTFontRef> {
+        RetainPtr<CTFontDescriptorRef> fontDescriptor;
+        if (fontSerializedAttributes)
+            fontDescriptor = adoptCF(CTFontDescriptorCreateWithAttributesAndOptions(fontSerializedAttributes->toCFDictionary().get(), fontDescriptorOptions));
+        else
+            fontDescriptor = adoptCF(CTFontDescriptorCreateWithNameAndSize(postScriptName.createCFString().get(), pointSize));
 
-    if (!matched || !CFArrayGetCount(matched.get()))
-        return std::nullopt;
+        RetainPtr matched = adoptCF(CTFontDescriptorCreateMatchingFontDescriptorsWithOptions(fontDescriptor.get(), NULL, kCTFontDescriptorMatchingOptionIncludeHiddenFonts));
+        if (!matched || !CFArrayGetCount(matched.get()))
+            return { };
 
-    RetainPtr<CTFontDescriptorRef> matchedDescriptor = dynamic_cf_cast<CTFontDescriptorRef>(CFArrayGetValueAtIndex(matched.get(), 0));
-    RetainPtr<CTFontRef> font = adoptCF(CTFontCreateWithFontDescriptor(matchedDescriptor.get(), pointSize, NULL));
+        RetainPtr matchedDescriptor = dynamic_cf_cast<CTFontDescriptorRef>(CFArrayGetValueAtIndex(matched.get(), 0));
+        RetainPtr matchedFont = adoptCF(CTFontCreateWithFontDescriptor(matchedDescriptor.get(), pointSize, NULL));
 
-    if (String(adoptCF(CTFontCopyPostScriptName(font.get())).get()) != postScriptName)
-        return std::nullopt;
+        if (String(adoptCF(CTFontCopyPostScriptName(matchedFont.get())).get()) != postScriptName)
+            return { };
+
+        return matchedFont;
+    }();
+
+    if (!font)
+        font = adoptCF(CTFontCreateUIFontForLanguage(kCTFontUIFontSystem, pointSize, nil));
 
     return { { Font::create(FontPlatformData(font.get(), pointSize)) } };
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/DocumentEditingContext.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/DocumentEditingContext.mm
@@ -1728,4 +1728,22 @@ TEST(DocumentEditingContext, ContextWithWritingSuggestions)
     EXPECT_EQ(selectedRangeInMarkedText.length, 0U);
 }
 
+TEST(DocumentEditingContext, RequestAttributedTextWithCustomFont)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    [webView _setEditable:YES];
+    [webView synchronouslyLoadHTMLString:DocumentEditingContextTestHelpers::applyAhemStyle(threeSentencesExample)];
+    [webView objectByEvaluatingJavaScript:@"getSelection().setPosition(document.getElementById('text').childNodes[0], 3)"]; // After the first word, "The".
+    [webView waitForNextPresentationUpdate];
+
+    RetainPtr context = [webView synchronouslyRequestDocumentContext:makeRequest(UIWKDocumentRequestAttributed, UITextGranularityWord, 2)];
+    RetainPtr contextBefore = [dynamic_objc_cast<NSAttributedString>([context contextBefore]) string] ?: @"";
+    RetainPtr selectedText = [dynamic_objc_cast<NSAttributedString>([context selectedText]) string] ?: @"";
+    RetainPtr contextAfter = [dynamic_objc_cast<NSAttributedString>([context contextAfter]) string] ?: @"";
+
+    EXPECT_WK_STREQ(contextBefore.get(), "The");
+    EXPECT_WK_STREQ(selectedText.get(), "");
+    EXPECT_WK_STREQ(contextAfter.get(), " first sentence");
+}
+
 #endif // HAVE(UI_WK_DOCUMENT_CONTEXT)


### PR DESCRIPTION
#### c6af2674f2a0735f018d3a8ccd773d04c040b20a
<pre>
REGRESSION (300681@main): [visionOS] Web process crashes when editing any text
<a href="https://bugs.webkit.org/show_bug.cgi?id=300277">https://bugs.webkit.org/show_bug.cgi?id=300277</a>
<a href="https://rdar.apple.com/162071389">rdar://162071389</a>

Reviewed by Abrar Rahman Protyasha and Aditya Keerthi.

Instead of `MESSAGE_CHECK`-ing as a result of failing to decode a custom web font descriptor in
`FontWrapper::createFromIPCData`, fall back to the system font using `CTFontCreateUIFontForLanguage`.
This primarily affects visionOS, which requests document editing context data with attributed text
while the user types.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/DocumentEditingContext.mm

* Source/WebCore/editing/cocoa/AttributedString.mm:
(WebCore::AttributedString::FontWrapper::createFromIPCData):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/DocumentEditingContext.mm:
(TEST(DocumentEditingContext, RequestAttributedTextWithCustomFont)):

Add an API test that exercises this behavior by requesting `UIWKDocumentRequestAttributed` in an
editable container with a custom font (Ahem).

Canonical link: <a href="https://commits.webkit.org/301108@main">https://commits.webkit.org/301108@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ad01e10df1d3677020d7642fca7d5f4861494627

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124960 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44629 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35366 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131810 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76841 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/14f60a52-da34-43c8-9722-3bb1f5259982) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/126837 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45322 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53196 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95105 "Failed to checkout and rebase branch from PR 51904") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/63099 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8b731243-16d0-47a8-bee0-8bc90c0ae51a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127914 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36166 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/111760 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75653 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fd55a79a-accf-4efa-b5be-12a7898616a0) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/35097 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29913 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75290 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105929 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30144 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134483 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51787 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39587 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103585 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52210 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107973 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103361 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26315 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48701 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26992 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48811 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51668 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57467 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51046 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54402 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52739 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->