### PR TITLE
Crash in WebKit: WebKit::WebExtensionContext::declarativeNetRequestUpdateDynamicRules

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/API/WebExtensionContextAPIDeclarativeNetRequest.cpp
+++ b/Source/WebKit/UIProcess/Extensions/API/WebExtensionContextAPIDeclarativeNetRequest.cpp
@@ -171,7 +171,13 @@ void WebExtensionContext::declarativeNetRequestUpdateDynamicRules(String&& rules
         return ruleID;
     });
 
-    auto rulesToAdd = JSON::Value::parseJSON(rulesToAddJSON)->asArray();
+    Ref rulesToAdd = JSON::Array::create();
+    if (!rulesToAddJSON.isEmpty()) {
+        if (RefPtr parsedJSON = JSON::Value::parseJSON(rulesToAddJSON)) {
+            if (RefPtr rulesArray = parsedJSON->asArray())
+                rulesToAdd = *rulesArray;
+        }
+    }
 
     if (!ruleIDsToDelete.size() && !rulesToAdd->length()) {
         completionHandler({ });
@@ -184,7 +190,7 @@ void WebExtensionContext::declarativeNetRequestUpdateDynamicRules(String&& rules
         return;
     }
 
-    updateDeclarativeNetRequestRulesInStorage(declarativeNetRequestDynamicRulesStore(), "dynamic"_s, apiName, *rulesToAdd, ruleIDsToDelete, WTFMove(completionHandler));
+    updateDeclarativeNetRequestRulesInStorage(declarativeNetRequestDynamicRulesStore(), "dynamic"_s, apiName, rulesToAdd, ruleIDsToDelete, WTFMove(completionHandler));
 }
 
 void WebExtensionContext::declarativeNetRequestGetSessionRules(Vector<double>&& filter, CompletionHandler<void(Expected<String, WebExtensionError>&&)>&& completionHandler)
@@ -216,7 +222,13 @@ void WebExtensionContext::declarativeNetRequestUpdateSessionRules(String&& rules
         return ruleID;
     });
 
-    auto rulesToAdd = JSON::Value::parseJSON(rulesToAddJSON)->asArray();
+    Ref rulesToAdd = JSON::Array::create();
+    if (!rulesToAddJSON.isEmpty()) {
+        if (RefPtr parsedJSON = JSON::Value::parseJSON(rulesToAddJSON)) {
+            if (RefPtr rulesArray = parsedJSON->asArray())
+                rulesToAdd = *rulesArray;
+        }
+    }
 
     if (!ruleIDsToDelete.size() && !rulesToAdd->length()) {
         completionHandler({ });
@@ -229,7 +241,7 @@ void WebExtensionContext::declarativeNetRequestUpdateSessionRules(String&& rules
         return;
     }
 
-    updateDeclarativeNetRequestRulesInStorage(declarativeNetRequestSessionRulesStore(), "session"_s, apiName, *rulesToAdd, ruleIDsToDelete, WTFMove(completionHandler));
+    updateDeclarativeNetRequestRulesInStorage(declarativeNetRequestSessionRulesStore(), "session"_s, apiName, rulesToAdd, ruleIDsToDelete, WTFMove(completionHandler));
 }
 
 } // namespace WebKit

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDeclarativeNetRequest.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDeclarativeNetRequest.mm
@@ -583,6 +583,37 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, GetSessionRules)
     Util::loadAndRunExtension(declarativeNetRequestManifest, @{ @"background.js": backgroundScript  });
 }
 
+TEST(WKWebExtensionAPIDeclarativeNetRequest, RemoveSessionRules)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"let sessionRules = await browser.declarativeNetRequest.getSessionRules()",
+        @"browser.test.assertEq(sessionRules.length, 0)",
+
+        @"await browser.declarativeNetRequest.updateSessionRules({ addRules: [{ id: 1, priority: 1, action: {type: 'block'}, condition: { urlFilter: 'foo' } }] })",
+        @"await browser.declarativeNetRequest.updateSessionRules({ addRules: [{ id: 2, priority: 1, action: {type: 'block'}, condition: { urlFilter: 'bar' } }] })",
+        @"await browser.declarativeNetRequest.updateSessionRules({ addRules: [{ id: 3, priority: 1, action: {type: 'block'}, condition: { urlFilter: 'baz' } }] })",
+
+        @"sessionRules = await browser.declarativeNetRequest.getSessionRules({ })",
+        @"browser.test.assertEq(sessionRules.length, 3)",
+
+        // FIXME: rdar://162148560 (Unable to remove all dynamic or session rules)
+        @"await browser.declarativeNetRequest.updateSessionRules({ removeRuleIds: [1, 2] })",
+
+        @"sessionRules = await browser.declarativeNetRequest.getSessionRules({ })",
+        @"browser.test.assertEq(sessionRules.length, 1)",
+
+        @"browser.test.notifyPass()"
+    ]);
+
+    auto *declarativeNetRequestManifest = @{
+        @"manifest_version": @3,
+        @"permissions": @[ @"declarativeNetRequest" ],
+        @"background": @{ @"scripts": @[ @"background.js" ], @"type": @"module", @"persistent": @NO },
+    };
+
+    Util::loadAndRunExtension(declarativeNetRequestManifest, @{ @"background.js": backgroundScript  });
+}
+
 TEST(WKWebExtensionAPIDeclarativeNetRequest, DynamicRules)
 {
     TestWebKitAPI::HTTPServer server({
@@ -699,6 +730,37 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, GetDynamicRules)
         @"browser.test.assertEq(dynamicRules[0].id, 1)",
         @"browser.test.assertEq(dynamicRules[1].id, 2)",
         @"browser.test.assertEq(dynamicRules[2].id, 3)",
+
+        @"browser.test.notifyPass()"
+    ]);
+
+    auto *declarativeNetRequestManifest = @{
+        @"manifest_version": @3,
+        @"permissions": @[ @"declarativeNetRequest" ],
+        @"background": @{ @"scripts": @[ @"background.js" ], @"type": @"module", @"persistent": @NO },
+    };
+
+    Util::loadAndRunExtension(declarativeNetRequestManifest, @{ @"background.js": backgroundScript  });
+}
+
+TEST(WKWebExtensionAPIDeclarativeNetRequest, RemoveDynamicRules)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"let dynamicRules = await browser.declarativeNetRequest.getDynamicRules()",
+        @"browser.test.assertEq(dynamicRules.length, 0)",
+
+        @"await browser.declarativeNetRequest.updateDynamicRules({ addRules: [{ id: 1, priority: 1, action: {type: 'block'}, condition: { urlFilter: 'foo' } }] })",
+        @"await browser.declarativeNetRequest.updateDynamicRules({ addRules: [{ id: 2, priority: 1, action: {type: 'block'}, condition: { urlFilter: 'bar' } }] })",
+        @"await browser.declarativeNetRequest.updateDynamicRules({ addRules: [{ id: 3, priority: 1, action: {type: 'block'}, condition: { urlFilter: 'baz' } }] })",
+
+        @"dynamicRules = await browser.declarativeNetRequest.getDynamicRules({ })",
+        @"browser.test.assertEq(dynamicRules.length, 3)",
+
+        // FIXME: rdar://162148560 (Unable to remove all dynamic or session rules)
+        @"await browser.declarativeNetRequest.updateDynamicRules({ removeRuleIds: [1, 2] })",
+
+        @"dynamicRules = await browser.declarativeNetRequest.getDynamicRules({ })",
+        @"browser.test.assertEq(dynamicRules.length, 1)",
 
         @"browser.test.notifyPass()"
     ]);


### PR DESCRIPTION
#### a8daa1741f67d91cfe554dcd62019946165db6fb
<pre>
Crash in WebKit: WebKit::WebExtensionContext::declarativeNetRequestUpdateDynamicRules
<a href="https://bugs.webkit.org/show_bug.cgi?id=300330">https://bugs.webkit.org/show_bug.cgi?id=300330</a>
<a href="https://rdar.apple.com/161999838">rdar://161999838</a>

Reviewed by Brian Weinstein and Timothy Hatcher.

This patch fixes a crash when updating dynamic or session rules with an empty addRules key. To fix
this, we just need to check that the string is not empty prior to trying to parse it as a JSON
array.

Wrote a new test to validate the fix.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDeclarativeNetRequest.mm
* Source/WebKit/UIProcess/Extensions/API/WebExtensionContextAPIDeclarativeNetRequest.cpp:
(WebKit::WebExtensionContext::declarativeNetRequestUpdateDynamicRules):
(WebKit::WebExtensionContext::declarativeNetRequestUpdateSessionRules):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDeclarativeNetRequest.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, RemoveSessionRules)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, RemoveDynamicRules)):

Canonical link: <a href="https://commits.webkit.org/301212@main">https://commits.webkit.org/301212@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/165269fdbf57f19c51cdad45fd820a68b21c0d5b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125266 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44933 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35672 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/132117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/77139 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127143 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45624 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53494 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/132117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/77139 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128220 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/36430 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/112022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/132117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/35329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/30190 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/75596 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/106197 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/30415 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/134800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52075 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/39853 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/134800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52510 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/108243 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/134800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/48966 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/27255 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49179 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19615 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51967 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/57746 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51331 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54685 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/53023 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->