### PR TITLE
[WebRTC] Non-unified build issues in NetworkRTCMonitor and NetworkRTCSharedMonitor

### DIFF
--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCSharedMonitor.h
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCSharedMonitor.h
@@ -37,6 +37,7 @@
 #endif
 
 namespace WebKit {
+class NetworkRTCMonitor;
 
 class NetworkRTCSharedMonitor {
 public:


### PR DESCRIPTION
#### 2907b2fb04d62805ab8dce88d2938f796d020fc4
<pre>
[WebRTC] Non-unified build issues in NetworkRTCMonitor and NetworkRTCSharedMonitor
<a href="https://bugs.webkit.org/show_bug.cgi?id=300307">https://bugs.webkit.org/show_bug.cgi?id=300307</a>

Reviewed by Xabier Rodriguez-Calvar.

NetworkRTCSharedMonitor was making use of functions and classes defined in NetworkRTCMonitor,
implying they had to be in the same unified sources group. Those are now declared in the
NetworkRTCMonitor namespace.

* Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.cpp:
(WebKit::NetworkRTCMonitor::gatherNetworkMap):
(WebKit::NetworkRTCMonitor::getDefaultIPAddress):
(WebKit::NetworkRTCMonitor::isEqual):
(WebKit::NetworkRTCMonitor::hasNetworkChanged):
(WebKit::NetworkRTCMonitor::sortNetworks):
(): Deleted.
(WebKit::gatherNetworkMap): Deleted.
(WebKit::getDefaultIPAddress): Deleted.
(WebKit::isEqual): Deleted.
(WebKit::hasNetworkChanged): Deleted.
(WebKit::sortNetworks): Deleted.
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.h:
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCSharedMonitor.cpp:
(WebKit::NetworkRTCSharedMonitor::updateNetworks):
(WebKit::NetworkRTCSharedMonitor::onGatheredNetworks):
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCSharedMonitor.h:

Canonical link: <a href="https://commits.webkit.org/301304@main">https://commits.webkit.org/301304@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f92056ecb4e09d65cff29ca1dda73bb70066cee8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125016 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44685 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35422 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131865 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76986 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45377 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53251 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95160 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/63201 "Found 60 new test failures: compositing/clipping/border-radius-with-composited-descendant-nested.html compositing/clipping/border-radius-with-composited-descendant.html compositing/overlap-blending/children-opacity-huge.html compositing/overlap-blending/children-opacity-no-overlap.html compositing/overlap-blending/nested-non-overlap-clipping.html compositing/overlap-blending/nested-overlap.html compositing/reflections/nested-reflection-opacity2.html compositing/transitions/transform-on-large-layer.html compositing/webgl/webgl-no-alpha.html compositing/webgl/webgl-repaint.html ... (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127970 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36215 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111805 "Found 1 new API test failure: TestWebKitAPI.PasteMixedContent.CopyAndPasteWithCustomPasteboardDataOnly (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75703 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35135 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75347 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105978 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30188 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134541 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51838 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39634 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103633 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52263 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108017 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103407 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26438 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48743 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27035 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48880 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51723 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57516 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51097 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54454 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52788 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->