### PR TITLE
Address feedback on WebKitWebExtensions API

### DIFF
--- a/Source/WebCore/platform/graphics/gtk/IconGtk.cpp
+++ b/Source/WebCore/platform/graphics/gtk/IconGtk.cpp
@@ -36,7 +36,7 @@
 namespace WebCore {
 
 Icon::Icon(GRefPtr<GIcon>&& icon)
-    : m_icon(icon)
+    : m_icon(WTFMove(icon))
 {
 }
 

--- a/Source/WebKit/Shared/API/APIData.h
+++ b/Source/WebKit/Shared/API/APIData.h
@@ -86,6 +86,7 @@ public:
     static Ref<Data> createWithoutCopying(GRefPtr<GBytes>&& bytes)
     {
         auto span = WTF::span(bytes);
+        // The destroy function receives ownership of the GRefPtr, therefore destroying it
         return createWithoutCopying(span, [bytes = WTFMove(bytes)] () { });
     }
 #endif

--- a/Source/WebKit/Shared/Extensions/gtk/WebExtensionUtilitiesGtk.cpp
+++ b/Source/WebKit/Shared/Extensions/gtk/WebExtensionUtilitiesGtk.cpp
@@ -36,14 +36,12 @@ Vector<double> availableScreenScales()
 {
     Vector<double> screenScales;
 
-    auto* display = gdk_display_get_default();
-
 #if USE(GTK4)
+    auto* display = gdk_display_get_default();
     auto* monitors = gdk_display_get_monitors(display);
     unsigned currentMonitor = 0;
     while (auto* item = g_list_model_get_item(monitors, currentMonitor++)) {
         auto* monitor = GDK_MONITOR(item);
-        ASSERT(GDK_IS_MONITOR(monitor));
         screenScales.append(gdk_monitor_get_scale_factor(monitor));
     }
 #endif

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebExtension.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebExtension.h.in
@@ -37,10 +37,10 @@ G_BEGIN_DECLS
 WEBKIT_DECLARE_FINAL_TYPE (WebKitWebExtension, webkit_web_extension, WEBKIT, WEB_EXTENSION, GObject)
 
 WEBKIT_API WebKitWebExtension *
-webkit_web_extension_new                                     (GFile   *extension_path,
-                                                              GError **error);
+webkit_web_extension_new                                     (const char  *extension_path,
+                                                              GError     **error);
 
-WEBKIT_API GFile *
+WEBKIT_API const char *
 webkit_web_extension_get_path                                (WebKitWebExtension* extension);
 
 WEBKIT_API gdouble

--- a/Source/WebKit/UIProcess/API/glib/webkit.h.in
+++ b/Source/WebKit/UIProcess/API/glib/webkit.h.in
@@ -124,6 +124,8 @@
 #include <@API_INCLUDE_PREFIX@/WebKitWebContext.h>
 #if ENABLE(2022_GLIB_API)
 #include <@API_INCLUDE_PREFIX@/WebKitWebExtension.h>
+#endif
+#if PLATFORM(GTK)
 #include <@API_INCLUDE_PREFIX@/WebKitWebExtensionMatchPattern.h>
 #endif
 #if PLATFORM(GTK)

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebExtension.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebExtension.cpp
@@ -45,8 +45,7 @@ static void testExtensionCreationFromDirectory(Test*, gconstpointer)
     g_assert_true(g_file_set_contents(filePath.get(), extensionManifest, strlen(extensionManifest), &error.outPtr()));
     g_assert_no_error(error.get());
 
-    GRefPtr<GFile> file = adoptGRef(g_file_new_for_path(Test::dataDirectory()));
-    GRefPtr<WebKitWebExtension> extension = adoptGRef(webkit_web_extension_new(file.get(), &error.outPtr()));
+    GRefPtr<WebKitWebExtension> extension = adoptGRef(webkit_web_extension_new(Test::dataDirectory(), &error.outPtr()));
     g_assert_no_error(error.get());
 
     g_assert_cmpstr(webkit_web_extension_get_display_name(extension.get()), ==, "Test");

--- a/Tools/TestWebKitAPI/glib/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/glib/CMakeLists.txt
@@ -172,7 +172,9 @@ if (ENABLE_2022_GLIB_API)
     ADD_WK2_TEST(TestWebKitNetworkSession ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKitGLib/TestWebKitNetworkSession.cpp)
 
 if (ENABLE_WK_WEB_EXTENSIONS)
+if (ENABLE_2022_GLIB_API)
     ADD_WK2_TEST(TestWebKitWebExtension ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebExtension.cpp)
+endif ()
     ADD_WK2_TEST(TestWebKitWebExtensionMatchPattern ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebExtensionMatchPattern.cpp)
 endif ()
 


### PR DESCRIPTION
#### 4fa7914a27aae7a258bcf998218c57d64e12724e
<pre>
Address feedback on WebKitWebExtensions API
<a href="https://bugs.webkit.org/show_bug.cgi?id=300366">https://bugs.webkit.org/show_bug.cgi?id=300366</a>

Reviewed by Michael Catanzaro.

A few minor API design decisions, and fixing bugs with building WebKit without GTK4 enabled (-DUSE_GTK4=off)

Tests: Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebExtension.cpp
       Tools/TestWebKitAPI/glib/CMakeLists.txt
* Source/WebCore/platform/graphics/gtk/IconGtk.cpp:
(WebCore::Icon::Icon):
* Source/WebKit/Shared/API/APIData.h:
(API::Data::createWithoutCopying):
* Source/WebKit/Shared/Extensions/gtk/WebExtensionUtilitiesGtk.cpp:
(WebKit::availableScreenScales):
* Source/WebKit/UIProcess/API/glib/WebKitWebExtension.cpp:
(webkitWebExtensionGetProperty):
(webkitWebExtensionSetProperty):
(webkit_web_extension_class_init):
(webkit_web_extension_new):
(webkitWebExtensionSetPath):
(webkit_web_extension_get_path):
* Source/WebKit/UIProcess/API/glib/WebKitWebExtension.h.in:
* Source/WebKit/UIProcess/API/glib/webkit.h.in:
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebExtension.cpp:
(testExtensionCreationFromDirectory):
* Tools/TestWebKitAPI/glib/CMakeLists.txt:

Canonical link: <a href="https://commits.webkit.org/301229@main">https://commits.webkit.org/301229@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/35cd455f7b6f3f6c338827311d53d0b22dce86fd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125299 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44964 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35705 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132148 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/77166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127176 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45652 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53531 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95393 "Failed to checkout and rebase branch from PR 51986") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/77166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128253 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36454 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112051 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75934 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35353 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30220 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75625 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106221 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30446 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134834 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52103 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39881 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103870 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52541 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108273 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103631 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26399 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48989 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27284 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/49208 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51998 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57777 "Built successfully") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51356 "Hash 35cd455f for PR 51986 does not build (failure)") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54711 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53049 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->