### PR TITLE
[SaferC++] Improve memory safety in the Injected Bundle C API (part 4)

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -74,7 +74,6 @@ WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInRangeHandle.mm
 WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInScriptWorld.mm
 WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp
 WebProcess/InjectedBundle/API/c/WKBundleNodeHandle.cpp
-WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
 WebProcess/InjectedBundle/API/c/mac/WKBundleMac.mm
 WebProcess/InjectedBundle/API/c/mac/WKBundlePageBannerMac.mm
 WebProcess/InjectedBundle/API/mac/WKDOMDocument.mm

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
@@ -25,6 +25,7 @@
 
 #include "config.h"
 #include "WKBundlePage.h"
+#include "Shared/API/c/WKSharedAPICast.h"
 #include "WKBundlePagePrivate.h"
 
 #include "APIArray.h"
@@ -95,22 +96,22 @@ void WKBundlePageSetContextMenuClient(WKBundlePageRef pageRef, WKBundlePageConte
 
 void WKBundlePageSetEditorClient(WKBundlePageRef pageRef, WKBundlePageEditorClientBase* wkClient)
 {
-    WebKit::toImpl(pageRef)->setInjectedBundleEditorClient(wkClient ? makeUnique<WebKit::InjectedBundlePageEditorClient>(*wkClient) : makeUnique<API::InjectedBundle::EditorClient>());
+    WebKit::toProtectedImpl(pageRef)->setInjectedBundleEditorClient(wkClient ? makeUnique<WebKit::InjectedBundlePageEditorClient>(*wkClient) : makeUnique<API::InjectedBundle::EditorClient>());
 }
 
 void WKBundlePageSetFormClient(WKBundlePageRef pageRef, WKBundlePageFormClientBase* wkClient)
 {
-    WebKit::toImpl(pageRef)->setInjectedBundleFormClient(makeUnique<WebKit::InjectedBundlePageFormClient>(wkClient));
+    WebKit::toProtectedImpl(pageRef)->setInjectedBundleFormClient(makeUnique<WebKit::InjectedBundlePageFormClient>(wkClient));
 }
 
 void WKBundlePageSetPageLoaderClient(WKBundlePageRef pageRef, WKBundlePageLoaderClientBase* wkClient)
 {
-    WebKit::toImpl(pageRef)->setInjectedBundlePageLoaderClient(makeUnique<WebKit::InjectedBundlePageLoaderClient>(wkClient));
+    WebKit::toProtectedImpl(pageRef)->setInjectedBundlePageLoaderClient(makeUnique<WebKit::InjectedBundlePageLoaderClient>(wkClient));
 }
 
 void WKBundlePageSetResourceLoadClient(WKBundlePageRef pageRef, WKBundlePageResourceLoadClientBase* wkClient)
 {
-    WebKit::toImpl(pageRef)->setInjectedBundleResourceLoadClient(makeUnique<WebKit::InjectedBundlePageResourceLoadClient>(wkClient));
+    WebKit::toProtectedImpl(pageRef)->setInjectedBundleResourceLoadClient(makeUnique<WebKit::InjectedBundlePageResourceLoadClient>(wkClient));
 }
 
 void WKBundlePageSetPolicyClient(WKBundlePageRef, WKBundlePagePolicyClientBase*)
@@ -119,7 +120,7 @@ void WKBundlePageSetPolicyClient(WKBundlePageRef, WKBundlePagePolicyClientBase*)
 
 void WKBundlePageSetUIClient(WKBundlePageRef pageRef, WKBundlePageUIClientBase* wkClient)
 {
-    WebKit::toImpl(pageRef)->setInjectedBundleUIClient(makeUnique<WebKit::InjectedBundlePageUIClient>(wkClient));
+    WebKit::toProtectedImpl(pageRef)->setInjectedBundleUIClient(makeUnique<WebKit::InjectedBundlePageUIClient>(wkClient));
 }
 
 WKBundleFrameRef WKBundlePageGetMainFrame(WKBundlePageRef pageRef)
@@ -129,13 +130,13 @@ WKBundleFrameRef WKBundlePageGetMainFrame(WKBundlePageRef pageRef)
 
 WKFrameHandleRef WKBundleFrameCreateFrameHandle(WKBundleFrameRef bundleFrameRef)
 {
-    return WebKit::toAPI(&API::FrameHandle::create(WebKit::toImpl(bundleFrameRef)->frameID()).leakRef());
+    SUPPRESS_UNCOUNTED_ARG return WebKit::toAPI(&API::FrameHandle::create(WebKit::toImpl(bundleFrameRef)->frameID()).leakRef());
 }
 
 void WKBundlePageClickMenuItem(WKBundlePageRef pageRef, WKContextMenuItemRef item)
 {
 #if ENABLE(CONTEXT_MENUS)
-    WebKit::toImpl(pageRef)->contextMenu().itemSelected(WebKit::toImpl(item)->data());
+    WebKit::toProtectedImpl(pageRef)->contextMenu().itemSelected(WebKit::toImpl(item)->data());
 #else
     UNUSED_PARAM(pageRef);
     UNUSED_PARAM(item);
@@ -155,9 +156,9 @@ static Ref<API::Array> contextMenuItems(const WebKit::WebContextMenu& contextMen
 WKArrayRef WKBundlePageCopyContextMenuItems(WKBundlePageRef pageRef)
 {
 #if ENABLE(CONTEXT_MENUS)
-    Ref contextMenu = WebKit::toImpl(pageRef)->contextMenu();
+    Ref contextMenu = WebKit::toProtectedImpl(pageRef)->contextMenu();
 
-    return WebKit::toAPI(&contextMenuItems(contextMenu.get()).leakRef());
+    SUPPRESS_UNCOUNTED_ARG return WebKit::toAPI(&contextMenuItems(contextMenu.get()).leakRef());
 #else
     UNUSED_PARAM(pageRef);
     return nullptr;
@@ -171,11 +172,11 @@ WKArrayRef WKBundlePageCopyContextMenuAtPointInWindow(WKBundlePageRef pageRef, W
     if (!page)
         return nullptr;
 
-    RefPtr contextMenu = WebKit::toImpl(pageRef)->contextMenuAtPointInWindow(page->mainFrame().frameID(), WebKit::toIntPoint(point));
+    RefPtr contextMenu = WebKit::toProtectedImpl(pageRef)->contextMenuAtPointInWindow(page->mainFrame().frameID(), WebKit::toIntPoint(point));
     if (!contextMenu)
         return nullptr;
 
-    return WebKit::toAPI(&contextMenuItems(*contextMenu).leakRef());
+    SUPPRESS_UNCOUNTED_ARG return WebKit::toAPI(&contextMenuItems(*contextMenu).leakRef());
 #else
     UNUSED_PARAM(pageRef);
     UNUSED_PARAM(point);
@@ -185,14 +186,14 @@ WKArrayRef WKBundlePageCopyContextMenuAtPointInWindow(WKBundlePageRef pageRef, W
 
 void WKBundlePageInsertNewlineInQuotedContent(WKBundlePageRef pageRef)
 {
-    WebKit::toImpl(pageRef)->insertNewlineInQuotedContent();
+    WebKit::toProtectedImpl(pageRef)->insertNewlineInQuotedContent();
 }
 
 void WKAccessibilityTestingInjectPreference(WKBundlePageRef pageRef, WKStringRef domain, WKStringRef key, WKStringRef encodedValue)
 {
     if (!pageRef)
         return;
-    
+
 #if ENABLE(CFPREFS_DIRECT_MODE)
     WebKit::WebProcess::singleton().preferenceDidUpdate(WebKit::toWTFString(domain), WebKit::toWTFString(key), WebKit::toWTFString(encodedValue));
 #endif
@@ -221,7 +222,7 @@ void* WKAccessibilityFocusedObject(WKBundlePageRef pageRef)
 
     WebCore::AXObjectCache::enableAccessibility();
 
-    auto* axObjectCache = focusedDocument->axObjectCache();
+    CheckedPtr axObjectCache = focusedDocument->axObjectCache();
     if (!axObjectCache)
         return nullptr;
 
@@ -255,7 +256,7 @@ void WKAccessibilityAnnounce(WKBundlePageRef pageRef, WKStringRef message)
     if (!core->document())
         return;
 
-    if (auto* cache = core->document()->axObjectCache())
+    if (RefPtr cache = core->protectedDocument()->axObjectCache())
         cache->announce(WebKit::toWTFString(message));
 }
 
@@ -281,8 +282,8 @@ void WKAccessibilitySetForceInitialFrameCaching(bool shouldForce)
 
 void WKBundlePageSetEditable(WKBundlePageRef pageRef, bool isEditable)
 {
-    WebKit::WebPage* webPage = WebKit::toImpl(pageRef);
-    if (WebCore::Page* page = webPage ? webPage->corePage() : nullptr)
+    RefPtr<WebKit::WebPage> webPage = WebKit::toImpl(pageRef);
+    if (RefPtr page = webPage ? webPage->corePage() : nullptr)
         page->setEditable(isEditable);
 }
 
@@ -293,32 +294,32 @@ void WKBundlePageSetDefersLoading(WKBundlePageRef, bool)
 WKStringRef WKBundlePageCopyRenderTreeExternalRepresentation(WKBundlePageRef pageRef, RenderTreeExternalRepresentationBehavior options)
 {
     // Convert to webcore options.
-    return WebKit::toCopiedAPI(WebKit::toImpl(pageRef)->renderTreeExternalRepresentation(options));
+    return WebKit::toCopiedAPI(WebKit::toProtectedImpl(pageRef)->renderTreeExternalRepresentation(options));
 }
 
 WKStringRef WKBundlePageCopyRenderTreeExternalRepresentationForPrinting(WKBundlePageRef pageRef)
 {
-    return WebKit::toCopiedAPI(WebKit::toImpl(pageRef)->renderTreeExternalRepresentationForPrinting());
+    return WebKit::toCopiedAPI(WebKit::toProtectedImpl(pageRef)->renderTreeExternalRepresentationForPrinting());
 }
 
 void WKBundlePageClose(WKBundlePageRef pageRef)
 {
-    WebKit::toImpl(pageRef)->sendClose();
+    WebKit::toProtectedImpl(pageRef)->sendClose();
 }
 
 double WKBundlePageGetTextZoomFactor(WKBundlePageRef pageRef)
 {
-    return WebKit::toImpl(pageRef)->textZoomFactor();
+    return WebKit::toProtectedImpl(pageRef)->textZoomFactor();
 }
 
 double WKBundlePageGetPageZoomFactor(WKBundlePageRef pageRef)
 {
-    return WebKit::toImpl(pageRef)->pageZoomFactor();
+    return WebKit::toProtectedImpl(pageRef)->pageZoomFactor();
 }
 
 WKStringRef WKBundlePageDumpHistoryForTesting(WKBundlePageRef page, WKStringRef directory)
 {
-    return WebKit::toCopiedAPI(WebKit::toImpl(page)->dumpHistoryForTesting(WebKit::toWTFString(directory)));
+    return WebKit::toCopiedAPI(WebKit::toProtectedImpl(page)->dumpHistoryForTesting(WebKit::toWTFString(directory)));
 }
 
 WKBundleBackForwardListRef WKBundlePageGetBackForwardList(WKBundlePageRef pageRef)
@@ -328,28 +329,28 @@ WKBundleBackForwardListRef WKBundlePageGetBackForwardList(WKBundlePageRef pageRe
 
 void WKBundlePageInstallPageOverlay(WKBundlePageRef pageRef, WKBundlePageOverlayRef pageOverlayRef)
 {
-    WebKit::toImpl(pageRef)->corePage()->pageOverlayController().installPageOverlay(*WebKit::toImpl(pageOverlayRef)->coreOverlay(), WebCore::PageOverlay::FadeMode::DoNotFade);
+    WebKit::toImpl(pageRef)->corePage()->pageOverlayController().installPageOverlay(*WebKit::toImpl(pageOverlayRef)->protectedCoreOverlay(), WebCore::PageOverlay::FadeMode::DoNotFade);
 }
 
 void WKBundlePageUninstallPageOverlay(WKBundlePageRef pageRef, WKBundlePageOverlayRef pageOverlayRef)
 {
-    WebKit::toImpl(pageRef)->corePage()->pageOverlayController().uninstallPageOverlay(*WebKit::toImpl(pageOverlayRef)->coreOverlay(), WebCore::PageOverlay::FadeMode::DoNotFade);
+    WebKit::toImpl(pageRef)->corePage()->pageOverlayController().uninstallPageOverlay(*WebKit::toImpl(pageOverlayRef)->protectedCoreOverlay(), WebCore::PageOverlay::FadeMode::DoNotFade);
 }
 
 void WKBundlePageInstallPageOverlayWithAnimation(WKBundlePageRef pageRef, WKBundlePageOverlayRef pageOverlayRef)
 {
-    WebKit::toImpl(pageRef)->corePage()->pageOverlayController().installPageOverlay(*WebKit::toImpl(pageOverlayRef)->coreOverlay(), WebCore::PageOverlay::FadeMode::Fade);
+    WebKit::toImpl(pageRef)->corePage()->pageOverlayController().installPageOverlay(*WebKit::toImpl(pageOverlayRef)->protectedCoreOverlay(), WebCore::PageOverlay::FadeMode::Fade);
 }
 
 void WKBundlePageUninstallPageOverlayWithAnimation(WKBundlePageRef pageRef, WKBundlePageOverlayRef pageOverlayRef)
 {
-    WebKit::toImpl(pageRef)->corePage()->pageOverlayController().uninstallPageOverlay(*WebKit::toImpl(pageOverlayRef)->coreOverlay(), WebCore::PageOverlay::FadeMode::Fade);
+    WebKit::toImpl(pageRef)->corePage()->pageOverlayController().uninstallPageOverlay(*WebKit::toImpl(pageOverlayRef)->protectedCoreOverlay(), WebCore::PageOverlay::FadeMode::Fade);
 }
 
 void WKBundlePageSetTopOverhangImage(WKBundlePageRef pageRef, WKImageRef imageRef)
 {
 #if PLATFORM(MAC)
-    WebKit::toImpl(pageRef)->setTopOverhangImage(WebKit::toImpl(imageRef));
+    WebKit::toProtectedImpl(pageRef)->setTopOverhangImage(WebKit::toProtectedImpl(imageRef).get());
 #else
     UNUSED_PARAM(pageRef);
     UNUSED_PARAM(imageRef);
@@ -359,7 +360,7 @@ void WKBundlePageSetTopOverhangImage(WKBundlePageRef pageRef, WKImageRef imageRe
 void WKBundlePageSetBottomOverhangImage(WKBundlePageRef pageRef, WKImageRef imageRef)
 {
 #if PLATFORM(MAC)
-    WebKit::toImpl(pageRef)->setBottomOverhangImage(WebKit::toImpl(imageRef));
+    WebKit::toProtectedImpl(pageRef)->setBottomOverhangImage(WebKit::toProtectedImpl(imageRef).get());
 #else
     UNUSED_PARAM(pageRef);
     UNUSED_PARAM(imageRef);
@@ -369,18 +370,18 @@ void WKBundlePageSetBottomOverhangImage(WKBundlePageRef pageRef, WKImageRef imag
 #if !PLATFORM(IOS_FAMILY)
 void WKBundlePageSetHeaderBanner(WKBundlePageRef pageRef, WKBundlePageBannerRef bannerRef)
 {
-    WebKit::toImpl(pageRef)->setHeaderPageBanner(WebKit::toImpl(bannerRef));
+    WebKit::toProtectedImpl(pageRef)->setHeaderPageBanner(WebKit::toProtectedImpl(bannerRef).get());
 }
 
 void WKBundlePageSetFooterBanner(WKBundlePageRef pageRef, WKBundlePageBannerRef bannerRef)
 {
-    WebKit::toImpl(pageRef)->setFooterPageBanner(WebKit::toImpl(bannerRef));
+    WebKit::toProtectedImpl(pageRef)->setFooterPageBanner(WebKit::toProtectedImpl(bannerRef).get());
 }
 #endif // !PLATFORM(IOS_FAMILY)
 
 bool WKBundlePageHasLocalDataForURL(WKBundlePageRef pageRef, WKURLRef urlRef)
 {
-    return WebKit::toImpl(pageRef)->corePage()->hasLocalDataForURL(URL { WebKit::toWTFString(urlRef) });
+    return WebKit::toProtectedImpl(pageRef)->corePage()->hasLocalDataForURL(URL { WebKit::toWTFString(urlRef) });
 }
 
 bool WKBundlePageCanHandleRequest(WKURLRequestRef requestRef)
@@ -402,68 +403,68 @@ void WKBundlePageReplaceStringMatches(WKBundlePageRef pageRef, WKArrayRef matchI
         if (RefPtr indexAsObject = matchIndices->at<API::UInt64>(i))
             indices.append(indexAsObject->value());
     }
-    WebKit::toImpl(pageRef)->replaceStringMatchesFromInjectedBundle(indices, WebKit::toWTFString(replacementText), selectionOnly);
+    WebKit::toProtectedImpl(pageRef)->replaceStringMatchesFromInjectedBundle(indices, WebKit::toWTFString(replacementText), selectionOnly);
 }
 
 WKImageRef WKBundlePageCreateSnapshotWithOptions(WKBundlePageRef pageRef, WKRect rect, WKSnapshotOptions options)
 {
-    RefPtr<WebKit::WebImage> webImage = WebKit::toImpl(pageRef)->scaledSnapshotWithOptions(WebKit::toIntRect(rect), 1, WebKit::toSnapshotOptions(options));
-    return toAPI(webImage.leakRef());
+    RefPtr<WebKit::WebImage> webImage = WebKit::toProtectedImpl(pageRef)->scaledSnapshotWithOptions(WebKit::toIntRect(rect), 1, WebKit::toSnapshotOptions(options));
+    SUPPRESS_UNCOUNTED_ARG return toAPI(webImage.leakRef());
 }
 
 WKImageRef WKBundlePageCreateSnapshotInViewCoordinates(WKBundlePageRef pageRef, WKRect rect, WKImageOptions options)
 {
     auto snapshotOptions = WebKit::snapshotOptionsFromImageOptions(options);
     snapshotOptions.add(WebKit::SnapshotOption::InViewCoordinates);
-    RefPtr<WebKit::WebImage> webImage = WebKit::toImpl(pageRef)->scaledSnapshotWithOptions(WebKit::toIntRect(rect), 1, snapshotOptions);
-    return toAPI(webImage.leakRef());
+    RefPtr<WebKit::WebImage> webImage = WebKit::toProtectedImpl(pageRef)->scaledSnapshotWithOptions(WebKit::toIntRect(rect), 1, snapshotOptions);
+    SUPPRESS_UNCOUNTED_ARG return toAPI(webImage.leakRef());
 }
 
 WKImageRef WKBundlePageCreateSnapshotInDocumentCoordinates(WKBundlePageRef pageRef, WKRect rect, WKImageOptions options)
 {
-    RefPtr<WebKit::WebImage> webImage = WebKit::toImpl(pageRef)->scaledSnapshotWithOptions(WebKit::toIntRect(rect), 1, WebKit::snapshotOptionsFromImageOptions(options));
-    return toAPI(webImage.leakRef());
+    RefPtr<WebKit::WebImage> webImage = WebKit::toProtectedImpl(pageRef)->scaledSnapshotWithOptions(WebKit::toIntRect(rect), 1, WebKit::snapshotOptionsFromImageOptions(options));
+    SUPPRESS_UNCOUNTED_ARG return toAPI(webImage.leakRef());
 }
 
 WKImageRef WKBundlePageCreateScaledSnapshotInDocumentCoordinates(WKBundlePageRef pageRef, WKRect rect, double scaleFactor, WKImageOptions options)
 {
-    RefPtr<WebKit::WebImage> webImage = WebKit::toImpl(pageRef)->scaledSnapshotWithOptions(WebKit::toIntRect(rect), scaleFactor, WebKit::snapshotOptionsFromImageOptions(options));
-    return toAPI(webImage.leakRef());
+    RefPtr<WebKit::WebImage> webImage = WebKit::toProtectedImpl(pageRef)->scaledSnapshotWithOptions(WebKit::toIntRect(rect), scaleFactor, WebKit::snapshotOptionsFromImageOptions(options));
+    SUPPRESS_UNCOUNTED_ARG return toAPI(webImage.leakRef());
 }
 
 double WKBundlePageGetBackingScaleFactor(WKBundlePageRef pageRef)
 {
-    return WebKit::toImpl(pageRef)->deviceScaleFactor();
+    return WebKit::toProtectedImpl(pageRef)->deviceScaleFactor();
 }
 
 void WKBundlePageListenForLayoutMilestones(WKBundlePageRef pageRef, WKLayoutMilestones milestones)
 {
-    WebKit::toImpl(pageRef)->listenForLayoutMilestones(WebKit::toLayoutMilestones(milestones));
+    WebKit::toProtectedImpl(pageRef)->listenForLayoutMilestones(WebKit::toLayoutMilestones(milestones));
 }
 
 void WKBundlePageCloseInspectorForTest(WKBundlePageRef page)
 {
-    WebKit::toImpl(page)->inspector()->close();
+    WebKit::toProtectedImpl(page)->protectedInspector()->close();
 }
 
 void WKBundlePageEvaluateScriptInInspectorForTest(WKBundlePageRef page, WKStringRef script)
 {
-    WebKit::toImpl(page)->inspector()->evaluateScriptForTest(WebKit::toWTFString(script));
+    WebKit::toProtectedImpl(page)->protectedInspector()->evaluateScriptForTest(WebKit::toWTFString(script));
 }
 
 void WKBundlePageForceRepaint(WKBundlePageRef page)
 {
-    WebKit::toImpl(page)->updateRenderingWithForcedRepaintWithoutCallback();
+    WebKit::toProtectedImpl(page)->updateRenderingWithForcedRepaintWithoutCallback();
 }
 
 void WKBundlePageFlushPendingEditorStateUpdate(WKBundlePageRef page)
 {
-    WebKit::toImpl(page)->flushPendingEditorStateUpdate();
+    WebKit::toProtectedImpl(page)->flushPendingEditorStateUpdate();
 }
 
 uint64_t WKBundlePageGetRenderTreeSize(WKBundlePageRef pageRef)
 {
-    return WebKit::toImpl(pageRef)->renderTreeSize();
+    return WebKit::toProtectedImpl(pageRef)->renderTreeSize();
 }
 
 // This function should be kept around for compatibility with SafariForWebKitDevelopment.
@@ -484,12 +485,12 @@ void WKBundlePageSetPaintedObjectsCounterThreshold(WKBundlePageRef, uint64_t)
 
 bool WKBundlePageIsTrackingRepaints(WKBundlePageRef pageRef)
 {
-    return WebKit::toImpl(pageRef)->isTrackingRepaints();
+    return WebKit::toProtectedImpl(pageRef)->isTrackingRepaints();
 }
 
 WKArrayRef WKBundlePageCopyTrackedRepaintRects(WKBundlePageRef pageRef)
 {
-    return WebKit::toAPI(&WebKit::toImpl(pageRef)->trackedRepaintRects().leakRef());
+    SUPPRESS_UNCOUNTED_ARG return WebKit::toAPI(&WebKit::toProtectedImpl(pageRef)->trackedRepaintRects().leakRef());
 }
 
 void WKBundlePageSetComposition(WKBundlePageRef pageRef, WKStringRef text, int from, int length, bool suppressUnderline, WKArrayRef highlightData, WKArrayRef annotationData)
@@ -525,7 +526,7 @@ void WKBundlePageSetComposition(WKBundlePageRef pageRef, WKStringRef text, int f
             for (RefPtr dictionary : annotationDataArray->elementsOfType<API::Dictionary>()) {
                 auto location = downcast<API::UInt64>(dictionary->get("from"_s))->value();
                 auto length = downcast<API::UInt64>(dictionary->get("length"_s))->value();
-                auto name = downcast<API::String>(dictionary->get("annotation"_s))->string();
+                auto name = downcast<API::String>(dictionary->getProtected("annotation"_s))->string();
 
                 auto it = annotations.find(name);
                 if (it == annotations.end())
@@ -536,22 +537,22 @@ void WKBundlePageSetComposition(WKBundlePageRef pageRef, WKStringRef text, int f
         }
     }
 
-    WebKit::toImpl(pageRef)->setCompositionForTesting(WebKit::toWTFString(text), from, length, suppressUnderline, highlights, annotations);
+    WebKit::toProtectedImpl(pageRef)->setCompositionForTesting(WebKit::toWTFString(text), from, length, suppressUnderline, highlights, annotations);
 }
 
 bool WKBundlePageHasComposition(WKBundlePageRef pageRef)
 {
-    return WebKit::toImpl(pageRef)->hasCompositionForTesting();
+    return WebKit::toProtectedImpl(pageRef)->hasCompositionForTesting();
 }
 
 void WKBundlePageConfirmComposition(WKBundlePageRef pageRef)
 {
-    WebKit::toImpl(pageRef)->confirmCompositionForTesting(String());
+    WebKit::toProtectedImpl(pageRef)->confirmCompositionForTesting(String());
 }
 
 void WKBundlePageConfirmCompositionWithText(WKBundlePageRef pageRef, WKStringRef text)
 {
-    WebKit::toImpl(pageRef)->confirmCompositionForTesting(WebKit::toWTFString(text));
+    WebKit::toProtectedImpl(pageRef)->confirmCompositionForTesting(WebKit::toWTFString(text));
 }
 
 void WKBundlePageSetUseDarkAppearance(WKBundlePageRef pageRef, bool useDarkAppearance)
@@ -571,27 +572,27 @@ bool WKBundlePageIsUsingDarkAppearance(WKBundlePageRef pageRef)
 
 bool WKBundlePageCanShowMIMEType(WKBundlePageRef pageRef, WKStringRef mimeTypeRef)
 {
-    return WebKit::toImpl(pageRef)->canShowMIMEType(WebKit::toWTFString(mimeTypeRef));
+    return WebKit::toProtectedImpl(pageRef)->canShowMIMEType(WebKit::toWTFString(mimeTypeRef));
 }
 
 WKRenderingSuppressionToken WKBundlePageExtendIncrementalRenderingSuppression(WKBundlePageRef pageRef)
 {
-    return WebKit::toImpl(pageRef)->extendIncrementalRenderingSuppression();
+    return WebKit::toProtectedImpl(pageRef)->extendIncrementalRenderingSuppression();
 }
 
 void WKBundlePageStopExtendingIncrementalRenderingSuppression(WKBundlePageRef pageRef, WKRenderingSuppressionToken token)
 {
-    WebKit::toImpl(pageRef)->stopExtendingIncrementalRenderingSuppression(token);
+    WebKit::toProtectedImpl(pageRef)->stopExtendingIncrementalRenderingSuppression(token);
 }
 
 bool WKBundlePageIsUsingEphemeralSession(WKBundlePageRef pageRef)
 {
-    return WebKit::toImpl(pageRef)->usesEphemeralSession();
+    return WebKit::toProtectedImpl(pageRef)->usesEphemeralSession();
 }
 
 bool WKBundlePageIsControlledByAutomation(WKBundlePageRef pageRef)
 {
-    return WebKit::toImpl(pageRef)->isControlledByAutomation();
+    return WebKit::toProtectedImpl(pageRef)->isControlledByAutomation();
 }
 
 #if TARGET_OS_IPHONE
@@ -605,7 +606,7 @@ void WKBundlePageStartMonitoringScrollOperations(WKBundlePageRef pageRef, bool c
 {
     RefPtr webPage = WebKit::toImpl(pageRef);
     RefPtr page = webPage ? webPage->corePage() : nullptr;
-    
+
     if (!page)
         return;
 
@@ -616,12 +617,12 @@ bool WKBundlePageRegisterScrollOperationCompletionCallback(WKBundlePageRef pageR
 {
     if (!callback)
         return false;
-    
+
     RefPtr webPage = WebKit::toImpl(pageRef);
     RefPtr page = webPage ? webPage->corePage() : nullptr;
     if (!page || !page->isMonitoringWheelEvents())
         return false;
-    
+
     if (auto wheelEventTestMonitor = page->wheelEventTestMonitor()) {
         wheelEventTestMonitor->setTestCallbackAndStartMonitoring(expectWheelEndOrCancel, expectMomentumEnd, [=]() {
             callback(context);
@@ -634,12 +635,12 @@ void WKBundlePageCallAfterTasksAndTimers(WKBundlePageRef pageRef, WKBundlePageTe
 {
     if (!callback)
         return;
-    
+
     RefPtr webPage = WebKit::toImpl(pageRef);
     RefPtr page = webPage ? webPage->corePage() : nullptr;
     if (!page)
         return;
-    
+
     RefPtr localMainFrame = dynamicDowncast<WebCore::LocalFrame>(page->mainFrame());
     if (!localMainFrame)
         return;
@@ -647,7 +648,7 @@ void WKBundlePageCallAfterTasksAndTimers(WKBundlePageRef pageRef, WKBundlePageTe
     RefPtr document = localMainFrame->document();
     if (!document)
         return;
-    
+
     document->postTask([=] (WebCore::ScriptExecutionContext&) {
         WebCore::Timer::schedule(0_s, [=] {
             callback(context);
@@ -657,23 +658,23 @@ void WKBundlePageCallAfterTasksAndTimers(WKBundlePageRef pageRef, WKBundlePageTe
 
 void WKBundlePageFlushDeferredDidReceiveMouseEventForTesting(WKBundlePageRef page)
 {
-    WebKit::toImpl(page)->flushDeferredDidReceiveMouseEvent();
+    WebKit::toProtectedImpl(page)->flushDeferredDidReceiveMouseEvent();
 }
 
 void WKBundlePagePostMessage(WKBundlePageRef pageRef, WKStringRef messageNameRef, WKTypeRef messageBodyRef)
 {
-    WebKit::toImpl(pageRef)->postMessage(WebKit::toWTFString(messageNameRef), WebKit::toImpl(messageBodyRef));
+    WebKit::toProtectedImpl(pageRef)->postMessage(WebKit::toWTFString(messageNameRef), WebKit::toProtectedImpl(messageBodyRef).get());
 }
 
 void WKBundlePagePostMessageIgnoringFullySynchronousMode(WKBundlePageRef pageRef, WKStringRef messageNameRef, WKTypeRef messageBodyRef)
 {
-    WebKit::toImpl(pageRef)->postMessageIgnoringFullySynchronousMode(WebKit::toWTFString(messageNameRef), WebKit::toImpl(messageBodyRef));
+    WebKit::toProtectedImpl(pageRef)->postMessageIgnoringFullySynchronousMode(WebKit::toWTFString(messageNameRef), WebKit::toProtectedImpl(messageBodyRef).get());
 }
 
 void WKBundlePagePostSynchronousMessageForTesting(WKBundlePageRef pageRef, WKStringRef messageNameRef, WKTypeRef messageBodyRef, WKTypeRef* returnRetainedDataRef)
 {
     RefPtr<API::Object> returnData;
-    WebKit::toImpl(pageRef)->postSynchronousMessageForTesting(WebKit::toWTFString(messageNameRef), WebKit::toImpl(messageBodyRef), returnData);
+    WebKit::toProtectedImpl(pageRef)->postSynchronousMessageForTesting(WebKit::toWTFString(messageNameRef), WebKit::toProtectedImpl(messageBodyRef).get(), returnData);
     if (returnRetainedDataRef)
         *returnRetainedDataRef = WebKit::toAPI(returnData.leakRef());
 }
@@ -685,22 +686,22 @@ bool WKBundlePageIsSuspended(WKBundlePageRef pageRef)
 
 void WKBundlePageAddUserScript(WKBundlePageRef pageRef, WKStringRef source, _WKUserScriptInjectionTime injectionTime, WKUserContentInjectedFrames injectedFrames)
 {
-    WebKit::toImpl(pageRef)->addUserScript(WebKit::toWTFString(source), WebKit::InjectedBundleScriptWorld::normalWorldSingleton(), WebKit::toUserContentInjectedFrames(injectedFrames), WebKit::toUserScriptInjectionTime(injectionTime));
+    WebKit::toProtectedImpl(pageRef)->addUserScript(WebKit::toWTFString(source), WebKit::InjectedBundleScriptWorld::normalWorldSingleton(), WebKit::toUserContentInjectedFrames(injectedFrames), WebKit::toUserScriptInjectionTime(injectionTime));
 }
 
 void WKBundlePageAddUserScriptInWorld(WKBundlePageRef page, WKStringRef source, WKBundleScriptWorldRef scriptWorld, _WKUserScriptInjectionTime injectionTime, WKUserContentInjectedFrames injectedFrames)
 {
-    WebKit::toImpl(page)->addUserScript(WebKit::toWTFString(source), *WebKit::toImpl(scriptWorld), WebKit::toUserContentInjectedFrames(injectedFrames), WebKit::toUserScriptInjectionTime(injectionTime));
+    WebKit::toProtectedImpl(page)->addUserScript(WebKit::toWTFString(source), *WebKit::toProtectedImpl(scriptWorld), WebKit::toUserContentInjectedFrames(injectedFrames), WebKit::toUserScriptInjectionTime(injectionTime));
 }
 
 void WKBundlePageAddUserStyleSheet(WKBundlePageRef pageRef, WKStringRef source, WKUserContentInjectedFrames injectedFrames)
 {
-    WebKit::toImpl(pageRef)->addUserStyleSheet(WebKit::toWTFString(source), WebKit::toUserContentInjectedFrames(injectedFrames));
+    WebKit::toProtectedImpl(pageRef)->addUserStyleSheet(WebKit::toWTFString(source), WebKit::toUserContentInjectedFrames(injectedFrames));
 }
 
 void WKBundlePageRemoveAllUserContent(WKBundlePageRef pageRef)
 {
-    WebKit::toImpl(pageRef)->removeAllUserContent();
+    WebKit::toProtectedImpl(pageRef)->removeAllUserContent();
 }
 
 WKStringRef WKBundlePageCopyGroupIdentifier(WKBundlePageRef pageRef)
@@ -711,7 +712,7 @@ WKStringRef WKBundlePageCopyGroupIdentifier(WKBundlePageRef pageRef)
 void WKBundlePageSetCaptionDisplayMode(WKBundlePageRef page, WKStringRef mode)
 {
 #if ENABLE(VIDEO)
-    Ref captionPreferences = WebKit::toImpl(page)->corePage()->group().ensureCaptionPreferences();
+    Ref captionPreferences = WebKit::toImpl(page)->protectedCorePage()->group().ensureCaptionPreferences();
     auto displayMode = WTF::EnumTraits<WebCore::CaptionUserPreferences::CaptionDisplayMode>::fromString(WebKit::toWTFString(mode));
     if (displayMode.has_value())
         captionPreferences->setCaptionDisplayMode(displayMode.value());
@@ -724,8 +725,8 @@ void WKBundlePageSetCaptionDisplayMode(WKBundlePageRef page, WKStringRef mode)
 WKCaptionUserPreferencesTestingModeTokenRef WKBundlePageCreateCaptionUserPreferencesTestingModeToken(WKBundlePageRef page)
 {
 #if ENABLE(VIDEO)
-    Ref captionPreferences = WebKit::toImpl(page)->corePage()->group().ensureCaptionPreferences();
-    return WebKit::toAPI(&API::CaptionUserPreferencesTestingModeToken::create(captionPreferences.get()).leakRef());
+    Ref captionPreferences = WebKit::toProtectedImpl(page)->protectedCorePage()->group().ensureCaptionPreferences();
+    SUPPRESS_UNCOUNTED_ARG return WebKit::toAPI(&API::CaptionUserPreferencesTestingModeToken::create(captionPreferences.get()).leakRef());
 #else
     UNUSED_PARAM(page);
     return { };
@@ -734,7 +735,7 @@ WKCaptionUserPreferencesTestingModeTokenRef WKBundlePageCreateCaptionUserPrefere
 
 void WKBundlePageLayoutIfNeeded(WKBundlePageRef page)
 {
-    WebKit::toImpl(page)->layoutIfNeeded();
+    WebKit::toProtectedImpl(page)->layoutIfNeeded();
 }
 
 void WKBundlePageSetSkipDecidePolicyForResponseIfPossible(WKBundlePageRef page, bool skip)
@@ -744,5 +745,5 @@ void WKBundlePageSetSkipDecidePolicyForResponseIfPossible(WKBundlePageRef page, 
 
 WKStringRef WKBundlePageCopyFrameTextForTesting(WKBundlePageRef page, bool includeSubframes)
 {
-    return WebKit::toAPI(&API::String::create(WebKit::toImpl(page)->frameTextForTestingIncludingSubframes(includeSubframes)).leakRef());
+    SUPPRESS_UNCOUNTED_ARG return WebKit::toAPI(&API::String::create(WebKit::toProtectedImpl(page)->frameTextForTestingIncludingSubframes(includeSubframes)).leakRef());
 }


### PR DESCRIPTION
#### f3f8b6037e457fcfa3696a295d19038396986197
<pre>
[SaferC++] Improve memory safety in the Injected Bundle C API (part 4)
<a href="https://bugs.webkit.org/show_bug.cgi?id=300215">https://bugs.webkit.org/show_bug.cgi?id=300215</a>
<a href="https://rdar.apple.com/162011621">rdar://162011621</a>

Reviewed by NOBODY (OOPS!).

Improve memory safety in the Injected Bundle C API (part 4)

This time, in `API/c/WKBundlePage.cpp`

* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp:
(WKBundlePageSetEditorClient):
(WKBundlePageSetFormClient):
(WKBundlePageSetPageLoaderClient):
(WKBundlePageSetResourceLoadClient):
(WKBundlePageSetUIClient):
(WKBundleFrameCreateFrameHandle):
(WKBundlePageClickMenuItem):
(WKBundlePageCopyContextMenuItems):
(WKBundlePageCopyContextMenuAtPointInWindow):
(WKBundlePageInsertNewlineInQuotedContent):
(WKAccessibilityTestingInjectPreference):
(WKAccessibilityFocusedObject):
(WKAccessibilityAnnounce):
(WKBundlePageSetEditable):
(WKBundlePageCopyRenderTreeExternalRepresentation):
(WKBundlePageCopyRenderTreeExternalRepresentationForPrinting):
(WKBundlePageClose):
(WKBundlePageGetTextZoomFactor):
(WKBundlePageGetPageZoomFactor):
(WKBundlePageDumpHistoryForTesting):
(WKBundlePageInstallPageOverlay):
(WKBundlePageUninstallPageOverlay):
(WKBundlePageInstallPageOverlayWithAnimation):
(WKBundlePageUninstallPageOverlayWithAnimation):
(WKBundlePageSetTopOverhangImage):
(WKBundlePageSetBottomOverhangImage):
(WKBundlePageSetHeaderBanner):
(WKBundlePageSetFooterBanner):
(WKBundlePageHasLocalDataForURL):
(WKBundlePageReplaceStringMatches):
(WKBundlePageCreateSnapshotWithOptions):
(WKBundlePageCreateSnapshotInViewCoordinates):
(WKBundlePageCreateSnapshotInDocumentCoordinates):
(WKBundlePageCreateScaledSnapshotInDocumentCoordinates):
(WKBundlePageGetBackingScaleFactor):
(WKBundlePageListenForLayoutMilestones):
(WKBundlePageCloseInspectorForTest):
(WKBundlePageEvaluateScriptInInspectorForTest):
(WKBundlePageForceRepaint):
(WKBundlePageFlushPendingEditorStateUpdate):
(WKBundlePageGetRenderTreeSize):
(WKBundlePageIsTrackingRepaints):
(WKBundlePageCopyTrackedRepaintRects):
(WKBundlePageSetComposition):
(WKBundlePageHasComposition):
(WKBundlePageConfirmComposition):
(WKBundlePageConfirmCompositionWithText):
(WKBundlePageCanShowMIMEType):
(WKBundlePageExtendIncrementalRenderingSuppression):
(WKBundlePageStopExtendingIncrementalRenderingSuppression):
(WKBundlePageIsUsingEphemeralSession):
(WKBundlePageIsControlledByAutomation):
(WKBundlePageStartMonitoringScrollOperations):
(WKBundlePageRegisterScrollOperationCompletionCallback):
(WKBundlePageCallAfterTasksAndTimers):
(WKBundlePageFlushDeferredDidReceiveMouseEventForTesting):
(WKBundlePagePostMessage):
(WKBundlePagePostMessageIgnoringFullySynchronousMode):
(WKBundlePagePostSynchronousMessageForTesting):
(WKBundlePageAddUserScript):
(WKBundlePageAddUserScriptInWorld):
(WKBundlePageAddUserStyleSheet):
(WKBundlePageRemoveAllUserContent):
(WKBundlePageSetCaptionDisplayMode):
(WKBundlePageCreateCaptionUserPreferencesTestingModeToken):
(WKBundlePageLayoutIfNeeded):
(WKBundlePageCopyFrameTextForTesting):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f3f8b6037e457fcfa3696a295d19038396986197

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124991 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44660 "Hash f3f8b603 for PR 51919 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35397 "Hash f3f8b603 for PR 51919 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131840 "Hash f3f8b603 for PR 51919 does not build (failure)") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76873 "Hash f3f8b603 for PR 51919 does not build (failure)") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ab257ef7-9020-4de4-968c-40221d7600ca) 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45352 "Hash f3f8b603 for PR 51919 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53226 "Hash f3f8b603 for PR 51919 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/131840 "Hash f3f8b603 for PR 51919 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/76873 "Hash f3f8b603 for PR 51919 does not build (failure)") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9131ce14-ef82-4c0e-9b88-3db860358b62) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127945 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/130/builds/45352 "Hash f3f8b603 for PR 51919 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/138/builds/35397 "Hash f3f8b603 for PR 51919 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/131840 "Hash f3f8b603 for PR 51919 does not build (failure)") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/69177e99-693f-4dad-9423-191def29e26e) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/130/builds/45352 "Hash f3f8b603 for PR 51919 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/138/builds/35397 "Hash f3f8b603 for PR 51919 does not build (failure)") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75321 "Hash f3f8b603 for PR 51919 does not build (failure)") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/130/builds/45352 "Hash f3f8b603 for PR 51919 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/138/builds/35397 "Hash f3f8b603 for PR 51919 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134515 "Hash f3f8b603 for PR 51919 does not build (failure)") | | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51814 "Failed to compile WebKit") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/123/builds/53226 "Hash f3f8b603 for PR 51919 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/134515 "Hash f3f8b603 for PR 51919 does not build (failure)") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52239 "Hash f3f8b603 for PR 51919 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/138/builds/35397 "Hash f3f8b603 for PR 51919 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/134515 "Hash f3f8b603 for PR 51919 does not build (failure)") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/138/builds/35397 "Hash f3f8b603 for PR 51919 does not build (failure)") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48847 "Hash f3f8b603 for PR 51919 does not build (failure)") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51698 "Hash f3f8b603 for PR 51919 does not build (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57493 "Failed to build and analyze WebKit") | | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51073 "Hash f3f8b603 for PR 51919 does not build (failure)") | | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54429 "Hash f3f8b603 for PR 51919 does not build (failure)") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52764 "Hash f3f8b603 for PR 51919 does not build (failure)") | | | | 
<!--EWS-Status-Bubble-End-->