### PR TITLE
Fix UncountedCallArgs errors for code generated by generate-inspector-protocol-bindings.py

### DIFF
--- a/Source/JavaScriptCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/JavaScriptCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -73,7 +73,6 @@ heap/MarkingConstraintSolver.cpp
 heap/ParallelSourceAdapter.h
 heap/SubspaceInlines.h
 inspector/ConsoleMessage.cpp
-inspector/InspectorProtocolObjects.h
 inspector/JSGlobalObjectInspectorController.cpp
 inspector/JSInjectedScriptHost.cpp
 inspector/JSJavaScriptCallFrame.cpp

--- a/Source/JavaScriptCore/inspector/scripts/codegen/generate_cpp_protocol_types_header.py
+++ b/Source/JavaScriptCore/inspector/scripts/codegen/generate_cpp_protocol_types_header.py
@@ -342,7 +342,7 @@ class CppProtocolTypesHeaderGenerator(CppGenerator):
         lines.append('        Builder<STATE | %(camelName)sSet>& set%(camelName)s(%(memberType)s %(memberName)s)' % setter_args)
         lines.append('        {')
         lines.append('            static_assert(!(STATE & %(camelName)sSet), "property %(memberKey)s already set");' % setter_args)
-        lines.append('            m_result->%(setter)s("%(memberKey)s"_s, %(memberValue)s);' % setter_args)
+        lines.append('            Ref { * m_result }->%(setter)s("%(memberKey)s"_s, %(memberValue)s);' % setter_args)
         lines.append('            return castState<%(camelName)sSet>();' % setter_args)
         lines.append('        }')
         if type_member.is_nullable:
@@ -350,7 +350,7 @@ class CppProtocolTypesHeaderGenerator(CppGenerator):
             lines.append('        Builder<STATE | %(camelName)sSet>& set%(camelName)sIsNull()' % setter_args)
             lines.append('        {')
             lines.append('            static_assert(!(STATE & %(camelName)sSet), "property %(memberKey)s already set");' % setter_args)
-            lines.append('            m_result->setValue("%(memberKey)s"_s, JSON::Value::null());' % setter_args)
+            lines.append('            Ref { * m_result }->setValue("%(memberKey)s"_s, JSON::Value::null());' % setter_args)
             lines.append('            return castState<%(camelName)sSet>();' % setter_args)
             lines.append('        }')
         return '\n'.join(lines)

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/commands-with-async-attribute.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/commands-with-async-attribute.json-result
@@ -686,14 +686,14 @@ public:
         Builder<STATE | MessageSet>& setMessage(const String& in_message)
         {
             static_assert(!(STATE & MessageSet), "property message already set");
-            m_result->setString("message"_s, in_message);
+            Ref { * m_result }->setString("message"_s, in_message);
             return castState<MessageSet>();
         }
 
         Builder<STATE | CodeSet>& setCode(int in_code)
         {
             static_assert(!(STATE & CodeSet), "property code already set");
-            m_result->setInteger("code"_s, in_code);
+            Ref { * m_result }->setInteger("code"_s, in_code);
             return castState<CodeSet>();
         }
 

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/commands-with-optional-call-return-parameters.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/commands-with-optional-call-return-parameters.json-result
@@ -600,14 +600,14 @@ public:
         Builder<STATE | MessageSet>& setMessage(const String& in_message)
         {
             static_assert(!(STATE & MessageSet), "property message already set");
-            m_result->setString("message"_s, in_message);
+            Ref { * m_result }->setString("message"_s, in_message);
             return castState<MessageSet>();
         }
 
         Builder<STATE | CodeSet>& setCode(int in_code)
         {
             static_assert(!(STATE & CodeSet), "property code already set");
-            m_result->setInteger("code"_s, in_code);
+            Ref { * m_result }->setInteger("code"_s, in_code);
             return castState<CodeSet>();
         }
 

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/definitions-with-mac-platform.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/definitions-with-mac-platform.json-result
@@ -535,14 +535,14 @@ public:
         Builder<STATE | MessageSet>& setMessage(const String& in_message)
         {
             static_assert(!(STATE & MessageSet), "property message already set");
-            m_result->setString("message"_s, in_message);
+            Ref { * m_result }->setString("message"_s, in_message);
             return castState<MessageSet>();
         }
 
         Builder<STATE | CodeSet>& setCode(int in_code)
         {
             static_assert(!(STATE & CodeSet), "property code already set");
-            m_result->setInteger("code"_s, in_code);
+            Ref { * m_result }->setInteger("code"_s, in_code);
             return castState<CodeSet>();
         }
 

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/domain-exposed-as-other-name.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/domain-exposed-as-other-name.json-result
@@ -716,14 +716,14 @@ public:
         Builder<STATE | MessageSet>& setMessage(const String& in_message)
         {
             static_assert(!(STATE & MessageSet), "property message already set");
-            m_result->setString("message"_s, in_message);
+            Ref { * m_result }->setString("message"_s, in_message);
             return castState<MessageSet>();
         }
 
         Builder<STATE | CodeSet>& setCode(int in_code)
         {
             static_assert(!(STATE & CodeSet), "property code already set");
-            m_result->setInteger("code"_s, in_code);
+            Ref { * m_result }->setInteger("code"_s, in_code);
             return castState<CodeSet>();
         }
 

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/events-with-optional-parameters.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/events-with-optional-parameters.json-result
@@ -472,14 +472,14 @@ public:
         Builder<STATE | MessageSet>& setMessage(const String& in_message)
         {
             static_assert(!(STATE & MessageSet), "property message already set");
-            m_result->setString("message"_s, in_message);
+            Ref { * m_result }->setString("message"_s, in_message);
             return castState<MessageSet>();
         }
 
         Builder<STATE | CodeSet>& setCode(int in_code)
         {
             static_assert(!(STATE & CodeSet), "property code already set");
-            m_result->setInteger("code"_s, in_code);
+            Ref { * m_result }->setInteger("code"_s, in_code);
             return castState<CodeSet>();
         }
 

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/generate-domains-with-feature-guards.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/generate-domains-with-feature-guards.json-result
@@ -508,14 +508,14 @@ public:
         Builder<STATE | MessageSet>& setMessage(const String& in_message)
         {
             static_assert(!(STATE & MessageSet), "property message already set");
-            m_result->setString("message"_s, in_message);
+            Ref { * m_result }->setString("message"_s, in_message);
             return castState<MessageSet>();
         }
 
         Builder<STATE | CodeSet>& setCode(int in_code)
         {
             static_assert(!(STATE & CodeSet), "property code already set");
-            m_result->setInteger("code"_s, in_code);
+            Ref { * m_result }->setInteger("code"_s, in_code);
             return castState<CodeSet>();
         }
 

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/shadowed-optional-type-setters.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/shadowed-optional-type-setters.json-result
@@ -404,7 +404,7 @@ public:
         Builder<STATE | TypeSet>& setType(Type in_type)
         {
             static_assert(!(STATE & TypeSet), "property type already set");
-            m_result->setString("type"_s, Protocol::TestHelpers::getEnumConstantValue(in_type));
+            Ref { * m_result }->setString("type"_s, Protocol::TestHelpers::getEnumConstantValue(in_type));
             return castState<TypeSet>();
         }
 

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/type-declaration-object-type.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/type-declaration-object-type.json-result
@@ -426,14 +426,14 @@ public:
         Builder<STATE | MessageSet>& setMessage(const String& in_message)
         {
             static_assert(!(STATE & MessageSet), "property message already set");
-            m_result->setString("message"_s, in_message);
+            Ref { * m_result }->setString("message"_s, in_message);
             return castState<MessageSet>();
         }
 
         Builder<STATE | CodeSet>& setCode(int in_code)
         {
             static_assert(!(STATE & CodeSet), "property code already set");
-            m_result->setInteger("code"_s, in_code);
+            Ref { * m_result }->setInteger("code"_s, in_code);
             return castState<CodeSet>();
         }
 
@@ -610,63 +610,63 @@ public:
         Builder<STATE | ColumnNamesSet>& setColumnNames(Ref<JSON::ArrayOf<String>>&& in_columnNames)
         {
             static_assert(!(STATE & ColumnNamesSet), "property columnNames already set");
-            m_result->setArray("columnNames"_s, WTFMove(in_columnNames));
+            Ref { * m_result }->setArray("columnNames"_s, WTFMove(in_columnNames));
             return castState<ColumnNamesSet>();
         }
 
         Builder<STATE | ButtonsSet>& setButtons(Ref<JSON::ArrayOf<Protocol::Database::MouseButton>>&& in_buttons)
         {
             static_assert(!(STATE & ButtonsSet), "property buttons already set");
-            m_result->setArray("buttons"_s, WTFMove(in_buttons));
+            Ref { * m_result }->setArray("buttons"_s, WTFMove(in_buttons));
             return castState<ButtonsSet>();
         }
 
         Builder<STATE | DirectionalitySet>& setDirectionality(Directionality in_directionality)
         {
             static_assert(!(STATE & DirectionalitySet), "property directionality already set");
-            m_result->setString("directionality"_s, Protocol::TestHelpers::getEnumConstantValue(in_directionality));
+            Ref { * m_result }->setString("directionality"_s, Protocol::TestHelpers::getEnumConstantValue(in_directionality));
             return castState<DirectionalitySet>();
         }
 
         Builder<STATE | NotesSet>& setNotes(const String& in_notes)
         {
             static_assert(!(STATE & NotesSet), "property notes already set");
-            m_result->setString("notes"_s, in_notes);
+            Ref { * m_result }->setString("notes"_s, in_notes);
             return castState<NotesSet>();
         }
 
         Builder<STATE | TimestampSet>& setTimestamp(double in_timestamp)
         {
             static_assert(!(STATE & TimestampSet), "property timestamp already set");
-            m_result->setDouble("timestamp"_s, in_timestamp);
+            Ref { * m_result }->setDouble("timestamp"_s, in_timestamp);
             return castState<TimestampSet>();
         }
 
         Builder<STATE | ValuesSet>& setValues(Ref<JSON::Object>&& in_values)
         {
             static_assert(!(STATE & ValuesSet), "property values already set");
-            m_result->setObject("values"_s, WTFMove(in_values));
+            Ref { * m_result }->setObject("values"_s, WTFMove(in_values));
             return castState<ValuesSet>();
         }
 
         Builder<STATE | PayloadSet>& setPayload(Ref<JSON::Value>&& in_payload)
         {
             static_assert(!(STATE & PayloadSet), "property payload already set");
-            m_result->setValue("payload"_s, WTFMove(in_payload));
+            Ref { * m_result }->setValue("payload"_s, WTFMove(in_payload));
             return castState<PayloadSet>();
         }
 
         Builder<STATE | ErrorSet>& setError(Ref<Protocol::Database::Error>&& in_error)
         {
             static_assert(!(STATE & ErrorSet), "property error already set");
-            m_result->setObject("error"_s, WTFMove(in_error));
+            Ref { * m_result }->setObject("error"_s, WTFMove(in_error));
             return castState<ErrorSet>();
         }
 
         Builder<STATE | ErrorListSet>& setErrorList(Ref<Protocol::Database::ErrorList>&& in_errorList)
         {
             static_assert(!(STATE & ErrorListSet), "property errorList already set");
-            m_result->setArray("errorList"_s, WTFMove(in_errorList));
+            Ref { * m_result }->setArray("errorList"_s, WTFMove(in_errorList));
             return castState<ErrorListSet>();
         }
 
@@ -735,35 +735,35 @@ public:
         Builder<STATE | IntegerSet>& setInteger(const String& in_integer)
         {
             static_assert(!(STATE & IntegerSet), "property integer already set");
-            m_result->setString("integer"_s, in_integer);
+            Ref { * m_result }->setString("integer"_s, in_integer);
             return castState<IntegerSet>();
         }
 
         Builder<STATE | ArraySet>& setArray(const String& in_array)
         {
             static_assert(!(STATE & ArraySet), "property array already set");
-            m_result->setString("array"_s, in_array);
+            Ref { * m_result }->setString("array"_s, in_array);
             return castState<ArraySet>();
         }
 
         Builder<STATE | StringSet>& setString(const String& in_string)
         {
             static_assert(!(STATE & StringSet), "property string already set");
-            m_result->setString("string"_s, in_string);
+            Ref { * m_result }->setString("string"_s, in_string);
             return castState<StringSet>();
         }
 
         Builder<STATE | ValueSet>& setValue(const String& in_value)
         {
             static_assert(!(STATE & ValueSet), "property value already set");
-            m_result->setString("value"_s, in_value);
+            Ref { * m_result }->setString("value"_s, in_value);
             return castState<ValueSet>();
         }
 
         Builder<STATE | ObjectSet>& setObject(const String& in_object)
         {
             static_assert(!(STATE & ObjectSet), "property object already set");
-            m_result->setString("object"_s, in_object);
+            Ref { * m_result }->setString("object"_s, in_object);
             return castState<ObjectSet>();
         }
 
@@ -872,14 +872,14 @@ public:
         Builder<STATE | NullableObjectSet>& setNullableObject(Ref<Protocol::Database::DummyObject>&& in_nullableObject)
         {
             static_assert(!(STATE & NullableObjectSet), "property nullableObject already set");
-            m_result->setObject("nullableObject"_s, WTFMove(in_nullableObject));
+            Ref { * m_result }->setObject("nullableObject"_s, WTFMove(in_nullableObject));
             return castState<NullableObjectSet>();
         }
 
         Builder<STATE | NullableObjectSet>& setNullableObjectIsNull()
         {
             static_assert(!(STATE & NullableObjectSet), "property nullableObject already set");
-            m_result->setValue("nullableObject"_s, JSON::Value::null());
+            Ref { * m_result }->setValue("nullableObject"_s, JSON::Value::null());
             return castState<NullableObjectSet>();
         }
 
@@ -972,56 +972,56 @@ public:
         Builder<STATE | DirectionalitySet>& setDirectionality(Directionality in_directionality)
         {
             static_assert(!(STATE & DirectionalitySet), "property directionality already set");
-            m_result->setString("directionality"_s, Protocol::TestHelpers::getEnumConstantValue(in_directionality));
+            Ref { * m_result }->setString("directionality"_s, Protocol::TestHelpers::getEnumConstantValue(in_directionality));
             return castState<DirectionalitySet>();
         }
 
         Builder<STATE | ButtonsSet>& setButtons(Ref<JSON::ArrayOf<Protocol::Database::MouseButton>>&& in_buttons)
         {
             static_assert(!(STATE & ButtonsSet), "property buttons already set");
-            m_result->setArray("buttons"_s, WTFMove(in_buttons));
+            Ref { * m_result }->setArray("buttons"_s, WTFMove(in_buttons));
             return castState<ButtonsSet>();
         }
 
         Builder<STATE | ColumnNamesSet>& setColumnNames(Ref<JSON::ArrayOf<String>>&& in_columnNames)
         {
             static_assert(!(STATE & ColumnNamesSet), "property columnNames already set");
-            m_result->setArray("columnNames"_s, WTFMove(in_columnNames));
+            Ref { * m_result }->setArray("columnNames"_s, WTFMove(in_columnNames));
             return castState<ColumnNamesSet>();
         }
 
         Builder<STATE | NotesSet>& setNotes(const String& in_notes)
         {
             static_assert(!(STATE & NotesSet), "property notes already set");
-            m_result->setString("notes"_s, in_notes);
+            Ref { * m_result }->setString("notes"_s, in_notes);
             return castState<NotesSet>();
         }
 
         Builder<STATE | TimestampSet>& setTimestamp(double in_timestamp)
         {
             static_assert(!(STATE & TimestampSet), "property timestamp already set");
-            m_result->setDouble("timestamp"_s, in_timestamp);
+            Ref { * m_result }->setDouble("timestamp"_s, in_timestamp);
             return castState<TimestampSet>();
         }
 
         Builder<STATE | ValuesSet>& setValues(Ref<JSON::Object>&& in_values)
         {
             static_assert(!(STATE & ValuesSet), "property values already set");
-            m_result->setObject("values"_s, WTFMove(in_values));
+            Ref { * m_result }->setObject("values"_s, WTFMove(in_values));
             return castState<ValuesSet>();
         }
 
         Builder<STATE | PayloadSet>& setPayload(Ref<JSON::Value>&& in_payload)
         {
             static_assert(!(STATE & PayloadSet), "property payload already set");
-            m_result->setValue("payload"_s, WTFMove(in_payload));
+            Ref { * m_result }->setValue("payload"_s, WTFMove(in_payload));
             return castState<PayloadSet>();
         }
 
         Builder<STATE | ErrorSet>& setError(Ref<Protocol::Database::Error>&& in_error)
         {
             static_assert(!(STATE & ErrorSet), "property error already set");
-            m_result->setObject("error"_s, WTFMove(in_error));
+            Ref { * m_result }->setObject("error"_s, WTFMove(in_error));
             return castState<ErrorSet>();
         }
 

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/type-requiring-runtime-casts.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/type-requiring-runtime-casts.json-result
@@ -422,35 +422,35 @@ public:
         Builder<STATE | StringSet>& setString(const String& in_string)
         {
             static_assert(!(STATE & StringSet), "property string already set");
-            m_result->setString("string"_s, in_string);
+            Ref { * m_result }->setString("string"_s, in_string);
             return castState<StringSet>();
         }
 
         Builder<STATE | NumberSet>& setNumber(int in_number)
         {
             static_assert(!(STATE & NumberSet), "property number already set");
-            m_result->setInteger("number"_s, in_number);
+            Ref { * m_result }->setInteger("number"_s, in_number);
             return castState<NumberSet>();
         }
 
         Builder<STATE | AnimalsSet>& setAnimals(Protocol::Test::CastedAnimals in_animals)
         {
             static_assert(!(STATE & AnimalsSet), "property animals already set");
-            m_result->setString("animals"_s, Protocol::TestHelpers::getEnumConstantValue(in_animals));
+            Ref { * m_result }->setString("animals"_s, Protocol::TestHelpers::getEnumConstantValue(in_animals));
             return castState<AnimalsSet>();
         }
 
         Builder<STATE | IdSet>& setId(int in_id)
         {
             static_assert(!(STATE & IdSet), "property id already set");
-            m_result->setInteger("id"_s, in_id);
+            Ref { * m_result }->setInteger("id"_s, in_id);
             return castState<IdSet>();
         }
 
         Builder<STATE | TreeSet>& setTree(Ref<Protocol::Test::RecursiveObject1>&& in_tree)
         {
             static_assert(!(STATE & TreeSet), "property tree already set");
-            m_result->setObject("tree"_s, WTFMove(in_tree));
+            Ref { * m_result }->setObject("tree"_s, WTFMove(in_tree));
             return castState<TreeSet>();
         }
 

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/type-with-open-parameters.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/type-with-open-parameters.json-result
@@ -387,14 +387,14 @@ public:
         Builder<STATE | OneSet>& setOne(double in_one)
         {
             static_assert(!(STATE & OneSet), "property one already set");
-            m_result->setDouble("one"_s, in_one);
+            Ref { * m_result }->setDouble("one"_s, in_one);
             return castState<OneSet>();
         }
 
         Builder<STATE | TwoSet>& setTwo(double in_two)
         {
             static_assert(!(STATE & TwoSet), "property two already set");
-            m_result->setDouble("two"_s, in_two);
+            Ref { * m_result }->setDouble("two"_s, in_two);
             return castState<TwoSet>();
         }
 
@@ -452,14 +452,14 @@ public:
         Builder<STATE | AlphaSet>& setAlpha(double in_alpha)
         {
             static_assert(!(STATE & AlphaSet), "property alpha already set");
-            m_result->setDouble("alpha"_s, in_alpha);
+            Ref { * m_result }->setDouble("alpha"_s, in_alpha);
             return castState<AlphaSet>();
         }
 
         Builder<STATE | BetaSet>& setBeta(double in_beta)
         {
             static_assert(!(STATE & BetaSet), "property beta already set");
-            m_result->setDouble("beta"_s, in_beta);
+            Ref { * m_result }->setDouble("beta"_s, in_beta);
             return castState<BetaSet>();
         }
 

--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -1,4 +1,3 @@
-AutomationProtocolObjects.h
 GeneratedSerializers.mm
 Platform/IPC/ArgumentCoders.h
 UIProcess/API/C/mac/WKPagePrivateMac.mm
@@ -44,7 +43,6 @@ UIProcess/API/Cocoa/_WKUserStyleSheet.mm
 UIProcess/API/Cocoa/_WKWebAuthenticationAssertionResponse.mm
 UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm
 UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.mm
-WebDriverBidiProtocolObjects.h
 WebProcess/Extensions/API/Cocoa/WebExtensionAPIAlarmsCocoa.mm
 WebProcess/Extensions/API/Cocoa/WebExtensionAPIDeclarativeNetRequestCocoa.mm
 WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsInspectedWindowCocoa.mm


### PR DESCRIPTION
#### 1a60c58e0682f10b64c0d640938adeaffdce4b4f
<pre>
Fix UncountedCallArgs errors for code generated by generate-inspector-protocol-bindings.py
<a href="https://bugs.webkit.org/show_bug.cgi?id=300309">https://bugs.webkit.org/show_bug.cgi?id=300309</a>

Reviewed by Devin Rousso.

m_result is a RefPtr member but per [1] we need either it to be a smart
pointer on the stack or to be a const. The latter is not possible
because of [2].

[1] <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines#mark-data-members-that-are-smart-pointers-as-const-if-they-never-get-reassigned">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines#mark-data-members-that-are-smart-pointers-as-const-if-they-never-get-reassigned</a>
[2] <a href="https://searchfox.org/wubkat/rev/dd05eb230972a07f0240b959e6e22ca685ef3445/Source/JavaScriptCore/inspector/scripts/codegen/cpp_generator_templates.py#224">https://searchfox.org/wubkat/rev/dd05eb230972a07f0240b959e6e22ca685ef3445/Source/JavaScriptCore/inspector/scripts/codegen/cpp_generator_templates.py#224</a>

* Source/JavaScriptCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations: Update expectations.
* Source/JavaScriptCore/inspector/scripts/codegen/generate_cpp_protocol_types_header.py: Store smart pointer for m_result on the stack.
* Source/JavaScriptCore/inspector/scripts/tests/expected/commands-with-async-attribute.json-result: Regenerate expectation.
* Source/JavaScriptCore/inspector/scripts/tests/expected/commands-with-optional-call-return-parameters.json-result: Ditto.
* Source/JavaScriptCore/inspector/scripts/tests/expected/definitions-with-mac-platform.json-result: Ditto.
* Source/JavaScriptCore/inspector/scripts/tests/expected/domain-exposed-as-other-name.json-result: Ditto.
* Source/JavaScriptCore/inspector/scripts/tests/expected/events-with-optional-parameters.json-result: Ditto.
* Source/JavaScriptCore/inspector/scripts/tests/expected/fail-on-command-targetTypes-value.json-error: Ditto.
* Source/JavaScriptCore/inspector/scripts/tests/expected/fail-on-domain-targetTypes-value.json-error: Ditto.
* Source/JavaScriptCore/inspector/scripts/tests/expected/fail-on-event-targetTypes-value.json-error: Ditto.
* Source/JavaScriptCore/inspector/scripts/tests/expected/generate-domains-with-feature-guards.json-result: Ditto.
* Source/JavaScriptCore/inspector/scripts/tests/expected/shadowed-optional-type-setters.json-result: Ditto.
* Source/JavaScriptCore/inspector/scripts/tests/expected/type-declaration-object-type.json-result: Ditto.
* Source/JavaScriptCore/inspector/scripts/tests/expected/type-declaration-object-type.json-result: Ditto.
* Source/JavaScriptCore/inspector/scripts/tests/expected/type-requiring-runtime-casts.json-result: Ditto.
* Source/JavaScriptCore/inspector/scripts/tests/expected/type-with-open-parameters.json-result: Ditto.
* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations: Update expectations.

Canonical link: <a href="https://commits.webkit.org/301256@main">https://commits.webkit.org/301256@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/37512d395e96c93d870baa5d4d41721b3e6ce82e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125231 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44898 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35637 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132082 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77194 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45589 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53517 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95341 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/63347 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128185 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36400 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111988 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75912 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35297 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30156 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75560 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/117322 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106167 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30381 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134763 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/123749 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52040 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39877 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103810 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52475 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108209 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103577 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26412 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48932 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27221 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49126 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51932 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57711 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/156772 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51294 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39255 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54650 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52988 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->