### PR TITLE
[SaferC++] Use smart pointers in the Injected Bundle C API (part 5/5)

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -13,7 +13,6 @@ WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
 WebProcess/GPU/media/RemoteLegacyCDMFactory.cpp
 WebProcess/GPU/media/RemoteMediaPlayerManager.cpp
 WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInFrame.mm
-WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp
 WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
 WebProcess/InjectedBundle/API/mac/WKDOMDocument.mm
 WebProcess/InjectedBundle/API/mac/WKDOMElement.mm

--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -72,7 +72,6 @@ WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInHitTestResult.mm
 WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInNodeHandle.mm
 WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInRangeHandle.mm
 WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInScriptWorld.mm
-WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp
 WebProcess/InjectedBundle/API/c/WKBundleNodeHandle.cpp
 WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
 WebProcess/InjectedBundle/API/c/mac/WKBundleMac.mm

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp
@@ -56,27 +56,27 @@ WKTypeID WKBundleFrameGetTypeID()
 
 bool WKBundleFrameIsMainFrame(WKBundleFrameRef frameRef)
 {
-    return WebKit::toImpl(frameRef)->isMainFrame();
+    return WebKit::toProtectedImpl(frameRef)->isMainFrame();
 }
 
 WKBundleFrameRef WKBundleFrameGetParentFrame(WKBundleFrameRef frameRef)
 {
-    return toAPI(WebKit::toImpl(frameRef)->parentFrame().get());
+    return toAPI(WebKit::toProtectedImpl(frameRef)->parentFrame().get());
 }
 
 WKURLRef WKBundleFrameCopyURL(WKBundleFrameRef frameRef)
 {
-    return WebKit::toCopiedURLAPI(WebKit::toImpl(frameRef)->url());
+    return WebKit::toCopiedURLAPI(WebKit::toProtectedImpl(frameRef)->url());
 }
 
 WKURLRef WKBundleFrameCopyProvisionalURL(WKBundleFrameRef frameRef)
 {
-    return WebKit::toCopiedURLAPI(WebKit::toImpl(frameRef)->provisionalURL());
+    return WebKit::toCopiedURLAPI(WebKit::toProtectedImpl(frameRef)->provisionalURL());
 }
 
 WKFrameLoadState WKBundleFrameGetFrameLoadState(WKBundleFrameRef frameRef)
 {
-    RefPtr coreFrame = WebKit::toImpl(frameRef)->coreLocalFrame();
+    RefPtr coreFrame = WebKit::toProtectedImpl(frameRef)->coreLocalFrame();
     if (!coreFrame)
         return kWKFrameLoadStateFinished;
 
@@ -95,12 +95,12 @@ WKFrameLoadState WKBundleFrameGetFrameLoadState(WKBundleFrameRef frameRef)
 
 WKArrayRef WKBundleFrameCopyChildFrames(WKBundleFrameRef frameRef)
 {
-    return WebKit::toAPI(&WebKit::toImpl(frameRef)->childFrames().leakRef());    
+    SUPPRESS_UNCOUNTED_ARG return WebKit::toAPI(&WebKit::toProtectedImpl(frameRef)->childFrames().leakRef());
 }
 
 JSGlobalContextRef WKBundleFrameGetJavaScriptContext(WKBundleFrameRef frameRef)
 {
-    return WebKit::toImpl(frameRef)->jsContext();
+    return WebKit::toProtectedImpl(frameRef)->jsContext();
 }
 
 WKBundleFrameRef WKBundleFrameForJavaScriptContext(JSContextRef context)
@@ -110,22 +110,22 @@ WKBundleFrameRef WKBundleFrameForJavaScriptContext(JSContextRef context)
 
 JSGlobalContextRef WKBundleFrameGetJavaScriptContextForWorld(WKBundleFrameRef frameRef, WKBundleScriptWorldRef worldRef)
 {
-    return WebKit::toImpl(frameRef)->jsContextForWorld(WebKit::toImpl(worldRef));
+    return WebKit::toProtectedImpl(frameRef)->jsContextForWorld(WebKit::toProtectedImpl(worldRef).get());
 }
 
 JSValueRef WKBundleFrameGetJavaScriptWrapperForNodeForWorld(WKBundleFrameRef frameRef, WKBundleNodeHandleRef nodeHandleRef, WKBundleScriptWorldRef worldRef)
 {
-    return WebKit::toImpl(frameRef)->jsWrapperForWorld(WebKit::toImpl(nodeHandleRef), WebKit::toImpl(worldRef));
+    return WebKit::toProtectedImpl(frameRef)->jsWrapperForWorld(WebKit::toProtectedImpl(nodeHandleRef).get(), WebKit::toProtectedImpl(worldRef).get());
 }
 
 JSValueRef WKBundleFrameGetJavaScriptWrapperForRangeForWorld(WKBundleFrameRef frameRef, WKBundleRangeHandleRef rangeHandleRef, WKBundleScriptWorldRef worldRef)
 {
-    return WebKit::toImpl(frameRef)->jsWrapperForWorld(WebKit::toImpl(rangeHandleRef), WebKit::toImpl(worldRef));
+    return WebKit::toProtectedImpl(frameRef)->jsWrapperForWorld(WebKit::toProtectedImpl(rangeHandleRef).get(), WebKit::toProtectedImpl(worldRef).get());
 }
 
 WKStringRef WKBundleFrameCopyName(WKBundleFrameRef frameRef)
 {
-    return WebKit::toCopiedAPI(WebKit::toImpl(frameRef)->name());
+    return WebKit::toCopiedAPI(WebKit::toProtectedImpl(frameRef)->name());
 }
 
 WKStringRef WKBundleFrameCopyCounterValue(WKBundleFrameRef frameRef, JSObjectRef element)
@@ -135,27 +135,27 @@ WKStringRef WKBundleFrameCopyCounterValue(WKBundleFrameRef frameRef, JSObjectRef
 
 unsigned WKBundleFrameGetPendingUnloadCount(WKBundleFrameRef frameRef)
 {
-    return WebKit::toImpl(frameRef)->pendingUnloadCount();
+    return WebKit::toProtectedImpl(frameRef)->pendingUnloadCount();
 }
 
 WKBundlePageRef WKBundleFrameGetPage(WKBundleFrameRef frameRef)
 {
-    return toAPI(WebKit::toImpl(frameRef)->page());
+    return toAPI(WebKit::toProtectedImpl(frameRef)->protectedPage().get());
 }
 
 void WKBundleFrameStopLoading(WKBundleFrameRef frameRef)
 {
-    WebKit::toImpl(frameRef)->stopLoading();
+    WebKit::toProtectedImpl(frameRef)->stopLoading();
 }
 
 WKStringRef WKBundleFrameCopyLayerTreeAsText(WKBundleFrameRef frameRef)
 {
-    return WebKit::toCopiedAPI(WebKit::toImpl(frameRef)->layerTreeAsText());
+    return WebKit::toCopiedAPI(WebKit::toProtectedImpl(frameRef)->layerTreeAsText());
 }
 
 bool WKBundleFrameAllowsFollowingLink(WKBundleFrameRef frameRef, WKURLRef urlRef)
 {
-    return WebKit::toImpl(frameRef)->allowsFollowingLink(URL { WebKit::toWTFString(urlRef) });
+    return WebKit::toProtectedImpl(frameRef)->allowsFollowingLink(URL { WebKit::toWTFString(urlRef) });
 }
 
 bool WKBundleFrameHandlesPageScaleGesture(WKBundleFrameRef)
@@ -166,57 +166,57 @@ bool WKBundleFrameHandlesPageScaleGesture(WKBundleFrameRef)
 
 WKRect WKBundleFrameGetContentBounds(WKBundleFrameRef frameRef)
 {
-    return WebKit::toAPI(WebKit::toImpl(frameRef)->contentBounds());
+    return WebKit::toAPI(WebKit::toProtectedImpl(frameRef)->contentBounds());
 }
 
 WKRect WKBundleFrameGetVisibleContentBounds(WKBundleFrameRef frameRef)
 {
-    return WebKit::toAPI(WebKit::toImpl(frameRef)->visibleContentBounds());
+    return WebKit::toAPI(WebKit::toProtectedImpl(frameRef)->visibleContentBounds());
 }
 
 WKRect WKBundleFrameGetVisibleContentBoundsExcludingScrollbars(WKBundleFrameRef frameRef)
 {
-    return WebKit::toAPI(WebKit::toImpl(frameRef)->visibleContentBoundsExcludingScrollbars());
+    return WebKit::toAPI(WebKit::toProtectedImpl(frameRef)->visibleContentBoundsExcludingScrollbars());
 }
 
 WKSize WKBundleFrameGetScrollOffset(WKBundleFrameRef frameRef)
 {
-    return WebKit::toAPI(WebKit::toImpl(frameRef)->scrollOffset());
+    return WebKit::toAPI(WebKit::toProtectedImpl(frameRef)->scrollOffset());
 }
 
 bool WKBundleFrameHasHorizontalScrollbar(WKBundleFrameRef frameRef)
 {
-    return WebKit::toImpl(frameRef)->hasHorizontalScrollbar();
+    return WebKit::toProtectedImpl(frameRef)->hasHorizontalScrollbar();
 }
 
 bool WKBundleFrameHasVerticalScrollbar(WKBundleFrameRef frameRef)
 {
-    return WebKit::toImpl(frameRef)->hasVerticalScrollbar();
+    return WebKit::toProtectedImpl(frameRef)->hasVerticalScrollbar();
 }
 
 bool WKBundleFrameGetDocumentBackgroundColor(WKBundleFrameRef frameRef, double* red, double* green, double* blue, double* alpha)
 {
-    return WebKit::toImpl(frameRef)->getDocumentBackgroundColor(red, green, blue, alpha);
+    return WebKit::toProtectedImpl(frameRef)->getDocumentBackgroundColor(red, green, blue, alpha);
 }
 
 WKStringRef WKBundleFrameCopySuggestedFilenameForResourceWithURL(WKBundleFrameRef frameRef, WKURLRef urlRef)
 {
-    return WebKit::toCopiedAPI(WebKit::toImpl(frameRef)->suggestedFilenameForResourceWithURL(URL { WebKit::toWTFString(urlRef) }));
+    return WebKit::toCopiedAPI(WebKit::toProtectedImpl(frameRef)->suggestedFilenameForResourceWithURL(URL { WebKit::toWTFString(urlRef) }));
 }
 
 WKStringRef WKBundleFrameCopyMIMETypeForResourceWithURL(WKBundleFrameRef frameRef, WKURLRef urlRef)
 {
-    return WebKit::toCopiedAPI(WebKit::toImpl(frameRef)->mimeTypeForResourceWithURL(URL { WebKit::toWTFString(urlRef) }));
+    return WebKit::toCopiedAPI(WebKit::toProtectedImpl(frameRef)->mimeTypeForResourceWithURL(URL { WebKit::toWTFString(urlRef) }));
 }
 
 bool WKBundleFrameContainsAnyFormElements(WKBundleFrameRef frameRef)
 {
-    return WebKit::toImpl(frameRef)->containsAnyFormElements();
+    return WebKit::toProtectedImpl(frameRef)->containsAnyFormElements();
 }
 
 bool WKBundleFrameContainsAnyFormControls(WKBundleFrameRef frameRef)
 {
-    return WebKit::toImpl(frameRef)->containsAnyFormControls();
+    return WebKit::toProtectedImpl(frameRef)->containsAnyFormControls();
 }
 
 void WKBundleFrameSetTextDirection(WKBundleFrameRef frameRef, WKStringRef directionRef)
@@ -224,7 +224,7 @@ void WKBundleFrameSetTextDirection(WKBundleFrameRef frameRef, WKStringRef direct
     if (!frameRef)
         return;
 
-    WebKit::toImpl(frameRef)->setTextDirection(WebKit::toWTFString(directionRef));
+    WebKit::toProtectedImpl(frameRef)->setTextDirection(WebKit::toWTFString(directionRef));
 }
 
 void WKBundleFrameSetAccessibleName(WKBundleFrameRef frameRef, WKStringRef accessibleNameRef)
@@ -232,7 +232,7 @@ void WKBundleFrameSetAccessibleName(WKBundleFrameRef frameRef, WKStringRef acces
     if (!frameRef)
         return;
 
-    WebKit::toImpl(frameRef)->setAccessibleName(AtomString { WebKit::toWTFString(accessibleNameRef) });
+    WebKit::toProtectedImpl(frameRef)->setAccessibleName(AtomString { WebKit::toWTFString(accessibleNameRef) });
 }
 
 WKDataRef WKBundleFrameCopyWebArchive(WKBundleFrameRef frameRef)
@@ -243,7 +243,7 @@ WKDataRef WKBundleFrameCopyWebArchive(WKBundleFrameRef frameRef)
 WKDataRef WKBundleFrameCopyWebArchiveFilteringSubframes(WKBundleFrameRef frameRef, WKBundleFrameFrameFilterCallback frameFilterCallback, void* context)
 {
 #if PLATFORM(COCOA)
-    RetainPtr<CFDataRef> data = WebKit::toImpl(frameRef)->webArchiveData(frameFilterCallback, context);
+    RetainPtr<CFDataRef> data = WebKit::toProtectedImpl(frameRef)->webArchiveData(frameFilterCallback, context);
     if (data)
         return WKDataCreate(CFDataGetBytePtr(data.get()), CFDataGetLength(data.get()));
 #else
@@ -251,7 +251,7 @@ WKDataRef WKBundleFrameCopyWebArchiveFilteringSubframes(WKBundleFrameRef frameRe
     UNUSED_PARAM(frameFilterCallback);
     UNUSED_PARAM(context);
 #endif
-    
+
     return nullptr;
 }
 
@@ -260,7 +260,7 @@ bool WKBundleFrameCallShouldCloseOnWebView(WKBundleFrameRef frameRef)
     if (!frameRef)
         return true;
 
-    RefPtr coreFrame = WebKit::toImpl(frameRef)->coreLocalFrame();
+    RefPtr coreFrame = WebKit::toProtectedImpl(frameRef)->coreLocalFrame();
     if (!coreFrame)
         return true;
 
@@ -270,21 +270,21 @@ bool WKBundleFrameCallShouldCloseOnWebView(WKBundleFrameRef frameRef)
 WKBundleHitTestResultRef WKBundleFrameCreateHitTestResult(WKBundleFrameRef frameRef, WKPoint point)
 {
     ASSERT(frameRef);
-    return WebKit::toAPI(WebKit::toImpl(frameRef)->hitTest(WebKit::toIntPoint(point)).leakRef());
+    SUPPRESS_UNCOUNTED_ARG return WebKit::toAPI(WebKit::toProtectedImpl(frameRef)->hitTest(WebKit::toIntPoint(point)).leakRef());
 }
 
 WKSecurityOriginRef WKBundleFrameCopySecurityOrigin(WKBundleFrameRef frameRef)
 {
-    RefPtr coreFrame = WebKit::toImpl(frameRef)->coreLocalFrame();
+    RefPtr coreFrame = WebKit::toProtectedImpl(frameRef)->coreLocalFrame();
     if (!coreFrame)
         return 0;
 
-    return WebKit::toCopiedAPI(&coreFrame->document()->securityOrigin());
+    return WebKit::toCopiedAPI(&coreFrame->protectedDocument()->protectedSecurityOrigin().get());
 }
 
 void WKBundleFrameFocus(WKBundleFrameRef frameRef)
 {
-    RefPtr coreFrame = WebKit::toImpl(frameRef)->coreLocalFrame();
+    RefPtr coreFrame = WebKit::toProtectedImpl(frameRef)->coreLocalFrame();
     if (!coreFrame)
         return;
 
@@ -296,12 +296,12 @@ void _WKBundleFrameGenerateTestReport(WKBundleFrameRef frameRef, WKStringRef mes
     if (!frameRef)
         return;
 
-    RefPtr coreFrame = WebKit::toImpl(frameRef)->coreLocalFrame();
+    RefPtr coreFrame = WebKit::toProtectedImpl(frameRef)->coreLocalFrame();
     if (!coreFrame)
         return;
 
     if (RefPtr document = coreFrame->document())
-        document->reportingScope().generateTestReport(WebKit::toWTFString(message), WebKit::toWTFString(group));
+        document->protectedReportingScope()->generateTestReport(WebKit::toWTFString(message), WebKit::toWTFString(group));
 }
 
 void* _WKAccessibilityRootObjectForTesting(WKBundleFrameRef frameRef)
@@ -312,7 +312,7 @@ void* _WKAccessibilityRootObjectForTesting(WKBundleFrameRef frameRef)
     auto getAXObjectCache = [&frameRef] () -> CheckedPtr<WebCore::AXObjectCache> {
         WebCore::AXObjectCache::enableAccessibility();
 
-        RefPtr frame = WebKit::toImpl(frameRef)->coreLocalFrame();
+        RefPtr frame = WebKit::toProtectedImpl(frameRef)->coreLocalFrame();
         RefPtr document = frame ? frame->rootFrame().document() : nullptr;
         return document ? document->axObjectCache() : nullptr;
     };
@@ -338,6 +338,6 @@ void* _WKAccessibilityRootObjectForTesting(WKBundleFrameRef frameRef)
 #endif // ENABLE(ACCESSIBILITY_ISOLATED_TREE)
 
     CheckedPtr cache = getAXObjectCache();
-    RefPtr root = cache ? cache->rootObjectForFrame(*WebKit::toImpl(frameRef)->coreLocalFrame()) : nullptr;
+    RefPtr root = cache ? cache->rootObjectForFrame(*WebKit::toProtectedImpl(frameRef)->protectedCoreLocalFrame()) : nullptr;
     return root ? root->wrapper() : nullptr;
 }


### PR DESCRIPTION
#### 1baeb0a85d0f74e0cb256755f2d9b0c324d160a2
<pre>
[SaferC++] Use smart pointers in the Injected Bundle C API (part 5/5)
<a href="https://bugs.webkit.org/show_bug.cgi?id=300297">https://bugs.webkit.org/show_bug.cgi?id=300297</a>
<a href="https://rdar.apple.com/162095972">rdar://162095972</a>

Reviewed by NOBODY (OOPS!).

Final patch to fix violations in the Injected Bundle C API.

Fix them in WKBundleFrame.cpp.

* Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp:
(WKBundleFrameIsMainFrame):
(WKBundleFrameGetParentFrame):
(WKBundleFrameCopyURL):
(WKBundleFrameCopyProvisionalURL):
(WKBundleFrameGetFrameLoadState):
(WKBundleFrameCopyChildFrames):
(WKBundleFrameGetJavaScriptContext):
(WKBundleFrameGetJavaScriptContextForWorld):
(WKBundleFrameGetJavaScriptWrapperForNodeForWorld):
(WKBundleFrameGetJavaScriptWrapperForRangeForWorld):
(WKBundleFrameCopyName):
(WKBundleFrameGetPendingUnloadCount):
(WKBundleFrameGetPage):
(WKBundleFrameStopLoading):
(WKBundleFrameCopyLayerTreeAsText):
(WKBundleFrameAllowsFollowingLink):
(WKBundleFrameGetContentBounds):
(WKBundleFrameGetVisibleContentBounds):
(WKBundleFrameGetVisibleContentBoundsExcludingScrollbars):
(WKBundleFrameGetScrollOffset):
(WKBundleFrameHasHorizontalScrollbar):
(WKBundleFrameHasVerticalScrollbar):
(WKBundleFrameGetDocumentBackgroundColor):
(WKBundleFrameCopySuggestedFilenameForResourceWithURL):
(WKBundleFrameCopyMIMETypeForResourceWithURL):
(WKBundleFrameContainsAnyFormElements):
(WKBundleFrameContainsAnyFormControls):
(WKBundleFrameSetTextDirection):
(WKBundleFrameSetAccessibleName):
(WKBundleFrameCopyWebArchiveFilteringSubframes):
(WKBundleFrameCallShouldCloseOnWebView):
(WKBundleFrameCreateHitTestResult):
(WKBundleFrameCopySecurityOrigin):
(WKBundleFrameFocus):
(_WKBundleFrameGenerateTestReport):
(_WKAccessibilityRootObjectForTesting):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1baeb0a85d0f74e0cb256755f2d9b0c324d160a2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/127644 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/47292 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/38460 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/134915 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79201 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2e994268-4b33-4e74-94fe-67b8b009adf2) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/47915 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/55823 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97165 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65197 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c8ceda50-2c7c-402e-8dfb-9dba59f70323) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/130592 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/38318 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114347 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/77646 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/052860a8-cac6-4e70-ba79-3ab98c786b54) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/37122 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78274 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108186 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/32891 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/137398 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/54303 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/41857 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/105686 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/54814 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/110703 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/105338 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/50856 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29293 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/51924 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/54240 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/60416 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/53475 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/56931 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/55233 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->