### PR TITLE
pip and cancel buttons specs in video full screen for iOS do not match AVKit

### DIFF
--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
@@ -65,6 +65,7 @@
 static const NSTimeInterval showHideAnimationDuration = 0.1;
 static const NSTimeInterval pipHideAnimationDuration = 0.2;
 static const NSTimeInterval autoHideDelay = 4.0;
+static constexpr CGFloat buttonContentInset = 8.0;
 
 #if ENABLE(FULLSCREEN_DISMISSAL_GESTURES)
 static const Seconds bannerMinimumHideDelay = 1_s;
@@ -162,6 +163,10 @@ private:
     RetainPtr<WKExtrinsicButton> _pipButton;
     RetainPtr<UIButton> _locationButton;
     RetainPtr<UILayoutGuide> _topGuide;
+#if !PLATFORM(VISION)
+    RetainPtr<WKFullscreenStackView> _closeStack;
+    RetainPtr<WKFullscreenStackView> _controlsStack;
+#endif
     RetainPtr<NSLayoutConstraint> _topConstraint;
     String _location;
     WebKit::FullscreenTouchSecheuristic _secheuristic;
@@ -300,8 +305,16 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     }
     [UIView animateWithDuration:showHideAnimationDuration animations:^{
         [[self delegate] showUI];
+#if PLATFORM(VISION)
         [_stackView setHidden:NO];
         [_stackView setAlpha:1];
+#else
+        [_closeStack setHidden:NO];
+        [_closeStack setAlpha:1];
+        [_controlsStack setHidden:!_controlsStack.get().arrangedSubviews.count];
+        if (![_controlsStack isHidden])
+            [_controlsStack setAlpha:1];
+#endif
         self.prefersStatusBarHidden = NO;
         self.prefersHomeIndicatorAutoHidden = NO;
         if (_topConstraint)
@@ -334,7 +347,12 @@ ALLOW_DEPRECATED_DECLARATIONS_END
             [NSLayoutConstraint deactivateConstraints:@[_topConstraint.get()]];
         _topConstraint = [[_topGuide topAnchor] constraintEqualToAnchor:self.view.topAnchor constant:self.view.safeAreaInsets.top];
         [_topConstraint setActive:YES];
+#if PLATFORM(VISION)
         [_stackView setAlpha:0];
+#else
+        [_closeStack setAlpha:0];
+        [_controlsStack setAlpha:0];
+#endif
         self.prefersStatusBarHidden = YES;
         self.prefersHomeIndicatorAutoHidden = YES;
 #if ENABLE(LINEAR_MEDIA_PLAYER)
@@ -344,7 +362,12 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         if (!finished)
             return;
 
+#if PLATFORM(VISION)
         [_stackView setHidden:YES];
+#else
+        [_closeStack setHidden:YES];
+        [_controlsStack setHidden:YES];
+#endif
 #if ENABLE(LINEAR_MEDIA_PLAYER)
         [_centeredStackView setHidden:YES];
 #endif
@@ -519,7 +542,11 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     }
 
     if (_environmentPickerButtonViewController == environmentPickerButtonViewController) {
+#if PLATFORM(VISION)
         ASSERT(!environmentPickerButtonViewController || [[_stackView arrangedSubviews] containsObject:environmentPickerButtonViewController.view]);
+#else
+        ASSERT(!environmentPickerButtonViewController || [[_controlsStack arrangedSubviews] containsObject:environmentPickerButtonViewController.view]);
+#endif
         return;
     }
 
@@ -528,7 +555,11 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         return;
 
     [self addChildViewController:environmentPickerButtonViewController];
+#if PLATFORM(VISION)
     [_stackView insertArrangedSubview:environmentPickerButtonViewController.view atIndex:1];
+#else
+    [_controlsStack insertArrangedSubview:environmentPickerButtonViewController.view atIndex:0];
+#endif
     [environmentPickerButtonViewController didMoveToParentViewController:self];
     _environmentPickerButtonViewController = environmentPickerButtonViewController;
     _buttonState.add(EnvironmentPicker);
@@ -542,7 +573,11 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     UIView *environmentPickerButtonView = [_environmentPickerButtonViewController view];
 
     [_environmentPickerButtonViewController willMoveToParentViewController:nil];
+#if PLATFORM(VISION)
     [_stackView removeArrangedSubview:environmentPickerButtonView];
+#else
+    [_controlsStack removeArrangedSubview:environmentPickerButtonView];
+#endif
     [environmentPickerButtonView removeFromSuperview];
     [self removeChildViewController:_environmentPickerButtonViewController.get()];
 
@@ -761,6 +796,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     [_cancelButton setImage:[doneImage imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate] forState:UIControlStateNormal];
     [_cancelButton sizeToFit];
     [_cancelButton addTarget:self action:@selector(_cancelAction:) forControlEvents:UIControlEventTouchUpInside];
+    [[_cancelButton layer] setCornerRadius:buttonSize.width / 2.0];
+    [[_cancelButton layer] setMasksToBounds:1];
 #if PLATFORM(APPLETV)
     [_cancelButton setConfiguration:UIButtonConfiguration.filledButtonConfiguration];
 #endif
@@ -770,9 +807,13 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     [_pipButton setImage:[UIImage systemImageNamed:@"pip.exit"] forState:UIControlStateSelected];
     [_pipButton sizeToFit];
     [_pipButton addTarget:self action:@selector(_togglePiPAction:) forControlEvents:UIControlEventTouchUpInside];
+    [[_pipButton layer] setCornerRadius:buttonSize.width / 2.0];
+    [[_pipButton layer] setMasksToBounds:1];
 
     if (alternateFullScreenControlDesignEnabled) {
         UIButtonConfiguration *buttonConfiguration = [UIButtonConfiguration filledButtonConfiguration];
+        buttonConfiguration.cornerStyle = UIButtonConfigurationCornerStyleCapsule;
+        buttonConfiguration.contentInsets = NSDirectionalEdgeInsetsMake(buttonContentInset, buttonContentInset, buttonContentInset, buttonContentInset);
         [_cancelButton setConfiguration:buttonConfiguration];
         [_pipButton setConfiguration:buttonConfiguration];
 
@@ -783,6 +824,43 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         [_moreActionsButton setMenu:self._webView.fullScreenWindowSceneDimmingAction];
         [_moreActionsButton setShowsMenuAsPrimaryAction:YES];
         [_moreActionsButton setImage:[[UIImage systemImageNamed:@"ellipsis"] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate] forState:UIControlStateNormal];
+        [[_moreActionsButton layer] setCornerRadius:buttonSize.width / 2.0];
+        [[_moreActionsButton layer] setMasksToBounds:1];
+
+        _stackView = adoptNS([[UIStackView alloc] init]);
+        [_stackView addArrangedSubview:_cancelButton.get()];
+        [_stackView addArrangedSubview:_pipButton.get()];
+        [_stackView addArrangedSubview:_moreActionsButton.get()];
+        [_stackView setSpacing:24.0];
+#else
+        _closeStack = adoptNS([[WKFullscreenStackView alloc] init]);
+        [_closeStack setAxis:UILayoutConstraintAxisHorizontal];
+        [_closeStack setAlignment:UIStackViewAlignmentCenter];
+        [_closeStack setTranslatesAutoresizingMaskIntoConstraints:NO];
+#if PLATFORM(APPLETV)
+        [_closeStack addArrangedSubview:_cancelButton.get()];
+#else
+        [_closeStack addArrangedSubview:_cancelButton.get() applyingMaterialStyle:AVBackgroundViewMaterialStyleSecondary tintEffectStyle:AVBackgroundViewTintEffectStyleSecondary];
+#endif
+        [_animatingView addSubview:_closeStack.get()];
+
+        [[_closeStack widthAnchor] constraintEqualToConstant:buttonSize.width].active = YES;
+        [[_closeStack heightAnchor] constraintEqualToConstant:buttonSize.width].active = YES;
+
+        _controlsStack = adoptNS([[WKFullscreenStackView alloc] init]);
+        [_controlsStack setAxis:UILayoutConstraintAxisHorizontal];
+        [_controlsStack setAlignment:UIStackViewAlignmentCenter];
+        [_controlsStack setSpacing:16.0];
+        [_controlsStack setTranslatesAutoresizingMaskIntoConstraints:NO];
+#if PLATFORM(APPLETV)
+        [_controlsStack addArrangedSubview:_pipButton.get()];
+#else
+        [_controlsStack addArrangedSubview:_pipButton.get() applyingMaterialStyle:AVBackgroundViewMaterialStylePrimary tintEffectStyle:AVBackgroundViewTintEffectStyleSecondary];
+#endif
+        [_animatingView addSubview:_controlsStack.get()];
+
+        [[_controlsStack widthAnchor] constraintEqualToConstant:buttonSize.width].active = YES;
+        [[_controlsStack heightAnchor] constraintEqualToConstant:buttonSize.width].active = YES;
 #endif
 
 #if ENABLE(LINEAR_MEDIA_PLAYER)
@@ -794,27 +872,44 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         _centeredStackView = adoptNS([[UIStackView alloc] init]);
         [_centeredStackView setSpacing:24.0];
 #endif
-
-        _stackView = adoptNS([[UIStackView alloc] init]);
-        [_stackView addArrangedSubview:_cancelButton.get()];
-        [_stackView addArrangedSubview:_pipButton.get()];
-#if PLATFORM(VISION)
-        [_stackView addArrangedSubview:_moreActionsButton.get()];
-#endif
-        [_stackView setSpacing:24.0];
     } else {
         RetainPtr<WKFullscreenStackView> stackView = adoptNS([[WKFullscreenStackView alloc] init]);
-#if PLATFORM(APPLETV)
-        [stackView addArrangedSubview:_cancelButton.get()];
-#else
+#if PLATFORM(VISION)
         [stackView addArrangedSubview:_cancelButton.get() applyingMaterialStyle:AVBackgroundViewMaterialStyleSecondary tintEffectStyle:AVBackgroundViewTintEffectStyleSecondary];
         [stackView addArrangedSubview:_pipButton.get() applyingMaterialStyle:AVBackgroundViewMaterialStylePrimary tintEffectStyle:AVBackgroundViewTintEffectStyleSecondary];
-#endif
         _stackView = WTFMove(stackView);
+#else
+        _closeStack = adoptNS([[WKFullscreenStackView alloc] init]);
+        [_closeStack setTranslatesAutoresizingMaskIntoConstraints:NO];
+#if PLATFORM(APPLETV)
+        [_closeStack addArrangedSubview:_cancelButton.get()];
+#else
+        [_closeStack addArrangedSubview:_cancelButton.get() applyingMaterialStyle:AVBackgroundViewMaterialStyleSecondary tintEffectStyle:AVBackgroundViewTintEffectStyleSecondary];
+#endif
+        [_animatingView addSubview:_closeStack.get()];
+
+        [[_closeStack widthAnchor] constraintEqualToConstant:buttonSize.width].active = YES;
+        [[_closeStack heightAnchor] constraintEqualToConstant:buttonSize.width].active = YES;
+
+        _controlsStack = WTFMove(stackView);
+        [_controlsStack setTranslatesAutoresizingMaskIntoConstraints:NO];
+        [_controlsStack setAlignment:UIStackViewAlignmentCenter];
+#if PLATFORM(APPLETV)
+        [_controlsStack addArrangedSubview:_pipButton.get()];
+#else
+        [_controlsStack addArrangedSubview:_pipButton.get() applyingMaterialStyle:AVBackgroundViewMaterialStylePrimary tintEffectStyle:AVBackgroundViewTintEffectStyleSecondary];
+#endif
+        [_animatingView addSubview:_controlsStack.get()];
+
+        [[_controlsStack widthAnchor] constraintEqualToConstant:buttonSize.width].active = YES;
+        [[_controlsStack heightAnchor] constraintEqualToConstant:buttonSize.width].active = YES;
+#endif
     }
 
+#if PLATFORM(VISION)
     [_stackView setTranslatesAutoresizingMaskIntoConstraints:NO];
     [_animatingView addSubview:_stackView.get()];
+#endif
 
 #if ENABLE(LINEAR_MEDIA_PLAYER)
     [_centeredStackView setTranslatesAutoresizingMaskIntoConstraints:NO];
@@ -849,12 +944,13 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     _topGuide = adoptNS([[UILayoutGuide alloc] init]);
     [self.view addLayoutGuide:_topGuide.get()];
     NSLayoutYAxisAnchor *topAnchor = [_topGuide topAnchor];
+    _topConstraint = [topAnchor constraintEqualToAnchor:safeArea.topAnchor];
+#if PLATFORM(VISION)
     NSLayoutConstraint *stackViewToTopGuideConstraint;
     if (alternateFullScreenControlDesignEnabled)
         stackViewToTopGuideConstraint = [[_stackView topAnchor] constraintEqualToSystemSpacingBelowAnchor:topAnchor multiplier:3];
     else
         stackViewToTopGuideConstraint = [[_stackView topAnchor] constraintEqualToAnchor:topAnchor];
-    _topConstraint = [topAnchor constraintEqualToAnchor:safeArea.topAnchor];
     [NSLayoutConstraint activateConstraints:@[
         _topConstraint.get(),
         stackViewToTopGuideConstraint,
@@ -869,9 +965,33 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         [[_centeredStackView centerXAnchor] constraintEqualToAnchor:[_animatingView centerXAnchor]],
 #endif
     ]];
+#else
+    [NSLayoutConstraint activateConstraints:@[
+        _topConstraint.get(),
+        [[_closeStack topAnchor] constraintEqualToAnchor:topAnchor],
+        [[_controlsStack topAnchor] constraintEqualToAnchor:topAnchor],
+        [[_closeStack leadingAnchor] constraintEqualToAnchor:margins.leadingAnchor],
+        [[_controlsStack leadingAnchor] constraintEqualToSystemSpacingAfterAnchor:_closeStack.get().trailingAnchor multiplier:1.0],
+#if ENABLE(FULLSCREEN_DISMISSAL_GESTURES)
+        [[_banner topAnchor] constraintEqualToSystemSpacingBelowAnchor:[_controlsStack bottomAnchor] multiplier:3],
+        [[_banner centerXAnchor] constraintEqualToAnchor:self.view.centerXAnchor],
+#endif
+#if ENABLE(LINEAR_MEDIA_PLAYER)
+        [[_centeredStackView topAnchor] constraintEqualToAnchor:[_closeStack topAnchor]],
+        [[_centeredStackView centerXAnchor] constraintEqualToAnchor:[_animatingView centerXAnchor]],
+#endif
+    ]];
+#endif
 
+#if PLATFORM(VISION)
     [_stackView setAlpha:0];
     [_stackView setHidden:YES];
+#else
+    [_closeStack setAlpha:0];
+    [_closeStack setHidden:YES];
+    [_controlsStack setAlpha:0];
+    [_controlsStack setHidden:YES];
+#endif
 #if ENABLE(LINEAR_MEDIA_PLAYER)
     [_centeredStackView setAlpha:0];
     [_centeredStackView setHidden:YES];
@@ -936,6 +1056,20 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     [self._webView setFrame:[_animatingView bounds]];
 #if ENABLE(FULLSCREEN_DISMISSAL_GESTURES)
     [_bannerLabel setPreferredMaxLayoutWidth:self.view.bounds.size.width];
+#endif
+#if !PLATFORM(VISION)
+    auto alternateFullScreenControlDesignEnabled = self._webView._page->preferences().alternateFullScreenControlDesignEnabled();
+    CGFloat buttonDimension = alternateFullScreenControlDesignEnabled ? 44.0 : 60.0;
+
+    if (_closeStack) {
+        [[_closeStack layer] setCornerRadius:buttonDimension / 2.0];
+        [[_closeStack layer] setMasksToBounds:1];
+    }
+
+    if (_controlsStack) {
+        [[_controlsStack layer] setCornerRadius:buttonDimension / 2.0];
+        [[_controlsStack layer] setMasksToBounds:1];
+    }
 #endif
 }
 
@@ -1004,7 +1138,17 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
     CGRect cancelFrame = _cancelButton.get().frame;
     CGPoint maxXY = CGPointMake(CGRectGetMaxX(cancelFrame), CGRectGetMaxY(cancelFrame));
-    insets.setTop([_cancelButton convertPoint:maxXY toView:self.view].y);
+    CGFloat topY = [_cancelButton convertPoint:maxXY toView:self.view].y;
+
+#if !PLATFORM(VISION)
+    if (_controlsStack) {
+        CGRect controlsFrame = _controlsStack.get().frame;
+        CGPoint controlsMax = CGPointMake(CGRectGetMaxX(controlsFrame), CGRectGetMaxY(controlsFrame));
+        topY =  std::max(topY, [_controlsStack convertPoint:controlsMax toView:self.view].y);
+    }
+#endif
+
+    insets.setTop(topY);
     return insets;
 }
 


### PR DESCRIPTION
#### 9426662ca5ee5b13c84a8d2d30b6d68b1c99aa6e
<pre>
pip and cancel buttons specs in video full screen for iOS do not match AVKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=300269">https://bugs.webkit.org/show_bug.cgi?id=300269</a>
<a href="https://rdar.apple.com/162074060">rdar://162074060</a>

Reviewed by NOBODY (OOPS!).

Separate pip and close buttons into their own containers. Apply rounded corners to make them
circular.

* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm:
(-[WKFullScreenViewController showUI]):
(-[WKFullScreenViewController hideUI]):
(-[WKFullScreenViewController configureEnvironmentPickerOrFullscreenVideoButtonView]):
(-[WKFullScreenViewController _removeEnvironmentPickerButtonView]):
(-[WKFullScreenViewController loadView]):
(-[WKFullScreenViewController viewDidLayoutSubviews]):
(-[WKFullScreenViewController _effectiveFullscreenInsets]):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9426662ca5ee5b13c84a8d2d30b6d68b1c99aa6e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125303 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44968 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35709 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132152 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77268 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45656 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53535 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95399 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/63413 "Build is in progress. Recent messages:") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128257 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36459 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112052 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75939 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35358 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75629 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106227 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30447 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134838 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52107 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39888 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103873 "12 flakes 58 failures") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52545 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108274 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103634 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48993 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27285 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/49212 "The change is no longer eligible for processing.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52002 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57781 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51360 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54715 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53053 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->