### PR TITLE
Enable WebKitSwiftOverlay on internal watchOS and tvOS builds

### DIFF
--- a/Source/WebKit/Scripts/generate-swift-availability-macros
+++ b/Source/WebKit/Scripts/generate-swift-availability-macros
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 for search_path in "${BUILT_PRODUCTS_DIR}" "${SDKROOT}"; do
     candidate="${search_path}/usr/local/include/WebKitAdditions/Scripts/postprocess-framework-headers-definitions"
@@ -12,27 +12,27 @@ done
 
 if [[ "${WK_PLATFORM_NAME}" == "macosx" ]]; then
     [[ -n ${OSX_VERSION} ]] || OSX_VERSION=${MACOSX_DEPLOYMENT_TARGET}
-    [[ -n ${XROS_VERSION} ]] || XROS_VERSION="9999"
-    [[ -n ${IOS_VERSION} ]] || IOS_VERSION="9999"
 elif [[ "${WK_PLATFORM_NAME}" == "maccatalyst" ]]; then
     # On Mac Catalyst `LLVM_TARGET_TRIPLE_OS_VERSION` will be in the format `ios{major}.{minor}`.
     [[ -n ${IOS_VERSION} ]] || IOS_VERSION=${LLVM_TARGET_TRIPLE_OS_VERSION#ios}
-    [[ -n ${XROS_VERSION} ]] || XROS_VERSION="9999"
-    [[ -n ${OSX_VERSION} ]] || OSX_VERSION="9999"
 elif [[ "${WK_PLATFORM_NAME}" =~ "iphone" ]]; then
     [[ -n ${IOS_VERSION} ]] || IOS_VERSION=${IPHONEOS_DEPLOYMENT_TARGET}
-    [[ -n ${XROS_VERSION} ]] || XROS_VERSION="9999"
-    [[ -n ${OSX_VERSION} ]] || OSX_VERSION="9999"
 elif [[ "${PLATFORM_NAME}" == xr* ]]; then
     [[ -n ${XROS_VERSION} ]] || XROS_VERSION=${XROS_DEPLOYMENT_TARGET}
-    [[ -n ${IOS_VERSION} ]] || IOS_VERSION="9999"
-    [[ -n ${OSX_VERSION} ]] || OSX_VERSION="9999"
-else
-    [[ -n ${OSX_VERSION} ]] || OSX_VERSION="9999"
-    [[ -n ${XROS_VERSION} ]] || XROS_VERSION="9999"
-    [[ -n ${IOS_VERSION} ]] || IOS_VERSION="9999"
+elif [[ "${PLATFORM_NAME}" == watch* ]]; then
+    [[ -n ${WATCHOS_VERSION} ]] || WATCHOS_VERSION=${WATCHOS_DEPLOYMENT_TARGET}
+elif [[ "${PLATFORM_NAME}" == appletv* ]]; then
+    [[ -n ${TVOS_VERSION} ]] | TVOS_VERSION=${TVOS_DEPLOYMENT_TARGET}
 fi
+
+[[ -n ${OSX_VERSION} ]] || OSX_VERSION="9999"
+[[ -n ${IOS_VERSION} ]] || IOS_VERSION="9999"
+[[ -n ${XROS_VERSION} ]] || XROS_VERSION="9999"
+[[ -n ${WATCHOS_VERSION} ]] || WATCHOS_VERSION="9999"
+[[ -n ${TVOS_VERSION} ]] || TVOS_VERSION="9999"
 
 echo "-Xfrontend -define-availability -Xfrontend \"WK_IOS_TBA:iOS ${IOS_VERSION}\"" \
     "-Xfrontend -define-availability -Xfrontend \"WK_MAC_TBA:macOS ${OSX_VERSION}\"" \
-    "-Xfrontend -define-availability -Xfrontend \"WK_XROS_TBA:visionOS ${XROS_VERSION}\"" | tee "${SCRIPT_OUTPUT_FILE_0}"
+    "-Xfrontend -define-availability -Xfrontend \"WK_XROS_TBA:visionOS ${XROS_VERSION}\"" \
+    "-Xfrontend -define-availability -Xfrontend \"WK_WATCHOS_TBA:watchOS ${WATCHOS_VERSION}\"" \
+    "-Xfrontend -define-availability -Xfrontend \"WK_TVOS_TBA:tvOS ${TVOS_VERSION}\"" | tee "${SCRIPT_OUTPUT_FILE_0}"

--- a/Source/WebKit/Scripts/postprocess-header-rule
+++ b/Source/WebKit/Scripts/postprocess-header-rule
@@ -40,22 +40,23 @@ done
 if [[ "${WK_FRAMEWORK_HEADER_POSTPROCESSING_DISABLED}" != "YES" ]]; then
     if [[ "${WK_PLATFORM_NAME}" == "macosx" ]]; then
         [[ -n ${OSX_VERSION} ]] || OSX_VERSION=${MACOSX_DEPLOYMENT_TARGET}
-        [[ -n ${XROS_VERSION} ]] || XROS_VERSION="NA"
-        [[ -n ${IOS_VERSION} ]] || IOS_VERSION="NA"
     elif [[ "${WK_PLATFORM_NAME}" == "maccatalyst" ]]; then
         # On Mac Catalyst `LLVM_TARGET_TRIPLE_OS_VERSION` will be in the format `ios{major}.{minor}`.
         [[ -n ${IOS_VERSION} ]] || IOS_VERSION=${LLVM_TARGET_TRIPLE_OS_VERSION#ios}
-        [[ -n ${XROS_VERSION} ]] || XROS_VERSION="NA"
-        [[ -n ${OSX_VERSION} ]] || OSX_VERSION="NA"
     elif [[ "${WK_PLATFORM_NAME}" =~ "iphone" ]]; then
         [[ -n ${IOS_VERSION} ]] || IOS_VERSION=${IPHONEOS_DEPLOYMENT_TARGET}
-        [[ -n ${XROS_VERSION} ]] || XROS_VERSION="NA"
-        [[ -n ${OSX_VERSION} ]] || OSX_VERSION="NA"
     elif [[ "${PLATFORM_NAME}" == xr* ]]; then
         [[ -n ${XROS_VERSION} ]] || XROS_VERSION=${XROS_DEPLOYMENT_TARGET}
-        [[ -n ${IOS_VERSION} ]] || IOS_VERSION="NA"
-        [[ -n ${OSX_VERSION} ]] || OSX_VERSION="NA"
+    elif [[ "${PLATFORM_NAME}" == watch* ]]; then
+        [[ -n ${WATCHOS_VERSION} ]] || WATCHOS_VERSION=${WATCHOS_DEPLOYMENT_TARGET}
+    elif [[ "${PLATFORM_NAME}" == appletv* ]]; then
+        [[ -n ${TVOS_VERSION} ]] | TVOS_VERSION=${TVOS_DEPLOYMENT_TARGET}
     fi
+    [[ -n ${OSX_VERSION} ]] || OSX_VERSION="NA"
+    [[ -n ${XROS_VERSION} ]] || XROS_VERSION="NA"
+    [[ -n ${IOS_VERSION} ]] || IOS_VERSION="NA"
+    [[ -n ${WATCHOS_VERSION} ]] || WATCHOS_VERSION="NA"
+    [[ -n ${TVOS_VERSION} ]] || TVOS_VERSION="NA"
 
     SED_OPTIONS=()
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WebKitSwiftOverlay.swift
+++ b/Source/WebKit/UIProcess/API/Cocoa/WebKitSwiftOverlay.swift
@@ -23,7 +23,7 @@
 
 // FIXME: Eliminate this file since the refined API can now just go with the rest of the normal API where it belongs.
 
-#if !os(tvOS) && !os(watchOS)
+#if USE_APPLE_INTERNAL_SDK || (!os(tvOS) && !os(watchOS))
 
 // Older versions of the Swift compiler fail to import WebKit_Private. Can be
 // removed when WebKit drops support for macOS Sonoma.
@@ -32,6 +32,7 @@ internal import WebKit_Private.WKWebExtensionPrivate
 #endif
 
 @available(iOS 14.0, macOS 10.16, *)
+@_spi_available(WK_WATCHOS_TBA, WK_TVOS_TBA, *)
 extension WKPDFConfiguration {
     // This is pre-existing API whose documentation does not use the source code.
     // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
@@ -42,6 +43,7 @@ extension WKPDFConfiguration {
 }
 
 @available(iOS 14.0, macOS 10.16, *)
+@_spi_available(WK_WATCHOS_TBA, WK_TVOS_TBA, *)
 extension WKWebView {
     // This is pre-existing API whose documentation does not use the source code.
     // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
@@ -100,6 +102,7 @@ extension WKWebView {
 }
 
 @available(iOS 15.0, macOS 12.0, *)
+@_spi_available(WK_WATCHOS_TBA, WK_TVOS_TBA, *)
 extension WKWebView {
     // This is pre-existing API whose documentation does not use the source code.
     // swift-format-ignore: AllPublicDeclarationsHaveDocumentation


### PR DESCRIPTION
#### 861609076b57914584d2fd237a98c3d471ba65de
<pre>
Enable WebKitSwiftOverlay on internal watchOS and tvOS builds
<a href="https://bugs.webkit.org/show_bug.cgi?id=300338">https://bugs.webkit.org/show_bug.cgi?id=300338</a>
<a href="https://rdar.apple.com/161606521">rdar://161606521</a>

Reviewed by Richard Robinson.

There are still issues using the open source watchOS and tvOS SDKs,
but internal SDKs don&apos;t have that same issue.  Enable for internal builds.

Swift requires that SPI declarations have an availability version in
order to use contemporary language features. Introduce support for
WK_WATCHOS_TBA and WK_TVOS_TBA availability versions and add
@_spi_available attributes to these declarations.

For completeness, also support these availability versions in ObjC
headers, although WebKit does not have precedent for using SPI_AVAILABLE
on SPI-only platforms.

* Source/WebKit/Scripts/generate-swift-availability-macros:
* Source/WebKit/Scripts/postprocess-header-rule:
* Source/WebKit/UIProcess/API/Cocoa/WebKitSwiftOverlay.swift:

Co-authored-by: Elliott Williams &lt;emw@apple.com&gt;
Canonical link: <a href="https://commits.webkit.org/302201@main">https://commits.webkit.org/302201@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/695fdc82c7d2b2e5521ee1fc323ef63566e8c48e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/128319 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/595 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/39151 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/135710 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/79788 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/905f64da-3594-44d4-b2d0-5b2eabb8d769) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/531 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/469 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/97672 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/65575 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/751a7aa2-7cea-4824-ac9b-1bc6a8872b10) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/131267 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/362 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/114956 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/78263 "Found 2 new API test failures: WPE/TestWebsiteData:/webkit/WebKitWebsiteData/itp, WPE/TestWebsiteData:/webkit/WebKitWebsiteData/configuration (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/47317b46-6cdd-4265-b036-1918a4df796e) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/127670 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/345 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/78998 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/108729 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/33547 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/138166 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/440 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/416 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/106210 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/479 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/111297 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/106010 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27019 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/352 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/29847 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/52750 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/491 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/63663 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/390 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/457 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/453 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->