### PR TITLE
Enhanced <select>: element nesting changes

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/common-dom-interfaces/collections/htmloptionscollection.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/common-dom-interfaces/collections/htmloptionscollection.html
@@ -92,8 +92,8 @@ test(function() {
   newChild.appendChild(newOption);
   a.appendChild(newChild);
   a.value = 3;
-  assert_equals(a_opts.length, 5, "Correct length");
-  assert_values_equals(a_opts, ["1","2","3","4","5"], "Correct elements inserted")
+  assert_equals(a_opts.length, 6, "Correct length");
+  assert_values_equals(a_opts, ["1","2","3","4","5","6"], "Correct elements inserted")
   assert_equals(a.value, "3", "Correct value set");
 }, "Insert <p><option>6</option></p> into <select>");
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/nested-options.tenative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/nested-options.tenative-expected.txt
@@ -1,6 +1,6 @@
 
 
 PASS The HTML parser should disallow nested options in select datalist.
-FAIL Nested <options> not should be listed in <select> IDLs. assert_equals: select.options.length expected 1 but got 0
+PASS Nested <options> not should be listed in <select> IDLs.
 PASS Showing the popup with nested <option>s should not crash.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/nested-options.tenative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/nested-options.tenative.html
@@ -33,6 +33,7 @@ test(() => {
 
 // Manually nest the <options> anyway for the following tests.
 o1.appendChild(o2);
+document.querySelector('select').appendChild(o1);
 
 test(() => {
   assert_equals(select.options.length, 1, 'select.options.length');

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/option-disabled-optgroup-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/option-disabled-optgroup-expected.txt
@@ -1,6 +1,6 @@
 
 
-FAIL options should check ancestor optgroup for disabled state. assert_equals: color after optgroup disabled expected "rgb(128, 128, 128)" but got "rgb(0, 0, 0)"
+PASS options should check ancestor optgroup for disabled state.
 PASS nested optgroup
 PASS disabled select
 PASS select in optgroup

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/option-form-ancestor-select-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/option-form-ancestor-select-expected.txt
@@ -1,6 +1,5 @@
 
 
 
-FAIL option.form should look up the ancestor chain for a select element to get its form from. assert_equals: option1 expected Element node <form id="form">
-  <select id="select1"><div><option></op... but got null
+PASS option.form should look up the ancestor chain for a select element to get its form from.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/option-list-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/option-list-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL select's option list should not include descendants of options, hrs, or nested optgroups. assert_equals: childSelect.length expected 3 but got 2
+PASS select's option list should not include descendants of options, hrs, or nested optgroups.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-options-id-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-options-id-expected.txt
@@ -1,6 +1,6 @@
 
 
-FAIL Option elements should work if they are a descendant of a selects wrapper div. assert_equals: select.length expected 6 but got 1
-FAIL Options in wrapper div should still work when the multiple attribute is added. assert_equals: select.length expected 6 but got 1
-FAIL Options in wrapper div in multiple should work after re-parsing and re-attaching. assert_equals: select.length expected 6 but got 1
+PASS Option elements should work if they are a descendant of a selects wrapper div.
+PASS Options in wrapper div should still work when the multiple attribute is added.
+PASS Options in wrapper div in multiple should work after re-parsing and re-attaching.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-value-selectedOption-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-value-selectedOption-expected.txt
@@ -7,7 +7,7 @@ PASS Test value and selectedOption when value is undefined
 PASS Test value with non-HTMLOptionElement elements labeled as parts
 PASS Test that value and selectedOption are updated when options are removed
 FAIL Test that slotted-in selected-value part is updated to value of select assert_equals: Custom selected value part should be set to initial value of select expected "one" but got "Default custom selected-value text"
-FAIL Test that option parts in a slotted-in listbox are reflected in the value property assert_equals: value should start with the text of the first option part expected "one" but got ""
+FAIL Test that option parts in a slotted-in listbox are reflected in the value property assert_equals: Custom selected value part should be set to initial value of select expected "one" but got "Default custom selected-value text"
 PASS Test that value and selectedOption are correctly updated
 PASS Test that HTMLOption.selected updates select.value and select.selectedOptions
 PASS Test that HTMLOption.value updates select.value

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/select-selectedOptions-nesting.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/select-selectedOptions-nesting.window-expected.txt
@@ -1,0 +1,13 @@
+
+PASS <select> containing <option><option selected>
+PASS <select> containing <hr><option selected>
+PASS <select> containing <select><option selected>
+PASS <select><optgroup> containing <option><option selected>
+PASS <select><optgroup> containing <hr><option selected>
+PASS <select><optgroup> containing <select><option selected>
+PASS <select><optgroup> containing <optgroup><option selected>
+PASS <select><div><optgroup><div> containing <option><option selected>
+PASS <select><div><optgroup><div> containing <hr><option selected>
+PASS <select><div><optgroup><div> containing <select><option selected>
+PASS <select><div><optgroup><div> containing <optgroup><option selected>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/select-selectedOptions-nesting.window.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/select-selectedOptions-nesting.window.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/select-selectedOptions-nesting.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/select-selectedOptions-nesting.window.js
@@ -1,0 +1,89 @@
+
+for (const optionParentElementName of ["option", "hr", "select"]) {
+  test(() => {
+    const select = document.createElement("select");
+    const selectedOptions = select.selectedOptions;
+    select.innerHTML = "<option>1";
+
+    assert_equals(selectedOptions.length, 1);
+    assert_equals(selectedOptions[0], select.firstChild);
+    assert_equals(select.value, "1");
+
+    const optionParent = select.appendChild(document.createElement(optionParentElementName));
+
+    assert_equals(selectedOptions.length, 1);
+    assert_equals(selectedOptions[0], select.firstChild);
+    assert_equals(select.value, "1");
+
+    const option = optionParent.appendChild(document.createElement("option"));
+    option.setAttribute("selected", "");
+    option.textContent = "2";
+
+    assert_equals(selectedOptions.length, 1);
+    assert_equals(selectedOptions[0], select.firstChild);
+    assert_equals(select.value, "1");
+  }, `<select> containing <${optionParentElementName}><option selected>`);
+}
+
+for (const optionParentElementName of ["option", "hr", "select", "optgroup"]) {
+  test(() => {
+    const select = document.createElement("select");
+    const selectedOptions = select.selectedOptions;
+    select.innerHTML = "<optgroup><option>1";
+
+    assert_equals(selectedOptions.length, 1);
+    assert_equals(selectedOptions[0], select.firstChild.firstChild);
+    assert_equals(select.value, "1");
+
+    const optionParent = select.firstChild.appendChild(document.createElement(optionParentElementName));
+
+    assert_equals(selectedOptions.length, 1);
+    assert_equals(selectedOptions[0], select.firstChild.firstChild);
+    assert_equals(select.value, "1");
+
+    const option = optionParent.appendChild(document.createElement("option"));
+    option.setAttribute("selected", "");
+    option.textContent = "2";
+
+    assert_equals(selectedOptions.length, 1);
+    assert_equals(selectedOptions[0], select.firstChild.firstChild);
+    assert_equals(select.value, "1");
+
+  }, `<select><optgroup> containing <${optionParentElementName}><option selected>`);
+}
+
+for (const optionParentElementName of ["option", "hr", "select", "optgroup"]) {
+  test(() => {
+    const select = document.createElement("select");
+    select.multiple = true;
+    const selectedOptions = select.selectedOptions;
+    select.innerHTML = "<div><optgroup><div><option selected>1";
+
+    assert_equals(selectedOptions.length, 1);
+    assert_equals(selectedOptions[0], select.firstChild.firstChild.firstChild.firstChild);
+    assert_equals(select.value, "1");
+
+    const optionParent = select.firstChild.firstChild.firstChild.appendChild(document.createElement(optionParentElementName));
+
+    assert_equals(selectedOptions.length, 1);
+    assert_equals(selectedOptions[0], select.firstChild.firstChild.firstChild.firstChild);
+    assert_equals(select.value, "1");
+
+    const option = optionParent.appendChild(document.createElement("option"));
+    option.setAttribute("selected", "");
+    option.textContent = "2";
+
+    assert_equals(selectedOptions.length, 1);
+    assert_equals(selectedOptions[0], select.firstChild.firstChild.firstChild.firstChild);
+    assert_equals(select.value, "1");
+
+    const secondOption = select.appendChild(document.createElement("option"));
+    secondOption.setAttribute("selected", "");
+    secondOption.textContent = "3";
+
+    assert_equals(selectedOptions.length, 2);
+    assert_equals(selectedOptions[0], select.firstChild.firstChild.firstChild.firstChild);
+    assert_equals(selectedOptions[1], secondOption);
+    assert_equals(select.value, "1");
+  }, `<select><div><optgroup><div> containing <${optionParentElementName}><option selected>`);
+}

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/select-value-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/select-value-expected.txt
@@ -1,6 +1,6 @@
 
 PASS options
 PASS optgroups
-FAIL option is child of div assert_equals: expected "1" but got ""
+PASS option is child of div
 PASS no options
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/w3c-import.log
@@ -54,6 +54,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/select-popover-position-with-zoom.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/select-remove.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/select-required-attribute.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/select-selectedOptions-nesting.window.js
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/select-selectedOptions.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/select-setcustomvalidity.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/select-tab-navigation.tentative.html

--- a/Source/WebCore/html/GenericCachedHTMLCollection.cpp
+++ b/Source/WebCore/html/GenericCachedHTMLCollection.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,9 +27,7 @@
 #include "GenericCachedHTMLCollection.h"
 
 #include "CachedHTMLCollectionInlines.h"
-#include "HTMLFieldSetElement.h"
 #include "HTMLNames.h"
-#include "HTMLObjectElement.h"
 #include "HTMLOptionElement.h"
 
 namespace WebCore {
@@ -68,7 +66,11 @@ bool GenericCachedHTMLCollection<traversalType>::elementMatches(Element& element
         return element.hasTagName(trTag);
     case CollectionType::SelectedOptions: {
         auto* optionElement = dynamicDowncast<HTMLOptionElement>(element);
-        return optionElement && optionElement->selected();
+        if (!optionElement)
+            return false;
+        if (!element.document().settings().htmlEnhancedSelectParsingEnabled())
+            return optionElement->selected();
+        return optionElement->selected() && optionElement->ownerSelectElement() == &this->ownerNode();
     }
     case CollectionType::DataListOptions:
         return is<HTMLOptionElement>(element);

--- a/Source/WebCore/html/HTMLHRElement.h
+++ b/Source/WebCore/html/HTMLHRElement.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
- * Copyright (C) 2010 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2025 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -36,9 +36,14 @@ public:
 private:
     HTMLHRElement(const QualifiedName&, Document&);
 
+    InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;
+    void removedFromAncestor(RemovalType, ContainerNode& oldParentOfRemovedTree) final;
+
     bool hasPresentationalHintsForAttribute(const QualifiedName&) const final;
     void collectPresentationalHintsForAttribute(const QualifiedName&, const AtomString&, MutableStyleProperties&) final;
     bool canContainRangeEndPoint() const final;
+
+    WeakPtr<HTMLSelectElement, WeakPtrImplWithEventTargetData> m_ownerSelect;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/HTMLOptGroupElement.h
+++ b/Source/WebCore/html/HTMLOptGroupElement.h
@@ -2,7 +2,7 @@
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
  *           (C) 2000 Dirk Mueller (mueller@kde.org)
- * Copyright (C) 2004, 2005, 2006, 2007, 2010 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2025 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -43,6 +43,9 @@ public:
 private:
     HTMLOptGroupElement(const QualifiedName&, Document&);
 
+    InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;
+    void removedFromAncestor(RemovalType, ContainerNode& oldParentOfRemovedTree) final;
+
     const AtomString& formControlType() const;
     bool isFocusable() const final;
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
@@ -55,6 +58,7 @@ private:
     void recalcSelectOptions();
 
     bool m_isDisabled { false };
+    WeakPtr<HTMLSelectElement, WeakPtrImplWithEventTargetData> m_ownerSelect;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/HTMLOptionElement.h
+++ b/Source/WebCore/html/HTMLOptionElement.h
@@ -2,7 +2,7 @@
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
  *           (C) 2000 Dirk Mueller (mueller@kde.org)
- * Copyright (C) 2004-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2025 Apple Inc. All rights reserved.
  * Copyright (C) 2010 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
@@ -70,6 +70,9 @@ public:
 private:
     HTMLOptionElement(const QualifiedName&, Document&);
 
+    InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;
+    void removedFromAncestor(RemovalType, ContainerNode& oldParentOfRemovedTree) final;
+
     bool isFocusable() const final;
     bool rendererIsNeeded(const RenderStyle&) final { return false; }
     bool matchesDefaultPseudoClass() const final;
@@ -88,6 +91,7 @@ private:
     bool m_disabled { false };
     bool m_isSelected { false };
     bool m_isDefault { false };
+    WeakPtr<HTMLSelectElement, WeakPtrImplWithEventTargetData> m_ownerSelect;
 };
 
 } // namespace

--- a/Source/WebCore/html/HTMLOptionsCollectionInlines.h
+++ b/Source/WebCore/html/HTMLOptionsCollectionInlines.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -43,14 +43,8 @@ inline const HTMLSelectElement& HTMLOptionsCollection::selectElement() const
 
 inline bool HTMLOptionsCollection::elementMatches(Element& element) const
 {
-    if (!element.hasTagName(HTMLNames::optionTag))
-        return false;
-
-    if (element.parentNode() == &selectElement())
-        return true;
-
-    ASSERT(element.parentNode());
-    return element.parentNode()->hasTagName(HTMLNames::optgroupTag) && element.parentNode()->parentNode() == &selectElement();
+    auto* optionElement = dynamicDowncast<HTMLOptionElement>(element);
+    return optionElement && optionElement->ownerSelectElement() == &ownerNode();
 }
 
-}
+} // namespace WebCore

--- a/Source/WebCore/html/HTMLSelectElement.h
+++ b/Source/WebCore/html/HTMLSelectElement.h
@@ -3,7 +3,7 @@
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
  *           (C) 2000 Dirk Mueller (mueller@kde.org)
- * Copyright (C) 2004-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2025 Apple Inc. All rights reserved.
  * Copyright (C) 2010-2015 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
@@ -40,6 +40,9 @@ class HTMLSelectElement : public HTMLFormControlElement, private TypeAheadDataSo
 public:
     static Ref<HTMLSelectElement> create(const QualifiedName&, Document&, HTMLFormElement*);
     static Ref<HTMLSelectElement> create(Document&);
+
+    enum class ExcludeOptGroup : bool { No, Yes };
+    static HTMLSelectElement* findOwnerSelect(ContainerNode*, ExcludeOptGroup);
 
     WEBCORE_EXPORT int selectedIndex() const;
     WEBCORE_EXPORT void setSelectedIndex(int);


### PR DESCRIPTION
#### 71fdfc0b942fc5eb8547d2963c0325dd6db46d08
<pre>
Enhanced &lt;select&gt;: element nesting changes
<a href="https://bugs.webkit.org/show_bug.cgi?id=300317">https://bugs.webkit.org/show_bug.cgi?id=300317</a>
<a href="https://rdar.apple.com/162596003">rdar://162596003</a>

Reviewed by Ryosuke Niwa.

&lt;select&gt;, &lt;optgroup&gt;, &lt;option&gt;, and &lt;hr&gt; elements can now be more
arbitrarily nested.

We also ensure that &lt;select&gt;.options and &lt;select&gt;.selectedOptions
only return &lt;option&gt; elements that belong to the &lt;select&gt; element in
question.

All of this is gated behind the HTMLEnhancedSelectParsingEnabled
preference as this new behavior is only really relevant if the HTML
parser supports such arbitrary nesting.

Tests:

- <a href="https://github.com/web-platform-tests/wpt/pull/55419">https://github.com/web-platform-tests/wpt/pull/55419</a>
- <a href="https://github.com/web-platform-tests/wpt/pull/55424">https://github.com/web-platform-tests/wpt/pull/55424</a>

This does not handle dynamic changes for &lt;option&gt; element descendants.

Canonical link: <a href="https://commits.webkit.org/302288@main">https://commits.webkit.org/302288@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7de9821cfa01b5423a74ae9f0c8ce32e84bf3a49

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128445 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/715 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39276 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135840 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79893 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/57d73f78-c504-4b3f-93ae-359d32cad6aa) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130317 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/658 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/588 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97778 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65681 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/75671271-5f5e-4a56-9df0-be1e8d2cf3fa) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131393 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/472 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115073 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78389 "Found 1 new API test failure: WPE/TestWebsiteData:/webkit/WebKitWebsiteData/itp (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8b76b361-9aab-4507-bf98-efe52341dde2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/433 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33180 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79122 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108839 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33664 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138289 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/555 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/524 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106319 "Found 1 new test failure: imported/blink/fast/pagination/viewport-y-horizontal-bt-rtl.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/596 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111414 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106129 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27066 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/459 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29957 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52881 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/607 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/63800 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/501 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/561 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/565 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->