### PR TITLE
Speculation Rules: fix up navigation-timing values.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-sizes.https_prefetch=true&bypass_cache=true-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-sizes.https_prefetch=true&bypass_cache=true-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL PerformanceNavigationTiming.transferSize/encodedBodySize/decodedBodySize test, same origin prefetch. assert_greater_than: expected a number greater than 0 but got 0
+PASS PerformanceNavigationTiming.transferSize/encodedBodySize/decodedBodySize test, same origin prefetch.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-sizes.https_prefetch=true-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-sizes.https_prefetch=true-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL PerformanceNavigationTiming.transferSize/encodedBodySize/decodedBodySize test, same origin prefetch. assert_greater_than: expected a number greater than 0 but got 0
+PASS PerformanceNavigationTiming.transferSize/encodedBodySize/decodedBodySize test, same origin prefetch.
 


### PR DESCRIPTION
#### ee89e36ccfe22d2180669985d38c3a107014e498
<pre>
Speculation Rules: fix up navigation-timing values.
<a href="https://bugs.webkit.org/show_bug.cgi?id=300299">https://bugs.webkit.org/show_bug.cgi?id=300299</a>

Reviewed by Alex Christensen.

This PR saves the NetworkLoadMetrics when a DocumentPrefetcher gets them and applies them to a document when it finishes loading and its URL matches a prefetched document.
It also simplifies the DocumentPrefetcher logic related to prefetched CachedResources.

* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-sizes.https_prefetch=true&amp;bypass_cache=true-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/navigation-timing-sizes.https_prefetch=true-expected.txt: Progression.
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::notifyFinished): Apply the saved NetworkLoadMetrics.
* Source/WebCore/loader/DocumentPrefetcher.cpp:
(WebCore::DocumentPrefetcher::prefetch): Change m_prefetchedResources data structure to m_prefetchedData.
(WebCore::DocumentPrefetcher::notifyFinished): Save NetworkLoadMetrics and avoid spurious lookups in prefetched resources.
(WebCore::DocumentPrefetcher::takePrefetchedNetworkLoadMetrics): Return NetworkLoadMetrics from the prefetched resource, based on URL.
(WebCore::DocumentPrefetcher::~DocumentPrefetcher): Remove manual cleanups that should happen when the client is removed.
(WebCore::DocumentPrefetcher::redirectReceived): Deleted.
* Source/WebCore/loader/DocumentPrefetcher.h: Add PrefetchedResourceData struct.

Canonical link: <a href="https://commits.webkit.org/301163@main">https://commits.webkit.org/301163@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c657692c14b974cc9cc1249a444668fa83b8236

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125081 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44749 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35487 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131929 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76955 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/126958 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45440 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53314 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95217 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/63181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128035 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36273 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111864 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75758 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35183 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30020 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75410 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106037 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30249 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134607 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51899 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39692 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103685 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52326 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108077 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103458 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26349 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48802 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27094 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48971 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51786 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57578 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51158 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54514 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52849 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->