### PR TITLE
[World Leaks] Fix leaks in LayoutTests/imported/w3c/web-platform-tests/scroll-animations/

### DIFF
--- a/LayoutTests/animations/animation-timeline-does-not-leak-expected.txt
+++ b/LayoutTests/animations/animation-timeline-does-not-leak-expected.txt
@@ -1,0 +1,10 @@
+Tests that animations with animation-timeline:none do not leak the document object
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS The iframe document didn't leak.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/animations/animation-timeline-does-not-leak.html
+++ b/LayoutTests/animations/animation-timeline-does-not-leak.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+</head>
+<body>
+<script src="../resources/js-test.js"></script>
+<script src="../resources/document-leak-test.js"></script>
+<script>
+    description("Tests that animations with animation-timeline:none do not leak the document object");
+    onload = () => runDocumentLeakTest({ frameURL: "resources/animation-timeline-leak-test.html", framesToCreate: 20 });
+</script>
+</body>
+</html>

--- a/LayoutTests/animations/resources/animation-timeline-leak-test.html
+++ b/LayoutTests/animations/resources/animation-timeline-leak-test.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<body>
+<style>
+  @keyframes expand {
+    from { width: 100px; }
+    to { width: 200px; }
+  }
+
+  .test {
+    width: 0px;
+    animation-name: expand;
+    animation-duration: 1s;
+  }
+
+  #element_unknown_timeline {
+    animation-timeline: --unknown_timeline;
+  }
+</style>
+<div class=test id=element_unknown_timeline></div>
+<script>
+let elem = document.getElementById('element_unknown_timeline');
+getComputedStyle(elem).width;
+onload = () => parent.postMessage("iframeLoaded");
+</script>
+</body>
+</html>

--- a/Source/WebCore/animation/WebAnimation.cpp
+++ b/Source/WebCore/animation/WebAnimation.cpp
@@ -1645,6 +1645,7 @@ void WebAnimation::stop()
 {
     ActiveDOMObject::stop();
     removeAllEventListeners();
+    setEffectInternal(nullptr);
 }
 
 bool WebAnimation::virtualHasPendingActivity() const


### PR DESCRIPTION
#### 56f36c24abfdf7d5b1be8dc65698c77064fe34a6
<pre>
[World Leaks] Fix leaks in LayoutTests/imported/w3c/web-platform-tests/scroll-animations/
<a href="https://bugs.webkit.org/show_bug.cgi?id=300333">https://bugs.webkit.org/show_bug.cgi?id=300333</a>
<a href="https://rdar.apple.com/162132950">rdar://162132950</a>

Reviewed by Antoine Quint.

Change WebAnimation::stop() such that upon stopping a WebAnimation we also remove the effect
by calling setEffectInternal(nullptr). This fixes approximately 10 leaky tests.

Test: animations/animation-timeline-does-not-leak.html

* LayoutTests/animations/animation-timeline-does-not-leak-expected.txt: Added.
* LayoutTests/animations/animation-timeline-does-not-leak.html: Added.
* LayoutTests/animations/resources/animation-timeline-leak-test.html: Added.
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::stop):

Canonical link: <a href="https://commits.webkit.org/301956@main">https://commits.webkit.org/301956@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a16556ea7a2c8c018a5d2f656d27bb03cec268af

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/126058 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45711 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36491 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132881 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77872 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127929 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/46381 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/54256 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95999 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/64099 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/129006 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/37106 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112730 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76488 "Found 1 new API test failure: WPE/TestWebKitWebContext:/webkit/WebKitWebContext/no-web-process-leak (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/36011 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30915 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/76353 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106888 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/31135 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135581 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52815 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40546 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104493 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/53272 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108948 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/104210 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26850 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49611 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27937 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/50193 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52712 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58545 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/52046 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/55393 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53750 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->