### PR TITLE
[CSS] Re-use element rule matching for pseudo-element style resolution

### DIFF
--- a/Source/WebCore/css/CSSSelector.cpp
+++ b/Source/WebCore/css/CSSSelector.cpp
@@ -995,6 +995,23 @@ bool complexSelectorMatchesElementBackedPseudoElement(const CSSSelector& complex
     return result;
 }
 
+bool complexSelectorMatchesOnlyPseudoElement(const CSSSelector& complexSelector)
+{
+    // Check if selector is pseudo-element-only (e.g., "::before" or "::before:hover")
+    // Returns true if the selector has no element part that can match actual elements.
+    if (!complexSelector.matchesPseudoElement())
+        return false;
+
+    // Walk through the selector chain looking for any element-matching parts
+    for (auto* selector = complexSelector.precedingInComplexSelector(); selector; selector = selector->precedingInComplexSelector()) {
+        // Pseudo-elements and pseudo-classes don't match elements, everything else does
+        if (!selector->matchesPseudoElement() && selector->match() != CSSSelector::Match::PseudoClass)
+            return false; // Found an element-matching part
+    }
+
+    return true; // Only pseudo-elements and pseudo-classes, no element part
+}
+
 bool CSSSelector::simpleSelectorEqual(const CSSSelector& other) const
 {
     auto valuesEqual = [&] {

--- a/Source/WebCore/css/CSSSelector.h
+++ b/Source/WebCore/css/CSSSelector.h
@@ -280,6 +280,7 @@ private:
 
 bool complexSelectorCanMatchPseudoElement(const CSSSelector&);
 bool complexSelectorMatchesElementBackedPseudoElement(const CSSSelector&);
+bool complexSelectorMatchesOnlyPseudoElement(const CSSSelector&);
 
 // In the AllowNonElementBackedPseudoElements mode `.foo::before` and `.foo` compare equal.
 enum class ComplexSelectorsEqualMode : bool { Full, IgnoreNonElementBackedPseudoElements };

--- a/Source/WebCore/css/SelectorChecker.cpp
+++ b/Source/WebCore/css/SelectorChecker.cpp
@@ -240,11 +240,16 @@ bool SelectorChecker::match(const CSSSelector& selector, const Element& element,
         return collectedPseudoElements.contains(requestedPseudoElement->type);
 
     if (collectedPseudoElements) {
-        if (checkingContext.resolvingMode == Mode::ResolvingStyle)
+        if (checkingContext.resolvingMode == Mode::ResolvingStyle) {
             checkingContext.publicPseudoElements = collectedPseudoElements & allPublicPseudoElementTypes;
-
+            // Allow the match to succeed so that pseudo-element rules can be collected during element matching.
+            // The selector has already been fully checked by this point (including the element part),
+            // so we return true to indicate that this rule applies to this element's pseudo-element.
+            return true;
+        }
         return checkingContext.resolvingMode == Mode::StyleInvalidation || result.matchType == MatchType::Element;
     }
+
     return true;
 }
 
@@ -492,10 +497,17 @@ SelectorChecker::MatchResult SelectorChecker::matchRecursively(CheckingContext& 
             nextContext.hasSelectionPseudo = collectedPseudoElements.contains(PseudoElementType::Selection);
             nextContext.hasViewTransitionPseudo = hasViewTransitionPseudoElement(collectedPseudoElements);
 
+            // Skip this check when collecting pseudo-element rules during element matching (ResolvingStyle mode without a requested pseudo-element).
+            // We need to continue checking the element part of the selector to determine if it matches.
+            // FIXME: not sure
+            bool collectingPseudoElementRulesDuringElementMatching = checkingContext.resolvingMode == Mode::ResolvingStyle && !context.requestedPseudoElement;
+
             if ((context.isMatchElement || checkingContext.resolvingMode == Mode::CollectingRules) && collectedPseudoElements
                 && !nextContext.hasSelectionPseudo
-                && !((nextContext.hasScrollbarPseudo || nextContext.hasViewTransitionPseudo) && nextContext.selector->match() == CSSSelector::Match::PseudoClass))
+                && !((nextContext.hasScrollbarPseudo || nextContext.hasViewTransitionPseudo) && nextContext.selector->match() == CSSSelector::Match::PseudoClass)
+                && !collectingPseudoElementRulesDuringElementMatching) {
                 return MatchResult::fails(Match::SelectorFailsCompletely);
+            }
 
             MatchResult result = matchRecursively(checkingContext, nextContext, collectedPseudoElements);
 

--- a/Source/WebCore/css/SelectorChecker.h
+++ b/Source/WebCore/css/SelectorChecker.h
@@ -78,6 +78,7 @@ class SelectorChecker {
 public:
     enum class Mode : unsigned char {
         ResolvingStyle = 0,
+        // This is used for the Web Inspector
         CollectingRules,
         StyleInvalidation,
         // This is used for querySelector() API

--- a/Source/WebCore/cssjit/SelectorCompiler.cpp
+++ b/Source/WebCore/cssjit/SelectorCompiler.cpp
@@ -4501,11 +4501,14 @@ void SelectorCodeGenerator::generateMarkPseudoStyleForPseudoElement(Assembler::J
         auto pseudoElementSetDataAddress = pseudoElementSetAddress.withOffset(EnumSet<PseudoElementType>::storageMemoryOffset());
         EnumSet<PseudoElementType> value { pseudoElementType };
         m_assembler.store32(Assembler::TrustedImm32(value.toRaw()), pseudoElementSetDataAddress);
+
+        // Allow the match to succeed so that pseudo-element rules can be collected during element matching.
+        // This enables caching of pseudo-element match results.
+        successCases.append(m_assembler.jump());
     }
 
-    // We have a pseudoElementSelector, we are not in CollectingRulesIgnoringVirtualPseudoElements so
-    // we must match that pseudo element. Since the context does not have a requested pseudo element we fail matching
-    // after the marking.
+    // When not in ResolvingStyle mode, we have a pseudoElementSelector but no requested pseudo element,
+    // so we fail matching after the marking.
     failureCases.append(m_assembler.jump());
 
     successCases.link(&m_assembler);

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -3234,7 +3234,7 @@ std::unique_ptr<RenderStyle> Document::styleForElementIgnoringPendingStylesheets
         if ((type == PseudoElementType::FirstLetter || type == PseudoElementType::FirstLine) && elementStyle.style && !Style::supportsFirstLineAndLetterPseudoElement(*elementStyle.style))
             return { };
 
-        auto style = resolver->styleForPseudoElement(element, { *pseudoElementIdentifier }, { parentStyle.get() });
+        auto style = resolver->styleForPseudoElement(element, { *pseudoElementIdentifier }, { parentStyle.get(), nullptr, nullptr, nullptr, nullptr, elementStyle.elementMatchedRules.get() });
         if (!style)
             return nullptr;
         return WTF::move(style->style);

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -1834,7 +1834,10 @@ std::unique_ptr<RenderStyle> RenderElement::getUncachedPseudoStyle(const Style::
     Ref element = *this->element();
     auto& styleResolver = element->styleResolver();
 
-    auto resolvedStyle = styleResolver.styleForPseudoElement(element, pseudoElementRequest, { parentStyle });
+    // Retrieve cached elementMatchedRules from the parent style to avoid re-matching
+    auto* matchedRules = parentStyle->elementMatchedRules();
+
+    auto resolvedStyle = styleResolver.styleForPseudoElement(element, pseudoElementRequest, { parentStyle, nullptr, nullptr, nullptr, nullptr, matchedRules });
     if (!resolvedStyle)
         return nullptr;
 

--- a/Source/WebCore/rendering/style/RenderStyleBase.h
+++ b/Source/WebCore/rendering/style/RenderStyleBase.h
@@ -30,6 +30,10 @@
 
 namespace WebCore {
 
+namespace Style {
+struct MatchedRule;
+}
+
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(RenderStyleBase);
 class RenderStyleBase {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(RenderStyleBase, RenderStyleBase);
@@ -174,6 +178,9 @@ public:
 
     bool hasCachedPseudoStyles() const { return m_computedStyle.hasCachedPseudoStyles(); }
     const Style::PseudoStyleCache& cachedPseudoStyles() const { return m_computedStyle.cachedPseudoStyles(); }
+
+    const Vector<Style::MatchedRule>* elementMatchedRules() const { return m_computedStyle.elementMatchedRules(); }
+    void setElementMatchedRules(std::unique_ptr<Vector<Style::MatchedRule>>&& rules) { m_computedStyle.setElementMatchedRules(WTF::move(rules)); }
 
     // MARK: - Custom properties
 

--- a/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
@@ -440,6 +440,10 @@ void RenderTreeUpdater::updateElementRenderer(Element& element, const Style::Ele
 
     auto elementUpdateStyle = RenderStyle::cloneIncludingPseudoElements(*elementUpdate.style);
 
+    // Transfer elementMatchedRules from ElementUpdate to the cloned style for reuse during pseudo-element resolution
+    if (elementUpdate.elementMatchedRules)
+        elementUpdateStyle.setElementMatchedRules(makeUnique<Vector<Style::MatchedRule>>(*elementUpdate.elementMatchedRules));
+
     bool shouldTearDownRenderers = [&]() {
         if (element.isInTopLayer() && elementUpdate.changes.contains(Style::Change::Inherited) && elementUpdate.style->isSkippedRootOrSkippedContent())
             return true;

--- a/Source/WebCore/style/ElementRuleCollector.cpp
+++ b/Source/WebCore/style/ElementRuleCollector.cpp
@@ -87,13 +87,15 @@ IGNORE_GCC_WARNINGS_END
 }
 
 struct MatchRequest {
-    MatchRequest(const RuleSet& ruleSet, ScopeOrdinal styleScopeOrdinal = ScopeOrdinal::Element)
+    MatchRequest(const RuleSet& ruleSet, ScopeOrdinal styleScopeOrdinal = ScopeOrdinal::Element, DeclarationOrigin origin = DeclarationOrigin::Author)
         : ruleSet(ruleSet)
         , styleScopeOrdinal(styleScopeOrdinal)
+        , declarationOrigin(origin)
     {
     }
     const RuleSet& ruleSet;
     ScopeOrdinal styleScopeOrdinal;
+    DeclarationOrigin declarationOrigin;
     bool matchingPartPseudoElementRules { false };
 };
 
@@ -137,10 +139,13 @@ const Vector<Ref<const StyleRule>>& ElementRuleCollector::matchedRuleList() cons
     return m_matchedRuleList;
 }
 
-inline void ElementRuleCollector::addMatchedRule(const RuleData& ruleData, unsigned specificity, unsigned scopingRootDistance, const MatchRequest& matchRequest)
+inline void ElementRuleCollector::addMatchedRule(const RuleData& ruleData, unsigned specificity, unsigned scopingRootDistance, const MatchRequest& matchRequest, DeclarationOrigin origin, const EnumSet<PseudoElementType>& pseudoIdSet)
 {
     auto cascadeLayerPriority = matchRequest.ruleSet.cascadeLayerPriorityFor(ruleData);
-    m_matchedRules.append({ &ruleData, specificity, scopingRootDistance, matchRequest.styleScopeOrdinal, cascadeLayerPriority });
+    MatchedRule matchedRule { &ruleData, specificity, scopingRootDistance, matchRequest.styleScopeOrdinal, cascadeLayerPriority, pseudoIdSet, origin };
+    m_matchedRules.append(matchedRule);
+    if (pseudoIdSet)
+        m_pseudoElementMatchedRules.append(matchedRule);
 }
 
 void ElementRuleCollector::clearMatchedRules()
@@ -287,6 +292,10 @@ void ElementRuleCollector::transferMatchedRules(DeclarationOrigin declarationOri
         if (fromScope && matchedRule.styleScopeOrdinal < *fromScope)
             break;
 
+        // Skip rules that only apply to pseudo-elements when matching for the element itself.
+        if (!m_pseudoElementRequest && matchedRule.pseudoIdSet)
+            continue;
+
         if (m_mode == SelectorChecker::Mode::CollectingRules) {
             m_matchedRuleList.append(matchedRule.ruleData->styleRule());
             continue;
@@ -334,7 +343,7 @@ void ElementRuleCollector::matchUserAgentPartRules(DeclarationOrigin origin)
     if (!hostRules)
         return;
 
-    MatchRequest hostRequest { *hostRules, ScopeOrdinal::ContainingHost };
+    MatchRequest hostRequest { *hostRules, ScopeOrdinal::ContainingHost, origin };
     collectMatchingUserAgentPartRules(hostRequest);
 }
 
@@ -350,7 +359,7 @@ void ElementRuleCollector::matchHostPseudoClassRules(DeclarationOrigin origin)
         if (rules.isEmpty())
             return;
 
-        MatchRequest hostMatchRequest { *shadowRules, ScopeOrdinal::Shadow };
+        MatchRequest hostMatchRequest { *shadowRules, ScopeOrdinal::Shadow, origin };
         collectMatchingRulesForList(&rules, hostMatchRequest);
     };
 
@@ -376,7 +385,7 @@ void ElementRuleCollector::matchSlottedPseudoElementRules(DeclarationOrigin orig
         if (!scopeRules)
             continue;
 
-        MatchRequest scopeMatchRequest(*scopeRules, styleScopeOrdinal);
+        MatchRequest scopeMatchRequest(*scopeRules, styleScopeOrdinal, origin);
         collectMatchingRulesForList(&scopeRules->slottedPseudoElementRules(), scopeMatchRequest);
 
         if (styleScopeOrdinal == ScopeOrdinal::SlotLimit)
@@ -413,7 +422,7 @@ void ElementRuleCollector::matchPartPseudoElementRulesForScope(const Element& pa
         if (!hostRules)
             continue;
 
-        MatchRequest scopeMatchRequest(*hostRules, styleScopeOrdinal);
+        MatchRequest scopeMatchRequest(*hostRules, styleScopeOrdinal, origin);
         scopeMatchRequest.matchingPartPseudoElementRules = true;
 
         collectMatchingRulesForList(&hostRules->partPseudoElementRules(), scopeMatchRequest);
@@ -471,7 +480,7 @@ void ElementRuleCollector::matchUARules(const RuleSet& rules)
 {
     clearMatchedRules();
 
-    collectMatchingRules(MatchRequest(rules));
+    collectMatchingRules(MatchRequest(rules, ScopeOrdinal::Element, DeclarationOrigin::UserAgent));
 
     sortAndTransferMatchedRules(DeclarationOrigin::UserAgent);
 }
@@ -491,7 +500,7 @@ static Vector<AtomString> classListForNamedViewTransitionPseudoElement(const Doc
     return capturedElement->classList;
 }
 
-inline bool ElementRuleCollector::ruleMatches(const RuleData& ruleData, unsigned& specificity, ScopeOrdinal styleScopeOrdinal, std::optional<ScopingRootWithDistance> scopingRoot)
+inline bool ElementRuleCollector::ruleMatches(const RuleData& ruleData, unsigned& specificity, ScopeOrdinal styleScopeOrdinal, std::optional<ScopingRootWithDistance> scopingRoot, EnumSet<PseudoElementType>& pseudoIdSet)
 {
     // We know a sufficiently simple single part selector matches simply because we found it from the rule hash when filtering the RuleSet.
     // This is limited to HTML only so we don't need to check the namespace (because of tag name match).
@@ -558,6 +567,7 @@ inline bool ElementRuleCollector::ruleMatches(const RuleData& ruleData, unsigned
 
     bool selectorMatches;
 #if ENABLE(CSS_SELECTOR_JIT)
+    // The JIT code implements the logic to return true for pseudo-element rules during element matching.
     if (compilerEnabled && compiledSelector.status == SelectorCompilationStatus::SelectorCheckerWithCheckingContext) {
         compiledSelector.wasUsed();
         selectorMatches = SelectorCompiler::ruleCollectorSelectorCheckerWithCheckingContext(compiledSelector, &element(), &context, &specificity);
@@ -574,6 +584,9 @@ inline bool ElementRuleCollector::ruleMatches(const RuleData& ruleData, unsigned
 
     m_matchedPseudoElements.add(context.publicPseudoElements);
     m_styleRelations.appendVector(context.styleRelations);
+
+    // Populate the output parameter with pseudo-elements this rule applies to.
+    pseudoIdSet = context.publicPseudoElements;
 
     return selectorMatches;
 }
@@ -609,8 +622,10 @@ void ElementRuleCollector::collectMatchingRulesForListSlow(const RuleSet::RuleDa
 
         auto addRuleIfMatches = [&] (const ScopingRootWithDistance& scopingRootWithDistance = { }) {
             unsigned specificity;
-            if (ruleMatches(ruleData, specificity, matchRequest.styleScopeOrdinal, scopingRootWithDistance))
-                addMatchedRule(ruleData, specificity, scopingRootWithDistance.distance, matchRequest);
+            EnumSet<PseudoElementType> pseudoIdSet;
+            bool matched = ruleMatches(ruleData, specificity, matchRequest.styleScopeOrdinal, scopingRootWithDistance, pseudoIdSet);
+            if (matched)
+                addMatchedRule(ruleData, specificity, scopingRootWithDistance.distance, matchRequest, matchRequest.declarationOrigin, pseudoIdSet);
         };
 
         if (scopingRoots) {

--- a/Source/WebCore/style/ElementRuleCollector.h
+++ b/Source/WebCore/style/ElementRuleCollector.h
@@ -45,6 +45,8 @@ struct MatchedRule {
     unsigned scopingRootDistance { 0 };
     ScopeOrdinal styleScopeOrdinal;
     CascadeLayerPriority cascadeLayerPriority;
+    EnumSet<PseudoElementType> pseudoIdSet; // Pseudo-elements this rule applies to (empty for element-only rules)
+    DeclarationOrigin declarationOrigin;
 };
 
 class ElementRuleCollector {
@@ -74,6 +76,8 @@ public:
 
     EnumSet<PseudoElementType> matchedPseudoElements() const { return m_matchedPseudoElements; }
     const Relations& styleRelations() const { return m_styleRelations; }
+    const auto& matchedRules() const { return m_matchedRules; }
+    const auto& pseudoElementMatchedRules() const { return m_pseudoElementMatchedRules; }
 
     void addAuthorKeyframeRules(const StyleRuleKeyframe&);
 
@@ -102,6 +106,7 @@ private:
         unsigned distance { std::numeric_limits<unsigned>::max() };
         bool matchesVisited { false };
     };
+    bool ruleMatches(const RuleData&, unsigned& specificity, ScopeOrdinal, std::optional<ScopingRootWithDistance>, EnumSet<PseudoElementType>& pseudoIdSet);
     bool ruleMatches(const RuleData&, unsigned& specificity, ScopeOrdinal, std::optional<ScopingRootWithDistance> scopingRoot = { });
     bool containerQueriesMatch(const RuleData&, const MatchRequest&);
     std::pair<bool, std::optional<Vector<ScopingRootWithDistance>>> scopeRulesMatch(const RuleData&, const MatchRequest&);
@@ -112,7 +117,7 @@ private:
     void sortAndTransferMatchedRules(DeclarationOrigin);
     void transferMatchedRules(DeclarationOrigin, std::optional<ScopeOrdinal> forScope = { });
 
-    void addMatchedRule(const RuleData&, unsigned specificity, unsigned scopingRootDistance, const MatchRequest&);
+    void addMatchedRule(const RuleData&, unsigned specificity, unsigned scopingRootDistance, const MatchRequest&, DeclarationOrigin, const EnumSet<PseudoElementType>& = { });
     void addMatchedProperties(MatchedProperties&&, DeclarationOrigin);
 
     const Element& element() const { return m_element.get(); }
@@ -137,6 +142,7 @@ private:
     Ref<MatchResult> m_result;
     Relations m_styleRelations;
     EnumSet<PseudoElementType> m_matchedPseudoElements;
+    Vector<MatchedRule> m_pseudoElementMatchedRules;
 };
 
 ALWAYS_INLINE void ElementRuleCollector::collectMatchingRulesForList(const RuleSet::RuleDataVector* rules, const MatchRequest& matchRequest)

--- a/Source/WebCore/style/ResolvedStyle.h
+++ b/Source/WebCore/style/ResolvedStyle.h
@@ -26,16 +26,20 @@
 namespace WebCore {
 namespace Style {
 
+struct MatchedRule;
+
 struct UnadjustedStyle {
     std::unique_ptr<RenderStyle> style;
     std::unique_ptr<Relations> relations { };
     RefPtr<const MatchResult> matchResult { };
+    std::unique_ptr<Vector<MatchedRule>> elementMatchedRules { };
 };
 
 struct ResolvedStyle {
     std::unique_ptr<RenderStyle> style;
     std::unique_ptr<Relations> relations { };
     RefPtr<const MatchResult> matchResult { };
+    std::unique_ptr<Vector<MatchedRule>> elementMatchedRules { };
 };
 
 } // namespace Style

--- a/Source/WebCore/style/RuleData.cpp
+++ b/Source/WebCore/style/RuleData.cpp
@@ -118,6 +118,7 @@ RuleData::RuleData(const StyleRule& styleRule, unsigned selectorIndex, unsigned 
     , m_selectorListIndex(selectorListIndex)
     , m_matchBasedOnRuleHash(enumToUnderlyingType(computeMatchBasedOnRuleHash(selector())))
     , m_canMatchPseudoElement(complexSelectorCanMatchPseudoElement(selector()))
+    , m_matchesOnlyPseudoElement(complexSelectorMatchesOnlyPseudoElement(selector()))
     , m_propertyAllowlist(enumToUnderlyingType(determinePropertyAllowlist(selector())))
     , m_isStartingStyle(enumToUnderlyingType(isStartingStyle))
     , m_isEnabled(true)

--- a/Source/WebCore/style/RuleData.h
+++ b/Source/WebCore/style/RuleData.h
@@ -62,6 +62,7 @@ public:
     unsigned selectorListIndex() const { return m_selectorListIndex; }
 
     bool canMatchPseudoElement() const { return m_canMatchPseudoElement; }
+    bool matchesOnlyPseudoElement() const { return m_matchesOnlyPseudoElement; }
     MatchBasedOnRuleHash matchBasedOnRuleHash() const { return static_cast<MatchBasedOnRuleHash>(m_matchBasedOnRuleHash); }
     unsigned linkMatchType() const { return m_linkMatchType; }
     void setLinkMatchType(unsigned value) { m_linkMatchType = value; }
@@ -80,12 +81,13 @@ private:
     unsigned m_selectorListIndex : 16;
     unsigned m_matchBasedOnRuleHash : 3;
     unsigned m_canMatchPseudoElement : 1;
+    unsigned m_matchesOnlyPseudoElement : 1;
     unsigned m_linkMatchType : 2; //  SelectorChecker::LinkMatchMask
     unsigned m_propertyAllowlist : 2;
     unsigned m_isStartingStyle : 1;
     unsigned m_isEnabled : 1;
     // If we have more rules than 2^bitcount here we'll get confused about rule order.
-    unsigned m_position : 21;
+    unsigned m_position : 20;
     SelectorFilter::Hashes m_descendantSelectorIdentifierHashes;
 };
 

--- a/Source/WebCore/style/RuleSet.cpp
+++ b/Source/WebCore/style/RuleSet.cpp
@@ -412,6 +412,13 @@ void RuleSet::addRule(RuleData&& ruleData, CascadeLayerIdentifier cascadeLayerId
 
     // If we didn't find a specialized map to stick it in, file under universal rules.
     m_universalRules.append(ruleData);
+
+    // Also check if this is a pure pseudo-element selector (no element constraints)
+    // These can be pre-cached for fast pseudo-element matching
+    if (ruleData.matchesOnlyPseudoElement()) {
+        if (auto pseudoType = CSSSelector::stylePseudoElementTypeFor(ruleData.selector().pseudoElement()))
+            m_universalPseudoElementUARules.ensure(enumToUnderlyingType(*pseudoType), [] { return RuleDataVector { }; }).iterator->value.append(ruleData);
+    }
 }
 
 void RuleSet::addPageRule(StyleRulePage& rule)

--- a/Source/WebCore/style/RuleSet.h
+++ b/Source/WebCore/style/RuleSet.h
@@ -31,6 +31,7 @@
 #include <wtf/HashMap.h>
 #include <wtf/text/AtomString.h>
 #include <wtf/text/AtomStringHash.h>
+#include <wtf/HashTraits.h>
 
 namespace WebCore {
 
@@ -113,6 +114,11 @@ public:
     const RuleDataVector* focusVisiblePseudoClassRules() const { return &m_focusVisiblePseudoClassRules; }
     const RuleDataVector* rootElementRules() const { return &m_rootElementRules; }
     const RuleDataVector* universalRules() const { return &m_universalRules; }
+    const RuleDataVector* universalPseudoElementUARules(PseudoElementType type) const
+    {
+        auto it = m_universalPseudoElementUARules.find(enumToUnderlyingType(type));
+        return it != m_universalPseudoElementUARules.end() ? &it->value : nullptr;
+    }
 
     const Vector<StyleRulePage*>& pageRules() const { return m_pageRules; }
 
@@ -240,6 +246,10 @@ private:
 
     // @position-try
     HashMap<AtomString, Ref<const StyleRulePositionTry>> m_positionTryRules;
+
+    // Pre-matched universal pseudo-element UA rules (rules that match only pseudo-elements without element constraints)
+    // Uses underlying integer type as key since PseudoElementType doesn't have HashTraits
+    HashMap<unsigned, RuleDataVector> m_universalPseudoElementUARules;
 
     bool m_hasHostPseudoClassRulesMatchingInShadowTree { false };
     bool m_hasViewportDependentMediaQueries { false };

--- a/Source/WebCore/style/StyleResolver.cpp
+++ b/Source/WebCore/style/StyleResolver.cpp
@@ -43,6 +43,7 @@
 #include "CSSViewTransitionRule.h"
 #include "CompositeOperation.h"
 #include "CustomFunctionRegistry.h"
+#include "DeclarationOrigin.h"
 #include "DocumentInlines.h"
 #include "DocumentResourceLoader.h"
 #include "DocumentView.h"
@@ -97,6 +98,8 @@
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/Vector.h>
 #include <wtf/text/AtomStringHash.h>
+
+#include <wtf/TimingScope.h>
 
 namespace WTF {
 
@@ -342,15 +345,24 @@ UnadjustedStyle Resolver::unadjustedStyleForElement(Element& element, const Reso
 
     applyMatchedProperties(state, collector.matchResult(), PropertyCascade::normalProperties());
 
+    // Store matched rules for lazy pseudo-element processing.
+    // This avoids building declarations for all pseudo-elements eagerly.
+    std::unique_ptr<Vector<MatchedRule>> elementMatchedRules;
+
+    if (!collector.pseudoElementMatchedRules().isEmpty())
+        elementMatchedRules = makeUnique<Vector<MatchedRule>>(collector.pseudoElementMatchedRules());
+
     return {
         .style = state.takeStyle(),
         .relations = WTF::move(elementStyleRelations),
-        .matchResult = collector.releaseMatchResult()
+        .matchResult = collector.releaseMatchResult(),
+        .elementMatchedRules = WTF::move(elementMatchedRules)
     };
 }
 
 ResolvedStyle Resolver::styleForElement(Element& element, const ResolutionContext& context, RuleMatchingBehavior matchingBehavior)
 {
+    // WTF::TimingScope scope("styleForElement", 1'000);
     auto unadjustedStyle = unadjustedStyleForElement(element, context, matchingBehavior);
     auto& parentStyle = context.parentStyle ? *context.parentStyle : RenderStyle::defaultStyleSingleton();
 
@@ -362,7 +374,8 @@ ResolvedStyle Resolver::styleForElement(Element& element, const ResolutionContex
     return {
         .style = WTF::move(style),
         .relations = WTF::move(unadjustedStyle.relations),
-        .matchResult = WTF::move(unadjustedStyle.matchResult)
+        .matchResult = WTF::move(unadjustedStyle.matchResult),
+        .elementMatchedRules = WTF::move(unadjustedStyle.elementMatchedRules)
     };
 }
 
@@ -575,6 +588,7 @@ bool Resolver::keyframeStylesForAnimation(Element& element, const RenderStyle& e
 
 std::optional<ResolvedStyle> Resolver::styleForPseudoElement(Element& element, const PseudoElementRequest& pseudoElementRequest, const ResolutionContext& context)
 {
+    WTF::TimingScope scope("ppppseudoElement", 10'000);
     auto state = State(element, context.parentStyle, context.documentElementStyle, context.treeResolutionState.get());
 
     if (state.parentStyle()) {
@@ -585,31 +599,247 @@ std::optional<ResolvedStyle> Resolver::styleForPseudoElement(Element& element, c
         state.setParentStyle(RenderStyle::clonePtr(*state.style()));
     }
 
-    ElementRuleCollector collector(element, m_ruleSets, context.selectorMatchingState);
-    collector.setPseudoElementRequest(pseudoElementRequest);
-    collector.setMedium(m_mediaQueryEvaluator);
-    collector.matchUARules();
+    auto matchResultFromCollectingRulesForPseudoElement = [&] {
+        // WTF::TimingScope scope("collecting", 1'000);
+        ElementRuleCollector collector(element, m_ruleSets, context.selectorMatchingState);
+        collector.setPseudoElementRequest(pseudoElementRequest);
+        collector.setMedium(m_mediaQueryEvaluator);
+        collector.matchUARules();
 
-    if (m_matchAuthorAndUserStyles) {
-        collector.matchUserRules();
-        collector.matchAuthorRules();
-    }
+        if (m_matchAuthorAndUserStyles) {
+            collector.matchUserRules();
+            collector.matchAuthorRules();
+        }
+        ASSERT(!collector.matchedPseudoElements());
+        auto result = collector.releaseMatchResult();
 
-    ASSERT(!collector.matchedPseudoElements());
+        return result;
+    };
+    
+    auto matchResultFromElementMatchedRules = [&] {
+        // WTF::TimingScope scope("caching", 10'000);
+        auto type = pseudoElementRequest.type();
+        auto matchResult = MatchResult::create(element.isLink());
 
-    if (collector.matchResult().isEmpty())
+        // Use pre-matched universal pseudo-element UA rules for fast matching
+        // These are pure pseudo-element selectors (e.g., ::marker { unicode-bidi: isolate })
+        // that have no element constraints and are pre-cached in the RuleSet
+        auto addUniversalPseudoElementRules = [&](const RuleSet& ruleSet) {
+            auto* rules = ruleSet.universalPseudoElementUARules(type);
+            if (!rules)
+                return;
+
+            auto cascadeLayerPriority = RuleSet::cascadeLayerPriorityForUnlayered;
+            for (auto& ruleData : *rules) {
+                matchResult->userAgentDeclarations.append({
+                    ruleData.styleRule().properties(),
+                    static_cast<uint8_t>(ruleData.linkMatchType()),
+                    ruleData.propertyAllowlist(),
+                    ScopeOrdinal::Element,
+                    FromStyleAttribute::No,
+                    cascadeLayerPriority,
+                    ruleData.isStartingStyle()
+                });
+            }
+        };
+
+        // Add UA rules from all UA RuleSets
+        auto* userAgentStyleSheet = m_mediaQueryEvaluator.isPrintMedia()
+            ? UserAgentStyle::defaultPrintStyle : UserAgentStyle::defaultStyle;
+        addUniversalPseudoElementRules(*userAgentStyleSheet);
+
+        if (element.document().inQuirksMode())
+            addUniversalPseudoElementRules(*UserAgentStyle::defaultQuirksStyle);
+
+        if (auto* mediaQueryStyle = m_ruleSets.userAgentMediaQueryStyle())
+            addUniversalPseudoElementRules(*mediaQueryStyle);
+
+        if (auto* viewTransitionsStyle = m_ruleSets.dynamicViewTransitionsStyle())
+            addUniversalPseudoElementRules(*viewTransitionsStyle);
+
+        // Add universal pseudo-element rules from author rulesets (e.g., ::highlight(...))
+        auto addUniversalPseudoElementAuthorRules = [&](const RuleSet& ruleSet) {
+            auto* rules = ruleSet.universalPseudoElementUARules(type);
+            if (!rules)
+                return;
+
+            auto cascadeLayerPriority = RuleSet::cascadeLayerPriorityForUnlayered;
+            for (auto& ruleData : *rules) {
+                // For functional pseudo-elements like ::highlight(name), filter by name
+                auto& selector = ruleData.selector();
+                if (auto* stringList = selector.stringList()) {
+                    if (stringList->first() != pseudoElementRequest.nameArgument())
+                        continue;
+                }
+
+                matchResult->authorDeclarations.append({
+                    ruleData.styleRule().properties(),
+                    static_cast<uint8_t>(ruleData.linkMatchType()),
+                    ruleData.propertyAllowlist(),
+                    ScopeOrdinal::Element,
+                    FromStyleAttribute::No,
+                    cascadeLayerPriority,
+                    ruleData.isStartingStyle()
+                });
+            }
+        };
+
+        if (m_matchAuthorAndUserStyles)
+            addUniversalPseudoElementAuthorRules(m_ruleSets.authorStyle());
+
+        // Add named pseudo-element rules (e.g., ::highlight(name)) from author rulesets
+        // These are bucketed by name, not in universalPseudoElementUARules
+        if (m_matchAuthorAndUserStyles && pseudoElementRequest.nameArgument() != nullAtom()) {
+            auto* namedRules = m_ruleSets.authorStyle().namedPseudoElementRules(pseudoElementRequest.nameArgument());
+            if (namedRules) {
+                auto cascadeLayerPriority = RuleSet::cascadeLayerPriorityForUnlayered;
+                for (auto& ruleData : *namedRules) {
+                    matchResult->authorDeclarations.append({
+                        ruleData.styleRule().properties(),
+                        static_cast<uint8_t>(ruleData.linkMatchType()),
+                        ruleData.propertyAllowlist(),
+                        ScopeOrdinal::Element,
+                        FromStyleAttribute::No,
+                        cascadeLayerPriority,
+                        ruleData.isStartingStyle()
+                    });
+                }
+            }
+        }
+
+        // Filter cached element matched rules that apply to this pseudo-element.
+        // This includes user and author rules from element matching.
+        // We need to collect them first, then sort them by cascade order before appending.
+
+        // Comparison function for sorting rules by cascade order
+        // This matches the logic in ElementRuleCollector::compareRules
+        auto compareRules = [](const MatchedRule& r1, const MatchedRule& r2) {
+            // For normal properties the earlier scope wins
+            if (r1.styleScopeOrdinal != r2.styleScopeOrdinal)
+                return r1.styleScopeOrdinal > r2.styleScopeOrdinal;
+
+            if (r1.cascadeLayerPriority != r2.cascadeLayerPriority)
+                return r1.cascadeLayerPriority < r2.cascadeLayerPriority;
+
+            if (r1.specificity != r2.specificity)
+                return r1.specificity < r2.specificity;
+
+            // Rule with the smallest distance has priority
+            if (r1.scopingRootDistance != r2.scopingRootDistance)
+                return r2.scopingRootDistance < r1.scopingRootDistance;
+
+            return r1.ruleData->position() < r2.ruleData->position();
+        };
+
+        // Collect filtered rules by origin
+        Vector<MatchedRule> userAgentRules;
+        Vector<MatchedRule> userRules;
+        Vector<MatchedRule> authorRules;
+
+        for (const auto& matchedRule : *context.elementMatchedRules) {
+            if (!matchedRule.pseudoIdSet.contains(type))
+                continue;
+
+            // Skip pure pseudo-element rules (e.g., ::highlight(name), ::marker)
+            // These are handled by addUniversalPseudoElementRules/addUniversalPseudoElementAuthorRules
+            // which properly filter by name for functional pseudo-elements like ::highlight(name)
+            if (matchedRule.ruleData->matchesOnlyPseudoElement())
+                continue;
+
+            switch (matchedRule.declarationOrigin) {
+            case DeclarationOrigin::UserAgent:
+                // Element-specific UA rules (e.g., dialog::backdrop) need to be collected
+                // Universal UA rules are already handled above via universalPseudoElementUARules
+                userAgentRules.append(matchedRule);
+                break;
+            case DeclarationOrigin::User:
+                userRules.append(matchedRule);
+                break;
+            case DeclarationOrigin::Author:
+                authorRules.append(matchedRule);
+                break;
+            }
+        }
+
+        // Sort rules by cascade order
+        std::ranges::sort(userAgentRules, compareRules);
+        std::ranges::sort(userRules, compareRules);
+        std::ranges::sort(authorRules, compareRules);
+
+        // Helper to convert MatchedRule to MatchedProperties and append
+        auto appendSortedRules = [&](const Vector<MatchedRule>& rules, Vector<MatchedProperties>& declarations) {
+            for (const auto& matchedRule : rules) {
+                auto matchedProperties = MatchedProperties {
+                    matchedRule.ruleData->styleRule().properties(),
+                    static_cast<uint8_t>(matchedRule.ruleData->linkMatchType()),
+                    matchedRule.ruleData->propertyAllowlist(),
+                    matchedRule.styleScopeOrdinal,
+                    FromStyleAttribute::No,
+                    matchedRule.cascadeLayerPriority,
+                    matchedRule.ruleData->isStartingStyle()
+                };
+
+                // Set hasStartingStyle flag if this is a starting-style rule
+                if (matchedProperties.isStartingStyle == IsStartingStyle::Yes)
+                    matchResult->hasStartingStyle = true;
+
+                // Handle cacheability flags
+                if (matchedProperties.isCacheable == IsCacheable::Partially && !matchResult->isCompletelyNonCacheable) {
+                    for (auto property : matchedProperties.properties.get())
+                        matchResult->nonCacheablePropertyIds.append(property.id());
+                }
+                if (matchedProperties.isCacheable == IsCacheable::No) {
+                    matchResult->isCompletelyNonCacheable = true;
+                    matchResult->nonCacheablePropertyIds.clear();
+                }
+
+                declarations.append(WTF::move(matchedProperties));
+            }
+        };
+
+        // Append sorted rules to their respective declaration lists
+        appendSortedRules(userAgentRules, matchResult->userAgentDeclarations);
+        appendSortedRules(userRules, matchResult->userDeclarations);
+        appendSortedRules(authorRules, matchResult->authorDeclarations);
+        return matchResult;
+    };
+    
+    // Use cached path only when elementMatchedRules is available
+    // For FirstLine and FirstLetter, always use the slow path as they have complex
+    // inheritance relationships and the cached path may not handle them correctly.
+    // View transition pseudo-elements also need the slow path as they have special
+    // matching requirements.
+    auto type = pseudoElementRequest.type();
+    auto needsSlowPath = [&] {
+        switch (type) {
+        case PseudoElementType::FirstLine:
+        case PseudoElementType::FirstLetter:
+        case PseudoElementType::ViewTransition:
+        case PseudoElementType::ViewTransitionGroup:
+        case PseudoElementType::ViewTransitionImagePair:
+        case PseudoElementType::ViewTransitionOld:
+        case PseudoElementType::ViewTransitionNew:
+            return true;
+        default:
+            return false;
+        }
+    }();
+    bool useCached = context.elementMatchedRules != nullptr && !needsSlowPath;
+    auto matchResult = useCached ? matchResultFromElementMatchedRules() : matchResultFromCollectingRulesForPseudoElement();
+
+    if (matchResult->isEmpty())
         return { };
 
     state.style()->setPseudoElementIdentifier(pseudoElementRequest.identifier());
 
-    applyMatchedProperties(state, collector.matchResult(), PropertyCascade::normalProperties());
+    applyMatchedProperties(state, matchResult.get(), PropertyCascade::normalProperties());
 
     Adjuster adjuster(document(), *state.parentStyle(), context.parentBoxStyle, nullptr);
     adjuster.adjust(*state.style());
 
     Adjuster::adjustVisibilityForPseudoElement(*state.style(), element);
 
-    return ResolvedStyle { state.takeStyle(), nullptr, collector.releaseMatchResult() };
+    return ResolvedStyle { state.takeStyle(), nullptr, WTF::move(matchResult) };
 }
 
 std::unique_ptr<RenderStyle> Resolver::styleForPage(int pageIndex)

--- a/Source/WebCore/style/StyleResolver.h
+++ b/Source/WebCore/style/StyleResolver.h
@@ -86,6 +86,8 @@ struct ResolutionContext {
     const RenderStyle* documentElementStyle { nullptr };
     SelectorMatchingState* selectorMatchingState { nullptr };
     CheckedPtr<TreeResolutionState> treeResolutionState { };
+    // Matched rules from element matching, to be processed lazily for pseudo-elements on-demand.
+    const Vector<MatchedRule>* elementMatchedRules { nullptr };
 
     bool isSVGUseTreeRoot { false };
 };

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -219,7 +219,8 @@ ResolvedStyle TreeResolver::styleForStyleable(const Styleable& styleable, Resolu
     ResolvedStyle resolvedStyle {
         .style = WTF::move(style),
         .relations = { },
-        .matchResult = WTF::move(unadjustedStyle.matchResult)
+        .matchResult = WTF::move(unadjustedStyle.matchResult),
+        .elementMatchedRules = WTF::move(unadjustedStyle.elementMatchedRules)
     };
 
     // Invalidate the last successful position option here. This is the only place where
@@ -695,7 +696,8 @@ ResolutionContext TreeResolver::makeResolutionContextForPseudoElement(const Elem
         parentBoxStyleForPseudoElement(elementUpdate),
         documentElementStyle(),
         &scope().selectorMatchingState,
-        &m_treeResolutionState
+        &m_treeResolutionState,
+        elementUpdate.elementMatchedRules.get()
     };
 }
 
@@ -934,7 +936,7 @@ ElementUpdate TreeResolver::createAnimatedElementUpdate(ResolvedStyle&& resolved
         return false;
     }();
 
-    return { WTF::move(newStyle), changes, shouldRecompositeLayer, mayNeedRebuildRoot };
+    return { WTF::move(newStyle), changes, shouldRecompositeLayer, mayNeedRebuildRoot, WTF::move(resolvedStyle.elementMatchedRules) };
 }
 
 std::unique_ptr<RenderStyle> TreeResolver::resolveStartingStyle(const ResolvedStyle& resolvedStyle, const Styleable& styleable, const ResolutionContext& resolutionContext)

--- a/Source/WebCore/style/StyleUpdate.h
+++ b/Source/WebCore/style/StyleUpdate.h
@@ -43,11 +43,14 @@ class Text;
 
 namespace Style {
 
+struct MatchedRule;
+
 struct ElementUpdate {
     std::unique_ptr<RenderStyle> style;
     OptionSet<Change> changes { };
     bool recompositeLayer { false };
     bool mayNeedRebuildRoot { false };
+    std::unique_ptr<Vector<MatchedRule>> elementMatchedRules { nullptr };
 };
 
 struct TextUpdate {

--- a/Source/WebCore/style/computed/StyleComputedStyleBase.cpp
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase.cpp
@@ -27,6 +27,7 @@
 #include "StyleComputedStyleBase+SettersInlines.h"
 
 #include "AutosizeStatus.h"
+#include "ElementRuleCollector.h"
 #include "FontCascade.h"
 #include "FontSelector.h"
 #include "Logging.h"
@@ -115,6 +116,16 @@ RenderStyle* ComputedStyleBase::addCachedPseudoStyle(std::unique_ptr<RenderStyle
     auto* result = pseudo.get();
     m_cachedPseudoStyles.add(*result->pseudoElementIdentifier(), WTF::move(pseudo));
     return result;
+}
+
+const Vector<MatchedRule>* ComputedStyleBase::elementMatchedRules() const
+{
+    return m_nonInheritedData->rareData->elementMatchedRules.get();
+}
+
+void ComputedStyleBase::setElementMatchedRules(std::unique_ptr<Vector<MatchedRule>>&& rules)
+{
+    m_nonInheritedData.access().rareData.access().elementMatchedRules = WTF::move(rules);
 }
 
 // MARK: - Custom properties

--- a/Source/WebCore/style/computed/StyleComputedStyleBase.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase.h
@@ -222,6 +222,7 @@ struct AlignItems;
 struct AlignSelf;
 struct Animation;
 struct AnchorNames;
+struct MatchedRule;
 struct AppleColorFilter;
 struct AspectRatio;
 struct BackgroundLayer;
@@ -591,6 +592,9 @@ public:
 
     bool hasCachedPseudoStyles() const { return !m_cachedPseudoStyles.isEmpty(); }
     const PseudoStyleCache& cachedPseudoStyles() const { return m_cachedPseudoStyles; }
+
+    const Vector<MatchedRule>* elementMatchedRules() const;
+    void setElementMatchedRules(std::unique_ptr<Vector<MatchedRule>>&&);
 
     // MARK: - Custom properties
 

--- a/Source/WebCore/style/computed/data/StyleNonInheritedRareData.cpp
+++ b/Source/WebCore/style/computed/data/StyleNonInheritedRareData.cpp
@@ -22,6 +22,7 @@
 #include "config.h"
 #include "StyleNonInheritedRareData.h"
 
+#include "ElementRuleCollector.h"
 #include "StyleComputedStyle+DifferenceLogging.h"
 #include "StyleComputedStyle+InitialInlines.h"
 #include "StylePrimitiveKeyword+Logging.h"
@@ -250,6 +251,7 @@ inline NonInheritedRareData::NonInheritedRareData(const NonInheritedRareData& o)
     , contain(o.contain)
     , overflowContinue(o.overflowContinue)
     , scrollSnapStop(o.scrollSnapStop)
+    , elementMatchedRules(o.elementMatchedRules ? makeUnique<Vector<MatchedRule>>(*o.elementMatchedRules) : nullptr)
 {
 }
 

--- a/Source/WebCore/style/computed/data/StyleNonInheritedRareData.h
+++ b/Source/WebCore/style/computed/data/StyleNonInheritedRareData.h
@@ -96,6 +96,7 @@ class GridData;
 class GridItemData;
 class MarqueeData;
 class MaskBorderData;
+struct MatchedRule;
 
 // This class is for rarely used non-inherited property data. By grouping them
 // together, we save space, and only allocate this object when someone actually
@@ -255,6 +256,9 @@ public:
     PREFERRED_TYPE(Contain) unsigned contain : 5;
     PREFERRED_TYPE(OverflowContinue) unsigned overflowContinue : 1;
     PREFERRED_TYPE(ScrollSnapStop) unsigned scrollSnapStop : 1;
+
+    // Cached rules from element matching for reuse during pseudo-element matching
+    std::unique_ptr<Vector<MatchedRule>> elementMatchedRules;
 
 private:
     NonInheritedRareData();


### PR DESCRIPTION
#### 574ebf0b5072be5dab5a27eec911944d2f258116
<pre>
[CSS] Re-use element rule matching for pseudo-element style resolution
<a href="https://bugs.webkit.org/show_bug.cgi?id=305046">https://bugs.webkit.org/show_bug.cgi?id=305046</a>
<a href="https://rdar.apple.com/158728258">rdar://158728258</a>

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

No new tests (OOPS!).
* Source/WebCore/style/ElementRuleCollector.cpp:
(WebCore::Style::ElementRuleCollector::addMatchedRule):
(WebCore::Style::ElementRuleCollector::ruleMatches):
(WebCore::Style::ElementRuleCollector::collectMatchingRulesForList):
(WebCore::Style::ElementRuleCollector::collectPseudoElementMatchResults):
(WebCore::Style::ElementRuleCollector::matchAllRules):
* Source/WebCore/style/ElementRuleCollector.h:
(WebCore::Style::ElementRuleCollector::pseudoElementMatchResults const):
* Source/WebCore/style/MatchResult.h:
(WebCore::Style::MatchResult::operator==): Deleted.
* Source/WebCore/style/ResolvedStyle.h:
* Source/WebCore/style/StyleResolver.cpp:
(WebCore::Style::Resolver::unadjustedStyleForElement):
(WebCore::Style::Resolver::styleForElement):
(WebCore::Style::Resolver::styleForPseudoElement):
* Source/WebCore/style/StyleResolver.h:
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::makeResolutionContextForPseudoElement):
(WebCore::Style::TreeResolver::createAnimatedElementUpdate):
* Source/WebCore/style/StyleUpdate.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/574ebf0b5072be5dab5a27eec911944d2f258116

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140956 "5 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13340 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2599 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149407 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94052 "Failed to checkout and rebase branch from PR 51973") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/142829 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14050 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13492 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108182 "Found 23 new test failures: fast/clip/clip-hit-null-iterator-path-comparison.html fast/css/hover-invalidation-no-jit.html fast/dom/css-selectorText.html fast/inline/first-line-style-too-early-crash.html imported/w3c/web-platform-tests/css/css-anchor-position/popover-anchor-backdrop-transition.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/backdrop-invalidation.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/pseudo-elements-011.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/pseudo-elements-012.html imported/w3c/web-platform-tests/css/css-grid/fieldset-first-line-crash.html imported/w3c/web-platform-tests/css/css-highlight-api/highlight-pseudo-computed.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/94052 "Failed to checkout and rebase branch from PR 51973") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143907 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10849 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126163 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89086 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10446 "Too many flaky failures: imported/w3c/web-platform-tests/content-security-policy/reporting-api/report-to-directive-allowed-in-meta.https.sub.html, imported/w3c/web-platform-tests/css/css-anchor-position/popover-anchor-backdrop-transition.html, imported/w3c/web-platform-tests/css/css-conditional/container-queries/backdrop-invalidation.html, imported/w3c/web-platform-tests/css/css-conditional/container-queries/pseudo-elements-011.html, imported/w3c/web-platform-tests/css/css-conditional/container-queries/pseudo-elements-012.html, imported/w3c/web-platform-tests/css/css-grid/fieldset-first-line-crash.html, imported/w3c/web-platform-tests/css/css-highlight-api/highlight-pseudo-computed.html, imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-painting-002.html, imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-painting-invalidation-007.html, imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-painting-overlapping-highlights-002.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8027 "Passed tests") | [⏳ 🛠 wpe-libwebrtc ](https://ews-build.webkit.org/#/builders/WPE-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119697 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2153 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151920 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13026 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2856 "161 new passes 32 failures") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116390 "Found 24 new test failures: fast/clip/clip-hit-null-iterator-path-comparison.html fast/css/hover-invalidation-no-jit.html fast/dom/css-selectorText.html fast/inline/first-line-style-too-early-crash.html imported/w3c/web-platform-tests/css/css-anchor-position/popover-anchor-backdrop-transition.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/backdrop-invalidation.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/pseudo-elements-011.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/pseudo-elements-012.html imported/w3c/web-platform-tests/css/css-grid/fieldset-first-line-crash.html imported/w3c/web-platform-tests/css/css-highlight-api/highlight-pseudo-computed.html ... (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13041 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11385 "Too many flaky failures: editing/input/cocoa/do-not-allow-inline-predictions-if-text-changes.html, editing/input/mac/show-inline-prediction-with-adjacent-text.html, fast/clip/clip-hit-null-iterator-path-comparison.html, fast/css/checkVisibility-no-renderer-crash.html, fast/css/hover-invalidation-no-jit.html, fast/dom/css-selectorText.html, fast/inline/first-line-style-too-early-crash.html, http/tests/canvas/canvas-slow-font-loading.html, http/tests/media/hls/hls-webvtt-flashing.html, http/tests/media/progress-events-generated-correctly.html (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116730 "Found 1 new API test failure: WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/snapshot (failure)") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/12798 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122836 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/68187 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13069 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2345 "172 new passes 34 failures") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12808 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76770 "Found 3 new failures in style/StyleResolver.cpp") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13007 "Failed to checkout and rebase branch from PR 51973") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12852 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->