### PR TITLE
[JSC] Remove !useWasmIPInt code in OMG

### DIFF
--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -898,7 +898,7 @@ private:
     void reloadMemoryRegistersFromInstance(const MemoryInformation&, Value* instance, BasicBlock*);
 
     Value* loadFromScratchBuffer(unsigned& indexInBuffer, Value* pointer, B3::Type);
-    void connectValuesAtEntrypoint(unsigned& indexInBuffer, Value* pointer, Stack& expressionStack, Variable* exceptionVariable);
+    void connectValuesAtEntrypoint(unsigned& indexInBuffer, Value* pointer, Stack& expressionStack);
     Value* emitCatchImpl(CatchKind, ControlType&, unsigned exceptionIndex = 0);
     void emitCatchTableImpl(ControlData& entryData, const ControlData::TryTableTarget&);
     RefPtr<PatchpointExceptionHandle> preparePatchpointForExceptions(BasicBlock*, PatchpointValue*);
@@ -4810,7 +4810,7 @@ Value* OMGIRGenerator::loadFromScratchBuffer(unsigned& indexInBuffer, Value* poi
     return m_currentBlock->appendNew<MemoryValue>(m_proc, Load, type, origin(), pointer, offset);
 }
 
-void OMGIRGenerator::connectValuesAtEntrypoint(unsigned& indexInBuffer, Value* pointer, Stack& expressionStack, Variable* exceptionVariable)
+void OMGIRGenerator::connectValuesAtEntrypoint(unsigned& indexInBuffer, Value* pointer, Stack& expressionStack)
 {
     TRACE_CF("Connect values at entrypoint");
     for (unsigned i = 0; i < expressionStack.size(); i++) {
@@ -4818,11 +4818,7 @@ void OMGIRGenerator::connectValuesAtEntrypoint(unsigned& indexInBuffer, Value* p
         Value* load = loadFromScratchBuffer(indexInBuffer, pointer, value->type());
         m_currentBlock->appendNew<VariableValue>(m_proc, Set, origin(), value.value(), load);
     }
-    if (!Options::useWasmIPInt() && exceptionVariable) {
-        Value* load = loadFromScratchBuffer(indexInBuffer, pointer, pointerType());
-        m_currentBlock->appendNew<VariableValue>(m_proc, Set, origin(), exceptionVariable, load);
-    }
-};
+}
 
 auto OMGIRGenerator::addLoop(BlockSignature signature, Stack& enclosingStack, ControlType& block, Stack& newStack, uint32_t loopIndex) -> PartialResult
 {
@@ -4855,25 +4851,22 @@ auto OMGIRGenerator::addLoop(BlockSignature signature, Stack& enclosingStack, Co
         for (auto& local : m_locals)
             m_currentBlock->appendNew<VariableValue>(m_proc, Set, Origin(), local, loadFromScratchBuffer(indexInBuffer, pointer, local->type()));
 
-        if (Options::useWasmIPInt()) {
-            for (unsigned controlIndex = 0; controlIndex < m_parser->controlStack().size(); ++controlIndex) {
-                auto& data = m_parser->controlStack()[controlIndex].controlData;
-                if (ControlType::isAnyCatch(data)) {
-                    auto* load = loadFromScratchBuffer(indexInBuffer, pointer, pointerType());
-                    m_currentBlock->appendNew<VariableValue>(m_proc, Set, origin(), data.exception(), load);
-                } else if (ControlType::isTry(data))
-                    ++indexInBuffer;
-            }
-        }
-
         for (unsigned controlIndex = 0; controlIndex < m_parser->controlStack().size(); ++controlIndex) {
             auto& data = m_parser->controlStack()[controlIndex].controlData;
-            auto& expressionStack = m_parser->controlStack()[controlIndex].enclosedExpressionStack;
-            ASSERT(&data != &block);
-            Variable* exceptionVariable = ControlType::isAnyCatch(data) ? data.exception() : nullptr;
-            connectValuesAtEntrypoint(indexInBuffer, pointer, expressionStack, exceptionVariable);
+            if (ControlType::isAnyCatch(data)) {
+                auto* load = loadFromScratchBuffer(indexInBuffer, pointer, pointerType());
+                m_currentBlock->appendNew<VariableValue>(m_proc, Set, origin(), data.exception(), load);
+            } else if (ControlType::isTry(data))
+                ++indexInBuffer;
         }
-        connectValuesAtEntrypoint(indexInBuffer, pointer, enclosingStack, nullptr);
+
+        for (auto& entry : m_parser->controlStack()) {
+            auto& data = entry.controlData;
+            auto& expressionStack = entry.enclosedExpressionStack;
+            ASSERT_UNUSED(data, &data != &block);
+            connectValuesAtEntrypoint(indexInBuffer, pointer, expressionStack);
+        }
+        connectValuesAtEntrypoint(indexInBuffer, pointer, enclosingStack);
         // The loop's stack can be read by the loop body, so the restored values should join using the loop-back phi nodes.
         for (unsigned i = 0; i < newStack.size(); i++) {
             auto* load = loadFromScratchBuffer(indexInBuffer, pointer, newStack[i]->type());
@@ -5047,7 +5040,7 @@ RefPtr<PatchpointExceptionHandle> OMGIRGenerator::preparePatchpointForExceptions
 }
 
 // Must be kept in sync with preparePatchpointForExceptions.
-void OMGIRGenerator::connectValuesForCatchEntrypoint(ControlData& catchData, Value* pointer)
+void OMGIRGenerator::connectValuesForCatchEntrypoint(ControlData&, Value* pointer)
 {
     unsigned indexInBuffer = 0;
 
@@ -5060,18 +5053,13 @@ void OMGIRGenerator::connectValuesForCatchEntrypoint(ControlData& catchData, Val
         for (auto& local : currentFrame->m_locals)
             m_currentBlock->appendNew<VariableValue>(m_proc, Set, Origin(), local, loadFromScratchBuffer(indexInBuffer, pointer, local->type()));
 
-        for (unsigned controlIndex = 0; controlIndex < currentFrame->m_parser->controlStack().size(); ++controlIndex) {
-            auto& controlData = currentFrame->m_parser->controlStack()[controlIndex].controlData;
-            auto& expressionStack = currentFrame->m_parser->controlStack()[controlIndex].enclosedExpressionStack;
-            Variable* exceptionVariable = nullptr;
-            if (ControlType::isAnyCatch(controlData) && &controlData != &catchData)
-                exceptionVariable = controlData.exception();
-            connectValuesAtEntrypoint(indexInBuffer, pointer, expressionStack, exceptionVariable);
-        }
+        for (auto& entry : currentFrame->m_parser->controlStack())
+            connectValuesAtEntrypoint(indexInBuffer, pointer, entry.enclosedExpressionStack);
+
         // inlineParent frames only
         if (currentFrame != this) {
             auto& topExpressionStack = currentFrame->m_parser->expressionStack();
-            connectValuesAtEntrypoint(indexInBuffer, pointer, topExpressionStack, nullptr);
+            connectValuesAtEntrypoint(indexInBuffer, pointer, topExpressionStack);
         }
     }
 }


### PR DESCRIPTION
#### 3a3ced8ec6d3df2a47b33528f620385bdc015e0c
<pre>
[JSC] Remove !useWasmIPInt code in OMG
<a href="https://bugs.webkit.org/show_bug.cgi?id=300286">https://bugs.webkit.org/show_bug.cgi?id=300286</a>
<a href="https://rdar.apple.com/problem/162088162">rdar://problem/162088162</a>

Reviewed by NOBODY (OOPS!).

Using !useWasmIPInt condition is not correct. It basically meant
useWasmLLInt. But now it is removed, and !useWasmIPInt can be used when
IPInt is disabled and BBQ straight tierup is enabled. In this case, OMG
should not behave differently. Thus, we should just do the same thing
regardless of useWasmIPInt condition.

* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::OMGIRGenerator::connectValuesAtEntrypoint):
(JSC::Wasm::OMGIRGenerator::addLoop):
(JSC::Wasm::OMGIRGenerator::connectValuesForCatchEntrypoint):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3a3ced8ec6d3df2a47b33528f620385bdc015e0c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124976 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44645 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35382 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131825 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76853 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d50b8d9b-b39b-4e65-9d05-b144d409034a) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45337 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53211 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95117 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/63111 "Found 60 new test failures: compositing/clipping/border-radius-with-composited-descendant-nested.html compositing/clipping/border-radius-with-composited-descendant.html compositing/overlap-blending/children-opacity-huge.html compositing/overlap-blending/children-opacity-no-overlap.html compositing/overlap-blending/nested-non-overlap-clipping.html compositing/overlap-blending/nested-overlap.html compositing/reflections/nested-reflection-opacity2.html compositing/transitions/transform-on-large-layer.html compositing/webgl/update-composited-canvas-layer.html compositing/webgl/webgl-no-alpha.html ... (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8bc90116-c24d-492e-9626-a2a3e29a216a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127930 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36180 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111772 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75664 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1fe4ec62-2d3b-49bd-a366-d677f310c3f6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35109 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29925 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-position/overlay/animation/overlay-interpolation.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75305 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/117074 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105943 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30156 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134499 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/123494 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51799 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39599 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103595 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52224 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107985 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103371 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48712 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27003 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48824 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51683 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57478 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/156519 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51057 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39201 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54414 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52749 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->