### PR TITLE
[JSC] Improve error messages for invalid constructor of derived classes

### DIFF
--- a/JSTests/stress/class-derived-from-null.js
+++ b/JSTests/stress/class-derived-from-null.js
@@ -117,7 +117,7 @@ function test6() {
     class F extends jsNull() { constructor() { return 25; } }
     class G extends jsNull() { constructor() { super(); } }
     assertThrow(() => Reflect.construct(E, [], D), `ReferenceError: 'super()' must be called in derived constructor before accessing |this| or returning non-object.`);
-    assertThrow(() => Reflect.construct(F, [], D), 'TypeError: Cannot return a non-object type in the constructor of a derived class.');
+    assertThrow(() => Reflect.construct(F, [], D), 'TypeError: Cannot return a non-object type in the constructor of a derived class F.');
 
     let threw = false;
     try {

--- a/JSTests/stress/derived-constructor-return-non-object.js
+++ b/JSTests/stress/derived-constructor-return-non-object.js
@@ -1,0 +1,75 @@
+function shouldThrow(testFunction, expectedError) {
+    let actualError = null;
+    try {
+        testFunction();
+    } catch (e) {
+        actualError = e;
+    }
+
+    if (!actualError) {
+        throw new Error(
+            `Expected to throw "${expectedError}" but no error was thrown`,
+        );
+    }
+
+    const actualMessage = String(actualError);
+    if (actualMessage !== expectedError) {
+        throw new Error(
+            `Expected error: "${expectedError}"\nActual error: "${actualMessage}"`,
+        );
+    }
+}
+
+{
+    class Base {}
+    class DerivedReturningNumber extends Base {
+        constructor() {
+            super();
+            return 123;
+        }
+    }
+
+    shouldThrow(() => {
+        new DerivedReturningNumber();
+    }, "TypeError: Cannot return a non-object type in the constructor of a derived class DerivedReturningNumber.");
+}
+
+{
+    class Base {}
+    class DerivedReturningString extends Base {
+        constructor() {
+            super();
+            return "hello";
+        }
+    }
+
+    shouldThrow(() => {
+        new DerivedReturningString();
+    }, "TypeError: Cannot return a non-object type in the constructor of a derived class DerivedReturningString.");
+}
+
+{
+    class Base {}
+    class DerivedReturningBoolean extends Base {
+        constructor() {
+            super();
+            return true;
+        }
+    }
+
+    shouldThrow(() => {
+        new DerivedReturningBoolean();
+    }, "TypeError: Cannot return a non-object type in the constructor of a derived class DerivedReturningBoolean.");
+}
+
+{
+    class Base {}
+    shouldThrow(() => {
+        new (class extends Base {
+            constructor() {
+                super();
+                return 42;
+            }
+        })();
+    }, "TypeError: Cannot return a non-object type in the constructor of a derived class.");
+}

--- a/LayoutTests/js/class-syntax-extends-expected.txt
+++ b/LayoutTests/js/class-syntax-extends-expected.txt
@@ -60,7 +60,7 @@ PASS class x {}; new (class extends null { constructor () { return new x; } }) i
 PASS new (class extends null { constructor () { this; } }):::ReferenceError: 'super()' must be called in derived constructor before accessing |this| or returning non-object.
 PASS new (class extends null { constructor () { super(); } }):::TypeError: function is not a constructor (evaluating 'super()')
 PASS x = {}; new (class extends null { constructor () { return x } }):::x
-PASS y = 12; class C extends null { constructor () { return y; } }; new C;:::TypeError: Cannot return a non-object type in the constructor of a derived class.
+PASS y = 12; class C extends null { constructor () { return y; } }; new C;:::TypeError: Cannot return a non-object type in the constructor of a derived class C.
 PASS class x {}; new (class extends null { constructor () { return new x; } }) instanceof x
 PASS x = null; Object.getPrototypeOf((class extends x { }).prototype):::null
 PASS Object.prototype.isPrototypeOf(class { })

--- a/LayoutTests/js/script-tests/class-syntax-extends.js
+++ b/LayoutTests/js/script-tests/class-syntax-extends.js
@@ -118,7 +118,7 @@ shouldBeTrue ('class x {}; new (class extends null { constructor () { return new
 shouldThrow('new (class extends null { constructor () { this; } })');
 shouldThrow('new (class extends null { constructor () { super(); } })', '"TypeError: function is not a constructor (evaluating \'super()\')"');
 shouldBe('x = {}; new (class extends null { constructor () { return x } })', 'x');
-shouldThrow('y = 12; class C extends null { constructor () { return y; } }; new C;', '"TypeError: Cannot return a non-object type in the constructor of a derived class."');
+shouldThrow('y = 12; class C extends null { constructor () { return y; } }; new C;', '"TypeError: Cannot return a non-object type in the constructor of a derived class C."');
 shouldBeTrue ('class x {}; new (class extends null { constructor () { return new x; } }) instanceof x');
 shouldBe('x = null; Object.getPrototypeOf((class extends x { }).prototype)', 'null');
 shouldBeTrue('Object.prototype.isPrototypeOf(class { })');


### PR DESCRIPTION
#### e2c7e56a95169145b290ab99d7bf4bf0bfc9c744
<pre>
[JSC] Improve error messages for invalid constructor of derived classes
<a href="https://bugs.webkit.org/show_bug.cgi?id=300291">https://bugs.webkit.org/show_bug.cgi?id=300291</a>

Reviewed by Yusuke Suzuki.

Returning non object values from constructor of derived class is invalid:

  class Base {}
  class Derived extends Base {
      constructor() {
          super();
          return 123;
      }
  }
  new Derived();

Current JSC throws a TypeError with the message &quot;Cannot return a non-object
type in the constructor of a derived class.&quot;

This patch changes this error message to include the constructor name
for debugging experience.

Test: JSTests/stress/derived-constructor-return-non-object.js
* JSTests/stress/class-derived-from-null.js:
(test6):
* JSTests/stress/derived-constructor-return-non-object.js: Added.
(shouldThrow):
(throw.new.Error):
(throw.new.Error.DerivedReturningNumber):
(DerivedReturningString):
(new.DerivedReturningString.Base):
(new.DerivedReturningString.DerivedReturningBoolean):
(new.DerivedReturningString):
* LayoutTests/js/class-syntax-extends-expected.txt:
* LayoutTests/js/script-tests/class-syntax-extends.js:
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp:
(JSC::BytecodeGenerator::emitReturn):

Canonical link: <a href="https://commits.webkit.org/301258@main">https://commits.webkit.org/301258@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d2d94f472b33cef96c7c58a3d902c94abb76007d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124982 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44651 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35388 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131831 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76861 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45343 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53217 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95124 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/63116 "An unexpected error occured. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Skipped layout-tests; Exiting early after 60 failures. 6372 tests run. 60 failures; Uploaded test results; Exiting early after 60 failures. 6409 tests run. 60 failures; Compiled WebKit; layout-tests (exception)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127936 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36186 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111778 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75671 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35113 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29931 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75315 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/117080 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105949 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30162 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134505 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/123500 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51805 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39606 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103600 "Found 1 new test failure: imported/blink/fast/pagination/viewport-y-horizontal-bt-rtl.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52230 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107991 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103376 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26414 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48717 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27009 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48830 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51689 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57484 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/156525 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51063 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39202 "Found 8 new JSC stress test failures: wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.default-wasm, wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.wasm-bbq, wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.wasm-bbq-no-consts, wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.wasm-collect-continuously, wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.wasm-eager, wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.wasm-eager-jettison, wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.wasm-no-cjit, wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.wasm-slow-memory (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54420 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52755 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->