### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException for IDBConnectionToServerDelegate

### DIFF
--- a/Source/WebCore/Modules/indexeddb/client/IDBConnectionToServer.cpp
+++ b/Source/WebCore/Modules/indexeddb/client/IDBConnectionToServer.cpp
@@ -62,7 +62,7 @@ IDBConnectionToServer::~IDBConnectionToServer() = default;
 
 IDBConnectionIdentifier IDBConnectionToServer::identifier() const
 {
-    return *m_delegate->identifier();
+    return *protectedDelegate()->identifier();
 }
 
 void IDBConnectionToServer::callResultFunctionWithErrorLater(ResultFunction function, const IDBResourceIdentifier& requestIdentifier)
@@ -77,7 +77,7 @@ void IDBConnectionToServer::deleteDatabase(const IDBOpenRequestData& request)
     LOG(IndexedDB, "IDBConnectionToServer::deleteDatabase - %s", request.databaseIdentifier().loggingString().utf8().data());
     
     if (m_serverConnectionIsValid)
-        m_delegate->deleteDatabase(request);
+        protectedDelegate()->deleteDatabase(request);
     else
         callResultFunctionWithErrorLater(&IDBConnectionToServer::didDeleteDatabase, request.requestIdentifier());
 }
@@ -93,7 +93,7 @@ void IDBConnectionToServer::openDatabase(const IDBOpenRequestData& request)
     LOG(IndexedDB, "IDBConnectionToServer::openDatabase - %s (%s) (%" PRIu64 ")", request.databaseIdentifier().loggingString().utf8().data(), request.requestIdentifier().loggingString().utf8().data(), request.requestedVersion());
 
     if (m_serverConnectionIsValid)
-        m_delegate->openDatabase(request);
+        protectedDelegate()->openDatabase(request);
     else
         callResultFunctionWithErrorLater(&IDBConnectionToServer::didOpenDatabase, request.requestIdentifier());
 }
@@ -110,7 +110,7 @@ void IDBConnectionToServer::createObjectStore(const IDBRequestData& requestData,
     ASSERT(isMainThread());
 
     if (m_serverConnectionIsValid)
-        m_delegate->createObjectStore(requestData, info);
+        protectedDelegate()->createObjectStore(requestData, info);
     else
         callResultFunctionWithErrorLater(&IDBConnectionToServer::didCreateObjectStore, requestData.requestIdentifier());
 }
@@ -127,7 +127,7 @@ void IDBConnectionToServer::deleteObjectStore(const IDBRequestData& requestData,
     ASSERT(isMainThread());
 
     if (m_serverConnectionIsValid)
-        m_delegate->deleteObjectStore(requestData, objectStoreName);
+        protectedDelegate()->deleteObjectStore(requestData, objectStoreName);
     else
         callResultFunctionWithErrorLater(&IDBConnectionToServer::didDeleteObjectStore, requestData.requestIdentifier());
 }
@@ -144,7 +144,7 @@ void IDBConnectionToServer::renameObjectStore(const IDBRequestData& requestData,
     ASSERT(isMainThread());
 
     if (m_serverConnectionIsValid)
-        m_delegate->renameObjectStore(requestData, objectStoreIdentifier, newName);
+        protectedDelegate()->renameObjectStore(requestData, objectStoreIdentifier, newName);
     else
         callResultFunctionWithErrorLater(&IDBConnectionToServer::didRenameObjectStore, requestData.requestIdentifier());
 }
@@ -161,7 +161,7 @@ void IDBConnectionToServer::clearObjectStore(const IDBRequestData& requestData, 
     ASSERT(isMainThread());
 
     if (m_serverConnectionIsValid)
-        m_delegate->clearObjectStore(requestData, objectStoreIdentifier);
+        protectedDelegate()->clearObjectStore(requestData, objectStoreIdentifier);
     else
         callResultFunctionWithErrorLater(&IDBConnectionToServer::didClearObjectStore, requestData.requestIdentifier());
 }
@@ -178,7 +178,7 @@ void IDBConnectionToServer::createIndex(const IDBRequestData& requestData, const
     ASSERT(isMainThread());
 
     if (m_serverConnectionIsValid)
-        m_delegate->createIndex(requestData, info);
+        protectedDelegate()->createIndex(requestData, info);
     else
         callResultFunctionWithErrorLater(&IDBConnectionToServer::didCreateIndex, requestData.requestIdentifier());
 }
@@ -195,7 +195,7 @@ void IDBConnectionToServer::deleteIndex(const IDBRequestData& requestData, IDBOb
     ASSERT(isMainThread());
 
     if (m_serverConnectionIsValid)
-        m_delegate->deleteIndex(requestData, objectStoreIdentifier, indexName);
+        protectedDelegate()->deleteIndex(requestData, objectStoreIdentifier, indexName);
     else
         callResultFunctionWithErrorLater(&IDBConnectionToServer::didDeleteIndex, requestData.requestIdentifier());
 }
@@ -212,7 +212,7 @@ void IDBConnectionToServer::renameIndex(const IDBRequestData& requestData, IDBOb
     ASSERT(isMainThread());
 
     if (m_serverConnectionIsValid)
-        m_delegate->renameIndex(requestData, objectStoreIdentifier, indexIdentifier, newName);
+        protectedDelegate()->renameIndex(requestData, objectStoreIdentifier, indexIdentifier, newName);
     else
         callResultFunctionWithErrorLater(&IDBConnectionToServer::didRenameIndex, requestData.requestIdentifier());
 }
@@ -229,7 +229,7 @@ void IDBConnectionToServer::putOrAdd(const IDBRequestData& requestData, const ID
     ASSERT(isMainThread());
 
     if (m_serverConnectionIsValid)
-        m_delegate->putOrAdd(requestData, key, value, indexKeys, overwriteMode);
+        protectedDelegate()->putOrAdd(requestData, key, value, indexKeys, overwriteMode);
     else
         callResultFunctionWithErrorLater(&IDBConnectionToServer::didPutOrAdd, requestData.requestIdentifier());
 }
@@ -247,7 +247,7 @@ void IDBConnectionToServer::getRecord(const IDBRequestData& requestData, const I
     ASSERT(!getRecordData.keyRangeData.isNull());
 
     if (m_serverConnectionIsValid)
-        m_delegate->getRecord(requestData, getRecordData);
+        protectedDelegate()->getRecord(requestData, getRecordData);
     else
         callResultFunctionWithErrorLater(&IDBConnectionToServer::didGetRecord, requestData.requestIdentifier());
 }
@@ -264,7 +264,7 @@ void IDBConnectionToServer::getAllRecords(const IDBRequestData& requestData, con
     ASSERT(isMainThread());
 
     if (m_serverConnectionIsValid)
-        m_delegate->getAllRecords(requestData, getAllRecordsData);
+        protectedDelegate()->getAllRecords(requestData, getAllRecordsData);
     else
         callResultFunctionWithErrorLater(&IDBConnectionToServer::didGetAllRecords, requestData.requestIdentifier());
 }
@@ -282,7 +282,7 @@ void IDBConnectionToServer::getCount(const IDBRequestData& requestData, const ID
     ASSERT(!keyRangeData.isNull());
 
     if (m_serverConnectionIsValid)
-        m_delegate->getCount(requestData, keyRangeData);
+        protectedDelegate()->getCount(requestData, keyRangeData);
     else
         callResultFunctionWithErrorLater(&IDBConnectionToServer::didGetCount, requestData.requestIdentifier());
 }
@@ -300,7 +300,7 @@ void IDBConnectionToServer::deleteRecord(const IDBRequestData& requestData, cons
     ASSERT(!keyRangeData.isNull());
 
     if (m_serverConnectionIsValid)
-        m_delegate->deleteRecord(requestData, keyRangeData);
+        protectedDelegate()->deleteRecord(requestData, keyRangeData);
     else
         callResultFunctionWithErrorLater(&IDBConnectionToServer::didDeleteRecord, requestData.requestIdentifier());
 }
@@ -317,7 +317,7 @@ void IDBConnectionToServer::openCursor(const IDBRequestData& requestData, const 
     ASSERT(isMainThread());
 
     if (m_serverConnectionIsValid)
-        m_delegate->openCursor(requestData, info);
+        protectedDelegate()->openCursor(requestData, info);
     else
         callResultFunctionWithErrorLater(&IDBConnectionToServer::didOpenCursor, requestData.requestIdentifier());
 }
@@ -334,7 +334,7 @@ void IDBConnectionToServer::iterateCursor(const IDBRequestData& requestData, con
     ASSERT(isMainThread());
 
     if (m_serverConnectionIsValid)
-        m_delegate->iterateCursor(requestData, data);
+        protectedDelegate()->iterateCursor(requestData, data);
     else
         callResultFunctionWithErrorLater(&IDBConnectionToServer::didIterateCursor, requestData.requestIdentifier());
 }
@@ -351,7 +351,7 @@ void IDBConnectionToServer::establishTransaction(IDBDatabaseConnectionIdentifier
     ASSERT(isMainThread());
 
     if (m_serverConnectionIsValid)
-        m_delegate->establishTransaction(databaseConnectionIdentifier, info);
+        protectedDelegate()->establishTransaction(databaseConnectionIdentifier, info);
 }
 
 void IDBConnectionToServer::commitTransaction(const IDBResourceIdentifier& transactionIdentifier, uint64_t handledRequestResultsCount)
@@ -360,7 +360,7 @@ void IDBConnectionToServer::commitTransaction(const IDBResourceIdentifier& trans
     ASSERT(isMainThread());
 
     if (m_serverConnectionIsValid)
-        m_delegate->commitTransaction(transactionIdentifier, handledRequestResultsCount);
+        protectedDelegate()->commitTransaction(transactionIdentifier, handledRequestResultsCount);
     else {
         callOnMainThread([this, protectedThis = Ref { *this }, transactionIdentifier] {
             didCommitTransaction(transactionIdentifier, IDBError::serverConnectionLostError());
@@ -382,7 +382,7 @@ void IDBConnectionToServer::didFinishHandlingVersionChangeTransaction(IDBDatabas
     ASSERT(isMainThread());
 
     if (m_serverConnectionIsValid)
-        m_delegate->didFinishHandlingVersionChangeTransaction(databaseConnectionIdentifier, transactionIdentifier);
+        protectedDelegate()->didFinishHandlingVersionChangeTransaction(databaseConnectionIdentifier, transactionIdentifier);
 }
 
 void IDBConnectionToServer::abortTransaction(const IDBResourceIdentifier& transactionIdentifier)
@@ -391,7 +391,7 @@ void IDBConnectionToServer::abortTransaction(const IDBResourceIdentifier& transa
     ASSERT(isMainThread());
 
     if (m_serverConnectionIsValid)
-        m_delegate->abortTransaction(transactionIdentifier);
+        protectedDelegate()->abortTransaction(transactionIdentifier);
     else {
         callOnMainThread([this, protectedThis = Ref { *this }, transactionIdentifier] {
             didAbortTransaction(transactionIdentifier, IDBError::serverConnectionLostError());
@@ -421,7 +421,7 @@ void IDBConnectionToServer::didFireVersionChangeEvent(IDBDatabaseConnectionIdent
     ASSERT(isMainThread());
 
     if (m_serverConnectionIsValid)
-        m_delegate->didFireVersionChangeEvent(databaseConnectionIdentifier, requestIdentifier, connectionClosed);
+        protectedDelegate()->didFireVersionChangeEvent(databaseConnectionIdentifier, requestIdentifier, connectionClosed);
 }
 
 void IDBConnectionToServer::generateIndexKeyForRecord(const IDBResourceIdentifier& requestIdentifier, const IDBIndexInfo& indexInfo, const std::optional<IDBKeyPath>& keyPath, const IDBKeyData& key, const IDBValue& value, std::optional<int64_t> recordID)
@@ -436,7 +436,7 @@ void IDBConnectionToServer::didGenerateIndexKeyForRecord(const IDBResourceIdenti
     ASSERT(isMainThread());
 
     if (m_serverConnectionIsValid)
-        m_delegate->didGenerateIndexKeyForRecord(transactionIdentifier, requestIdentifier, indexInfo, key, indexKey, recordID);
+        protectedDelegate()->didGenerateIndexKeyForRecord(transactionIdentifier, requestIdentifier, indexInfo, key, indexKey, recordID);
 }
 
 void IDBConnectionToServer::didStartTransaction(const IDBResourceIdentifier& transactionIdentifier, const IDBError& error)
@@ -479,7 +479,7 @@ void IDBConnectionToServer::openDBRequestCancelled(const IDBOpenRequestData& req
     ASSERT(isMainThread());
 
     if (m_serverConnectionIsValid)
-        m_delegate->openDBRequestCancelled(requestData);
+        protectedDelegate()->openDBRequestCancelled(requestData);
 }
 
 void IDBConnectionToServer::databaseConnectionPendingClose(IDBDatabaseConnectionIdentifier databaseConnectionIdentifier)
@@ -488,7 +488,7 @@ void IDBConnectionToServer::databaseConnectionPendingClose(IDBDatabaseConnection
     ASSERT(isMainThread());
 
     if (m_serverConnectionIsValid)
-        m_delegate->databaseConnectionPendingClose(databaseConnectionIdentifier);
+        protectedDelegate()->databaseConnectionPendingClose(databaseConnectionIdentifier);
 }
 
 void IDBConnectionToServer::databaseConnectionClosed(IDBDatabaseConnectionIdentifier databaseConnectionIdentifier)
@@ -497,7 +497,7 @@ void IDBConnectionToServer::databaseConnectionClosed(IDBDatabaseConnectionIdenti
     ASSERT(isMainThread());
 
     if (m_serverConnectionIsValid)
-        m_delegate->databaseConnectionClosed(databaseConnectionIdentifier);
+        protectedDelegate()->databaseConnectionClosed(databaseConnectionIdentifier);
 }
 
 void IDBConnectionToServer::abortOpenAndUpgradeNeeded(IDBDatabaseConnectionIdentifier databaseConnectionIdentifier, const std::optional<IDBResourceIdentifier>& transactionIdentifier)
@@ -506,7 +506,7 @@ void IDBConnectionToServer::abortOpenAndUpgradeNeeded(IDBDatabaseConnectionIdent
     ASSERT(isMainThread());
 
     if (m_serverConnectionIsValid)
-        m_delegate->abortOpenAndUpgradeNeeded(databaseConnectionIdentifier, transactionIdentifier);
+        protectedDelegate()->abortOpenAndUpgradeNeeded(databaseConnectionIdentifier, transactionIdentifier);
 }
 
 void IDBConnectionToServer::getAllDatabaseNamesAndVersions(const IDBResourceIdentifier& requestIdentifier, const ClientOrigin& origin)
@@ -515,7 +515,7 @@ void IDBConnectionToServer::getAllDatabaseNamesAndVersions(const IDBResourceIden
     ASSERT(isMainThread());
 
     if (m_serverConnectionIsValid) {
-        m_delegate->getAllDatabaseNamesAndVersions(requestIdentifier, origin);
+        protectedDelegate()->getAllDatabaseNamesAndVersions(requestIdentifier, origin);
         return;
     }
 

--- a/Source/WebCore/Modules/indexeddb/client/IDBConnectionToServer.h
+++ b/Source/WebCore/Modules/indexeddb/client/IDBConnectionToServer.h
@@ -159,7 +159,9 @@ private:
     typedef void (IDBConnectionToServer::*ResultFunction)(const IDBResultData&);
     void callResultFunctionWithErrorLater(ResultFunction, const IDBResourceIdentifier& requestIdentifier);
 
-    WeakPtr<IDBConnectionToServerDelegate> m_delegate;
+    Ref<IDBConnectionToServerDelegate> protectedDelegate() const { return m_delegate.get(); }
+
+    WeakRef<IDBConnectionToServerDelegate> m_delegate;
     bool m_serverConnectionIsValid { true };
 
     const UniqueRef<IDBConnectionProxy> m_proxy;

--- a/Source/WebCore/Modules/indexeddb/client/IDBConnectionToServerDelegate.h
+++ b/Source/WebCore/Modules/indexeddb/client/IDBConnectionToServerDelegate.h
@@ -30,6 +30,7 @@
 #include <WebCore/IDBObjectStoreIdentifier.h>
 #include <WebCore/IDBResourceIdentifier.h>
 #include <WebCore/IndexKey.h>
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
 
@@ -37,11 +38,6 @@ namespace WebCore {
 namespace IDBClient {
 class IDBConnectionToServerDelegate;
 }
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::IDBClient::IDBConnectionToServerDelegate> : std::true_type { };
 }
 
 namespace WebCore {
@@ -70,7 +66,7 @@ struct IDBKeyRangeData;
 
 namespace IDBClient {
 
-class IDBConnectionToServerDelegate : public CanMakeWeakPtr<IDBConnectionToServerDelegate> {
+class IDBConnectionToServerDelegate : public AbstractRefCountedAndCanMakeWeakPtr<IDBConnectionToServerDelegate> {
 public:
     virtual ~IDBConnectionToServerDelegate() = default;
 

--- a/Source/WebKit/WebProcess/Databases/IndexedDB/WebIDBConnectionToServer.cpp
+++ b/Source/WebKit/WebProcess/Databases/IndexedDB/WebIDBConnectionToServer.cpp
@@ -56,8 +56,9 @@ Ref<WebIDBConnectionToServer> WebIDBConnectionToServer::create(PAL::SessionID se
 }
 
 WebIDBConnectionToServer::WebIDBConnectionToServer(PAL::SessionID sessionID)
-    : m_connectionToServer(IDBClient::IDBConnectionToServer::create(*this, sessionID))
 {
+    relaxAdoptionRequirement();
+    lazyInitialize(m_connectionToServer, IDBClient::IDBConnectionToServer::create(*this, sessionID));
 }
 
 WebIDBConnectionToServer::~WebIDBConnectionToServer() = default;
@@ -74,7 +75,7 @@ IPC::Connection* WebIDBConnectionToServer::messageSenderConnection() const
 
 IDBClient::IDBConnectionToServer& WebIDBConnectionToServer::coreConnectionToServer()
 {
-    return m_connectionToServer;
+    return *m_connectionToServer;
 }
 
 void WebIDBConnectionToServer::deleteDatabase(const IDBOpenRequestData& requestData)

--- a/Source/WebKit/WebProcess/Databases/IndexedDB/WebIDBConnectionToServer.h
+++ b/Source/WebKit/WebProcess/Databases/IndexedDB/WebIDBConnectionToServer.h
@@ -48,6 +48,9 @@ public:
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&);
     void connectionToServerLost();
 
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
 private:
     WebIDBConnectionToServer(PAL::SessionID);
 
@@ -110,7 +113,7 @@ private:
     void notifyOpenDBRequestBlocked(const WebCore::IDBResourceIdentifier& requestIdentifier, uint64_t oldVersion, uint64_t newVersion);
     void didGetAllDatabaseNamesAndVersions(const WebCore::IDBResourceIdentifier&, Vector<WebCore::IDBDatabaseNameAndVersion>&&);
 
-    const Ref<WebCore::IDBClient::IDBConnectionToServer> m_connectionToServer;
+    const RefPtr<WebCore::IDBClient::IDBConnectionToServer> m_connectionToServer;
 };
 
 } // namespace WebKit

--- a/Source/WebKitLegacy/Storage/InProcessIDBServer.h
+++ b/Source/WebKitLegacy/Storage/InProcessIDBServer.h
@@ -68,6 +68,9 @@ public:
     WebCore::IDBServer::IDBConnectionToClient& connectionToClient() const;
     WebCore::IDBServer::IDBServer& server() { return *m_server; }
 
+    void ref() const final { ThreadSafeRefCounted::ref(); }
+    void deref() const final { ThreadSafeRefCounted::deref(); }
+
     // IDBConnectionToServer
     void deleteDatabase(const WebCore::IDBOpenRequestData&) final;
     void openDatabase(const WebCore::IDBOpenRequestData&) final;


### PR DESCRIPTION
#### 3732840bc997b418a56258c6aa85eea926caaca4
<pre>
Drop IsDeprecatedWeakRefSmartPointerException for IDBConnectionToServerDelegate
<a href="https://bugs.webkit.org/show_bug.cgi?id=300300">https://bugs.webkit.org/show_bug.cgi?id=300300</a>

Reviewed by Geoffrey Garen and Rupin Mittal.

* Source/WebCore/Modules/indexeddb/client/IDBConnectionToServer.cpp:
(WebCore::IDBClient::IDBConnectionToServer::identifier const):
(WebCore::IDBClient::IDBConnectionToServer::deleteDatabase):
(WebCore::IDBClient::IDBConnectionToServer::openDatabase):
(WebCore::IDBClient::IDBConnectionToServer::createObjectStore):
(WebCore::IDBClient::IDBConnectionToServer::deleteObjectStore):
(WebCore::IDBClient::IDBConnectionToServer::renameObjectStore):
(WebCore::IDBClient::IDBConnectionToServer::clearObjectStore):
(WebCore::IDBClient::IDBConnectionToServer::createIndex):
(WebCore::IDBClient::IDBConnectionToServer::deleteIndex):
(WebCore::IDBClient::IDBConnectionToServer::renameIndex):
(WebCore::IDBClient::IDBConnectionToServer::putOrAdd):
(WebCore::IDBClient::IDBConnectionToServer::getRecord):
(WebCore::IDBClient::IDBConnectionToServer::getAllRecords):
(WebCore::IDBClient::IDBConnectionToServer::getCount):
(WebCore::IDBClient::IDBConnectionToServer::deleteRecord):
(WebCore::IDBClient::IDBConnectionToServer::openCursor):
(WebCore::IDBClient::IDBConnectionToServer::iterateCursor):
(WebCore::IDBClient::IDBConnectionToServer::establishTransaction):
(WebCore::IDBClient::IDBConnectionToServer::commitTransaction):
(WebCore::IDBClient::IDBConnectionToServer::didFinishHandlingVersionChangeTransaction):
(WebCore::IDBClient::IDBConnectionToServer::abortTransaction):
(WebCore::IDBClient::IDBConnectionToServer::didFireVersionChangeEvent):
(WebCore::IDBClient::IDBConnectionToServer::didGenerateIndexKeyForRecord):
(WebCore::IDBClient::IDBConnectionToServer::openDBRequestCancelled):
(WebCore::IDBClient::IDBConnectionToServer::databaseConnectionPendingClose):
(WebCore::IDBClient::IDBConnectionToServer::databaseConnectionClosed):
(WebCore::IDBClient::IDBConnectionToServer::abortOpenAndUpgradeNeeded):
(WebCore::IDBClient::IDBConnectionToServer::getAllDatabaseNamesAndVersions):
* Source/WebCore/Modules/indexeddb/client/IDBConnectionToServer.h:
* Source/WebCore/Modules/indexeddb/client/IDBConnectionToServerDelegate.h:
* Source/WebCore/loader/EmptyClients.cpp:
* Source/WebKit/WebProcess/Databases/IndexedDB/WebIDBConnectionToServer.cpp:
(WebKit::WebIDBConnectionToServer::WebIDBConnectionToServer):
(WebKit::WebIDBConnectionToServer::coreConnectionToServer):
* Source/WebKit/WebProcess/Databases/IndexedDB/WebIDBConnectionToServer.h:
* Source/WebKitLegacy/Storage/InProcessIDBServer.h:

Canonical link: <a href="https://commits.webkit.org/301183@main">https://commits.webkit.org/301183@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7e260145f403607a7dbd65b4e20befe785abe356

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125161 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44828 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35567 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132011 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77023 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c4d4c357-b892-4d5f-9afb-f0cb6adb2668) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127038 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45519 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53389 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95279 "") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/63224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/64cbb4dc-ab26-46a8-a33a-76cb8be33df5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128115 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36336 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111923 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75820 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5d27fee6-53e6-4ee8-a870-d64250afa99b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35238 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30088 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75489 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106103 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30316 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134690 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51970 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39754 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103745 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52405 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108144 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103516 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26366 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48866 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27157 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49035 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51862 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57641 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51226 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54582 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52919 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->