### PR TITLE
Drop IsDeprecatedWeakRefSmartPointerException use in platform/network/cocoa

### DIFF
--- a/Source/WebCore/platform/network/NetworkStorageSession.h
+++ b/Source/WebCore/platform/network/NetworkStorageSession.h
@@ -172,6 +172,7 @@ public:
     CFURLStorageSessionRef platformSession() { return m_platformSession.get(); }
     WEBCORE_EXPORT RetainPtr<CFHTTPCookieStorageRef> cookieStorage() const;
     CookieStorageObserver& cookieStorageObserver() const;
+    CheckedRef<CookieStorageObserver> checkedCookieStorageObserver() const;
 #elif USE(SOUP)
     WEBCORE_EXPORT explicit NetworkStorageSession(PAL::SessionID, IsInMemoryCookieStore = IsInMemoryCookieStore::No);
     ~NetworkStorageSession();

--- a/Source/WebCore/platform/network/cocoa/CookieStorageObserver.h
+++ b/Source/WebCore/platform/network/cocoa/CookieStorageObserver.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <pal/spi/cf/CFNetworkSPI.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/Function.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/TZoneMalloc.h>
@@ -38,17 +39,13 @@ namespace WebCore {
 class CookieStorageObserver;
 }
 
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::CookieStorageObserver> : std::true_type { };
-}
-
 namespace WebCore {
 
 // Use eager initialization for the WeakPtrFactory since we construct WeakPtrs on a non-main thread.
-class WEBCORE_EXPORT CookieStorageObserver : public CanMakeWeakPtr<CookieStorageObserver, WeakPtrFactoryInitialization::Eager> {
+class WEBCORE_EXPORT CookieStorageObserver final : public CanMakeWeakPtr<CookieStorageObserver, WeakPtrFactoryInitialization::Eager>, public CanMakeCheckedPtr<CookieStorageObserver> {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(CookieStorageObserver, WEBCORE_EXPORT);
     WTF_MAKE_NONCOPYABLE(CookieStorageObserver);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CookieStorageObserver);
 public:
     explicit CookieStorageObserver(NSHTTPCookieStorage *);
     ~CookieStorageObserver();

--- a/Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm
@@ -195,6 +195,11 @@ CookieStorageObserver& NetworkStorageSession::cookieStorageObserver() const
     return *m_cookieStorageObserver;
 }
 
+CheckedRef<CookieStorageObserver> NetworkStorageSession::checkedCookieStorageObserver() const
+{
+    return cookieStorageObserver();
+}
+
 RetainPtr<CFURLStorageSessionRef> createPrivateStorageSession(CFStringRef identifier, std::optional<HTTPCookieAcceptPolicy> cookieAcceptPolicy, NetworkStorageSession::ShouldDisableCFURLCache shouldDisableCFURLCache)
 {
     const void* sessionPropertyKeys[] = { _kCFURLStorageSessionIsPrivate };

--- a/Source/WebCore/platform/network/cocoa/RangeResponseGenerator.mm
+++ b/Source/WebCore/platform/network/cocoa/RangeResponseGenerator.mm
@@ -34,24 +34,17 @@
 #import "SharedBuffer.h"
 #import "WebCoreNSURLSession.h"
 #import <pal/spi/cf/CFNetworkSPI.h>
+#import <wtf/CheckedPtr.h>
 #import <wtf/FastMalloc.h>
 #import <wtf/FunctionDispatcher.h>
 #import <wtf/text/MakeString.h>
 #import <wtf/text/StringBuilder.h>
 
 namespace WebCore {
-struct RangeResponseGeneratorDataTaskData;
-}
 
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::RangeResponseGeneratorDataTaskData> : std::true_type { };
-}
-
-namespace WebCore {
-
-struct RangeResponseGeneratorDataTaskData : public CanMakeWeakPtr<RangeResponseGeneratorDataTaskData> {
+struct RangeResponseGeneratorDataTaskData final : public CanMakeWeakPtr<RangeResponseGeneratorDataTaskData>, public CanMakeCheckedPtr<RangeResponseGeneratorDataTaskData> {
     WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED(RangeResponseGeneratorDataTaskData);
+    WTF_STRUCT_OVERRIDE_DELETE_FOR_CHECKED_PTR(RangeResponseGeneratorDataTaskData);
     RangeResponseGeneratorDataTaskData(ParsedRequestRange&& range)
         : range(WTFMove(range))
         , nextByteToGiveBufferIndex(range.begin) { }
@@ -141,14 +134,15 @@ void RangeResponseGenerator::giveResponseToTaskIfBytesInRangeReceived(WebCoreNSU
         return;
 
     auto buffer = data.buffer.get();
-    auto* taskData = data.taskData.get(task);
+    CheckedPtr taskData = data.taskData.get(task);
     if (!taskData)
         return;
 
-    auto giveBytesToTask = [task = retainPtr(task), buffer, bufferSize, taskData = WeakPtr { *taskData }, weakGenerator = ThreadSafeWeakPtr { *this }, targetQueue = m_targetDispatcher] {
+    auto giveBytesToTask = [task = retainPtr(task), buffer, bufferSize, weakTaskData = WeakPtr { *taskData }, weakGenerator = ThreadSafeWeakPtr { *this }, targetQueue = m_targetDispatcher] {
         assertIsCurrent(targetQueue);
         if ([task state] != NSURLSessionTaskStateRunning)
             return;
+        CheckedPtr taskData = weakTaskData.get();
         if (!taskData)
             return;
         auto& range = taskData->range;
@@ -178,7 +172,7 @@ void RangeResponseGenerator::giveResponseToTaskIfBytesInRangeReceived(WebCoreNSU
     switch (taskData->responseState) {
     case RangeResponseGeneratorDataTaskData::ResponseState::NotSynthesizedYet: {
         auto response = synthesizedResponseForRange(data.originalResponse, range, expectedContentLength);
-        [task resource:nullptr receivedResponse:response completionHandler:[giveBytesToTask = WTFMove(giveBytesToTask), taskData = WeakPtr { taskData }, task = retainPtr(task)] (WebCore::ShouldContinuePolicyCheck shouldContinue) mutable {
+        [task resource:nullptr receivedResponse:response completionHandler:[giveBytesToTask = WTFMove(giveBytesToTask), taskData = WeakPtr { *taskData }, task = retainPtr(task)] (WebCore::ShouldContinuePolicyCheck shouldContinue) mutable {
             if (taskData)
                 taskData->responseState = RangeResponseGeneratorDataTaskData::ResponseState::SessionCalledCompletionHandler;
             if (shouldContinue == ShouldContinuePolicyCheck::Yes)

--- a/Source/WebCore/platform/network/mac/CookieStorageMac.mm
+++ b/Source/WebCore/platform/network/mac/CookieStorageMac.mm
@@ -33,12 +33,12 @@ namespace WebCore {
 
 void startObservingCookieChanges(NetworkStorageSession& storageSession, WTF::Function<void()>&& callback)
 {
-    storageSession.cookieStorageObserver().startObserving(WTFMove(callback));
+    storageSession.checkedCookieStorageObserver()->startObserving(WTFMove(callback));
 }
 
 void stopObservingCookieChanges(NetworkStorageSession& storageSession)
 {
-    storageSession.cookieStorageObserver().stopObserving();
+    storageSession.checkedCookieStorageObserver()->stopObserving();
 }
 
 }


### PR DESCRIPTION
#### b8b561b1b6d7ce5c78258dc60f9e29ded6a6aa98
<pre>
Drop IsDeprecatedWeakRefSmartPointerException use in platform/network/cocoa
<a href="https://bugs.webkit.org/show_bug.cgi?id=300360">https://bugs.webkit.org/show_bug.cgi?id=300360</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/platform/network/NetworkStorageSession.h:
* Source/WebCore/platform/network/cocoa/CookieStorageObserver.h:
* Source/WebCore/platform/network/cocoa/CookieStorageObserver.mm:
(-[WebCookieObserverAdapter initWithObserver:]):
(-[WebCookieObserverAdapter cookiesChangedNotificationHandler:]):
(WebCore::CookieStorageObserver::cookiesDidChange):
* Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm:
(WebCore::NetworkStorageSession::checkedCookieStorageObserver const):
* Source/WebCore/platform/network/cocoa/RangeResponseGenerator.mm:
(WebCore::RangeResponseGenerator::giveResponseToTaskIfBytesInRangeReceived):
(WebCore::RangeResponseGeneratorDataTaskData::RangeResponseGeneratorDataTaskData): Deleted.
* Source/WebCore/platform/network/mac/CookieStorageMac.mm:
(WebCore::startObservingCookieChanges):
(WebCore::stopObservingCookieChanges):

Canonical link: <a href="https://commits.webkit.org/301191@main">https://commits.webkit.org/301191@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/134e21d85f98af79796ef5565d312e767c4ef684

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125199 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44866 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35605 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132050 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/77064 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2a5da31d-d9ca-4438-80ee-78b34c1092ca) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127076 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45557 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53427 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95314 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/77064 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/872ed96b-e552-4075-a94f-6c76e45e3796) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128153 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36370 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111959 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75854 "Found 1 new API test failure: WPE/TestWebKitWebContext:/webkit/WebKitWebContext/no-web-process-leak (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2273a59b-c8bd-46fe-8bb9-4ba97a1023ef) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35267 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30127 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75528 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106136 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30352 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134730 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52008 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/39791 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103780 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52443 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108180 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103550 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26371 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48902 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27192 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49087 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51900 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57680 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51264 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54620 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52957 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->