### PR TITLE
[JSC] Keep Debugger until JSGlobalObject gets switched

### DIFF
--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -969,8 +969,6 @@ void JSGlobalObject::init(VM& vm)
 
     convertToDictionary(vm);
 
-    m_debugger = nullptr;
-
 #if ENABLE(REMOTE_INSPECTOR)
     m_inspectorController = makeUnique<Inspector::JSGlobalObjectInspectorController>(*this);
     m_inspectorDebuggable = JSGlobalObjectDebuggable::create(*this);

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -226,6 +226,7 @@ private:
 public:
     template<typename T> using Initializer = typename LazyProperty<JSGlobalObject, T>::Initializer;
 
+    Debugger* m_debugger { nullptr };
     WriteBarrier<JSObject> m_globalThis;
 
     WriteBarrier<JSGlobalLexicalEnvironment> m_globalLexicalEnvironment;
@@ -459,8 +460,6 @@ public:
     StructureCache m_structureCache;
 
     String m_name;
-
-    Debugger* m_debugger;
 
 #if ENABLE(REMOTE_INSPECTOR)
     // FIXME: <http://webkit.org/b/246237> Local inspection should be controlled by `inspectable` API.

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -1366,19 +1366,26 @@ void VM::drainMicrotasks()
         if (!m_defaultMicrotaskQueue.isEmpty())
             entryScope.emplace(*this, nullptr);
         do {
+            JSGlobalObject* currentGlobalObject = nullptr;
+            Debugger* currentDebugger = nullptr;
             m_defaultMicrotaskQueue.performMicrotaskCheckpoint(*this,
                 [&](QueuedTask& task) ALWAYS_INLINE_LAMBDA {
                     auto* globalObject = task.globalObject();
-                    entryScope->setGlobalObject(globalObject);
+                    if (currentGlobalObject != globalObject) {
+                        currentGlobalObject = globalObject;
+                        currentDebugger = globalObject->debugger();
+                        entryScope->setGlobalObject(globalObject);
+                    }
+
                     if (RefPtr dispatcher = task.dispatcher())
                         return dispatcher->run(task);
 
                     auto identifier = task.identifier();
                     {
                         auto catchScope = DECLARE_CATCH_SCOPE(*this);
-                        if (auto* debugger = globalObject->debugger()) [[unlikely]] {
+                        if (currentDebugger) [[unlikely]] {
                             DeferTerminationForAWhile deferTerminationForAWhile(*this);
-                            debugger->willRunMicrotask(globalObject, identifier);
+                            globalObject->debugger()->willRunMicrotask(globalObject, identifier);
                             if (!catchScope.clearExceptionExceptTermination()) [[unlikely]]
                                 return QueuedTask::Result::Executed;
                         }
@@ -1387,9 +1394,9 @@ void VM::drainMicrotasks()
                         if (!catchScope.clearExceptionExceptTermination()) [[unlikely]]
                             return QueuedTask::Result::Executed;
 
-                        if (auto* debugger = globalObject->debugger()) [[unlikely]] {
+                        if (currentDebugger) [[unlikely]] {
                             DeferTerminationForAWhile deferTerminationForAWhile(*this);
-                            debugger->didRunMicrotask(globalObject, identifier);
+                            globalObject->debugger()->didRunMicrotask(globalObject, identifier);
                             if (!catchScope.clearExceptionExceptTermination()) [[unlikely]]
                                 return QueuedTask::Result::Executed;
                         }

--- a/Source/WebCore/bindings/js/JSExecState.cpp
+++ b/Source/WebCore/bindings/js/JSExecState.cpp
@@ -57,7 +57,7 @@ JSC::JSValue evaluateHandlerFromAnyThread(JSC::JSGlobalObject* lexicalGlobalObje
 void JSExecState::runTask(JSC::JSGlobalObject* globalObject, JSC::QueuedTask& task)
 {
     JSExecState currentState(globalObject);
-    MicrotaskQueue::runJSMicrotask(globalObject, globalObject->vm(), task);
+    MicrotaskQueue::runJSMicrotask(globalObject, globalObject->vm(), task, globalObject->debugger());
 }
 
 ScriptExecutionContext* executionContext(JSC::JSGlobalObject* globalObject)

--- a/Source/WebCore/dom/Microtasks.cpp
+++ b/Source/WebCore/dom/Microtasks.cpp
@@ -69,13 +69,13 @@ void MicrotaskQueue::append(JSC::QueuedTask&& task)
     m_microtaskQueue.enqueue(WTFMove(task));
 }
 
-void MicrotaskQueue::runJSMicrotask(JSC::JSGlobalObject* globalObject, JSC::VM& vm, JSC::QueuedTask& task)
+void MicrotaskQueue::runJSMicrotask(JSC::JSGlobalObject* globalObject, JSC::VM& vm, JSC::QueuedTask& task, JSC::Debugger* debugger)
 {
     auto scope = DECLARE_CATCH_SCOPE(vm);
 
-    if (auto* debugger = globalObject->debugger()) [[unlikely]] {
+    if (debugger) [[unlikely]] {
         JSC::DeferTerminationForAWhile deferTerminationForAWhile(vm);
-        debugger->willRunMicrotask(globalObject, task.identifier());
+        globalObject->debugger()->willRunMicrotask(globalObject, task.identifier());
         if (!scope.clearExceptionExceptTermination()) [[unlikely]]
             return;
     }
@@ -90,9 +90,9 @@ void MicrotaskQueue::runJSMicrotask(JSC::JSGlobalObject* globalObject, JSC::VM& 
             return;
     }
 
-    if (auto* debugger = globalObject->debugger()) [[unlikely]] {
+    if (debugger) [[unlikely]] {
         JSC::DeferTerminationForAWhile deferTerminationForAWhile(vm);
-        debugger->didRunMicrotask(globalObject, task.identifier());
+        globalObject->debugger()->didRunMicrotask(globalObject, task.identifier());
         if (!scope.clearExceptionExceptTermination()) [[unlikely]]
             return;
     }
@@ -110,9 +110,11 @@ void MicrotaskQueue::performMicrotaskCheckpoint()
     {
         SUPPRESS_UNCOUNTED_ARG auto& data = threadGlobalDataSingleton();
         auto* previousState = data.currentState();
+
+        JSC::JSGlobalObject* currentGlobalObject = nullptr;
+        JSC::Debugger* currentDebugger = nullptr;
         std::optional<JSC::VMEntryScope> entryScope;
         std::optional<JSC::ScriptProfilingScope> profilingScope;
-        JSC::JSGlobalObject* currentGlobalObject = nullptr;
         m_microtaskQueue.performMicrotaskCheckpoint(vm,
             [&](JSC::QueuedTask& task) ALWAYS_INLINE_LAMBDA {
                 RefPtr dispatcher = downcast<WebCoreMicrotaskDispatcher>(task.dispatcher());
@@ -126,14 +128,15 @@ void MicrotaskQueue::performMicrotaskCheckpoint()
                         auto* globalObject = task.globalObject();
                         data.setCurrentState(globalObject);
                         if (currentGlobalObject != globalObject) {
+                            currentGlobalObject = globalObject;
+                            currentDebugger = globalObject->debugger();
                             if (!entryScope)
                                 entryScope.emplace(vm, globalObject);
                             else
                                 entryScope->setGlobalObject(globalObject);
                             profilingScope.emplace(globalObject, JSC::ProfilingReason::Microtask);
-                            currentGlobalObject = globalObject;
                         }
-                        runJSMicrotask(globalObject, vm, task);
+                        runJSMicrotask(globalObject, vm, task, currentDebugger);
                         break;
                     }
                     case WebCoreMicrotaskDispatcher::Type::None:
@@ -142,6 +145,7 @@ void MicrotaskQueue::performMicrotaskCheckpoint()
                         entryScope = std::nullopt;
                         profilingScope = std::nullopt;
                         currentGlobalObject = nullptr;
+                        currentDebugger = nullptr;
                         data.setCurrentState(previousState);
                         dispatcher->run(task);
                         break;

--- a/Source/WebCore/dom/Microtasks.h
+++ b/Source/WebCore/dom/Microtasks.h
@@ -29,6 +29,7 @@
 #include <wtf/WeakPtr.h>
 
 namespace JSC {
+class Debugger;
 class VM;
 } // namespace JSC
 
@@ -69,7 +70,7 @@ public:
     bool hasMicrotasksForFullyActiveDocument() const;
     bool isPerformingCheckpoint() const { return m_performingMicrotaskCheckpoint; }
 
-    static void runJSMicrotask(JSC::JSGlobalObject*, JSC::VM&, JSC::QueuedTask&);
+    static void runJSMicrotask(JSC::JSGlobalObject*, JSC::VM&, JSC::QueuedTask&, JSC::Debugger*);
 
 private:
     JSC::VM& vm() const { return m_vm.get(); }


### PR DESCRIPTION
#### 328c81f5f67b30108b37a2e097d5a7285b8e283b
<pre>
[JSC] Keep Debugger until JSGlobalObject gets switched
<a href="https://bugs.webkit.org/show_bug.cgi?id=300361">https://bugs.webkit.org/show_bug.cgi?id=300361</a>
<a href="https://rdar.apple.com/162165892">rdar://162165892</a>

Reviewed by NOBODY (OOPS!).

WIP

* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::init):
* Source/JavaScriptCore/runtime/JSGlobalObject.h:
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::drainMicrotasks):
* Source/WebCore/bindings/js/JSExecState.cpp:
(WebCore::JSExecState::runTask):
* Source/WebCore/dom/Microtasks.cpp:
(WebCore::MicrotaskQueue::runJSMicrotask):
(WebCore::MicrotaskQueue::performMicrotaskCheckpoint):
* Source/WebCore/dom/Microtasks.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/328c81f5f67b30108b37a2e097d5a7285b8e283b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125182 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44849 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35588 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132033 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77228 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a29017c9-baa0-4769-b4d5-3d970fe2565b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127059 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45540 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53410 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95303 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/63372 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/91c6ec6a-bbfe-4b95-9760-f21ed6b7ee08) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128136 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36357 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111945 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75843 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3db0e2ec-2405-407a-a56f-d1efd3f31158) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35256 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30112 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75511 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/117273 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106123 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30338 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134713 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/123700 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51991 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39775 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103769 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52426 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108166 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103539 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48889 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27179 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49062 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51883 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57662 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/156723 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51247 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/39243 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54603 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52940 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->