### PR TITLE
[github perf] Deduplicate invalidation selectors

### DIFF
--- a/Source/WebCore/css/CSSSelectorList.cpp
+++ b/Source/WebCore/css/CSSSelectorList.cpp
@@ -257,4 +257,15 @@ bool CSSSelectorList::hasOnlyNestingSelector() const
     return singleSelector->match() == CSSSelector::Match::NestingParent;
 }
 
+bool CSSSelectorList::operator==(const CSSSelectorList& other) const
+{
+    for (auto a = begin(), b = other.begin(); a != end() || b != other.end(); ++a, ++b) {
+        if (a == end() || b == other.end())
+            return false;
+        if (!complexSelectorsEqual(*a, *b))
+            return false;
+    }
+    return true;
+}
+
 } // namespace WebCore

--- a/Source/WebCore/css/CSSSelectorList.h
+++ b/Source/WebCore/css/CSSSelectorList.h
@@ -114,6 +114,8 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     CSSSelectorList& operator=(CSSSelectorList&&) = default;
 
+    bool operator==(const CSSSelectorList&) const;
+
 private:
     // End of a multipart selector is indicated by m_isLastInComplexSelector bit in the last item.
     // End of the array is indicated by m_isLastInSelectorList bit in the last item.

--- a/Source/WebCore/style/RuleFeature.cpp
+++ b/Source/WebCore/style/RuleFeature.cpp
@@ -127,6 +127,10 @@ RuleAndSelector::RuleAndSelector(const RuleData& ruleData)
     ASSERT(selectorListIndex == ruleData.selectorListIndex());
 }
 
+const CSSSelector& RuleAndSelector::selector() const
+{
+    return *styleRule->selectorList().selectorAt(selectorIndex);
+}
 
 RuleFeature::RuleFeature(const RuleData& ruleData, MatchElement matchElement, IsNegation isNegation)
     : RuleAndSelector(ruleData)
@@ -139,6 +143,20 @@ RuleFeatureWithInvalidationSelector::RuleFeatureWithInvalidationSelector(const R
     : RuleFeature(data, matchElement, isNegation)
     , invalidationSelector(WTFMove(invalidationSelector))
 {
+}
+
+
+static bool equalIgnoringPseudoElement(const RuleFeature& a, const RuleFeature& b)
+{
+    return a.matchElement == b.matchElement
+        && a.isNegation == b.isNegation
+        && complexSelectorsEqual(a.selector(), b.selector(), ComplexSelectorsEqualMode::IgnoreNonElementBackedPseudoElements);
+}
+
+static bool equalIgnoringPseudoElement(const RuleFeatureWithInvalidationSelector& a, const RuleFeatureWithInvalidationSelector& b)
+{
+    return equalIgnoringPseudoElement(static_cast<RuleFeature>(a), static_cast<RuleFeature>(b))
+        && a.invalidationSelector == b.invalidationSelector;
 }
 
 static MatchElement computeNextMatchElement(MatchElement matchElement, CSSSelector::Relation relation)
@@ -444,14 +462,34 @@ void RuleFeatureSet::collectFeatures(const RuleData& ruleData, const Vector<Ref<
     if (ruleData.usedRuleTypes().contains(UsedRuleType::StartingStyle))
         hasStartingStyleRules = true;
 
+    auto addToVectorDeduplicating = [](auto& featureVector, auto&& featureToAdd) {
+        // FIXME: Make selectors hashable.
+        constexpr auto maximumSearchCount = 32;
+        auto count = 0;
+        for (auto& existing : makeReversedRange(featureVector)) {
+            if (++count > maximumSearchCount)
+                break;
+            // Selectors like '.foo' and '.foo::before' are equal for invalidation as they both invalidate the generating element.
+            if (equalIgnoringPseudoElement(existing, featureToAdd))
+                return;
+        }
+        featureVector.append(WTFMove(featureToAdd));
+    };
+
     auto addToMap = [&]<typename HostAffectingNames>(auto& map, auto& entries, HostAffectingNames hostAffectingNames) {
         for (auto& entry : entries) {
             auto& [selector, matchElement, isNegation] = entry;
             auto& name = selector->value();
 
-            map.ensure(name, [] {
+            auto& featureVector = *map.ensure(name, [] {
                 return makeUnique<RuleFeatureVector>();
-            }).iterator->value->append({ ruleData, matchElement, isNegation });
+            }).iterator->value;
+
+            addToVectorDeduplicating(featureVector, RuleFeature {
+                ruleData,
+                matchElement,
+                isNegation
+            });
 
             setUsesMatchElement(matchElement);
 
@@ -467,14 +505,17 @@ void RuleFeatureSet::collectFeatures(const RuleData& ruleData, const Vector<Ref<
 
     for (auto& entry : selectorFeatures.attributes) {
         auto& [selector, matchElement, isNegation] = entry;
-        attributeRules.ensure(selector->attribute().localNameLowercase(), [] {
+        auto& featureVector = *attributeRules.ensure(selector->attribute().localNameLowercase(), [] {
             return makeUnique<Vector<RuleFeatureWithInvalidationSelector>>();
-        }).iterator->value->append({
+        }).iterator->value;
+
+        addToVectorDeduplicating(featureVector, RuleFeatureWithInvalidationSelector {
             ruleData,
             matchElement,
             isNegation,
             CSSSelectorList::makeCopyingSimpleSelector(*selector)
         });
+
         if (matchElement == MatchElement::Host)
             attributesAffectingHost.add(selector->attribute().localNameLowercase());
         setUsesMatchElement(matchElement);
@@ -482,9 +523,15 @@ void RuleFeatureSet::collectFeatures(const RuleData& ruleData, const Vector<Ref<
 
     for (auto& entry : selectorFeatures.pseudoClasses) {
         auto& [selector, matchElement, isNegation] = entry;
-        pseudoClassRules.ensure(makePseudoClassInvalidationKey(selector->pseudoClass(), *selector), [] {
+        auto& featureVector = *pseudoClassRules.ensure(makePseudoClassInvalidationKey(selector->pseudoClass(), *selector), [] {
             return makeUnique<Vector<RuleFeature>>();
-        }).iterator->value->append({ ruleData, matchElement, isNegation });
+        }).iterator->value;
+
+        addToVectorDeduplicating(featureVector, RuleFeature {
+            ruleData,
+            matchElement,
+            isNegation
+        });
 
         if (matchElement == MatchElement::Host)
             pseudoClassesAffectingHost.add(selector->pseudoClass());
@@ -496,9 +543,11 @@ void RuleFeatureSet::collectFeatures(const RuleData& ruleData, const Vector<Ref<
     for (auto& entry : selectorFeatures.hasPseudoClasses) {
         auto& [selector, matchElement, isNegation, doesBreakScope] = entry;
         // The selector argument points to a selector inside :has() selector list instead of :has() itself.
-        hasPseudoClassRules.ensure(makePseudoClassInvalidationKey(CSSSelector::PseudoClass::Has, *selector), [] {
+        auto& featureVector = *hasPseudoClassRules.ensure(makePseudoClassInvalidationKey(CSSSelector::PseudoClass::Has, *selector), [] {
             return makeUnique<Vector<RuleFeatureWithInvalidationSelector>>();
-        }).iterator->value->append({
+        }).iterator->value;
+
+        addToVectorDeduplicating(featureVector, RuleFeatureWithInvalidationSelector {
             ruleData,
             matchElement,
             isNegation,

--- a/Source/WebCore/style/RuleFeature.h
+++ b/Source/WebCore/style/RuleFeature.h
@@ -82,6 +82,8 @@ struct RuleAndSelector {
     RefPtr<const StyleRule> styleRule;
     uint16_t selectorIndex; // Keep in sync with RuleData's selectorIndex size.
     uint16_t selectorListIndex; // Keep in sync with RuleData's selectorListIndex size.
+
+    const CSSSelector& selector() const;
 };
 
 struct RuleFeature : public RuleAndSelector {


### PR DESCRIPTION
#### 0fdbbfbe25ea91a8952f14f72cc8175183aeaa72
<pre>
[github perf] Deduplicate invalidation selectors
<a href="https://bugs.webkit.org/show_bug.cgi?id=300327">https://bugs.webkit.org/show_bug.cgi?id=300327</a>
<a href="https://rdar.apple.com/162120232">rdar://162120232</a>

Reviewed by Alan Baradlay.

We may end up with multiple copies of the same selector in invalidation RuleSets if the
same selector is repeated in the stylesheets.

We also unnecessarily include pseudo-elements to these RuleSets as most pseudo-elements
invalidate their originating element.

* Source/WebCore/css/CSSSelector.cpp:
(WebCore::CSSSelector::RareData::equals const):
(WebCore::CSSSelector::simpleSelectorEqual const):
(WebCore::isElementBackedPseudoElement):
(WebCore::complexSelectorsEqual):

Add selector equality test functions. Allow testing equality while ignoring pseudo-elements.

* Source/WebCore/css/CSSSelector.h:
* Source/WebCore/css/CSSSelectorList.cpp:
(WebCore::CSSSelectorList::operator== const):
* Source/WebCore/css/CSSSelectorList.h:
* Source/WebCore/style/RuleFeature.cpp:
(WebCore::Style::RuleAndSelector::selector const):
(WebCore::Style::equalIgnoringPseudoElement):
(WebCore::Style::RuleFeatureSet::collectFeatures):

Try to deduplicate newly added RuleFeatures against the existing ones.

* Source/WebCore/style/RuleFeature.h:
* Source/WebCore/style/StyleScopeRuleSets.cpp:
(WebCore::Style::ensureInvalidationRuleSets):

Also deduplicate invalidation selectors.

Canonical link: <a href="https://commits.webkit.org/302297@main">https://commits.webkit.org/302297@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/57cbd0767fc9040e9937740814a7c85a317e52ce

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128639 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/905 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39472 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/136028 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/80042 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/27450598-a3b1-4df6-9631-4b55a3da2a0b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/130511 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/852 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/780 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97926 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65841 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/dc0fab30-7fc4-4d09-9710-da406c29e74c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131587 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/630 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/115257 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78545 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9fed3b19-35f9-4cbe-8674-0f8174a1f1ef) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/566 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/33366 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/79309 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/109011 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33846 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138481 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/733 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/698 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106462 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/780 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111596 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106285 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27070 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/618 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/30125 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/53096 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/793 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/64037 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/659 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/716 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/742 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->