### PR TITLE
Fix integer overflow during FEConvolveMatrix IPC decoder validator

### DIFF
--- a/LayoutTests/ipc/decode-feConvolveMatrix-kernelSize-overflow-expected.txt
+++ b/LayoutTests/ipc/decode-feConvolveMatrix-kernelSize-overflow-expected.txt
@@ -1,0 +1,1 @@
+This test passes if WebKit does not crash.

--- a/LayoutTests/ipc/decode-feConvolveMatrix-kernelSize-overflow.html
+++ b/LayoutTests/ipc/decode-feConvolveMatrix-kernelSize-overflow.html
@@ -1,0 +1,225 @@
+<!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<p>This test passes if WebKit does not crash.</p>
+<script src="../resources/ipc.js"></script>
+<script>
+testRunner?.dumpAsText();
+testRunner?.waitUntilDone();
+
+setTimeout(async () => {
+    if (!window.IPC)
+        return testRunner?.notifyDone();
+
+    const { CoreIPC } = await import('./coreipc.js');
+    const renderingBackendIdentifier = randomIPCID();
+    o58 = CoreIPC.newStreamConnection();
+    CoreIPC.GPU.GPUConnectionToWebProcess.CreateRenderingBackend(
+        0, { renderingBackendIdentifier : renderingBackendIdentifier, connectionHandle : o58 });
+    o60 = o58.newInterface("RemoteRenderingBackend", renderingBackendIdentifier);
+
+    const didInitializeReply = o58.connection.waitForMessage(renderingBackendIdentifier, IPC.messages.RemoteRenderingBackendProxy_DidInitialize.name, 1)
+    o58.connection.setSemaphores(didInitializeReply[0].value, didInitializeReply[1].value);
+
+    s7 = 'A';
+    s10 = '';
+        o60.CacheFilter({
+            filter : {
+            subclasses : {
+                variantType : 'WebCore::CSSFilterRenderer',
+                variant : {
+                functions : [
+                    {
+                    subclasses : {
+                        variantType : 'WebCore::FEComposite',
+                        variant : {
+                        operation : 5,
+                        k1 : -86242.08364529378,
+                        k2 : -0.0000015329670121806829,
+                        k3 : 8.407790785948902e-44,
+                        k4 : -8.633401098587574e-14,
+                        operatingColorSpace : {
+                            serializableColorSpace : {
+                            alias : {
+                                m_cgColorSpace : {
+                                alias : {
+                                    variantType : 'RetainPtr<CFTypeRef>',
+                                    variant : {
+                                    object : {
+                                        alias : {
+                                        variantType : 'std::nullptr_t',
+                                        variant : null
+                                        }
+                                    }
+                                    }
+                                }
+                                }
+                            }
+                            }
+                        }
+                        }
+                    }
+                    },
+                    {
+                    subclasses : {
+                        variantType : 'WebCore::SourceAlpha',
+                        variant : {
+                        operatingColorSpace : {
+                            serializableColorSpace : {
+                            alias : {
+                                m_cgColorSpace : {
+                                alias : {
+                                    variantType : 'RetainPtr<CFStringRef>',
+                                    variant : s7
+                                }
+                                }
+                            }
+                            }
+                        }
+                        }
+                    }
+                    },
+                    {
+                    subclasses : {
+                        variantType : 'WebCore::FEFlood',
+                        variant : {
+                        floodColor : { data : {} },
+                        floodOpacity : -2.4559581509165345e-24,
+                        operatingColorSpace : {
+                            serializableColorSpace : {
+                            alias : {
+                                m_cgColorSpace : {
+                                alias : {
+                                    variantType : 'WebCore::ColorSpace',
+                                    variant : 0
+                                }
+                                }
+                            }
+                            }
+                        }
+                        }
+                    }
+                    },
+                    {
+                    subclasses : {
+                        variantType : 'WebCore::FEComposite',
+                        variant : {
+                        operation : 5,
+                        k1 : -66822039598.69408,
+                        k2 : -1.175494351e-38,
+                        k3 : 1.0369608636003646e-43,
+                        k4 : 4.344025239406933e-44,
+                        operatingColorSpace : {
+                            serializableColorSpace : {
+                            alias : {
+                                m_cgColorSpace : {
+                                alias : {
+                                    variantType : 'WebCore::ColorSpace',
+                                    variant : 12
+                                }
+                                }
+                            }
+                            }
+                        }
+                        }
+                    }
+                    },
+                    {
+                    subclasses : {
+                        variantType : 'WebCore::FEMerge',
+                        variant : {
+                        numberOfEffectInputs : 93,
+                        operatingColorSpace : {
+                            serializableColorSpace : {
+                            alias : {
+                                m_cgColorSpace : {
+                                alias : {
+                                    variantType : 'RetainPtr<CFStringRef>',
+                                    variant : s10
+                                }
+                                }
+                            }
+                            }
+                        }
+                        }
+                    }
+                    },
+                    {
+                    subclasses : {
+                        variantType : 'WebCore::SourceGraphic',
+                        variant : {
+                        operatingColorSpace : {
+                            serializableColorSpace : {
+                            alias : {
+                                m_cgColorSpace : {
+                                alias : {
+                                    variantType : 'WebCore::ColorSpace',
+                                    variant : 13
+                                }
+                                }
+                            }
+                            }
+                        }
+                        }
+                    }
+                    },
+                    {
+                    subclasses : {
+                        variantType : 'WebCore::FEConvolveMatrix',
+                        variant : {
+                        kernelSize : { width : 363433, height : 296419329 },
+                        divisor : 653.8013334138727,
+                        bias : -1.17549421e-38,
+                        targetOffset : { x : 28, y : 624448 },
+                        edgeMode : 0,
+                        kernelUnitLength : {
+                            x : 1.789584885814042e-10,
+                            y : 1.7656360650492695e-43
+                        },
+                        preserveAlpha : false,
+                        kernel : [],
+                        operatingColorSpace : {
+                            serializableColorSpace : {
+                            alias : {
+                                m_cgColorSpace : {
+                                alias : {
+                                    variantType : 'RetainPtr<CFTypeRef>',
+                                    variant : {
+                                    object : {
+                                        alias : {
+                                        variantType : 'WebKit::CoreIPCData',
+                                        variant : { dataReference : {} }
+                                        }
+                                    }
+                                    }
+                                }
+                                }
+                            }
+                            }
+                        }
+                        }
+                    }
+                    }
+                ],
+                filterRenderingModes : 135,
+                filterScale :
+                    { width : 3.2175183536110756e-38, height : 1.4142135623730951 },
+                filterRegion : {
+                    location :
+                    { x : -509502506841300.9, y : -5.566387275235406e-27 },
+                    size : {
+                    width : 1.961817850054744e-44,
+                    height : 1.723597111119525e-43
+                    }
+                }
+                }
+            }
+            }
+        });
+
+    o58.connection.invalidate();
+}, 20);
+
+setTimeout(() => {
+    testRunner?.notifyDone();
+}, 500);
+</script>
+

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -3944,7 +3944,7 @@ header: <WebCore/FEComponentTransfer.h>
     WebCore::EdgeModeType edgeMode();
     [Validator='kernelUnitLength->x() > 0 && kernelUnitLength->y() > 0'] WebCore::FloatPoint kernelUnitLength();
     bool preserveAlpha();
-    [Validator='kernelSize->area() == kernel->size()'] Vector<float> kernel();
+    [Validator='kernelSize->unclampedArea() == kernel->size()'] Vector<float> kernel();
 
     WebCore::DestinationColorSpace operatingColorSpace();
 };


### PR DESCRIPTION
#### 97d27fbddaca8412e0370afd58185195d60ec66e
<pre>
Fix integer overflow during FEConvolveMatrix IPC decoder validator
<a href="https://bugs.webkit.org/show_bug.cgi?id=300303">https://bugs.webkit.org/show_bug.cgi?id=300303</a>
<a href="https://rdar.apple.com/161647030">rdar://161647030</a>

Reviewed by Mike Wyrzykowski.

In the IPC decoder validator for FEConvolveMatrix, the kernelSize()-&gt;area()
overflows if given large width and height values. This causes a crash in GPUP.
The fix is to use unclampedArea() which will never overflow.

The fuzzer test case is altered slightly to consume the DidInitialize message
that gets sent back to WebContent to prevent it from reaching the dummy MessageReceiver
and hitting ASSERT_NOT_REACHED()

Test: ipc/decode-feConvolveMatrix-kernelSize-overflow.html
* LayoutTests/ipc/decode-feConvolveMatrix-kernelSize-overflow-expected.txt: Added.
* LayoutTests/ipc/decode-feConvolveMatrix-kernelSize-overflow.html: Added.
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/301246@main">https://commits.webkit.org/301246@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/edc4d33886ce242f71d6ebfe604d74f5ce84ef6f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125340 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45005 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35746 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132189 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77209 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b4581ec1-baf4-42ef-af94-dc7765f27cef) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45693 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53570 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95427 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/63356 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/28aee5d2-52fd-4dfc-9518-15ce50a63f84) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128294 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36499 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112090 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75966 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35398 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30258 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75667 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106267 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30484 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134875 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52143 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39923 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103905 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52581 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108311 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103663 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26406 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49031 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27322 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49259 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52038 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57817 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51395 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54751 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53089 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->