### PR TITLE
SpeculationRules: Fix up the Sec-Speculation-Tags implementation.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/cross-site-prefetch.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/cross-site-prefetch.https-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL cross-site prefetch should not have Sec-Speculation-Tags be sent assert_equals: expected "__no_tags__" but got "tag1"
+FAIL cross-site prefetch should not have Sec-Speculation-Tags be sent assert_equals: expected "__no_tags__" but got "\"tag1\""
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/cross-site-to-same-site-redirection-prefetch.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/cross-site-to-same-site-redirection-prefetch.https-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL same-site redirection prefetch should have Sec-Speculation-Tags even if cross-site url in the redirection chain assert_equals: expected "\"tag1\"" but got "tag1"
+PASS same-site redirection prefetch should have Sec-Speculation-Tags even if cross-site url in the redirection chain
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/deduped-and-sorted-tags.https_type=prefetch-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/deduped-and-sorted-tags.https_type=prefetch-expected.txt
@@ -1,7 +1,7 @@
 
 FAIL Sec-Speculation-Tags: deduped and sorted tags assert_equals: expected (string) "prefetch" but got (object) null
 FAIL Sec-Speculation-Tags: deduped and sorted tags within rules assert_equals: expected (string) "prefetch" but got (object) null
-FAIL Sec-Speculation-Tags: deduped and sorted tags within multiple rulesets assert_equals: expected "\"abc\", \"def\", \"ghi\", \"jkl\"" but got "def, jkl"
-FAIL Sec-Speculation-Tags: 'null' tags and no tags within multiple rulesets assert_equals: expected "null, \"abc\", \"def\", \"null\"" but got ""
-FAIL Sec-Speculation-Tags: removed ruleset assert_equals: expected "\"def\", \"ghi\", \"jkl\"" but got "def, jkl"
+FAIL Sec-Speculation-Tags: deduped and sorted tags within multiple rulesets assert_equals: expected "\"abc\", \"def\", \"ghi\", \"jkl\"" but got "\"def\", \"jkl\""
+FAIL Sec-Speculation-Tags: 'null' tags and no tags within multiple rulesets assert_equals: expected "null, \"abc\", \"def\", \"null\"" but got "null"
+FAIL Sec-Speculation-Tags: removed ruleset assert_equals: expected "\"def\", \"ghi\", \"jkl\"" but got "\"def\", \"jkl\""
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/invalid-tags.https_tag-level=rule&type=prefetch-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/invalid-tags.https_tag-level=rule&type=prefetch-expected.txt
@@ -6,7 +6,7 @@ PASS Sec-Speculation-Tags [rule-based]: non-printable character tag
 PASS Sec-Speculation-Tags [rule-based]: string with non-printable character tag
 PASS Sec-Speculation-Tags [rule-based]: non-ascii string tag
 PASS Sec-Speculation-Tags [rule-based]: 0x19 tag
-FAIL Sec-Speculation-Tags [rule-based]: 0x20 tag assert_equals: expected "\" \"" but got ""
-FAIL Sec-Speculation-Tags [rule-based]: 0x7E tag assert_equals: expected "\"~\"" but got "~"
+PASS Sec-Speculation-Tags [rule-based]: 0x20 tag
+PASS Sec-Speculation-Tags [rule-based]: 0x7E tag
 PASS Sec-Speculation-Tags [rule-based]: 0x7F tag
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/invalid-tags.https_tag-level=ruleset&type=prefetch-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/invalid-tags.https_tag-level=ruleset&type=prefetch-expected.txt
@@ -6,7 +6,7 @@ PASS Sec-Speculation-Tags [ruleset-based]: non-printable character tag
 PASS Sec-Speculation-Tags [ruleset-based]: string with non-printable character tag
 PASS Sec-Speculation-Tags [ruleset-based]: non-ascii string tag
 PASS Sec-Speculation-Tags [ruleset-based]: 0x19 tag
-FAIL Sec-Speculation-Tags [ruleset-based]: 0x20 tag assert_equals: expected "\" \"" but got ""
-FAIL Sec-Speculation-Tags [ruleset-based]: 0x7E tag assert_equals: expected "\"~\"" but got "~"
+PASS Sec-Speculation-Tags [ruleset-based]: 0x20 tag
+PASS Sec-Speculation-Tags [ruleset-based]: 0x7E tag
 PASS Sec-Speculation-Tags [ruleset-based]: 0x7F tag
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/no-tags.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/no-tags.https-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Sec-Speculation-Tags: no tags (prefetch) assert_equals: Sec-Speculation-Tags expected "null" but got ""
+PASS Sec-Speculation-Tags: no tags (prefetch)
 FAIL Sec-Speculation-Tags: no tags (prerender) promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: PrerenderingRemoteContextHelper"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/prefetch-eagerness-pointer-down.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/prefetch-eagerness-pointer-down.https-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Sec-Speculation-Tags prefetch with eagerness triggered by point down assert_equals: Sec-Speculation-Tags expected "\"conservative\", \"moderate\"" but got "conservative"
+FAIL Sec-Speculation-Tags prefetch with eagerness triggered by point down assert_equals: Sec-Speculation-Tags expected "\"conservative\", \"moderate\"" but got "\"conservative\""
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/prefetch-eagerness-pointer-hover.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/prefetch-eagerness-pointer-hover.https-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Sec-Speculation-Tags prefetch with eagerness triggered by point hover assert_equals: Sec-Speculation-Tags expected "\"moderate\"" but got "conservative"
+FAIL Sec-Speculation-Tags prefetch with eagerness triggered by point hover assert_equals: Sec-Speculation-Tags expected "\"moderate\"" but got "\"conservative\""
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/same-site-to-cross-site-redirection-prefetch.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/same-site-to-cross-site-redirection-prefetch.https-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL same-site to cross-site redirection prefetch should not have Sec-Speculation-Tags be sent assert_equals: expected "__no_tags__" but got "tag1"
+FAIL same-site to cross-site redirection prefetch should not have Sec-Speculation-Tags be sent assert_equals: expected "__no_tags__" but got "\"tag1\""
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/valid-tags.https_tag-level=rule&type=prefetch-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/valid-tags.https_tag-level=rule&type=prefetch-expected.txt
@@ -1,10 +1,10 @@
 
-FAIL Sec-Speculation-Tags [rule-based]: string tag assert_equals: expected "\"my-rules\"" but got "my-rules"
-FAIL Sec-Speculation-Tags [rule-based]: 'null' string tag assert_equals: expected "\"null\"" but got "null"
-FAIL Sec-Speculation-Tags [rule-based]: empty string tag assert_equals: expected "\"\"" but got ""
-FAIL Sec-Speculation-Tags [rule-based]: single space tag assert_equals: expected "\" \"" but got ""
-FAIL Sec-Speculation-Tags [rule-based]: double quote tag assert_equals: expected "\"\\\"\"" but got "\""
-FAIL Sec-Speculation-Tags [rule-based]: double quotes tag assert_equals: expected "\"\\\"\\\"\\\"\"" but got "\"\"\""
-FAIL Sec-Speculation-Tags [rule-based]: backslash tag assert_equals: expected "\"\\\\\"" but got "\\"
-FAIL Sec-Speculation-Tags [rule-based]: backslashes tag assert_equals: expected "\"\\\\\\\\\\\\\"" but got "\\\\\\"
+PASS Sec-Speculation-Tags [rule-based]: string tag
+PASS Sec-Speculation-Tags [rule-based]: 'null' string tag
+PASS Sec-Speculation-Tags [rule-based]: empty string tag
+PASS Sec-Speculation-Tags [rule-based]: single space tag
+PASS Sec-Speculation-Tags [rule-based]: double quote tag
+PASS Sec-Speculation-Tags [rule-based]: double quotes tag
+PASS Sec-Speculation-Tags [rule-based]: backslash tag
+PASS Sec-Speculation-Tags [rule-based]: backslashes tag
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/valid-tags.https_tag-level=ruleset&type=prefetch-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/valid-tags.https_tag-level=ruleset&type=prefetch-expected.txt
@@ -1,10 +1,10 @@
 
-FAIL Sec-Speculation-Tags [ruleset-based]: string tag assert_equals: expected "\"my-rules\"" but got "my-rules"
-FAIL Sec-Speculation-Tags [ruleset-based]: 'null' string tag assert_equals: expected "\"null\"" but got "null"
-FAIL Sec-Speculation-Tags [ruleset-based]: empty string tag assert_equals: expected "\"\"" but got ""
-FAIL Sec-Speculation-Tags [ruleset-based]: single space tag assert_equals: expected "\" \"" but got ""
-FAIL Sec-Speculation-Tags [ruleset-based]: double quote tag assert_equals: expected "\"\\\"\"" but got "\""
-FAIL Sec-Speculation-Tags [ruleset-based]: double quotes tag assert_equals: expected "\"\\\"\\\"\\\"\"" but got "\"\"\""
-FAIL Sec-Speculation-Tags [ruleset-based]: backslash tag assert_equals: expected "\"\\\\\"" but got "\\"
-FAIL Sec-Speculation-Tags [ruleset-based]: backslashes tag assert_equals: expected "\"\\\\\\\\\\\\\"" but got "\\\\\\"
+PASS Sec-Speculation-Tags [ruleset-based]: string tag
+PASS Sec-Speculation-Tags [ruleset-based]: 'null' string tag
+PASS Sec-Speculation-Tags [ruleset-based]: empty string tag
+PASS Sec-Speculation-Tags [ruleset-based]: single space tag
+PASS Sec-Speculation-Tags [ruleset-based]: double quote tag
+PASS Sec-Speculation-Tags [ruleset-based]: double quotes tag
+PASS Sec-Speculation-Tags [ruleset-based]: backslash tag
+PASS Sec-Speculation-Tags [ruleset-based]: backslashes tag
 

--- a/Source/WebCore/loader/DocumentPrefetcher.cpp
+++ b/Source/WebCore/loader/DocumentPrefetcher.cpp
@@ -88,6 +88,7 @@ static ResourceRequest makePrefetchRequest(URL&& url, const Vector<String>& tags
     ResourceRequest request { WTFMove(url) };
     request.setPriority(ResourceLoadPriority::VeryLow);
 
+    // https://html.spec.whatwg.org/multipage/speculative-loading.html#the-sec-speculation-tags-header
     if (!tags.isEmpty()) {
         StringBuilder builder;
         for (size_t i = 0; i < tags.size(); ++i) {


### PR DESCRIPTION
#### 72a5bca1bfec1f958c4b2c60d341a84fbb7fe0e0
<pre>
SpeculationRules: Fix up the Sec-Speculation-Tags implementation.
<a href="https://bugs.webkit.org/show_bug.cgi?id=300310">https://bugs.webkit.org/show_bug.cgi?id=300310</a>

Reviewed by Alex Christensen.

This PR fixes up the Speculation-Tags implementation to properly JSON quote the tag values,
and add a null value when there aren&apos;t any tags. This fixes the failing tests.

* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/cross-site-prefetch.https-expected.txt: Failing differently.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/cross-site-to-same-site-redirection-prefetch.https-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/deduped-and-sorted-tags.https_type=prefetch-expected.txt: Still failing as behavior is not implemented.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/invalid-tags.https_tag-level=rule&amp;type=prefetch-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/invalid-tags.https_tag-level=ruleset&amp;type=prefetch-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/no-tags.https-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/prefetch-eagerness-pointer-down.https-expected.txt: No support for &quot;moderate&quot;.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/prefetch-eagerness-pointer-hover.https-expected.txt: No support for &quot;moderate&quot;.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/same-site-to-cross-site-redirection-prefetch.https-expected.txt: Failing differently.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/valid-tags.https_tag-level=rule&amp;type=prefetch-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/valid-tags.https_tag-level=ruleset&amp;type=prefetch-expected.txt: Progression.
* Source/WebCore/loader/DocumentPrefetcher.cpp:
(WebCore::makePrefetchRequest): Add spec link.
* Source/WebCore/loader/SpeculationRules.cpp:
(WebCore::parseSingleRule): Quote values and add null string.
(WebCore::SpeculationRules::parseSpeculationRules): Quote values.

Canonical link: <a href="https://commits.webkit.org/301143@main">https://commits.webkit.org/301143@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/15c9a2fb50d2bae71c63beb80aeb47cab0d31329

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125035 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44704 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35441 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131884 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76914 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/126912 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45396 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53270 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95175 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/63155 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127989 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36234 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111819 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75718 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35150 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29973 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75366 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105997 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30202 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134560 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51857 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39652 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103668 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52282 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108031 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103421 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26340 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48762 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27049 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48906 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51742 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57535 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51116 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54473 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52807 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->