### PR TITLE
Add IPC decoder validator for DestinationColorSpace serializableColorSpace

### DIFF
--- a/LayoutTests/ipc/decode-destinationColorSpace-null-crash-expected.txt
+++ b/LayoutTests/ipc/decode-destinationColorSpace-null-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if WebKit does not crash.

--- a/LayoutTests/ipc/decode-destinationColorSpace-null-crash.html
+++ b/LayoutTests/ipc/decode-destinationColorSpace-null-crash.html
@@ -1,0 +1,74 @@
+<!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<p>This test passes if WebKit does not crash.</p>
+<script src="../resources/ipc.js"></script>
+<script>
+testRunner?.dumpAsText();
+testRunner?.waitUntilDone();
+
+setTimeout(async () => {
+    if (!window.IPC)
+        return testRunner?.notifyDone();
+
+    const { CoreIPC } = await import('./coreipc.js');
+    const renderingBackendIdentifier = randomIPCID();
+    o58 = CoreIPC.newStreamConnection();
+    CoreIPC.GPU.GPUConnectionToWebProcess.CreateRenderingBackend(
+        0, { renderingBackendIdentifier : renderingBackendIdentifier, connectionHandle : o58 });
+    o60 = o58.newInterface("RemoteRenderingBackend", renderingBackendIdentifier);
+
+    const didInitializeReply = o58.connection.waitForMessage(renderingBackendIdentifier, IPC.messages.RemoteRenderingBackendProxy_DidInitialize.name, 1)
+    o58.connection.setSemaphores(didInitializeReply[0].value, didInitializeReply[1].value);
+
+    o60.CacheFilter({
+        filter : {
+            subclasses : {
+                variantType : 'WebCore::CSSFilterRenderer',
+                variant : {
+                    functions : [
+                        {
+                            subclasses : {
+                                variantType : 'WebCore::FEFlood',
+                                variant : {
+                                    floodColor : { data : {} },
+                                    floodOpacity : 1.0,
+                                    operatingColorSpace : {
+                                        serializableColorSpace : {
+                                            alias : {
+                                                m_cgColorSpace : {
+                                                    alias : {
+                                                        variantType : 'RetainPtr<CFTypeRef>',
+                                                        variant : {
+                                                            object : {
+                                                                alias : {
+                                                                    variantType : 'std::nullptr_t',
+                                                                    variant : null
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    ],
+                    filterRenderingModes : 0,
+                    filterScale : { width : 1.0, height : 1.0 },
+                    filterRegion : {
+                        location : { x : 0, y : 0 },
+                        size : { width : 100, height : 100 }
+                    }
+                }
+            }
+        }
+    });
+
+    o58.connection.invalidate();
+}, 20);
+
+setTimeout(() => {
+    testRunner?.notifyDone();
+}, 500);
+</script>

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2062,9 +2062,15 @@ using WebCore::PlatformColorSpace = sk_sp<SkColorSpace>;
 #endif
 #endif
 
+#if USE(CG) || USE(SKIA)
 [AdditionalEncoder=StreamConnectionEncoder] class WebCore::DestinationColorSpace {
-        WebCore::PlatformColorSpace serializableColorSpace();
+    [Validator='*serializableColorSpace'] WebCore::PlatformColorSpace serializableColorSpace();
 };
+#else
+[AdditionalEncoder=StreamConnectionEncoder] class WebCore::DestinationColorSpace {
+    WebCore::PlatformColorSpace serializableColorSpace();
+};
+#endif
 
 struct WebCore::WindowFeatures {
     bool hasAdditionalFeatures;


### PR DESCRIPTION
#### 5ebd2945412c73342afd22c12fca9d1fd51b5dac
<pre>
Add IPC decoder validator for DestinationColorSpace serializableColorSpace
<a href="https://bugs.webkit.org/show_bug.cgi?id=300355">https://bugs.webkit.org/show_bug.cgi?id=300355</a>
<a href="https://rdar.apple.com/162160316">rdar://162160316</a>

Reviewed by Ryosuke Niwa.

Along with PR #51927, other CoreIPC fuzzer test cases hit an unrelated assert
in Debug builds. This assert (ASSERTION FAILED: m_platformColorSpace) comes up
in the DestinationColorSpace() constructor and is triggered because a null
colorspace gets passed in thru IPC.
This fix adds a validator to do a null check.

Test: ipc/decode-destinationColorSpace-null-crash.html
* LayoutTests/ipc/decode-destinationColorSpace-null-crash-expected.txt: Added.
* LayoutTests/ipc/decode-destinationColorSpace-null-crash.html: Added.
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/301222@main">https://commits.webkit.org/301222@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/beda61e7b6b6f974b444e407dd27c7922133bc3d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125277 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44944 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35683 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132128 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77152 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0fe82027-1944-4992-8503-4ad88030071b) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45634 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53504 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95379 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/63319 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/09284e13-89a0-4caa-8532-ea38a197b699) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128231 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36441 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112030 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75920 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/db7f0d24-75b2-4c6f-9f44-93221b0b5009) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35340 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30198 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75607 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106208 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30423 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134811 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52085 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39861 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103854 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52521 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108251 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103619 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26392 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48972 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27263 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49190 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51978 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57757 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51341 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54694 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53032 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->