### PR TITLE
[Gardening]: REGRESSION (300539@main): [ macOS Debug ] TestWebKitAPI.ContentExtensionTest.InvalidJSON is a consistent timeout

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebCore/ContentExtensions.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/ContentExtensions.cpp
@@ -1474,6 +1474,7 @@ TEST_F(ContentExtensionTest, MatchesEverything)
     testRequest(backend6, subResourceRequest("http://example.com/ignore"_s, "http://example.com/"_s, ResourceType::Script), { });
 }
 
+#if !PLATFORM(MAC) || defined(NDEBUG)
 TEST_F(ContentExtensionTest, InvalidJSON)
 {
     checkCompilerError("["_s, ContentExtensionError::JSONInvalid);
@@ -1629,6 +1630,7 @@ TEST_F(ContentExtensionTest, InvalidJSON)
     checkCompilerError("[{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\".*\"},\"_identifier\":[]}]"_s, ContentExtensionError::JSONInvalidRuleIdentifier);
     checkCompilerError("[{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\".*\"},\"_identifier\":{}}]"_s, ContentExtensionError::JSONInvalidRuleIdentifier);
 }
+#endif
 
 TEST_F(ContentExtensionTest, StrictPrefixSeparatedMachines1)
 {


### PR DESCRIPTION
#### caaaf6cef64c3443133e263d3ec51bedbb8e1fb4
<pre>
[Gardening]: REGRESSION (300539@main): [ macOS Debug ] TestWebKitAPI.ContentExtensionTest.InvalidJSON is a consistent timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=300348">https://bugs.webkit.org/show_bug.cgi?id=300348</a>
<a href="https://rdar.apple.com/162150695">rdar://162150695</a>

Unreviewed test gardening.

Disable API test for macOS debug.

* Tools/TestWebKitAPI/Tests/WebCore/ContentExtensions.cpp:

Canonical link: <a href="https://commits.webkit.org/301168@main">https://commits.webkit.org/301168@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6b20445ead1adf724f7aaedf3b5894c9a6ec2bde

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125145 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44812 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35551 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131995 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/77011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127022 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45503 "Failed to checkout and rebase branch from PR 51969") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53375 "Failed to checkout and rebase branch from PR 51969") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/95264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/77011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128099 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/130/builds/45503 "Failed to checkout and rebase branch from PR 51969") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/111915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/75806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/130/builds/45503 "Failed to checkout and rebase branch from PR 51969") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/30080 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/75473 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/130/builds/45503 "Failed to checkout and rebase branch from PR 51969") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/30308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/134674 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/51955 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/123/builds/53375 "Failed to checkout and rebase branch from PR 51969") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/134674 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52389 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/108136 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/134674 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/48854 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/27149 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49021 "Failed to checkout and rebase branch from PR 51969") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19601 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/51847 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/51214 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/54570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/52904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->