### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException for UniqueIDBDatabase & UniqueIDBDatabaseManager

### DIFF
--- a/Source/WebCore/Modules/indexeddb/server/IDBServer.h
+++ b/Source/WebCore/Modules/indexeddb/server/IDBServer.h
@@ -49,8 +49,9 @@ struct IDBGetRecordData;
 
 namespace IDBServer {
 
-class IDBServer : public UniqueIDBDatabaseManager {
+class IDBServer final : public UniqueIDBDatabaseManager {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(IDBServer, WEBCORE_EXPORT);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(IDBServer);
 public:
     using SpaceRequester = Function<bool(const ClientOrigin&, uint64_t spaceRequested)>;
     WEBCORE_EXPORT IDBServer(const String& databaseDirectoryPath, SpaceRequester&&, Lock&);

--- a/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.h
+++ b/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.h
@@ -47,11 +47,6 @@ class UniqueIDBDatabase;
 }
 }
 
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::IDBServer::UniqueIDBDatabase> : std::true_type { };
-}
-
 namespace WebCore {
 
 struct ClientOrigin;
@@ -79,8 +74,9 @@ using GetResultCallback = Function<void(const IDBError&, const IDBGetResult&)>;
 using GetAllResultsCallback = Function<void(const IDBError&, const IDBGetAllResult&)>;
 using CountCallback = Function<void(const IDBError&, uint64_t)>;
 
-class UniqueIDBDatabase : public CanMakeWeakPtr<UniqueIDBDatabase> {
+class UniqueIDBDatabase final : public CanMakeWeakPtr<UniqueIDBDatabase>, public CanMakeThreadSafeCheckedPtr<UniqueIDBDatabase> {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(UniqueIDBDatabase, WEBCORE_EXPORT);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(UniqueIDBDatabase);
 public:
     WEBCORE_EXPORT UniqueIDBDatabase(UniqueIDBDatabaseManager&, const IDBDatabaseIdentifier&);
     UniqueIDBDatabase(UniqueIDBDatabase&) = delete;

--- a/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseConnection.h
+++ b/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseConnection.h
@@ -53,6 +53,7 @@ public:
 
     const IDBResourceIdentifier& openRequestIdentifier() { return m_openRequestIdentifier; }
     UniqueIDBDatabase* database() { return m_database.get(); }
+    CheckedPtr<UniqueIDBDatabase> checkedDatabase();
     UniqueIDBDatabaseManager* manager();
     IDBConnectionToClient& connectionToClient() { return m_connectionToClient; }
     Ref<IDBConnectionToClient> protectedConnectionToClient();

--- a/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseManager.h
+++ b/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseManager.h
@@ -34,11 +34,6 @@ class UniqueIDBDatabaseManager;
 }
 }
 
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::IDBServer::UniqueIDBDatabaseManager> : std::true_type { };
-}
-
 namespace WebCore {
 
 struct ClientOrigin;
@@ -49,8 +44,9 @@ class IDBBackingStore;
 class UniqueIDBDatabaseConnection;
 class UniqueIDBDatabaseTransaction;
 
-class UniqueIDBDatabaseManager : public CanMakeWeakPtr<UniqueIDBDatabaseManager> {
-    WTF_MAKE_TZONE_NON_HEAP_ALLOCATABLE(UniqueIDBDatabaseManager);
+class UniqueIDBDatabaseManager : public CanMakeWeakPtr<UniqueIDBDatabaseManager>, public CanMakeThreadSafeCheckedPtr<UniqueIDBDatabaseManager> {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(UniqueIDBDatabaseManager);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(UniqueIDBDatabaseManager);
 public:
     virtual ~UniqueIDBDatabaseManager() { }
     virtual void registerConnection(UniqueIDBDatabaseConnection&) = 0;

--- a/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseTransaction.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseTransaction.cpp
@@ -50,12 +50,12 @@ UniqueIDBDatabaseTransaction::UniqueIDBDatabaseTransaction(UniqueIDBDatabaseConn
     ASSERT(database());
 
     if (m_transactionInfo.mode() == IDBTransactionMode::Versionchange)
-        m_originalDatabaseInfo = makeUnique<IDBDatabaseInfo>(database()->info());
+        m_originalDatabaseInfo = makeUnique<IDBDatabaseInfo>(checkedDatabase()->info());
 
     if (!m_databaseConnection)
         return;
 
-    if (auto* manager = m_databaseConnection->manager())
+    if (CheckedPtr manager = m_databaseConnection->manager())
         manager->registerTransaction(*this);
 }
 
@@ -64,7 +64,7 @@ UniqueIDBDatabaseTransaction::~UniqueIDBDatabaseTransaction()
     if (!m_databaseConnection)
         return;
 
-    if (auto* manager = m_databaseConnection->manager())
+    if (CheckedPtr manager = m_databaseConnection->manager())
         manager->unregisterTransaction(*this);
 }
 
@@ -83,7 +83,7 @@ void UniqueIDBDatabaseTransaction::abort()
 {
     LOG(IndexedDB, "UniqueIDBDatabaseTransaction::abort");
     
-    auto* database = this->database();
+    CheckedPtr database = this->database();
     if (!database)
         return;
 
@@ -109,6 +109,11 @@ void UniqueIDBDatabaseTransaction::abortWithoutCallback()
 UniqueIDBDatabase* UniqueIDBDatabaseTransaction::database() const
 {
     return m_databaseConnection ? m_databaseConnection->database() : nullptr;
+}
+
+CheckedPtr<UniqueIDBDatabase> UniqueIDBDatabaseTransaction::checkedDatabase() const
+{
+    return database();
 }
 
 bool UniqueIDBDatabaseTransaction::isVersionChange() const
@@ -138,7 +143,7 @@ void UniqueIDBDatabaseTransaction::commit(uint64_t handledRequestResultsCount)
 {
     LOG(IndexedDB, "UniqueIDBDatabaseTransaction::commit");
 
-    auto* database = this->database();
+    CheckedPtr database = this->database();
     if (!database)
         return;
 
@@ -161,7 +166,7 @@ void UniqueIDBDatabaseTransaction::createObjectStore(const IDBRequestData& reque
     RELEASE_ASSERT(isVersionChange());
     ASSERT(m_transactionInfo.identifier() == requestData.transactionIdentifier());
 
-    auto* database = this->database();
+    CheckedPtr database = this->database();
     if (!database)
         return;
 
@@ -190,7 +195,7 @@ void UniqueIDBDatabaseTransaction::deleteObjectStore(const IDBRequestData& reque
     RELEASE_ASSERT(isVersionChange());
     ASSERT(m_transactionInfo.identifier() == requestData.transactionIdentifier());
 
-    auto* database = this->database();
+    CheckedPtr database = this->database();
     if (!database)
         return;
 
@@ -221,7 +226,7 @@ void UniqueIDBDatabaseTransaction::renameObjectStore(const IDBRequestData& reque
     RELEASE_ASSERT(isVersionChange());
     ASSERT(m_transactionInfo.identifier() == requestData.transactionIdentifier());
 
-    auto* database = this->database();
+    CheckedPtr database = this->database();
     if (!database)
         return;
 
@@ -249,7 +254,7 @@ void UniqueIDBDatabaseTransaction::clearObjectStore(const IDBRequestData& reques
 
     ASSERT(m_transactionInfo.identifier() == requestData.transactionIdentifier());
 
-    auto* database = this->database();
+    CheckedPtr database = this->database();
     if (!database)
         return;
 
@@ -280,7 +285,7 @@ void UniqueIDBDatabaseTransaction::deleteIndex(const IDBRequestData& requestData
     RELEASE_ASSERT(isVersionChange());
     ASSERT(m_transactionInfo.identifier() == requestData.transactionIdentifier());
 
-    auto* database = this->database();
+    CheckedPtr database = this->database();
     if (!database)
         return;
     
@@ -309,7 +314,7 @@ void UniqueIDBDatabaseTransaction::renameIndex(const IDBRequestData& requestData
     RELEASE_ASSERT(isVersionChange());
     ASSERT(m_transactionInfo.identifier() == requestData.transactionIdentifier());
 
-    auto* database = this->database();
+    CheckedPtr database = this->database();
     if (!database)
         return;
     
@@ -339,7 +344,7 @@ void UniqueIDBDatabaseTransaction::putOrAdd(const IDBRequestData& requestData, c
     ASSERT(!isReadOnly());
     ASSERT(m_transactionInfo.identifier() == requestData.transactionIdentifier());
     
-    auto* database = this->database();
+    CheckedPtr database = this->database();
     if (!database)
         return;
     
@@ -369,7 +374,7 @@ void UniqueIDBDatabaseTransaction::getRecord(const IDBRequestData& requestData, 
 
     ASSERT(m_transactionInfo.identifier() == requestData.transactionIdentifier());
 
-    auto* database = this->database();
+    CheckedPtr database = this->database();
     if (!database)
         return;
     
@@ -399,7 +404,7 @@ void UniqueIDBDatabaseTransaction::getAllRecords(const IDBRequestData& requestDa
 
     ASSERT(m_transactionInfo.identifier() == requestData.transactionIdentifier());
     
-    auto* database = this->database();
+    CheckedPtr database = this->database();
     if (!database)
         return;
     
@@ -429,7 +434,7 @@ void UniqueIDBDatabaseTransaction::getCount(const IDBRequestData& requestData, c
 
     ASSERT(m_transactionInfo.identifier() == requestData.transactionIdentifier());
     
-    auto* database = this->database();
+    CheckedPtr database = this->database();
     if (!database)
         return;
     
@@ -459,7 +464,7 @@ void UniqueIDBDatabaseTransaction::deleteRecord(const IDBRequestData& requestDat
 
     ASSERT(m_transactionInfo.identifier() == requestData.transactionIdentifier());
     
-    auto* database = this->database();
+    CheckedPtr database = this->database();
     if (!database)
         return;
     
@@ -489,7 +494,7 @@ void UniqueIDBDatabaseTransaction::openCursor(const IDBRequestData& requestData,
 
     ASSERT(m_transactionInfo.identifier() == requestData.transactionIdentifier());
     
-    auto* database = this->database();
+    CheckedPtr database = this->database();
     if (!database)
         return;
 
@@ -519,7 +524,7 @@ void UniqueIDBDatabaseTransaction::iterateCursor(const IDBRequestData& requestDa
 
     ASSERT(m_transactionInfo.identifier() == requestData.transactionIdentifier());
 
-    auto* database = this->database();
+    CheckedPtr database = this->database();
     if (!database)
         return;
     
@@ -551,7 +556,7 @@ const Vector<IDBObjectStoreIdentifier>& UniqueIDBDatabaseTransaction::objectStor
     if (!m_objectStoreIdentifiers.isEmpty())
         return m_objectStoreIdentifiers;
 
-    auto* database = this->database();
+    CheckedPtr database = this->database();
     if (!database)
         return m_objectStoreIdentifiers;
 
@@ -584,7 +589,7 @@ void UniqueIDBDatabaseTransaction::createIndex(const IDBRequestData& requestData
     ASSERT(isVersionChange());
     ASSERT(m_transactionInfo.identifier() == requestData.transactionIdentifier());
 
-    auto* database = this->database();
+    CheckedPtr database = this->database();
     if (!database)
         return;
 
@@ -631,7 +636,7 @@ void UniqueIDBDatabaseTransaction::didGenerateIndexKeyForRecord(IDBResourceIdent
         return;
 
     --m_pendingGenerateIndexKeyRequests;
-    auto* database = this->database();
+    CheckedPtr database = this->database();
     if (!database)
         return;
 

--- a/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseTransaction.h
+++ b/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseTransaction.h
@@ -63,6 +63,7 @@ public:
 
     UniqueIDBDatabaseConnection* databaseConnection() const;
     UniqueIDBDatabase* database() const;
+    CheckedPtr<UniqueIDBDatabase> checkedDatabase() const;
     const IDBTransactionInfo& info() const { return m_transactionInfo; }
     WEBCORE_EXPORT bool isVersionChange() const;
     bool isReadOnly() const;

--- a/Source/WebCore/Modules/indexeddb/shared/IDBResultData.cpp
+++ b/Source/WebCore/Modules/indexeddb/shared/IDBResultData.cpp
@@ -109,7 +109,7 @@ IDBResultData IDBResultData::openDatabaseSuccess(const IDBResourceIdentifier& re
     IDBResultData result { requestIdentifier };
     result.m_type = IDBResultType::OpenDatabaseSuccess;
     result.m_databaseConnectionIdentifier = connection.identifier();
-    result.m_databaseInfo = makeUnique<IDBDatabaseInfo>(connection.database()->info());
+    result.m_databaseInfo = makeUnique<IDBDatabaseInfo>(connection.checkedDatabase()->info());
     return result;
 }
 
@@ -119,7 +119,7 @@ IDBResultData IDBResultData::openDatabaseUpgradeNeeded(const IDBResourceIdentifi
     IDBResultData result { requestIdentifier };
     result.m_type = IDBResultType::OpenDatabaseUpgradeNeeded;
     result.m_databaseConnectionIdentifier = connection.identifier();
-    result.m_databaseInfo = makeUnique<IDBDatabaseInfo>(connection.database()->info());
+    result.m_databaseInfo = makeUnique<IDBDatabaseInfo>(connection.checkedDatabase()->info());
     result.m_transactionInfo = makeUnique<IDBTransactionInfo>(transaction.info());
     return result;
 }

--- a/Source/WebKit/NetworkProcess/storage/IDBStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/IDBStorageManager.h
@@ -47,6 +47,7 @@ class IDBStorageRegistry;
 
 class IDBStorageManager final : public WebCore::IDBServer::UniqueIDBDatabaseManager {
     WTF_MAKE_TZONE_ALLOCATED(IDBStorageManager);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(IDBStorageManager);
 public:
     static void createVersionDirectoryIfNeeded(const String& rootDirectory);
     static String idbStorageOriginDirectory(const String& rootDirectory, const WebCore::ClientOrigin&);

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -1326,7 +1326,7 @@ void NetworkStorageManager::suspend(CompletionHandler<void()>&& completionHandle
         for (auto& manager : m_originStorageManagers.values()) {
             if (auto localStorageManager = manager->existingLocalStorageManager())
                 localStorageManager->syncLocalStorage();
-            if (auto idbStorageManager = manager->existingIDBStorageManager())
+            if (CheckedPtr idbStorageManager = manager->existingIDBStorageManager())
                 idbStorageManager->stopDatabaseActivitiesForSuspend();
         }
     }, WTFMove(completionHandler));
@@ -1353,7 +1353,7 @@ void NetworkStorageManager::handleLowMemoryWarning()
         for (auto& manager : m_originStorageManagers.values()) {
             if (auto localStorageManager = manager->existingLocalStorageManager())
                 localStorageManager->handleLowMemoryWarning();
-            if (auto idbStorageManager = manager->existingIDBStorageManager())
+            if (CheckedPtr idbStorageManager = manager->existingIDBStorageManager())
                 idbStorageManager->handleLowMemoryWarning();
         }
     });
@@ -1722,18 +1722,18 @@ void NetworkStorageManager::clear(IPC::Connection& connection, StorageAreaIdenti
 void NetworkStorageManager::openDatabase(IPC::Connection& connection, const WebCore::IDBOpenRequestData& requestData)
 {
     Ref connectionToClient = m_idbStorageRegistry->ensureConnectionToClient(connection.uniqueID(), *requestData.requestIdentifier().connectionIdentifier());
-    checkedOriginStorageManager(requestData.databaseIdentifier().origin())->idbStorageManager(*m_idbStorageRegistry).openDatabase(connectionToClient, requestData);
+    checkedOriginStorageManager(requestData.databaseIdentifier().origin())->checkedIDBStorageManager(*m_idbStorageRegistry)->openDatabase(connectionToClient, requestData);
 }
 
 void NetworkStorageManager::openDBRequestCancelled(const WebCore::IDBOpenRequestData& requestData)
 {
-    checkedOriginStorageManager(requestData.databaseIdentifier().origin())->idbStorageManager(*m_idbStorageRegistry).openDBRequestCancelled(requestData);
+    checkedOriginStorageManager(requestData.databaseIdentifier().origin())->checkedIDBStorageManager(*m_idbStorageRegistry)->openDBRequestCancelled(requestData);
 }
 
 void NetworkStorageManager::deleteDatabase(IPC::Connection& connection, const WebCore::IDBOpenRequestData& requestData)
 {
     Ref connectionToClient = m_idbStorageRegistry->ensureConnectionToClient(connection.uniqueID(), *requestData.requestIdentifier().connectionIdentifier());
-    checkedOriginStorageManager(requestData.databaseIdentifier().origin())->idbStorageManager(*m_idbStorageRegistry).deleteDatabase(connectionToClient, requestData);
+    checkedOriginStorageManager(requestData.databaseIdentifier().origin())->checkedIDBStorageManager(*m_idbStorageRegistry)->deleteDatabase(connectionToClient, requestData);
 }
 
 void NetworkStorageManager::establishTransaction(WebCore::IDBDatabaseConnectionIdentifier databaseConnectionIdentifier, const WebCore::IDBTransactionInfo& transactionInfo)
@@ -1944,7 +1944,7 @@ void NetworkStorageManager::getAllDatabaseNamesAndVersions(IPC::Connection& conn
 {
     MESSAGE_CHECK(requestIdentifier.connectionIdentifier(), connection);
     Ref connectionToClient = m_idbStorageRegistry->ensureConnectionToClient(connection.uniqueID(), *requestIdentifier.connectionIdentifier());
-    auto result = checkedOriginStorageManager(origin)->idbStorageManager(*m_idbStorageRegistry).getAllDatabaseNamesAndVersions();
+    auto result = checkedOriginStorageManager(origin)->checkedIDBStorageManager(*m_idbStorageRegistry)->getAllDatabaseNamesAndVersions();
     connectionToClient->didGetAllDatabaseNamesAndVersions(requestIdentifier, WTFMove(result));
 }
 

--- a/Source/WebKit/NetworkProcess/storage/OriginStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/OriginStorageManager.h
@@ -78,6 +78,7 @@ public:
     SessionStorageManager& sessionStorageManager(StorageAreaRegistry&);
     SessionStorageManager* existingSessionStorageManager();
     IDBStorageManager& idbStorageManager(IDBStorageRegistry&);
+    CheckedRef<IDBStorageManager> checkedIDBStorageManager(IDBStorageRegistry&);
     IDBStorageManager* existingIDBStorageManager();
     CacheStorageManager& cacheStorageManager(CacheStorageRegistry&, const WebCore::ClientOrigin&, Ref<WorkQueue>&&);
     Ref<CacheStorageManager> protectedCacheStorageManager(CacheStorageRegistry&, const WebCore::ClientOrigin&, Ref<WorkQueue>&&);


### PR DESCRIPTION
#### f6329418200d21e618a8c379ed1359e844465e68
<pre>
Drop IsDeprecatedWeakRefSmartPointerException for UniqueIDBDatabase &amp; UniqueIDBDatabaseManager
<a href="https://bugs.webkit.org/show_bug.cgi?id=300305">https://bugs.webkit.org/show_bug.cgi?id=300305</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/Modules/indexeddb/server/IDBServer.cpp:
(WebCore::IDBServer::IDBServer::openDatabase):
(WebCore::IDBServer::IDBServer::deleteDatabase):
(WebCore::IDBServer::IDBServer::establishTransaction):
(WebCore::IDBServer::IDBServer::databaseConnectionClosed):
(WebCore::IDBServer::IDBServer::openDBRequestCancelled):
* Source/WebCore/Modules/indexeddb/server/IDBServer.h:
* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.cpp:
(WebCore::IDBServer::UniqueIDBDatabase::performCurrentOpenOperation):
(WebCore::IDBServer::UniqueIDBDatabase::performCurrentOpenOperationAfterSpaceCheck):
(WebCore::IDBServer::UniqueIDBDatabase::deleteBackingStore):
(WebCore::IDBServer::UniqueIDBDatabase::createObjectStore):
(WebCore::IDBServer::UniqueIDBDatabase::deleteObjectStore):
(WebCore::IDBServer::UniqueIDBDatabase::renameObjectStore):
(WebCore::IDBServer::UniqueIDBDatabase::clearObjectStore):
(WebCore::IDBServer::UniqueIDBDatabase::createIndexAsync):
(WebCore::IDBServer::UniqueIDBDatabase::deleteIndex):
(WebCore::IDBServer::UniqueIDBDatabase::renameIndex):
(WebCore::IDBServer::UniqueIDBDatabase::putOrAdd):
(WebCore::IDBServer::UniqueIDBDatabase::putOrAddAfterSpaceCheck):
(WebCore::IDBServer::UniqueIDBDatabase::getRecord):
(WebCore::IDBServer::UniqueIDBDatabase::getAllRecords):
(WebCore::IDBServer::UniqueIDBDatabase::getCount):
(WebCore::IDBServer::UniqueIDBDatabase::deleteRecord):
(WebCore::IDBServer::UniqueIDBDatabase::openCursor):
(WebCore::IDBServer::UniqueIDBDatabase::iterateCursor):
(WebCore::IDBServer::UniqueIDBDatabase::commitTransaction):
(WebCore::IDBServer::UniqueIDBDatabase::abortTransaction):
* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.h:
(WebCore::IDBServer::UniqueIDBDatabase::identifier const): Deleted.
* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseConnection.cpp:
(WebCore::IDBServer::UniqueIDBDatabaseConnection::UniqueIDBDatabaseConnection):
(WebCore::IDBServer::UniqueIDBDatabaseConnection::checkedDatabase):
(WebCore::IDBServer::UniqueIDBDatabaseConnection::~UniqueIDBDatabaseConnection):
(WebCore::IDBServer::UniqueIDBDatabaseConnection::abortTransactionWithoutCallback):
(WebCore::IDBServer::UniqueIDBDatabaseConnection::connectionClosedFromClient):
(WebCore::IDBServer::UniqueIDBDatabaseConnection::didFireVersionChangeEvent):
(WebCore::IDBServer::UniqueIDBDatabaseConnection::didFinishHandlingVersionChange):
(WebCore::IDBServer::UniqueIDBDatabaseConnection::createVersionChangeTransaction):
(WebCore::IDBServer::UniqueIDBDatabaseConnection::establishTransaction):
* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseConnection.h:
* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseManager.h:
* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseTransaction.cpp:
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::UniqueIDBDatabaseTransaction):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::~UniqueIDBDatabaseTransaction):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::abort):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::checkedDatabase const):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::commit):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::createObjectStore):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::deleteObjectStore):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::renameObjectStore):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::clearObjectStore):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::deleteIndex):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::renameIndex):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::putOrAdd):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::getRecord):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::getAllRecords):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::getCount):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::deleteRecord):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::openCursor):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::iterateCursor):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::objectStoreIdentifiers):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::createIndex):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::didGenerateIndexKeyForRecord):
* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseTransaction.h:
* Source/WebCore/Modules/indexeddb/shared/IDBResultData.cpp:
(WebCore::IDBResultData::openDatabaseSuccess):
(WebCore::IDBResultData::openDatabaseUpgradeNeeded):
* Source/WebKit/NetworkProcess/storage/IDBStorageManager.cpp:
(WebKit::IDBStorageManager::openDatabase):
(WebKit::IDBStorageManager::deleteDatabase):
(WebKit::IDBStorageManager::openDBRequestCancelled):
* Source/WebKit/NetworkProcess/storage/IDBStorageManager.h:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::suspend):
(WebKit::NetworkStorageManager::handleLowMemoryWarning):
(WebKit::NetworkStorageManager::openDatabase):
(WebKit::NetworkStorageManager::openDBRequestCancelled):
(WebKit::NetworkStorageManager::deleteDatabase):
(WebKit::NetworkStorageManager::getAllDatabaseNamesAndVersions):
* Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp:
(WebKit::OriginStorageManager::StorageBucket::isActive const):
(WebKit::OriginStorageManager::StorageBucket::hasDataInMemory const):
(WebKit::OriginStorageManager::StorageBucket::fetchDataTypesInListFromMemory):
(WebKit::OriginStorageManager::StorageBucket::deleteIDBStorageData):
(WebKit::OriginStorageManager::StorageBucket::moveData):
(WebKit::OriginStorageManager::checkedIDBStorageManager):
* Source/WebKit/NetworkProcess/storage/OriginStorageManager.h:

Canonical link: <a href="https://commits.webkit.org/301188@main">https://commits.webkit.org/301188@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3952eabf363f8f824f6123a3d80efa4526d5fbf8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125195 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44862 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35601 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132046 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/77060 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e15377fa-aa17-4590-9ff0-8d482d119c56) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127072 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45553 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53423 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95311 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/77060 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7eb17105-3fc9-4f28-aab1-6a387edbbc8c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128149 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36363 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111955 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75851 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a755decc-9174-48d2-af53-2fca54634a7b) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/35265 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30122 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75524 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106129 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30348 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134726 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52004 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39787 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/103778 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52439 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108176 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/103548 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26368 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48899 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27188 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49077 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51896 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57676 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51260 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54616 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52953 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->