### PR TITLE
Address safer CPP warnings in AuthenticationChallengeProxyCocoa

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
@@ -62,7 +62,6 @@ UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm
 UIProcess/API/Cocoa/_WKWebPushAction.mm
 UIProcess/API/mac/WKWebViewMac.mm
 UIProcess/API/mac/WKWebViewTestingMac.mm
-UIProcess/Authentication/cocoa/AuthenticationChallengeProxyCocoa.mm
 UIProcess/Automation/mac/WebAutomationSessionMac.mm
 UIProcess/Cocoa/UIDelegate.mm
 UIProcess/Cocoa/WKStorageAccessAlert.mm

--- a/Source/WebKit/UIProcess/Authentication/cocoa/SecKeyProxyStore.h
+++ b/Source/WebKit/UIProcess/Authentication/cocoa/SecKeyProxyStore.h
@@ -50,7 +50,7 @@ public:
 private:
     SecKeyProxyStore() = default;
 
-    RetainPtr<SecKeyProxy> m_secKeyProxy;
+    const RetainPtr<SecKeyProxy> m_secKeyProxy;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Authentication/cocoa/SecKeyProxyStore.mm
+++ b/Source/WebKit/UIProcess/Authentication/cocoa/SecKeyProxyStore.mm
@@ -38,7 +38,7 @@ bool SecKeyProxyStore::initialize(const WebCore::Credential& credential)
     if (!credential.isEmpty()) {
         RetainPtr nsCredential = credential.nsCredential();
         if (RetainPtr identity = [nsCredential.get() identity])
-            m_secKeyProxy = adoptNS([[SecKeyProxy alloc] initWithIdentity:identity.get()]);
+            lazyInitialize(m_secKeyProxy, adoptNS([[SecKeyProxy alloc] initWithIdentity:identity.get()]));
     }
     return isInitialized();
 }


### PR DESCRIPTION
#### ef7832d91846d4a9f6e39830989b7d5ed1b2b4a4
<pre>
Address safer CPP warnings in AuthenticationChallengeProxyCocoa
<a href="https://bugs.webkit.org/show_bug.cgi?id=300325">https://bugs.webkit.org/show_bug.cgi?id=300325</a>

Reviewed by Chris Dumez.

* Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations:
* Source/WebKit/UIProcess/Authentication/cocoa/AuthenticationChallengeProxyCocoa.mm:
(WebKit::AuthenticationChallengeProxy::sendClientCertificateCredentialOverXpc):
* Source/WebKit/UIProcess/Authentication/cocoa/SecKeyProxyStore.h:
* Source/WebKit/UIProcess/Authentication/cocoa/SecKeyProxyStore.mm:
(WebKit::SecKeyProxyStore::initialize):

Canonical link: <a href="https://commits.webkit.org/301225@main">https://commits.webkit.org/301225@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3e3c4a2e5dc1e0da93fe64c3bd8fbd80b44736e2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125257 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44924 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35663 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132108 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77126 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45615 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53512 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95368 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/63302 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128211 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36421 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112009 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75908 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35320 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75587 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106188 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30402 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134791 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52066 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39867 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103832 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52501 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108230 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103600 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26396 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48956 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27242 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49162 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51958 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57737 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51322 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54676 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53014 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->