### PR TITLE
Change casing of register_custom_url_scheme

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitWebExtensionMatchPattern.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebExtensionMatchPattern.cpp
@@ -67,6 +67,24 @@ G_DEFINE_BOXED_TYPE(WebKitWebExtensionMatchPattern, webkit_web_extension_match_p
 #if ENABLE(WK_WEB_EXTENSIONS)
 
 /**
+ * webkit_web_extension_match_pattern_register_custom_url_scheme:
+ * @urlScheme: The custom URL scheme to register
+ *
+ * Registers a custom URL scheme that can be used in match patterns.
+ * 
+ * This method should be used to register any custom URL schemes used by the app for the extension base URLs,
+ * other than `webkit-extension`, or if extensions should have access to other supported URL schemes when using `<all_urls>`.
+ *
+ * Since: 2.52
+ */
+void webkit_web_extension_match_pattern_register_custom_url_scheme(const gchar* urlScheme)
+{
+    g_return_if_fail(WTF::URLParser::maybeCanonicalizeScheme(String::fromUTF8(urlScheme)));
+
+    WebKit::WebExtensionMatchPattern::registerCustomURLScheme(String::fromUTF8(urlScheme));
+}
+
+/**
  * webkit_web_extension_match_pattern_register_custom_URL_scheme:
  * @urlScheme: The custom URL scheme to register
  *
@@ -76,6 +94,8 @@ G_DEFINE_BOXED_TYPE(WebKitWebExtensionMatchPattern, webkit_web_extension_match_p
  * other than `webkit-extension`, or if extensions should have access to other supported URL schemes when using `<all_urls>`.
  *
  * Since: 2.48
+ * 
+ * Deprecated: 2.52: Use webkit_web_extension_match_pattern_register_custom_url_scheme() instead.
  */
 void webkit_web_extension_match_pattern_register_custom_URL_scheme(const gchar* urlScheme)
 {
@@ -418,7 +438,7 @@ WebKitWebExtensionMatchPattern* webkit_web_extension_match_pattern_new_with_sche
     return nullptr;
 }
 
-void webkit_web_extension_match_pattern_register_custom_URL_scheme(const gchar* urlScheme)
+void webkit_web_extension_match_pattern_register_custom_url_scheme(const gchar* urlScheme)
 {
     return;
 }

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebExtensionMatchPattern.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebExtensionMatchPattern.h.in
@@ -76,6 +76,9 @@ webkit_web_extension_match_pattern_new_with_scheme (const gchar  *scheme,
                                                     GError      **error);
 
 WEBKIT_API void
+webkit_web_extension_match_pattern_register_custom_url_scheme (const gchar *urlScheme);
+
+WEBKIT_DEPRECATED_FOR(webkit_web_extension_match_pattern_register_custom_url_scheme) void
 webkit_web_extension_match_pattern_register_custom_URL_scheme (const gchar *urlScheme);
 
 WEBKIT_API const gchar *

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebExtensionMatchPattern.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebExtensionMatchPattern.cpp
@@ -961,7 +961,7 @@ static void testCustomURLScheme(Test*, gconstpointer)
     g_assert_null(toPattern("bar", "*", "/", &error.outPtr()));
     g_assert_cmpstr(error.get()->message, ==, "Scheme \"bar\" is invalid.");
 
-    webkit_web_extension_match_pattern_register_custom_URL_scheme("foo");
+    webkit_web_extension_match_pattern_register_custom_url_scheme("foo");
 
     g_assert_nonnull(toPattern("foo", "*", "/", &error.outPtr()));
     g_assert_no_error(error.get());
@@ -969,7 +969,7 @@ static void testCustomURLScheme(Test*, gconstpointer)
     g_assert_null(toPattern("bar", "*", "/", &error.outPtr()));
     g_assert_cmpstr(error.get()->message, ==, "Scheme \"bar\" is invalid.");
 
-    webkit_web_extension_match_pattern_register_custom_URL_scheme("bar");
+    webkit_web_extension_match_pattern_register_custom_url_scheme("bar");
 
     g_assert_nonnull(toPattern("foo", "*", "/", &error.outPtr()));
     g_assert_no_error(error.get());


### PR DESCRIPTION
#### f2ee8ad67867cf0c9e8e9587f6f0376e7b954792
<pre>
Change casing of register_custom_url_scheme
<a href="https://bugs.webkit.org/show_bug.cgi?id=300324">https://bugs.webkit.org/show_bug.cgi?id=300324</a>

Reviewed by Michael Catanzaro and Adrian Perez de Castro.

This function should be webkit_web_extension_match_pattern_register_custom_url_scheme, with the lowercased URL.

Test: Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebExtensionMatchPattern.cpp
* Source/WebKit/UIProcess/API/glib/WebKitWebExtensionMatchPattern.cpp:
(webkit_web_extension_match_pattern_register_custom_url_scheme):
(webkit_web_extension_match_pattern_register_custom_URL_scheme): Deleted.
* Source/WebKit/UIProcess/API/glib/WebKitWebExtensionMatchPattern.h.in:
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebExtensionMatchPattern.cpp:
(testCustomURLScheme):

Canonical link: <a href="https://commits.webkit.org/301230@main">https://commits.webkit.org/301230@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e148406b95c94f4c904f3e542b373de9cde2fd5a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125077 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44745 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35483 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131925 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77146 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/126954 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45436 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53310 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95212 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/63313 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128031 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36272 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111853 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75753 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35182 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30007 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75406 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106036 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30236 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134603 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51895 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39689 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103682 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52322 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108065 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103455 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26398 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48795 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27082 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/48948 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51782 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57574 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51154 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54510 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52845 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->