### PR TITLE
Use uncheckedDowncast<>() in generated toJSNewlyCreated() functions

### DIFF
--- a/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
+++ b/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
@@ -5579,7 +5579,7 @@ END
                     }
                 }
                 push(@implContent, "    if (is<${childImplType}>(impl))\n");
-                push(@implContent, "        return toJSNewlyCreated(lexicalGlobalObject, globalObject, downcast<${childImplType}>(WTFMove(impl)));\n");
+                push(@implContent, "        return toJSNewlyCreated(lexicalGlobalObject, globalObject, uncheckedDowncast<${childImplType}>(WTFMove(impl)));\n");
                 push(@implContent, "#endif\n") if $conditional;
             });
         }

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSON.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSON.cpp
@@ -893,7 +893,7 @@ JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlo
 {
     UNUSED_PARAM(lexicalGlobalObject);
     if (is<TestDefaultToJSONInherit>(impl))
-        return toJSNewlyCreated(lexicalGlobalObject, globalObject, downcast<TestDefaultToJSONInherit>(WTFMove(impl)));
+        return toJSNewlyCreated(lexicalGlobalObject, globalObject, uncheckedDowncast<TestDefaultToJSONInherit>(WTFMove(impl)));
     return createWrapper<TestDefaultToJSON>(globalObject, WTFMove(impl));
 }
 

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONInherit.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONInherit.cpp
@@ -341,9 +341,9 @@ JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlo
 {
     UNUSED_PARAM(lexicalGlobalObject);
     if (is<TestDefaultToJSONIndirectInheritance>(impl))
-        return toJSNewlyCreated(lexicalGlobalObject, globalObject, downcast<TestDefaultToJSONIndirectInheritance>(WTFMove(impl)));
+        return toJSNewlyCreated(lexicalGlobalObject, globalObject, uncheckedDowncast<TestDefaultToJSONIndirectInheritance>(WTFMove(impl)));
     if (is<TestDefaultToJSONInheritFinal>(impl))
-        return toJSNewlyCreated(lexicalGlobalObject, globalObject, downcast<TestDefaultToJSONInheritFinal>(WTFMove(impl)));
+        return toJSNewlyCreated(lexicalGlobalObject, globalObject, uncheckedDowncast<TestDefaultToJSONInheritFinal>(WTFMove(impl)));
     return createWrapper<TestDefaultToJSONInherit>(globalObject, WTFMove(impl));
 }
 


### PR DESCRIPTION
#### 287f8c8f6baf7578da8c01b56761ddf09bec76c0
<pre>
Use uncheckedDowncast&lt;&gt;() in generated toJSNewlyCreated() functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=300364">https://bugs.webkit.org/show_bug.cgi?id=300364</a>

Reviewed by Sam Weinig.

Use uncheckedDowncast&lt;&gt;() in generated toJSNewlyCreated() functions instead
of downcast&lt;&gt;(), since the code does a `is&lt;&gt;()` check right before and we
want to guarantee the compiler doesn&apos;t generate the type check twice.

* Source/WebCore/bindings/scripts/CodeGeneratorJS.pm:
(GenerateImplementation):
* Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSON.cpp:
(WebCore::toJSNewlyCreated):
* Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONInherit.cpp:
(WebCore::toJSNewlyCreated):

Canonical link: <a href="https://commits.webkit.org/301186@main">https://commits.webkit.org/301186@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dfac6397e4021937d705687c657f4375a6146f82

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125187 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44854 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35593 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132038 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77051 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ce8a10f0-1556-4cf7-b705-1c58a024f2e4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127064 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45545 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53415 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95304 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/63245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/32390020-1ca7-48f7-9bd0-81571e6bd0ad) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128141 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36359 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111949 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75844 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b28013ee-91f1-4f90-9e80-d31aaa88bd8a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35258 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30116 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75516 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/106125 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30342 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134718 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51996 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39779 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103768 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52431 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108170 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103538 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26369 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48892 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27183 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49067 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51888 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57667 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51252 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54608 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52945 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->