### PR TITLE
[JSC] WASM IPInt SIMD: uINT stack_vector should not clobber sc2

### DIFF
--- a/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
@@ -10967,15 +10967,10 @@ uintAlign(_stack)
 
 uintAlign(_stack_vector)
     subp 2 * SlotSize, sc0
-    if ARM64 or ARM64E
-        loadpairq [sp], sc1, sc2
-        storepairq sc1, sc2, [sc0]
-    else
-        loadq [sp], sc1
-        loadq 8[sp], sc2
-        storeq sc1, [sc0]
-        storeq sc2, 8[sc0]
-    end
+    loadq [sp], sc1
+    storeq sc1, [sc0]
+    loadq 8[sp], sc1
+    storeq sc1, 8[sc0]
     addq StackValueSize, sp
     uintDispatch()
 


### PR DESCRIPTION
#### b4965f817ff33ae7aa73e757bcd5e9b3c4d60b97
<pre>
[JSC] WASM IPInt SIMD: uINT stack_vector should not clobber sc2
<a href="https://bugs.webkit.org/show_bug.cgi?id=300280">https://bugs.webkit.org/show_bug.cgi?id=300280</a>
<a href="https://rdar.apple.com/162086434">rdar://162086434</a>

Reviewed by Yusuke Suzuki.

uINT stack bytecode has this:

    popInt64(sc1, sc2)

which implies that register sc2 is not live at this point, and
so I had used it in uINT stack_vector to do parallel loads/stores.
However, on X86_64, that is not the case. And popInt64 doesn&apos;t
actually use the scratch, which explains why this doesn&apos;t cause
trouble without vector stack returns.

So, don&apos;t use sc2 in stack_vector. This bytecode is only used when
there are more than 8 FP and vector results, so it&apos;s very uncommon,
so let&apos;s just simplify it and use the same code on all platforms.

I&apos;ll follow up with another commit to remove the misleading, but
benign, &quot;use&quot; of sc2 in popInt64 arguments.

Testing: On X86_64, see that this fixes a crash when
running simd-instructions-calls.js tests in parallel.

* Source/JavaScriptCore/llint/InPlaceInterpreter64.asm:

Canonical link: <a href="https://commits.webkit.org/301136@main">https://commits.webkit.org/301136@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/21467bd73727f57ad2bd0bf8a52c9249bc1fecea

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124967 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44636 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35373 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131817 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76908 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5c671214-f485-464f-a51d-2a6e47cc81c6) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45329 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53203 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95110 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/63149 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6de81ffb-0718-4d6e-a59a-12e6c4383308) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127921 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36174 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111763 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75658 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/510d4f6c-bbaa-4901-8f34-80544971fdb7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35104 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29916 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75297 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/117065 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105937 "Found 1 new API test failure: TestWebKitAPI.SiteIsolation.PostMessageWithMessagePorts (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30147 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134490 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/123486 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51794 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39594 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103589 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52217 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107976 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103365 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26334 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48706 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26995 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48818 "Hash 21467bd7 for PR 51908 does not build (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51675 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57473 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/156511 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51052 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39197 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54409 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52744 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->