### PR TITLE
Drop custom toJS() / toJSNewlyCreated() functions for DOMException

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUPipelineError.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUPipelineError.cpp
@@ -29,7 +29,7 @@
 namespace WebCore {
 
 GPUPipelineError::GPUPipelineError(String&& message, GPUPipelineErrorInit reason)
-    : DOMException(0, "GPUPipelineError"_s, WTFMove(message))
+    : DOMException(0, "GPUPipelineError"_s, WTFMove(message), Type::GPUPipelineError)
     , m_reason(reason)
 {
 }

--- a/Source/WebCore/Modules/WebGPU/GPUPipelineError.h
+++ b/Source/WebCore/Modules/WebGPU/GPUPipelineError.h
@@ -51,3 +51,6 @@ private:
 
 } // namespace WebCore
 
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::GPUPipelineError)
+    static bool isType(const WebCore::DOMException& exception) { return exception.type() == WebCore::DOMException::Type::GPUPipelineError; }
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/Modules/mediastream/RTCError.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCError.cpp
@@ -31,7 +31,7 @@
 namespace WebCore {
 
 RTCError::RTCError(const Init& initializer, String&& message)
-    : DOMException(0, "OperationError"_s, WTFMove(message))
+    : DOMException(0, "OperationError"_s, WTFMove(message), Type::RTCError)
     , m_values(initializer)
 {
 }

--- a/Source/WebCore/Modules/mediastream/RTCError.h
+++ b/Source/WebCore/Modules/mediastream/RTCError.h
@@ -61,4 +61,8 @@ private:
 
 } // namespace WebCore
 
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::RTCError)
+    static bool isType(const WebCore::DOMException& exception) { return exception.type() == WebCore::DOMException::Type::RTCError; }
+SPECIALIZE_TYPE_TRAITS_END()
+
 #endif // ENABLE(WEB_RTC)

--- a/Source/WebCore/Modules/webtransport/WebTransportError.h
+++ b/Source/WebCore/Modules/webtransport/WebTransportError.h
@@ -44,3 +44,7 @@ private:
 };
 
 }
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::WebTransportError)
+    static bool isType(const WebCore::DOMException& exception) { return exception.type() == WebCore::DOMException::Type::WebTransportError; }
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -678,7 +678,6 @@ bindings/js/JSDOMConvertDate.cpp
 bindings/js/JSDOMConvertNumbers.cpp
 bindings/js/JSDOMConvertStrings.cpp
 bindings/js/JSDOMConvertWebGL.cpp
-bindings/js/JSDOMExceptionCustom.cpp
 bindings/js/JSDOMExceptionHandling.cpp
 bindings/js/JSDOMGlobalObject.cpp
 bindings/js/JSDOMGuardedObject.cpp

--- a/Source/WebCore/dom/DOMException.h
+++ b/Source/WebCore/dom/DOMException.h
@@ -62,7 +62,7 @@ public:
     static ASCIILiteral name(ExceptionCode ec) { return description(ec).name; }
     static ASCIILiteral message(ExceptionCode ec) { return description(ec).message; }
 
-    enum class Type : bool { Default, WebTransportError };
+    enum class Type : uint8_t { Default, WebTransportError, GPUPipelineError, RTCError };
     Type type() const { return m_type; }
 
 protected:

--- a/Source/WebCore/dom/DOMException.idl
+++ b/Source/WebCore/dom/DOMException.idl
@@ -27,7 +27,6 @@
  */
 
 [
-    CustomToJSObject,
     DoNotCheckConstants,
     Exposed=(Window,Worker),
     Exception


### PR DESCRIPTION
#### 2ca6fa26f43c7361a798d40a4ca0a054382c8c8a
<pre>
Drop custom toJS() / toJSNewlyCreated() functions for DOMException
<a href="https://bugs.webkit.org/show_bug.cgi?id=300282">https://bugs.webkit.org/show_bug.cgi?id=300282</a>

Reviewed by Ryosuke Niwa.

Drop custom toJS() / toJSNewlyCreated() functions for DOMException now that
the bindings generator knows how to generate this properly after 301038@main.

* Source/WebCore/Modules/WebGPU/GPUPipelineError.cpp:
(WebCore::GPUPipelineError::GPUPipelineError):
* Source/WebCore/Modules/WebGPU/GPUPipelineError.h:
(isType):
* Source/WebCore/Modules/mediastream/RTCError.cpp:
(WebCore::RTCError::RTCError):
* Source/WebCore/Modules/mediastream/RTCError.h:
(isType):
* Source/WebCore/Modules/webtransport/WebTransportError.h:
(isType):
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/DOMException.h:
* Source/WebCore/dom/DOMException.idl:

Canonical link: <a href="https://commits.webkit.org/301113@main">https://commits.webkit.org/301113@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1c9ca08123bac642e85f2fdc9b1df44af6b8315b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124965 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44634 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35371 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131815 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76845 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/68869bbd-874b-4b04-b947-d87005b0470b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/126842 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45327 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53201 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95111 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/63105 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f216516d-3a69-44c8-abe4-f0540c94ce2a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127919 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36173 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111762 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75659 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f523e639-c15e-4941-a567-fef4af89504f) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/35103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29915 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75295 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105936 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30146 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134488 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51792 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39593 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103592 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52215 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107975 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103368 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26318 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48705 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26994 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48816 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51673 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57471 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51050 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54407 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52742 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->