### PR TITLE
Fix Swift demo build on recent toolchains

### DIFF
--- a/Source/WTF/Configurations/modulemap.toml
+++ b/Source/WTF/Configurations/modulemap.toml
@@ -44,6 +44,15 @@ headers = ['AutodrainedPool.h']
 requirements = ['cplusplus20']
 headers = ['spi/mac/MetadataSPI.h']
 
+# Require objc.
+[module.NSLocaleSPI]
+requirements = ['objc']
+headers = ['spi/cocoa/NSLocaleSPI.h']
+
+[module.NSObjCRuntimeSPI]
+requirements = ['objc']
+headers = ['spi/cocoa/NSObjCRuntimeSPI.h']
+
 # Swiftc cannot currently parse various bits of WTF so we have to
 # exile them outside the main WTF module.
 

--- a/Source/WebKit/Scripts/generate-plain-cpp-swift-interop-header.sh
+++ b/Source/WebKit/Scripts/generate-plain-cpp-swift-interop-header.sh
@@ -25,4 +25,5 @@ set -e
 
 xcrun swiftc -typecheck -emit-clang-header-path "${SCRIPT_OUTPUT_FILE_0}" "${SCRIPT_INPUT_FILE_1}" -DENABLE_SWIFT_DEMO_URI_SCHEME \
     -I${SRCROOT}/Modules/Internal -I${SRCROOT} -cxx-interoperability-mode=default -Xcc -std=c++2b -module-name WebKit \
-    -sdk ${SDKROOT}
+    -sdk ${SDKROOT} \
+    -F ${SDKROOT}/System/Library/PrivateFrameworks


### PR DESCRIPTION
#### ccd4552c26b0762867e074c48806b08286099afc
<pre>
Fix Swift demo build on recent toolchains
<a href="https://bugs.webkit.org/show_bug.cgi?id=300314">https://bugs.webkit.org/show_bug.cgi?id=300314</a>
<a href="https://rdar.apple.com/162108584">rdar://162108584</a>

Reviewed by Richard Robinson.

This makes two changes related to the WTF modulemap so that it builds
OK with recent toolchains. Specifically,
* Two of its headers require objc and that&apos;s now noted. (That does
  not fix the build bug here, but seems the right thing to do)
* On Apple internal builds, those headers require headers from
  private frameworks, and that was not previously accommodated by
  the build script.

A note on the build script itself: first, it&apos;s only used if
ENABLE_SWIFT_DEMO_URI_SCHEME is turned on, which is not the case
in any EWS or consumer builds. Secondly, this script is expected
to be removed within a few weeks, when the most recent toolchains
have the fixes we need to generate this header as part of the
standard Xcode built-in step. This work is tracked by #50307
although that&apos;s presently paused until we get those fixes.

Canonical link: <a href="https://commits.webkit.org/301216@main">https://commits.webkit.org/301216@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b69a09238e0f854894217a729e3a3a7b30baee19

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125047 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44715 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35453 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131894 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77033 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/42c4bc57-de56-496b-81b5-271cf9d42d50) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45406 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53280 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95184 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/63231 "An unexpected error occured. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; layout-tests (exception)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ae92307a-e398-4f15-8361-228bfd873fdd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128001 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36243 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111839 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75727 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/91807ab9-1008-4dd5-b355-0878bf509b52) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/124403 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35158 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29992 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75376 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/117143 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106006 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30221 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134572 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/123565 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51866 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39662 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103655 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52292 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108050 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103429 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26387 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48769 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27068 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48915 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51752 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57545 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/156587 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51125 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39219 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54482 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52816 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->