### PR TITLE
AVStreamDataParser incorrectly given to AVContentKeySession.removeContentKeyRecipient

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h
@@ -175,7 +175,6 @@ private:
     void attachContentKeyToSampleIfNeeded(const MediaSampleAVFObjC&);
     void didBecomeReadyForMoreSamples(TrackID);
     void appendCompleted(bool);
-    void destroyStreamDataParser();
     void destroyRendererTracks();
     void clearTracks();
 
@@ -242,7 +241,7 @@ private:
     RefPtr<CDMInstanceFairPlayStreamingAVFObjC> m_cdmInstance;
     UniqueRef<Observer<void()>> m_keyStatusesChangedObserver;
     KeyIDs m_keyIDs;
-    RetainPtr<AVStreamDataParser> m_streamDataParser;
+    const RetainPtr<AVStreamDataParser> m_streamDataParser;
 #endif
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
@@ -130,7 +130,6 @@ SourceBufferPrivateAVFObjC::~SourceBufferPrivateAVFObjC()
 {
     ALWAYS_LOG(LOGIDENTIFIER);
 
-    destroyStreamDataParser();
     destroyRendererTracks();
     clearTracks();
 
@@ -521,19 +520,6 @@ void SourceBufferPrivateAVFObjC::resetParserStateInternal()
     });
 }
 
-void SourceBufferPrivateAVFObjC::destroyStreamDataParser()
-{
-    auto parser = this->streamDataParser();
-    if (!parser)
-        return;
-#if ENABLE(ENCRYPTED_MEDIA) && HAVE(AVCONTENTKEYSESSION)
-    if (RefPtr cdmInstance = m_cdmInstance) {
-        if (RefPtr instanceSession = cdmInstance->sessionForKeyIDs(m_keyIDs))
-            [instanceSession->contentKeySession() removeContentKeyRecipient:parser];
-    }
-#endif
-}
-
 void SourceBufferPrivateAVFObjC::destroyRendererTracks()
 {
     ALWAYS_LOG(LOGIDENTIFIER);
@@ -574,7 +560,6 @@ void SourceBufferPrivateAVFObjC::removedFromMediaSource()
 {
     ALWAYS_LOG(LOGIDENTIFIER);
 
-    destroyStreamDataParser();
     destroyRendererTracks();
 
     SourceBufferPrivate::removedFromMediaSource();


### PR DESCRIPTION
#### 135d895ded315f6a8bf581e6cbb07dc70c573aba
<pre>
AVStreamDataParser incorrectly given to AVContentKeySession.removeContentKeyRecipient
<a href="https://bugs.webkit.org/show_bug.cgi?id=300306">https://bugs.webkit.org/show_bug.cgi?id=300306</a>
<a href="https://rdar.apple.com/162100592">rdar://162100592</a>

Reviewed by Jer Noble.

We incorrectly called removeContentKeyRecipient with the AVStreamDataParser
when it was never added in the first place (and doesn&apos;t need to be added).

No change in observable behaviours.

* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h: Make member const.
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm:
(WebCore::SourceBufferPrivateAVFObjC::~SourceBufferPrivateAVFObjC):
(WebCore::SourceBufferPrivateAVFObjC::removedFromMediaSource):
(WebCore::SourceBufferPrivateAVFObjC::destroyStreamDataParser): Deleted.

Canonical link: <a href="https://commits.webkit.org/301169@main">https://commits.webkit.org/301169@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dbbf35353bcae1bd7a442c776d5e89934e66f538

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125018 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44687 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35424 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131867 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76994 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1cf95629-5923-4cef-ac36-fa7b88c781f6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/126895 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45379 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53253 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95162 "4 flakes 17 failures") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/63203 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8a351bf2-e67d-48c4-9206-795ae2ad9518) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127972 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36218 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111807 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75705 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/221c3831-949c-4800-a126-648e0fde9995) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35137 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29960 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75349 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105981 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30190 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134543 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51840 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39637 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103631 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52265 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108019 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103405 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26353 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48747 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27037 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48882 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51725 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57518 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51099 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54456 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52790 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->